### PR TITLE
optimize(parsercore): Reserve compact record arenas from source length

### DIFF
--- a/internal/parsercorephase0/arena_reserve.go
+++ b/internal/parsercorephase0/arena_reserve.go
@@ -1,0 +1,188 @@
+package parsercorephase0
+
+import (
+	"math"
+	"math/bits"
+)
+
+// Record-arena reserve densities, expressed as records per 1024 source bytes
+// so the estimate stays exact integer arithmetic (no float, no rounding
+// drift, same reserve on every run for the same source length).
+//
+// The numbers come from a census of the four canonical Go admission fixtures
+// (5 KB, 20 KB, 41 KB, 236 KB), which span the measured density range of
+// real Go source:
+//
+//	fixture        nodes/B  links/B  subtrees/B  children/B
+//	rewrite         0.5878   0.5876      0.5129      0.5409
+//	query_compile   0.7333   0.7333      0.6489      0.6820
+//	language        0.3655   0.3654      0.3153      0.3472
+//	grammargen_lr   0.6356   0.6356      0.5562      0.5979
+//
+// Each constant sits just above that family's densest fixture, so a source
+// of ordinary density needs no growth at all and a denser-than-canonical
+// source still starts from a base that removes almost every copy. nodes and
+// nodeLineages share one count because appendNodeAt appends to both on every
+// node, one for one.
+//
+// These are a capacity estimate and nothing else. They never bound what the
+// parse may publish: Limits alone does that, and every append still checks
+// it. A reserve that is too small only costs the growth it used to cost; a
+// reserve that is too large only costs capacity the parse would have reached
+// anyway.
+const (
+	reserveNodesPerKiB    = 768 // 0.7500 records per source byte
+	reserveLinksPerKiB    = 768 // 0.7500
+	reserveSubtreesPerKiB = 680 // 0.6641
+	reserveChildrenPerKiB = 730 // 0.7129
+)
+
+// ReserveRecordArenas reserves record-arena capacity for one parse over a
+// source of sourceLen bytes, so the five arenas that carry the compact
+// core's record mass -- nodes, nodeLineages, links, subtrees, children --
+// start at their expected size instead of growing there from zero.
+//
+// Why this exists: Go grows a large slice by about 1.25x, so an arena that
+// ends at S bytes allocates roughly 4.5-5.3x S cumulatively and copies about
+// 4x S through growslice. On a first parse (a fresh core, empty arenas --
+// the one-shot pattern every caller that parses a file once and exits uses)
+// those five growth series are the dominant allocation cost of the whole
+// parse. Reserving the capacity up front replaces the series with one
+// allocation per arena.
+//
+// maxBytes caps the total reserve. When the source-proportional estimate
+// exceeds it, every arena is scaled down by the same rational factor, so the
+// reserve keeps its measured shape and the sum lands at or under maxBytes.
+// The caller sets maxBytes from its own memory budget, because
+// FootprintBytes gauges capacity: a reserve raises that gauge immediately,
+// at construction, before the parse publishes a single record.
+//
+// ReserveRecordArenas is a pure capacity operation. It changes no length, no
+// record, no identifier, and no Work counter, so it cannot change a parse
+// result. It does nothing at all unless every arena it touches is empty
+// (call it directly after New or Reset and before the seed), and it only
+// ever grows: an arena that already holds enough retained capacity from an
+// earlier parse on the same core keeps it.
+func (c *Core) ReserveRecordArenas(sourceLen int, maxBytes uint64) {
+	if c == nil || sourceLen <= 0 {
+		return
+	}
+	if len(c.nodes) != 0 || len(c.nodeLineages) != 0 || len(c.links) != 0 ||
+		len(c.subtrees) != 0 || len(c.children) != 0 {
+		return
+	}
+	nodes := reserveRecordCount(sourceLen, reserveNodesPerKiB, c.limits.MaxNodes)
+	links := reserveRecordCount(sourceLen, reserveLinksPerKiB, c.limits.MaxLinks)
+	subtrees := reserveRecordCount(sourceLen, reserveSubtreesPerKiB, c.limits.MaxSubtrees)
+	children := reserveRecordCount(sourceLen, reserveChildrenPerKiB, c.limits.MaxChildren)
+	total := reserveTotalBytes(nodes, links, subtrees, children)
+	if total == 0 {
+		return
+	}
+	if maxBytes > 0 && total > maxBytes {
+		nodes = scaleReserveCount(nodes, maxBytes, total)
+		links = scaleReserveCount(links, maxBytes, total)
+		subtrees = scaleReserveCount(subtrees, maxBytes, total)
+		children = scaleReserveCount(children, maxBytes, total)
+	}
+	c.nodes = reserveArena(c.nodes, nodes)
+	c.nodeLineages = reserveArena(c.nodeLineages, nodes)
+	c.links = reserveArena(c.links, links)
+	c.subtrees = reserveArena(c.subtrees, subtrees)
+	c.children = reserveArena(c.children, children)
+}
+
+// ReserveRecordArenaBytes reports the total record-arena capacity, in bytes,
+// that ReserveRecordArenas would take ON AN EMPTY CORE at sourceLen and
+// maxBytes. It allocates nothing. Callers use it to check a reserve against
+// a memory budget before they take it, and tests use it to pin the reserve's
+// arithmetic.
+//
+// The "empty core" qualifier is the whole contract. ReserveRecordArenas does
+// nothing at all when any arena already holds a record, and it keeps any
+// arena whose capacity is already large enough, so on a warm core this
+// function is an upper bound on the real cost rather than the real cost. It
+// deliberately reports the estimate itself, not the difference from the
+// core's current state, because a budget check wants to know what a fresh
+// parse of this source costs.
+func (c *Core) ReserveRecordArenaBytes(sourceLen int, maxBytes uint64) uint64 {
+	if c == nil || sourceLen <= 0 {
+		return 0
+	}
+	nodes := reserveRecordCount(sourceLen, reserveNodesPerKiB, c.limits.MaxNodes)
+	links := reserveRecordCount(sourceLen, reserveLinksPerKiB, c.limits.MaxLinks)
+	subtrees := reserveRecordCount(sourceLen, reserveSubtreesPerKiB, c.limits.MaxSubtrees)
+	children := reserveRecordCount(sourceLen, reserveChildrenPerKiB, c.limits.MaxChildren)
+	total := reserveTotalBytes(nodes, links, subtrees, children)
+	if maxBytes > 0 && total > maxBytes {
+		return reserveTotalBytes(
+			scaleReserveCount(nodes, maxBytes, total),
+			scaleReserveCount(links, maxBytes, total),
+			scaleReserveCount(subtrees, maxBytes, total),
+			scaleReserveCount(children, maxBytes, total),
+		)
+	}
+	return total
+}
+
+// reserveTotalBytes is the byte cost of one reserve. nodes counts twice
+// because nodes and nodeLineages are reserved to the same count.
+func reserveTotalBytes(nodes, links, subtrees, children int) uint64 {
+	return uint64(nodes)*coreNodeRecordBytes +
+		uint64(nodes)*coreNodeLineageRecordBytes +
+		uint64(links)*coreLinkRecordBytes +
+		uint64(subtrees)*coreSubtreeRecordBytes +
+		uint64(children)*coreChildRecordBytes
+}
+
+// reserveRecordCount converts a source length to a record count at the given
+// density, then clamps it to this family's configured Limits ceiling. The
+// parse can never publish more than the limit, so reserving past it would be
+// pure waste.
+func reserveRecordCount(sourceLen int, perKiB uint64, limit uint32) int {
+	if sourceLen <= 0 || perKiB == 0 || limit == 0 {
+		return 0
+	}
+	count := (uint64(sourceLen)*perKiB + 1023) / 1024
+	if count > uint64(limit) {
+		count = uint64(limit)
+	}
+	if count > math.MaxInt32 {
+		count = math.MaxInt32
+	}
+	return int(count)
+}
+
+// scaleReserveCount shrinks one arena's count by allowed/total, the same
+// factor every arena in the reserve gets.
+//
+// The product is taken at 128 bits. count is clamped to MaxInt32 and allowed
+// is a byte ceiling, so a 64-bit product cannot overflow for any ceiling this
+// package ships; computing it wide anyway keeps the result exact for any
+// ceiling a future caller passes.
+//
+// bits.Div64 cannot panic here. It panics only when the quotient would not
+// fit in 64 bits, and the guard above establishes allowed < total, so the
+// quotient is strictly below count, which is itself at most MaxInt32.
+func scaleReserveCount(count int, allowed, total uint64) int {
+	if count <= 0 || total == 0 || allowed >= total {
+		return count
+	}
+	hi, lo := bits.Mul64(uint64(count), allowed)
+	scaled, _ := bits.Div64(hi, lo, total)
+	return int(scaled)
+}
+
+// reserveArena returns an empty slice with at least want capacity, keeping
+// the caller's existing backing array whenever it is already large enough.
+func reserveArena[T any](arena []T, want int) []T {
+	if want <= 0 || cap(arena) >= want {
+		return arena
+	}
+	return make([]T, 0, want)
+}
+
+// RetentionCapBytesForTest exposes coreRetentionCapBytes so a caller in
+// another package can prove its own reserve ceiling stays strictly below the
+// size at which this core drops retained capacity.
+func RetentionCapBytesForTest() uint64 { return coreRetentionCapBytes }

