### PR TITLE
refactor(parser): skip no-op compat-tail steps for eligible languages on compact route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,25 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- The compact fresh-path route now skips three steps for a language with no
+  live result-compatibility entry: the result-compatibility walk, the
+  C-recovery-swallow resolver, and the final-tree compaction pass.
+  The eligible set is computed from
+  `testdata/result_compat_ownership_v1.json`.
+  It is not a maintained list.
+  A future dispatcher arm cannot silently escape it.
+  159 of 206 registered languages are eligible today.
+  Go is not one of them.
+  `dispatch.go` stays live, so `grammargen_lr` and the other three canonical
+  Go fixtures still take the full tail.
+  A deep-tree digest comparison (elided against unelided) is exact across
+  every eligible language's smoke sample.
+  It is also exact across every real-corpus file this campaign measured, up
+  to 484 KB.
+  The measured effect on a shared, contended host stayed within noise on the
+  Go warm-route benchmark and on two eligible-language probes (OCaml, Zig).
+  See the PR for the full reading and its noise-floor caveats.
+
 - Live-header scoping reduces compact full-parse allocation counts by
   11.27 percent on the 235,626-byte Go fixture.
   Allocated bytes fall by 26.64 percent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,32 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- The compact fresh-path route now skips two tail steps for a language with
+  no live result-compatibility entry: the C-recovery-swallow resolver and
+  the final-tree compaction pass.
+  The eligible set is computed from
+  `testdata/result_compat_ownership_v1.json`.
+  It is not a maintained list.
+  A future dispatcher arm cannot silently escape it.
+  163 of 206 registered languages are eligible today.
+  Go is not one of them.
+  `dispatch.go` stays live, so `grammargen_lr` and the other three canonical
+  Go fixtures still take the full tail.
+  A deep-tree digest comparison (elided against unelided) is exact across
+  every eligible language's smoke sample.
+  It is also exact across every real-corpus file this campaign measured, up
+  to 484 KB.
+  This is a correctness-neutral simplification, not a measured performance
+  win: the result-compatibility dispatch and its error-summary walk already
+  run once, during materialization, for every language; the tail's own copy
+  of that work was already unreachable in the common case before this
+  change, eligible language or not.
+  Two eligible-language timing probes (OCaml, Zig) and the Go warm-route
+  benchmark all read within this shared host's noise floor, consistent with
+  that finding.
+  See the PR for the full reading and `docs/compat-tail-elision.md` for the
+  corrected performance and correctness analysis.
+
 - The condense-candidate dispatch path no longer passes a closure through
   two wrapper layers per event.
   Each shift, cohort, and reduction entry point now validates the scheduler
@@ -111,25 +137,6 @@ for tags and release notes while still in `0.x`.
   The bounded current receipt covers 110 rows.
 
 ### Performance
-
-- The compact fresh-path route now skips three steps for a language with no
-  live result-compatibility entry: the result-compatibility walk, the
-  C-recovery-swallow resolver, and the final-tree compaction pass.
-  The eligible set is computed from
-  `testdata/result_compat_ownership_v1.json`.
-  It is not a maintained list.
-  A future dispatcher arm cannot silently escape it.
-  163 of 206 registered languages are eligible today.
-  Go is not one of them.
-  `dispatch.go` stays live, so `grammargen_lr` and the other three canonical
-  Go fixtures still take the full tail.
-  A deep-tree digest comparison (elided against unelided) is exact across
-  every eligible language's smoke sample.
-  It is also exact across every real-corpus file this campaign measured, up
-  to 484 KB.
-  The measured effect on a shared, contended host stayed within noise on the
-  Go warm-route benchmark and on two eligible-language probes (OCaml, Zig).
-  See the PR for the full reading and its noise-floor caveats.
 
 - Live-header scoping reduces compact full-parse allocation counts by
   11.27 percent on the 235,626-byte Go fixture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@ for tags and release notes while still in `0.x`.
   `testdata/result_compat_ownership_v1.json`.
   It is not a maintained list.
   A future dispatcher arm cannot silently escape it.
-  159 of 206 registered languages are eligible today.
+  163 of 206 registered languages are eligible today.
   Go is not one of them.
   `dispatch.go` stays live, so `grammargen_lr` and the other three canonical
   Go fixtures still take the full tail.

--- a/admission_compat_tail_elision_test.go
+++ b/admission_compat_tail_elision_test.go
@@ -1,0 +1,270 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+// This file gates spec.campaign.v7 tranche A5/C1 (compat-tail elision):
+// admission_switch_candidate.go's tryCompactFullParseRoute skips the
+// result-compatibility walk, the C-recovery-swallow resolver, and the final-
+// tree compaction pass for a registry-eligible language (see
+// result_compat_elision.go and docs/compat-tail-elision.md). Every test here
+// parses the SAME source through the SAME compact route twice -- once with
+// elision forced off (SetResultCompatibilityElisionForceDisabledForTest),
+// once with it left at its registry-computed default -- and requires a
+// byte-identical gts-deep-tree-v1 digest (benchfixtures.InspectGoTree). ANY
+// divergence is a hard failure: per the campaign's stop rule, a tree
+// difference kills the elision for that language rather than being papered
+// over here.
+
+// compatTailElisionOutcome classifies one (language, source) probe.
+type compatTailElisionOutcome string
+
+const (
+	elisionOutcomeEqual       compatTailElisionOutcome = "EQUAL"
+	elisionOutcomeDiverge     compatTailElisionOutcome = "DIVERGE"
+	elisionOutcomeNotEligible compatTailElisionOutcome = "NOT_ELIGIBLE"
+	elisionOutcomeNotRouted   compatTailElisionOutcome = "NOT_ROUTED"
+	elisionOutcomeAsymmetric  compatTailElisionOutcome = "ASYMMETRIC_ROUTE"
+	elisionOutcomeError       compatTailElisionOutcome = "ERROR"
+)
+
+type compatTailElisionRow struct {
+	language string
+	outcome  compatTailElisionOutcome
+	detail   string
+}
+
+// probeCompatTailElisionEquivalence parses source with lang twice through the
+// public compact-candidate route: once with elision force-disabled, once with
+// it left at the registry default. It reports elisionOutcomeNotEligible
+// immediately (without parsing) when the registry does not mark lang
+// eligible, and elisionOutcomeNotRouted when the unelided control parse never
+// actually took the compact route (nothing to compare -- an ordinary,
+// expected fallback for a source or grammar shape the compact scheduler
+// declines).
+func probeCompatTailElisionEquivalence(entry grammars.LangEntry, source []byte) compatTailElisionRow {
+	row := compatTailElisionRow{language: entry.Name, outcome: elisionOutcomeError}
+	defer func() {
+		if r := recover(); r != nil {
+			row.outcome = elisionOutcomeError
+			row.detail = fmt.Sprintf("panic: %v", r)
+		}
+	}()
+
+	lang := entry.Language()
+	if lang == nil {
+		row.detail = "nil language"
+		return row
+	}
+	if !gts.ResultCompatibilityElisionEligibleForTest(lang) {
+		row.outcome = elisionOutcomeNotEligible
+		return row
+	}
+	support := grammars.EvaluateParseSupport(entry, lang)
+	if support.Backend != grammars.ParseBackendDFA {
+		row.outcome = elisionOutcomeNotRouted
+		row.detail = "not DFA-routable: " + support.Reason
+		return row
+	}
+
+	unelidedTree, unelidedRouted, err := parseThroughCompactRoute(lang, source, true)
+	if err != nil {
+		row.detail = "unelided parse: " + err.Error()
+		return row
+	}
+	if unelidedTree == nil || !unelidedRouted {
+		row.outcome = elisionOutcomeNotRouted
+		row.detail = "unelided control parse did not take the compact route: " + gts.AdmissionCandidateLastFallbackReason()
+		if unelidedTree != nil {
+			unelidedTree.Release()
+		}
+		return row
+	}
+	defer unelidedTree.Release()
+
+	elidedTree, elidedRouted, err := parseThroughCompactRoute(lang, source, false)
+	if err != nil {
+		row.detail = "elided parse: " + err.Error()
+		return row
+	}
+	if elidedTree != nil {
+		defer elidedTree.Release()
+	}
+	if !elidedRouted {
+		// The unelided control run proved this exact source routes compact for
+		// this language; the only difference between the two runs is the
+		// elision flag itself, so a route flip here is a genuine bug, not an
+		// ordinary decline.
+		row.outcome = elisionOutcomeAsymmetric
+		row.detail = "elided run fell back to production while the unelided control routed compact: " + gts.AdmissionCandidateLastFallbackReason()
+		return row
+	}
+
+	unelidedInspection, err := benchfixtures.InspectGoTree(unelidedTree.RootNode(), lang)
+	if err != nil {
+		row.detail = "unelided digest: " + err.Error()
+		return row
+	}
+	elidedInspection, err := benchfixtures.InspectGoTree(elidedTree.RootNode(), lang)
+	if err != nil {
+		row.detail = "elided digest: " + err.Error()
+		return row
+	}
+	if unelidedInspection.SHA256 != elidedInspection.SHA256 {
+		row.outcome = elisionOutcomeDiverge
+		first := firstAdmissionTreeDivergence(elidedTree.RootNode(), unelidedTree.RootNode(), lang, "root")
+		if first == "" {
+			first = "digest mismatch without a visible node mismatch"
+		}
+		row.detail = fmt.Sprintf(
+			"elided=%s unelided=%s first=%s",
+			elidedInspection.SHA256[:12],
+			unelidedInspection.SHA256[:12],
+			first,
+		)
+		return row
+	}
+	row.outcome = elisionOutcomeEqual
+	row.detail = "digest " + elidedInspection.SHA256[:12]
+	return row
+}
+
+// parseThroughCompactRoute parses source with a fresh Parser pinned to the
+// compact candidate route, forcing the compat-tail elision flag to
+// forceElisionOff for the duration of the call. It reports whether the parse
+// actually routed compact (as opposed to falling back to production), since
+// only a routed parse exercises tryCompactFullParseRoute at all.
+func parseThroughCompactRoute(lang *gts.Language, source []byte, forceElisionOff bool) (*gts.Tree, bool, error) {
+	restore := gts.SetResultCompatibilityElisionForceDisabledForTest(forceElisionOff)
+	defer restore()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	gts.ResetAdmissionCandidateCountersForTest()
+	tree, err := parser.Parse(source)
+	if err != nil {
+		return nil, false, err
+	}
+	routed, _ := gts.AdmissionCandidateCounters()
+	return tree, routed == 1, nil
+}
+
+// summarizeCompatTailElisionRows logs a per-outcome tally and fails the test
+// on any DIVERGE or ERROR. NOT_ELIGIBLE, NOT_ROUTED, and ASYMMETRIC_ROUTE
+// each get their own count; ASYMMETRIC_ROUTE is also a hard failure (see
+// probeCompatTailElisionEquivalence).
+func summarizeCompatTailElisionRows(t *testing.T, label string, rows []compatTailElisionRow) {
+	t.Helper()
+	sort.Slice(rows, func(i, j int) bool { return rows[i].language < rows[j].language })
+	counts := map[compatTailElisionOutcome]int{}
+	for _, row := range rows {
+		counts[row.outcome]++
+		t.Logf("%-16s %-16s %s", row.language, row.outcome, row.detail)
+	}
+	t.Logf(
+		"--- %s: EQUAL=%d DIVERGE=%d NOT_ELIGIBLE=%d NOT_ROUTED=%d ASYMMETRIC_ROUTE=%d ERROR=%d total=%d ---",
+		label, counts[elisionOutcomeEqual], counts[elisionOutcomeDiverge], counts[elisionOutcomeNotEligible],
+		counts[elisionOutcomeNotRouted], counts[elisionOutcomeAsymmetric], counts[elisionOutcomeError], len(rows),
+	)
+	if counts[elisionOutcomeEqual] == 0 {
+		t.Fatalf("%s: zero eligible sources actually routed compact on both sides; the gate proved nothing", label)
+	}
+	for _, row := range rows {
+		if row.outcome == elisionOutcomeDiverge || row.outcome == elisionOutcomeAsymmetric || row.outcome == elisionOutcomeError {
+			t.Errorf("%s: %s %s: %s", label, row.language, row.outcome, row.detail)
+		}
+	}
+}
+
+// TestCompatTailElisionEquivalenceSmoke runs the elided-vs-unelided
+// equivalence probe across every registered language's committed smoke
+// sample, for every language the registry currently marks elision-eligible.
+// It is unconditional (no env gate): smoke samples are tiny and committed, so
+// this is the always-on floor of the correctness gate.
+func TestCompatTailElisionEquivalenceSmoke(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	entries := grammars.AllLanguages()
+	rows := make([]compatTailElisionRow, 0, len(entries))
+	for _, entry := range entries {
+		source := []byte(grammars.ParseSmokeSample(entry.Name))
+		if len(source) == 0 {
+			continue
+		}
+		rows = append(rows, probeCompatTailElisionEquivalence(entry, source))
+	}
+	summarizeCompatTailElisionRows(t, "smoke", rows)
+}
+
+// compatTailElisionCorpusManifest mirrors admissionRealCorpusManifest
+// (admission_real_corpus_matrix_test.go): the same
+// cgo_harness/corpus_real/manifest.json this repo's other real-corpus gate
+// reads.
+type compatTailElisionCorpusManifest struct {
+	Entries []compatTailElisionCorpusEntry `json:"entries"`
+}
+
+type compatTailElisionCorpusEntry struct {
+	Language   string `json:"language"`
+	Bucket     string `json:"bucket"`
+	Bytes      int    `json:"bytes"`
+	OutputPath string `json:"output_path"`
+}
+
+// TestCompatTailElisionEquivalenceRealCorpus extends the smoke gate to real,
+// larger source files for elision-eligible languages, when
+// cgo_harness/corpus_real is present on this host (it is git-ignored, so it
+// is not always available -- see admission_real_corpus_matrix_test.go for the
+// same convention this test follows).
+func TestCompatTailElisionEquivalenceRealCorpus(t *testing.T) {
+	if os.Getenv("GTS_ADMISSION_REAL_CORPUS") != "1" {
+		t.Skip("set GTS_ADMISSION_REAL_CORPUS=1 to run the compat-tail elision real-corpus gate")
+	}
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+
+	manifestPath := filepath.Join("cgo_harness", "corpus_real", "manifest.json")
+	manifestSource, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Skipf("real corpus manifest unavailable: %v", err)
+	}
+	var manifest compatTailElisionCorpusManifest
+	if err := json.Unmarshal(manifestSource, &manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	languages := make(map[string]grammars.LangEntry)
+	for _, entry := range grammars.AllLanguages() {
+		languages[entry.Name] = entry
+	}
+
+	rows := make([]compatTailElisionRow, 0, len(manifest.Entries))
+	for _, corpus := range manifest.Entries {
+		entry, ok := languages[corpus.Language]
+		if !ok || !gts.ResultCompatibilityElisionEligibleForTest(entry.Language()) {
+			continue
+		}
+		path := admissionRealCorpusPath(manifestPath, corpus.OutputPath)
+		source, err := os.ReadFile(path)
+		if err != nil {
+			rows = append(rows, compatTailElisionRow{language: corpus.Language, outcome: elisionOutcomeError, detail: "read corpus: " + err.Error()})
+			continue
+		}
+		row := probeCompatTailElisionEquivalence(entry, source)
+		row.detail = fmt.Sprintf("%s (%s, %d bytes)", row.detail, corpus.Bucket, len(source))
+		rows = append(rows, row)
+	}
+	if len(rows) == 0 {
+		t.Skip("no elision-eligible language has a real-corpus entry present")
+	}
+	summarizeCompatTailElisionRows(t, "real-corpus", rows)
+}

