### PR TITLE
HELD: fix(perl): bareword-call derivation rescue, parked pending merge-time election

### DIFF
--- a/cgo_harness/perl_a3_certification_sweep_test.go
+++ b/cgo_harness/perl_a3_certification_sweep_test.go
@@ -42,17 +42,30 @@ func TestPerlA3CompactCertificationFullCorpusSweep(t *testing.T) {
 // perlA3KnownDivergences are already-triaged, pre-existing production-route
 // defects the tightened sweep criterion surfaced: the compact route only
 // reproduces what production already produces (verified directly, with the
-// compact route disabled) on each of these witnesses. All four are family D
-// (GLR derivation selection at a declared conflict: Go's
+// compact route disabled) on each of these witnesses. Both remaining entries
+// are family D (GLR derivation selection at a declared conflict: Go's
 // reduceForkWindowPreference disagrees with C's ts_parser__select_tree on
 // which branch of a real grammar-declared conflict to keep). Not tied
 // elections, not this gate's scope; repair lanes are tracked separately.
+//
+// Two entries burned down when the zero-width external-token fork rescue
+// landed (parser_dfa_token_source.go,
+// preferGLRUnionDFAOverExternalToken). Perl's bareword call conflict
+// ([$.function, $.function_call_expression], grammar.js:170) needs the
+// zero-width `_NONASSOC` external token to reach function_call_expression,
+// and the shared-frontier lexer used to drop that token in favor of the
+// higher-specificity DFA token, which killed the only fork that could use
+// it:
+//
+//   - local_dynamic_scope now matches the C oracle on both routes.
+//   - medium__statements.pm now matches the C oracle on the compact route
+//     and is reported as an adjudicated exception. Its production route
+//     still elects ambiguous_function_call_expression at 12 points, all of
+//     them bareword calls inside try/catch/finally blocks. The fork now
+//     survives to the end there; the remaining defect is the derivation
+//     selection between the two surviving derivations, which is the
+//     separate family-D tie-break lane.
 var perlA3KnownDivergences = []a3KnownDivergence{
-	{
-		Witness:   "medium__statements.pm",
-		FirstPath: "/source_file/try_statement[69]/block[1]/expression_statement[1]/ambiguous_function_call_expression[0]",
-		GoValue:   "ambiguous_function_call_expression", CValue: "function_call_expression", Family: "D",
-	},
 	{
 		Witness:   "join_assignment",
 		FirstPath: "/source_file/expression_statement[0]/list_expression[0]",
@@ -62,11 +75,6 @@ var perlA3KnownDivergences = []a3KnownDivergence{
 		Witness:   "return_list",
 		FirstPath: "/source_file/subroutine_declaration_statement[0]/block[2]/expression_statement[1]/list_expression[0]",
 		GoValue:   "list_expression", CValue: "return_expression", Family: "D",
-	},
-	{
-		Witness:   "local_dynamic_scope",
-		FirstPath: "/source_file/subroutine_declaration_statement[2]/block[2]/expression_statement[3]/ambiguous_function_call_expression[0]",
-		GoValue:   "ambiguous_function_call_expression", CValue: "function_call_expression", Family: "D",
 	},
 }
 

--- a/cgo_harness/perl_a3_certification_sweep_test.go
+++ b/cgo_harness/perl_a3_certification_sweep_test.go
@@ -60,11 +60,16 @@ func TestPerlA3CompactCertificationFullCorpusSweep(t *testing.T) {
 //   - local_dynamic_scope now matches the C oracle on both routes.
 //   - medium__statements.pm now matches the C oracle on the compact route
 //     and is reported as an adjudicated exception. Its production route
-//     still elects ambiguous_function_call_expression at 12 points, all of
-//     them bareword calls inside try/catch/finally blocks. The fork now
-//     survives to the end there; the remaining defect is the derivation
-//     selection between the two surviving derivations, which is the
-//     separate family-D tie-break lane.
+//     still elects ambiguous_function_call_expression at 12 points. The
+//     try/catch/finally blocks in that file are where those points sit, but
+//     the block kind is NOT the condition: the residual is that two bareword
+//     calls compete for one election, so exactly one of the pair keeps the
+//     ambiguous derivation. "A();\nB();" reproduces it in ten bytes with no
+//     block at all (see
+//     TestPerlBarewordCallResidualDivergenceCOracleParity). The fork now
+//     survives to the end in every one of these; the remaining defect is the
+//     derivation selection between the two surviving derivations, which is
+//     the separate family-D tie-break lane.
 var perlA3KnownDivergences = []a3KnownDivergence{
 	{
 		Witness:   "join_assignment",

--- a/cgo_harness/perl_bareword_call_derivation_parity_test.go
+++ b/cgo_harness/perl_bareword_call_derivation_parity_test.go
@@ -16,29 +16,28 @@ import (
 // derivation against the locked C oracle on the production route.
 //
 // Perl declares the conflict [$.function, $.function_call_expression]
-// (tree-sitter-perl grammar.js:170). At state 873 with lookahead "(" the
-// blob holds two actions: reduce to `function`, and shift into state 4185.
-// State 4185 has an action only on `_NONASSOC` (symbol 289), the zero-width
-// external token that function_call_expression (grammar.js:784-790) uses to
-// commit to the unambiguous form. C lexes every stack version with that
-// version's own lex mode, so the version parked on 4185 always receives
-// `_NONASSOC`. The Go runtime lexes one token for the whole GLR frontier,
-// and the shared-frontier arbitration
-// (preferGLRUnionDFAOverExternalToken) used to hand the frontier the ")"
-// DFA token instead, because ")" scored higher on the name-shape
+// (tree-sitter-perl grammar.js:170). At state 873 with lookahead "(" the blob
+// holds two actions: reduce to `function`, and shift into state 4185. State
+// 4185 has an action only on `_NONASSOC` (symbol 289), the zero-width external
+// token that function_call_expression (grammar.js:784-790) uses to commit to
+// the unambiguous form. C lexes every stack version with that version's own
+// lex mode, so the version parked on 4185 always receives `_NONASSOC`. The Go
+// runtime lexes one token for the whole GLR frontier, and the shared-frontier
+// arbitration (preferGLRUnionDFAOverExternalToken) used to hand the frontier
+// the ")" DFA token instead, because ")" scored higher on the name-shape
 // specificity tie-break. That killed the only fork that could reach
-// function_call_expression, so EVERY bareword call in Perl -- the most
-// common construct in the language -- produced
-// ambiguous_function_call_expression where C produces
 // function_call_expression.
 //
-// The rescue is in the arbitration: a zero-width external token consumes no
-// input, so keeping it costs the stacks that cannot use it nothing (they
-// skip it and re-lex the same byte), while dropping it permanently removes
-// a derivation. Every source below must therefore match the C oracle
-// exactly. "&g();" and "print(\"x\");" were already clean before the fix
-// (each reaches state 4185 with a single live stack, so no arbitration
-// ran); they are kept here as controls.
+// SCOPE, measured, not assumed. This repair does NOT make every bareword call
+// in Perl match C. It restores the derivation for a bareword call whose fork
+// does not compete with another bareword call's fork. When a file carries two
+// such calls, one of them still loses the election; see
+// TestPerlBarewordCallResidualDivergenceCOracleParity for those witnesses. The
+// residual is the separate family-D derivation-selection lane.
+//
+// "&g();" and "print(\"x\");" were already clean before the repair (each
+// reaches state 4185 with a single live stack, so no arbitration ran). They are
+// kept here as controls.
 func TestPerlBarewordCallDerivationCOracleParity(t *testing.T) {
 	goLang := grammars.PerlLanguage()
 	cLang, err := COracleLanguage("perl")
@@ -99,5 +98,130 @@ func TestPerlBarewordCallDerivationCOracleParity(t *testing.T) {
 					strings.Join(mismatches, "\n"))
 			}
 		})
+	}
+}
+
+// TestPerlBarewordCallResidualDivergenceCOracleParity records the bareword
+// call shapes the fork rescue does NOT fix, so the repair's scope stays honest.
+// In each source two bareword calls compete, and exactly one of them still
+// materializes as ambiguous_function_call_expression where C produces
+// function_call_expression. The fork now survives to the end in both cases, so
+// this is no longer a lexing defect: it is the derivation SELECTION between two
+// surviving derivations, the separate family-D tie-break lane.
+//
+// wantDivergence is implicit and always true here. If a case stops diverging,
+// that lane has been repaired for that shape -- re-verify and move the witness
+// up into TestPerlBarewordCallDerivationCOracleParity.
+func TestPerlBarewordCallResidualDivergenceCOracleParity(t *testing.T) {
+	goLang := grammars.PerlLanguage()
+	cLang, err := COracleLanguage("perl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		source string
+	}{
+		// The FIRST call stays ambiguous; the second is repaired.
+		{"two_top_level_calls", "A();\nB();\n"},
+		// The SECOND call stays ambiguous; the first is repaired.
+		{"two_sub_bodies", "sub f { A(); }\nsub g { B(); }\n"},
+		// Real-corpus shape: bareword calls inside try/catch/finally, the
+		// 12 remaining production points in corpus_real/perl/medium__statements.pm.
+		{"try_catch_blocks", "try { A(); } catch($e) { B(); }\n"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			scheduleParityMemoryScavenge(t)
+			src := []byte(test.source)
+
+			goParser := gotreesitter.NewParser(goLang)
+			goParser.SetAdmissionCandidateRoute(false)
+			tree, err := goParser.Parse(src)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer tree.Release()
+
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(src, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parse returned a nil tree")
+			}
+			defer cTree.Close()
+
+			var mismatches []string
+			compareNodes(tree.RootNode(), goLang, cTree.RootNode(), "root", &mismatches)
+			if len(mismatches) == 0 {
+				t.Fatalf(
+					"expected %q to still diverge from the C oracle on the derivation-selection lane, "+
+						"but it now matches; move this witness into "+
+						"TestPerlBarewordCallDerivationCOracleParity after re-verifying",
+					test.source)
+			}
+			t.Skipf("known derivation-selection residual:\n  go: %s\n   c: %s\n%s",
+				tree.RootNode().SExpr(goLang), cTree.RootNode().ToSexp(),
+				strings.Join(mismatches, "\n"))
+		})
+	}
+}
+
+// TestPerlForkedFrontierKeepsRecoveringToEOF is the permanent regression
+// witness for the cost of keeping a rescued fork alive. Holding an extra live
+// version past the point where it used to be pruned changes how many versions
+// the no-action recovery ladder sees. While that ladder asked len(stacks), a
+// frontier that had ever forked lost its recovery entirely: every version was
+// killed, the parse ended at ParseStopNoStacksAlive, and the tail of the file
+// was never parsed. This source lost 6 of its 41 bytes that way.
+//
+// The gates now ask whether a LIVE sibling remains
+// (anotherLiveParseStackRemains), so the last live version still reaches the
+// recovery ladder. The tree here is an ERROR tree in both runtimes -- the
+// source is deliberately malformed -- so this test asserts coverage, not
+// shape: the parse must reach the end of the source and must recover the
+// trailing statement, exactly as the C oracle does.
+func TestPerlForkedFrontierKeepsRecoveringToEOF(t *testing.T) {
+	goLang := grammars.PerlLanguage()
+	cLang, err := COracleLanguage("perl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := []byte("foo { A(); } bar($e) { B(); }\nmy $z = 1;\n")
+
+	scheduleParityMemoryScavenge(t)
+	goParser := gotreesitter.NewParser(goLang)
+	goParser.SetAdmissionCandidateRoute(false)
+	tree, err := goParser.Parse(source)
+	if err != nil {
+		t.Fatalf("production parse: %v", err)
+	}
+	defer tree.Release()
+
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("C parse returned a nil tree")
+	}
+	defer cTree.Close()
+
+	goEnd := int(tree.RootNode().EndByte())
+	cEnd := int(cTree.RootNode().EndByte())
+	if goEnd < cEnd {
+		t.Fatalf("production parse stopped %d byte(s) short of the C oracle (go=%d c=%d of %d):\n  go: %s",
+			cEnd-goEnd, goEnd, cEnd, len(source), tree.RootNode().SExpr(goLang))
+	}
+	if got := tree.RootNode().SExpr(goLang); !strings.Contains(got, "assignment_expression") {
+		t.Fatalf("production parse did not recover the trailing `my $z = 1;` statement:\n  go: %s", got)
 	}
 }

--- a/cgo_harness/perl_bareword_call_derivation_parity_test.go
+++ b/cgo_harness/perl_bareword_call_derivation_parity_test.go
@@ -1,0 +1,103 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"strings"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestPerlBarewordCallDerivationCOracleParity pins the Perl bareword call
+// derivation against the locked C oracle on the production route.
+//
+// Perl declares the conflict [$.function, $.function_call_expression]
+// (tree-sitter-perl grammar.js:170). At state 873 with lookahead "(" the
+// blob holds two actions: reduce to `function`, and shift into state 4185.
+// State 4185 has an action only on `_NONASSOC` (symbol 289), the zero-width
+// external token that function_call_expression (grammar.js:784-790) uses to
+// commit to the unambiguous form. C lexes every stack version with that
+// version's own lex mode, so the version parked on 4185 always receives
+// `_NONASSOC`. The Go runtime lexes one token for the whole GLR frontier,
+// and the shared-frontier arbitration
+// (preferGLRUnionDFAOverExternalToken) used to hand the frontier the ")"
+// DFA token instead, because ")" scored higher on the name-shape
+// specificity tie-break. That killed the only fork that could reach
+// function_call_expression, so EVERY bareword call in Perl -- the most
+// common construct in the language -- produced
+// ambiguous_function_call_expression where C produces
+// function_call_expression.
+//
+// The rescue is in the arbitration: a zero-width external token consumes no
+// input, so keeping it costs the stacks that cannot use it nothing (they
+// skip it and re-lex the same byte), while dropping it permanently removes
+// a derivation. Every source below must therefore match the C oracle
+// exactly. "&g();" and "print(\"x\");" were already clean before the fix
+// (each reaches state 4185 with a single live stack, so no arbitration
+// ran); they are kept here as controls.
+func TestPerlBarewordCallDerivationCOracleParity(t *testing.T) {
+	goLang := grammars.PerlLanguage()
+	cLang, err := COracleLanguage("perl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{"bareword_no_args", "g();"},
+		{"bareword_one_scalar_arg", "g($x);"},
+		{"bareword_two_number_args", "foo(1, 2);"},
+		{"bareword_call_in_assignment", "my $y = f(3);"},
+		{"package_qualified_bareword", "Foo::bar(1);"},
+		{"ampersand_call_control", "&g();"},
+		{"builtin_print_control", "print(\"x\");"},
+		{"bareword_call_in_bare_block", "{ A(); }\n"},
+		{"bareword_call_in_sub_body", "sub f { A(); }\n"},
+		{"bareword_call_in_conditional_block", "if (1) { A(); }\n"},
+		// The A3 sweep's local_dynamic_scope witness
+		// (perl_a3_certification_sweep_test.go), which this repair burned
+		// down out of perlA3KnownDivergences.
+		{"local_dynamic_scope", "our $x = 1;\nsub f { local $x = 2; g(); }\n"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			scheduleParityMemoryScavenge(t)
+			src := []byte(test.source)
+
+			goParser := gotreesitter.NewParser(goLang)
+			goParser.SetAdmissionCandidateRoute(false)
+			tree, err := goParser.Parse(src)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer tree.Release()
+
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(src, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parse returned a nil tree")
+			}
+			defer cTree.Close()
+
+			var mismatches []string
+			compareNodes(tree.RootNode(), goLang, cTree.RootNode(), "root", &mismatches)
+			if len(mismatches) != 0 {
+				t.Fatalf("production tree diverges from the C oracle for %q:\n  go: %s\n   c: %s\n%s",
+					test.source, tree.RootNode().SExpr(goLang), cTree.RootNode().ToSexp(),
+					strings.Join(mismatches, "\n"))
+			}
+		})
+	}
+}

