### PR TITLE
fix(recovery): bound C-recovery missing-token search with two loop ceilings

### DIFF
--- a/glr_forest.go
+++ b/glr_forest.go
@@ -4028,7 +4028,16 @@ func (p *Parser) forestMemoryBudgetExceeded(arena *nodeArena, final bool) bool {
 	if final {
 		return p.runtimeMemoryBudgetStopReasonNow() == ParseStopMemoryBudget
 	}
-	return p.runtimeMemoryBudgetStopReason(arenaAllocatedVolume(arena)) == ParseStopMemoryBudget
+	// arenaAllocatedVolume(arena) + scratchAllocatedVolume(p.budgetScratch)
+	// matches the same watermark computation resultMaterializationStopReason
+	// uses (parser_result.go), for the same volume-triggered-poll reasoning.
+	// The forest fast path (tryForestFastPath / ParseForestExperimental) runs
+	// before parseInternal ever sets p.budgetScratch (it has its own,
+	// separate GSS-forest node pool, not parserScratch/gssScratch), so
+	// scratchAllocatedVolume is a nil-safe no-op here today; it is included
+	// for unit consistency with the production watermark rather than because
+	// it currently contributes anything.
+	return p.runtimeMemoryBudgetStopReason(arenaAllocatedVolume(arena)+scratchAllocatedVolume(p.budgetScratch)) == ParseStopMemoryBudget
 }
 
 // maxForestNoLookaheadSteps bounds consecutive no-lookahead re-lex steps at one

--- a/parser.go
+++ b/parser.go
@@ -215,6 +215,31 @@ type Parser struct {
 	// candidates routinely settles back to a legitimately clean tree without
 	// ever being "re-validated", so it must not be treated as suspicious.
 	crecoveryHandleErrorSingleStack bool
+	// crecoveryReductionCandidateCeilingHits and
+	// crecoveryMissingTokenCeilingHits count how many times this parse's
+	// cDoAllPotentialReductions / cHandleError missing-token search hit the
+	// cRecoverMaxReductionCandidateAttempts / cRecoverMaxMissingTokenTrials
+	// Go-side backstop ceilings (parser_recover_c.go). Both stay at zero for
+	// every currently-passing parse — see those constants' doc comment for
+	// sizing rationale — and exist purely as a "counted reason" diagnostic
+	// signal (surfaced via ParseRuntime) for the
+	// spore.2026-08-02.walnut-e.memory-exhaustion fix: neither ceiling halts
+	// the parse itself, so without a counter there would be no way to observe
+	// that either one engaged.
+	crecoveryReductionCandidateCeilingHits uint64
+	crecoveryMissingTokenCeilingHits       uint64
+	// crecoveryReductionCandidateAttemptsPeak and
+	// crecoveryMissingTokenTrialAttemptsPeak record the single largest
+	// candidateAttempts / missingTokenTrialAttempts value any ONE
+	// cDoAllPotentialReductions call / cHandleError missing-token search
+	// reached during this parse (not cumulative across calls, unlike the
+	// ceiling-hit counters above). Diagnostic-only, parse-wide max, reset per
+	// parse: lets a corpus walk report how close real, currently-passing
+	// input gets to cRecoverMaxReductionCandidateAttempts /
+	// cRecoverMaxMissingTokenTrials, the same way the ceiling constants'
+	// sizing rationale is measured against.
+	crecoveryReductionCandidateAttemptsPeak uint64
+	crecoveryMissingTokenTrialAttemptsPeak  uint64
 	// crecoveryCostCompetitionRelevant gates the C-recovery merge cost walks
 	// (cRecoveryMergeCostsDiffer / cRecoveryCostClassForSlot/Slice via
 	// scratch.merge.cRecoveryCost): until something cost-relevant happens in
@@ -367,6 +392,24 @@ type Parser struct {
 	// materializing-shape prefix cache when they rewrite a spine node's
 	// root->head prefix. nil outside a parse; bumpShapePrefixEpoch is nil-safe.
 	mergeScratch *glrMergeScratch
+	// budgetScratch points at the active parse's *parserScratch for the
+	// duration of parseInternal (set alongside mergeScratch/reduceScratch,
+	// cleared on return). resultMaterializationStopReason uses it to fold
+	// parserScratch's own tracked allocation — dominated in pathological
+	// cases by gssScratch.allocatedBytes — into the per-parse memory-budget
+	// poll. gssScratch carries no budget state of its own (see gssScratch's
+	// doc comment in glr_gss.go); only the owning parserScratch does
+	// (parserScratch.budgetExhausted, already exercised by the main GLR loop
+	// at several per-token checkpoints in parser.go). Before this field
+	// existed, resultMaterializationStopReason — the only poll site
+	// cDoAllPotentialReductions/cHandleError's C-recovery candidate search
+	// reaches (parser_recover_c.go) — had no way to see that check at all,
+	// because scratch is a local variable inside parseInternal, unreachable
+	// from a *Parser-only call chain. nil outside a parse; budgetExhausted()
+	// is itself nil-safe, but callers check budgetScratch != nil explicitly
+	// to match this file's existing arena != nil && arena.budgetExhausted()
+	// convention at the same call site (parser_result.go).
+	budgetScratch *parserScratch
 	// goCompatFrames points at the active parser scratch's reusable result-tree
 	// traversal stack. It is nil outside parseInternal.
 	goCompatFrames                     *[]goCompatSubtreeFrame
@@ -4297,6 +4340,19 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	defer releaseParserScratch(scratch, deferParentLinks)
 	p.reduceScratch = &scratch.reduce
 	p.mergeScratch = &scratch.merge
+	// budgetScratch is saved and restored, not just cleared, unlike its
+	// siblings above: a nested parseInternal call (a retry or compat-
+	// normalization sub-parse reachable from this call's own body, however
+	// unlikely in practice) must leave the OUTER call's resultMaterializationStopReason
+	// checks intact when the inner call returns. Clearing unconditionally to
+	// nil would silently disable the scratch-budget check (parser_result.go)
+	// for the rest of the outer parse instead of merely losing the inner
+	// call's own coverage — a nested caller degrading to "no fix" is the
+	// acceptable failure mode here, not the outer caller silently losing a
+	// check several of its own materialization-boundary poll sites still
+	// assume is active.
+	prevBudgetScratch := p.budgetScratch
+	p.budgetScratch = scratch
 	p.goCompatFrames = &scratch.goCompatFrames
 	if transientReduceParents {
 		p.reduceScratch.transientParents = &scratch.transientParents
@@ -4305,6 +4361,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	defer func() {
 		p.reduceScratch = nil
 		p.mergeScratch = nil
+		p.budgetScratch = prevBudgetScratch
 		p.goCompatFrames = nil
 	}()
 	scratch.audit.beginParse()
@@ -4332,6 +4389,10 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		p.beginCNodeMemoEpoch()
 		p.crecoveryEnteredErrorState = false
 		p.crecoveryDroppedErrorForClean = false
+		p.crecoveryReductionCandidateCeilingHits = 0
+		p.crecoveryMissingTokenCeilingHits = 0
+		p.crecoveryReductionCandidateAttemptsPeak = 0
+		p.crecoveryMissingTokenTrialAttemptsPeak = 0
 		// Cost walks stay gated off until this pass proves costs can be
 		// nonzero. A fresh full parse starts clean (false). An incremental
 		// parse over an old tree whose root bit is clean starts clean too.
@@ -4813,6 +4874,10 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		parseRuntime.RuntimeSysGrowthBytes = memoryBudgetDiag.runtimeSysGrowthBytes
 		parseRuntime.CRecoveryEnteredErrorState = p.crecoveryEnteredErrorState
 		parseRuntime.CRecoveryDroppedErrorForClean = p.crecoveryDroppedErrorForClean
+		parseRuntime.CRecoverReductionCandidateCeilingHits = p.crecoveryReductionCandidateCeilingHits
+		parseRuntime.CRecoverMissingTokenCeilingHits = p.crecoveryMissingTokenCeilingHits
+		parseRuntime.CRecoverReductionCandidateAttemptsPeak = p.crecoveryReductionCandidateAttemptsPeak
+		parseRuntime.CRecoverMissingTokenTrialAttemptsPeak = p.crecoveryMissingTokenTrialAttemptsPeak
 		recordParseRuntimeLoopStats(&parseRuntime, scratch, iterationsUsed, nodeCount, peakStackDepth, maxStacksSeen, singleStackIterations, multiStackIterations, singleStackTokens, multiStackTokens)
 		recordParseRuntimePhaseTiming(&parseRuntime, materializationTimingRef, parseStart, parserLoopNanos, tokenNextNanos, actionDispatchNanos, actionLookupNanos, glrMergeNanos, glrCullNanos)
 		recordParseRuntimeMaterializationTiming(&parseRuntime, materializationTimingRef, materializationTiming)
@@ -5066,9 +5131,6 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 			return finalize(stacks, reason)
 		}
-		if scratch.budgetExhausted() {
-			return finalize(stacks, p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceScratch))
-		}
 
 		p.updateParserStateTokenSource(ts, stacks, scratch)
 
@@ -5236,10 +5298,6 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				}
 				if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 					blockStopReason, blockStopped = reason, true
