### PR TITLE
fix(parsercore): close byte-continuity false-clean class in compact scheduler

### DIFF
--- a/admission_route_equality_byte_continuity_gap_test.go
+++ b/admission_route_equality_byte_continuity_gap_test.go
@@ -1,0 +1,119 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestCompactRouteLexerSkippedByteGapDeclines pins the campaign v7 class-e
+// closure (spore.2026-08-02.alder-e.js-false-clean and
+// spore.2026-08-02.hornbeam-e.byte-continuity): a lexer-skipped byte run the
+// compact scheduler used to silently shift across, tolerated only because the
+// B1 leaf-tiling auditor's own bytesAreSingleByteDecorationTrivia exemption
+// (parsercore_phase0_driver.go) excused the resulting gap. The javascript
+// witness `function A(){A000000} # 0` is the record's literal reproduction:
+// byte 22 holds a stray "#" flanked by spaces; the DFA lexer's skipOneRune
+// path (lexer.go) silently drops it (javascript does not set
+// cRecoveryEnabled), and the compact scheduler used to shift the next real
+// token ("number" at byte 24) across the gap with no continuity check,
+// publishing HasError()==false while production and the C oracle both report
+// an error. Retiring bytesAreSingleByteDecorationTrivia closes the class: the
+// B1 leaf-tiling auditor now declines every one of these gaps on its own
+// terms (accepted-leaf-tiling-gap), the same gate that already covers
+// html_min_a and the 18-witness manifest
+// (admission_route_equality_leaf_tiling_test.go).
+//
+// The correctness contract this test pins is servedHasError ==
+// productionHasError == true for every case, not "compact must decline":
+// an independent, later compact improvement (native html erroneous-end-tag
+// recovery) can legitimately promote a witness from "declines, production
+// serves" to "compact accepts its own correct tree" without regressing
+// anything this tranche cares about. Where compact still declines, the
+// reason is also pinned to accepted-leaf-tiling-gap as direct evidence of
+// which gate closed it.
+func TestCompactRouteLexerSkippedByteGapDeclines(t *testing.T) {
+	// html and javascript are not otherwise loaded by the always-on
+	// (untagged) suite; purge the process-wide embedded cache afterward so
+	// this test does not inflate heap for later whole-process tests (matches
+	// admission_scorecard_test.go's convention).
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+
+	cases := []struct {
+		name   string
+		lang   string
+		source string
+	}{
+		{"js_function_stray_hash", "javascript", "function A(){A000000} # 0"},
+		{"js_statement_stray_hash", "javascript", "a; # ; b"},
+		{"html_amp_stray", "html", "<html> & <body>Hello</body></html>"},
+		{"bash_stray_backslash_space", "bash", "e \\ cho hi"},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			entry := grammars.DetectLanguageByName(c.lang)
+			if entry == nil {
+				t.Fatalf("language %q is not registered", c.lang)
+			}
+			lang := entry.Language()
+			source := []byte(c.source)
+
+			production := gts.NewParser(lang)
+			production.SetAdmissionCandidateRoute(false)
+			productionTree, err := production.Parse(source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer productionTree.Release()
+			if !productionTree.RootNode().HasError() {
+				t.Fatalf("production HasError=false, want true for %q", c.source)
+			}
+
+			gts.ResetAdmissionCandidateCountersForTest()
+			candidate := gts.NewParser(lang)
+			candidate.SetAdmissionCandidateRoute(true)
+			candidateTree, err := candidate.Parse(source)
+			if err != nil {
+				t.Fatalf("candidate parse: %v", err)
+			}
+			defer candidateTree.Release()
+
+			// The caller-visible tree -- production-served on a decline
+			// (post-fallback within the same Parse call), or compact's own
+			// accepted tree when a native recovery path admits it directly --
+			// must match production's own HasError verdict either way. This
+			// is the class-e contract: no route may publish HasError()==false
+			// for an input production (and the C oracle) call an error.
+			if got := candidateTree.RootNode().HasError(); got != productionTree.RootNode().HasError() {
+				t.Fatalf("served HasError=%t, want %t (production's own verdict)",
+					got, productionTree.RootNode().HasError())
+			}
+			if !candidateTree.RootNode().HasError() {
+				t.Fatal("served tree HasError=false, want true")
+			}
+
+			routed, fallback := gts.AdmissionCandidateCounters()
+			switch {
+			case fallback == 1 && routed == 0:
+				// Declined through the B1 leaf-tiling gate this fix restores:
+				// pin the exact mechanism as direct evidence.
+				reason := gts.AdmissionCandidateLastFallbackReason()
+				if !strings.Contains(reason, "accepted-leaf-tiling-gap") {
+					t.Fatalf("fallback reason=%q, want it to cite accepted-leaf-tiling-gap", reason)
+				}
+			case routed == 1 && fallback == 0:
+				// Compact accepted its own correct tree (verified above)
+				// through a native recovery path unrelated to this gate. Not
+				// a regression; the HasError check above is what matters.
+			default:
+				t.Fatalf("route counters routed=%d fallback=%d, want exactly one of (routed=1,fallback=0) or (routed=0,fallback=1)", routed, fallback)
+			}
+		})
+	}
+}

--- a/admission_route_equality_byte_continuity_gap_test.go
+++ b/admission_route_equality_byte_continuity_gap_test.go
@@ -10,32 +10,57 @@ import (
 	"github.com/odvcencio/gotreesitter/grammars"
 )
 
-// TestCompactRouteLexerSkippedByteGapDeclines pins the campaign v7 class-e
-// closure (spore.2026-08-02.alder-e.js-false-clean and
+// TestCompactRouteLexerSkippedByteGapDeclines pins four witnesses of the
+// campaign v7 class-e closure (spore.2026-08-02.alder-e.js-false-clean and
 // spore.2026-08-02.hornbeam-e.byte-continuity): a lexer-skipped byte run the
 // compact scheduler used to silently shift across, tolerated only because the
 // B1 leaf-tiling auditor's own bytesAreSingleByteDecorationTrivia exemption
