### PR TITLE
fix(parser): Classify PowerShell backtick continuation as parser padding

### DIFF
--- a/glr_forest.go
+++ b/glr_forest.go
@@ -738,7 +738,7 @@ func (p *Parser) finalizeForestRoot(root *Node, source []byte) {
 	// The forest fast path builds every node fresh (no subtree reuse), so
 	// range-limited normalization does not apply; pass nil to keep the full walk.
 	p.finalizeResultRoot(root, source, nil, false, false, nil)
-	extendRootToAcceptedCleanTail(root, source, uint32(len(source)), nil)
+	extendRootToAcceptedCleanTail(root, source, uint32(len(source)), nil, p.lineContinuationEscapeByte())
 }
 
 func forestAcceptedRuntime(root *Node, source []byte) ParseRuntime {

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -26,6 +26,7 @@ type builtinLanguageRuntimeProfile struct {
 	compactPrimaryAcceptDerivation     bool
 	exactStackNodeEquivalence          bool
 	compactStrategy2ErrorRegion        bool
+	lineContinuationEscapeByte         byte
 	conflictPolicies                   []gotreesitter.ConflictPolicy
 }
 
@@ -476,6 +477,19 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 			},
 		},
 	},
+	// PowerShell's backtick immediately followed by a newline is the
+	// language's line-continuation escape: the C reference scanner consumes
+	// it as ordinary skipped trivia (zero ERROR nodes across the sequence,
+	// two children on the enclosing command_argument_sep — the same shape as
+	// any other run of whitespace), never as a token of its own. Declaring it
+	// here lets bytesAreParserPadding give it the same unconditional
+	// treatment already applied to backslash+newline instead of falling
+	// through to skipped-gap ERROR materialization. C-oracle verified on the
+	// enclosing command_argument_sep shape (TestPowerShellBacktickContinuationIsParserPadding).
+	"powershell": {
+		blobSHA256:                 mustRuntimeProfileSHA256("8c7a2b47a39efb590cde7f75c9a1135c6423bc07b13b9604f1fa9f0061231687"),
+		lineContinuationEscapeByte: '`',
+	},
 }
 
 func mustRuntimeProfileSHA256(raw string) (sum [32]byte) {
@@ -551,6 +565,10 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	}
 	if profile.compactStrategy2ErrorRegion && !lang.CompactStrategy2ErrorRegionCertified {
 		lang.CompactStrategy2ErrorRegionCertified = true
+		changed = true
+	}
+	if profile.lineContinuationEscapeByte != 0 && lang.LineContinuationEscapeByte != profile.lineContinuationEscapeByte {
+		lang.LineContinuationEscapeByte = profile.lineContinuationEscapeByte
 		changed = true
 	}
 	for _, policy := range profile.conflictPolicies {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -78,7 +78,11 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	// 45 = the prior 44 plus the B3 stage S3 html entry, certifying native
 	// strategy-2 error-region recovery for the html_erroneous_end_tag class
 	// (spec.compact-recovery-ownership.v1).
-	if got, want := len(builtinLanguageRuntimeProfiles), 45; got != want {
+	// 46 = the prior 45 plus the powershell entry, declaring backtick as the
+	// language's line-continuation escape byte (Language.LineContinuationEscapeByte)
+	// so bytesAreParserPadding classifies backtick+newline as padding, matching
+	// the C oracle (spore.2026-08-02.birch-g.powershell-bisect).
+	if got, want := len(builtinLanguageRuntimeProfiles), 46; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -108,6 +112,9 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	}
 	if lang.ExactStackNodeEquivalenceCertified {
 		t.Fatal("unknown runtime profile enabled exact stack-node equivalence")
+	}
+	if lang.LineContinuationEscapeByte != 0 {
+		t.Fatalf("unknown runtime profile set a line-continuation escape byte: %q", lang.LineContinuationEscapeByte)
 	}
 }
 

--- a/incremental.go
+++ b/incremental.go
@@ -584,9 +584,9 @@ func (c *reuseCursor) sourceBytesIdentical() bool {
 	return c != nil && c.wholeSourceIdentical
 }
 
