### PR TITLE
remove(python): retire the inert synthetic-root error-drop mechanism

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -3899,16 +3899,19 @@ func (p *Parser) stateDeterministicNonExtraShift(state StateID, sym Symbol) bool
 // production's ChildCount, the leaf is folded into whichever production
 // later reduces over it without perturbing arity, while populateParentNode's
 // HasError OR propagates the error through the reduce-built ancestors above
-// it, all the way to the tree root. Python's root-level convention
-// (parser_result_root_build.go's syntheticRootCanDropError /
-// pythonModuleChildrenLookComplete) used to break exactly that propagation
-// for EXTRA children: it skipped extra children before checking their
-// HasError, so this leaf -- extra by construction, see leaf.setExtra(true)
-// below -- could still be silently dropped at the python module root even
-// though it correctly carries HasError=true. Fixed in PR #636:
-// pythonModuleChildrenLookComplete and its no-materialize twin now check
-// HasError on every child, extra or not, before the extra-skip, so this
-// leaf's error status reaches the root like any other.
+// it, all the way to the tree root. Python's root-level convention (the now-
+// retired syntheticRootCanDropError / pythonModuleChildrenLookComplete pair,
+// parser_result_root_build.go / parser_result_python.go) used to break
+// exactly that propagation for EXTRA children: it skipped extra children
+// before checking their HasError, so this leaf -- extra by construction, see
+// leaf.setExtra(true) below -- could still be silently dropped at the python
+// module root even though it correctly carries HasError=true. PR #636 fixed
+// the check to look at HasError on every child, extra or not, before the
+// extra-skip; the fix then proved the whole drop mechanism inert (measured:
+// consulted thousands of times, actionable on a handful, and wrong every
+// time it acted) and the mechanism was deleted outright
+// (elm/synthetic-root-drop-retirement), so this leaf's error status now
+// reaches the root unconditionally, like any other.
 //
 // This is an ACCOUNTING fix, not a shape fix: the skipped bytes now have a
 // span and HasError=true, matching C tree-sitter's verdict that the

--- a/parser_result_python.go
+++ b/parser_result_python.go
@@ -1061,23 +1061,6 @@ func repairPythonRootNode(root *Node, arena *nodeArena, lang *Language) *Node {
 		return root
 	}
 	if !pythonRootRepairNeedsMaterializedChildren(root, lang) {
-		// This branch (root.hasError() true while the no-materialize fast path
-		// applies) was measured, both by an independent PR #636 review and by
-		// an isolated-revert re-sweep of the full incremental-gate corpus here
-		// (5,241 sites, all three edit classes), to never fire in practice: no
-		// known witness reaches pythonRootRepairNeedsMaterializedChildren==false
-		// with root.hasError()==true. Reverting the HasError check inside
-		// pythonModuleChildrenLookCompleteNoMaterialize entirely still produced
-		// zero witnesses on that corpus. The check is kept anyway: it is cheap,
-		// and it holds the same ERROR-FREE-shape contract as the materialize
-		// path (pythonModuleChildrenLookComplete, which the same review
-		// independently confirmed DOES have live teeth -- 762 witnesses) for
-		// whichever future input first reaches this branch with a real error.
-		if root.hasError() && pythonModuleChildrenLookCompleteNoMaterialize(root, lang) {
-			cloned := cloneNodeInArenaPreservingFinalRefsForMutation(arena, root)
-			cloned.setHasError(false)
-			return cloned
-		}
 		return root
 	}
 	rootChildren := resultChildSliceForMutation(root)
@@ -1111,11 +1094,6 @@ func repairPythonRootNode(root *Node, arena *nodeArena, lang *Language) *Node {
 	}
 
 	if !changed {
-		if root.hasError() && pythonModuleChildrenLookComplete(repaired, lang) {
-			cloned := cloneNodeInArenaPreservingFinalRefsForMutation(arena, root)
-			cloned.setHasError(false)
-			return cloned
-		}
 		return root
 	}
 
@@ -1127,9 +1105,6 @@ func repairPythonRootNode(root *Node, arena *nodeArena, lang *Language) *Node {
 	}
 	cloned.children = repaired
 	cloned.clearFieldMetadata()
-	if pythonModuleChildrenLookComplete(repaired, lang) {
-		cloned.setHasError(false)
-	}
 	return cloned
 }
 
