### PR TITLE
add(parsercorephase0): add inert acceptance election port with ratchets

### DIFF
--- a/internal/parsercorephase0/acceptance_election.go
+++ b/internal/parsercorephase0/acceptance_election.go
@@ -1,0 +1,478 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ---------------------------------------------------------------------------
+// acceptance_election.go -- the reference runtime's tied-tree selection order,
+// ported for the compact core.
+//
+// THE PINNED C ORACLE IS THE EXECUTABLE SPECIFICATION for this file
+// (decision 0007, hypha://m31labs/gotreesitter): tree-sitter v0.25.0's
+// ts_parser__select_tree (parser.c:836-879) and ts_subtree_compare
+// (subtree.c:591-618). The production Go port of the same order lives in the
+// root package -- stackCompareForResultSelectionWithRawShape
+// (parser_result.go) at result granularity, and reduceForkWindowPreference /
+// compareRawStackEntriesRec (parser_reduce.go) at fork granularity. Every
+// rung, constant, and evaluation order below mirrors the C functions; a
+// divergence gets a receipt, not a silent "improvement".
+//
+// ts_parser__select_tree(left, right) answers one question: does right
+// replace left? Its rungs, in order:
+//
+//	1. right error cost  <  left error cost   -> take right
+//	2. left  error cost  <  right error cost  -> keep left
+//	3. right dyn. prec.  >  left dyn. prec.   -> take right
+//	4. left  dyn. prec.  >  right dyn. prec.  -> keep left
+//	5. left error cost   >  0                 -> take right
+//	6. ts_subtree_compare(left, right) < 0    -> keep left
+//	   ts_subtree_compare(left, right) > 0    -> take right
+//	   ts_subtree_compare(left, right) == 0   -> keep left
+//
+// Rung 5 is not a typo and is not dead: when two candidates carry the SAME
+// nonzero error cost and the same dynamic precedence, C takes the later
+// candidate. Production's port carries the identical rung with the identical
+// note (parser_result.go, `else if ac > 0`).
+//
+// ---------------------------------------------------------------------------
+// THIS FILE IS INERT. NOTHING IN THIS PACKAGE, AND NOTHING IN THE ROOT
+// PACKAGE, CALLS IT. TestAcceptanceElectionNoOutsideCallSitesRatchet enforces
+// that as a compile-time property, in the same style as
+// recovery_cost.go's own ratchet.
+//
+// It is inert BECAUSE IT WAS MEASURED, not because it is unfinished. The
+// intended use was to replace the compact acceptance election's fail-closed
+// decline on a tied accept (completeAcceptance, parsercore_phase0_driver.go)
+// with this order, so a tie would resolve to the tree the reference runtime
+// keeps instead of handing the input back to the production parser. Wired
+// that way and run against the locked C oracle, the order produced a
+// DIFFERENT tree from the oracle on 8 of the 10 tied accepts it newly
+// admitted across the apex, perl, ada, and kotlin certification sweeps.
+//
+// The two witnesses that state the finding most plainly:
+//
+//   - apex "Object t = RecordPage.class;". The two live derivations are
+//     class_literal (symbol 268) and field_access (symbol 270). Rung 6 orders
+//     by LOWER symbol id, so it selects class_literal. The C oracle's
+//     published tree is field_access, with an "object" field on its first
+//     child. The oracle's tree also reads the source text "class" as an
+//     identifier token, which the class_literal derivation cannot do: the
+//     reference runtime never built that alternative at all.
+//   - perl "print $fh, \"a\", \"b\";". The two live derivations nest
+//     list_expression (333) and ambiguous_function_call_expression (395) the
+//     opposite way round. Rung 6 selects the list_expression nesting; the C
+//     oracle publishes the ambiguous_function_call_expression nesting.
+//
+// In both, the oracle keeps the alternative rung 6 ranks SECOND, so no
+// ordering of these candidate sets reproduces the oracle. The defect is not
+// in this port: it is that the compact core's live-derivation set at a tied
+// accept is not the reference runtime's live-version set. The compact
+// scheduler re-lexes and forks per header, and its condense step
+// deliberately defers precedence ties instead of collapsing them
+// (Core.condense, core.go), so it can carry alternatives the reference
+// runtime never creates. Ranking a set that contains such an alternative
+// cannot recover the reference answer, whatever the ranking.
+//
+// So this file lands as a verified library with its own tests, and the
+// shipping acceptance election keeps its fail-closed decline unchanged. The
+// prerequisite for using it is a live-derivation set proven equal to the
+// reference runtime's live-version set; that is a scheduler and lexer
+// question, not a selection question, and it is not solved here.
+// ---------------------------------------------------------------------------
+
+// ErrAcceptanceElectionEmpty reports that an election ran over no candidates.
+// The compact driver never calls the election with an empty candidate set;
+// this exists so a caller error surfaces as an error instead of an index
+// panic.
+var ErrAcceptanceElectionEmpty = errors.New("parser-core phase zero: acceptance election requires at least one derivation")
+
+// AcceptanceElectionCompare is the compact port of ts_subtree_compare
+// (subtree.c:591-618). It returns -1 when a sorts before b, 1 when b sorts
+// before a, and 0 when the two compare equal on every axis C inspects.
+//
+// C compares exactly three things, in this order: the raw subtree symbol
+// (LOWER symbol id sorts first), the raw child count (FEWER children sorts
+// first), and then the children pairwise, left to right, recursively. It
+// does NOT compare spans, production ids, field maps, alias sequences,
+// extra/external flags, or dynamic precedence -- those are decided by the
+// earlier rungs of ts_parser__select_tree, or not at all. Two candidates
+// that differ only in a field assignment therefore compare EQUAL here, and
+// the election's fold resolves them by C's own "keep left" tie answer.
+//
+// The C implementation is iterative over an explicit stack whose children
+// are pushed last-to-first so the pairs pop left-to-right; this port keeps
+// that shape (rather than recursing) so a deep tree cannot grow the Go
+// stack, and so the traversal order is the same one the oracle takes.
+//
+// src supplies the symbol and children of each id. RecoveryCostSource is
+// reused rather than introducing a second, near-identical source interface:
+// RecoveryCostNode already carries both fields this comparison reads, and
+// the election needs the same source for its error-cost rungs anyway.
+func AcceptanceElectionCompare(src RecoveryCostSource, a, b SubtreeID) (int, error) {
+	if src == nil {
+		return 0, errors.New("parser-core phase zero: acceptance election requires a subtree source")
+	}
+	var scratch acceptanceElectionCompareScratch
+	return acceptanceElectionCompare(src, &scratch, a, b)
+}
+
+// acceptanceElectionCompareScratch carries the explicit pair stack across one
+// comparison so a whole election reuses one allocation instead of one per
+// compared pair.
+type acceptanceElectionCompareScratch struct {
+	pairs []acceptanceElectionPair
+}
+
+type acceptanceElectionPair struct {
+	left  SubtreeID
+	right SubtreeID
+}
+
+func acceptanceElectionCompare(src RecoveryCostSource, scratch *acceptanceElectionCompareScratch, a, b SubtreeID) (int, error) {
+	scratch.pairs = append(scratch.pairs[:0], acceptanceElectionPair{left: a, right: b})
+	for len(scratch.pairs) > 0 {
+		pair := scratch.pairs[len(scratch.pairs)-1]
+		scratch.pairs = scratch.pairs[:len(scratch.pairs)-1]
+		// A zero id is the compact analogue of C's NULL subtree. C never
+		// stores one in a children array, so neither side should ever be
+		// zero here; order the pair deterministically rather than
+		// dereferencing, and keep the walk going.
+		if pair.left == 0 || pair.right == 0 {
+			if pair.left == pair.right {
+				continue
+			}
+			scratch.pairs = scratch.pairs[:0]
+			if pair.left == 0 {
+				return -1, nil
+			}
+			return 1, nil
+		}
+		left, err := src.RecoveryCostNode(pair.left)
+		if err != nil {
+			return 0, fmt.Errorf("parser-core phase zero: acceptance election subtree %d: %w", pair.left, err)
+		}
+		right, err := src.RecoveryCostNode(pair.right)
+		if err != nil {
+			return 0, fmt.Errorf("parser-core phase zero: acceptance election subtree %d: %w", pair.right, err)
+		}
+		result := 0
+		switch {
+		case left.Symbol < right.Symbol:
+			result = -1
+		case right.Symbol < left.Symbol:
+			result = 1
+		case len(left.Children) < len(right.Children):
+			result = -1
+		case len(right.Children) < len(left.Children):
+			result = 1
+		}
+		if result != 0 {
+			scratch.pairs = scratch.pairs[:0]
+			return result, nil
+		}
+		for i := len(left.Children); i > 0; i-- {
+			scratch.pairs = append(scratch.pairs, acceptanceElectionPair{
+				left:  left.Children[i-1],
+				right: right.Children[i-1],
+			})
+		}
+	}
+	return 0, nil
+}
+
+// AcceptanceElectionCompareRoots applies AcceptanceElectionCompare to two
+// accepted derivations' payload roots.
+//
+// One compact derivation is a LIST of accepted payload roots, not a single
+// subtree: C's ts_parser__accept pops every tree off the accepted version's
+// stack and wraps them in one root node whose children are exactly those
+// trees (parser.c). Comparing the two lists the way ts_subtree_compare
+// compares one node's children -- count first, then pairwise, left to right
+// -- is therefore the same comparison C runs on the roots it would have
+// built. The wrapping root's own symbol is the grammar's start symbol on
+// both sides (the same accepted state), so the symbol rung is vacuous at
+// this level and is skipped rather than fabricated.
+//
+// Production's port of the same list-level comparison is
+// compareRawReduceWindows (parser_reduce.go): length first, then elementwise.
+func AcceptanceElectionCompareRoots(src RecoveryCostSource, a, b []SubtreeID) (int, error) {
+	if src == nil {
+		return 0, errors.New("parser-core phase zero: acceptance election requires a subtree source")
+	}
+	var scratch acceptanceElectionCompareScratch
+	return acceptanceElectionCompareRoots(src, &scratch, a, b)
+}
+
+func acceptanceElectionCompareRoots(src RecoveryCostSource, scratch *acceptanceElectionCompareScratch, a, b []SubtreeID) (int, error) {
+	if len(a) != len(b) {
+		if len(a) < len(b) {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	for i := range a {
+		cmp, err := acceptanceElectionCompare(src, scratch, a[i], b[i])
+		if err != nil {
+			return 0, err
+		}
+		if cmp != 0 {
+			return cmp, nil
+		}
+	}
+	return 0, nil
+}
+
+// AcceptanceElectionErrorCost is the compact analogue of cStackErrorCost
+// (parser_recover_c.go) for one accepted derivation: the sum of every
+// payload root's own subtree error cost.
+//
+// C stores error_cost on each subtree and sums children into the parent
+// during ts_subtree_summarize_children (subtree.c), so the root
+// ts_parser__accept builds carries exactly this sum. Summing the roots here
+// reproduces that number without building the root.
+//
+// memo may be nil. Passing a shared memo across the whole election makes the
+// total work linear in the number of DISTINCT subtrees the candidates
+// reference, not in candidates times tree size: tied derivations of one
+// accepted head share almost all of their subtrees.
+//
+// On a clean, non-recovery accept every payload's cost is 0: compact
+// publishes an ERROR container only under an admitted native strategy-2
+// error region (error_region.go), and it never publishes a MISSING node at
+// all. This function is still computed rather than assumed, because an
+// admitted error region CAN reach an accept with a nonzero-cost payload, and
+// rungs 1, 2, and 5 of the C ladder are only correct when the real number is
+// used.
+func AcceptanceElectionErrorCost(
+	symbols []SelectedSymbolPolicy, src RecoveryCostSource, memo *RecoveryCostMemo, payloads []SubtreeID,
+) (uint32, error) {
+	if src == nil {
+		return 0, errors.New("parser-core phase zero: acceptance election requires a subtree source")
+	}
+	var total uint32
+	for _, id := range payloads {
+		if id == 0 {
+			continue
+		}
+		cost, err := recoveryNodeErrorCost(symbols, src, memo, id)
+		if err != nil {
+			return 0, err
+		}
+		total += cost
+	}
+	return total, nil
+}
+
+// AcceptanceElectionOutcome reports which candidate the election elected and
+// the evidence behind the pick, so callers can log or assert against the C
+// oracle without re-running the ladder.
+type AcceptanceElectionOutcome struct {
+	// Index is the elected candidate's position in the caller's slice.
+	Index int
+	// ErrorCost is the elected candidate's derivation error cost.
+	ErrorCost uint32
+	// Rung names the LAST ladder rung that moved the incumbent, or
+	// "sole-candidate" when only one candidate existed, or "incumbent" when
+	// no challenger ever displaced the first candidate.
+	Rung string
+	// MaxErrorCost is the highest derivation error cost seen across every
+	// candidate. Zero proves the whole election ran on the clean path, where
+	// rungs 1, 2, and 5 are vacuous.
+	MaxErrorCost uint32
+	// ComparatorDecided reports whether rung 6 (ts_subtree_compare) ever
+	// returned a nonzero answer during the fold: the election needed the
+	// structural comparison, not just error cost and dynamic precedence.
+	ComparatorDecided bool
+	// StructurallyTied reports whether rung 6 answered 0 for at least one
+	// challenger: two candidates that C itself cannot order structurally,
+	// resolved by C's own "keep left" answer.
+	StructurallyTied bool
+}
+
+// Rung names for AcceptanceElectionOutcome.Rung.
+const (
+	AcceptanceElectionRungSoleCandidate = "sole-candidate"
+	AcceptanceElectionRungIncumbent     = "incumbent"
+	AcceptanceElectionRungErrorCost     = "error-cost"
+	AcceptanceElectionRungDynamicPrec   = "dynamic-precedence"
+	AcceptanceElectionRungErrorTakeLate = "error-cost-tie-takes-later"
+	AcceptanceElectionRungComparator    = "subtree-compare"
+)
+
+// AcceptanceElectionFoldOrder returns the candidate indexes in the order the
+// C runtime would have folded them, appended to dst.
+//
+// THIS ORDER IS LOAD-BEARING, not cosmetic. Rung 6 of the ladder answers 0
+// whenever two candidates share every axis ts_subtree_compare reads, and C
+// resolves that answer by KEEPING THE INCUMBENT. Whichever candidate the fold
+// starts from therefore wins every structurally tied election -- including
+// the whole family where two derivations share a symbol and shape and differ
+// only in which production built them, and so only in the field map the
+// published tree carries.
+//
+// C's incumbent is the lower stack version index. Version indices are handed
+// out in creation order, and ts_parser__advance creates them by walking a
+// conflict cell's actions from ordinal 0 upward: ordinal 0's reduction makes
+// the first new version, each later ordinal makes a higher-numbered one. When
+// two versions later merge, ts_stack_merge(stack, j, i) always keeps the
+// lower index j and folds i into it (parser.c ts_parser__condense_stack,
+// ts_parser__reduce). So C's fold order is: the primary arm first, then each
+// secondary arm in ascending action-ordinal order.
+//
+// Core.Derivations enumerates in link-insertion order, which is a property of
+// how the compact conflict executor and condense step happened to publish
+// links, not a statement about C's version numbering. This function does not
+// rely on it. The fork stamps the compact core already records rebuild C's
+// order directly: a link created by a secondary arm carries that dispatch's
+// ForkOrder, a link created by the primary arm carries none, and
+// Core.Derivations propagates the latest stamp seen along a path. So:
+//
+//   - a candidate with no stamp never left the primary arm at any conflict.
+//     It is C's original, un-forked version: fold key 0, first.
+//   - a candidate with a stamp forked at the dispatch that stamped it. Fork
+//     stamps come from one monotone per-parse counter that increments in
+//     action-ordinal order within a dispatch and in dispatch order across
+//     the parse, so ascending stamp order is ascending version-creation
+//     order: fold key stamp+1.
+//
+// The sort is stable, so two candidates carrying the same key keep their
+// enumeration order relative to each other.
+func AcceptanceElectionFoldOrder(dst []int, paths []Derivation) []int {
+	dst = dst[:0]
+	for index := range paths {
+		dst = append(dst, index)
+	}
+	// Insertion sort, stable, over a candidate set bounded by the driver's
+	// own election cap. It avoids a sort.Slice closure allocation on a path
+	// that runs inside an accept.
+	for i := 1; i < len(dst); i++ {
+		value := dst[i]
+		key := acceptanceElectionFoldKey(paths[value])
+		j := i - 1
+		for j >= 0 && acceptanceElectionFoldKey(paths[dst[j]]) > key {
+			dst[j+1] = dst[j]
+			j--
+		}
+		dst[j+1] = value
+	}
+	return dst
+}
+
+func acceptanceElectionFoldKey(path Derivation) uint64 {
+	if !path.HasBranchOrder {
+		return 0
+	}
+	if path.BranchOrder == ^uint64(0) {
+		return ^uint64(0)
+	}
+	return path.BranchOrder + 1
+}
+
+// ElectAcceptanceDerivation folds ts_parser__select_tree over paths and
+// reports the elected candidate.
+//
+// The fold is C's own: the first candidate in C's version order is the
+// incumbent ("left"), every later candidate challenges it ("right"), and a
+// challenger replaces the incumbent exactly when ts_parser__select_tree would
+// have returned true. AcceptanceElectionFoldOrder supplies that version
+// order; it is NOT the caller's enumeration order, and the difference decides
+// every structurally tied election.
+//
+// symbols is the visible-symbol policy the error-cost rungs read
+// (SelectedStorePolicy.Symbols). src resolves every referenced subtree.
+// memo may be nil; supplying one makes the error-cost rungs linear in the
+// number of distinct subtrees.
+//
+// The returned outcome always names a candidate when err is nil: the ladder
+// is total, so this function has no "cannot order" answer to report. Index is
+// a position in the caller's own paths slice, not in the fold order.
+func ElectAcceptanceDerivation(
+	symbols []SelectedSymbolPolicy, src RecoveryCostSource, memo *RecoveryCostMemo, paths []Derivation,
+) (AcceptanceElectionOutcome, error) {
+	if len(paths) == 0 {
+		return AcceptanceElectionOutcome{}, ErrAcceptanceElectionEmpty
+	}
+	if src == nil {
+		return AcceptanceElectionOutcome{}, errors.New("parser-core phase zero: acceptance election requires a subtree source")
+	}
+	order := AcceptanceElectionFoldOrder(nil, paths)
+	incumbentCost, err := AcceptanceElectionErrorCost(symbols, src, memo, paths[order[0]].Payloads)
+	if err != nil {
+		return AcceptanceElectionOutcome{}, err
+	}
+	outcome := AcceptanceElectionOutcome{
+		Index:        order[0],
+		ErrorCost:    incumbentCost,
+		Rung:         AcceptanceElectionRungIncumbent,
+		MaxErrorCost: incumbentCost,
+	}
+	if len(paths) == 1 {
+		outcome.Rung = AcceptanceElectionRungSoleCandidate
+		return outcome, nil
+	}
+	var scratch acceptanceElectionCompareScratch
+	for _, index := range order[1:] {
+		challenger := paths[index]
+		challengerCost, err := AcceptanceElectionErrorCost(symbols, src, memo, challenger.Payloads)
+		if err != nil {
+			return AcceptanceElectionOutcome{}, err
+		}
+		if challengerCost > outcome.MaxErrorCost {
+			outcome.MaxErrorCost = challengerCost
+		}
+		take, rung, err := acceptanceElectionTakeChallenger(
+			src, &scratch, paths[outcome.Index], incumbentCost, challenger, challengerCost, &outcome,
+		)
+		if err != nil {
+			return AcceptanceElectionOutcome{}, err
+		}
+		if take {
+			outcome.Index = index
+			outcome.Rung = rung
+			incumbentCost = challengerCost
+		}
+	}
+	outcome.ErrorCost = incumbentCost
+	return outcome, nil
+}
+
+// acceptanceElectionTakeChallenger is one ts_parser__select_tree call:
+// reports whether right replaces left, and which rung decided it.
+func acceptanceElectionTakeChallenger(
+	src RecoveryCostSource, scratch *acceptanceElectionCompareScratch,
+	left Derivation, leftCost uint32, right Derivation, rightCost uint32,
+	outcome *AcceptanceElectionOutcome,
+) (bool, string, error) {
+	if rightCost < leftCost {
+		return true, AcceptanceElectionRungErrorCost, nil
+	}
+	if leftCost < rightCost {
+		return false, "", nil
+	}
+	if right.Score > left.Score {
+		return true, AcceptanceElectionRungDynamicPrec, nil
+	}
+	if left.Score > right.Score {
+		return false, "", nil
+	}
+	if leftCost > 0 {
+		return true, AcceptanceElectionRungErrorTakeLate, nil
+	}
+	cmp, err := acceptanceElectionCompareRoots(src, scratch, left.Payloads, right.Payloads)
+	if err != nil {
+		return false, "", err
+	}
+	switch {
+	case cmp < 0:
+		outcome.ComparatorDecided = true
+		return false, "", nil
+	case cmp > 0:
+		outcome.ComparatorDecided = true
+		return true, AcceptanceElectionRungComparator, nil
+	default:
+		outcome.StructurallyTied = true
+		return false, "", nil
+	}
+}

--- a/internal/parsercorephase0/acceptance_election_ratchet_test.go
+++ b/internal/parsercorephase0/acceptance_election_ratchet_test.go
@@ -1,0 +1,101 @@
+package parsercorephase0
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAcceptanceElectionNoOutsideCallSitesRatchet is the compile-time
+// guardrail that keeps acceptance_election.go inert: every symbol it declares
+// at package scope must be referenced from nowhere else in this package's
+// non-test source. It is the same pattern as
+// TestRecoveryCostNoOutsideCallSitesRatchet
+// (recovery_cost_ratchet_test.go) and
+// TestCondenseWithOutcomeAtomicProvenanceRatchet
+// (condense_outcome_provenance_ratchet_test.go).
+//
+// WHY THIS FILE IS INERT is measured, not provisional -- see
+// acceptance_election.go's own header for the eight C-oracle witnesses where
+// wiring the order into the compact acceptance election published a different
+// tree from the reference runtime. The prerequisite for wiring it in is a
+// live-derivation set proven equal to the reference runtime's live-version
+// set. A change that wires this file in without that proof will make this
+// ratchet fail; that failure is the signal to produce the proof, not to
+// delete the ratchet.
+//
+// Method names are excluded from the banned set for the same reason
+// recovery_cost.go's ratchet excludes them: they are selected through a
+// receiver, not referenced as bare package-scope identifiers.
+func TestAcceptanceElectionNoOutsideCallSitesRatchet(t *testing.T) {
+	const homeFile = "acceptance_election.go"
+
+	fset := token.NewFileSet()
+	home, err := parser.ParseFile(fset, homeFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", homeFile, err)
+	}
+
+	banned := map[string]bool{}
+	for _, decl := range home.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if d.Recv != nil {
+				continue
+			}
+			banned[d.Name.Name] = true
+		case *ast.GenDecl:
+			for _, spec := range d.Specs {
+				switch s := spec.(type) {
+				case *ast.TypeSpec:
+					banned[s.Name.Name] = true
+				case *ast.ValueSpec:
+					for _, name := range s.Names {
+						if name.Name != "_" {
+							banned[name.Name] = true
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(banned) == 0 {
+		t.Fatalf("collected zero package-scope identifiers from %s; the ratchet would vacuously pass", homeFile)
+	}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	violations := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") || name == homeFile {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Clean(name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			ident, ok := node.(*ast.Ident)
+			if !ok || !banned[ident.Name] {
+				return true
+			}
+			violations++
+			t.Errorf("%s references %s, an acceptance_election.go (inert) declaration -- "+
+				"the shipping acceptance election must not call the selection order until the "+
+				"compact live-derivation set is proven equal to the reference runtime's "+
+				"live-version set; see acceptance_election.go's header for the measured witnesses",
+				fset.Position(ident.Pos()), ident.Name)
+			return true
+		})
+	}
+	if violations != 0 {
+		t.Fatalf("%d reference(s) to acceptance_election.go declarations found outside acceptance_election.go and its own tests", violations)
+	}
+}

--- a/internal/parsercorephase0/acceptance_election_test.go
+++ b/internal/parsercorephase0/acceptance_election_test.go
@@ -1,0 +1,430 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"math/rand"
+	"testing"
+)
+
+// electionFixture builds one fake source shared by several derivations, so a
+// test can publish distinct candidate trees and then compare them the way the
+// election does.
+type electionFixture struct {
+	src  fakeRecoveryCostSource
+	next SubtreeID
+}
+
+func newElectionFixture() *electionFixture {
+	return &electionFixture{src: fakeRecoveryCostSource{}}
+}
+
+func (f *electionFixture) publish(spec *recoveryCostSpec) SubtreeID {
+	return publishRecoveryCostSpec(f.src, &f.next, spec)
+}
+
+func leaf(symbol Symbol) *recoveryCostSpec {
+	return &recoveryCostSpec{symbol: symbol}
+}
+
+func node(symbol Symbol, children ...*recoveryCostSpec) *recoveryCostSpec {
+	return &recoveryCostSpec{symbol: symbol, children: children}
+}
+
+// TestAcceptanceElectionCompareSymbolRung pins ts_subtree_compare's first
+// rung (subtree.c:600-601): the LOWER symbol id sorts first.
+func TestAcceptanceElectionCompareSymbolRung(t *testing.T) {
+	f := newElectionFixture()
+	low := f.publish(leaf(3))
+	high := f.publish(leaf(9))
+
+	if got, err := AcceptanceElectionCompare(f.src, low, high); err != nil || got != -1 {
+		t.Fatalf("compare(low, high) = %d, %v; want -1, nil", got, err)
+	}
+	if got, err := AcceptanceElectionCompare(f.src, high, low); err != nil || got != 1 {
+		t.Fatalf("compare(high, low) = %d, %v; want 1, nil", got, err)
+	}
+	if got, err := AcceptanceElectionCompare(f.src, low, low); err != nil || got != 0 {
+		t.Fatalf("compare(low, low) = %d, %v; want 0, nil", got, err)
+	}
+}
+
+// TestAcceptanceElectionCompareChildCountRung pins ts_subtree_compare's
+// second rung (subtree.c:602-603): with equal symbols, FEWER children sorts
+// first.
+func TestAcceptanceElectionCompareChildCountRung(t *testing.T) {
+	f := newElectionFixture()
+	fewer := f.publish(node(4, leaf(7)))
+	more := f.publish(node(4, leaf(7), leaf(7)))
+
+	if got, err := AcceptanceElectionCompare(f.src, fewer, more); err != nil || got != -1 {
+		t.Fatalf("compare(fewer, more) = %d, %v; want -1, nil", got, err)
+	}
+	if got, err := AcceptanceElectionCompare(f.src, more, fewer); err != nil || got != 1 {
+		t.Fatalf("compare(more, fewer) = %d, %v; want 1, nil", got, err)
+	}
+}
+
+// TestAcceptanceElectionCompareRecursesLeftToRight pins ts_subtree_compare's
+// third rung (subtree.c:609-614): with equal symbols and child counts, the
+// children decide, and the FIRST differing child pair decides -- the C loop
+// pushes children last-to-first onto a stack so the pairs pop left to right.
+func TestAcceptanceElectionCompareRecursesLeftToRight(t *testing.T) {
+	f := newElectionFixture()
+	// Both roots have symbol 4 and two children. The first child pair ties;
+	// the second differs. A right-to-left walk would report the same answer
+	// here, so the third pair below makes the direction observable: the FIRST
+	// difference must win even when a later pair disagrees with it.
+	left := f.publish(node(4, leaf(7), leaf(2), leaf(9)))
+	right := f.publish(node(4, leaf(7), leaf(5), leaf(1)))
+
+	if got, err := AcceptanceElectionCompare(f.src, left, right); err != nil || got != -1 {
+		t.Fatalf("compare(left, right) = %d, %v; want -1, nil (child 1: symbol 2 < 5)", got, err)
+	}
+	if got, err := AcceptanceElectionCompare(f.src, right, left); err != nil || got != 1 {
+		t.Fatalf("compare(right, left) = %d, %v; want 1, nil", got, err)
+	}
+}
+
+// TestAcceptanceElectionCompareIgnoresNonSymbolAxes pins what
+// ts_subtree_compare deliberately does NOT read. Two subtrees with the same
+// symbol, child count, and children compare equal even when their spans and
+// extra flags differ, because C compares none of those. This is the exact
+// property that makes the apex class_literal_alias family (two candidates
+// differing only in a field assignment, which is a production-id property)
+// resolve on the election's "keep the incumbent" answer rather than on a
+// structural difference.
+func TestAcceptanceElectionCompareIgnoresNonSymbolAxes(t *testing.T) {
+	f := newElectionFixture()
+	a := f.publish(&recoveryCostSpec{symbol: 4, start: 0, end: 10, children: []*recoveryCostSpec{leaf(7)}})
+	b := f.publish(&recoveryCostSpec{symbol: 4, start: 3, end: 40, extra: true, children: []*recoveryCostSpec{leaf(7)}})
+
+	if got, err := AcceptanceElectionCompare(f.src, a, b); err != nil || got != 0 {
+		t.Fatalf("compare = %d, %v; want 0, nil", got, err)
+	}
+}
+
+// TestAcceptanceElectionCompareRootsComparesCountThenElements pins the
+// list-level comparison: a derivation is a list of accepted payload roots,
+// compared the way ts_subtree_compare compares one node's children -- count
+// first, then pairwise, left to right.
+func TestAcceptanceElectionCompareRootsComparesCountThenElements(t *testing.T) {
+	f := newElectionFixture()
+	low := f.publish(leaf(3))
+	high := f.publish(leaf(9))
+
+	if got, err := AcceptanceElectionCompareRoots(f.src, []SubtreeID{low}, []SubtreeID{low, high}); err != nil || got != -1 {
+		t.Fatalf("compare(1 root, 2 roots) = %d, %v; want -1, nil", got, err)
+	}
+	if got, err := AcceptanceElectionCompareRoots(f.src, []SubtreeID{low, high}, []SubtreeID{low}); err != nil || got != 1 {
+		t.Fatalf("compare(2 roots, 1 root) = %d, %v; want 1, nil", got, err)
+	}
+	if got, err := AcceptanceElectionCompareRoots(f.src, []SubtreeID{high, low}, []SubtreeID{high, high}); err != nil || got != -1 {
+		t.Fatalf("compare = %d, %v; want -1, nil (second root: 3 < 9)", got, err)
+	}
+	if got, err := AcceptanceElectionCompareRoots(f.src, []SubtreeID{low, high}, []SubtreeID{low, high}); err != nil || got != 0 {
+		t.Fatalf("compare(equal, equal) = %d, %v; want 0, nil", got, err)
+	}
+}
+
+// TestAcceptanceElectionCompareReportsSourceError pins that a malformed
+// handle surfaces as an error instead of an invented order.
+func TestAcceptanceElectionCompareReportsSourceError(t *testing.T) {
+	f := newElectionFixture()
+	present := f.publish(leaf(3))
+	if _, err := AcceptanceElectionCompare(f.src, present, 999); !errors.Is(err, ErrRecoveryCostNodeMissing) {
+		t.Fatalf("compare with an absent id: err = %v, want ErrRecoveryCostNodeMissing", err)
+	}
+	if _, err := AcceptanceElectionCompare(nil, present, present); err == nil {
+		t.Fatal("compare with a nil source: err = nil, want an error")
+	}
+}
+
+// TestAcceptanceElectionErrorCostSumsRoots pins that a derivation's error
+// cost is the sum over its payload roots, the compact analogue of the root
+// ts_parser__accept would have built.
+func TestAcceptanceElectionErrorCostSumsRoots(t *testing.T) {
+	f := newElectionFixture()
+	clean := f.publish(node(ordinarySymbol, leaf(ordinarySymbol)))
+	// An ERROR container spanning ten bytes and one row, wrapping one
+	// visible skipped tree.
+	erroneous := f.publish(&recoveryCostSpec{
+		symbol: RecoveryErrorSymbol, start: 0, end: 10, endRow: 1,
+		children: []*recoveryCostSpec{{symbol: ordinarySymbol}},
+	})
+
+	symbols := visibleSymbols()
+	if got, err := AcceptanceElectionErrorCost(symbols, f.src, nil, []SubtreeID{clean}); err != nil || got != 0 {
+		t.Fatalf("clean derivation cost = %d, %v; want 0, nil", got, err)
+	}
+	want := uint32(RecoveryCostPerSkippedTree + RecoveryCostPerRecovery + RecoveryCostPerSkippedChar*10 + RecoveryCostPerSkippedLine*1)
+	if got, err := AcceptanceElectionErrorCost(symbols, f.src, nil, []SubtreeID{erroneous}); err != nil || got != want {
+		t.Fatalf("erroneous derivation cost = %d, %v; want %d, nil", got, err, want)
+	}
+	if got, err := AcceptanceElectionErrorCost(symbols, f.src, nil, []SubtreeID{clean, erroneous}); err != nil || got != want {
+		t.Fatalf("summed derivation cost = %d, %v; want %d, nil", got, err, want)
+	}
+	var memo RecoveryCostMemo
+	if got, err := AcceptanceElectionErrorCost(symbols, f.src, &memo, []SubtreeID{clean, erroneous}); err != nil || got != want {
+		t.Fatalf("memoized derivation cost = %d, %v; want %d, nil", got, err, want)
+	}
+}
+
+// TestElectAcceptanceDerivationLadder walks every rung of
+// ts_parser__select_tree in the order C evaluates them.
+func TestElectAcceptanceDerivationLadder(t *testing.T) {
+	f := newElectionFixture()
+	symbols := visibleSymbols()
+	cheapLow := f.publish(leaf(3))
+	cheapHigh := f.publish(leaf(9))
+	costly := f.publish(&recoveryCostSpec{
+		symbol: RecoveryErrorSymbol, start: 0, end: 4,
+		children: []*recoveryCostSpec{{symbol: ordinarySymbol}},
+	})
+	costlier := f.publish(&recoveryCostSpec{
+		symbol: RecoveryErrorSymbol, start: 0, end: 40,
+		children: []*recoveryCostSpec{{symbol: ordinarySymbol}},
+	})
+
+	tests := []struct {
+		name     string
+		paths    []Derivation
+		wantIdx  int
+		wantRung string
+	}{
+		{
+			name:     "sole candidate",
+			paths:    []Derivation{{Payloads: []SubtreeID{cheapHigh}}},
+			wantIdx:  0,
+			wantRung: AcceptanceElectionRungSoleCandidate,
+		},
+		{
+			name: "rung 1: lower error cost takes the challenger",
+			paths: []Derivation{
+				{Payloads: []SubtreeID{costly}},
+				{Payloads: []SubtreeID{cheapHigh}},
+			},
+			wantIdx:  1,
+			wantRung: AcceptanceElectionRungErrorCost,
+		},
+		{
+			name: "rung 2: lower error cost keeps the incumbent",
+			paths: []Derivation{
+				{Payloads: []SubtreeID{cheapHigh}},
+				{Payloads: []SubtreeID{costly}},
+			},
+			wantIdx:  0,
+			wantRung: AcceptanceElectionRungIncumbent,
+		},
+		{
+			name: "rung 3: higher dynamic precedence takes the challenger",
+			paths: []Derivation{
+				{Payloads: []SubtreeID{cheapLow}, Score: 1},
+				{Payloads: []SubtreeID{cheapHigh}, Score: 7},
+			},
+			wantIdx:  1,
+			wantRung: AcceptanceElectionRungDynamicPrec,
+		},
+		{
+			name: "rung 4: higher dynamic precedence keeps the incumbent",
+			paths: []Derivation{
+				{Payloads: []SubtreeID{cheapHigh}, Score: 7},
+				{Payloads: []SubtreeID{cheapLow}, Score: 1},
+			},
+			wantIdx:  0,
+			wantRung: AcceptanceElectionRungIncumbent,
+		},
+		{
+			name: "rung 5: an equal nonzero error cost takes the later candidate",
+			paths: []Derivation{
+				{Payloads: []SubtreeID{costly}},
+				{Payloads: []SubtreeID{costly}},
+			},
+			wantIdx:  1,
+			wantRung: AcceptanceElectionRungErrorTakeLate,
+		},
+		{
+			name: "rung 6: the comparator takes a lower-symbol challenger",
+			paths: []Derivation{
+				{Payloads: []SubtreeID{cheapHigh}},
+				{Payloads: []SubtreeID{cheapLow}},
+			},
+			wantIdx:  1,
+			wantRung: AcceptanceElectionRungComparator,
+		},
+		{
+			name: "rung 6: the comparator keeps a lower-symbol incumbent",
+			paths: []Derivation{
+				{Payloads: []SubtreeID{cheapLow}},
+				{Payloads: []SubtreeID{cheapHigh}},
+			},
+			wantIdx:  0,
+			wantRung: AcceptanceElectionRungIncumbent,
+		},
+		{
+			name: "rung 6 tie: C keeps the incumbent",
+			paths: []Derivation{
+				{Payloads: []SubtreeID{cheapLow}},
+				{Payloads: []SubtreeID{cheapLow}},
+			},
+			wantIdx:  0,
+			wantRung: AcceptanceElectionRungIncumbent,
+		},
+		{
+			name: "error cost outranks dynamic precedence",
+			paths: []Derivation{
+				{Payloads: []SubtreeID{costlier}, Score: 99},
+				{Payloads: []SubtreeID{costly}, Score: -99},
+			},
+			wantIdx:  1,
+			wantRung: AcceptanceElectionRungErrorCost,
+		},
+		{
+			name: "dynamic precedence outranks the comparator",
+			paths: []Derivation{
+				{Payloads: []SubtreeID{cheapLow}, Score: 1},
+				{Payloads: []SubtreeID{cheapHigh}, Score: 2},
+			},
+			wantIdx:  1,
+			wantRung: AcceptanceElectionRungDynamicPrec,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outcome, err := ElectAcceptanceDerivation(symbols, f.src, nil, tt.paths)
+			if err != nil {
+				t.Fatalf("elect: %v", err)
+			}
+			if outcome.Index != tt.wantIdx {
+				t.Fatalf("elected index = %d, want %d (rung %q)", outcome.Index, tt.wantIdx, outcome.Rung)
+			}
+			if outcome.Rung != tt.wantRung {
+				t.Fatalf("deciding rung = %q, want %q", outcome.Rung, tt.wantRung)
+			}
+		})
+	}
+}
+
+// TestElectAcceptanceDerivationReportsCleanPathEvidence pins the outcome
+// fields the certification sweeps read: a clean election reports zero
+// MaxErrorCost, and the structural rung reports whether it decided or tied.
+func TestElectAcceptanceDerivationReportsCleanPathEvidence(t *testing.T) {
+	f := newElectionFixture()
+	symbols := visibleSymbols()
+	low := f.publish(leaf(3))
+	high := f.publish(leaf(9))
+
+	outcome, err := ElectAcceptanceDerivation(symbols, f.src, nil, []Derivation{
+		{Payloads: []SubtreeID{high}},
+		{Payloads: []SubtreeID{low}},
+	})
+	if err != nil {
+		t.Fatalf("elect: %v", err)
+	}
+	if outcome.MaxErrorCost != 0 || outcome.ErrorCost != 0 {
+		t.Fatalf("clean election costs = %d/%d, want 0/0", outcome.ErrorCost, outcome.MaxErrorCost)
+	}
+	if !outcome.ComparatorDecided || outcome.StructurallyTied {
+		t.Fatalf("clean election evidence decided=%t tied=%t, want true/false",
+			outcome.ComparatorDecided, outcome.StructurallyTied)
+	}
+
+	outcome, err = ElectAcceptanceDerivation(symbols, f.src, nil, []Derivation{
+		{Payloads: []SubtreeID{low}},
+		{Payloads: []SubtreeID{low}},
+	})
+	if err != nil {
+		t.Fatalf("elect: %v", err)
+	}
+	if outcome.ComparatorDecided || !outcome.StructurallyTied {
+		t.Fatalf("tied election evidence decided=%t tied=%t, want false/true",
+			outcome.ComparatorDecided, outcome.StructurallyTied)
+	}
+}
+
+// TestElectAcceptanceDerivationRejectsEmptyInput pins the two caller errors
+// the election reports instead of guessing.
+func TestElectAcceptanceDerivationRejectsEmptyInput(t *testing.T) {
+	f := newElectionFixture()
+	if _, err := ElectAcceptanceDerivation(nil, f.src, nil, nil); !errors.Is(err, ErrAcceptanceElectionEmpty) {
+		t.Fatalf("empty candidate set: err = %v, want ErrAcceptanceElectionEmpty", err)
+	}
+	if _, err := ElectAcceptanceDerivation(nil, nil, nil, []Derivation{{}}); err == nil {
+		t.Fatal("nil source: err = nil, want an error")
+	}
+}
+
+// TestElectAcceptanceDerivationIsOrderStableUnderFold pins the property that
+// makes the election deterministic: on a clean candidate set the fold elects
+// the C-minimum under ts_subtree_compare, and it elects the SAME candidate
+// no matter how many equal-comparing duplicates surround it, because C's tie
+// answer keeps the incumbent.
+func TestElectAcceptanceDerivationIsOrderStableUnderFold(t *testing.T) {
+	f := newElectionFixture()
+	symbols := visibleSymbols()
+	ids := []SubtreeID{f.publish(leaf(11)), f.publish(leaf(4)), f.publish(leaf(7)), f.publish(leaf(4))}
+
+	paths := make([]Derivation, 0, len(ids))
+	for _, id := range ids {
+		paths = append(paths, Derivation{Payloads: []SubtreeID{id}})
+	}
+	outcome, err := ElectAcceptanceDerivation(symbols, f.src, nil, paths)
+	if err != nil {
+		t.Fatalf("elect: %v", err)
+	}
+	// Index 1 and index 3 both carry symbol 4 and compare equal; C keeps the
+	// earlier one.
+	if outcome.Index != 1 {
+		t.Fatalf("elected index = %d, want 1", outcome.Index)
+	}
+}
+
+// TestElectAcceptanceDerivationMemoMatchesUnmemoized runs a model-based
+// property check: the elected candidate never depends on whether the caller
+// supplied an error-cost memo.
+func TestElectAcceptanceDerivationMemoMatchesUnmemoized(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x52322026))
+	symbols := visibleSymbols()
+	for trial := 0; trial < 200; trial++ {
+		f := newElectionFixture()
+		count := 2 + rng.Intn(5)
+		paths := make([]Derivation, 0, count)
+		for i := 0; i < count; i++ {
+			roots := make([]SubtreeID, 0, 2)
+			for r := 0; r < 1+rng.Intn(2); r++ {
+				roots = append(roots, f.publish(randomElectionSpec(rng, 0)))
+			}
+			paths = append(paths, Derivation{Payloads: roots, Score: int64(rng.Intn(5)) - 2})
+		}
+		unmemoized, err := ElectAcceptanceDerivation(symbols, f.src, nil, paths)
+		if err != nil {
+			t.Fatalf("trial %d unmemoized: %v", trial, err)
+		}
+		var memo RecoveryCostMemo
+		memoized, err := ElectAcceptanceDerivation(symbols, f.src, &memo, paths)
+		if err != nil {
+			t.Fatalf("trial %d memoized: %v", trial, err)
+		}
+		if unmemoized.Index != memoized.Index || unmemoized.Rung != memoized.Rung ||
+			unmemoized.ErrorCost != memoized.ErrorCost {
+			t.Fatalf("trial %d: unmemoized=%+v memoized=%+v", trial, unmemoized, memoized)
+		}
+	}
+}
+
+func randomElectionSpec(rng *rand.Rand, depth int) *recoveryCostSpec {
+	spec := &recoveryCostSpec{symbol: Symbol(rng.Intn(4) + 4)}
+	if rng.Intn(6) == 0 {
+		spec.symbol = RecoveryErrorSymbol
+		spec.start = 0
+		spec.end = uint32(rng.Intn(20))
+		spec.endRow = uint32(rng.Intn(3))
+	}
+	if depth >= 3 {
+		return spec
+	}
+	for i, n := 0, rng.Intn(3); i < n; i++ {
+		spec.children = append(spec.children, randomElectionSpec(rng, depth+1))
+	}
+	return spec
+}