--- a/cgo_harness/perl_forked_frontier_recovery_residual_test.go
+++ b/cgo_harness/perl_forked_frontier_recovery_residual_test.go
@@ -1,0 +1,186 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// perlResidualTailBody builds a long, valid Perl tail. The residual shapes
+// below only lose a few bytes on a one-line file, which is what made the first
+// measurement of this lane read "max 32 bytes". That number was an artifact of
+// the mutation corpus using short bases. With a realistic tail behind the
+// defect, the SAME shapes lose essentially the whole file, because the version
+// that survives the fork resyncs into a state that cannot make progress and
+// nothing after the defect is ever parsed.
+func perlResidualTailBody() string {
+	var b strings.Builder
+	for i := 0; i < 60; i++ {
+		fmt.Fprintf(&b, "my $v%d = %d;\nsub f%d { return $v%d + 1; }\n", i, i, i, i)
+	}
+	return b.String()
+}
+
+// TestPerlForkedFrontierRecoveryResiduals pins the two shapes that the
+// live-sibling recovery gates (parser.go, anotherLiveParseStackRemains) still
+// get wrong, so the cost of those gates is on the record and so the
+// merge-election lane has an acceptance instrument.
+//
+// MECHANISM. Every one of these sources reaches a frontier holding two
+// versions at the same state, byte offset, and depth, differing only in a
+// buried subtree. C collapses that pair at ts_stack_merge and elects one
+// subtree with ts_parser__select_tree, so C's frontier returns to one version
+// immediately. Go refuses the merge because the shapes differ
+// (gssStacksHaveDistinctMaterializingShapes), so the duplicate frontier
+// persists. Every gate in this lane is then a heuristic about how long to keep
+// a version alive, which is a proxy for the merge-time election Go never
+// performs. When a real syntax error arrives, the surviving version resyncs
+// into a state with no forward progress and the rest of the file is lost.
+//
+// SCOPE OF THE RESIDUAL. These are NOT caused by the zero-width external-token
+// rescue. On "try { A(;) } ..." the reference runtime emits `_NONASSOC` at the
+// same byte with no rescue at all; the divergence is introduced purely by the
+// recovery gates. Measured against origin/main at 4347068b, production route.
+//
+// Each case asserts that the defect is STILL PRESENT. If one stops failing,
+// the merge-election lane has repaired it: delete the entry and record the
+// receipt.
+func TestPerlForkedFrontierRecoveryResiduals(t *testing.T) {
+	goLang := grammars.PerlLanguage()
+	cLang, err := COracleLanguage("perl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tail := perlResidualTailBody()
+
+	tests := []struct {
+		name string
+		// source is the defect line plus, for the "long" variants, a valid tail.
+		source string
+		// baseEnd is the end byte origin/main@4347068b reaches on this source.
+		baseEnd int
+		// baseStop is the stop reason origin/main reports.
+		baseStop string
+	}{
+		{
+			// Unclosed call with a `;` inside, one line.
+			name:     "unclosed_call_semicolon_short",
+			source:   "try { A(;) } catch($e) { B(); }\n",
+			baseEnd:  32,
+			baseStop: "accepted",
+		},
+		{
+			// The same defect with a realistic tail behind it. This is the
+			// case the short measurement hid: 2563 of 2572 bytes lost.
+			name:     "unclosed_call_semicolon_long",
+			source:   "try { A(;) } catch($e) { B(); }\n" + tail,
+			baseEnd:  2572,
+			baseStop: "accepted",
+		},
+		{
+			// Missing open paren after `catch`, one line.
+			name:     "catch_missing_open_paren_short",
+			source:   "try { A(); } catch$e) { B(); }\n",
+			baseEnd:  31,
+			baseStop: "accepted",
+		},
+		{
+			// The same defect with a realistic tail: 2545 of 2571 bytes lost.
+			// The earlier note called this "a reduce-chain cycle"; that is this
+			// mechanism, and on a real file it costs the whole file, not five
+			// bytes.
+			name:     "catch_missing_open_paren_long",
+			source:   "try { A(); } catch$e) { B(); }\n" + tail,
+			baseEnd:  2571,
+			baseStop: "accepted",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			scheduleParityMemoryScavenge(t)
+			src := []byte(test.source)
+
+			goParser := gotreesitter.NewParser(goLang)
+			goParser.SetAdmissionCandidateRoute(false)
+			tree, err := goParser.Parse(src)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer tree.Release()
+
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(src, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parse returned a nil tree")
+			}
+			defer cTree.Close()
+
+			goEnd := int(tree.RootNode().EndByte())
+			cEnd := int(cTree.RootNode().EndByte())
+			stop := string(tree.ParseStopReason())
+
+			if goEnd >= cEnd {
+				t.Fatalf(
+					"%q now reaches the end of the source (go=%d c=%d of %d, stop=%s). The "+
+						"merge-election lane has repaired this residual: delete this entry and "+
+						"record the receipt.",
+					test.name, goEnd, cEnd, len(src), stop)
+			}
+			t.Skipf(
+				"known recovery-gate residual: go stops at %d of %d (stop=%s), C reaches %d; "+
+					"origin/main@4347068b reached %d (stop=%s), so this lane loses %d byte(s) (%d%%)",
+				goEnd, len(src), stop, cEnd, test.baseEnd, test.baseStop,
+				test.baseEnd-goEnd, (test.baseEnd-goEnd)*100/test.baseEnd)
+		})
+	}
+}
+
+// TestPerlForkedFrontierRecoveryStopReasonCensus records the stop-reason shift
+// the recovery gates cause, because coverage alone hid it. Over a 1170-case
+// deterministic Perl mutation corpus, origin/main@4347068b reports 1073
+// `accepted` and 97 `no_stacks_alive`; this lane reports 1044 and 126, with 47
+// cases moving from `accepted` into `no_stacks_alive` and 18 the other way.
+// The net coverage number (5 truncations against 24 repairs) is therefore NOT
+// the whole cost: a case can keep its byte coverage and still change how the
+// parse terminated.
+//
+// This test pins the smallest source that makes the shift visible, so the
+// census is reproducible without the corpus generator.
+func TestPerlForkedFrontierRecoveryStopReasonCensus(t *testing.T) {
+	goLang := grammars.PerlLanguage()
+
+	// origin/main@4347068b reports "accepted" for this source and reaches the
+	// end. This lane reports no_stacks_alive and stops early.
+	source := []byte("try { A(;) } catch($e) { B(); }\n")
+
+	scheduleParityMemoryScavenge(t)
+	p := gotreesitter.NewParser(goLang)
+	p.SetAdmissionCandidateRoute(false)
+	tree, err := p.Parse(source)
+	if err != nil {
+		t.Fatalf("production parse: %v", err)
+	}
+	defer tree.Release()
+
+	stop := string(tree.ParseStopReason())
+	if stop == "accepted" && int(tree.RootNode().EndByte()) >= len(source) {
+		t.Fatalf(
+			"stop reason is back to %q with full coverage; the recovery-gate residual is "+
+				"repaired -- delete this witness and record the receipt", stop)
+	}
+	t.Skipf("known recovery-gate residual: stop=%s end=%d of %d (origin/main@4347068b: accepted, %d)",
+		stop, tree.RootNode().EndByte(), len(source), len(source))
+}