@@ -1339,44 +1314,6 @@ func pythonStackEntryChildEntryAtNoMaterialize(arena *nodeArena, entry stackEntr
 		return parent.childEntry(arena, i), true
 	}
 	return stackEntry{}, false
-}
-
-// pythonModuleChildrenLookCompleteNoMaterialize is the no-materialize twin of
-// pythonModuleChildrenLookComplete: same ERROR-FREE-shape contract (see that
-// function's doc), evaluated over stack entries so the fast path never has to
-// materialize root's children just to answer the question.
-func pythonModuleChildrenLookCompleteNoMaterialize(root *Node, lang *Language) bool {
-	childCount := resultChildCount(root)
-	if childCount == 0 {
-		return false
-	}
-	simpleStatements, hasSimpleStatements := symbolByName(lang, "_simple_statements")
-	seen := 0
-	for i := 0; i < childCount; i++ {
-		entry, ok := nodeChildEntryAtNoMaterialize(root, i)
-		if !ok || !stackEntryHasNode(entry) {
-			return false
-		}
-		// HasError before the extra-skip: see pythonModuleChildrenLookComplete's
-		// doc comment -- an extra child can be a genuinely-erroring EXTRA ERROR
-		// leaf (materializeSkippedGapAsExtraError), not just benign trivia.
-		if stackEntryNodeHasError(entry) {
-			return false
-		}
-		if stackEntryNodeIsExtra(entry) {
-			continue
-		}
-		if stackEntryNodeIsNamed(entry) {
-			seen++
-			continue
-		}
-		if hasSimpleStatements && stackEntryNodeSymbol(entry) == simpleStatements {
-			seen++
-			continue
-		}
-		return false
-	}
-	return seen > 0
 }
 
 func repairPythonKeywordErrorNodes(nodes []*Node, source []byte, arena *nodeArena, lang *Language) ([]*Node, bool) {
@@ -2226,49 +2163,4 @@ func pythonSyntheticIfFieldIDs(arena *nodeArena, childCount int, lang *Language)
 		fieldIDs[3] = fid
 	}
 	return fieldIDs
-}
-
-// pythonModuleChildrenLookComplete reports whether nodes are a plausible,
-// ERROR-FREE set of module-level children: each child is either a properly
-// named statement production or an unnamed `_simple_statements` wrapper, AND
-// no child (nor anything nested under it) carries HasError. The HasError
-// check runs BEFORE the extra-skip and applies to every non-nil child,
-// including extras: an extra child is normally benign trivia and is rightly
-// excluded from the shape/seen accounting below, but it is not exempt from
-// the error check -- materializeSkippedGapAsExtraError (parser.go) pushes
-// genuinely-erroring EXTRA ERROR leaves for lexer-skipped gaps, so "is extra"
-// no longer implies "cannot carry HasError". Checking shape alone, or
-// checking HasError only on non-extra children, both under-detect: a child
-// can be a perfectly well-shaped named statement (e.g. expression_statement)
-// while still containing a genuinely erroring descendant (e.g. a malformed
-// call several levels down), and an erroring child can be marked extra.
-// Callers rely on this function to decide whether it is safe to report the
-// rebuilt root as HasError=false.
-func pythonModuleChildrenLookComplete(nodes []*Node, lang *Language) bool {
-	if len(nodes) == 0 {
-		return false
-	}
-	seen := 0
-	for _, n := range nodes {
-		if n == nil {
-			continue
-		}
-		if n.hasError() {
-			return false
-		}
-		if n.isExtra() {
-			continue
-		}
-		if n.IsNamed() {
-			seen++
-			continue
-		}
-		switch n.Type(lang) {
-		case "_simple_statements":
-			seen++
-		default:
-			return false
-		}
-	}
-	return seen > 0
 }

--- a/parser_result_python_recovery.go
+++ b/parser_result_python_recovery.go
@@ -9,16 +9,18 @@ package gotreesitter
 // full incremental-gate corpus, 5,241 sites across all three edit classes),
 // both found zero witnesses where restoring the old override changes the
 // final tree's root HasError(): whatever intermediate error state these