--- a/internal/parsercorephase0/recovery_cost_ratchet_test.go
+++ b/internal/parsercorephase0/recovery_cost_ratchet_test.go
@@ -11,13 +11,11 @@ import (
 )
 
 // TestRecoveryCostNoOutsideCallSitesRatchet is the compile-time,
-// clean-path-zero-cost guardrail for recovery_cost.go (campaign v7 tranche
+// bounded-call-site guardrail for recovery_cost.go (campaign v7 tranche
 // B3 stage S2, design section 8 gates G2/G3): every symbol recovery_cost.go
-// declares at package scope must be referenced from nowhere else in this
-// package's non-test source, proving by construction that ordinary
-// condense, shift, reduce, and materialization code paths cannot reach the
-// cost model. This is the same pattern as
-// TestCondenseWithOutcomeAtomicProvenanceRatchet
+// declares at package scope must be referenced from nowhere in this
+// package's non-test source EXCEPT the one file listed in callers below.
+// This is the same pattern as TestCondenseWithOutcomeAtomicProvenanceRatchet
 // (condense_outcome_provenance_ratchet_test.go), generalized from one
 // function name to a whole file's declared surface.
 //
@@ -27,11 +25,22 @@ import (
 // for one) that banning them by name would false-positive on unrelated
 // methods. What this ratchet protects is the set of package-scope
 // declarations recovery_cost.go introduces: its exported API plus its two
-// unexported helper functions/constant. A later stage that wires this file
-// in (S3 onward) will make this ratchet fail on purpose -- that failure is
-// the signal to update or retire it alongside the real call site landing.
+// unexported helper functions/constant.
+//
+// callers is the authorized call-site list, and it is deliberately a list of
+// exactly one file rather than an "off" switch. The one authorized caller is
+// acceptance_election.go, which reads the cost model for rungs 1, 2, and 5 of
+// ts_parser__select_tree and reuses RecoveryCostSource for the symbol and
+// child-count view ts_subtree_compare needs.
+//
+// That caller is ITSELF inert (TestAcceptanceElectionNoOutsideCallSitesRatchet,
+// acceptance_election_ratchet_test.go), so the clean-path-zero-cost property
+// stage S2 established is unchanged: no condense, shift, reduce, or
+// materialization path can reach the cost model, and now no shipping path
+// can reach it through the election either.
 func TestRecoveryCostNoOutsideCallSitesRatchet(t *testing.T) {
 	const homeFile = "recovery_cost.go"
+	callers := map[string]bool{"acceptance_election.go": true}
 
 	fset := token.NewFileSet()
 	home, err := parser.ParseFile(fset, homeFile, nil, 0)
@@ -75,7 +84,8 @@ func TestRecoveryCostNoOutsideCallSitesRatchet(t *testing.T) {
 	violations := 0
 	for _, entry := range entries {
 		name := entry.Name()
-		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") || name == homeFile {
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") ||
+			name == homeFile || callers[name] {
 			continue
 		}
 		file, err := parser.ParseFile(fset, filepath.Clean(name), nil, 0)


### PR DESCRIPTION
## What this changes

This adds a library and no shipped behavior. The compact acceptance election
keeps the fail-closed decline it has today. Every route, digest, and sweep
number is unchanged.

`internal/parsercorephase0/acceptance_election.go` ports the reference
runtime's tied-tree selection order: `ts_parser__select_tree`
(parser.c:836-879) and `ts_subtree_compare` (subtree.c:591-618), tree-sitter
v0.25.0. The order has six rungs: error cost twice, dynamic precedence twice,
a take-the-later rule for equal nonzero error cost, and a recursive structural
comparison that orders by lower symbol id, then by fewer children, then by
children pairwise.

The file is inert. `TestAcceptanceElectionNoOutsideCallSitesRatchet` fails if
any non-test source in the package references it.

## Why it is inert

The plan was to replace the tied-accept decline with this order, so a tie
would resolve to the tree the reference runtime keeps instead of handing the
input back to the production parser. That was built and measured against the
locked C oracle. It published a different tree from the oracle on 8 of the 10
tied accepts it newly admitted.

Per-witness result, elected pick against the C oracle:

| language | witness | elected pick | C oracle | verdict |
|---|---|---|---|---|
| apex | class_literal_alias | class_literal (268) | field_access (270) with an "object" field | diverges |
| perl | print_filehandle_list_material_election | list_expression outer | ambiguous_function_call_expression outer | diverges |
| perl | unshift_two_args | list_expression outer | ambiguous_function_call_expression outer | diverges |
| perl | join_bare | list_expression outer | ambiguous_function_call_expression outer | diverges |
| ada | bare_aggregate_assignment_material_election | record_aggregate with a "name" field | record_aggregate with no field | diverges |
| ada | record_aggregate_named | record_aggregate with a "name" field | record_aggregate with no field | diverges |
| ada | discriminated_record | component_definition, 1 child | component_definition, 2 children | diverges (production defect, newly surfaced) |
| kotlin | annotated_declaration | source_file, 2 children | source_file, 1 child | diverges |
| kotlin | 2 further object_declaration witnesses | matches the oracle | matches the oracle | agrees, production diverges |

Sweep totals with the order wired in, against the shipped numbers:

| language | shipped | wired | change |
|---|---|---|---|
| apex | 21 accept / 4 decline / 0 diverge | 22 / 3 / 1 | +1 accept, +1 divergence |
| perl | 16 / 4 / 0 | 19 / 1 / 3 | +3 accepts, +3 divergences |
| ada | 20 / 3 / 0 | 23 / 0 / 3 | +3 accepts, +3 divergences |
| kotlin | 10 / 4 / 0 | 13 / 1 / 1 | +3 accepts, 2 agree, 1 divergence |
| python | 29 / 0 / 0 | 29 / 0 / 0 | unchanged |

The cause is not the port. Take apex. The two live derivations are
`class_literal` (symbol 268) and `field_access` (symbol 270). The structural
rung orders by lower symbol id, so it selects `class_literal`, and no ordering
of that pair selects `field_access`. The oracle's own tree reads the text
"class" as an identifier token, which the `class_literal` derivation cannot
do. The reference runtime never built that alternative.

Perl states the same thing from the other side: the oracle keeps the
alternative the structural rung ranks second there too.

So the compact core's live-derivation set at a tied accept is not the
reference runtime's live-version set. The compact scheduler re-lexes and forks
per header, and its condense step defers precedence ties instead of collapsing
them, so it can carry alternatives the reference runtime never creates.
Ranking a set that contains such an alternative cannot recover the reference
answer, whatever the ranking.

The prerequisite for using this order is a live-derivation set proven equal to
the reference runtime's live-version set. That is a scheduler and lexer
question, not a selection question.

## What lands

- `acceptance_election.go`: the ported order, with the fold order rebuilt from
  the compact core's own fork stamps, an iterative structural comparison that
  matches the reference traversal, and an error-cost model over derivation
  payload roots.
- `acceptance_election_test.go`: one case per ladder rung, rung-precedence
  cases, structural comparison axes, fold stability, and a randomized property
  check that the elected candidate never depends on memoization.
- `acceptance_election_ratchet_test.go`: the inertness guardrail.
- `recovery_cost_ratchet_test.go`: authorizes `acceptance_election.go` as the
  one caller of the cost model. That caller is itself inert, so the
  clean-path-zero-cost property the earlier ratchet established is unchanged.

## Verification

- `go test .` green. `go test ./grammars` green.
- `go test -race ./internal/parsercorephase0` green.
- Admission scorecard: PASS=198 DIVERGE=0 FALLBACK=3 SKIP=5 total=206, equal
  to the shipped ratchet.
- W5 editor latency gates green.
- All five certification sweeps against the locked C oracle report the shipped
  numbers, with zero divergences.