--- a/parser.go
+++ b/parser.go
@@ -5745,6 +5745,13 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				// stack has an action for the lookahead, so re-lexing cannot steal a
 				// token another version was going to consume, whatever the grammar.
 				canRelexNoLiveAction := !sameState && p.language != nil && p.noLiveStackCanAcceptLookahead(stacks, tok)
+				// The recovery ladder below is written for "no other version can
+				// carry this parse". The slice length is the wrong way to ask
+				// that question: it also counts versions this same dispatch pass
+				// has already killed, so a frontier that ever forked silently
+				// loses its recovery even when this is its last live version.
+				// Ask about live siblings instead.
+				lastLiveStack := !anotherLiveParseStackRemains(stacks, si)
 				if tok.Symbol == errorSymbol && tok.StartByte != tok.EndByte && p.errorCostCompetitionEnabled() {
 					// Faithful C recovery port: an unlexable-run lookahead has
 					// no table actions in C either; the version pauses and the
@@ -5896,7 +5903,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				// nested declaration-start construct as an error rather than
 				// silently accepting it — see
 				// TestOpportunisticTopLevelResyncDoesNotLiftNestedDeclarationStarts/java_import_inside_malformed_method.
-				if len(stacks) == 1 && !p.resyncTopLevelLanguage() && !p.errorCostCompetitionEnabled() {
+				if lastLiveStack && !p.resyncTopLevelLanguage() && !p.errorCostCompetitionEnabled() {
 					switch p.tryOpportunisticTopLevelResyncRecovery(source, s, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 					case resyncRetry:
 						currentState = s.top().state
@@ -5964,7 +5971,17 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					}
 					continue
 				}
-				if len(stacks) > 1 {
+				// Killing a version because it has no action for the lookahead
+				// is only safe while another version can still carry the parse.
+				// The old gate read the raw slice length, so the LAST live
+				// version was killed too whenever the frontier had ever forked,
+				// and the parse ended at ParseStopNoStacksAlive with the rest of
+				// the file unparsed. C never does that: ts_parser__advance runs
+				// ts_parser__handle_error once no version can act, so the file
+				// is always consumed to EOF. Keep the kill for versions that
+				// leave a live sibling behind, and give the last live version
+				// the single-stack recovery ladder below.
+				if !lastLiveStack {
 					if p.glrTrace {
 						fmt.Printf("  stack[%d] KILLED: no action for sym=%d in state=%d (multiple stacks)\n", si, tok.Symbol, currentState)
 					}
@@ -7444,6 +7461,19 @@ func (p *Parser) traceParseIteration(iter int, tok Token, stacks []glrStack, nee
 		fmt.Printf("  s[%d]: st=%d dead=%v shift=%v dep=%d byte=%d\n",
 			si, stacks[si].top().state, stacks[si].dead, stacks[si].shifted, stacks[si].depth(), stacks[si].byteOffset)
 	}
+}
+
+// anotherLiveParseStackRemains reports whether some version other than
+// stacks[si] is still live, so killing stacks[si] leaves the parse a carrier.
+// A version that already accepted still counts: it holds a complete parse.
+func anotherLiveParseStackRemains(stacks []glrStack, si int) bool {
+	for i := range stacks {
+		if i == si || stacks[i].dead {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func parseStacksShareState(stacks []glrStack, state StateID) bool {

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -755,6 +755,25 @@ func (d *dfaTokenSource) preferGLRUnionDFAOverExternalToken(extTok Token, extEnd
 		}
 		return Token{}, 0, 0, 0, false
 	}
+	// A zero-width external token consumes no input, so keeping it costs the
+	// live stacks that cannot use it nothing: parser.go's zero-width no-action
+	// branch makes each of them skip the token and re-lex the same byte, and
+	// the zero-width retry filter (extZeroTried) stops the scanner from
+	// offering it a second time at that position. Dropping it, by contrast, is
+	// final. Any stack whose only continuation is that external token loses its
+	// one lookahead and dies, which removes a whole derivation from the parse.
+	// C never makes that trade: it lexes every stack version with that
+	// version's own lex mode, so a version gated behind a zero-width external
+	// token always receives it. Keep the external token whenever some live GLR
+	// state can act on it and cannot act on the DFA token.
+	if extTok.EndByte == extTok.StartByte && d.hasGLRActionSupportExclusiveTo(extTok.Symbol, dfaTok.Symbol) {
+		if DebugDFA.Load() {
+			fmt.Printf("  GLR ext/dfa keep external: zero-width ext=%s(%d) has a state the dfa=%s(%d) cannot serve\n",
+				d.symbolName(extTok.Symbol), extTok.Symbol,
+				d.symbolName(dfaTok.Symbol), dfaTok.Symbol)
+		}
+		return Token{}, 0, 0, 0, false
+	}
 	dfaSupport := d.countGLRActionSupport(dfaTok.Symbol)
 	dfaSpecificity := tokenSymbolSpecificity(d.language, dfaTok.Symbol)
 	extSpecificity := tokenSymbolSpecificity(d.language, extTok.Symbol)

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -755,17 +755,28 @@ func (d *dfaTokenSource) preferGLRUnionDFAOverExternalToken(extTok Token, extEnd
 		}
 		return Token{}, 0, 0, 0, false
 	}
-	// A zero-width external token consumes no input, so keeping it costs the
-	// live stacks that cannot use it nothing: parser.go's zero-width no-action
-	// branch makes each of them skip the token and re-lex the same byte, and
-	// the zero-width retry filter (extZeroTried) stops the scanner from
-	// offering it a second time at that position. Dropping it, by contrast, is
-	// final. Any stack whose only continuation is that external token loses its
-	// one lookahead and dies, which removes a whole derivation from the parse.
-	// C never makes that trade: it lexes every stack version with that
-	// version's own lex mode, so a version gated behind a zero-width external
-	// token always receives it. Keep the external token whenever some live GLR
-	// state can act on it and cannot act on the DFA token.
+	// A zero-width external token consumes no input. The live stacks that
+	// cannot act on it take parser.go's zero-width no-action branch, skip it,
+	// and re-lex the same byte, so keeping it does not cost them their
+	// lookahead. Dropping it, by contrast, is final: any stack whose only
+	// continuation is that external token loses its one lookahead and dies,
+	// which removes a whole derivation from the parse. C never makes that
+	// trade, because it lexes every stack version with that version's own lex
+	// mode, so a version gated behind a zero-width external token always
+	// receives it. Keep the external token whenever some live GLR state can act
+	// on it and cannot act on the DFA token.
+	//
+	// What stops the scanner offering the same zero-width token again at that
+	// byte is the external validity set computed for the NEW frontier, not the
+	// (position, primary state) filter in extZeroTried. That filter goes inert
+	// as soon as the rescued fork shifts, because the primary parser state then
+	// changes and no longer matches the recorded one. Measured on "g();": the
+	// second lex at byte 2 runs with primary state 183, and the union over the
+	// live states {183, 285} does not admit _NONASSOC at all.
+	//
+	// Keeping a fork alive longer is not free elsewhere. It changes how many
+	// live versions the error-recovery ladder sees, so this rescue lands
+	// together with the live-sibling gates in parser.go's no-action ladder.
 	if extTok.EndByte == extTok.StartByte && d.hasGLRActionSupportExclusiveTo(extTok.Symbol, dfaTok.Symbol) {
 		if DebugDFA.Load() {
 			fmt.Printf("  GLR ext/dfa keep external: zero-width ext=%s(%d) has a state the dfa=%s(%d) cannot serve\n",

--- a/parser_dfa_zero_width_external_fork_test.go
+++ b/parser_dfa_zero_width_external_fork_test.go
@@ -1,0 +1,103 @@
+package gotreesitter
+
+import "testing"
+
+// zeroWidthExternalForkLanguage builds the minimal shape of the Perl bareword
+// call conflict: two live GLR stacks, one that can only shift a real DFA token
+// and one that can only shift a ZERO-WIDTH external token.
+//
+//   - state 1: has an action for the DFA token ")" (symbol 1) and none for the
+//     external "_ZW" (symbol 2).
+//   - state 2: has an action for "_ZW" and none for ")".
+//
+// This is state 873 / state 4185 in perl's blob, reduced to its essentials.
+func zeroWidthExternalForkLanguage() *Language {
+	return &Language{
+		SymbolNames: []string{"end", ")", "_ZW"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "end", Visible: false, Named: false},
+			{Name: ")", Visible: true, Named: false},
+			{Name: "_ZW", Visible: false, Named: false},
+		},
+		SymbolCount:     3,
+		TokenCount:      3,
+		StateCount:      3,
+		LargeStateCount: 3,
+		InitialState:    1,
+		ExternalSymbols: []Symbol{2},
+		// LexStates 1 and 2 are distinct rows with identical behavior: both
+		// lex ")" into the accepting row 3. The two live stacks must sit in
+		// DIFFERENT lex modes, otherwise nextGLRUnionDFAToken short-circuits
+		// on its all-same check and no arbitration happens at all.
+		LexStates: []LexState{
+			{Default: -1, EOF: -1},
+			{AcceptToken: 0, Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: ')', Hi: ')', NextState: 3}}},
+			{AcceptToken: 0, Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: ')', Hi: ')', NextState: 3}}},
+			{AcceptToken: 1, Default: -1, EOF: -1},
+		},
+		LexModes: []LexMode{
+			{LexState: 0},
+			{LexState: 1},
+			{LexState: 2},
+		},
+		// row[state][symbol] -> ParseActions index; 0 means no action.
+		ParseTable: [][]uint16{
+			{0, 0, 0},
+			{0, 1, 0},
+			{0, 0, 1},
+		},
+		ParseActions: []ParseActionEntry{
+			{Actions: nil},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 1}}},
+		},
+	}
+}
+
+// TestPreferGLRUnionDFAKeepsZeroWidthExternalTokenNeededByAFork pins the fork
+// rescue that restores Perl's function_call_expression derivation. When the
+// external scanner produces a ZERO-WIDTH token that one live GLR stack can act
+// on and the competing DFA token cannot serve, the shared-frontier arbitration
+// must keep the external token. A zero-width token consumes no input, so the
+// stacks that cannot use it skip it and re-lex the same byte; dropping it
+// instead kills the only fork that can continue through it.
+func TestPreferGLRUnionDFAKeepsZeroWidthExternalTokenNeededByAFork(t *testing.T) {
+	lang := zeroWidthExternalForkLanguage()
+	parser := NewParser(lang)
+	d := &dfaTokenSource{
+		lexer:             NewLexer(lang.LexStates, []byte(")")),
+		language:          lang,
+		state:             1,
+		glrStates:         []StateID{1, 2},
+		lookupActionIndex: parser.lookupActionIndex,
+	}
+
+	extTok := Token{Symbol: 2, StartByte: 0, EndByte: 0, ExternalScannerToken: true}
+	if _, _, _, _, preferDFA := d.preferGLRUnionDFAOverExternalToken(extTok, 0, 0, 0, 0, 0, 0); preferDFA {
+		t.Fatal("arbitration chose the DFA token over a zero-width external token that only one fork can act on; that fork loses its only lookahead and dies")
+	}
+}
+
+// TestPreferGLRUnionDFAStillPrefersDFAWhenExternalTokenHasWidth keeps the
+// rescue narrow. A non-zero-width external token DOES consume input, so
+// keeping it is not free for the stacks that cannot use it, and the existing
+// support/specificity ladder still decides.
+func TestPreferGLRUnionDFAStillPrefersDFAWhenExternalTokenHasWidth(t *testing.T) {
+	lang := zeroWidthExternalForkLanguage()
+	parser := NewParser(lang)
+	d := &dfaTokenSource{
+		lexer:             NewLexer(lang.LexStates, []byte(")")),
+		language:          lang,
+		state:             1,
+		glrStates:         []StateID{1, 2},
+		lookupActionIndex: parser.lookupActionIndex,
+	}
+
+	extTok := Token{Symbol: 2, StartByte: 0, EndByte: 1, ExternalScannerToken: true}
+	dfaTok, _, _, _, preferDFA := d.preferGLRUnionDFAOverExternalToken(extTok, 1, 0, 1, 0, 0, 0)
+	if !preferDFA {
+		t.Fatal("arbitration kept a width-carrying external token; the support/specificity ladder should still pick the DFA token here")
+	}
+	if dfaTok.Symbol != 1 {
+		t.Fatalf("dfa token symbol = %d, want 1 (%q)", dfaTok.Symbol, lang.SymbolNames[1])
+	}
+}

