### PR TITLE
add(parsercore): Add an acceptance candidate-set differential instrument

### DIFF
--- a/cgo_harness/README.md
+++ b/cgo_harness/README.md
@@ -725,3 +725,34 @@ Tunable inputs:
 ```sh
 RUNS=7 SIZES="500 2000 10000" CFLAGS_EXTRA="-march=native -flto" ./pure_c/run_claim_suite.sh
 ```
+
+## Run the Derivation-Set Differential (Opt-In)
+
+The derivation-set differential compares, at every accept, the compact core's
+live derivation set against the reference runtime's live version set. It is
+stage D0 of `spec.derivation-set-equivalence.v1`.
+
+The compact side records the set behind the `gts_derivation_set_census` build
+tag. The default build carries no census code at all, so the shipped parse
+path is unchanged. The C side reconstructs the version set from
+`ts_parser_set_logger` output alone; the vendored C source stays unpatched.
+
+```sh
+cd cgo_harness
+GOFLAGS=-buildvcs=false \
+GTS_PARITY_ALLOW_HOST=1 \
+GTS_PARITY_C_REF_BUILD_CACHE="$PWD/../harness_out/parity_c_ref_cache" \
+CGO_ENABLED=1 \
+go test -tags "cgo treesitter_c_parity gts_derivation_set_census" \
+  -run '^TestDerivationSetDifferential' -count=1 -v -timeout 40m .
+```
+
+Two receipts run:
+
+- `TestDerivationSetDifferentialWitnessReproduction` pins the classification
+  of the eight witnesses the R2 measurement falsified.
+- `TestDerivationSetDifferentialBaselineCensus` publishes the per-language
+  baseline: EXTRA, MISSING, DIFFERENT and ORDER counts, plus the mechanism
+  attribution. The constructed-source totals are pinned and reproduce on any
+  host. The real-corpus totals are reported separately, because
+  `cgo_harness/corpus_real` is a generated, gitignored fixture.

