### PR TITLE
add(outline): add a language-neutral outline projection over a parsed tree

### DIFF
--- a/outline.go
+++ b/outline.go
@@ -1,0 +1,567 @@
+package gotreesitter
+
+import (
+	"sort"
+	"strings"
+)
+
+// outlineDefinitionPrefix is the tags-query capture prefix that marks a
+// definition. It matches the convention Tagger uses (see extractTag).
+const outlineDefinitionPrefix = "definition."
+
+// outlineNameCapture is the tags-query capture that carries a definition name.
+const outlineNameCapture = "name"
+
+// outlineKindTable is the one fixed, language-neutral normalization table for
+// definition kinds. The key is the "@definition.X" capture suffix; the value is
+// the normalized Kind. The table is keyed by capture data, never by language
+// name, so a new language needs no code change.
+//
+// A suffix that is not listed passes through unchanged. New tags data
+// therefore works immediately, and the outline never invents a kind.
+var outlineKindTable = map[string]string{
+	"function":    "function",
+	"method":      "method",
+	"class":       "class",
+	"interface":   "interface",
+	"type":        "type",
+	"constructor": "constructor",
+	"constant":    "constant",
+	"variable":    "variable",
+	"module":      "module",
+}
+
+// outlineKindRefinement is the second fixed table. It refines a kind by the
+// grammar node type when the shared tags patterns cannot express the
+// distinction. The key is the node type; the value is the refined kind.
+//
+// A row applies only when the capture already resolved to one of the kinds in
+// outlineRefinableKinds, so a refinement can never overrule a more specific
+// capture. Node types are cross-language data, not language names: every
+// grammar that spells an enumeration "enum_declaration" gets the same answer.
+var outlineKindRefinement = map[string]string{
+	"enum_declaration":   "enum",
+	"enum_item":          "enum",
+	"record_declaration": "record",
+}
+
+// outlineRefinableKinds lists the kinds a node-type refinement may replace.
+var outlineRefinableKinds = map[string]bool{
+	"type":  true,
+	"class": true,
+}
+
+// Outliner projects a language-neutral file outline from a parsed tree. It
+// compiles one tags query and reuses it across trees.
+//
+// The outliner is a read-only projection. It runs no parse, it changes no
+// tree, and it holds no parser state. Build one per language and call
+// OutlineTree with trees that language produced.
+//
+// Outliner is not safe for concurrent use.
+type Outliner struct {
+	lang       *Language
+	query      *Query
+	queryEmpty bool
+
+	ownerRules map[string][]OutlineOwnerRule
+
+	hasMatchLimit bool
+	matchLimit    uint32
+	hasWorkBudget bool
+	workBudget    int
+}
+
+// OutlinerOption configures an Outliner.
+type OutlinerOption func(*Outliner)
+
+// WithOutlineOwnerRules attaches declarative owner rules, indexed by node
+// type. The grammars package owns the per-language rows; the core holds none.
+//
+// Owner resolution is NOT applied in this change. The outliner validates and
+// retains the rules, every OutlineSymbol.Owner stays empty, and
+// OutlineReport.OwnerRuleMisses stays zero. Owner reads a child field name, and
+// field-name projection became trustworthy only after the field-projection
+// alignment change; ownership therefore ships in its own change, behind its own
+// differential gate.
+//
+// A rule with an empty NodeType or an empty OwnerField is rejected at
+// construction, because such a rule can never resolve an owner.
+func WithOutlineOwnerRules(rules []OutlineOwnerRule) OutlinerOption {
+	return func(o *Outliner) {
+		if len(rules) == 0 {
+			return
+		}
+		if o.ownerRules == nil {
+			o.ownerRules = make(map[string][]OutlineOwnerRule, len(rules))
+		}
+		for _, rule := range rules {
+			o.ownerRules[rule.NodeType] = append(o.ownerRules[rule.NodeType], rule)
+		}
+	}
+}
+
+// WithOutlineMatchLimit bounds the number of query matches the outliner
+// accepts. When the limit is reached, OutlineReport.Truncated reports true and
+// the symbol list is partial. A limit of zero keeps the query engine default.
+func WithOutlineMatchLimit(limit uint32) OutlinerOption {
+	return func(o *Outliner) {
+		o.hasMatchLimit = true
+		o.matchLimit = limit
+	}
+}
+
+// WithOutlineMatchWorkBudget bounds the enumeration steps the matcher may take
+// for each pattern and node. Exhausting the budget sets
+// OutlineReport.Truncated. Raise it for very large files whose outline comes
+// back truncated. A budget of zero means unlimited.
+func WithOutlineMatchWorkBudget(budget int) OutlinerOption {
+	return func(o *Outliner) {
+		o.hasWorkBudget = true
+		o.workBudget = budget
+	}
+}
+
+// NewOutliner creates an Outliner for a language and its tags query.
+//
+// An empty or blank tags query is not an error. The outliner declines: it
+// returns no symbols and sets OutlineReport.QueryEmpty, so a language without
+// tags data is observably uncovered instead of silently empty.
+func NewOutliner(lang *Language, tagsQuery string, opts ...OutlinerOption) (*Outliner, error) {
+	if lang == nil {
+		return nil, errOutlineNilLanguage
+	}
+
+	o := &Outliner{lang: lang}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(o)
+		}
+	}
+	if err := validateOutlineOwnerRules(o.ownerRules); err != nil {
+		return nil, err
+	}
+
+	if strings.TrimSpace(tagsQuery) == "" {
+		o.queryEmpty = true
+		return o, nil
+	}
+
+	q, err := NewQuery(tagsQuery, lang)
+	if err != nil {
+		return nil, err
+	}
+	o.query = q
+	return o, nil
+}
+
+// Language returns the language this outliner was built for.
+func (o *Outliner) Language() *Language {
+	if o == nil {
+		return nil
+	}
+	return o.lang
+}
+
+// QueryEmpty reports whether the outliner declined for want of tags data.
+func (o *Outliner) QueryEmpty() bool {
+	return o != nil && o.queryEmpty
+}
+
+// OutlineTree projects the outline of an already-parsed tree.
+//
+// The call is read-only: it runs the tags query over the tree, normalizes the
+// kinds, drops ambiguous candidates, and assembles the containment forest. It
+// parses nothing and mutates nothing.
+//
+// Trees that hold ERROR or MISSING nodes are not special-cased. The outline is
+// the projection of whatever the tags query matched on the tree as the parser
+// produced it. Definitions the parser could not recover simply do not appear.
+// The result stays well-defined: every candidate is emitted or counted.
+func (o *Outliner) OutlineTree(tree *Tree) ([]OutlineSymbol, OutlineReport) {
+	var report OutlineReport
+	if o == nil {
+		return nil, report
+	}
+	report.QueryEmpty = o.queryEmpty
+	if o.queryEmpty || o.query == nil {
+		return nil, report
+	}
+	if tree == nil {
+		return nil, report
+	}
+	root := tree.RootNode()
+	if root == nil {
+		return nil, report
+	}
+	if !o.treeLanguageMatches(tree) {
+		report.LanguageMismatch = true
+		return nil, report
+	}
+
+	candidates, truncated := o.collectOutlineCandidates(root, tree.Source())
+	report.Truncated = truncated
+
+	kept := filterOutlineCandidates(candidates, &report)
+	symbols := buildOutlineForest(kept, &report)
+	report.Symbols = countOutlineSymbols(symbols)
+	return symbols, report
+}
+
+// treeLanguageMatches reports whether the tree came from the same language the
+// query compiled against. Query symbol identifiers are language specific, so
+// running a query over a foreign tree yields nonsense; the outliner declines
+// instead.
+func (o *Outliner) treeLanguageMatches(tree *Tree) bool {
+	treeLang := tree.Language()
+	if treeLang == nil {
+		return false
+	}
+	if treeLang == o.lang {
+		return true
+	}
+	return treeLang.Name != "" && treeLang.Name == o.lang.Name
+}
+
+// outlineCandidate is one definition capture paired with its name capture,
+// before the ambiguity rules run.
+type outlineCandidate struct {
+	// order is the emission index of the match. It is the deterministic
+	// tie-break for candidates that are otherwise identical.
+	order     int
+	kind      string
+	name      string
+	nodeType  string
+	rng       Range
+	nameRange Range
+}
+
+// collectOutlineCandidates runs the tags query and reduces each match to at
+// most one candidate.
+//
+// Capture handling mirrors Tagger.extractTag so the outline and the tagger
+// always agree on the same query: the last "@name" capture and the last
+// "@definition.X" capture in a match win. Matches that carry no definition
+// capture -- "@reference.X" matches, for instance -- are discarded without a
+// counter, because they are not outline candidates at all.
+func (o *Outliner) collectOutlineCandidates(root *Node, source []byte) ([]outlineCandidate, bool) {
+	cursor := o.query.Exec(root, o.lang, source)
+	if cursor == nil {
+		return nil, false
+	}
+	if o.hasMatchLimit {
+		cursor.SetMatchLimit(o.matchLimit)
+	}
+	if o.hasWorkBudget {
+		cursor.SetMatchWorkBudget(o.workBudget)
+	}
+
+	var candidates []outlineCandidate
+	order := 0
+	for {
+		match, ok := cursor.NextMatch()
+		if !ok {
+			break
+		}
+
+		var (
+			defCapture  string
+			defNode     *Node
+			hasName     bool
+			nameText    string
+			nameSpan    Range
+			hasDefNode  bool
+			nameCapture QueryCapture
+		)
+		for _, capture := range match.Captures {
+			switch {
+			case capture.Name == outlineNameCapture:
+				if capture.Node == nil {
+					continue
+				}
+				nameCapture = capture
+				hasName = true
+				nameText = nameCapture.Text(source)
+				nameSpan = capture.Node.Range()
+			case isOutlineDefinitionCapture(capture.Name):
+				if capture.Node == nil {
+					continue
+				}
+				defCapture = capture.Name
+				defNode = capture.Node
+				hasDefNode = true
+			}
+		}
+		if !hasDefNode {
+			continue
+		}
+
+		candidate := outlineCandidate{
+			order:    order,
+			kind:     normalizeOutlineKind(defCapture, defNode.Type(o.lang)),
+			nodeType: defNode.Type(o.lang),
+			rng:      defNode.Range(),
+		}
+		if hasName {
+			candidate.name = nameText
+			candidate.nameRange = nameSpan
+		}
+		candidates = append(candidates, candidate)
+		order++
+	}
+
+	return candidates, cursor.DidExceedMatchLimit()
+}
+
+// isOutlineDefinitionCapture reports whether a capture name marks a definition
+// and carries a non-empty kind suffix.
+func isOutlineDefinitionCapture(name string) bool {
+	return len(name) > len(outlineDefinitionPrefix) &&
+		strings.HasPrefix(name, outlineDefinitionPrefix)
+}
+
+// normalizeOutlineKind maps a "@definition.X" capture name to a normalized
+// kind through the two fixed tables. It reads capture data and node types
+// only; it never reads the language name.
+func normalizeOutlineKind(captureName, nodeType string) string {
+	suffix := strings.TrimPrefix(captureName, outlineDefinitionPrefix)
+	kind := suffix
+	if mapped, ok := outlineKindTable[suffix]; ok {
+		kind = mapped
+	}
+	if outlineRefinableKinds[kind] {
+		if refined, ok := outlineKindRefinement[nodeType]; ok {
+			kind = refined
+		}
+	}
+	return kind
+}
+
+// filterOutlineCandidates applies the ambiguity rules and returns the
+// survivors in candidate order. Every dropped candidate lands in exactly one
+// counter.
+//
+// "Ambiguous", operationally, is any of:
+//
+//  1. no usable name;
+//  2. a name span that is not inside the definition span;
+//  3. a repeat of an accepted (Range, Kind) pair;
+//  4. one span carrying two different kinds;
+//  5. a span that partially overlaps an accepted span (rule 5 runs in
+//     buildOutlineForest, where the containment forest is assembled).
+func filterOutlineCandidates(candidates []outlineCandidate, report *OutlineReport) []outlineCandidate {
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	// Rules 1 and 2: per-candidate validity.
+	valid := make([]outlineCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		candidate.name = strings.TrimSpace(candidate.name)
+		if candidate.name == "" {
+			report.OmittedNoName++
+			continue
+		}
+		if !outlineRangeContains(candidate.rng, candidate.nameRange) {
+			report.OmittedInvalidNameRange++
+			continue
+		}
+		valid = append(valid, candidate)
+	}
+	if len(valid) == 0 {
+		return nil
+	}
+
+	// Rules 3 and 4: group by exact span.
+	type spanKey struct{ start, end uint32 }
+	groups := make(map[spanKey][]int, len(valid))
+	spanOrder := make([]spanKey, 0, len(valid))
+	for i, candidate := range valid {
+		key := spanKey{start: candidate.rng.StartByte, end: candidate.rng.EndByte}
+		if _, seen := groups[key]; !seen {
+			spanOrder = append(spanOrder, key)
+		}
+		groups[key] = append(groups[key], i)
+	}
+
+	kept := make([]outlineCandidate, 0, len(valid))
+	for _, key := range spanOrder {
+		members := groups[key]
+		conflict := false
+		for _, idx := range members[1:] {
+			if valid[idx].kind != valid[members[0]].kind {
+				conflict = true
+				break
+			}
+		}
+		if conflict {
+			// Rule 4: the span means two things at once. Drop the whole
+			// group and count every member. Do not guess.
+			report.OmittedConflict += len(members)
+			continue
+		}
+		// Rule 3: keep the first member in emission order.
+		best := members[0]
+		for _, idx := range members[1:] {
+			if valid[idx].order < valid[best].order {
+				best = idx
+			}
+		}
+		report.OmittedDuplicate += len(members) - 1
+		kept = append(kept, valid[best])
+	}
+
+	return kept
+}
+
+// outlineRangeContains reports whether inner sits inside outer, by bytes. A
+// span equal to outer counts as contained. An inverted outer span contains
+// nothing.
+func outlineRangeContains(outer, inner Range) bool {
+	if outer.EndByte < outer.StartByte {
+		return false
+	}
+	if inner.EndByte < inner.StartByte {
+		return false
+	}
+	return inner.StartByte >= outer.StartByte && inner.EndByte <= outer.EndByte
+}
+
+// buildOutlineForest assembles the containment forest.
+//
+// It sorts by start byte ascending, then end byte descending, so a container
+// always precedes everything it contains. It then walks the sorted list with a
+// stack: pop while the top does not reach the current span, and the remaining
+// top is the parent. A span that starts inside the top but ends after it
+// overlaps without containing -- rule 5 -- so it is dropped and counted.
+//
+// Materialization runs in reverse index order. Every child has a higher sorted
+// index than its parent, so each parent finds its children already built. The
+// pass is iterative and allocates one slice per parent that has children.
+func buildOutlineForest(candidates []outlineCandidate, report *OutlineReport) []OutlineSymbol {
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	sorted := make([]outlineCandidate, len(candidates))
+	copy(sorted, candidates)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].rng.StartByte != sorted[j].rng.StartByte {
+			return sorted[i].rng.StartByte < sorted[j].rng.StartByte
+		}
+		if sorted[i].rng.EndByte != sorted[j].rng.EndByte {
+			return sorted[i].rng.EndByte > sorted[j].rng.EndByte
+		}
+		return sorted[i].order < sorted[j].order
+	})
+
+	accepted := make([]outlineCandidate, 0, len(sorted))
+	parentOf := make([]int, 0, len(sorted))
+	childrenOf := make([][]int, 0, len(sorted))
+	stack := make([]int, 0, 16)
+
+	for _, candidate := range sorted {
+		for len(stack) > 0 {
+			top := accepted[stack[len(stack)-1]]
+			if candidate.rng.StartByte < top.rng.EndByte {
+				break
+			}
+			stack = stack[:len(stack)-1]
+		}
+
+		parent := -1
+		if len(stack) > 0 {
+			topIdx := stack[len(stack)-1]
+			top := accepted[topIdx]
+			if candidate.rng.EndByte > top.rng.EndByte {
+				// Rule 5: partial overlap. The forest has no well-defined
+				// shape here, so drop the later start.
+				report.OmittedOverlap++
+				continue
+			}
+			parent = topIdx
+		}
+
+		idx := len(accepted)
+		accepted = append(accepted, candidate)
+		parentOf = append(parentOf, parent)
+		childrenOf = append(childrenOf, nil)
+		if parent >= 0 {
+			childrenOf[parent] = append(childrenOf[parent], idx)
+		}
+		stack = append(stack, idx)
+	}
+
+	built := make([]OutlineSymbol, len(accepted))
+	for idx := len(accepted) - 1; idx >= 0; idx-- {
+		candidate := accepted[idx]
+		symbol := OutlineSymbol{
+			Kind:      candidate.kind,
+			Name:      candidate.name,
+			NodeType:  candidate.nodeType,
+			Range:     candidate.rng,
+			NameRange: candidate.nameRange,
+		}
+		if kids := childrenOf[idx]; len(kids) > 0 {
+			symbol.Children = make([]OutlineSymbol, 0, len(kids))
+			for _, kid := range kids {
+				symbol.Children = append(symbol.Children, built[kid])
+			}
+		}
+		built[idx] = symbol
+	}
+
+	roots := make([]OutlineSymbol, 0, len(accepted))
+	for idx := range accepted {
+		if parentOf[idx] == -1 {
+			roots = append(roots, built[idx])
+		}
+	}
+	return roots
+}
+
+// countOutlineSymbols counts a forest, nested symbols included.
+func countOutlineSymbols(symbols []OutlineSymbol) int {
+	total := 0
+	stack := make([][]OutlineSymbol, 0, 8)
+	stack = append(stack, symbols)
+	for len(stack) > 0 {
+		level := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		total += len(level)
+		for i := range level {
+			if len(level[i].Children) > 0 {
+				stack = append(stack, level[i].Children)
+			}
+		}
+	}
+	return total
+}
+
+// validateOutlineOwnerRules rejects rules that can never resolve an owner.
+func validateOutlineOwnerRules(rules map[string][]OutlineOwnerRule) error {
+	for nodeType, rows := range rules {
+		if strings.TrimSpace(nodeType) == "" {
+			return errOutlineOwnerRuleNodeType
+		}
+		for _, row := range rows {
+			if strings.TrimSpace(row.NodeType) == "" {
+				return errOutlineOwnerRuleNodeType
+			}
+			if strings.TrimSpace(row.OwnerField) == "" {
+				return errOutlineOwnerRuleField
+			}
+		}
+	}
+	return nil
+}
+
+type outlineError string
+
+func (e outlineError) Error() string { return string(e) }
+
+const (
+	errOutlineNilLanguage       outlineError = "outline: language is nil"
+	errOutlineOwnerRuleNodeType outlineError = "outline: owner rule needs a node type"
+	errOutlineOwnerRuleField    outlineError = "outline: owner rule needs an owner field"
+)

