### PR TITLE
add(outline): add a per-language outline-symbol coverage census

### DIFF
--- a/grammars/outline_census.go
+++ b/grammars/outline_census.go
@@ -1,0 +1,316 @@
+package grammars
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// OutlineTier is the computed coverage classification for one registered
+// language, per spec.outline-api.v1 section 5. Every language falls into
+// exactly one tier; nothing here is hand-maintained -- the census computes
+// it fresh from the registry, the inferred tags-query table, and (when
+// present) an external real-source corpus.
+type OutlineTier string
+
+const (
+	// OutlineTierOne: the inferred tags query is non-empty AND a real
+	// per-language corpus is present on this host and holds at least one
+	// file matching the language's registered extensions.
+	OutlineTierOne OutlineTier = "T1"
+	// OutlineTierOneUnmeasured: the inferred tags query is non-empty, but
+	// the real-corpus root itself is absent on this host, so T1 versus T2
+	// cannot be decided here. This tier exists so a missing corpus is
+	// reported honestly instead of silently folded into T2.
+	OutlineTierOneUnmeasured OutlineTier = "T1_unmeasured"
+	// OutlineTierTwo: the inferred tags query is non-empty and, on a host
+	// where the real-corpus root is present, this language has no matching
+	// real-corpus file. Fixture = the language's dedicated smoke sample.
+	OutlineTierTwo OutlineTier = "T2"
+	// OutlineTierThree: the inferred tags query is empty, but the grammar
+	// defines at least one candidate definition-shape node type drawn from
+	// the inference pattern table -- the promotion backlog. Remediation is
+	// a data edit to inferredTagsQueryPatterns/inferredTagsQueryOverrides,
+	// never a code branch.
+	OutlineTierThree OutlineTier = "T3"
+	// OutlineTierFour: the inferred tags query is empty and the grammar
+	// defines none of the inference table's candidate definition-shape node
+	// types. Declined with a receipt; nothing to promote without new data.
+	OutlineTierFour OutlineTier = "T4"
+)
+
+// outlineRealCorpusRootEnv overrides the real-corpus root. This matches the
+// convention every other real-corpus test in this repository already uses
+// (grammargen/dfa_minimize_parity_test.go, parser_recover_cycle_sweep_test.go,
+// grammars/csharp_external_lex_states_regression_test.go): an external
+// sibling checkout, not an in-repo path. cgo_harness/corpus_sources/<name>
+// (the path spec.outline-api.v1 section 5 names) corresponds to submodule
+// registrations that exist only in local, uncommitted .git/config state on
+// some hosts -- no .gitmodules is tracked and no gitlink entries exist in
+// the tree, so that path is never populated by a plain clone. The working,
+// already-adopted mechanism is this env var, defaulting to a sibling
+// checkout of the gotreesitter-corpora repository.
+const outlineRealCorpusRootEnv = "GOT_CORPUS_SOURCES_ROOT"
+
+// outlineRealCorpusWalkBudget bounds the per-language directory walk so one
+// large corpus checkout cannot make the census slow. Every corpus this repo
+// pulls from is a language's own grammar-source repository, so a matching
+// file is expected within the first few hundred entries; this budget is
+// headroom, not a fit to any single corpus's size.
+const outlineRealCorpusWalkBudget = 50000
+
+// OutlineCensusRow is the computed, per-language record the outline-tier
+// census produces.
+type OutlineCensusRow struct {
+	Language          string      `json:"language"`
+	Tier              OutlineTier `json:"tier"`
+	TagsQueryNonEmpty bool        `json:"tags_query_non_empty"`
+	SmokeCaptureCount int         `json:"smoke_capture_count"`
+	SmokeCaptureNames []string    `json:"smoke_capture_names,omitempty"`
+	SmokeParseError   string      `json:"smoke_parse_error,omitempty"`
+	RealCorpusPresent bool        `json:"real_corpus_present"`
+	CandidateSymbols  []string    `json:"candidate_symbols,omitempty"`
+}
+
+// OutlineCensusResult is the full, stable census output.
+type OutlineCensusResult struct {
+	ReproductionCommand  string             `json:"reproduction_command"`
+	LanguageCount        int                `json:"language_count"`
+	RealCorpusRoot       string             `json:"real_corpus_root"`
+	RealCorpusRootExists bool               `json:"real_corpus_root_exists"`
+	CountsByTier         map[string]int     `json:"counts_by_tier"`
+	Rows                 []OutlineCensusRow `json:"rows"`
+}
+
+// outlineCandidateDefinitionSymbols returns the deduplicated set of outer
+// (definition-shape) node types referenced by inferredTagsQueryPatterns, in
+// table order. These are the node types the T3 promotion backlog measures
+// grammars against.
+func outlineCandidateDefinitionSymbols() []string {
+	seen := make(map[string]struct{}, len(inferredTagsQueryPatterns))
+	out := make([]string, 0, len(inferredTagsQueryPatterns))
+	for _, pattern := range inferredTagsQueryPatterns {
+		if len(pattern.Symbols) == 0 {
+			continue
+		}
+		sym := pattern.Symbols[0]
+		if _, ok := seen[sym]; ok {
+			continue
+		}
+		seen[sym] = struct{}{}
+		out = append(out, sym)
+	}
+	return out
+}
+
+// outlineResolveRealCorpusRoot resolves the real-corpus root the same way
+// the existing real-corpus tests do: an explicit env override, else a
+// sibling checkout under the user's home directory.
+func outlineResolveRealCorpusRoot() string {
+	if root := strings.TrimSpace(os.Getenv(outlineRealCorpusRootEnv)); root != "" {
+		return root
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(home, "work", "gotreesitter-corpora", "corpus_sources")
+}
+
+// errOutlineCorpusMatchFound is a sentinel walk error that stops
+// outlineRealCorpusHasMatch's directory walk the moment a matching file
+// turns up, rather than merely skipping the rest of one directory.
+var errOutlineCorpusMatchFound = errStr("outline: corpus match found")
+
+type errStr string
+
+func (e errStr) Error() string { return string(e) }
+
+// outlineRealCorpusHasMatch reports whether root/name holds at least one
+// file whose extension is in exts, bounded by outlineRealCorpusWalkBudget
+// directory entries. It returns false immediately if root/name does not
+// exist or is empty.
+func outlineRealCorpusHasMatch(root, name string, exts []string) bool {
+	if root == "" || name == "" || len(exts) == 0 {
+		return false
+	}
+	langDir := filepath.Join(root, name)
+	info, err := os.Stat(langDir)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	normalized := make([]string, 0, len(exts))
+	for _, ext := range exts {
+		normalized = append(normalized, strings.ToLower(ext))
+	}
+	visited := 0
+	walkErr := filepath.Walk(langDir, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // best-effort walk; unreadable entries are skipped, not fatal
+		}
+		visited++
+		if visited > outlineRealCorpusWalkBudget {
+			return filepath.SkipAll
+		}
+		if fi.IsDir() {
+			return nil
+		}
+		lowerName := strings.ToLower(fi.Name())
+		for _, ext := range normalized {
+			if strings.HasSuffix(lowerName, ext) {
+				return errOutlineCorpusMatchFound
+			}
+		}
+		return nil
+	})
+	return walkErr == errOutlineCorpusMatchFound
+}
+
+// outlineSmokeCaptures resolves the tags query, parses the language's smoke
+// sample, and runs the query over the resulting tree. It returns the sorted,
+// deduplicated capture names and total capture count. A non-nil error string
+// records why the sample could not be measured (parse failure, no loader,
+// etc); an empty query short-circuits with no error.
+func outlineSmokeCaptures(entry LangEntry, query string) (count int, names []string, errMsg string) {
+	if strings.TrimSpace(query) == "" {
+		return 0, nil, ""
+	}
+	if entry.Language == nil {
+		return 0, nil, "no language loader registered"
+	}
+	lang := entry.Language()
+	if lang == nil {
+		return 0, nil, "language loader returned nil"
+	}
+	q, err := gotreesitter.NewQuery(query, lang)
+	if err != nil {
+		return 0, nil, "compile tags query: " + err.Error()
+	}
+	sample := []byte(ParseSmokeSample(entry.Name))
+	support := EvaluateParseSupport(entry, lang)
+	parser := gotreesitter.NewParser(lang)
+	var tree *gotreesitter.Tree
+	if support.Backend == ParseBackendTokenSource && entry.TokenSourceFactory != nil {
+		tree, err = parser.ParseWithTokenSource(sample, entry.TokenSourceFactory(sample, lang))
+	} else {
+		tree, err = parser.Parse(sample)
+	}
+	if err != nil {
+		return 0, nil, "parse smoke sample: " + err.Error()
+	}
+	if tree == nil || tree.RootNode() == nil {
+		return 0, nil, "parse smoke sample: nil tree"
+	}
+	matches := q.Execute(tree)
+	nameSet := make(map[string]struct{})
+	total := 0
+	for _, m := range matches {
+		for _, c := range m.Captures {
+			total++
+			nameSet[c.Name] = struct{}{}
+		}
+	}
+	sortedNames := make([]string, 0, len(nameSet))
+	for n := range nameSet {
+		sortedNames = append(sortedNames, n)
+	}
+	sort.Strings(sortedNames)
+	return total, sortedNames, ""
+}
+
+// computeOutlineTierCensus classifies every entry into exactly one
+// OutlineTier and returns the full, stable census result. entries should be
+// AllLanguages() in production use; a caller-supplied slice keeps this
+// function unit-testable without the full registry.
+func computeOutlineTierCensus(entries []LangEntry) OutlineCensusResult {
+	corpusRoot := outlineResolveRealCorpusRoot()
+	corpusRootExists := false
+	if corpusRoot != "" {
+		if info, err := os.Stat(corpusRoot); err == nil && info.IsDir() {
+			corpusRootExists = true
+		}
+	}
+	candidateSymbols := outlineCandidateDefinitionSymbols()
+
+	rows := make([]OutlineCensusRow, 0, len(entries))
+	counts := make(map[string]int, 5)
+	for _, entry := range entries {
+		query := ResolveTagsQuery(entry)
+		nonEmpty := strings.TrimSpace(query) != ""
+		captureCount, captureNames, parseErr := outlineSmokeCaptures(entry, query)
+
+		row := OutlineCensusRow{
+			Language:          entry.Name,
+			TagsQueryNonEmpty: nonEmpty,
+			SmokeCaptureCount: captureCount,
+			SmokeCaptureNames: captureNames,
+			SmokeParseError:   parseErr,
+		}
+
+		switch {
+		case nonEmpty:
+			if !corpusRootExists {
+				row.Tier = OutlineTierOneUnmeasured
+			} else {
+				exts := entry.Extensions
+				if outlineRealCorpusHasMatch(corpusRoot, entry.Name, exts) {
+					row.Tier = OutlineTierOne
+					row.RealCorpusPresent = true
+				} else {
+					row.Tier = OutlineTierTwo
+				}
+			}
+		default:
+			var present []string
+			if entry.Language != nil {
+				if lang := entry.Language(); lang != nil {
+					for _, sym := range candidateSymbols {
+						if _, ok := lang.SymbolByName(sym); ok {
+							present = append(present, sym)
+						}
+					}
+				}
+			}
+			row.CandidateSymbols = present
+			if len(present) > 0 {
+				row.Tier = OutlineTierThree
+			} else {
+				row.Tier = OutlineTierFour
+			}
+		}
+
+		counts[string(row.Tier)]++
+		rows = append(rows, row)
+	}
+
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Language < rows[j].Language })
+
+	return OutlineCensusResult{
+		ReproductionCommand: "GTS_OUTLINE_CENSUS_OUT=harness_out/outline/tier_census.json " +
+			"GOFLAGS=-buildvcs=false go test ./grammars -run TestOutlineTierCensus -count=1",
+		LanguageCount:        len(entries),
+		RealCorpusRoot:       corpusRoot,
+		RealCorpusRootExists: corpusRootExists,
+		CountsByTier:         counts,
+		Rows:                 rows,
+	}
+}
+
+// writeOutlineCensusJSON marshals result as indented JSON to path, creating
+// parent directories as needed.
+func writeOutlineCensusJSON(path string, result OutlineCensusResult) error {
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
+}

