### PR TITLE
Restore the Kotlin recovered-root normalization and gate the included-ranges route

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -802,7 +802,7 @@ jobs:
             --goflags -p=1 \
             --test-parallel 1 \
             --timeout 20m \
-            --run '^TestParityFreshParse$|^TestParityIncrementalParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$|^TestParityGLRCanaryGo$|^TestParityGLRCanarySet$|^TestParityGLRCapPressureTopLanguages$|^TestParityGateCoverageRatchet$|^TestParityHighlight$|^TestParityJavaScriptAutomaticSemicolonBeforeTrailingComment$|^TestParityJavaScriptAdjacentBlockCommentsDoNotConsumeFollowingToken$|^TestIncludedRangesGoRootParity$|^TestIncludedRangesGoArmGuardsRootSymbol$'
+            --run '^TestParityFreshParse$|^TestParityIncrementalParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$|^TestParityGLRCanaryGo$|^TestParityGLRCanarySet$|^TestParityGLRCapPressureTopLanguages$|^TestParityGateCoverageRatchet$|^TestParityHighlight$|^TestParityJavaScriptAutomaticSemicolonBeforeTrailingComment$|^TestParityJavaScriptAdjacentBlockCommentsDoNotConsumeFollowingToken$|^TestIncludedRangesGoRootParity$|^TestIncludedRangesGoArmGuardsRootSymbol$|^TestIncludedRangesKotlinRootParity$'
 
   parity-cgo-exhaustive:
     needs: exhaustive_parity_scope
@@ -828,7 +828,7 @@ jobs:
             --goflags -p=1 \
             --test-parallel 1 \
             --timeout 30m \
-            --run '^TestParityFreshParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$|^TestParityKnownDegradedStructuralStillDiverges$|^TestParityJavaScriptAutomaticSemicolonBeforeTrailingComment$|^TestParityJavaScriptAdjacentBlockCommentsDoNotConsumeFollowingToken$|^TestIncludedRangesGoRootParity$|^TestIncludedRangesGoArmGuardsRootSymbol$'
+            --run '^TestParityFreshParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$|^TestParityKnownDegradedStructuralStillDiverges$|^TestParityJavaScriptAutomaticSemicolonBeforeTrailingComment$|^TestParityJavaScriptAdjacentBlockCommentsDoNotConsumeFollowingToken$|^TestIncludedRangesGoRootParity$|^TestIncludedRangesGoArmGuardsRootSymbol$|^TestIncludedRangesKotlinRootParity$'
 
       - name: CGo Structural Parity Exhaustive (Incremental + GLR)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,25 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- Kotlin published an `ERROR` root instead of `source_file` when a parse used
+  `Parser.SetIncludedRanges` with more than one range and the parse entered
+  recovery.
+  The recovered-root normalization that owns this result was removed on
+  2026-08-02 as dead code.
+  The census behind that removal measured the fresh, over-64-KiB, incremental
+  and pinned routes.
+  It never measured the included-ranges route, and the member is live there.
+  The member is restored.
+  On the committed witness, `testdata/included_ranges/kotlin_work_queue_test.kt`
+  with three ranges, the root returns to `source_file`, which is the kind the
+  locked Kotlin C reference runtime publishes for the same input.
+  Production reaches this route through injection.
+  The member retags the root.
+  Its downstream consequence is not always toward the reference runtime: on one
+  measured file the retag lets a later stage flatten a clean
+  `class_declaration` into root-level members.
+  The route now has committed test coverage for Kotlin, in the root package and
+  in the C-parity lane.
 - The C-recovery missing-token search (`cHandleError` /
   `cDoAllPotentialReductions`, `parser_recover_c.go`) cloned the whole GSS
   stack without a work limit.