--- a/parser_dfa_zero_width_external_fork_test.go
+++ b/parser_dfa_zero_width_external_fork_test.go
@@ -101,3 +101,31 @@ func TestPreferGLRUnionDFAStillPrefersDFAWhenExternalTokenHasWidth(t *testing.T)
 		t.Fatalf("dfa token symbol = %d, want 1 (%q)", dfaTok.Symbol, lang.SymbolNames[1])
 	}
 }
+
+// TestAnotherLiveParseStackRemainsIgnoresDeadSiblings pins the predicate the
+// no-action recovery ladder now uses instead of the raw slice length. Versions
+// this same dispatch pass already killed must not count: while they did, a
+// frontier that had ever forked lost its recovery entirely and the parse ended
+// with the rest of the file unparsed.
+func TestAnotherLiveParseStackRemainsIgnoresDeadSiblings(t *testing.T) {
+	stacks := make([]glrStack, 3)
+	stacks[0].dead = true
+	stacks[1].dead = true
+
+	if anotherLiveParseStackRemains(stacks, 2) {
+		t.Fatal("stacks[2] is the last live version, but the predicate reported a live sibling")
+	}
+	if !anotherLiveParseStackRemains(stacks, 0) {
+		t.Fatal("stacks[2] is live, so killing stacks[0] leaves a carrier")
+	}
+
+	stacks[1].dead = false
+	if !anotherLiveParseStackRemains(stacks, 2) {
+		t.Fatal("stacks[1] is live again, so stacks[2] is no longer the last live version")
+	}
+
+	single := make([]glrStack, 1)
+	if anotherLiveParseStackRemains(single, 0) {
+		t.Fatal("a one-version frontier has no sibling")
+	}
+}


