### PR TITLE
fix(python): derive rebuilt root HasError from children

### DIFF
--- a/cgo_harness/python_root_haserror_c_receipt_test.go
+++ b/cgo_harness/python_root_haserror_c_receipt_test.go
@@ -1,0 +1,246 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// TestPythonRootHasErrorLockedCParity pins the finding's own hand example
+// (finding.pre-existing-route-divergences-2026-08-02 section 3) as a locked,
+// structural C-parity regression: the Go tree must match the C reference
+// parser node-for-node, AND the root HasError() flag must agree.
+//
+// The two checks are deliberately both present and independent.
+// runParityCase's compareNodes walks Type/StartByte/EndByte/IsNamed/
+// IsMissing/ChildCount/FieldName but never inspects HasError() at any node,
+// root included -- confirmed by reading compareNodes (parity_cgo_test.go):
+// it is structurally blind to exactly the class of bug this test exists to
+// pin. runParityCase alone would have reported this witness as passing even
+// before the fix (verified interactively), because the pre-fix Go tree was
+// already node-for-node identical to C's -- only the root's HasError() flag
+// disagreed. The explicit HasError comparison below is what actually pins
+// the regression; runParityCase is kept alongside it as a stronger, general
+// structural-parity corroboration for this exact input.
+func TestPythonRootHasErrorLockedCParity(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+	}{
+		// The finding's own hand example: a Go tree that matches C
+		// node-for-node, where only root HasError() diverged pre-fix.
+		{name: "dotted_import_trailing_dot", source: "from a import b, .c"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runParityCase(t, parityCase{name: "python"}, test.name, []byte(test.source))
+
+			cLang, err := ParityCLanguage("python")
+			if err != nil {
+				t.Fatalf("load C reference python parser: %v", err)
+			}
+			goTree, _, err := parseWithGo(parityCase{name: "python"}, []byte(test.source), nil)
+			if err != nil {
+				t.Fatalf("gotreesitter parse error: %v", err)
+			}
+			defer releaseGoTree(goTree)
+			goRoot := goTree.RootNode()
+
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatalf("C parser SetLanguage error: %v", err)
+			}
+			cTree := cParser.Parse([]byte(test.source), nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatalf("C reference parser returned nil tree")
+			}
+			defer cTree.Close()
+			cRoot := cTree.RootNode()
+
+			if !cRoot.HasError() {
+				t.Fatal("expected C reference root HasError()=true for this witness; witness may be stale")
+			}
+			if goRoot.HasError() != cRoot.HasError() {
+				t.Errorf("root HasError() disagreement: go=%v c=%v", goRoot.HasError(), cRoot.HasError())
+			}
+		})
+	}
+}
+
+// TestPythonRootHasErrorLockedCParityByteDrop pins the finding's second named
+// witness: deleting byte 834 of the incremental-gate python_setup.py fixture
+// (a call[632:1712] HasError=true nested under a module root that, pre-fix,
+// read HasError=false). Reads the fixture relative to the top-level module's
+// testdata directory since cgo_harness is its own Go module.
+//
+// This checks root HasError() agreement only, NOT full node-for-node parity
+// (runParityCase's compareNodes): at this exact site the Go root also has a
+// pre-existing, unrelated ChildCount divergence from the C reference (Go
+// keeps 8 top-level siblings where C's error recovery groups them under
+// fewer nodes) that is a structural-shape gap, not a false-clean HasError
+// bug, and out of scope for the root-HasError propagation repair this test
+// pins. The finding itself only ever claimed HasError agreement for this
+// witness.
+func TestPythonRootHasErrorLockedCParityByteDrop(t *testing.T) {
+	src, err := os.ReadFile("../testdata/incremental_gate/python_setup.py")
+	if err != nil {
+		t.Fatalf("read python_setup.py fixture: %v", err)
+	}
+	if len(src) <= 834 {
+		t.Fatalf("fixture too short for byte-834 witness: %d bytes", len(src))
+	}
+	edited := make([]byte, 0, len(src)-1)
+	edited = append(edited, src[:834]...)
+	edited = append(edited, src[835:]...)
+
+	cLang, err := ParityCLanguage("python")
+	if err != nil {
+		t.Fatalf("load C reference python parser: %v", err)
+	}
+	goTree, _, err := parseWithGo(parityCase{name: "python"}, edited, nil)
+	if err != nil {
+		t.Fatalf("gotreesitter parse error: %v", err)
+	}
+	defer releaseGoTree(goTree)
+	goRoot := goTree.RootNode()
+
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatalf("C parser SetLanguage error: %v", err)
+	}
+	cTree := cParser.Parse(edited, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatalf("C reference parser returned nil tree")
+	}
+	defer cTree.Close()
+	cRoot := cTree.RootNode()
+
+	if !cRoot.HasError() {
+		t.Fatal("expected C reference root HasError()=true for the byte-834-deleted witness; witness may be stale")
+	}
+	if goRoot.HasError() != cRoot.HasError() {
+		t.Errorf("root HasError() disagreement: go=%v c=%v", goRoot.HasError(), cRoot.HasError())
+	}
+}
+
+// TestPythonRootHasErrorAgreementCReceipts is the broader C-receipt sample
+// required by the python root-HasError repair: for a spread of the
+// incremental-gate corpus edit sites that were false-clean before the fix
+// (root HasError()=false despite the tree containing ERROR/MISSING), assert
+// specifically that the fixed Go root's HasError() now agrees with the C
+// reference parser's root HasError() on the identical edited text. This is a
+// narrower check than full structural parity (compareNodes) deliberately:
+// the point is root-flag agreement, not full node-for-node identity, which a
+// handful of these arbitrary byte-level error-recovery sites are not
+// expected to have with the C reference (a separate, out-of-scope surface --
+// see TestParityIncrementalParse and the incremental invariant gate for
+// structural-shape parity).
+func TestPythonRootHasErrorAgreementCReceipts(t *testing.T) {
+	type site struct {
+		path  string
+		pos   int
+		class string
+	}
+	sites := []site{
+		{"python_setup.py", 12, "delete"},
+		{"python_setup.py", 181, "delete"},
+		{"python_setup.py", 269, "delete"},
+		{"python_setup.py", 370, "replace"},
+		{"python_setup.py", 463, "delete"},
+		{"python_setup.py", 515, "delete"},
+		{"python_setup.py", 550, "replace"},
+		{"python_setup.py", 637, "insert"},
+		{"python_setup.py", 683, "replace"},
+		{"python_setup.py", 744, "insert"},
+		{"python_setup.py", 1690, "replace"},
+		{"python_setup.py", 1712, "delete"},
+		{"python_large_indent.py", 901, "delete"},
+		{"python_large_indent.py", 5401, "insert"},
+		{"python_large_indent.py", 8101, "replace"},
+		{"python_large_indent.py", 26101, "delete"},
+		{"python_large_indent.py", 29701, "replace"},
+	}
+
+	cLang, err := ParityCLanguage("python")
+	if err != nil {
+		t.Fatalf("load C reference python parser: %v", err)
+	}
+
+	fileCache := map[string][]byte{}
+	for _, s := range sites {
+		s := s
+		t.Run(fmt.Sprintf("%s_pos%d_%s", strings.TrimSuffix(s.path, ".py"), s.pos, s.class), func(t *testing.T) {
+			src, ok := fileCache[s.path]
+			if !ok {
+				var err error
+				src, err = os.ReadFile(filepath.Join("..", "testdata", "incremental_gate", s.path))
+				if err != nil {
+					t.Fatalf("read fixture %s: %v", s.path, err)
+				}
+				fileCache[s.path] = src
+			}
+			edited := pythonReceiptBuildEdit(src, s.pos, s.class)
+
+			goTree, goLang, err := parseWithGo(parityCase{name: "python"}, edited, nil)
+			if err != nil {
+				t.Fatalf("gotreesitter parse error: %v", err)
+			}
+			defer releaseGoTree(goTree)
+			goRoot := goTree.RootNode()
+
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatalf("C parser SetLanguage error: %v", err)
+			}
+			cTree := cParser.Parse(edited, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatalf("C reference parser returned nil tree")
+			}
+			defer cTree.Close()
+			cRoot := cTree.RootNode()
+
+			if goRoot.HasError() != cRoot.HasError() {
+				t.Errorf("root HasError() disagreement: go=%v c=%v (go type=%q c kind=%q, lang=%v)",
+					goRoot.HasError(), cRoot.HasError(), goRoot.Type(goLang), cRoot.Kind(), goLang != nil)
+			}
+			if !cRoot.HasError() {
+				t.Errorf("expected this site to be a pre-fix false-clean witness (C root HasError=true); "+
+					"C now reports false for %s pos=%d class=%s -- sample site list may be stale", s.path, s.pos, s.class)
+			}
+		})
+	}
+}
+
+func pythonReceiptBuildEdit(src []byte, i int, class string) []byte {
+	switch class {
+	case "delete":
+		edited := make([]byte, 0, len(src)-1)
+		edited = append(edited, src[:i]...)
+		edited = append(edited, src[i+1:]...)
+		return edited
+	case "insert":
+		edited := make([]byte, 0, len(src)+1)
+		edited = append(edited, src[:i]...)
+		edited = append(edited, src[i])
+		edited = append(edited, src[i:]...)
+		return edited
+	case "replace":
+		repByte := byte('z')
+		if src[i] == 'z' {
+			repByte = 'y'
+		}
+		edited := append([]byte{}, src...)
+		edited[i] = repByte
+		return edited
+	default:
+		panic("pythonReceiptBuildEdit: unknown edit class " + class)
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -3884,13 +3884,16 @@ func (p *Parser) stateDeterministicNonExtraShift(state StateID, sym Symbol) bool
 // production's ChildCount, the leaf is folded into whichever production
 // later reduces over it without perturbing arity, while populateParentNode's
 // HasError OR propagates the error through the reduce-built ancestors above
-// it. That propagation is not universal all the way to the tree root: python
-// specifically can still report a clean root over a genuinely erroring
-// subtree (parser_result_root_build.go's syntheticRootCanDropError /
-// pythonModuleChildrenLookComplete, a pre-existing, python-only root-level
-// convention this fix does not change and does not fully interact well
-// with -- see the PR discussion for the measured effect on root-level
-// HasError()).
+// it, all the way to the tree root. Python's root-level convention
+// (parser_result_root_build.go's syntheticRootCanDropError /
+// pythonModuleChildrenLookComplete) used to break exactly that propagation
+// for EXTRA children: it skipped extra children before checking their
+// HasError, so this leaf -- extra by construction, see leaf.setExtra(true)
+// below -- could still be silently dropped at the python module root even
+// though it correctly carries HasError=true. Fixed in PR #636:
+// pythonModuleChildrenLookComplete and its no-materialize twin now check
+// HasError on every child, extra or not, before the extra-skip, so this
+// leaf's error status reaches the root like any other.
 //
 // This is an ACCOUNTING fix, not a shape fix: the skipped bytes now have a
 // span and HasError=true, matching C tree-sitter's verdict that the

--- a/parser_result_python.go
+++ b/parser_result_python.go
@@ -1329,6 +1329,10 @@ func pythonStackEntryChildEntryAtNoMaterialize(arena *nodeArena, entry stackEntr
 	return stackEntry{}, false
 }
 
+// pythonModuleChildrenLookCompleteNoMaterialize is the no-materialize twin of
+// pythonModuleChildrenLookComplete: same ERROR-FREE-shape contract (see that
+// function's doc), evaluated over stack entries so the fast path never has to
+// materialize root's children just to answer the question.
 func pythonModuleChildrenLookCompleteNoMaterialize(root *Node, lang *Language) bool {
 	childCount := resultChildCount(root)
 	if childCount == 0 {
@@ -1339,6 +1343,12 @@ func pythonModuleChildrenLookCompleteNoMaterialize(root *Node, lang *Language) b
 	for i := 0; i < childCount; i++ {
 		entry, ok := nodeChildEntryAtNoMaterialize(root, i)
 		if !ok || !stackEntryHasNode(entry) {
+			return false
+		}
+		// HasError before the extra-skip: see pythonModuleChildrenLookComplete's
+		// doc comment -- an extra child can be a genuinely-erroring EXTRA ERROR
+		// leaf (materializeSkippedGapAsExtraError), not just benign trivia.
+		if stackEntryNodeHasError(entry) {
 			return false
 		}
 		if stackEntryNodeIsExtra(entry) {
@@ -2206,13 +2216,35 @@ func pythonSyntheticIfFieldIDs(arena *nodeArena, childCount int, lang *Language)
 	return fieldIDs
 }
 
+// pythonModuleChildrenLookComplete reports whether nodes are a plausible,
+// ERROR-FREE set of module-level children: each child is either a properly
+// named statement production or an unnamed `_simple_statements` wrapper, AND
+// no child (nor anything nested under it) carries HasError. The HasError
+// check runs BEFORE the extra-skip and applies to every non-nil child,
+// including extras: an extra child is normally benign trivia and is rightly
+// excluded from the shape/seen accounting below, but it is not exempt from
+// the error check -- materializeSkippedGapAsExtraError (parser.go) pushes
+// genuinely-erroring EXTRA ERROR leaves for lexer-skipped gaps, so "is extra"
+// no longer implies "cannot carry HasError". Checking shape alone, or
+// checking HasError only on non-extra children, both under-detect: a child
+// can be a perfectly well-shaped named statement (e.g. expression_statement)
+// while still containing a genuinely erroring descendant (e.g. a malformed
+// call several levels down), and an erroring child can be marked extra.
+// Callers rely on this function to decide whether it is safe to report the
+// rebuilt root as HasError=false.
 func pythonModuleChildrenLookComplete(nodes []*Node, lang *Language) bool {
 	if len(nodes) == 0 {
 		return false
 	}
 	seen := 0
 	for _, n := range nodes {
-		if n == nil || n.isExtra() {
+		if n == nil {
+			continue
+		}
+		if n.hasError() {
+			return false
+		}
+		if n.isExtra() {
 			continue
 		}
 		if n.IsNamed() {

--- a/parser_result_python.go
+++ b/parser_result_python.go
@@ -1061,6 +1061,18 @@ func repairPythonRootNode(root *Node, arena *nodeArena, lang *Language) *Node {
 		return root
 	}
 	if !pythonRootRepairNeedsMaterializedChildren(root, lang) {
+		// This branch (root.hasError() true while the no-materialize fast path
+		// applies) was measured, both by an independent PR #636 review and by
+		// an isolated-revert re-sweep of the full incremental-gate corpus here
+		// (5,241 sites, all three edit classes), to never fire in practice: no
+		// known witness reaches pythonRootRepairNeedsMaterializedChildren==false
+		// with root.hasError()==true. Reverting the HasError check inside
+		// pythonModuleChildrenLookCompleteNoMaterialize entirely still produced
+		// zero witnesses on that corpus. The check is kept anyway: it is cheap,
+		// and it holds the same ERROR-FREE-shape contract as the materialize
+		// path (pythonModuleChildrenLookComplete, which the same review
+		// independently confirmed DOES have live teeth -- 762 witnesses) for
+		// whichever future input first reaches this branch with a real error.
 		if root.hasError() && pythonModuleChildrenLookCompleteNoMaterialize(root, lang) {
 			cloned := cloneNodeInArenaPreservingFinalRefsForMutation(arena, root)
 			cloned.setHasError(false)

--- a/parser_result_python_recovery.go
+++ b/parser_result_python_recovery.go
@@ -86,11 +86,17 @@ func collapsePythonClassFragments(nodes []*Node, arena *nodeArena, lang *Languag
 			copy(buf, bodyChildren)
 			bodyChildren = buf
 		}
+		// blockNode/classDef are freshly built by newParentNodeInArena, which
+		// already runs populateParentNode over their exact children -- HasError
+		// is already the correct OR-over-children value (bodyChildren for
+		// blockNode; classChildren, which includes blockNode, for classDef).
+		// Do NOT force it to false here: a body fragment can be shaped exactly
+		// like a complete class body while still containing a genuinely
+		// erroring descendant several levels down, and forcing false would
+		// silently discard that signal on its way up to the module root.
 		blockNode := newParentNodeInArena(arena, blockSym, true, bodyChildren, nil, 0)
 		if repairedBlock, changed := repairPythonBlock(blockNode, arena, lang, true); changed {
 			blockNode = repairedBlock
-		} else {
-			blockNode.setHasError(false)
 		}
 
 		classChildren := make([]*Node, 0, 5)
@@ -106,7 +112,6 @@ func collapsePythonClassFragments(nodes []*Node, arena *nodeArena, lang *Languag
 		}
 		classFieldIDs := pythonSyntheticClassFieldIDs(arena, len(classChildren), argNode != nil, lang)
 		classDef := newParentNodeInArena(arena, classDefSym, true, classChildren, classFieldIDs, 0)
-		classDef.setHasError(false)
 
 		out := make([]*Node, 0, len(nodes)-(bodyEnd-i)+1)
 		out = append(out, nodes[:i]...)
@@ -162,11 +167,13 @@ func collapsePythonFunctionFragments(nodes []*Node, arena *nodeArena, lang *Lang
 			copy(buf, bodyChildren)
 			bodyChildren = buf
 		}
+		// See the matching comment in collapsePythonClassFragments: blockNode
+		// and fn already carry the correct populateParentNode-derived HasError
+		// from their real children; forcing false here would drop a genuine
+		// nested error on the floor instead of letting it propagate to root.
 		blockNode := newParentNodeInArena(arena, blockSym, true, bodyChildren, nil, 0)
 		if repairedBlock, changed := repairPythonBlock(blockNode, arena, lang, false); changed {
 			blockNode = repairedBlock
-		} else {
-			blockNode.setHasError(false)
 		}
 		fnChildren := []*Node{defNode, nameNode, paramsNode, colonNode, blockNode}
 		if arena != nil {
@@ -175,7 +182,6 @@ func collapsePythonFunctionFragments(nodes []*Node, arena *nodeArena, lang *Lang
 			fnChildren = buf
 		}
 		fn := newParentNodeInArena(arena, functionDefSym, true, fnChildren, pythonSyntheticFunctionFieldIDs(arena, len(fnChildren), lang), 0)
-		fn.setHasError(false)
 
 		out := make([]*Node, 0, len(nodes)-(bodyEnd-i)+1)
 		out = append(out, nodes[:i]...)
@@ -226,8 +232,10 @@ func collapsePythonTerminalIfSuffix(nodes []*Node, arena *nodeArena, lang *Langu
 		copy(buf, blockChildren)
 		blockChildren = buf
 	}
+	// blockNode/ifStmt again already carry the correct
+	// populateParentNode-derived HasError from their real children (see
+	// collapsePythonClassFragments); no override needed or wanted here.
 	blockNode := newParentNodeInArena(arena, blockSym, true, blockChildren, nil, 0)
-	blockNode.setHasError(false)
 
 	ifChildren := []*Node{ifNode, condNode, colonNode, blockNode}
 	if arena != nil {
@@ -237,7 +245,6 @@ func collapsePythonTerminalIfSuffix(nodes []*Node, arena *nodeArena, lang *Langu
 	}
 	ifFieldIDs := pythonSyntheticIfFieldIDs(arena, len(ifChildren), lang)
 	ifStmt := newParentNodeInArena(arena, ifSym, true, ifChildren, ifFieldIDs, 0)
-	ifStmt.setHasError(false)
 
 	out := make([]*Node, 0, n-5)
 	out = append(out, nodes[:n-6]...)

--- a/parser_result_python_recovery.go
+++ b/parser_result_python_recovery.go
@@ -1,5 +1,24 @@
 package gotreesitter
 
+// collapsePythonRootFragments and its three collapse* helpers below
+// (collapsePythonClassFragments, collapsePythonFunctionFragments,
+// collapsePythonTerminalIfSuffix) no longer force setHasError(false) on the
+// block/class/function/if nodes they build; see each helper's own comment.
+// An independent PR #636 review, and an isolated-revert re-sweep performed
+// here (re-adding the removed setHasError(false) calls, then re-running the
+// full incremental-gate corpus, 5,241 sites across all three edit classes),
+// both found zero witnesses where restoring the old override changes the
+// final tree's root HasError(): whatever intermediate error state these
+// helpers construct on the way in is either fully resolved (no error
+// remains once dropZeroWidthUnnamedTail/repairPythonNode-style repair
+// finishes) or is separately caught by pythonModuleChildrenLookComplete
+// (which the same review confirmed DOES have live teeth -- 762 witnesses)
+// before it would matter. The removals are kept anyway, as defense in
+// depth: forcing HasError to false regardless of children is never
+// correct per populateParentNode's own contract, and removing that override
+// costs nothing. If a future input reaches these functions with an error
+// that genuinely does survive to the final tree, this is the mechanism that
+// keeps it visible at the root.
 func collapsePythonRootFragments(nodes []*Node, arena *nodeArena, lang *Language) []*Node {
 	if len(nodes) == 0 || lang == nil || lang.Name != "python" {
 		return nodes

--- a/python_root_haserror_gate_test.go
+++ b/python_root_haserror_gate_test.go
@@ -1,0 +1,171 @@
+package gotreesitter_test
+
+// TestPythonRootHasErrorAgreementGate is the standing root-flag-agreement
+// gate identified as missing by
+// finding.pre-existing-route-divergences-2026-08-02 section 3: the
+// incremental invariant gate above scopes "clean" strictly by a recursive
+// IsError()/IsMissing() walk and deliberately never reads Node.HasError() (see
+// that file's doc comment), so it has no way to notice when a tree's ROOT
+// HasError() flag disagrees with the tree's own content.
+//
+// This gate closes that hole directly: it reuses the same corpus and the
+// same delete/insert/replace edit-site generation as
+// TestIncrementalInvariantGate (incrGateCorpus, incrGateBuildEdit), restricted
+// to python (the only language the source investigation found the class on --
+// a companion sweep of javascript, json, go, rust, css and c found zero), and
+// asserts a single invariant per fresh-parsed edited site: if the tree
+// contains ANY IsError()/IsMissing() node anywhere, RootNode().HasError() must
+// be true. tree-sitter's own contract for HasError() is exactly "the node is
+// a syntax error or contains any syntax errors" -- true recursively -- so
+// there is no legitimate parse shape where this can disagree; the exception
+// list below is expected to stay empty. If it ever needs an entry, that entry
+// must carry a C-oracle receipt proving tree-sitter's C implementation
+// independently agrees the root should read HasError()=false on that exact
+// site, because Parse()'s root HasError() is defined against that oracle, not
+// against this engine's own convenience.
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// pythonRootHasErrorAgreementExceptions is the C-verified exception list for
+// TestPythonRootHasErrorAgreementGate. Empty: no site swept by this gate has
+// ever been found where the C oracle also reports root HasError()=false while
+// the tree contains ERROR/MISSING. Adding an entry here without a C receipt
+// in the accompanying PR/commit is a doctrine violation.
+var pythonRootHasErrorAgreementExceptions = map[string]bool{}
+
+type pythonRootHasErrorWitness struct {
+	path        string
+	pos         int
+	class       string
+	errN, missN int
+	firstType   string
+}
+
+func (w pythonRootHasErrorWitness) key() string {
+	return fmt.Sprintf("%s|%s|pos=%d", w.path, w.class, w.pos)
+}
+
+func TestPythonRootHasErrorAgreementGate(t *testing.T) {
+	var entries []incrGateCorpusEntry
+	for _, e := range incrGateCorpus {
+		if e.language == "python" {
+			entries = append(entries, e)
+		}
+	}
+	if len(entries) == 0 {
+		t.Fatal("no python entries in incrGateCorpus to sweep")
+	}
+
+	for _, entry := range entries {
+		entry := entry
+		t.Run(entry.path, func(t *testing.T) {
+			witnesses, totalSites := sweepPythonRootHasErrorWitnesses(t, entry)
+			t.Logf("sites=%d witnesses=%d", totalSites, len(witnesses))
+			for _, w := range witnesses {
+				if pythonRootHasErrorAgreementExceptions[w.key()] {
+					continue
+				}
+				t.Errorf("ROOT-FLAG DISAGREEMENT unlisted: %s pos=%d class=%s: "+
+					"tree contains %d ERROR + %d MISSING node(s) (first: %s) but RootNode().HasError()=false. "+
+					"Either this is a regression in root HasError derivation, or a genuinely new site needs a "+
+					"C-oracle-verified entry in pythonRootHasErrorAgreementExceptions.",
+					entry.path, w.pos, w.class, w.errN, w.missN, w.firstType)
+			}
+		})
+	}
+}
+
+// sweepPythonRootHasErrorWitnesses parses entry's fixture, then walks every
+// delete/insert/replace edit site at entry's stride (matching
+// TestIncrementalInvariantGate's own methodology exactly, per incrGateBuildEdit),
+// fresh-parses the edited buffer, and records every site where the resulting
+// tree contains an ERROR/MISSING node while its root reports HasError()=false.
+func sweepPythonRootHasErrorWitnesses(t *testing.T, entry incrGateCorpusEntry) ([]pythonRootHasErrorWitness, int) {
+	t.Helper()
+
+	e := grammars.DetectLanguageByName(entry.language)
+	if e == nil {
+		t.Fatalf("unknown language %q", entry.language)
+	}
+	lang := e.Language()
+	support := grammars.EvaluateParseSupport(*e, lang)
+	if support.Backend == grammars.ParseBackendUnsupported || support.Backend == grammars.ParseBackendDFAPartial {
+		t.Fatalf("language %q has no usable full-parse backend for the gate: %s", entry.language, support.Reason)
+	}
+
+	src, err := os.ReadFile(filepath.Join("testdata", "incremental_gate", entry.path))
+	if err != nil {
+		t.Fatalf("read corpus file: %v", err)
+	}
+	if len(src) < 8 {
+		t.Fatalf("corpus file too small to sweep: %s", entry.path)
+	}
+
+	p := gts.NewParser(lang)
+	parseFresh := func(s []byte) *gts.Tree {
+		if support.Backend == grammars.ParseBackendTokenSource {
+			tr, _ := p.ParseWithTokenSource(s, e.TokenSourceFactory(s, lang))
+			return tr
+		}
+		tr, _ := p.Parse(s)
+		return tr
+	}
+
+	stride := entry.stride
+	if stride < 1 {
+		stride = 1
+	}
+
+	var witnesses []pythonRootHasErrorWitness
+	totalSites := 0
+	editClasses := []string{"delete", "insert", "replace"}
+
+	for i := 1; i < len(src)-1; i += stride {
+		for _, cls := range editClasses {
+			edited, _ := incrGateBuildEdit(src, i, cls)
+			tree := parseFresh(edited)
+			if tree == nil || tree.RootNode() == nil {
+				continue
+			}
+			totalSites++
+			root := tree.RootNode()
+			errN, missN := incrGateTreeStats(root)
+			if errN == 0 && missN == 0 {
+				continue // nothing to disagree about at this site
+			}
+			if root.HasError() {
+				continue // agrees with its own content -- not a witness
+			}
+			firstType := firstErrorOrMissingNodeType(lang, root)
+			witnesses = append(witnesses, pythonRootHasErrorWitness{
+				path: entry.path, pos: i, class: cls,
+				errN: errN, missN: missN, firstType: firstType,
+			})
+		}
+	}
+	return witnesses, totalSites
+}
+
+// firstErrorOrMissingNodeType returns the type of the first IsError() or
+// IsMissing() node found in a pre-order walk of n, or "<none>" if none exists.
+func firstErrorOrMissingNodeType(lang *gts.Language, n *gts.Node) string {
+	if n == nil {
+		return "<none>"
+	}
+	if n.IsError() || n.IsMissing() {
+		return n.Type(lang)
+	}
+	for i := 0; i < n.ChildCount(); i++ {
+		if t := firstErrorOrMissingNodeType(lang, n.Child(i)); t != "<none>" {
+			return t
+		}
+	}
+	return "<none>"
+}

--- a/python_root_haserror_gate_test.go
+++ b/python_root_haserror_gate_test.go
@@ -3,10 +3,12 @@ package gotreesitter_test
 // TestPythonRootHasErrorAgreementGate is the standing root-flag-agreement
 // gate identified as missing by
 // finding.pre-existing-route-divergences-2026-08-02 section 3: the
-// incremental invariant gate above scopes "clean" strictly by a recursive
-// IsError()/IsMissing() walk and deliberately never reads Node.HasError() (see
-// that file's doc comment), so it has no way to notice when a tree's ROOT
-// HasError() flag disagrees with the tree's own content.
+// incremental invariant gate (TestIncrementalInvariantGate,
+// incremental_invariant_gate_test.go, a separate file in this same package)
+// scopes "clean" strictly by a recursive IsError()/IsMissing() walk and
+// deliberately never reads Node.HasError() (see that file's doc comment), so
+// it has no way to notice when a tree's ROOT HasError() flag disagrees with
+// the tree's own content.
 //
 // This gate closes that hole directly: it reuses the same corpus and the
 // same delete/insert/replace edit-site generation as


### PR DESCRIPTION
## Summary

- Derive `HasError` on rebuilt python module, class, function, and if nodes from their children, the same way `populateParentNode` derives it for ordinary nodes.
- Add a root-flag agreement gate for the python incremental-gate corpus.

## Problem

Some rebuilt python trees reported root `HasError()=false` while a nested node held `HasError()=true`. Two mechanisms caused this.

- Three python fragment-collapse functions forced `HasError` to false on new block, class, function, and if nodes. They ignored the children's real error state.
- The completeness check that allows the root to drop its error flag skipped extra children before it checked their error state. An extra child can now carry a genuine error, for example a lexer-skipped-gap leaf. The old check never tested extra children for errors, so it missed this case.

## Fix

- Remove the forced `false` overrides. Let the constructor's own child-derived value stand.
- Move the error check ahead of the extra-skip step in the completeness check. An erroring extra child now blocks the drop too.

## Witness counts

Swept `python_setup.py` and `python_large_indent.py` under the incremental-gate corpus's own delete/insert/replace edit method, at every site where the tree contains an ERROR or MISSING node.

- Before: 749 sites on `python_setup.py`, 13 on `python_large_indent.py`.
- After: 0 and 0.

The finding this fix closes recorded 746 and 13; the small delta is sweep-loop boundary noise, not a different mechanism (confirmed: `python_large_indent.py` matches exactly).

## C reference parser receipts

Checked against an independently built tree-sitter C reference parser (`cgo_harness`, tags `cgo treesitter_c_parity`).

- `from a import b, .c`: root `HasError()` is now `true`, matching the C reference parser. The Go tree already matched C node for node before this fix; only the root flag disagreed.
- `python_setup.py` with byte 834 deleted: root `HasError()` is now `true`, matching the C reference parser. This site has a separate, pre-existing child-count divergence from C, unrelated to `HasError` and out of scope here.
- 17 further sampled sites (12 from `python_setup.py`, 5 from `python_large_indent.py`) all now agree with the C reference parser's root `HasError()` value.

All of the above fail against the C reference parser without this fix and pass with it. See `cgo_harness/python_root_haserror_c_receipt_test.go`.

## New gate

`TestPythonRootHasErrorAgreementGate` sweeps the python incremental-gate corpus. It fails if any tree contains an ERROR or MISSING node while its root reports `HasError()=false`, unless the site carries a C-verified exception entry. The exception list is empty.

## Regression coverage

Independent review measured that reverting either the no-materialize completeness check (`pythonModuleChildrenLookCompleteNoMaterialize`) or all six `setHasError(false)` deletions alone leaves the full suite green; only the materialize-path check (`pythonModuleChildrenLookComplete`) has a live witness (762 sites on the reviewer's corpus).

Verified both findings directly: re-added each removed piece in isolation and re-ran the full incremental-gate corpus (5,241 sites, all three edit classes) after each. Both isolated reverts hold at 0 witnesses; only reverting `pythonModuleChildrenLookComplete` itself brings witnesses back.

For the no-materialize check specifically, also confirmed the fast path (`parser_result_python.go:1063`, `root.hasError() && pythonModuleChildrenLookCompleteNoMaterialize(...)`) is entered zero times: across the full incremental-gate corpus, and across the entire top-level `go test .` suite (213s). Documented this in code comments at both sites rather than force a witness that does not exist in any corpus available here: both checks are kept as correct, cheap defense-in-depth consistent with `populateParentNode`'s own contract, and both explain in comments what would give them teeth. Tried reproducing the reviewer's literal `class GrammarTests(unittest.TestCase):` / `d   def test_a(self):` example and a real-corpus analog at the same shape (`python_large_indent.py`, byte 1921, replace edit, inside a `unittest.TestCase` subclass): both resolve to trees with zero ERROR/MISSING nodes anywhere, which is the separate, already-tracked "silent byte absorption" class (zero-error-node false-cleans), not this fix's root-flag-propagation class. Do not have access to the reviewer's broader 4,283-file / 40,000-mutant corpus that produced the exact witness; happy to add a literal pin immediately given the source bytes.

## Digest deltas

No committed digest changes. Root-flag deltas plus 405/3000 shape deltas on erroring python mutants, all neutral or toward C (for example root `ERROR[0:22]` becomes `module[0:22]`, matching C; `shape_away=0` across all 405). Zero non-python deltas across 206 languages.

The repository's only committed tree-digest pins are four Go-language fixtures in `internal/benchfixtures/go_fixtures.go`; this fix does not touch that path. The one committed python tree receipt that records a root `HasError` value, `cgo_harness/testdata/canonical_incremental_before_state_receipt_v1.json` case `python_scanner_dedent`, is an error-free control case on both engines and is unaffected: this fix only changes behavior when a child genuinely carries an error.

## Scope

This fix is python-only. The shared mechanism, `syntheticRootCanDropError`, checks `isLanguage("python")` and does not run for other languages. A companion sweep of javascript, json, go, rust, css, and c found zero witnesses of this class before the fix.

## Testing

- `go test . -run TestPythonRootHasErrorAgreementGate -v -count=1`
- `go test . -count=1`
- `go test ./grammars -count=1`
- `go test . -race -run "TestPythonRootHasErrorAgreementGate|TestBuildResultFromNodesCollapsesPython|TestBuildResultFromNodesUnwrapsPython|TestBuildResultFromNodesRepairsPython|TestBuildResultFromNodesHoistsPython" -v -count=1`
- `GTS_ADMISSION_SCORECARD=1 go test . -tags gts_parsercorephase0 -run TestAdmissionCandidateScorecard206 -v -count=1` (PASS=200 DIVERGE=0 FALLBACK=1 SKIP=5 ERROR=0, total=206; the one fallback is `markdown_inline`, unrelated to this change)
- `GTS_PARITY_ALLOW_HOST=1 GTS_PARITY_C_REF_BUILD_CACHE=<cache> CGO_ENABLED=1 go test ./cgo_harness -tags "cgo treesitter_c_parity" -run "TestPythonRootHasErrorLockedCParity|TestPythonRootHasErrorAgreementCReceipts|TestPythonSchedulerAction|TestPythonA3CompactCertificationFullCorpusSweep|TestParityFreshParse/python|TestParityHasNoErrors"`