--- a/outline.go
+++ b/outline.go
@@ -58,7 +58,10 @@ var outlineRefinableKinds = map[string]bool{
 // tree, and it holds no parser state. Build one per language and call
 // OutlineTree with trees that language produced.
 //
-// Outliner is not safe for concurrent use.
+// An Outliner is safe for concurrent use by several goroutines. OutlineTree
+// writes no Outliner field, and every call takes its own query cursor and its
+// own working slices. TestOutlineTreeIsSafeForConcurrentUse runs the shared
+// path under the race detector and compares every result.
 type Outliner struct {
 	lang       *Language
 	query      *Query
@@ -77,6 +80,8 @@ type OutlinerOption func(*Outliner)
 
 // WithOutlineOwnerRules attaches declarative owner rules, indexed by node
 // type. The grammars package owns the per-language rows; the core holds none.
+// A later call REPLACES the rules an earlier call set; the option does not
+// accumulate.
 //
 // Owner resolution is NOT applied in this change. The outliner validates and
 // retains the rules, every OutlineSymbol.Owner stays empty, and
@@ -85,16 +90,22 @@ type OutlinerOption func(*Outliner)
 // alignment change; ownership therefore ships in its own change, behind its own
 // differential gate.
 //
-// A rule with an empty NodeType or an empty OwnerField is rejected at
-// construction, because such a rule can never resolve an owner.
+// What construction checks today: every rule must name a NodeType and an
+// OwnerField, because a rule missing either can never resolve an owner.
+//
+// What construction does NOT check today: it accepts an empty NameTypes list,
+// a blank entry inside Unwrap or NameTypes, and a NodeType or OwnerField the
+// language does not define. Each of those fails closed at resolution time and
+// will inflate OwnerRuleMisses rather than produce a wrong Owner. Gating rules
+// on symbol and field presence belongs with the ownership change, which owns
+// the per-language table.
 func WithOutlineOwnerRules(rules []OutlineOwnerRule) OutlinerOption {
 	return func(o *Outliner) {
+		o.ownerRules = nil
 		if len(rules) == 0 {
 			return
 		}
-		if o.ownerRules == nil {
-			o.ownerRules = make(map[string][]OutlineOwnerRule, len(rules))
-		}
+		o.ownerRules = make(map[string][]OutlineOwnerRule, len(rules))
 		for _, rule := range rules {
 			o.ownerRules[rule.NodeType] = append(o.ownerRules[rule.NodeType], rule)
 		}
@@ -103,10 +114,14 @@ func WithOutlineOwnerRules(rules []OutlineOwnerRule) OutlinerOption {
 
 // WithOutlineMatchLimit bounds the number of query matches the outliner
 // accepts. When the limit is reached, OutlineReport.Truncated reports true and
-// the symbol list is partial. A limit of zero keeps the query engine default.
+// the symbol list is partial.
+//
+// A limit of zero keeps the query engine default, exactly as a budget of zero
+// does in WithOutlineMatchWorkBudget. Zero always means "leave the default
+// alone" in both options.
 func WithOutlineMatchLimit(limit uint32) OutlinerOption {
 	return func(o *Outliner) {
-		o.hasMatchLimit = true
+		o.hasMatchLimit = limit > 0
 		o.matchLimit = limit
 	}
 }
@@ -114,10 +129,15 @@ func WithOutlineMatchLimit(limit uint32) OutlinerOption {
 // WithOutlineMatchWorkBudget bounds the enumeration steps the matcher may take
 // for each pattern and node. Exhausting the budget sets
 // OutlineReport.Truncated. Raise it for very large files whose outline comes
-// back truncated. A budget of zero means unlimited.
+// back truncated.
+//
+// A budget of zero keeps the query engine default. This option cannot disable
+// the guard: the underlying engine reads zero as "unlimited", and an outline
+// caller writing zero means "default", so the option refuses to pass zero
+// through. Removing the guard is not an outline concern.
 func WithOutlineMatchWorkBudget(budget int) OutlinerOption {
 	return func(o *Outliner) {
-		o.hasWorkBudget = true
+		o.hasWorkBudget = budget > 0
 		o.workBudget = budget
 	}
 }
@@ -168,6 +188,38 @@ func (o *Outliner) QueryEmpty() bool {
 	return o != nil && o.queryEmpty
 }
 
+// DefinitionKinds returns the normalized kinds the compiled query can emit, in
+// sorted order. It is derived from the query's capture names, so it states
+// what the tags DATA can express for this language.
+//
+// Use it to read an outline honestly. A Go outline, for example, reports only
+// "function" and "method", because the Go tags override carries no pattern for
+// a type, a constant, or a variable. Those definitions never become candidates
+// and never reach an omission counter, so an all-zero receipt does not mean the
+// file held nothing else.
+//
+// The list is an upper bound on Kind values, not a promise that each appears.
+// A node-type refinement can also map a capture to a kind outside this list;
+// the refinement rows are documented on outlineKindRefinement.
+func (o *Outliner) DefinitionKinds() []string {
+	if o == nil || o.query == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	for _, name := range o.query.CaptureNames() {
+		if !isOutlineDefinitionCapture(name) {
+			continue
+		}
+		seen[normalizeOutlineKind(name, "")] = struct{}{}
+	}
+	kinds := make([]string, 0, len(seen))
+	for kind := range seen {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	return kinds
+}
+
 // OutlineTree projects the outline of an already-parsed tree.
 //
 // The call is read-only: it runs the tags query over the tree, normalizes the
@@ -176,30 +228,39 @@ func (o *Outliner) QueryEmpty() bool {
 //
 // Trees that hold ERROR or MISSING nodes are not special-cased. The outline is
 // the projection of whatever the tags query matched on the tree as the parser
-// produced it. Definitions the parser could not recover simply do not appear.
-// The result stays well-defined: every candidate is emitted or counted.
+// produced it. The receipt says so through OutlineReport.TreeHasError; read
+// that field's documentation before trusting an outline over a damaged tree.
+//
+// When the outliner refuses to run, the returned report carries a
+// DeclineReason and no symbols. An empty DeclineReason with no symbols is a
+// different fact: the query ran and matched nothing.
 func (o *Outliner) OutlineTree(tree *Tree) ([]OutlineSymbol, OutlineReport) {
 	var report OutlineReport
 	if o == nil {
+		report.DeclineReason = OutlineDeclineNilOutliner
 		return nil, report
 	}
-	report.QueryEmpty = o.queryEmpty
 	if o.queryEmpty || o.query == nil {
+		report.DeclineReason = OutlineDeclineQueryEmpty
 		return nil, report
 	}
 	if tree == nil {
+		report.DeclineReason = OutlineDeclineNilTree
 		return nil, report
 	}
 	root := tree.RootNode()
 	if root == nil {
+		report.DeclineReason = OutlineDeclineNilRootNode
 		return nil, report
 	}
 	if !o.treeLanguageMatches(tree) {
-		report.LanguageMismatch = true
+		report.DeclineReason = OutlineDeclineLanguageMismatch
 		return nil, report
 	}
 
-	candidates, truncated := o.collectOutlineCandidates(root, tree.Source())
+	report.TreeHasError = root.HasError()
+
+	candidates, truncated := o.collectOutlineCandidates(root, tree.Source(), &report)
 	report.Truncated = truncated
 
 	kept := filterOutlineCandidates(candidates, &report)
@@ -212,6 +273,15 @@ func (o *Outliner) OutlineTree(tree *Tree) ([]OutlineSymbol, OutlineReport) {
 // query compiled against. Query symbol identifiers are language specific, so
 // running a query over a foreign tree yields nonsense; the outliner declines
 // instead.
+//
+// The check is pointer identity first, then a structural comparison of the
+// name together with the symbol, field, and state counts. Name alone is not
+// enough: two distinct grammars can carry the same name, and a name-only
+// check would run a foreign query with no receipt. The counts do not prove
+// two languages are the same grammar, so this check catches a swapped
+// language, not a regenerated one; a regenerated grammar with identical
+// counts still recompiles the query at construction, which is where a real
+// symbol change surfaces.
 func (o *Outliner) treeLanguageMatches(tree *Tree) bool {
 	treeLang := tree.Language()
 	if treeLang == nil {
@@ -220,7 +290,12 @@ func (o *Outliner) treeLanguageMatches(tree *Tree) bool {
 	if treeLang == o.lang {
 		return true
 	}
-	return treeLang.Name != "" && treeLang.Name == o.lang.Name
+	if treeLang.Name == "" || treeLang.Name != o.lang.Name {
+		return false
+	}
+	return treeLang.SymbolCount == o.lang.SymbolCount &&
+		treeLang.FieldCount == o.lang.FieldCount &&
+		treeLang.StateCount == o.lang.StateCount
 }
 
 // outlineCandidate is one definition capture paired with its name capture,
@@ -240,11 +315,17 @@ type outlineCandidate struct {
 // most one candidate.
 //
 // Capture handling mirrors Tagger.extractTag so the outline and the tagger
-// always agree on the same query: the last "@name" capture and the last
-// "@definition.X" capture in a match win. Matches that carry no definition
-// capture -- "@reference.X" matches, for instance -- are discarded without a
-// counter, because they are not outline candidates at all.
-func (o *Outliner) collectOutlineCandidates(root *Node, source []byte) ([]outlineCandidate, bool) {
+// agree on the same query: the last "@name" capture in a match wins. Matches
+// that carry no definition capture -- "@reference.X" matches, for instance --
+// are discarded without a counter, because they are not outline candidates at
+// all.
+//
+// The one deliberate divergence from the tagger: a match carrying MORE THAN
+// ONE "@definition.X" capture is dropped and counted in
+// OmittedMultipleDefinitions. The tagger silently keeps the last such capture.
+// For an outline that would pick one of two definitions by capture order, so
+// the outline refuses. No inferred pattern produces this shape today.
+func (o *Outliner) collectOutlineCandidates(root *Node, source []byte, report *OutlineReport) ([]outlineCandidate, bool) {
 	cursor := o.query.Exec(root, o.lang, source)
 	if cursor == nil {
 		return nil, false
@@ -265,41 +346,41 @@ func (o *Outliner) collectOutlineCandidates(root *Node, source []byte) ([]outlin
 		}
 
 		var (
-			defCapture  string
-			defNode     *Node
-			hasName     bool
-			nameText    string
-			nameSpan    Range
-			hasDefNode  bool
-			nameCapture QueryCapture
+			defCapture string
+			defNode    *Node
+			defCount   int
+			hasName    bool
+			nameText   string
+			nameSpan   Range
 		)
 		for _, capture := range match.Captures {
+			if capture.Node == nil {
+				continue
+			}
 			switch {
 			case capture.Name == outlineNameCapture:
-				if capture.Node == nil {
-					continue
-				}
-				nameCapture = capture
 				hasName = true
-				nameText = nameCapture.Text(source)
+				nameText = capture.Text(source)
 				nameSpan = capture.Node.Range()
 			case isOutlineDefinitionCapture(capture.Name):
-				if capture.Node == nil {
-					continue
-				}
 				defCapture = capture.Name
 				defNode = capture.Node
-				hasDefNode = true
+				defCount++
 			}
 		}
-		if !hasDefNode {
+		if defCount == 0 {
+			continue
+		}
+		if defCount > 1 {
+			report.OmittedMultipleDefinitions++
 			continue
 		}
 
+		nodeType := defNode.Type(o.lang)
 		candidate := outlineCandidate{
 			order:    order,
-			kind:     normalizeOutlineKind(defCapture, defNode.Type(o.lang)),
-			nodeType: defNode.Type(o.lang),
+			kind:     normalizeOutlineKind(defCapture, nodeType),
+			nodeType: nodeType,
 			rng:      defNode.Range(),
 		}
 		if hasName {
@@ -345,10 +426,17 @@ func normalizeOutlineKind(captureName, nodeType string) string {
 //
 //  1. no usable name;
 //  2. a name span that is not inside the definition span;
-//  3. a repeat of an accepted (Range, Kind) pair;
-//  4. one span carrying two different kinds;
-//  5. a span that partially overlaps an accepted span (rule 5 runs in
+//  3. one span carrying two different kinds;
+//  4. one span and kind carrying two different names;
+//  5. an exact repeat of an accepted (Range, Kind, Name, NameRange) tuple;
+//  6. a span that partially overlaps an accepted span (this rule runs in
 //     buildOutlineForest, where the containment forest is assembled).
+//
+// Rules 3 and 4 both drop every member of the group. A group that disagrees
+// about what it names cannot be resolved without reading the language, and
+// reading the language is what this projection refuses to do. Only rule 5
+// keeps a member, and only when the members are indistinguishable, so keeping
+// the first is not a choice between them.
 func filterOutlineCandidates(candidates []outlineCandidate, report *OutlineReport) []outlineCandidate {
 	if len(candidates) == 0 {
 		return nil
@@ -372,7 +460,7 @@ func filterOutlineCandidates(candidates []outlineCandidate, report *OutlineRepor
 		return nil
 	}
 
-	// Rules 3 and 4: group by exact span.
+	// Rules 3, 4, and 5: group by exact span.
 	type spanKey struct{ start, end uint32 }
 	groups := make(map[spanKey][]int, len(valid))
 	spanOrder := make([]spanKey, 0, len(valid))
@@ -387,20 +475,38 @@ func filterOutlineCandidates(candidates []outlineCandidate, report *OutlineRepor
 	kept := make([]outlineCandidate, 0, len(valid))
 	for _, key := range spanOrder {
 		members := groups[key]
-		conflict := false
+		first := valid[members[0]]
+
+		kindConflict := false
+		nameConflict := false
 		for _, idx := range members[1:] {
-			if valid[idx].kind != valid[members[0]].kind {
-				conflict = true
+			if valid[idx].kind != first.kind {
+				kindConflict = true
 				break
 			}
+			if !outlineSameName(valid[idx], first) {
+				nameConflict = true
+			}
 		}
-		if conflict {
-			// Rule 4: the span means two things at once. Drop the whole
+
+		switch {
+		case kindConflict:
+			// Rule 3: the span means two things at once. Drop the whole
 			// group and count every member. Do not guess.
 			report.OmittedConflict += len(members)
 			continue
+		case nameConflict:
+			// Rule 4: the span agrees on the kind and disagrees on the
+			// name. Picking by capture order publishes whichever binding
+			// the grammar happened to reach first, which in C-family
+			// method syntax is the return type. Drop the group instead
+			// and count it, so the data gap is legible.
+			report.OmittedNameConflict += len(members)
+			continue
 		}
-		// Rule 3: keep the first member in emission order.
+
+		// Rule 5: the members are indistinguishable, so keep the first in
+		// emission order and count the rest as exact repeats.
 		best := members[0]
 		for _, idx := range members[1:] {
 			if valid[idx].order < valid[best].order {
@@ -412,6 +518,15 @@ func filterOutlineCandidates(candidates []outlineCandidate, report *OutlineRepor
 	}
 
 	return kept
+}
+
+// outlineSameName reports whether two candidates name the same thing at the
+// same place. Both the text and the span must agree: a symbol carries both,
+// so a disagreement about either leaves the emitted symbol undetermined.
+func outlineSameName(a, b outlineCandidate) bool {
+	return a.name == b.name &&
+		a.nameRange.StartByte == b.nameRange.StartByte &&
+		a.nameRange.EndByte == b.nameRange.EndByte
 }
 
 // outlineRangeContains reports whether inner sits inside outer, by bytes. A

--- a/outline_api_test.go
+++ b/outline_api_test.go
@@ -1,0 +1,368 @@
+package gotreesitter_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// outlineGoReceiverRule is the Go rule the specification writes out. Stage 1
+// ships no owner resolution, so this rule is used only to prove that supplying
+// it changes nothing.
+var outlineGoReceiverRule = gts.OutlineOwnerRule{
+	NodeType:   "method_declaration",
+	OwnerField: "receiver",
+	Unwrap:     []string{"parameter_list", "parameter_declaration", "pointer_type", "generic_type"},
+	NameTypes:  []string{"type_identifier"},
+}
+
+// loadOutlineFixture parses one committed fixture and returns its tree, its
+// language, and its resolved tags query.
+func loadOutlineFixture(t *testing.T, language, file string) (*gts.Tree, *gts.Language, string) {
+	t.Helper()
+
+	entry := grammars.DetectLanguageByName(language)
+	if entry == nil {
+		t.Fatalf("language %q is not registered", language)
+	}
+	lang := entry.Language()
+	if lang == nil {
+		t.Fatalf("language %q failed to load", language)
+	}
+	query := grammars.ResolveTagsQuery(*entry)
+
+	source, err := os.ReadFile(filepath.Join(outlineGoldenRoot, file))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", file, err)
+	}
+	parser := gts.NewParser(lang)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	t.Cleanup(tree.Release)
+	return tree, lang, query
+}
+
+func TestNewOutlinerRejectsNilLanguage(t *testing.T) {
+	if _, err := gts.NewOutliner(nil, "(x) @definition.function"); err == nil {
+		t.Fatal("NewOutliner accepted a nil language")
+	}
+}
+
+func TestNewOutlinerRejectsBrokenQuery(t *testing.T) {
+	_, lang, _ := loadOutlineFixture(t, "go", "go/service.go.fixture")
+	if _, err := gts.NewOutliner(lang, "(this_node_type_does_not_exist) @definition.function"); err == nil {
+		t.Fatal("NewOutliner accepted a query the language cannot compile")
+	}
+}
+
+func TestNewOutlinerRejectsUnusableOwnerRules(t *testing.T) {
+	_, lang, query := loadOutlineFixture(t, "go", "go/service.go.fixture")
+	cases := []struct {
+		name string
+		rule gts.OutlineOwnerRule
+	}{
+		{"no node type", gts.OutlineOwnerRule{OwnerField: "receiver"}},
+		{"no owner field", gts.OutlineOwnerRule{NodeType: "method_declaration"}},
+	}
+	for _, tc := range cases {
+		if _, err := gts.NewOutliner(lang, query, gts.WithOutlineOwnerRules([]gts.OutlineOwnerRule{tc.rule})); err == nil {
+			t.Errorf("%s: NewOutliner accepted an owner rule that can never resolve an owner", tc.name)
+		}
+	}
+}
+
+// TestOutlineDeclinesWithoutTagsQuery proves requirement 5 of the issue: a
+// language with no tags data does not fail and does not pretend to be empty.
+// It declines, and the receipt says so.
+func TestOutlineDeclinesWithoutTagsQuery(t *testing.T) {
+	tree, lang, _ := loadOutlineFixture(t, "go", "go/service.go.fixture")
+
+	for _, query := range []string{"", "   ", "\n\t "} {
+		outliner, err := gts.NewOutliner(lang, query)
+		if err != nil {
+			t.Fatalf("NewOutliner(%q) = %v, want a declining outliner and no error", query, err)
+		}
+		if !outliner.QueryEmpty() {
+			t.Errorf("NewOutliner(%q) did not record an empty query", query)
+		}
+		symbols, report := outliner.OutlineTree(tree)
+		if len(symbols) != 0 {
+			t.Errorf("NewOutliner(%q) produced %d symbols, want none", query, len(symbols))
+		}
+		if !report.QueryEmpty {
+			t.Errorf("NewOutliner(%q) report.QueryEmpty = false, want true", query)
+		}
+		if report.Symbols != 0 || report.Omitted() != 0 {
+			t.Errorf("NewOutliner(%q) report = %+v, want an all-zero receipt beside QueryEmpty", query, report)
+		}
+	}
+}
+
+// TestOutlineDeclinesForeignTree proves the outliner does not run a query
+// whose symbol identifiers belong to another grammar. It declines and reports.
+func TestOutlineDeclinesForeignTree(t *testing.T) {
+	pythonTree, _, _ := loadOutlineFixture(t, "python", "python/app.py")
+	_, goLang, goQuery := loadOutlineFixture(t, "go", "go/service.go.fixture")
+
+	outliner, err := gts.NewOutliner(goLang, goQuery)
+	if err != nil {
+		t.Fatalf("build outliner: %v", err)
+	}
+	symbols, report := outliner.OutlineTree(pythonTree)
+	if len(symbols) != 0 {
+		t.Errorf("outlining a foreign tree produced %d symbols, want none", len(symbols))
+	}
+	if !report.LanguageMismatch {
+		t.Error("report.LanguageMismatch = false, want true")
+	}
+}
+
+func TestOutlineHandlesNilAndEmptyInput(t *testing.T) {
+	_, lang, query := loadOutlineFixture(t, "go", "go/service.go.fixture")
+	outliner, err := gts.NewOutliner(lang, query)
+	if err != nil {
+		t.Fatalf("build outliner: %v", err)
+	}
+
+	symbols, report := outliner.OutlineTree(nil)
+	if len(symbols) != 0 || report.Symbols != 0 {
+		t.Errorf("OutlineTree(nil) = %+v / %+v, want empty", symbols, report)
+	}
+
+	var nilOutliner *gts.Outliner
+	if symbols, report := nilOutliner.OutlineTree(nil); len(symbols) != 0 || report.Symbols != 0 {
+		t.Errorf("nil outliner returned %+v / %+v, want empty", symbols, report)
+	}
+	if nilOutliner.QueryEmpty() {
+		t.Error("nil outliner reported an empty query rather than staying inert")
+	}
+	if nilOutliner.Language() != nil {
+		t.Error("nil outliner returned a language")
+	}
+}
+
+// TestOutlineOwnerStaysEmpty is the stage-1 ownership proof. It supplies the
+// exact Go receiver rule from the specification, outlines a fixture whose
+// methods all carry receivers, and asserts that every Owner is still empty and
+// that no owner-rule miss was recorded. Ownership is field-derived and ships in
+// its own change, behind its own differential gate.
+func TestOutlineOwnerStaysEmpty(t *testing.T) {
+	for _, fixture := range outlineGoldenFixtures {
+		fixture := fixture
+		t.Run(fixture.File, func(t *testing.T) {
+			tree, lang, query := loadOutlineFixture(t, fixture.Language, fixture.File)
+
+			withRules, err := gts.NewOutliner(lang, query,
+				gts.WithOutlineOwnerRules([]gts.OutlineOwnerRule{outlineGoReceiverRule}))
+			if err != nil {
+				t.Fatalf("build outliner with owner rules: %v", err)
+			}
+			withoutRules, err := gts.NewOutliner(lang, query)
+			if err != nil {
+				t.Fatalf("build outliner without owner rules: %v", err)
+			}
+
+			ruled, ruledReport := withRules.OutlineTree(tree)
+			plain, plainReport := withoutRules.OutlineTree(tree)
+
+			if ruledReport != plainReport {
+				t.Errorf("owner rules changed the receipt: %+v with rules, %+v without", ruledReport, plainReport)
+			}
+			if !outlineSymbolsEqual(ruled, plain) {
+				t.Error("owner rules changed the symbol forest; stage 1 must not resolve ownership")
+			}
+			if ruledReport.OwnerRuleMisses != 0 {
+				t.Errorf("OwnerRuleMisses = %d, want 0 while ownership does not run", ruledReport.OwnerRuleMisses)
+			}
+			owners := collectOutlineOwners(ruled)
+			if len(owners) != 0 {
+				t.Errorf("Owner is populated on %d symbols (%v); stage 1 must leave it empty", len(owners), owners)
+			}
+		})
+	}
+}
+
+// TestOutlineGoFixtureHasReceiverMethods proves the ownership test above is
+// not vacuous: the Go fixture really does hold methods whose receiver field a
+// later owner rule would read.
+func TestOutlineGoFixtureHasReceiverMethods(t *testing.T) {
+	tree, lang, query := loadOutlineFixture(t, "go", "go/service.go.fixture")
+	outliner, err := gts.NewOutliner(lang, query)
+	if err != nil {
+		t.Fatalf("build outliner: %v", err)
+	}
+	symbols, _ := outliner.OutlineTree(tree)
+
+	methods := 0
+	withReceiverField := 0
+	for _, symbol := range symbols {
+		if symbol.Kind != "method" {
+			continue
+		}
+		methods++
+		node := tree.NamedNodeAtByte(symbol.Range.StartByte)
+		for ; node != nil; node = node.Parent() {
+			if node.Type(lang) != symbol.NodeType {
+				continue
+			}
+			if node.ChildByFieldName("receiver", lang) != nil {
+				withReceiverField++
+			}
+			break
+		}
+	}
+	if methods == 0 {
+		t.Fatal("the Go fixture holds no method symbols, so the ownership proof is vacuous")
+	}
+	if withReceiverField != methods {
+		t.Errorf("%d of %d method symbols expose a receiver field; the ownership stage needs them all", withReceiverField, methods)
+	}
+}
+
+// TestOutlinerHoldsNoParser proves structurally that an Outliner cannot parse:
+// no field it holds, at any depth, is a parser.
+func TestOutlinerHoldsNoParser(t *testing.T) {
+	parserType := reflect.TypeOf(&gts.Parser{})
+	outlinerType := reflect.TypeOf(gts.Outliner{})
+
+	seen := map[reflect.Type]bool{}
+	var walk func(reflect.Type, string)
+	walk = func(typ reflect.Type, path string) {
+		if typ == nil || seen[typ] {
+			return
+		}
+		seen[typ] = true
+		if typ == parserType || typ == parserType.Elem() {
+			t.Errorf("Outliner reaches a parser through %s", path)
+			return
+		}
+		switch typ.Kind() {
+		case reflect.Ptr, reflect.Slice, reflect.Array, reflect.Chan:
+			walk(typ.Elem(), path+".*")
+		case reflect.Map:
+			walk(typ.Key(), path+".key")
+			walk(typ.Elem(), path+".value")
+		case reflect.Struct:
+			for i := 0; i < typ.NumField(); i++ {
+				field := typ.Field(i)
+				walk(field.Type, path+"."+field.Name)
+			}
+		}
+	}
+	walk(outlinerType, "Outliner")
+}
+
+// TestOutlineReportsTruncationUnderAMatchLimit proves the truncation receipt
+// is real: a limit low enough to bite sets Truncated, and the default does
+// not.
+func TestOutlineReportsTruncationUnderAMatchLimit(t *testing.T) {
+	tree, lang, query := loadOutlineFixture(t, "python", "python/app.py")
+
+	full, err := gts.NewOutliner(lang, query)
+	if err != nil {
+		t.Fatalf("build outliner: %v", err)
+	}
+	fullSymbols, fullReport := full.OutlineTree(tree)
+	if fullReport.Truncated {
+		t.Fatal("the fixture truncates at the default budget; shrink it")
+	}
+	if len(fullSymbols) == 0 {
+		t.Fatal("the fixture produced no symbols")
+	}
+
+	limited, err := gts.NewOutliner(lang, query, gts.WithOutlineMatchLimit(2))
+	if err != nil {
+		t.Fatalf("build limited outliner: %v", err)
+	}
+	limitedSymbols, limitedReport := limited.OutlineTree(tree)
+	if !limitedReport.Truncated {
+		t.Errorf("a match limit of 2 did not set Truncated; report = %+v", limitedReport)
+	}
+	if limitedReport.Symbols > fullReport.Symbols {
+		t.Errorf("a truncated outline reports %d symbols, more than the full %d", limitedReport.Symbols, fullReport.Symbols)
+	}
+	_ = limitedSymbols
+}
+
+// TestOutlineReceiptBalancesOnEveryFixture asserts the accounting identity
+// against live extraction, not against the committed goldens.
+func TestOutlineReceiptBalancesOnEveryFixture(t *testing.T) {
+	for _, fixture := range outlineGoldenFixtures {
+		fixture := fixture
+		t.Run(fixture.File, func(t *testing.T) {
+			tree, lang, query := loadOutlineFixture(t, fixture.Language, fixture.File)
+			outliner, err := gts.NewOutliner(lang, query)
+			if err != nil {
+				t.Fatalf("build outliner: %v", err)
+			}
+			symbols, report := outliner.OutlineTree(tree)
+
+			if got := countLiveOutlineSymbols(symbols); got != report.Symbols {
+				t.Errorf("forest holds %d symbols, receipt says %d", got, report.Symbols)
+			}
+			if report.Candidates() != report.Symbols+report.Omitted() {
+				t.Errorf("receipt does not balance: %+v", report)
+			}
+			assertOutlineForestIsWellFormed(t, symbols, nil)
+		})
+	}
+}
+
+// assertOutlineForestIsWellFormed checks the two structural promises of the
+// forest: every child sits inside its parent, and siblings run in source order
+// without overlap.
+func assertOutlineForestIsWellFormed(t *testing.T, symbols []gts.OutlineSymbol, parent *gts.OutlineSymbol) {
+	t.Helper()
+	var previous *gts.OutlineSymbol
+	for i := range symbols {
+		symbol := symbols[i]
+		if symbol.NameRange.StartByte < symbol.Range.StartByte || symbol.NameRange.EndByte > symbol.Range.EndByte {
+			t.Errorf("%s %q: name span %d-%d is outside the definition span %d-%d",
+				symbol.Kind, symbol.Name,
+				symbol.NameRange.StartByte, symbol.NameRange.EndByte,
+				symbol.Range.StartByte, symbol.Range.EndByte)
+		}
+		if parent != nil {
+			if symbol.Range.StartByte < parent.Range.StartByte || symbol.Range.EndByte > parent.Range.EndByte {
+				t.Errorf("%s %q is not contained in its parent %q", symbol.Kind, symbol.Name, parent.Name)
+			}
+		}
+		if previous != nil {
+			if symbol.Range.StartByte < previous.Range.StartByte {
+				t.Errorf("%s %q precedes its earlier sibling %q; siblings must run in source order",
+					symbol.Kind, symbol.Name, previous.Name)
+			}
+			if symbol.Range.StartByte < previous.Range.EndByte {
+				t.Errorf("%s %q overlaps its sibling %q", symbol.Kind, symbol.Name, previous.Name)
+			}
+		}
+		previous = &symbols[i]
+		assertOutlineForestIsWellFormed(t, symbol.Children, &symbols[i])
+	}
+}
+
+func collectOutlineOwners(symbols []gts.OutlineSymbol) []string {
+	var out []string
+	for _, symbol := range symbols {
+		if strings.TrimSpace(symbol.Owner) != "" {
+			out = append(out, symbol.Name+"="+symbol.Owner)
+		}
+		out = append(out, collectOutlineOwners(symbol.Children)...)
+	}
+	return out
+}
+
+func countLiveOutlineSymbols(symbols []gts.OutlineSymbol) int {
+	total := len(symbols)
+	for _, symbol := range symbols {
+		total += countLiveOutlineSymbols(symbol.Children)
+	}
+	return total
+}

--- a/outline_api_test.go
+++ b/outline_api_test.go
@@ -1,10 +1,12 @@
 package gotreesitter_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	gts "github.com/odvcencio/gotreesitter"
@@ -96,55 +98,207 @@ func TestOutlineDeclinesWithoutTagsQuery(t *testing.T) {
 		if len(symbols) != 0 {
 			t.Errorf("NewOutliner(%q) produced %d symbols, want none", query, len(symbols))
 		}
-		if !report.QueryEmpty {
-			t.Errorf("NewOutliner(%q) report.QueryEmpty = false, want true", query)
+		if report.DeclineReason != gts.OutlineDeclineQueryEmpty {
+			t.Errorf("NewOutliner(%q) DeclineReason = %q, want %q", query, report.DeclineReason, gts.OutlineDeclineQueryEmpty)
+		}
+		if !report.Declined() {
+			t.Errorf("NewOutliner(%q) Declined() = false, want true", query)
 		}
 		if report.Symbols != 0 || report.Omitted() != 0 {
-			t.Errorf("NewOutliner(%q) report = %+v, want an all-zero receipt beside QueryEmpty", query, report)
+			t.Errorf("NewOutliner(%q) report = %+v, want an all-zero receipt beside the decline", query, report)
 		}
 	}
 }
 
-// TestOutlineDeclinesForeignTree proves the outliner does not run a query
-// whose symbol identifiers belong to another grammar. It declines and reports.
-func TestOutlineDeclinesForeignTree(t *testing.T) {
+// TestOutlineDeclineReasonsAreDistinguishable is the fix for a receipt shape
+// that made four different failures byte identical. A caller must be able to
+// tell a genuinely empty file from a projection that never ran.
+func TestOutlineDeclineReasonsAreDistinguishable(t *testing.T) {
+	goTree, goLang, goQuery := loadOutlineFixture(t, "go", "go/service.go.fixture")
 	pythonTree, _, _ := loadOutlineFixture(t, "python", "python/app.py")
-	_, goLang, goQuery := loadOutlineFixture(t, "go", "go/service.go.fixture")
 
-	outliner, err := gts.NewOutliner(goLang, goQuery)
+	working, err := gts.NewOutliner(goLang, goQuery)
 	if err != nil {
 		t.Fatalf("build outliner: %v", err)
 	}
-	symbols, report := outliner.OutlineTree(pythonTree)
-	if len(symbols) != 0 {
-		t.Errorf("outlining a foreign tree produced %d symbols, want none", len(symbols))
+	declining, err := gts.NewOutliner(goLang, "")
+	if err != nil {
+		t.Fatalf("build declining outliner: %v", err)
 	}
-	if !report.LanguageMismatch {
-		t.Error("report.LanguageMismatch = false, want true")
+
+	// An empty source file: the query RAN and matched nothing. This is the
+	// case that must not look like a decline.
+	emptyParser := gts.NewParser(goLang)
+	emptyTree, err := emptyParser.Parse([]byte("package empty\n"))
+	if err != nil {
+		t.Fatalf("parse empty source: %v", err)
+	}
+	defer emptyTree.Release()
+
+	var nilOutliner *gts.Outliner
+
+	cases := []struct {
+		name       string
+		reason     string
+		run        func() (int, gts.OutlineReport)
+		wantSymbol bool
+	}{
+		{
+			name:   "nil outliner",
+			reason: gts.OutlineDeclineNilOutliner,
+			run:    func() (int, gts.OutlineReport) { s, r := nilOutliner.OutlineTree(goTree); return len(s), r },
+		},
+		{
+			name:   "empty query",
+			reason: gts.OutlineDeclineQueryEmpty,
+			run:    func() (int, gts.OutlineReport) { s, r := declining.OutlineTree(goTree); return len(s), r },
+		},
+		{
+			name:   "nil tree",
+			reason: gts.OutlineDeclineNilTree,
+			run:    func() (int, gts.OutlineReport) { s, r := working.OutlineTree(nil); return len(s), r },
+		},
+		{
+			name:   "foreign tree",
+			reason: gts.OutlineDeclineLanguageMismatch,
+			run:    func() (int, gts.OutlineReport) { s, r := working.OutlineTree(pythonTree); return len(s), r },
+		},
+		{
+			name:   "empty file, query ran",
+			reason: "",
+			run:    func() (int, gts.OutlineReport) { s, r := working.OutlineTree(emptyTree); return len(s), r },
+		},
+	}
+
+	seen := map[string]string{}
+	for _, tc := range cases {
+		count, report := tc.run()
+		if count != 0 {
+			t.Errorf("%s: produced %d symbols, want none", tc.name, count)
+		}
+		if report.DeclineReason != tc.reason {
+			t.Errorf("%s: DeclineReason = %q, want %q", tc.name, report.DeclineReason, tc.reason)
+		}
+		if report.Declined() != (tc.reason != "") {
+			t.Errorf("%s: Declined() = %v, want %v", tc.name, report.Declined(), tc.reason != "")
+		}
+		if previous, ok := seen[report.DeclineReason]; ok {
+			t.Errorf("%s and %s produce the same receipt %q; a caller cannot tell them apart",
+				tc.name, previous, report.DeclineReason)
+		}
+		seen[report.DeclineReason] = tc.name
+	}
+
+	if len(seen) != len(cases) {
+		t.Errorf("%d cases collapsed into %d distinguishable receipts", len(cases), len(seen))
 	}
 }
 
 func TestOutlineHandlesNilAndEmptyInput(t *testing.T) {
-	_, lang, query := loadOutlineFixture(t, "go", "go/service.go.fixture")
-	outliner, err := gts.NewOutliner(lang, query)
-	if err != nil {
-		t.Fatalf("build outliner: %v", err)
-	}
-
-	symbols, report := outliner.OutlineTree(nil)
-	if len(symbols) != 0 || report.Symbols != 0 {
-		t.Errorf("OutlineTree(nil) = %+v / %+v, want empty", symbols, report)
-	}
-
 	var nilOutliner *gts.Outliner
-	if symbols, report := nilOutliner.OutlineTree(nil); len(symbols) != 0 || report.Symbols != 0 {
-		t.Errorf("nil outliner returned %+v / %+v, want empty", symbols, report)
-	}
 	if nilOutliner.QueryEmpty() {
 		t.Error("nil outliner reported an empty query rather than staying inert")
 	}
 	if nilOutliner.Language() != nil {
 		t.Error("nil outliner returned a language")
+	}
+	if nilOutliner.DefinitionKinds() != nil {
+		t.Error("nil outliner returned definition kinds")
+	}
+}
+
+// TestOutlineDefinitionKindsBoundWhatTheOutlineCanContain covers the reading
+// trap behind "every counter is zero". The Go tags override carries no type,
+// constant, or variable pattern, so a Go outline can only ever hold functions
+// and methods, however many types the file declares.
+func TestOutlineDefinitionKindsBoundWhatTheOutlineCanContain(t *testing.T) {
+	tree, lang, query := loadOutlineFixture(t, "go", "go/service.go.fixture")
+	outliner, err := gts.NewOutliner(lang, query)
+	if err != nil {
+		t.Fatalf("build outliner: %v", err)
+	}
+
+	kinds := outliner.DefinitionKinds()
+	want := []string{"function", "method"}
+	if !reflect.DeepEqual(kinds, want) {
+		t.Errorf("go DefinitionKinds() = %v, want %v", kinds, want)
+	}
+
+	symbols, report := outliner.OutlineTree(tree)
+	allowed := map[string]bool{}
+	for _, kind := range kinds {
+		allowed[kind] = true
+	}
+	var check func([]gts.OutlineSymbol)
+	check = func(list []gts.OutlineSymbol) {
+		for _, symbol := range list {
+			if !allowed[symbol.Kind] {
+				t.Errorf("symbol %q has kind %q, which DefinitionKinds() does not list", symbol.Name, symbol.Kind)
+			}
+			check(symbol.Children)
+		}
+	}
+	check(symbols)
+
+	// The fixture declares a struct, an interface, and a constant. None
+	// reaches a candidate, so none reaches an omission counter either. That
+	// is the fact DefinitionKinds exists to make visible.
+	if report.Omitted() != 0 {
+		t.Errorf("Omitted() = %d, want 0 for this fixture", report.Omitted())
+	}
+	source, err := os.ReadFile(filepath.Join(outlineGoldenRoot, "go/service.go.fixture"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	for _, declared := range []string{"type Registry struct", "type Named interface", "const defaultName"} {
+		if !strings.Contains(string(source), declared) {
+			t.Fatalf("fixture no longer declares %q, so this test proves nothing", declared)
+		}
+	}
+	if report.Symbols != 4 {
+		t.Errorf("Symbols = %d, want 4: the query reaches only functions and methods", report.Symbols)
+	}
+}
+
+// TestOutlineTreeIsSafeForConcurrentUse backs the concurrency promise in the
+// Outliner documentation. Under the race detector this fails loudly if
+// OutlineTree writes shared state.
+func TestOutlineTreeIsSafeForConcurrentUse(t *testing.T) {
+	tree, lang, query := loadOutlineFixture(t, "python", "python/app.py")
+	outliner, err := gts.NewOutliner(lang, query)
+	if err != nil {
+		t.Fatalf("build outliner: %v", err)
+	}
+	wantSymbols, wantReport := outliner.OutlineTree(tree)
+	if wantReport.Symbols == 0 {
+		t.Fatal("the fixture produced no symbols")
+	}
+
+	const goroutines = 16
+	const callsEach = 20
+	var wg sync.WaitGroup
+	errs := make(chan string, goroutines*callsEach)
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < callsEach; i++ {
+				symbols, report := outliner.OutlineTree(tree)
+				if report != wantReport {
+					errs <- fmt.Sprintf("receipt diverged: %+v", report)
+					return
+				}
+				if !outlineSymbolsEqual(symbols, wantSymbols) {
+					errs <- "symbols diverged under concurrent use"
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for msg := range errs {
+		t.Error(msg)
 	}
 }
 
@@ -291,9 +445,15 @@ func TestOutlineReportsTruncationUnderAMatchLimit(t *testing.T) {
 	_ = limitedSymbols
 }
 
-// TestOutlineReceiptBalancesOnEveryFixture asserts the accounting identity
-// against live extraction, not against the committed goldens.
-func TestOutlineReceiptBalancesOnEveryFixture(t *testing.T) {
+// TestOutlineReceiptMatchesIndependentGroundTruth is the real accounting gate.
+//
+// Comparing Candidates() to Symbols + Omitted() proves nothing, because
+// Candidates() is DEFINED as that sum. This test instead runs the same
+// compiled query a second time, independently of the outliner, counts the
+// matches that carry exactly one definition capture, and compares that ground
+// truth to the receipt. A candidate that vanished without a counter fails
+// here.
+func TestOutlineReceiptMatchesIndependentGroundTruth(t *testing.T) {
 	for _, fixture := range outlineGoldenFixtures {
 		fixture := fixture
 		t.Run(fixture.File, func(t *testing.T) {
@@ -304,13 +464,87 @@ func TestOutlineReceiptBalancesOnEveryFixture(t *testing.T) {
 			}
 			symbols, report := outliner.OutlineTree(tree)
 
+			singleDefinition, multipleDefinitions := countDefinitionBearingMatches(t, lang, query, tree)
+			if singleDefinition == 0 {
+				t.Fatal("the query produced no definition-bearing match, so this gate is vacuous")
+			}
+			if report.Candidates() != singleDefinition+multipleDefinitions {
+				t.Errorf("the query produced %d definition-bearing matches (%d single, %d multiple) but the receipt accounts for %d: symbols=%d omitted=%d %+v",
+					singleDefinition+multipleDefinitions, singleDefinition, multipleDefinitions,
+					report.Candidates(), report.Symbols, report.Omitted(), report)
+			}
+			if report.OmittedMultipleDefinitions != multipleDefinitions {
+				t.Errorf("OmittedMultipleDefinitions = %d, ground truth %d", report.OmittedMultipleDefinitions, multipleDefinitions)
+			}
 			if got := countLiveOutlineSymbols(symbols); got != report.Symbols {
 				t.Errorf("forest holds %d symbols, receipt says %d", got, report.Symbols)
 			}
-			if report.Candidates() != report.Symbols+report.Omitted() {
-				t.Errorf("receipt does not balance: %+v", report)
-			}
 			assertOutlineForestIsWellFormed(t, symbols, nil)
+		})
+	}
+}
+
+// countDefinitionBearingMatches runs the compiled query independently of the
+// outliner and counts matches by how many definition captures they carry.
+func countDefinitionBearingMatches(t *testing.T, lang *gts.Language, queryText string, tree *gts.Tree) (single, multiple int) {
+	t.Helper()
+	compiled, err := gts.NewQuery(queryText, lang)
+	if err != nil {
+		t.Fatalf("compile ground-truth query: %v", err)
+	}
+	for _, match := range compiled.Execute(tree) {
+		definitions := 0
+		for _, capture := range match.Captures {
+			if capture.Node == nil {
+				continue
+			}
+			if strings.HasPrefix(capture.Name, "definition.") && len(capture.Name) > len("definition.") {
+				definitions++
+			}
+		}
+		switch {
+		case definitions == 1:
+			single++
+		case definitions > 1:
+			multiple++
+		}
+	}
+	return single, multiple
+}
+
+// TestOutlineNameAgreesWithNameRange enforces the invariant documented on
+// OutlineSymbol.Name: the emitted name is the trimmed text of the capture
+// node, so the source bytes at NameRange must trim to exactly Name. A language
+// where a directive rewrites the text would surface here rather than ship a
+// name that does not match its own span.
+func TestOutlineNameAgreesWithNameRange(t *testing.T) {
+	for _, fixture := range outlineGoldenFixtures {
+		fixture := fixture
+		t.Run(fixture.File, func(t *testing.T) {
+			tree, lang, query := loadOutlineFixture(t, fixture.Language, fixture.File)
+			outliner, err := gts.NewOutliner(lang, query)
+			if err != nil {
+				t.Fatalf("build outliner: %v", err)
+			}
+			symbols, _ := outliner.OutlineTree(tree)
+			source := tree.Source()
+
+			var check func([]gts.OutlineSymbol)
+			check = func(list []gts.OutlineSymbol) {
+				for _, symbol := range list {
+					if int(symbol.NameRange.EndByte) > len(source) {
+						t.Errorf("%q: NameRange ends past the source", symbol.Name)
+						continue
+					}
+					span := strings.TrimSpace(string(source[symbol.NameRange.StartByte:symbol.NameRange.EndByte]))
+					if span != symbol.Name {
+						t.Errorf("%s %q: source at NameRange is %q; Name and NameRange disagree",
+							symbol.Kind, symbol.Name, span)
+					}
+					check(symbol.Children)
+				}
+			}
+			check(symbols)
 		})
 	}
 }

--- a/outline_bench_test.go
+++ b/outline_bench_test.go
@@ -1,0 +1,169 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+// outlineBenchWorkload holds one already-parsed tree, one compiled outliner,
+// and one compiled tagger over the identical language and tags query. Both
+// benchmarks below reuse it, so they measure projection only: the parse and
+// both query compilations happen once, outside the timed loop.
+type outlineBenchWorkload struct {
+	id       string
+	tree     *gts.Tree
+	outliner *gts.Outliner
+	tagger   *gts.Tagger
+}
+
+func newOutlineBenchWorkloads(tb testing.TB) []outlineBenchWorkload {
+	tb.Helper()
+
+	entry := grammars.DetectLanguageByName("go")
+	if entry == nil {
+		tb.Fatal("the go grammar is not registered")
+	}
+	lang := entry.Language()
+	query := grammars.ResolveTagsQuery(*entry)
+	if query == "" {
+		tb.Fatal("the go tags query resolved empty")
+	}
+
+	fixtures, err := benchfixtures.LoadGoFullParseFixtures()
+	if err != nil {
+		tb.Fatalf("load go fixtures: %v", err)
+	}
+
+	workloads := make([]outlineBenchWorkload, 0, len(fixtures))
+	for _, fixture := range fixtures {
+		parser := gts.NewParser(lang)
+		tree, err := parser.Parse(fixture.Source)
+		if err != nil {
+			tb.Fatalf("%s: parse: %v", fixture.Fixture.ID, err)
+		}
+		tb.Cleanup(tree.Release)
+
+		outliner, err := gts.NewOutliner(lang, query)
+		if err != nil {
+			tb.Fatalf("%s: build outliner: %v", fixture.Fixture.ID, err)
+		}
+		tagger, err := gts.NewTagger(lang, query)
+		if err != nil {
+			tb.Fatalf("%s: build tagger: %v", fixture.Fixture.ID, err)
+		}
+		workloads = append(workloads, outlineBenchWorkload{
+			id:       fixture.Fixture.ID,
+			tree:     tree,
+			outliner: outliner,
+			tagger:   tagger,
+		})
+	}
+	return workloads
+}
+
+// BenchmarkOutlineTree measures the outline projection over already-parsed Go
+// corpus trees. Pair it with BenchmarkOutlineTaggerBaseline, which runs the
+// identical query over the identical trees, to read the ratio the
+// specification budgets at 1.5 times.
+//
+//	go test . -run '^$' -bench 'BenchmarkOutline' -benchtime 200x -count 5
+func BenchmarkOutlineTree(b *testing.B) {
+	workloads := newOutlineBenchWorkloads(b)
+	for _, workload := range workloads {
+		workload := workload
+		b.Run(workload.id, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				symbols, report := workload.outliner.OutlineTree(workload.tree)
+				if report.Symbols == 0 || len(symbols) == 0 {
+					b.Fatalf("%s: outline produced nothing", workload.id)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkOutlineTaggerBaseline is the comparison arm: the same tags query,
+// the same trees, through Tagger.TagTree.
+func BenchmarkOutlineTaggerBaseline(b *testing.B) {
+	workloads := newOutlineBenchWorkloads(b)
+	for _, workload := range workloads {
+		workload := workload
+		b.Run(workload.id, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				tags := workload.tagger.TagTree(workload.tree)
+				if len(tags) == 0 {
+					b.Fatalf("%s: tagger produced nothing", workload.id)
+				}
+			}
+		})
+	}
+}
+
+// TestOutlineTreeCostStaysNearTagger is the continuous-integration-visible
+// half of the performance gate. Wall time on a shared runner is too noisy to
+// assert, so this test asserts the deterministic cost driver instead: the
+// outline and the tagger execute the same query over the same tree, so the
+// outline must not visit more matches than the tagger produces tags, and its
+// allocation count must stay inside a fixed multiple of the tagger's.
+//
+// Allocation counts are deterministic for a fixed tree and query, so this
+// assertion does not flake on a contended host. The wall-clock ratio is
+// measured by the two benchmarks above and reported with the change.
+func TestOutlineTreeCostStaysNearTagger(t *testing.T) {
+	// The allocation budget: the outline allocates the candidate slice, the
+	// sorted copy, the accepted and parent and children slices, and one
+	// slice per parent that has children. Four times the tagger's count
+	// leaves room for that without hiding a new pass over the tree.
+	const allocationBudgetMultiple = 4
+
+	workloads := newOutlineBenchWorkloads(t)
+	if len(workloads) == 0 {
+		t.Fatal("no benchmark workloads")
+	}
+
+	for _, workload := range workloads {
+		workload := workload
+		t.Run(workload.id, func(t *testing.T) {
+			symbols, report := workload.outliner.OutlineTree(workload.tree)
+			tags := workload.tagger.TagTree(workload.tree)
+			if len(symbols) == 0 || report.Symbols == 0 {
+				t.Fatalf("%s: outline produced nothing", workload.id)
+			}
+			if len(tags) == 0 {
+				t.Fatalf("%s: tagger produced nothing", workload.id)
+			}
+
+			// Every outline candidate comes from a definition tag, so the
+			// candidate count can never exceed the tag count. A larger
+			// number would mean the outline ran extra work over the tree.
+			if report.Candidates() > len(tags) {
+				t.Errorf("%s: outline saw %d candidates from %d tags; it must not do more query work than the tagger",
+					workload.id, report.Candidates(), len(tags))
+			}
+
+			outlineAllocs := testing.AllocsPerRun(3, func() {
+				workload.outliner.OutlineTree(workload.tree)
+			})
+			taggerAllocs := testing.AllocsPerRun(3, func() {
+				workload.tagger.TagTree(workload.tree)
+			})
+			if taggerAllocs <= 0 {
+				t.Fatalf("%s: tagger baseline allocated nothing, so the budget is meaningless", workload.id)
+			}
+			budget := taggerAllocs * allocationBudgetMultiple
+			if outlineAllocs > budget {
+				t.Errorf("%s: outline allocated %.0f times per call, budget %.0f (%d times the tagger's %.0f)",
+					workload.id, outlineAllocs, budget, allocationBudgetMultiple, taggerAllocs)
+			}
+			t.Logf("%s: outline %.0f allocs, tagger %.0f allocs, ratio %.2f; outline symbols=%d tags=%d",
+				workload.id, outlineAllocs, taggerAllocs, outlineAllocs/taggerAllocs, report.Symbols, len(tags))
+		})
+	}
+}

--- a/outline_bench_test.go
+++ b/outline_bench_test.go
@@ -1,6 +1,7 @@
 package gotreesitter_test
 
 import (
+	"strings"
 	"testing"
 
 	gts "github.com/odvcencio/gotreesitter"
@@ -117,11 +118,13 @@ func BenchmarkOutlineTaggerBaseline(b *testing.B) {
 // assertion does not flake on a contended host. The wall-clock ratio is
 // measured by the two benchmarks above and reported with the change.
 func TestOutlineTreeCostStaysNearTagger(t *testing.T) {
-	// The allocation budget: the outline allocates the candidate slice, the
-	// sorted copy, the accepted and parent and children slices, and one
-	// slice per parent that has children. Four times the tagger's count
-	// leaves room for that without hiding a new pass over the tree.
-	const allocationBudgetMultiple = 4
+	// The allocation budget. Observed ratios are 1.005 to 1.018, because the
+	// outline allocates only the candidate slice, the sorted copy, the
+	// accepted, parent, and children slices, and one slice per parent that
+	// has children. A budget of 1.5 leaves room for that and still fails on
+	// a regression that adds a per-node allocation; a looser budget would
+	// let a threefold regression through unnoticed.
+	const allocationBudgetMultiple = 1.5
 
 	workloads := newOutlineBenchWorkloads(t)
 	if len(workloads) == 0 {
@@ -140,12 +143,22 @@ func TestOutlineTreeCostStaysNearTagger(t *testing.T) {
 				t.Fatalf("%s: tagger produced nothing", workload.id)
 			}
 
-			// Every outline candidate comes from a definition tag, so the
-			// candidate count can never exceed the tag count. A larger
-			// number would mean the outline ran extra work over the tree.
-			if report.Candidates() > len(tags) {
-				t.Errorf("%s: outline saw %d candidates from %d tags; it must not do more query work than the tagger",
-					workload.id, report.Candidates(), len(tags))
+			// Every outline candidate comes from a DEFINITION tag.
+			// Comparing against every tag would be loose by an order of
+			// magnitude, because the Go tags query is mostly call
+			// references, so count the definition tags exactly.
+			definitionTags := 0
+			for _, tag := range tags {
+				if strings.HasPrefix(tag.Kind, "definition.") {
+					definitionTags++
+				}
+			}
+			if definitionTags == 0 {
+				t.Fatalf("%s: the tagger produced no definition tag, so the bound is vacuous", workload.id)
+			}
+			if report.Candidates() > definitionTags {
+				t.Errorf("%s: outline saw %d candidates from %d definition tags; it must not do more query work than the tagger",
+					workload.id, report.Candidates(), definitionTags)
 			}
 
 			outlineAllocs := testing.AllocsPerRun(3, func() {
@@ -159,7 +172,7 @@ func TestOutlineTreeCostStaysNearTagger(t *testing.T) {
 			}
 			budget := taggerAllocs * allocationBudgetMultiple
 			if outlineAllocs > budget {
-				t.Errorf("%s: outline allocated %.0f times per call, budget %.0f (%d times the tagger's %.0f)",
+				t.Errorf("%s: outline allocated %.0f times per call, budget %.0f (%.1f times the tagger's %.0f)",
 					workload.id, outlineAllocs, budget, allocationBudgetMultiple, taggerAllocs)
 			}
 			t.Logf("%s: outline %.0f allocs, tagger %.0f allocs, ratio %.2f; outline symbols=%d tags=%d",

--- a/outline_coupling_test.go
+++ b/outline_coupling_test.go
@@ -1,0 +1,194 @@
+package gotreesitter_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// outlineSourceFiles lists every file that carries the outline mechanism.
+// The static scan below reads exactly these files, so a new outline source
+// file must be added here or the scan will not cover it.
+var outlineSourceFiles = []string{
+	"outline.go",
+	"outline_report.go",
+}
+
+// outlineForbiddenIdentifiers names the parser-core surfaces the outline must
+// never touch. The outline is a read-only projection over a tree somebody else
+// already built: it must not parse, must not choose a parse route, must not
+// enter admission, and must not run result compatibility.
+//
+// The list mixes parse entry points, route dispatch, admission, and result
+// compatibility, which are the four surfaces whose behavior the parse gates
+// pin byte for byte.
+var outlineForbiddenIdentifiers = []string{
+	"parseInternal",
+	"parseIncrementalInternal",
+	"parseWithTokenSource",
+	"parseForRecovery",
+	"parseForest",
+	"dispatchParse",
+	"NewParser(",
+	"Parse(",
+	"admission",
+	"Admission",
+	"resultCompatibility",
+	"ResultCompatibility",
+	"normalizeResultCompatibility",
+	"compactRoute",
+	"runLanguageResultCompatibility",
+}
+
+// TestOutlineSourceHasNoParserCoreCoupling is gate G-4a: a static scan. It
+// proves by reading the shipped source that the outline mechanism names no
+// parse, route, admission, or result-compatibility identifier. A projection
+// that never mentions those surfaces cannot change what a parse produces.
+func TestOutlineSourceHasNoParserCoreCoupling(t *testing.T) {
+	for _, file := range outlineSourceFiles {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read outline source %s: %v", file, err)
+		}
+		text := string(data)
+		for _, forbidden := range outlineForbiddenIdentifiers {
+			if strings.Contains(text, forbidden) {
+				t.Errorf("%s names the parser-core identifier %q; the outline must stay a read-only projection over an already-built tree",
+					file, forbidden)
+			}
+		}
+	}
+}
+
+// TestOutlineSourceScanCoversEveryOutlineFile keeps the static scan honest. A
+// scan that reads a stale file list is the exact failure this repository has
+// seen before: a test that exists, passes, and covers nothing.
+func TestOutlineSourceScanCoversEveryOutlineFile(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package directory: %v", err)
+	}
+	listed := map[string]bool{}
+	for _, file := range outlineSourceFiles {
+		listed[file] = true
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasPrefix(name, "outline") || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		if !listed[name] {
+			t.Errorf("%s carries outline code but is missing from outlineSourceFiles, so the coupling scan skips it", name)
+		}
+	}
+	for _, file := range outlineSourceFiles {
+		if _, err := os.Stat(file); err != nil {
+			t.Errorf("outlineSourceFiles names %s, which does not exist: %v", file, err)
+		}
+	}
+}
+
+// TestOutlineSourceScanDetectsCoupling proves the scan can fail. A gate that
+// cannot fail is not a gate.
+func TestOutlineSourceScanDetectsCoupling(t *testing.T) {
+	sample := "func project() { p := NewParser(lang); _ = p }"
+	hit := false
+	for _, forbidden := range outlineForbiddenIdentifiers {
+		if strings.Contains(sample, forbidden) {
+			hit = true
+			break
+		}
+	}
+	if !hit {
+		t.Fatal("the forbidden-identifier list does not catch a direct parser construction; the scan is vacuous")
+	}
+}
+
+// TestOutlineTreeLeavesTheTreeUnchanged is gate G-4b: the behavioral half. It
+// parses once, digests the whole tree as an s-expression, projects the
+// outline, and digests again. A projection that changed any node, span, or
+// field would move the digest.
+func TestOutlineTreeLeavesTheTreeUnchanged(t *testing.T) {
+	for _, fixture := range outlineGoldenFixtures {
+		fixture := fixture
+		t.Run(fixture.File, func(t *testing.T) {
+			entry := grammars.DetectLanguageByName(fixture.Language)
+			if entry == nil {
+				t.Fatalf("language %q is not registered", fixture.Language)
+			}
+			lang := entry.Language()
+			source, err := os.ReadFile(outlineGoldenRoot + "/" + fixture.File)
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+
+			parser := gts.NewParser(lang)
+			tree, err := parser.Parse(source)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			defer tree.Release()
+
+			before := sExprDigest(tree.RootNode().SExpr(lang))
+			beforeSource := sha256.Sum256(tree.Source())
+
+			outliner, err := gts.NewOutliner(lang, grammars.ResolveTagsQuery(*entry))
+			if err != nil {
+				t.Fatalf("build outliner: %v", err)
+			}
+			// Project twice: a projection that mutated the tree would also
+			// have to be idempotent to hide, and this catches the rest.
+			firstSymbols, firstReport := outliner.OutlineTree(tree)
+			secondSymbols, secondReport := outliner.OutlineTree(tree)
+
+			after := sExprDigest(tree.RootNode().SExpr(lang))
+			afterSource := sha256.Sum256(tree.Source())
+
+			if before != after {
+				t.Errorf("tree s-expression digest moved across OutlineTree: %s -> %s", before, after)
+			}
+			if beforeSource != afterSource {
+				t.Error("tree source bytes changed across OutlineTree")
+			}
+			if firstReport != secondReport {
+				t.Errorf("OutlineTree is not repeatable: %+v then %+v", firstReport, secondReport)
+			}
+			if !outlineSymbolsEqual(firstSymbols, secondSymbols) {
+				t.Error("OutlineTree returned different symbols on the second call over the same tree")
+			}
+		})
+	}
+}
+
+func sExprDigest(sexpr string) string {
+	sum := sha256.Sum256([]byte(sexpr))
+	return hex.EncodeToString(sum[:])
+}
+
+func outlineSymbolsEqual(a, b []gts.OutlineSymbol) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Kind != b[i].Kind ||
+			a[i].Name != b[i].Name ||
+			a[i].NodeType != b[i].NodeType ||
+			a[i].Range != b[i].Range ||
+			a[i].NameRange != b[i].NameRange ||
+			a[i].Owner != b[i].Owner {
+			return false
+		}
+		if !outlineSymbolsEqual(a[i].Children, b[i].Children) {
+			return false
+		}
+	}
+	return true
+}

--- a/outline_golden_test.go
+++ b/outline_golden_test.go
@@ -29,7 +29,39 @@ type outlineGoldenFixture struct {
 	// Purpose records why this fixture exists, so a reviewer can see what
 	// the golden is meant to protect.
 	Purpose string
+	// Query overrides the language's resolved tags query. Leave it empty to
+	// use the shipped tags data, which is what a caller gets. Set it only to
+	// reach a shape the shared inference cannot produce on demand.
+	Query string
 }
+
+// outlineCounterProbeQuery is a deliberately ambiguous Go tags query. The
+// shared inference never emits these shapes, so without it not one of the
+// omission counters would be pinned by any committed golden.
+//
+// Each rule gets its own node type, so one rule cannot mask another.
+//
+//   - function_declaration is bound twice to the same kind, name, and span.
+//     The candidates are indistinguishable, so one survives and the repeat
+//     lands in OmittedDuplicate.
+//   - type_spec is bound to two different kinds at one span, so the span
+//     means two things at once and every member lands in OmittedConflict.
+//   - method_declaration is bound once to its own name and once to its
+//     receiver name. The two agree on the span and the kind and disagree on
+//     the name, so every member lands in OmittedNameConflict. This is the
+//     shape that made C-family outlines publish a return type as a method
+//     name.
+//   - const_declaration is captured with no name at all: OmittedNoName.
+//   - var_declaration carries two definition captures on one match, so the
+//     match names two definitions at once: OmittedMultipleDefinitions.
+const outlineCounterProbeQuery = `(function_declaration name: (identifier) @name) @definition.function
+(function_declaration name: (identifier) @name) @definition.function
+(type_spec name: (type_identifier) @name) @definition.type
+(type_spec name: (type_identifier) @name) @definition.class
+(method_declaration name: (field_identifier) @name) @definition.method
+(method_declaration receiver: (parameter_list (parameter_declaration name: (identifier) @name))) @definition.method
+(const_declaration) @definition.constant
+((var_declaration) @definition.variable @definition.constant)`
 
 // outlineGoldenFixtures is the stage-1 golden set. Every language listed is
 // tier 1 in the outline coverage census (grammars.TestOutlineTierCensus):
@@ -80,23 +112,43 @@ var outlineGoldenFixtures = []outlineGoldenFixture{
 	{
 		Language: "c",
 		File:     "c/registry.c",
-		// This golden also pins a known limit of the shared inferred tags
-		// data, not of the extractor: the pattern
+		// This golden pins a FLEET-WIDE defect in the shared inferred tags
+		// data, not a C quirk and not an extractor bug.
+		//
+		// The pattern
 		// "(struct_specifier (type_identifier) @name) @definition.type"
 		// matches a struct USE, such as the parameter type
-		// "struct Registry *registry", as well as a struct definition. The
-		// outline reports what the query captured, so the extra "Registry"
-		// entries nest inside the functions that mention the type. This is
-		// spec risk R1, inferred-query over-capture. Its remedy is a data
-		// edit to the pattern table or a per-language override, which is a
-		// later stage; the golden makes the behavior visible today and
-		// turns that data edit into a reviewable diff.
-		Purpose: "struct, typedef, and function definitions; also pins the inferred-query over-capture of struct uses (spec risk R1)",
+		// "struct Registry *registry", exactly as it matches a struct
+		// definition. Across the real corpus this makes 1179 of the 2400
+		// symbols emitted for C struct USES: 49 percent of the C outline is
+		// noise, so the signal-to-noise ratio is close to one to one.
+		//
+		// The same struct_specifier pattern reaches SEVEN languages:
+		// arduino, c, cpp, cuda, glsl, hlsl, and objc. Its class_specifier
+		// sibling reaches four more. A stage-5 data edit must therefore be
+		// scoped to the pattern, not to one language.
+		//
+		// The C++ golden looks clean only by accident: its
+		// "int total(const Registry &registry)" omits the "class" keyword,
+		// so the parameter type is not a class_specifier there. Do not read
+		// that golden as evidence the pattern is safe.
+		Purpose: "struct, typedef, and function definitions; pins the fleet-wide struct_specifier over-capture that makes 49 percent of the C outline struct uses (spec risk R1)",
 	},
 	{
 		Language: "cpp",
 		File:     "cpp/registry.cpp",
-		Purpose:  "class with member function definitions nested inside it",
+		Purpose:  "class with member function definitions nested inside it; clean of the struct_specifier over-capture only because the parameter type omits the class keyword",
+	},
+	{
+		Language: "c_sharp",
+		File:     "csharp/Service.cs",
+		Purpose:  "real-data name conflict: the shared inference binds @name to both the return type and the method name, so the group drops and OmittedNameConflict fires instead of publishing the return type",
+	},
+	{
+		Language: "go",
+		File:     "go/counters.go.fixture",
+		Query:    outlineCounterProbeQuery,
+		Purpose:  "pins OmittedDuplicate, OmittedConflict, OmittedNameConflict, OmittedNoName, and OmittedMultipleDefinitions end to end through a live query, which the shipped tags data cannot produce on demand",
 	},
 }
 
@@ -122,13 +174,17 @@ type outlineGoldenSymbol struct {
 }
 
 // outlineGoldenFile is the whole committed artifact for one fixture.
+//
+// DefinitionKinds is recorded beside the symbols on purpose. It states what
+// the compiled query CAN emit, so a reader can tell a kind the file does not
+// contain from a kind the tags data cannot express.
 type outlineGoldenFile struct {
-	Language string                `json:"language"`
-	Fixture  string                `json:"fixture"`
-	Purpose  string                `json:"purpose"`
-	HasError bool                  `json:"tree_has_error"`
-	Report   gts.OutlineReport     `json:"report"`
-	Symbols  []outlineGoldenSymbol `json:"symbols"`
+	Language        string                `json:"language"`
+	Fixture         string                `json:"fixture"`
+	Purpose         string                `json:"purpose"`
+	DefinitionKinds []string              `json:"query_definition_kinds"`
+	Report          gts.OutlineReport     `json:"report"`
+	Symbols         []outlineGoldenSymbol `json:"symbols"`
 }
 
 func outlineGoldenRangeOf(r gts.Range) outlineGoldenRange {
@@ -160,7 +216,12 @@ func outlineGoldenSymbolsOf(symbols []gts.OutlineSymbol) []outlineGoldenSymbol {
 }
 
 // outlineForFixture parses a committed fixture and projects its outline.
-func outlineForFixture(t *testing.T, fixture outlineGoldenFixture) (outlineGoldenFile, bool) {
+//
+// Most fixtures use the language's resolved tags query. A fixture that sets
+// Query uses that query instead, which is how the omission counters get pinned
+// end to end: the shared inference cannot produce a duplicate or a conflict on
+// demand, but an explicit query can, and it exercises the identical code path.
+func outlineForFixture(t *testing.T, fixture outlineGoldenFixture) outlineGoldenFile {
 	t.Helper()
 
 	entry := grammars.DetectLanguageByName(fixture.Language)
@@ -172,9 +233,12 @@ func outlineForFixture(t *testing.T, fixture outlineGoldenFixture) (outlineGolde
 		t.Fatalf("%s: language %q failed to load", fixture.File, fixture.Language)
 	}
 
-	query := grammars.ResolveTagsQuery(*entry)
-	if strings.TrimSpace(query) == "" {
-		t.Fatalf("%s: language %q resolved an empty tags query, so it is no longer tier 1", fixture.File, fixture.Language)
+	query := fixture.Query
+	if query == "" {
+		query = grammars.ResolveTagsQuery(*entry)
+		if strings.TrimSpace(query) == "" {
+			t.Fatalf("%s: language %q resolved an empty tags query, so it is no longer tier 1", fixture.File, fixture.Language)
+		}
 	}
 
 	source, err := os.ReadFile(filepath.Join(outlineGoldenRoot, fixture.File))
@@ -196,17 +260,14 @@ func outlineForFixture(t *testing.T, fixture outlineGoldenFixture) (outlineGolde
 
 	symbols, report := outliner.OutlineTree(tree)
 
-	root := tree.RootNode()
-	hasError := root != nil && root.HasError()
-
 	return outlineGoldenFile{
-		Language: fixture.Language,
-		Fixture:  fixture.File,
-		Purpose:  fixture.Purpose,
-		HasError: hasError,
-		Report:   report,
-		Symbols:  outlineGoldenSymbolsOf(symbols),
-	}, true
+		Language:        fixture.Language,
+		Fixture:         fixture.File,
+		Purpose:         fixture.Purpose,
+		DefinitionKinds: outliner.DefinitionKinds(),
+		Report:          report,
+		Symbols:         outlineGoldenSymbolsOf(symbols),
+	}
 }
 
 func outlineGoldenPath(fixture outlineGoldenFixture) string {
@@ -231,11 +292,7 @@ func TestOutlineGoldens(t *testing.T) {
 	for _, fixture := range outlineGoldenFixtures {
 		fixture := fixture
 		t.Run(fixture.File, func(t *testing.T) {
-			got, ok := outlineForFixture(t, fixture)
-			if !ok {
-				return
-			}
-			encoded := encodeOutlineGolden(t, got)
+			encoded := encodeOutlineGolden(t, outlineForFixture(t, fixture))
 			path := outlineGoldenPath(fixture)
 
 			if update {
@@ -281,15 +338,8 @@ func TestOutlineGoldenAccounting(t *testing.T) {
 			if counted != golden.Report.Symbols {
 				t.Errorf("%s: golden holds %d symbols, report says %d", path, counted, golden.Report.Symbols)
 			}
-			if golden.Report.Candidates() != golden.Report.Symbols+golden.Report.Omitted() {
-				t.Errorf("%s: receipt identity broken: candidates=%d symbols=%d omitted=%d",
-					path, golden.Report.Candidates(), golden.Report.Symbols, golden.Report.Omitted())
-			}
-			if golden.Report.QueryEmpty {
-				t.Errorf("%s: tier-1 fixture reports an empty query", path)
-			}
-			if golden.Report.LanguageMismatch {
-				t.Errorf("%s: fixture reports a language mismatch", path)
+			if golden.Report.Declined() {
+				t.Errorf("%s: fixture declined with reason %q", path, golden.Report.DeclineReason)
 			}
 			if golden.Report.Truncated {
 				t.Errorf("%s: fixture outline is truncated; raise the work budget or shrink the fixture", path)
@@ -298,10 +348,77 @@ func TestOutlineGoldenAccounting(t *testing.T) {
 				t.Errorf("%s: owner rules do not run in this change, so OwnerRuleMisses must stay 0, got %d",
 					path, golden.Report.OwnerRuleMisses)
 			}
-			if golden.Report.Symbols == 0 {
-				t.Errorf("%s: tier-1 fixture produced no symbols", path)
+			if golden.Report.Symbols == 0 && golden.Report.Omitted() == 0 {
+				t.Errorf("%s: fixture produced neither a symbol nor an omission", path)
+			}
+			if len(golden.DefinitionKinds) == 0 {
+				t.Errorf("%s: the query emits no definition kind at all", path)
 			}
 		})
+	}
+}
+
+// TestOutlineGoldensPinEveryOmissionCounter proves the omission taxonomy is
+// exercised end to end, not only by constructed unit cases. Without this,
+// every committed golden could carry an all-zero receipt and no counter would
+// be pinned anywhere.
+//
+// OmittedOverlap and OmittedInvalidNameRange are excluded on purpose and by
+// argument, not by omission: two nodes of one tree are always nested or
+// disjoint, and every capture of a match sits inside the matched subtree, so
+// neither shape can arise from a single tree. Both rules stay as defensive
+// guards and are exercised by the internal unit cases.
+func TestOutlineGoldensPinEveryOmissionCounter(t *testing.T) {
+	totals := map[string]int{}
+	for _, fixture := range outlineGoldenFixtures {
+		path := outlineGoldenPath(fixture)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read golden %s: %v", path, err)
+		}
+		var golden outlineGoldenFile
+		if err := json.Unmarshal(data, &golden); err != nil {
+			t.Fatalf("decode golden %s: %v", path, err)
+		}
+		totals["OmittedNoName"] += golden.Report.OmittedNoName
+		totals["OmittedDuplicate"] += golden.Report.OmittedDuplicate
+		totals["OmittedNameConflict"] += golden.Report.OmittedNameConflict
+		totals["OmittedConflict"] += golden.Report.OmittedConflict
+		totals["OmittedMultipleDefinitions"] += golden.Report.OmittedMultipleDefinitions
+	}
+
+	for _, counter := range []string{"OmittedNoName", "OmittedDuplicate", "OmittedNameConflict", "OmittedConflict", "OmittedMultipleDefinitions"} {
+		if totals[counter] == 0 {
+			t.Errorf("no committed golden exercises %s, so a regression in that rule would not show", counter)
+		}
+	}
+}
+
+// TestOutlineGoldensRecordTreeErrorState proves TreeHasError reaches the
+// receipt, and that it is not stuck on one value across the set.
+func TestOutlineGoldensRecordTreeErrorState(t *testing.T) {
+	withError, withoutError := 0, 0
+	for _, fixture := range outlineGoldenFixtures {
+		path := outlineGoldenPath(fixture)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read golden %s: %v", path, err)
+		}
+		var golden outlineGoldenFile
+		if err := json.Unmarshal(data, &golden); err != nil {
+			t.Fatalf("decode golden %s: %v", path, err)
+		}
+		if golden.Report.TreeHasError {
+			withError++
+		} else {
+			withoutError++
+		}
+	}
+	if withError == 0 {
+		t.Error("no committed golden records TreeHasError=true; the error signal is unpinned")
+	}
+	if withoutError == 0 {
+		t.Error("every committed golden records TreeHasError=true; the flag may be stuck on")
 	}
 }
 
@@ -309,34 +426,86 @@ func TestOutlineGoldenAccounting(t *testing.T) {
 // least one source the parser could not fully recover, and that its outline is
 // still well-defined: symbols before and after the damage still appear, and
 // the receipt still balances.
+// Each fixture runs in its own subtest, so a single Fatalf cannot abort the
+// scan of the rest.
 func TestOutlineGoldensCoverErrorBearingSource(t *testing.T) {
 	found := 0
 	for _, fixture := range outlineGoldenFixtures {
-		got, ok := outlineForFixture(t, fixture)
-		if !ok {
-			continue
-		}
-		if !got.HasError {
-			continue
-		}
-		found++
-
-		if got.Report.Symbols == 0 {
-			t.Errorf("%s: error-bearing fixture produced no symbols; the outline must survive an ERROR node", fixture.File)
-		}
-		if got.Report.Candidates() != got.Report.Symbols+got.Report.Omitted() {
-			t.Errorf("%s: receipt identity broken on an error-bearing tree", fixture.File)
-		}
-		names := map[string]bool{}
-		collectGoldenNames(got.Symbols, names)
-		for _, want := range []string{"Before", "After"} {
-			if !names[want] {
-				t.Errorf("%s: expected symbol %q to survive the ERROR node, got %v", fixture.File, want, sortedKeys(names))
+		fixture := fixture
+		t.Run(fixture.File, func(t *testing.T) {
+			got := outlineForFixture(t, fixture)
+			if !got.Report.TreeHasError {
+				t.Skip("this fixture parses clean")
 			}
-		}
+			found++
+
+			if got.Report.Symbols == 0 {
+				t.Errorf("error-bearing fixture produced no symbols; the outline must survive an ERROR node")
+			}
+			names := map[string]bool{}
+			collectGoldenNames(got.Symbols, names)
+			for _, want := range []string{"Before", "After"} {
+				if !names[want] {
+					t.Errorf("expected symbol %q to survive the ERROR node, got %v", want, sortedKeys(names))
+				}
+			}
+		})
 	}
 	if found == 0 {
 		t.Fatal("no committed fixture parses to a tree with an ERROR node; add one")
+	}
+}
+
+// TestOutlineOverErrorTreeReportsTheDamage is the contract test for the second
+// blocker: a one-character syntax error must not look like a clean, complete
+// outline.
+//
+// A Go file missing one closing brace parses to a truncated tree. The parser
+// recovers a single function whose Range swallows everything after it, and no
+// omission counter fires, because the query never produced a candidate for the
+// swallowed definitions. The ONLY signal a caller gets is TreeHasError, so it
+// must be present and true.
+func TestOutlineOverErrorTreeReportsTheDamage(t *testing.T) {
+	entry := grammars.DetectLanguageByName("go")
+	if entry == nil {
+		t.Fatal("the go grammar is not registered")
+	}
+	lang := entry.Language()
+	query := grammars.ResolveTagsQuery(*entry)
+
+	const truncated = "package p\n\nfunc A() {\n\nfunc B() {\n}\n\nfunc C() {\n}\n"
+	parser := gts.NewParser(lang)
+	tree, err := parser.Parse([]byte(truncated))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+
+	outliner, err := gts.NewOutliner(lang, query)
+	if err != nil {
+		t.Fatalf("build outliner: %v", err)
+	}
+	symbols, report := outliner.OutlineTree(tree)
+
+	if !report.TreeHasError {
+		t.Fatal("TreeHasError = false on a tree the parser could not recover; the damage is invisible to the caller")
+	}
+	if report.Declined() {
+		t.Errorf("DeclineReason = %q; a damaged tree is projected, not declined", report.DeclineReason)
+	}
+	if report.Omitted() != 0 {
+		t.Logf("this source now produces omissions (%+v); the test still holds, but the swallowing case has changed", report)
+	}
+
+	// The swallowing behaviour itself is the reason the flag matters. Record
+	// it rather than assert an exact shape, because recovery may improve.
+	t.Logf("truncated source: symbols=%d omitted=%d roots=%d", report.Symbols, report.Omitted(), len(symbols))
+	for _, symbol := range symbols {
+		t.Logf("  %s %q range=%d-%d children=%d",
+			symbol.Kind, symbol.Name, symbol.Range.StartByte, symbol.Range.EndByte, len(symbol.Children))
+	}
+	if report.Symbols == 0 {
+		t.Error("the recovered tree produced no symbols at all")
 	}
 }
 

--- a/outline_golden_test.go
+++ b/outline_golden_test.go
@@ -1,0 +1,428 @@
+package gotreesitter_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// outlineGoldenRoot holds the committed outline fixtures and their goldens.
+const outlineGoldenRoot = "testdata/outline"
+
+// outlineGoldenUpdateEnv regenerates the goldens when it is set. The
+// assertions always run; only the WRITE is opt-in, so no continuous
+// integration lane can silently skip the comparison.
+const outlineGoldenUpdateEnv = "GTS_UPDATE_OUTLINE_GOLDENS"
+
+// outlineGoldenFixture names one committed source file and the language that
+// parses it. The language is stated, never detected from the extension, so a
+// renamed fixture fails loudly instead of quietly changing grammar.
+type outlineGoldenFixture struct {
+	Language string
+	File     string
+	// Purpose records why this fixture exists, so a reviewer can see what
+	// the golden is meant to protect.
+	Purpose string
+}
+
+// outlineGoldenFixtures is the stage-1 golden set. Every language listed is
+// tier 1 in the outline coverage census (grammars.TestOutlineTierCensus):
+// each has a non-empty inferred tags query and real-corpus coverage. The
+// fixtures are committed here, not read from the corpus, so the goldens
+// reproduce on any host and in every continuous integration lane.
+var outlineGoldenFixtures = []outlineGoldenFixture{
+	{
+		Language: "go",
+		File:     "go/service.go.fixture",
+		Purpose:  "functions and methods from the hand-written Go tags override; a nested function literal that the query does not capture",
+	},
+	{
+		Language: "go",
+		File:     "go/broken.go.fixture",
+		Purpose:  "error-bearing source: the outline stays well-defined across an ERROR node",
+	},
+	{
+		Language: "python",
+		File:     "python/app.py",
+		Purpose:  "three nesting levels: module function, class, method, class inside a method",
+	},
+	{
+		Language: "javascript",
+		File:     "javascript/widget.js",
+		Purpose:  "class with methods, function nested in a method, empty class",
+	},
+	{
+		Language: "typescript",
+		File:     "typescript/model.ts",
+		Purpose:  "enum refinement by node type, interface, class, nested function",
+	},
+	{
+		Language: "tsx",
+		File:     "tsx/view.tsx",
+		Purpose:  "interface and class beside JSX; nested function in a component",
+	},
+	{
+		Language: "java",
+		File:     "java/Service.java",
+		Purpose:  "interface, enum refinement, constructor, method, nested class",
+	},
+	{
+		Language: "rust",
+		File:     "rust/lib.rs",
+		Purpose:  "struct, enum refinement by enum_item, trait, function nested in a function",
+	},
+	{
+		Language: "c",
+		File:     "c/registry.c",
+		// This golden also pins a known limit of the shared inferred tags
+		// data, not of the extractor: the pattern
+		// "(struct_specifier (type_identifier) @name) @definition.type"
+		// matches a struct USE, such as the parameter type
+		// "struct Registry *registry", as well as a struct definition. The
+		// outline reports what the query captured, so the extra "Registry"
+		// entries nest inside the functions that mention the type. This is
+		// spec risk R1, inferred-query over-capture. Its remedy is a data
+		// edit to the pattern table or a per-language override, which is a
+		// later stage; the golden makes the behavior visible today and
+		// turns that data edit into a reviewable diff.
+		Purpose: "struct, typedef, and function definitions; also pins the inferred-query over-capture of struct uses (spec risk R1)",
+	},
+	{
+		Language: "cpp",
+		File:     "cpp/registry.cpp",
+		Purpose:  "class with member function definitions nested inside it",
+	},
+}
+
+// outlineGoldenRange is the readable serialization of a Range. Byte offsets
+// stay separate fields so a diff shows exactly which offset moved; the points
+// collapse to "row:column" so line moves read at a glance.
+type outlineGoldenRange struct {
+	StartByte  uint32 `json:"start_byte"`
+	EndByte    uint32 `json:"end_byte"`
+	StartPoint string `json:"start_point"`
+	EndPoint   string `json:"end_point"`
+}
+
+// outlineGoldenSymbol mirrors gts.OutlineSymbol with stable JSON names.
+type outlineGoldenSymbol struct {
+	Kind      string                `json:"kind"`
+	Name      string                `json:"name"`
+	NodeType  string                `json:"node_type"`
+	Range     outlineGoldenRange    `json:"range"`
+	NameRange outlineGoldenRange    `json:"name_range"`
+	Owner     string                `json:"owner"`
+	Children  []outlineGoldenSymbol `json:"children,omitempty"`
+}
+
+// outlineGoldenFile is the whole committed artifact for one fixture.
+type outlineGoldenFile struct {
+	Language string                `json:"language"`
+	Fixture  string                `json:"fixture"`
+	Purpose  string                `json:"purpose"`
+	HasError bool                  `json:"tree_has_error"`
+	Report   gts.OutlineReport     `json:"report"`
+	Symbols  []outlineGoldenSymbol `json:"symbols"`
+}
+
+func outlineGoldenRangeOf(r gts.Range) outlineGoldenRange {
+	return outlineGoldenRange{
+		StartByte:  r.StartByte,
+		EndByte:    r.EndByte,
+		StartPoint: fmt.Sprintf("%d:%d", r.StartPoint.Row, r.StartPoint.Column),
+		EndPoint:   fmt.Sprintf("%d:%d", r.EndPoint.Row, r.EndPoint.Column),
+	}
+}
+
+func outlineGoldenSymbolsOf(symbols []gts.OutlineSymbol) []outlineGoldenSymbol {
+	if len(symbols) == 0 {
+		return nil
+	}
+	out := make([]outlineGoldenSymbol, 0, len(symbols))
+	for _, symbol := range symbols {
+		out = append(out, outlineGoldenSymbol{
+			Kind:      symbol.Kind,
+			Name:      symbol.Name,
+			NodeType:  symbol.NodeType,
+			Range:     outlineGoldenRangeOf(symbol.Range),
+			NameRange: outlineGoldenRangeOf(symbol.NameRange),
+			Owner:     symbol.Owner,
+			Children:  outlineGoldenSymbolsOf(symbol.Children),
+		})
+	}
+	return out
+}
+
+// outlineForFixture parses a committed fixture and projects its outline.
+func outlineForFixture(t *testing.T, fixture outlineGoldenFixture) (outlineGoldenFile, bool) {
+	t.Helper()
+
+	entry := grammars.DetectLanguageByName(fixture.Language)
+	if entry == nil {
+		t.Fatalf("%s: language %q is not registered", fixture.File, fixture.Language)
+	}
+	lang := entry.Language()
+	if lang == nil {
+		t.Fatalf("%s: language %q failed to load", fixture.File, fixture.Language)
+	}
+
+	query := grammars.ResolveTagsQuery(*entry)
+	if strings.TrimSpace(query) == "" {
+		t.Fatalf("%s: language %q resolved an empty tags query, so it is no longer tier 1", fixture.File, fixture.Language)
+	}
+
+	source, err := os.ReadFile(filepath.Join(outlineGoldenRoot, fixture.File))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	parser := gts.NewParser(lang)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("%s: parse: %v", fixture.File, err)
+	}
+	defer tree.Release()
+
+	outliner, err := gts.NewOutliner(lang, query)
+	if err != nil {
+		t.Fatalf("%s: build outliner: %v", fixture.File, err)
+	}
+
+	symbols, report := outliner.OutlineTree(tree)
+
+	root := tree.RootNode()
+	hasError := root != nil && root.HasError()
+
+	return outlineGoldenFile{
+		Language: fixture.Language,
+		Fixture:  fixture.File,
+		Purpose:  fixture.Purpose,
+		HasError: hasError,
+		Report:   report,
+		Symbols:  outlineGoldenSymbolsOf(symbols),
+	}, true
+}
+
+func outlineGoldenPath(fixture outlineGoldenFixture) string {
+	return filepath.Join(outlineGoldenRoot, fixture.File+".golden.json")
+}
+
+func encodeOutlineGolden(t *testing.T, got outlineGoldenFile) []byte {
+	t.Helper()
+	data, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf("encode golden: %v", err)
+	}
+	return append(data, '\n')
+}
+
+// TestOutlineGoldens pins the outline of every committed fixture. It always
+// compares; it writes only when GTS_UPDATE_OUTLINE_GOLDENS is set. A golden
+// change must therefore ship in the same commit as its cause.
+func TestOutlineGoldens(t *testing.T) {
+	update := strings.TrimSpace(os.Getenv(outlineGoldenUpdateEnv)) != ""
+
+	for _, fixture := range outlineGoldenFixtures {
+		fixture := fixture
+		t.Run(fixture.File, func(t *testing.T) {
+			got, ok := outlineForFixture(t, fixture)
+			if !ok {
+				return
+			}
+			encoded := encodeOutlineGolden(t, got)
+			path := outlineGoldenPath(fixture)
+
+			if update {
+				if err := os.WriteFile(path, encoded, 0o644); err != nil {
+					t.Fatalf("write golden %s: %v", path, err)
+				}
+				t.Logf("wrote %s", path)
+				return
+			}
+
+			want, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read golden %s: %v -- regenerate with %s=1 go test . -run TestOutlineGoldens",
+					path, err, outlineGoldenUpdateEnv)
+			}
+			if string(want) != string(encoded) {
+				t.Errorf("outline golden drift for %s.\nRegenerate with %s=1 go test . -run TestOutlineGoldens and ship the change with its cause.\n--- want ---\n%s\n--- got ---\n%s",
+					path, outlineGoldenUpdateEnv, want, encoded)
+			}
+		})
+	}
+}
+
+// TestOutlineGoldenAccounting asserts the receipt identity on every committed
+// golden: each candidate the tags query produced is either an emitted symbol
+// or exactly one omission. A drop that lands in no counter is a silent
+// coverage loss, and this test makes it impossible.
+func TestOutlineGoldenAccounting(t *testing.T) {
+	for _, fixture := range outlineGoldenFixtures {
+		fixture := fixture
+		t.Run(fixture.File, func(t *testing.T) {
+			path := outlineGoldenPath(fixture)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read golden %s: %v", path, err)
+			}
+			var golden outlineGoldenFile
+			if err := json.Unmarshal(data, &golden); err != nil {
+				t.Fatalf("decode golden %s: %v", path, err)
+			}
+
+			counted := countGoldenSymbols(golden.Symbols)
+			if counted != golden.Report.Symbols {
+				t.Errorf("%s: golden holds %d symbols, report says %d", path, counted, golden.Report.Symbols)
+			}
+			if golden.Report.Candidates() != golden.Report.Symbols+golden.Report.Omitted() {
+				t.Errorf("%s: receipt identity broken: candidates=%d symbols=%d omitted=%d",
+					path, golden.Report.Candidates(), golden.Report.Symbols, golden.Report.Omitted())
+			}
+			if golden.Report.QueryEmpty {
+				t.Errorf("%s: tier-1 fixture reports an empty query", path)
+			}
+			if golden.Report.LanguageMismatch {
+				t.Errorf("%s: fixture reports a language mismatch", path)
+			}
+			if golden.Report.Truncated {
+				t.Errorf("%s: fixture outline is truncated; raise the work budget or shrink the fixture", path)
+			}
+			if golden.Report.OwnerRuleMisses != 0 {
+				t.Errorf("%s: owner rules do not run in this change, so OwnerRuleMisses must stay 0, got %d",
+					path, golden.Report.OwnerRuleMisses)
+			}
+			if golden.Report.Symbols == 0 {
+				t.Errorf("%s: tier-1 fixture produced no symbols", path)
+			}
+		})
+	}
+}
+
+// TestOutlineGoldensCoverErrorBearingSource proves the golden set includes at
+// least one source the parser could not fully recover, and that its outline is
+// still well-defined: symbols before and after the damage still appear, and
+// the receipt still balances.
+func TestOutlineGoldensCoverErrorBearingSource(t *testing.T) {
+	found := 0
+	for _, fixture := range outlineGoldenFixtures {
+		got, ok := outlineForFixture(t, fixture)
+		if !ok {
+			continue
+		}
+		if !got.HasError {
+			continue
+		}
+		found++
+
+		if got.Report.Symbols == 0 {
+			t.Errorf("%s: error-bearing fixture produced no symbols; the outline must survive an ERROR node", fixture.File)
+		}
+		if got.Report.Candidates() != got.Report.Symbols+got.Report.Omitted() {
+			t.Errorf("%s: receipt identity broken on an error-bearing tree", fixture.File)
+		}
+		names := map[string]bool{}
+		collectGoldenNames(got.Symbols, names)
+		for _, want := range []string{"Before", "After"} {
+			if !names[want] {
+				t.Errorf("%s: expected symbol %q to survive the ERROR node, got %v", fixture.File, want, sortedKeys(names))
+			}
+		}
+	}
+	if found == 0 {
+		t.Fatal("no committed fixture parses to a tree with an ERROR node; add one")
+	}
+}
+
+// TestOutlineGoldensNestAndSpread proves the golden set is not a flat, single
+// kind sample: at least one fixture nests symbols, and the set as a whole
+// covers several normalized kinds.
+func TestOutlineGoldensNestAndSpread(t *testing.T) {
+	kinds := map[string]bool{}
+	maxDepth := 0
+	nestedFixtures := 0
+
+	for _, fixture := range outlineGoldenFixtures {
+		path := outlineGoldenPath(fixture)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read golden %s: %v", path, err)
+		}
+		var golden outlineGoldenFile
+		if err := json.Unmarshal(data, &golden); err != nil {
+			t.Fatalf("decode golden %s: %v", path, err)
+		}
+		depth := goldenDepth(golden.Symbols)
+		if depth > 1 {
+			nestedFixtures++
+		}
+		if depth > maxDepth {
+			maxDepth = depth
+		}
+		collectGoldenKinds(golden.Symbols, kinds)
+	}
+
+	if maxDepth < 3 {
+		t.Errorf("golden set nests only %d levels deep; a nesting regression would not show", maxDepth)
+	}
+	if nestedFixtures < 3 {
+		t.Errorf("only %d golden fixtures nest; widen the spread", nestedFixtures)
+	}
+	for _, want := range []string{"function", "method", "class", "interface", "type", "enum", "constructor"} {
+		if !kinds[want] {
+			t.Errorf("golden set covers no %q symbol; kinds present: %v", want, sortedKeys(kinds))
+		}
+	}
+}
+
+func countGoldenSymbols(symbols []outlineGoldenSymbol) int {
+	total := len(symbols)
+	for _, symbol := range symbols {
+		total += countGoldenSymbols(symbol.Children)
+	}
+	return total
+}
+
+func collectGoldenKinds(symbols []outlineGoldenSymbol, into map[string]bool) {
+	for _, symbol := range symbols {
+		into[symbol.Kind] = true
+		collectGoldenKinds(symbol.Children, into)
+	}
+}
+
+func collectGoldenNames(symbols []outlineGoldenSymbol, into map[string]bool) {
+	for _, symbol := range symbols {
+		into[symbol.Name] = true
+		collectGoldenNames(symbol.Children, into)
+	}
+}
+
+func goldenDepth(symbols []outlineGoldenSymbol) int {
+	best := 0
+	for _, symbol := range symbols {
+		depth := 1 + goldenDepth(symbol.Children)
+		if depth > best {
+			best = depth
+		}
+	}
+	return best
+}
+
+func sortedKeys(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for key := range set {
+		out = append(out, key)
+	}
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j] < out[j-1]; j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}

--- a/outline_internal_test.go
+++ b/outline_internal_test.go
@@ -1,0 +1,365 @@
+package gotreesitter
+
+import (
+	"reflect"
+	"testing"
+)
+
+func outlineTestRange(start, end uint32) Range {
+	return Range{
+		StartByte:  start,
+		EndByte:    end,
+		StartPoint: Point{Row: 0, Column: start},
+		EndPoint:   Point{Row: 0, Column: end},
+	}
+}
+
+func outlineTestCandidate(order int, kind, name string, start, end, nameStart, nameEnd uint32) outlineCandidate {
+	return outlineCandidate{
+		order:     order,
+		kind:      kind,
+		name:      name,
+		nodeType:  kind + "_node",
+		rng:       outlineTestRange(start, end),
+		nameRange: outlineTestRange(nameStart, nameEnd),
+	}
+}
+
+// runOutlineRules drives the two pure stages the way OutlineTree does, so the
+// unit cases exercise the shipped code path rather than a copy of it.
+func runOutlineRules(candidates []outlineCandidate) ([]OutlineSymbol, OutlineReport) {
+	var report OutlineReport
+	kept := filterOutlineCandidates(candidates, &report)
+	symbols := buildOutlineForest(kept, &report)
+	report.Symbols = countOutlineSymbols(symbols)
+	return symbols, report
+}
+
+// assertOutlineReceiptBalances checks the accounting identity that makes
+// fail-closed observable: every candidate is emitted or counted exactly once.
+func assertOutlineReceiptBalances(t *testing.T, candidates int, report OutlineReport) {
+	t.Helper()
+	if got := report.Candidates(); got != candidates {
+		t.Errorf("receipt does not balance: %d candidates in, symbols=%d omitted=%d (sum %d)",
+			candidates, report.Symbols, report.Omitted(), got)
+	}
+}
+
+func TestOutlineOmitsCandidateWithoutName(t *testing.T) {
+	candidates := []outlineCandidate{
+		outlineTestCandidate(0, "function", "", 0, 10, 0, 0),
+		outlineTestCandidate(1, "function", "   ", 20, 30, 20, 23),
+		outlineTestCandidate(2, "function", "kept", 40, 50, 40, 44),
+	}
+	symbols, report := runOutlineRules(candidates)
+
+	if report.OmittedNoName != 2 {
+		t.Errorf("OmittedNoName = %d, want 2", report.OmittedNoName)
+	}
+	if len(symbols) != 1 || symbols[0].Name != "kept" {
+		t.Errorf("symbols = %+v, want only the named candidate", symbols)
+	}
+	assertOutlineReceiptBalances(t, len(candidates), report)
+}
+
+func TestOutlineOmitsNameRangeOutsideDefinition(t *testing.T) {
+	candidates := []outlineCandidate{
+		// Name span starts before the definition span.
+		outlineTestCandidate(0, "function", "early", 10, 20, 5, 12),
+		// Name span ends after the definition span.
+		outlineTestCandidate(1, "function", "late", 30, 40, 35, 45),
+		// Inverted definition span contains nothing.
+		outlineTestCandidate(2, "function", "inverted", 60, 50, 60, 62),
+		outlineTestCandidate(3, "function", "kept", 70, 80, 70, 74),
+	}
+	symbols, report := runOutlineRules(candidates)
+
+	if report.OmittedInvalidNameRange != 3 {
+		t.Errorf("OmittedInvalidNameRange = %d, want 3", report.OmittedInvalidNameRange)
+	}
+	if len(symbols) != 1 || symbols[0].Name != "kept" {
+		t.Errorf("symbols = %+v, want only the valid candidate", symbols)
+	}
+	assertOutlineReceiptBalances(t, len(candidates), report)
+}
+
+func TestOutlineCollapsesDuplicateSpanAndKind(t *testing.T) {
+	candidates := []outlineCandidate{
+		outlineTestCandidate(0, "function", "first", 0, 10, 0, 5),
+		outlineTestCandidate(1, "function", "second", 0, 10, 0, 6),
+		outlineTestCandidate(2, "function", "third", 0, 10, 0, 5),
+	}
+	symbols, report := runOutlineRules(candidates)
+
+	if report.OmittedDuplicate != 2 {
+		t.Errorf("OmittedDuplicate = %d, want 2", report.OmittedDuplicate)
+	}
+	if len(symbols) != 1 || symbols[0].Name != "first" {
+		t.Errorf("symbols = %+v, want the first candidate in emission order", symbols)
+	}
+	assertOutlineReceiptBalances(t, len(candidates), report)
+}
+
+func TestOutlineDropsSpanWithConflictingKinds(t *testing.T) {
+	candidates := []outlineCandidate{
+		outlineTestCandidate(0, "function", "same", 0, 10, 0, 4),
+		outlineTestCandidate(1, "method", "same", 0, 10, 0, 4),
+		outlineTestCandidate(2, "class", "kept", 20, 30, 20, 24),
+	}
+	symbols, report := runOutlineRules(candidates)
+
+	if report.OmittedConflict != 2 {
+		t.Errorf("OmittedConflict = %d, want 2 (both members of the conflicting group)", report.OmittedConflict)
+	}
+	if report.OmittedDuplicate != 0 {
+		t.Errorf("OmittedDuplicate = %d, want 0: a conflict is not a duplicate", report.OmittedDuplicate)
+	}
+	if len(symbols) != 1 || symbols[0].Name != "kept" {
+		t.Errorf("symbols = %+v, want the conflicting span dropped and nothing guessed", symbols)
+	}
+	assertOutlineReceiptBalances(t, len(candidates), report)
+}
+
+func TestOutlineDropsWholeGroupWhenOneMemberConflicts(t *testing.T) {
+	candidates := []outlineCandidate{
+		outlineTestCandidate(0, "function", "a", 0, 10, 0, 1),
+		outlineTestCandidate(1, "function", "b", 0, 10, 0, 1),
+		outlineTestCandidate(2, "method", "c", 0, 10, 0, 1),
+	}
+	symbols, report := runOutlineRules(candidates)
+
+	if report.OmittedConflict != 3 {
+		t.Errorf("OmittedConflict = %d, want 3", report.OmittedConflict)
+	}
+	if len(symbols) != 0 {
+		t.Errorf("symbols = %+v, want none", symbols)
+	}
+	assertOutlineReceiptBalances(t, len(candidates), report)
+}
+
+func TestOutlineDropsPartialOverlap(t *testing.T) {
+	candidates := []outlineCandidate{
+		outlineTestCandidate(0, "function", "early", 0, 20, 0, 5),
+		// Starts inside "early" and ends after it: neither contains the
+		// other, so the later start is dropped.
+		outlineTestCandidate(1, "function", "straddles", 10, 30, 10, 19),
+		outlineTestCandidate(2, "function", "nested", 2, 8, 2, 8),
+	}
+	symbols, report := runOutlineRules(candidates)
+
+	if report.OmittedOverlap != 1 {
+		t.Errorf("OmittedOverlap = %d, want 1", report.OmittedOverlap)
+	}
+	if len(symbols) != 1 || symbols[0].Name != "early" {
+		t.Fatalf("symbols = %+v, want the earlier start kept", symbols)
+	}
+	if len(symbols[0].Children) != 1 || symbols[0].Children[0].Name != "nested" {
+		t.Errorf("children = %+v, want the contained candidate nested", symbols[0].Children)
+	}
+	assertOutlineReceiptBalances(t, len(candidates), report)
+}
+
+func TestOutlineBuildsNestingInSourceOrder(t *testing.T) {
+	candidates := []outlineCandidate{
+		// Deliberately out of source order to prove the sort drives nesting.
+		outlineTestCandidate(0, "function", "deep", 30, 40, 30, 34),
+		outlineTestCandidate(1, "class", "outer", 0, 100, 5, 10),
+		outlineTestCandidate(2, "method", "second", 50, 60, 50, 56),
+		outlineTestCandidate(3, "method", "first", 20, 45, 20, 25),
+		outlineTestCandidate(4, "class", "sibling", 200, 300, 205, 212),
+	}
+	symbols, report := runOutlineRules(candidates)
+
+	if len(symbols) != 2 {
+		t.Fatalf("roots = %d, want 2: %+v", len(symbols), symbols)
+	}
+	if symbols[0].Name != "outer" || symbols[1].Name != "sibling" {
+		t.Fatalf("roots are %q and %q, want source order", symbols[0].Name, symbols[1].Name)
+	}
+	gotChildren := []string{}
+	for _, child := range symbols[0].Children {
+		gotChildren = append(gotChildren, child.Name)
+	}
+	if !reflect.DeepEqual(gotChildren, []string{"first", "second"}) {
+		t.Errorf("children = %v, want [first second] in source order", gotChildren)
+	}
+	if len(symbols[0].Children[0].Children) != 1 || symbols[0].Children[0].Children[0].Name != "deep" {
+		t.Errorf("grandchildren = %+v, want [deep]", symbols[0].Children[0].Children)
+	}
+	if report.Symbols != 5 {
+		t.Errorf("Symbols = %d, want 5 including nested", report.Symbols)
+	}
+	assertOutlineReceiptBalances(t, len(candidates), report)
+}
+
+func TestOutlineNestsEqualEndSpans(t *testing.T) {
+	// A container and its last child can share an end byte. The sort places
+	// the wider span first, so the narrower one nests instead of being
+	// treated as an overlap.
+	candidates := []outlineCandidate{
+		outlineTestCandidate(0, "function", "tail", 10, 40, 10, 14),
+		outlineTestCandidate(1, "class", "outer", 0, 40, 0, 5),
+	}
+	symbols, report := runOutlineRules(candidates)
+
+	if len(symbols) != 1 || symbols[0].Name != "outer" {
+		t.Fatalf("roots = %+v, want only outer", symbols)
+	}
+	if len(symbols[0].Children) != 1 || symbols[0].Children[0].Name != "tail" {
+		t.Errorf("children = %+v, want tail nested", symbols[0].Children)
+	}
+	if report.OmittedOverlap != 0 {
+		t.Errorf("OmittedOverlap = %d, want 0", report.OmittedOverlap)
+	}
+	assertOutlineReceiptBalances(t, len(candidates), report)
+}
+
+func TestOutlineTreatsAdjacentSpansAsSiblings(t *testing.T) {
+	// End byte is exclusive, so a span that starts exactly where another
+	// ends is a sibling, not a child and not an overlap.
+	candidates := []outlineCandidate{
+		outlineTestCandidate(0, "function", "left", 0, 10, 0, 4),
+		outlineTestCandidate(1, "function", "right", 10, 20, 10, 15),
+	}
+	symbols, report := runOutlineRules(candidates)
+
+	if len(symbols) != 2 {
+		t.Fatalf("roots = %+v, want two siblings", symbols)
+	}
+	if report.OmittedOverlap != 0 {
+		t.Errorf("OmittedOverlap = %d, want 0", report.OmittedOverlap)
+	}
+	assertOutlineReceiptBalances(t, len(candidates), report)
+}
+
+func TestOutlineKindNormalizationIsTableDriven(t *testing.T) {
+	cases := []struct {
+		capture  string
+		nodeType string
+		want     string
+	}{
+		{"definition.function", "function_declaration", "function"},
+		{"definition.method", "method_declaration", "method"},
+		{"definition.class", "class_declaration", "class"},
+		{"definition.interface", "interface_declaration", "interface"},
+		{"definition.type", "type_spec", "type"},
+		{"definition.constructor", "constructor_declaration", "constructor"},
+		{"definition.constant", "const_spec", "constant"},
+		{"definition.variable", "var_spec", "variable"},
+		{"definition.module", "module", "module"},
+		// Node-type refinement, keyed by cross-language node types.
+		{"definition.type", "enum_declaration", "enum"},
+		{"definition.type", "enum_item", "enum"},
+		{"definition.class", "enum_declaration", "enum"},
+		{"definition.class", "record_declaration", "record"},
+		// A refinement never overrules a more specific capture.
+		{"definition.method", "enum_declaration", "method"},
+		{"definition.function", "record_declaration", "function"},
+		// An unknown suffix passes through, so new tags data needs no code.
+		{"definition.macro", "macro_definition", "macro"},
+		{"definition.trait", "trait_item", "trait"},
+	}
+	for _, tc := range cases {
+		if got := normalizeOutlineKind(tc.capture, tc.nodeType); got != tc.want {
+			t.Errorf("normalizeOutlineKind(%q, %q) = %q, want %q", tc.capture, tc.nodeType, got, tc.want)
+		}
+	}
+}
+
+func TestOutlineDefinitionCaptureNeedsSuffix(t *testing.T) {
+	cases := map[string]bool{
+		"definition.function": true,
+		"definition.x":        true,
+		"definition.":         false,
+		"definition":          false,
+		"name":                false,
+		"reference.call":      false,
+		"":                    false,
+	}
+	for capture, want := range cases {
+		if got := isOutlineDefinitionCapture(capture); got != want {
+			t.Errorf("isOutlineDefinitionCapture(%q) = %v, want %v", capture, got, want)
+		}
+	}
+}
+
+// TestOutlineKindTablesHoldNoLanguageNames is the doctrine gate for the
+// normalization data: the tables are keyed by capture suffix and by grammar
+// node type, never by a language name. A row keyed by a language name would
+// re-create the frozen definitionKind switch in a new place.
+func TestOutlineKindTablesHoldNoLanguageNames(t *testing.T) {
+	languageNames := []string{
+		"go", "java", "python", "starlark", "javascript", "typescript", "tsx",
+		"rust", "c", "cpp", "ruby", "kotlin", "swift", "scala",
+	}
+	for _, name := range languageNames {
+		if _, ok := outlineKindTable[name]; ok {
+			t.Errorf("outlineKindTable holds a row keyed by the language name %q", name)
+		}
+		if _, ok := outlineKindRefinement[name]; ok {
+			t.Errorf("outlineKindRefinement holds a row keyed by the language name %q", name)
+		}
+	}
+	for nodeType := range outlineKindRefinement {
+		if !isOutlineNodeTypeShaped(nodeType) {
+			t.Errorf("outlineKindRefinement key %q does not read as a grammar node type", nodeType)
+		}
+	}
+}
+
+// isOutlineNodeTypeShaped reports whether a key looks like a grammar node
+// type: lower snake case with at least one underscore. Every language name in
+// the registry is a single word, so this separates the two vocabularies.
+func isOutlineNodeTypeShaped(key string) bool {
+	underscores := 0
+	for i := 0; i < len(key); i++ {
+		c := key[i]
+		switch {
+		case c == '_':
+			underscores++
+		case c >= 'a' && c <= 'z':
+		default:
+			return false
+		}
+	}
+	return underscores > 0
+}
+
+func TestOutlineOwnerRuleValidationFailsClosed(t *testing.T) {
+	cases := []struct {
+		name  string
+		rules []OutlineOwnerRule
+		want  bool
+	}{
+		{
+			name:  "valid go receiver rule",
+			rules: []OutlineOwnerRule{{NodeType: "method_declaration", OwnerField: "receiver", Unwrap: []string{"parameter_list"}, NameTypes: []string{"type_identifier"}}},
+			want:  false,
+		},
+		{
+			name:  "missing node type",
+			rules: []OutlineOwnerRule{{OwnerField: "receiver"}},
+			want:  true,
+		},
+		{
+			name:  "missing owner field",
+			rules: []OutlineOwnerRule{{NodeType: "method_declaration"}},
+			want:  true,
+		},
+		{
+			name:  "blank owner field",
+			rules: []OutlineOwnerRule{{NodeType: "method_declaration", OwnerField: "  "}},
+			want:  true,
+		},
+	}
+	for _, tc := range cases {
+		indexed := map[string][]OutlineOwnerRule{}
+		for _, rule := range tc.rules {
+			indexed[rule.NodeType] = append(indexed[rule.NodeType], rule)
+		}
+		err := validateOutlineOwnerRules(indexed)
+		if (err != nil) != tc.want {
+			t.Errorf("%s: validateOutlineOwnerRules error = %v, want error %v", tc.name, err, tc.want)
+		}
+	}
+}

--- a/outline_internal_test.go
+++ b/outline_internal_test.go
@@ -83,19 +83,92 @@ func TestOutlineOmitsNameRangeOutsideDefinition(t *testing.T) {
 	assertOutlineReceiptBalances(t, len(candidates), report)
 }
 
-func TestOutlineCollapsesDuplicateSpanAndKind(t *testing.T) {
+// TestOutlineCollapsesExactRepeats covers rule 5. Only indistinguishable
+// candidates collapse, so keeping the first is not a choice between them.
+func TestOutlineCollapsesExactRepeats(t *testing.T) {
 	candidates := []outlineCandidate{
-		outlineTestCandidate(0, "function", "first", 0, 10, 0, 5),
-		outlineTestCandidate(1, "function", "second", 0, 10, 0, 6),
-		outlineTestCandidate(2, "function", "third", 0, 10, 0, 5),
+		outlineTestCandidate(0, "function", "same", 0, 10, 0, 5),
+		outlineTestCandidate(1, "function", "same", 0, 10, 0, 5),
+		outlineTestCandidate(2, "function", "same", 0, 10, 0, 5),
 	}
 	symbols, report := runOutlineRules(candidates)
 
 	if report.OmittedDuplicate != 2 {
 		t.Errorf("OmittedDuplicate = %d, want 2", report.OmittedDuplicate)
 	}
-	if len(symbols) != 1 || symbols[0].Name != "first" {
-		t.Errorf("symbols = %+v, want the first candidate in emission order", symbols)
+	if report.OmittedNameConflict != 0 {
+		t.Errorf("OmittedNameConflict = %d, want 0: the members are identical", report.OmittedNameConflict)
+	}
+	if len(symbols) != 1 || symbols[0].Name != "same" {
+		t.Errorf("symbols = %+v, want one symbol", symbols)
+	}
+	assertOutlineReceiptBalances(t, len(candidates), report)
+}
+
+// TestOutlineDropsSpanWithConflictingNames covers rule 4, the defect that
+// published a C-family return type as a method name. The shared inference can
+// bind "@name" twice on one definition node; the two bindings disagree, and no
+// language-neutral rule ranks them. The group drops and the counter says why.
+func TestOutlineDropsSpanWithConflictingNames(t *testing.T) {
+	candidates := []outlineCandidate{
+		// "Uri PathToUri(string p) {...}": the return type is captured
+		// first, the method name second. Choosing by order publishes "Uri".
+		outlineTestCandidate(0, "method", "Uri", 0, 40, 0, 3),
+		outlineTestCandidate(1, "method", "PathToUri", 0, 40, 4, 13),
+		outlineTestCandidate(2, "method", "kept", 50, 60, 50, 54),
+	}
+	symbols, report := runOutlineRules(candidates)
+
+	if report.OmittedNameConflict != 2 {
+		t.Errorf("OmittedNameConflict = %d, want 2 (both members of the group)", report.OmittedNameConflict)
+	}
+	if report.OmittedDuplicate != 0 {
+		t.Errorf("OmittedDuplicate = %d, want 0: a name conflict is not a duplicate", report.OmittedDuplicate)
+	}
+	if len(symbols) != 1 || symbols[0].Name != "kept" {
+		t.Fatalf("symbols = %+v, want only the unambiguous candidate", symbols)
+	}
+	for _, symbol := range symbols {
+		if symbol.Name == "Uri" {
+			t.Error("the outline published the return type as the symbol name")
+		}
+	}
+	assertOutlineReceiptBalances(t, len(candidates), report)
+}
+
+// TestOutlineTreatsDifferingNameSpansAsAConflict pins the stricter half of the
+// rule: identical name TEXT at different spans still leaves the emitted symbol
+// undetermined, because a symbol carries both.
+func TestOutlineTreatsDifferingNameSpansAsAConflict(t *testing.T) {
+	candidates := []outlineCandidate{
+		outlineTestCandidate(0, "function", "run", 0, 40, 0, 3),
+		outlineTestCandidate(1, "function", "run", 0, 40, 10, 13),
+	}
+	symbols, report := runOutlineRules(candidates)
+
+	if report.OmittedNameConflict != 2 {
+		t.Errorf("OmittedNameConflict = %d, want 2", report.OmittedNameConflict)
+	}
+	if len(symbols) != 0 {
+		t.Errorf("symbols = %+v, want none", symbols)
+	}
+	assertOutlineReceiptBalances(t, len(candidates), report)
+}
+
+// TestOutlineKindConflictOutranksNameConflict pins the precedence: a group
+// that disagrees about the kind is counted as a kind conflict, not twice.
+func TestOutlineKindConflictOutranksNameConflict(t *testing.T) {
+	candidates := []outlineCandidate{
+		outlineTestCandidate(0, "function", "a", 0, 10, 0, 1),
+		outlineTestCandidate(1, "method", "b", 0, 10, 2, 3),
+	}
+	_, report := runOutlineRules(candidates)
+
+	if report.OmittedConflict != 2 {
+		t.Errorf("OmittedConflict = %d, want 2", report.OmittedConflict)
+	}
+	if report.OmittedNameConflict != 0 {
+		t.Errorf("OmittedNameConflict = %d, want 0", report.OmittedNameConflict)
 	}
 	assertOutlineReceiptBalances(t, len(candidates), report)
 }
@@ -283,46 +356,93 @@ func TestOutlineDefinitionCaptureNeedsSuffix(t *testing.T) {
 	}
 }
 
-// TestOutlineKindTablesHoldNoLanguageNames is the doctrine gate for the
-// normalization data: the tables are keyed by capture suffix and by grammar
-// node type, never by a language name. A row keyed by a language name would
-// re-create the frozen definitionKind switch in a new place.
-func TestOutlineKindTablesHoldNoLanguageNames(t *testing.T) {
-	languageNames := []string{
-		"go", "java", "python", "starlark", "javascript", "typescript", "tsx",
-		"rust", "c", "cpp", "ruby", "kotlin", "swift", "scala",
+// TestOutlineKindTablesAreFrozenByExactKeySet is the doctrine gate for the
+// normalization data. The core cannot import the grammars registry, so it
+// cannot check a key against the 206 language names. Blocklisting a hand
+// written sample of those names has only partial teeth: 192 names would still
+// slip through.
+//
+// This gate freezes the whole key set instead. Any new row in either table
+// fails the test, whatever it is named, so a language-name row cannot land
+// without the reviewer seeing it here. Adding a genuine cross-language row is
+// a one-line edit to the expected set, in the same change, with its reason.
+func TestOutlineKindTablesAreFrozenByExactKeySet(t *testing.T) {
+	wantKindTable := map[string]string{
+		"function":    "function",
+		"method":      "method",
+		"class":       "class",
+		"interface":   "interface",
+		"type":        "type",
+		"constructor": "constructor",
+		"constant":    "constant",
+		"variable":    "variable",
+		"module":      "module",
 	}
-	for _, name := range languageNames {
-		if _, ok := outlineKindTable[name]; ok {
-			t.Errorf("outlineKindTable holds a row keyed by the language name %q", name)
-		}
-		if _, ok := outlineKindRefinement[name]; ok {
-			t.Errorf("outlineKindRefinement holds a row keyed by the language name %q", name)
+	// Every key here is a grammar node type shared by many grammars.
+	// "enum_declaration" alone appears in 18 registered languages.
+	wantRefinement := map[string]string{
+		"enum_declaration":   "enum",
+		"enum_item":          "enum",
+		"record_declaration": "record",
+	}
+	wantRefinable := map[string]bool{
+		"type":  true,
+		"class": true,
+	}
+
+	assertOutlineTableFrozen(t, "outlineKindTable", outlineKindTable, wantKindTable)
+	assertOutlineTableFrozen(t, "outlineKindRefinement", outlineKindRefinement, wantRefinement)
+
+	if len(outlineRefinableKinds) != len(wantRefinable) {
+		t.Errorf("outlineRefinableKinds holds %d rows, want exactly %d", len(outlineRefinableKinds), len(wantRefinable))
+	}
+	for kind, want := range wantRefinable {
+		if outlineRefinableKinds[kind] != want {
+			t.Errorf("outlineRefinableKinds[%q] = %v, want %v", kind, outlineRefinableKinds[kind], want)
 		}
 	}
-	for nodeType := range outlineKindRefinement {
-		if !isOutlineNodeTypeShaped(nodeType) {
-			t.Errorf("outlineKindRefinement key %q does not read as a grammar node type", nodeType)
+	for kind := range outlineRefinableKinds {
+		if !wantRefinable[kind] {
+			t.Errorf("outlineRefinableKinds holds an unexpected row %q; add it to the frozen set with its reason", kind)
 		}
 	}
 }
 
-// isOutlineNodeTypeShaped reports whether a key looks like a grammar node
-// type: lower snake case with at least one underscore. Every language name in
-// the registry is a single word, so this separates the two vocabularies.
-func isOutlineNodeTypeShaped(key string) bool {
-	underscores := 0
-	for i := 0; i < len(key); i++ {
-		c := key[i]
-		switch {
-		case c == '_':
-			underscores++
-		case c >= 'a' && c <= 'z':
-		default:
-			return false
+func assertOutlineTableFrozen(t *testing.T, name string, got, want map[string]string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s holds %d rows, want exactly %d", name, len(got), len(want))
+	}
+	for key, wantValue := range want {
+		gotValue, ok := got[key]
+		if !ok {
+			t.Errorf("%s is missing the frozen row %q", name, key)
+			continue
+		}
+		if gotValue != wantValue {
+			t.Errorf("%s[%q] = %q, want %q", name, key, gotValue, wantValue)
 		}
 	}
-	return underscores > 0
+	for key := range got {
+		if _, ok := want[key]; !ok {
+			t.Errorf("%s holds an unexpected row %q. If it is a genuine cross-language row, add it to the frozen set in this change. If it is a language name, it does not belong in this table at all.", name, key)
+		}
+	}
+}
+
+// TestOutlineKindTableFreezeCatchesALanguageNameRow proves the freeze has full
+// teeth for the case it exists to stop: a row keyed by a language name that no
+// hand-written blocklist happens to mention.
+func TestOutlineKindTableFreezeCatchesALanguageNameRow(t *testing.T) {
+	frozen := map[string]string{"function": "function"}
+	for _, injected := range []string{"go", "zig", "haskell", "gleam", "wgsl"} {
+		tampered := map[string]string{"function": "function", injected: "function"}
+		probe := &testing.T{}
+		assertOutlineTableFrozen(probe, "probe", tampered, frozen)
+		if !probe.Failed() {
+			t.Errorf("the freeze accepted an injected row keyed by the language name %q", injected)
+		}
+	}
 }
 
 func TestOutlineOwnerRuleValidationFailsClosed(t *testing.T) {

--- a/outline_report.go
+++ b/outline_report.go
@@ -12,15 +12,25 @@ type OutlineSymbol struct {
 	// table (outlineKindTable) plus one fixed node-type refinement table
 	// (outlineKindRefinement). It never comes from the language name.
 	Kind string
-	// Name is the text of the "@name" capture. A "#strip!" directive on the
-	// capture applies, because the text comes from QueryCapture.Text.
+	// Name is the text of the "@name" capture, with leading and trailing
+	// white space removed. A "#strip!" directive on the capture applies,
+	// because the text comes from QueryCapture.Text.
+	//
+	// Invariant: NameRange is the span of the capture NODE, so Name and the
+	// source bytes at NameRange agree only when no directive rewrote the
+	// text and the node carries no surrounding white space. Trimming or a
+	// directive can make Name shorter than NameRange.
+	// TestOutlineNameAgreesWithNameRange pins that agreement on every
+	// committed fixture, so a language where the two diverge shows up as a
+	// test failure rather than as a silently wrong span.
 	Name string
 	// NodeType is the grammar node type of the captured definition node.
 	NodeType string
 	// Range is the full span of the captured definition node.
 	Range Range
-	// NameRange is the span of the "@name" capture. It is always contained
-	// in Range; a candidate that breaks containment is omitted and counted.
+	// NameRange is the span of the "@name" capture node. It is always
+	// contained in Range; a candidate that breaks containment is omitted and
+	// counted.
 	NameRange Range
 	// Owner is the non-lexical owner name, for example the receiver type of
 	// a method. It is always empty in this change. Owner resolution runs
@@ -34,17 +44,42 @@ type OutlineSymbol struct {
 	Children []OutlineSymbol
 }
 
+// Outline decline reasons. An empty DeclineReason means the outliner ran the
+// query; it does not mean the file holds symbols.
+const (
+	// OutlineDeclineNilOutliner reports a call on a nil *Outliner.
+	OutlineDeclineNilOutliner = "nil_outliner"
+	// OutlineDeclineQueryEmpty reports that the language has no tags query.
+	OutlineDeclineQueryEmpty = "query_empty"
+	// OutlineDeclineNilTree reports a nil *Tree argument.
+	OutlineDeclineNilTree = "nil_tree"
+	// OutlineDeclineNilRootNode reports a tree with no root node.
+	OutlineDeclineNilRootNode = "nil_root_node"
+	// OutlineDeclineLanguageMismatch reports that the tree was parsed with a
+	// different language than the outliner was built for. This is caller
+	// misuse, not a property of the source.
+	OutlineDeclineLanguageMismatch = "language_mismatch"
+)
+
 // OutlineReport is the receipt for one OutlineTree call. Every candidate the
 // tags query produced is either emitted as a symbol or counted in exactly one
-// omission counter, so silent under-coverage cannot look like correctness.
+// omission counter, so a dropped candidate cannot look like an absent one.
 //
 // The accounting identity the gates assert is:
 //
-//	Symbols + OmittedNoName + OmittedDuplicate + OmittedConflict +
-//	    OmittedOverlap + OmittedInvalidNameRange == candidates
+//	Symbols + OmittedNoName + OmittedDuplicate + OmittedNameConflict +
+//	    OmittedConflict + OmittedOverlap + OmittedInvalidNameRange +
+//	    OmittedMultipleDefinitions == candidates
 //
 // OwnerRuleMisses is not an omission counter; a miss keeps the symbol and
 // leaves Owner empty.
+//
+// READ THIS BEFORE TREATING Omitted() == 0 AS "COMPLETE". Candidates() counts
+// what the tags query produced, not what the file contains. A definition the
+// query has no pattern for produces no candidate and no omission, so it is
+// invisible to every counter here. Call Outliner.DefinitionKinds to see the
+// kinds the compiled query can emit at all; a kind absent from that list can
+// never appear in the outline, however many such definitions the file holds.
 type OutlineReport struct {
 	// Symbols counts every emitted symbol, nested symbols included.
 	Symbols int
@@ -52,47 +87,92 @@ type OutlineReport struct {
 	// or whose name text trims to empty.
 	OmittedNoName int
 	// OmittedDuplicate counts candidates dropped because an earlier
-	// candidate holds the same Range and the same Kind.
+	// candidate holds the same Range, the same Kind, the same Name, and the
+	// same NameRange. These are true repeats: dropping one changes nothing.
 	OmittedDuplicate int
+	// OmittedNameConflict counts candidates dropped because two or more
+	// candidates hold the same Range and the same Kind but disagree about
+	// the name. Every member of such a group is dropped.
+	//
+	// This is the common shape when shared tags patterns bind "@name" twice
+	// on one definition node. In C-family method syntax the two bindings are
+	// the return type and the method name, and no language-neutral rule can
+	// tell them apart. Choosing by capture order would publish the return
+	// type as the method name, so the outline drops the group instead and
+	// counts it here. The remedy is a data edit: constrain the pattern with
+	// a "name:" field, the way the Go tags override already does.
+	OmittedNameConflict int
 	// OmittedConflict counts candidates dropped because two or more
 	// candidates hold the same Range with different Kinds. Every member of
 	// such a group is dropped; the outline does not guess which one is
 	// right.
 	OmittedConflict int
 	// OmittedOverlap counts candidates dropped because they partially
-	// overlap an accepted symbol. Neither range contains the other, so the
-	// forest has no well-defined shape; the later start is dropped.
+	// overlap an accepted symbol.
+	//
+	// This rule is defensive. Two nodes of one tree are always nested or
+	// disjoint, so a partial overlap cannot arise from a single tree today.
+	// The rule keeps the forest well-defined if a future capture source
+	// relaxes that, and the unit cases exercise it directly.
 	OmittedOverlap int
 	// OmittedInvalidNameRange counts candidates whose NameRange is not byte
-	// contained in Range, or whose Range is itself inverted.
+	// contained in Range, or whose Range is itself inverted. Like
+	// OmittedOverlap this is defensive: the captures of a match all sit
+	// inside the matched subtree, so a single tree does not produce this
+	// today.
 	OmittedInvalidNameRange int
+	// OmittedMultipleDefinitions counts matches dropped because they carry
+	// more than one "@definition.X" capture. Such a match names two
+	// definitions at once and the outline does not choose between them.
+	// No inferred pattern does this today; the counter exists so that a data
+	// edit that introduces the shape is visible instead of silent.
+	OmittedMultipleDefinitions int
 	// OwnerRuleMisses counts symbols where an owner rule matched the node
 	// type but the field or the normalization did not resolve a single
 	// name. It is always zero until owner resolution ships.
 	OwnerRuleMisses int
-	// QueryEmpty reports that the language has no tags query. The outliner
-	// declines: no symbols, and this flag as the receipt.
-	QueryEmpty bool
+	// DeclineReason names why the outliner produced nothing, or is empty
+	// when it ran the query. See the OutlineDecline constants. An empty
+	// reason with zero Symbols means the query ran and matched nothing,
+	// which is a different fact from every declined case.
+	DeclineReason string
 	// Truncated reports that query execution hit the match limit or the
 	// match work budget, so the symbol list is partial.
 	Truncated bool
-	// LanguageMismatch reports that the tree was parsed with a different
-	// language than the outliner was built for. The outliner declines,
-	// because query symbol identifiers are language specific.
-	LanguageMismatch bool
+	// TreeHasError reports that the parsed tree holds an ERROR or MISSING
+	// node, so the parser did not fully recover the source.
+	//
+	// Symbols are the query's projection of the RECOVERED tree. When
+	// TreeHasError is true, definitions inside or after unrecovered regions
+	// may be absent, over-long, or missing entirely, and no omission counter
+	// fires for them: the query never produced a candidate to omit. Do not
+	// read "every counter is zero" as "the outline is complete" on such a
+	// tree. Do not assume the symbols before the first error are
+	// trustworthy either; a truncated definition is itself a symbol, and its
+	// Range can swallow everything that follows it.
+	TreeHasError bool
 }
+
+// Declined reports whether the outliner produced nothing because it refused to
+// run, rather than because the query matched nothing.
+func (r OutlineReport) Declined() bool { return r.DeclineReason != "" }
 
 // Omitted returns the total number of candidates the outliner dropped.
 func (r OutlineReport) Omitted() int {
 	return r.OmittedNoName +
 		r.OmittedDuplicate +
+		r.OmittedNameConflict +
 		r.OmittedConflict +
 		r.OmittedOverlap +
-		r.OmittedInvalidNameRange
+		r.OmittedInvalidNameRange +
+		r.OmittedMultipleDefinitions
 }
 
 // Candidates returns the number of definition candidates the tags query
 // produced: the emitted symbols plus every omission.
+//
+// This is a count of QUERY OUTPUT, not of source content. A definition shape
+// the query has no pattern for never becomes a candidate.
 func (r OutlineReport) Candidates() int {
 	return r.Symbols + r.Omitted()
 }

--- a/outline_report.go
+++ b/outline_report.go
@@ -1,0 +1,124 @@
+package gotreesitter
+
+// OutlineSymbol is one entry of a language-neutral file outline: a definition
+// the tags query captured, its normalized kind, its name, its spans, and the
+// definitions lexically nested inside it.
+//
+// The projection is read-only. It never changes the tree and never copies a
+// definition body; Name and Owner are the only text it extracts.
+type OutlineSymbol struct {
+	// Kind is the normalized definition kind. It comes from the
+	// "@definition.X" capture suffix through one fixed, language-neutral
+	// table (outlineKindTable) plus one fixed node-type refinement table
+	// (outlineKindRefinement). It never comes from the language name.
+	Kind string
+	// Name is the text of the "@name" capture. A "#strip!" directive on the
+	// capture applies, because the text comes from QueryCapture.Text.
+	Name string
+	// NodeType is the grammar node type of the captured definition node.
+	NodeType string
+	// Range is the full span of the captured definition node.
+	Range Range
+	// NameRange is the span of the "@name" capture. It is always contained
+	// in Range; a candidate that breaks containment is omitted and counted.
+	NameRange Range
+	// Owner is the non-lexical owner name, for example the receiver type of
+	// a method. It is always empty in this change. Owner resolution runs
+	// from declarative OutlineOwnerRule rows and lands in a later change;
+	// see WithOutlineOwnerRules. Lexical containment never sets Owner --
+	// that information lives in Children.
+	Owner string
+	// Children holds the definitions lexically nested in this one, in source
+	// order. Nesting comes from byte containment of Range, never from the
+	// language name.
+	Children []OutlineSymbol
+}
+
+// OutlineReport is the receipt for one OutlineTree call. Every candidate the
+// tags query produced is either emitted as a symbol or counted in exactly one
+// omission counter, so silent under-coverage cannot look like correctness.
+//
+// The accounting identity the gates assert is:
+//
+//	Symbols + OmittedNoName + OmittedDuplicate + OmittedConflict +
+//	    OmittedOverlap + OmittedInvalidNameRange == candidates
+//
+// OwnerRuleMisses is not an omission counter; a miss keeps the symbol and
+// leaves Owner empty.
+type OutlineReport struct {
+	// Symbols counts every emitted symbol, nested symbols included.
+	Symbols int
+	// OmittedNoName counts definition captures whose name capture is absent
+	// or whose name text trims to empty.
+	OmittedNoName int
+	// OmittedDuplicate counts candidates dropped because an earlier
+	// candidate holds the same Range and the same Kind.
+	OmittedDuplicate int
+	// OmittedConflict counts candidates dropped because two or more
+	// candidates hold the same Range with different Kinds. Every member of
+	// such a group is dropped; the outline does not guess which one is
+	// right.
+	OmittedConflict int
+	// OmittedOverlap counts candidates dropped because they partially
+	// overlap an accepted symbol. Neither range contains the other, so the
+	// forest has no well-defined shape; the later start is dropped.
+	OmittedOverlap int
+	// OmittedInvalidNameRange counts candidates whose NameRange is not byte
+	// contained in Range, or whose Range is itself inverted.
+	OmittedInvalidNameRange int
+	// OwnerRuleMisses counts symbols where an owner rule matched the node
+	// type but the field or the normalization did not resolve a single
+	// name. It is always zero until owner resolution ships.
+	OwnerRuleMisses int
+	// QueryEmpty reports that the language has no tags query. The outliner
+	// declines: no symbols, and this flag as the receipt.
+	QueryEmpty bool
+	// Truncated reports that query execution hit the match limit or the
+	// match work budget, so the symbol list is partial.
+	Truncated bool
+	// LanguageMismatch reports that the tree was parsed with a different
+	// language than the outliner was built for. The outliner declines,
+	// because query symbol identifiers are language specific.
+	LanguageMismatch bool
+}
+
+// Omitted returns the total number of candidates the outliner dropped.
+func (r OutlineReport) Omitted() int {
+	return r.OmittedNoName +
+		r.OmittedDuplicate +
+		r.OmittedConflict +
+		r.OmittedOverlap +
+		r.OmittedInvalidNameRange
+}
+
+// Candidates returns the number of definition candidates the tags query
+// produced: the emitted symbols plus every omission.
+func (r OutlineReport) Candidates() int {
+	return r.Symbols + r.Omitted()
+}
+
+// OutlineOwnerRule is a declarative, per-language rule that resolves the
+// non-lexical owner of a definition, for example the receiver type of a Go
+// method. It reads a named field and unwraps through a fixed list of node
+// types until it reaches exactly one node of an accepted terminal type. If
+// unwrapping does not end at exactly one such node, the rule fails closed and
+// Owner stays empty.
+//
+// Rules are data. The core holds no rule rows; the grammars package owns the
+// per-language table and passes it through WithOutlineOwnerRules.
+//
+// Owner resolution is not applied in this change. See WithOutlineOwnerRules.
+type OutlineOwnerRule struct {
+	// NodeType is the definition node type the rule applies to, for example
+	// "method_declaration".
+	NodeType string
+	// OwnerField is the field name read through Node.ChildByFieldName, for
+	// example "receiver".
+	OwnerField string
+	// Unwrap lists node types the rule descends through, for example
+	// "parameter_list", "parameter_declaration", "pointer_type".
+	Unwrap []string
+	// NameTypes lists the accepted terminal node types, for example
+	// "type_identifier".
+	NameTypes []string
+}

--- a/testdata/outline/c/registry.c
+++ b/testdata/outline/c/registry.c
@@ -1,0 +1,20 @@
+#include <stddef.h>
+
+struct Registry {
+    int count;
+};
+
+typedef struct Registry RegistryAlias;
+
+enum Level {
+    LEVEL_LOW,
+    LEVEL_HIGH
+};
+
+int registry_count(struct Registry *registry) {
+    return registry->count;
+}
+
+void registry_reset(struct Registry *registry) {
+    registry->count = 0;
+}

--- a/testdata/outline/c/registry.c.golden.json
+++ b/testdata/outline/c/registry.c.golden.json
@@ -1,0 +1,152 @@
+{
+  "language": "c",
+  "fixture": "c/registry.c",
+  "purpose": "struct, typedef, and function definitions; also pins the inferred-query over-capture of struct uses (spec risk R1)",
+  "tree_has_error": false,
+  "report": {
+    "Symbols": 7,
+    "OmittedNoName": 0,
+    "OmittedDuplicate": 0,
+    "OmittedConflict": 0,
+    "OmittedOverlap": 0,
+    "OmittedInvalidNameRange": 0,
+    "OwnerRuleMisses": 0,
+    "QueryEmpty": false,
+    "Truncated": false,
+    "LanguageMismatch": false
+  },
+  "symbols": [
+    {
+      "kind": "type",
+      "name": "Registry",
+      "node_type": "struct_specifier",
+      "range": {
+        "start_byte": 21,
+        "end_byte": 55,
+        "start_point": "2:0",
+        "end_point": "4:1"
+      },
+      "name_range": {
+        "start_byte": 28,
+        "end_byte": 36,
+        "start_point": "2:7",
+        "end_point": "2:15"
+      },
+      "owner": ""
+    },
+    {
+      "kind": "type",
+      "name": "RegistryAlias",
+      "node_type": "type_definition",
+      "range": {
+        "start_byte": 58,
+        "end_byte": 96,
+        "start_point": "6:0",
+        "end_point": "6:38"
+      },
+      "name_range": {
+        "start_byte": 82,
+        "end_byte": 95,
+        "start_point": "6:24",
+        "end_point": "6:37"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "type",
+          "name": "Registry",
+          "node_type": "struct_specifier",
+          "range": {
+            "start_byte": 66,
+            "end_byte": 81,
+            "start_point": "6:8",
+            "end_point": "6:23"
+          },
+          "name_range": {
+            "start_byte": 73,
+            "end_byte": 81,
+            "start_point": "6:15",
+            "end_point": "6:23"
+          },
+          "owner": ""
+        }
+      ]
+    },
+    {
+      "kind": "function",
+      "name": "registry_count",
+      "node_type": "function_definition",
+      "range": {
+        "start_byte": 145,
+        "end_byte": 222,
+        "start_point": "13:0",
+        "end_point": "15:1"
+      },
+      "name_range": {
+        "start_byte": 149,
+        "end_byte": 163,
+        "start_point": "13:4",
+        "end_point": "13:18"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "type",
+          "name": "Registry",
+          "node_type": "struct_specifier",
+          "range": {
+            "start_byte": 164,
+            "end_byte": 179,
+            "start_point": "13:19",
+            "end_point": "13:34"
+          },
+          "name_range": {
+            "start_byte": 171,
+            "end_byte": 179,
+            "start_point": "13:26",
+            "end_point": "13:34"
+          },
+          "owner": ""
+        }
+      ]
+    },
+    {
+      "kind": "function",
+      "name": "registry_reset",
+      "node_type": "function_definition",
+      "range": {
+        "start_byte": 224,
+        "end_byte": 299,
+        "start_point": "17:0",
+        "end_point": "19:1"
+      },
+      "name_range": {
+        "start_byte": 229,
+        "end_byte": 243,
+        "start_point": "17:5",
+        "end_point": "17:19"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "type",
+          "name": "Registry",
+          "node_type": "struct_specifier",
+          "range": {
+            "start_byte": 244,
+            "end_byte": 259,
+            "start_point": "17:20",
+            "end_point": "17:35"
+          },
+          "name_range": {
+            "start_byte": 251,
+            "end_byte": 259,
+            "start_point": "17:27",
+            "end_point": "17:35"
+          },
+          "owner": ""
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/outline/c/registry.c.golden.json
+++ b/testdata/outline/c/registry.c.golden.json
@@ -1,19 +1,24 @@
 {
   "language": "c",
   "fixture": "c/registry.c",
-  "purpose": "struct, typedef, and function definitions; also pins the inferred-query over-capture of struct uses (spec risk R1)",
-  "tree_has_error": false,
+  "purpose": "struct, typedef, and function definitions; pins the fleet-wide struct_specifier over-capture that makes 49 percent of the C outline struct uses (spec risk R1)",
+  "query_definition_kinds": [
+    "function",
+    "type"
+  ],
   "report": {
     "Symbols": 7,
     "OmittedNoName": 0,
     "OmittedDuplicate": 0,
+    "OmittedNameConflict": 0,
     "OmittedConflict": 0,
     "OmittedOverlap": 0,
     "OmittedInvalidNameRange": 0,
+    "OmittedMultipleDefinitions": 0,
     "OwnerRuleMisses": 0,
-    "QueryEmpty": false,
+    "DeclineReason": "",
     "Truncated": false,
-    "LanguageMismatch": false
+    "TreeHasError": false
   },
   "symbols": [
     {

--- a/testdata/outline/cpp/registry.cpp
+++ b/testdata/outline/cpp/registry.cpp
@@ -1,0 +1,26 @@
+namespace demo {
+
+struct Point {
+    int x;
+    int y;
+};
+
+class Registry {
+public:
+    int count() const {
+        return count_;
+    }
+
+    void reset() {
+        count_ = 0;
+    }
+
+private:
+    int count_ = 0;
+};
+
+int total(const Registry &registry) {
+    return registry.count();
+}
+
+}  // namespace demo

--- a/testdata/outline/cpp/registry.cpp.golden.json
+++ b/testdata/outline/cpp/registry.cpp.golden.json
@@ -1,19 +1,25 @@
 {
   "language": "cpp",
   "fixture": "cpp/registry.cpp",
-  "purpose": "class with member function definitions nested inside it",
-  "tree_has_error": false,
+  "purpose": "class with member function definitions nested inside it; clean of the struct_specifier over-capture only because the parameter type omits the class keyword",
+  "query_definition_kinds": [
+    "class",
+    "function",
+    "type"
+  ],
   "report": {
     "Symbols": 5,
     "OmittedNoName": 0,
     "OmittedDuplicate": 0,
+    "OmittedNameConflict": 0,
     "OmittedConflict": 0,
     "OmittedOverlap": 0,
     "OmittedInvalidNameRange": 0,
+    "OmittedMultipleDefinitions": 0,
     "OwnerRuleMisses": 0,
-    "QueryEmpty": false,
+    "DeclineReason": "",
     "Truncated": false,
-    "LanguageMismatch": false
+    "TreeHasError": false
   },
   "symbols": [
     {

--- a/testdata/outline/cpp/registry.cpp.golden.json
+++ b/testdata/outline/cpp/registry.cpp.golden.json
@@ -1,0 +1,112 @@
+{
+  "language": "cpp",
+  "fixture": "cpp/registry.cpp",
+  "purpose": "class with member function definitions nested inside it",
+  "tree_has_error": false,
+  "report": {
+    "Symbols": 5,
+    "OmittedNoName": 0,
+    "OmittedDuplicate": 0,
+    "OmittedConflict": 0,
+    "OmittedOverlap": 0,
+    "OmittedInvalidNameRange": 0,
+    "OwnerRuleMisses": 0,
+    "QueryEmpty": false,
+    "Truncated": false,
+    "LanguageMismatch": false
+  },
+  "symbols": [
+    {
+      "kind": "type",
+      "name": "Point",
+      "node_type": "struct_specifier",
+      "range": {
+        "start_byte": 18,
+        "end_byte": 56,
+        "start_point": "2:0",
+        "end_point": "5:1"
+      },
+      "name_range": {
+        "start_byte": 25,
+        "end_byte": 30,
+        "start_point": "2:7",
+        "end_point": "2:12"
+      },
+      "owner": ""
+    },
+    {
+      "kind": "class",
+      "name": "Registry",
+      "node_type": "class_specifier",
+      "range": {
+        "start_byte": 59,
+        "end_byte": 214,
+        "start_point": "7:0",
+        "end_point": "19:1"
+      },
+      "name_range": {
+        "start_byte": 65,
+        "end_byte": 73,
+        "start_point": "7:6",
+        "end_point": "7:14"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "function",
+          "name": "count",
+          "node_type": "function_definition",
+          "range": {
+            "start_byte": 88,
+            "end_byte": 136,
+            "start_point": "9:4",
+            "end_point": "11:5"
+          },
+          "name_range": {
+            "start_byte": 92,
+            "end_byte": 97,
+            "start_point": "9:8",
+            "end_point": "9:13"
+          },
+          "owner": ""
+        },
+        {
+          "kind": "function",
+          "name": "reset",
+          "node_type": "function_definition",
+          "range": {
+            "start_byte": 142,
+            "end_byte": 182,
+            "start_point": "13:4",
+            "end_point": "15:5"
+          },
+          "name_range": {
+            "start_byte": 147,
+            "end_byte": 152,
+            "start_point": "13:9",
+            "end_point": "13:14"
+          },
+          "owner": ""
+        }
+      ]
+    },
+    {
+      "kind": "function",
+      "name": "total",
+      "node_type": "function_definition",
+      "range": {
+        "start_byte": 217,
+        "end_byte": 285,
+        "start_point": "21:0",
+        "end_point": "23:1"
+      },
+      "name_range": {
+        "start_byte": 221,
+        "end_byte": 226,
+        "start_point": "21:4",
+        "end_point": "21:9"
+      },
+      "owner": ""
+    }
+  ]
+}

--- a/testdata/outline/csharp/Service.cs
+++ b/testdata/outline/csharp/Service.cs
@@ -1,0 +1,33 @@
+namespace Demo
+{
+    public interface IService
+    {
+        string Name();
+    }
+
+    public class Registry : IService
+    {
+        private readonly string label;
+
+        public Registry(string label)
+        {
+            this.label = label;
+        }
+
+        public string Name()
+        {
+            return label;
+        }
+
+        public Uri PathToUri(string path)
+        {
+            return new Uri(path);
+        }
+    }
+
+    public enum Level
+    {
+        Low,
+        High
+    }
+}

--- a/testdata/outline/csharp/Service.cs.golden.json
+++ b/testdata/outline/csharp/Service.cs.golden.json
@@ -1,0 +1,140 @@
+{
+  "language": "c_sharp",
+  "fixture": "csharp/Service.cs",
+  "purpose": "real-data name conflict: the shared inference binds @name to both the return type and the method name, so the group drops and OmittedNameConflict fires instead of publishing the return type",
+  "query_definition_kinds": [
+    "class",
+    "constructor",
+    "interface",
+    "method",
+    "type"
+  ],
+  "report": {
+    "Symbols": 6,
+    "OmittedNoName": 0,
+    "OmittedDuplicate": 0,
+    "OmittedNameConflict": 2,
+    "OmittedConflict": 0,
+    "OmittedOverlap": 0,
+    "OmittedInvalidNameRange": 0,
+    "OmittedMultipleDefinitions": 0,
+    "OwnerRuleMisses": 0,
+    "DeclineReason": "",
+    "Truncated": false,
+    "TreeHasError": false
+  },
+  "symbols": [
+    {
+      "kind": "interface",
+      "name": "IService",
+      "node_type": "interface_declaration",
+      "range": {
+        "start_byte": 21,
+        "end_byte": 81,
+        "start_point": "2:4",
+        "end_point": "5:5"
+      },
+      "name_range": {
+        "start_byte": 38,
+        "end_byte": 46,
+        "start_point": "2:21",
+        "end_point": "2:29"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "method",
+          "name": "Name",
+          "node_type": "method_declaration",
+          "range": {
+            "start_byte": 61,
+            "end_byte": 75,
+            "start_point": "4:8",
+            "end_point": "4:22"
+          },
+          "name_range": {
+            "start_byte": 68,
+            "end_byte": 72,
+            "start_point": "4:15",
+            "end_point": "4:19"
+          },
+          "owner": ""
+        }
+      ]
+    },
+    {
+      "kind": "class",
+      "name": "Registry",
+      "node_type": "class_declaration",
+      "range": {
+        "start_byte": 87,
+        "end_byte": 434,
+        "start_point": "7:4",
+        "end_point": "25:5"
+      },
+      "name_range": {
+        "start_byte": 100,
+        "end_byte": 108,
+        "start_point": "7:17",
+        "end_point": "7:25"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "constructor",
+          "name": "Registry",
+          "node_type": "constructor_declaration",
+          "range": {
+            "start_byte": 174,
+            "end_byte": 255,
+            "start_point": "11:8",
+            "end_point": "14:9"
+          },
+          "name_range": {
+            "start_byte": 181,
+            "end_byte": 189,
+            "start_point": "11:15",
+            "end_point": "11:23"
+          },
+          "owner": ""
+        },
+        {
+          "kind": "method",
+          "name": "Name",
+          "node_type": "method_declaration",
+          "range": {
+            "start_byte": 265,
+            "end_byte": 331,
+            "start_point": "16:8",
+            "end_point": "19:9"
+          },
+          "name_range": {
+            "start_byte": 279,
+            "end_byte": 283,
+            "start_point": "16:22",
+            "end_point": "16:26"
+          },
+          "owner": ""
+        }
+      ]
+    },
+    {
+      "kind": "enum",
+      "name": "Level",
+      "node_type": "enum_declaration",
+      "range": {
+        "start_byte": 440,
+        "end_byte": 495,
+        "start_point": "27:4",
+        "end_point": "31:5"
+      },
+      "name_range": {
+        "start_byte": 452,
+        "end_byte": 457,
+        "start_point": "27:16",
+        "end_point": "27:21"
+      },
+      "owner": ""
+    }
+  ]
+}

--- a/testdata/outline/go/broken.go.fixture
+++ b/testdata/outline/go/broken.go.fixture
@@ -1,0 +1,17 @@
+package broken
+
+func Before() int {
+	return 1
+}
+
+func Damaged(a int {
+	return a
+}
+
+type Holder struct {
+	value int
+}
+
+func (h *Holder) After() int {
+	return h.value
+}

--- a/testdata/outline/go/broken.go.fixture.golden.json
+++ b/testdata/outline/go/broken.go.fixture.golden.json
@@ -1,0 +1,74 @@
+{
+  "language": "go",
+  "fixture": "go/broken.go.fixture",
+  "purpose": "error-bearing source: the outline stays well-defined across an ERROR node",
+  "tree_has_error": true,
+  "report": {
+    "Symbols": 3,
+    "OmittedNoName": 0,
+    "OmittedDuplicate": 0,
+    "OmittedConflict": 0,
+    "OmittedOverlap": 0,
+    "OmittedInvalidNameRange": 0,
+    "OwnerRuleMisses": 0,
+    "QueryEmpty": false,
+    "Truncated": false,
+    "LanguageMismatch": false
+  },
+  "symbols": [
+    {
+      "kind": "function",
+      "name": "Before",
+      "node_type": "function_declaration",
+      "range": {
+        "start_byte": 16,
+        "end_byte": 47,
+        "start_point": "2:0",
+        "end_point": "4:1"
+      },
+      "name_range": {
+        "start_byte": 21,
+        "end_byte": 27,
+        "start_point": "2:5",
+        "end_point": "2:11"
+      },
+      "owner": ""
+    },
+    {
+      "kind": "function",
+      "name": "Damaged",
+      "node_type": "function_declaration",
+      "range": {
+        "start_byte": 49,
+        "end_byte": 81,
+        "start_point": "6:0",
+        "end_point": "8:1"
+      },
+      "name_range": {
+        "start_byte": 54,
+        "end_byte": 61,
+        "start_point": "6:5",
+        "end_point": "6:12"
+      },
+      "owner": ""
+    },
+    {
+      "kind": "method",
+      "name": "After",
+      "node_type": "method_declaration",
+      "range": {
+        "start_byte": 118,
+        "end_byte": 166,
+        "start_point": "14:0",
+        "end_point": "16:1"
+      },
+      "name_range": {
+        "start_byte": 135,
+        "end_byte": 140,
+        "start_point": "14:17",
+        "end_point": "14:22"
+      },
+      "owner": ""
+    }
+  ]
+}

--- a/testdata/outline/go/broken.go.fixture.golden.json
+++ b/testdata/outline/go/broken.go.fixture.golden.json
@@ -2,18 +2,23 @@
   "language": "go",
   "fixture": "go/broken.go.fixture",
   "purpose": "error-bearing source: the outline stays well-defined across an ERROR node",
-  "tree_has_error": true,
+  "query_definition_kinds": [
+    "function",
+    "method"
+  ],
   "report": {
     "Symbols": 3,
     "OmittedNoName": 0,
     "OmittedDuplicate": 0,
+    "OmittedNameConflict": 0,
     "OmittedConflict": 0,
     "OmittedOverlap": 0,
     "OmittedInvalidNameRange": 0,
+    "OmittedMultipleDefinitions": 0,
     "OwnerRuleMisses": 0,
-    "QueryEmpty": false,
+    "DeclineReason": "",
     "Truncated": false,
-    "LanguageMismatch": false
+    "TreeHasError": true
   },
   "symbols": [
     {

--- a/testdata/outline/go/counters.go.fixture
+++ b/testdata/outline/go/counters.go.fixture
@@ -1,0 +1,17 @@
+package counters
+
+const limit = 10
+
+var shared = 0
+
+type Holder struct {
+	value int
+}
+
+func Standalone(a int) int {
+	return a
+}
+
+func (h *Holder) Value() int {
+	return h.value
+}

--- a/testdata/outline/go/counters.go.fixture.golden.json
+++ b/testdata/outline/go/counters.go.fixture.golden.json
@@ -1,0 +1,47 @@
+{
+  "language": "go",
+  "fixture": "go/counters.go.fixture",
+  "purpose": "pins OmittedDuplicate, OmittedConflict, OmittedNameConflict, OmittedNoName, and OmittedMultipleDefinitions end to end through a live query, which the shipped tags data cannot produce on demand",
+  "query_definition_kinds": [
+    "class",
+    "constant",
+    "function",
+    "method",
+    "type",
+    "variable"
+  ],
+  "report": {
+    "Symbols": 1,
+    "OmittedNoName": 1,
+    "OmittedDuplicate": 1,
+    "OmittedNameConflict": 2,
+    "OmittedConflict": 2,
+    "OmittedOverlap": 0,
+    "OmittedInvalidNameRange": 0,
+    "OmittedMultipleDefinitions": 1,
+    "OwnerRuleMisses": 0,
+    "DeclineReason": "",
+    "Truncated": false,
+    "TreeHasError": false
+  },
+  "symbols": [
+    {
+      "kind": "function",
+      "name": "Standalone",
+      "node_type": "function_declaration",
+      "range": {
+        "start_byte": 87,
+        "end_byte": 127,
+        "start_point": "10:0",
+        "end_point": "12:1"
+      },
+      "name_range": {
+        "start_byte": 92,
+        "end_byte": 102,
+        "start_point": "10:5",
+        "end_point": "10:15"
+      },
+      "owner": ""
+    }
+  ]
+}

--- a/testdata/outline/go/service.go.fixture
+++ b/testdata/outline/go/service.go.fixture
@@ -1,0 +1,33 @@
+package service
+
+import "fmt"
+
+const defaultName = "svc"
+
+type Registry struct {
+	entries map[string]int
+}
+
+type Named interface {
+	Name() string
+}
+
+func NewRegistry() *Registry {
+	return &Registry{entries: map[string]int{}}
+}
+
+func (r *Registry) Add(name string, weight int) {
+	r.entries[name] = weight
+	fmt.Println(name)
+}
+
+func (r *Registry) Name() string {
+	return defaultName
+}
+
+func Describe(n Named) string {
+	render := func(prefix string) string {
+		return prefix + n.Name()
+	}
+	return render("svc:")
+}

--- a/testdata/outline/go/service.go.fixture.golden.json
+++ b/testdata/outline/go/service.go.fixture.golden.json
@@ -1,0 +1,92 @@
+{
+  "language": "go",
+  "fixture": "go/service.go.fixture",
+  "purpose": "functions and methods from the hand-written Go tags override; a nested function literal that the query does not capture",
+  "tree_has_error": false,
+  "report": {
+    "Symbols": 4,
+    "OmittedNoName": 0,
+    "OmittedDuplicate": 0,
+    "OmittedConflict": 0,
+    "OmittedOverlap": 0,
+    "OmittedInvalidNameRange": 0,
+    "OwnerRuleMisses": 0,
+    "QueryEmpty": false,
+    "Truncated": false,
+    "LanguageMismatch": false
+  },
+  "symbols": [
+    {
+      "kind": "function",
+      "name": "NewRegistry",
+      "node_type": "function_declaration",
+      "range": {
+        "start_byte": 149,
+        "end_byte": 226,
+        "start_point": "14:0",
+        "end_point": "16:1"
+      },
+      "name_range": {
+        "start_byte": 154,
+        "end_byte": 165,
+        "start_point": "14:5",
+        "end_point": "14:16"
+      },
+      "owner": ""
+    },
+    {
+      "kind": "method",
+      "name": "Add",
+      "node_type": "method_declaration",
+      "range": {
+        "start_byte": 228,
+        "end_byte": 324,
+        "start_point": "18:0",
+        "end_point": "21:1"
+      },
+      "name_range": {
+        "start_byte": 247,
+        "end_byte": 250,
+        "start_point": "18:19",
+        "end_point": "18:22"
+      },
+      "owner": ""
+    },
+    {
+      "kind": "method",
+      "name": "Name",
+      "node_type": "method_declaration",
+      "range": {
+        "start_byte": 326,
+        "end_byte": 382,
+        "start_point": "23:0",
+        "end_point": "25:1"
+      },
+      "name_range": {
+        "start_byte": 345,
+        "end_byte": 349,
+        "start_point": "23:19",
+        "end_point": "23:23"
+      },
+      "owner": ""
+    },
+    {
+      "kind": "function",
+      "name": "Describe",
+      "node_type": "function_declaration",
+      "range": {
+        "start_byte": 384,
+        "end_byte": 510,
+        "start_point": "27:0",
+        "end_point": "32:1"
+      },
+      "name_range": {
+        "start_byte": 389,
+        "end_byte": 397,
+        "start_point": "27:5",
+        "end_point": "27:13"
+      },
+      "owner": ""
+    }
+  ]
+}

--- a/testdata/outline/go/service.go.fixture.golden.json
+++ b/testdata/outline/go/service.go.fixture.golden.json
@@ -2,18 +2,23 @@
   "language": "go",
   "fixture": "go/service.go.fixture",
   "purpose": "functions and methods from the hand-written Go tags override; a nested function literal that the query does not capture",
-  "tree_has_error": false,
+  "query_definition_kinds": [
+    "function",
+    "method"
+  ],
   "report": {
     "Symbols": 4,
     "OmittedNoName": 0,
     "OmittedDuplicate": 0,
+    "OmittedNameConflict": 0,
     "OmittedConflict": 0,
     "OmittedOverlap": 0,
     "OmittedInvalidNameRange": 0,
+    "OmittedMultipleDefinitions": 0,
     "OwnerRuleMisses": 0,
-    "QueryEmpty": false,
+    "DeclineReason": "",
     "Truncated": false,
-    "LanguageMismatch": false
+    "TreeHasError": false
   },
   "symbols": [
     {

--- a/testdata/outline/java/Service.java
+++ b/testdata/outline/java/Service.java
@@ -1,0 +1,31 @@
+package demo;
+
+public interface Service {
+    String name();
+}
+
+enum Level {
+    LOW,
+    HIGH;
+}
+
+record Point(int x, int y) {
+}
+
+public class Registry implements Service {
+    private final String label;
+
+    Registry(String label) {
+        this.label = label;
+    }
+
+    public String name() {
+        return label;
+    }
+
+    class Inner {
+        int depth() {
+            return 1;
+        }
+    }
+}

--- a/testdata/outline/java/Service.java.golden.json
+++ b/testdata/outline/java/Service.java.golden.json
@@ -2,18 +2,26 @@
   "language": "java",
   "fixture": "java/Service.java",
   "purpose": "interface, enum refinement, constructor, method, nested class",
-  "tree_has_error": false,
+  "query_definition_kinds": [
+    "class",
+    "constructor",
+    "interface",
+    "method",
+    "type"
+  ],
   "report": {
     "Symbols": 8,
     "OmittedNoName": 0,
     "OmittedDuplicate": 0,
+    "OmittedNameConflict": 0,
     "OmittedConflict": 0,
     "OmittedOverlap": 0,
     "OmittedInvalidNameRange": 0,
+    "OmittedMultipleDefinitions": 0,
     "OwnerRuleMisses": 0,
-    "QueryEmpty": false,
+    "DeclineReason": "",
     "Truncated": false,
-    "LanguageMismatch": false
+    "TreeHasError": false
   },
   "symbols": [
     {

--- a/testdata/outline/java/Service.java.golden.json
+++ b/testdata/outline/java/Service.java.golden.json
@@ -1,0 +1,170 @@
+{
+  "language": "java",
+  "fixture": "java/Service.java",
+  "purpose": "interface, enum refinement, constructor, method, nested class",
+  "tree_has_error": false,
+  "report": {
+    "Symbols": 8,
+    "OmittedNoName": 0,
+    "OmittedDuplicate": 0,
+    "OmittedConflict": 0,
+    "OmittedOverlap": 0,
+    "OmittedInvalidNameRange": 0,
+    "OwnerRuleMisses": 0,
+    "QueryEmpty": false,
+    "Truncated": false,
+    "LanguageMismatch": false
+  },
+  "symbols": [
+    {
+      "kind": "interface",
+      "name": "Service",
+      "node_type": "interface_declaration",
+      "range": {
+        "start_byte": 15,
+        "end_byte": 62,
+        "start_point": "2:0",
+        "end_point": "4:1"
+      },
+      "name_range": {
+        "start_byte": 32,
+        "end_byte": 39,
+        "start_point": "2:17",
+        "end_point": "2:24"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "method",
+          "name": "name",
+          "node_type": "method_declaration",
+          "range": {
+            "start_byte": 46,
+            "end_byte": 60,
+            "start_point": "3:4",
+            "end_point": "3:18"
+          },
+          "name_range": {
+            "start_byte": 53,
+            "end_byte": 57,
+            "start_point": "3:11",
+            "end_point": "3:15"
+          },
+          "owner": ""
+        }
+      ]
+    },
+    {
+      "kind": "enum",
+      "name": "Level",
+      "node_type": "enum_declaration",
+      "range": {
+        "start_byte": 64,
+        "end_byte": 97,
+        "start_point": "6:0",
+        "end_point": "9:1"
+      },
+      "name_range": {
+        "start_byte": 69,
+        "end_byte": 74,
+        "start_point": "6:5",
+        "end_point": "6:10"
+      },
+      "owner": ""
+    },
+    {
+      "kind": "class",
+      "name": "Registry",
+      "node_type": "class_declaration",
+      "range": {
+        "start_byte": 131,
+        "end_byte": 406,
+        "start_point": "14:0",
+        "end_point": "30:1"
+      },
+      "name_range": {
+        "start_byte": 144,
+        "end_byte": 152,
+        "start_point": "14:13",
+        "end_point": "14:21"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "constructor",
+          "name": "Registry",
+          "node_type": "constructor_declaration",
+          "range": {
+            "start_byte": 211,
+            "end_byte": 269,
+            "start_point": "17:4",
+            "end_point": "19:5"
+          },
+          "name_range": {
+            "start_byte": 211,
+            "end_byte": 219,
+            "start_point": "17:4",
+            "end_point": "17:12"
+          },
+          "owner": ""
+        },
+        {
+          "kind": "method",
+          "name": "name",
+          "node_type": "method_declaration",
+          "range": {
+            "start_byte": 275,
+            "end_byte": 325,
+            "start_point": "21:4",
+            "end_point": "23:5"
+          },
+          "name_range": {
+            "start_byte": 289,
+            "end_byte": 293,
+            "start_point": "21:18",
+            "end_point": "21:22"
+          },
+          "owner": ""
+        },
+        {
+          "kind": "class",
+          "name": "Inner",
+          "node_type": "class_declaration",
+          "range": {
+            "start_byte": 331,
+            "end_byte": 404,
+            "start_point": "25:4",
+            "end_point": "29:5"
+          },
+          "name_range": {
+            "start_byte": 337,
+            "end_byte": 342,
+            "start_point": "25:10",
+            "end_point": "25:15"
+          },
+          "owner": "",
+          "children": [
+            {
+              "kind": "method",
+              "name": "depth",
+              "node_type": "method_declaration",
+              "range": {
+                "start_byte": 353,
+                "end_byte": 398,
+                "start_point": "26:8",
+                "end_point": "28:9"
+              },
+              "name_range": {
+                "start_byte": 357,
+                "end_byte": 362,
+                "start_point": "26:12",
+                "end_point": "26:17"
+              },
+              "owner": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/outline/javascript/widget.js
+++ b/testdata/outline/javascript/widget.js
@@ -1,0 +1,21 @@
+function build(options) {
+  function normalize(value) {
+    return String(value);
+  }
+  return normalize(options.title);
+}
+
+class Widget {
+  constructor(title) {
+    this.title = title;
+  }
+
+  render() {
+    function inner() {
+      return 1;
+    }
+    return inner();
+  }
+}
+
+class Empty {}

--- a/testdata/outline/javascript/widget.js.golden.json
+++ b/testdata/outline/javascript/widget.js.golden.json
@@ -2,18 +2,24 @@
   "language": "javascript",
   "fixture": "javascript/widget.js",
   "purpose": "class with methods, function nested in a method, empty class",
-  "tree_has_error": false,
+  "query_definition_kinds": [
+    "class",
+    "function",
+    "method"
+  ],
   "report": {
     "Symbols": 7,
     "OmittedNoName": 0,
     "OmittedDuplicate": 0,
+    "OmittedNameConflict": 0,
     "OmittedConflict": 0,
     "OmittedOverlap": 0,
     "OmittedInvalidNameRange": 0,
+    "OmittedMultipleDefinitions": 0,
     "OwnerRuleMisses": 0,
-    "QueryEmpty": false,
+    "DeclineReason": "",
     "Truncated": false,
-    "LanguageMismatch": false
+    "TreeHasError": false
   },
   "symbols": [
     {

--- a/testdata/outline/javascript/widget.js.golden.json
+++ b/testdata/outline/javascript/widget.js.golden.json
@@ -1,0 +1,152 @@
+{
+  "language": "javascript",
+  "fixture": "javascript/widget.js",
+  "purpose": "class with methods, function nested in a method, empty class",
+  "tree_has_error": false,
+  "report": {
+    "Symbols": 7,
+    "OmittedNoName": 0,
+    "OmittedDuplicate": 0,
+    "OmittedConflict": 0,
+    "OmittedOverlap": 0,
+    "OmittedInvalidNameRange": 0,
+    "OwnerRuleMisses": 0,
+    "QueryEmpty": false,
+    "Truncated": false,
+    "LanguageMismatch": false
+  },
+  "symbols": [
+    {
+      "kind": "function",
+      "name": "build",
+      "node_type": "function_declaration",
+      "range": {
+        "start_byte": 0,
+        "end_byte": 122,
+        "start_point": "0:0",
+        "end_point": "5:1"
+      },
+      "name_range": {
+        "start_byte": 9,
+        "end_byte": 14,
+        "start_point": "0:9",
+        "end_point": "0:14"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "function",
+          "name": "normalize",
+          "node_type": "function_declaration",
+          "range": {
+            "start_byte": 28,
+            "end_byte": 85,
+            "start_point": "1:2",
+            "end_point": "3:3"
+          },
+          "name_range": {
+            "start_byte": 37,
+            "end_byte": 46,
+            "start_point": "1:11",
+            "end_point": "1:20"
+          },
+          "owner": ""
+        }
+      ]
+    },
+    {
+      "kind": "class",
+      "name": "Widget",
+      "node_type": "class_declaration",
+      "range": {
+        "start_byte": 124,
+        "end_byte": 274,
+        "start_point": "7:0",
+        "end_point": "18:1"
+      },
+      "name_range": {
+        "start_byte": 130,
+        "end_byte": 136,
+        "start_point": "7:6",
+        "end_point": "7:12"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "method",
+          "name": "constructor",
+          "node_type": "method_definition",
+          "range": {
+            "start_byte": 141,
+            "end_byte": 189,
+            "start_point": "8:2",
+            "end_point": "10:3"
+          },
+          "name_range": {
+            "start_byte": 141,
+            "end_byte": 152,
+            "start_point": "8:2",
+            "end_point": "8:13"
+          },
+          "owner": ""
+        },
+        {
+          "kind": "method",
+          "name": "render",
+          "node_type": "method_definition",
+          "range": {
+            "start_byte": 193,
+            "end_byte": 272,
+            "start_point": "12:2",
+            "end_point": "17:3"
+          },
+          "name_range": {
+            "start_byte": 193,
+            "end_byte": 199,
+            "start_point": "12:2",
+            "end_point": "12:8"
+          },
+          "owner": "",
+          "children": [
+            {
+              "kind": "function",
+              "name": "inner",
+              "node_type": "function_declaration",
+              "range": {
+                "start_byte": 208,
+                "end_byte": 248,
+                "start_point": "13:4",
+                "end_point": "15:5"
+              },
+              "name_range": {
+                "start_byte": 217,
+                "end_byte": 222,
+                "start_point": "13:13",
+                "end_point": "13:18"
+              },
+              "owner": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "class",
+      "name": "Empty",
+      "node_type": "class_declaration",
+      "range": {
+        "start_byte": 276,
+        "end_byte": 290,
+        "start_point": "20:0",
+        "end_point": "20:14"
+      },
+      "name_range": {
+        "start_byte": 282,
+        "end_byte": 287,
+        "start_point": "20:6",
+        "end_point": "20:11"
+      },
+      "owner": ""
+    }
+  ]
+}

--- a/testdata/outline/python/app.py
+++ b/testdata/outline/python/app.py
@@ -1,0 +1,24 @@
+CONSTANT = 3
+
+
+def top_level(value):
+    def helper(inner):
+        return inner + 1
+
+    return helper(value)
+
+
+class Service:
+    def __init__(self, name):
+        self.name = name
+
+    def render(self):
+        class Nested:
+            def deep(self):
+                return 1
+
+        return Nested().deep()
+
+
+class Empty:
+    pass

--- a/testdata/outline/python/app.py.golden.json
+++ b/testdata/outline/python/app.py.golden.json
@@ -2,18 +2,23 @@
   "language": "python",
   "fixture": "python/app.py",
   "purpose": "three nesting levels: module function, class, method, class inside a method",
-  "tree_has_error": false,
+  "query_definition_kinds": [
+    "class",
+    "function"
+  ],
   "report": {
     "Symbols": 8,
     "OmittedNoName": 0,
     "OmittedDuplicate": 0,
+    "OmittedNameConflict": 0,
     "OmittedConflict": 0,
     "OmittedOverlap": 0,
     "OmittedInvalidNameRange": 0,
+    "OmittedMultipleDefinitions": 0,
     "OwnerRuleMisses": 0,
-    "QueryEmpty": false,
+    "DeclineReason": "",
     "Truncated": false,
-    "LanguageMismatch": false
+    "TreeHasError": false
   },
   "symbols": [
     {

--- a/testdata/outline/python/app.py.golden.json
+++ b/testdata/outline/python/app.py.golden.json
@@ -1,0 +1,172 @@
+{
+  "language": "python",
+  "fixture": "python/app.py",
+  "purpose": "three nesting levels: module function, class, method, class inside a method",
+  "tree_has_error": false,
+  "report": {
+    "Symbols": 8,
+    "OmittedNoName": 0,
+    "OmittedDuplicate": 0,
+    "OmittedConflict": 0,
+    "OmittedOverlap": 0,
+    "OmittedInvalidNameRange": 0,
+    "OwnerRuleMisses": 0,
+    "QueryEmpty": false,
+    "Truncated": false,
+    "LanguageMismatch": false
+  },
+  "symbols": [
+    {
+      "kind": "function",
+      "name": "top_level",
+      "node_type": "function_definition",
+      "range": {
+        "start_byte": 15,
+        "end_byte": 110,
+        "start_point": "3:0",
+        "end_point": "7:24"
+      },
+      "name_range": {
+        "start_byte": 19,
+        "end_byte": 28,
+        "start_point": "3:4",
+        "end_point": "3:13"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "function",
+          "name": "helper",
+          "node_type": "function_definition",
+          "range": {
+            "start_byte": 41,
+            "end_byte": 84,
+            "start_point": "4:4",
+            "end_point": "5:24"
+          },
+          "name_range": {
+            "start_byte": 45,
+            "end_byte": 51,
+            "start_point": "4:8",
+            "end_point": "4:14"
+          },
+          "owner": ""
+        }
+      ]
+    },
+    {
+      "kind": "class",
+      "name": "Service",
+      "node_type": "class_definition",
+      "range": {
+        "start_byte": 113,
+        "end_byte": 312,
+        "start_point": "10:0",
+        "end_point": "19:30"
+      },
+      "name_range": {
+        "start_byte": 119,
+        "end_byte": 126,
+        "start_point": "10:6",
+        "end_point": "10:13"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "function",
+          "name": "__init__",
+          "node_type": "function_definition",
+          "range": {
+            "start_byte": 132,
+            "end_byte": 182,
+            "start_point": "11:4",
+            "end_point": "12:24"
+          },
+          "name_range": {
+            "start_byte": 136,
+            "end_byte": 144,
+            "start_point": "11:8",
+            "end_point": "11:16"
+          },
+          "owner": ""
+        },
+        {
+          "kind": "function",
+          "name": "render",
+          "node_type": "function_definition",
+          "range": {
+            "start_byte": 188,
+            "end_byte": 312,
+            "start_point": "14:4",
+            "end_point": "19:30"
+          },
+          "name_range": {
+            "start_byte": 192,
+            "end_byte": 198,
+            "start_point": "14:8",
+            "end_point": "14:14"
+          },
+          "owner": "",
+          "children": [
+            {
+              "kind": "class",
+              "name": "Nested",
+              "node_type": "class_definition",
+              "range": {
+                "start_byte": 214,
+                "end_byte": 280,
+                "start_point": "15:8",
+                "end_point": "17:24"
+              },
+              "name_range": {
+                "start_byte": 220,
+                "end_byte": 226,
+                "start_point": "15:14",
+                "end_point": "15:20"
+              },
+              "owner": "",
+              "children": [
+                {
+                  "kind": "function",
+                  "name": "deep",
+                  "node_type": "function_definition",
+                  "range": {
+                    "start_byte": 240,
+                    "end_byte": 280,
+                    "start_point": "16:12",
+                    "end_point": "17:24"
+                  },
+                  "name_range": {
+                    "start_byte": 244,
+                    "end_byte": 248,
+                    "start_point": "16:16",
+                    "end_point": "16:20"
+                  },
+                  "owner": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "class",
+      "name": "Empty",
+      "node_type": "class_definition",
+      "range": {
+        "start_byte": 315,
+        "end_byte": 336,
+        "start_point": "22:0",
+        "end_point": "23:8"
+      },
+      "name_range": {
+        "start_byte": 321,
+        "end_byte": 326,
+        "start_point": "22:6",
+        "end_point": "22:11"
+      },
+      "owner": ""
+    }
+  ]
+}

--- a/testdata/outline/rust/lib.rs
+++ b/testdata/outline/rust/lib.rs
@@ -1,0 +1,25 @@
+pub struct Registry {
+    count: usize,
+}
+
+pub enum Level {
+    Low,
+    High,
+}
+
+pub trait Named {
+    fn name(&self) -> String;
+}
+
+impl Named for Registry {
+    fn name(&self) -> String {
+        String::from("registry")
+    }
+}
+
+pub fn describe(registry: &Registry) -> String {
+    fn suffix() -> &'static str {
+        "!"
+    }
+    format!("{}{}", registry.name(), suffix())
+}

--- a/testdata/outline/rust/lib.rs.golden.json
+++ b/testdata/outline/rust/lib.rs.golden.json
@@ -2,18 +2,23 @@
   "language": "rust",
   "fixture": "rust/lib.rs",
   "purpose": "struct, enum refinement by enum_item, trait, function nested in a function",
-  "tree_has_error": false,
+  "query_definition_kinds": [
+    "function",
+    "type"
+  ],
   "report": {
     "Symbols": 7,
     "OmittedNoName": 0,
     "OmittedDuplicate": 0,
+    "OmittedNameConflict": 0,
     "OmittedConflict": 0,
     "OmittedOverlap": 0,
     "OmittedInvalidNameRange": 0,
+    "OmittedMultipleDefinitions": 0,
     "OwnerRuleMisses": 0,
-    "QueryEmpty": false,
+    "DeclineReason": "",
     "Truncated": false,
-    "LanguageMismatch": false
+    "TreeHasError": false
   },
   "symbols": [
     {

--- a/testdata/outline/rust/lib.rs.golden.json
+++ b/testdata/outline/rust/lib.rs.golden.json
@@ -1,0 +1,150 @@
+{
+  "language": "rust",
+  "fixture": "rust/lib.rs",
+  "purpose": "struct, enum refinement by enum_item, trait, function nested in a function",
+  "tree_has_error": false,
+  "report": {
+    "Symbols": 7,
+    "OmittedNoName": 0,
+    "OmittedDuplicate": 0,
+    "OmittedConflict": 0,
+    "OmittedOverlap": 0,
+    "OmittedInvalidNameRange": 0,
+    "OwnerRuleMisses": 0,
+    "QueryEmpty": false,
+    "Truncated": false,
+    "LanguageMismatch": false
+  },
+  "symbols": [
+    {
+      "kind": "type",
+      "name": "Registry",
+      "node_type": "struct_item",
+      "range": {
+        "start_byte": 0,
+        "end_byte": 41,
+        "start_point": "0:0",
+        "end_point": "2:1"
+      },
+      "name_range": {
+        "start_byte": 11,
+        "end_byte": 19,
+        "start_point": "0:11",
+        "end_point": "0:19"
+      },
+      "owner": ""
+    },
+    {
+      "kind": "enum",
+      "name": "Level",
+      "node_type": "enum_item",
+      "range": {
+        "start_byte": 43,
+        "end_byte": 80,
+        "start_point": "4:0",
+        "end_point": "7:1"
+      },
+      "name_range": {
+        "start_byte": 52,
+        "end_byte": 57,
+        "start_point": "4:9",
+        "end_point": "4:14"
+      },
+      "owner": ""
+    },
+    {
+      "kind": "type",
+      "name": "Named",
+      "node_type": "trait_item",
+      "range": {
+        "start_byte": 82,
+        "end_byte": 131,
+        "start_point": "9:0",
+        "end_point": "11:1"
+      },
+      "name_range": {
+        "start_byte": 92,
+        "end_byte": 97,
+        "start_point": "9:10",
+        "end_point": "9:15"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "function",
+          "name": "name",
+          "node_type": "function_signature_item",
+          "range": {
+            "start_byte": 104,
+            "end_byte": 129,
+            "start_point": "10:4",
+            "end_point": "10:29"
+          },
+          "name_range": {
+            "start_byte": 107,
+            "end_byte": 111,
+            "start_point": "10:7",
+            "end_point": "10:11"
+          },
+          "owner": ""
+        }
+      ]
+    },
+    {
+      "kind": "function",
+      "name": "name",
+      "node_type": "function_item",
+      "range": {
+        "start_byte": 163,
+        "end_byte": 228,
+        "start_point": "14:4",
+        "end_point": "16:5"
+      },
+      "name_range": {
+        "start_byte": 166,
+        "end_byte": 170,
+        "start_point": "14:7",
+        "end_point": "14:11"
+      },
+      "owner": ""
+    },
+    {
+      "kind": "function",
+      "name": "describe",
+      "node_type": "function_item",
+      "range": {
+        "start_byte": 232,
+        "end_byte": 381,
+        "start_point": "19:0",
+        "end_point": "24:1"
+      },
+      "name_range": {
+        "start_byte": 239,
+        "end_byte": 247,
+        "start_point": "19:7",
+        "end_point": "19:15"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "function",
+          "name": "suffix",
+          "node_type": "function_item",
+          "range": {
+            "start_byte": 285,
+            "end_byte": 332,
+            "start_point": "20:4",
+            "end_point": "22:5"
+          },
+          "name_range": {
+            "start_byte": 288,
+            "end_byte": 294,
+            "start_point": "20:7",
+            "end_point": "20:13"
+          },
+          "owner": ""
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/outline/tsx/view.tsx
+++ b/testdata/outline/tsx/view.tsx
@@ -1,0 +1,16 @@
+interface Props {
+  title: string;
+}
+
+export function View(props: Props) {
+  function label(): string {
+    return props.title;
+  }
+  return <div>{label()}</div>;
+}
+
+export class Panel {
+  render() {
+    return <span>panel</span>;
+  }
+}

--- a/testdata/outline/tsx/view.tsx.golden.json
+++ b/testdata/outline/tsx/view.tsx.golden.json
@@ -2,18 +2,26 @@
   "language": "tsx",
   "fixture": "tsx/view.tsx",
   "purpose": "interface and class beside JSX; nested function in a component",
-  "tree_has_error": false,
+  "query_definition_kinds": [
+    "class",
+    "function",
+    "interface",
+    "method",
+    "type"
+  ],
   "report": {
     "Symbols": 5,
     "OmittedNoName": 0,
     "OmittedDuplicate": 0,
+    "OmittedNameConflict": 0,
     "OmittedConflict": 0,
     "OmittedOverlap": 0,
     "OmittedInvalidNameRange": 0,
+    "OmittedMultipleDefinitions": 0,
     "OwnerRuleMisses": 0,
-    "QueryEmpty": false,
+    "DeclineReason": "",
     "Truncated": false,
-    "LanguageMismatch": false
+    "TreeHasError": false
   },
   "symbols": [
     {

--- a/testdata/outline/tsx/view.tsx.golden.json
+++ b/testdata/outline/tsx/view.tsx.golden.json
@@ -1,0 +1,114 @@
+{
+  "language": "tsx",
+  "fixture": "tsx/view.tsx",
+  "purpose": "interface and class beside JSX; nested function in a component",
+  "tree_has_error": false,
+  "report": {
+    "Symbols": 5,
+    "OmittedNoName": 0,
+    "OmittedDuplicate": 0,
+    "OmittedConflict": 0,
+    "OmittedOverlap": 0,
+    "OmittedInvalidNameRange": 0,
+    "OwnerRuleMisses": 0,
+    "QueryEmpty": false,
+    "Truncated": false,
+    "LanguageMismatch": false
+  },
+  "symbols": [
+    {
+      "kind": "interface",
+      "name": "Props",
+      "node_type": "interface_declaration",
+      "range": {
+        "start_byte": 0,
+        "end_byte": 36,
+        "start_point": "0:0",
+        "end_point": "2:1"
+      },
+      "name_range": {
+        "start_byte": 10,
+        "end_byte": 15,
+        "start_point": "0:10",
+        "end_point": "0:15"
+      },
+      "owner": ""
+    },
+    {
+      "kind": "function",
+      "name": "View",
+      "node_type": "function_declaration",
+      "range": {
+        "start_byte": 45,
+        "end_byte": 164,
+        "start_point": "4:7",
+        "end_point": "9:1"
+      },
+      "name_range": {
+        "start_byte": 54,
+        "end_byte": 58,
+        "start_point": "4:16",
+        "end_point": "4:20"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "function",
+          "name": "label",
+          "node_type": "function_declaration",
+          "range": {
+            "start_byte": 77,
+            "end_byte": 131,
+            "start_point": "5:2",
+            "end_point": "7:3"
+          },
+          "name_range": {
+            "start_byte": 86,
+            "end_byte": 91,
+            "start_point": "5:11",
+            "end_point": "5:16"
+          },
+          "owner": ""
+        }
+      ]
+    },
+    {
+      "kind": "class",
+      "name": "Panel",
+      "node_type": "class_declaration",
+      "range": {
+        "start_byte": 173,
+        "end_byte": 236,
+        "start_point": "11:7",
+        "end_point": "15:1"
+      },
+      "name_range": {
+        "start_byte": 179,
+        "end_byte": 184,
+        "start_point": "11:13",
+        "end_point": "11:18"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "method",
+          "name": "render",
+          "node_type": "method_definition",
+          "range": {
+            "start_byte": 189,
+            "end_byte": 234,
+            "start_point": "12:2",
+            "end_point": "14:3"
+          },
+          "name_range": {
+            "start_byte": 189,
+            "end_byte": 195,
+            "start_point": "12:2",
+            "end_point": "12:8"
+          },
+          "owner": ""
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/outline/typescript/model.ts
+++ b/testdata/outline/typescript/model.ts
@@ -1,0 +1,23 @@
+export enum Level {
+  Low,
+  High,
+}
+
+export interface Shape {
+  area(): number;
+}
+
+export class Circle implements Shape {
+  constructor(private radius: number) {}
+
+  area(): number {
+    function square(value: number): number {
+      return value * value;
+    }
+    return 3 * square(this.radius);
+  }
+}
+
+export function describe(shape: Shape): string {
+  return String(shape.area());
+}

--- a/testdata/outline/typescript/model.ts.golden.json
+++ b/testdata/outline/typescript/model.ts.golden.json
@@ -2,18 +2,26 @@
   "language": "typescript",
   "fixture": "typescript/model.ts",
   "purpose": "enum refinement by node type, interface, class, nested function",
-  "tree_has_error": false,
+  "query_definition_kinds": [
+    "class",
+    "function",
+    "interface",
+    "method",
+    "type"
+  ],
   "report": {
     "Symbols": 7,
     "OmittedNoName": 0,
     "OmittedDuplicate": 0,
+    "OmittedNameConflict": 0,
     "OmittedConflict": 0,
     "OmittedOverlap": 0,
     "OmittedInvalidNameRange": 0,
+    "OmittedMultipleDefinitions": 0,
     "OwnerRuleMisses": 0,
-    "QueryEmpty": false,
+    "DeclineReason": "",
     "Truncated": false,
-    "LanguageMismatch": false
+    "TreeHasError": false
   },
   "symbols": [
     {

--- a/testdata/outline/typescript/model.ts.golden.json
+++ b/testdata/outline/typescript/model.ts.golden.json
@@ -1,0 +1,150 @@
+{
+  "language": "typescript",
+  "fixture": "typescript/model.ts",
+  "purpose": "enum refinement by node type, interface, class, nested function",
+  "tree_has_error": false,
+  "report": {
+    "Symbols": 7,
+    "OmittedNoName": 0,
+    "OmittedDuplicate": 0,
+    "OmittedConflict": 0,
+    "OmittedOverlap": 0,
+    "OmittedInvalidNameRange": 0,
+    "OwnerRuleMisses": 0,
+    "QueryEmpty": false,
+    "Truncated": false,
+    "LanguageMismatch": false
+  },
+  "symbols": [
+    {
+      "kind": "enum",
+      "name": "Level",
+      "node_type": "enum_declaration",
+      "range": {
+        "start_byte": 7,
+        "end_byte": 36,
+        "start_point": "0:7",
+        "end_point": "3:1"
+      },
+      "name_range": {
+        "start_byte": 12,
+        "end_byte": 17,
+        "start_point": "0:12",
+        "end_point": "0:17"
+      },
+      "owner": ""
+    },
+    {
+      "kind": "interface",
+      "name": "Shape",
+      "node_type": "interface_declaration",
+      "range": {
+        "start_byte": 45,
+        "end_byte": 82,
+        "start_point": "5:7",
+        "end_point": "7:1"
+      },
+      "name_range": {
+        "start_byte": 55,
+        "end_byte": 60,
+        "start_point": "5:17",
+        "end_point": "5:22"
+      },
+      "owner": ""
+    },
+    {
+      "kind": "class",
+      "name": "Circle",
+      "node_type": "class_declaration",
+      "range": {
+        "start_byte": 91,
+        "end_byte": 304,
+        "start_point": "9:7",
+        "end_point": "18:1"
+      },
+      "name_range": {
+        "start_byte": 97,
+        "end_byte": 103,
+        "start_point": "9:13",
+        "end_point": "9:19"
+      },
+      "owner": "",
+      "children": [
+        {
+          "kind": "method",
+          "name": "constructor",
+          "node_type": "method_definition",
+          "range": {
+            "start_byte": 125,
+            "end_byte": 163,
+            "start_point": "10:2",
+            "end_point": "10:40"
+          },
+          "name_range": {
+            "start_byte": 125,
+            "end_byte": 136,
+            "start_point": "10:2",
+            "end_point": "10:13"
+          },
+          "owner": ""
+        },
+        {
+          "kind": "method",
+          "name": "area",
+          "node_type": "method_definition",
+          "range": {
+            "start_byte": 167,
+            "end_byte": 302,
+            "start_point": "12:2",
+            "end_point": "17:3"
+          },
+          "name_range": {
+            "start_byte": 167,
+            "end_byte": 171,
+            "start_point": "12:2",
+            "end_point": "12:6"
+          },
+          "owner": "",
+          "children": [
+            {
+              "kind": "function",
+              "name": "square",
+              "node_type": "function_declaration",
+              "range": {
+                "start_byte": 188,
+                "end_byte": 262,
+                "start_point": "13:4",
+                "end_point": "15:5"
+              },
+              "name_range": {
+                "start_byte": 197,
+                "end_byte": 203,
+                "start_point": "13:13",
+                "end_point": "13:19"
+              },
+              "owner": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "function",
+      "name": "describe",
+      "node_type": "function_declaration",
+      "range": {
+        "start_byte": 313,
+        "end_byte": 387,
+        "start_point": "20:7",
+        "end_point": "22:1"
+      },
+      "name_range": {
+        "start_byte": 322,
+        "end_byte": 330,
+        "start_point": "20:16",
+        "end_point": "20:24"
+      },
+      "owner": ""
+    }
+  ]
+}


### PR DESCRIPTION
Add a language-neutral outline projection over a parsed tree.

`NewOutliner(lang, tagsQuery, opts...)` compiles one tags query. `OutlineTree(tree)`
returns `([]OutlineSymbol, OutlineReport)`: definitions in source order, lexically
nested by byte containment, plus a receipt. The projection is read-only. It runs no
parse, changes no tree, and copies no definition body.

## Scope by coverage tier

The outline coverage census on `main` classifies all 206 registered languages:

| Tier | Meaning | Count |
|---|---|---|
| T1 | non-empty inferred tags query and real-corpus coverage | 69 |
| T2 | non-empty query, no corpus | 1 |
| T3 | empty query, candidate definition symbols present | 16 |
| T4 | no query, no candidates | 120 |

Reproduced before and after this change with:

```
GTS_OUTLINE_CENSUS_OUT=harness_out/outline/tier_census.json \
GOFLAGS=-buildvcs=false go test ./grammars -run TestOutlineTierCensus -count=1
```

Both runs give the same numbers. This change adds a projection over existing tags
data, so it moves no language between tiers.

Kinds come from tags-capture data through two fixed tables: one maps the
`@definition.X` capture suffix, one refines a kind by grammar node type. Both are
keyed by capture data and node type, never by a language name. Unknown suffixes pass
through unchanged, so new tags data needs no code.

## Ambiguity rules and omission counters

Every candidate the query produces is either emitted or counted in exactly one
counter, so a dropped candidate cannot look like an absent one:

| Counter | Cause |
|---|---|
| `OmittedNoName` | the definition capture has no usable name |
| `OmittedInvalidNameRange` | the name span is not inside the definition span |
| `OmittedConflict` | one span carries two different kinds; every member drops |
| `OmittedNameConflict` | one span and kind carry two different names; every member drops |
| `OmittedDuplicate` | an exact repeat of an accepted span, kind, name, and name span |
| `OmittedOverlap` | the span partially overlaps an accepted span |
| `OmittedMultipleDefinitions` | one match carries more than one definition capture |

Nothing is guessed. Only `OmittedDuplicate` keeps a member, and only when the members
are indistinguishable, so keeping the first is not a choice between them.

### Name conflicts: measured coverage effect

Grouping by span and kind alone was not enough. When shared inference binds `@name`
twice on one definition node, the candidates differ only in NAME, and choosing by
capture order publishes the wrong one. In C-family method syntax it selects the
RETURN TYPE: `Uri PathToUri(string p)` produced a method named `Uri`.

Measured independently over the real corpus, 11,631 files across 69 tier-1 languages
capped at 200 files per language:

| Metric | Count |
|---|---|
| Symbols emitted | 74,657 |
| Candidates dropped as name conflicts | 6,391 |
| Candidates dropped as true duplicates | **0** |
| Languages affected | 17 |

`OmittedDuplicate` never fires anywhere in that sweep. Every group the old rule
treated as a duplicate was in fact a name disagreement.

Worst affected, dropped candidates against emitted symbols: objc 3,505 / 6,126;
c_sharp 860 / 900; scala 572 / 4,278; c 540 / 12,754; groovy 268 / 1,112; odin
258 / 0. Odin now outlines empty; previously every one of its symbols carried a name
chosen by capture order.

This is a real coverage reduction and it is deliberate. A wrong name in an outline
sends a caller to the wrong place; a counted omission does not. The remedy is a data
edit, not an extractor change: constrain the pattern with a `name:` field, the way
the Go tags override already does. Go is unaffected for exactly that reason, which is
also the evidence that the extractor, not the grammar, decides how this is reported.

## Decline reasons

`DeclineReason` replaces a growing set of booleans. `""` means the query ran; the
`OutlineDecline*` constants cover `nil_outliner`, `query_empty`, `nil_tree`,
`nil_root_node`, and `language_mismatch`. `Declined()` is the predicate. This keeps a
genuinely empty file distinguishable from a projection that never ran, which four
previously identical receipts did not.

`treeLanguageMatches` now compares the symbol, field, and state counts as well as the
name, so two distinct grammars sharing a name no longer pass.

## Error-bearing trees

`TreeHasError` is on the receipt. Trees with ERROR or MISSING nodes are still not
special-cased; the outline is the projection of what the query matched on the
recovered tree. The flag exists because the failure is otherwise invisible: Go source
missing one closing brace yields one symbol, every omission counter zero, and that
symbol's Range swallowing everything after it. The field documents plainly that
definitions inside or after unrecovered regions may be absent, over-long, or missing,
that no counter fires for them, and that the symbols before the first error are NOT
therefore trustworthy, because the truncated definition is itself the first symbol.

## Reading a receipt honestly

`Omitted() == 0` does not mean complete. `Candidates()` counts query output, not file
content: a definition the query has no pattern for produces no candidate and no
omission. `Outliner.DefinitionKinds()` returns the kinds the compiled query can emit,
so a caller can see that a Go outline can only ever hold `function` and `method`,
however many types the file declares. Each golden records it.

## Goldens

Twelve fixtures across ten tier-1 languages. Depth reaches four levels; kinds cover
function, method, class, interface, type, enum, and constructor.

- `go/broken.go.fixture` is error-bearing and pins that the outline survives an ERROR
  node.
- `csharp/Service.cs` pins the name-conflict fix against real tags data.
- `go/counters.go.fixture` uses an explicit probe query to pin `OmittedDuplicate`,
  `OmittedConflict`, `OmittedNameConflict`, `OmittedNoName`, and
  `OmittedMultipleDefinitions` end to end, which shipped tags data cannot produce on
  demand. `OmittedOverlap` and `OmittedInvalidNameRange` are excluded by argument:
  two nodes of one tree are always nested or disjoint, and every capture of a match
  sits inside the matched subtree, so neither shape can arise from a single tree.
  Both stay as defensive guards with unit coverage.
- `c/registry.c` pins a FLEET-WIDE limit of the shared tags data, not a C quirk:
  `(struct_specifier (type_identifier) @name)` matches a struct USE as well as a
  definition. Across the real corpus 1,179 of 2,400 C symbols are struct uses, so
  roughly half the C outline is noise. The pattern reaches arduino, c, cpp, cuda,
  glsl, hlsl, and objc; its `class_specifier` sibling reaches four more. A data fix
  must be scoped to the pattern. The C++ golden is clean only by accident, because
  its parameter type omits the `class` keyword.

## No parser coupling

A static scan asserts the outline sources name no parse entry point, no route
dispatch, no admission identifier, and no result-compatibility identifier. One test
proves the scan covers every non-test `outline*.go`; another proves the forbidden
list catches a direct parser construction, so the scan can go neither stale nor
vacuous. The behavioral half digests the tree s-expression, projects twice, and
asserts the digest, source bytes, symbols, and receipt are unchanged.
`TestOutlinerHoldsNoParser` walks the type by reflection for any path to a parser.

The accounting gate no longer compares `Candidates()` to its own definition. It runs
the compiled query a second time, independently, counts definition-bearing matches,
and compares that ground truth to the receipt.

The kind tables are frozen by exact key set. The core cannot import the grammars
registry, so it cannot check a key against 206 language names; blocklisting a sample
of them had partial teeth. Freezing the whole key set means any new row fails the
test whatever it is named, and a companion test proves the freeze catches an injected
`zig` or `haskell` row.

## Owner stays empty

`WithOutlineOwnerRules` validates and retains rules; no rule is applied.
`TestOutlineOwnerStaysEmpty` supplies the Go receiver rule, outlines every fixture
twice, and asserts identical forests, identical receipts, zero `OwnerRuleMisses`, and
no populated `Owner`. `TestOutlineGoFixtureHasReceiverMethods` proves that is not
vacuous. The option documents what construction checks today (node type and owner
field present) and what it does not (empty or blank `NameTypes` and `Unwrap` entries,
and node types or fields the grammar does not define); each of those fails closed at
resolution and inflates `OwnerRuleMisses` rather than producing a wrong owner.

## Concurrency

An `Outliner` is safe for concurrent use. `OutlineTree` writes no field, and each
call takes its own cursor and working slices.
`TestOutlineTreeIsSafeForConcurrentUse` runs 16 goroutines by 20 calls on a shared
outliner under the race detector and compares every result.

`WithOutlineMatchLimit(0)` and `WithOutlineMatchWorkBudget(0)` now both mean "leave
the engine default alone". A budget of zero can no longer disable the work-budget
guard by accident.

## Performance

Budget: no worse than 1.5 times a bare `Tagger.TagTree` over the same tree and query.
Median wall time, `-benchtime 300x -count 6`, over the four frozen Go corpus fixtures:

| Fixture | Outline ns/op | Tagger ns/op | Ratio |
|---|---|---|---|
| query_compile | 467,113 | 476,647 | 0.98 |
| rewrite | 111,012 | 102,035 | 1.09 |
| language | 405,580 | 422,255 | 0.96 |
| grammargen_lr | 4,636,737 | 4,484,354 | 1.03 |

Inside budget. Honest caveat: this host is contended. Ratios below 1.0 are noise, not
a speedup, and deltas under about 10 percent do not resolve here.

Wall time is too noisy to assert on a shared runner, so the gate that runs in
continuous integration asserts the deterministic driver: the outline may not see more
candidates than the tagger produces DEFINITION tags, and allocations must stay inside
1.5 times the tagger's. Observed allocation ratios are 1.005 to 1.018, so the budget
fails on a regression that adds a per-node allocation.

## Gates

- `go build ./...`, `go vet ./...`: clean.
- `go test . -count=1`: pass.
- `go test ./grammars -count=1`: pass.
- `go test ./parser_result_test/... -count=1`: pass.
- Admission scorecard, exact, 206 languages: pass.
- `go test . -race` over the outline tests: pass, 120 results.
- Outline tier census: identical before and after.
- No existing file is modified, so no canonical digest can move.

## Continuous integration visibility

All outline tests are top-level tests in the root package with no build tag and no
opt-in variable. `.github/scripts/root_race_shard.sh` enumerates root targets with
`go test -race . -list` and partitions them round-robin, so they land in the
`race_root_shards` lane by construction. That lane is a required input to the `build`
gate. Verified on the previous run by downloading the four shard artifacts: 33 of 33
outline tests executed, 87 results with subtests, zero non-pass.

`GTS_UPDATE_OUTLINE_GOLDENS` gates only golden writing. The comparison is the default
path, so no lane can skip it.