### PR DESCRIPTION
> **HELD. Do not merge.** This branch is parked pending the merge-time
> derivation-election lane. The zero-width external-token rescue is sound and
> should be re-attempted on its own once that lane lands. The two recovery
> gates it needs today are heuristics about how long to keep a version alive,
> which is a proxy for the merge-time election Go never performs. This PR
> exists as the record and as the acceptance instrument for that lane.

## What is here

1. **The Perl bareword-call derivation repair** (`parser_dfa_token_source.go`).
   Sound, measured, and the part worth re-attempting alone.
2. **Two recovery gates** (`parser.go`) the repair needs today. These are what
   the hold is about.

## Root cause of the derivation loss

Perl declares the conflict `[$.function, $.function_call_expression]`
(tree-sitter-perl grammar.js:170). At state 873 with lookahead `(` the blob
holds two actions: reduce to `function`, and shift into state 4185. State
4185 has an action only on `_NONASSOC` (symbol 289), the zero-width external
token that commits to the unambiguous form.

C lexes every stack version with that version's own lex mode, so the version
parked on 4185 always receives `_NONASSOC`. Go lexes one token for the whole
GLR frontier and then arbitrates in `preferGLRUnionDFAOverExternalToken`. With
support tied 1-1 the tie-break is `tokenSymbolSpecificity`, a name-shape
heuristic that scores a one-character name 3 and an underscore-prefixed name
1. `)` beat `_NONASSOC`, and the fork died one token later.