--- a/internal/parsercorephase0/arena_reserve_test.go
+++ b/internal/parsercorephase0/arena_reserve_test.go
@@ -1,0 +1,190 @@
+package parsercorephase0
+
+import "testing"
+
+func reserveTestCore(t *testing.T, limits Limits) *Core {
+	t.Helper()
+	core, err := New(&fakeTable{}, limits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return core
+}
+
+func reserveTestLimits() Limits {
+	return Limits{
+		MaxNodes: 1 << 20, MaxLinks: 1 << 20, MaxSubtrees: 1 << 20,
+		MaxChildren: 4 << 20, MaxMetadata: 2 << 20,
+		MaxLinksPerBoundary: 8, MaxPopPaths: 1 << 16, MaxDerivations: 1 << 16,
+	}
+}
+
+// TestReserveRecordArenasTakesCapacityNotLength proves the reserve is a pure
+// capacity operation: every arena gains capacity and none gains a record.
+func TestReserveRecordArenasTakesCapacityNotLength(t *testing.T) {
+	core := reserveTestCore(t, reserveTestLimits())
+	const sourceLen = 235626
+	core.ReserveRecordArenas(sourceLen, 1<<30)
+
+	if got := len(core.nodes) + len(core.nodeLineages) + len(core.links) + len(core.subtrees) + len(core.children); got != 0 {
+		t.Fatalf("reserve published %d records, want 0", got)
+	}
+	if got := core.StorageBytes(); got != 0 {
+		t.Fatalf("reserve moved StorageBytes to %d, want 0", got)
+	}
+	want := map[string]int{
+		"nodes":        cap(core.nodes),
+		"nodeLineages": cap(core.nodeLineages),
+		"links":        cap(core.links),
+		"subtrees":     cap(core.subtrees),
+		"children":     cap(core.children),
+	}
+	for name, got := range want {
+		if got == 0 {
+			t.Fatalf("reserve left %s with zero capacity", name)
+		}
+	}
+	if cap(core.nodes) != cap(core.nodeLineages) {
+		t.Fatalf("nodes cap=%d nodeLineages cap=%d, want equal (appendNodeAt appends to both)",
+			cap(core.nodes), cap(core.nodeLineages))
+	}
+	// The densest canonical fixture publishes 7333 nodes per 10000 source
+	// bytes. The reserve must cover that density without growth.
+	if want := sourceLen * 7333 / 10000; cap(core.nodes) < want {
+		t.Fatalf("nodes cap=%d, want at least the densest measured fixture's %d", cap(core.nodes), want)
+	}
+}
+
+// TestReserveRecordArenaBytesMatchesFootprint proves the estimator a caller
+// checks against its budget reports what the reserve actually takes.
+func TestReserveRecordArenaBytesMatchesFootprint(t *testing.T) {
+	for _, sourceLen := range []int{1, 1024, 20168, 235626, 1 << 20} {
+		core := reserveTestCore(t, reserveTestLimits())
+		before := core.FootprintBytes()
+		want := core.ReserveRecordArenaBytes(sourceLen, 48<<20)
+		core.ReserveRecordArenas(sourceLen, 48<<20)
+		if got := core.FootprintBytes() - before; got != want {
+			t.Fatalf("sourceLen=%d footprint delta=%d, want ReserveRecordArenaBytes=%d", sourceLen, got, want)
+		}
+	}
+}
+
+// TestReserveRecordArenasHonorsMaxBytes proves the byte ceiling binds and that
+// the reserve keeps its shape when it does.
+func TestReserveRecordArenasHonorsMaxBytes(t *testing.T) {
+	const maxBytes = 8 << 20
+	core := reserveTestCore(t, reserveTestLimits())
+	core.ReserveRecordArenas(1<<20, maxBytes)
+	if got := core.FootprintBytes(); got > maxBytes {
+		t.Fatalf("reserve took %d bytes, want at most %d", got, maxBytes)
+	}
+	unclamped := reserveTestCore(t, reserveTestLimits())
+	if got := unclamped.ReserveRecordArenaBytes(1<<20, 0); got <= maxBytes {
+		t.Fatalf("unclamped reserve=%d, want more than the ceiling %d so this test proves the clamp", got, maxBytes)
+	}
+	// Shape: every arena keeps the same order relative to nodes.
+	if cap(core.nodes) != cap(core.nodeLineages) || cap(core.links) != cap(core.nodes) {
+		t.Fatalf("clamped reserve lost its shape: nodes=%d lineages=%d links=%d",
+			cap(core.nodes), cap(core.nodeLineages), cap(core.links))
+	}
+	if cap(core.subtrees) >= cap(core.nodes) || cap(core.children) >= cap(core.nodes) {
+		t.Fatalf("clamped reserve lost its shape: nodes=%d subtrees=%d children=%d",
+			cap(core.nodes), cap(core.subtrees), cap(core.children))
+	}
+}
+
+// TestReserveRecordArenasHonorsLimits proves a reserve never asks for capacity
+// the configured Limits would refuse to fill.
+func TestReserveRecordArenasHonorsLimits(t *testing.T) {
+	limits := reserveTestLimits()
+	limits.MaxNodes, limits.MaxLinks, limits.MaxSubtrees, limits.MaxChildren = 100, 200, 300, 400
+	core := reserveTestCore(t, limits)
+	core.ReserveRecordArenas(1<<20, 1<<30)
+	if cap(core.nodes) > 100 || cap(core.nodeLineages) > 100 {
+		t.Fatalf("nodes cap=%d lineages cap=%d, want at most MaxNodes=100", cap(core.nodes), cap(core.nodeLineages))
+	}
+	if cap(core.links) > 200 || cap(core.subtrees) > 300 || cap(core.children) > 400 {
+		t.Fatalf("links=%d subtrees=%d children=%d, want at most 200/300/400",
+			cap(core.links), cap(core.subtrees), cap(core.children))
+	}
+}
+
+// TestReserveRecordArenasOnlyGrows proves a reserve never drops retained
+// capacity a previous parse on the same core already earned, and never runs at
+// all once an arena holds records.
+func TestReserveRecordArenasOnlyGrows(t *testing.T) {
+	core := reserveTestCore(t, reserveTestLimits())
+	core.ReserveRecordArenas(235626, 1<<30)
+	big := cap(core.nodes)
+	core.ReserveRecordArenas(1024, 1<<30)
+	if cap(core.nodes) != big {
+		t.Fatalf("a smaller reserve shrank nodes cap from %d to %d", big, cap(core.nodes))
+	}
+
+	core.nodes = append(core.nodes, nodeRecord{})
+	core.nodeLineages = append(core.nodeLineages, nodeLineageRecord{})
+	linksBefore := cap(core.links)
+	core.ReserveRecordArenas(1<<20, 1<<30)
+	if cap(core.links) != linksBefore {
+		t.Fatalf("reserve ran on a non-empty core: links cap %d -> %d", linksBefore, cap(core.links))
+	}
+}
+
+// TestReserveRecordArenasIgnoresEmptyInput proves the degenerate inputs are
+// no-ops rather than panics.
+func TestReserveRecordArenasIgnoresEmptyInput(t *testing.T) {
+	core := reserveTestCore(t, reserveTestLimits())
+	core.ReserveRecordArenas(0, 1<<30)
+	core.ReserveRecordArenas(-1, 1<<30)
+	if got := core.FootprintBytes(); got != 0 {
+		t.Fatalf("reserve on empty input took %d bytes, want 0", got)
+	}
+	var nilCore *Core
+	nilCore.ReserveRecordArenas(1024, 1<<20)
+	if got := nilCore.ReserveRecordArenaBytes(1024, 1<<20); got != 0 {
+		t.Fatalf("nil core reserve estimate=%d, want 0", got)
+	}
+}
+
+// TestResetReleasingRetentionDropsTheReserve proves a declined attempt does
+// not leave its unfilled reserve billed to the cached core. The reserve is
+// taken before the seed, so every decline reason is discovered after it; and
+// the reserve is sized below coreRetentionCapBytes by construction, so the
+// size-gated release can never see it.
+func TestResetReleasingRetentionDropsTheReserve(t *testing.T) {
+	core := reserveTestCore(t, reserveTestLimits())
+	core.ReserveRecordArenas(235626, 24<<20)
+	reserved := core.FootprintBytes()
+	if reserved == 0 || reserved > coreRetentionCapBytes {
+		t.Fatalf("reserve footprint=%d, want non-zero and below the retention cap %d so this test proves the new rule",
+			reserved, uint64(coreRetentionCapBytes))
+	}
+	if err := core.ResetReleasingRetention(); err != nil {
+		t.Fatal(err)
+	}
+	for name, got := range map[string]int{
+		"nodes": cap(core.nodes), "nodeLineages": cap(core.nodeLineages),
+		"links": cap(core.links), "subtrees": cap(core.subtrees), "children": cap(core.children),
+	} {
+		if got != 0 {
+			t.Fatalf("decline kept %s capacity %d, want 0", name, got)
+		}
+	}
+	if got := core.FootprintBytes(); got >= reserved {
+		t.Fatalf("decline kept footprint %d, want below the reserved %d", got, reserved)
+	}
+}
+
+// TestResetKeepsTheReserve proves the plain accepted-path Reset still keeps
+// arena capacity for reuse. Only the decline path drops it.
+func TestResetKeepsTheReserve(t *testing.T) {
+	core := reserveTestCore(t, reserveTestLimits())
+	core.ReserveRecordArenas(235626, 24<<20)
+	want := cap(core.nodes)
+	if err := core.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	if got := cap(core.nodes); got != want {
+		t.Fatalf("accepted-path reset changed nodes capacity %d -> %d", want, got)
+	}
+}

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1425,19 +1425,24 @@ func (c *Core) Reset() error {
 }
 
 // ResetReleasingRetention performs the same truncation as Reset, then drops
-// any growable family's backing array whose combined FootprintBytes exceeds
-// coreRetentionCapBytes (releaseOversizedRetention). Reset alone preserves
-// capacity for legitimate reuse across repeated large-file parses -- the
-// routine "clear the slate before the next attempt" call every fresh parse
-// makes through the admission-candidate runner. This variant is for decline
-// paths specifically: a just-declined attempt's retained capacity has no
-// future value, and keeping it would otherwise stay billed to every later
+// retained capacity in two steps: every record arena ReserveRecordArenas
+// reserves goes unconditionally (releaseRecordArenaReserve), and every other
+// growable family goes when the combined FootprintBytes that remains still
+// exceeds coreRetentionCapBytes (releaseOversizedRetention). Reset alone
+// preserves capacity for legitimate reuse across repeated large-file parses
+// -- the routine "clear the slate before the next attempt" call every fresh
+// parse makes through the admission-candidate runner. This variant is for
+// decline paths specifically: a just-declined attempt's retained capacity has
+// no future value, and keeping it would otherwise stay billed to every later
 // unrelated parse on the same cached runner regardless of that parse's own
-// size (tranche B9 retention-cap gate).
+// size (tranche B9 retention-cap gate). The record arenas need the stronger
+// unconditional rule because a reserve is sized below the retention cap by
+// construction, so the size gate alone can never see it.
 func (c *Core) ResetReleasingRetention() error {
 	if err := c.Reset(); err != nil {
 		return err
 	}
+	c.releaseRecordArenaReserve()
 	c.releaseOversizedRetention()
 	return nil
 }

--- a/internal/parsercorephase0/storage_bytes.go
+++ b/internal/parsercorephase0/storage_bytes.go
@@ -220,6 +220,40 @@ const coreRetentionCapBytes = 48 << 20 // 48 MiB
 // capacity for legitimate reuse across repeated large-file parses. Dropping
 // unconditionally on every reset would instead force full reallocation on
 // every large-fixture benchmark iteration.
+// releaseRecordArenaReserve drops the backing array of every record arena
+// ReserveRecordArenas reserves, unconditionally and regardless of size.
+//
+// This is the decline-path counterpart of the reserve. The reserve is taken
+// from the source length before the seed publishes anything, because that is
+// the only point where it can remove the growth series it exists to remove;
+// but every decline reason is discovered after that point, so a declined
+// attempt leaves a full source-proportional reserve behind that it never
+// filled. releaseOversizedRetention alone cannot reclaim it: that gate
+// compares total FootprintBytes against coreRetentionCapBytes, and a reserve
+// is deliberately sized below that cap, so the whole reserve of a declined
+// parse would otherwise stay billed to the cached runner until some later
+// parse on the same Parser happened to clear the cap.
+//
+// Dropping unconditionally is right here for the same reason the surrounding
+// gate exists at all: a just-declined attempt's retained capacity has no
+// future value, and the caller is already running its production fallback
+// beside it. The cost of being wrong is one reserve on the next parse, which
+// is one allocation per arena -- the same allocation that parse would take
+// anyway on a cold core.
+//
+// Call this only after Reset, from a decline path. It assumes every tracked
+// length is already zero.
+func (c *Core) releaseRecordArenaReserve() {
+	if c == nil {
+		return
+	}
+	c.nodes = nil
+	c.nodeLineages = nil
+	c.links = nil
+	c.subtrees = nil
+	c.children = nil
+}
+
 func (c *Core) releaseOversizedRetention() {
 	if c == nil || c.FootprintBytes() <= coreRetentionCapBytes {
 		return

--- a/parsercore_phase0_arena_reserve.go
+++ b/parsercore_phase0_arena_reserve.go
@@ -1,0 +1,75 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+// compactArenaReserveCapBytes bounds how much record-arena capacity one parse
+// may reserve up front (Core.ReserveRecordArenas,
+// internal/parsercorephase0/arena_reserve.go).
+//
+// It is half the compact core's own retention cap (coreRetentionCapBytes, 48
+// MiB, internal/parsercorephase0/storage_bytes.go). Staying strictly below
+// that cap matters: releaseOversizedRetention compares the core's TOTAL
+// FootprintBytes against it, so a core born at a full 48 MiB reserve would
+// already be oversized by the project's own standard and would lose its
+// arenas on the next decline. Retention would then stop being monotonic in
+// source length -- a 400 KB source would keep its arenas while a 600 KB
+// source lost them. At 24 MiB a maximum reserve leaves room for the boundary
+// index, the checkpoint interner, and the scratch families before the
+// retention cap can trip on capacity the reserve took.
+//
+// 24 MiB also covers every canonical fixture whole: the largest, at 235,626
+// bytes, estimates 21.3 MiB. The cap starts to bind at roughly 265 KB of
+// source. Past that the reserve stays flat, so a large source starts from a
+// bounded base and grows the rest, which is still far cheaper than growing
+// the whole arena from zero.
+const compactArenaReserveCapBytes = 24 << 20
+
+// compactArenaReserveBudgetDivisor bounds the reserve as a fraction of every
+// memory limit the scheduler polls. Core.FootprintBytes gauges capacity, not
+// live length, and the scheduler's stop-control poll compares that one gauge
+// against BOTH the caller's soft budget and production's absolute hard
+// ceiling (stopControlMemoryBudgetReason, parsercore_phase0_driver.go). A
+// reserve therefore raises the gauge immediately, at construction, before
+// the parse publishes one record.
+//
+// Dividing by eight bounds that effect against each armed limit
+// independently: whatever the configured budget and ceiling are, the reserve
+// can add at most one eighth of the smaller one to the gauge, so a parse
+// that completes today still has at least seven eighths of every limit left
+// after the reserve. At the shipped defaults (512 MB budget, 2 GB ceiling)
+// the 24 MiB cap binds first and the real share is 4.7% of the budget.
+const compactArenaReserveBudgetDivisor = 8
+
+// compactArenaReserveBytes reports the record-arena reserve ceiling for a
+// parse whose soft memory budget is budgetBytes and whose absolute hard
+// ceiling is hardCeilingBytes.
+//
+// Both limits are honored, and each independently, because the scheduler
+// arms them independently: parseMemoryHardCeilingBytes stays on even when a
+// caller sets GOT_PARSE_MEMORY_BUDGET_MB to zero
+// (parsercore_phase0_fresh_full_runner.go), and stopControlMemoryBudgetReason
+// tests the same footprint gauge against each. A limit at or below zero is
+// not armed and does not constrain the reserve; when neither is armed (the
+// diagnostic and benchmark runners arm neither) only the absolute cap
+// applies.
+func compactArenaReserveBytes(budgetBytes, hardCeilingBytes int64) uint64 {
+	reserve := uint64(compactArenaReserveCapBytes)
+	for _, limit := range [2]int64{budgetBytes, hardCeilingBytes} {
+		if limit <= 0 {
+			continue
+		}
+		if share := uint64(limit) / compactArenaReserveBudgetDivisor; share < reserve {
+			reserve = share
+		}
+	}
+	return reserve
+}
+
+// sourceLength reports the byte length of the source this token source lexes,
+// or zero when it has none. It is the reserve estimator's only input.
+func (d *dfaTokenSource) sourceLength() int {
+	if d == nil || d.lexer == nil {
+		return 0
+	}
+	return len(d.lexer.source)
+}

--- a/parsercore_phase0_arena_reserve_internal_test.go
+++ b/parsercore_phase0_arena_reserve_internal_test.go
@@ -1,0 +1,157 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// TestCompactArenaReserveBytesStaysUnderBudget proves the record-arena reserve
+// can never take a share of the caller's soft memory budget large enough to
+// decline a parse that would otherwise complete. Core.FootprintBytes gauges
+// capacity, so the reserve raises the scheduler's budget gauge immediately, at
+// construction; this is the bound that makes that safe.
+func TestCompactArenaReserveBytesStaysUnderBudget(t *testing.T) {
+	limits := []int64{
+		1 << 20,   // 1 MiB
+		16 << 20,  // 16 MiB
+		40 << 20,  // below the absolute cap, so the divisor governs
+		96 << 20,  // the tranche B9 witness budget
+		512 << 20, // the shipped default soft budget
+		2048 << 20,
+	}
+	// Every armed limit constrains the reserve, and each independently: the
+	// scheduler polls one FootprintBytes gauge against BOTH the soft budget
+	// and the hard ceiling, and parseMemoryHardCeilingBytes stays armed even
+	// when a caller disables the soft budget.
+	for _, budget := range limits {
+		for _, ceiling := range limits {
+			reserve := compactArenaReserveBytes(budget, ceiling)
+			for name, limit := range map[string]int64{"budget": budget, "ceiling": ceiling} {
+				if reserve > uint64(limit)/compactArenaReserveBudgetDivisor {
+					t.Fatalf("budget=%d ceiling=%d reserve=%d, want at most one %dth of the %s %d",
+						budget, ceiling, reserve, compactArenaReserveBudgetDivisor, name, limit)
+				}
+			}
+			if reserve > compactArenaReserveCapBytes {
+				t.Fatalf("budget=%d ceiling=%d reserve=%d, want at most the absolute cap %d",
+					budget, ceiling, reserve, uint64(compactArenaReserveCapBytes))
+			}
+		}
+	}
+	// A hard ceiling alone constrains the reserve even when no soft budget is
+	// armed. This is the case a soft-budget-only ceiling used to miss: it let
+	// the reserve trip the hard-ceiling poll before the seed published one
+	// record, which declined a parse the compact route served before.
+	for _, ceiling := range []int64{16 << 20, 32 << 20, 40 << 20, 48 << 20} {
+		got := compactArenaReserveBytes(0, ceiling)
+		if want := uint64(ceiling) / compactArenaReserveBudgetDivisor; got != min(want, uint64(compactArenaReserveCapBytes)) {
+			t.Fatalf("ceiling-only reserve at %d = %d, want %d", ceiling, got, want)
+		}
+	}
+	// The shipped defaults: the absolute cap binds before either limit.
+	if got := compactArenaReserveBytes(512<<20, 2048<<20); got != compactArenaReserveCapBytes {
+		t.Fatalf("shipped-default reserve=%d, want the absolute cap %d", got, uint64(compactArenaReserveCapBytes))
+	}
+	// Neither limit armed (the diagnostic and benchmark runners arm neither):
+	// only the absolute cap applies.
+	for _, limit := range []int64{0, -1} {
+		if got := compactArenaReserveBytes(limit, limit); got != compactArenaReserveCapBytes {
+			t.Fatalf("unarmed reserve at %d = %d, want the absolute cap %d", limit, got, uint64(compactArenaReserveCapBytes))
+		}
+	}
+}
+
+// TestCompactArenaReserveStaysBelowCoreRetentionCap proves the reserve cannot
+// on its own make a core oversized by the compact core's own retention
+// standard. releaseOversizedRetention compares TOTAL FootprintBytes against
+// coreRetentionCapBytes, so a reserve at or above that cap would make every
+// maximum-size core born oversized and would make retention non-monotonic in
+// source length.
+func TestCompactArenaReserveStaysBelowCoreRetentionCap(t *testing.T) {
+	if compactArenaReserveCapBytes >= core.RetentionCapBytesForTest() {
+		t.Fatalf("reserve cap=%d, want strictly below the core retention cap %d",
+			uint64(compactArenaReserveCapBytes), core.RetentionCapBytesForTest())
+	}
+}
+
+// TestCompactArenaReserveNeverExceedsCeilingAtAnySourceLength walks the source
+// lengths a caller can actually present, from one byte to a hundred megabytes,
+// and proves the reserve the compact core would take stays inside the ceiling
+// at every one of them.
+func TestCompactArenaReserveNeverExceedsCeilingAtAnySourceLength(t *testing.T) {
+	lang, err := LoadLanguage(parserCoreCertifiedGoBlob)
+	if err != nil {
+		t.Skip(err)
+	}
+	tables, err := newParserCoreRootTables(NewParser(lang))
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact, err := core.New(tables, admissionCandidateLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	const defaultBudget = int64(512) << 20
+	const defaultHardCeiling = int64(2048) << 20
+	ceiling := compactArenaReserveBytes(defaultBudget, defaultHardCeiling)
+	lengths := []int{
+		1, 1 << 10, 5116, 20168, 41387, 235626, 484021,
+		1 << 20, 8 << 20, 100 << 20,
+	}
+	for _, sourceLen := range lengths {
+		reserve := compact.ReserveRecordArenaBytes(sourceLen, ceiling)
+		if reserve > ceiling {
+			t.Fatalf("sourceLen=%d reserve=%d, want at most the ceiling %d", sourceLen, reserve, ceiling)
+		}
+		if int64(reserve) >= defaultBudget {
+			t.Fatalf("sourceLen=%d reserve=%d clears the default budget %d", sourceLen, reserve, defaultBudget)
+		}
+	}
+	// The same sweep against a lowered hard ceiling with the soft budget left
+	// at its default. The ceiling arms independently, so it must still bound
+	// the reserve on its own.
+	for _, hardCeiling := range []int64{16 << 20, 32 << 20, 40 << 20, 48 << 20} {
+		lowered := compactArenaReserveBytes(defaultBudget, hardCeiling)
+		for _, sourceLen := range lengths {
+			if reserve := compact.ReserveRecordArenaBytes(sourceLen, lowered); int64(reserve)*compactArenaReserveBudgetDivisor > hardCeiling {
+				t.Fatalf("hardCeiling=%d sourceLen=%d reserve=%d, want at most one %dth of the ceiling",
+					hardCeiling, sourceLen, reserve, compactArenaReserveBudgetDivisor)
+			}
+		}
+	}
+	// The largest file in the project's own curated real corpus is 484,021
+	// bytes. Its reserve must stay well inside the default budget, with room
+	// for the parse the reserve exists to serve.
+	if reserve := compact.ReserveRecordArenaBytes(484021, ceiling); reserve*4 > uint64(defaultBudget) {
+		t.Fatalf("largest real-corpus reserve=%d, want under a quarter of the default budget %d", reserve, defaultBudget)
+	}
+}
+
+// TestDFATokenSourceSourceLength proves the reserve estimator's only input
+// reads the real source length and stays safe on the degenerate receivers.
+func TestDFATokenSourceSourceLength(t *testing.T) {
+	var nilSource *dfaTokenSource
+	if got := nilSource.sourceLength(); got != 0 {
+		t.Fatalf("nil token source length=%d, want 0", got)
+	}
+	if got := (&dfaTokenSource{}).sourceLength(); got != 0 {
+		t.Fatalf("lexer-free token source length=%d, want 0", got)
+	}
+	lang, err := LoadLanguage(parserCoreCertifiedGoBlob)
+	if err != nil {
+		t.Skip(err)
+	}
+	source := []byte("package p\n\nfunc main() {}\n")
+	parser := NewParser(lang)
+	tokenSource := parser.acquireParserDFATokenSource(source)
+	if tokenSource == nil {
+		t.Fatal("production DFA token source unavailable")
+	}
+	defer tokenSource.Close()
+	if got := tokenSource.sourceLength(); got != len(source) {
+		t.Fatalf("token source length=%d, want %d", got, len(source))
+	}
+}

--- a/parsercore_phase0_canonical_admission_internal_test.go
+++ b/parsercore_phase0_canonical_admission_internal_test.go
@@ -259,11 +259,7 @@ func TestDiagnosticParserCoreBoundaryIndexCensus(t *testing.T) {
 			var scannerScratch []byte
 			scheduler, err := executeDiagnosticParserCoreGenericSchedulerFromSeed(
 				compact, tokenSource, &scannerScratch, lang.InitialState,
-				DiagnosticParserCorePrefixOptions{
-					ReceiptMode: DiagnosticParserCoreReceiptSummary,
-					MaxTokens:   300000, MaxDispatches: 600000,
-					Limits: diagnosticParserCoreCanonicalLimits(),
-				},
+				diagnosticParserCoreCanonicalSeedOptions(lang),
 				observer,
 			)
 			if err != nil {
@@ -298,11 +294,7 @@ func BenchmarkDiagnosticParserCoreCanonicalSchedulerCold(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			options := DiagnosticParserCorePrefixOptions{
-				ReceiptMode: DiagnosticParserCoreReceiptSummary,
-				MaxTokens:   300000, MaxDispatches: 600000,
-				Limits: diagnosticParserCoreCanonicalLimits(),
-			}
+			options := diagnosticParserCoreCanonicalSeedOptions(lang)
 			var scannerScratch []byte
 			b.ReportAllocs()
 			b.SetBytes(int64(len(fixture.Source)))
@@ -375,6 +367,33 @@ func diagnosticParserCoreCanonicalLimits() core.Limits {
 		MaxChildren: 4 << 20, MaxMetadata: 2 << 20,
 		MaxLinksPerBoundary: 8, MaxPopPaths: 1 << 16, MaxDerivations: 1 << 16,
 	}
+}
+
+// diagnosticParserCoreCanonicalSeedOptions builds the prefix options for the
+// canonical instruments that seed the generic scheduler themselves rather
+// than call DiagnosticParseParserCorePrefix.
+//
+// allowConvergedSplitDropArtifact is the load-bearing field. The driver sets
+// it from the language's own certification record
+// (lang.CompactConvergedReductionSplitDropsCertified,
+// parsercore_phase0_driver.go), so every route that goes through
+// DiagnosticParseParserCorePrefix or the admission-candidate runner carries
+// it. An instrument that builds its own option literal and seeds
+// executeDiagnosticParserCoreGenericSchedulerFromSeed directly bypasses that
+// seam. Without this field the certified Go grammar's converged-path
+// reduction split no-action drop fails the alternative-set coverage proof
+// (dropGenericNoActionHeads) and every canonical fixture declines, so the
+// instrument measures nothing at all.
+func diagnosticParserCoreCanonicalSeedOptions(lang *Language) DiagnosticParserCorePrefixOptions {
+	options := DiagnosticParserCorePrefixOptions{
+		ReceiptMode: DiagnosticParserCoreReceiptSummary,
+		MaxTokens:   300000, MaxDispatches: 600000,
+		Limits: diagnosticParserCoreCanonicalLimits(),
+	}
+	if lang != nil {
+		options.allowConvergedSplitDropArtifact = lang.CompactConvergedReductionSplitDropsCertified
+	}
+	return options
 }
 
 func loadDiagnosticParserCoreCanonicalFixture(t testing.TB, id string) DiagnosticParserCoreCanonicalFixtureForTest {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2408,6 +2408,20 @@ func executeDiagnosticParserCoreGenericSchedulerFromSeedInto(
 	if err := compact.SetPhaseCheckpoint(initialCheckpointID); err != nil {
 		return nil, err
 	}
+	// Reserve the five record arenas from the source length before the seed
+	// publishes the first node, so a cold parse starts at its expected
+	// capacity instead of growing there from zero. The ceiling comes from
+	// compactArenaReserveBytes (parsercore_phase0_arena_reserve.go); the
+	// estimator is Core.ReserveRecordArenas
+	// (internal/parsercorephase0/arena_reserve.go). This is the one seam
+	// every compact route passes through: the shipped admission-candidate
+	// route, the diagnostic prefix route, and the benchmark runners all reach
+	// the scheduler here. Pure capacity -- no length, no record, and no Work
+	// counter moves -- so it cannot change a parse result.
+	compact.ReserveRecordArenas(
+		tokenSource.sourceLength(),
+		compactArenaReserveBytes(options.stopControlMemoryBudgetBytes, options.stopControlHardCeilingBytes),
+	)
 	head, err := compact.Seed(core.StateID(initialState), 0)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What this changes

Presize the compact core's five record arenas — `nodes`, `nodeLineages`, `links`, `subtrees`, `children` — from the source length at the scheduler seed, so a first parse starts at its expected capacity instead of growing there from zero.

Go grows a large slice by about 1.25x. An arena that ends at S bytes therefore allocates 4.5-5.3x S cumulatively and copies about 4x S through `growslice`. A first parse on a fresh `Parser` grew all five arenas from zero, and that growth series was the dominant allocation cost of the parse.

The reserve is **pure capacity**. It changes no length, no record, no identifier, and no `Work` counter, so it cannot change a parse result.

> **Revision note.** This body is rewritten after review. Three things changed in the code — the reserve now honors the hard ceiling as well as the soft budget, the absolute cap dropped from 48 MiB to 24 MiB, and the decline path now drops the reserve unconditionally — and the cost section below is restated on the real corpus rather than on the four Go fixtures alone. Corrections to earlier claims are marked **[corrected]**.

## The win: sources the compact route serves

First parse on a fresh `Parser` through the shipped route, exact `runtime.MemStats` deltas, four interleaved A/B rounds against the merge base, process pools warm.

| fixture | source bytes | cumulative before | after | delta | allocs | GCs | wall (ms) |
|---|---|---|---|---|---|---|---|
| rewrite | 5,116 | 1,652,696 | 817,112 | **-50.6%** | 274 → 208 | 0 → 0 | 2.7 → 2.4 |
| query_compile | 20,168 | 9,019,848 | 2,480,584 | **-72.5%** | 330 → 236 | 0 → 0 | 14.3 → 10.7 |
| language | 41,387 | 9,137,936 | 4,613,904 | **-49.5%** | 383 → 289 | 0 → 0 | 14.1 → 12.4 |
| grammargen_lr | 235,626 | 103,662,080 | 26,300,264 | **-74.6%** | 584 → 439 | 2 → 0 | 142.5 → 121.5 |

Scheduler-only cold benchmark (`BenchmarkDiagnosticParserCoreCanonicalSchedulerCold`, no materialization): rewrite -28.3%, query_compile -62.5%, language -38.8%, grammargen_lr -70.7% B/op.

Real-corpus files the compact route serves, cold `TotalAlloc`, 79 files: **1,352,279,880 → 872,735,136, -48.0%**. Largest single win: `zig/large__x86.zig` (483,491 bytes) -129,566,984 B, -40.8%.

## The cost: sources the compact route declines

The reserve is taken before the seed, because that is the only point where it can remove the growth series. Every decline reason in this codebase is discovered after that point. A declined parse therefore pays for a reserve it never fills, and **43% of the real corpus declines**.

Measured cold `TotalAlloc` across all 146 real-corpus files, reproducible to under 0.1%:

| subset | files | before | after | delta |
|---|---|---|---|---|
| compact served | 79 | 877,384,088 | 455,839,416 | **-48.0%** |
| compact declined | 67 | 1,958,739,824 | 2,143,481,880 | **+9.4%** |
| **whole corpus** | **146** | **2,836,123,912** | **2,599,321,296** | **-8.3%** |

Worst individual regressions, all declined, each delta within a few percent of that file's own reserve:

| file | bytes | delta |
|---|---|---|
| typescript/large__parser.ts | 376,385 | +25,048,488 (+300.8%) |
| d/large__date.d | 433,122 | +24,933,352 (+26.0%) |
| julia/large__abstractinterpretation.jl | 224,616 | +21,234,536 (+5.8%) |
| c/large__cluster.c | 216,674 | +20,625,952 (+42.0%) |

The headline "-50% to -75%" is the served case. **The real-corpus aggregate is -8.3%.**

### Retained memory

Twenty long-lived `Parser`s, each parsing one file once, heap measured after two forced collections:

| file | route | HeapAlloc before | after | Sys | TotalAlloc |
|---|---|---|---|---|---|
| d/large__date.d | declines | 135,263,480 | 132,880,520 (-1.8%) | +23.2% | +138.0% |
| zig/large__x86.zig | serves | 1,280,853,528 | 1,149,127,800 (**-10.3%**) | **-19.4%** | **-42.4%** |
| go/large__proc.go | serves | 221,828,976 | 280,963,680 (+26.7%) | **-20.1%** | **-65.8%** |
| css/large__github.com.css | serves | 200,763,048 | 318,890,840 (+58.8%) | +6.3% | **-58.9%** |

Review found the declined case retaining **+607%** heap, because `releaseOversizedRetention` drops backing arrays only above 48 MiB and a reserve is sized below that by construction. The decline path now drops every record arena unconditionally, which is why `d/large__date.d` above reads **-1.8%** instead. The declined case still allocates its reserve and throws it away: that is the +138% `TotalAlloc` in that row, and it is the residual cost of taking the reserve before the route can decline.

For served sources the honest trade is: dense sources win on every axis; sparse sources trade retained heap for a large cut in allocation rate and, usually, in `Sys`. A synthetic comment-only Go file at 520 KB — density far below any real fixture — retains 5.0x more heap while its allocation rate falls; that is the worst shape this reserve has, and the 24 MiB cap bounds it.

## How the estimate is derived

Census of the four canonical Go fixtures, which span the measured density range of real Go source:

| fixture | nodes/byte | links/byte | subtrees/byte | children/byte |
|---|---|---|---|---|
| rewrite | 0.5878 | 0.5876 | 0.5129 | 0.5409 |
| query_compile | 0.7333 | 0.7333 | 0.6489 | 0.6820 |
| language | 0.3655 | 0.3654 | 0.3153 | 0.3472 |
| grammargen_lr | 0.6356 | 0.6356 | 0.5562 | 0.5979 |

Each per-arena constant sits just above its densest fixture: 0.7500 nodes and links, 0.6641 subtrees, 0.7129 children, expressed as records per 1024 bytes so the arithmetic is exact integer math. `nodes` and `nodeLineages` share one count because `appendNodeAt` appends to both, one for one. About 95 slab bytes per source byte.

## Memory-gauge interaction

`Core.FootprintBytes` gauges `cap()`, not live length, and the scheduler's stop-control poll compares that one gauge against **two** limits: the caller's soft budget and production's absolute hard ceiling. The two arm independently — `parseMemoryHardCeilingBytes` stays on even when a caller sets `GOT_PARSE_MEMORY_BUDGET_MB=0`.

**[corrected]** The first revision took only the soft budget, so its "one eighth" invariant did not hold for the hard ceiling, and the reserve tripped the ceiling poll before the seed published a record. Reproduced by review on a 520,052-byte low-density Go source at the default soft budget: at `GOT_PARSE_MEMORY_HARD_CEILING_MB=40`, `32` and `16` the base routed and the PR fell back with `scheduler stop-control tripped: memory_budget`.

`compactArenaReserveBytes` now takes both limits and applies the divisor to each armed one:

| hard ceiling | base | this PR | reserve ceiling |
|---|---|---|---|
| 48 MB | routed | routed | 6.00 MiB |
| 40 MB | routed | routed | 5.00 MiB |
| 32 MB | routed | routed | 4.00 MiB |
| 16 MB | routed | routed | 2.00 MiB |

Three ceilings bound the reserve: an absolute 24 MiB cap, one eighth of the soft budget, one eighth of the hard ceiling. At the shipped defaults (512 MB budget, 2 GB ceiling) the absolute cap binds, at **4.69% of the budget and 1.17% of the ceiling**.

**[corrected]** The cap was 48 MiB and its rationale said a reserve at the cap is "capacity the core would hold anyway". That was wrong: `releaseOversizedRetention` compares **total** `FootprintBytes` against `coreRetentionCapBytes`, so a core born at a full 48 MiB reserve is already oversized by the project's own standard and loses its arenas on the next decline — retention would stop being monotonic in source length. The cap is now **24 MiB**, strictly below the retention cap, and a test pins that relation. All four canonical fixtures still reserve whole (the largest estimates 21.36 MiB), so none of the numbers above moved.

Reserve at the shipped defaults for the largest file of each language in the curated real corpus: json5/zig/d/typescript/ocaml all clamp at 24.00 MiB (4.69% of budget); javascript 22.43 MiB; powershell 20.50; julia 20.37; c 19.65; java 16.34; go 10.77. The clamp starts to bind at about 265 KB of source and the reserve is flat past it, verified to 100 MB.

## Instrument fix

`BenchmarkDiagnosticParserCoreCanonicalSchedulerCold` and `TestDiagnosticParserCoreBoundaryIndexCensus` failed on **all four** canonical fixtures before this change, with `converged-path reduction split no-action drop lacks alternative-set coverage`. Both built their own option literal and seeded the generic scheduler directly, which bypasses the seam that sets `allowConvergedSplitDropArtifact` from the language's certification record. Without it the certified Go grammar's converged-path reduction split fails the alternative-set coverage proof and every fixture declines, so the instruments measured nothing. Both now build options through one shared helper. This fix stands on its own.

## Editor latency

**[corrected]** Re-measured on a far quieter host (load average 5-6, against 8-12 at review time), three interleaved rounds, 324 paired samples per metric.

| metric | p50 | p90 | p95 | p99 | mean |
|---|---|---|---|---|---|
| incremental edit | -1.4% | -8.2% | -0.1% | -3.5% | -2.9% |
| fresh full parse | +0.3% | -3.7% | -4.2% | -6.5% | -2.5% |

The cold reserve does not cost first-parse latency. The p50 is flat and the tail improves. Every W5 identity and reuse counter is identical; `scratchBytes` varies between runs on both sides and is pre-existing nondeterminism.

## Warm path

The pinned scheduler-only ratchet is **208 B/op, 6 allocs/op on both sides**. `BenchmarkDiagnosticParserCoreWarmTotalQueryCompile` reads 280 / 288 / 284-288 B/op at 100x / 400x / 800x on both sides.

**[corrected]** The earlier claim that the shipped warm route improves from 6,266-6,391 to 3,273-3,277 B/op does not reproduce. It was an artifact of amortizing one cold parse over 50 iterations. Warm is unchanged, not improved.

## Tranche B9 cumulative-allocation contract

| measurement | base | this PR |
|---|---|---|
| production pinned | 3.24x budget | 3.23x budget |
| shipped route | 8.18x budget | **7.53x budget** |

The saving is deterministic at -65.8 MB per run. It does **not** bring the replica inside the production 6x contract.

**[corrected]** The residual is not simply "production's fallback". The PR's 7.53x decomposes as **3.23x production plus 4.30x compact attempt**, so the compact attempt is still the larger single contributor. Base decomposes as 3.24x plus 4.94x.

## Gates

- Four canonical `deepTreeSHA256` digests **byte-identical**; an independent structural digest over kind, name flag, missing flag, error flag and byte span also matches on all four.
- All 146 real-corpus files: **zero digest drift, zero routing drift**.
- Exact `core.Work` rows per fixture unchanged.
- `go test .`, `go test ./parser_result_test/...`, `go test ./grammars`, `go test ./internal/parsercorephase0/`: pass.
- 206-language admission scorecard: **exact**, 201 rows identical including per-language digests.
- W5 gates: all pass.
- Race detector on the touched paths and on `internal/parsercorephase0`: clean.
- The `gts_parsercorephase0` tagged lane's failure set is a strict subset of main's: `TestDiagnosticParserCoreBoundaryIndexCensus` turns green, nothing new fails.
- The library builds and vets clean under `-tags gts_no_parsercorephase0`. `cmd/c4tablestats` does not build under that tag on main either; that is pre-existing and unrelated.

## New surface

`Core.ReserveRecordArenas` and `Core.ReserveRecordArenaBytes` in `internal/parsercorephase0`. The second allocates nothing and reports what the first would take **on an empty core** — the qualifier matters, since the reserve does nothing on a core that already holds records and keeps any capacity already large enough, so on a warm core it is an upper bound. `scaleReserveCount` takes its product at 128 bits. Eight unit tests pin the arithmetic and the invariants, including that a decline drops the reserve and that a plain accepted-path `Reset` keeps it.

## Not included

Census-sizing the materialization tree arena and the replay-state buffers was measured and left out. `fullArenaPool` is process-global, so its cost is a pool fill rather than a per-parse cost. Measured on grammargen_lr in a fresh process: the first-parse premium is 22,829,408-22,829,584 B on base and 22,814,000-22,821,864 B here — the same within 0.07%, **[corrected]** not byte-identical, and review measured a different witness where the PR premium was 569,120 B higher. `compactReplayStatePool` is a `sync.Pool`, so its share recurs at GC cadence rather than once per process. Presizing these needs the production arena estimator, which is parser-flag dependent and carries its own gauge interaction. It deserves its own change.

Option (a) from review — reserve a fraction up front and top up once the route survives a prefix — is the change that would remove the declined-file cost entirely. It needs a top-up seam inside the dispatch loop and its own correctness argument, so it is deliberately not attempted here.