--- a/cgo_harness/included_ranges_kotlin_root_parity_cgo_test.go
+++ b/cgo_harness/included_ranges_kotlin_root_parity_cgo_test.go
@@ -1,0 +1,163 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+// C-oracle coverage for the included-ranges route, Kotlin arm.
+//
+// normalizeKotlinRecoveredSourceFileRoot was deleted on 2026-08-02 as dead code
+// and is restored. The census behind the deletion measured the fresh,
+// over-64-KiB, incremental and pinned routes and never measured
+// Parser.SetIncludedRanges. On that route the member fires and moves the
+// published root toward this oracle: without it the root is `ERROR`, with it
+// the root is `source_file`, and the oracle publishes `source_file`.
+//
+// Production reaches the route through injection: injection.go calls
+// childParser.SetIncludedRanges for every injected child.
+//
+// Run: GTS_PARITY_ALLOW_HOST=1 CGO_ENABLED=1 \
+//        go test . -tags "cgo treesitter_c_parity" \
+//        -run TestIncludedRangesKotlinRootParity -v
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// includedRangesKotlinSpans matches the spans pinned by the non-cgo gate in
+// parser_included_ranges_kotlin_root_test.go. Two interior gaps carry
+// non-whitespace Kotlin text.
+var includedRangesKotlinSpans = [3][2]int{{0, 795}, {883, 1987}, {2019, 3094}}
+
+func includedRangesKotlinPointAt(src []byte, off int) (uint, uint) {
+	var row, col uint
+	for i := 0; i < off && i < len(src); i++ {
+		if src[i] == '\n' {
+			row++
+			col = 0
+			continue
+		}
+		col++
+	}
+	return row, col
+}
+
+// TestIncludedRangesKotlinRootParity pins the root symbol against the locked
+// Kotlin C oracle on the included-ranges route, and pins the route's known
+// span and error divergences so a change surfaces instead of passing silently.
+//
+// The root kind is a hard parity assertion: it is the value the restored arm
+// member owns. The root span and the root error flag still diverge, because the
+// route drops the third included range through an unrelated defect
+// (bytesAreParserPadding scans raw bytes between ranges with no clipping). Those
+// two are pinned, not asserted equal. When the clipping fix lands this test
+// fails and the pins move to the oracle values.
+func TestIncludedRangesKotlinRootParity(t *testing.T) {
+	cLang, err := COracleLanguage("kotlin")
+	if err != nil {
+		t.Fatalf("load kotlin C oracle: %v", err)
+	}
+	goLang := grammars.KotlinLanguage()
+	if goLang == nil {
+		t.Skip("kotlin grammar unavailable")
+	}
+
+	path := filepath.Join("..", "testdata", "included_ranges", "kotlin_work_queue_test.kt")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read included-ranges fixture: %v", err)
+	}
+
+	cRanges := make([]sitter.Range, 0, len(includedRangesKotlinSpans))
+	goRanges := make([]gts.Range, 0, len(includedRangesKotlinSpans))
+	for _, span := range includedRangesKotlinSpans {
+		start, end := span[0], span[1]
+		if end > len(src) {
+			end = len(src)
+		}
+		sr, sc := includedRangesKotlinPointAt(src, start)
+		er, ec := includedRangesKotlinPointAt(src, end)
+		cRanges = append(cRanges, sitter.Range{
+			StartByte:  uint(start),
+			EndByte:    uint(end),
+			StartPoint: sitter.Point{Row: sr, Column: sc},
+			EndPoint:   sitter.Point{Row: er, Column: ec},
+		})
+		goRanges = append(goRanges, gts.Range{
+			StartByte:  uint32(start),
+			EndByte:    uint32(end),
+			StartPoint: gts.Point{Row: uint32(sr), Column: uint32(sc)},
+			EndPoint:   gts.Point{Row: uint32(er), Column: uint32(ec)},
+		})
+	}
+
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatalf("set C language: %v", err)
+	}
+	if err := cParser.SetIncludedRanges(cRanges); err != nil {
+		t.Fatalf("C SetIncludedRanges: %v", err)
+	}
+	cTree := cParser.Parse(src, nil)
+	if cTree == nil {
+		t.Fatal("C parse returned nil")
+	}
+	defer cTree.Close()
+	cRoot := cTree.RootNode()
+
+	goParser := gts.NewParser(goLang)
+	goParser.SetIncludedRanges(goRanges)
+	goTree, err := goParser.Parse(src)
+	if err != nil {
+		t.Fatalf("go parse: %v", err)
+	}
+	if goTree == nil || goTree.RootNode() == nil {
+		t.Fatal("go parse returned no tree")
+	}
+	defer goTree.Release()
+	goRoot := goTree.RootNode()
+
+	t.Logf("C   root kind=%s isError=%v hasError=%v span=[%d,%d) children=%d",
+		cRoot.Kind(), cRoot.IsError(), cRoot.HasError(),
+		cRoot.StartByte(), cRoot.EndByte(), cRoot.ChildCount())
+	t.Logf("GTS root kind=%s isError=%v hasError=%v span=[%d,%d) children=%d",
+		goRoot.Type(goLang), goRoot.IsError(), goRoot.HasError(),
+		goRoot.StartByte(), goRoot.EndByte(), goRoot.ChildCount())
+
+	// The regression guard. The restored arm member owns this result. Delete the
+	// member and gotreesitter publishes `ERROR` here.
+	if got, want := goRoot.Type(goLang), cRoot.Kind(); got != want {
+		t.Fatalf("included-ranges root kind: gotreesitter=%q C=%q", got, want)
+	}
+	if goRoot.IsError() {
+		t.Fatal("included-ranges root is an ERROR node while C publishes a named root")
+	}
+	if got, want := goRoot.StartByte(), uint32(cRoot.StartByte()); got != want {
+		t.Errorf("included-ranges root start byte: gotreesitter=%d C=%d", got, want)
+	}
+
+	// Pinned pre-existing divergences, both owned by the unclipped padding scan
+	// and not by the restored member. Neither value is asserted as correct; the
+	// pins make any change visible.
+	const (
+		pinnedGoEnd     = uint32(1986)
+		pinnedCEnd      = uint32(3094)
+		pinnedCChildren = 8
+	)
+	if goRoot.EndByte() != pinnedGoEnd || uint32(cRoot.EndByte()) != pinnedCEnd {
+		t.Errorf("included-ranges root end byte moved: gotreesitter=%d C=%d, pinned gotreesitter=%d C=%d",
+			goRoot.EndByte(), cRoot.EndByte(), pinnedGoEnd, pinnedCEnd)
+	}
+	if cRoot.HasError() != false || goRoot.HasError() != true {
+		t.Errorf("included-ranges root HasError moved: C=%v gotreesitter=%v, pinned C=false gotreesitter=true",
+			cRoot.HasError(), goRoot.HasError())
+	}
+	if got := int(cRoot.ChildCount()); got != pinnedCChildren {
+		t.Errorf("C oracle root child count = %d, pinned %d", got, pinnedCChildren)
+	}
+}

--- a/parser_included_ranges_kotlin_root_test.go
+++ b/parser_included_ranges_kotlin_root_test.go
@@ -124,13 +124,16 @@ func TestIncludedRangesKotlinArmMemberIsLive(t *testing.T) {
 	}
 	defer tree.Release()
 
-	// Census receipts are recorded on the production route only. With the
-	// default candidate route ParseRuntime().NormalizationPasses is nil and
-	// nothing is recorded, so read the subpass receipt through the runtime and
-	// skip when the route did not populate it.
+	// Census receipts are recorded on the production route only. An
+	// included-ranges parse always lands there today, because
+	// admission_switch.go declines the compact candidate route whenever the
+	// parser carries included ranges. This is a Fatal, not a Skip: if the
+	// compact runner ever gains included-ranges support, this positive control
+	// must fail loudly instead of turning into a silent skip that stops
+	// guarding the member.
 	passesPtr := tree.ParseRuntime().NormalizationPasses
 	if passesPtr == nil || len(*passesPtr) == 0 {
-		t.Skip("no census receipts on this route")
+		t.Fatal("included-ranges parse recorded no census receipts; the route no longer pins production")
 	}
 	const subpass = "dispatch.kotlin.recovered-source-file-root"
 	var found bool