Traced receipts on `g();`, production route: the fork IS created and DOES
shift into 4185; action-table probing DOES mark `_NONASSOC` valid
(`EXT valid pos=2 state=285 glr=[285 4185] valid=...,37:_NONASSOC`); the
arbitration discards it (`GLR ext/dfa choose dfa: ext=_NONASSOC(289)[2-2]
support=1 dfa=)(17)[2-3] support=1`); the fork dies (`stack[1] KILLED: no
action for sym=17 in state=4185`).

The missing-`ExternalLexStates` hypothesis is refuted: the arbitration never
reads that table, probing already found the token, and perl's upstream
repository checks in no `src/parser.c` for the generator to read.

The reviewer's preferred narrowing -- require that no live stack is exclusive
to the DFA token -- was tested and reverts the repair outright, because perl's
own case has BOTH tokens exclusive on different stacks (4185 exclusive to
`_NONASSOC`, 285 exclusive to `)`). That condition is also already covered by
the existing `dfaSupport < extSupport` rung.

## CORRECTED residual measurement

An earlier revision of this body reported the residual as "5 cases, max 32
bytes, mean 14". **That was wrong, and wrong in the direction that matters.**
It was an artifact of the mutation corpus using one-line bases for the two
residual shapes. Put a realistic tail behind the same defect and the loss is
the whole file. Measured against origin/main at 4347068b, production route:

