### PR TITLE
fix(recovery): correct the ceiling derivation, tighten its corpus gate, widen its fuzzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- The C-recovery missing-token search (`cHandleError` /
+  `cDoAllPotentialReductions`, `parser_recover_c.go`) cloned the whole GSS
+  stack without a work limit.
+  A 4-byte erlang input and a 56-byte jsdoc input drove heap use past 2 GB
+  in seconds.
+  Two new loop ceilings now bound the search directly.
+  `cRecoverMaxReductionCandidateAttempts` caps candidate attempts within one
+  `cDoAllPotentialReductions` call.
+  `cRecoverMaxMissingTokenTrials` caps total trials across one
+  `cHandleError` search.
+  `cRecoverMaxReductionCandidateAttempts` is the active mechanism.
+  It is what stops every known witness and every corpus file measured so
+  far.
+  `cRecoverMaxMissingTokenTrials` has not fired once on any of them.
+  It stays in place as an unexercised backstop for input this codebase has
+  not sampled yet, not as a mechanism this fix currently relies on.
+  A new `Parser.budgetScratch` pointer feeds GSS-scratch allocation into
+  the existing 512 MB soft memory budget.
+  The check already in the main parse loop now covers the C-recovery
+  candidate search too.
+
+  Measured through the shipped regression test on the `erlang_pfx_017_71b`
+  witness (`testdata/recovery_memory_bound_witnesses/`): heap growth after
+  this fix is 144.1 MB on the production route and 138.9 MB on the compact
+  route, in well under half a second.
+  Before this fix, the same input reached 695 MB and 52.0 seconds.
+  Both post-fix numbers are the real, reproducible figures.
+  An earlier draft of this fix reported smaller ones.
+
+  `parser_memory_budget_runtime.go`'s `runtimeMemoryHardCeilingEnabled`
+  function keeps its exact prior behavior.
+  This fix adds a comment there recording why an earlier draft's
+  source-length-independent hard ceiling was tried and dropped.
+  It reopened issue #454's determinism symptom class on sub-64 KiB input.
+  It also cost 3.6-9x more time on ordinary small parses, with no
+  offsetting protection over the two loop ceilings above.
+
 - The GSS-forest link cap could silently drop the widest hidden-symbol
   alternative when it tied a narrower one on score and error cost.
   The cap kept the earlier arrival by default in every tie.

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -135,12 +135,34 @@ const (
 //     produces routinely, falling through to step 3's discontinuity-push +
 //     ts_parser__recover-equivalent path.
 //
-// Sizing: measured TokenCount across all 206 bundled grammars tops out at 585
-// (cobol); cDoAllPotentialReductions's own outer loop is bounded to roughly
-// cRecoverMaxVersionCount (reprocess-in-place rounds) +
-// cRecoverMaxVersionCount+1 (version slots) outer passes regardless of
-// grammar, so a naive worst case is on the order of 7*585 =~ 4095 candidate
-// attempts. Measured directly (2026-08-02, consolidating PR #641): a
+// Sizing: the measured distribution sets this ceiling, not a tight algebraic
+// bound on the loop shape below. A dedicated corpus pass (2026-08-02,
+// consolidating PR #641 and its follow-up review) recorded
+// CRecoverReductionCandidateAttemptsPeak — the largest candidateAttempts
+// value any one cDoAllPotentialReductions call reached — across 719 real
+// corpus files: 326 files never entered the search (peak 0), 243 files
+// reached 1-9, 148 files reached 10-99, and only 2 files reached 100 or
+// more. The highest value seen anywhere in that walk was 256: a 16x margin
+// below this 4096 ceiling, with zero ceiling hits.
+//
+// A loop-shape argument motivated the original 4096 pick. Read it as rough
+// orientation, not a derivation: it does not land on 4096 cleanly.
+// cDoAllPotentialReductions's outer `for iter` loop shares ONE `iter` counter
+// across the whole call, and the "reprocess in place" branch that can fire
+// up to cRecoverMaxVersionCount (6) times is gated on that same shared
+// counter (`iter < cRecoverMaxVersionCount`) — so those up-to-6 passes sit
+// INSIDE the first 6 total passes, not stacked on top of them. Counting them
+// separately anyway, alongside the up to cRecoverMaxVersionCount+1 (7)
+// passes `v` can spend advancing across version slots before the loop stops
+// accepting new ones, gives a loose upper bound of 6+7 = 13 outer passes,
+// each visiting up to TokenCount (585, cobol, the largest of all 206 bundled
+// grammars) reduce candidates: a naive worst case near 13*585 = 7,605 —
+// already above this 4096 ceiling, so this loop shape alone does not justify
+// 4096 either. The measured distribution above is the reason 4096 holds
+// anyway: real recovery search terminates far short of any of these naive
+// bounds on every file this corpus covers.
+//
+// Corpus-scale sweep, same basis (2026-08-02, consolidating PR #641): a
 // 212-language, 12,717-file walk of real-world source under
 // gotreesitter-corpora/corpus_sources — deliberately including files whose
 // content does not match the language directory it was sampled from (e.g. a
@@ -165,6 +187,22 @@ const (
 // them costs a small, bounded amount of additional work (combined with the
 // memory-budget feed alongside this one) well under a second, instead of an
 // unbounded multi-GB climb.
+//
+// cRecoverMaxReductionCandidateAttempts is the ACTIVE mechanism: every
+// witness and corpus-walk ceiling hit recorded against these two backstops
+// (CRecoverReductionCandidateCeilingHits) came from this constant.
+// cRecoverMaxMissingTokenTrials is a backstop that has never fired: across
+// all four memory-exhaustion witnesses and the 719-file corpus pass above,
+// CRecoverMissingTokenCeilingHits stayed 0 and
+// CRecoverMissingTokenTrialAttemptsPeak (mtPeak) ranged 1-11 on the four
+// witnesses and topped out at 120 across the corpus — a 68x margin below
+// this 8192 ceiling. It stays in place: an unfired backstop still guards
+// against a future input shape this codebase has not sampled, and the reduction-
+// candidate ceiling above bounds a narrower scope (one
+// cDoAllPotentialReductions call) than this one does (one entire
+// cHandleError missing-token search). Do not read its silence as proof it is
+// unreachable, and do not treat it as load-bearing for any witness fixed so
+// far — it is not.
 const (
 	cRecoverMaxReductionCandidateAttempts = 4096
 	cRecoverMaxMissingTokenTrials         = 8192

--- a/parser_recovery_memory_bound_test.go
+++ b/parser_recovery_memory_bound_test.go
@@ -188,12 +188,19 @@ func assertRecoveryMemoryBoundedParse(t *testing.T, name string, lang *gotreesit
 // serves the input -- exactly what spore.2026-08-02.walnut-e.memory-
 // exhaustion's four-combination reproduction (two witnesses times
 // compact-forced/production-forced) established was broken.
+// cobol joined this list to cover the widest search fan-out this codebase
+// has: cReductionCandidatesForAction's per-state candidate scan and
+// cHandleError's per-symbol missing-token scan both range over
+// language.TokenCount, and cobol's TokenCount (585) is the largest of all
+// 206 bundled grammars -- see cRecoverMaxReductionCandidateAttempts's doc
+// comment (parser_recover_c.go) for the sizing basis this bounds against.
 var recoveryFuzzLanguages = []struct {
 	name string
 	lang func() *gotreesitter.Language
 }{
 	{"erlang", grammars.ErlangLanguage},
 	{"jsdoc", grammars.JsdocLanguage},
+	{"cobol", grammars.CobolLanguage},
 }
 
 // recoveryFuzzMaxInputBytes caps fuzzed input size. The bug class this
@@ -228,6 +235,14 @@ func FuzzRecoveryMissingTokenSearchStaysBounded(f *testing.F) {
 	// grammar finds pathological is worth trying against the other.
 	f.Add([]byte{0x6b, 0x1c, 0x03, 0x21}, byte(1))
 	f.Add([]byte("/**\n * @param {string} name\n * #  @returns {number}\n */\n"), byte(0))
+	// cobol seed: a truncated PROGRAM-ID paragraph (missing both the program
+	// name and the terminating period) against cobol itself (index 2) and
+	// cross-paired against erlang and jsdoc, same rationale as above.
+	f.Add([]byte("       IDENTIFICATION DIVISION.\n       PROGRAM-ID. "), byte(2))
+	f.Add([]byte("       IDENTIFICATION DIVISION.\n       PROGRAM-ID. "), byte(0))
+	f.Add([]byte("       IDENTIFICATION DIVISION.\n       PROGRAM-ID. "), byte(1))
+	f.Add([]byte{0x6b, 0x1c, 0x03, 0x21}, byte(2))
+	f.Add([]byte("/**\n * @param {string} name\n * #  @returns {number}\n */\n"), byte(2))
 
 	f.Fuzz(func(t *testing.T, src []byte, langSel byte) {
 		if len(src) >= recoveryFuzzMaxInputBytes {
@@ -273,11 +288,30 @@ func FuzzRecoveryMissingTokenSearchStaysBounded(f *testing.F) {
 	})
 }
 
+// recoveryCeilingGreenCorpusPeakMargin bounds CRecoverReductionCandidateAttemptsPeak
+// on every green-corpus fixture, not just its ceiling-hit count. A dedicated
+// 719-file real-corpus pass (2026-08-02, consolidating PR #641's follow-up
+// review) recorded this peak directly: 326 files never entered the search
+// (peak 0), 243 files reached 1-9, 148 files reached 10-99, and only 2 files
+// reached 100 or more, topping out at 256. This threshold sits 4x above that
+// measured maximum, leaving headroom for legitimate input this repo has not
+// sampled yet while still catching upward drift in the search's real-world
+// cost long before any single fixture could reach
+// cRecoverMaxReductionCandidateAttempts (4096) itself. The corpus embedded in
+// this test (smoke samples plus curated stress fixtures) peaks far lower
+// still — 3, as of this writing — so this margin is not a tight fit to what
+// ships here; it is sized to the wider real-corpus measurement on purpose.
+const recoveryCeilingGreenCorpusPeakMargin = 1024
+
 // TestRecoveryCeilingsNeverTripOnGreenCorpus is the corpus assertion for
 // cRecoverMaxReductionCandidateAttempts and cRecoverMaxMissingTokenTrials
 // (parser_recover_c.go): both ceilings must stay unreached on every green
 // (non-adversarial) input, or they would change a currently-correct recovery
-// outcome instead of only bounding a pathological search. Scope: the
+// outcome instead of only bounding a pathological search. It also asserts a
+// margin on CRecoverReductionCandidateAttemptsPeak
+// (recoveryCeilingGreenCorpusPeakMargin): a ceiling-hit count of 0 alone only
+// proves the search stayed under 4096; the margin catches search-cost drift
+// toward that ceiling long before any fixture could reach it. Scope: the
 // smoke-sample corpus (one representative fixture per each of the 206
 // registered languages, grammars.ParseSmokeSample) plus a small curated set
 // of malformed-but-plausible recovery-stress snippets across widely used
@@ -307,6 +341,11 @@ func TestRecoveryCeilingsNeverTripOnGreenCorpus(t *testing.T) {
 		if rt.CRecoverMissingTokenCeilingHits != 0 {
 			t.Fatalf("%s: CRecoverMissingTokenCeilingHits = %d, want 0 -- the ceiling tripped on green input, "+
 				"which changes a currently-correct recovery outcome", label, rt.CRecoverMissingTokenCeilingHits)
+		}
+		if rt.CRecoverReductionCandidateAttemptsPeak >= recoveryCeilingGreenCorpusPeakMargin {
+			t.Fatalf("%s: CRecoverReductionCandidateAttemptsPeak = %d, want < %d -- the search cost on this green "+
+				"input drifted past the measured real-corpus margin (see recoveryCeilingGreenCorpusPeakMargin)",
+				label, rt.CRecoverReductionCandidateAttemptsPeak, recoveryCeilingGreenCorpusPeakMargin)
 		}
 	}
 


### PR DESCRIPTION
## Summary

PR #641 (recovery memory bounds) merged with five non-blocking nits from
adversarial review. This PR fixes all five, documentation and test only.

- Correct the recovery-ceiling sizing derivation
  (`cRecoverMaxReductionCandidateAttempts`, `parser_recover_c.go`). The
  prose stated a 13-pass outer-loop bound, then used 7 in the arithmetic.
  Neither number derives 4096 cleanly. The comment now leads with the
  measured basis: a 719-file real-corpus pass recording the actual
  candidate-attempt peak per file (max 256, a 16x margin below the 4096
  ceiling), with the loop-shape argument kept only as explicitly-labeled
  rough orientation.
- Tighten `TestRecoveryCeilingsNeverTripOnGreenCorpus`
  (`parser_recovery_memory_bound_test.go`) with a margin assertion, not
  only a ceiling-hit count. `CRecoverReductionCandidateAttemptsPeak` must
  now stay under 1024 on every green fixture, 4x the measured real-corpus
  maximum, so future drift toward the ceiling surfaces long before any
  fixture could reach it.
- Widen `FuzzRecoveryMissingTokenSearchStaysBounded` to cobol, the largest
  bundled grammar by TokenCount (585) and therefore the widest recovery
  search fan-out. Five new seeds; the four existing ones are unchanged.
- Disclose that `cRecoverMaxReductionCandidateAttempts` is the ceiling that
  actually stops every known witness, while `cRecoverMaxMissingTokenTrials`
  has never fired and is an unexercised backstop, at both the constant's
  doc comment and in `CHANGELOG.md`.
- Add the missing `CHANGELOG.md` entry for PR #641 (none existed), with two
  corrections: `parser_memory_budget_runtime.go`'s
  `runtimeMemoryHardCeilingEnabled` function is behaviorally unchanged (the
  fix only adds a comment there), and the `erlang_pfx_017_71b` witness's
  post-fix heap growth was understated in the original PR body — re-measured
  directly through the shipped regression test.

No production code paths change. The two ceiling constants
(`cRecoverMaxReductionCandidateAttempts = 4096`,
`cRecoverMaxMissingTokenTrials = 8192`) are unchanged.

## Test plan

- [x] `go test . -count=1`
- [x] `go test ./grammars`
- [x] `go test ./parser_result_test/... -count=1`
- [x] `go test -race` on the touched recovery tests, plus
      `go test -race ./parser_result_test/...`
- [x] Admission scorecard, strict + ratchet mode:
      PASS=198 DIVERGE=0 FALLBACK=3 SKIP=5 ERROR=0 total=206 (exact match)
- [x] Widened fuzzer: all 9 committed seeds pass; a 60-second live `-fuzz`
      run against the widened language set (including cobol) found no
      panic, hang, or ceiling hit
- [x] Strengthened margin assertion verified against the real-corpus data
      available on this host (the exact corpus cited in the underlying
      measurement was not present locally; verified instead against the
      largest available substitute)