--- a/parser_included_ranges_kotlin_root_test.go
+++ b/parser_included_ranges_kotlin_root_test.go
@@ -1,0 +1,199 @@
+package gotreesitter_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// The included-ranges route reaches the Kotlin result-compatibility arm and no
+// test covered it. normalizeKotlinRecoveredSourceFileRoot was deleted on
+// 2026-08-02 as dead code. The census behind that deletion measured the fresh,
+// over-64-KiB, incremental and pinned routes. It never measured
+// Parser.SetIncludedRanges. The member is live on that fifth route: it
+// publishes a `source_file` root where the deletion published `ERROR`.
+//
+// Production reaches this route through injection. injection.go calls
+// childParser.SetIncludedRanges for every injected child, and any host document
+// that carries two or more Kotlin regions produces exactly this shape.
+//
+// These tests are the route's committed floor for Kotlin. The C-oracle
+// comparison lives in
+// cgo_harness/included_ranges_kotlin_root_parity_cgo_test.go.
+//
+// Fixture provenance: testdata/included_ranges/kotlin_work_queue_test.kt is a
+// byte-exact copy of kotlinx-coroutines-core/jvm/test/scheduling/WorkQueueTest.kt
+// from the kotlinx.coroutines project, Apache License 2.0. The copy is byte
+// exact because the pinned ranges below are byte offsets into it.
+
+func includedRangesKotlinPointAt(src []byte, off int) gotreesitter.Point {
+	var point gotreesitter.Point
+	for i := 0; i < off && i < len(src); i++ {
+		if src[i] == '\n' {
+			point.Row++
+			point.Column = 0
+			continue
+		}
+		point.Column++
+	}
+	return point
+}
+
+// includedRangesKotlinFixtureSpans is the fixture's three included ranges. Two
+// interior gaps carry non-whitespace Kotlin text, the way an injection child
+// receives separated regions of a host document.
+var includedRangesKotlinFixtureSpans = [3][2]int{{0, 795}, {883, 1987}, {2019, 3094}}
+
+func loadIncludedRangesKotlinFixture(tb testing.TB) ([]byte, []gotreesitter.Range) {
+	tb.Helper()
+	src, err := os.ReadFile("testdata/included_ranges/kotlin_work_queue_test.kt")
+	if err != nil {
+		tb.Fatalf("read included-ranges fixture: %v", err)
+	}
+	ranges := make([]gotreesitter.Range, 0, len(includedRangesKotlinFixtureSpans))
+	for _, span := range includedRangesKotlinFixtureSpans {
+		start, end := span[0], span[1]
+		if end > len(src) {
+			end = len(src)
+		}
+		ranges = append(ranges, gotreesitter.Range{
+			StartByte:  uint32(start),
+			EndByte:    uint32(end),
+			StartPoint: includedRangesKotlinPointAt(src, start),
+			EndPoint:   includedRangesKotlinPointAt(src, end),
+		})
+	}
+	return src, ranges
+}
+
+// TestIncludedRangesKotlinRootStaysSourceFile pins the root symbol on the
+// included-ranges route. The Kotlin arm's normalizeKotlinRecoveredSourceFileRoot
+// member owns this result. Removing the member turns the root into `ERROR`,
+// which diverges from the locked Kotlin C oracle. That oracle publishes
+// `source_file` for the same input and the same ranges.
+func TestIncludedRangesKotlinRootStaysSourceFile(t *testing.T) {
+	lang := grammars.KotlinLanguage()
+	if lang == nil {
+		t.Skip("kotlin grammar unavailable")
+	}
+	src, ranges := loadIncludedRangesKotlinFixture(t)
+
+	parser := gotreesitter.NewParser(lang)
+	parser.SetIncludedRanges(ranges)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("included-ranges parse: %v", err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("included-ranges parse returned no tree")
+	}
+	defer tree.Release()
+
+	root := tree.RootNode()
+	if got := root.Type(lang); got != "source_file" {
+		t.Fatalf("included-ranges root type = %q, want %q", got, "source_file")
+	}
+	if root.IsError() {
+		t.Fatal("included-ranges root is an ERROR node")
+	}
+}
+
+// TestIncludedRangesKotlinArmMemberIsLive records that the arm's recovered-root
+// member actually rewrites the tree on this route. It is the positive control
+// that makes the test above a real gate instead of an accident: if the member
+// ever becomes inert here, this fails and the retirement question reopens with
+// evidence.
+func TestIncludedRangesKotlinArmMemberIsLive(t *testing.T) {
+	lang := grammars.KotlinLanguage()
+	if lang == nil {
+		t.Skip("kotlin grammar unavailable")
+	}
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	src, ranges := loadIncludedRangesKotlinFixture(t)
+
+	parser := gotreesitter.NewParser(lang)
+	parser.SetIncludedRanges(ranges)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("included-ranges parse: %v", err)
+	}
+	if tree == nil {
+		t.Fatal("included-ranges parse returned no tree")
+	}
+	defer tree.Release()
+
+	// Census receipts are recorded on the production route only. With the
+	// default candidate route ParseRuntime().NormalizationPasses is nil and
+	// nothing is recorded, so read the subpass receipt through the runtime and
+	// skip when the route did not populate it.
+	passesPtr := tree.ParseRuntime().NormalizationPasses
+	if passesPtr == nil || len(*passesPtr) == 0 {
+		t.Skip("no census receipts on this route")
+	}
+	const subpass = "dispatch.kotlin.recovered-source-file-root"
+	var found bool
+	for _, pass := range *passesPtr {
+		if pass.Name != subpass {
+			continue
+		}
+		found = true
+		if pass.NodesRewritten == 0 {
+			t.Fatalf("%s recorded no rewrite on the included-ranges route", subpass)
+		}
+		t.Logf("%s rewrote %d nodes", subpass, pass.NodesRewritten)
+	}
+	if !found {
+		t.Fatalf("%s has no census receipt on the included-ranges route", subpass)
+	}
+}
+
+// TestIncludedRangesKotlinRootCoveragePinned pins the route's known coverage
+// defect so a change becomes loud instead of silent.
+//
+// The parse stops with no_stacks_alive and the root ends at byte 1986, so the
+// third included range is dropped. The C oracle publishes `source_file [0,3094)`
+// with no error for the same input. The cause is separate from the member this
+// file gates: bytesAreParserPadding scans raw bytes between the stack offset and
+// the next token start with no range clipping, so a non-whitespace gap between
+// ranges kills every GLR stack. The truncation predates the member deletion and
+// predates its restoration; it is measured identical on both.
+//
+// When the clipping fix lands, this test fails. That is the intended signal.
+// Update the pins then, from a fresh C-oracle receipt.
+func TestIncludedRangesKotlinRootCoveragePinned(t *testing.T) {
+	lang := grammars.KotlinLanguage()
+	if lang == nil {
+		t.Skip("kotlin grammar unavailable")
+	}
+	src, ranges := loadIncludedRangesKotlinFixture(t)
+
+	parser := gotreesitter.NewParser(lang)
+	parser.SetIncludedRanges(ranges)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("included-ranges parse: %v", err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("included-ranges parse returned no tree")
+	}
+	defer tree.Release()
+
+	root := tree.RootNode()
+	const (
+		pinnedStart = uint32(0)
+		pinnedEnd   = uint32(1986)
+		oracleEnd   = uint32(3094)
+	)
+	if got := root.StartByte(); got != pinnedStart {
+		t.Errorf("included-ranges root start byte = %d, pinned %d", got, pinnedStart)
+	}
+	if got := root.EndByte(); got != pinnedEnd {
+		t.Errorf("included-ranges root end byte = %d, pinned %d (C oracle publishes %d)",
+			got, pinnedEnd, oracleEnd)
+	}
+	if !root.HasError() {
+		t.Error("included-ranges root reports no error; the pinned value is true while the C oracle reports false")
+	}
+}

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -177,7 +177,9 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 	case "ledger":
 		dispatcherArmCensus(ctx, "dispatch.ledger", func() { normalizeLedgerCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang) })
 	case "kotlin":