-func reuseSubtreeGapIsParserPadding(source []byte, stackByteOffset, nodeStart uint32) bool {
+func reuseSubtreeGapIsParserPadding(source []byte, stackByteOffset, nodeStart uint32, continuationEscape byte) bool {
 	stack := glrStack{byteOffset: stackByteOffset}
-	return realTokenAttachmentGapIsParserPadding(source, &stack, Token{StartByte: nodeStart})
+	return realTokenAttachmentGapIsParserPadding(source, &stack, Token{StartByte: nodeStart}, continuationEscape)
 }
 
 func reuseStackByteOffsetAfterTruncate(s *glrStack, depth int, entryScratch *glrEntryScratch) (uint32, bool) {
@@ -610,6 +610,7 @@ func reuseStackByteOffsetAfterTruncate(s *glrStack, depth int, entryScratch *glr
 // On success it appends the reused node to the stack and returns the first
 // lookahead token that begins at or after the node's end byte.
 func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, idx *reuseCursor, entryScratch *glrEntryScratch, gssScratch *gssScratch) (Token, uint32, bool) {
+	continuationEscape := p.lineContinuationEscapeByte()
 	candidates := idx.candidates(lookahead.StartByte)
 	if perfCountersEnabled {
 		perfRecordReuseCandidates(len(candidates))
@@ -645,7 +646,7 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 		if !ok {
 			continue
 		}
-		if !reuseSubtreeGapIsParserPadding(idx.newSource, s.byteOffset, n.StartByte()) {
+		if !reuseSubtreeGapIsParserPadding(idx.newSource, s.byteOffset, n.StartByte(), continuationEscape) {
 			continue
 		}
 		cp, ok := canReuseNodeWithExternalScannerCheckpointAtLookahead(ts, state, n, lookahead.StartByte)
@@ -723,7 +724,7 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 				continue
 			}
 		}
-		if !reuseSubtreeGapIsParserPadding(idx.newSource, reuseByteOffset, n.StartByte()) {
+		if !reuseSubtreeGapIsParserPadding(idx.newSource, reuseByteOffset, n.StartByte(), continuationEscape) {
 			continue
 		}
 		if truncateDepth > 0 && truncateDepth < s.depth() {

--- a/language.go
+++ b/language.go
@@ -721,6 +721,25 @@ type Language struct {
 	// uncertified grammar keeps declining to production at the same
 	// no-action point exactly as before this stage landed.
 	CompactStrategy2ErrorRegionCertified bool
+
+	// LineContinuationEscapeByte declares the single byte this language's
+	// scanner treats as a line-continuation escape when immediately followed
+	// by a newline (LF, or CR+LF) — for example PowerShell's backtick. C
+	// tree-sitter's scanner consumes an escape+newline pair as ordinary
+	// skipped trivia, the same treatment bytesAreParserPadding already gives
+	// backslash+newline unconditionally. Backslash needs no per-language gate
+	// because it carries no competing meaning as bare trivia in any grammar
+	// this parser loads; an arbitrary escape byte cannot get that same
+	// unconditional treatment because it can collide with unrelated grammar
+	// meaning elsewhere (for example backtick opens a Markdown fence and a
+	// shell command substitution), so acceptance requires this explicit
+	// per-language declaration. Zero (the default) declares no continuation
+	// escape and leaves padding classification exactly as it was before this
+	// field existed. Exact built-in profiles set this only after C-oracle
+	// parity confirms the escape+newline pair is scanner-owned padding for
+	// the certified blob (see grammars/runtime_profiles.go). Custom, adapted,
+	// and generated languages default to zero and are unaffected.
+	LineContinuationEscapeByte byte
 }
 
 type symbolNameNamedKey struct {

--- a/language.go
+++ b/language.go
@@ -726,19 +726,25 @@ type Language struct {
 	// scanner treats as a line-continuation escape when immediately followed
 	// by a newline (LF, or CR+LF) — for example PowerShell's backtick. C
 	// tree-sitter's scanner consumes an escape+newline pair as ordinary
-	// skipped trivia, the same treatment bytesAreParserPadding already gives
-	// backslash+newline unconditionally. Backslash needs no per-language gate
-	// because it carries no competing meaning as bare trivia in any grammar
-	// this parser loads; an arbitrary escape byte cannot get that same
-	// unconditional treatment because it can collide with unrelated grammar
-	// meaning elsewhere (for example backtick opens a Markdown fence and a
-	// shell command substitution), so acceptance requires this explicit
-	// per-language declaration. Zero (the default) declares no continuation
-	// escape and leaves padding classification exactly as it was before this
-	// field existed. Exact built-in profiles set this only after C-oracle
-	// parity confirms the escape+newline pair is scanner-owned padding for
-	// the certified blob (see grammars/runtime_profiles.go). Custom, adapted,
-	// and generated languages default to zero and are unaffected.
+	// skipped trivia, the same treatment bytesAreParserPadding (mid-parse gap
+	// classification) and parserTailAllowsCleanAcceptance (accepted-stack and
+	// accepted-tree tail classification) already give backslash+newline
+	// unconditionally. Backslash needs no per-language gate because no
+	// grammar this parser loads leaves a bare backslash+newline as an
+	// uncovered gap that must not be crossed: languages whose grammar assigns
+	// backslash+newline its own meaning (for example Python's line_continuation
+	// node) tokenize it as a real, accounted-for node rather than leaving a
+	// gap for these padding checks to ever see. An arbitrary escape byte
+	// cannot get that same unconditional treatment because it can collide
+	// with unrelated grammar meaning elsewhere (for example backtick opens a
+	// Markdown fence and a shell command substitution), so acceptance
+	// requires this explicit per-language declaration. Zero (the default)
+	// declares no continuation escape and leaves padding classification
+	// exactly as it was before this field existed. Exact built-in profiles
+	// set this only after C-oracle parity confirms the escape+newline pair is
+	// scanner-owned padding for the certified blob (see
+	// grammars/runtime_profiles.go). Custom, adapted, and generated languages
+	// default to zero and are unaffected.
 	LineContinuationEscapeByte byte
 }
 

--- a/parser.go
+++ b/parser.go
@@ -3816,7 +3816,15 @@ func copyParseRuntimeToTiming(timing *incrementalParseTiming, parseRuntime Parse
 	timing.normalizationNanos = parseRuntime.NormalizationNanos
 }
 
-func realTokenAttachmentGapIsParserPadding(source []byte, s *glrStack, tok Token) bool {
+// realTokenAttachmentGapIsParserPadding reports whether the gap between the
+// stack's current byte offset and tok's start is trivia the parser may
+// silently cross before attaching tok. continuationEscape is the calling
+// Parser's language-declared line-continuation escape byte (0 if none —
+// see Language.LineContinuationEscapeByte and (*Parser).lineContinuationEscapeByte),
+// threaded through to bytesAreParserPadding so a language-declared
+// escape+newline (for example PowerShell's backtick) counts as padding here
+// exactly like the unconditional backslash+newline case.
+func realTokenAttachmentGapIsParserPadding(source []byte, s *glrStack, tok Token, continuationEscape byte) bool {
 	if s == nil || tok.Missing || tok.NoLookahead || tok.StartByte <= s.byteOffset {
 		return true
 	}
@@ -3826,11 +3834,11 @@ func realTokenAttachmentGapIsParserPadding(source []byte, s *glrStack, tok Token
 	if int(s.byteOffset) > len(source) || int(tok.StartByte) > len(source) {
 		return true
 	}
-	return bytesAreParserPadding(source, s.byteOffset, tok.StartByte)
+	return bytesAreParserPadding(source, s.byteOffset, tok.StartByte, continuationEscape)
 }
 
-func realShiftGapIsParserPadding(source []byte, s *glrStack, tok Token) bool {
-	return realTokenAttachmentGapIsParserPadding(source, s, tok)
+func realShiftGapIsParserPadding(source []byte, s *glrStack, tok Token, continuationEscape byte) bool {
+	return realTokenAttachmentGapIsParserPadding(source, s, tok, continuationEscape)
 }
 
 // skippedRealGapContinuesSeparatedList reports whether the sole active stack is
@@ -3883,6 +3891,20 @@ func (p *Parser) stateDeterministicNonExtraShift(state StateID, sym Symbol) bool
 		return false
 	}
 	return actions[0].Type == ParseActionShift && !actions[0].Extra
+}
+
+// lineContinuationEscapeByte returns p's language-declared line-continuation
+// escape byte (see Language.LineContinuationEscapeByte), or 0 when p or its
+// language is nil, or the language declares none. Every production caller of
+// realTokenAttachmentGapIsParserPadding / bytesAreParserPadding that has a
+// Parser in scope reads the escape byte through this single accessor so the
+// gap-padding classification stays consistent (and default-off for every
+// language that has not declared an escape) across every caller.
+func (p *Parser) lineContinuationEscapeByte() byte {
+	if p == nil || p.language == nil {
+		return 0
+	}
+	return p.language.LineContinuationEscapeByte
 }
 
 // materializeSkippedGapAsExtraError covers a lexer-skipped mid-production gap
@@ -3945,7 +3967,7 @@ func (p *Parser) materializeSkippedGapAsExtraError(s *glrStack, state StateID, t
 }
 
 func (p *Parser) tryMaterializeSkippedRealGap(source []byte, s *glrStack, state StateID, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) bool {
-	if s == nil || tok.StartByte <= s.byteOffset || realTokenAttachmentGapIsParserPadding(source, s, tok) {
+	if s == nil || tok.StartByte <= s.byteOffset || realTokenAttachmentGapIsParserPadding(source, s, tok, p.lineContinuationEscapeByte()) {
 		return false
 	}
 	// A stray run of bytes that the lexer skipped mid-production, immediately
@@ -4108,7 +4130,15 @@ func extendHiddenErrorAncestorEnd(n *Node, end uint32, point Point) {
 	n.setHasError(true)
 }
 
-func bytesAreParserPadding(source []byte, start, end uint32) bool {
+// bytesAreParserPadding reports whether source[start:end] is entirely
+// trivia a real parser skips silently: plain whitespace, backslash+newline
+// (unconditional — see the field doc for why backslash needs no per-language
+// gate), or, when continuationEscape is non-zero, that language-declared
+// escape byte immediately followed by a newline (see
+// Language.LineContinuationEscapeByte). Pass 0 for continuationEscape at any
+// call site without a language-specific escape to declare; that reproduces
+// this function's behavior before the parameter existed exactly.
+func bytesAreParserPadding(source []byte, start, end uint32, continuationEscape byte) bool {
 	if start > end || int(end) > len(source) {
 		return false
 	}
@@ -4117,7 +4147,8 @@ func bytesAreParserPadding(source []byte, start, end uint32) bool {
 		i = len(utf8BOM)
 	}
 	for ; i < int(end); i++ {
-		switch source[i] {
+		b := source[i]
+		switch b {
 		case ' ', '\t', '\n', '\r', '\f', '\v':
 			continue
 		case '\\':
@@ -4132,6 +4163,17 @@ func bytesAreParserPadding(source []byte, start, end uint32) bool {
 			}
 			return false
 		default:
+			if continuationEscape != 0 && b == continuationEscape {
+				next := i + 1
+				if next < int(end) && source[next] == '\n' {
+					i = next
+					continue
+				}
+				if next+1 < int(end) && source[next] == '\r' && source[next+1] == '\n' {
+					i = next + 1
+					continue
+				}
+			}
 			return false
 		}
 	}
@@ -4145,8 +4187,15 @@ func parserTailAllowsCleanAcceptance(source []byte, start, end uint32, included 
 	if start > end || int(end) > len(source) {
 		return false
 	}
+	// continuationEscape is 0 here: trailing-tail EOF acceptance is a distinct
+	// concept from the real-token-attachment gap check below (different
+	// callers, different question — "can the root span silently swallow the
+	// rest of the file" vs "can the parser silently cross this one gap before
+	// shifting") and is out of the verified scope of the PowerShell
+	// continuation-padding fix. See realTokenAttachmentGapIsParserPadding for
+	// the language-aware caller.
 	if len(included) == 0 {
-		return bytesAreParserPadding(source, start, end)
+		return bytesAreParserPadding(source, start, end, 0)
 	}
 	for _, r := range included {
 		if r.EndByte <= start {
@@ -4163,7 +4212,7 @@ func parserTailAllowsCleanAcceptance(source []byte, start, end uint32, included 
 		if r.EndByte < overlapEnd {
 			overlapEnd = r.EndByte
 		}
-		if overlapStart < overlapEnd && !bytesAreParserPadding(source, overlapStart, overlapEnd) {
+		if overlapStart < overlapEnd && !bytesAreParserPadding(source, overlapStart, overlapEnd, 0) {
 			return false
 		}
 	}
@@ -4189,7 +4238,7 @@ func cleanAcceptedTreeLeavesRealTail(tree *Tree, source []byte, expectedEOFByte 
 }
 
 func (p *Parser) guardRealTokenAttachmentGap(source []byte, s *glrStack, tok Token, consumer string) bool {
-	if realTokenAttachmentGapIsParserPadding(source, s, tok) {
+	if realTokenAttachmentGapIsParserPadding(source, s, tok, p.lineContinuationEscapeByte()) {
 		return true
 	}
 	if consumer == "" {

--- a/parser.go
+++ b/parser.go
@@ -3697,7 +3697,7 @@ func recordParseRuntimeRootStats(parseRuntime *ParseRuntime, tree *Tree, source 
 	if parseRuntime.LastTokenWasEOF && parseRuntime.LastTokenEndByte > tailStart && parseRuntime.LastTokenEndByte <= expectedEOFByte {
 		tailStart = parseRuntime.LastTokenEndByte
 	}
-	if parseRuntime.Truncated && parserTailAllowsCleanAcceptance(tailSource, tailStart, expectedEOFByte, included) {
+	if parseRuntime.Truncated && parserTailAllowsCleanAcceptance(tailSource, tailStart, expectedEOFByte, included, languageLineContinuationEscapeByte(lang)) {
 		parseRuntime.Truncated = false
 	}
 	if !collectFinalStats {
@@ -3893,18 +3893,36 @@ func (p *Parser) stateDeterministicNonExtraShift(state StateID, sym Symbol) bool
 	return actions[0].Type == ParseActionShift && !actions[0].Extra
 }
 
+// languageLineContinuationEscapeByte returns lang's declared line-continuation
+// escape byte (see Language.LineContinuationEscapeByte), or 0 when lang is nil
+// or declares none. This is the single accessor every padding-classification
+// call site reads through — both callers that only have a *Language (a Tree
+// already carries its language; some compact-engine call sites carry lang
+// directly) and (*Parser).lineContinuationEscapeByte below, which is the same
+// lookup for callers that have a *Parser instead. Keeping both behind the
+// same function keeps the gap-padding and tail-acceptance classifications
+// consistent (and default-off for every language that has not declared an
+// escape) no matter which handle a given call site holds.
+func languageLineContinuationEscapeByte(lang *Language) byte {
+	if lang == nil {
+		return 0
+	}
+	return lang.LineContinuationEscapeByte
+}
+
 // lineContinuationEscapeByte returns p's language-declared line-continuation
 // escape byte (see Language.LineContinuationEscapeByte), or 0 when p or its
 // language is nil, or the language declares none. Every production caller of
-// realTokenAttachmentGapIsParserPadding / bytesAreParserPadding that has a
-// Parser in scope reads the escape byte through this single accessor so the
-// gap-padding classification stays consistent (and default-off for every
+// realTokenAttachmentGapIsParserPadding / bytesAreParserPadding /
+// parserTailAllowsCleanAcceptance's chain that has a Parser in scope reads the
+// escape byte through this single accessor so the gap-padding and
+// tail-acceptance classifications stay consistent (and default-off for every
 // language that has not declared an escape) across every caller.
 func (p *Parser) lineContinuationEscapeByte() byte {
-	if p == nil || p.language == nil {
+	if p == nil {
 		return 0
 	}
-	return p.language.LineContinuationEscapeByte
+	return languageLineContinuationEscapeByte(p.language)
 }
 
 // materializeSkippedGapAsExtraError covers a lexer-skipped mid-production gap
@@ -4180,22 +4198,37 @@ func bytesAreParserPadding(source []byte, start, end uint32, continuationEscape 
 	return true
 }
 
-func parserTailAllowsCleanAcceptance(source []byte, start, end uint32, included []Range) bool {
+// parserTailAllowsCleanAcceptance reports whether source[start:end] — the
+// tail beyond an accepted stack's, or an accepted tree root's, own span — is
+// entirely parser padding, so the caller may treat that tail as silently
+// swallowed rather than a real, uncovered remainder. continuationEscape
+// carries the same language-declared line-continuation escape byte
+// bytesAreParserPadding accepts elsewhere (0 when the caller has no language
+// in scope, or the language declares none): a trailing continuation escape
+// immediately followed by a newline — for example a PowerShell file or
+// incremental edit that ends mid-backtick-continuation — is exactly as much
+// scanner-owned trivia at the tail as it is mid-file, and every caller here
+// that reaches this function with a language in scope now passes its real
+// escape byte instead of a hardcoded 0. Passing 0 for a language that HAS
+// declared an escape (the historical shape of this function) is the actual
+// defect this parameter closes: an accepted PowerShell stack with nothing but
+// trailing padding used to still get declined here whenever
+// materializeSkippedGapAsExtraError's spurious ERROR (removed for the
+// backtick-continuation gap-classification fix, see
+// realTokenAttachmentGapIsParserPadding) was gone and stackResultErrorRank
+// read 0 — the accepted stack then genuinely reached this tail check, which,
+// blind to the continuation escape, called an ordinary trailing
+// backtick+newline a real tail and forced a degraded fallback despite the
+// stack (and the C oracle) agreeing the parse was clean.
+func parserTailAllowsCleanAcceptance(source []byte, start, end uint32, included []Range, continuationEscape byte) bool {
 	if start >= end {
 		return true
 	}
 	if start > end || int(end) > len(source) {
 		return false
 	}
-	// continuationEscape is 0 here: trailing-tail EOF acceptance is a distinct
-	// concept from the real-token-attachment gap check below (different
-	// callers, different question — "can the root span silently swallow the
-	// rest of the file" vs "can the parser silently cross this one gap before
-	// shifting") and is out of the verified scope of the PowerShell
-	// continuation-padding fix. See realTokenAttachmentGapIsParserPadding for
-	// the language-aware caller.
 	if len(included) == 0 {
-		return bytesAreParserPadding(source, start, end, 0)
+		return bytesAreParserPadding(source, start, end, continuationEscape)
 	}
 	for _, r := range included {
 		if r.EndByte <= start {
@@ -4212,29 +4245,29 @@ func parserTailAllowsCleanAcceptance(source []byte, start, end uint32, included 
 		if r.EndByte < overlapEnd {
 			overlapEnd = r.EndByte
 		}
-		if overlapStart < overlapEnd && !bytesAreParserPadding(source, overlapStart, overlapEnd, 0) {
+		if overlapStart < overlapEnd && !bytesAreParserPadding(source, overlapStart, overlapEnd, continuationEscape) {
 			return false
 		}
 	}
 	return true
 }
 
-func cleanAcceptedStackSelectableAtEOF(source []byte, expectedEOFByte uint32, included []Range, arena *nodeArena, s *glrStack) bool {
+func cleanAcceptedStackSelectableAtEOF(source []byte, expectedEOFByte uint32, included []Range, arena *nodeArena, s *glrStack, continuationEscape byte) bool {
 	if s == nil || !s.accepted {
 		return false
 	}
 	if stackResultErrorRank(s, arena) != 0 {
 		return true
 	}
-	return parserTailAllowsCleanAcceptance(source, s.byteOffset, expectedEOFByte, included)
+	return parserTailAllowsCleanAcceptance(source, s.byteOffset, expectedEOFByte, included, continuationEscape)
 }
 
-func cleanAcceptedTreeLeavesRealTail(tree *Tree, source []byte, expectedEOFByte uint32, included []Range) bool {
+func cleanAcceptedTreeLeavesRealTail(tree *Tree, source []byte, expectedEOFByte uint32, included []Range, continuationEscape byte) bool {
 	root := rawRootOrNil(tree)
 	if root == nil || root.HasError() || root.EndByte() >= expectedEOFByte {
 		return false
 	}
-	return !parserTailAllowsCleanAcceptance(source, root.EndByte(), expectedEOFByte, included)
+	return !parserTailAllowsCleanAcceptance(source, root.EndByte(), expectedEOFByte, included, continuationEscape)
 }
 
 func (p *Parser) guardRealTokenAttachmentGap(source []byte, s *glrStack, tok Token, consumer string) bool {
@@ -4821,7 +4854,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				}
 			}
 		}
-		if stopReason == ParseStopAccepted && cleanAcceptedTreeLeavesRealTail(tree, source, expectedEOFByte, p.included) {
+		if stopReason == ParseStopAccepted && cleanAcceptedTreeLeavesRealTail(tree, source, expectedEOFByte, p.included, p.lineContinuationEscapeByte()) {
 			stopReason = ParseStopNoStacksAlive
 			tree = replaceWithOwnedErrorTree(tree, stopReason)
 		}
@@ -6735,8 +6768,9 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			if !p.errorCostCompetitionEnabled() || liveUnaccepted == 0 {
 				accepted := compactAcceptedStacks(stacks)
 				selectable := accepted[:0]
+				continuationEscape := p.lineContinuationEscapeByte()
 				for i := range accepted {
-					if cleanAcceptedStackSelectableAtEOF(source, expectedEOFByte, p.included, arena, &accepted[i]) {
+					if cleanAcceptedStackSelectableAtEOF(source, expectedEOFByte, p.included, arena, &accepted[i], continuationEscape) {
 						selectable = append(selectable, accepted[i])
 					}
 				}

--- a/parser_api.go
+++ b/parser_api.go
@@ -381,9 +381,10 @@ func finalizeReturnedTreeRootSpan(tree *Tree, source []byte) {
 	if root == nil {
 		return
 	}
+	continuationEscape := languageLineContinuationEscapeByte(tree.language)
 	rt := tree.parseRuntime
 	if rt.StopReason == ParseStopAccepted {
-		extendRootToAcceptedCleanTail(root, source, rt.ExpectedEOFByte, tree.includedRanges)
+		extendRootToAcceptedCleanTail(root, source, rt.ExpectedEOFByte, tree.includedRanges, continuationEscape)
 	}
 	rt.RootEndByte = root.endByte
 	rt.Truncated = rt.ExpectedEOFByte > root.endByte
@@ -391,7 +392,7 @@ func finalizeReturnedTreeRootSpan(tree *Tree, source []byte) {
 	if rt.LastTokenWasEOF && rt.LastTokenEndByte > tailStart && rt.LastTokenEndByte <= rt.ExpectedEOFByte {
 		tailStart = rt.LastTokenEndByte
 	}
-	if rt.Truncated && parserTailAllowsCleanAcceptance(source, tailStart, rt.ExpectedEOFByte, tree.includedRanges) {
+	if rt.Truncated && parserTailAllowsCleanAcceptance(source, tailStart, rt.ExpectedEOFByte, tree.includedRanges, continuationEscape) {
 		rt.Truncated = false
 	}
 	markTruncatedTreeHasError(rt, root)
@@ -428,11 +429,11 @@ func markTruncatedTreeHasError(rt ParseRuntime, root *Node) {
 	root.setHasError(true)
 }
 
-func extendRootToAcceptedCleanTail(root *Node, source []byte, expectedEOFByte uint32, included []Range) bool {
+func extendRootToAcceptedCleanTail(root *Node, source []byte, expectedEOFByte uint32, included []Range, continuationEscape byte) bool {
 	if root == nil || expectedEOFByte <= root.endByte {
 		return false
 	}
-	if !parserTailAllowsCleanAcceptance(source, root.endByte, expectedEOFByte, included) {
+	if !parserTailAllowsCleanAcceptance(source, root.endByte, expectedEOFByte, included, continuationEscape) {
 		return false
 	}
 	extendNodeEndToByte(root, source, expectedEOFByte)

--- a/parser_dfa_token_source_test.go
+++ b/parser_dfa_token_source_test.go
@@ -296,7 +296,7 @@ func TestRelexExternalScannerTokenPreservesSkippedGapProvenance(t *testing.T) {
 	}
 
 	stack := newGLRStack(0)
-	if !realShiftGapIsParserPadding(source, &stack, relexed) {
+	if !realShiftGapIsParserPadding(source, &stack, relexed, 0) {
 		t.Fatalf("relexed scanner-owned gap rejected for %q; token=%+v", source[:relexed.StartByte], relexed)
 	}
 }

--- a/parser_powershell_continuation_padding_test.go
+++ b/parser_powershell_continuation_padding_test.go
@@ -29,64 +29,143 @@ import (
 // Pre-fix (main HEAD before this change), production Go instead produced 3
 // children at each site -- (" ", ERROR, " ") -- with a 2-byte EXTRA ERROR
 // leaf spanning exactly the backtick+newline, diverging from C.
+//
+// Runs under both the production route and the compact-candidate route.
+// PowerShell's compact route declines this snippet's real-corpus siblings
+// (large__packaging.psm1, medium__Install-PowerShellRemoting.ps1 both
+// decline per the bisect), so this is primarily a route-equality check: the
+// candidate route either serves its own tree (verified equal to production
+// by the compact engine's own admission contract) or declines and falls
+// back to production transparently -- either way this test's caller-visible
+// assertions must hold identically. Route equality for this fix was also
+// verified by hand across 7 continuation witnesses.
 func TestPowerShellBacktickContinuationIsParserPadding(t *testing.T) {
 	src := []byte("New-RpmSpec `\n    -Name $Name `\n    -Version $Version\n")
 	lang := grammars.PowershellLanguage()
-	parser := gts.NewParser(lang)
-	parser.SetAdmissionCandidateRoute(false)
-	tree, err := parser.Parse(src)
-	if err != nil {
-		t.Fatalf("PowerShell parse error: %v", err)
-	}
-	defer tree.Release()
-	root := requireCompleteParse(t, tree, src, lang, "PowerShell backtick continuation")
 
-	if root.HasError() {
-		t.Fatalf("root.HasError() = true, want false; tree=%s", root.SExpr(lang))
-	}
-	if errs := collectNodesByType(root, lang, "ERROR"); len(errs) != 0 {
-		t.Fatalf("found %d ERROR node(s), want 0: %v; tree=%s", len(errs), errs, root.SExpr(lang))
-	}
+	for _, route := range []struct {
+		name  string
+		force bool
+	}{
+		{"production", false},
+		{"compact-candidate", true},
+	} {
+		t.Run(route.name, func(t *testing.T) {
+			parser := gts.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(route.force)
+			tree, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("PowerShell parse error: %v", err)
+			}
+			defer tree.Release()
+			root := requireCompleteParse(t, tree, src, lang, "PowerShell backtick continuation")
 
-	seps := collectNodesByType(root, lang, "command_argument_sep")
-	type wantSep struct {
-		start, end     uint32
-		c0Start, c0End uint32
-		c1Start, c1End uint32
-	}
-	wantSeps := []wantSep{
-		{start: 11, end: 18, c0Start: 11, c0End: 12, c1Start: 14, c1End: 18},
-		{start: 29, end: 36, c0Start: 29, c0End: 30, c1Start: 32, c1End: 36},
-	}
+			if root.HasError() {
+				t.Fatalf("root.HasError() = true, want false; tree=%s", root.SExpr(lang))
+			}
+			if errs := collectNodesByType(root, lang, "ERROR"); len(errs) != 0 {
+				t.Fatalf("found %d ERROR node(s), want 0: %v; tree=%s", len(errs), errs, root.SExpr(lang))
+			}
 
-	var gapSeps []*gts.Node
-	for _, n := range seps {
-		if n.ChildCount() > 1 {
-			gapSeps = append(gapSeps, n)
-		}
+			seps := collectNodesByType(root, lang, "command_argument_sep")
+			type wantSep struct {
+				start, end     uint32
+				c0Start, c0End uint32
+				c1Start, c1End uint32
+			}
+			wantSeps := []wantSep{
+				{start: 11, end: 18, c0Start: 11, c0End: 12, c1Start: 14, c1End: 18},
+				{start: 29, end: 36, c0Start: 29, c0End: 30, c1Start: 32, c1End: 36},
+			}
+
+			var gapSeps []*gts.Node
+			for _, n := range seps {
+				if n.ChildCount() > 1 {
+					gapSeps = append(gapSeps, n)
+				}
+			}
+			if len(gapSeps) != len(wantSeps) {
+				t.Fatalf("multi-child command_argument_sep count = %d, want %d; all seps=%v; tree=%s",
+					len(gapSeps), len(wantSeps), describeNodes(seps), root.SExpr(lang))
+			}
+			for i, n := range gapSeps {
+				want := wantSeps[i]
+				if n.StartByte() != want.start || n.EndByte() != want.end {
+					t.Fatalf("command_argument_sep[%d] span = [%d,%d), want [%d,%d)", i, n.StartByte(), n.EndByte(), want.start, want.end)
+				}
+				if got := n.ChildCount(); got != 2 {
+					t.Fatalf("command_argument_sep[%d] ChildCount = %d, want 2 (C matches this exact shape; #633 minted a third ERROR child here); tree=%s", i, got, root.SExpr(lang))
+				}
+				c0, c1 := n.Child(0), n.Child(1)
+				if c0.IsError() || c1.IsError() {
+					t.Fatalf("command_argument_sep[%d] has an ERROR child: c0=%s c1=%s", i, describeNode(c0, lang), describeNode(c1, lang))
+				}
+				if c0.StartByte() != want.c0Start || c0.EndByte() != want.c0End {
+					t.Fatalf("command_argument_sep[%d] child0 span = [%d,%d), want [%d,%d)", i, c0.StartByte(), c0.EndByte(), want.c0Start, want.c0End)
+				}
+				if c1.StartByte() != want.c1Start || c1.EndByte() != want.c1End {
+					t.Fatalf("command_argument_sep[%d] child1 span = [%d,%d), want [%d,%d)", i, c1.StartByte(), c1.EndByte(), want.c1Start, want.c1End)
+				}
+			}
+		})
 	}
-	if len(gapSeps) != len(wantSeps) {
-		t.Fatalf("multi-child command_argument_sep count = %d, want %d; all seps=%v; tree=%s",
-			len(gapSeps), len(wantSeps), describeNodes(seps), root.SExpr(lang))
-	}
-	for i, n := range gapSeps {
-		want := wantSeps[i]
-		if n.StartByte() != want.start || n.EndByte() != want.end {
-			t.Fatalf("command_argument_sep[%d] span = [%d,%d), want [%d,%d)", i, n.StartByte(), n.EndByte(), want.start, want.end)
-		}
-		if got := n.ChildCount(); got != 2 {
-			t.Fatalf("command_argument_sep[%d] ChildCount = %d, want 2 (C matches this exact shape; #633 minted a third ERROR child here); tree=%s", i, got, root.SExpr(lang))
-		}
-		c0, c1 := n.Child(0), n.Child(1)
-		if c0.IsError() || c1.IsError() {
-			t.Fatalf("command_argument_sep[%d] has an ERROR child: c0=%s c1=%s", i, describeNode(c0, lang), describeNode(c1, lang))
-		}
-		if c0.StartByte() != want.c0Start || c0.EndByte() != want.c0End {
-			t.Fatalf("command_argument_sep[%d] child0 span = [%d,%d), want [%d,%d)", i, c0.StartByte(), c0.EndByte(), want.c0Start, want.c0End)
-		}
-		if c1.StartByte() != want.c1Start || c1.EndByte() != want.c1End {
-			t.Fatalf("command_argument_sep[%d] child1 span = [%d,%d), want [%d,%d)", i, c1.StartByte(), c1.EndByte(), want.c1Start, want.c1End)
-		}
+}
+
+// TestPowerShellTrailingContinuationDoesNotForceDegradedFallback pins a
+// second, distinct defect this same repair closes: a trailing backtick
+// continuation at (or near) the very end of a file. Before threading
+// p.lineContinuationEscapeByte() into parserTailAllowsCleanAcceptance and
+// its chain (cleanAcceptedStackSelectableAtEOF, cleanAcceptedTreeLeavesRealTail,
+// extendRootToAcceptedCleanTail, recordParseRuntimeRootStats,
+// finalizeReturnedTreeRootSpan, retryTreeCoversExpectedEOF,
+// parserCoreFreshFullAcceptedTailIsClean), this exact class of input hit a
+// two-fix interaction: removing materializeSkippedGapAsExtraError's spurious
+// mid-file ERROR (the first half of this repair) also removed the non-zero
+// stackResultErrorRank that used to short-circuit
+// cleanAcceptedStackSelectableAtEOF before it ever reached the tail check.
+// With the ERROR gone, a clean accepted stack legitimately reached
+// parserTailAllowsCleanAcceptance, which -- hardcoded to continuationEscape
+// 0 -- called an ordinary trailing backtick+newline a real, uncovered tail
+// and forced production to decline the clean accept, falling back to a
+// degraded flat ERROR-wrapped tree instead of the properly nested shape.
+//
+// This witness's root does carry one pre-existing, unrelated PowerShell
+// divergence from the C oracle around a trailing statement terminator
+// (present identically on main before any of today's changes; out of scope
+// here), so this pin checks the structural invariant the tail-acceptance fix
+// actually restores -- a full-span, properly nested tree, not a collapsed
+// ERROR wrapper -- rather than asserting byte-for-byte C parity.
+func TestPowerShellTrailingContinuationDoesNotForceDegradedFallback(t *testing.T) {
+	src := []byte("Get-Item a `\n | Out-Null `\n")
+	lang := grammars.PowershellLanguage()
+
+	for _, route := range []struct {
+		name  string
+		force bool
+	}{
+		{"production", false},
+		{"compact-candidate", true},
+	} {
+		t.Run(route.name, func(t *testing.T) {
+			parser := gts.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(route.force)
+			tree, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("PowerShell parse error: %v", err)
+			}
+			defer tree.Release()
+			root := requireCompleteParse(t, tree, src, lang, "PowerShell trailing continuation")
+
+			if got, want := root.Type(lang), "program"; got != want {
+				t.Fatalf("root.Type() = %q, want %q; tree=%s", got, want, root.SExpr(lang))
+			}
+			if root.ChildCount() != 1 || root.Child(0).IsError() {
+				t.Fatalf("root is a degraded ERROR wrapper, want a properly nested program>statement_list tree; tree=%s", root.SExpr(lang))
+			}
+			if got, want := root.Child(0).Type(lang), "statement_list"; got != want {
+				t.Fatalf("root's only child = %q, want %q (degraded fallback wraps the tree in ERROR instead); tree=%s", got, want, root.SExpr(lang))
+			}
+		})
 	}
 }
 
@@ -106,33 +185,62 @@ func TestPowerShellLineContinuationEscapeByteIsBacktick(t *testing.T) {
 }
 
 // TestPowerShellNonContinuationErrorsStillMaterialize pins the composition
-// half of the repair: declaring PowerShell's backtick-newline continuation
-// as padding must not disable PowerShell's ordinary error materialization.
-// This snippet's error has nothing to do with line continuation (an
-// incomplete "$" variable reference); it still must surface as a real ERROR
-// with HasError() set, exactly as before the continuation-padding change.
-// See TestBytesAreParserPaddingLineContinuationEscapeComposes
+// half of the repair: only backtick immediately followed by a newline is
+// PowerShell's declared continuation escape (Language.LineContinuationEscapeByte).
+// A bare backtick at the SAME structural position as
+// TestPowerShellBacktickContinuationIsParserPadding's positive witness --
+// immediately after the command name's separator, before the next parameter
+// -- but followed by "x" instead of a newline, is not the declared escape
+// sequence and must still surface as a real, HasError()==true parse, exactly
+// as it did before this change. Unlike the incomplete-"$" witness this
+// replaces, this one shares byte-for-byte structural position with the
+// positive witness, so it actually exercises the padding classification: if
+// bytesAreParserPadding's continuationEscape case ever widened to accept a
+// bare escape byte without requiring a following newline (or matched an
+// undeclared byte), this witness would flip from erroring to clean and catch
+// it. See TestBytesAreParserPaddingLineContinuationEscapeComposes
 // (parser_shift_gap_test.go) for the same composition property pinned
 // directly at the bytesAreParserPadding predicate.
+//
+// The backtick+"x" sequence here defeats the parser badly enough that the
+// GLR frontier runs out of live stacks before reaching EOF (unrelated to
+// this fix -- PowerShell's command-argument tokenizer is permissive enough
+// that few byte sequences are lexer-skipped "gaps" at all; this is one of
+// the few that still is), so the returned tree is honestly truncated rather
+// than full-span. HasError() is still the right, and only, invariant to
+// check: requireCompleteParse's full-span requirement does not apply to a
+// witness whose whole point is that the parse must NOT complete cleanly.
 func TestPowerShellNonContinuationErrorsStillMaterialize(t *testing.T) {
-	src := []byte("New-RpmSpec $ -Name $Name\n")
+	src := []byte("New-RpmSpec `x -Name $Name\n")
 	lang := grammars.PowershellLanguage()
-	parser := gts.NewParser(lang)
-	parser.SetAdmissionCandidateRoute(false)
-	tree, err := parser.Parse(src)
-	if err != nil {
-		t.Fatalf("PowerShell parse error: %v", err)
-	}
-	defer tree.Release()
-	root := requireCompleteParse(t, tree, src, lang, "PowerShell non-continuation error control")
+	for _, route := range []struct {
+		name  string
+		force *bool
+	}{
+		{"production", boolPtr(false)},
+		{"compact-candidate", boolPtr(true)},
+	} {
+		t.Run(route.name, func(t *testing.T) {
+			parser := gts.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(*route.force)
+			tree, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("PowerShell parse error: %v", err)
+			}
+			defer tree.Release()
+			root := tree.RootNode()
+			if root == nil {
+				t.Fatal("PowerShell parse returned a nil root")
+			}
 
-	if !root.HasError() {
-		t.Fatalf("root.HasError() = false, want true for a genuine syntax error; tree=%s", root.SExpr(lang))
-	}
-	if errs := collectNodesByType(root, lang, "ERROR"); len(errs) == 0 {
-		t.Fatalf("found 0 ERROR nodes, want at least 1 for a genuine syntax error; tree=%s", root.SExpr(lang))
+			if !root.HasError() {
+				t.Fatalf("root.HasError() = false, want true for a genuine syntax error; tree=%s", root.SExpr(lang))
+			}
+		})
 	}
 }
+
+func boolPtr(b bool) *bool { return &b }
 
 func collectNodesByType(n *gts.Node, lang *gts.Language, typ string) []*gts.Node {
 	if n == nil {

--- a/parser_powershell_continuation_padding_test.go
+++ b/parser_powershell_continuation_padding_test.go
@@ -1,0 +1,168 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestPowerShellBacktickContinuationIsParserPadding pins the repair for the
+// PR #633 regression (materializeSkippedGapAsExtraError minting a spurious
+// EXTRA ERROR leaf over PowerShell's backtick line continuation): a
+// command_argument_sep that contains a backtick immediately followed by a
+// newline must keep its C-sided two-child shape (the two surrounding
+// whitespace runs) rather than gain a third, ERROR child.
+//
+// The source mirrors the exact shape found at byte 51746 and byte 51784 of
+// cgo_harness/corpus_real/powershell/large__packaging.psm1 (bisect
+// spore.2026-08-02.birch-g.powershell-bisect, "Sample 1"/"Sample 2" C
+// verdicts): a bare command name, then a parameter continued across a
+// backtick-newline line break. C-oracle receipt for this exact snippet
+// (locked C reference, tree-sitter-powershell @ da65ba3a, verified directly
+// against cgo_harness's ParityCLanguage/compareNodes):
+//
+//	command_argument_sep [11,18) 2 children: [11,12) [14,18)  (no ERROR)
+//	command_argument_sep [29,36) 2 children: [29,30) [32,36)  (no ERROR)
+//	root.HasError() == false, zero ERROR nodes in the whole tree
+//
+// Pre-fix (main HEAD before this change), production Go instead produced 3
+// children at each site -- (" ", ERROR, " ") -- with a 2-byte EXTRA ERROR
+// leaf spanning exactly the backtick+newline, diverging from C.
+func TestPowerShellBacktickContinuationIsParserPadding(t *testing.T) {
+	src := []byte("New-RpmSpec `\n    -Name $Name `\n    -Version $Version\n")
+	lang := grammars.PowershellLanguage()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("PowerShell parse error: %v", err)
+	}
+	defer tree.Release()
+	root := requireCompleteParse(t, tree, src, lang, "PowerShell backtick continuation")
+
+	if root.HasError() {
+		t.Fatalf("root.HasError() = true, want false; tree=%s", root.SExpr(lang))
+	}
+	if errs := collectNodesByType(root, lang, "ERROR"); len(errs) != 0 {
+		t.Fatalf("found %d ERROR node(s), want 0: %v; tree=%s", len(errs), errs, root.SExpr(lang))
+	}
+
+	seps := collectNodesByType(root, lang, "command_argument_sep")
+	type wantSep struct {
+		start, end     uint32
+		c0Start, c0End uint32
+		c1Start, c1End uint32
+	}
+	wantSeps := []wantSep{
+		{start: 11, end: 18, c0Start: 11, c0End: 12, c1Start: 14, c1End: 18},
+		{start: 29, end: 36, c0Start: 29, c0End: 30, c1Start: 32, c1End: 36},
+	}
+
+	var gapSeps []*gts.Node
+	for _, n := range seps {
+		if n.ChildCount() > 1 {
+			gapSeps = append(gapSeps, n)
+		}
+	}
+	if len(gapSeps) != len(wantSeps) {
+		t.Fatalf("multi-child command_argument_sep count = %d, want %d; all seps=%v; tree=%s",
+			len(gapSeps), len(wantSeps), describeNodes(seps), root.SExpr(lang))
+	}
+	for i, n := range gapSeps {
+		want := wantSeps[i]
+		if n.StartByte() != want.start || n.EndByte() != want.end {
+			t.Fatalf("command_argument_sep[%d] span = [%d,%d), want [%d,%d)", i, n.StartByte(), n.EndByte(), want.start, want.end)
+		}
+		if got := n.ChildCount(); got != 2 {
+			t.Fatalf("command_argument_sep[%d] ChildCount = %d, want 2 (C matches this exact shape; #633 minted a third ERROR child here); tree=%s", i, got, root.SExpr(lang))
+		}
+		c0, c1 := n.Child(0), n.Child(1)
+		if c0.IsError() || c1.IsError() {
+			t.Fatalf("command_argument_sep[%d] has an ERROR child: c0=%s c1=%s", i, describeNode(c0, lang), describeNode(c1, lang))
+		}
+		if c0.StartByte() != want.c0Start || c0.EndByte() != want.c0End {
+			t.Fatalf("command_argument_sep[%d] child0 span = [%d,%d), want [%d,%d)", i, c0.StartByte(), c0.EndByte(), want.c0Start, want.c0End)
+		}
+		if c1.StartByte() != want.c1Start || c1.EndByte() != want.c1End {
+			t.Fatalf("command_argument_sep[%d] child1 span = [%d,%d), want [%d,%d)", i, c1.StartByte(), c1.EndByte(), want.c1Start, want.c1End)
+		}
+	}
+}
+
+// TestPowerShellLineContinuationEscapeByteIsBacktick pins the declaration
+// itself: PowerShell's built-in runtime profile (grammars/runtime_profiles.go)
+// must attach exactly the backtick byte, and only for a real loaded
+// PowerShell Language (never a zero-value or caller-constructed one, which
+// keeps the conservative default of 0 -- no declared continuation escape).
+func TestPowerShellLineContinuationEscapeByteIsBacktick(t *testing.T) {
+	lang := grammars.PowershellLanguage()
+	if got, want := lang.LineContinuationEscapeByte, byte('`'); got != want {
+		t.Fatalf("PowershellLanguage().LineContinuationEscapeByte = %q, want %q", got, want)
+	}
+	if got := (&gts.Language{}).LineContinuationEscapeByte; got != 0 {
+		t.Fatalf("zero-value Language.LineContinuationEscapeByte = %q, want 0 (conservative default)", got)
+	}
+}
+
+// TestPowerShellNonContinuationErrorsStillMaterialize pins the composition
+// half of the repair: declaring PowerShell's backtick-newline continuation
+// as padding must not disable PowerShell's ordinary error materialization.
+// This snippet's error has nothing to do with line continuation (an
+// incomplete "$" variable reference); it still must surface as a real ERROR
+// with HasError() set, exactly as before the continuation-padding change.
+// See TestBytesAreParserPaddingLineContinuationEscapeComposes
+// (parser_shift_gap_test.go) for the same composition property pinned
+// directly at the bytesAreParserPadding predicate.
+func TestPowerShellNonContinuationErrorsStillMaterialize(t *testing.T) {
+	src := []byte("New-RpmSpec $ -Name $Name\n")
+	lang := grammars.PowershellLanguage()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("PowerShell parse error: %v", err)
+	}
+	defer tree.Release()
+	root := requireCompleteParse(t, tree, src, lang, "PowerShell non-continuation error control")
+
+	if !root.HasError() {
+		t.Fatalf("root.HasError() = false, want true for a genuine syntax error; tree=%s", root.SExpr(lang))
+	}
+	if errs := collectNodesByType(root, lang, "ERROR"); len(errs) == 0 {
+		t.Fatalf("found 0 ERROR nodes, want at least 1 for a genuine syntax error; tree=%s", root.SExpr(lang))
+	}
+}
+
+func collectNodesByType(n *gts.Node, lang *gts.Language, typ string) []*gts.Node {
+	if n == nil {
+		return nil
+	}
+	var out []*gts.Node
+	if n.Type(lang) == typ {
+		out = append(out, n)
+	}
+	for i := 0; i < n.ChildCount(); i++ {
+		out = append(out, collectNodesByType(n.Child(i), lang, typ)...)
+	}
+	return out
+}
+
+func describeNode(n *gts.Node, lang *gts.Language) string {
+	if n == nil {
+		return "<nil>"
+	}
+	return n.Type(lang)
+}
+
+func describeNodes(nodes []*gts.Node) []string {
+	out := make([]string, len(nodes))
+	for i, n := range nodes {
+		if n == nil {
+			out[i] = "<nil>"
+			continue
+		}
+		out[i] = n.SExpr(nil)
+	}
+	return out
+}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -5740,7 +5740,12 @@ func spanBridgeIsParserPadding(source []byte, from, to uint32) bool {
 	if len(source) == 0 || from >= to {
 		return false
 	}
-	return bytesAreParserPadding(source, from, to)
+	// continuationEscape is 0: this is the invisible-child span-extension
+	// bridge used while building a reduced parent's span, a distinct
+	// question from the real-token-attachment gap check
+	// (realTokenAttachmentGapIsParserPadding) that the PowerShell
+	// continuation-padding fix targets. Out of that fix's verified scope.
+	return bytesAreParserPadding(source, from, to, 0)
 }
 
 func buildInvisibleSpanSymbolTables(symbolNames []string) ([]bool, []bool) {

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -422,7 +422,7 @@ func retryTreeCoversExpectedEOF(tree *Tree) bool {
 		return true
 	}
 	endByte := retryTreeEndByte(tree)
-	return endByte >= rt.ExpectedEOFByte || parserTailAllowsCleanAcceptance(tree.Source(), endByte, rt.ExpectedEOFByte, tree.includedRanges)
+	return endByte >= rt.ExpectedEOFByte || parserTailAllowsCleanAcceptance(tree.Source(), endByte, rt.ExpectedEOFByte, tree.includedRanges, languageLineContinuationEscapeByte(tree.language))
 }
 
 func retryStopRank(rt *ParseRuntime) int {

--- a/parser_shift_gap_test.go
+++ b/parser_shift_gap_test.go
@@ -132,6 +132,33 @@ func TestBytesAreParserPaddingLineContinuationEscapeComposes(t *testing.T) {
 	}
 }
 
+// TestRealTokenAttachmentGapIsParserPaddingAcceptsDeclaredEscape drives a
+// non-zero continuationEscape through realTokenAttachmentGapIsParserPadding
+// itself (every other direct call in this file passes 0, since those tests
+// predate the continuation-escape parameter and pin unrelated gap shapes).
+// This closes that gap in direct coverage: the function that
+// tryMaterializeSkippedRealGap, guardRealTokenAttachmentGap, and
+// tryReuseSubtree all actually call is exercised here with the same
+// declared-escape argument production passes, not just its
+// bytesAreParserPadding helper in isolation.
+func TestRealTokenAttachmentGapIsParserPaddingAcceptsDeclaredEscape(t *testing.T) {
+	source := []byte("a `\n   b") // same shape TestBytesAreParserPaddingLineContinuationEscapeComposes pins
+	stack := newGLRStack(1)
+	stack.byteOffset = 1
+	tok := Token{
+		Symbol:    1,
+		StartByte: 7,
+		EndByte:   8,
+	}
+
+	if !realTokenAttachmentGapIsParserPadding(source, &stack, tok, '`') {
+		t.Fatalf("realTokenAttachmentGapIsParserPadding(escape='`') = false, want true for gap %q", source[stack.byteOffset:tok.StartByte])
+	}
+	if realTokenAttachmentGapIsParserPadding(source, &stack, tok, 0) {
+		t.Fatalf("realTokenAttachmentGapIsParserPadding(escape=0) = true, want false: an undeclared escape must not become padding for gap %q", source[stack.byteOffset:tok.StartByte])
+	}
+}
+
 func TestRealShiftGapAllowsNoLookaheadToken(t *testing.T) {
 	source := []byte("call(arg1/*c*/)")
 	stack := newGLRStack(1)

--- a/parser_shift_gap_test.go
+++ b/parser_shift_gap_test.go
@@ -15,7 +15,7 @@ func TestRealShiftGapRejectsNonTriviaSource(t *testing.T) {
 		EndByte:   uint32(len(source)),
 	}
 
-	if realShiftGapIsParserPadding(source, &stack, tok) {
+	if realShiftGapIsParserPadding(source, &stack, tok, 0) {
 		t.Fatalf("realShiftGapIsParserPadding = true, want false for gap %q", source[stack.byteOffset:tok.StartByte])
 	}
 
@@ -38,7 +38,7 @@ func TestRealTokenAttachmentGapRejectsCommentSource(t *testing.T) {
 		EndByte:   uint32(len(source)),
 	}
 
-	if realTokenAttachmentGapIsParserPadding(source, &stack, tok) {
+	if realTokenAttachmentGapIsParserPadding(source, &stack, tok, 0) {
 		t.Fatalf("realTokenAttachmentGapIsParserPadding = true, want false for comment gap %q", source[stack.byteOffset:tok.StartByte])
 	}
 
@@ -61,7 +61,7 @@ func TestRealShiftGapAllowsTriviaOnlySource(t *testing.T) {
 		EndByte:   uint32(len(source)),
 	}
 
-	if !realShiftGapIsParserPadding(source, &stack, tok) {
+	if !realShiftGapIsParserPadding(source, &stack, tok, 0) {
 		t.Fatalf("realShiftGapIsParserPadding = false, want true for gap %q", source[stack.byteOffset:tok.StartByte])
 	}
 
@@ -84,7 +84,7 @@ func TestRealShiftGapAllowsEscapedNewlinePadding(t *testing.T) {
 		EndByte:   uint32(len(source)),
 	}
 
-	if !realShiftGapIsParserPadding(source, &stack, tok) {
+	if !realShiftGapIsParserPadding(source, &stack, tok, 0) {
 		t.Fatalf("realShiftGapIsParserPadding = false, want true for gap %q", source[stack.byteOffset:tok.StartByte])
 	}
 
@@ -94,6 +94,41 @@ func TestRealShiftGapAllowsEscapedNewlinePadding(t *testing.T) {
 	}
 	if stack.dead {
 		t.Fatal("stack.dead = true, want false")
+	}
+}
+
+// TestBytesAreParserPaddingLineContinuationEscapeComposes pins the composition
+// the PowerShell backtick-continuation repair depends on: a language-declared
+// continuation escape (Language.LineContinuationEscapeByte, threaded here as
+// bytesAreParserPadding's continuationEscape parameter) accepts exactly that
+// byte immediately followed by a newline as padding, the same unconditional
+// treatment backslash+newline already gets, while leaving every other gap
+// shape — including a DIFFERENT stray byte at the same position, and the
+// same escape byte with no declaration at all (continuationEscape == 0, what
+// every language gets by default) — exactly as rejected as before this
+// parameter existed. Regression: PR #633 (materializeSkippedGapAsExtraError)
+// must still materialize an ERROR for a genuine lexer-skipped stray; only a
+// declared continuation escape may bypass that path.
+func TestBytesAreParserPaddingLineContinuationEscapeComposes(t *testing.T) {
+	source := []byte("a `\n   b")
+	// [1:7) = " `\n   " -- backtick+LF then three spaces, mirroring the
+	// PowerShell command_argument_sep shape from cgo_harness/corpus_real's
+	// large__packaging.psm1 (C-oracle verified: 2 children, zero ERROR nodes).
+	const start, end = 1, 7
+
+	if !bytesAreParserPadding(source, start, end, '`') {
+		t.Fatalf("bytesAreParserPadding(%q, escape='`') = false, want true", source[start:end])
+	}
+	if bytesAreParserPadding(source, start, end, 0) {
+		t.Fatalf("bytesAreParserPadding(%q, escape=0) = true, want false: an undeclared escape must not become padding", source[start:end])
+	}
+	if bytesAreParserPadding(source, start, end, '@') {
+		t.Fatalf("bytesAreParserPadding(%q, escape='@') = true, want false: declaring an unrelated escape byte must not match a different stray byte", source[start:end])
+	}
+
+	strayNonNewline := []byte("a `x   b") // backtick NOT followed by a newline
+	if bytesAreParserPadding(strayNonNewline, start, end, '`') {
+		t.Fatalf("bytesAreParserPadding(%q, escape='`') = true, want false: the escape byte alone (no following newline) is not padding", strayNonNewline[start:end])
 	}
 }
 
@@ -108,7 +143,7 @@ func TestRealShiftGapAllowsNoLookaheadToken(t *testing.T) {
 		NoLookahead: true,
 	}
 
-	if !realShiftGapIsParserPadding(source, &stack, tok) {
+	if !realShiftGapIsParserPadding(source, &stack, tok, 0) {
 		t.Fatal("realShiftGapIsParserPadding = false, want true for NoLookahead token")
 	}
 
@@ -134,7 +169,7 @@ func TestRealShiftGapAllowsExternalScannerOwnedSkippedGap(t *testing.T) {
 		ExternalScannerStartByte: 0,
 	}
 
-	if !realShiftGapIsParserPadding(source, &stack, tok) {
+	if !realShiftGapIsParserPadding(source, &stack, tok, 0) {
 		t.Fatalf("realShiftGapIsParserPadding = false, want true for scanner-owned gap %q", source[stack.byteOffset:tok.StartByte])
 	}
 
@@ -160,7 +195,7 @@ func TestRealShiftGapRejectsExternalScannerTokenFromDifferentStart(t *testing.T)
 		ExternalScannerStartByte: 2,
 	}
 
-	if realShiftGapIsParserPadding(source, &stack, tok) {
+	if realShiftGapIsParserPadding(source, &stack, tok, 0) {
 		t.Fatalf("realShiftGapIsParserPadding = true, want false for mismatched scanner start gap %q", source[stack.byteOffset:tok.StartByte])
 	}
 
@@ -225,7 +260,7 @@ func TestRealShiftGapAllowsLeadingBOMPadding(t *testing.T) {
 			EndByte:   uint32(len(source)),
 		}
 
-		if !realShiftGapIsParserPadding(source, &stack, tok) {
+		if !realShiftGapIsParserPadding(source, &stack, tok, 0) {
 			t.Fatalf("realShiftGapIsParserPadding(%q) = false, want true", source[:tok.StartByte])
 		}
 	}
@@ -241,7 +276,7 @@ func TestRealShiftGapRejectsNonLeadingBOM(t *testing.T) {
 		EndByte:   uint32(len(source)),
 	}
 
-	if realShiftGapIsParserPadding(source, &stack, tok) {
+	if realShiftGapIsParserPadding(source, &stack, tok, 0) {
 		t.Fatalf("realShiftGapIsParserPadding = true, want false for non-leading BOM gap %q", source[stack.byteOffset:tok.StartByte])
 	}
 }
@@ -450,7 +485,7 @@ func TestRealShiftGapAllowsSyntheticMissingToken(t *testing.T) {
 		Missing:   true,
 	}
 
-	if !realShiftGapIsParserPadding(source, &stack, tok) {
+	if !realShiftGapIsParserPadding(source, &stack, tok, 0) {
 		t.Fatal("realShiftGapIsParserPadding = false, want true for synthetic missing token")
 	}
 }

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2655,11 +2655,11 @@ func materializeDiagnosticParserCoreAcceptedTree(compact *core.Core, head core.H
 // the !root.IsError() && !root.HasError() bar so a genuinely recovered tree
 // can complete -- the span-completeness half of the check (root must still
 // cover the whole source) stays in force unconditionally either way.
-func finalizeDiagnosticParserCoreAcceptedRootSpan(root *Node, source []byte, sourceLen uint32, allowErrorRoot bool, tokenCount uint32) error {
+func finalizeDiagnosticParserCoreAcceptedRootSpan(root *Node, source []byte, sourceLen uint32, allowErrorRoot bool, tokenCount uint32, continuationEscape byte) error {
 	expectedStart := firstNonTriviaByteStart(source)
 	clean := allowErrorRoot || (!root.IsError() && !root.HasError())
 	if root.startByte == expectedStart && root.endByte < sourceLen && clean {
-		extendRootToAcceptedCleanTail(root, source, sourceLen, nil)
+		extendRootToAcceptedCleanTail(root, source, sourceLen, nil, continuationEscape)
 	}
 	if root.startByte == expectedStart && root.endByte == sourceLen && clean {
 		if allowErrorRoot {
@@ -3377,7 +3377,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 	}
 	sourceLen := uint32(len(source))
 	root := tree.root
-	if err := finalizeDiagnosticParserCoreAcceptedRootSpan(root, source, sourceLen, allowErrorRoot, parser.language.TokenCount); err != nil {
+	if err := finalizeDiagnosticParserCoreAcceptedRootSpan(root, source, sourceLen, allowErrorRoot, parser.language.TokenCount, parser.lineContinuationEscapeByte()); err != nil {
 		return rejectTree(err)
 	}
 	// accepted-root-leading-gap: the derivation's own root reduce is exempt

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -160,7 +160,7 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 		tokenSource.Close()
 		return nil, nil, err
 	}
-	if err := requireParserCoreFreshFullAcceptance(scheduler, source, r.allowConvergedReductionSplitDrops); err != nil {
+	if err := requireParserCoreFreshFullAcceptance(scheduler, source, r.allowConvergedReductionSplitDrops, languageLineContinuationEscapeByte(r.lang)); err != nil {
 		tokenSource.Close()
 		// The scheduler run itself already committed here (RunFreshSchedulerSession,
 		// invoked from inside executeDiagnosticParserCoreGenericSchedulerFromSeedInto,
@@ -179,7 +179,7 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 	return scheduler, tokenSource, nil
 }
 
-func requireParserCoreFreshFullAcceptance(scheduler *diagnosticParserCoreGenericScheduler, source []byte, allowConvergedReductionSplitDrops bool) error {
+func requireParserCoreFreshFullAcceptance(scheduler *diagnosticParserCoreGenericScheduler, source []byte, allowConvergedReductionSplitDrops bool, continuationEscape byte) error {
 	if scheduler == nil || scheduler.receipt == nil || scheduler.receipt.Acceptance == nil || scheduler.acceptedHead.Node == 0 {
 		// GTS_ADMISSION_CENSUS=1 (admission_census.go) re-surfaces the boundary
 		// and detail the scheduler already recorded in scheduler.receipt.Stop
@@ -201,7 +201,7 @@ func requireParserCoreFreshFullAcceptance(scheduler *diagnosticParserCoreGeneric
 	if acceptance.Token.Symbol != 0 || acceptance.Token.StartByte != wantEOF || acceptance.Token.EndByte != wantEOF ||
 		acceptance.Token.Missing || acceptance.Token.NoLookahead || acceptance.Token.ExternalScannerToken ||
 		!header.Accepted || header.Paused || header.ExactPaths != 1 && !selectedCertifiedPrimary ||
-		!parserCoreFreshFullAcceptedTailIsClean(source, header.ByteOffset) || acceptance.Accepts != 1 || acceptance.Work.Accepts != 1 {
+		!parserCoreFreshFullAcceptedTailIsClean(source, header.ByteOffset, continuationEscape) || acceptance.Accepts != 1 || acceptance.Work.Accepts != 1 {
 		// See the comment above: census classification is opt-in and additive.
 		if admissionCensusEnabled() {
 			return admissionCensusAcceptanceDecline(acceptance, wantEOF)
@@ -226,12 +226,16 @@ func requireParserCoreFreshFullAcceptance(scheduler *diagnosticParserCoreGeneric
 // parserCoreFreshFullAcceptedTailIsClean applies the production parser's
 // existing accepted-tail proof to compact acceptance. The compact head may
 // end before authenticated EOF only when every remaining byte is parser
-// padding; a real source byte keeps the route fail-closed.
-func parserCoreFreshFullAcceptedTailIsClean(source []byte, headByte uint32) bool {
+// padding; a real source byte keeps the route fail-closed. continuationEscape
+// is the runner's language-declared line-continuation escape byte (0 when
+// the language declares none), threaded down from requireParserCoreFreshFullAcceptance
+// so a trailing language-declared continuation is padding here exactly like
+// it is in the production parser's own tail check.
+func parserCoreFreshFullAcceptedTailIsClean(source []byte, headByte uint32, continuationEscape byte) bool {
 	if uint64(len(source)) > uint64(^uint32(0)) || headByte > uint32(len(source)) {
 		return false
 	}
-	return parserTailAllowsCleanAcceptance(source, headByte, uint32(len(source)), nil)
+	return parserTailAllowsCleanAcceptance(source, headByte, uint32(len(source)), nil, continuationEscape)
 }
 
 // s3AllowErrorRoot reports whether this runner's current options admit

--- a/parsercore_phase0_fresh_full_runner_internal_test.go
+++ b/parsercore_phase0_fresh_full_runner_internal_test.go
@@ -260,7 +260,7 @@ func TestParserCoreFreshFullAcceptedTailRequiresParserPadding(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := parserCoreFreshFullAcceptedTailIsClean([]byte(test.source), test.headByte); got != test.want {
+			if got := parserCoreFreshFullAcceptedTailIsClean([]byte(test.source), test.headByte, 0); got != test.want {
 				t.Fatalf("clean accepted tail=%t, want %t", got, test.want)
 			}
 		})


### PR DESCRIPTION
## Summary

- Classify a language-declared line-continuation escape, followed by a newline, as parser padding. This matches the existing rule for backslash and newline, but only for languages that declare an escape byte.
- Declare backtick as PowerShell's continuation escape. The declaration lives in a new `Language.LineContinuationEscapeByte` field, set only for the certified PowerShell blob. No other language sets this field.
- Apply the same rule to two related checks: the mid-parse gap check that decides whether a run of bytes is real content or padding, and the end-of-file tail check that decides whether an accepted parse can accept a trailing run of bytes as padding. Both checks now treat a declared continuation escape the same way.
- Pin two shapes: a `command_argument_sep` node that spans a backtick and a newline now has 2 children, matching the C reference parser. A file that ends with a trailing continuation now keeps its normal, nested tree shape instead of a flat error wrapper.

## Before and after

`cgo_harness/corpus_real/powershell/large__packaging.psm1` (43 sites):

| | ERROR nodes | Total nodes |
|---|---|---|
| Before | 93 | 80413 |
| After | 50 | 80370 |

The "after" values match the tree from before the regression.

Node-by-node divergences against the locked C reference parser:

| File | Before | After |
|---|---|---|
| large__packaging.psm1 | 94 | 51 |
| medium__Install-PowerShellRemoting.ps1 | 2 | 2 |
| small__Microsoft.PowerShell.Host.psd1 | 0 | 0 |
| Total | 96 | 53 |

A trailing-continuation witness (a command whose last line ends with a continuation) went from a flat error-wrapped tree to the normal nested tree shape, matching the C reference parser's own shape.

## Corpus sweep

The sweep covers `cgo_harness/corpus_real`: 148 files across 51 languages. Exactly one file changed: the PowerShell file above. Every other file kept the same node count, ERROR count, root type, and root `HasError()` value.

## Tests

- `TestPowerShellBacktickContinuationIsParserPadding` pins the 2-child shape, under both the production and compact-candidate parse routes. The C reference parser verifies it.
- `TestPowerShellTrailingContinuationDoesNotForceDegradedFallback` pins the end-of-file case, under both parse routes.
- `TestPowerShellNonContinuationErrorsStillMaterialize` and `TestBytesAreParserPaddingLineContinuationEscapeComposes` pin that other lexer-skipped bytes still produce an error, and that an undeclared escape byte never becomes padding.
- `TestPowerShellLineContinuationEscapeByteIsBacktick` pins the declaration.