--- a/cgo_harness/derivation_set_differential.go
+++ b/cgo_harness/derivation_set_differential.go
@@ -1,0 +1,722 @@
+//go:build cgo && treesitter_c_parity && gts_derivation_set_census
+
+package cgoharness
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// Derivation-set differential instrument, stage D0 of
+// spec.derivation-set-equivalence.v1.
+//
+// The lane's premise (finding.derivation-set-equivalence-prerequisite) is
+// that selection cannot repair a wrong candidate set: the compact core's
+// live derivation set D at a tied accept is not the reference runtime's live
+// version set V. Before any repair, the difference must be MEASURED. This
+// file measures it.
+//
+// Compact side. The root package records D at every accept behind the
+// gts_derivation_set_census build tag
+// (parsercore_phase0_derivation_set_census.go). Each candidate carries its
+// materialized public tree, its summed dynamic precedence, and its fork
+// stamp.
+//
+// C side. The vendored C source stays unpatched. ts_parser_set_logger gives
+// the parse event stream, and ts_parser__accept
+// (go-tree-sitter@v0.25.0/src/parser.c:1046-1097) folds every popped root
+// into finished_tree through ts_parser__select_tree (parser.c:836-879). The
+// first root sets finished_tree with no log line; every later root logs
+// exactly one select_* line. |V| is therefore
+//
+//	1 + (number of select_* lines that immediately follow an accept line)
+//
+// counted over the whole parse. ts_parser__select_tree is also reached from
+// ts_parser__select_children inside a reduce (parser.c:901), so only the
+// contiguous run of select_* lines directly after an accept line belongs to
+// an accept fold; every other select_* line is preceded by at least a
+// "reduce" line. recover_eof (parser.c:1346) also calls ts_parser__accept,
+// so it counts as an accept event too.
+//
+// What the logger gives and what it withholds is stated exactly in
+// cVersionSetReceipt. The instrument never guesses past that boundary: an
+// undecidable axis is reported as undetermined, not as agreement.
+
+// Difference classes of the D0 taxonomy.
+const (
+	// derivationDiffExtra: compact carries an alternative the reference
+	// runtime never builds. |D| > |V|.
+	derivationDiffExtra = "EXTRA"
+	// derivationDiffMissing: the reference runtime carries an alternative
+	// compact lacks. |V| > |D|.
+	derivationDiffMissing = "MISSING"
+	// derivationDiffDifferent: the reference runtime's published tree is not
+	// any compact candidate's tree, so the sets disagree on content at equal
+	// or unequal cardinality.
+	derivationDiffDifferent = "DIFFERENT"
+	// derivationDiffOrder: the sets agree, but the compact fold order lists
+	// the reference runtime's published tree at a different position than
+	// C's version-index order does (equivalence criterion 4).
+	derivationDiffOrder = "ORDER"
+)
+
+// Mechanism attribution of one difference, per spec sections 2 and 3.
+const (
+	// derivationMechanismToken: the differing candidates do not share a leaf
+	// sequence, so the two runtimes lexed different tokens. Section 3, the
+	// first-leaf token cache; stage D2.
+	derivationMechanismToken = "token-class"
+	// derivationMechanismCondense: the differing candidates share an
+	// identical leaf sequence and differ only in how those leaves are
+	// grouped, which is the condense-time tie the compact core defers.
+	// Section 2, condense-time tie collapse; stage D1.
+	derivationMechanismCondense = "condense-class"
+	// derivationMechanismUnattributed: no second candidate was available to
+	// compare against, so the mechanism stays unnamed rather than guessed.
+	derivationMechanismUnattributed = "unattributed"
+)
+
+// dsTree is one materialized tree, rebuilt from either runtime into a single
+// shape so the two can be compared directly.
+type dsTree struct {
+	Field    string
+	Type     string
+	Start    uint32
+	End      uint32
+	Named    bool
+	Extra    bool
+	Missing  bool
+	Children []*dsTree
+}
+
+// dsTreeFromCensus rebuilds a compact candidate's tree from the pre-order
+// node slice the census records.
+func dsTreeFromCensus(nodes []gotreesitter.DerivationSetCensusNode) *dsTree {
+	if len(nodes) == 0 {
+		return nil
+	}
+	index := 0
+	var build func() *dsTree
+	build = func() *dsTree {
+		if index >= len(nodes) {
+			return nil
+		}
+		entry := nodes[index]
+		index++
+		node := &dsTree{
+			Field: entry.Field, Type: entry.Type,
+			Start: entry.StartByte, End: entry.EndByte,
+			Named: entry.Named, Extra: entry.Extra, Missing: entry.Missing,
+		}
+		for child := 0; child < entry.ChildCount; child++ {
+			node.Children = append(node.Children, build())
+		}
+		return node
+	}
+	return build()
+}
+
+// dsTreeFromC rebuilds the reference runtime's published tree in the same
+// shape. The compact side normalizes a zero-terminator sentinel type to the
+// empty string (compactT3GoNodeType); nothing on the C side produces one.
+func dsTreeFromC(node *sitter.Node, field string) *dsTree {
+	if node == nil {
+		return nil
+	}
+	out := &dsTree{
+		Field: field, Type: node.Kind(),
+		Start: uint32(node.StartByte()), End: uint32(node.EndByte()),
+		Named: node.IsNamed(), Extra: node.IsExtra(), Missing: node.IsMissing(),
+	}
+	count := node.ChildCount()
+	for index := uint(0); index < count; index++ {
+		out.Children = append(out.Children, dsTreeFromC(node.Child(index), node.FieldNameForChild(uint32(index))))
+	}
+	return out
+}
+
+// dsShape renders the canonical identity of a tree. Two trees with equal
+// shapes publish the same public tree on every axis the materiality gate
+// compares (compactAcceptanceDerivationTreesEqual).
+func dsShape(node *dsTree) string {
+	var builder strings.Builder
+	dsWriteShape(&builder, node)
+	return builder.String()
+}
+
+func dsWriteShape(builder *strings.Builder, node *dsTree) {
+	if node == nil {
+		builder.WriteString("(nil)")
+		return
+	}
+	builder.WriteString("(")
+	if node.Field != "" {
+		builder.WriteString(node.Field)
+		builder.WriteString(":")
+	}
+	builder.WriteString(node.Type)
+	builder.WriteString("[")
+	builder.WriteString(strconv.FormatUint(uint64(node.Start), 10))
+	builder.WriteString("-")
+	builder.WriteString(strconv.FormatUint(uint64(node.End), 10))
+	builder.WriteString("]")
+	if !node.Named {
+		builder.WriteString("!anon")
+	}
+	if node.Extra {
+		builder.WriteString("!extra")
+	}
+	if node.Missing {
+		builder.WriteString("!missing")
+	}
+	for _, child := range node.Children {
+		builder.WriteString(" ")
+		dsWriteShape(builder, child)
+	}
+	builder.WriteString(")")
+}
+
+// dsLeaves returns the tree's terminal sequence as "type[start-end]" entries.
+// The mechanism attribution turns on this sequence: equal leaves with a
+// different grouping is a condense-time tie (spec section 2); different
+// leaves is a token election difference (spec section 3).
+func dsLeaves(node *dsTree, out []string) []string {
+	if node == nil {
+		return out
+	}
+	if len(node.Children) == 0 {
+		return append(out, fmt.Sprintf("%s[%d-%d]", node.Type, node.Start, node.End))
+	}
+	for _, child := range node.Children {
+		out = dsLeaves(child, out)
+	}
+	return out
+}
+
+// dsFirstDifferencePath returns a readable path to the first node where two
+// trees disagree, and the two node descriptions there.
+func dsFirstDifferencePath(left, right *dsTree) (path, leftDesc, rightDesc string, found bool) {
+	return dsWalkFirstDifference(left, right, "/root")
+}
+
+func dsWalkFirstDifference(left, right *dsTree, path string) (string, string, string, bool) {
+	if left == nil || right == nil {
+		if left == nil && right == nil {
+			return "", "", "", false
+		}
+		return path, dsDescribe(left), dsDescribe(right), true
+	}
+	if left.Type != right.Type || left.Start != right.Start || left.End != right.End ||
+		left.Named != right.Named || left.Extra != right.Extra || left.Missing != right.Missing ||
+		left.Field != right.Field || len(left.Children) != len(right.Children) {
+		return path, dsDescribe(left), dsDescribe(right), true
+	}
+	for index := range left.Children {
+		childPath := fmt.Sprintf("%s/%s[%d]", path, left.Children[index].Type, index)
+		if p, l, r, ok := dsWalkFirstDifference(left.Children[index], right.Children[index], childPath); ok {
+			return p, l, r, ok
+		}
+	}
+	return "", "", "", false
+}
+
+func dsDescribe(node *dsTree) string {
+	if node == nil {
+		return "<nil>"
+	}
+	field := ""
+	if node.Field != "" {
+		field = node.Field + ":"
+	}
+	return fmt.Sprintf("%s%s[%d-%d] children=%d", field, node.Type, node.Start, node.End, len(node.Children))
+}
+
+// dsAttributeMechanism names the mechanism that separates two candidate
+// trees. Equal leaf sequences mean both runtimes lexed the same tokens and
+// only the grouping differs, which is the same-span precedence tie
+// Core.condense defers and stack_node_add_link collapses (spec section 2).
+// Different leaf sequences mean the token election itself differed, which is
+// the first-leaf token cache (spec section 3).
+func dsAttributeMechanism(left, right *dsTree) string {
+	if left == nil || right == nil {
+		return derivationMechanismUnattributed
+	}
+	leftLeaves := dsLeaves(left, nil)
+	rightLeaves := dsLeaves(right, nil)
+	if len(leftLeaves) != len(rightLeaves) {
+		return derivationMechanismToken
+	}
+	for index := range leftLeaves {
+		if leftLeaves[index] != rightLeaves[index] {
+			return derivationMechanismToken
+		}
+	}
+	return derivationMechanismCondense
+}
+
+// cAcceptFold is one ts_parser__select_tree call the logger reported inside
+// an accept fold.
+type cAcceptFold struct {
+	// Rung is the select_* line kind: select_smaller_error,
+	// select_higher_precedence, select_earlier, or select_existing.
+	Rung string
+	// WinnerSymbol and LoserSymbol are the two root symbol names the line
+	// carries, winner first. Both are usually the grammar's start symbol at
+	// an accept fold, which is why the incumbent cannot always be told from
+	// the challenger; see cVersionSetReceipt.WinnerIndexKnown.
+	WinnerSymbol string
+	LoserSymbol  string
+	// WinnerPrecedence and LoserPrecedence are set only for
+	// select_higher_precedence, the sole rung that prints numbers.
+	WinnerPrecedence int
+	LoserPrecedence  int
+	HasPrecedence    bool
+}
+
+// cAcceptEvent is one accept action (or one recover_eof wrap) and the folds
+// it performed.
+type cAcceptEvent struct {
+	RecoverEOF bool
+	Folds      []cAcceptFold
+}
+
+// cVersionSetReceipt is the reference runtime's live version set V,
+// reconstructed from the logger alone.
+//
+// What the logger gives:
+//   - the number of roots folded at accept, exactly (Roots);
+//   - the root symbol name of both sides of every fold;
+//   - the dynamic precedence of both sides when the precedence rung fires;
+//   - the relative error cost when the smaller-error rung fires;
+//   - the live stack version count at every step (VersionCountMax), from the
+//     "process version:%u, version_count:%u, ..." line (parser.c:2149).
+//
+// What the logger withholds:
+//   - the span, child count and deep shape of a losing root. A losing root
+//     is released inside ts_parser__accept and never reaches the caller, so
+//     only the winner (the published tree) is inspectable.
+//   - which side of a fold line is the incumbent when both print the same
+//     root symbol, which is the normal case because every accept root
+//     carries the grammar's start symbol. WinnerIndexKnown reports whether
+//     the published root's version index could be established.
+type cVersionSetReceipt struct {
+	Accepts []cAcceptEvent
+	// Roots is |V|: the total number of root trees folded into
+	// finished_tree, equal to C's own accept_count.
+	Roots int
+	// VersionCountMax is the highest live stack version count the parse
+	// reported.
+	VersionCountMax int
+	// WinnerIndex is the version-order index of the published root, valid
+	// only when WinnerIndexKnown is true.
+	WinnerIndex      int
+	WinnerIndexKnown bool
+	// Published is the tree the reference runtime published.
+	Published *dsTree
+	// LogLines is the total parse-log line count, recorded so a silent
+	// logger failure cannot masquerade as a one-root parse.
+	LogLines int
+}
+
+// cReconstructVersionSet parses source with the locked C oracle and rebuilds
+// V from the parse log. It never patches or re-reads the vendored C source.
+func cReconstructVersionSet(cLang *sitter.Language, source []byte) (cVersionSetReceipt, error) {
+	parser := sitter.NewParser()
+	defer parser.Close()
+	if err := parser.SetLanguage(cLang); err != nil {
+		return cVersionSetReceipt{}, fmt.Errorf("set C oracle language: %w", err)
+	}
+	var lines []string
+	parser.SetLogger(func(kind sitter.LogType, message string) {
+		if kind == sitter.LogTypeParse {
+			lines = append(lines, message)
+		}
+	})
+	tree := parser.Parse(source, nil)
+	if tree == nil || tree.RootNode() == nil {
+		return cVersionSetReceipt{}, fmt.Errorf("C oracle parse returned no root")
+	}
+	defer tree.Close()
+
+	receipt := cVersionSetReceipt{LogLines: len(lines), Published: dsTreeFromC(tree.RootNode(), "")}
+	for index := 0; index < len(lines); index++ {
+		line := lines[index]
+		if count, ok := cParseVersionCount(line); ok && count > receipt.VersionCountMax {
+			receipt.VersionCountMax = count
+		}
+		if line != "accept" && line != "recover_eof" {
+			continue
+		}
+		event := cAcceptEvent{RecoverEOF: line == "recover_eof"}
+		for index+1 < len(lines) && strings.HasPrefix(lines[index+1], "select_") {
+			index++
+			event.Folds = append(event.Folds, cParseSelectLine(lines[index]))
+		}
+		receipt.Accepts = append(receipt.Accepts, event)
+	}
+	if len(receipt.Accepts) == 0 {
+		return receipt, nil
+	}
+	receipt.Roots = 1
+	for _, event := range receipt.Accepts {
+		receipt.Roots += len(event.Folds)
+	}
+	receipt.WinnerIndex, receipt.WinnerIndexKnown = cWinnerVersionIndex(receipt.Accepts)
+	return receipt, nil
+}
+
+// cWinnerVersionIndex derives the version-order index of the published root
+// when the log determines it. select_existing always keeps the incumbent, so
+// a fold sequence made only of select_existing lines proves the winner is
+// version 0. Every other rung prints the winner first, and both sides carry
+// the same start symbol at an accept fold, so the incumbent cannot be told
+// from the challenger and the index stays unknown. The instrument reports
+// unknown rather than guessing.
+func cWinnerVersionIndex(events []cAcceptEvent) (int, bool) {
+	for _, event := range events {
+		for _, fold := range event.Folds {
+			if fold.Rung != "select_existing" {
+				return 0, false
+			}
+		}
+	}
+	return 0, true
+}
+
+var cVersionCountPrefix = "process version:"
+
+func cParseVersionCount(line string) (int, bool) {
+	if !strings.HasPrefix(line, cVersionCountPrefix) {
+		return 0, false
+	}
+	for _, field := range strings.Split(line, ", ") {
+		if !strings.HasPrefix(field, "version_count:") {
+			continue
+		}
+		value, err := strconv.Atoi(strings.TrimPrefix(field, "version_count:"))
+		if err != nil {
+			return 0, false
+		}
+		return value, true
+	}
+	return 0, false
+}
+
+// cParseSelectLine decodes one select_* log line. The four line shapes are
+// fixed by parser.c:841-877.
+func cParseSelectLine(line string) cAcceptFold {
+	rung := line
+	if space := strings.IndexByte(line, ' '); space > 0 {
+		rung = line[:space]
+	}
+	fold := cAcceptFold{Rung: rung}
+	for _, field := range strings.Split(line, ", ") {
+		switch {
+		case strings.Contains(field, "symbol:") && !strings.Contains(field, "over_symbol:") && !strings.Contains(field, "other_"):
+			if at := strings.Index(field, "symbol:"); at >= 0 {
+				fold.WinnerSymbol = field[at+len("symbol:"):]
+			}
+		case strings.HasPrefix(field, "over_symbol:"):
+			fold.LoserSymbol = strings.TrimPrefix(field, "over_symbol:")
+		case strings.HasPrefix(field, "prec:"):
+			if value, err := strconv.Atoi(strings.TrimPrefix(field, "prec:")); err == nil {
+				fold.WinnerPrecedence, fold.HasPrecedence = value, true
+			}
+		case strings.HasPrefix(field, "other_prec:"):
+			if value, err := strconv.Atoi(strings.TrimPrefix(field, "other_prec:")); err == nil {
+				fold.LoserPrecedence = value
+			}
+		}
+	}
+	return fold
+}
+
+// derivationSetDifference is one classified set-level difference at one
+// source.
+type derivationSetDifference struct {
+	Class     string
+	Mechanism string
+	Detail    string
+}
+
+// derivationSetReport is the full differential receipt for one source.
+type derivationSetReport struct {
+	Language string
+	Name     string
+	// CompactAccepts is the number of accept events the compact scheduler
+	// reached. Zero means the compact route never reached an accept, so
+	// there is nothing to compare.
+	CompactAccepts int
+	// CompactSetSize is |D|, summed over the recorded accepts.
+	CompactSetSize int
+	// CompactTruncated reports a capped derivation enumeration, which leaves
+	// D unknown.
+	CompactTruncated bool
+	// CompactDeclined reports that the R1 materiality gate declined.
+	CompactDeclined bool
+	// CompactSelectedFoldIndex is the fold-order position of the derivation
+	// the route selected, or -1 when it selected none.
+	CompactSelectedFoldIndex int
+	// CompactDeclineReason is the route's own fallback reason, recorded only
+	// when the compact route reached no accept at all.
+	CompactDeclineReason string
+	// CVersionSetSize is |V|.
+	CVersionSetSize int
+	// CVersionCountMax is C's highest live stack version count.
+	CVersionCountMax int
+	// CWinnerIndexKnown reports whether the published root's version index
+	// could be established from the log.
+	CWinnerIndexKnown bool
+	// CPublishedInCompactSet reports whether the reference runtime's
+	// published tree is one of the compact candidates.
+	CPublishedInCompactSet bool
+	// CPublishedFoldIndex is the compact fold-order position of the
+	// candidate that matches the published tree, or -1.
+	CPublishedFoldIndex int
+	// CandidateShapes and PublishedShape are the compared identities, kept so
+	// a receipt can print exactly what the instrument matched.
+	CandidateShapes []string
+	PublishedShape  string
+	// Differences is the classified set-level difference list. An empty list
+	// means the two sets agreed on every axis this instrument can decide.
+	Differences []derivationSetDifference
+	// Skipped records why no comparison ran.
+	Skipped string
+}
+
+// runDerivationSetDifferential measures one source on both runtimes and
+// classifies the set-level difference.
+//
+// The five legitimate representation differences the spec names are excluded
+// by construction, never by a filter:
+//
+//   - Link cap. The compact core fails closed with LiveLinkCapacityError; C
+//     silently drops a ninth link. Neither is compared here: the instrument
+//     compares published candidate sets, not link arrays.
+//   - Dynamic precedence carrier. The compact core sums per-link ScoreDelta
+//     per derivation; C keeps a node-level running maximum. The instrument
+//     compares the maximum Score over D against the precedence C's fold
+//     lines report, never per-link deltas.
+//   - External scanner state. The compact core interns CheckpointIDs; C
+//     compares serialized bytes. Neither appears in a published tree, so
+//     neither is compared.
+//   - Head-merge key. boundaryKey against C's (state, position, error cost,
+//     external state). Not compared: the instrument reads the accept, not
+//     the merge.
+//   - Order carrier. Fork stamps against version indices. Compared only as
+//     positions, through the fold order, never as raw values.
+func runDerivationSetDifferential(
+	language, cLangName string, lang *gotreesitter.Language, cLang *sitter.Language,
+	name string, source []byte,
+) (derivationSetReport, error) {
+	report := derivationSetReport{Language: language, Name: name, CPublishedFoldIndex: -1, CompactSelectedFoldIndex: -1}
+
+	gotreesitter.DerivationSetCensusReset()
+	parser := gotreesitter.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		return report, fmt.Errorf("%s/%s: compact-route parse: %w", language, name, err)
+	}
+	tree.Release()
+	accepts := gotreesitter.DerivationSetCensusSnapshot()
+
+	report.CompactAccepts = len(accepts)
+	if len(accepts) == 0 {
+		report.Skipped = "compact route reached no accept"
+		report.CompactDeclineReason = gotreesitter.AdmissionCandidateLastFallbackReason()
+		return report, nil
+	}
+
+	// D is the derivation set at THE accept, not the union over a parse. The
+	// shipped route reaches an authenticated EOF accept with exactly one
+	// surviving header, so one parse normally records one accept. A parse
+	// that records more (a re-run seed, for example) would otherwise make an
+	// n-candidate set look like an n-accept run, so the last recorded accept
+	// -- the one that terminated the run -- is the set under comparison and
+	// CompactAccepts keeps the count visible.
+	accept := accepts[len(accepts)-1]
+	report.CompactTruncated = accept.EnumerationTruncated
+	report.CompactDeclined = accept.DeclinedMaterial
+	report.CompactSelectedFoldIndex = accept.SelectedFoldIndex
+
+	var candidates []*dsTree
+	var candidateShapes []string
+	for _, candidate := range accept.Candidates {
+		report.CompactSetSize++
+		if candidate.MaterializeError != "" {
+			candidates = append(candidates, nil)
+			candidateShapes = append(candidateShapes, "<materialize-error: "+candidate.MaterializeError+">")
+			continue
+		}
+		built := dsTreeFromCensus(candidate.Nodes)
+		candidates = append(candidates, built)
+		candidateShapes = append(candidateShapes, dsShape(built))
+	}
+	if report.CompactTruncated {
+		report.Skipped = "compact derivation enumeration capped; D unknown"
+		return report, nil
+	}
+
+	receipt, err := cReconstructVersionSet(cLang, source)
+	if err != nil {
+		return report, fmt.Errorf("%s/%s: C version-set reconstruction: %w", language, name, err)
+	}
+	report.CVersionSetSize = receipt.Roots
+	report.CVersionCountMax = receipt.VersionCountMax
+	report.CWinnerIndexKnown = receipt.WinnerIndexKnown
+	if receipt.Roots == 0 {
+		report.Skipped = "C oracle log reported no accept event"
+		return report, nil
+	}
+
+	publishedShape := dsShape(receipt.Published)
+	report.CandidateShapes = candidateShapes
+	report.PublishedShape = publishedShape
+	for index, shape := range candidateShapes {
+		if shape == publishedShape {
+			report.CPublishedInCompactSet = true
+			report.CPublishedFoldIndex = index
+			break
+		}
+	}
+
+	// The candidate that best represents "what compact would have to give up
+	// or gain" is the one that does not match C. Pick the first non-matching
+	// candidate for the mechanism attribution, compared against the matching
+	// one when it exists and against C's published tree otherwise.
+	var oddOne *dsTree
+	for index, shape := range candidateShapes {
+		if shape != publishedShape {
+			oddOne = candidates[index]
+			break
+		}
+	}
+	reference := receipt.Published
+	if report.CPublishedInCompactSet && report.CPublishedFoldIndex >= 0 {
+		reference = candidates[report.CPublishedFoldIndex]
+	}
+
+	switch {
+	case report.CompactSetSize > receipt.Roots:
+		mechanism := derivationMechanismUnattributed
+		detail := fmt.Sprintf("|D|=%d |V|=%d", report.CompactSetSize, receipt.Roots)
+		if oddOne != nil {
+			mechanism = dsAttributeMechanism(oddOne, reference)
+			path, left, right, ok := dsFirstDifferencePath(oddOne, reference)
+			if ok {
+				detail = fmt.Sprintf("|D|=%d |V|=%d; extra candidate diverges at %s: compact=%s reference=%s", report.CompactSetSize, receipt.Roots, path, left, right)
+			}
+		}
+		report.Differences = append(report.Differences, derivationSetDifference{
+			Class: derivationDiffExtra, Mechanism: mechanism, Detail: detail,
+		})
+	case report.CompactSetSize < receipt.Roots:
+		mechanism := derivationMechanismUnattributed
+		if oddOne != nil {
+			mechanism = dsAttributeMechanism(oddOne, reference)
+		}
+		report.Differences = append(report.Differences, derivationSetDifference{
+			Class: derivationDiffMissing, Mechanism: mechanism,
+			Detail: fmt.Sprintf("|D|=%d |V|=%d", report.CompactSetSize, receipt.Roots),
+		})
+	}
+
+	if !report.CPublishedInCompactSet {
+		mechanism := derivationMechanismUnattributed
+		detail := fmt.Sprintf("|D|=%d |V|=%d; no compact candidate equals the published tree", report.CompactSetSize, receipt.Roots)
+		if len(candidates) > 0 && candidates[0] != nil {
+			mechanism = dsAttributeMechanism(candidates[0], receipt.Published)
+			if path, left, right, ok := dsFirstDifferencePath(candidates[0], receipt.Published); ok {
+				detail = fmt.Sprintf("|D|=%d |V|=%d; candidate 0 diverges at %s: compact=%s reference=%s", report.CompactSetSize, receipt.Roots, path, left, right)
+			}
+		}
+		report.Differences = append(report.Differences, derivationSetDifference{
+			Class: derivationDiffDifferent, Mechanism: mechanism, Detail: detail,
+		})
+	}
+
+	// ORDER, equivalence criterion 4. Only decidable when the log
+	// established the published root's version index. Every other case is
+	// reported as undetermined by the census, not as agreement.
+	if report.CPublishedInCompactSet && receipt.WinnerIndexKnown && report.CompactSetSize == receipt.Roots &&
+		report.CPublishedFoldIndex != receipt.WinnerIndex {
+		report.Differences = append(report.Differences, derivationSetDifference{
+			Class: derivationDiffOrder, Mechanism: derivationMechanismUnattributed,
+			Detail: fmt.Sprintf("published tree sits at compact fold index %d but C version index %d", report.CPublishedFoldIndex, receipt.WinnerIndex),
+		})
+	}
+
+	return report, nil
+}
+
+// derivationSetCensusTotals aggregates classified differences.
+type derivationSetCensusTotals struct {
+	Sources           int
+	Compared          int
+	SkippedNoAccept   int
+	SkippedOther      int
+	Declined          int
+	ByClass           map[string]int
+	ByMechanism       map[string]int
+	OrderUndetermined int
+	Differences       int
+}
+
+func newDerivationSetCensusTotals() *derivationSetCensusTotals {
+	return &derivationSetCensusTotals{ByClass: map[string]int{}, ByMechanism: map[string]int{}}
+}
+
+func (t *derivationSetCensusTotals) add(report derivationSetReport) {
+	t.Sources++
+	switch {
+	case report.Skipped == "":
+		t.Compared++
+	case strings.Contains(report.Skipped, "no accept"):
+		t.SkippedNoAccept++
+	default:
+		t.SkippedOther++
+	}
+	if report.CompactDeclined {
+		t.Declined++
+	}
+	if report.Skipped == "" && !report.CWinnerIndexKnown {
+		t.OrderUndetermined++
+	}
+	for _, difference := range report.Differences {
+		t.Differences++
+		t.ByClass[difference.Class]++
+		t.ByMechanism[difference.Mechanism]++
+	}
+}
+
+func (t *derivationSetCensusTotals) classLine() string {
+	classes := []string{derivationDiffExtra, derivationDiffMissing, derivationDiffDifferent, derivationDiffOrder}
+	parts := make([]string, 0, len(classes))
+	for _, class := range classes {
+		parts = append(parts, fmt.Sprintf("%s=%d", class, t.ByClass[class]))
+	}
+	return strings.Join(parts, " ")
+}
+
+func (t *derivationSetCensusTotals) mechanismLine() string {
+	keys := make([]string, 0, len(t.ByMechanism))
+	for key := range t.ByMechanism {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", key, t.ByMechanism[key]))
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, " ")
+}