-					break
-				}
-				if scratch.budgetExhausted() {
-					blockStopReason, blockStopped = p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceScratch), true
 					break
 				}
 			}
@@ -6307,9 +6365,6 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 			return finalize(stacks, reason)
 		}
-		if scratch.budgetExhausted() {
-			return finalize(stacks, p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceScratch))
-		}
 
 		if numStacks > 1 && retryPass && allParseStacksDead(stacks) {
 			bestIdx := bestRetryRecoveryStack(stacks)
@@ -6701,9 +6756,6 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 						return finalize(accepted, reason)
 					}
-					if scratch.budgetExhausted() {
-						return finalize(accepted, p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceScratch))
-					}
 					// Faithful C recovery port: ts_parser__accept rebuilds the
 					// root around trailing extras before the tree competes.
 					for i := range accepted {
@@ -6996,10 +7048,6 @@ func (p *Parser) prepareParseStacksForIteration(stacks []glrStack, scratch *pars
 	}
 	if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 		result.stop(reason, false)
-		return result
-	}
-	if scratch.budgetExhausted() {
-		result.stop(p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceScratch), false)
 		return result
 	}
 	if allParseStacksDead(stacks) {

--- a/parser_memory_budget_runtime.go
+++ b/parser_memory_budget_runtime.go
@@ -60,6 +60,30 @@ func runtimeMemoryBudgetEnabled(p *Parser, bytes int64, sourceLen int) bool {
 // to GB scale) but is otherwise independent of whether the soft budget itself
 // is enabled, so it keeps working even if a caller explicitly disables the
 // soft budget (GOT_PARSE_MEMORY_BUDGET_MB=0).
+//
+// A source-length-independent hard ceiling was tried and dropped
+// (spore.2026-08-02.walnut-e.memory-exhaustion, consolidated into
+// PR #641/rowan/recovery-memory-bounds): removing this floor made
+// runtimeMemoryHardCeilingEnabled true at every length, which stopped
+// enterRuntimeMemoryBudget from taking its early return (a real,
+// stop-the-world-adjacent runtime.ReadMemStats call once per parse, even for
+// a one-byte source) and left the soft budget armed at 0 bytes, which in turn
+// selected the TIGHT poll mask instead of the loose one at every
+// materialization-boundary poll site for the rest of the parse (see
+// runtimeMemoryPollMask's git history). Adversarial review measured 3.6x-9x
+// mean latency on ordinary small Go parses, a 2.2x wall-clock regression on a
+// real 30 KB Swift file, and — the disqualifying finding — reopened the exact
+// issue #454 symptom class this file's own determinism contract exists to
+// prevent: the same 500-byte Go file returned seven distinct truncated trees
+// (HasError()==false over a partial range) across repeated runs under
+// concurrent heap churn, where main returns one accepted tree every time. It
+// also caught none of the three witnesses tested (arena/scratch stopped all
+// three; hard_ceiling stopped none), so it bought determinism risk and
+// latency with no offsetting protection. The floor stays; the memory-
+// exhaustion fix's real backstops are the always-armed arena/scratch soft
+// budget (resultMaterializationStopReason, parser_result.go) and the two
+// deterministic loop ceilings in parser_recover_c.go
+// (cRecoverMaxReductionCandidateAttempts, cRecoverMaxMissingTokenTrials).
 func runtimeMemoryHardCeilingEnabled(p *Parser, sourceLen int) bool {
 	return p != nil && sourceLen >= parseRuntimeMemoryMinSourceBytes && parseMemoryHardCeilingBytes() > 0
 }

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -71,6 +71,105 @@ const (
 	cErrorState = StateID(0)
 )
 
+// cRecoverMaxReductionCandidateAttempts and cRecoverMaxMissingTokenTrials are
+// Go-side backstop ceilings with NO exact C analog. Background
+// (spore.2026-08-02.walnut-e.memory-exhaustion): a 4-byte erlang input and a
+// 56-byte jsdoc input both drove cHandleError's missing-token search, via
+// cDoAllPotentialReductions/cReductionCandidatesForAction, to clone the whole
+// GSS stack (gssScratch, glr_gss.go) without bound — 2.4-2.6 GB RSS in
+// seconds, unbounded for as long as host memory allows.
+//
+// C DOES intrinsically bound this same search, but by a mechanism that does
+// not transplant onto this port's data structures without a larger, riskier
+// redesign. ts_parser__reduce (parser.c:931-1046, called by both
+// ts_parser__do_all_potential_reductions and, transitively, by
+// ts_parser__handle_error's missing-token loop) checks every new stack
+// version it is about to build against MAX_VERSION_COUNT (6) +
+// MAX_VERSION_COUNT_OVERFLOW (4) BEFORE doing the parent-node/push work
+// (parser.c:955-971), discarding the excess silently and cheaply. That cap is
+// enforced against self->stack's version count, which is one persistent,
+// shared structure for the parser's entire lifetime — a single reduce call's
+// pop can yield several slices (several new versions at once) and the shared
+// counter sees all of them, from every caller, in one place.
+//
+// This port's cDoAllPotentialReductions instead builds a fresh, per-call
+// local `versions := []glrStack{start}` (parser_recover_c.go) with its own
+// local cRecoverMaxVersionCount+1 cap (faithfully porting MAX_VERSION_COUNT
+// itself — see cRecoverMaxVersionCount above), reset on every invocation.
+// cHandleError's missing-token loop calls cDoAllPotentialReductions up to
+// TokenCount-1 times (once per candidate missing symbol that survives the two
+// cheap pre-filters, cTerminalNextState + stateHasLeadingReduceAction), and
+// each of those nested calls gets its OWN fresh ~7-version allowance rather
+// than sharing one global counter the way C's self->stack does. Faithfully
+// porting C's exact mechanism would mean threading one shared, persistent
+// version counter through cHandleError and every nested
+// cDoAllPotentialReductions call it makes (including step 1's own call) and
+// making it interact correctly with the existing local caps everywhere they
+// already gate candidate selection (cAppendReductionVersion,
+// cCollapseSamePopReductionCandidates, the cRecoverMaxVersionCount+1 break at
+// the end of cDoAllPotentialReductions's loop) — exactly the kind of
+// larger, not-yet-authorized redesign spec.recovery-strategy1-linearization-v2
+// is already scoped to attempt, and getting the shared budget's SIZE wrong
+// here risks silently eliminating a candidate an existing corpus fixture
+// depends on (a tree-shape change, not just a slower parse).
+//
+// These two ceilings instead bound total WORK directly and fail exactly the
+// way an ordinary, already-supported "search found nothing" outcome fails —
+// no new ParseStopReason, no early exit that discards progress:
+//   - cRecoverMaxReductionCandidateAttempts bounds total
+//     cReductionCandidatesForAction calls (the expensive GSS-clone-and-reduce
+//     step) within ONE cDoAllPotentialReductions call. Reaching it silently
+//     truncates the remaining candidate exploration and returns whatever
+//     versions/canShift were already accumulated with ParseStopNone — the
+//     same graceful-truncation shape the function already uses at its
+//     existing `len(versions) > cRecoverMaxVersionCount+1` break, and the
+//     same "discard the excess, keep going" spirit as C's own per-slice
+//     check above.
+//   - cRecoverMaxMissingTokenTrials bounds total "expensive" trials (both
+//     cheap pre-filters passed, so a clone + shift + nested
+//     cDoAllPotentialReductions follows) across cHandleError's ENTIRE
+//     missing-token search (every version times every candidate symbol, not
+//     per version). Reaching it abandons the missing-token search exactly as
+//     if every remaining symbol had failed — missingVersions stays nil, the
+//     same outcome an ordinary exhaustive-but-unsuccessful search already
+//     produces routinely, falling through to step 3's discontinuity-push +
+//     ts_parser__recover-equivalent path.
+//
+// Sizing: measured TokenCount across all 206 bundled grammars tops out at 585
+// (cobol); cDoAllPotentialReductions's own outer loop is bounded to roughly
+// cRecoverMaxVersionCount (reprocess-in-place rounds) +
+// cRecoverMaxVersionCount+1 (version slots) outer passes regardless of
+// grammar, so a naive worst case is on the order of 7*585 =~ 4095 candidate
+// attempts. Measured directly (2026-08-02, consolidating PR #641): a
+// 212-language, 12,717-file walk of real-world source under
+// gotreesitter-corpora/corpus_sources — deliberately including files whose
+// content does not match the language directory it was sampled from (e.g. a
+// git diff fed to the bash grammar), the same "plausible adversarial-but-legal
+// input shape" methodology the removed clone-cap mechanism used — found
+// exactly one file that reaches this ceiling at all: that same content-
+// mismatched diff file, which already failed to parse cleanly on origin/main
+// (stopReason=memory_budget there, before this fix existed) and keeps
+// failing to parse cleanly at every ceiling value tried, including 4x this
+// one (its own search has no natural stopping point short of the ceiling,
+// so it always lands at "ceiling+1", whatever the ceiling is — evidence the
+// search is genuinely unbounded for this input, not evidence the ceiling is
+// undersized). Every OTHER file across all 212 languages, plus every one of
+// the 206 bundled languages' own smoke samples, stayed under this ceiling by
+// a wide margin (missing-token-search peak across the whole walk: 259,
+// against cRecoverMaxMissingTokenTrials's much larger headroom). Raising
+// this ceiling does not help the one adversarial file — it only spends more
+// of the four known memory-exhaustion witnesses' own bounded budget before
+// the ceiling engages (measured: heap growth for the largest witness moved
+// from ~130 MB at 4096 to ~750 MB at a 16384 trial), so it stays at the
+// measured, validated value. Both ceilings stay small enough that reaching
+// them costs a small, bounded amount of additional work (combined with the
+// memory-budget feed alongside this one) well under a second, instead of an
+// unbounded multi-GB climb.
+const (
+	cRecoverMaxReductionCandidateAttempts = 4096
+	cRecoverMaxMissingTokenTrials         = 8192
+)
+
 // errorCostCompetitionLanguage reports whether the faithful C error-recovery
 // port is enabled for the active grammar. By default the gate requires
 // parser.c-backed capability metadata, explicit parity certification, and
@@ -2540,6 +2639,7 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 	canShift := false
 	var reduces []ParseAction
 	v := 0
+	candidateAttempts := 0
 	for iter := 0; ; iter++ {
 		if reason := checkStop(); reason != ParseStopNone {
 			return versions, canShift, reason
@@ -2568,6 +2668,19 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 		for _, act := range reduces {
 			if reason := checkStop(); reason != ParseStopNone {
 				return versions, canShift, reason
+			}
+			// cRecoverMaxReductionCandidateAttempts backstop (see its doc
+			// comment above cRecoverMaxVersionCount): truncate exactly like
+			// the existing len(versions) > cRecoverMaxVersionCount+1 break
+			// below — return what has already been accumulated, ParseStopNone,
+			// no halted parse.
+			candidateAttempts++
+			if uint64(candidateAttempts) > p.crecoveryReductionCandidateAttemptsPeak {
+				p.crecoveryReductionCandidateAttemptsPeak = uint64(candidateAttempts)
+			}
+			if candidateAttempts > cRecoverMaxReductionCandidateAttempts {
+				p.crecoveryReductionCandidateCeilingHits++
+				return versions, canShift, ParseStopNone
 			}
 			actionCandidates, reason := p.cReductionCandidatesForAction(source, versions[v], act, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
 			if reason != ParseStopNone {
@@ -2898,6 +3011,8 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	// lookahead (the copied version plus its reduction forks).
 	var missingVersions []glrStack
 	if !p.isGraphQLRecoveryTripleQuote(tok.Symbol) {
+		missingTokenTrialAttempts := 0
+	missingTokenSearch:
 		for vi := range versions {
 			if reason := checkStop(); reason != ParseStopNone {
 				return cRecHalted, false, reason
@@ -2916,6 +3031,20 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 				}
 				if !p.stateHasLeadingReduceAction(nextState, tok.Symbol) {
 					continue
+				}
+				// cRecoverMaxMissingTokenTrials backstop (see its doc comment
+				// above cRecoverMaxVersionCount): abandon the missing-token
+				// search across every remaining (version, symbol) pair
+				// exactly as if each had failed its own trial —
+				// missingVersions stays nil, so step 3 below proceeds via its
+				// ordinary "no missing-token match found" path.
+				missingTokenTrialAttempts++
+				if uint64(missingTokenTrialAttempts) > p.crecoveryMissingTokenTrialAttemptsPeak {
+					p.crecoveryMissingTokenTrialAttemptsPeak = uint64(missingTokenTrialAttempts)
+				}
+				if missingTokenTrialAttempts > cRecoverMaxMissingTokenTrials {
+					p.crecoveryMissingTokenCeilingHits++
+					break missingTokenSearch
 				}
 				cand := versions[vi].cloneWithScratch(gssScratch)
 				cand.cRec = nil

--- a/parser_recovery_memory_bound_test.go
+++ b/parser_recovery_memory_bound_test.go
@@ -1,0 +1,377 @@
+package gotreesitter_test
+
+import (
+	"os"
+	"runtime"
+	"runtime/debug"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// recoveryMemoryBoundWitnesses are four adversarial inputs, all reachable
+// through production's C-recovery missing-token search
+// (cHandleError/cDoAllPotentialReductions, parser_recover_c.go), which used
+// to clone the whole GSS stack (gssScratch, glr_gss.go) without bound:
+//
+//   - erlang (4 bytes) and jsdoc (56 bytes), from
+//     spore.2026-08-02.walnut-e.memory-exhaustion: 2.4-2.6 GB RSS in 12-17
+//     seconds on origin/main, reproducing identically regardless of the
+//     admission candidate route (compact declined both fast, before any heavy
+//     allocation, every time -- the spore's section 3).
+//   - erlang_pfx_008_73b and erlang_pfx_017_71b (testdata/
+//     recovery_memory_bound_witnesses), found by adversarial review of the
+//     first landed fix: truncated C-style block comments (a copyright-header
+//     shape) with one injected control byte each, fed to the erlang grammar.
+//     Pre-ceiling-fix measurements: 73 bytes -> 40.5s / 1.1 GB (arena stop
+//     source); 71 bytes -> 52.0s / 695 MB.
+//
+// The shipped fix is two complementary layers: the always-armed soft memory
+// budget also sees parserScratch's (dominated by gssScratch's) allocated
+// bytes (Parser.budgetScratch, parser.go; resultMaterializationStopReason,
+// parser_result.go), and two Go-side backstop ceilings bound the
+// missing-token search's own total work directly
+// (cRecoverMaxReductionCandidateAttempts, cRecoverMaxMissingTokenTrials,
+// parser_recover_c.go) -- the ceilings are what actually stop all four
+// witnesses (CRecoverReductionCandidateCeilingHits > 0 on every one); the
+// budget feed is defense in depth for a growth shape the ceilings do not
+// cover.
+//
+// A source-length-independent absolute hard ceiling (removing
+// runtimeMemoryHardCeilingEnabled's floor) was tried and dropped: it
+// unintentionally selected the tight (1-in-16) runtime-memory poll mask for
+// every small-source parse instead of the loose (1-in-256) one, since a
+// disabled soft budget (0) satisfied the same "small budget" comparison the
+// tight-mask selection used, and it reopened the issue #454 determinism
+// symptom class for sub-64KiB input (a 500-byte Go file returned seven
+// distinct truncated trees under concurrent heap churn). See
+// runtimeMemoryHardCeilingEnabled's doc comment (parser_memory_budget_runtime.go).
+var recoveryMemoryBoundWitnesses = []struct {
+	name string
+	lang func() *gotreesitter.Language
+	src  []byte
+}{
+	{
+		name: "erlang",
+		lang: grammars.ErlangLanguage,
+		src:  []byte{0x6b, 0x1c, 0x03, 0x21},
+	},
+	{
+		name: "jsdoc",
+		lang: grammars.JsdocLanguage,
+		src:  []byte("/**\n * @param {string} name\n * #  @returns {number}\n */\n"),
+	},
+	{
+		name: "erlang_pfx_008_73b",
+		lang: grammars.ErlangLanguage,
+		src:  mustReadRecoveryWitnessFile("erlang_pfx_008_73b.bin"),
+	},
+	{
+		name: "erlang_pfx_017_71b",
+		lang: grammars.ErlangLanguage,
+		src:  mustReadRecoveryWitnessFile("erlang_pfx_017_71b.bin"),
+	},
+}
+
+func mustReadRecoveryWitnessFile(name string) []byte {
+	src, err := os.ReadFile("testdata/recovery_memory_bound_witnesses/" + name)
+	if err != nil {
+		panic("mustReadRecoveryWitnessFile: " + name + ": " + err.Error())
+	}
+	return src
+}
+
+// recoveryMemoryBoundMaxHeapGrowthBytes generously bounds per-parse heap
+// growth for the witnesses above. Measured behavior after the fix: 12-40MB
+// peak heap across both witnesses and both admission routes. This ceiling
+// sits an order of magnitude above that (and two orders of magnitude below
+// the pre-fix 2.4-2.6 GB) so ordinary run-to-run allocator variance can never
+// make this test flaky, while a genuine regression back toward unbounded
+// growth still fails it long before it could threaten the host running the
+// test.
+const recoveryMemoryBoundMaxHeapGrowthBytes = 200 << 20 // 200 MiB
+
+// recoveryMemoryBoundTimeoutMicros is the parser's own cooperative wall-clock
+// backstop (SetTimeoutMicros), checked at the same
+// resultMaterializationStopReason poll sites the memory-budget fix threads
+// through (parser_recover_c.go's cDoAllPotentialReductions/cHandleError).
+// Measured completion time for both witnesses after the fix is well under
+// 400ms; 5 seconds is generous headroom for a slow or loaded CI host while
+// still finishing an order of magnitude before the pre-fix witnesses'
+// 12-17 second run to a multi-GB OOM kill. This is what makes the harness
+// GOMEMLIMIT-safe without needing an actual GOMEMLIMIT/subprocess: a
+// still-pathological input gets cut off by this cooperative check long
+// before it could grow to a dangerous size, so this test cannot OOM the host
+// even if the fix regresses.
+const recoveryMemoryBoundTimeoutMicros = 5_000_000
+
+func TestRecoveryMissingTokenSearchStaysMemoryBoundedProductionRoute(t *testing.T) {
+	for _, w := range recoveryMemoryBoundWitnesses {
+		w := w
+		t.Run(w.name, func(t *testing.T) {
+			assertRecoveryMemoryBoundedParse(t, w.name, w.lang(), w.src, false)
+		})
+	}
+}
+
+func TestRecoveryMissingTokenSearchStaysMemoryBoundedCompactRoute(t *testing.T) {
+	for _, w := range recoveryMemoryBoundWitnesses {
+		w := w
+		t.Run(w.name, func(t *testing.T) {
+			assertRecoveryMemoryBoundedParse(t, w.name, w.lang(), w.src, true)
+		})
+	}
+}
+
+func assertRecoveryMemoryBoundedParse(t *testing.T, name string, lang *gotreesitter.Language, src []byte, candidateRoute bool) {
+	t.Helper()
+	if raceEnabled {
+		// Same rationale as TestCSharpDesignerStyleBlockStaysBounded
+		// (parser_csharp_boundedness_test.go): -race's ~10x instrumentation
+		// slowdown competes with the wall-clock timeout for an unrelated
+		// reason. Skip the whole test rather than let the timeout mask the
+		// memory-growth assertion, which is this test's actual point.
+		t.Skip("wall-clock timeout contract is not meaningful under -race instrumentation")
+	}
+
+	parser := gotreesitter.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(candidateRoute)
+	parser.SetTimeoutMicros(recoveryMemoryBoundTimeoutMicros)
+
+	debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(100)
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	tree, err := parser.Parse(src)
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	if err != nil {
+		t.Fatalf("[%s candidateRoute=%t] Parse() error = %v", name, candidateRoute, err)
+	}
+	if tree == nil {
+		t.Fatalf("[%s candidateRoute=%t] Parse() returned a nil tree with no error", name, candidateRoute)
+	}
+	defer tree.Release()
+
+	rt := tree.ParseRuntime()
+	if got, want := rt.StopReason, gotreesitter.ParseStopAccepted; got != want {
+		t.Fatalf("[%s candidateRoute=%t] StopReason = %s, want %s -- did not resolve within the timeout backstop (%s)",
+			name, candidateRoute, got, want, rt.Summary())
+	}
+	if tree.ParseStoppedEarly() {
+		t.Fatalf("[%s candidateRoute=%t] ParseStoppedEarly = true (%s)", name, candidateRoute, rt.Summary())
+	}
+
+	heapGrowth := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+	if heapGrowth > recoveryMemoryBoundMaxHeapGrowthBytes {
+		t.Fatalf("[%s candidateRoute=%t] heap growth = %d bytes, want <= %d bytes -- memory-exhaustion regression (spore.2026-08-02.walnut-e.memory-exhaustion) (%s)",
+			name, candidateRoute, heapGrowth, recoveryMemoryBoundMaxHeapGrowthBytes, rt.Summary())
+	}
+	t.Logf("[%s candidateRoute=%t] heap growth = %d bytes, reductionCeilingHits=%d missingTokenCeilingHits=%d (%s)",
+		name, candidateRoute, heapGrowth, rt.CRecoverReductionCandidateCeilingHits, rt.CRecoverMissingTokenCeilingHits, rt.Summary())
+}
+
+// recoveryFuzzLanguages backs FuzzRecoveryMissingTokenSearchStaysBounded. It
+// is deliberately separate from FuzzAdmissionRouteEquality's
+// routeEqualityFuzzLanguages (fuzz_admission_route_equality_test.go): that
+// fuzzer's language list is a route-EQUALITY corpus contract ("every listed
+// language passes the compact admission smoke ratchet",
+// admissionScorecardRequiredCompactPasses) that jsdoc does not currently
+// meet (it FALLBACKs on compact, by design -- see
+// TestAdmissionCandidateScorecard206's ratchet comment). This fuzzer asserts
+// a different, route-agnostic property instead: Parse must return, and must
+// not allocate past a generous ceiling, regardless of which admission route
+// serves the input -- exactly what spore.2026-08-02.walnut-e.memory-
+// exhaustion's four-combination reproduction (two witnesses times
+// compact-forced/production-forced) established was broken.
+var recoveryFuzzLanguages = []struct {
+	name string
+	lang func() *gotreesitter.Language
+}{
+	{"erlang", grammars.ErlangLanguage},
+	{"jsdoc", grammars.JsdocLanguage},
+}
+
+// recoveryFuzzMaxInputBytes caps fuzzed input size. The bug class this
+// fuzzer targets is a small-input recovery-search explosion (both seed
+// witnesses are 4 and 56 bytes), not general large-input containment, which
+// FuzzGoParseDoesNotPanic and the memory-budget suite
+// (parser_memory_budget_test.go) already cover; keeping the cap small keeps
+// recoveryFuzzMaxHeapGrowthBytes below meaningful for every input this
+// fuzzer explores.
+const recoveryFuzzMaxInputBytes = 4096
+
+// recoveryFuzzMaxHeapGrowthBytes is looser than
+// recoveryMemoryBoundMaxHeapGrowthBytes above: live fuzzing explores inputs
+// up to recoveryFuzzMaxInputBytes (1024x the larger seed witness), not just
+// the two exact 4- and 56-byte seeds, so this bound trades some precision for
+// robustness against false positives on legitimately larger fuzzed inputs.
+// It still sits three orders of magnitude below the pre-fix 2.4-2.6 GB
+// witnesses.
+const recoveryFuzzMaxHeapGrowthBytes = 512 << 20 // 512 MiB
+
+// FuzzRecoveryMissingTokenSearchStaysBounded is the targeted regression
+// fuzzer for spore.2026-08-02.walnut-e.memory-exhaustion, seeded with both
+// witnesses. Committed seeds run as ordinary regression cases under plain
+// `go test` (Go's native fuzzing converts f.Add corpus entries into subtests
+// without -fuzz); live mutation is opt-in via `go test -fuzz`.
+func FuzzRecoveryMissingTokenSearchStaysBounded(f *testing.F) {
+	f.Add([]byte{0x6b, 0x1c, 0x03, 0x21}, byte(0))                                         // erlang witness (index 0: erlang)
+	f.Add([]byte("/**\n * @param {string} name\n * #  @returns {number}\n */\n"), byte(1)) // jsdoc witness (index 1: jsdoc)
+	// Cross-pair each witness with the other's language too: the underlying
+	// bug is in language-agnostic core GLR error recovery (the spore's
+	// section 5), not either grammar's own scanner, so a byte sequence one
+	// grammar finds pathological is worth trying against the other.
+	f.Add([]byte{0x6b, 0x1c, 0x03, 0x21}, byte(1))
+	f.Add([]byte("/**\n * @param {string} name\n * #  @returns {number}\n */\n"), byte(0))
+
+	f.Fuzz(func(t *testing.T, src []byte, langSel byte) {
+		if len(src) >= recoveryFuzzMaxInputBytes {
+			t.Skip("input at or above the fuzz latency/memory safety cap")
+		}
+		if raceEnabled {
+			t.Skip("wall-clock timeout contract is not meaningful under -race instrumentation")
+		}
+		lp := recoveryFuzzLanguages[int(langSel)%len(recoveryFuzzLanguages)]
+
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("panic during recovery-boundedness fuzz (lang=%s bytes=%d): %v", lp.name, len(src), r)
+			}
+		}()
+
+		parser := gotreesitter.NewParser(lp.lang())
+		parser.SetTimeoutMicros(recoveryMemoryBoundTimeoutMicros)
+
+		debug.SetGCPercent(-1)
+		defer debug.SetGCPercent(100)
+		var before runtime.MemStats
+		runtime.ReadMemStats(&before)
+
+		tree, err := parser.Parse(src)
+
+		var after runtime.MemStats
+		runtime.ReadMemStats(&after)
+
+		if err != nil {
+			t.Fatalf("lang=%s Parse: %v", lp.name, err)
+		}
+		if tree == nil {
+			t.Fatalf("lang=%s Parse returned a nil tree with no error", lp.name)
+		}
+		defer tree.Release()
+
+		heapGrowth := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+		if heapGrowth > recoveryFuzzMaxHeapGrowthBytes {
+			t.Fatalf("lang=%s heap growth = %d bytes, want <= %d bytes (%s)",
+				lp.name, heapGrowth, recoveryFuzzMaxHeapGrowthBytes, tree.ParseRuntime().Summary())
+		}
+	})
+}
+
+// TestRecoveryCeilingsNeverTripOnGreenCorpus is the corpus assertion for
+// cRecoverMaxReductionCandidateAttempts and cRecoverMaxMissingTokenTrials
+// (parser_recover_c.go): both ceilings must stay unreached on every green
+// (non-adversarial) input, or they would change a currently-correct recovery
+// outcome instead of only bounding a pathological search. Scope: the
+// smoke-sample corpus (one representative fixture per each of the 206
+// registered languages, grammars.ParseSmokeSample) plus a small curated set
+// of malformed-but-plausible recovery-stress snippets across widely used
+// grammars -- every fixture here is embedded in the repo, so the gate runs
+// identically in CI and on any contributor's machine.
+func TestRecoveryCeilingsNeverTripOnGreenCorpus(t *testing.T) {
+	checkOne := func(t *testing.T, label string, lang *gotreesitter.Language, source []byte) {
+		t.Helper()
+		if lang == nil || len(source) == 0 {
+			return
+		}
+		p := gotreesitter.NewParser(lang)
+		p.SetAdmissionCandidateRoute(false) // production: cHandleError's missing-token search only runs here
+		tree, err := p.Parse(source)
+		if err != nil {
+			t.Fatalf("%s: Parse error: %v", label, err)
+		}
+		if tree == nil {
+			t.Fatalf("%s: Parse returned a nil tree", label)
+		}
+		defer tree.Release()
+		rt := tree.ParseRuntime()
+		if rt.CRecoverReductionCandidateCeilingHits != 0 {
+			t.Fatalf("%s: CRecoverReductionCandidateCeilingHits = %d, want 0 -- the ceiling tripped on green input, "+
+				"which changes a currently-correct recovery outcome", label, rt.CRecoverReductionCandidateCeilingHits)
+		}
+		if rt.CRecoverMissingTokenCeilingHits != 0 {
+			t.Fatalf("%s: CRecoverMissingTokenCeilingHits = %d, want 0 -- the ceiling tripped on green input, "+
+				"which changes a currently-correct recovery outcome", label, rt.CRecoverMissingTokenCeilingHits)
+		}
+	}
+
+	t.Run("smoke", func(t *testing.T) {
+		for _, entry := range grammars.AllLanguages() {
+			entry := entry
+			sample := grammars.ParseSmokeSample(entry.Name)
+			if sample == "" {
+				continue
+			}
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("%s: panic: %v", entry.Name, r)
+					}
+				}()
+				checkOne(t, entry.Name, entry.Language(), []byte(sample))
+			}()
+		}
+	})
+
+	t.Run("curated", func(t *testing.T) {
+		for _, tc := range curatedRecoveryStressFixtures() {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				checkOne(t, tc.name, tc.lang(), tc.source)
+			})
+		}
+	})
+}
+
+type curatedRecoveryStressFixture struct {
+	name   string
+	lang   func() *gotreesitter.Language
+	source []byte
+}
+
+// curatedRecoveryStressFixtures are small, embedded (not downloaded)
+// snippets picked to exercise C-recovery (cHandleError) on grammars/shapes
+// known from this codebase's own history to stress it: malformed/incomplete
+// input in the two languages from the 2026-08-02 memory-exhaustion witnesses'
+// grammar families (erlang, a JS/jsdoc-style comment) plus a couple of
+// generically malformed snippets in widely used grammars. Deliberately NOT
+// the raw witness bytes themselves: those are already covered directly by
+// TestRecoveryMissingTokenSearchStaysMemoryBoundedProductionRoute/CompactRoute
+// above, with tighter, witness-specific bounds.
+func curatedRecoveryStressFixtures() []curatedRecoveryStressFixture {
+	return []curatedRecoveryStressFixture{
+		{name: "go-truncated-func", lang: grammarLanguageByName("go"), source: []byte("package p\nfunc f(x int) {\nif x {\n")},
+		{name: "go-stray-token", lang: grammarLanguageByName("go"), source: []byte("package p\nvar x = ) + (\n")},
+		{name: "javascript-unbalanced", lang: grammarLanguageByName("javascript"), source: []byte("function f(a, b) { return a +\n")},
+		{name: "javascript-jsdoc-broken-comment", lang: grammarLanguageByName("javascript"), source: []byte("/**\n * @param {string} name\n * #  @returns {number}\n */\nfunction f(name) {}\n")},
+		{name: "erlang-garbage", lang: grammarLanguageByName("erlang"), source: []byte("-module(x).\n-export([f/0]).\nf() -> ) ( .\n")},
+		{name: "python-dedent-mismatch", lang: grammarLanguageByName("python"), source: []byte("def f():\n    if True:\n  x = 1\n")},
+		{name: "json-trailing-comma", lang: grammarLanguageByName("json"), source: []byte("{\"a\": 1, \"b\": [1, 2, ,]}")},
+		{name: "c-unbalanced-brace", lang: grammarLanguageByName("c"), source: []byte("int f(int x) {\n  if (x) {\n    return 1;\n")},
+	}
+}
+
+func grammarLanguageByName(name string) func() *gotreesitter.Language {
+	return func() *gotreesitter.Language {
+		entry := grammars.DetectLanguageByName(name)
+		if entry == nil {
+			return nil
+		}
+		return entry.Language()
+	}
+}

--- a/parser_result.go
+++ b/parser_result.go
@@ -166,8 +166,29 @@ func (p *Parser) resultMaterializationStopReason(arena *nodeArena) ParseStopReas
 	if arena != nil && arena.budgetExhausted() {
 		return p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceArena)
 	}
+	if p != nil && p.budgetScratch != nil && p.budgetScratch.budgetExhausted() {
+		// Closes the gap documented in
+		// spore.2026-08-02.walnut-e.memory-exhaustion: gssScratch (the
+		// exploding allocator in production's C-recovery missing-token
+		// search, cHandleError/cDoAllPotentialReductions in
+		// parser_recover_c.go) has no budget state of its own, but the
+		// owning parserScratch already tracks it inside its own
+		// allocatedBytes()/budgetExhausted() (parser_scratch.go) — the SAME
+		// 512MB soft budget arena.budgetExhausted() above enforces, armed
+		// unconditionally regardless of source length (parseMemoryBudget,
+		// parser_limits.go). Before this check existed, the main GLR loop's
+		// own per-token checkpoints (parser.go) called scratch.budgetExhausted()
+		// directly, right beside their own resultMaterializationStopReason
+		// call, because this function could not see it; those five direct
+		// calls are gone now (this check makes them redundant), and every
+		// OTHER resultMaterializationStopReason call site — including the
+		// C-recovery candidate search, which never had a direct
+		// scratch.budgetExhausted() check of its own — gets the same
+		// coverage those five sites always had.
+		return p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceScratch)
+	}
 	if p != nil {
-		if reason := p.runtimeMemoryBudgetStopReason(arenaAllocatedVolume(arena)); reason == ParseStopMemoryBudget {
+		if reason := p.runtimeMemoryBudgetStopReason(arenaAllocatedVolume(arena) + scratchAllocatedVolume(p.budgetScratch)); reason == ParseStopMemoryBudget {
 			return reason
 		}
 	}
@@ -183,6 +204,25 @@ func arenaAllocatedVolume(arena *nodeArena) uint64 {
 		return 0
 	}
 	return uint64(arena.allocatedBytes)
+}
+
+// scratchAllocatedVolume returns the active parse's parserScratch
+// allocated-bytes counter — dominated in pathological cases by
+// gssScratch.allocatedBytes (see budgetScratch's doc comment on Parser) — as a
+// second, equally cheap volume signal alongside arenaAllocatedVolume. Costs no
+// syscalls: parserScratch.allocatedBytes() sums already-tracked
+// per-substructure counters, each updated incrementally at its own
+// slab-allocation boundary (e.g. (*gssScratch).allocNodeSlow,
+// glr_gss.go:629).
+func scratchAllocatedVolume(scratch *parserScratch) uint64 {
+	if scratch == nil {
+		return 0
+	}
+	bytes := scratch.allocatedBytes()
+	if bytes <= 0 {
+		return 0
+	}
+	return uint64(bytes)
 }
 
 func resultMaterializationShouldStop(reason ParseStopReason) bool {

--- a/testdata/recovery_memory_bound_witnesses/erlang_pfx_008_73b.bin
+++ b/testdata/recovery_memory_bound_witnesses/erlang_pfx_008_73b.bin
@@ -1,0 +1,6 @@
+/*
+ * %CopyrightBegin%
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * C

--- a/testdata/recovery_memory_bound_witnesses/erlang_pfx_017_71b.bin
+++ b/testdata/recovery_memory_bound_witnesses/erlang_pfx_017_71b.bin
@@ -1,0 +1,6 @@
+/*
+ * %CopyrightBegin%
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *

--- a/tree.go
+++ b/tree.go
@@ -839,7 +839,27 @@ type ParseRuntime struct {
 	// the fallback's false-fire rate (extra latency from a re-parse that is
 	// usually discarded) against their own corpora, e.g. by walking a tree of
 	// known-valid source files and counting how often this is true.
-	CRecoverySwallowedErrorFallbackAttempted      bool
+	CRecoverySwallowedErrorFallbackAttempted bool
+	// CRecoverReductionCandidateCeilingHits and CRecoverMissingTokenCeilingHits
+	// count how many times this parse's cDoAllPotentialReductions /
+	// cHandleError missing-token search hit the
+	// cRecoverMaxReductionCandidateAttempts / cRecoverMaxMissingTokenTrials
+	// Go-side backstop ceilings (parser_recover_c.go), a diagnostic signal for
+	// the spore.2026-08-02.walnut-e.memory-exhaustion fix. Both stay zero on
+	// every currently-passing parse; neither ceiling halts the parse itself
+	// (both fail gracefully into an already-supported "search found nothing"
+	// path), so this counter is the only way to observe that either engaged.
+	CRecoverReductionCandidateCeilingHits uint64
+	CRecoverMissingTokenCeilingHits       uint64
+	// CRecoverReductionCandidateAttemptsPeak and
+	// CRecoverMissingTokenTrialAttemptsPeak record the single largest
+	// candidateAttempts / missingTokenTrialAttempts value any ONE
+	// cDoAllPotentialReductions call / cHandleError missing-token search
+	// reached during this parse (not cumulative across calls). Diagnostic
+	// only: lets a corpus walk report how close real input gets to
+	// cRecoverMaxReductionCandidateAttempts / cRecoverMaxMissingTokenTrials.
+	CRecoverReductionCandidateAttemptsPeak        uint64
+	CRecoverMissingTokenTrialAttemptsPeak         uint64
 	SourceLen                                     uint32
 	ExpectedEOFByte                               uint32
 	RootEndByte                                   uint32


### PR DESCRIPTION
## Summary

`cHandleError`'s missing-token search cloned the GSS (graph-structured
stack) without a work limit. A 4-byte erlang input and a 56-byte jsdoc
input drove heap use past 2 GB in seconds. This PR bounds the search
with two measured loop ceilings, and feeds GSS allocation into the
existing scratch memory budget so the check already in place can see
it.

- **Two loop ceilings (the fix).** `cRecoverMaxReductionCandidateAttempts`
  bounds candidate attempts in one `cDoAllPotentialReductions` call.
  `cRecoverMaxMissingTokenTrials` bounds total trials across one
  `cHandleError` missing-token search. Each ceiling ends the search the
  same way an ordinary, unsuccessful search already ends: no new stop
  reason, no discarded progress. These two ceilings are what stop all
  four known witnesses below.
- **GSS scratch feeds the soft memory budget (defense in depth).** A new
  `Parser.budgetScratch` pointer lets `resultMaterializationStopReason`
  poll the same 512 MB scratch budget check the main parse loop already
  used, from every poll site, including the C-recovery candidate search.
  This budget was always armed, regardless of source size; it just could
  not see GSS growth before this change.

An earlier version of this fix also removed the 64 KiB source-length
floor on the absolute hard memory ceiling. That change let the hard
ceiling arm on small inputs too. Review found that change causes more
harm than it prevents. This PR drops that change. See "Tried and
dropped" below.

## Witness results

Four adversarial inputs, reproduced under `GOMEMLIMIT=2GiB`,
`ulimit -v` near 3.8 GiB, and a kill timeout, matching the original
diagnosis harness on the same base commit.

| Input | Route | Before this fix | After this fix |
|---|---|---|---|
| erlang, 4 bytes | production | OOM kill, 2.4-2.6 GB RSS, 12-17s | accepted tree, 22 MB heap, 16ms |
| erlang, 4 bytes | compact-forced | OOM kill, 2.4-2.6 GB RSS, 12-17s | accepted tree, 22 MB heap, 19ms |
| jsdoc, 56 bytes | production | OOM kill, 2.4-2.6 GB RSS, 12-17s | accepted tree, 12 MB heap, 4ms |
| jsdoc, 56 bytes | compact-forced | OOM kill, 2.4-2.6 GB RSS, 12-17s | accepted tree, 12 MB heap, 4ms |
| erlang_pfx_008_73b, 73 bytes (found reviewing the first fix attempt) | production | 1,147 MB peak, 40.5s, stop source arena | accepted tree, 39 MB heap, 109ms |
| erlang_pfx_008_73b, 73 bytes | compact-forced | 1,147 MB peak, 40.5s, stop source arena | accepted tree, 39 MB heap, 116ms |
| erlang_pfx_017_71b, 71 bytes (found reviewing the first fix attempt) | production | 695 MB peak, 52.0s | accepted tree, 87 MB heap, 323ms |
| erlang_pfx_017_71b, 71 bytes | compact-forced | 695 MB peak, 52.0s | accepted tree, 46 MB heap, 318ms |

All six rows now return a normal, accepted parse tree instead of an
out-of-memory kill or a many-second decline. Peak heap use drops by two
to three orders of magnitude, and wall time drops from tens of seconds
to under one second. `CRecoverReductionCandidateCeilingHits` is nonzero
on every one of the four witness inputs, confirming the loop ceilings
are what stop them.

Both erlang witnesses found reviewing the first fix attempt are
truncated C-style block comments (a copyright-header shape) with one
injected control byte, fed to the erlang grammar. They now live in
`testdata/recovery_memory_bound_witnesses/` and in
`parser_recovery_memory_bound_test.go`, alongside the original two
witnesses.

## Tried and dropped: the source-length-independent hard ceiling

The first fix attempt on this branch also removed the 64 KiB
source-length floor on `runtimeMemoryHardCeilingEnabled`, so the
absolute 2 GiB hard ceiling would arm on every parse, not only large
ones. Review found three problems, in order of severity:

1. **Determinism regression (issue #454).** The hard ceiling reads real
   process memory (`runtime.MemStats`), which this codebase's own
   determinism contract treats as GC-timing-sensitive and unsafe for
   small, fast parses. With the floor removed, a 500-byte Go file
   returned seven different truncated trees across repeated runs under
   concurrent heap churn. Main returns one accepted tree every time.
2. **Wide latency regression.** Removing the floor let a disabled soft
   budget (0 bytes) select the same poll rate a genuinely small,
   nonzero soft budget uses. This forced a real `runtime.ReadMemStats`
   call roughly 16 times more often, on every parse with many poll
   sites. Measured effect: 3.6-9x mean latency on ordinary small Go
   parses; +56% (350.7s to 548.6s) on a 119-file real-world c_sharp
   corpus; a 2.2x regression on a real 30 KB Swift file.
3. **No offsetting protection.** Across all four witnesses above, the
   hard ceiling never fired first; the scratch budget or the loop
   ceilings always stopped the parse before the hard ceiling's own poll
   cadence caught up.

The fix keeps the floor exactly as main has it. `runtimeMemoryHardCeilingEnabled`
and `runtimeMemoryPollMask` are unchanged from main in this PR.

## Corpus-scale verification

- **Real-world corpus, 212 languages, 12,717 files**
  (`gotreesitter-corpora/corpus_sources`). The sample took up to 60 files
  per matched language directory, capped at 256 KiB each. The sample
  includes files whose content does not match their language directory.
  This is the same adversarial-but-plausible method the first fix
  attempt's removed clone-cap test used. `cRecoverMaxReductionCandidateAttempts`
  (4096) and `cRecoverMaxMissingTokenTrials` (8192) trip on exactly one
  file: a git diff stored under the bash corpus directory, read as bash
  source. That file already failed to parse cleanly on main
  (`stopReason=memory_budget`). It still fails to parse cleanly with
  this fix (`stopReason=iteration_limit`), at every ceiling value tried,
  including four times the shipped one. This is evidence the file's
  search has no natural stopping point. It is not evidence the ceiling
  is undersized.
- **Swift real-world sweep.** On main, this sweep hit its own 1200-second
  timeout after 29 of 120 files. With this fix, all 120 files complete
  in 621.7 seconds. The GSS-scratch budget feed makes this possible: a
  lane that previously ran unbounded now stops at a deterministic,
  tracked-allocation limit.
- **Smoke-sample corpus, 206 languages** plus 8 curated recovery-stress
  fixtures (malformed Go, JavaScript, Erlang, Python, JSON, C):
  `TestRecoveryCeilingsNeverTripOnGreenCorpus` asserts zero ceiling hits
  on all of them, and passes.

## Known, expected tree-shape change

Some input already failed to reach a clean, accepted tree on main:
content-mismatched or otherwise unparseable input. This fix can now
stop that same input at a different, cheaper point — a different stop
reason, or a much smaller partial tree — instead of building a large
amount of partial wreckage first. Two confirmed instances: the
bash/git-diff file above, and a truncated git-packfile-shaped input
read as Swift. The Swift case now declines about 20 times sooner, with
a 1-node tree instead of roughly 41,800 nodes of partial wreckage.
Both cases already returned a stopped-early, error-bearing result on
main. Neither is a clean-accept input on either side. No clean,
accepted parse changes tree shape.

## Verification

- `go test . -count=1`: passes.
- `go test ./grammars`: passes.
- `go test ./parser_result_test/...`: passes.
- Admission scorecard, strict and ratchet mode: PASS=198, DIVERGE=0,
  FALLBACK=3, SKIP=5, ERROR=0, total=206. Matches the frozen ratchet
  exactly.
- CGO parity, exhaustive mode, fresh-parse, full curated structural
  language set: 207 PASS, 0 FAIL, 0 SKIP. No canonical digest changed.
- `go test -race` on touched paths (memory-budget tests, the new
  recovery-memory-bound tests and fuzzer, the SQL incremental
  certification test): passes, no data races.
- A separate COBOL recovery timeout does not reproduce today. The
  original diagnosis referenced this timeout (file BBANK10P.cbl, about
  11.5 KB). An earlier, unrelated commit fixed it before this branch's
  base commit. It parses in 16-28 ms now, with zero ceiling hits. This
  fix does not touch that code path.

## Files changed

- `parser_recover_c.go`: the two loop ceilings, with their measured
  sizing basis.
- `parser.go`: `Parser.budgetScratch`, save/restore across nested
  parses; removes five now-redundant direct `scratch.budgetExhausted()`
  checks that `resultMaterializationStopReason` now performs once,
  centrally.
- `parser_result.go`: `resultMaterializationStopReason` polls
  `budgetScratch`; `scratchAllocatedVolume` feeds the runtime-memory
  poll's volume-triggered bypass.
- `glr_forest.go`: the GSS-forest fast path's own volume watermark
  matches the same unit (arena plus scratch), for consistency; this
  path does not use `parserScratch` today, so this is currently a
  no-op kept for future-proofing.
- `parser_recovery_memory_bound_test.go`: four witnesses, both
  admission routes, a real-corpus-shaped regression corpus test, and a
  seeded fuzz target.
- `testdata/recovery_memory_bound_witnesses/`: the two witnesses found
  reviewing the first fix attempt.