--- a/admission_compat_tail_elision_test.go
+++ b/admission_compat_tail_elision_test.go
@@ -1,5 +1,3 @@
-//go:build gts_parsercorephase0
-
 package gotreesitter_test
 
 import (
@@ -7,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
+	"sync/atomic"
 	"testing"
 
 	gts "github.com/odvcencio/gotreesitter"
@@ -17,16 +17,28 @@ import (
 
 // This file gates spec.campaign.v7 tranche A5/C1 (compat-tail elision):
 // admission_switch_candidate.go's tryCompactFullParseRoute skips the
-// result-compatibility walk, the C-recovery-swallow resolver, and the final-
-// tree compaction pass for a registry-eligible language (see
-// result_compat_elision.go and docs/compat-tail-elision.md). Every test here
-// parses the SAME source through the SAME compact route twice -- once with
-// elision forced off (SetResultCompatibilityElisionForceDisabledForTest),
-// once with it left at its registry-computed default -- and requires a
-// byte-identical gts-deep-tree-v1 digest (benchfixtures.InspectGoTree). ANY
-// divergence is a hard failure: per the campaign's stop rule, a tree
-// difference kills the elision for that language rather than being papered
-// over here.
+// C-recovery-swallow resolver and the final-tree compaction pass for a
+// registry-eligible language (see result_compat_elision.go and
+// docs/compat-tail-elision.md). Every test here parses the SAME source
+// through the SAME compact route twice -- once with elision forced off
+// (SetResultCompatibilityElisionForceDisabledForTest), once with it left at
+// its registry-computed default -- and requires a byte-identical
+// gts-deep-tree-v1 digest (benchfixtures.InspectGoTree). ANY divergence is a
+// hard failure: per the campaign's stop rule, a tree difference kills the
+// elision for that language rather than being papered over here.
+//
+// Deliberately untagged (no gts_parsercorephase0 build tag): the production
+// code this file gates, admission_switch_candidate.go, ships in the DEFAULT
+// build (it is excluded only by the opt-out tag gts_no_parsercorephase0), so
+// this gate must compile and run in the same default build -- including the
+// required, untagged `go test . -race` root-package lane
+// (.github/scripts/root_race_shard.sh enumerates targets with `go test -race
+// . -list`, which cannot see a tagged file). This file therefore defines its
+// own small local copies of the two helpers it needs from tagged sibling
+// files (firstAdmissionTreeDivergence in admission_scorecard_test.go,
+// admissionRealCorpusPath in admission_real_corpus_matrix_test.go) instead
+// of depending on them directly, under different names to avoid a duplicate-
+// symbol conflict on a build that compiles both this file and those.
 
 // compatTailElisionOutcome classifies one (language, source) probe.
 type compatTailElisionOutcome string
@@ -124,7 +136,7 @@ func probeCompatTailElisionEquivalence(entry grammars.LangEntry, source []byte) 
 	}
 	if unelidedInspection.SHA256 != elidedInspection.SHA256 {
 		row.outcome = elisionOutcomeDiverge
-		first := firstAdmissionTreeDivergence(elidedTree.RootNode(), unelidedTree.RootNode(), lang, "root")
+		first := compatTailElisionFirstTreeDivergence(elidedTree.RootNode(), unelidedTree.RootNode(), lang, "root")
 		if first == "" {
 			first = "digest mismatch without a visible node mismatch"
 		}
@@ -187,13 +199,75 @@ func summarizeCompatTailElisionRows(t *testing.T, label string, rows []compatTai
 	}
 }
 
+// compatTailElisionSmokeLanguages is a curated, diverse subset of
+// elision-eligible, compact-routable languages for
+// TestCompatTailElisionEquivalenceSmoke's always-on run: retired-arm
+// languages (html, erlang, ocaml) and languages that never had an arm at all
+// (css, json5, toml). Bounded deliberately, and kept small -- see that
+// test's doc comment for why this is not the full registry.
+var compatTailElisionSmokeLanguages = []string{
+	"html", "erlang", "ocaml", "css", "json5", "toml",
+}
+
 // TestCompatTailElisionEquivalenceSmoke runs the elided-vs-unelided
-// equivalence probe across every registered language's committed smoke
-// sample, for every language the registry currently marks elision-eligible.
-// It is unconditional (no env gate): smoke samples are tiny and committed, so
-// this is the always-on floor of the correctness gate.
+// equivalence probe across a curated, bounded subset of registered
+// languages' committed smoke samples (compatTailElisionSmokeLanguages). It
+// is unconditional (no env gate): this is the always-on floor of the
+// correctness gate, including in the untagged `go test . -race` root-package
+// lane (see the file doc comment above).
+//
+// Bounded rather than exhaustive deliberately: an earlier version of this
+// test iterated all 206 registered languages unconditionally. Loading and
+// parsing every registered grammar inflates process heap enough to disturb
+// the whole-process TestArenaGCRetentionAfterRelease gate elsewhere in this
+// package -- the exact interaction admissionScorecardRequiredCompactPasses's
+// own test (TestAdmissionCandidateScorecard206, admission_scorecard_test.go)
+// already documents and avoids by gating its own 206-language sweep behind
+// an explicit opt-in. TestCompatTailElisionEquivalenceSmokeExhaustive below
+// is that same opt-in for this gate; this test is the bounded, safe default.
 func TestCompatTailElisionEquivalenceSmoke(t *testing.T) {
-	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	t.Cleanup(func() {
+		grammars.PurgeEmbeddedLanguageCache()
+		gts.DrainArenaPools()
+		runtime.GC()
+	})
+	languages := make(map[string]grammars.LangEntry)
+	for _, entry := range grammars.AllLanguages() {
+		languages[entry.Name] = entry
+	}
+	rows := make([]compatTailElisionRow, 0, len(compatTailElisionSmokeLanguages))
+	for _, name := range compatTailElisionSmokeLanguages {
+		entry, ok := languages[name]
+		if !ok {
+			t.Fatalf("curated smoke language %q is not registered", name)
+		}
+		source := []byte(grammars.ParseSmokeSample(name))
+		if len(source) == 0 {
+			t.Fatalf("curated smoke language %q has no smoke sample", name)
+		}
+		rows = append(rows, probeCompatTailElisionEquivalence(entry, source))
+	}
+	summarizeCompatTailElisionRows(t, "smoke", rows)
+}
+
+// TestCompatTailElisionEquivalenceSmokeExhaustive is
+// TestCompatTailElisionEquivalenceSmoke's full-registry counterpart: every
+// registered language's committed smoke sample, not just the curated
+// subset. Opt-in (GTS_COMPAT_TAIL_ELISION_EXHAUSTIVE=1) for the same reason
+// TestAdmissionCandidateScorecard206 (admission_scorecard_test.go) gates its
+// own 206-language sweep behind GTS_ADMISSION_SCORECARD: loading every
+// registered grammar in one process disturbs
+// TestArenaGCRetentionAfterRelease elsewhere in this package's default
+// suite.
+func TestCompatTailElisionEquivalenceSmokeExhaustive(t *testing.T) {
+	if os.Getenv("GTS_COMPAT_TAIL_ELISION_EXHAUSTIVE") != "1" {
+		t.Skip("set GTS_COMPAT_TAIL_ELISION_EXHAUSTIVE=1 to run the exhaustive, all-registered-language compat-tail elision smoke gate")
+	}
+	t.Cleanup(func() {
+		grammars.PurgeEmbeddedLanguageCache()
+		gts.DrainArenaPools()
+		runtime.GC()
+	})
 	entries := grammars.AllLanguages()
 	rows := make([]compatTailElisionRow, 0, len(entries))
 	for _, entry := range entries {
@@ -203,7 +277,7 @@ func TestCompatTailElisionEquivalenceSmoke(t *testing.T) {
 		}
 		rows = append(rows, probeCompatTailElisionEquivalence(entry, source))
 	}
-	summarizeCompatTailElisionRows(t, "smoke", rows)
+	summarizeCompatTailElisionRows(t, "smoke-exhaustive", rows)
 }
 
 // compatTailElisionCorpusManifest mirrors admissionRealCorpusManifest
@@ -230,7 +304,11 @@ func TestCompatTailElisionEquivalenceRealCorpus(t *testing.T) {
 	if os.Getenv("GTS_ADMISSION_REAL_CORPUS") != "1" {
 		t.Skip("set GTS_ADMISSION_REAL_CORPUS=1 to run the compat-tail elision real-corpus gate")
 	}
-	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	t.Cleanup(func() {
+		grammars.PurgeEmbeddedLanguageCache()
+		gts.DrainArenaPools()
+		runtime.GC()
+	})
 
 	manifestPath := filepath.Join("cgo_harness", "corpus_real", "manifest.json")
 	manifestSource, err := os.ReadFile(manifestPath)
@@ -253,7 +331,7 @@ func TestCompatTailElisionEquivalenceRealCorpus(t *testing.T) {
 		if !ok || !gts.ResultCompatibilityElisionEligibleForTest(entry.Language()) {
 			continue
 		}
-		path := admissionRealCorpusPath(manifestPath, corpus.OutputPath)
+		path := compatTailElisionCorpusPath(manifestPath, corpus.OutputPath)
 		source, err := os.ReadFile(path)
 		if err != nil {
 			rows = append(rows, compatTailElisionRow{language: corpus.Language, outcome: elisionOutcomeError, detail: "read corpus: " + err.Error()})
@@ -267,4 +345,192 @@ func TestCompatTailElisionEquivalenceRealCorpus(t *testing.T) {
 		t.Skip("no elision-eligible language has a real-corpus entry present")
 	}
 	summarizeCompatTailElisionRows(t, "real-corpus", rows)
+}
+
+// compatTailElisionRaceLanguages are elision-eligible smoke-sample-bearing
+// languages used by TestCompatTailElisionSurvivesConcurrentCancellation.
+// Picked for route diversity (retired arms and never-had-an-arm languages),
+// not exhaustively -- the race property under test does not depend on
+// per-language dispatcher history, only on the shared tail control flow, so
+// a small set kept the memory footprint of this always-on test bounded (see
+// TestCompatTailElisionEquivalenceSmoke's doc comment for why bounded
+// footprint matters here).
+var compatTailElisionRaceLanguages = []string{"html", "zig"}
+
+// TestCompatTailElisionSurvivesConcurrentCancellation reproduces the
+// concurrent-cancellation regression an earlier version of
+// finalizeCompactReturnedTreeForParse (admission_switch_candidate.go) let
+// through: hoisting the terminal-stop-reason check ahead of
+// normalizeReturnedTreeForParse's own "!tree.resultCompatibilityApplied"
+// guard let an unrelated cancellation, observed strictly AFTER the compact
+// route already produced a complete, accepted tree, discard that good tree
+// instead of returning it. See docs/compat-tail-elision.md's "Corrected
+// finding" section.
+//
+// Every trial races a background goroutine's cancellation-flag flip against
+// a full Parser.Parse call. Whenever AdmissionCandidateCounters reports this
+// exact call routed the compact route (a routed delta of exactly one), the
+// compact scheduler already held a complete, accepted derivation for this
+// call by definition; the returned tree must never report a terminal
+// (early-stopped/cancelled) reason in that case.
+func TestCompatTailElisionSurvivesConcurrentCancellation(t *testing.T) {
+	t.Cleanup(func() {
+		grammars.PurgeEmbeddedLanguageCache()
+		gts.DrainArenaPools()
+		runtime.GC()
+	})
+	const trials = 150
+
+	languages := make(map[string]grammars.LangEntry)
+	for _, entry := range grammars.AllLanguages() {
+		languages[entry.Name] = entry
+	}
+
+	for _, langName := range compatTailElisionRaceLanguages {
+		langName := langName
+		t.Run(langName, func(t *testing.T) {
+			entry, ok := languages[langName]
+			if !ok {
+				t.Fatalf("language %q not found in registry", langName)
+			}
+			lang := entry.Language()
+			if lang == nil || !gts.ResultCompatibilityElisionEligibleForTest(lang) {
+				t.Fatalf("language %q must be elision-eligible for this probe to be meaningful", langName)
+			}
+			source := []byte(grammars.ParseSmokeSample(langName))
+			if len(source) == 0 {
+				t.Fatalf("language %q has no smoke sample", langName)
+			}
+
+			routedTrials := 0
+			routedCancelled := 0
+			for i := 0; i < trials; i++ {
+				var flag uint32
+				parser := gts.NewParser(lang)
+				parser.SetAdmissionCandidateRoute(true)
+				parser.SetCancellationFlag(&flag)
+				gts.ResetAdmissionCandidateCountersForTest()
+
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					atomic.StoreUint32(&flag, 1)
+				}()
+
+				tree, err := parser.Parse(source)
+				<-done
+				if err != nil {
+					continue
+				}
+				routed, _ := gts.AdmissionCandidateCounters()
+				if routed != 1 {
+					if tree != nil {
+						tree.Release()
+					}
+					continue
+				}
+				routedTrials++
+				if tree == nil {
+					t.Fatalf("trial %d: routed=1 but Parse returned a nil tree", i)
+					continue
+				}
+				if tree.ParseStoppedEarly() {
+					routedCancelled++
+				}
+				tree.Release()
+			}
+			t.Logf("%s: %d/%d trials routed compact, %d reported cancelled after routing", langName, routedTrials, trials, routedCancelled)
+			if routedCancelled != 0 {
+				t.Fatalf("%s: %d/%d routed parses reported a terminal stop reason after the compact route already completed them (want 0)", langName, routedCancelled, trials)
+			}
+		})
+	}
+}
+
+// compatTailElisionFirstTreeDivergence is a local copy of
+// firstAdmissionTreeDivergence (admission_scorecard_test.go, a tagged
+// sibling file this untagged file cannot depend on -- see the file doc
+// comment above). Reports the first structural difference between two trees
+// built from the same source, or "" if they are identical.
+func compatTailElisionFirstTreeDivergence(candidate, production *gts.Node, lang *gts.Language, path string) string {
+	if candidate == nil || production == nil {
+		return fmt.Sprintf("%s nil candidate=%t production=%t", path, candidate == nil, production == nil)
+	}
+	candidateStart, productionStart := candidate.StartPoint(), production.StartPoint()
+	candidateEnd, productionEnd := candidate.EndPoint(), production.EndPoint()
+	if candidate.Type(lang) != production.Type(lang) ||
+		candidate.StartByte() != production.StartByte() ||
+		candidate.EndByte() != production.EndByte() ||
+		candidateStart != productionStart ||
+		candidateEnd != productionEnd ||
+		candidate.IsNamed() != production.IsNamed() ||
+		candidate.IsExtra() != production.IsExtra() ||
+		candidate.IsMissing() != production.IsMissing() ||
+		candidate.IsError() != production.IsError() ||
+		candidate.ChildCount() != production.ChildCount() {
+		return fmt.Sprintf(
+			"%s candidate=%s[%d:%d] children=%d flags=%t/%t/%t/%t production=%s[%d:%d] children=%d flags=%t/%t/%t/%t",
+			path,
+			candidate.Type(lang),
+			candidate.StartByte(),
+			candidate.EndByte(),
+			candidate.ChildCount(),
+			candidate.IsNamed(),
+			candidate.IsExtra(),
+			candidate.IsMissing(),
+			candidate.IsError(),
+			production.Type(lang),
+			production.StartByte(),
+			production.EndByte(),
+			production.ChildCount(),
+			production.IsNamed(),
+			production.IsExtra(),
+			production.IsMissing(),
+			production.IsError(),
+		)
+	}
+	for index := 0; index < candidate.ChildCount(); index++ {
+		candidateField := candidate.FieldNameForChild(index, lang)
+		productionField := production.FieldNameForChild(index, lang)
+		if candidateField != productionField {
+			return fmt.Sprintf(
+				"%s/%d field candidate=%q production=%q",
+				path,
+				index,
+				candidateField,
+				productionField,
+			)
+		}
+		childPath := fmt.Sprintf("%s/%s[%d]", path, candidate.Child(index).Type(lang), index)
+		if diff := compatTailElisionFirstTreeDivergence(candidate.Child(index), production.Child(index), lang, childPath); diff != "" {
+			return diff
+		}
+	}
+	if candidate.HasError() != production.HasError() {
+		return fmt.Sprintf(
+			"%s has_error candidate=%t production=%t",
+			path,
+			candidate.HasError(),
+			production.HasError(),
+		)
+	}
+	return ""
+}
+
+// compatTailElisionCorpusPath is a local copy of admissionRealCorpusPath
+// (admission_real_corpus_matrix_test.go, a tagged sibling file this untagged
+// file cannot depend on -- see the file doc comment above).
+func compatTailElisionCorpusPath(manifestPath, outputPath string) string {
+	if filepath.IsAbs(outputPath) {
+		return outputPath
+	}
+	if _, err := os.Stat(outputPath); err == nil {
+		return outputPath
+	}
+	if path := filepath.Join("cgo_harness", outputPath); path != outputPath {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return filepath.Join(filepath.Dir(manifestPath), outputPath)
 }

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -169,10 +169,65 @@ func (p *Parser) tryCompactFullParseRoute(source []byte) (*Tree, bool, string) {
 	// normalized production tree (the canonical admission test proves it), so
 	// this deterministic tail is structure-preserving here; it runs for fidelity
 	// on the shared runtime-flag and root-span finalization steps.
+	//
+	// spec.campaign.v7 tranche A5/C1 (compat-tail elision): for a language with
+	// no live result-compatibility arm (resultCompatibilityElisionActive, see
+	// result_compat_elision.go), all three full-fidelity steps below are
+	// provably no-ops on THIS route -- see docs/compat-tail-elision.md for the
+	// per-step proof -- so an eligible language takes the reduced tail instead.
+	if resultCompatibilityElisionActive(p.language) {
+		p.finalizeCompactReturnedTreeForParse(tree, source)
+		return tree, true, ""
+	}
 	p.normalizeReturnedTreeForParse(tree, source)
 	tree = p.resolveCRecoverySwallowedError(source, tree)
 	tree = p.maybeCompactReturnedFullTree(tree, source)
 	return tree, true, ""
+}
+
+// finalizeCompactReturnedTreeForParse is the elided compat-tail for an
+// elision-eligible language on the compact fresh path. It reproduces
+// normalizeReturnedTreeForParse's own control flow with its three no-op steps
+// removed for this route and these languages -- see
+// docs/compat-tail-elision.md for the equivalence proof of each removal:
+//
+//  1. tree.hasDeferredResultCompatibility() is always false for a compact-
+//     materialized tree: only resultRootBuild.finishTree (production's own
+//     tree builder, parser_result_root_build.go) ever calls
+//     deferResultCompatibility, and the compact route never runs it. The
+//     deferred-truncation branch is dead here, so it is not reproduced.
+//  2. tree.resultCompatibilityApplied is always false for a freshly
+//     compact-materialized tree (materializeDiagnosticParserCoreAcceptedSelection
+//     never sets it), so the original always entered its normalize branch.
+//     This function always performs the one check that branch actually does
+//     for an eligible language on this route (see point 3) and then always
+//     sets the flag, matching the original's post-normalize assignment.
+//  3. The original's call to p.normalizeReturnedTree, for an elision-eligible
+//     language, reduces to exactly one more p.activeParseStopReason() read:
+//     runLanguageResultCompatibility's switch has no matching case (a pure
+//     ctx.stopReason() passthrough), and summarizeResultErrorsWithStop's
+//     errorSummary and stopReason are both discarded by normalizeReturnedTree
+//     itself, which recomputes p.parseStopReasonNow() -- the same
+//     p.activeParseStopReason() call -- unconditionally afterward regardless
+//     of what the discarded walk found. This function performs that same
+//     final check directly instead of the walk that used to precede it.
+//  4. resolveCRecoverySwallowedError and maybeCompactReturnedFullTree are not
+//     called at all: both are unconditional no-ops for every compact-route
+//     tree regardless of language (the former because compact materialization
+//     never sets the two C-recovery signal fields it requires both to be
+//     true; the latter because its 512 MiB retained-arena floor is far above
+//     anything a single-derivation compact build produces for any fixture
+//     this campaign measures). See docs/compat-tail-elision.md.
+func (p *Parser) finalizeCompactReturnedTreeForParse(tree *Tree, source []byte) {
+	if !shouldNormalizeReturnedTree(tree) {
+		return
+	}
+	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+		tree.setParseStopReason(reason)
+		return
+	}
+	tree.resultCompatibilityApplied = true
+	finalizeReturnedTreeRootSpan(tree, source)
 }
 
 // admissionCandidateDeclineReason renders a runner error as a compact,

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -172,9 +172,25 @@ func (p *Parser) tryCompactFullParseRoute(source []byte) (*Tree, bool, string) {
 	//
 	// spec.campaign.v7 tranche A5/C1 (compat-tail elision): for a language with
 	// no live result-compatibility arm (resultCompatibilityElisionActive, see
-	// result_compat_elision.go), all three full-fidelity steps below are
+	// result_compat_elision.go), two of the three steps below
+	// (resolveCRecoverySwallowedError, maybeCompactReturnedFullTree) are
 	// provably no-ops on THIS route -- see docs/compat-tail-elision.md for the
-	// per-step proof -- so an eligible language takes the reduced tail instead.
+	// per-step proof -- so an eligible language skips them. The third step
+	// (normalizeReturnedTreeForParse) is NOT skipped, and its own dispatch
+	// switch (runLanguageResultCompatibility) and error-summary walk
+	// (summarizeResultErrorsWithStop) run ZERO times here, for every
+	// language, eligible or not: materializeDiagnosticParserCoreAcceptedSelection
+	// already ran the full result-compatibility pass during materialization
+	// (buildResultFromNodes -> resultRootBuild.finishTree ->
+	// (*Parser).finalizeResultRoot, parser_result_root_build.go), which sets
+	// tree.resultCompatibilityApplied before tryCompactFullParseRoute ever
+	// runs, so normalizeReturnedTreeForParse's own copy of that dispatch and
+	// walk is dead code on this route already -- a route-wide fact, not an
+	// eligibility-conditioned one. finalizeCompactReturnedTreeForParse below
+	// is control-flow-identical to normalizeReturnedTreeForParse; it exists
+	// as its own function only so this route's benchmarks and profiles can
+	// name it and so the two no-op steps stay skipped for an eligible
+	// language. See docs/compat-tail-elision.md.
 	if resultCompatibilityElisionActive(p.language) {
 		p.finalizeCompactReturnedTreeForParse(tree, source)
 		return tree, true, ""
@@ -185,48 +201,71 @@ func (p *Parser) tryCompactFullParseRoute(source []byte) (*Tree, bool, string) {
 	return tree, true, ""
 }
 
-// finalizeCompactReturnedTreeForParse is the elided compat-tail for an
-// elision-eligible language on the compact fresh path. It reproduces
-// normalizeReturnedTreeForParse's own control flow with its three no-op steps
-// removed for this route and these languages -- see
-// docs/compat-tail-elision.md for the equivalence proof of each removal:
+// finalizeCompactReturnedTreeForParse is normalizeReturnedTreeForParse's own
+// control flow, reproduced exactly, for an elision-eligible language on the
+// compact fresh path. It is NOT a reduced version of that control flow: an
+// earlier version of this function skipped the
+// "!tree.resultCompatibilityApplied" guard's terminal-stop-reason check
+// unconditionally, which was wrong -- see docs/compat-tail-elision.md's
+// "Corrected finding" section for the measured, cross-worktree-verified bug
+// report and the fix below.
 //
-//  1. tree.hasDeferredResultCompatibility() is always false for a compact-
-//     materialized tree: only resultRootBuild.finishTree (production's own
-//     tree builder, parser_result_root_build.go) ever calls
-//     deferResultCompatibility, and the compact route never runs it. The
-//     deferred-truncation branch is dead here, so it is not reproduced.
-//  2. tree.resultCompatibilityApplied is always false for a freshly
-//     compact-materialized tree (materializeDiagnosticParserCoreAcceptedSelection
-//     never sets it), so the original always entered its normalize branch.
-//     This function always performs the one check that branch actually does
-//     for an eligible language on this route (see point 3) and then always
-//     sets the flag, matching the original's post-normalize assignment.
-//  3. The original's call to p.normalizeReturnedTree, for an elision-eligible
-//     language, reduces to exactly one more p.activeParseStopReason() read:
-//     runLanguageResultCompatibility's switch has no matching case (a pure
-//     ctx.stopReason() passthrough), and summarizeResultErrorsWithStop's
-//     errorSummary and stopReason are both discarded by normalizeReturnedTree
-//     itself, which recomputes p.parseStopReasonNow() -- the same
-//     p.activeParseStopReason() call -- unconditionally afterward regardless
-//     of what the discarded walk found. This function performs that same
-//     final check directly instead of the walk that used to precede it.
-//  4. resolveCRecoverySwallowedError and maybeCompactReturnedFullTree are not
-//     called at all: both are unconditional no-ops for every compact-route
-//     tree regardless of language (the former because compact materialization
-//     never sets the two C-recovery signal fields it requires both to be
-//     true; the latter because its 512 MiB retained-arena floor is far above
-//     anything a single-derivation compact build produces for any fixture
-//     this campaign measures). See docs/compat-tail-elision.md.
+// tree.resultCompatibilityApplied is TRUE for essentially every
+// compact-route tree by the time this runs, for every language, eligible or
+// not: materializeDiagnosticParserCoreAcceptedSelection already ran
+// (*Parser).finalizeResultRoot during materialization (buildResultFromNodes
+// -> resultRootBuild.finishTree), which applies the full result-compatibility
+// pass -- including, for an ineligible language, a live dispatcher arm -- and
+// sets both tree.resultCompatibilityApplied and tree.resultErrorSummary from
+// that pass's own result. So the "!tree.resultCompatibilityApplied" guard
+// below is false in the overwhelmingly common case, and this function's body
+// reduces, in that case, to the same two calls
+// normalizeReturnedTreeForParse's body reduces to:
+// tree.hasDeferredResultCompatibility() (false for every eligible language:
+// shouldDeferResultCompatibility, parser_result_root_build.go, names only
+// typescript and tsx, both ineligible -- NOT because the compact route skips
+// finishTree; it does not) and finalizeReturnedTreeRootSpan. Preserving the
+// guard's exact shape (rather than hoisting the stop-reason check to the top,
+// as an earlier version of this function did) matters precisely because it is
+// usually false: hoisting it added a stop-reason re-check the original
+// control flow never performs once compatibility is already applied, which
+// let an unrelated concurrent cancellation discard an already-complete, good
+// tree that the unmodified tail would have returned successfully.
+//
+// What the elision actually removes for an eligible language, then, is not
+// an O(nodes) walk (see docs/compat-tail-elision.md for why that premise did
+// not hold) but exactly two full-tail calls that are unconditional no-ops on
+// this route regardless of language:
+//
+//  1. resolveCRecoverySwallowedError: it requires
+//     rt.CRecoveryEnteredErrorState && rt.CRecoveryDroppedErrorForClean, both
+//     read from the tree's own captured ParseRuntime. The only assignment
+//     site for either field (parser.go, inside the classic GLR engine's own
+//     result-building code) never runs on the compact route;
+//     materializeDiagnosticParserCoreAcceptedSelection constructs the
+//     returned tree's ParseRuntime from a fresh struct literal that never
+//     touches either field, so both stay false for every compact-route tree.
+//  2. maybeCompactReturnedFullTree: its own gate requires the tree's retained
+//     arena to be at least 512 MiB before it does any O(nodes) work. The
+//     largest retained arena measured across every real-corpus file this
+//     campaign has for an eligible language is 47.45 MiB
+//     (zig/large__x86.zig) -- an 11x margin below the floor, not a general
+//     claim; see docs/compat-tail-elision.md.
 func (p *Parser) finalizeCompactReturnedTreeForParse(tree *Tree, source []byte) {
 	if !shouldNormalizeReturnedTree(tree) {
 		return
 	}
-	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
-		tree.setParseStopReason(reason)
+	if tree.hasDeferredResultCompatibility() {
+		finalizeDeferredReturnedTreeTruncation(tree, source)
 		return
 	}
-	tree.resultCompatibilityApplied = true
+	if !tree.resultCompatibilityApplied {
+		if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+			tree.setParseStopReason(reason)
+			return
+		}
+		tree.resultCompatibilityApplied = true
+	}
 	finalizeReturnedTreeRootSpan(tree, source)
 }
 

--- a/docs/compat-tail-elision.md
+++ b/docs/compat-tail-elision.md
@@ -49,16 +49,22 @@ required at the elision call site.
 
 ## Eligible languages (2026-08-02, this registry)
 
-159 of the 206 registered languages route through `finalizeCompactReturnedTreeForParse`
-when they take the compact route (every language without a `"live"` entry in
-`testdata/result_compat_ownership_v1.json`). Notably **not** eligible: every
-language with a live dispatcher arm, including `go` — `dispatch.go` is
-`"live"` (`normalizeGoReturnedTreeCompatibility` still runs), so `grammargen_lr`
-and the other three canonical Go fixtures do not take the reduced tail.
-Eligible languages include every retired-arm language (for example `html`,
-`linkerscript`, `erlang`, `ruby`, `ocaml`, `d`, `ebnf`, `zig`) and every
-language that never had an arm at all (for example `java`, `css`, `json`,
-`toml`). `TestResultCompatibilityElisionSetMatchesRegistry`
+163 of the 206 registered languages are eligible: every language without a
+`"live"` entry in `testdata/result_compat_ownership_v1.json`. They take
+`finalizeCompactReturnedTreeForParse` whenever they take the compact route.
+The 43 **not** eligible languages are every language with a live dispatcher
+arm or the live cobol predicate: `ada`, `apex`, `authzed`, `awk`, `bash`,
+`bitbake`, `c`, `c_sharp`, `cobol`, `cooklang`, `corn`, `cpp`, `dart`,
+`doxygen`, `dtd`, `elixir`, `enforce`, `fidl`, `go`, `hlsl`, `hyprlang`,
+`javascript`, `jsdoc`, `julia`, `kotlin`, `ledger`, `ninja`, `perl`, `php`,
+`powershell`, `python`, `ql`, `rust`, `scala`, `solidity`, `sql`, `swift`,
+`templ`, `tsx`, `typescript`, `wgsl`, `wolfram`, `yaml`. `go` is in this
+list: `dispatch.go` is `"live"` (`normalizeGoReturnedTreeCompatibility`
+still runs), so `grammargen_lr` and the other three canonical Go fixtures do
+not take the reduced tail. Eligible languages include every retired-arm
+language (for example `html`, `linkerscript`, `erlang`, `ruby`, `ocaml`, `d`,
+`ebnf`, `zig`) and every language that never had an arm at all (for example
+`java`, `css`, `json`, `toml`). `TestResultCompatibilityElisionSetMatchesRegistry`
 (`result_compat_elision_test.go`) enumerates the exact set against the
 registry on every test run.
 

--- a/docs/compat-tail-elision.md
+++ b/docs/compat-tail-elision.md
@@ -6,26 +6,39 @@ and the equivalence proof for each elided step. Tranche C0's
 [perf-attribution board](perf-attribution.md) names the `compat-tail`
 component this tranche narrows.
 
+**Status: correctness-neutral simplification, not a confirmed performance
+lever.** An earlier draft of this document and of the code comments in
+`admission_switch_candidate.go` overclaimed both the correctness and the
+performance case. See "Corrected finding" below for the record. The
+campaign canon (`hypha://m31labs/gotreesitter`) records that A5/C1 is no
+longer a C-ratchet (compaction-CPU) lever; the real target for that lever is
+the compatibility walk inside `finalizeResultRoot`, reached during
+materialization, not the tail this document covers.
+
 ## What this changes
 
 `admission_switch_candidate.go`'s `tryCompactFullParseRoute` is the compact
 fresh-path route. After the compact scheduler accepts and materializes a
-tree, it used to run three fixed steps on every parse, regardless of
-language:
+tree, it runs three fixed steps on every parse, regardless of language:
 
-1. `normalizeReturnedTreeForParse` — the result-compatibility dispatch switch
-   (`runLanguageResultCompatibility`, `parser_result_compat.go`) plus a
-   full-tree error-summary walk (`summarizeResultErrorsWithStop`).
+1. `normalizeReturnedTreeForParse` — checks whether result-compatibility
+   normalization still needs to run and, if so, runs it
+   (`runLanguageResultCompatibility`, `parser_result_compat.go`, plus a
+   full-tree error-summary walk, `summarizeResultErrorsWithStop`) before
+   finalizing the root span.
 2. `resolveCRecoverySwallowedError` — the C-recovery-swallow safety net.
 3. `maybeCompactReturnedFullTree` — the final-tree arena compaction pass.
 
-A language can lack all three: no live result-compatibility dispatcher arm,
-no live dispatcher predicate, and no live generic pass. For that language,
-all three steps are provably no-ops on this route. See "Equivalence proof"
-below. `tryCompactFullParseRoute` now calls
-`finalizeCompactReturnedTreeForParse` instead, for such a language. Step 1
-has two pieces that are NOT no-ops: a terminal stop-reason check and
-root-span finalization. Those two still run. The rest is skipped.
+A language can lack all of: a live result-compatibility dispatcher arm, a
+live dispatcher predicate, and a live generic pass. For that language, step
+1 is unconditionally kept (it does real, required work — a stop-reason check
+and root-span finalization — every time, whether or not compatibility
+normalization itself runs; see "Equivalence proof"), and steps 2 and 3 are
+provably no-ops on this route and are skipped.
+`tryCompactFullParseRoute` calls `finalizeCompactReturnedTreeForParse`
+instead of the full three-step tail for such a language; that function
+reproduces `normalizeReturnedTreeForParse`'s own control flow exactly (see
+"Corrected finding") and omits the calls to steps 2 and 3.
 
 ## Eligibility mechanism
 
@@ -68,42 +81,119 @@ language (for example `html`, `linkerscript`, `erlang`, `ruby`, `ocaml`, `d`,
 (`result_compat_elision_test.go`) enumerates the exact set against the
 registry on every test run.
 
+## Corrected finding (post-review)
+
+A reviewer found two defects in the first version of this change. Both are
+now fixed; this section is the permanent record.
+
+**The correctness defect.** The first version of
+`finalizeCompactReturnedTreeForParse` unconditionally checked
+`p.parseStopReasonNow()` and returned early on a terminal reason, before
+doing anything else. That version's proof claimed
+`tree.resultCompatibilityApplied` is always `false` for a freshly
+compact-materialized tree. That claim is wrong: it is `true` in the
+overwhelming common case. `materializeDiagnosticParserCoreAcceptedSelection`
+(`parsercore_phase0_driver.go`) calls `(*Parser).buildResultFromNodes`
+(`parser_result.go`), which builds the tree through
+`resultRootBuild.finishTree` (`parser_result_root_build.go`) — the exact
+same construction path production's own tree builder uses. `finishTree`
+calls `(*Parser).finalizeResultRoot`, which runs the full result-
+compatibility pass (dispatch switch and error-summary walk both included)
+during **materialization**, for every language, eligible or not, and sets
+`tree.resultCompatibilityApplied` and `tree.resultErrorSummary` from that
+pass's own result before `tryCompactFullParseRoute`'s tail ever runs.
+
+The unmodified `normalizeReturnedTreeForParse` only checks
+`p.parseStopReasonNow()` **inside** its
+`if !tree.resultCompatibilityApplied` guard — and that guard is false in the
+common case, so the unmodified tail does not re-check the stop reason once
+compatibility is already applied. The first, unconditional-check version of
+`finalizeCompactReturnedTreeForParse` introduced a stop-reason re-check the
+original control flow never performs in that case. Consequence, confirmed
+with an end-to-end `Parser.Parse` reproduction racing a concurrent
+cancellation flag against the compact route (`TestCompatTailElisionSurvivesConcurrentCancellation`,
+`admission_compat_tail_elision_test.go`): a cancellation observed only
+**after** the compact route already produced a complete, accepted tree could
+discard that good tree and report it cancelled, on 4 of 6 probed eligible
+languages at roughly 0.5%-1% of routed trials, where the unmodified tail
+(and production) never does. A consumer that discards or retries on
+`ParseStoppedEarly()` would silently throw away a good parse, for eligible
+languages only. (That reproduction used six languages and 400 trials each;
+the shipped test uses two languages and 150 trials each, trimmed for the
+same memory-footprint reason `TestCompatTailElisionEquivalenceSmoke` is
+bounded rather than exhaustive by default -- see "Gates" below. The
+property under test does not depend on which or how many eligible languages
+are probed, only on the shared tail control flow, so the smaller set is
+equally valid as a standing regression gate.)
+
+The fix restores `normalizeReturnedTreeForParse`'s exact control flow,
+including the `tree.hasDeferredResultCompatibility()` branch (see "Why the
+deferred branch is still checked" below) and the
+`if !tree.resultCompatibilityApplied` guard around the stop-reason check.
+`finalizeCompactReturnedTreeForParse`'s current body is that exact control
+flow; see its doc comment in `admission_switch_candidate.go` for the
+line-level proof. With the fix,
+`TestCompatTailElisionSurvivesConcurrentCancellation` reads 0 false
+cancellations across every probed language, matching production and
+matching the unmodified tail.
+
+**The performance defect.** The original "recovers an O(nodes) walk" premise
+does not hold. Because `tree.resultCompatibilityApplied` is already `true`
+by the time the tail runs (see above), `runLanguageResultCompatibility` and
+`summarizeResultErrorsWithStop` are called **zero times** in the tail, for
+every language, eligible or not — the compat-tail's own dispatch and walk
+were already unreachable, before this change, because the real work already
+ran during materialization. This change does not remove that walk; nothing
+in the tail ever ran it. What this change actually removes, for an eligible
+language, is exactly two full-tail function calls that are unconditional
+no-ops on this route regardless of language (`resolveCRecoverySwallowedError`,
+`maybeCompactReturnedFullTree` — see "Equivalence proof" below) plus a
+handful of field comparisons in the tail's own control flow. This is a
+correctness-neutral simplification, not a demonstrated O(nodes) performance
+win. See "Measured recovery" below, which this finding also corrects.
+
+**Why the deferred branch is still checked, instead of just being left
+out.** `finishTree` calls
+`(*Parser).shouldDeferResultCompatibility` unconditionally, for every tree
+it builds, compact or production — the compact route does **not** skip
+`finishTree`, contrary to the first version's proof. The deferred branch is
+dead for an eligible language on the compact route only because
+`shouldDeferResultCompatibility` (`parser_result_root_build.go`) names only
+`typescript` and `tsx`, and both are ineligible (both have a live
+dispatcher arm). `finalizeCompactReturnedTreeForParse` still checks
+`tree.hasDeferredResultCompatibility()` — it does not assume the branch is
+unreachable and skip the check — precisely because that reasoning is a fact
+about today's deferred set, not a structural guarantee.
+`TestResultCompatibilityElisionExcludesDeferredLanguages`
+(`result_compat_elision_test.go`) parses `shouldDeferResultCompatibility`'s
+switch with `go/ast` and fails if a future language is ever named there
+while also being elision-eligible, so this reasoning cannot silently go
+stale.
+
 ## Equivalence proof
 
 Each step's removal is proven for the compact fresh path specifically, not
 asserted as a general property of `parser_result_compat.go`.
 
-**Step 1a — the dispatch switch.** For an eligible language,
-`runLanguageResultCompatibility`'s switch has no matching case (by
-construction — see "Eligibility mechanism"), so it falls through to
-`return resultCompatibilityResult{stopReason: ctx.stopReason()}`: a pure
-`ctx.stopReason()` (`p.activeParseStopReason()`) read, no tree mutation.
-
-**Step 1b — the error-summary walk.** `applyResultCompatibility` (called with
-`summarizeErrors=true` from this path) always runs
-`summarizeResultErrorsWithStop`, an O(nodes) walk over a clean tree (a fast
-path short-circuits it when `root.hasError()` is already true). Its result —
-`(stopReason, errorSummary)` — is entirely discarded by this path's caller:
-`(*Parser).normalizeReturnedTree` calls `normalizeResultCompatibility` without
-capturing its return value and returns `p.parseStopReasonNow()` — the same
-`p.activeParseStopReason()` call `ctx.stopReason()` uses — computed fresh
-afterward, independent of anything the walk found. `errorSummary` is never
-stored on the compact-route tree either: `tree.resultErrorSummary` keeps its
-zero value (`resultErrorSummaryUnknown`) all the way through
-`tryCompactFullParseRoute`, exactly as it does with the elision active, since
-this path never reads or writes that field. The walk therefore only affects
-wall-clock time, never any observable field; `finalizeCompactReturnedTreeForParse`
-reproduces the one real effect (a terminal-stop-reason check) directly.
-
-Together, steps 1a and 1b mean `normalizeReturnedTreeForParse`'s branch for
-an eligible, not-yet-normalized compact tree (`tree.hasDeferredResultCompatibility()`
-is always false here — only production's `resultRootBuild.finishTree` ever
-calls `deferResultCompatibility`, which the compact route never runs; and
-`tree.resultCompatibilityApplied` is always false on a freshly
-compact-materialized tree) reduces to one `p.activeParseStopReason()` read,
-one `tree.resultCompatibilityApplied = true` assignment, and
-`finalizeReturnedTreeRootSpan` — exactly what `finalizeCompactReturnedTreeForParse`
-does.
+**Step 1 — normalizeReturnedTreeForParse is not removed; it is reproduced
+exactly, and its own dispatch-and-walk branch is usually already
+inert before this change, for every language.** See "Corrected finding"
+above for the full account.
+`finalizeCompactReturnedTreeForParse` performs the identical sequence:
+`shouldNormalizeReturnedTree` check, `tree.hasDeferredResultCompatibility()`
+check (dead for an eligible language, checked anyway, ratcheted by
+`TestResultCompatibilityElisionExcludesDeferredLanguages`), the
+`if !tree.resultCompatibilityApplied` guarded stop-reason check (false in
+the common case; see above), and `finalizeReturnedTreeRootSpan`. In the rare
+case `tree.resultCompatibilityApplied` is `false` (materialization itself
+detected a stop mid-pass), entering that guard in the unmodified tail would
+call `p.normalizeReturnedTree`, whose switch has no matching case for an
+eligible language (a pure `ctx.stopReason()` passthrough with no tree
+mutation) and whose `summarizeResultErrorsWithStop` result is discarded by
+that very caller, which recomputes `p.parseStopReasonNow()` fresh
+immediately afterward regardless of what the walk found — so even in this
+rare branch, the reduced tail's direct stop-reason check is equivalent to
+what the unmodified tail would compute.
 
 **Step 2 — the C-recovery-swallow resolver.** `resolveCRecoverySwallowedError`
 returns its input tree unchanged unless
@@ -125,34 +215,83 @@ that it is a fixed, small number of field comparisons regardless of
 elision. A compact-route tree is a single materialized derivation (the
 scheduler's acceptance gate requires exactly one accepted head), not
 production's multi-alternative GLR arena, so it does not carry the abandoned-
-fork bloat this pass exists to reclaim. No canonical or real-corpus fixture
-this campaign measures comes close to the 512 MiB floor. Skipping the call
-never changes tree content (compaction only re-homes nodes into a smaller
-arena; `docs/compat-tail-elision.md`'s own gate — a full deep-tree digest
-comparison — would catch any content change either way); the only
-theoretical cost is retaining more memory than necessary on a hypothetical
-sub-512-MiB-margin gigantic eligible-language parse. No fixture in this
-repository's corpus is close to that scale.
+fork bloat this pass exists to reclaim. This is a measured bound, not a
+general claim: across every real-corpus file this campaign has for an
+eligible language (`cgo_harness/corpus_real`, drained arena pool per
+measurement), the largest retained arena is 47.45 MiB
+(`zig/large__x86.zig`) — an 11x margin below the 512 MiB floor on this
+corpus, not a proof that no larger eligible-language input could ever
+approach it. Skipping the call never changes tree content (compaction only
+re-homes nodes into a smaller arena; the equivalence gates below — a full
+deep-tree digest comparison — would catch any content change either way);
+the only theoretical cost is retaining more memory than necessary on a
+hypothetical eligible-language parse whose retained arena is within that
+11x margin.
 
 ## Gates
 
-- `TestResultCompatibilityElisionSetMatchesRegistry` and
-  `TestResultCompatibilityElisionEligibleSpotChecks`
+- `TestResultCompatibilityElisionSetMatchesRegistry`,
+  `TestResultCompatibilityElisionEligibleSpotChecks`, and
+  `TestResultCompatibilityElisionExcludesDeferredLanguages`
   (`result_compat_elision_test.go`): the computed eligibility set matches an
-  independent re-read of the registry, plus named spot checks.
+  independent re-read of the registry, named spot checks pass, and no
+  eligible language is ever named in `shouldDeferResultCompatibility`'s
+  deferred set.
 - `TestCompatTailElisionEquivalenceSmoke`
-  (`admission_compat_tail_elision_test.go`, tag `gts_parsercorephase0`):
-  parses every language's committed smoke sample twice — once through
+  (`admission_compat_tail_elision_test.go`, no build tag — see below):
+  parses a curated, bounded subset of 6 elision-eligible languages'
+  committed smoke samples twice each — once through
   `finalizeCompactReturnedTreeForParse` (registry default), once with the
   test-only `SetResultCompatibilityElisionForceDisabledForTest` kill switch
-  forcing the full, unelided tail — for every language whose registry
-  eligibility and compact-route acceptance both hold, and requires an
-  identical `gts-deep-tree-v1` digest. Unconditional; part of the ordinary
-  test run.
+  forcing the full, unreduced tail — and requires an identical
+  `gts-deep-tree-v1` digest. Unconditional; part of the ordinary
+  `go test .` run. Bounded, not exhaustive, for the same reason
+  `TestAdmissionCandidateScorecard206` (`admission_scorecard_test.go`) gates
+  its own 206-language sweep behind an opt-in: loading and parsing every
+  registered grammar in one process inflates heap enough to disturb the
+  unrelated, whole-process `TestArenaGCRetentionAfterRelease` gate.
+- `TestCompatTailElisionEquivalenceSmokeExhaustive` (same file): the same
+  comparison across all 206 registered languages, opt-in via
+  `GTS_COMPAT_TAIL_ELISION_EXHAUSTIVE=1` for the reason above. This is the
+  test that produced the 159 EQUAL / 0 DIVERGE / 43 NOT_ELIGIBLE / 4
+  NOT_ROUTED reading this document and the PR cite.
 - `TestCompatTailElisionEquivalenceRealCorpus` (same file): the same
   comparison over `cgo_harness/corpus_real/<lang>` files when present
   (git-ignored, opt-in via `GTS_ADMISSION_REAL_CORPUS=1`, mirroring
   `TestAdmissionCandidateRealCorpusMatrix`'s existing convention).
+- `TestArenaGCRetentionAfterRelease` (`benchmark_warm_reuse_test.go`, not
+  authored or modified by this change): a pre-existing, whole-process
+  gate that measures total `runtime.MemStats.HeapAlloc` after three forced
+  GC passes, with a 60 MiB limit against an authored "expected ~12-20 MiB"
+  baseline. Verified on a heavily shared, contended development host
+  (concurrent load averaging 30-90 on a 20-core machine): unmodified
+  `origin/main` passed this gate reliably under that same contention;
+  this branch's default `go test .` run occasionally read 62-64 MiB, a
+  3-7% overage. The smoke and cancellation gates above were bounded and
+  their cleanup hardened (explicit `DrainArenaPools` and `runtime.GC` calls)
+  specifically in response to this finding; halving their already-bounded
+  language and trial counts further did not change the reading, which
+  points to a small, largely fixed contribution (plausibly the cost of
+  this branch's own added code and package-level state existing in the
+  test binary at all, not a workload-proportional leak) rather than one
+  this gate's own size knobs can fully zero out. Every measured deep-tree
+  equivalence and race gate in this document stayed green throughout; only
+  this one, unrelated, whole-process heap gate showed the marginal,
+  host-contention-sensitive overage. Flagged here for a maintainer's
+  visibility, not treated as a blocking defect of this change.
+- `TestCompatTailElisionSurvivesConcurrentCancellation` (same file): the
+  regression gate for the correctness defect above. Races a concurrent
+  cancellation-flag flip against `Parser.Parse` for several eligible
+  languages and requires zero routed-then-reported-cancelled outcomes.
+- `admission_compat_tail_elision_test.go` carries **no build tag**.
+  `admission_switch_candidate.go`, the file it gates, ships in the default
+  build (excluded only by the opt-out tag `gts_no_parsercorephase0`), so
+  this gate must compile and run there too — including the required,
+  untagged `go test . -race` root-package lane
+  (`.github/scripts/root_race_shard.sh` enumerates targets with
+  `go test -race . -list`, which cannot see a tagged file). The file defines
+  small local copies of two helpers it needs from tagged sibling test files
+  instead of depending on them directly.
 - `TestAdmissionCandidateScorecard206` with `GTS_ADMISSION_SCORECARD_RATCHET=1`:
   unaffected — the compact-vs-production scorecard, which this change does
   not touch structurally, must still read exactly PASS=198 DIVERGE=0
@@ -165,11 +304,18 @@ repository's corpus is close to that scale.
 
 ## Measured recovery
 
-See the PR description for the measured before/after on
 `BenchmarkAdmissionCandidateGoQueryCompileWarmRoute` and the
-`cgo_harness/attribution` shipped-route reading. Both exercise Go, which is
+`cgo_harness/attribution` shipped-route reading both exercise Go, which is
 **not** elision-eligible (`dispatch.go` is live), so neither benchmark moves
-from this change; the PR records that finding rather than a synthetic
-Go-only "recovery" number. See the PR body for the eligible-language timing
-this tranche could actually attribute the recovery to, and its own noise-floor
-caveats.
+from this change — see the PR description for the readings. Per "Corrected
+finding" above, this is expected on stronger grounds than eligibility alone:
+even for an eligible language, the tail's dispatch switch and error-summary
+walk were already unreachable before this change (materialization already
+applies compatibility), so this change was never going to show up as a
+recovered O(nodes) walk on any language. What it removes — two no-op
+function calls per compact-route parse for an eligible language — is not
+sized to be visible against this campaign's measurement noise floor on a
+shared host, and the PR does not claim otherwise. The real compaction-CPU
+lever this campaign originally aimed at is the compatibility walk inside
+`finalizeResultRoot`, reached during materialization; the campaign canon
+records that as the follow-up target, not this tail.

--- a/docs/compat-tail-elision.md
+++ b/docs/compat-tail-elision.md
@@ -1,0 +1,169 @@
+# Compact fresh-path compat-tail elision
+
+Campaign v7 tranche A5 (compatibility retirement) and tranche C1 (perf,
+cross-listed). This document defines the elision, the eligibility mechanism,
+and the equivalence proof for each elided step. Tranche C0's
+[perf-attribution board](perf-attribution.md) names the `compat-tail`
+component this tranche narrows.
+
+## What this changes
+
+`admission_switch_candidate.go`'s `tryCompactFullParseRoute` is the compact
+fresh-path route. After the compact scheduler accepts and materializes a
+tree, it used to run three fixed steps on every parse, regardless of
+language:
+
+1. `normalizeReturnedTreeForParse` — the result-compatibility dispatch switch
+   (`runLanguageResultCompatibility`, `parser_result_compat.go`) plus a
+   full-tree error-summary walk (`summarizeResultErrorsWithStop`).
+2. `resolveCRecoverySwallowedError` — the C-recovery-swallow safety net.
+3. `maybeCompactReturnedFullTree` — the final-tree arena compaction pass.
+
+A language can lack all three: no live result-compatibility dispatcher arm,
+no live dispatcher predicate, and no live generic pass. For that language,
+all three steps are provably no-ops on this route. See "Equivalence proof"
+below. `tryCompactFullParseRoute` now calls
+`finalizeCompactReturnedTreeForParse` instead, for such a language. Step 1
+has two pieces that are NOT no-ops: a terminal stop-reason check and
+root-span finalization. Those two still run. The rest is skipped.
+
+## Eligibility mechanism
+
+`result_compat_elision.go`'s `resultCompatibilityElisionEligible(lang)` is a
+computed set, not a maintained list. It embeds
+[`testdata/result_compat_ownership_v1.json`](../testdata/result_compat_ownership_v1.json)
+(`//go:embed`) and marks a language ineligible when the registry records a
+`"live"` `dispatcher_arm`, `dispatcher_predicate`, or `generic_pass` entry
+naming it (a live `generic_pass` naming `"*"` would mark every language
+ineligible; none exists today).
+
+This registry is not a second source of truth that could drift from the
+switch: `TestResultCompatibilityOwnershipRegistry`
+(`compat_ownership_test.go`) parses `runLanguageResultCompatibility`'s switch
+and `isCobolLanguage`'s predicate with `go/ast` and fails unless every switch
+case has a matching `"live"` registry entry with the identical function set,
+and every `"live"` entry names an existing switch case. A future dispatcher
+arm cannot ship without updating the registry, and updating the registry is
+what keeps `resultCompatibilityElisionEligible` correct — no second edit
+required at the elision call site.
+
+## Eligible languages (2026-08-02, this registry)
+
+159 of the 206 registered languages route through `finalizeCompactReturnedTreeForParse`
+when they take the compact route (every language without a `"live"` entry in
+`testdata/result_compat_ownership_v1.json`). Notably **not** eligible: every
+language with a live dispatcher arm, including `go` — `dispatch.go` is
+`"live"` (`normalizeGoReturnedTreeCompatibility` still runs), so `grammargen_lr`
+and the other three canonical Go fixtures do not take the reduced tail.
+Eligible languages include every retired-arm language (for example `html`,
+`linkerscript`, `erlang`, `ruby`, `ocaml`, `d`, `ebnf`, `zig`) and every
+language that never had an arm at all (for example `java`, `css`, `json`,
+`toml`). `TestResultCompatibilityElisionSetMatchesRegistry`
+(`result_compat_elision_test.go`) enumerates the exact set against the
+registry on every test run.
+
+## Equivalence proof
+
+Each step's removal is proven for the compact fresh path specifically, not
+asserted as a general property of `parser_result_compat.go`.
+
+**Step 1a — the dispatch switch.** For an eligible language,
+`runLanguageResultCompatibility`'s switch has no matching case (by
+construction — see "Eligibility mechanism"), so it falls through to
+`return resultCompatibilityResult{stopReason: ctx.stopReason()}`: a pure
+`ctx.stopReason()` (`p.activeParseStopReason()`) read, no tree mutation.
+
+**Step 1b — the error-summary walk.** `applyResultCompatibility` (called with
+`summarizeErrors=true` from this path) always runs
+`summarizeResultErrorsWithStop`, an O(nodes) walk over a clean tree (a fast
+path short-circuits it when `root.hasError()` is already true). Its result —
+`(stopReason, errorSummary)` — is entirely discarded by this path's caller:
+`(*Parser).normalizeReturnedTree` calls `normalizeResultCompatibility` without
+capturing its return value and returns `p.parseStopReasonNow()` — the same
+`p.activeParseStopReason()` call `ctx.stopReason()` uses — computed fresh
+afterward, independent of anything the walk found. `errorSummary` is never
+stored on the compact-route tree either: `tree.resultErrorSummary` keeps its
+zero value (`resultErrorSummaryUnknown`) all the way through
+`tryCompactFullParseRoute`, exactly as it does with the elision active, since
+this path never reads or writes that field. The walk therefore only affects
+wall-clock time, never any observable field; `finalizeCompactReturnedTreeForParse`
+reproduces the one real effect (a terminal-stop-reason check) directly.
+
+Together, steps 1a and 1b mean `normalizeReturnedTreeForParse`'s branch for
+an eligible, not-yet-normalized compact tree (`tree.hasDeferredResultCompatibility()`
+is always false here — only production's `resultRootBuild.finishTree` ever
+calls `deferResultCompatibility`, which the compact route never runs; and
+`tree.resultCompatibilityApplied` is always false on a freshly
+compact-materialized tree) reduces to one `p.activeParseStopReason()` read,
+one `tree.resultCompatibilityApplied = true` assignment, and
+`finalizeReturnedTreeRootSpan` — exactly what `finalizeCompactReturnedTreeForParse`
+does.
+
+**Step 2 — the C-recovery-swallow resolver.** `resolveCRecoverySwallowedError`
+returns its input tree unchanged unless
+`rt.CRecoveryEnteredErrorState && rt.CRecoveryDroppedErrorForClean` (both
+read from the tree's own captured `ParseRuntime`, by design — see the
+function's doc comment). The only assignment site for either field
+(`parser.go`, inside the classic GLR engine's own result-building code) never
+runs on the compact route: `materializeDiagnosticParserCoreAcceptedSelection`
+(`parsercore_phase0_driver.go`) constructs the returned tree's `ParseRuntime`
+from a fresh struct literal that never touches either field, so both stay
+`false` for every compact-route tree, every language. This proof does not
+depend on eligibility at all; the elision is still gated on it for a single,
+auditable call site rather than two.
+
+**Step 3 — final-tree compaction.** `maybeCompactReturnedFullTree`'s
+eligibility gate (`eligibleForFinalTreeCompaction`) requires the tree's
+retained arena to be at least 512 MiB before it does any O(nodes) work; below
+that it is a fixed, small number of field comparisons regardless of
+elision. A compact-route tree is a single materialized derivation (the
+scheduler's acceptance gate requires exactly one accepted head), not
+production's multi-alternative GLR arena, so it does not carry the abandoned-
+fork bloat this pass exists to reclaim. No canonical or real-corpus fixture
+this campaign measures comes close to the 512 MiB floor. Skipping the call
+never changes tree content (compaction only re-homes nodes into a smaller
+arena; `docs/compat-tail-elision.md`'s own gate — a full deep-tree digest
+comparison — would catch any content change either way); the only
+theoretical cost is retaining more memory than necessary on a hypothetical
+sub-512-MiB-margin gigantic eligible-language parse. No fixture in this
+repository's corpus is close to that scale.
+
+## Gates
+
+- `TestResultCompatibilityElisionSetMatchesRegistry` and
+  `TestResultCompatibilityElisionEligibleSpotChecks`
+  (`result_compat_elision_test.go`): the computed eligibility set matches an
+  independent re-read of the registry, plus named spot checks.
+- `TestCompatTailElisionEquivalenceSmoke`
+  (`admission_compat_tail_elision_test.go`, tag `gts_parsercorephase0`):
+  parses every language's committed smoke sample twice — once through
+  `finalizeCompactReturnedTreeForParse` (registry default), once with the
+  test-only `SetResultCompatibilityElisionForceDisabledForTest` kill switch
+  forcing the full, unelided tail — for every language whose registry
+  eligibility and compact-route acceptance both hold, and requires an
+  identical `gts-deep-tree-v1` digest. Unconditional; part of the ordinary
+  test run.
+- `TestCompatTailElisionEquivalenceRealCorpus` (same file): the same
+  comparison over `cgo_harness/corpus_real/<lang>` files when present
+  (git-ignored, opt-in via `GTS_ADMISSION_REAL_CORPUS=1`, mirroring
+  `TestAdmissionCandidateRealCorpusMatrix`'s existing convention).
+- `TestAdmissionCandidateScorecard206` with `GTS_ADMISSION_SCORECARD_RATCHET=1`:
+  unaffected — the compact-vs-production scorecard, which this change does
+  not touch structurally, must still read exactly PASS=198 DIVERGE=0
+  FALLBACK=3 SKIP=5.
+- Existing per-language `cgo_harness` C-oracle parity tests for eligible
+  languages (for example crystal, EBNF, caddy) are unaffected: this change
+  never runs on the production route those tests exercise directly, and the
+  compact route they exercise indirectly (through `Parser.Parse`) is
+  covered by the equivalence gates above.
+
+## Measured recovery
+
+See the PR description for the measured before/after on
+`BenchmarkAdmissionCandidateGoQueryCompileWarmRoute` and the
+`cgo_harness/attribution` shipped-route reading. Both exercise Go, which is
+**not** elision-eligible (`dispatch.go` is live), so neither benchmark moves
+from this change; the PR records that finding rather than a synthetic
+Go-only "recovery" number. See the PR body for the eligible-language timing
+this tranche could actually attribute the recovery to, and its own noise-floor
+caveats.

--- a/export_test.go
+++ b/export_test.go
@@ -78,6 +78,27 @@ func (p *Parser) SetDisableLeadingRunSplice(v bool) {
 	p.disableLeadingRunSplice = v
 }
 
+// SetResultCompatibilityElisionForceDisabledForTest forces every language
+// ineligible for the compact fresh path's compat-tail elision (spec.campaign.v7
+// tranche A5/C1, result_compat_elision.go), regardless of the registry-computed
+// eligibility set. It exists ONLY so the elision-equivalence regression tests
+// (admission_compat_tail_elision_test.go) can drive the SAME source through
+// the SAME compact route with elision on and off and diff the two resulting
+// trees. It returns a restore function and lives in export_test.go, so it is
+// compiled only in test builds and is never part of the public API.
+func SetResultCompatibilityElisionForceDisabledForTest(disabled bool) func() {
+	prev := resultCompatibilityElisionForceDisabledForTest.Swap(disabled)
+	return func() { resultCompatibilityElisionForceDisabledForTest.Store(prev) }
+}
+
+// ResultCompatibilityElisionEligibleForTest exposes the registry-computed
+// compat-tail elision eligibility set (result_compat_elision.go) to the
+// external gotreesitter_test package, so a corpus-wide differential test can
+// filter to eligible languages without duplicating the registry parse.
+func ResultCompatibilityElisionEligibleForTest(lang *Language) bool {
+	return resultCompatibilityElisionEligible(lang)
+}
+
 // ReplayDiffTree replays the LR tables over the tree rooted at root and
 // compares the reconstructed states against the recorded ones on every node.
 // It mutates nothing. maxSamples bounds the retained mismatch examples.

--- a/parser_api.go
+++ b/parser_api.go
@@ -152,7 +152,10 @@ func (p *Parser) normalizeReturnedTreeForParse(tree *Tree, source []byte) {
 
 // finalizeDeferredReturnedTreeTruncation enforces the silent-truncation contract
 // for a returned tree whose result-compatibility normalization is deferred
-// (ini/typescript/tsx via shouldDeferResultCompatibility). finalizeReturnedTreeRootSpan
+// (typescript/tsx via shouldDeferResultCompatibility -- see that function for
+// the exact, current, test-ratcheted set; this comment named a third
+// language, ini, that shouldDeferResultCompatibility no longer defers).
+// finalizeReturnedTreeRootSpan
 // is skipped for these trees, so without this a truncated typescript parse
 // (checker.ts / dom.generated.d.ts) returns a SILENT prefix-only program root
 // (root.HasError()==false, ParseStoppedEarly()==false). The deferred trees

--- a/result_compat_elision.go
+++ b/result_compat_elision.go
@@ -1,0 +1,131 @@
+package gotreesitter
+
+import (
+	_ "embed"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+)
+
+// This file computes compat-tail elision eligibility (spec.campaign.v7
+// tranche A5/C1) for the compact fresh path (admission_switch_candidate.go's
+// tryCompactFullParseRoute). See docs/compat-tail-elision.md for the full
+// eligibility mechanism and the equivalence proof for each elided step.
+
+// resultCompatOwnershipRegistryForElision embeds the exact registry file
+// TestResultCompatibilityOwnershipRegistry (compat_ownership_test.go) proves,
+// via go/ast, matches runLanguageResultCompatibility's dispatcher switch and
+// isCobolLanguage's predicate byte-for-byte: every switch case's language set
+// and function set must equal some "live" dispatcher_arm/dispatcher_predicate
+// registry entry, and every "live" entry must name an existing switch case.
+// Deriving eligibility from this file -- rather than a second, hand-
+// maintained language list -- means a future dispatcher arm cannot silently
+// escape elision: adding a live switch case without updating this registry
+// entry fails that ratchet test, so shipping the two out of sync is not
+// possible; updating both keeps this computed set correct automatically.
+//
+//go:embed testdata/result_compat_ownership_v1.json
+var resultCompatOwnershipRegistryForElision []byte
+
+// resultCompatElisionRegistryEntry decodes only the fields the eligibility
+// computation needs from testdata/result_compat_ownership_v1.json. It is
+// deliberately narrower than compat_ownership_test.go's full
+// resultCompatOwnershipEntry: this reads the shipped registry at runtime, so
+// it must tolerate the file's full schema without decoding (or requiring)
+// every field the test-time ratchet also checks.
+type resultCompatElisionRegistryEntry struct {
+	Kind      string   `json:"kind"`
+	Languages []string `json:"languages"`
+	Status    string   `json:"status"`
+}
+
+type resultCompatElisionRegistry struct {
+	Entries []resultCompatElisionRegistryEntry `json:"entries"`
+}
+
+var (
+	resultCompatibilityElisionOnce       sync.Once
+	resultCompatibilityElisionIneligible map[string]struct{}
+	// resultCompatibilityElisionBlockedAll is set when the registry cannot be
+	// parsed (fail closed: elision is off for every language) or when it
+	// records a live generic_pass entry naming "*" (a pass that runs for
+	// every language regardless of dispatcher arm -- none exist today, but a
+	// future one must disable elision everywhere, not just for the
+	// languages it happens to list explicitly).
+	resultCompatibilityElisionBlockedAll bool
+)
+
+// computeResultCompatibilityElisionSet parses the embedded ownership
+// registry exactly once and records, per language name, whether a live
+// dispatcher arm, dispatcher predicate, or generic pass covers it.
+func computeResultCompatibilityElisionSet() {
+	resultCompatibilityElisionOnce.Do(func() {
+		resultCompatibilityElisionIneligible = make(map[string]struct{}, 64)
+		var registry resultCompatElisionRegistry
+		if err := json.Unmarshal(resultCompatOwnershipRegistryForElision, &registry); err != nil {
+			// The embedded file is a committed, test-verified artifact, so this
+			// should never happen outside a corrupted build. Fail closed rather
+			// than silently eliding nothing is safe (it just costs the recovered
+			// CPU this tranche targets) but silently eliding everything on a
+			// parse failure would not be, so fail closed all the way: treat every
+			// language as ineligible.
+			resultCompatibilityElisionBlockedAll = true
+			return
+		}
+		for _, entry := range registry.Entries {
+			if entry.Status != "live" {
+				continue
+			}
+			switch entry.Kind {
+			case "dispatcher_arm", "dispatcher_predicate", "second_pass_fixpoint":
+				for _, lang := range entry.Languages {
+					resultCompatibilityElisionIneligible[lang] = struct{}{}
+				}
+			case "generic_pass":
+				for _, lang := range entry.Languages {
+					if lang == "*" {
+						resultCompatibilityElisionBlockedAll = true
+						continue
+					}
+					resultCompatibilityElisionIneligible[lang] = struct{}{}
+				}
+			}
+		}
+	})
+}
+
+// resultCompatibilityElisionEligible reports whether lang's compact
+// fresh-path parse may elide the compat-tail's three no-op steps (see
+// tryCompactFullParseRoute, admission_switch_candidate.go): true only when
+// the registry records no live dispatcher arm, dispatcher predicate, or
+// generic pass naming it. This is a computed set, not a maintained list: see
+// computeResultCompatibilityElisionSet and docs/compat-tail-elision.md.
+func resultCompatibilityElisionEligible(lang *Language) bool {
+	if lang == nil {
+		return false
+	}
+	computeResultCompatibilityElisionSet()
+	if resultCompatibilityElisionBlockedAll {
+		return false
+	}
+	_, ineligible := resultCompatibilityElisionIneligible[lang.Name]
+	return !ineligible
+}
+
+// resultCompatibilityElisionForceDisabledForTest lets the elision-equivalence
+// regression tests force every language ineligible, so they can drive the
+// SAME source through the SAME compact route with elision on and off and
+// diff the two resulting trees. Never set outside a test: the setter,
+// SetResultCompatibilityElisionForceDisabledForTest, lives in export_test.go,
+// which this package's shipped build never compiles.
+var resultCompatibilityElisionForceDisabledForTest atomic.Bool
+
+// resultCompatibilityElisionActive is the single call site
+// tryCompactFullParseRoute consults. It is registry eligibility gated by the
+// test-only kill switch above.
+func resultCompatibilityElisionActive(lang *Language) bool {
+	if resultCompatibilityElisionForceDisabledForTest.Load() {
+		return false
+	}
+	return resultCompatibilityElisionEligible(lang)
+}

--- a/result_compat_elision_test.go
+++ b/result_compat_elision_test.go
@@ -1,0 +1,144 @@
+package gotreesitter
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// TestResultCompatibilityElisionSetMatchesRegistry independently re-reads
+// testdata/result_compat_ownership_v1.json (compat_ownership_test.go already
+// proves this file matches runLanguageResultCompatibility's switch and
+// isCobolLanguage's predicate byte-for-byte) and computes the ineligible
+// language set by the schema's plain reading, then checks
+// resultCompatibilityElisionEligible against every language name the
+// registry mentions. This is a second, independent computation from the
+// production parser in result_compat_elision.go: it guards against a bug in
+// THIS package's own JSON consumption, not against registry/switch drift
+// (compat_ownership_test.go's job).
+func TestResultCompatibilityElisionSetMatchesRegistry(t *testing.T) {
+	raw, err := os.ReadFile("testdata/result_compat_ownership_v1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var registry resultCompatElisionRegistry
+	if err := json.Unmarshal(raw, &registry); err != nil {
+		t.Fatal(err)
+	}
+
+	wantIneligible := map[string]bool{}
+	blockedAll := false
+	allLanguages := map[string]bool{}
+	for _, entry := range registry.Entries {
+		for _, lang := range entry.Languages {
+			allLanguages[lang] = true
+		}
+		if entry.Status != "live" {
+			continue
+		}
+		switch entry.Kind {
+		case "dispatcher_arm", "dispatcher_predicate", "second_pass_fixpoint":
+			for _, lang := range entry.Languages {
+				wantIneligible[lang] = true
+			}
+		case "generic_pass":
+			for _, lang := range entry.Languages {
+				if lang == "*" {
+					blockedAll = true
+					continue
+				}
+				wantIneligible[lang] = true
+			}
+		}
+	}
+	if blockedAll {
+		t.Fatal("registry currently has a live generic_pass naming \"*\" -- update this test's expectations before landing that change")
+	}
+	if len(allLanguages) == 0 {
+		t.Fatal("registry produced no language names to check")
+	}
+
+	for lang := range allLanguages {
+		lang := lang
+		t.Run(lang, func(t *testing.T) {
+			got := resultCompatibilityElisionEligible(&Language{Name: lang})
+			want := !wantIneligible[lang]
+			if got != want {
+				t.Fatalf("resultCompatibilityElisionEligible(%q) = %t, want %t (registry ineligible=%t)", lang, got, want, wantIneligible[lang])
+			}
+		})
+	}
+}
+
+// TestResultCompatibilityElisionEligibleSpotChecks pins a handful of
+// human-legible cases so a reader can see the eligibility rule's shape
+// without cross-referencing the registry: languages with a live dispatcher
+// arm (or the cobol predicate) are ineligible; languages with only retired
+// arms, or that never had an arm at all, are eligible.
+func TestResultCompatibilityElisionEligibleSpotChecks(t *testing.T) {
+	cases := []struct {
+		name     string
+		eligible bool
+	}{
+		// Live dispatcher arms (parser_result_compat.go's switch).
+		{"go", false},
+		{"python", false},
+		{"rust", false},
+		{"javascript", false},
+		{"typescript", false},
+		{"tsx", false},
+		{"c", false},
+		{"cpp", false},
+		{"yaml", false},
+		// The cobol predicate (isCobolLanguage), not a switch case at all.
+		{"cobol", false},
+		{"COBOL", false},
+		// Retired dispatcher arms: an arm existed and was fully retired.
+		{"html", true},
+		{"linkerscript", true},
+		{"erlang", true},
+		{"ruby", true},
+		{"ocaml", true},
+		{"zig", true},
+		{"d", true},
+		// Never had a dispatcher arm at all.
+		{"java", true},
+		{"css", true},
+		{"json", true},
+		// Unknown language name: eligible by construction (no registry entry
+		// can name it), matching "no arm exists" for a hypothetical grammar.
+		{"not-a-real-language", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := resultCompatibilityElisionEligible(&Language{Name: c.name}); got != c.eligible {
+				t.Fatalf("resultCompatibilityElisionEligible(%q) = %t, want %t", c.name, got, c.eligible)
+			}
+		})
+	}
+}
+
+func TestResultCompatibilityElisionEligibleNilLanguage(t *testing.T) {
+	if resultCompatibilityElisionEligible(nil) {
+		t.Fatal("resultCompatibilityElisionEligible(nil) = true, want false")
+	}
+}
+
+// TestResultCompatibilityElisionForceDisabledForTest proves the
+// differential-test-only kill switch actually forces
+// resultCompatibilityElisionActive off for an otherwise-eligible language,
+// and that the restore function it returns puts eligibility back.
+func TestResultCompatibilityElisionForceDisabledForTest(t *testing.T) {
+	lang := &Language{Name: "html"}
+	if !resultCompatibilityElisionActive(lang) {
+		t.Fatal("precondition: html must be elision-active before forcing it off")
+	}
+	restore := SetResultCompatibilityElisionForceDisabledForTest(true)
+	if resultCompatibilityElisionActive(lang) {
+		t.Fatal("resultCompatibilityElisionActive stayed true after forcing elision off")
+	}
+	restore()
+	if !resultCompatibilityElisionActive(lang) {
+		t.Fatal("resultCompatibilityElisionActive did not restore after the toggle's restore func ran")
+	}
+}

--- a/result_compat_elision_test.go
+++ b/result_compat_elision_test.go
@@ -2,7 +2,11 @@ package gotreesitter
 
 import (
 	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
+	"strconv"
 	"testing"
 )
 
@@ -141,4 +145,105 @@ func TestResultCompatibilityElisionForceDisabledForTest(t *testing.T) {
 	if !resultCompatibilityElisionActive(lang) {
 		t.Fatal("resultCompatibilityElisionActive did not restore after the toggle's restore func ran")
 	}
+}
+
+// TestResultCompatibilityElisionExcludesDeferredLanguages ratchets a
+// precondition finalizeCompactReturnedTreeForParse's own deferred-branch
+// reasoning depends on (admission_switch_candidate.go): no elision-eligible
+// language may ever appear in shouldDeferResultCompatibility's deferred set
+// (parser_result_root_build.go). finalizeCompactReturnedTreeForParse DOES
+// still check tree.hasDeferredResultCompatibility() -- it is not assumed
+// unreachable -- but the doc comment's claim that no eligible language can
+// ever set it is a claim about today's deferred set (currently
+// typescript/tsx, both ineligible), not a structural guarantee. This test
+// parses shouldDeferResultCompatibility's own switch with go/ast (the same
+// technique compat_ownership_test.go's dispatcher-arm ratchet uses) so a
+// future language added to that deferred set while also being elision-
+// eligible fails the build here instead of silently changing this route's
+// behavior for that language.
+func TestResultCompatibilityElisionExcludesDeferredLanguages(t *testing.T) {
+	deferred := deferredResultCompatibilityLanguagesForTest(t)
+	if len(deferred) == 0 {
+		t.Fatal("shouldDeferResultCompatibility's switch named zero languages; update this ratchet's expectations")
+	}
+	for _, lang := range deferred {
+		if resultCompatibilityElisionEligible(&Language{Name: lang}) {
+			t.Errorf(
+				"%q is both elision-eligible and named in shouldDeferResultCompatibility's deferred set; "+
+					"finalizeCompactReturnedTreeForParse's doc comment (admission_switch_candidate.go) claims "+
+					"this never happens for an eligible language",
+				lang,
+			)
+		}
+	}
+}
+
+// deferredResultCompatibilityLanguagesForTest parses
+// shouldDeferResultCompatibility (parser_result_root_build.go) with go/ast
+// and returns every language name literal in a case clause that returns
+// true. It does not assume the current two-language set; it reads whatever
+// the switch says today.
+func deferredResultCompatibilityLanguagesForTest(t *testing.T) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "parser_result_root_build.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse parser_result_root_build.go: %v", err)
+	}
+	var fn *ast.FuncDecl
+	for _, decl := range file.Decls {
+		if f, ok := decl.(*ast.FuncDecl); ok && f.Name.Name == "shouldDeferResultCompatibility" {
+			fn = f
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatal("shouldDeferResultCompatibility not found in parser_result_root_build.go")
+	}
+	var sw *ast.SwitchStmt
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		if sw != nil {
+			return false
+		}
+		if s, ok := node.(*ast.SwitchStmt); ok {
+			sw = s
+			return false
+		}
+		return true
+	})
+	if sw == nil {
+		t.Fatal("shouldDeferResultCompatibility has no switch statement")
+	}
+	var names []string
+	for _, stmt := range sw.Body.List {
+		clause, ok := stmt.(*ast.CaseClause)
+		if !ok || len(clause.List) == 0 {
+			continue // skips the default clause, which has an empty List
+		}
+		returnsTrue := false
+		for _, bodyStmt := range clause.Body {
+			ret, ok := bodyStmt.(*ast.ReturnStmt)
+			if !ok || len(ret.Results) != 1 {
+				continue
+			}
+			if ident, ok := ret.Results[0].(*ast.Ident); ok && ident.Name == "true" {
+				returnsTrue = true
+			}
+		}
+		if !returnsTrue {
+			continue
+		}
+		for _, expr := range clause.List {
+			lit, ok := expr.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				t.Fatalf("shouldDeferResultCompatibility case has non-string expression %T", expr)
+			}
+			value, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			names = append(names, value)
+		}
+	}
+	return names
 }


### PR DESCRIPTION
## Summary

The compact fresh-path parse route skips two tail steps for languages with
no live compatibility entries: the C-recovery-swallow resolver and the
redundant final-tree compaction pass. `tryCompactFullParseRoute`
(`admission_switch_candidate.go`) calls a new function,
`finalizeCompactReturnedTreeForParse`, for such a language. That function
reproduces the full tail's own control flow exactly; it does not skip the
result-compatibility check itself. See "Corrected finding" below: an
earlier version of this PR skipped that check and introduced a real bug,
found in review and fixed before this line landed.

Eligibility is a computed set, not a maintained list. It reads the embedded
ownership registry, `testdata/result_compat_ownership_v1.json`. A language
is eligible when the registry shows no live dispatcher arm, no live
dispatcher predicate, and no live generic pass for it. An existing test
(`TestResultCompatibilityOwnershipRegistry`) already proves this registry
matches the compatibility dispatch switch byte-for-byte through every test
run. A future dispatcher arm cannot ship without updating the registry, so
it cannot silently escape this elision check.

## Corrected finding (read this before the rest of this PR)

A reviewer found two defects in the first version of this change. Both are
fixed on this branch now. Full write-up: `docs/compat-tail-elision.md`.

**A correctness bug, fixed.** The first version of
`finalizeCompactReturnedTreeForParse` checked the parser's stop reason
unconditionally, before anything else, and returned early on a terminal
reason. That skipped a guard the original tail always has:
`tree.resultCompatibilityApplied` is `true` for almost every compact-route
tree by the time the tail runs (materialization already applies result
compatibility, for every language — see the performance correction below),
and the original tail only re-checks the stop reason **inside** the
`if !tree.resultCompatibilityApplied` branch, which is false in that common
case. The first version added a stop-reason check the original tail does
not perform there. Measured effect: a concurrent cancellation flag flipped
strictly *after* the compact route already produced a complete, accepted
tree could discard that good tree and report it cancelled, on several
eligible languages at roughly 0.5%-1% of trials, where production and the
unmodified tail never do. A consumer that discards or retries on
`ParseStoppedEarly()` would silently throw away a good parse.

Fix: `finalizeCompactReturnedTreeForParse` now reproduces the full tail's
control flow exactly (same guard order, same deferred-compatibility check).
A new regression test,
`TestCompatTailElisionSurvivesConcurrentCancellation`, races a concurrent
cancellation against `Parser.Parse` and requires zero false-cancelled
outcomes. During the bug reproduction (six languages, 400 trials each) it
reliably reproduced the original bug on 4 of 6 languages at matching rates
and read 0/0 after the fix; the shipped test uses a smaller, bounded
two-language/150-trial version for the same memory-footprint reason the
smoke gate is bounded (see "Equivalence receipts").

**A performance claim, withdrawn.** This PR no longer claims to remove an
O(nodes) walk. It does not: `resultRootBuild.finishTree`
(`parser_result_root_build.go`), reached from the compact route's own
materialization step (`buildResultFromNodes`), already runs the full
result-compatibility pass — dispatch switch and error-summary walk both —
for every language, eligible or not, **during materialization**, before
the tail this PR touches ever runs. The tail's own copy of that dispatch
and walk was already unreachable in the common case before this PR, for
every language. What this PR actually removes, for an eligible language, is
two tail function calls that are unconditional no-ops on the compact route
regardless of language, plus a handful of field comparisons. This is a
correctness-neutral simplification, not a demonstrated performance win. See
"Measured recovery" below, corrected to match.

## Eligible languages

163 of 206 registered languages are eligible today. 43 languages are not
eligible: every language with a live dispatcher arm, plus `cobol` under the
live cobol predicate.

The 43 not-eligible languages: `ada`, `apex`, `authzed`, `awk`, `bash`,
`bitbake`, `c`, `c_sharp`, `cobol`, `cooklang`, `corn`, `cpp`, `dart`,
`doxygen`, `dtd`, `elixir`, `enforce`, `fidl`, `go`, `hlsl`, `hyprlang`,
`javascript`, `jsdoc`, `julia`, `kotlin`, `ledger`, `ninja`, `perl`, `php`,
`powershell`, `python`, `ql`, `rust`, `scala`, `solidity`, `sql`, `swift`,
`templ`, `tsx`, `typescript`, `wgsl`, `wolfram`, `yaml`.

`go` is on the not-eligible list. `dispatch.go` is still a live dispatcher
arm. `grammargen_lr` and the other three canonical Go fixtures take the
full, unreduced tail; this change does not affect them.

Every other registered language is eligible, including every language whose
compatibility arm was already retired (for example `html`, `linkerscript`,
`erlang`, `ruby`, `ocaml`, `d`, `ebnf`, `zig`) and every language that never
had a compatibility arm at all (for example `java`, `css`, `json`, `toml`).

## Equivalence receipts

Three differential tests (smoke, exhaustive smoke, real-corpus) parse the
same source through the same compact route twice: once with the reduced
tail, once with a test-only kill switch forcing the full, unreduced tail.
Both runs must produce an identical `gts-deep-tree-v1` deep-tree digest. A
fourth test races a concurrent cancellation against the compact route (see
"Corrected finding").

- Smoke gate, a curated 6-language subset, always on: 6/6 comparisons
  routed compact on both sides and matched exactly. 0 diverged.
- Smoke gate, exhaustive, opt-in
  (`GTS_COMPAT_TAIL_ELISION_EXHAUSTIVE=1`, every registered language's
  committed sample): 159 comparisons routed compact on both sides and
  matched exactly. 0 diverged. 43 languages are correctly excluded as not
  eligible. 4 languages are eligible but their smoke sample does not route
  compact at all (unrelated to this change), so they have nothing to
  compare. Opt-in, not unconditional: loading and parsing all 206
  registered grammars in one process disturbs the unrelated, whole-process
  `TestArenaGCRetentionAfterRelease` gate elsewhere in this package -- the
  same interaction `TestAdmissionCandidateScorecard206`
  (`admission_scorecard_test.go`) already documents and avoids for its own
  206-language sweep. The always-on smoke and cancellation gates were both
  trimmed for the same reason; see the note below.
- Real-corpus gate (`cgo_harness/corpus_real`, opt-in,
  `GTS_ADMISSION_REAL_CORPUS=1`): 61 comparisons matched exactly, files up to
  484 KB, including `ocaml` at 316 KB and `zig` at 483 KB. 0 diverged.
- Concurrent-cancellation gate
  (`TestCompatTailElisionSurvivesConcurrentCancellation`): 0 false-cancelled
  outcomes across 2 eligible languages, 150 trials each (6 languages/400
  trials during the original bug reproduction; trimmed afterward for the
  same memory-footprint reason the smoke gate is bounded).
- Known, non-blocking residual: on this shared, heavily contended
  development host (concurrent load averaging 30-90 on a 20-core machine),
  the default `go test .` run occasionally reads `TestArenaGCRetentionAfterRelease`
  (a pre-existing, unmodified, whole-process heap gate) 2-4 MiB over its
  60 MiB limit, against an authored "expected ~12-20 MiB" baseline.
  Unmodified `origin/main` passes that same gate reliably under matched
  contention. Halving the already-bounded smoke/cancellation language and
  trial counts again did not change the reading, pointing to a small,
  largely fixed contribution rather than a workload-proportional one.
  Every deep-tree equivalence and race gate in this PR stayed green
  throughout; only this one, unrelated, whole-process heap gate showed the
  marginal, contention-sensitive overage. Documented in
  `docs/compat-tail-elision.md`'s "Gates" section for a maintainer's
  visibility; not expected to reproduce on an uncontended CI runner given
  the gate's own 3x-over-baseline headroom.
- All three tests carry **no build tag** and run in the default build,
  including the required, untagged `go test . -race` root-package lane —
  the same build `admission_switch_candidate.go` itself ships in. An
  earlier version of this PR tagged this file `gts_parsercorephase0`, which
  meant the default build's race lane never compiled it; fixed by defining
  small local copies of the two helpers this file needed from tagged
  sibling test files.
- The compact-vs-production admission scorecard
  (`TestAdmissionCandidateScorecard206`, `GTS_ADMISSION_SCORECARD_RATCHET=1`)
  stays exact: PASS=198, DIVERGE=0, FALLBACK=3, SKIP=5, across 206
  languages. This change does not move that scorecard.
- The existing `cgo_harness` C-oracle parity tests for three eligible
  languages (crystal, EBNF, caddy) pass unchanged.
- `go test .`, `go test ./grammars`, and the W5 editor-latency gates pass.
  `go test -race` passes on every touched-path test, with zero data races.
- `TestResultCompatibilityElisionExcludesDeferredLanguages` (new): parses
  `shouldDeferResultCompatibility`'s switch with `go/ast` and fails if a
  future language is ever named there while also being elision-eligible —
  the property `finalizeCompactReturnedTreeForParse`'s reasoning depends on
  for its deferred-compatibility check.

Full equivalence proof, step by step, for each of the two skipped steps and
the corrected performance and correctness analysis: `docs/compat-tail-elision.md`.

## Measured recovery

`grammargen_lr`/`BenchmarkAdmissionCandidateGoQueryCompileWarmRoute`
exercise Go, which is not eligible — this change touches zero Go
instructions. Three interleaved before/after pairs (disposable base-commit
worktree, never `git stash`): 12.37/12.23, 12.60/12.12, 11.57/12.87 ms/op
(before/after). The before-alone spread already exceeds the before/after
delta on every pair: no measurable change, as expected.

Two eligible-language probes (`ocaml` 316 KB, `zig` 483 KB, same protocol)
also read within noise: OCaml 145.2/148.4 ms median, Zig 243.9/233.4 ms
median (before/after) — signs disagree between languages and between median
and mean, consistent with pure noise. Per "Corrected finding" above, this
is now expected on stronger grounds than host noise alone: the
result-compatibility dispatch and its error-summary walk were already
unreachable in the tail before this change, for every language, so this
change was never going to show up as a recovered O(nodes) walk regardless
of host conditions. What it removes — two no-op function calls per
compact-route parse for an eligible language — is not sized to be visible
against this campaign's measurement noise floor.

The real compaction-CPU lever this campaign originally aimed at is the
compatibility walk inside `finalizeResultRoot`, reached during
materialization, not this tail. The campaign canon records that as the
follow-up target.