--- a/cgo_harness/derivation_set_differential_test.go
+++ b/cgo_harness/derivation_set_differential_test.go
@@ -1,0 +1,513 @@
+//go:build cgo && treesitter_c_parity && gts_derivation_set_census
+
+package cgoharness
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// Stage D0 receipts for spec.derivation-set-equivalence.v1.
+//
+// Reproduce both with:
+//
+//	cd cgo_harness
+//	GOFLAGS=-buildvcs=false GTS_PARITY_ALLOW_HOST=1 \
+//	  GTS_PARITY_C_REF_BUILD_CACHE=<cache> CGO_ENABLED=1 \
+//	  go test -tags "cgo treesitter_c_parity gts_derivation_set_census" \
+//	  -run 'TestDerivationSet' -count=1 -v .
+//
+// The gts_derivation_set_census tag is what compiles the compact-side census
+// into the library at all. Without it the library has no instrument, so both
+// tests below are absent from the build and every shipped gate runs against
+// exactly the code main ships.
+
+// derivationSetCensusLanguage is one language's differential corpus.
+type derivationSetCensusLanguage struct {
+	Name        string
+	CName       string
+	Language    func() *gotreesitter.Language
+	Constructed func() []a3CertificationSweepSource
+	RealDir     string
+}
+
+// derivationSetCensusLanguages mirrors the five A3 certification sweeps
+// (apex, perl, ada, kotlin, python) source for source, so the baseline
+// census denominator equals the sweeps' own denominator on the same host.
+func derivationSetCensusLanguages() []derivationSetCensusLanguage {
+	return []derivationSetCensusLanguage{
+		{
+			Name: "apex", CName: "apex", Language: grammars.ApexLanguage,
+			Constructed: func() []a3CertificationSweepSource {
+				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("apex"))}}
+				sources = append(sources, apexA3TiedElectionWitnesses()...)
+				return append(sources, apexA3AdversarialSources()...)
+			},
+		},
+		{
+			Name: "perl", CName: "perl", Language: grammars.PerlLanguage,
+			Constructed: func() []a3CertificationSweepSource {
+				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("perl"))}}
+				return append(sources, perlA3AdversarialSources()...)
+			},
+			RealDir: filepath.Join("corpus_real", "perl"),
+		},
+		{
+			Name: "ada", CName: "ada", Language: grammars.AdaLanguage,
+			Constructed: func() []a3CertificationSweepSource {
+				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("ada"))}}
+				sources = append(sources, adaA3TiedElectionWitnesses()...)
+				return append(sources, adaA3AdversarialSources()...)
+			},
+		},
+		{
+			Name: "kotlin", CName: "kotlin", Language: grammars.KotlinLanguage,
+			Constructed: func() []a3CertificationSweepSource {
+				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("kotlin"))}}
+				return append(sources, kotlinA3AdversarialSources()...)
+			},
+			RealDir: filepath.Join("corpus_real", "kotlin"),
+		},
+		{
+			Name: "python", CName: "python", Language: grammars.PythonLanguage,
+			Constructed: func() []a3CertificationSweepSource {
+				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("python"))}}
+				return append(sources, pythonA3AdversarialSources()...)
+			},
+			RealDir: filepath.Join("corpus_real", "python"),
+		},
+	}
+}
+
+// derivationSetLoadRealCorpus reads a real-corpus directory when it exists.
+// Unlike a3LoadRealCorpusDir it never skips the caller: the baseline census
+// pins its constructed-source numbers, which every host reproduces, and
+// reports the real-corpus numbers separately with their file count.
+func derivationSetLoadRealCorpus(t *testing.T, dir string) []a3CertificationSweepSource {
+	t.Helper()
+	if dir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read corpus dir %s: %v", dir, err)
+	}
+	var out []a3CertificationSweepSource
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read corpus file %s: %v", path, err)
+		}
+		out = append(out, a3CertificationSweepSource{Name: entry.Name(), Source: data})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// TestDerivationSetDifferentialWitnessReproduction is stage D0's must-pass
+// acceptance criterion: the eight witnesses R2 falsified must reproduce as
+// classified set-level differences.
+//
+// The R2 measurement (finding.derivation-set-equivalence-prerequisite) wired
+// a faithful port of C's selection ladder and produced 10 new accepts, 8 of
+// them C-divergent. Ranking cannot repair those 8, because the candidate set
+// itself is wrong. This test states, per witness, exactly which set-level
+// difference the instrument measures. Every expectation here is a
+// MEASUREMENT pinned after the fact, not a prediction: a change in any of
+// them is a change in the lane's ground truth and must be re-adjudicated,
+// not re-fitted.
+func TestDerivationSetDifferentialWitnessReproduction(t *testing.T) {
+	if !gotreesitter.DerivationSetCensusBuilt() {
+		t.Fatal("derivation-set census is not compiled into the library; build with -tags gts_derivation_set_census")
+	}
+
+	type witness struct {
+		Language string
+		CName    string
+		Lang     func() *gotreesitter.Language
+		Name     string
+		Source   string
+		// Classes is the exact difference-class multiset the instrument must
+		// report, in report order.
+		Classes []string
+		// Mechanisms is the exact mechanism attribution per class entry.
+		Mechanisms []string
+		// CompactSetSize and CVersionSetSize pin |D| and |V|.
+		CompactSetSize  int
+		CVersionSetSize int
+		// ForceConvergedSplitDrops grants the converged-split-drop
+		// certification kotlin withholds, for the duration of this one
+		// measurement. It follows the established in-place force-and-restore
+		// pattern (kotlin_a3_certification_object_declaration_regression_test.go).
+		ForceConvergedSplitDrops bool
+		// ExpectNoAccept marks a witness the compact route declines before
+		// any accept, so no derivation set exists to compare.
+		ExpectNoAccept bool
+		// Note records why this witness sits in the lane.
+		Note string
+	}
+
+	witnesses := []witness{
+		{
+			Language: "apex", CName: "apex", Lang: grammars.ApexLanguage,
+			Name:   "class_literal_alias",
+			Source: "public class C {\n  void m() {\n    Object t = RecordPage.class;\n  }\n}\n",
+			Note:   "the named apex hypothesis: compact builds a class_literal alternative the reference runtime never builds",
+		},
+		{
+			Language: "perl", CName: "perl", Lang: grammars.PerlLanguage,
+			Name:   "print_filehandle_list_material_election",
+			Source: "print $fh, \"a\", \"b\";\n",
+			Note:   "list_expression against ambiguous_function_call_expression",
+		},
+		{
+			Language: "perl", CName: "perl", Lang: grammars.PerlLanguage,
+			Name:   "unshift_two_args",
+			Source: "unshift @found, $_;\n",
+			Note:   "list_expression against ambiguous_function_call_expression",
+		},
+		{
+			Language: "perl", CName: "perl", Lang: grammars.PerlLanguage,
+			Name:   "join_bare",
+			Source: "join \"\\n\", \"a\", \"b\";\n",
+			Note:   "list_expression against ambiguous_function_call_expression",
+		},
+		{
+			Language: "ada", CName: "ada", Lang: grammars.AdaLanguage,
+			Name:   "bare_aggregate_assignment_material_election",
+			Source: "procedure P is\nbegin\n   R := (F => 1, G => 2);\nend;\n",
+			Note:   "record_aggregate against named_array_aggregate",
+		},
+		{
+			Language: "ada", CName: "ada", Lang: grammars.AdaLanguage,
+			Name: "record_aggregate_named",
+			Source: "package P is\n" +
+				"   type R is record\n" +
+				"      X : Integer;\n" +
+				"      Y : Integer;\n" +
+				"   end record;\n" +
+				"   V : constant R := (X => 1, Y => 2);\n" +
+				"end P;\n",
+			Note: "record_aggregate field difference",
+		},
+		{
+			Language: "ada", CName: "ada", Lang: grammars.AdaLanguage,
+			Name: "discriminated_record",
+			Source: "package P is\n" +
+				"   type Buffer (Size : Positive) is record\n" +
+				"      Data : String (1 .. Size);\n" +
+				"   end record;\n" +
+				"end P;\n",
+			Note: "child-count difference; the spec and the finding both record this one as a pre-existing production defect that R1's decline was masking",
+		},
+		{
+			Language: "kotlin", CName: "kotlin", Lang: grammars.KotlinLanguage,
+			Name:           "annotated_declaration",
+			Source:         "@Suppress(\"UNUSED\")\nfun f() {}\n",
+			ExpectNoAccept: true,
+			Note:           "source_file child count; measured: the shipped kotlin profile declines this input at the no-action boundary, so no accept-time derivation set exists",
+		},
+		{
+			Language: "kotlin", CName: "kotlin", Lang: grammars.KotlinLanguage,
+			Name:                     "annotated_declaration_forced_split_drops",
+			Source:                   "@Suppress(\"UNUSED\")\nfun f() {}\n",
+			ForceConvergedSplitDrops: true,
+			Note:                     "same source with the converged-split-drop certification kotlin withholds, which is the configuration that reaches an accept at all",
+		},
+	}
+
+	// Expectations, pinned from the first measurement. Keyed by
+	// language/name.
+	expected := map[string]struct {
+		Classes         []string
+		Mechanisms      []string
+		CompactSetSize  int
+		CVersionSetSize int
+	}{
+		"apex/class_literal_alias":                        {Classes: []string{derivationDiffExtra}, Mechanisms: []string{derivationMechanismCondense}, CompactSetSize: 2, CVersionSetSize: 1},
+		"perl/print_filehandle_list_material_election":    {Classes: []string{derivationDiffExtra}, Mechanisms: []string{derivationMechanismCondense}, CompactSetSize: 2, CVersionSetSize: 1},
+		"perl/unshift_two_args":                           {Classes: []string{derivationDiffExtra}, Mechanisms: []string{derivationMechanismCondense}, CompactSetSize: 2, CVersionSetSize: 1},
+		"perl/join_bare":                                  {Classes: []string{derivationDiffExtra, derivationDiffDifferent}, Mechanisms: []string{derivationMechanismToken, derivationMechanismToken}, CompactSetSize: 2, CVersionSetSize: 1},
+		"ada/bare_aggregate_assignment_material_election": {Classes: []string{derivationDiffExtra, derivationDiffDifferent}, Mechanisms: []string{derivationMechanismCondense, derivationMechanismCondense}, CompactSetSize: 2, CVersionSetSize: 1},
+		"ada/record_aggregate_named":                      {Classes: []string{derivationDiffExtra, derivationDiffDifferent}, Mechanisms: []string{derivationMechanismCondense, derivationMechanismCondense}, CompactSetSize: 2, CVersionSetSize: 1},
+		"ada/discriminated_record":                        {Classes: []string{derivationDiffExtra}, Mechanisms: []string{derivationMechanismCondense}, CompactSetSize: 2, CVersionSetSize: 1},
+		// The only witness whose cardinalities agree: |D| = |V| = 2, and the
+		// sets still disagree on content. It is the reason DIFFERENT is a
+		// class of its own and not a synonym for EXTRA.
+		"kotlin/annotated_declaration_forced_split_drops": {Classes: []string{derivationDiffDifferent}, Mechanisms: []string{derivationMechanismCondense}, CompactSetSize: 2, CVersionSetSize: 2},
+	}
+
+	languages := map[string]*gotreesitter.Language{}
+	cLanguages := map[string]*sitter.Language{}
+	for _, w := range witnesses {
+		if _, ok := languages[w.Language]; !ok {
+			languages[w.Language] = w.Lang()
+		}
+		if _, ok := cLanguages[w.CName]; !ok {
+			cLang, err := COracleLanguage(w.CName)
+			if err != nil {
+				t.Fatalf("load %s C oracle: %v", w.CName, err)
+			}
+			cLanguages[w.CName] = cLang
+		}
+	}
+
+	reproduced := 0
+	for _, w := range witnesses {
+		key := w.Language + "/" + w.Name
+		lang := languages[w.Language]
+		if w.ForceConvergedSplitDrops {
+			previous := lang.CompactConvergedReductionSplitDropsCertified
+			lang.CompactConvergedReductionSplitDropsCertified = true
+			defer func() { lang.CompactConvergedReductionSplitDropsCertified = previous }()
+		}
+		report, err := runDerivationSetDifferential(w.Language, w.CName, lang, cLanguages[w.CName], w.Name, []byte(w.Source))
+		if w.ForceConvergedSplitDrops {
+			lang.CompactConvergedReductionSplitDropsCertified = false
+		}
+		if err != nil {
+			t.Fatalf("%s: %v", key, err)
+		}
+		classes := make([]string, 0, len(report.Differences))
+		mechanisms := make([]string, 0, len(report.Differences))
+		for _, difference := range report.Differences {
+			classes = append(classes, difference.Class)
+			mechanisms = append(mechanisms, difference.Mechanism)
+		}
+		t.Logf(
+			"WITNESS %-46s accepts=%d |D|=%d |V|=%d c-version-count-max=%d declined=%v selected-fold=%d c-published-in-D=%v c-published-fold=%d classes=%v mechanisms=%v (%s)",
+			key, report.CompactAccepts, report.CompactSetSize, report.CVersionSetSize, report.CVersionCountMax,
+			report.CompactDeclined, report.CompactSelectedFoldIndex, report.CPublishedInCompactSet, report.CPublishedFoldIndex,
+			classes, mechanisms, w.Note,
+		)
+		if report.CompactDeclineReason != "" {
+			t.Logf("    compact route fallback reason: %s", report.CompactDeclineReason)
+		}
+		for _, difference := range report.Differences {
+			t.Logf("    %-9s %-15s %s", difference.Class, difference.Mechanism, difference.Detail)
+		}
+		if testing.Verbose() {
+			for index, shape := range report.CandidateShapes {
+				t.Logf("    compact candidate %d shape: %s", index, shape)
+			}
+			t.Logf("    reference published shape: %s", report.PublishedShape)
+		}
+		if w.ExpectNoAccept {
+			// A measured non-reproduction, pinned as such. The witness is
+			// real, but it is not a set difference at an accept on the
+			// shipped profile: the compact route declines earlier, so D does
+			// not exist. Stage D0 reports this rather than forcing it into
+			// the taxonomy.
+			if report.Skipped == "" {
+				t.Errorf("%s: expected no accept-time derivation set, but the instrument compared one", key)
+				continue
+			}
+			reproduced++
+			continue
+		}
+		if report.Skipped != "" {
+			t.Errorf("%s: no comparison ran: %s", key, report.Skipped)
+			continue
+		}
+		if len(report.Differences) == 0 {
+			t.Errorf("%s: witness did NOT reproduce -- the instrument measured no set-level difference", key)
+			continue
+		}
+		want, ok := expected[key]
+		if !ok {
+			t.Errorf("%s: no pinned expectation", key)
+			continue
+		}
+		if !equalStrings(classes, want.Classes) {
+			t.Errorf("%s: difference classes %v, want %v", key, classes, want.Classes)
+		}
+		if !equalStrings(mechanisms, want.Mechanisms) {
+			t.Errorf("%s: mechanisms %v, want %v", key, mechanisms, want.Mechanisms)
+		}
+		if report.CompactSetSize != want.CompactSetSize {
+			t.Errorf("%s: |D|=%d, want %d", key, report.CompactSetSize, want.CompactSetSize)
+		}
+		if report.CVersionSetSize != want.CVersionSetSize {
+			t.Errorf("%s: |V|=%d, want %d", key, report.CVersionSetSize, want.CVersionSetSize)
+		}
+		reproduced++
+	}
+	if reproduced != len(witnesses) {
+		t.Fatalf("reproduced %d of %d witness measurements", reproduced, len(witnesses))
+	}
+	t.Logf(
+		"all %d witness measurements match their pinned classification (8 falsified witnesses; kotlin's is measured twice, once on the shipped profile and once with the withheld certification forced)",
+		len(witnesses),
+	)
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+// derivationSetBaselineConstructed pins the constructed-source portion of the
+// D0 baseline census. Constructed sources are compiled into this package, so
+// every host reproduces these numbers exactly. Stages D1 and D2 must drive
+// the difference counts down; a rise is a regression.
+var derivationSetBaselineConstructed = map[string]struct {
+	Sources     int
+	Compared    int
+	Extra       int
+	Missing     int
+	Different   int
+	Order       int
+	Differences int
+}{
+	"apex":   {Sources: 25, Compared: 22, Extra: 1, Missing: 0, Different: 0, Order: 0, Differences: 1},
+	"perl":   {Sources: 17, Compared: 17, Extra: 7, Missing: 1, Different: 4, Order: 0, Differences: 12},
+	"ada":    {Sources: 23, Compared: 23, Extra: 6, Missing: 0, Different: 9, Order: 0, Differences: 15},
+	"kotlin": {Sources: 13, Compared: 7, Extra: 0, Missing: 0, Different: 0, Order: 0, Differences: 0},
+	"python": {Sources: 26, Compared: 26, Extra: 2, Missing: 0, Different: 2, Order: 0, Differences: 4},
+}
+
+// derivationSetBaselineConstructedTotal is the D0 baseline: the total
+// set-difference count over the five A3 sweep corpora's constructed sources.
+// Stages D1 and D2 must drive this number down.
+const derivationSetBaselineConstructedTotal = 32
+
+// TestDerivationSetDifferentialBaselineCensus publishes the first baseline
+// census: how many set-level differences each of the five A3 sweep corpora
+// carries, by class and by mechanism. That total is the number stages D1 and
+// D2 must drive down.
+//
+// The constructed portion is pinned exactly (derivationSetBaselineConstructed).
+// The real-corpus portion is reported with its file count, because
+// cgo_harness/corpus_real is a generated, gitignored fixture that is not
+// present on every host; a host without it still reproduces the pinned
+// numbers.
+func TestDerivationSetDifferentialBaselineCensus(t *testing.T) {
+	if !gotreesitter.DerivationSetCensusBuilt() {
+		t.Fatal("derivation-set census is not compiled into the library; build with -tags gts_derivation_set_census")
+	}
+
+	grand := newDerivationSetCensusTotals()
+	grandConstructed := newDerivationSetCensusTotals()
+	var rows []string
+
+	for _, entry := range derivationSetCensusLanguages() {
+		lang := entry.Language()
+		cLang, err := COracleLanguage(entry.CName)
+		if err != nil {
+			t.Fatalf("load %s C oracle: %v", entry.CName, err)
+		}
+		constructed := entry.Constructed()
+		real := derivationSetLoadRealCorpus(t, entry.RealDir)
+
+		constructedTotals := newDerivationSetCensusTotals()
+		realTotals := newDerivationSetCensusTotals()
+		for _, source := range constructed {
+			report, err := runDerivationSetDifferential(entry.Name, entry.CName, lang, cLang, source.Name, source.Source)
+			if err != nil {
+				t.Fatalf("%s: %v", entry.Name, err)
+			}
+			constructedTotals.add(report)
+			grandConstructed.add(report)
+			grand.add(report)
+			derivationSetLogDifferences(t, report)
+		}
+		for _, source := range real {
+			report, err := runDerivationSetDifferential(entry.Name, entry.CName, lang, cLang, source.Name, source.Source)
+			if err != nil {
+				t.Fatalf("%s: %v", entry.Name, err)
+			}
+			realTotals.add(report)
+			grand.add(report)
+			derivationSetLogDifferences(t, report)
+		}
+
+		rows = append(rows, fmt.Sprintf(
+			"%-7s constructed: sources=%3d compared=%3d declined=%3d %s | mechanisms: %s",
+			entry.Name, constructedTotals.Sources, constructedTotals.Compared, constructedTotals.Declined,
+			constructedTotals.classLine(), constructedTotals.mechanismLine(),
+		))
+		rows = append(rows, fmt.Sprintf(
+			"%-7s real       : sources=%3d compared=%3d declined=%3d %s | mechanisms: %s",
+			entry.Name, realTotals.Sources, realTotals.Compared, realTotals.Declined,
+			realTotals.classLine(), realTotals.mechanismLine(),
+		))
+
+		want, pinned := derivationSetBaselineConstructed[entry.Name]
+		if !pinned {
+			t.Errorf("%s: no pinned constructed baseline", entry.Name)
+			continue
+		}
+		if constructedTotals.Sources != want.Sources {
+			t.Errorf("%s: constructed source count %d, want %d", entry.Name, constructedTotals.Sources, want.Sources)
+		}
+		if constructedTotals.Compared != want.Compared {
+			t.Errorf("%s: constructed compared count %d, want %d", entry.Name, constructedTotals.Compared, want.Compared)
+		}
+		if constructedTotals.ByClass[derivationDiffExtra] != want.Extra {
+			t.Errorf("%s: constructed EXTRA %d, want %d", entry.Name, constructedTotals.ByClass[derivationDiffExtra], want.Extra)
+		}
+		if constructedTotals.ByClass[derivationDiffMissing] != want.Missing {
+			t.Errorf("%s: constructed MISSING %d, want %d", entry.Name, constructedTotals.ByClass[derivationDiffMissing], want.Missing)
+		}
+		if constructedTotals.ByClass[derivationDiffDifferent] != want.Different {
+			t.Errorf("%s: constructed DIFFERENT %d, want %d", entry.Name, constructedTotals.ByClass[derivationDiffDifferent], want.Different)
+		}
+		if constructedTotals.ByClass[derivationDiffOrder] != want.Order {
+			t.Errorf("%s: constructed ORDER %d, want %d", entry.Name, constructedTotals.ByClass[derivationDiffOrder], want.Order)
+		}
+		if constructedTotals.Differences != want.Differences {
+			t.Errorf("%s: constructed total set differences %d, want %d", entry.Name, constructedTotals.Differences, want.Differences)
+		}
+	}
+
+	t.Log("D0 BASELINE CENSUS -- derivation-set differences per language")
+	for _, row := range rows {
+		t.Log(row)
+	}
+	t.Logf(
+		"TOTAL constructed: sources=%d compared=%d skipped-no-accept=%d skipped-other=%d declined=%d %s | mechanisms: %s | order-undetermined=%d",
+		grandConstructed.Sources, grandConstructed.Compared, grandConstructed.SkippedNoAccept, grandConstructed.SkippedOther,
+		grandConstructed.Declined, grandConstructed.classLine(), grandConstructed.mechanismLine(), grandConstructed.OrderUndetermined,
+	)
+	t.Logf(
+		"TOTAL all corpora: sources=%d compared=%d skipped-no-accept=%d skipped-other=%d declined=%d %s | mechanisms: %s | order-undetermined=%d",
+		grand.Sources, grand.Compared, grand.SkippedNoAccept, grand.SkippedOther,
+		grand.Declined, grand.classLine(), grand.mechanismLine(), grand.OrderUndetermined,
+	)
+	t.Logf("TOTAL SET-DIFFERENCE COUNT (constructed)=%d (all corpora)=%d", grandConstructed.Differences, grand.Differences)
+	if grandConstructed.Differences != derivationSetBaselineConstructedTotal {
+		t.Errorf(
+			"D0 baseline total set-difference count is %d, pinned at %d -- a fall is the point of stages D1 and D2, but the pin must move with the receipt, never silently",
+			grandConstructed.Differences, derivationSetBaselineConstructedTotal,
+		)
+	}
+}
+
+func derivationSetLogDifferences(t *testing.T, report derivationSetReport) {
+	t.Helper()
+	for _, difference := range report.Differences {
+		t.Logf("%s/%s: %s %s -- %s", report.Language, report.Name, difference.Class, difference.Mechanism, difference.Detail)
+	}
+}

--- a/parsercore_phase0_derivation_set_census.go
+++ b/parsercore_phase0_derivation_set_census.go
@@ -1,0 +1,342 @@
+//go:build !gts_no_parsercorephase0 && gts_derivation_set_census
+
+package gotreesitter
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// Derivation-set differential instrument, compact side (stage D0 of
+// spec.derivation-set-equivalence.v1).
+//
+// The lane's prerequisite is a proof that the compact core's live derivation
+// set D at an accept equals the reference runtime's live version set V.
+// Selection cannot repair a wrong candidate set
+// (finding.derivation-set-equivalence-prerequisite), so the set difference
+// must first be MEASURED. This file publishes D.
+//
+// The whole file is behind the gts_derivation_set_census build tag. The
+// shipped build compiles
+// parsercore_phase0_derivation_set_census_disabled.go instead, whose
+// recordDerivationSetCensusAccept is an empty function the inliner removes.
+// The default binary therefore contains no census code at all, so the
+// instrument cannot cost the shipped path -- a stronger guarantee than an
+// env-var read.
+//
+// The census NEVER influences routing. completeAcceptance calls it after the
+// acceptance derivation set is already enumerated and after the materiality
+// gate has already decided; the recorded decision is copied, never made
+// here. Materializing every candidate is expensive, which is the second
+// reason for the build tag.
+
+// DerivationSetCensusCandidate is one live compact derivation at an accept:
+// one root-to-head path through the persistent link DAG
+// (internal/parsercorephase0/core.go, Core.Derivations).
+type DerivationSetCensusCandidate struct {
+	// FoldIndex is the candidate's position in the compact fold order the
+	// spec defines: the unstamped primary first, then stamped links by
+	// ascending fork stamp. Criterion 4 of the equivalence statement
+	// compares this position against C's version-index position.
+	FoldIndex int
+	// Score is the summed dynamic precedence of the path (core.Derivation
+	// Score). The spec's criterion 3 compares it with C's dynamic
+	// precedence.
+	Score int64
+	// BranchOrder is the fork stamp, present only when HasBranchOrder is
+	// true. An absent stamp marks the primary path.
+	BranchOrder    uint64
+	HasBranchOrder bool
+	// PayloadCount is the number of stack payloads on the path. C's
+	// equivalent is the popped slice length at ts_parser__accept.
+	PayloadCount int
+	// RootSymbol, RootStartByte, RootEndByte and RootChildCount describe the
+	// materialized public root, which is what C assembles from its popped
+	// slice.
+	RootSymbol     string
+	RootStartByte  uint32
+	RootEndByte    uint32
+	RootChildCount int
+	// Shape is the canonical deep dump used as this candidate's identity:
+	// symbol, span, named/extra/missing flags, field names, and children,
+	// recursively. Two candidates with equal Shape publish the same public
+	// tree, which is the same predicate the materiality gate
+	// (compactAcceptanceDerivationTreesEqual) applies.
+	Shape string
+	// Nodes is the same materialized tree in pre-order, one entry per node.
+	// The differential rebuilds the tree from it to attribute a set
+	// difference to a mechanism, which a flat string cannot support.
+	Nodes []DerivationSetCensusNode
+	// MaterializeError records a failed trial materialization. The instrument
+	// reports such a candidate as unclassifiable rather than guessing.
+	MaterializeError string
+}
+
+// DerivationSetCensusNode is one node of a materialized candidate, recorded
+// in pre-order. ChildCount lets a reader rebuild the tree from the flat
+// slice without a second pass.
+type DerivationSetCensusNode struct {
+	Field      string
+	Type       string
+	StartByte  uint32
+	EndByte    uint32
+	ChildCount int
+	Named      bool
+	Extra      bool
+	Missing    bool
+}
+
+// DerivationSetCensusAccept is the derivation set D recorded at one accept
+// event, plus the route's own outcome at that accept.
+type DerivationSetCensusAccept struct {
+	// ElectionIndex is the scheduler election that reached the accept.
+	ElectionIndex int
+	// ByteOffset is the accepted head's byte offset.
+	ByteOffset uint32
+	// Candidates is D in compact fold order.
+	Candidates []DerivationSetCensusCandidate
+	// SelectedFoldIndex is the derivation selectCompactAcceptanceDerivation
+	// picked, or -1 when no derivation was selected.
+	SelectedFoldIndex int
+	// DeclinedMaterial is true when the R1 materiality gate declined this
+	// accept because the tied election was not proven vacuous.
+	DeclinedMaterial bool
+	// EnumerationTruncated is true when the derivation enumeration cap fired
+	// and D is incomplete.
+	EnumerationTruncated bool
+}
+
+var (
+	derivationSetCensusMu      sync.Mutex
+	derivationSetCensusAccepts []DerivationSetCensusAccept
+)
+
+// DerivationSetCensusBuilt reports whether this binary carries the
+// derivation-set census. It is true only under the gts_derivation_set_census
+// build tag; the shipped build's stub returns false.
+func DerivationSetCensusBuilt() bool { return true }
+
+// DerivationSetCensusReset drops every recorded accept. Call it before each
+// parse the instrument measures.
+func DerivationSetCensusReset() {
+	derivationSetCensusMu.Lock()
+	derivationSetCensusAccepts = nil
+	derivationSetCensusMu.Unlock()
+}
+
+// DerivationSetCensusSnapshot returns a copy of every accept recorded since
+// the last reset.
+func DerivationSetCensusSnapshot() []DerivationSetCensusAccept {
+	derivationSetCensusMu.Lock()
+	defer derivationSetCensusMu.Unlock()
+	out := make([]DerivationSetCensusAccept, len(derivationSetCensusAccepts))
+	copy(out, derivationSetCensusAccepts)
+	return out
+}
+
+// censusAcceptanceDerivationSet records the compact derivation set D at one
+// accept. completeAcceptance calls it after the route has already decided, so
+// it can only observe. declinedMaterial reports whether the R1 materiality
+// gate refused this accept.
+func (s *diagnosticParserCoreGenericScheduler) censusAcceptanceDerivationSet(
+	paths []core.Derivation, selected core.Derivation, hasSelected bool, declinedMaterial bool,
+) {
+	if len(s.headers) == 0 {
+		return
+	}
+	recordDerivationSetCensusAccept(
+		s.compact, s.options.materializationParser, s.options.materializationSource,
+		s.options.materializationForceReplayParseStates, s.options.materializationContextSet,
+		s.headers[0].head, paths, selected, hasSelected, declinedMaterial,
+		s.electionIndex, s.token.StartByte,
+	)
+}
+
+// censusAcceptanceDerivationSetTruncated records an accept whose derivation
+// enumeration hit the cap, so D is unknown at this accept.
+func (s *diagnosticParserCoreGenericScheduler) censusAcceptanceDerivationSetTruncated() {
+	recordDerivationSetCensusTruncated(s.electionIndex, s.token.StartByte)
+}
+
+// recordDerivationSetCensusAccept records D at one accept. Every failure
+// inside it is recorded as text on the candidate; it never returns an error
+// and never changes the caller's control flow.
+func recordDerivationSetCensusAccept(
+	compact *core.Core, parser *Parser, source []byte,
+	forceReplayParseStates bool, contextSet bool,
+	head core.Head, paths []core.Derivation, selected core.Derivation,
+	hasSelected bool, declinedMaterial bool,
+	electionIndex int, byteOffset uint32,
+) {
+	record := DerivationSetCensusAccept{
+		ElectionIndex:     electionIndex,
+		ByteOffset:        byteOffset,
+		SelectedFoldIndex: -1,
+		DeclinedMaterial:  declinedMaterial,
+	}
+	ordered := derivationSetCensusFoldOrder(paths)
+	for foldIndex, index := range ordered {
+		path := paths[index]
+		candidate := DerivationSetCensusCandidate{
+			FoldIndex:      foldIndex,
+			Score:          path.Score,
+			BranchOrder:    path.BranchOrder,
+			HasBranchOrder: path.HasBranchOrder,
+			PayloadCount:   len(path.Payloads),
+		}
+		if hasSelected && derivationSetCensusSamePath(path, selected) {
+			record.SelectedFoldIndex = foldIndex
+		}
+		if !contextSet || compact == nil || parser == nil {
+			candidate.MaterializeError = "no materialization context"
+			record.Candidates = append(record.Candidates, candidate)
+			continue
+		}
+		tree, err := materializeDiagnosticParserCoreAcceptedSelection(
+			compact, head, path.Payloads, parser, source, nil, forceReplayParseStates, false,
+		)
+		if err != nil {
+			candidate.MaterializeError = err.Error()
+			record.Candidates = append(record.Candidates, candidate)
+			continue
+		}
+		root := tree.RootNode()
+		if root != nil {
+			candidate.RootSymbol = root.Type(parser.language)
+			candidate.RootStartByte = root.StartByte()
+			candidate.RootEndByte = root.EndByte()
+			candidate.RootChildCount = root.ChildCount()
+			var builder strings.Builder
+			derivationSetCensusShape(&builder, parser.language, root, "")
+			candidate.Shape = builder.String()
+			candidate.Nodes = derivationSetCensusNodes(nil, parser.language, root, "")
+		} else {
+			candidate.MaterializeError = "materialized tree has no root"
+		}
+		tree.Release()
+		record.Candidates = append(record.Candidates, candidate)
+	}
+
+	derivationSetCensusMu.Lock()
+	derivationSetCensusAccepts = append(derivationSetCensusAccepts, record)
+	derivationSetCensusMu.Unlock()
+}
+
+// recordDerivationSetCensusTruncated records an accept whose derivation
+// enumeration hit the cap, so D is unknown. The instrument must not treat an
+// unknown set as an empty one.
+func recordDerivationSetCensusTruncated(electionIndex int, byteOffset uint32) {
+	derivationSetCensusMu.Lock()
+	derivationSetCensusAccepts = append(derivationSetCensusAccepts, DerivationSetCensusAccept{
+		ElectionIndex:        electionIndex,
+		ByteOffset:           byteOffset,
+		SelectedFoldIndex:    -1,
+		EnumerationTruncated: true,
+	})
+	derivationSetCensusMu.Unlock()
+}
+
+// derivationSetCensusFoldOrder returns indices into paths in the compact fold
+// order the spec names: the unstamped primary first, then stamped paths by
+// ascending fork stamp, ties broken by enumeration position so the order is
+// total and reproducible. Core.Derivations already enumerates per link and
+// predecessor; this only imposes the stamp order the equivalence criterion
+// compares against C's version indices.
+func derivationSetCensusFoldOrder(paths []core.Derivation) []int {
+	order := make([]int, len(paths))
+	for index := range paths {
+		order[index] = index
+	}
+	// Insertion sort keeps the enumeration position as the stable tiebreak
+	// and stays allocation-free for the observed candidate counts (at most 8).
+	for i := 1; i < len(order); i++ {
+		for j := i; j > 0; j-- {
+			if !derivationSetCensusFoldLess(paths[order[j]], paths[order[j-1]]) {
+				break
+			}
+			order[j], order[j-1] = order[j-1], order[j]
+		}
+	}
+	return order
+}
+
+func derivationSetCensusFoldLess(left, right core.Derivation) bool {
+	if left.HasBranchOrder != right.HasBranchOrder {
+		return !left.HasBranchOrder
+	}
+	if !left.HasBranchOrder {
+		return false
+	}
+	return left.BranchOrder < right.BranchOrder
+}
+
+func derivationSetCensusSamePath(left, right core.Derivation) bool {
+	if left.Score != right.Score || left.HasBranchOrder != right.HasBranchOrder || left.BranchOrder != right.BranchOrder {
+		return false
+	}
+	if len(left.Payloads) != len(right.Payloads) {
+		return false
+	}
+	for index := range left.Payloads {
+		if left.Payloads[index] != right.Payloads[index] {
+			return false
+		}
+	}
+	return true
+}
+
+// derivationSetCensusShape writes the canonical deep dump of one materialized
+// candidate. It records exactly the axes the materiality gate compares
+// (symbol, span, named/extra/missing, per-child field name, children), so a
+// shape match and a gate match always agree.
+func derivationSetCensusShape(builder *strings.Builder, lang *Language, node *Node, field string) {
+	if node == nil {
+		builder.WriteString("(nil)")
+		return
+	}
+	builder.WriteString("(")
+	if field != "" {
+		builder.WriteString(field)
+		builder.WriteString(":")
+	}
+	fmt.Fprintf(builder, "%s[%d-%d]", node.Type(lang), node.StartByte(), node.EndByte())
+	if !node.IsNamed() {
+		builder.WriteString("!anon")
+	}
+	if node.IsExtra() {
+		builder.WriteString("!extra")
+	}
+	if node.IsMissing() {
+		builder.WriteString("!missing")
+	}
+	childCount := node.ChildCount()
+	for index := 0; index < childCount; index++ {
+		builder.WriteString(" ")
+		derivationSetCensusShape(builder, lang, node.Child(index), node.FieldNameForChild(index, lang))
+	}
+	builder.WriteString(")")
+}
+
+// derivationSetCensusNodes appends one pre-order entry per node of the
+// materialized candidate.
+func derivationSetCensusNodes(out []DerivationSetCensusNode, lang *Language, node *Node, field string) []DerivationSetCensusNode {
+	if node == nil {
+		// Keep one entry per declared child so the flat slice always
+		// rebuilds a tree with the recorded child counts.
+		return append(out, DerivationSetCensusNode{Field: field, Type: "<nil>"})
+	}
+	childCount := node.ChildCount()
+	out = append(out, DerivationSetCensusNode{
+		Field: field, Type: node.Type(lang),
+		StartByte: node.StartByte(), EndByte: node.EndByte(),
+		ChildCount: childCount,
+		Named:      node.IsNamed(), Extra: node.IsExtra(), Missing: node.IsMissing(),
+	})
+	for index := 0; index < childCount; index++ {
+		out = derivationSetCensusNodes(out, lang, node.Child(index), node.FieldNameForChild(index, lang))
+	}
+	return out
+}

--- a/parsercore_phase0_derivation_set_census_disabled.go
+++ b/parsercore_phase0_derivation_set_census_disabled.go
@@ -1,0 +1,28 @@
+//go:build !gts_no_parsercorephase0 && !gts_derivation_set_census
+
+package gotreesitter
+
+import (
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// Shipped build of the derivation-set differential instrument (stage D0 of
+// spec.derivation-set-equivalence.v1): the instrument is absent.
+//
+// parsercore_phase0_derivation_set_census.go carries the whole census behind
+// the gts_derivation_set_census build tag. This file supplies the same two
+// call-site names as empty functions so completeAcceptance compiles
+// unchanged in the default build. Both bodies are empty, so the inliner
+// removes the calls and the shipped binary keeps the exact instruction
+// stream it had before the instrument existed.
+
+// DerivationSetCensusBuilt reports whether this binary carries the
+// derivation-set census. The shipped build never does.
+func DerivationSetCensusBuilt() bool { return false }
+
+func (s *diagnosticParserCoreGenericScheduler) censusAcceptanceDerivationSet(
+	_ []core.Derivation, _ core.Derivation, _ bool, _ bool,
+) {
+}
+
+func (s *diagnosticParserCoreGenericScheduler) censusAcceptanceDerivationSetTruncated() {}

--- a/parsercore_phase0_derivation_set_census_inert_test.go
+++ b/parsercore_phase0_derivation_set_census_inert_test.go
@@ -1,0 +1,23 @@
+//go:build !gts_no_parsercorephase0 && !gts_derivation_set_census
+
+package gotreesitter
+
+import "testing"
+
+// TestDerivationSetCensusIsAbsentFromTheDefaultBuild is the inertness ratchet
+// for the stage D0 differential instrument
+// (spec.derivation-set-equivalence.v1).
+//
+// The instrument records the whole live derivation set at every accept and
+// materializes every candidate to do it. That cost must never reach a shipped
+// parse. A build tag, not an env var, is what keeps it out: the default build
+// compiles parsercore_phase0_derivation_set_census_disabled.go, whose two
+// call-site methods have empty bodies, so the accept path keeps the exact
+// instruction stream it had before the instrument existed.
+//
+// This test fails the moment the default build starts carrying the census.
+func TestDerivationSetCensusIsAbsentFromTheDefaultBuild(t *testing.T) {
+	if DerivationSetCensusBuilt() {
+		t.Fatal("the derivation-set census is compiled into the default build; it must stay behind the gts_derivation_set_census build tag")
+	}
+}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -4588,10 +4588,16 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
 	}
 	paths, err := compactDerivationsForAcceptance(s.compact, s.headers[0].head)
 	if err != nil {
+		// Stage D0 instrument (spec.derivation-set-equivalence.v1): a capped
+		// enumeration leaves D unknown, which the differential must not read
+		// as an empty set. Compiled out of the shipped build; see
+		// parsercore_phase0_derivation_set_census_disabled.go.
+		s.censusAcceptanceDerivationSetTruncated()
 		return err
 	}
 	path, selected := selectCompactAcceptanceDerivation(paths, s.options.allowPrimaryAcceptDerivation)
 	if !selected {
+		s.censusAcceptanceDerivationSet(paths, core.Derivation{}, false, false)
 		return s.finish(DiagnosticParserCoreAccept, "generic scheduler requires one certified accepted derivation", 0)
 	}
 	// R1 materiality gate: selectCompactAcceptanceDerivation's tie guard has
@@ -4626,6 +4632,7 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
 			// this cap rather than pay for a comparison this rare. Counted
 			// under the same material-acceptance-election census mechanism
 			// (admission_census.go), with a distinguishable detail string.
+			s.censusAcceptanceDerivationSet(paths, path, true, true)
 			return s.finish(DiagnosticParserCoreAccept, compactAcceptanceElectionCandidateCapDetail, 0)
 		}
 		if !s.options.materializationContextSet {
@@ -4637,6 +4644,7 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
 			// executeSchedulerOpen, diagnosticParseParserCoreGenericFromSeed),
 			// so this is a fail-closed guard for a caller shape not observed
 			// in the certified sweep corpora.
+			s.censusAcceptanceDerivationSet(paths, path, true, true)
 			return s.finish(DiagnosticParserCoreAccept, compactAcceptanceElectionNoContextDetail, 0)
 		}
 		if !compactAcceptanceElectionIsVacuous(
@@ -4644,9 +4652,13 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
 			s.options.materializationForceReplayParseStates, s.options.materializationContextSet,
 			s.headers[0].head, paths, path,
 		) {
+			s.censusAcceptanceDerivationSet(paths, path, true, true)
 			return s.finish(DiagnosticParserCoreAccept, compactAcceptanceElectionMaterialDetail, 0)
 		}
 	}
