### PR TITLE
fix(parser): start aliased multi-token nodes at their first token

### DIFF
--- a/cgo_harness/python_a3_certification_sweep_test.go
+++ b/cgo_harness/python_a3_certification_sweep_test.go
@@ -49,20 +49,19 @@ func TestPythonA3CompactCertificationFullCorpusSweep(t *testing.T) {
 // materialization: an inherited field-map entry named the comma in a
 // comma-separated import list. C's node.c never names that comma. PR #638
 // repaired applyParentFieldToFlattenedHiddenSpan, so both divergences
-// stopped occurring, and the entries came out with the repair. The
-// stale-entry ratchet in a3ReportSweep now fails this test if a remaining
-// entry stops matching a live divergence.
+// stopped occurring, and the entries came out with the repair.
 //
 // The repair of large__python3.8_grammar.py uncovered a second, independent
-// divergence further into the same file. It is family S (materialization,
-// aliased multi-token span): Go starts the "not in" operator wrapper one
-// byte early. Go uses the previous sibling's end byte instead of the first
-// token's own start byte, so the wrapper includes the separating space.
-// The defect is older than PR #638. Only the family-M point ahead of it in
-// traversal order masked it, because a3MatchesKnownDivergence gates on the
-// first divergence. The entry below tracks the defect, so the family-M
-// burn-down does not turn an already-known defect into a false hard
-// failure.
+// divergence further into the same file, which PR #638 tracked as its own
+// family-S entry: Go started the "not in" operator wrapper one byte early,
+// using the previous sibling's end byte instead of the first token's own
+// start byte, so the wrapper swallowed the separating space. This PR fixes
+// that defect at its source (flattenedHiddenPaddingTarget /
+// flattenedHiddenPaddingSourceReachesTarget, parser_reduce.go) and removes
+// the entry with the repair, verified directly against the C oracle on this
+// exact file. large__python3.8_grammar.py now carries no tracked divergence
+// at all. The stale-entry ratchet in a3ReportSweep enforces this: it fails
+// the sweep if a remaining entry stops matching a live divergence.
 //
 // The two f-string entries are family D (a first-class declared
 // pattern_list/expression_list ambiguity; Go's reduceForkWindowPreference
@@ -70,13 +69,6 @@ func TestPythonA3CompactCertificationFullCorpusSweep(t *testing.T) {
 // tied elections, not this gate's scope; repair lanes are tracked
 // separately.
 var pythonA3KnownDivergences = []a3KnownDivergence{
-	{
-		// Pre-existing production-level aliased-multi-token span defect.
-		// A repair lane is queued.
-		Witness:   "large__python3.8_grammar.py",
-		FirstPath: "/module/class_definition[25]/block[4]/function_definition[56]/block[6]/if_statement[12]/comparison_operator[1]/not in[15]",
-		GoValue:   "1190:45-1190:52 @37238..37245", CValue: "1190:46-1190:52 @37239..37245", Family: "S",
-	},
 	{
 		Witness:   "fstring_interpolation_bare_tuple",
 		FirstPath: "/module/assignment[2]/string[2]/interpolation[1]/pattern_list[1]",

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -1359,11 +1359,18 @@ func coalesceForestWithRawAndAlternatives(p *Parser, arena *nodeArena, index *gs
 		// production silently truncating, not this gate picking a wrong
 		// alternative. The one genuine forest-vs-C divergence found in the
 		// sweep (python `not in`/`is not` compound-token leaf span, off by the
-		// leading space) reproduces identically with this whole hunk reverted
-		// to the original HEAD (pre-existing, unrelated to hidden-symbol
-		// dedup — see forest_gap_rejection_test.go / the cap-eviction tiebreak
-		// in forestCapReplacementIndex below for the mechanism that made this
-		// specific python file reachable enough to expose it).
+		// leading space) reproduced identically with this whole hunk reverted
+		// to HEAD, confirming it was pre-existing and unrelated to
+		// hidden-symbol dedup here — see forest_gap_rejection_test.go / the
+		// cap-eviction tiebreak in forestCapReplacementIndex below for the
+		// mechanism that made this specific python file reachable enough to
+		// expose it. Fixed at its actual source: flattenedHiddenPaddingTarget
+		// (parser_reduce.go) let a preceding sibling's trailing gap widen an
+		// aliased multi-token wrapper's already-correct start backward over
+		// the separating space whenever the wrapper was the second-or-later
+		// element of an operator repeat. That helper is shared by every route
+		// through buildReduceChildrenWithPath, so the forest route's copy of
+		// the divergence closed along with production's.
 		hiddenSym := p != nil && p.language != nil && !symbolIsVisible(p.language, esym)
 		for i := range node.links {
 			l := &node.links[i]

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -6753,6 +6753,23 @@ func flattenedHiddenPaddingTarget(n, source *Node, symbolMeta []SymbolMetadata) 
 	if n.isExternalScannerToken() {
 		return false
 	}
+	if len(n.children) > 0 && !flattenedHiddenPaddingSourceReachesTarget(n, source) {
+		// n has children (the only shape a preceding hidden node's overhang
+		// can legitimately widen -- see the metadata checks below), but
+		// source's own span ends before n's begins: source cannot be the
+		// hidden node whose flattening produced n, because a real container
+		// always spans at least up to its own descendant's start. That
+		// shape means source is an already-finished, unrelated PRECEDING
+		// SIBLING (e.g. the previous element of an operator repeat), and n
+		// is an independently reduced node -- typically an aliased
+		// multi-token wrapper, e.g. python's `not in` -- whose own span was
+		// already computed correctly from its own first child. The gap
+		// between them is ordinary unclaimed inter-sibling trivia, not
+		// padding a hidden node lost; widening n backward over it would
+		// swallow the separator instead of leaving it unclaimed like any
+		// other inter-token gap.
+		return false
+	}
 	if idx := int(n.symbol); idx >= 0 && idx < len(symbolMeta) {
 		meta := symbolMeta[n.symbol]
 		if !meta.Visible || meta.Named {
@@ -6761,6 +6778,17 @@ func flattenedHiddenPaddingTarget(n, source *Node, symbolMeta []SymbolMetadata) 
 		return len(n.children) > 0
 	}
 	return !n.isNamed() && len(n.children) > 0
+}
+
+// flattenedHiddenPaddingSourceReachesTarget reports whether source's own
+// span extends at least as far as n's recorded start byte -- the shape a
+// genuine container has over a descendant it has not fully accounted for
+// yet (source.startByte <= n.startByte always holds by construction; this
+// checks the other edge). When source's span ends before n begins, source
+// cannot be n's flattening origin: it is a finished, disjoint sibling
+// instead, and any gap before n belongs to neither.
+func flattenedHiddenPaddingSourceReachesTarget(n, source *Node) bool {
+	return source != nil && source.endByte >= n.startByte
 }
 
 func flattenedHiddenSiblingPaddingTarget(n, source *Node, symbolMeta []SymbolMetadata) bool {

--- a/parser_reduce_span_test.go
+++ b/parser_reduce_span_test.go
@@ -803,3 +803,69 @@ func TestFlattenedGeneratedRepeatPaddingWidensAnonymousWrapper(t *testing.T) {
 		t.Fatalf("generated-repeat anonymous wrapper endByte = %d, want %d", got, want)
 	}
 }
+
+// TestFlattenedSiblingGapDoesNotWidenAliasedWrapper is the family-S
+// regression fixture (spore.2026-08-02.maple-e.shared-divergence-census;
+// elm/aliased-span-fix): a minimal, hand-built shape of python's
+// `1 in 1 not in 1` -- an aliased multi-token wrapper (visible, unnamed, has
+// children -- the same shape TestFlattenedGeneratedRepeatPaddingWidensAnonymousWrapper
+// legitimately widens) sits as the FIRST flattened node of the SECOND
+// element of an operator repeat, with a one-byte unclaimed gap (the
+// separating space) between it and the first element's already-finished,
+// disjoint sibling subtree.
+//
+// The two cases share flattenedHiddenPaddingTarget's exact "visible,
+// unnamed, has children" shape check and must be told apart by whether the
+// padding source's span actually reaches the candidate's start
+// (flattenedHiddenPaddingSourceReachesTarget): the legitimate case's source
+// is the wrapper's own enclosing hidden node, which by construction always
+// spans at least up to its descendant; here the source is a finished,
+// disjoint PRECEDING SIBLING two levels up (elem1), whose span ends before
+// the wrapper begins. Before the fix, elem1's trailing edge leaked across
+// that sibling boundary and pulled the wrapper's start back over the gap
+// (matching the measured Go span 10..17 vs C's 11..17 on
+// `a = 1 in 1 not in 1`).
+func TestFlattenedSiblingGapDoesNotWidenAliasedWrapper(t *testing.T) {
+	op1 := NewLeafNode(3, false, 0, 2, Point{Row: 0, Column: 0}, Point{Row: 0, Column: 2})
+	elem1 := NewParentNode(4, false, []*Node{op1}, nil, 0)
+	elem1.startByte, elem1.endByte = 0, 2
+	elem1.startPoint, elem1.endPoint = Point{Row: 0, Column: 0}, Point{Row: 0, Column: 2}
+
+	// Byte 2 is an unclaimed gap (the separating space); the wrapper's own
+	// content does not start until byte 3.
+	content := NewLeafNode(2, true, 3, 5, Point{Row: 0, Column: 3}, Point{Row: 0, Column: 5})
+	wrapper := NewParentNode(1, false, []*Node{content}, nil, 0)
+	wrapper.startByte, wrapper.endByte = 3, 5
+	wrapper.startPoint, wrapper.endPoint = Point{Row: 0, Column: 3}, Point{Row: 0, Column: 5}
+	elem2 := NewParentNode(4, false, []*Node{wrapper}, nil, 0)
+	elem2.startByte, elem2.endByte = 3, 5
+	elem2.startPoint, elem2.endPoint = Point{Row: 0, Column: 3}, Point{Row: 0, Column: 5}
+
+	repeatList := NewParentNode(5, false, []*Node{elem1, elem2}, nil, 0)
+	repeatList.startByte, repeatList.endByte = 0, 5
+	repeatList.startPoint, repeatList.endPoint = Point{Row: 0, Column: 0}, Point{Row: 0, Column: 5}
+
+	symbolMeta := []SymbolMetadata{
+		{},
+		{Name: "not_in", Visible: true, Named: false},
+		{Name: "content", Visible: true, Named: true},
+		{Name: "op", Visible: true, Named: false},
+		{Name: "_repeat_elem", Visible: false},
+		{Name: "_repeat_list", Visible: false},
+	}
+
+	scratch := &reduceBuildScratch{}
+	appendFlattenedHiddenChildrenToScratch(scratch, repeatList, symbolMeta, nil)
+	if got, want := len(scratch.nodes), 2; got != want {
+		t.Fatalf("flattened child count = %d, want %d", got, want)
+	}
+	if got, want := scratch.nodes[0].startByte, uint32(0); got != want {
+		t.Fatalf("first element startByte = %d, want %d", got, want)
+	}
+	if got, want := scratch.nodes[1].startByte, uint32(3); got != want {
+		t.Fatalf("aliased wrapper startByte = %d, want %d (must not widen across the preceding sibling's gap)", got, want)
+	}
+	if got, want := scratch.nodes[1].endByte, uint32(5); got != want {
+		t.Fatalf("aliased wrapper endByte = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes `flattenedHiddenPaddingTarget` (`parser_reduce.go`): a preceding, already-finished sibling's trailing gap was incorrectly widening an aliased multi-token wrapper's already-correct span backward, swallowing the separating whitespace, whenever the wrapper was the second-or-later element of an operator repeat.
- The fix adds `flattenedHiddenPaddingSourceReachesTarget`: a genuine container's span always reaches at least to its descendant's start; a finished, disjoint sibling's span does not. Checking that before widening tells the two cases apart without touching the legitimate `GeneratedRepeatAux` padding case the mechanism exists for.

**Rebased onto `main` after PR #638 (family-M field-projection fix) merged and touched the same file.** #638 also fixed python's family-M divergence in `large__python3.8_grammar.py` and, in doing so, unmasked and separately tracked this PR's family-S divergence as its own `a3KnownDivergence` entry with a new stale-entry ratchet in `a3ReportSweep`. Rebase resolved cleanly in `parser_reduce.go`/`glr_forest.go` (no logical overlap: #638 removed unused parameters from functions adjacent to mine, my functions' bodies and call sites were untouched); the one real conflict was the doc comment in `cgo_harness/python_a3_certification_sweep_test.go`, resolved by hand. See "Allowlist" below for the updated, now-required entry removal.

## Before/after (C oracle receipts, re-verified on the rebased HEAD)

| Source | Go before | C | Go after |
|---|---|---|---|
| `a = 1 in 1 not in 1` | `not in` @10..17 | @11..17 | @11..17 (matches) |
| `a = 1 in 1 not in 1 not in 1` | 2 divergences | — | 0 |
| `a = 1 in 1 is not 1` | `is not` @10..17 | @11..17 | @11..17 (matches) |
| `a = 1 not in 2` (first position) | already clean | — | unaffected |

Real-corpus witness `cgo_harness/corpus_real/python/large__python3.8_grammar.py`: **0 C divergences on this HEAD.** Before this PR (but after #638's family-M fix on `main`) it carried exactly 1 divergence, the family-S point at row 1190 (0-indexed) — `not in` at column 45→46 — that #638 tracked explicitly. This PR closes it; the file is now byte-for-byte identical to the C oracle.

Cross-language safety net (re-run on the rebased HEAD): parsed 128 real-corpus files across 51 languages and C-compared every one. 26 files diverge (down from 36 pre-#638, since #638's field-projection fix also repaired several other languages) — zero of them are "span"-category divergences. Every divergence shown is a pre-existing type/child_count issue unrelated to this change (e.g. perl's known bareword-call family-D gap, swift's known child-count gap).

## Regression caught during verification

The first version of this fix (checking whether the wrapper's own span already matched its first child) broke `TestFlattenedGeneratedRepeatPaddingWidensAnonymousWrapper`, a legitimate case with the identical "visible, unnamed, has children" shape. The final fix keys off the padding source's span reaching the candidate's start instead, which correctly distinguishes the two. Added `TestFlattenedSiblingGapDoesNotWidenAliasedWrapper` next to the existing test as a permanent regression fixture; re-confirmed on the rebased HEAD that it fails without the fix (reproduces the exact wrong span) and passes with it, and that `TestFlattenedGeneratedRepeatPaddingWidensAnonymousWrapper` stays green.

## Allowlist — entry removed (superseded finding)

Earlier revisions of this PR investigated this question against the pre-#638 base and found no separate family-S entry existed to remove (family M gated first in the witness file back then, masking family S). **That finding no longer applies**: #638 fixed family M in this file and, anticipating this repair, added a dedicated family-S `a3KnownDivergence` entry plus a stale-entry ratchet in `a3ReportSweep` that fails the sweep if a tracked entry stops matching a live divergence. This PR's fix closes that exact divergence, so the entry is now genuinely stale — **removed** in this revision (`cgo_harness/python_a3_certification_sweep_test.go`), along with the doc comment above `pythonA3KnownDivergences`, rewritten to describe the current state: `large__python3.8_grammar.py` carries no tracked divergence at all, and only the two pre-existing family-D f-string entries remain. Verified directly: `TestPythonA3CompactCertificationFullCorpusSweep` passes on this HEAD with the entry removed (it would fail the stale-entry ratchet otherwise).

## Gates (HEAD `f723ee43`, rebased onto `main` at `4347068b`)

- `go test .`: PASS (419.0s)
- `go test ./grammars`: PASS (374.6s)
- `go test ./parser_result_test/...`: PASS (520.9s) — a separate package `go test .` alone does not cover; re-run specifically against the merged #638 state (its ada probe digests and dispatcher-census receipts moved with #638, independent of this PR)
- `go test -race` on touched paths (`TestFlattened*`, `TestReduce*`, `TestParentLinkConcurrentAccessNoRace`): PASS
- `TestAdmissionCandidateScorecard206`: PASS=198 DIVERGE=0 FALLBACK=3 SKIP=5 ERROR=0 (identical to baseline, same per-language digests)
- `TestPythonA3CompactCertificationFullCorpusSweep`: PASS, stale-entry ratchet satisfied, only the 2 pre-existing family-D entries remain tracked
- Cross-language C-oracle sweep: 51 languages, 128 files, zero new span divergences (26 divergent files total, down from 36 pre-#638)
- Canonical digests: no digest changed. The one runnable canonical-parity preflight in this repo (`TestCanonicalGoBenchmarkPreflight`, cgo_harness) fails identically on an unmodified `main` checkout and this branch — a pre-existing host/fixture-data gap unrelated to this change, re-confirmed on the rebased HEAD.

## Caveats

- Family D (GLR derivation tie-break) is untouched and out of scope; the two f-string entries remain tracked in the allowlist for their own follow-up PR.