| witness | bytes | main reaches | this branch reaches | lost |
|---|---|---|---|---|
| `try { A(;) } catch($e) { B(); }` | 32 | 32, `accepted` | 9, `no_stacks_alive` | 23 (71%) |
| same + 2540 B valid tail | 2572 | 2572, `accepted` | 9, `no_stacks_alive` | **2563 (99%)** |
| `try { A(); } catch$e) { B(); }` | 31 | 31, `accepted` | 26, `no_stacks_alive` | 5 (16%) |
| same + 2540 B valid tail | 2571 | 2571, `accepted` | 26, `no_stacks_alive` | **2545 (98%)** |

The earlier note that `catch$e)` "enters a reduce-chain cycle" describes this
mechanism. On a one-line file it costs five bytes; on a real file it costs the
file. The reviewer independently measured the same class as iteration-limit
trips costing 1990-2196 bytes each (66-73% of file); my corpus surfaces it as
`no_stacks_alive` instead. Same defect, same magnitude class: the surviving
version resyncs into a state that cannot make progress and nothing after the
defect is parsed.

These four are now pinned as
`TestPerlForkedFrontierRecoveryResiduals`.

### Stop-reason census, which coverage alone hid

1170-case deterministic Perl mutation corpus, production route, C-adjudicated:

| stop reason | base (4347068b) | rescue only | kill gate only | both gates |
|---|---|---|---|---|
| `accepted` | 1073 | 973 | 973 | 1044 |
| `no_stacks_alive` | 97 | 197 | 197 | 126 |

Transitions base to both-gates: 47 cases move `accepted` to
`no_stacks_alive`, 18 move the other way. So the headline coverage number
(5 truncations against 24 repairs) is **not** the whole cost: a case can keep
its byte coverage and still change how the parse terminated. Pinned as
`TestPerlForkedFrontierRecoveryStopReasonCensus`.

Coverage table for completeness:

| configuration | truncates where main is complete | complete where main truncates |
|---|---|---|
| rescue alone | 69 (max 2576 B, mean 97) | 6 |
| kill gate only | 69 (max 2576 B, mean 97) -- identical to rescue alone | 6 |
| both gates | 5 (max 32 B on this corpus) | 24 |

The kill gate alone is measurably a no-op; the resync gate does the work.

## The change is NOT Perl-scoped

`anotherLiveParseStackRemains` replaces `len(stacks)` in the SHARED no-action
recovery ladder (`parser.go`), so it applies to all 206 grammars whether or
not they ever reach the zero-width rescue.

### Julia receipt, four-variant attribution

`corpus_real/julia/large__abstractinterpretation.jl`, 224,616 bytes,
production route:

| variant | root | coverage | all nodes | named | ERROR nodes | digest |
|---|---|---|---|---|---|---|
| base 4347068b | `source_file` | 224616/224616 | 47580 | 32057 | 59 | `dbb7d086` |
| rescue only | `source_file` | 224616/224616 | 47626 | 32087 | 54 | `dbb7d086` |
| kill gate only | `source_file` | 224616/224616 | 47626 | 32087 | 54 | `5783eece` |
| both gates | `source_file` | 224616/224616 | 47630 | 32083 | 43 | `8cadacf0` |

The digests reproduce the reviewer's exactly. Two attribution facts:

- **The rescue does not move julia at all** (`dbb7d086`, identical to base).
  The tree change is entirely the gates.
- **The kill gate alone already moves it** (`5783eece`), which refines the
  earlier attribution to the resync gate: both gates move julia, the resync
  gate moves it further.

One discrepancy is open and the next attempt must settle it. The reviewer
measured 729 nodes against base's 1364 (46% fewer) with C at 31,721. On the
production route and on the compact route I measure 47,580 versus 47,630 all
nodes and 32,057 versus 32,083 named, with the branch producing FEWER ERROR
nodes (43 versus 59) and identical full coverage. I could not reproduce the
729/1364 figure by route. Whatever counter produced it is not the plain
tree walk, and it needs identifying before this lands.

## Scope of the derivation repair, measured

This does NOT make every bareword call in Perl match C. It restores the
derivation for a bareword call whose fork does not compete with another
bareword call's fork. When two compete, one still loses the election:
`A();\nB();` leaves the FIRST call ambiguous, `sub f { A(); }\nsub g { B(); }`
leaves the SECOND. Pinned in
`TestPerlBarewordCallResidualDivergenceCOracleParity`.

Witnesses that do flip, production route, versus the locked C oracle:

| Source | Before | After |
|---|---|---|
| `g();` | 2 divergences | 0 |
| `g($x);` | 3 | 0 |
| `foo(1, 2);` | 3 | 0 |
| `my $y = f(3);` | 3 | 0 |
| `Foo::bar(1);` | 3 | 0 |
| `{ A(); }` | divergent | 0 |
| `sub f { A(); }` | divergent | 0 |
| `if (1) { A(); }` | divergent | 0 |
| `local_dynamic_scope` | 2 | 0 |
| `&g();` (control) | 0 | 0 |
| `print("x");` (control) | 0 | 0 |

## Why this is held, in one paragraph

Every residual shares one shape: two versions at the same state, byte offset,
and depth, differing only in a buried subtree. C collapses that pair at
`ts_stack_merge` and elects one subtree with `ts_parser__select_tree`, so C's
frontier returns to one version immediately. Go refuses the merge because the
shapes differ (`gssStacksHaveDistinctMaterializingShapes`), so the duplicate
frontier persists and perturbs every stack-count-sensitive decision
downstream. Both gates in this PR are heuristics about version lifetime, which
is a proxy for that election. Landing the proxy buys about 21 net repairs
today and installs two shared-path heuristics the real lane must unwind, plus
a julia tree change it may not absorb.

## Gates, against origin/main at 4347068b

- 206-language admission scorecard: byte-identical on every row including
  every digest. `PASS=198 DIVERGE=0 FALLBACK=3 SKIP=5 ERROR=0`. Note this gate
  cannot see the julia change: julia's smoke sample is one line.
- `GTS_PARITY_MODE=exhaustive TestParityFreshParse` and
  `TestParityStructuralCorpus`: pass, 0 divergences.
- `go test .`, `go test ./grammars`, `go vet ./...`: pass.
- `go test -tags gts_parsercorephase0 .`: 15 failures, the identical set
  origin/main produces.
- Full `cgo_harness` suite: 9 failures, the identical set origin/main
  produces.
- `-race` over the lexer, external-scanner, GLR, relex, recovery, and resync
  paths: pass.

## Out of scope, reported for its own lane

The 11-byte Perl input `mb #$x =1;$` parses for more than two minutes on both
origin/main and this branch. Pre-existing and unrelated.
