### PR TITLE
Run the full-breadth elision differential in CI and add a deterministic cancellation check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,25 @@ jobs:
           go-version-file: go.mod
 
       - name: Validate compact admission breadth, route precedence, depth, and incremental bridge
+        # GTS_COMPAT_TAIL_ELISION_EXHAUSTIVE=1 adds the full-registry (206
+        # language) compat-tail elision equivalence gate
+        # (TestCompatTailElisionEquivalenceSmokeExhaustive,
+        # admission_compat_tail_elision_test.go) to this lane. It shares this
+        # lane's own reason for gating a full-registry sweep behind an opt-in
+        # env var instead of running it unconditionally (loading every
+        # registered grammar in one process disturbs
+        # TestArenaGCRetentionAfterRelease elsewhere in this package's
+        # default suite); this lane's own `-run` selection already excludes
+        # that test, so the two do not interact here. Measured added cost is
+        # a few seconds.
         run: |
           set -euo pipefail
           GTS_ADMISSION_SCORECARD=1 \
           GTS_ADMISSION_SCORECARD_RATCHET=1 \
+          GTS_COMPAT_TAIL_ELISION_EXHAUSTIVE=1 \
           GOMAXPROCS=1 \
           go test -tags gts_parsercorephase0 . \
-            -run '^(TestAdmissionCandidateScorecard206|TestAdmissionSwitchRoutePrecedenceRatchet|TestAdmissionCandidateYAMLZeroWidthDepth|TestAdmissionCandidateRepresentativeDepthRatchet|TestAdmissionCompactTreeCarriesIncrementalReuseProof|TestDiagnosticParserCoreClassifiedBoundaryAndReductionPlanShape|TestDiagnosticParserCoreSummaryReceiptPreservesExactRewrite)$' \
+            -run '^(TestAdmissionCandidateScorecard206|TestAdmissionSwitchRoutePrecedenceRatchet|TestAdmissionCandidateYAMLZeroWidthDepth|TestAdmissionCandidateRepresentativeDepthRatchet|TestAdmissionCompactTreeCarriesIncrementalReuseProof|TestDiagnosticParserCoreClassifiedBoundaryAndReductionPlanShape|TestDiagnosticParserCoreSummaryReceiptPreservesExactRewrite|TestCompatTailElisionEquivalenceSmokeExhaustive)$' \
             -count=1 -timeout 10m
 
   admission_route_equality_fuzz:

--- a/admission_compat_tail_elision_test.go
+++ b/admission_compat_tail_elision_test.go
@@ -300,9 +300,21 @@ type compatTailElisionCorpusEntry struct {
 // cgo_harness/corpus_real is present on this host (it is git-ignored, so it
 // is not always available -- see admission_real_corpus_matrix_test.go for the
 // same convention this test follows).
+//
+// This gate does NOT run in CI: cgo_harness/corpus_real is git-ignored and no
+// CI job provisions it, so GTS_ADMISSION_REAL_CORPUS is never set there (see
+// docs/ci-gate-coverage.md). A prior PR cited this test's results as merge
+// evidence despite that -- both skip paths below print directly to stderr in
+// addition to t.Skip's own message, so the reason is captured verbatim by
+// `go test -json` (which race_root_shards/race_root_isolated already run
+// this untagged file under) and by any -v invocation, not only visible to
+// someone who happens to pass -v by hand, precisely so that mistake cannot
+// repeat silently.
 func TestCompatTailElisionEquivalenceRealCorpus(t *testing.T) {
 	if os.Getenv("GTS_ADMISSION_REAL_CORPUS") != "1" {
-		t.Skip("set GTS_ADMISSION_REAL_CORPUS=1 to run the compat-tail elision real-corpus gate")
+		reason := "SKIP " + t.Name() + ": GTS_ADMISSION_REAL_CORPUS is not set to 1; this gate requires cgo_harness/corpus_real, which is git-ignored and NOT provisioned by any CI job (see docs/ci-gate-coverage.md) -- its results are not CI evidence"
+		fmt.Fprintln(os.Stderr, reason)
+		t.Skip(reason)
 	}
 	t.Cleanup(func() {
 		grammars.PurgeEmbeddedLanguageCache()
@@ -313,7 +325,9 @@ func TestCompatTailElisionEquivalenceRealCorpus(t *testing.T) {
 	manifestPath := filepath.Join("cgo_harness", "corpus_real", "manifest.json")
 	manifestSource, err := os.ReadFile(manifestPath)
 	if err != nil {
-		t.Skipf("real corpus manifest unavailable: %v", err)
+		reason := fmt.Sprintf("SKIP %s: real corpus manifest unavailable at %s: %v", t.Name(), manifestPath, err)
+		fmt.Fprintln(os.Stderr, reason)
+		t.Skip(reason)
 	}
 	var manifest compatTailElisionCorpusManifest
 	if err := json.Unmarshal(manifestSource, &manifest); err != nil {

--- a/admission_switch_candidate_tail_cancellation_internal_test.go
+++ b/admission_switch_candidate_tail_cancellation_internal_test.go
@@ -1,0 +1,114 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+)
+
+// TestFinalizeCompactReturnedTreeForParsePreservesCompletedTreeUnderPresetCancellation
+// is the deterministic counterpart to the end-to-end race,
+// TestCompatTailElisionSurvivesConcurrentCancellation
+// (admission_compat_tail_elision_test.go), which reproduces the reintroduced
+// regression only on some fraction of runs because it races a background
+// goroutine's flag flip against a live Parse call. This test removes the
+// race entirely: it materializes a real compact-route tree directly (the
+// same runner.parse call tryCompactFullParseRoute itself makes), THEN sets
+// the cancellation flag, THEN calls the returned-tree tail function
+// directly. With the flag already set before the call, the mechanism either
+// catches the reintroduced bug or it does not on every single run -- no
+// timing window, no flake.
+//
+// See admission_switch_candidate.go's finalizeCompactReturnedTreeForParse doc
+// comment ("Corrected finding") for the historical bug this guards: an
+// earlier version checked the terminal stop reason unconditionally, ahead of
+// the "!tree.resultCompatibilityApplied" guard, so a cancellation observed
+// strictly after materialization already completed a good tree discarded
+// that tree instead of returning it.
+//
+// Both tail functions are exercised on their own real compact-materialized
+// tree: finalizeCompactReturnedTreeForParse (the elision-eligible path that
+// carried the historical bug) and normalizeReturnedTreeForParse (the
+// production tail every non-eligible language still runs, and the oracle
+// finalizeCompactReturnedTreeForParse's own doc comment says its control
+// flow reproduces exactly).
+func TestFinalizeCompactReturnedTreeForParsePreservesCompletedTreeUnderPresetCancellation(t *testing.T) {
+	source := []byte("1 + 2 + 3")
+
+	t.Run("finalizeCompactReturnedTreeForParse", func(t *testing.T) {
+		p := NewParser(buildArithmeticLanguage())
+		p.SetAdmissionCandidateRoute(true)
+		tree := mustMaterializeCompactTreeForTailTest(t, p, source)
+		defer tree.Release()
+		requireCompactTailPreconditions(t, tree, "finalizeCompactReturnedTreeForParse")
+
+		var flag uint32 = 1
+		p.SetCancellationFlag(&flag)
+
+		p.finalizeCompactReturnedTreeForParse(tree, source)
+
+		if tree.ParseStoppedEarly() {
+			t.Fatalf("finalizeCompactReturnedTreeForParse discarded an already-complete compact tree under a pre-set cancellation flag: ParseStopReason()=%q", tree.ParseStopReason())
+		}
+	})
+
+	t.Run("normalizeReturnedTreeForParse", func(t *testing.T) {
+		p := NewParser(buildArithmeticLanguage())
+		p.SetAdmissionCandidateRoute(true)
+		tree := mustMaterializeCompactTreeForTailTest(t, p, source)
+		defer tree.Release()
+		requireCompactTailPreconditions(t, tree, "normalizeReturnedTreeForParse")
+
+		var flag uint32 = 1
+		p.SetCancellationFlag(&flag)
+
+		p.normalizeReturnedTreeForParse(tree, source)
+
+		if tree.ParseStoppedEarly() {
+			t.Fatalf("normalizeReturnedTreeForParse discarded an already-complete compact tree under a pre-set cancellation flag: ParseStopReason()=%q", tree.ParseStopReason())
+		}
+	})
+}
+
+// mustMaterializeCompactTreeForTailTest drives a real compact-route parse
+// through the same runner.parse call tryCompactFullParseRoute itself makes,
+// stopping short of that function's own tail call so the caller can invoke
+// the tail directly and control exactly when the cancellation flag is set.
+func mustMaterializeCompactTreeForTailTest(t *testing.T, p *Parser, source []byte) *Tree {
+	t.Helper()
+	runner, err := p.acquireAdmissionCandidateRunner()
+	if err != nil {
+		t.Fatalf("acquire admission candidate runner: %v", err)
+	}
+	endOp := p.beginParseOperationBudget()
+	defer endOp()
+	endParse := p.enterParseBudget()
+	defer endParse()
+	tree, err := runner.parse(source)
+	if err != nil {
+		t.Fatalf("compact runner declined a real materialization: %v", err)
+	}
+	if tree == nil {
+		t.Fatal("compact runner returned a nil tree")
+	}
+	return tree
+}
+
+// requireCompactTailPreconditions asserts the two facts that make this test
+// meaningful: the tree is a genuine compact-route materialization
+// (resultCompatibilityApplied already true, matching every real
+// compact-route tree per finalizeCompactReturnedTreeForParse's doc comment)
+// and it has not already stopped early (so shouldNormalizeReturnedTree lets
+// the tail function's body run at all).
+func requireCompactTailPreconditions(t *testing.T, tree *Tree, label string) {
+	t.Helper()
+	if !tree.compactMaterialized {
+		t.Fatalf("%s: precondition failed: tree is not compact-materialized", label)
+	}
+	if !tree.resultCompatibilityApplied {
+		t.Fatalf("%s: precondition failed: tree.resultCompatibilityApplied is false before the tail call; this test is meaningless unless materialization already applied result compatibility", label)
+	}
+	if tree.rawParseStoppedEarly() {
+		t.Fatalf("%s: precondition failed: tree already reports stopped-early before the tail call", label)
+	}
+}

--- a/docs/ci-gate-coverage.md
+++ b/docs/ci-gate-coverage.md
@@ -1,0 +1,274 @@
+# CI gate coverage map
+
+Date: 2026-08-02. Base commit: `158d0eeb` (origin/main). Branch:
+`yew/wire-dark-gates`.
+
+## Why this exists
+
+Four times in one day, a review found a test that exists, passes locally, and
+never runs in CI: a build-tagged equivalence test invisible to the untagged
+lanes; a `parser_result_test` package with no gate set running it; a
+corruption case anchored to the wrong opcode; and the two env-gated
+differentials this branch wires (below). A merged PR had cited two of those
+differentials' results ("159 EQUAL / 0 DIVERGE") as evidence, even though
+neither had ever executed in CI. This document is the coverage map so the
+next worker can see the gap instead of rediscovering it, plus a systematic
+sweep for the rest of the class.
+
+## Part 1: fixed in this branch
+
+### 1a. `TestCompatTailElisionEquivalenceSmokeExhaustive` — now wired
+
+`GTS_COMPAT_TAIL_ELISION_EXHAUSTIVE` gated the 163(+)-language exhaustive
+compat-tail elision equivalence gate
+(`admission_compat_tail_elision_test.go`). It appeared nowhere under
+`.github/`. Fixed: added to the existing `compact_admission_ratchet` lane
+(`.github/workflows/ci.yml`), which already runs a 206-language sweep under
+`-tags gts_parsercorephase0` and — checked explicitly — does not select
+`TestArenaGCRetentionAfterRelease`, so the whole-process heap interaction
+that forced the bounded/exhaustive split does not apply there.
+
+- Verified locally with the lane's exact `-run` expression plus the new
+  test, env vars matching `ci.yml` exactly
+  (`GTS_ADMISSION_SCORECARD=1 GTS_ADMISSION_SCORECARD_RATCHET=1
+  GTS_COMPAT_TAIL_ELISION_EXHAUSTIVE=1 GOMAXPROCS=1 go test -tags
+  gts_parsercorephase0 . -run '...' -count=1 -timeout 10m`): all 8 selected
+  tests pass, including `EQUAL=159 DIVERGE=0 NOT_ELIGIBLE=43 NOT_ROUTED=4
+  ASYMMETRIC_ROUTE=0 ERROR=0 total=206` — the exact 159/0 split the merged
+  PR cited.
+- Timed: baseline lane (existing 7 tests) 4.22s wall; with the exhaustive
+  test added, 6.85s wall. Added cost ≈2.6s, comfortably inside the
+  "about 4 seconds" estimate and the stop-rule budget.
+- Confirmed `TestArenaGCRetentionAfterRelease` is absent from the lane's
+  `-run` selection (grep of `benchmark_warm_reuse_test.go` vs. the regex).
+
+### 1b. `TestCompatTailElisionEquivalenceRealCorpus` — cannot run in CI; skip made loud
+
+`GTS_ADMISSION_REAL_CORPUS` reads `cgo_harness/corpus_real/manifest.json`.
+`cgo_harness/corpus_real/` is git-ignored (`.gitignore:36`) and no CI job
+provisions it (no workflow or script references the path). **This gate
+cannot run in CI today** — decided not to force it, per the stop rule.
+Instead both of its skip paths were made loud: each now prints the reason
+directly to stderr (bypassing the testing package's per-test buffering, so
+it is visible in a plain compiled-binary run and is captured verbatim by
+`-json`, which `race_root_shards`/`race_root_isolated` already use for every
+untagged root-package test, including this one — see below), and the
+messages now name the exact missing fixture path and state plainly that the
+gate's results are not CI evidence.
+
+Note: this file (`admission_compat_tail_elision_test.go`) carries no build
+tag, so `TestCompatTailElisionEquivalenceRealCorpus` and
+`TestCompatTailElisionEquivalenceSmokeExhaustive` were both already being
+*compiled and skip-executed* inside the untagged `race_root_shards` /
+`race_root_isolated` matrix (confirmed via `go test -race . -list`) — they
+were reached by CI, just always skipped there. The env-gate fix above is
+still required because `race_root_shards` never sets either env var, so
+without the `compact_admission_ratchet` wiring the exhaustive gate still
+never executed its body anywhere in CI.
+
+### 1c. Deterministic cancellation detector — new, 20/20
+
+`TestCompatTailElisionSurvivesConcurrentCancellation` (end-to-end, races a
+goroutine's flag flip against `Parser.Parse`) catches a reintroduced
+regression in `finalizeCompactReturnedTreeForParse` about 90% of the time
+(reviewer's measurement: 18/20). Added, alongside it (not replacing it):
+`TestFinalizeCompactReturnedTreeForParsePreservesCompletedTreeUnderPresetCancellation`
+(`admission_switch_candidate_tail_cancellation_internal_test.go`, package
+`gotreesitter`, `//go:build !gts_no_parsercorephase0` — the default build,
+same tag as the production file it tests). It materializes a real
+compact-route tree via the same `runner.parse` call
+`tryCompactFullParseRoute` itself makes, stops short of that function's own
+tail call, sets the cancellation flag, and only then calls the tail function
+directly — no timing window. Both tail functions are exercised on their own
+real tree: `finalizeCompactReturnedTreeForParse` (the function that carried
+the historical bug) and `normalizeReturnedTreeForParse` (the production
+oracle it must match).
+
+**Proof (reverted the fix in a scratch copy, ran 20 times, restored):**
+reverting `finalizeCompactReturnedTreeForParse` to the unconditional
+stop-reason-check form made the new test fail **20 of 20** runs, always at
+the same assertion, always with `ParseStopReason()="cancelled"` — the exact
+regression signature. The `normalizeReturnedTreeForParse` subtest (the
+never-buggy oracle) stayed green throughout, as expected. The file was then
+restored to `git diff --exit-code` clean.
+
+The new test is untagged-build-visible: `go test -race . -list` includes it,
+so it lands automatically in one of the four `race_root_shards` (or
+`race_root_isolated`, if later added to that manifest) without any further
+CI wiring.
+
+## Part 2: systematic audit
+
+### 2a. `os.Getenv`/`t.Setenv` gates on a `_test.go` file, cross-referenced against `.github/`
+
+61 distinct env-var names gate test behavior in root-module `_test.go` files
+(excluding the separate `cgo_harness` module, which has its own large surface
+and is called out separately below, not exhaustively). 6 are referenced under
+`.github/` after this branch:
+
+| Env var | Set in CI? | Where |
+|---|---|---|
+| `GOTREESITTER_GRAMMAR_BLOB_DIR` | Yes | `ci.yml` (`parity_report`) |
+| `GOT_BENCH_FUNC_COUNT` | Yes | `ci.yml` (`perf-regression`) |
+| `GTS_ADMISSION_SCORECARD` | Yes | `ci.yml` (`compact_admission_ratchet`) |
+| `GTS_ADMISSION_SCORECARD_RATCHET` | Yes | `ci.yml` (`compact_admission_ratchet`) |
+| `GTS_COMPAT_TAIL_ELISION_EXHAUSTIVE` | **Yes (this branch)** | `ci.yml` (`compact_admission_ratchet`) |
+| `GTS_W5_SLOW_TIER` | Yes | `ci.yml` (`oedit_latency_gate_full`, `workflow_dispatch` only) |
+
+The other 55 are never set anywhere under `.github/`. Most are legitimate
+opt-in diagnostics (trace/debug output, report paths, config knobs) whose
+absence does not skip a meaningful assertion — the base test still runs and
+asserts without them (`GOT_STATS`, `GTS_ATTRIBUTION_OUT`/`_DURATION`,
+`GTS_CSS_DEBUG_DFA`, `GTS_DECODE*`, `DART_H5_TRACE*`, `DIAG_TS_*`,
+`GTS_C4_PASSMIX_RESULT`, `GTS_RUST_*_DIAGNOSTIC`, `GTS_ADMISSION_SCORECARD_STRICT`,
+`GTS_CORE100_STRICT_SMOKE`, `GTS_SQL_SCANNER_SLOW_TIER`, `GOT_GLR_MAX_STACKS`,
+`GOT_LALR_LR0_CORE_BUDGET`, `GOT_GLR_FOREST`), or are named manual
+reproduction harnesses for a specific historical issue
+(`GTS_REPRO_FILE`/`_INSERT`/`_DELETE`/`_FULL`/`_ORGANIC`/`_ORGANIC_DEL`/
+`_WARM_PROFILE`/`_PROFILE_OUT`, all in the `issue380_*_repro_test.go` files) —
+not correctness gates a PR would cite as evidence, lower priority.
+
+The subset below **does** skip a real assertion when unset, and none of them
+run in CI:
+
+| Env var | Test(s) | Notes |
+|---|---|---|
+| `GTS_ADMISSION_REAL_CORPUS`(+`_MANIFEST`/`_MAX_BYTES`/`_RATCHET`) | `TestAdmissionCandidateRealCorpusMatrix` (`admission_real_corpus_matrix_test.go`) | Same fixture problem as 1b, un-loudened sibling gate — see backlog. |
+| `GOT_RECOVERY_SWEEP` | `TestCRecoveryCorpusTruncationAcyclicitySweep`-class (`parser_recover_cycle_sweep_test.go`) | "slow; multi-language corpora" per its own skip message. |
+| `GTS_B4B_SHADOW_CENSUS_REPORT` | Two tests across `parsercore_phase0_b4b_shadow_census_test.go` and `..._internal_test.go` | Report-generation, gated off by default. |
+| `GTS_CORPORA_GRAMMAR_PARITY` | `corpuscheck/census_gts_corpora_test.go` | Compounded: the `corpuscheck` package itself is not reached by any CI lane — see 2d. |
+| `GTS_FOREST_INCR` | `TestForestIncrementalCorrectness` | Reads `cgo_harness/corpus_real/...` paths — gitignored, unavailable in CI even if the var were set. |
+| `GTS_GRAMMARGEN_FORTRAN_TARGETED_PARITY`, `GTS_GRAMMARGEN_SPLIT_EVAL`, `GTS_GRAMMARGEN_SPLIT_LANG_EVAL` | `grammargen/fortran_targeted_parity_test.go`, `grammargen/lr_split_real_test.go` | In `grammargen`, already documented non-blocking/advisory in `ci.yml`; lower severity by that existing design. |
+| `GTS_HTTP_LOCKED_CORPUS` | `grammars/http_section_native_regression_test.go` | `grammars` package **is** run in CI; this one test inside it never asserts anything there. |
+| `GTS_RUST_DOT_RANGE_CORPUS`(+`_EXPECT_FILES`) | `grammars/rust_dot_range_census_test.go` | Same shape as above: reached package, unreached test. |
+| `GTS_WORK_COUNT_SOURCE`/`_RESULT`/`_FIXTURE` | `work_count_parsercore_child_internal_test.go` and siblings | Moot in practice: gated behind the `gts_workcount` build tag, which is never passed anywhere in `.github/` — see 2b. |
+| `OEDIT_MEASURE` | `oedit_range_normalize_bench_test.go` | Benchmark-shaped measurement, not part of default `go test` execution regardless. |
+
+### 2b. `//go:build` tags on test files, cross-referenced against tags CI builds with
+
+Distinct tag expressions found (root module, counts = number of `_test.go`
+files):
+
+| Tag expression | Files | Built by CI? |
+|---|---|---|
+| `!gts_no_parsercorephase0` (default build) | 15 | Yes — every untagged/default lane |
+| (no tag, plain default build) | (majority of the tree) | Yes |
+| `!grammar_subset` / `!grammar_subset \|\| grammar_subset_X` | 35 + ~28 | Yes, as the default (`grammar_subset` is never set by CI, so `!grammar_subset` is always true) |
+| `gts_parsercorephase0` (bare or combined, e.g. `&& gts_parsercorephase0a`) | 57 (root package) | Partially — see below |
+| `gts_workcount` (bare or combined) | 7 + 2 combined + 2 negated | **No** — `gts_workcount` appears nowhere under `.github/` |
+| `race` / `!race` | 4 + 4 | Yes, both sides (race lanes vs. non-race `compile`/`draft-correctness`) |
+| `gts_no_parsercorephase0` (emergency stub build) | 1 (+1 negated combo) | **No** — never built by any CI job |
+| `grammar_blobs_external`, `docker_parity`, `grammar_set_core` | 1 each | Situational — `grammar_blobs_external` is used by `parity_report`; the other two not found under `.github/` |
+
+Headline finding: the **`gts_parsercorephase0`-tagged surface is large and
+mostly unexecuted**. 57 root-package `_test.go` files carry that tag (alone
+or combined), containing **277** top-level `Test`/`Fuzz`/`Benchmark`
+functions. Exactly two CI jobs pass `-tags gts_parsercorephase0` to the root
+package (`selected_store_admission`, `compact_admission_ratchet`), and both
+use narrow, explicit `-run` allow-lists — together naming on the order of a
+dozen distinct test functions. The rest of the 277 are compiled (a real
+build-break there would be caught) but their bodies never execute in CI.
+This is the same defect class as the two items fixed in Part 1, at a much
+larger scale; it is not something this branch can respond to inside the stop
+rules (would mean redesigning multiple CI lanes), so it is filed in the
+backlog below rather than fixed here.
+
+The emergency opt-out build (`-tags gts_no_parsercorephase0`, the stub route
+in `admission_switch_stub.go`) is never compiled by any CI job — the
+fail-closed emergency path itself is untested.
+
+### 2c. `t.Skip`/`t.Skipf` on a missing fixture or directory: loud or silent?
+
+~90 such skips were found (root module + `grammargen` + `grammars`,
+excluding `cgo_harness`). Nearly all already carry a reason string, so by the
+strict "has a logged reason" reading almost none are silent — but under
+plain `go test` (no `-v`), Go's test tool suppresses **all** output
+(including any reason string) from a package that ends up passing, skip
+included; the message becomes visible only under `-v`, under `-json` (which
+`race_root_shards`/`race_root_isolated` already use for the untagged root
+package), or when the test fails. That is normal Go behavior, not a bug
+introduced here, but it is exactly the mechanism that let the two Part-1
+gates go unnoticed. The loudening fix in 1b (`fmt.Fprintln(os.Stderr, ...)`
+before `t.Skip`) is the direct countermeasure and is only applied to that
+one gate so far; the sibling gate `GTS_ADMISSION_REAL_CORPUS` in
+`admission_real_corpus_matrix_test.go` has the identical shape and is not
+yet loudened (backlog below).
+
+**Separate, more serious finding: hardcoded developer-machine paths.** Five
+test files reference an absolute path under `/home/draco/...` and `t.Skipf`
+when it is absent:
+
+| File | Path referenced |
+|---|---|
+| `parser_result_go_compat_byte_identity_test.go` | `/home/draco/work/gotreesitter-corpora/corpus_sources/{go,fidl}/.../zerrors_windows.go` |
+| `parser_recover_cycle_sweep_test.go` | same (shares `zerrorsCandidatePaths`) |
+| `grammars/csharp_external_lex_states_regression_test.go` | `/home/draco/work/gotreesitter-corpora/corpus_sources/c_sharp/.../DeclaredTypeManager.cs` |
+| `grammargen/markdown_grammar_test.go` | `/home/draco/work/mdpp/examples/conformance` |
+| `grammargen/markdown_grammar_corpus_test.go` | `/home/draco/work/mdpp/testdata/cst-snapshots` |
+
+These are not env-gated at all — there is no variable a CI workflow could
+set to enable them. They can only ever run on the machine(s) that happen to
+have those exact paths, i.e. effectively never in CI and only for whichever
+engineer's checkout layout happens to match. `TestGoZerrorsNormalizerByteIdentity`
+and `TestCRecoveryZerrorsTruncationAcyclic` in particular are named
+regression tests for a documented historical defect ("hung forever",
+"O(n^2) hardening") — real regression coverage that is currently
+unreachable by anyone but the original author. See backlog, high severity.
+
+### 2d. Package directories whose tests are not reached by CI lane package selections
+
+Cross-referencing `go list ./...` against every package-selecting `-run`/
+package-filter pattern in `ci.yml` (the same awk logic `race_packages` uses,
+run locally against this branch):
+
+| Package | Test files | Reached by any CI lane? |
+|---|---|---|
+| `corpuscheck` | 5 (`census_test.go`, `census_gts_corpora_test.go`, `compare_test.go`, `format_test.go`, `sexpr_test.go`) | **No.** Compiled only (`go build ./...`, `go vet ./...`, `go test ./... -run '^$'` in `compile`); no lane's package filter matches `corpuscheck` (only `corpuscheck/cmd/corpuscheck` matches `/cmd/`, a different package). |
+| `wasm/runtime` | 3 (`blob_test.go`, `bridge_test.go` [260 lines], `incremental_test.go`) | **No.** Same as above — compile-checked only. |
+| `internal/benchfixtures` | 2 (`deep_digest_test.go`, `go_fixtures_test.go`) | **No.** Notable: this package's `InspectGoTree` digest function is what dozens of *other* tests (including the ones fixed in Part 1) trust as their oracle; its own test suite is compile-checked only. |
+| `cmd/grammargen` | 2 (`commands_test.go`, `grammar_js_cli_test.go`) | **No — and this one is an accident.** `race_packages`'s `cmd` lane filter is `/cmd/`, which should match, but the same job's exclusion rule `$0 ~ /\/grammargen$/ { next }` — intended to keep the advisory top-level `grammargen` package out of the blocking suite — also matches `cmd/grammargen` on the same string suffix and drops it too. |
+| `parser_result_test` | — | Already fixed (prior PR): matched by the `parser-result` lane (`/parser_result_test$`). Confirmed present and passing below. |
+| `internal/parsercorephase0` | many | Reached — explicit `go test -race ./internal/parsercorephase0` in `selected_store_admission` (both tag variants). |
+| `taproot`, `taproot/diag`, `taproot/walk`, `grep` | — | Reached — `support` lane (`/grep$\|/taproot($\|/)`), confirmed via the exact awk match. |
+
+`cmd/grammargen`'s exclusion is a one-line, low-risk wiring fix (change the
+exclusion rule to match the top-level `grammargen` package exactly instead of
+by suffix); it is filed in the backlog rather than made in this branch to
+keep this PR's CI-config surface to the two items in scope, per the stop
+rule ("if wiring ... makes ANY test in it fail ... stop and report") — this
+fix touches a shared `race_packages` matrix entry outside the two named
+targets and deserves its own verification pass.
+
+### `cgo_harness` (separate Go module) — not audited to the same depth
+
+`cgo_harness/go.mod` makes it a separate module with its own, much larger
+surface (94 files tagged `cgo && treesitter_c_parity`, plus several smaller
+combinations). The `parity-cgo`, `parity-cgo-exhaustive`, and
+`compact-t3-oracle-cgo` jobs each pass narrow, explicit `-run` allow-lists
+into that module, the same shape as the `gts_parsercorephase0` finding above.
+Given this branch's scope and the stop rules, this was noted but not
+quantified test-by-test; a dedicated audit pass is filed in the backlog.
+
+## Backlog (not fixed in this branch)
+
+| Item | Severity | Why |
+|---|---|---|
+| `cmd/grammargen` accidentally excluded from `race_packages` by a suffix-matching exclusion rule meant for top-level `grammargen` only | Medium | One-line fix, but shares a matrix entry with other lanes; needs its own verification pass per the stop rule. |
+| `corpuscheck`, `wasm/runtime`, `internal/benchfixtures` packages reached by no CI lane (compile-checked only) | Medium–High | `internal/benchfixtures` is the digest oracle many other tests trust; its own correctness is unverified by CI. |
+| Hardcoded `/home/draco/...` absolute paths in 5 test files, including two named historical-regression tests (`TestGoZerrorsNormalizerByteIdentity`, `TestCRecoveryZerrorsTruncationAcyclic`) | High | Not just uncovered — unreachable by CI or any engineer without that exact local layout; no env var exists to opt in. |
+| `gts_parsercorephase0`-tagged surface: 277 top-level test functions across 57 root-package files, only on the order of a dozen actually executed by CI's narrow `-run` allow-lists | High (scale) | Same defect class as the two fixed items, much larger; needs a lane redesign, not a one-line change. |
+| `gts_workcount` build tag never passed by any CI job | Medium | Entire work-count differential harness (9+ files) compiled nowhere, run nowhere. |
+| `gts_no_parsercorephase0` (emergency stub) build never compiled by CI | Medium | The fail-closed emergency route itself is untested; would only be discovered broken during an actual incident. |
+| `GTS_ADMISSION_REAL_CORPUS` in `admission_real_corpus_matrix_test.go` has the same silent-by-default shape as the gate loudened in 1b, not yet loudened itself | Low–Medium | Same fixture problem (`cgo_harness/corpus_real`), same fix shape as 1b; not touched here to keep this branch's diff minimal. |
+| `cgo_harness` module's own `gts_parsercorephase0`-style narrow-`-run`-vs-broad-tag-surface pattern (94 `treesitter_c_parity`-tagged files) | Unquantified | Flagged, not measured; separate module, separate audit warranted. |
+
+## Unverified-claim findings
+
+The only confirmed case of a **merged PR citing results from a gate that
+never ran in CI** is the one this branch fixes (1a/1b): `159 EQUAL / 0
+DIVERGE` for the exhaustive compat-tail elision gate, and the (still
+CI-unreachable) real-corpus variant's results. No other specific merged-PR
+citation was traced during this audit — the `gts_parsercorephase0` and
+`gts_workcount` findings above are coverage gaps, not confirmed cases of a
+specific cited claim, but given their scale they carry the same risk and are
+flagged at High/Medium severity above rather than left implicit.


### PR DESCRIPTION
## Summary

- Add `GTS_COMPAT_TAIL_ELISION_EXHAUSTIVE=1` to the existing `compact_admission_ratchet` CI lane, so the full-registry (206-language) compat-tail elision equivalence differential actually runs in CI instead of only by hand. Measured added cost: about 3 seconds. `TestArenaGCRetentionAfterRelease` is confirmed absent from that lane's test selection, so the whole-process heap interaction that forced the bounded/exhaustive split does not apply.
- The real-corpus variant of the same differential still cannot run in CI (its fixture directory is git-ignored and no CI job provisions it). Its skip is now loud: both skip paths name the missing fixture and print to stderr so the reason is captured verbatim by `go test -json`, which the root-package race lanes already run this file under.
- Add a deterministic internal test for the compact-route cancellation-ordering regression, alongside the existing probabilistic end-to-end test (kept, not replaced). It materializes a real compact-route tree, pre-sets the cancellation flag, then calls the tail function directly — no timing window. Reverting the fix in a scratch copy and running the new test 20 times failed it 20 of 20 runs with the exact historical regression signature; the fix was then restored.
- Add `docs/ci-gate-coverage.md`: a systematic sweep of env-gated tests, build tags, fixture-gated skips, and package selections against what CI actually runs, plus a backlog of gaps this PR does not fix.

## Audit headline counts (docs/ci-gate-coverage.md)

- 61 distinct env vars gate test behavior in root-module test files; only 6 are set anywhere under `.github/` after this PR (previously 5).
- 57 root-package test files carry the `gts_parsercorephase0` build tag (277 top-level test functions); CI's narrow `-run` allow-lists execute on the order of a dozen of them.
- 4 package directories (`corpuscheck`, `wasm/runtime`, `internal/benchfixtures`, `cmd/grammargen`) are compiled by CI but reached by no test-execution lane; `cmd/grammargen` is excluded by an unintended suffix match in an existing exclusion rule.
- 5 test files reference a hardcoded developer-machine absolute path with no env-var opt-in, including two named historical-regression tests that are consequently unreachable by CI or by any other engineer's checkout.

## Test plan

- [x] `go test . -count=1`
- [x] `go test ./grammars -count=1`
- [x] `go test ./parser_result_test/... -count=1`
- [x] `compact_admission_ratchet` lane's exact `-run` expression and env vars, run locally (206-language exhaustive gate passes: `EQUAL=159 DIVERGE=0 NOT_ELIGIBLE=43 NOT_ROUTED=4 ASYMMETRIC_ROUTE=0 ERROR=0`)
- [x] `go test . -race` on the touched test paths
- [x] Reverted `finalizeCompactReturnedTreeForParse` in a scratch copy and confirmed the new deterministic test fails 20/20 runs, then restored the fix
- [x] `actionlint` and a full YAML parse of the modified workflow