-		dispatcherArmCensus(ctx, "dispatch.kotlin", func() { normalizeKotlinCompatibility(ctx.root, ctx.source, ctx.lang) })
+		dispatcherArmSubpassCensus(ctx, "dispatch.kotlin", func(census materializationSubpassCensus) {
+			normalizeKotlinCompatibilityWithCensus(ctx.root, ctx.source, ctx.lang, census)
+		})
 	case "ninja":
 		dispatcherArmCensus(ctx, "dispatch.ninja", func() { normalizeNinjaCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "perl":

--- a/parser_result_kotlin.go
+++ b/parser_result_kotlin.go
@@ -637,6 +637,34 @@ func normalizeKotlinRawStringTrailingContent(root *Node, source []byte, lang *La
 //
 // The route gate lives in parser_included_ranges_kotlin_root_test.go and
 // cgo_harness/included_ranges_kotlin_root_parity_cgo_test.go.
+//
+// READ THIS BEFORE PROPOSING THIS MEMBER FOR RETIREMENT AGAIN. This comment
+// justifies the member TODAY. It is not a permanent justification, for two
+// measured reasons.
+//
+//  1. The route is defective, and the member may be live only because of that
+//     defect. bytesAreParserPadding (parser.go), reached through
+//     realTokenAttachmentGapIsParserPadding, scans raw bytes between the stack
+//     offset and the next token start with no range clipping. A non-whitespace
+//     gap between two included ranges therefore kills every GLR stack and
+//     forces C-recovery where the reference runtime never recovers. The
+//     range-aware twin already exists: parserTailAllowsCleanAcceptance. Make
+//     the ranges of the witness contiguous and both facts appear together: the
+//     parse reaches the oracle's span with no error, and this member goes
+//     inert. After the clipping fix lands, re-run the census and decide this
+//     member's fate on the corrected route.
+//
+//  2. What this member DOES is retag the root. What it CAUSES is wider, and
+//     not always toward the reference runtime. On
+//     kotlinx-coroutines-core/common/test/DelayTest.kt with three ranges, the
+//     retag alone is necessary and sufficient to make a later stage flatten a
+//     clean class_declaration into root-level members: 7 children become 12,
+//     while the C oracle and the pre-restoration build both keep the
+//     class_declaration. Neither normalizeKotlinTopLevelFunctionFragments nor
+//     the error refresh is involved; skipping either still reproduces the
+//     flattening, and skipping only retagResultRoot removes it. So a census
+//     receipt for this member bounds what it rewrote, not what its retag led
+//     downstream stages to do.
 func normalizeKotlinRecoveredSourceFileRoot(root *Node, source []byte, lang *Language) {
 	if root == nil || lang == nil || lang.Name != "kotlin" || root.Type(lang) != "ERROR" {
 		return

--- a/parser_result_kotlin.go
+++ b/parser_result_kotlin.go
@@ -3,6 +3,18 @@ package gotreesitter
 import "strings"
 
 func normalizeKotlinCompatibility(root *Node, source []byte, lang *Language) {
+	normalizeKotlinCompatibilityWithCensus(root, source, lang, materializationSubpassCensus{})
+}
+
+func normalizeKotlinCompatibilityWithCensus(
+	root *Node,
+	source []byte,
+	lang *Language,
+	census materializationSubpassCensus,
+) {
+	census.run("dispatch.kotlin.recovered-source-file-root", func() {
+		normalizeKotlinRecoveredSourceFileRoot(root, source, lang)
+	})
 	normalizeKotlinInterpolatedCallExpressions(root, lang)
 	normalizeKotlinGenericCallTypeArguments(root, source, lang)
 	normalizeKotlinPrefixComparisonExpressions(root, source, lang)
@@ -607,6 +619,120 @@ func normalizeKotlinRawStringTrailingContent(root *Node, source []byte, lang *La
 		n.startByte, n.endByte = startByte, endByte
 		n.startPoint, n.endPoint = startPoint, endPoint
 	})
+}
+
+// normalizeKotlinRecoveredSourceFileRoot retags a recovered ERROR root as
+// `source_file` when its children still look like Kotlin top-level
+// declarations.
+//
+// This member was deleted on 2026-08-02 as dead code and is restored here. The
+// census behind the deletion measured the fresh, over-64-KiB, incremental and
+// pinned routes. It did not measure Parser.SetIncludedRanges. On that route the
+// member fires and moves the published root toward the reference runtime.
+//
+// Witness: testdata/included_ranges/kotlin_work_queue_test.kt with the three
+// ranges pinned by parser_included_ranges_kotlin_root_test.go. Without this
+// member the root is `ERROR`; with it the root is `source_file`, which is the
+// kind the locked Kotlin C oracle publishes for the same input.
+//
+// The route gate lives in parser_included_ranges_kotlin_root_test.go and
+// cgo_harness/included_ranges_kotlin_root_parity_cgo_test.go.
+func normalizeKotlinRecoveredSourceFileRoot(root *Node, source []byte, lang *Language) {
+	if root == nil || lang == nil || lang.Name != "kotlin" || root.Type(lang) != "ERROR" {
+		return
+	}
+	if !kotlinRootLooksRecoverableSourceFile(root, lang) {
+		return
+	}
+	normalizeKotlinTopLevelFunctionFragments(root, source, lang)
+	sym, ok := symbolByName(lang, "source_file")
+	if !ok {
+		return
+	}
+	retagResultRootAndRefreshError(root, sym, symbolIsNamed(lang, sym))
+}
+
+func kotlinRootLooksRecoverableSourceFile(root *Node, lang *Language) bool {
+	if root == nil || lang == nil || resultChildCount(root) == 0 {
+		return false
+	}
+	for i := 0; i < resultChildCount(root); i++ {
+		child := resultChildAt(root, i)
+		if child == nil {
+			continue
+		}
+		switch child.Type(lang) {
+		case "package_header",
+			"import_list",
+			"class_declaration",
+			"function_declaration",
+			"object_declaration",
+			"property_declaration",
+			"typealias_declaration",
+			"multiline_comment",
+			"line_comment":
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeKotlinTopLevelFunctionFragments(root *Node, source []byte, lang *Language) {
+	fnSym, ok := symbolByName(lang, "function_declaration")
+	if !ok {
+		return
+	}
+	funSym, ok := symbolByName(lang, "fun")
+	if !ok {
+		return
+	}
+	children := resultChildSliceForMutation(root)
+	if len(children) < 3 {
+		return
+	}
+	arena := root.ownerArena
+	if arena == nil {
+		return
+	}
+	rebuilt := make([]*Node, 0, len(children))
+	changed := false
+	for i := 0; i < len(children); i++ {
+		if fn, ok := kotlinRecoveredTopLevelFunction(arena, children, i, source, lang, fnSym, funSym); ok {
+			rebuilt = append(rebuilt, fn)
+			i += 2
+			changed = true
+			continue
+		}
+		rebuilt = append(rebuilt, children[i])
+	}
+	if !changed {
+		return
+	}
+	replaceNodeChildrenUnfielded(root, cloneNodeSliceInArena(arena, rebuilt))
+}
+
+func kotlinRecoveredTopLevelFunction(arena *nodeArena, children []*Node, idx int, source []byte, lang *Language, fnSym, funSym Symbol) (*Node, bool) {
+	if idx+2 >= len(children) {
+		return nil, false
+	}
+	funKeyword := children[idx]
+	name := children[idx+1]
+	params := children[idx+2]
+	if funKeyword == nil || name == nil || params == nil {
+		return nil, false
+	}
+	if funKeyword.Type(lang) != "ERROR" || strings.TrimSpace(funKeyword.Text(source)) != "fun" {
+		return nil, false
+	}
+	if name.Type(lang) != "simple_identifier" || params.Type(lang) != "function_value_parameters" {
+		return nil, false
+	}
+	retagResultRoot(funKeyword, funSym, symbolIsNamed(lang, funSym))
+	funKeyword.setHasError(false)
+	fnChildren := cloneNodeSliceInArena(funKeyword.ownerArena, []*Node{funKeyword, name, params})
+	fn := newParentNodeInArena(funKeyword.ownerArena, fnSym, symbolIsNamed(lang, fnSym), fnChildren, nil, 0)
+	fn.setHasError(true)
+	return fn, true
 }
 
 func normalizeKotlinInterpolatedCallExpressions(root *Node, lang *Language) {

--- a/parser_result_test/materialization_subpass_census_test.go
+++ b/parser_result_test/materialization_subpass_census_test.go
@@ -420,5 +420,23 @@ func materializationSubpassProbes() []materializationSubpassProbe {
 				"dispatch.go.new-make-type",
 			},
 		},
+		{
+			// Pins the Kotlin arm's recovered-root subpass id and its
+			// INERTNESS off the included-ranges route. The member was retired
+			// on 2026-08-02 as dead code and restored on 2026-08-03 because it
+			// is live on the included-ranges route only. This probe is the
+			// other half of that claim: on the fresh route it is reached and
+			// rewrites nothing. Its live route is covered by
+			// parser_included_ranges_kotlin_root_test.go and
+			// cgo_harness/included_ranges_kotlin_root_parity_cgo_test.go.
+			name:     "kotlin_clean_source_file_root_is_inert",
+			language: grammars.KotlinLanguage,
+			source:   "package demo\n\nfun main() {\n    println(\"hi\")\n}\n",
+			expectedSubpasses: []string{
+				"dispatch.kotlin",
+				"dispatch.kotlin.recovered-source-file-root",
+			},
+			rewrittenSubpasses: nil,
+		},
 	}
 }

--- a/testdata/included_ranges/kotlin_work_queue_test.kt
+++ b/testdata/included_ranges/kotlin_work_queue_test.kt
@@ -1,0 +1,108 @@
+package kotlinx.coroutines.scheduling
+
+import kotlinx.coroutines.testing.*
+import kotlinx.coroutines.*
+import org.junit.*
+import org.junit.Test
+import kotlin.jvm.internal.Ref.ObjectRef
+import kotlin.test.*
+
+class WorkQueueTest : TestBase() {
+
+    private val timeSource = TestTimeSource(0)
+
+    @Before
+    fun setUp() {
+        schedulerTimeSource = timeSource
+    }
+
+    @After
+    fun tearDown() {
+        schedulerTimeSource = NanoTimeSource
+    }
+
+    @Test
+    fun testLastScheduledComesFirst() {
+        val queue = WorkQueue()
+        (1L..4L).forEach { queue.add(task(it)) }
+        assertEquals(listOf(4L, 1L, 2L, 3L), queue.drain(ObjectRef()))
+    }
+
+    @Test
+    fun testAddWithOffload() {
+        val queue = WorkQueue()
+        val size = 130L
+        val offload = GlobalQueue()
+        (0 until size).forEach { queue.add(task(it))?.let { t -> offload.addLast(t) } }
+
+        val expectedResult = listOf(129L) + (0L..126L).toList()
+        val actualResult = queue.drain(ObjectRef())
+        assertEquals(expectedResult, actualResult)
+        assertEquals((0L until size).toSet().minus(expectedResult.toSet()), offload.drain().toSet())
+    }
+
+    @Test
+    fun testWorkOffloadPrecision() {
+        val queue = WorkQueue()
+        val globalQueue = GlobalQueue()
+        repeat(128) { assertNull(queue.add(task(it.toLong()))) }
+        assertTrue(globalQueue.isEmpty)
+        assertEquals(127L, queue.add(task(0))?.submissionTime)
+    }
+
+    @Test
+    fun testStealingFromHead() {
+        val victim = WorkQueue()
+        victim.add(task(1L))
+        victim.add(task(2L))
+        timeSource.step()
+        timeSource.step(3)
+
+        val stealer = WorkQueue()
+        val ref = ObjectRef<Task?>()
+        assertEquals(TASK_STOLEN, victim.trySteal(ref))
+        assertEquals(arrayListOf(1L), stealer.drain(ref))
+
+        assertEquals(TASK_STOLEN, victim.trySteal(ref))
+        assertEquals(arrayListOf(2L), stealer.drain(ref))
+    }
+
+    @Test
+    fun testPollBlocking() {
+        val queue = WorkQueue()
+        assertNull(queue.pollBlocking())
+        val blockingTask = blockingTask(1L)
+        queue.add(blockingTask)
+        queue.add(task(1L))
+        assertSame(blockingTask, queue.pollBlocking())
+    }
+}
+
+internal fun task(n: Long) = Runnable {}.asTask(n, NonBlockingContext)
+internal fun blockingTask(n: Long) = Runnable {}.asTask(n, BlockingContext)
+
+internal fun WorkQueue.drain(ref: ObjectRef<Task?>): List<Long> {
+    var task: Task? = poll()
+    val result = arrayListOf<Long>()
+    while (task != null) {
+        result += task.submissionTime
+        task = poll()
+    }
+    if (ref.element != null) {
+        result += ref.element!!.submissionTime
+        ref.element = null
+    }
+    return result
+}
+
+internal fun GlobalQueue.drain(): List<Long> {
+    var task: Task? = removeFirstOrNull()
+    val result = arrayListOf<Long>()
+    while (task != null) {
+        result += task.submissionTime
+        task = removeFirstOrNull()
+    }
+    return result
+}
+
+internal fun WorkQueue.trySteal(stolenTaskRef: ObjectRef<Task?>): Long = trySteal(STEAL_ANY, stolenTaskRef)

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -1667,18 +1667,19 @@
           "files": [
             "parser_result_kotlin.go"
           ],
-          "purpose": "Retag a recovered ERROR root as source_file when its children still look like Kotlin top-level declarations. Restored on 2026-08-03 after the retirement of 2026-08-02 was reversed.",
+          "purpose": "Retag a recovered ERROR root as source_file when its children still look like Kotlin top-level declarations. Restored on 2026-08-03 after the retirement of 2026-08-02 was reversed. Live on the included-ranges route and inert on the fresh route; both halves are pinned by the witnesses below.",
           "authoritative_owner": "derivation_election_selection",
           "witnesses": [
             "parser_included_ranges_kotlin_root_test.go",
-            "cgo_harness/included_ranges_kotlin_root_parity_cgo_test.go"
+            "cgo_harness/included_ranges_kotlin_root_parity_cgo_test.go",
+            "parser_result_test/materialization_subpass_census_test.go"
           ]
         }
       ],
       "languages": [
         "kotlin"
       ],
-      "purpose": "Reconcile Kotlin derivation selection and returned-tree shape. Member normalizeKotlinRecoveredSourceFileRoot was retired as dead code on 2026-08-02 and RESTORED on 2026-08-03: that census measured the fresh, over-64-KiB, incremental and pinned routes and never measured Parser.SetIncludedRanges. On the included-ranges route the member fires and moves the published root toward the reference runtime. Witness testdata/included_ranges/kotlin_work_queue_test.kt with ranges [0,795), [883,1987) and [2019,3094): without the member the root is ERROR, with the member the root is source_file, and the locked Kotlin C oracle publishes source_file [0,3094). The member is correct today; re-evaluate it after the unclipped padding scan in bytesAreParserPadding gains range clipping, because that defect is why the route enters recovery at all. The members normalizeKotlinGenericCallTypeArguments and normalizeKotlinPrefixComparisonExpressions stay load-bearing.",
+      "purpose": "Reconcile Kotlin derivation selection and returned-tree shape. Member normalizeKotlinRecoveredSourceFileRoot was retired as dead code on 2026-08-02 and RESTORED on 2026-08-03: that census measured the fresh, over-64-KiB, incremental and pinned routes and never measured Parser.SetIncludedRanges. On the included-ranges route the member fires and moves the published ROOT toward the reference runtime. Witness testdata/included_ranges/kotlin_work_queue_test.kt with ranges [0,795), [883,1987) and [2019,3094): without the member the root is ERROR, with the member the root is source_file, and the locked Kotlin C oracle publishes source_file [0,3094). The member's effect is a root retag, and its DOWNSTREAM consequence is not always toward the reference runtime: on kotlinx-coroutines-core/common/test/DelayTest.kt with three ranges, the retag alone is necessary and sufficient to make a later stage flatten a clean class_declaration into root-level members (7 children become 12) where main and the C oracle both keep the class_declaration. Do not read the root receipt as a whole-tree improvement. The member is correct today; re-evaluate it after the unclipped padding scan in bytesAreParserPadding gains range clipping, because that defect is why the route enters recovery at all. The members normalizeKotlinGenericCallTypeArguments and normalizeKotlinPrefixComparisonExpressions stay load-bearing.",
       "authoritative_owner": "derivation_election_selection",
       "witnesses": [
         "cgo_harness/parity_cgo_test.go",

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -1653,21 +1653,40 @@
       "id": "dispatch.kotlin",
       "kind": "dispatcher_arm",
       "functions": [
-        "normalizeKotlinCompatibility"
+        "normalizeKotlinCompatibilityWithCensus"
       ],
       "files": [
         "parser_result_kotlin.go"
       ],
+      "subpasses": [
+        {
+          "id": "dispatch.kotlin.recovered-source-file-root",
+          "functions": [
+            "normalizeKotlinRecoveredSourceFileRoot"
+          ],
+          "files": [
+            "parser_result_kotlin.go"
+          ],
+          "purpose": "Retag a recovered ERROR root as source_file when its children still look like Kotlin top-level declarations. Restored on 2026-08-03 after the retirement of 2026-08-02 was reversed.",
+          "authoritative_owner": "derivation_election_selection",
+          "witnesses": [
+            "parser_included_ranges_kotlin_root_test.go",
+            "cgo_harness/included_ranges_kotlin_root_parity_cgo_test.go"
+          ]
+        }
+      ],
       "languages": [
         "kotlin"
       ],
-      "purpose": "Reconcile Kotlin derivation selection and returned-tree shape. Retired member normalizeKotlinRecoveredSourceFileRoot as dead code on 2026-08-02: no route sets its ERROR-root guard on any tested witness, so the retag never fires. The remaining members, normalizeKotlinGenericCallTypeArguments and normalizeKotlinPrefixComparisonExpressions, stay load-bearing.",
+      "purpose": "Reconcile Kotlin derivation selection and returned-tree shape. Member normalizeKotlinRecoveredSourceFileRoot was retired as dead code on 2026-08-02 and RESTORED on 2026-08-03: that census measured the fresh, over-64-KiB, incremental and pinned routes and never measured Parser.SetIncludedRanges. On the included-ranges route the member fires and moves the published root toward the reference runtime. Witness testdata/included_ranges/kotlin_work_queue_test.kt with ranges [0,795), [883,1987) and [2019,3094): without the member the root is ERROR, with the member the root is source_file, and the locked Kotlin C oracle publishes source_file [0,3094). The member is correct today; re-evaluate it after the unclipped padding scan in bytesAreParserPadding gains range clipping, because that defect is why the route enters recovery at all. The members normalizeKotlinGenericCallTypeArguments and normalizeKotlinPrefixComparisonExpressions stay load-bearing.",
       "authoritative_owner": "derivation_election_selection",
       "witnesses": [
         "cgo_harness/parity_cgo_test.go",
-        "query_kotlin_regression_test.go"
+        "query_kotlin_regression_test.go",
+        "parser_included_ranges_kotlin_root_test.go",
+        "cgo_harness/included_ranges_kotlin_root_parity_cgo_test.go"
       ],
-      "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, included-ranges, and C-oracle route receipts are exact. The included-ranges route is mandatory: it reversed the 2026-08-02 retirement of normalizeKotlinRecoveredSourceFileRoot.",
       "route_coverage": {
         "production": "shared_result_compatibility_tail",
         "compact": "shared_result_compatibility_tail",


### PR DESCRIPTION
## What this changes

Restore the Kotlin recovered-root normalization and gate the included-ranges
route.

PR #632 deleted `normalizeKotlinRecoveredSourceFileRoot` and three helpers as
dead code on 2026-08-02. The census behind that deletion covered four routes:
fresh, over-64-KiB, incremental, and pinned. It never covered
`Parser.SetIncludedRanges`. The member is live on that fifth route. This PR
restores it, adds the route's first Kotlin gate, and adds the parity gate to
both C-parity lanes.

## The witness

`testdata/included_ranges/kotlin_work_queue_test.kt`, 3094 bytes, three
included ranges `[0,795)`, `[883,1987)`, `[2019,3094)`.

| build | root kind | root span | HasError | children |
|---|---|---|---|---|
| main | `ERROR` | `[0,1986)` | true | 26 |
| this branch | `source_file` | `[0,1986)` | true | 26 |
| pre-#632 (6fab988d) | `source_file` | `[0,1986)` | true | 26 |
| locked Kotlin C oracle | `source_file` | `[0,3094)` | false | 8 |

The restoration reproduces the pre-#632 tree exactly and returns the root kind
to the value the reference runtime publishes. The member's census receipt moves
from `rewritten=0` to `rewritten=1` on the same input.

Production reaches this route through injection: `injection.go` calls
`childParser.SetIncludedRanges` for every injected child, and the multi-range
path is the one that leads here.

## The member retags the ROOT; its downstream consequence is not always toward C

This is the caveat that keeps the claim honest, and it is measured.

A 384-file included-ranges differential found 70 files change. Sixty-nine
change the root kind only, toward C. One does more:
`kotlinx-coroutines-core/common/test/DelayTest.kt` with three ranges. Main and
the C oracle both publish `class_declaration [86,377)`. This branch decomposes
that class and hoists its members to the root: 7 children become 12. On that
input the restoration trades one root-kind divergence for about six
child-level ones.

This is faithfully restored pre-#632 behaviour, not new breakage. The
pre-compat tree is identical on both builds, main's compat stage is a no-op
there, stubbing the member reproduces main exactly, and 6fab988d reproduces
this branch's shape.

The mechanism is now isolated to a single call. Neither
`normalizeKotlinTopLevelFunctionFragments` nor the error refresh is involved:
stubbing either one still reproduces the flattening, and skipping only
`retagResultRoot` removes it. So the root retag alone is necessary and
sufficient to make a later stage flatten a clean `class_declaration`. Which
post-arm stage does the flattening is filed as a follow-up, not fixed here.

Do not read "moves the published root toward the reference runtime" as "moves
the tree toward the reference runtime". An arm-level census receipt bounds
what the arm DID, not what it CAUSED, because removing an arm changes what
downstream stages see. That is recorded on the member's own doc comment, in
the registry `purpose`, and in the changelog.

## Correction to the record

The census summary said main also truncates the third range as part of the #632
regression. Measured, the truncation is not attributable to #632. Commit
6fab988d, which is main minus #632, produces the identical span `[0,1986)` and
the identical `no_stacks_alive` stop. The truncation belongs elsewhere. #632
changed exactly one observable thing on this witness: the root kind. That is
the regression this PR reverses.

## The member is still inert where the census measured it dead

Two independent checks:

1. The 206-language admission scorecard is byte-identical to `origin/main`,
   all 207 lines: every per-language digest and the summary
   `PASS=198 DIVERGE=0 FALLBACK=3 SKIP=5 ERROR=0 total=206`.
2. A sweep over 1039 Kotlin corpus files on the fresh, over-64-KiB and
   incremental routes recorded the member's subpass with zero rewrites on
   every parse. The reviewer added the pinned route, so inertness now covers
   all four censused routes across 4,156 parses.

`parser_result_test/materialization_subpass_census_test.go` now pins that
inertness as a committed probe, so the claim most likely to be re-litigated
has a test instead of a receipt in a PR body.

## Sequencing note

The census spec's preferred order was: land the range-aware clipping fix
first, re-census, then decide the member's fate. This PR restores first. That
is defensible because restoring returns to the status quo ante rather than
introducing a new behaviour, and because main is worse than both its own past
and the reference runtime on this input today. The two records are not in
conflict; the fate decision still waits for the corrected route.

## The gate

The included-ranges route had no Kotlin test. That is why a full green suite
could not see the regression. This PR adds four:

- `TestIncludedRangesKotlinRootStaysSourceFile` pins the root symbol.
- `TestIncludedRangesKotlinArmMemberIsLive` is the positive control. It reads
  the census subpass `dispatch.kotlin.recovered-source-file-root` and fails
  when the member stops rewriting, so the gate above cannot pass by accident.
  A missing receipt is now a failure, not a skip, matching #650.
- `TestIncludedRangesKotlinRootCoveragePinned` pins the route's known coverage
  defect, root end 1986 against the oracle's 3094, so a change is loud.
- `TestIncludedRangesKotlinRootParity` compares against the locked Kotlin C
  oracle. Root kind is a hard parity assertion. Root span, error flag and child
  count are pinned, not asserted equal, because they diverge for an unrelated
  reason.

Both directions are proven. With the member stubbed to return early:

- `included-ranges root type = "ERROR", want "source_file"`
- `dispatch.kotlin.recovered-source-file-root recorded no rewrite on the included-ranges route`
- `included-ranges root kind: gotreesitter="ERROR" C="source_file"`

The fixture is committed. No test reads a host path.

## CI visibility

Verified by reading the workflow, not assumed.

- The three root-package tests run in `race_root_shards`.
  `.github/scripts/root_race_shard.sh` enumerates every root target through
  `go test -race . -list` and partitions it across four shards, so new tests
  join automatically. Confirmed on the rebased tree: shard 0 runs
  `...RootCoveragePinned`, shard 1 runs `...RootStaysSourceFile`, shard 3 runs
  `...ArmMemberIsLive`.
- The parity test needed explicit edits. Every parity lane runs a fixed
  `--run` regex, so a new cgo test runs nowhere by default.
  `^TestIncludedRangesKotlinRootParity$` is added to the `parity-cgo` smoke
  lane AND to the `parity-cgo-exhaustive` fresh step, matching what #650 did
  for its Go names. Touching `parser_result_*.go` triggers the exhaustive job;
  the name in the regex is what makes the test actually run inside it.

## Re-evaluate this after the clipping fix

This restoration is correct today, and it should be re-examined later.

Several compatibility arms may be live on the included-ranges route only
because the route is broken. `bytesAreParserPadding` (parser.go), reached
through `realTokenAttachmentGapIsParserPadding`, scans raw bytes between the
stack offset and the next token start with no range clipping. A non-whitespace
gap between two included ranges therefore kills every GLR stack and forces
C-recovery where the reference runtime never recovers. The range-aware twin
already exists: `parserTailAllowsCleanAcceptance`.

Making the witness ranges contiguous confirms the causal story three ways at
once: the parse reaches the oracle's `[0,3094)` with `HasError=false`, and the
member goes inert. That fix is a separate lane and is not attempted here. Once
it lands, re-run the census and re-evaluate this member on the corrected
route. It may become genuinely dead then. The warning is on the member's own
doc comment, which is the artifact a future retirement worker reads first.

## Registry

The `dispatch.kotlin` entry records the reversal, cites the witness and the
three ranges, records the DelayTest.kt downstream exception, registers the new
subpass, and adds the included-ranges route to the retirement condition. The
`route_coverage` object stays a closed five-key vocabulary; adding a sixth key
touches every entry and belongs to the doctrine lane.

## Gates

Re-run on the rebased tree, on top of #650.

- Full root package suite: green.
- `./grammars`: green.
- `./parser_result_test/...`: green, including the new Kotlin inertness probe.
- `./internal/...`: green.
- Kotlin A3 full-corpus sweep: 16 sources, divergences 0.
- Kotlin and included-ranges cgo parity, including #650's Go gates and the new
  Kotlin gate: green.
- Race on the touched paths: green, no data race.
- Admission scorecard, strict: `PASS=198 DIVERGE=0 FALLBACK=3 SKIP=5 ERROR=0
  total=206`, and all 207 scorecard lines byte-identical to `origin/main`.
- `go vet ./...` clean. `gofmt` clean on every touched file.

No performance claim is made.