--- a/grammars/outline_census_test.go
+++ b/grammars/outline_census_test.go
@@ -1,0 +1,196 @@
+package grammars
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// outlineCensusBaselinePath is the committed, stable baseline artifact this
+// test ratchets against. It is regenerated deliberately, in the same change
+// as whatever caused it to move (grammar update, pattern-table edit, smoke
+// sample edit), never silently.
+const outlineCensusBaselinePath = "testdata/outline_census/baseline.json"
+
+// TestOutlineTierCensus computes the workstream-D outline-symbol coverage
+// census for every registered language (spec.outline-api.v1 section 5,
+// origin https://github.com/odvcencio/gotreesitter/issues/649) and is the
+// single source of truth for coverage claims in every later workstream-D
+// stage. It ships no outline API and changes no shipped behavior; it is
+// instrument-only.
+//
+// Reproduce with:
+//
+//	GTS_OUTLINE_CENSUS_OUT=harness_out/outline/tier_census.json \
+//	GOFLAGS=-buildvcs=false go test ./grammars -run TestOutlineTierCensus -count=1
+func TestOutlineTierCensus(t *testing.T) {
+	// The census loads every registered grammar (like the existing
+	// TestInferredTagsQueryCoverage in registry_test.go). Purge afterward so
+	// it does not inflate process heap for later tests in this package.
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+
+	entries := AllLanguages()
+	result := computeOutlineTierCensus(entries)
+
+	if result.LanguageCount != len(entries) {
+		t.Fatalf("census processed %d languages, registry has %d", result.LanguageCount, len(entries))
+	}
+
+	validTiers := map[OutlineTier]bool{
+		OutlineTierOne:           true,
+		OutlineTierOneUnmeasured: true,
+		OutlineTierTwo:           true,
+		OutlineTierThree:         true,
+		OutlineTierFour:          true,
+	}
+
+	sumCounts := 0
+	for tier, n := range result.CountsByTier {
+		if !validTiers[OutlineTier(tier)] {
+			t.Errorf("unknown tier %q in counts_by_tier", tier)
+		}
+		sumCounts += n
+	}
+	if sumCounts != len(entries) {
+		t.Fatalf("tier counts sum to %d, want %d -- every language must land in exactly one tier", sumCounts, len(entries))
+	}
+
+	seen := make(map[string]bool, len(result.Rows))
+	for _, row := range result.Rows {
+		if !validTiers[row.Tier] {
+			t.Errorf("%s: invalid tier %q", row.Language, row.Tier)
+		}
+		if seen[row.Language] {
+			t.Errorf("%s: duplicate census row", row.Language)
+		}
+		seen[row.Language] = true
+		if row.Tier == OutlineTierThree && len(row.CandidateSymbols) == 0 {
+			t.Errorf("%s: classified T3 but carries no candidate symbols", row.Language)
+		}
+		if row.Tier == OutlineTierFour && len(row.CandidateSymbols) != 0 {
+			t.Errorf("%s: classified T4 but carries candidate symbols %v", row.Language, row.CandidateSymbols)
+		}
+	}
+	for _, entry := range entries {
+		if !seen[entry.Name] {
+			t.Errorf("%s: registered language missing from census", entry.Name)
+		}
+	}
+
+	t.Logf("=== Outline tier census (%d languages) ===", len(result.Rows))
+	t.Logf("real corpus root: %q exists=%v", result.RealCorpusRoot, result.RealCorpusRootExists)
+	if !result.RealCorpusRootExists {
+		t.Log("*** T1 IS UNMEASURABLE ON THIS HOST: the real-corpus root does not exist, so no language can be " +
+			"confirmed T1 here. Query-covered languages are reported T1_unmeasured, never silently folded into T2. ***")
+	}
+	for _, tier := range []OutlineTier{OutlineTierOne, OutlineTierOneUnmeasured, OutlineTierTwo, OutlineTierThree, OutlineTierFour} {
+		t.Logf("  %-14s %d", tier, result.CountsByTier[string(tier)])
+	}
+	t.Log("--- T3 pattern backlog: query empty, candidate symbols present (actionable via a data edit) ---")
+	for _, row := range result.Rows {
+		if row.Tier == OutlineTierThree {
+			t.Logf("  %-18s candidates=%v", row.Language, row.CandidateSymbols)
+		}
+	}
+
+	if out := strings.TrimSpace(os.Getenv("GTS_OUTLINE_CENSUS_OUT")); out != "" {
+		if err := writeOutlineCensusJSON(out, result); err != nil {
+			t.Fatalf("write census JSON to %s: %v", out, err)
+		}
+		t.Logf("wrote census JSON to %s", out)
+	}
+
+	assertOutlineCensusBaseline(t, result)
+}
+
+// assertOutlineCensusBaseline ratchets the deterministic portion of the
+// census -- whether each language's inferred tags query is non-empty, its
+// T3/T4 split and candidate symbols when the query is empty, and its
+// smoke-sample capture shape when the query is non-empty -- against the
+// committed baseline. These facts derive only from the compiled grammar,
+// the shared inference pattern table, and the fixed smoke samples, so they
+// reproduce identically on every host; drift is a real coverage change and
+// is hard-failed, mirroring how the derivation-set differential's baseline
+// is pinned (cgo_harness/derivation_set_differential_test.go,
+// TestDerivationSetDifferentialBaselineCensus).
+//
+// The corpus-dependent T1/T2/T1_unmeasured split depends on an external,
+// non-repo-tracked real-corpus checkout (GOT_CORPUS_SOURCES_ROOT) that
+// varies by host and can drift independently of this repository, so it is
+// only logged against the baseline, never asserted.
+func assertOutlineCensusBaseline(t *testing.T, result OutlineCensusResult) {
+	t.Helper()
+
+	data, err := os.ReadFile(outlineCensusBaselinePath)
+	if err != nil {
+		t.Fatalf("read committed baseline %s: %v", outlineCensusBaselinePath, err)
+	}
+	var baseline OutlineCensusResult
+	if err := json.Unmarshal(data, &baseline); err != nil {
+		t.Fatalf("decode committed baseline %s: %v", outlineCensusBaselinePath, err)
+	}
+
+	baselineByLang := make(map[string]OutlineCensusRow, len(baseline.Rows))
+	for _, row := range baseline.Rows {
+		baselineByLang[row.Language] = row
+	}
+
+	drift := 0
+	for _, row := range result.Rows {
+		base, ok := baselineByLang[row.Language]
+		if !ok {
+			t.Errorf("%s: not present in committed baseline %s -- add it in the same change", row.Language, outlineCensusBaselinePath)
+			drift++
+			continue
+		}
+
+		if row.TagsQueryNonEmpty != base.TagsQueryNonEmpty {
+			t.Errorf("%s: tags-query coverage changed (was non-empty=%v, now non-empty=%v) -- update %s in the same change with a stated reason",
+				row.Language, base.TagsQueryNonEmpty, row.TagsQueryNonEmpty, outlineCensusBaselinePath)
+			drift++
+			continue
+		}
+
+		if !row.TagsQueryNonEmpty {
+			if row.Tier != base.Tier {
+				t.Errorf("%s: query-empty tier changed (was %s, now %s) -- update %s in the same change with a stated reason",
+					row.Language, base.Tier, row.Tier, outlineCensusBaselinePath)
+				drift++
+			}
+			if !stringSlicesEqual(row.CandidateSymbols, base.CandidateSymbols) {
+				t.Errorf("%s: candidate symbols changed (was %v, now %v) -- update %s in the same change with a stated reason",
+					row.Language, base.CandidateSymbols, row.CandidateSymbols, outlineCensusBaselinePath)
+				drift++
+			}
+			continue
+		}
+
+		if row.SmokeCaptureCount != base.SmokeCaptureCount || !stringSlicesEqual(row.SmokeCaptureNames, base.SmokeCaptureNames) {
+			t.Errorf("%s: smoke-sample capture shape changed (was count=%d names=%v, now count=%d names=%v) -- update %s in the same change with a stated reason",
+				row.Language, base.SmokeCaptureCount, base.SmokeCaptureNames, row.SmokeCaptureCount, row.SmokeCaptureNames, outlineCensusBaselinePath)
+			drift++
+		}
+
+		if row.Tier != base.Tier {
+			t.Logf("%s: corpus-dependent tier observed %s, baseline recorded %s (host-dependent, not asserted -- see real_corpus_root_exists)",
+				row.Language, row.Tier, base.Tier)
+		}
+	}
+
+	if drift > 0 {
+		t.Fatalf("%d language(s) drifted from the committed, host-independent census baseline (%s)", drift, outlineCensusBaselinePath)
+	}
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/grammars/testdata/outline_census/baseline.json
+++ b/grammars/testdata/outline_census/baseline.json
@@ -1,0 +1,1632 @@
+{
+  "reproduction_command": "GTS_OUTLINE_CENSUS_OUT=harness_out/outline/tier_census.json GOFLAGS=-buildvcs=false go test ./grammars -run TestOutlineTierCensus -count=1",
+  "language_count": 206,
+  "real_corpus_root": "/home/draco/work/gotreesitter-corpora/corpus_sources",
+  "real_corpus_root_exists": true,
+  "counts_by_tier": {
+    "T1": 69,
+    "T2": 1,
+    "T3": 16,
+    "T4": 120
+  },
+  "rows": [
+    {
+      "language": "ada",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "agda",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "angular",
+      "tier": "T2",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "apex",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 4,
+      "smoke_capture_names": [
+        "definition.class",
+        "definition.method",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "arduino",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 4,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "asm",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "astro",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "authzed",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "awk",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "bash",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "function_definition"
+      ]
+    },
+    {
+      "language": "bass",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "beancount",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "bibtex",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "bicep",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "bitbake",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "blade",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "brightscript",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "c",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "c_sharp",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "caddy",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "cairo",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "capnp",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "chatito",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "circom",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "clojure",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "cmake",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "cobol",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "comment",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "commonlisp",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "cooklang",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "corn",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "cpon",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "cpp",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "crystal",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "css",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "csv",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "cuda",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "cue",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "cylc",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "d",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "dart",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "desktop",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "devicetree",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "dhall",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "diff",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "disassembly",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "djot",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "dockerfile",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "dot",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "doxygen",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "dtd",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "earthfile",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "ebnf",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "editorconfig",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "eds",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "eex",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "elisp",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "function_definition"
+      ]
+    },
+    {
+      "language": "elixir",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 6,
+      "smoke_capture_names": [
+        "name",
+        "reference.call"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "elm",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "type_declaration"
+      ]
+    },
+    {
+      "language": "elsa",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "embedded_template",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "enforce",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "erlang",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "call"
+      ]
+    },
+    {
+      "language": "facility",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "faust",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "fennel",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "fidl",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "firrtl",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "fish",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "function_definition"
+      ]
+    },
+    {
+      "language": "foam",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "forth",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "fortran",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "fsharp",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "gdscript",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "git_config",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "git_rebase",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "gitattributes",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "gitcommit",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "gitignore",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "gleam",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "glsl",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 4,
+      "smoke_capture_names": [
+        "definition.function",
+        "name",
+        "reference.call"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "gn",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "name",
+        "reference.call"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "go",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 4,
+      "smoke_capture_names": [
+        "definition.function",
+        "name",
+        "reference.call"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "godot_resource",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "gomod",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "graphql",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "type_definition"
+      ]
+    },
+    {
+      "language": "groovy",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "hack",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "hare",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "haskell",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "haxe",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 4,
+      "smoke_capture_names": [
+        "definition.class",
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "hcl",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "heex",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "hlsl",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "html",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "http",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "hurl",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "hyprlang",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "ini",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "janet",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "java",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.class",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "javascript",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "jinja2",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "jq",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "jsdoc",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "json",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "json5",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "jsonnet",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "julia",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "just",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "kconfig",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "type_definition"
+      ]
+    },
+    {
+      "language": "kdl",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "kotlin",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "ledger",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "less",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "linkerscript",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "call_expression"
+      ]
+    },
+    {
+      "language": "liquid",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "llvm",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "call"
+      ]
+    },
+    {
+      "language": "lua",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "luau",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "make",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "call"
+      ]
+    },
+    {
+      "language": "markdown",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "markdown_inline",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "matlab",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "mermaid",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "meson",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "mojo",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 4,
+      "smoke_capture_names": [
+        "definition.function",
+        "name",
+        "reference.call"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "move",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "nginx",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "nickel",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "nim",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "name",
+        "reference.call"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "ninja",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "nix",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "norg",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "nushell",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "objc",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "ocaml",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "method_definition",
+        "class_definition",
+        "constructor_declaration",
+        "type_definition",
+        "method_invocation"
+      ]
+    },
+    {
+      "language": "odin",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "org",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "pascal",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "pem",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "perl",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "php",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "function_definition",
+        "method_declaration",
+        "class_declaration",
+        "interface_declaration",
+        "enum_declaration"
+      ]
+    },
+    {
+      "language": "pkl",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "powershell",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "prisma",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "prolog",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "promql",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "properties",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "proto",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "pug",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "puppet",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.class",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "purescript",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "class_declaration"
+      ]
+    },
+    {
+      "language": "python",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "ql",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "r",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "racket",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "regex",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "rego",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "requirements",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "rescript",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "robot",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "ron",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "rst",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "ruby",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "rust",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "scala",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "scheme",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "scss",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "smithy",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "solidity",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "sparql",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "sql",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "squirrel",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "ssh_config",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "starlark",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "svelte",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "swift",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "tablegen",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "tcl",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "teal",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "templ",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "textproto",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "thrift",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "tlaplus",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "tmux",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "todotxt",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "toml",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "tsx",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "turtle",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "twig",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "typescript",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "typst",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "call"
+      ]
+    },
+    {
+      "language": "uxntal",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "v",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "verilog",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "function_declaration",
+        "class_declaration",
+        "interface_declaration",
+        "type_declaration"
+      ]
+    },
+    {
+      "language": "vhdl",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    },
+    {
+      "language": "vimdoc",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "vue",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "wat",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "wgsl",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
+    },
+    {
+      "language": "wolfram",
+      "tier": "T3",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false,
+      "candidate_symbols": [
+        "call"
+      ]
+    },
+    {
+      "language": "xml",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "yaml",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "yuck",
+      "tier": "T4",
+      "tags_query_non_empty": false,
+      "smoke_capture_count": 0,
+      "real_corpus_present": false
+    },
+    {
+      "language": "zig",
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 0,
+      "real_corpus_present": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This adds a census that classifies per-language outline-symbol coverage. It computes, for every registered language, which of four coverage tiers it falls into. It ships no outline API and changes no shipped parser or query behavior; it is instrument-only.

The census is `TestOutlineTierCensus` (`grammars/outline_census_test.go`, `grammars/outline_census.go`). It reads the existing tags-query inference table and the existing per-language smoke samples; it adds no new per-language data.

## Tiers

| Tier | Meaning | Count (this host) |
|---|---|---|
| T1 | Inferred tags query is non-empty and a real per-language corpus is present with a matching file | 69 |
| T1_unmeasured | Query is non-empty but the real-corpus root is absent on this host | 0 |
| T2 | Query is non-empty and no real-corpus match exists for the language | 1 |
| T3 | Query is empty but the grammar defines a candidate definition-shape node type (the promotion backlog) | 16 |
| T4 | Query is empty and no candidate symbol is present | 120 |

Total: 206 registered languages, one tier each.

The T3 list is the actionable backlog: `bash`, `elisp`, `elm`, `erlang`, `fish`, `graphql`, `kconfig`, `linkerscript`, `llvm`, `make`, `ocaml`, `php`, `purescript`, `typst`, `verilog`, `wolfram`. Each carries the specific grammar node types the census found, so a future data edit to the inference pattern table has a concrete target.

## Real-corpus detection

The design doc for this workstream named `cgo_harness/corpus_sources/<name>` as the real-corpus path. That path corresponds to submodule registrations that exist only in local, uncommitted `.git/config` state on some hosts; no `.gitmodules` is tracked and no gitlink entries exist in the tree, so a plain clone never populates it. This change instead uses the convention several existing tests in this repository already rely on: an external sibling checkout, overridable with `GOT_CORPUS_SOURCES_ROOT`. When that root is absent, the census reports `T1_unmeasured` rather than folding the language into T2, so a missing corpus never masquerades as measured coverage.

## Baseline and ratchet

`grammars/testdata/outline_census/baseline.json` is a committed snapshot of the full census. `TestOutlineTierCensus` hard-fails when a language's tags-query coverage, T3/T4 classification, candidate symbols, or smoke-sample capture shape drifts from that baseline, since those facts derive only from the compiled grammar and the fixed smoke samples and reproduce identically on every host. The real-corpus-dependent T1/T2 split is logged against the baseline but not asserted, since it depends on an external checkout that varies by host.

## Reproduction

```
GTS_OUTLINE_CENSUS_OUT=harness_out/outline/tier_census.json \
GOFLAGS=-buildvcs=false go test ./grammars -run TestOutlineTierCensus -count=1
```

## Test plan

- [x] `go build ./...`
- [x] `go test . -count=1`
- [x] `go test ./grammars -count=1`
- [x] `go test ./parser_result_test/... -count=1`
- [x] `go test ./grammars -run TestOutlineTierCensus -count=1 -race`
- [x] `gofmt -l` and `go vet ./grammars/...` clean on the new files
- [x] No existing file modified; new files only