-// (parsercore_phase0_driver.go) excused the resulting gap. The javascript
-// witness `function A(){A000000} # 0` is the record's literal reproduction:
-// byte 22 holds a stray "#" flanked by spaces; the DFA lexer's skipOneRune
-// path (lexer.go) silently drops it (javascript does not set
-// cRecoveryEnabled), and the compact scheduler used to shift the next real
-// token ("number" at byte 24) across the gap with no continuity check,
-// publishing HasError()==false while production and the C oracle both report
-// an error. Retiring bytesAreSingleByteDecorationTrivia closes the class: the
-// B1 leaf-tiling auditor now declines every one of these gaps on its own
-// terms (accepted-leaf-tiling-gap), the same gate that already covers
+// (parsercore_phase0_driver.go) excused the resulting gap. Retiring that
+// predicate makes the B1 leaf-tiling auditor decline every such gap on its
+// own terms (accepted-leaf-tiling-gap), the same gate that already covers
 // html_min_a and the 18-witness manifest
 // (admission_route_equality_leaf_tiling_test.go).
 //
-// The correctness contract this test pins is servedHasError ==
-// productionHasError == true for every case, not "compact must decline":
-// an independent, later compact improvement (native html erroneous-end-tag
-// recovery) can legitimately promote a witness from "declines, production
-// serves" to "compact accepts its own correct tree" without regressing
-// anything this tranche cares about. Where compact still declines, the
-// reason is also pinned to accepted-leaf-tiling-gap as direct evidence of
-// which gate closed it.
+// The four cases do NOT all pin the same claim. Verified per case, against
+// the C oracle where noted, before writing this comment:
+//
+//   - js_function_stray_hash, js_statement_stray_hash: genuine false-clean
+//     closures. Production and the C oracle both report an error for these
+//     two inputs; the compact route used to publish HasError()==false; it
+//     now correctly declines.
+//   - html_amp_stray: NOT a closure this PR delivers. By the time this PR
+//     landed, an independent, separately-merged change (PR #630, native
+//     erroneous-end-tag recovery) already makes compact accept this exact
+//     input directly, with HasError()==true, C-exact -- with or without
+//     this PR's predicate retirement. This case pins that route-level
+//     behavior stays stable (a regression guard), not a false-clean this
+//     fix closes. The html slice of the original defect class (42
+//     instances in the record's own sweep) is real and is closed by this
+//     predicate retirement in general; this specific witness just no
+//     longer needs that closure to already be correct.
+//   - bash_stray_backslash_space: NOT a false-clean at all, and NOT a
+//     closure. The C oracle parses `e \ cho hi` CLEAN
+//     (HasError()==false): a backslash-space is a scanner-skipped escape
+//     in bash, and the two skipped bytes are legitimately uncovered by any
+//     leaf in C's OWN tree -- the leaf-tiling invariant this gate enforces
+//     is not a C invariant for scanner-skip escape classes. Before this
+//     fix, compact accepted this input directly and matched the C oracle
+//     byte-exactly. After this fix, the now-narrower
+//     bytesAreSingleByteDecorationTrivia-free auditor cannot tell this
+//     shape apart from a genuine drop, so it declines -- a coverage loss
+//     traded for safety, not a defect closure: the auditor's own decline
+//     contract is "stop rather than guess," and it is honoring that
+//     contract correctly here even though the input was actually fine.
+//     The production tree served after the decline (a flat
+//     ERROR[0:10], HasError()==true) diverges from the C oracle; that
+//     divergence is a pre-existing, unrelated production defect in how
+//     the GLR engine handles a bare backslash-space escape (real shell:
+//     `echo \ leading`, `tar -c \ -f x.tar dir`, `VAR=1 \ cmd`;
+//     backslash-newline line continuation is a different, unaffected
+//     class), not something this PR introduces or fixes. It is exposed
+//     here only because compact no longer masks it by accepting the
+//     input directly. Tracked separately as a production bash repair
+//     lane; out of scope for this PR.
 func TestCompactRouteLexerSkippedByteGapDeclines(t *testing.T) {
 	// html and javascript are not otherwise loaded by the always-on
 	// (untagged) suite; purge the process-wide embedded cache afterward so
@@ -48,9 +73,21 @@ func TestCompactRouteLexerSkippedByteGapDeclines(t *testing.T) {
 		lang   string
 		source string
 	}{
+		// Genuine false-clean closures: production and the C oracle both
+		// report an error; compact used to publish HasError()==false and
+		// now correctly declines. See the doc comment above.
 		{"js_function_stray_hash", "javascript", "function A(){A000000} # 0"},
 		{"js_statement_stray_hash", "javascript", "a; # ; b"},
+		// Route-behavior regression guard, not a closure this PR delivers:
+		// PR #630's independent native erroneous-end-tag recovery already
+		// makes compact accept this input correctly. See the doc comment
+		// above.
 		{"html_amp_stray", "html", "<html> & <body>Hello</body></html>"},
+		// NOT a false-clean: the C oracle reports this input clean. Pins
+		// the auditor's fail-closed decline contract, not a defect
+		// closure; the production-served tree's own divergence from C is
+		// a separate, pre-existing production defect. See the doc comment
+		// above.
 		{"bash_stray_backslash_space", "bash", "e \\ cho hi"},
 	}
 
@@ -71,6 +108,12 @@ func TestCompactRouteLexerSkippedByteGapDeclines(t *testing.T) {
 				t.Fatalf("production parse: %v", err)
 			}
 			defer productionTree.Release()
+			// Production's own verdict is HasError()==true for all four
+			// cases, including bash_stray_backslash_space -- that witness's
+			// production tree diverges from the C oracle (see the doc
+			// comment above), but production still reports it as an error
+			// on its own terms, which is the verdict the route-safety check
+			// below holds compact's served tree to.
 			if !productionTree.RootNode().HasError() {
 				t.Fatalf("production HasError=false, want true for %q", c.source)
 			}
@@ -86,31 +129,33 @@ func TestCompactRouteLexerSkippedByteGapDeclines(t *testing.T) {
 
 			// The caller-visible tree -- production-served on a decline
 			// (post-fallback within the same Parse call), or compact's own
-			// accepted tree when a native recovery path admits it directly --
-			// must match production's own HasError verdict either way. This
-			// is the class-e contract: no route may publish HasError()==false
-			// for an input production (and the C oracle) call an error.
+			// accepted tree when a route admits it directly -- must match
+			// production's own HasError verdict either way. This is a
+			// route-safety invariant (the caller never sees a route-level
+			// disagreement), independent of whether production's own
+			// verdict happens to agree with the C oracle: bash's case
+			// above satisfies this invariant while still diverging from C,
+			// which is exactly why it is pinned as a route-behavior case,
+			// not a false-clean-closure case.
 			if got := candidateTree.RootNode().HasError(); got != productionTree.RootNode().HasError() {
 				t.Fatalf("served HasError=%t, want %t (production's own verdict)",
 					got, productionTree.RootNode().HasError())
-			}
-			if !candidateTree.RootNode().HasError() {
-				t.Fatal("served tree HasError=false, want true")
 			}
 
 			routed, fallback := gts.AdmissionCandidateCounters()
 			switch {
 			case fallback == 1 && routed == 0:
-				// Declined through the B1 leaf-tiling gate this fix restores:
-				// pin the exact mechanism as direct evidence.
+				// Declined through the B1 leaf-tiling gate this fix
+				// restores: pin the exact mechanism as direct evidence.
 				reason := gts.AdmissionCandidateLastFallbackReason()
 				if !strings.Contains(reason, "accepted-leaf-tiling-gap") {
 					t.Fatalf("fallback reason=%q, want it to cite accepted-leaf-tiling-gap", reason)
 				}
 			case routed == 1 && fallback == 0:
-				// Compact accepted its own correct tree (verified above)
-				// through a native recovery path unrelated to this gate. Not
-				// a regression; the HasError check above is what matters.
+				// Compact accepted its own tree (verified above to match
+				// production's HasError verdict) through a route unrelated
+				// to this gate. Not a regression; the HasError check above
+				// is what matters.
 			default:
 				t.Fatalf("route counters routed=%d fallback=%d, want exactly one of (routed=1,fallback=0) or (routed=0,fallback=1)", routed, fallback)
 			}

--- a/admission_scorecard_test.go
+++ b/admission_scorecard_test.go
@@ -78,7 +78,7 @@ var admissionScorecardRequiredCompactPasses = map[string]struct{}{
 	"gdscript": {}, "git_config": {}, "git_rebase": {}, "gitattributes": {}, "gitcommit": {}, "gitignore": {}, "gleam": {},
 	"glsl": {}, "gn": {}, "go": {}, "godot_resource": {}, "gomod": {}, "graphql": {},
 	"groovy": {}, "hack": {}, "hare": {}, "haskell": {}, "haxe": {}, "hcl": {}, "heex": {},
-	"hlsl": {}, "html": {}, "http": {}, "hurl": {}, "hyprlang": {}, "ini": {}, "janet": {}, "javascript": {}, "jinja2": {}, "jq": {}, "jsdoc": {},
+	"hlsl": {}, "html": {}, "http": {}, "hurl": {}, "hyprlang": {}, "ini": {}, "janet": {}, "javascript": {}, "jinja2": {}, "jq": {},
 	"json5": {}, "jsonnet": {}, "julia": {}, "just": {}, "kconfig": {}, "kdl": {}, "kotlin": {},
 	"ledger": {}, "less": {}, "linkerscript": {}, "liquid": {}, "llvm": {}, "lua": {},
 	"luau": {}, "make": {}, "markdown": {}, "matlab": {}, "mermaid": {}, "mojo": {},
@@ -147,22 +147,35 @@ func TestAdmissionCandidateScorecard206(t *testing.T) {
 		// registry drift, or surrendered route coverage require an explicit
 		// review and ratchet update.
 		//
-		// minPass moved 200 -> 199 and maxFallback 1 -> 2 when
-		// selectCompactAcceptanceDerivation's materiality gate
-		// (parsercore_phase0_driver.go, compactAcceptanceElectionIsVacuous)
-		// landed: meson's smoke sample ("message('hello')") has a genuine,
-		// score-tied grammar ambiguity between two distinct real symbols
-		// (variableunit and var_unit -- both present in the compiled
-		// language's SymbolNames). The old positional rule happened to pick
-		// the derivation that matches production; the gate cannot prove that
-		// pick correct without a C oracle, so it now declines instead of
-		// publishing an unproven tree, and the route falls back to
-		// production (still a PASS-safe FALLBACK, never a DIVERGE -- see
-		// counts[scorecardDiverge] below, unaffected at 0).
+		// minPass moved 200 -> 198 and maxFallback 1 -> 3 across two
+		// independent landings that collided on the same pair of numbers:
+		//
+		//   - meson moved PASS -> FALLBACK when
+		//     selectCompactAcceptanceDerivation's materiality gate
+		//     (parsercore_phase0_driver.go, compactAcceptanceElectionIsVacuous)
+		//     landed: meson's smoke sample ("message('hello')") has a genuine,
+		//     score-tied grammar ambiguity between two distinct real symbols
+		//     (variableunit and var_unit -- both present in the compiled
+		//     language's SymbolNames). The old positional rule happened to
+		//     pick the derivation that matches production; the gate cannot
+		//     prove that pick correct without a C oracle, so it now declines
+		//     instead of publishing an unproven tree.
+		//   - jsdoc moved PASS -> FALLBACK (campaign v7 class-e closure,
+		//     spore.2026-08-02.hornbeam-e.byte-continuity): retiring
+		//     bytesAreSingleByteDecorationTrivia (parsercore_phase0_driver.go)
+		//     closes a measured 189-input false-clean class across
+		//     javascript, haskell, html, and bash, and moves jsdoc from PASS
+		//     to FALLBACK (accepted-leaf-tiling-gap: its own interior
+		//     comment-continuation gap no longer has a tolerating exemption).
+		//
+		// Both moves are PASS-safe FALLBACKs, never a DIVERGE (see
+		// counts[scorecardDiverge] below, unaffected at 0). No other
+		// language's status changes; production still serves meson and
+		// jsdoc correctly.
 		const (
 			wantTotal   = 206
-			minPass     = 199
-			maxFallback = 2
+			minPass     = 198
+			maxFallback = 3
 			wantSkip    = 5
 		)
 		if got := len(admissionScorecardRequiredCompactPasses); got != minPass {
@@ -197,9 +210,17 @@ func TestAdmissionCandidateScorecard206(t *testing.T) {
 }
 
 func TestAdmissionCandidateNoLookaheadSmokeRatchet(t *testing.T) {
+	// jsdoc dropped from this set (campaign v7 class-e closure,
+	// spore.2026-08-02.hornbeam-e.byte-continuity): its smoke sample now
+	// correctly declines at accepted-leaf-tiling-gap once
+	// bytesAreSingleByteDecorationTrivia (parsercore_phase0_driver.go) no
+	// longer excuses its interior comment-continuation gap. That decline is
+	// unrelated to the no-lookahead root-reduce shape this test otherwise
+	// covers; see admissionScorecardRequiredCompactPasses's own ratchet
+	// comment (above) for the full accounting. doxygen and vhdl are
+	// unaffected and keep the PASS assertion below.
 	wanted := map[string]struct{}{
 		"doxygen": {},
-		"jsdoc":   {},
 		"vhdl":    {},
 	}
 	var doxygen grammars.LangEntry

--- a/admission_scorecard_test.go
+++ b/admission_scorecard_test.go
@@ -147,9 +147,13 @@ func TestAdmissionCandidateScorecard206(t *testing.T) {
 		// registry drift, or surrendered route coverage require an explicit
 		// review and ratchet update.
 		//
-		// minPass moved 200 -> 198 and maxFallback 1 -> 3 across two
-		// independent landings that collided on the same pair of numbers:
+		// minPass moved 200 -> 198 and maxFallback 1 -> 3. Three languages
+		// carry the three FALLBACK rows counted here:
 		//
+		//   - markdown_inline: the pre-existing baseline FALLBACK, already
+		//     present before either landing below and unrelated to both.
+		//     Never in admissionScorecardRequiredCompactPasses, so it was
+		//     never counted in minPass either.
 		//   - meson moved PASS -> FALLBACK when
 		//     selectCompactAcceptanceDerivation's materiality gate
 		//     (parsercore_phase0_driver.go, compactAcceptanceElectionIsVacuous)
@@ -167,11 +171,17 @@ func TestAdmissionCandidateScorecard206(t *testing.T) {
 		//     javascript, haskell, html, and bash, and moves jsdoc from PASS
 		//     to FALLBACK (accepted-leaf-tiling-gap: its own interior
 		//     comment-continuation gap no longer has a tolerating exemption).
+		//     Every jsdoc full parse now pays a measured 2.2x-2.5x latency
+		//     cost relative to a plain production parse: the compact route
+		//     always attempts jsdoc first, always declines at this gate, and
+		//     production then parses the same source a second time from
+		//     scratch. Acceptable for a rare grammar on a fail-closed route;
+		//     not free.
 		//
-		// Both moves are PASS-safe FALLBACKs, never a DIVERGE (see
-		// counts[scorecardDiverge] below, unaffected at 0). No other
-		// language's status changes; production still serves meson and
-		// jsdoc correctly.
+		// meson's and jsdoc's moves are both PASS-safe FALLBACKs, never a
+		// DIVERGE (see counts[scorecardDiverge] below, unaffected at 0). No
+		// other language's status changes; production still serves
+		// markdown_inline, meson, and jsdoc correctly.
 		const (
 			wantTotal   = 206
 			minPass     = 198

--- a/fuzz_admission_route_equality_test.go
+++ b/fuzz_admission_route_equality_test.go
@@ -284,6 +284,21 @@ func seedAdmissionRouteEqualityCorpus(f *testing.F, languages []admissionRouteEq
 		}
 		f.Add([]byte(w.SourceUTF8), idx)
 	}
+
+	// Class-e pin (campaign v7 class-e closure, spore.2026-08-02.alder-e.js-
+	// false-clean and spore.2026-08-02.hornbeam-e.byte-continuity): a lexer-
+	// skipped byte run the compact scheduler silently shifted across, tolerated
+	// by the now-retired bytesAreSingleByteDecorationTrivia predicate
+	// (parsercore_phase0_driver.go). Each seed is one isolated, space-padded
+	// stray byte between two real tokens -- the exact shape the mechanical
+	// sweep that found 189 occurrences (javascript 75, haskell 65, html 42,
+	// bash 7) injected. See TestCompactRouteLexerSkippedByteGapDeclines
+	// (admission_route_equality_byte_continuity_gap_test.go) for the pinned
+	// direct regression on the first witness.
+	f.Add([]byte("function A(){A000000} # 0"), langIndex["javascript"])
+	f.Add([]byte("a; # ; b"), langIndex["javascript"])
+	f.Add([]byte("<html> & <body>Hello</body></html>"), langIndex["html"])
+	f.Add([]byte("e \\ cho hi"), langIndex["bash"])
 }
 
 // routeEqualityTreeCarriesNativeRecoveryErrorContainer reports whether root's

--- a/parser_result_julia_test.go
+++ b/parser_result_julia_test.go
@@ -175,6 +175,31 @@ func TestJuliaBracketForComprehensionCompatibility(t *testing.T) {
 	}
 }
 
+// TestJuliaTrailingCommaAssignmentTupleCompatibility pins the tree shape for
+// a lexer-skipped "=" between a trailing tuple comma and its next real
+// token. The shape moved (campaign v7 class-e closure,
+// spore.2026-08-02.hornbeam-e.byte-continuity): retiring the compact
+// scheduler's bytesAreSingleByteDecorationTrivia exemption
+// (parsercore_phase0_driver.go) makes compact correctly decline this input
+// (the "=" gap is a genuine byte-coverage hole, not tolerable trivia) and
+// fall back to production. Production's own gap materialization already
+// changed independently, in the already-merged PR #633
+// ("materializeSkippedGapAsExtraError", parser.go): a lexer-skipped gap
+// mid-separated-list now gets a real, transparent EXTRA ERROR leaf spanning
+// the whole gap (here " = ", both flanking spaces included) instead of the
+// old silent byte-offset bump the language-specific
+// normalizeJuliaTrailingCommaAssignmentTuple (parser_result_julia.go)
+// synthesized a narrower ERROR for after the fact. That normalizer's own
+// pattern match (comma directly followed by the next real token, with no
+// node at all between them) no longer applies once production's own general
+// mechanism already inserts the ERROR node first, so it now correctly
+// no-ops for this input; the general, per-parse fix it was standing in for
+// (see that function's doc comment) has arrived. This test was previously
+// masked from ever exercising this exact shape by the same falsified
+// bytesAreSingleByteDecorationTrivia exemption: compact used to accept the
+// input silently (no error), so this Parse call -- which does not force a
+// route -- never fell back to the now-current production shape until the
+// exemption was retired.
 func TestJuliaTrailingCommaAssignmentTupleCompatibility(t *testing.T) {
 	lang := grammars.JuliaLanguage()
 	if lang == nil {
@@ -191,6 +216,10 @@ func TestJuliaTrailingCommaAssignmentTupleCompatibility(t *testing.T) {
 	}
 	defer tree.Release()
 
+	if !tree.RootNode().HasError() {
+		t.Fatalf("root HasError=false, want true (a lexer-skipped \"=\" is a real error); tree:\n%s", tree.RootNode().SExpr(lang))
+	}
+
 	tuple := findNodeByText(tree.RootNode(), lang, source, "open_tuple", "minarg, maxarg, = T_IFUNC[iidx]")
 	if tuple == nil {
 		t.Fatalf("open_tuple not found:\n%s", tree.RootNode().SExpr(lang))
@@ -201,14 +230,14 @@ func TestJuliaTrailingCommaAssignmentTupleCompatibility(t *testing.T) {
 	if got := tuple.Child(4).Type(lang); got != "ERROR" {
 		t.Fatalf("open_tuple child[4] = %q, want ERROR; tree:\n%s", got, tree.RootNode().SExpr(lang))
 	}
-	if got := tuple.Child(4).Text(source); got != "=" {
-		t.Fatalf("open_tuple ERROR text = %q, want %q", got, "=")
+	if got := tuple.Child(4).Text(source); got != " = " {
+		t.Fatalf("open_tuple ERROR text = %q, want %q", got, " = ")
 	}
-	if got, want := tuple.Child(4).ChildCount(), 1; got != want {
-		t.Fatalf("open_tuple ERROR child count = %d, want %d; tree:\n%s", got, want, tree.RootNode().SExpr(lang))
+	if !tuple.Child(4).IsExtra() {
+		t.Fatalf("open_tuple ERROR IsExtra=false, want true (materializeSkippedGapAsExtraError, parser.go); tree:\n%s", tree.RootNode().SExpr(lang))
 	}
-	if got := tuple.Child(4).Child(0).Type(lang); got != "operator" {
-		t.Fatalf("open_tuple ERROR child[0] = %q, want operator; tree:\n%s", got, tree.RootNode().SExpr(lang))
+	if got, want := tuple.Child(4).ChildCount(), 0; got != want {
+		t.Fatalf("open_tuple ERROR child count = %d, want %d (a flat EXTRA leaf, not a wrapped operator); tree:\n%s", got, want, tree.RootNode().SExpr(lang))
 	}
 }
 

--- a/parser_result_julia_test.go
+++ b/parser_result_julia_test.go
@@ -194,12 +194,26 @@ func TestJuliaBracketForComprehensionCompatibility(t *testing.T) {
 // node at all between them) no longer applies once production's own general
 // mechanism already inserts the ERROR node first, so it now correctly
 // no-ops for this input; the general, per-parse fix it was standing in for
-// (see that function's doc comment) has arrived. This test was previously
-// masked from ever exercising this exact shape by the same falsified
+// (see materializeSkippedGapAsExtraError's own doc comment, parser.go --
+// normalizeJuliaTrailingCommaAssignmentTuple itself carries no doc comment
+// of its own) has arrived. This test was previously masked from ever
+// exercising this exact shape by the same falsified
 // bytesAreSingleByteDecorationTrivia exemption: compact used to accept the
 // input silently (no error), so this Parse call -- which does not force a
 // route -- never fell back to the now-current production shape until the
 // exemption was retired.
+//
+// The pinned shape below (Text()==" = ", ChildCount()==0) itself diverges
+// from the C oracle, which reports this same ERROR as Text()=="=" with one
+// child. That divergence is not this test's own defect and is not new: it
+// is the known, already-documented accounting-not-shape gap
+// materializeSkippedGapAsExtraError's own doc comment names explicitly (see
+// "This is an ACCOUNTING fix, not a shape fix", parser.go) -- the leaf's
+// span still covers the whole lexer-skipped gap rather than only the true
+// stray token, and the leaf is still childless where C wraps the stray as
+// its own child, both named there as open follow-up work. This test pins
+// production's actual, current output, not a claim that this output
+// matches C.
 func TestJuliaTrailingCommaAssignmentTupleCompatibility(t *testing.T) {
 	lang := grammars.JuliaLanguage()
 	if lang == nil {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2949,80 +2949,51 @@ func diagnosticParserCoreReduceChildrenTilingGap(startByte, endByte uint32, entr
 }
 
 // diagnosticParserCoreGapIsTolerated reports whether an apparent coverage
-// gap is not, in fact, a real one: either ordinary inter-token trivia
+// gap is not, in fact, a real one: ordinary inter-token trivia
 // (bytesAreInterTokenTrivia, matching the forest's own reduce-time coverage
-// rejection), or a single decoration byte strictly enclosed by trivia on
-// both sides (bytesAreSingleByteDecorationTrivia).
+// rejection).
+//
+// RETIRED (campaign v7 class-e closure, spore.2026-08-02.alder-e.js-false-
+// clean): this gate used to also tolerate a single decoration byte strictly
+// enclosed by trivia on both sides (bytesAreSingleByteDecorationTrivia),
+// added to excuse a doxygen/jsdoc comment-continuation marker ("* ") this B1
+// post-hoc auditor could not otherwise place. That predicate's own doctrine
+// comment claimed the shape was not a plausible one for a real scheduler
+// drop to produce; a stray byte injected between two spaces produces that
+// exact shape. The measured false-clean sweep found 189 occurrences of it
+// across javascript, haskell, html, and bash. Direct measurement (disabling
+// only this predicate, no other change) closes the class: 0 residual
+// divergences in a 624-input javascript-family probe, and only the
+// pre-existing, separately tracked 25-input haskell residual (a different
+// mechanism; compact may be correct there) surviving the 5,148-input
+// 9-language sweep. Retiring this predicate moves jsdoc from PASS to
+// FALLBACK on the 206-language admission scorecard (its own gap now
+// correctly declines at accepted-leaf-tiling-gap below); doxygen does not
+// regress -- verified directly, its gap sits at the derivation root
+// (isDerivationRootReduce, materializeDiagnosticParserCoreAcceptedSelection's
+// reduce visitor below), a position this predicate's retirement does not
+// touch.
+//
+// A companion dispatch-time byte-continuity guard in dispatchPassActive
+// (declining before any shift crosses an unexplained gap, one site upstream
+// of every compact shift call) was built and measured as a candidate
+// replacement. It over-declines: production's own tolerance for this exact
+// doxygen shape is decided only after full tree construction, by the
+// language-general "result compatibility" normalization layer
+// (finalizeResultRoot / normalizeResultCompatibility, parser_result_root_
+// build.go and parser_result_compat.go), which drops the interior error
+// production's own single-stack GLR run really does create for doxygen's
+// smoke sample (verified with GLR tracing: production shifts the gap,
+// tryMaterializeSkippedRealGap pushes a real, hasError=true ERROR node, the
+// root reduce includes it as a raw child with hasError=true, and only the
+// later result-compatibility pass removes it and clears the flag). No
+// three-exemption mirror at the compact scheduler's dispatch point --
+// necessarily earlier than materialization, let alone this later
+// normalization pass -- can see that decision. The guard was reverted for
+// this reason; this predicate retirement alone is the shipped fix. See
+// spore.2026-08-02.hornbeam-e.byte-continuity for the full account.
 func diagnosticParserCoreGapIsTolerated(gap []byte) bool {
-	return bytesAreInterTokenTrivia(gap) || bytesAreSingleByteDecorationTrivia(gap)
-}
-
-// bytesAreSingleByteDecorationTrivia is the second, narrow trivia exception
-// this gate needs, found by directly root-causing a currently-passing
-// smoke-corpus collision (doxygen, jsdoc -- javadoc/doxygen-style
-// "/** ... * @tag ... */" comment bodies): the continuation-line marker
-// "* " that begins every interior comment line is not represented by any
-// node -- hidden or public -- in either engine's tree. Verified by direct
-// inspection of both compact's raw, pre-filter view.Children (the exact
-// input this function receives, gap-for-gap) and production's own raw node
-// children: production's root for the doxygen smoke fixture has no child at
-// all for "/**" or the repeated "* ", only for the @tag content between
-// them. It is legitimate, lexer-level filler that the scanner treats the
-// same way it treats ordinary whitespace between tokens, just with a
-// literal '*' inside it, so the fixed ASCII-whitespace set
-// bytesAreInterTokenTrivia checks does not recognize it, and no
-// per-language exception is available to ask (tree-sitter's compiled DFA
-// transition tables have no queryable "is this byte skippable here"
-// surface at this layer).
-//
-// The rule requires trivia (bytesAreTrivia) strictly BEFORE AND AFTER the
-// one marker byte, never touching either of the gap's own edges. This is
-// deliberately the strict form, not "buffered on at least one side": an
-// earlier, one-sided version of this rule was built and measured against
-// the full 206-language admission scorecard, and it silently re-admitted 5
-// of the 8 already-fixed javascript witnesses (js_log_1, js_log_3, js_log_5,
-// js_log_6, js_log_7 -- their real dropped-byte gaps also happen to touch
-// one edge, e.g. immediately preceding the next real token with only
-// leading trivia), which is exactly the false-clean escape this tranche
-// exists to close. It was reverted; only the two-sided form ships. This
-// fixes doxygen outright (its one gap is interior, buffered on both sides).
-// jsdoc has two such gaps: an interior one this rule also fixes, and a
-// second one where the comment's closing "*/" (no leading space) puts the
-// decoration marker on the gap's own trailing edge -- correctly left
-// unrecognized here, since that exact shape is indistinguishable from a
-// genuine drop (js_log_3 and js_log_7 have the same trailing-edge shape and
-// must stay rejected). jsdoc's remaining root-level gap is instead closed by
-// the separate, narrower isDerivationRootReduce exemption in
-// materializeDiagnosticParserCoreAcceptedSelection's reduce visitor, not by
-// widening this predicate further.
-//
-// The general, language-independent shape that separates the tolerated
-// case from a genuine dropped byte (the html/js defect class this gate
-// exists to catch -- witness html_min_a's gap is the single byte "^",
-// touching both of its own gap edges at once, directly adjacent to real
-// content on both sides with no trivia buffer at all) is: exactly one
-// non-trivia byte, with ordinary trivia on both sides of it within the same
-// gap. A scheduler bug that truly skips real input skips a whole token or a
-// recognizable fragment sitting flush against a neighbor on at least one
-// edge; manufacturing an isolated, symmetrically trivia-padded punctuation
-// byte is not a plausible shape for that defect class. All 18 fixed
-// html/js witnesses were re-verified against this exact rule and none
-// qualify for it (admission_route_equality_leaf_tiling_test.go).
-func bytesAreSingleByteDecorationTrivia(gap []byte) bool {
-	if len(gap) < 3 {
-		return false
-	}
-	marker := -1
-	for i := 0; i < len(gap); i++ {
-		if bytesAreTrivia(gap[i : i+1]) {
-			continue
-		}
-		if marker != -1 {
-			return false
-		}
-		marker = i
-	}
-	return marker > 0 && marker < len(gap)-1
+	return bytesAreInterTokenTrivia(gap)
 }
 
 // materializeDiagnosticParserCoreAcceptedSelection materializes the accepted
@@ -3205,9 +3176,10 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 			// by finalizeDiagnosticParserCoreAcceptedRootSpan's own checks) is a
 			// materially different, narrower risk than an internal gap anywhere
 			// below it, which every enclosing reduce's own tiling check still
-			// catches. This closes the jsdoc residual left after
-			// bytesAreSingleByteDecorationTrivia: javadoc/doxygen-style comments
-			// that close with "*/" (no leading space) put the decoration marker
+			// catches. This closes a jsdoc residual the retired
+			// bytesAreSingleByteDecorationTrivia predicate used to leave standing:
+			// javadoc/doxygen-style comments that close with "*/" (no leading
+			// space) put the decoration marker
 			// on the trailing edge of the root reduce's own gap, indistinguishable
 			// in isolation from a genuine drop (js_log_3 and js_log_7 have the
 			// identical trailing-edge shape and must still be rejected -- verified

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2965,8 +2965,15 @@ func diagnosticParserCoreReduceChildrenTilingGap(startByte, endByte uint32, entr
 // only this predicate, no other change) closes the class: 0 residual
 // divergences in a 624-input javascript-family probe, and only the
 // pre-existing, separately tracked 25-input haskell residual (a different
-// mechanism; compact may be correct there) surviving the 5,148-input
-// 9-language sweep. Retiring this predicate moves jsdoc from PASS to
+// mechanism; compact may be correct there) surviving the 5,148-input probe
+// restricted to the 9 curated languages (routeEqualityFuzzLanguages,
+// fuzz_admission_route_equality_test.go). A wider, 45-language review sweep
+// (11,884 inputs, unchanged before and after this predicate's retirement)
+// separately observed two more residual members outside that curated set,
+// hcl (12 instances) and doxygen (22 instances) -- both a different
+// mechanism from this class-e closure, neither touched by this predicate's
+// removal, and neither in scope here; they need their own adjudication,
+// same as the haskell residual. Retiring this predicate moves jsdoc from PASS to
 // FALLBACK on the 206-language admission scorecard (its own gap now
 // correctly declines at accepted-leaf-tiling-gap below); doxygen does not
 // regress -- verified directly, its gap sits at the derivation root


### PR DESCRIPTION
## Summary

The compact scheduler shifted across lexer-skipped bytes with no continuity
check. A tolerance predicate in the B1 leaf-tiling auditor
(`bytesAreSingleByteDecorationTrivia`) excused the resulting gap for a
narrow shape: one non-trivia byte flanked by trivia on both sides. A stray
byte injected between two spaces produces that exact shape. For genuine
false-clean inputs, the compact route then published `HasError()==false`
while production and the locked C oracle both report an error.

This PR retires that tolerance predicate. The B1 leaf-tiling auditor now
declines every gap of this shape on its own terms
(`accepted-leaf-tiling-gap`), the same gate that already covers the
`html_min_a` reference witness. It pins the fixed class with a direct
regression test and four new seeds in the `FuzzAdmissionRouteEquality`
corpus.

A companion dispatch-time byte-continuity guard (declining before any shift
crosses an unexplained gap) was built and measured as a stronger
alternative, but over-declines: production's own tolerance for one
legitimate shape (a doxygen/jsdoc comment-continuation marker) is decided
only after full tree construction, by a general post-parse normalization
layer the compact scheduler's dispatch point runs strictly before. That
guard was not shipped; the predicate retirement alone closes the measured
class without the false positive.

## Before / after

The four pinned witnesses do not all represent the same outcome. Verified
per witness, against the C oracle where noted:

**Genuine false-clean closures (C-verified):**

| Witness | Language | Before | After |
|---|---|---|---|
| `function A(){A000000} # 0` | javascript | HasError=false | HasError=true |
| `a; # ; b` | javascript | HasError=false | HasError=true |

Production and the C oracle both report an error for these two inputs;
compact used to publish `HasError()==false`; it now correctly declines.

**Route-behavior pin, not a closure this PR delivers:**

| Witness | Language | Outcome |
|---|---|---|
| `<html> & <body>Hello</body></html>` | html | HasError=true, matching C, on both sides of this change |

By the time this PR lands, an independent, separately-merged PR (#630,
native erroneous-end-tag recovery) already makes compact accept this exact
input directly and correctly, with or without this PR's predicate
retirement. This witness pins that route-level behavior stays stable; it is
not evidence this PR fixes anything for this specific input. The html slice
of the original defect class (42 instances in the root-cause record's own
sweep) is real, and retiring this predicate does close it in general --
just not through this particular witness anymore.

**Not a false-clean, and not a closure:**

| Witness | Language | C oracle | Before | After |
|---|---|---|---|---|
| `e \ cho hi` | bash | HasError=false (clean) | HasError=false | HasError=true |

The C oracle parses this input clean: a backslash-space is a
scanner-skipped escape in bash, and the two skipped bytes are legitimately
uncovered by any leaf in C's own tree. The leaf-tiling invariant this gate
enforces is not a C invariant for scanner-skip escape classes, so the
now-narrower auditor cannot distinguish this shape from a genuine drop and
declines -- a coverage loss traded for safety, not a defect closure. The
production tree served after the decline (a flat `ERROR[0:10]`,
`HasError=true`) itself diverges from the C oracle. That divergence is a
pre-existing, unrelated production defect in how the GLR engine handles a
bare backslash-space escape (real shell: `echo \ leading`,
`tar -c \ -f x.tar dir`, `VAR=1 \ cmd`; backslash-newline line continuation
is a different, unaffected class) -- not something this PR introduces or
fixes. It is exposed here only because compact no longer masks it by
accepting the input directly. Tracked separately as a production bash
repair lane; out of scope here. The decline itself is kept: it is
fail-closed-correct on the auditor's own terms, even though this specific
input turns out to have been fine.

**Mechanical sweep** (one space-padded stray byte at every position of each
language's curated smoke sample, over the full printable-ASCII stray-byte
alphabet -- a raw divergence count, not a per-input C adjudication; see the
bash caveat below):

| Language | False-cleans before | False-cleans after |
|---|---:|---:|
| javascript | 212 / 4794 injected | 0 / 4794 |
| html | 0 / 3102 injected | 0 / 3102 |
| bash | 7 / 846 injected | 0 / 846 |
| haskell | 252 / 6862 injected | 103 / 6862 (residual, see below) |

The curated html smoke sample does not happen to reproduce the defect
through this sweep's injection positions. Every one of the 7 bash sweep
hits is the same scanner-skip-escape shape as the direct witness above,
per a subsequent, more thorough review sweep: not genuine false-cleans, so
this row is a coverage-loss count, not a closure count, for bash.

The haskell residual is not touched by this change. 103 of its 6,862
injected inputs still diverge, all a separate, pre-existing, position-only
mechanism (compact tiles the whole file cleanly; production wraps it in one
top-level `ERROR` with several children) already tracked apart from this
class. Compact may be correct there; it needs its own adjudication. A
subsequent, wider 45-language review sweep (11,884 inputs) separately
observed two more residual members outside this PR's 9-language sweep --
hcl (12 instances) and doxygen (22 instances) -- both a different
mechanism, both unchanged before and after this predicate's retirement,
neither in scope here.

## Scorecard delta

This PR's own change alone moved `minPass` 200 -> 199 and `maxFallback`
1 -> 2 (`jsdoc` PASS -> FALLBACK). PR #634 merged first with an identical
199/2 pair for an unrelated language (`meson`). Reconciled here to
`minPass=198`, `maxFallback=3`, with all three FALLBACK languages
documented in the ratchet comment:

- Before (pre-#634, pre-this-PR): PASS=200 DIVERGE=0 FALLBACK=1 SKIP=5.
- After (both landed): PASS=198 DIVERGE=0 FALLBACK=3 SKIP=5. Verified
  directly on the rebased branch, three runs, exact and stable. The three
  FALLBACK rows are `jsdoc` (this PR), `meson` (#634), and
  `markdown_inline` (the pre-existing baseline FALLBACK, unrelated to
  either change).
- `jsdoc`: its own interior comment-continuation gap no longer has a
  tolerating exemption, and correctly declines at
  `accepted-leaf-tiling-gap`. Production still serves jsdoc correctly, at a
  measured 2.2x-2.5x latency cost per parse (compact's own declined attempt
  plus production's full re-parse) -- acceptable for a rare grammar on a
  fail-closed route, not free.
- No other language changes status. `doxygen` does not regress: its gap
  sits at the derivation root, a position this predicate's retirement does
  not touch.

## Incidental fix

`TestJuliaTrailingCommaAssignmentTupleCompatibility` asserted a narrow ERROR
node shape that a separate, already-merged change
(`materializeSkippedGapAsExtraError`) superseded. That shape was never
exercised by this test until this fix stopped the compact route from
silently accepting the input first. The test now asserts the current,
correct tree shape (a flat, EXTRA-flagged ERROR leaf spanning the full
gap), and states explicitly that this shape itself still diverges from the
C oracle (`Text()==" = "`/`ChildCount()==0` here vs. C's `"="`/`1`) as the
already-documented, already-tracked accounting-not-shape gap named in
`materializeSkippedGapAsExtraError`'s own doc comment (`parser.go`), not a
new or hidden divergence.

## Testing

- `go test .` (2 runs) and `go test ./grammars`: green.
- 206-language admission scorecard: exact at PASS=198 FALLBACK=3 (3 runs,
  post-reconciliation with #634).
- W5 editor-latency gates: green.
- Canonical admission tree digests: unchanged.
- `go test . -race` on every touched path: green, no data races.
- B1 witness suite (`TestCompactRoute*Declines*` family, including the new
  `TestCompactRouteLexerSkippedByteGapDeclines`): green.
- `FuzzAdmissionRouteEquality` seed-corpus regression, including the four
  new seeds: green.
