### PR TITLE
fix(parser): align child field-name projection with the reference runtime's inherited-entry filter

### DIFF
--- a/cgo_harness/a3_certification_sweep_helpers_test.go
+++ b/cgo_harness/a3_certification_sweep_helpers_test.go
@@ -59,6 +59,12 @@ type a3CertificationSweepResult struct {
 	AdjudicatedExceptions []string
 	Divergences           []string
 	TrackedDivergences    []string
+	// MatchedKnownDivergences records every a3KnownDivergence entry that
+	// a3MatchesKnownDivergence actually matched against a live divergence
+	// during this sweep. a3ReportSweep diffs this against the caller's known
+	// list to catch a repaired entry nobody removed: see the stale-entry
+	// ratchet there.
+	MatchedKnownDivergences map[a3KnownDivergence]bool
 }
 
 // a3KnownDivergence is one already-triaged, pre-existing production-route
@@ -149,7 +155,11 @@ func a3DeclineReasonClass(reason string) string {
 // lang.
 func runA3CertificationSweep(t *testing.T, language, cLangName string, lang *gotreesitter.Language, sources []a3CertificationSweepSource, known []a3KnownDivergence) a3CertificationSweepResult {
 	t.Helper()
-	result := a3CertificationSweepResult{Language: language, DeclineByReason: map[string]int{}}
+	result := a3CertificationSweepResult{
+		Language:                language,
+		DeclineByReason:         map[string]int{},
+		MatchedKnownDivergences: map[a3KnownDivergence]bool{},
+	}
 
 	cLang, err := COracleLanguage(cLangName)
 	if err != nil {
@@ -216,6 +226,7 @@ func runA3CertificationSweep(t *testing.T, language, cLangName string, lang *got
 				// divergence at a different node or with different Go/C
 				// values, is not a match and still fails.
 				if k, ok := a3MatchesKnownDivergence(known, src.Name, cDivergences[0]); ok {
+					result.MatchedKnownDivergences[k] = true
 					detail := fmt.Sprintf(
 						"%s: TRACKED DIVERGENCE (family %s, pre-existing production-route defect) -- compact matches production but both diverge from the C oracle at %d point(s), first: %s",
 						src.Name, k.Family, len(cDivergences), compactT3FormatDivergence(cDivergences[0]),
@@ -232,6 +243,7 @@ func runA3CertificationSweep(t *testing.T, language, cLangName string, lang *got
 				t.Log(detail)
 			default:
 				if k, ok := a3MatchesKnownDivergence(known, src.Name, cDivergences[0]); ok {
+					result.MatchedKnownDivergences[k] = true
 					detail := fmt.Sprintf(
 						"%s: TRACKED DIVERGENCE (family %s, pre-existing production-route defect) -- compact matches neither production (%d pt(s), first: %s) nor the C oracle (%d pt(s), first: %s)",
 						src.Name, k.Family, len(prodDivergences), prodDivergences[0], len(cDivergences), compactT3FormatDivergence(cDivergences[0]),
@@ -267,10 +279,13 @@ func runA3CertificationSweep(t *testing.T, language, cLangName string, lang *got
 }
 
 // a3ReportSweep logs the scorecard and fails the test if any unadjudicated
-// divergence was found. Declines, adjudicated exceptions, and tracked
+// divergence was found, or if any entry in known went stale (see the
+// stale-entry ratchet below). Declines, adjudicated exceptions, and tracked
 // (already-triaged, pre-existing production-route) divergences never fail
-// the sweep.
-func a3ReportSweep(t *testing.T, result a3CertificationSweepResult) {
+// the sweep on their own. known must be the exact list runA3CertificationSweep
+// produced result from; pass nil for a language with no known-divergence
+// list.
+func a3ReportSweep(t *testing.T, result a3CertificationSweepResult, known []a3KnownDivergence) {
 	t.Helper()
 	t.Logf(
 		"%s A3 sweep: files=%d accepted=%d declined=%d adjudicated-exceptions=%d tracked-divergences=%d divergences=%d",
@@ -286,6 +301,27 @@ func a3ReportSweep(t *testing.T, result a3CertificationSweepResult) {
 	for _, d := range result.TrackedDivergences {
 		t.Logf("%s tracked divergence: %s", result.Language, d)
 	}
+
+	// Stale-entry ratchet: a known-divergence entry suppresses one exact,
+	// currently-live divergence. After the repair for that divergence lands,
+	// the sweep no longer reaches the entry. runA3CertificationSweep records
+	// a match only when a3MatchesKnownDivergence fires. Such an entry then
+	// certifies nothing, but it still reads as a live defect to a person who
+	// skims the list. Fail loud instead. PR #638 removed eight repaired
+	// entries by hand; this ratchet makes the next burn-down mandatory.
+	var stale []string
+	for _, k := range known {
+		if !result.MatchedKnownDivergences[k] {
+			stale = append(stale, fmt.Sprintf("%s (family %s, path %s)", k.Witness, k.Family, k.FirstPath))
+		}
+	}
+	if len(stale) != 0 {
+		for _, s := range stale {
+			t.Errorf("%s A3 sweep: stale allowlist entry -- remove it: %s", result.Language, s)
+		}
+		t.Fatalf("%s A3 sweep found %d stale known-divergence entry(s) that matched nothing this run; the repair landed, burn the entry down", result.Language, len(stale))
+	}
+
 	if len(result.Divergences) != 0 {
 		for _, d := range result.Divergences {
 			t.Error(d)

--- a/cgo_harness/a3_certification_sweep_helpers_test.go
+++ b/cgo_harness/a3_certification_sweep_helpers_test.go
@@ -89,6 +89,15 @@ type a3KnownDivergence struct {
 	GoValue   string
 	CValue    string
 	Family    string
+	// Dormant exempts this entry from the stale-entry ratchet in
+	// a3ReportSweep. Set it only for an entry that stays a true statement
+	// about the production route but cannot match today, because the sweep
+	// declines the witness before it compares trees. A dormant entry
+	// reattaches on its own when the decline goes away. Every use needs a
+	// written reason beside the entry that names what suppresses the match.
+	// Do not set it to quiet an entry whose defect the repair fixed: that
+	// entry must come out.
+	Dormant bool
 }
 
 // a3MatchesKnownDivergence reports whether first (the first entry in a
@@ -309,8 +318,16 @@ func a3ReportSweep(t *testing.T, result a3CertificationSweepResult, known []a3Kn
 	// certifies nothing, but it still reads as a live defect to a person who
 	// skims the list. Fail loud instead. PR #638 removed eight repaired
 	// entries by hand; this ratchet makes the next burn-down mandatory.
+	//
+	// An entry marked Dormant is exempt. A dormant entry describes a
+	// production defect that is still real, but the sweep declines its
+	// witness before it compares trees, so no match can happen today. See
+	// the Dormant field's own comment for the rules.
 	var stale []string
 	for _, k := range known {
+		if k.Dormant {
+			continue
+		}
 		if !result.MatchedKnownDivergences[k] {
 			stale = append(stale, fmt.Sprintf("%s (family %s, path %s)", k.Witness, k.Family, k.FirstPath))
 		}

--- a/cgo_harness/ada_a3_certification_sweep_test.go
+++ b/cgo_harness/ada_a3_certification_sweep_test.go
@@ -40,7 +40,7 @@ func TestAdaA3CompactCertificationFullCorpusSweep(t *testing.T) {
 	t.Logf("ada A3 full-corpus sweep source denominator: real=0 (no corpus_real/ada on any host) constructed=%d total=%d", len(sources), len(sources))
 
 	result := runA3CertificationSweep(t, "ada", "ada", lang, sources, adaA3KnownDivergences)
-	a3ReportSweep(t, result)
+	a3ReportSweep(t, result, adaA3KnownDivergences)
 }
 
 // adaA3KnownDivergences are already-triaged, pre-existing production-route
@@ -48,18 +48,21 @@ func TestAdaA3CompactCertificationFullCorpusSweep(t *testing.T) {
 // reproduces what production already produces (verified directly, with the
 // compact route disabled) on each of these witnesses.
 //
-// Six of the seven are family M (materialization: an inherited field-map
-// entry names a child Go's flattened-hidden-span heuristic should not; C's
-// node.c filters inherited entries and never does). Ada's grammar declares
-// "name"/"subtype_mark" as inherited fields on productions whose actual
-// child production (named_array_aggregate, range_g) never carries them
-// directly; Go's applyParentFieldToFlattenedHiddenSpan re-attaches the
-// inherited field anyway.
-//
 // attribute_constraint is family D: Ada's grammar declares
 // prec.dynamic(1, discriminant_constraint) over index_constraint with an
 // explicit grammar comment choosing it, and Go's reduceForkWindowPreference
 // still picks index_constraint.
+//
+// This list carried six family-M entries before PR #638:
+// locked_positional_array_aggregate, array_others_choice,
+// named_array_aggregate, mixed_positional_named_aggregate,
+// qualified_expression, and attribute_range_and_first_last. Family M is
+// materialization: an inherited field-map entry named a child that C's
+// node.c never names. PR #638 repaired
+// applyParentFieldToFlattenedHiddenSpan, so those six divergences stopped
+// occurring, and the entries came out with the repair. The stale-entry
+// ratchet in a3ReportSweep now fails this test if a remaining entry stops
+// matching a live divergence.
 //
 // Not tied elections, not this gate's scope; repair lanes are tracked
 // separately.
@@ -68,36 +71,6 @@ var adaA3KnownDivergences = []a3KnownDivergence{
 		Witness:   "attribute_constraint",
 		FirstPath: "/compilation/compilation_unit[0]/subprogram_body[0]/handled_sequence_of_statements[3]/assignment_statement[0]/expression[2]/term[0]/allocator[0]/index_constraint[2]",
 		GoValue:   "index_constraint", CValue: "discriminant_constraint", Family: "D",
-	},
-	{
-		Witness:   "locked_positional_array_aggregate",
-		FirstPath: "/compilation/compilation_unit[0]/package_declaration[0]/full_type_declaration[3]/array_type_definition[3]/range_g[2]",
-		GoValue:   "subtype_mark", CValue: "", Family: "M",
-	},
-	{
-		Witness:   "array_others_choice",
-		FirstPath: "/compilation/compilation_unit[0]/subprogram_body[0]/handled_sequence_of_statements[3]/assignment_statement[0]/expression[2]/term[0]/named_array_aggregate[0]",
-		GoValue:   "name", CValue: "", Family: "M",
-	},
-	{
-		Witness:   "named_array_aggregate",
-		FirstPath: "/compilation/compilation_unit[0]/package_declaration[0]/full_type_declaration[3]/array_type_definition[3]/range_g[2]",
-		GoValue:   "subtype_mark", CValue: "", Family: "M",
-	},
-	{
-		Witness:   "mixed_positional_named_aggregate",
-		FirstPath: "/compilation/compilation_unit[0]/package_declaration[0]/full_type_declaration[3]/array_type_definition[3]/range_g[2]",
-		GoValue:   "subtype_mark", CValue: "", Family: "M",
-	},
-	{
-		Witness:   "qualified_expression",
-		FirstPath: "/compilation/compilation_unit[0]/package_declaration[0]/full_type_declaration[3]/array_type_definition[3]/range_g[2]",
-		GoValue:   "subtype_mark", CValue: "", Family: "M",
-	},
-	{
-		Witness:   "attribute_range_and_first_last",
-		FirstPath: "/compilation/compilation_unit[0]/subprogram_body[0]/non_empty_declarative_part[2]/full_type_declaration[0]/array_type_definition[3]/range_g[2]",
-		GoValue:   "subtype_mark", CValue: "", Family: "M",
 	},
 }
 

--- a/cgo_harness/apex_a3_certification_sweep_test.go
+++ b/cgo_harness/apex_a3_certification_sweep_test.go
@@ -41,7 +41,7 @@ func TestApexA3CompactCertificationFullCorpusSweep(t *testing.T) {
 	// No known-divergence entries: apex's sweep has zero unadjudicated
 	// divergences at both the pre- and post-tightening criterion.
 	result := runA3CertificationSweep(t, "apex", "apex", lang, sources, nil)
-	a3ReportSweep(t, result)
+	a3ReportSweep(t, result, nil)
 }
 
 // apexA3TiedElectionWitnesses reuses the three witnesses already vetted in

--- a/cgo_harness/kotlin_a3_certification_sweep_test.go
+++ b/cgo_harness/kotlin_a3_certification_sweep_test.go
@@ -66,7 +66,7 @@ func TestKotlinA3CompactCertificationFullCorpusSweep(t *testing.T) {
 	t.Logf("kotlin A3 full-corpus sweep source denominator: real=%d constructed=%d total=%d", len(real), len(constructed), len(sources))
 
 	result := runA3CertificationSweep(t, "kotlin", "kotlin", lang, sources, kotlinA3KnownDivergences)
-	a3ReportSweep(t, result)
+	a3ReportSweep(t, result, kotlinA3KnownDivergences)
 }
 
 // kotlinA3KnownDivergences is an already-triaged, pre-existing

--- a/cgo_harness/kotlin_a3_certification_sweep_test.go
+++ b/cgo_harness/kotlin_a3_certification_sweep_test.go
@@ -95,6 +95,13 @@ var kotlinA3KnownDivergences = []a3KnownDivergence{
 		Witness:   "large__DeprecatedInstant.kt",
 		FirstPath: "/source_file/assignment[14]",
 		GoValue:   "assignment", CValue: "getter", Family: "D",
+		// Dormant for the reason the paragraph above records: the withheld
+		// split-drops certificate makes this witness decline, so the sweep
+		// never reaches the comparison that would match this entry. The
+		// entry stays a true statement about production and reattaches if
+		// split-drops is re-granted. The stale-entry ratchet in
+		// a3ReportSweep skips it for that reason alone.
+		Dormant: true,
 	},
 }
 

--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -254,13 +254,21 @@ func parityIncludeHighlightLanguage(name string) bool {
 	return smokeParityLanguages[name]
 }
 
+// parityCompareFields gates FieldName comparison in compareNodes (production
+// vs the C oracle) and compareGoNodes (production vs compact route
+// equality). Field parity is on by default: the reference runtime's
+// !field_map->inherited filter (node.c:673-687) is part of the tree shape
+// the locked C oracle defines, not an optional extra, so a parity run that
+// silently skips it is not exercising the gate its name promises. Set
+// GTS_PARITY_COMPARE_FIELDS to a falsy value (0/false/no/off) to opt back
+// out for bisection.
 var parityCompareFields = func() bool {
 	raw := strings.TrimSpace(os.Getenv("GTS_PARITY_COMPARE_FIELDS"))
 	switch strings.ToLower(raw) {
-	case "1", "true", "yes", "on":
-		return true
-	default:
+	case "0", "false", "no", "off":
 		return false
+	default:
+		return true
 	}
 }()
 

--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -254,9 +254,10 @@ func parityIncludeHighlightLanguage(name string) bool {
 	return smokeParityLanguages[name]
 }
 
-// parityCompareFields gates FieldName comparison in compareNodes (production
-// vs the C oracle) and compareGoNodes (production vs compact route
-// equality). Field parity is on by default: the reference runtime's
+// parityCompareFields gates FieldName comparison in compareNodes (a Go tree
+// vs the C oracle) and compareGoNodes (Go incremental-parse output vs Go
+// fresh-parse output, i.e. incremental-parse field correctness). Field
+// parity is on by default: the reference runtime's
 // !field_map->inherited filter (node.c:673-687) is part of the tree shape
 // the locked C oracle defines, not an optional extra, so a parity run that
 // silently skips it is not exercising the gate its name promises. Set

--- a/cgo_harness/perl_a3_certification_sweep_test.go
+++ b/cgo_harness/perl_a3_certification_sweep_test.go
@@ -36,7 +36,7 @@ func TestPerlA3CompactCertificationFullCorpusSweep(t *testing.T) {
 	t.Logf("perl A3 full-corpus sweep source denominator: real=%d constructed=%d total=%d", len(real), len(constructed), len(sources))
 
 	result := runA3CertificationSweep(t, "perl", "perl", lang, sources, perlA3KnownDivergences)
-	a3ReportSweep(t, result)
+	a3ReportSweep(t, result, perlA3KnownDivergences)
 }
 
 // perlA3KnownDivergences are already-triaged, pre-existing production-route

--- a/cgo_harness/python_a3_certification_sweep_test.go
+++ b/cgo_harness/python_a3_certification_sweep_test.go
@@ -36,19 +36,34 @@ func TestPythonA3CompactCertificationFullCorpusSweep(t *testing.T) {
 	t.Logf("python A3 full-corpus sweep source denominator: real=%d constructed=%d total=%d", len(real), len(constructed), len(sources))
 
 	result := runA3CertificationSweep(t, "python", "python", lang, sources, pythonA3KnownDivergences)
-	a3ReportSweep(t, result)
+	a3ReportSweep(t, result, pythonA3KnownDivergences)
 }
 
 // pythonA3KnownDivergences are already-triaged, pre-existing production-route
 // defects the tightened sweep criterion surfaced: the compact route only
 // reproduces what production already produces (verified directly, with the
-// compact route disabled) on each of these witnesses. The two real-corpus
-// entries are family M (materialization: an inherited field-map entry names
-// a child Go's flattened-hidden-span heuristic should not; C's node.c filters
-// inherited entries and never does). large__python3.8_grammar.py's first
-// point is family M; it also carries a family S point further in (an
-// aliased "not in"/"is not" span that starts one byte early) not enumerated
-// as a separate entry here, since only the first divergence gates the match.
+// compact route disabled) on each of these witnesses.
+//
+// This list carried two family-M entries before PR #638:
+// large__python3.8_grammar.py and medium__setup.py. Family M is
+// materialization: an inherited field-map entry named the comma in a
+// comma-separated import list. C's node.c never names that comma. PR #638
+// repaired applyParentFieldToFlattenedHiddenSpan, so both divergences
+// stopped occurring, and the entries came out with the repair. The
+// stale-entry ratchet in a3ReportSweep now fails this test if a remaining
+// entry stops matching a live divergence.
+//
+// The repair of large__python3.8_grammar.py uncovered a second, independent
+// divergence further into the same file. It is family S (materialization,
+// aliased multi-token span): Go starts the "not in" operator wrapper one
+// byte early. Go uses the previous sibling's end byte instead of the first
+// token's own start byte, so the wrapper includes the separating space.
+// The defect is older than PR #638. Only the family-M point ahead of it in
+// traversal order masked it, because a3MatchesKnownDivergence gates on the
+// first divergence. The entry below tracks the defect, so the family-M
+// burn-down does not turn an already-known defect into a false hard
+// failure.
+//
 // The two f-string entries are family D (a first-class declared
 // pattern_list/expression_list ambiguity; Go's reduceForkWindowPreference
 // disagrees with C's ts_parser__select_tree on which side to keep). Not
@@ -56,14 +71,11 @@ func TestPythonA3CompactCertificationFullCorpusSweep(t *testing.T) {
 // separately.
 var pythonA3KnownDivergences = []a3KnownDivergence{
 	{
+		// Pre-existing production-level aliased-multi-token span defect.
+		// A repair lane is queued.
 		Witness:   "large__python3.8_grammar.py",
-		FirstPath: "/module/class_definition[25]/block[4]/function_definition[13]/block[6]/import_from_statement[0]/,[4]",
-		GoValue:   "name", CValue: "", Family: "M",
-	},
-	{
-		Witness:   "medium__setup.py",
-		FirstPath: "/module/import_from_statement[2]/,[4]",
-		GoValue:   "name", CValue: "", Family: "M",
+		FirstPath: "/module/class_definition[25]/block[4]/function_definition[56]/block[6]/if_statement[12]/comparison_operator[1]/not in[15]",
+		GoValue:   "1190:45-1190:52 @37238..37245", CValue: "1190:46-1190:52 @37239..37245", Family: "S",
 	},
 	{
 		Witness:   "fstring_interpolation_bare_tuple",

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -5880,36 +5880,6 @@ func flattenedSpanHasFieldID(fieldIDs []FieldID, start, end int, fid FieldID) bo
 	return false
 }
 
-func flattenedSpanHasAnyDirectField(children []*Node, fieldIDs []FieldID, fieldSources []uint8, start, end int) bool {
-	for i := start; i < end; i++ {
-		if i < len(fieldIDs) && fieldIDs[i] != 0 && fieldSourceIsDirect(fieldSourceAt(fieldSources, i)) {
-			return true
-		}
-		if i < len(children) && nodeHasAnyDirectField(children[i]) {
-			return true
-		}
-	}
-	return false
-}
-
-func flattenedSpanSingleDescendantFieldTarget(children []*Node, start, end int, fid FieldID) (int, bool) {
-	if fid == 0 {
-		return 0, false
-	}
-	target := -1
-	for i := start; i < end; i++ {
-		child := children[i]
-		if child == nil || child.isExtra() || !nodeHasDirectFieldID(child, fid) {
-			continue
-		}
-		if target >= 0 {
-			return 0, false
-		}
-		target = i
-	}
-	return target, target >= 0
-}
-
 type reduceBuildScratch struct {
 	nodes             []*Node
 	fieldIDs          []FieldID
@@ -6619,64 +6589,49 @@ func (p *Parser) appendVisibleReduceChildToScratch(scratch *reduceBuildScratch, 
 	}
 }
 
+// applyParentFieldToFlattenedHiddenSpan projects the field-map entry
+// hiddenParent's own enclosing production recorded at hiddenParent's
+// structural position onto the span hiddenParent flattened into. This
+// mirrors the C runtime's two-function field resolution exactly
+// (tree-sitter lib/src/node.c):
+//
+//   - ts_node__field_name_from_language (node.c:673-687) filters
+//     !field_map->inherited unconditionally: an inherited entry is never
+//     itself usable as a field name.
+//   - ts_node_field_name_for_child (node.c:689-729) resolves an inherited
+//     entry only by recursing into the referenced child's own (structural,
+//     unflattened) production and repeating the same non-inherited check
+//     one level closer to the target -- the field depends on which hidden
+//     production the child actually came through, not on the shape
+//     (child count, leaf-ness, sibling pattern) of whatever ended up there.
+//
+// Go performs that same recursion eagerly, one hidden level at a time, in
+// appendFlattenedHiddenChildrenWithFieldScratch and resolveDeferredParentField:
+// each hidden node's own field plan (built from its own production id, see
+// buildFieldPlanForProduction/fixedFieldIDsForProduction) is applied to its
+// own children as they are flattened, bottom-up, before this function ever
+// runs for an ancestor's span. So by the time this function is reached for
+// hiddenParent's span, every deeper level has already applied whatever
+// non-inherited entry it owns; flattenedSpanHasFieldID (consulted inside
+// applyFieldToFlattenedSpan for the direct case, and folded into
+// normalizeMixedSourceFieldSpan's existing-assignment checks here) reports
+// exactly what a strictly deeper, non-inherited hit resolved.
+//
+// When inherited is true, this function must therefore never invent a new
+// assignment from hiddenParent's span shape -- doing so (via a "single
+// non-leaf child" proxy and an "anonymous gap between direct fields" filler,
+// neither of which C has) was the fleet-wide field over-projection defect
+// (finding.production-divergence-census-2026-08-02). There is nothing left
+// to resolve at this level: either a deeper non-inherited hit already
+// claimed the field, or C itself has no field here, and Go must agree.
 func applyParentFieldToFlattenedHiddenSpan(children []*Node, fieldIDs []FieldID, fieldSources []uint8, hiddenParent *Node, spanStart, fieldEnd int, fid FieldID, inherited, appearsLater bool) {
-	source := fieldSourceForInheritance(inherited)
-	hasField := flattenedSpanHasFieldID(fieldIDs, spanStart, fieldEnd, fid)
-	if inherited && hasField {
-		fillAnonymousGapsBetweenDirectFields(children, fieldIDs, fieldSources, spanStart, fieldEnd, fid)
+	if inherited {
 		normalizeMixedSourceFieldSpan(fieldIDs, fieldSources, spanStart, fieldEnd)
 		return
 	}
-	if inherited && !hasField {
-		if assignSingleDescendantInheritedField(children, fieldIDs, fieldSources, spanStart, fieldEnd, fid) {
-			normalizeMixedSourceFieldSpan(fieldIDs, fieldSources, spanStart, fieldEnd)
-			return
-		}
-		if shouldSkipInheritedParentFieldForFlattenedSpan(children, fieldIDs, fieldSources, hiddenParent, spanStart, fieldEnd, fid) {
-			return
-		}
-	}
-	if inherited && appearsLater {
-		return
-	}
+	source := fieldSourceForInheritance(inherited)
 	applyFieldToFlattenedSpan(children, fieldIDs, fieldSources, spanStart, fieldEnd, fid, source, true)
 	normalizeMixedSourceFieldSpan(fieldIDs, fieldSources, spanStart, fieldEnd)
-}
-
-func fillAnonymousGapsBetweenDirectFields(
-	children []*Node,
-	fieldIDs []FieldID,
-	fieldSources []uint8,
-	start int,
-	end int,
-	fid FieldID,
-) {
-	previous := -1
-	for i := start; i < end; i++ {
-		if fieldIDs[i] != fid || !fieldSourceIsDirect(fieldSourceAt(fieldSources, i)) {
-			continue
-		}
-		if previous < 0 {
-			previous = i
-			continue
-		}
-		fill := true
-		for gap := previous + 1; gap < i; gap++ {
-			child := children[gap]
-			if child == nil || child.isNamed() || child.isExtra() || child.isMissing() || fieldIDs[gap] != 0 {
-				fill = false
-				break
-			}
-		}
-		if !fill {
-			previous = i
-			continue
-		}
-		for gap := previous + 1; gap < i; gap++ {
-			assignFlattenedField(fieldIDs, fieldSources, gap, fid, fieldSourceDirect)
-		}
-		previous = i
-	}
 }
 
 func resolveDeferredParentField(children []*Node, fieldIDs []FieldID, fieldSources []uint8, hiddenParent *Node, spanStart, fieldEnd int, fid FieldID, source uint8) (direct, deferred bool) {
@@ -6705,42 +6660,6 @@ func fieldSourceForInheritance(inherited bool) uint8 {
 		return fieldSourceInherited
 	}
 	return fieldSourceDirect
-}
-
-func assignSingleDescendantInheritedField(children []*Node, fieldIDs []FieldID, fieldSources []uint8, spanStart, fieldEnd int, fid FieldID) bool {
-	target, ok := flattenedSpanSingleDescendantFieldTarget(children, spanStart, fieldEnd, fid)
-	if !ok {
-		return false
-	}
-	fieldIDs[target] = fid
-	fieldSources[target] = fieldSourceInherited
-	return true
-}
-
-func shouldSkipInheritedParentFieldForFlattenedSpan(children []*Node, fieldIDs []FieldID, fieldSources []uint8, hiddenParent *Node, spanStart, fieldEnd int, fid FieldID) bool {
-	if fieldEnd-spanStart == 1 {
-		child := children[spanStart]
-		if child == nil || nodeHasDirectFieldID(child, fid) || len(child.children) == 0 {
-			return true
-		}
-	}
-	if hiddenParent.isNamed() && countEligibleNamedFieldTargets(children, fieldIDs, spanStart, fieldEnd) > 1 {
-		return true
-	}
-	if fieldEnd-spanStart > 1 {
-		first := children[spanStart]
-		if first != nil && !first.isNamed() && !first.isExtra() && !first.isMissing() {
-			return true
-		}
-	}
-	if !flattenedSpanHasAnyDirectField(children, fieldIDs, fieldSources, spanStart, fieldEnd) {
-		return false
-	}
-	if fieldEnd-spanStart != 1 {
-		return true
-	}
-	child := children[spanStart]
-	return child == nil || !nodeHasDirectFieldID(child, fid)
 }
 
 func (p *Parser) shouldSuppressVisibleDirectField(n *Node, fid FieldID) bool {
@@ -7090,7 +7009,22 @@ func applyDirectFieldToUnassignedFlattenedSpan(children []*Node, fieldIDs []Fiel
 	case allowAnonymousSingleDirectTarget:
 		assignFirstUnassignedFlattenedField(children, fieldIDs, fieldSources, start, end, fid, source, false)
 	case namedTargets > 1:
-		assignAllUnassignedFlattenedFields(children, fieldIDs, fieldSources, start, end, fid, source, true)
+		// A direct (non-inherited) field-map entry that lands on this whole
+		// flattened span (spanning multiple targets with no field of their
+		// own yet) is C's carried fallback for the entire span, not just its
+		// named members: ts_node_field_name_for_child (node.c:689-729) sets
+		// inherited_field_name from a !inherited entry at the position it is
+		// about to descend through, and that value is the answer for every
+		// descendant reached through it -- punctuation included -- unless a
+		// deeper, more specific entry overrides it first (which
+		// flattenedSpanHasFieldID/hasField above already accounts for by the
+		// time this span is unassigned). Excluding anonymous targets here
+		// undershoots C: scala's `import foo.bar.Baz` field-maps "path"
+		// directly onto _namespace_expression's sep1(".", identifier) slot
+		// (grammar.js:232), and the resulting "." separators inside the
+		// generated repeat helper carry no field of their own, so they must
+		// inherit "path" from this level exactly like the identifiers do.
+		assignAllUnassignedFlattenedFields(children, fieldIDs, fieldSources, start, end, fid, source, false)
 	case namedTargets == 1 && totalTargets > 1:
 		assignAllUnassignedFlattenedFields(children, fieldIDs, fieldSources, start, end, fid, source, false)
 	case namedTargets == 1:
@@ -7174,25 +7108,6 @@ func nodeHasDirectFieldID(n *Node, fid FieldID) bool {
 	}
 	for _, fieldID := range n.fieldIDs() {
 		if fieldID == fid {
-			return true
-		}
-	}
-	return false
-}
-
-func nodeHasAnyDirectField(n *Node) bool {
-	if n == nil {
-		return false
-	}
-	fieldIDs := n.fieldIDs()
-	fieldSources := n.fieldSources()
-	for i := range fieldIDs {
-		if fieldIDs[i] != 0 && fieldSourceIsDirect(fieldSourceAt(fieldSources, i)) {
-			return true
-		}
-	}
-	for _, child := range n.children {
-		if nodeHasAnyDirectField(child) {
 			return true
 		}
 	}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -5792,32 +5792,26 @@ const (
 	// rules as the eager path when the chain reaches a visible boundary.
 	fieldSourceDeferredDirect
 	fieldSourceDeferredInherited
-	fieldSourceDeferredInheritedLater
 	// A projected direct field keeps its hidden-parent provenance until the
 	// visible reduction resolves competing parent fields.
 	fieldSourceProjectedDirect
 )
 
-func deferredFieldSource(inherited, appearsLater bool) uint8 {
+func deferredFieldSource(inherited bool) uint8 {
 	if !inherited {
 		return fieldSourceDeferredDirect
-	}
-	if appearsLater {
-		return fieldSourceDeferredInheritedLater
 	}
 	return fieldSourceDeferredInherited
 }
 
-func decodeDeferredFieldSource(source uint8) (inherited, appearsLater, ok bool) {
+func decodeDeferredFieldSource(source uint8) (inherited, ok bool) {
 	switch source {
 	case fieldSourceDeferredDirect:
-		return false, false, true
+		return false, true
 	case fieldSourceDeferredInherited:
-		return true, false, true
-	case fieldSourceDeferredInheritedLater:
-		return true, true, true
+		return true, true
 	default:
-		return false, false, false
+		return false, false
 	}
 }
 
@@ -5854,18 +5848,6 @@ func countEligibleFieldTargets(children []*Node, fieldIDs []FieldID, start, end 
 		count++
 	}
 	return count
-}
-
-func fieldIDAppearsLater(fieldIDs []FieldID, start int, fid FieldID) bool {
-	if fid == 0 || start < 0 {
-		return false
-	}
-	for i := start; i < len(fieldIDs); i++ {
-		if fieldIDs[i] == fid {
-			return true
-		}
-	}
-	return false
 }
 
 func flattenedSpanHasFieldID(fieldIDs []FieldID, start, end int, fid FieldID) bool {
@@ -6046,7 +6028,7 @@ func appendFlattenedHiddenChildrenWithFieldScratch(scratch *reduceBuildScratch, 
 		source := fieldSourceAt(fieldSources, i)
 		if direct, deferred := resolveDeferredParentField(
 			scratch.nodes, scratch.fieldIDs, scratch.fieldSources,
-			child, spanStart, spanEnd, fieldIDs[i], source,
+			spanStart, spanEnd, fieldIDs[i], source,
 		); deferred {
 			if direct {
 				scratch.recordRepeatedField(repeatEpoch, fieldIDs[i], fieldSourceDirect)
@@ -6233,7 +6215,7 @@ func (p *Parser) buildReduceChildrenWithPath(entries []stackEntry, start, end, c
 		}
 	}
 
-	rawFieldIDs, rawInherited, rawConflictedInherited := p.buildFieldIDs(childCount, productionID, arena)
+	rawFieldIDs, rawInherited, _ := p.buildFieldIDs(childCount, productionID, arena)
 	if children, fieldIDs, fieldSources, ok := p.buildReduceChildrenAllVisible(entries, start, end, childCount, aliasSeq, rawFieldIDs, rawInherited, parentVisible, symbolMeta, arena); ok {
 		if len(p.unaryWrapperFlatteningSet) != 0 {
 			children = p.flattenNativeUnaryWrapperChildren(parentSymbol, children)
@@ -6242,7 +6224,7 @@ func (p *Parser) buildReduceChildrenWithPath(entries []stackEntry, start, end, c
 	}
 
 	scratch := p.newReduceBuildScratch(rawFieldIDs)
-	p.appendReduceChildrenToScratch(scratch, entries, start, end, productionID, aliasSeq, rawFieldIDs, rawInherited, rawConflictedInherited, parentVisible, symbolMeta, arena, lang)
+	p.appendReduceChildrenToScratch(scratch, entries, start, end, aliasSeq, rawFieldIDs, rawInherited, parentVisible, symbolMeta, arena, lang)
 	if scratch.trackFields {
 		p.suppressReducedChildFields(scratch.nodes, scratch.fieldIDs, scratch.fieldSources)
 		if parentVisible {
@@ -6397,19 +6379,16 @@ type reduceChildBuildItem struct {
 	node                *Node
 	fieldID             FieldID
 	inherited           bool
-	conflictedInherited bool
-	structuralIndex     int
 	nextStructuralIndex int
 }
 
-func (p *Parser) reduceChildBuildItemForEntry(entry stackEntry, structuralChildIndex int, aliasSeq []Symbol, rawFieldIDs []FieldID, rawInherited []bool, rawConflictedInherited []bool, arena *nodeArena) (reduceChildBuildItem, bool) {
+func (p *Parser) reduceChildBuildItemForEntry(entry stackEntry, structuralChildIndex int, aliasSeq []Symbol, rawFieldIDs []FieldID, rawInherited []bool, arena *nodeArena) (reduceChildBuildItem, bool) {
 	n := stackEntryNode(entry)
 	if n == nil {
 		return reduceChildBuildItem{}, false
 	}
 	item := reduceChildBuildItem{
 		node:                n,
-		structuralIndex:     structuralChildIndex,
 		nextStructuralIndex: structuralChildIndex,
 	}
 	if n.isExtra() {
@@ -6419,9 +6398,6 @@ func (p *Parser) reduceChildBuildItemForEntry(entry stackEntry, structuralChildI
 		item.fieldID = rawFieldIDs[structuralChildIndex]
 		if structuralChildIndex < len(rawInherited) {
 			item.inherited = rawInherited[structuralChildIndex]
-		}
-		if structuralChildIndex < len(rawConflictedInherited) {
-			item.conflictedInherited = rawConflictedInherited[structuralChildIndex]
 		}
 	}
 	if structuralChildIndex < len(aliasSeq) {
@@ -6433,19 +6409,19 @@ func (p *Parser) reduceChildBuildItemForEntry(entry stackEntry, structuralChildI
 	return item, true
 }
 
-func (p *Parser) appendReduceChildrenToScratch(scratch *reduceBuildScratch, entries []stackEntry, start, end int, productionID uint16, aliasSeq []Symbol, rawFieldIDs []FieldID, rawInherited []bool, rawConflictedInherited []bool, parentVisible bool, symbolMeta []SymbolMetadata, arena *nodeArena, lang *Language) {
+func (p *Parser) appendReduceChildrenToScratch(scratch *reduceBuildScratch, entries []stackEntry, start, end int, aliasSeq []Symbol, rawFieldIDs []FieldID, rawInherited []bool, parentVisible bool, symbolMeta []SymbolMetadata, arena *nodeArena, lang *Language) {
 	structuralChildIndex := 0
 	var pendingPaddingStart uint32
 	var pendingPaddingPoint Point
 	var pendingPaddingSource *Node
 	havePendingPadding := false
 	for i := start; i < end; i++ {
-		item, ok := p.reduceChildBuildItemForEntry(entries[i], structuralChildIndex, aliasSeq, rawFieldIDs, rawInherited, rawConflictedInherited, arena)
+		item, ok := p.reduceChildBuildItemForEntry(entries[i], structuralChildIndex, aliasSeq, rawFieldIDs, rawInherited, arena)
 		if !ok {
 			continue
 		}
 		structuralChildIndex = item.nextStructuralIndex
-		spanStart, spanEnd := p.appendReduceChildItemToScratch(scratch, item, productionID, rawFieldIDs, structuralChildIndex, parentVisible, symbolMeta, havePendingPadding, pendingPaddingStart, pendingPaddingPoint, pendingPaddingSource, arena)
+		spanStart, spanEnd := p.appendReduceChildItemToScratch(scratch, item, parentVisible, symbolMeta, havePendingPadding, pendingPaddingStart, pendingPaddingPoint, pendingPaddingSource, arena)
 		if !symbolVisibleForPending(item.node.symbol, symbolMeta) {
 			pendingPaddingStart, pendingPaddingPoint, havePendingPadding = flattenedHiddenEntryPadding(item.node, scratch.nodes, spanStart, spanEnd)
 			pendingPaddingSource = item.node
@@ -6455,7 +6431,7 @@ func (p *Parser) appendReduceChildrenToScratch(scratch *reduceBuildScratch, entr
 	}
 }
 
-func (p *Parser) appendReduceChildItemToScratch(scratch *reduceBuildScratch, item reduceChildBuildItem, productionID uint16, rawFieldIDs []FieldID, nextStructuralChildIndex int, parentVisible bool, symbolMeta []SymbolMetadata, havePadding bool, paddingStartByte uint32, paddingStartPoint Point, paddingSource *Node, arena *nodeArena) (int, int) {
+func (p *Parser) appendReduceChildItemToScratch(scratch *reduceBuildScratch, item reduceChildBuildItem, parentVisible bool, symbolMeta []SymbolMetadata, havePadding bool, paddingStartByte uint32, paddingStartPoint Point, paddingSource *Node, arena *nodeArena) (int, int) {
 	n := item.node
 	if symbolVisibleForPending(n.symbol, symbolMeta) {
 		if havePadding && flattenedHiddenSiblingPaddingTarget(n, paddingSource, symbolMeta) && paddingStartByte < n.startByte {
@@ -6478,10 +6454,7 @@ func (p *Parser) appendReduceChildItemToScratch(scratch *reduceBuildScratch, ite
 				scratch.ensureFieldStorage()
 			}
 			scratch.fieldIDs[spanStart] = item.fieldID
-			scratch.fieldSources[spanStart] = deferredFieldSource(
-				item.inherited,
-				fieldIDAppearsLater(rawFieldIDs, nextStructuralChildIndex, item.fieldID),
-			)
+			scratch.fieldSources[spanStart] = deferredFieldSource(item.inherited)
 		}
 		return spanStart, len(scratch.nodes)
 	}
@@ -6493,15 +6466,6 @@ func (p *Parser) appendReduceChildItemToScratch(scratch *reduceBuildScratch, ite
 		appendFlattenedHiddenChildrenToScratch(scratch, n, symbolMeta, nil)
 	}
 	if item.fieldID == 0 {
-		if !n.isExtra() && item.conflictedInherited {
-			p.projectConflictedInheritedFields(
-				scratch,
-				productionID,
-				item.structuralIndex,
-				spanStart,
-				len(scratch.nodes),
-			)
-		}
 		return spanStart, len(scratch.nodes)
 	}
 	if !scratch.trackFields {
@@ -6512,69 +6476,12 @@ func (p *Parser) appendReduceChildItemToScratch(scratch *reduceBuildScratch, ite
 		scratch.nodes,
 		scratch.fieldIDs,
 		scratch.fieldSources,
-		n,
 		spanStart,
 		fieldEnd,
 		item.fieldID,
 		item.inherited,
-		fieldIDAppearsLater(rawFieldIDs, nextStructuralChildIndex, item.fieldID),
 	)
 	return spanStart, len(scratch.nodes)
-}
-
-func (p *Parser) projectConflictedInheritedFields(
-	scratch *reduceBuildScratch,
-	productionID uint16,
-	structuralChildIndex int,
-	spanStart int,
-	spanEnd int,
-) {
-	if p == nil ||
-		p.language == nil ||
-		scratch == nil ||
-		structuralChildIndex < 0 ||
-		spanStart < 0 ||
-		spanStart >= spanEnd ||
-		spanEnd > len(scratch.nodes) {
-		return
-	}
-	pid := int(productionID)
-	if pid < 0 || pid >= len(p.language.FieldMapSlices) {
-		return
-	}
-	fieldMap := p.language.FieldMapSlices[pid]
-	start := int(fieldMap[0])
-	end := start + int(fieldMap[1])
-	if start < 0 || start >= len(p.language.FieldMapEntries) {
-		return
-	}
-	if end > len(p.language.FieldMapEntries) {
-		end = len(p.language.FieldMapEntries)
-	}
-	scratch.ensureFieldStorage()
-	for _, entry := range p.language.FieldMapEntries[start:end] {
-		if int(entry.ChildIndex) != structuralChildIndex ||
-			!entry.Inherited ||
-			entry.FieldID == 0 ||
-			int(entry.FieldID) >= len(p.language.FieldNames) {
-			continue
-		}
-		fieldName := p.language.FieldNames[entry.FieldID]
-		if fieldName == "" {
-			continue
-		}
-		for index := spanStart; index < spanEnd; index++ {
-			child := scratch.nodes[index]
-			if child == nil ||
-				!child.isNamed() ||
-				scratch.fieldIDs[index] != 0 ||
-				symbolTypeName(p.language, child.symbol) != fieldName {
-				continue
-			}
-			scratch.fieldIDs[index] = entry.FieldID
-			scratch.fieldSources[index] = fieldSourceInherited
-		}
-	}
 }
 
 func (p *Parser) appendVisibleReduceChildToScratch(scratch *reduceBuildScratch, n *Node, fid FieldID, inherited bool) {
@@ -6589,11 +6496,11 @@ func (p *Parser) appendVisibleReduceChildToScratch(scratch *reduceBuildScratch, 
 	}
 }
 
-// applyParentFieldToFlattenedHiddenSpan projects the field-map entry
-// hiddenParent's own enclosing production recorded at hiddenParent's
-// structural position onto the span hiddenParent flattened into. This
-// mirrors the C runtime's two-function field resolution exactly
-// (tree-sitter lib/src/node.c):
+// applyParentFieldToFlattenedHiddenSpan projects one field-map entry of the
+// enclosing production onto the span [spanStart, fieldEnd). That entry sits
+// at the structural position of the hidden node that flattened into the
+// span. The function mirrors the C runtime's two-function field resolution
+// exactly (tree-sitter lib/src/node.c):
 //
 //   - ts_node__field_name_from_language (node.c:673-687) filters
 //     !field_map->inherited unconditionally: an inherited entry is never
@@ -6610,21 +6517,21 @@ func (p *Parser) appendVisibleReduceChildToScratch(scratch *reduceBuildScratch, 
 // each hidden node's own field plan (built from its own production id, see
 // buildFieldPlanForProduction/fixedFieldIDsForProduction) is applied to its
 // own children as they are flattened, bottom-up, before this function ever
-// runs for an ancestor's span. So by the time this function is reached for
-// hiddenParent's span, every deeper level has already applied whatever
-// non-inherited entry it owns; flattenedSpanHasFieldID (consulted inside
-// applyFieldToFlattenedSpan for the direct case, and folded into
-// normalizeMixedSourceFieldSpan's existing-assignment checks here) reports
-// exactly what a strictly deeper, non-inherited hit resolved.
+// runs for an ancestor's span. So by the time this function is reached,
+// every deeper level has already applied whatever non-inherited entry it
+// owns; flattenedSpanHasFieldID (consulted inside applyFieldToFlattenedSpan
+// for the direct case, and folded into normalizeMixedSourceFieldSpan's
+// existing-assignment checks here) reports exactly what a strictly deeper,
+// non-inherited hit resolved.
 //
 // When inherited is true, this function must therefore never invent a new
-// assignment from hiddenParent's span shape -- doing so (via a "single
-// non-leaf child" proxy and an "anonymous gap between direct fields" filler,
-// neither of which C has) was the fleet-wide field over-projection defect
+// assignment from the span's shape -- doing so (via a "single non-leaf
+// child" proxy and an "anonymous gap between direct fields" filler, neither
+// of which C has) was the fleet-wide field over-projection defect
 // (finding.production-divergence-census-2026-08-02). There is nothing left
 // to resolve at this level: either a deeper non-inherited hit already
 // claimed the field, or C itself has no field here, and Go must agree.
-func applyParentFieldToFlattenedHiddenSpan(children []*Node, fieldIDs []FieldID, fieldSources []uint8, hiddenParent *Node, spanStart, fieldEnd int, fid FieldID, inherited, appearsLater bool) {
+func applyParentFieldToFlattenedHiddenSpan(children []*Node, fieldIDs []FieldID, fieldSources []uint8, spanStart, fieldEnd int, fid FieldID, inherited bool) {
 	if inherited {
 		normalizeMixedSourceFieldSpan(fieldIDs, fieldSources, spanStart, fieldEnd)
 		return
@@ -6634,8 +6541,8 @@ func applyParentFieldToFlattenedHiddenSpan(children []*Node, fieldIDs []FieldID,
 	normalizeMixedSourceFieldSpan(fieldIDs, fieldSources, spanStart, fieldEnd)
 }
 
-func resolveDeferredParentField(children []*Node, fieldIDs []FieldID, fieldSources []uint8, hiddenParent *Node, spanStart, fieldEnd int, fid FieldID, source uint8) (direct, deferred bool) {
-	inherited, appearsLater, deferred := decodeDeferredFieldSource(source)
+func resolveDeferredParentField(children []*Node, fieldIDs []FieldID, fieldSources []uint8, spanStart, fieldEnd int, fid FieldID, source uint8) (direct, deferred bool) {
+	inherited, deferred := decodeDeferredFieldSource(source)
 	if !deferred {
 		return false, false
 	}
@@ -6643,10 +6550,7 @@ func resolveDeferredParentField(children []*Node, fieldIDs []FieldID, fieldSourc
 		applyDeferredDirectFieldToFlattenedSpan(children, fieldIDs, fieldSources, spanStart, fieldEnd, fid)
 		return true, true
 	}
-	applyParentFieldToFlattenedHiddenSpan(
-		children, fieldIDs, fieldSources, hiddenParent,
-		spanStart, fieldEnd, fid, inherited, appearsLater,
-	)
+	applyParentFieldToFlattenedHiddenSpan(children, fieldIDs, fieldSources, spanStart, fieldEnd, fid, inherited)
 	return false, true
 }
 
@@ -6745,7 +6649,7 @@ func appendFlattenedHiddenChildrenWithFields(dst []*Node, fieldDst []FieldID, fi
 		if fieldDst != nil && i < len(fieldIDs) && fieldIDs[i] != 0 {
 			source := fieldSourceAt(fieldSources, i)
 			if direct, deferred := resolveDeferredParentField(
-				dst, fieldDst, fieldSrcDst, child,
+				dst, fieldDst, fieldSrcDst,
 				spanStart, out, fieldIDs[i], source,
 			); deferred {
 				if direct && spanStart < out {
@@ -7024,6 +6928,11 @@ func applyDirectFieldToUnassignedFlattenedSpan(children []*Node, fieldIDs []Fiel
 		// (grammar.js:232), and the resulting "." separators inside the
 		// generated repeat helper carry no field of their own, so they must
 		// inherit "path" from this level exactly like the identifiers do.
+		// The scala span is a regression-avoidance witness, not proof of a
+		// new repair: the span-shape heuristics PR #638 removed already
+		// produced "path" here. The genuine base defect this branch repairs
+		// is extends_clause under-projection, tracked separately as its own
+		// residual family.
 		assignAllUnassignedFlattenedFields(children, fieldIDs, fieldSources, start, end, fid, source, false)
 	case namedTargets == 1 && totalTargets > 1:
 		assignAllUnassignedFlattenedFields(children, fieldIDs, fieldSources, start, end, fid, source, false)

--- a/parser_reduce_fields_test.go
+++ b/parser_reduce_fields_test.go
@@ -208,7 +208,23 @@ func TestBuildReduceChildrenDefersDirectHiddenFieldUntilVisibleBoundary(t *testi
 	}
 }
 
-func TestBuildReduceChildrenDeferredInheritedFieldRespectsLaterDirectField(t *testing.T) {
+// TestBuildReduceChildrenDeferredInheritedFieldStaysEmptyAlongsideSiblingDirectField
+// covers a two-level hidden chain: _outer wraps [_inner (no field map of
+// its own), tail]. _outer's own production carries an inherited entry over
+// the hidden position and an unrelated direct entry over the sibling
+// visible position. Both entries name the same field id.
+//
+// The test used to also assert which deferred-source marker the inherited
+// edge received: fieldSourceDeferredInherited or the since-removed
+// fieldSourceDeferredInheritedLater. That distinction never changed the
+// resolved field. applyParentFieldToFlattenedHiddenSpan ignored it, and the
+// O(remaining) fieldIDAppearsLater scan that computed it was dead work on
+// the reduce hot path. PR #638 removed both.
+//
+// This test still verifies the part that matters. The inherited edge
+// resolves to nothing, because no deeper non-inherited entry claims it. The
+// sibling's own direct entry resolves independently at its own position.
+func TestBuildReduceChildrenDeferredInheritedFieldStaysEmptyAlongsideSiblingDirectField(t *testing.T) {
 	lang := &Language{
 		SymbolNames: []string{"EOF", "_inner", "_outer", "operator", "identifier", "visible_parent"},
 		SymbolMetadata: []SymbolMetadata{
@@ -240,7 +256,7 @@ func TestBuildReduceChildrenDeferredInheritedFieldRespectsLaterDirectField(t *te
 	if got, want := len(children), 2; got != want {
 		t.Fatalf("deferred len(children) = %d, want %d", got, want)
 	}
-	if got, want := fieldSourceAt(fieldSources, 0), uint8(fieldSourceDeferredInheritedLater); got != want {
+	if got, want := fieldSourceAt(fieldSources, 0), uint8(fieldSourceDeferredInherited); got != want {
 		t.Fatalf("first deferred field source = %d, want %d", got, want)
 	}
 	if got, want := fieldSourceAt(fieldSources, 1), uint8(fieldSourceDirect); got != want {
@@ -377,7 +393,9 @@ func TestBuildReduceChildrenInheritedFieldDoesNotOverrideAlreadyResolvedInnerFie
 	withTok := newLeafNodeInArena(arena, 3, false, 13, 17, Point{Row: 0, Column: 13}, Point{Row: 0, Column: 17})
 	right := newLeafNodeInArena(arena, 2, true, 18, 25, Point{Row: 0, Column: 18}, Point{Row: 0, Column: 25})
 	hidden := newParentNodeInArena(arena, 1, false, []*Node{left, withTok, right}, []FieldID{2, 2, 2}, 0)
-	hidden.setFieldSources([]uint8{fieldSourceInherited, fieldSourceInherited, fieldSourceInherited})
+	// fieldSourceDirect models a deeper level that already resolved this
+	// field. The outer reduction must leave the assignment alone.
+	hidden.setFieldSources([]uint8{fieldSourceDirect, fieldSourceDirect, fieldSourceDirect})
 
 	children, fieldIDs, _ := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, hidden)}, 0, 1, 1, 4, 0, arena)
 	if got, want := len(children), 3; got != want {
@@ -393,7 +411,18 @@ func TestBuildReduceChildrenInheritedFieldDoesNotOverrideAlreadyResolvedInnerFie
 	}
 }
 
-func TestBuildReduceChildrenProjectsConflictedInheritedFieldsBySymbol(t *testing.T) {
+// TestBuildReduceChildrenLeavesMatchedInheritedFieldConflictUnprojected is a
+// regression witness against a return of type-name-matching field
+// projection. The child symbol names ("imports", "declarations") equal the
+// conflicting field names. C still assigns no field here: its
+// ts_node__field_name_from_language (node.c:673-687) filters every
+// inherited entry and stops. C never matches a child's type name against
+// the field map. projectConflictedInheritedFields did that match. PR #638
+// removed the function, after a review disabled it and measured identical
+// output on a 52-language sweep. This test pairs with
+// TestBuildReduceChildrenLeavesUnmatchedInheritedFieldConflictUnprojected,
+// which covers the same conflict shape with names that do not match.
+func TestBuildReduceChildrenLeavesMatchedInheritedFieldConflictUnprojected(t *testing.T) {
 	lang := &Language{
 		SymbolNames: []string{"EOF", "_sections", "imports", "declarations", "root"},
 		SymbolMetadata: []SymbolMetadata{
@@ -419,7 +448,7 @@ func TestBuildReduceChildrenProjectsConflictedInheritedFieldsBySymbol(t *testing
 	declarations := newLeafNodeInArena(arena, 3, true, 8, 20, Point{Column: 8}, Point{Column: 20})
 	sections := newParentNodeInArena(arena, 1, true, []*Node{imports, declarations}, nil, 0)
 
-	children, fieldIDs, fieldSources := parser.buildReduceChildren(
+	children, fieldIDs, _ := parser.buildReduceChildren(
 		[]stackEntry{newStackEntryNode(0, sections)},
 		0,
 		1,
@@ -431,13 +460,8 @@ func TestBuildReduceChildrenProjectsConflictedInheritedFieldsBySymbol(t *testing
 	if got, want := len(children), 2; got != want {
 		t.Fatalf("child count = %d, want %d", got, want)
 	}
-	for index, want := range []FieldID{1, 2} {
-		if got := fieldIDs[index]; got != want {
-			t.Fatalf("field %d = %d, want %d", index, got, want)
-		}
-		if got := fieldSourceAt(fieldSources, index); got != fieldSourceInherited {
-			t.Fatalf("field source %d = %d, want inherited", index, got)
-		}
+	if fieldIDSliceHasAny(fieldIDs) {
+		t.Fatalf("matched conflict fields = %v, want none", fieldIDs)
 	}
 }
 

--- a/parser_reduce_fields_test.go
+++ b/parser_reduce_fields_test.go
@@ -175,6 +175,16 @@ func TestBuildReduceChildrenDefersDirectHiddenFieldUntilVisibleBoundary(t *testi
 		t.Fatalf("deferred field source = %d, want %d", got, want)
 	}
 
+	// _outer's entry for _inner's position is direct (non-inherited), not
+	// deferred-to-inherited: it is C's carried fallback for every descendant
+	// _inner flattens to, punctuation included, exactly like the scala
+	// `import foo.bar.Baz` case field-maps "path" directly onto
+	// _namespace_expression's whole sep1(".", identifier) slot
+	// (tree-sitter-scala grammar.js:229-232) and the "." separators inside
+	// the generated repeat helper inherit "path" from that level. See
+	// ts_node_field_name_for_child (tree-sitter lib/src/node.c:689-729):
+	// a !inherited entry at the position being descended through sets
+	// inherited_field_name for everything reached beneath it.
 	outer := newParentNodeInArenaWithFieldSources(arena, 2, false, children, fieldIDs, fieldSources, 0)
 	children, fieldIDs, fieldSources = parser.buildReduceChildren(
 		[]stackEntry{newStackEntryNode(0, outer)}, 0, 1, 1, 5, 1, arena,
@@ -183,8 +193,8 @@ func TestBuildReduceChildrenDefersDirectHiddenFieldUntilVisibleBoundary(t *testi
 		t.Fatalf("visible len(children) = %d, want %d", got, want)
 	}
 	wantChildren := []*Node{dot0, a, dot1, b}
-	wantFields := []FieldID{0, 1, 0, 1}
-	wantSources := []uint8{fieldSourceNone, fieldSourceDirect, fieldSourceNone, fieldSourceDirect}
+	wantFields := []FieldID{1, 1, 1, 1}
+	wantSources := []uint8{fieldSourceDirect, fieldSourceDirect, fieldSourceDirect, fieldSourceDirect}
 	for i := range wantChildren {
 		if children[i] != wantChildren[i] {
 			t.Fatalf("children[%d] = %p, want %p", i, children[i], wantChildren[i])
@@ -331,7 +341,18 @@ func TestBuildReduceChildrenDeferredDirectCountsAsRepeatedField(t *testing.T) {
 	assertFlattened("array", arrayChildren, arrayIDs, arraySources)
 }
 
-func TestBuildReduceChildrenInheritedFieldOverridesInheritedInnerFieldOnFlattenedSpan(t *testing.T) {
+// TestBuildReduceChildrenInheritedFieldDoesNotOverrideAlreadyResolvedInnerField
+// covers a hidden child whose own children already carry field data (of a
+// different field id) when the enclosing production also marks that hidden
+// child's position inherited. C never uses an inherited field-map entry to
+// name a child directly (ts_node__field_name_from_language, tree-sitter
+// lib/src/node.c:673-687, filters !field_map->inherited unconditionally), so
+// an inherited entry at this outer level can never override what a deeper
+// level already resolved -- it can only confirm it or add nothing. This test
+// used to assert the opposite (the outer inherited field replacing the
+// already-resolved inner one); that was the fleet-wide field over-projection
+// bug (finding.production-divergence-census-2026-08-02).
+func TestBuildReduceChildrenInheritedFieldDoesNotOverrideAlreadyResolvedInnerField(t *testing.T) {
 	lang := &Language{
 		SymbolNames: []string{"EOF", "_hidden_inner", "type_identifier", "with", "visible_parent"},
 		SymbolMetadata: []SymbolMetadata{
@@ -366,7 +387,7 @@ func TestBuildReduceChildrenInheritedFieldOverridesInheritedInnerFieldOnFlattene
 		t.Fatalf("len(fieldIDs) = %d, want %d", got, want)
 	}
 	for i, fid := range fieldIDs {
-		if got, want := fid, FieldID(1); got != want {
+		if got, want := fid, FieldID(2); got != want {
 			t.Fatalf("fieldIDs[%d] = %d, want %d", i, got, want)
 		}
 	}
@@ -537,7 +558,18 @@ func TestBuildReduceChildrenDirectFieldKeepsInnerHiddenProjection(t *testing.T) 
 	}
 }
 
-func TestBuildReduceChildrenInheritedFieldDoesNotBlanketSpanWithoutConflict(t *testing.T) {
+// TestBuildReduceChildrenInheritedFieldWithNoDirectEntryAnywhereProjectsNothing
+// covers a hidden child whose own production declares no fields at all, spliced
+// under a parent whose only field-map entry for that position is inherited. C
+// only ever answers a field query with a genuine !inherited entry found
+// somewhere along the descent (ts_node_field_name_for_child, tree-sitter
+// lib/src/node.c:689-729); with no such entry at any level here, C's answer is
+// empty for every descendant, not just the punctuation. This test used to
+// assert that the first (named, non-leaf-adjacent) descendant received the
+// field anyway -- picking a target from shape (position, leaf-ness) rather
+// than from a real grammar declaration was the fleet-wide field
+// over-projection bug (finding.production-divergence-census-2026-08-02).
+func TestBuildReduceChildrenInheritedFieldWithNoDirectEntryAnywhereProjectsNothing(t *testing.T) {
 	lang := &Language{
 		SymbolNames: []string{"EOF", "_hidden_inner", "identifier", ".", "namespace_wildcard", "visible_parent"},
 		SymbolMetadata: []SymbolMetadata{
@@ -571,8 +603,8 @@ func TestBuildReduceChildrenInheritedFieldDoesNotBlanketSpanWithoutConflict(t *t
 	if got, want := len(fieldIDs), 3; got != want {
 		t.Fatalf("len(fieldIDs) = %d, want %d", got, want)
 	}
-	if got, want := fieldIDs[0], FieldID(1); got != want {
-		t.Fatalf("fieldIDs[0] = %d, want %d", got, want)
+	if got := fieldIDs[0]; got != 0 {
+		t.Fatalf("fieldIDs[0] = %d, want 0", got)
 	}
 	if got := fieldIDs[1]; got != 0 {
 		t.Fatalf("fieldIDs[1] = %d, want 0", got)
@@ -727,7 +759,21 @@ func TestBuildReduceChildrenRepeatedDirectFieldOnHiddenPathLeavesAnonymousGapUnf
 	}
 }
 
-func TestBuildReduceChildrenInheritedFieldFillsRepeatedDirectAnonymousGaps(t *testing.T) {
+// TestBuildReduceChildrenInheritedFieldLeavesRepeatedDirectAnonymousGapsUnfielded
+// covers a hidden child whose own production wraps the field around each
+// repeat element independently (java DOT net DOT url, each identifier's own
+// direct entry, like python's commaSep1(field('name', ...)) shape
+// (tree-sitter-python grammar.js:175-181) rather than around the whole
+// repeat as one unit). C resolves the field for each child with its own
+// independent descent (ts_node_field_name_for_child, tree-sitter
+// lib/src/node.c:689-729): the separators have no field-map entry of their
+// own at any level, so C never assigns them one just because same-fielded
+// siblings surround them. Verified against the C oracle: `from a import b,
+// c` in python leaves the comma fieldless
+// (finding.production-divergence-census-2026-08-02). This test used to
+// assert the opposite -- that the gaps inherit the surrounding field -- which
+// was exactly that over-projection bug.
+func TestBuildReduceChildrenInheritedFieldLeavesRepeatedDirectAnonymousGapsUnfielded(t *testing.T) {
 	lang := &Language{
 		SymbolNames: []string{"EOF", "_hidden_inner", ".", "identifier", "visible_parent"},
 		SymbolMetadata: []SymbolMetadata{
@@ -781,9 +827,13 @@ func TestBuildReduceChildrenInheritedFieldFillsRepeatedDirectAnonymousGaps(t *te
 	if got, want := len(children), 5; got != want {
 		t.Fatalf("child count = %d, want %d", got, want)
 	}
-	for index := range children {
-		if got, want := fieldIDs[index], FieldID(1); got != want {
+	wantFieldIDs := []FieldID{1, 0, 1, 0, 1}
+	for index, want := range wantFieldIDs {
+		if got := fieldIDs[index]; got != want {
 			t.Fatalf("field %d = %d, want %d", index, got, want)
+		}
+		if want == 0 {
+			continue
 		}
 		if got, want := fieldSourceAt(fieldSources, index), uint8(fieldSourceDirect); got != want {
 			t.Fatalf("field source %d = %d, want %d", index, got, want)
@@ -1115,7 +1165,20 @@ func TestBuildReduceChildrenInheritedFieldSkipsProjectionWhenDescendantHasDirect
 	}
 }
 
-func TestBuildReduceChildrenInheritedFieldProjectsSingleHiddenChildWhenDescendantHasDirectField(t *testing.T) {
+// TestBuildReduceChildrenInheritedFieldDoesNotProjectFromUnrelatedVisibleSiblingField
+// covers a hidden child whose own production declares no fields, where one of
+// its visible (opaque, not-further-flattened) children happens to carry a
+// same-numbered field id on ITS OWN production for an unrelated reason. C
+// only walks a hidden node's own field map when deciding what a child of the
+// enclosing production inherits (ts_node_field_name_for_child, tree-sitter
+// lib/src/node.c:689-729); once the target is itself a relevant (visible)
+// node, C never looks inside that node's own children to justify a field on
+// the node as a whole. This test used to assert that the coincidental match
+// (matching purely because it was the sole descendant carrying any direct
+// field id) was projected onto call's outer position -- that
+// "single-descendant" heuristic was the fleet-wide field over-projection bug
+// (finding.production-divergence-census-2026-08-02).
+func TestBuildReduceChildrenInheritedFieldDoesNotProjectFromUnrelatedVisibleSiblingField(t *testing.T) {
 	lang := &Language{
 		SymbolNames: []string{"EOF", "_hidden", "call", "identifier", "arguments", "visible_parent"},
 		SymbolMetadata: []SymbolMetadata{
@@ -1144,15 +1207,15 @@ func TestBuildReduceChildrenInheritedFieldProjectsSingleHiddenChildWhenDescendan
 	outerArgs := newLeafNodeInArena(arena, 4, true, 10, 13, Point{Row: 0, Column: 10}, Point{Row: 0, Column: 13})
 	hidden := newParentNodeInArena(arena, 1, false, []*Node{call, outerArgs}, nil, 0)
 
-	children, fieldIDs, fieldSources := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, hidden)}, 0, 1, 1, 5, 0, arena)
+	children, fieldIDs, _ := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, hidden)}, 0, 1, 1, 5, 0, arena)
 	if got, want := len(children), 2; got != want {
 		t.Fatalf("len(children) = %d, want %d", got, want)
 	}
-	if got, want := fieldIDs[0], FieldID(1); got != want {
-		t.Fatalf("fieldIDs[0] = %d, want %d", got, want)
+	if got := fieldIDs[0]; got != 0 {
+		t.Fatalf("fieldIDs[0] = %d, want 0", got)
 	}
-	if got, want := fieldSourceAt(fieldSources, 0), uint8(fieldSourceInherited); got != want {
-		t.Fatalf("fieldSources[0] = %d, want %d", got, want)
+	if got := fieldIDs[1]; got != 0 {
+		t.Fatalf("fieldIDs[1] = %d, want 0", got)
 	}
 }
 
@@ -1188,7 +1251,21 @@ func TestBuildReduceChildrenInheritedFieldSkipsSingleLeafHiddenProjectionWithout
 	}
 }
 
-func TestBuildReduceChildrenInheritedFieldProjectsSingleNonLeafHiddenChildWithoutDirectField(t *testing.T) {
+// TestBuildReduceChildrenInheritedFieldSkipsSingleNonLeafHiddenProjectionWithoutDirectField
+// mirrors the sibling leaf case above for a non-leaf single descendant: the
+// hidden child's sole child (decl) has children of its own but declares no
+// field anywhere along its own production. Whether the lone descendant is a
+// leaf or not is irrelevant to C -- ts_node_field_name_for_child (tree-sitter
+// lib/src/node.c:689-729) only ever answers from a genuine !inherited
+// field-map entry found along the descent, never from "this position's
+// child count." Verified against the C oracle: ada's `A : Integer_Array
+// (1..3) := (others => 0)` leaves the aggregate fieldless even though it is
+// the single, non-leaf child of term's inherited "name" position
+// (finding.production-divergence-census-2026-08-02, ada grammar.js:561-566).
+// This test used to assert the opposite -- that a single non-leaf descendant
+// without its own field still received the parent's inherited field -- which
+// was exactly that "has children" over-projection heuristic.
+func TestBuildReduceChildrenInheritedFieldSkipsSingleNonLeafHiddenProjectionWithoutDirectField(t *testing.T) {
 	lang := &Language{
 		SymbolNames: []string{"EOF", "_hidden", "local", "function_declaration", "visible_parent"},
 		SymbolMetadata: []SymbolMetadata{
@@ -1213,15 +1290,12 @@ func TestBuildReduceChildrenInheritedFieldProjectsSingleNonLeafHiddenChildWithou
 	decl := newParentNodeInArena(arena, 3, true, []*Node{localTok}, nil, 0)
 	hidden := newParentNodeInArena(arena, 1, false, []*Node{decl}, nil, 0)
 
-	children, fieldIDs, fieldSources := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, hidden)}, 0, 1, 1, 4, 0, arena)
+	children, fieldIDs, _ := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, hidden)}, 0, 1, 1, 4, 0, arena)
 	if got, want := len(children), 1; got != want {
 		t.Fatalf("len(children) = %d, want %d", got, want)
 	}
-	if got, want := fieldIDs[0], FieldID(1); got != want {
-		t.Fatalf("fieldIDs[0] = %d, want %d", got, want)
-	}
-	if got, want := fieldSourceAt(fieldSources, 0), uint8(fieldSourceInherited); got != want {
-		t.Fatalf("fieldSources[0] = %d, want %d", got, want)
+	if got := fieldIDs[0]; got != 0 {
+		t.Fatalf("fieldIDs[0] = %d, want 0", got)
 	}
 }
 

--- a/parser_result_test/dispatcher_census_test.go
+++ b/parser_result_test/dispatcher_census_test.go
@@ -330,6 +330,23 @@ type trackedDispatcherCensusReceipt struct {
 
 // TestDispatcherArmCensusTrackedReceipt validates a small tracked corpus on
 // every run. The full authenticated corpus remains an external release gate.
+//
+// The typescript fixture's nodes_rewritten count moved from 20 to 15 with
+// the inherited-field projection repair (PR #638). A dispatch pass counts a
+// node as rewritten when it must correct that node. The repair makes the
+// reduce path produce correct fields earlier, so the pass finds less to
+// correct. Both steps of the drop are measured, not estimated:
+//
+//   - 20 to 16: the reduce-path repair (parser_reduce.go). Four nodes now
+//     arrive with the fields C assigns, so the pass leaves them alone.
+//   - 16 to 15: the isNamed guard in typeScriptAssignMemberFields
+//     (parser_result_typescript.go). The pass no longer projects "value"
+//     onto the anonymous "=" token of the one public_field_definition in
+//     this fixture. C's field map has no entry for that position.
+//
+// checked, run, and nodes_visited are unchanged, so the pass still runs over
+// the same tree. The structural parity gate reports 0 divergences against
+// the locked C oracle for this fixture with field comparison on.
 func TestDispatcherArmCensusTrackedReceipt(t *testing.T) {
 	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
 

--- a/parser_result_test/materialization_subpass_census_test.go
+++ b/parser_result_test/materialization_subpass_census_test.go
@@ -159,8 +159,14 @@ func materializationSubpassProbes() []materializationSubpassProbe {
 				"   V : constant A := (1 => True, 2 => False);\n" +
 				"   V2 : constant A := (1 => True, others => False);\n" +
 				"end P;\n",
-			wantRawDigest:    "728491faf7df326e0557c468af03e026a9b4461b86f9de9f28da9162f9510c71",
-			wantResultDigest: "728491faf7df326e0557c468af03e026a9b4461b86f9de9f28da9162f9510c71",
+			// Both digests moved with the inherited-field projection repair
+			// (PR #638). The old digests pinned a "subtype_mark" field on
+			// range_g that the C runtime never assigns. C receipt, taken
+			// with field comparison on: this source now reports 0 mismatches
+			// against the locked C oracle on the raw route and 0 on the
+			// production route.
+			wantRawDigest:    "d04b5a44207f4e4691e8aea35d0b15c01f225b5bbbd2f2bef3f75532fc5a517c",
+			wantResultDigest: "d04b5a44207f4e4691e8aea35d0b15c01f225b5bbbd2f2bef3f75532fc5a517c",
 			expectedSubpasses: []string{
 				"dispatch.ada",
 			},
@@ -173,8 +179,17 @@ func materializationSubpassProbes() []materializationSubpassProbe {
 				"   type A is array (1 .. 3) of Boolean;\n" +
 				"   V : constant A := (1, 2, 3);\n" +
 				"end;\n",
-			wantRawDigest:    "2548948d4cac86cf3b438642ac347917b72371467fd928be0de7437210e98a50",
-			wantResultDigest: "c056e4222c7e642fbf23054a75b40f3ff186ff687eb49e8bcd5a36c513d10f14",
+			// Both digests moved with the inherited-field projection repair
+			// (PR #638). The old digests pinned a "subtype_mark" field on
+			// range_g that the C runtime never assigns. C receipt, taken
+			// with field comparison on: the production route now reports 0
+			// mismatches against the locked C oracle. The raw route keeps
+			// only the 2 pre-existing aggregate-kind election mismatches
+			// (record_aggregate for positional_array_aggregate) that
+			// dispatch.ada.aggregate-kind-election repairs, and 0 field
+			// mismatches.
+			wantRawDigest:    "03ed84353f6116db108013a4124c9e573333fbc9454464fe28711527b1e7d6ec",
+			wantResultDigest: "78ef4359be68f12055d075c272b5fbf63be2a9f0fe8672f5c26979308ba149ff",
 			expectedSubpasses: []string{
 				"dispatch.ada",
 				"dispatch.ada.aggregate-kind-election",
@@ -205,8 +220,18 @@ func materializationSubpassProbes() []materializationSubpassProbe {
 				"begin\n" +
 				"   A := (others => 0);\n" +
 				"end;\n",
-			wantRawDigest:    "436a2b8ebb3e7d0a6ebad2fddaae9bd3a1f7a040a91741581109fa3d59558f7e",
-			wantResultDigest: "67f7351db255e847be4172f69a33cd349b2883c693b837eebb32979ccaf4b9a7",
+			// Both digests moved with the inherited-field projection repair
+			// (PR #638). The old digests pinned a "name" field on
+			// named_array_aggregate that the C runtime never assigns. C
+			// receipt, taken with field comparison on: the production route
+			// now reports 0 mismatches against the locked C oracle. The raw
+			// route keeps only the 6 pre-existing aggregate-kind and
+			// association-choice election mismatches that
+			// dispatch.ada.aggregate-kind-election and
+			// dispatch.ada.association-choice-materialization repair, and 0
+			// field mismatches.
+			wantRawDigest:    "ad2718a1e309fadba012881bc82689ff1dabec69814106b0dcbe3a39b6d70b27",
+			wantResultDigest: "95edae06bdbba04a19749854656b7c439a334cf9ae7bba367ed762386cf28d15",
 			expectedSubpasses: []string{
 				"dispatch.ada",
 				"dispatch.ada.aggregate-kind-election",

--- a/parser_result_typescript.go
+++ b/parser_result_typescript.go
@@ -2135,7 +2135,15 @@ func typeScriptAssignMemberFields(node *Node, ctx *typeScriptNormalizationContex
 			case "statement_block":
 				fieldIDs[i] = ctx.bodyFieldID
 			default:
-				if node.symbol == ctx.publicFieldDefinitionSym && child.startByte > node.children[nameIdx].endByte {
+				// _initializer: $ => seq('=', field('value', $.expression))
+				// (javascript grammar.js) wraps only the expression, never
+				// the '=' token. C's field map has no entry for the
+				// anonymous '=' position (ts_node__field_name_from_language,
+				// tree-sitter lib/src/node.c:673-687); requiring isNamed
+				// here keeps this reconstruction from re-introducing that
+				// same over-projection on the reduce-time recovered/rewritten
+				// path (finding.production-divergence-census-2026-08-02).
+				if node.symbol == ctx.publicFieldDefinitionSym && child.isNamed() && child.startByte > node.children[nameIdx].endByte {
 					fieldIDs[i] = ctx.valueFieldID
 				}
 			}

--- a/testdata/dispatcher_census_tracked_v1.json
+++ b/testdata/dispatcher_census_tracked_v1.json
@@ -76,7 +76,7 @@
       "checked": 1,
       "run": 1,
       "nodes_visited": 1462,
-      "nodes_rewritten": 20,
+      "nodes_rewritten": 15,
       "error_root": false
     }
   ]


### PR DESCRIPTION
## Summary

- Align child field-name projection with the reference runtime's inherited-entry filter.
- Gate field parity by default in the structural parity harness.
- Burn down the tracked-divergence entries this repair fixes, and add a ratchet that fails a sweep on a stale entry.

Field-name assignment for a child now matches the reference C runtime exactly. The parser no longer guesses a field name from a node's shape: child count, position, or leaf status. It assigns a field only when the grammar's own declaration places one there, resolved the same way the reference runtime resolves it.

The parity harness now compares field names by default on every run. An explicit opt-out environment variable stays available for bisection.

## Before / after divergence tables

Every row compares the Go parser's production route against the locked C reference parser, with field-name comparison on (`GTS_PARITY_COMPARE_FIELDS=1`, now the default). Byte spans, node types, and error state stay unchanged; only field-name assignment changed. Each "before" figure comes from a fresh run against the unmodified base commit these measurements used (963ea0a3), not from an earlier report. Every number below is freshly reproduced.

### Locked structural corpus (`cgo_harness/corpus_structural/`)

| File | Field divergences before | Field divergences after |
|---|---|---|
| javascript_sample.js | 3 | 0 |
| python_sample.py | 5 | 0 |
| typescript_sample.ts | 1 | 0 |
| go_sample.go | 0 | 0 |
| java_sample.java | 0 | 0 |

### Minimal reproductions (each checked directly against the C reference parser)

| Source | Divergent node (path) | Field before | Field after | C reference |
|---|---|---|---|---|
| `from a import b, c` (python) | the `,` separator | `name` | (none) | (none) |
| `from a import b` (python) | — | (none, unaffected) | (none) | (none) |
| `import a, b` (python) | the `,` separator | `name` | (none) | (none) |
| `A : Integer_Array (1..3) := (others => 0);` (ada) | `named_array_aggregate` | `name` | (none) | (none) |
| `type T is array (1..3) of Integer;` (ada) | `range_g` | `subtype_mark` | (none) | (none) |
| `class C { x = new Foo(); }` (typescript) | — | (none, unaffected) | (none) | (none) |
| `class C { private x = new Foo(); }` (typescript) | the `=` token | `value` | (none) | (none) |
| `class C { private readonly x = new Foo(); }` (typescript) | the `=` token | `value` | (none) | (none) |

`import foo.bar.Baz` (scala) is a verified-clean regression check, not a fix. The `.` separators inside the generated repeat helper carry field `path` on both the unmodified base commit and this branch. The scala grammar wraps the whole repeated segment in one field declaration (`field("path", sep1(".", $._identifier))`), not each element separately. An intermediate version of this fix broke that case before it landed. The final rule fixes both defect shapes with one principle: assign a field only where the grammar's own declaration — direct, or carried down from an enclosing hidden production — actually places it.

## Tracked-divergence burn-down

The A3 certification sweeps carry per-language lists of already-triaged, pre-existing divergences. This repair fixes eight of those entries, so the branch removes them:

- ada, six family-M entries: `locked_positional_array_aggregate`, `array_others_choice`, `named_array_aggregate`, `mixed_positional_named_aggregate`, `qualified_expression`, and `attribute_range_and_first_last`.
- python, two family-M entries: `large__python3.8_grammar.py` and `medium__setup.py`.

The repair of `large__python3.8_grammar.py` uncovered one further divergence in the same file, so the branch adds one entry for it:

- python, one family-S entry: the `not in` operator wrapper starts one byte early, at the previous sibling's end byte. The defect is older than this branch. The removed family-M point stood ahead of it in traversal order and masked it, because the sweep matches on the first divergence only. A repair lane is queued.

Net change to the tracked lists: eight entries out, one entry in.

An entry that suppresses a repaired divergence certifies nothing, but it still reads as a live defect. To stop that state from returning, `a3ReportSweep` now records which entries matched a live divergence and fails the sweep on any entry that matched none. The message names the stale entry and asks for its removal.

One entry legitimately matches nothing: kotlin's `large__DeprecatedInstant.kt` describes a real production defect, but the sweep declines that witness before it compares trees while the converged-split-drop certificate stays withheld. A `Dormant` flag exempts such an entry, and its field comment limits the flag to a declined witness with a written reason. A negative control confirms both paths: a non-dormant entry that matches nothing fails the sweep, and a dormant entry does not.

## Result-expectation updates

Three ada probes and one census receipt in `parser_result_test` pinned the projection this repair corrects, so the branch re-pins them:

- `ada_locked_named_array_aggregate`, `ada_locked_positional_array_aggregate`, and `ada_array_others_choice`: raw and result digests. The old digests held a `subtype_mark` field on `range_g` and a `name` field on `named_array_aggregate` that the reference runtime never assigns. Receipt, taken with field comparison on: all three sources now report 0 mismatches against the locked C reference on the production route. The raw route keeps only the pre-existing aggregate-kind and association-choice election mismatches that the `dispatch.ada` subpasses repair, and 0 field mismatches.
- The tracked dispatcher census for `typescript_sample.ts`: 20 rewritten nodes to 15. Both steps are measured. The reduce-path repair accounts for 4, because those nodes now arrive with the fields the reference runtime assigns. The `isNamed` guard in `typeScriptAssignMemberFields` accounts for 1, the anonymous `=` token of the one `public_field_definition` in the fixture. `checked`, `run`, and `nodes_visited` do not move.

## Digest-delta enumeration

No canonical digest fixture needed an update. The repository's only frozen tree digests cover four Go source fixtures: `query_compile`, `rewrite`, `language`, and `grammargen_lr`. None of them exercise a grammar shape this fix changes. `TestDiagnosticParserCoreCanonicalAdmissions` confirms all four digests stay unchanged before and after. No other language in the repository carries a frozen tree-digest fixture.

## Compact-route agreement

The compact materializer (`internal/parsercorephase0`) does not reimplement the reference runtime's field-inheritance resolution. It never independently produced the over-projection this fix corrects. Its own field-assignment step declines outright whenever resolving a field would need an inherited field-map entry, and falls back to the production route for that reduction (`selected_store.go`, `selected_store_builder_onepass.go`: `if entry.Inherited || field != 0 { return ...error... }`).

Before this fix, compact matched production only by falling back to it, inheriting production's wrong answer on every affected shape. After this fix, the same fallback inherits the corrected answer instead. The five A3 certification sweeps (ada, apex, kotlin, perl, python; full real-and-constructed corpus, field names included) confirm zero production/compact divergences both before and after this change. Compact never had its own opinion on these shapes.

## Removed machinery

The branch also removes parser code that no longer serves the corrected rule:

- A per-child scan that looked ahead for a later use of the same field id. The reduce path ran the scan and then discarded its result. Its two deferred-source markers collapse into one.
- A projection step that assigned a field by a match between a child's type name and a conflicting field-map entry. The reference runtime never makes that match. Sweeps across 52 and 206 grammars give identical trees without the step.

## Verification

All gates below ran on the branch rebased onto current `main` (8070e1ad).

- Full test suite: `go test .` and `go test ./grammars`, both green.
- `go test ./parser_result_test/...`, green, with `-race` on the same package. This package is a separate directory, so `go test .` and `go test ./grammars` do not reach it. Its CI lane (`race_packages`, shard `parser-result`) is what caught the expectation updates above. Run it for any change to field projection or to a normalization subpass. Its two real-corpus tests skip on CI, because `cgo_harness/corpus_real/` is not tracked; they were run locally and pass.
- C reference parity: the locked structural corpus (5 files, 0 divergences), the five A3 certification sweeps with the burned-down lists and the new ratchet active (all green, 0 unadjudicated divergences), and an exhaustive fresh-parse run across all 206 registered grammars with field comparison on (207 subtests, 0 failures).
- Ten minimal reproductions across python, ada, typescript, and scala, checked directly against the C reference parser. All match.
- Unrelated defect families reproduce unchanged against the C reference parser: derivation-selection choices at declared grammar conflicts, and one aliased-span byte-offset case. This confirms the fix stayed scoped to field projection.
- Admission scorecard across all 206 grammars: PASS=198 DIVERGE=0 FALLBACK=3 SKIP=5 ERROR=0, identical to the current `main` baseline.
- Race detector on every touched code path: green.
- W5 editor-latency gate: green.
- Benchmarks (`BenchmarkGoParseWarmRealDFA`, 3 runs before and after): the largest and most stable fixture (`grammargen_lr`, 330K nodes) shows no regression, within measurement noise from concurrent load on the build host.