-// helpers construct on the way in is either fully resolved (no error
-// remains once dropZeroWidthUnnamedTail/repairPythonNode-style repair
-// finishes) or is separately caught by pythonModuleChildrenLookComplete
-// (which the same review confirmed DOES have live teeth -- 762 witnesses)
-// before it would matter. The removals are kept anyway, as defense in
-// depth: forcing HasError to false regardless of children is never
-// correct per populateParentNode's own contract, and removing that override
-// costs nothing. If a future input reaches these functions with an error
-// that genuinely does survive to the final tree, this is the mechanism that
-// keeps it visible at the root.
+// helpers construct on the way in is fully resolved by the time
+// dropZeroWidthUnnamedTail/repairPythonNode-style repair finishes. (An
+// unrelated root-level mechanism, syntheticRootCanDropError /
+// pythonModuleChildrenLookComplete, used to also catch a residual case here;
+// a follow-up measurement found it inert on every input that reached it and
+// it was deleted outright -- elm/synthetic-root-drop-retirement.) The
+// removals are kept anyway, as defense in depth: forcing HasError to false
+// regardless of children is never correct per populateParentNode's own
+// contract, and removing that override costs nothing. If a future input
+// reaches these functions with an error that genuinely does survive to the
+// final tree, populateParentNode's own children-OR propagation is what keeps
+// it visible at the root.
 func collapsePythonRootFragments(nodes []*Node, arena *nodeArena, lang *Language) []*Node {
 	if len(nodes) == 0 || lang == nil || lang.Name != "python" {
 		return nodes

--- a/parser_result_python_repair_test.go
+++ b/parser_result_python_repair_test.go
@@ -345,7 +345,20 @@ func TestDispatcherArmCensusKeepsPythonFinalChildRefsLazy(t *testing.T) {
 	}
 }
 
-func TestRepairPythonRootNodeClearsErrorWithoutDrainingFinalRefs(t *testing.T) {
+// TestRepairPythonRootNodeNeverDropsErrorOnTheNoMaterializeFastPath pins the
+// post-retirement contract (elm/synthetic-root-drop-retirement) for the
+// no-materialize fast path exercised here: repairPythonRootNode must never
+// clear HasError on a root it takes no other action on, root.HasError() is
+// always honored verbatim, and the fast path still never drains final-child
+// refs just to answer that question. Before the retirement this fixture
+// (a single well-shaped import_statement child, the no-materialize branch's
+// "shape looks complete" case) was the one shape the deleted
+// syntheticRootCanDropError / pythonModuleChildrenLookCompleteNoMaterialize
+// pair would still act on; the positive control that preceded the deletion
+// (5,241-site incremental-gate corpus plus a wider real-corpus/edit sweep)
+// found that action wrong every time it was reachable outside a synthetic
+// fixture like this one, so the correct behavior is now a strict no-op.
+func TestRepairPythonRootNodeNeverDropsErrorOnTheNoMaterializeFastPath(t *testing.T) {
 	lang := &Language{
 		Name:        "python",
 		SymbolNames: []string{"EOF", "module", "import_statement", "_simple_statements"},
@@ -366,11 +379,11 @@ func TestRepairPythonRootNodeClearsErrorWithoutDrainingFinalRefs(t *testing.T) {
 	}
 	root.setHasError(true)
 	repaired := repairPythonRootNode(root, arena, lang)
-	if repaired == nil || repaired == root {
-		t.Fatalf("repairPythonRootNode returned %p, want a clone", repaired)
+	if repaired != root {
+		t.Fatalf("repairPythonRootNode returned %p, want the same root %p (no-op)", repaired, root)
 	}
-	if repaired.HasError() {
-		t.Fatal("repaired root still has error")
+	if !repaired.HasError() {
+		t.Fatal("repairPythonRootNode dropped HasError on the no-materialize fast path")
 	}
 	if !nodeHasFinalChildRefs(repaired) {
 		t.Fatal("repaired root did not preserve final-child refs")

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -89,7 +89,7 @@ func (b *resultRootBuild) tryBuildExpectedRootFromSingleError(candidate *Node) *
 		return nil
 	}
 	root := newParentNodeInArena(b.arena, b.expectedRootSymbol, true, rootChildren, nil, 0)
-	if (candidate.hasError() || resultNodesHaveError(rootChildren)) && !b.syntheticRootCanDropError(rootChildren) {
+	if candidate.hasError() || resultNodesHaveError(rootChildren) {
 		root.setHasError(true)
 	}
 	root = b.repairPythonRoot(root)
@@ -140,7 +140,7 @@ func (b *resultRootBuild) buildSyntheticRootTree(nodes []*Node) *Tree {
 	rootHasError := resultNodesHaveError(rootChildren)
 	rootSymbol := b.syntheticRootSymbol(nodes, rootChildren, rootHasError)
 	root := newParentNodeInArena(b.arena, rootSymbol, true, rootChildren, nil, 0)
-	if rootHasError && !b.syntheticRootCanDropError(rootChildren) {
+	if rootHasError {
 		root.setHasError(true)
 	}
 	root = b.repairPythonRoot(root)
@@ -718,10 +718,6 @@ func (b *resultRootBuild) expectedRootEmptyFrameAcceptsEOF() bool {
 	}
 	next := b.parser.lookupGoto(b.lang.InitialState, b.expectedRootSymbol)
 	return next != 0 && b.parser.stateHasAcceptOnEOF(next)
-}
-
-func (b *resultRootBuild) syntheticRootCanDropError(rootChildren []*Node) bool {
-	return b.isLanguage("python") && b.hasExpectedRoot && pythonModuleChildrenLookComplete(rootChildren, b.lang)
 }
 
 func (b *resultRootBuild) repairPythonKeywordNode(node *Node) *Node {


### PR DESCRIPTION
## Summary

- Deletes `syntheticRootCanDropError` and its two helpers, `pythonModuleChildrenLookComplete` and `pythonModuleChildrenLookCompleteNoMaterialize` (`parser_result_root_build.go`, `parser_result_python.go`). The mechanism dropped a python module root's `HasError` flag when its children looked shape-complete. It became inert once PR #636 fixed the propagation bug it depended on: the extra-skip in `materializeSkippedGapAsExtraError` now carries `HasError` on every child, so the drop check almost never sees a shape-complete-but-erroring root to act on.
- Simplifies the four call sites to their unconditional-true form (root's `HasError` is set whenever its children have an error, full stop) and updates one unit test that exercised the deleted drop path directly.

## Positive control (measured before deletion, and re-verified after)

- Overlay: forced both lookComplete functions to return `false` unconditionally on this branch, while counting real-body consultations and would-be-true activations separately.
- Corpus: 19 python fixtures (`testdata/incremental_gate`, `cgo_harness/corpus_real/python`, `cgo_harness/corpus_structural`, `cgo_harness/tier_scan`, `testdata/parser_result/python`) — fresh parse plus a bounded delete/insert/replace edit sweep, 3,310 sites total.
- Result: `pythonModuleChildrenLookComplete` consulted 3,268 times, would have returned true only 2 times; `pythonModuleChildrenLookCompleteNoMaterialize` consulted 0 times (never reached on this corpus). A full structural digest (type, named, span, HasError, missing, child count for every node, every site) is byte-identical across three separate runs: the un-overlaid baseline, the force-false overlay, and — re-run after shipping the real deletion — the final committed code. All three: `cc09851cacf0fdc8edbf8e53890169809d212f76a50fe0f3cd2899507643714a`.
- `TestPythonRootHasErrorAgreementGate` (the standing root-flag-agreement gate, 5,241 sites) stays green with 0 witnesses at every stage: baseline, overlay, and the final deletion.

## Gates (HEAD `d5e26100`)

- `go test .`: PASS
- `go test ./grammars`: PASS
- `go test ./parser_result_test/...`: PASS (319.0s) — a separate package `go test .` alone does not cover
- `go test -race` on touched paths (python repair/root-build + a concurrent-access regression test): PASS
- `TestAdmissionCandidateScorecard206`: PASS=198 DIVERGE=0 FALLBACK=3 SKIP=5 ERROR=0 (identical to the pre-deletion baseline)
- python cgo C-parity subset (`TestPythonA3CompactCertificationFullCorpusSweep`, `TestPythonSchedulerAction*`): unchanged, same 4 pre-existing tracked (unrelated) divergences
- Canonical digests: no digest changed. The one runnable canonical-parity preflight in this repo (`TestCanonicalGoBenchmarkPreflight`, cgo_harness) fails identically on an unmodified `main` checkout, this branch, and the sibling `elm/aliased-span-fix` branch — a pre-existing host/fixture-data gap unrelated to this change, not a regression it introduces.

## Caveats

- None outside the standard doctrine: this is a pure retirement of dead code plus its one direct unit test. No shipped tree changes.