+	// Stage D0 instrument (spec.derivation-set-equivalence.v1): record the
+	// accepted derivation set D. Compiled out of the shipped build.
+	s.censusAcceptanceDerivationSet(paths, path, true, false)
 	if core.Phase0AEnabled {
 		if err := core.RecordPhase0ADiagnosticAcceptedRoots(s.compact, path.Payloads); err != nil {
 			return err


### PR DESCRIPTION
## What this adds

A differential instrument that compares, at every accept, the compact parser
core's acceptance candidate set against the reference runtime's candidate set.
The instrument only measures. No shipped behavior changes.

The compact side records the candidate set behind the
`gts_derivation_set_census` build tag. The default build compiles a stub whose
two call-site methods have empty bodies, so the shipped accept path keeps the
instruction stream it had before. The C side reconstructs the reference
candidate set from `ts_parser_set_logger` output alone, so the vendored C
source stays unpatched.

## Reconstruction method

`ts_parser__accept` folds every popped root into `finished_tree` through
`ts_parser__select_tree`. The first root sets `finished_tree` and logs
nothing; every later root logs exactly one `select_*` line. The candidate
count is therefore `1 + (select_* lines that immediately follow an accept
line)`, counted over the parse. `ts_parser__select_tree` is also reached from
`ts_parser__select_children` inside a reduce, so only the contiguous run of
`select_*` lines directly after an `accept` line belongs to an accept fold;
every other `select_*` line is preceded by at least a `reduce` line.
`recover_eof` also reaches `ts_parser__accept`, so it counts as an accept
event.

The logger gives the candidate count exactly, both root symbols per fold, the
dynamic precedence when the precedence rung fires, and the live version count
at every step. The logger withholds the span and deep shape of a losing root,
and it withholds which side of a fold is the incumbent when both print the
same root symbol. The instrument reports an undecidable axis as undetermined,
never as agreement.

## Taxonomy

| Class | Meaning |
|---|---|
| EXTRA | The compact core carries an alternative the reference runtime never builds. |
| MISSING | The reference runtime carries an alternative the compact core lacks. |
| DIFFERENT | The reference runtime's published tree is not any compact candidate's tree. |
| ORDER | The sets agree, but the fold order lists the published tree at a different position. |

Each difference also carries a mechanism attribution. Equal leaf sequences
with a different grouping is `condense-class`. A different leaf sequence is
`token-class`.

The five legitimate representation differences are excluded by construction,
not by a filter: link cap, precedence carrier, external scanner state
identity, head-merge key, and order carrier. None of the five appears in a
published tree, and the instrument compares published candidate sets.

## Witness reproduction

`TestDerivationSetDifferentialWitnessReproduction` pins all eight witnesses.

| Witness | Set sizes | Class | Mechanism |
|---|---|---|---|
| apex/class_literal_alias | 2 against 1 | EXTRA | condense-class |
| perl/print_filehandle_list_material_election | 2 against 1 | EXTRA | condense-class |
| perl/unshift_two_args | 2 against 1 | EXTRA | condense-class |
| perl/join_bare | 2 against 1 | EXTRA, DIFFERENT | token-class, token-class |
| ada/bare_aggregate_assignment_material_election | 2 against 1 | EXTRA, DIFFERENT | condense-class, condense-class |
| ada/record_aggregate_named | 2 against 1 | EXTRA, DIFFERENT | condense-class, condense-class |
| ada/discriminated_record | 2 against 1 | EXTRA | condense-class |
| kotlin/annotated_declaration | no accept | measured non-reproduction | not applicable |
| kotlin/annotated_declaration (withheld certification forced) | 2 against 2 | DIFFERENT | condense-class |

Three measurements refine the plan of record:

1. The apex witness is a `condense-class` difference, not a token-class one.
   Both compact candidates root the same node with the same leaf sequence and
   differ only in the field assignment. That is the equivalence class
   `stack_node_add_link` collapses.
2. The kotlin witness does not reproduce on the shipped profile. The compact
   route declines it at the no-action boundary, so no accept-time candidate
   set exists. With the withheld certification forced, the accept is reached
   and the classification is DIFFERENT at equal cardinality.
3. `perl/join_bare` is the only perl witness whose mechanism is `token-class`.
   The reference runtime builds an `escape_sequence` leaf the compact core
   does not.

## Baseline census

`TestDerivationSetDifferentialBaselineCensus` publishes the first baseline.
Constructed-source counts are pinned and reproduce on any host.

| Language | Sources | Compared | EXTRA | MISSING | DIFFERENT | ORDER | Total |
|---|---|---|---|---|---|---|---|
| apex | 25 | 22 | 1 | 0 | 0 | 0 | 1 |
| perl | 17 | 17 | 7 | 1 | 4 | 0 | 12 |
| ada | 23 | 23 | 6 | 0 | 9 | 0 | 15 |
| kotlin | 13 | 7 | 0 | 0 | 0 | 0 | 0 |
| python | 26 | 26 | 2 | 0 | 2 | 0 | 4 |
| **total** | **104** | **95** | **16** | **1** | **15** | **0** | **32** |

Mechanism split over the constructed sources: `condense-class` 26,
`token-class` 4, `unattributed` 2. Five comparisons could not decide the
order axis from the log; they are counted as undetermined.

With the generated real corpus present, the totals rise to 113 sources, 100
compared, and 35 set differences.

## Reproduction

```sh
cd cgo_harness
GOFLAGS=-buildvcs=false GTS_PARITY_ALLOW_HOST=1 \
  GTS_PARITY_C_REF_BUILD_CACHE="$PWD/../harness_out/parity_c_ref_cache" \
  CGO_ENABLED=1 \
  go test -tags "cgo treesitter_c_parity gts_derivation_set_census" \
  -run '^TestDerivationSetDifferential' -count=1 -v -timeout 40m .
```

## Gates

- `go test . -count=1`: pass.
- `go test ./grammars -count=1`: pass.
- `go test ./parser_result_test/... -count=1`: pass.
- `go test -race ./internal/parsercorephase0/... -count=1`: pass.
- Five A3 certification sweeps: pass, and every count and decline reason class
  is identical to `origin/main` on the same host.
- Admission scorecard: PASS=198 DIVERGE=0 FALLBACK=3 SKIP=5 ERROR=0 total=206.
  All 206 rows and digests are identical to `origin/main`.
- C oracle deep-digest gates: pass.
- `go tool nm` on the default test binary reports no census symbol.
- `benchstat` over ten runs of `BenchmarkGoParseFreshParserPerFileDFA` reports
  no significant change against `origin/main`, and allocations per operation
  are unchanged at 2.738k.

`TestCanonicalGoBenchmarkPreflight` fails identically on `origin/main` and on
this branch, so it is a pre-existing condition of this host.
