### PR TITLE
add(merge-census): count stack-merge events against the reference runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,6 +543,7 @@ jobs:
       - perf_scan_budget
       - exhaustive_parity_scope
       - compact-t3-oracle-cgo
+      - merge-event-census-cgo
       - parity-cgo-exhaustive
     if: always()
     runs-on: ubuntu-latest
@@ -564,6 +565,7 @@ jobs:
           EXHAUSTIVE_PARITY_SCOPE_RESULT: ${{ needs.exhaustive_parity_scope.result }}
           EXHAUSTIVE_PARITY_SCOPE: ${{ needs.exhaustive_parity_scope.outputs.run_exhaustive }}
           COMPACT_T3_ORACLE_CGO_RESULT: ${{ needs.compact-t3-oracle-cgo.result }}
+          MERGE_EVENT_CENSUS_CGO_RESULT: ${{ needs.merge-event-census-cgo.result }}
           EXHAUSTIVE_PARITY_RESULT: ${{ needs.parity-cgo-exhaustive.result }}
         run: |
           set -euo pipefail
@@ -600,6 +602,7 @@ jobs:
           require_success "parity_report" "$PARITY_REPORT_RESULT"
           require_success "perf_scan_budget" "$PERF_SCAN_BUDGET_RESULT"
           require_success "compact-t3-oracle-cgo" "$COMPACT_T3_ORACLE_CGO_RESULT"
+          require_success "merge-event-census-cgo" "$MERGE_EVENT_CENSUS_CGO_RESULT"
 
           if [ "$IS_DRAFT" = "true" ]; then
             require_success "draft_focused_tests" "$DRAFT_FOCUSED_RESULT"
@@ -777,6 +780,48 @@ jobs:
             --c-ref-build-jobs 1 \
             --timeout 20m \
             --run '^TestCompactT3OracleAdjudication$'
+
+  # merge-event-census-cgo runs stage M0 of spec.merge-time-election.v1: the
+  # census that counts stack-merge events on both sides and breaks production's
+  # refusals down by gate. Every cgo parity lane in this file runs a FIXED
+  # --run regex, so a new cgo test runs nowhere unless it is named here; see
+  # docs/ci-gate-coverage.md. This lane names it.
+  #
+  # The census needs its own build tags, so it uses the docker runner's custom
+  # command form rather than --run: gts_merge_census compiles the production
+  # instrument into the library, and the lane is the only place it is compiled
+  # at all (merge_event_census_inert_test.go ratchets its absence everywhere
+  # else). The reference side compiles the repository's own work-count patch
+  # against the pinned runtime source from the module cache, so the lane needs
+  # cc and git, which the harness image already carries.
+  merge-event-census-cgo:
+    needs: exhaustive_parity_scope
+    if: needs.exhaustive_parity_scope.outputs.run_code_ci == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Merge-event census (stage M0 baseline and Foo[int](a) receipt)
+        run: |
+          GTS_PARITY_MODE=smoke \
+          bash cgo_harness/docker/run_parity_in_docker.sh \
+            --label ci-merge-event-census \
+            --memory 8g \
+            --cpus 2 \
+            --pids 4096 \
+            --gomemlimit 6GiB \
+            --goflags -p=1 \
+            --test-parallel 1 \
+            --c-ref-build-jobs 1 \
+            --timeout 30m \
+            -- "cd /workspace/cgo_harness && GOWORK=off go test \
+              -tags 'cgo treesitter_c_parity gts_merge_census' \
+              -run '^TestMergeEventCensus' -count=1 -v -timeout 30m ."
 
   parity-cgo:
     needs: exhaustive_parity_scope

--- a/cgo_harness/census_corpora_test.go
+++ b/cgo_harness/census_corpora_test.go
@@ -1,0 +1,110 @@
+//go:build cgo && treesitter_c_parity && (gts_derivation_set_census || gts_merge_census)
+
+package cgoharness
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// Shared census corpora.
+//
+// Stage D0 of spec.derivation-set-equivalence.v1 (the derivation-set
+// differential) and stage M0 of spec.merge-time-election.v1 (the merge-event
+// census) measure the SAME sources, so the two censuses share one
+// denominator. This file holds that corpus definition, and each census
+// compiles it behind its own build tag.
+
+// derivationSetCensusLanguage is one language's differential corpus.
+type derivationSetCensusLanguage struct {
+	Name        string
+	CName       string
+	Language    func() *gotreesitter.Language
+	Constructed func() []a3CertificationSweepSource
+	RealDir     string
+}
+
+// derivationSetCensusLanguages mirrors the five A3 certification sweeps
+// (apex, perl, ada, kotlin, python) source for source, so the baseline
+// census denominator equals the sweeps' own denominator on the same host.
+func derivationSetCensusLanguages() []derivationSetCensusLanguage {
+	return []derivationSetCensusLanguage{
+		{
+			Name: "apex", CName: "apex", Language: grammars.ApexLanguage,
+			Constructed: func() []a3CertificationSweepSource {
+				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("apex"))}}
+				sources = append(sources, apexA3TiedElectionWitnesses()...)
+				return append(sources, apexA3AdversarialSources()...)
+			},
+		},
+		{
+			Name: "perl", CName: "perl", Language: grammars.PerlLanguage,
+			Constructed: func() []a3CertificationSweepSource {
+				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("perl"))}}
+				return append(sources, perlA3AdversarialSources()...)
+			},
+			RealDir: filepath.Join("corpus_real", "perl"),
+		},
+		{
+			Name: "ada", CName: "ada", Language: grammars.AdaLanguage,
+			Constructed: func() []a3CertificationSweepSource {
+				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("ada"))}}
+				sources = append(sources, adaA3TiedElectionWitnesses()...)
+				return append(sources, adaA3AdversarialSources()...)
+			},
+		},
+		{
+			Name: "kotlin", CName: "kotlin", Language: grammars.KotlinLanguage,
+			Constructed: func() []a3CertificationSweepSource {
+				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("kotlin"))}}
+				return append(sources, kotlinA3AdversarialSources()...)
+			},
+			RealDir: filepath.Join("corpus_real", "kotlin"),
+		},
+		{
+			Name: "python", CName: "python", Language: grammars.PythonLanguage,
+			Constructed: func() []a3CertificationSweepSource {
+				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("python"))}}
+				return append(sources, pythonA3AdversarialSources()...)
+			},
+			RealDir: filepath.Join("corpus_real", "python"),
+		},
+	}
+}
+
+// derivationSetLoadRealCorpus reads a real-corpus directory when it exists.
+// Unlike a3LoadRealCorpusDir it never skips the caller: the baseline census
+// pins its constructed-source numbers, which every host reproduces, and
+// reports the real-corpus numbers separately with their file count.
+func derivationSetLoadRealCorpus(t *testing.T, dir string) []a3CertificationSweepSource {
+	t.Helper()
+	if dir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read corpus dir %s: %v", dir, err)
+	}
+	var out []a3CertificationSweepSource
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read corpus file %s: %v", path, err)
+		}
+		out = append(out, a3CertificationSweepSource{Name: entry.Name(), Source: data})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}

--- a/cgo_harness/derivation_set_differential_test.go
+++ b/cgo_harness/derivation_set_differential_test.go
@@ -4,9 +4,6 @@ package cgoharness
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
-	"sort"
 	"testing"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
@@ -29,95 +26,6 @@ import (
 // into the library at all. Without it the library has no instrument, so both
 // tests below are absent from the build and every shipped gate runs against
 // exactly the code main ships.
-
-// derivationSetCensusLanguage is one language's differential corpus.
-type derivationSetCensusLanguage struct {
-	Name        string
-	CName       string
-	Language    func() *gotreesitter.Language
-	Constructed func() []a3CertificationSweepSource
-	RealDir     string
-}
-
-// derivationSetCensusLanguages mirrors the five A3 certification sweeps
-// (apex, perl, ada, kotlin, python) source for source, so the baseline
-// census denominator equals the sweeps' own denominator on the same host.
-func derivationSetCensusLanguages() []derivationSetCensusLanguage {
-	return []derivationSetCensusLanguage{
-		{
-			Name: "apex", CName: "apex", Language: grammars.ApexLanguage,
-			Constructed: func() []a3CertificationSweepSource {
-				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("apex"))}}
-				sources = append(sources, apexA3TiedElectionWitnesses()...)
-				return append(sources, apexA3AdversarialSources()...)
-			},
-		},
-		{
-			Name: "perl", CName: "perl", Language: grammars.PerlLanguage,
-			Constructed: func() []a3CertificationSweepSource {
-				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("perl"))}}
-				return append(sources, perlA3AdversarialSources()...)
-			},
-			RealDir: filepath.Join("corpus_real", "perl"),
-		},
-		{
-			Name: "ada", CName: "ada", Language: grammars.AdaLanguage,
-			Constructed: func() []a3CertificationSweepSource {
-				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("ada"))}}
-				sources = append(sources, adaA3TiedElectionWitnesses()...)
-				return append(sources, adaA3AdversarialSources()...)
-			},
-		},
-		{
-			Name: "kotlin", CName: "kotlin", Language: grammars.KotlinLanguage,
-			Constructed: func() []a3CertificationSweepSource {
-				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("kotlin"))}}
-				return append(sources, kotlinA3AdversarialSources()...)
-			},
-			RealDir: filepath.Join("corpus_real", "kotlin"),
-		},
-		{
-			Name: "python", CName: "python", Language: grammars.PythonLanguage,
-			Constructed: func() []a3CertificationSweepSource {
-				sources := []a3CertificationSweepSource{{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("python"))}}
-				return append(sources, pythonA3AdversarialSources()...)
-			},
-			RealDir: filepath.Join("corpus_real", "python"),
-		},
-	}
-}
-
-// derivationSetLoadRealCorpus reads a real-corpus directory when it exists.
-// Unlike a3LoadRealCorpusDir it never skips the caller: the baseline census
-// pins its constructed-source numbers, which every host reproduces, and
-// reports the real-corpus numbers separately with their file count.
-func derivationSetLoadRealCorpus(t *testing.T, dir string) []a3CertificationSweepSource {
-	t.Helper()
-	if dir == "" {
-		return nil
-	}
-	entries, err := os.ReadDir(dir)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
-		t.Fatalf("read corpus dir %s: %v", dir, err)
-	}
-	var out []a3CertificationSweepSource
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		path := filepath.Join(dir, entry.Name())
-		data, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("read corpus file %s: %v", path, err)
-		}
-		out = append(out, a3CertificationSweepSource{Name: entry.Name(), Source: data})
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
-	return out
-}
 
 // TestDerivationSetDifferentialWitnessReproduction is stage D0's must-pass
 // acceptance criterion: the eight witnesses R2 falsified must reproduce as

--- a/cgo_harness/merge_event_census.go
+++ b/cgo_harness/merge_event_census.go
@@ -1,0 +1,660 @@
+//go:build cgo && treesitter_c_parity && gts_merge_census
+
+package cgoharness
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// Merge-event census (stage M0 of spec.merge-time-election.v1).
+//
+// The lane's thesis, from finding.late-election-unifying-cause: the reference
+// runtime packs duplicate versions at the merge and elects across the packed
+// pair at the first spanning pop, while this parser refuses to pack when the
+// subtree shapes differ, carries both versions, and elects at the end. The
+// direct test of that thesis is a count: how many merges does the reference
+// runtime perform, how many does production perform, and which gate refuses
+// the rest. This file takes that measurement. It ships ZERO behaviour change.
+//
+// The census extends the stage-D0 derivation-set differential
+// (derivation_set_differential.go, PR #646) rather than building a parallel
+// instrument. It reuses D0's corpora (derivationSetCensusLanguages), D0's
+// per-source loop shape, and D0's pinned-baseline discipline. D0's baseline
+// is 32 set differences over 95 constructed sources; this one's is merge
+// counts and refusal counts.
+//
+// # The reference-runtime counting method, and why the logger is not enough
+//
+// D0 reconstructs the reference runtime's live version set from
+// ts_parser_set_logger output. That method CANNOT reach a merge event.
+// parser.c calls ts_stack_merge at four sites (parser.c:1033 after a reduce
+// slice, :1114 inside ts_parser__do_all_potential_reductions, :1513 in error
+// handling, and :1796/:1805 in ts_parser__condense_stack) and none of them
+// logs. The only merge-adjacent log line is "condense" (parser.c:1855), which
+// fires once per condense turn when made_changes is set by ANY of removal,
+// merge, or version swap, so it cannot be attributed to a merge. The
+// "process version:%u, version_count:%u" line (parser.c:2149) reports the
+// live version count, but a version count falls for removal and cap
+// enforcement as well as for merge, so a difference is not a merge count.
+//
+// The census therefore reads the instrumented build, which this repository
+// already carries and already validates: cgo_harness/work_count/tree_sitter_v0_25_1.patch
+// puts merge_attempts_proxy and merge_successes_proxy directly around
+// ts_stack_merge and the six GTSLinkUnionOutcome counters around
+// stack_node_add_link. No new C instrumentation is invented here.
+//
+// Two properties keep the instrumented build equal to D0's oracle:
+//
+//   - The runtime source is the SAME source. The patch is applied to
+//     github.com/tree-sitter/go-tree-sitter@v0.25.0/src, resolved from the
+//     module cache, which is exactly the runtime D0's sitter.NewParser()
+//     compiles. The compile flags are the module's own cgo flags.
+//   - The grammar table is the SAME table. The driver dlopens the shared
+//     object COracleIdentity reports, which the parity C-reference loader
+//     built from grammars/languages.lock.
+
+const (
+	mergeCensusRuntimeModule  = "github.com/tree-sitter/go-tree-sitter"
+	mergeCensusDriverSchema   = "gts-merge-census-c/v1"
+	mergeCensusParseTimeoutUS = "30000000"
+)
+
+// mergeCensusCRow is one reference-runtime measurement, decoded from the
+// driver's per-source JSON line.
+type mergeCensusCRow struct {
+	Schema        string `json:"schema"`
+	Path          string `json:"path"`
+	Status        string `json:"status"`
+	SourceBytes   uint32 `json:"source_bytes"`
+	RootEndByte   uint32 `json:"root_end_byte"`
+	RootHasError  bool   `json:"root_has_error"`
+	MergeAttempts uint64 `json:"merge_attempts_proxy"`
+	// MergeSuccesses is M_c: the number of ts_stack_merge calls that
+	// collapsed two versions into one.
+	MergeSuccesses         uint64 `json:"merge_successes_proxy"`
+	VersionCreations       uint64 `json:"stack_version_creations_proxy"`
+	Shifts                 uint64 `json:"shifts"`
+	Reductions             uint64 `json:"reductions"`
+	Accepts                uint64 `json:"accept_actions"`
+	ExplicitRecovers       uint64 `json:"explicit_recover_actions"`
+	ReductionPopRequests   uint64 `json:"reduction_pop_requests"`
+	EmittedPopPaths        uint64 `json:"emitted_pop_paths"`
+	LinkUnionAttempts      uint64 `json:"predecessor_link_union_attempts"`
+	LinkUnionDuplicate     uint64 `json:"predecessor_link_union_duplicate_noop"`
+	LinkUnionPrecedence    uint64 `json:"predecessor_link_union_precedence_replaced"`
+	LinkUnionRecursive     uint64 `json:"predecessor_link_union_recursive_changed"`
+	LinkUnionAppended      uint64 `json:"predecessor_link_union_alternate_appended"`
+	LinkUnionRejected      uint64 `json:"predecessor_link_union_rejected"`
+	AlternateLinksAppended uint64 `json:"alternate_predecessor_links_appended"`
+	GraphLinkAdditions     uint64 `json:"graph_link_additions_proxy"`
+	Overflow               bool   `json:"overflow"`
+}
+
+// mergeCensusCOracle is a built driver: the patched runtime plus the census
+// driver, linked into one executable.
+type mergeCensusCOracle struct {
+	Binary     string
+	RuntimeDir string
+	RuntimeSHA string
+	PatchSHA   string
+	DriverSHA  string
+	root       string
+}
+
+// Cleanup removes the private build tree.
+func (o *mergeCensusCOracle) Cleanup() {
+	if o == nil || o.root == "" {
+		return
+	}
+	_ = os.RemoveAll(o.root)
+}
+
+// mergeCensusBuildCOracle snapshots the pinned runtime source, applies the
+// work-count patch, and links the census driver. The build is hermetic: no
+// network, no repository checkout, and no write to the module cache.
+func mergeCensusBuildCOracle(repoRoot string) (*mergeCensusCOracle, error) {
+	runtimeDir, err := mergeCensusRuntimeDir(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	patchPath := filepath.Join(repoRoot, "cgo_harness", "work_count", "tree_sitter_v0_25_1.patch")
+	driverPath := filepath.Join(repoRoot, "cgo_harness", "pure_c", "merge_census_oracle.c")
+	patchSHA, err := mergeCensusFileSHA(patchPath)
+	if err != nil {
+		return nil, err
+	}
+	driverSHA, err := mergeCensusFileSHA(driverPath)
+	if err != nil {
+		return nil, err
+	}
+
+	root, err := os.MkdirTemp("", "gts-merge-census-c-*")
+	if err != nil {
+		return nil, fmt.Errorf("create merge-census build root: %w", err)
+	}
+	oracle := &mergeCensusCOracle{
+		RuntimeDir: runtimeDir, PatchSHA: patchSHA, DriverSHA: driverSHA, root: root,
+	}
+
+	libRoot := filepath.Join(root, "lib")
+	if err := mergeCensusCopyTree(filepath.Join(runtimeDir, "src"), filepath.Join(libRoot, "src")); err != nil {
+		oracle.Cleanup()
+		return nil, err
+	}
+	if err := mergeCensusCopyTree(filepath.Join(runtimeDir, "include"), filepath.Join(libRoot, "include")); err != nil {
+		oracle.Cleanup()
+		return nil, err
+	}
+	runtimeSHA, err := mergeCensusTreeSHA(libRoot)
+	if err != nil {
+		oracle.Cleanup()
+		return nil, err
+	}
+	oracle.RuntimeSHA = runtimeSHA
+
+	// Make the snapshot its own repository before patching. git apply resolves
+	// paths against the enclosing repository when there is one, so a temporary
+	// directory that happens to sit inside a checkout would otherwise send the
+	// hunks to the wrong tree.
+	initialize := exec.Command("git", "init", "-q", ".")
+	initialize.Dir = root
+	if out, err := initialize.CombinedOutput(); err != nil {
+		oracle.Cleanup()
+		return nil, fmt.Errorf("initialize the runtime snapshot repository: %w: %s", err, bytes.TrimSpace(out))
+	}
+
+	apply := exec.Command("git", "apply", "-p1", patchPath)
+	apply.Dir = root
+	if out, err := apply.CombinedOutput(); err != nil {
+		oracle.Cleanup()
+		return nil, fmt.Errorf(
+			"apply work-count patch to the pinned runtime snapshot: %w: %s\n"+
+				"the patch is the repository's own C instrument; a failure here means the pinned runtime moved and the census must be re-adjudicated, not re-fitted",
+			err, bytes.TrimSpace(out),
+		)
+	}
+
+	binary := filepath.Join(root, "merge_census_oracle")
+	compile := exec.Command(
+		mergeCensusCompiler(),
+		"-O1", "-std=c11", "-D_POSIX_C_SOURCE=200112L", "-D_DEFAULT_SOURCE",
+		"-I"+filepath.Join(libRoot, "include", "tree_sitter"),
+		"-I"+filepath.Join(libRoot, "include"),
+		"-I"+filepath.Join(libRoot, "src"),
+		driverPath,
+		filepath.Join(libRoot, "src", "lib.c"),
+		"-ldl", "-o", binary,
+	)
+	if out, err := compile.CombinedOutput(); err != nil {
+		oracle.Cleanup()
+		return nil, fmt.Errorf("compile merge-census C oracle: %w: %s", err, bytes.TrimSpace(out))
+	}
+	oracle.Binary = binary
+
+	// Run the patch's own three counter models before trusting any count.
+	check := exec.Command(binary, "--exact-model")
+	out, err := check.Output()
+	if err != nil {
+		oracle.Cleanup()
+		return nil, fmt.Errorf("merge-census C oracle self-check: %w", err)
+	}
+	var model struct {
+		Schema string `json:"schema"`
+		Passed bool   `json:"passed"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(out), &model); err != nil {
+		oracle.Cleanup()
+		return nil, fmt.Errorf("decode merge-census C oracle self-check: %w", err)
+	}
+	if model.Schema != "gts-merge-census-c-exact-model/v1" || !model.Passed {
+		oracle.Cleanup()
+		return nil, fmt.Errorf("merge-census C oracle self-check failed: %+v", model)
+	}
+	return oracle, nil
+}
+
+// mergeCensusRepoRoot resolves the repository root from the parity lock the
+// C-reference loader already locates, so the census needs no new path
+// convention.
+func mergeCensusRepoRoot() (string, error) {
+	lockPath, err := findParityLockPath()
+	if err != nil {
+		return "", err
+	}
+	absolute, err := filepath.Abs(lockPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(filepath.Dir(absolute)), nil
+}
+
+func mergeCensusCompiler() string {
+	if value := strings.TrimSpace(os.Getenv("CC")); value != "" {
+		return value
+	}
+	return "cc"
+}
+
+// mergeCensusRuntimeDir resolves the pinned runtime source directory from the
+// module cache. It never downloads and never writes.
+func mergeCensusRuntimeDir(repoRoot string) (string, error) {
+	command := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", mergeCensusRuntimeModule)
+	command.Dir = filepath.Join(repoRoot, "cgo_harness")
+	out, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("resolve %s module directory: %w", mergeCensusRuntimeModule, err)
+	}
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		return "", fmt.Errorf("resolve %s module directory: empty result", mergeCensusRuntimeModule)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "src", "lib.c")); err != nil {
+		return "", fmt.Errorf("pinned runtime source is not at %s: %w", dir, err)
+	}
+	return dir, nil
+}
+
+func mergeCensusFileSHA(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func mergeCensusTreeSHA(root string) (string, error) {
+	digest := sha256.New()
+	var paths []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return "", err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(digest, "%s\n%x\n", filepath.ToSlash(relative), sha256.Sum256(data))
+	}
+	return hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+func mergeCensusCopyTree(source, destination string) error {
+	return filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(destination, relative)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	})
+}
+
+// mergeCensusCSymbols returns the grammar entry-point candidates for a lock
+// row, in the same order the parity loader tries them.
+func mergeCensusCSymbols(name string) ([]string, error) {
+	lockPath, err := findParityLockPath()
+	if err != nil {
+		return nil, err
+	}
+	lock, err := loadParityLock(lockPath)
+	if err != nil {
+		return nil, err
+	}
+	entry, ok := lock[name]
+	if !ok {
+		return nil, fmt.Errorf("parity lock has no entry for %q", name)
+	}
+	return parityLanguageSymbols(entry), nil
+}
+
+// mergeCensusRunC measures every source in one batch. Sources are written to
+// a private directory in manifest order, so the returned rows line up with
+// the input slice index for index.
+func mergeCensusRunC(oracle *mergeCensusCOracle, language string, sources []a3CertificationSweepSource) ([]mergeCensusCRow, error) {
+	if len(sources) == 0 {
+		return nil, nil
+	}
+	identity, err := COracleIdentity(language)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s C oracle identity: %w", language, err)
+	}
+	symbols, err := mergeCensusCSymbols(language)
+	if err != nil {
+		return nil, err
+	}
+
+	batchRoot, err := os.MkdirTemp("", "gts-merge-census-batch-*")
+	if err != nil {
+		return nil, fmt.Errorf("create merge-census batch root: %w", err)
+	}
+	defer os.RemoveAll(batchRoot)
+
+	var manifest strings.Builder
+	paths := make([]string, len(sources))
+	for index, source := range sources {
+		path := filepath.Join(batchRoot, fmt.Sprintf("%06d.src", index))
+		if err := os.WriteFile(path, source.Source, 0o644); err != nil {
+			return nil, fmt.Errorf("write merge-census source: %w", err)
+		}
+		paths[index] = path
+		manifest.WriteString(path)
+		manifest.WriteString("\n")
+	}
+	manifestPath := filepath.Join(batchRoot, "manifest.txt")
+	if err := os.WriteFile(manifestPath, []byte(manifest.String()), 0o644); err != nil {
+		return nil, fmt.Errorf("write merge-census manifest: %w", err)
+	}
+
+	command := exec.Command(
+		oracle.Binary, identity.GrammarArtifactPath,
+		strings.Join(symbols, ","), manifestPath, mergeCensusParseTimeoutUS,
+	)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		return nil, fmt.Errorf("run merge-census C oracle for %s: %w: %s", language, err, bytes.TrimSpace(stderr.Bytes()))
+	}
+
+	byPath := make(map[string]mergeCensusCRow, len(sources))
+	scanner := bufio.NewScanner(&stdout)
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<22)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var row mergeCensusCRow
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			return nil, fmt.Errorf("decode merge-census C row: %w: %s", err, line)
+		}
+		if row.Schema != mergeCensusDriverSchema {
+			return nil, fmt.Errorf("merge-census C row schema %q, want %q", row.Schema, mergeCensusDriverSchema)
+		}
+		byPath[row.Path] = row
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read merge-census C rows: %w", err)
+	}
+
+	rows := make([]mergeCensusCRow, len(sources))
+	for index, path := range paths {
+		row, ok := byPath[path]
+		if !ok {
+			return nil, fmt.Errorf("merge-census C oracle produced no row for %s/%s", language, sources[index].Name)
+		}
+		rows[index] = row
+	}
+	return rows, nil
+}
+
+// mergeCensusRow is one source's full accounting: the reference runtime's
+// merge counts, production's merge counts and refusal breakdown, and the
+// compact core's link-union counts.
+type mergeCensusRow struct {
+	Language string
+	Name     string
+
+	C  mergeCensusCRow
+	Go gotreesitter.MergeEventCensusCounts
+
+	// CompactAccepted reports whether the compact route reached an accept, so
+	// the compact link-union numbers are readable.
+	CompactAccepted bool
+	// GoParseError records a production parse failure. The row still carries
+	// the reference-runtime numbers.
+	GoParseError string
+}
+
+// MergeRatio is M_p/M_c for this source: production merge successes divided
+// by the reference runtime's merge successes. It is defined only when the
+// reference runtime merged at least once.
+func (r mergeCensusRow) MergeRatio() (float64, bool) {
+	if r.C.MergeSuccesses == 0 {
+		return 0, false
+	}
+	return float64(r.Go.Successes) / float64(r.C.MergeSuccesses), true
+}
+
+// runMergeEventCensusRow measures one source on all three engines.
+//
+// Production runs on the DEFAULT route, because the refusal gates under
+// measurement (the score-equality gate, the distinct-materializing-shapes
+// refusal, and the deep link-payload test) are production GSS code. The
+// compact route runs second, only to read the compact core's own link-union
+// counters at its acceptance.
+func runMergeEventCensusRow(
+	language string, lang *gotreesitter.Language, name string, source []byte, cRow mergeCensusCRow,
+) mergeCensusRow {
+	row := mergeCensusRow{Language: language, Name: name, C: cRow}
+
+	gotreesitter.MergeEventCensusReset()
+	parser := gotreesitter.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		row.GoParseError = err.Error()
+	} else if tree != nil {
+		tree.Release()
+	}
+	row.Go = gotreesitter.MergeEventCensusSnapshot()
+
+	compactParser := gotreesitter.NewParser(lang)
+	compactParser.SetAdmissionCandidateRoute(true)
+	compactTree, compactErr := compactParser.Parse(source)
+	if compactErr == nil && compactTree != nil {
+		compactTree.Release()
+	}
+	compact := gotreesitter.MergeEventCensusSnapshot()
+	if compact.CompactAcceptancesObserved > row.Go.CompactAcceptancesObserved {
+		row.CompactAccepted = true
+		row.Go.CompactLinkUnionAttempts = compact.CompactLinkUnionAttempts
+		row.Go.CompactLinkUnionDuplicateNoop = compact.CompactLinkUnionDuplicateNoop
+		row.Go.CompactLinkUnionPrecedenceReplaced = compact.CompactLinkUnionPrecedenceReplaced
+		row.Go.CompactLinkUnionRecursiveChanged = compact.CompactLinkUnionRecursiveChanged
+		row.Go.CompactLinkUnionAlternateAppended = compact.CompactLinkUnionAlternateAppended
+		row.Go.CompactLinkUnionRejected = compact.CompactLinkUnionRejected
+		row.Go.CompactAcceptancesObserved = compact.CompactAcceptancesObserved
+	}
+	return row
+}
+
+// mergeCensusTotals aggregates rows for one corpus.
+type mergeCensusTotals struct {
+	Sources int
+
+	CMergeAttempts  uint64
+	CMergeSuccesses uint64
+	CLinkUnionAttempts,
+	CLinkUnionDuplicate,
+	CLinkUnionPrecedence,
+	CLinkUnionRecursive,
+	CLinkUnionAppended,
+	CLinkUnionRejected uint64
+
+	GoAttempts  uint64
+	GoSuccesses uint64
+
+	RefuseNoGSSHead      uint64
+	RefuseNoGSSHeadBoth  uint64
+	RefuseNoGSSHeadOne   uint64
+	RefuseStatus         uint64
+	RefuseScoreOrShifted uint64
+	RefuseScoreOnly      uint64
+	RefuseShiftedOnly    uint64
+	RefuseStateOrOffset  uint64
+	RefuseCleanZero      uint64
+	RefuseErrorCost      uint64
+	RefuseDistinctShapes uint64
+	RefuseMergeFailed    uint64
+
+	LinkPayloadTests              uint64
+	LinkPayloadDeepAccepts        uint64
+	LinkPayloadDeepRefusals       uint64
+	LinkPayloadShallowWouldAccept uint64
+	LinkPayloadDeepWouldAccept    uint64
+	LinkPayloadPending            uint64
+
+	CompactAccepted     int
+	CompactUnionAttempt uint64
+	CompactUnionAppend  uint64
+	CompactUnionDup     uint64
+	CompactUnionReject  uint64
+
+	// SourcesWhereGoOverMerges is the stop-the-line class of gate G6: a source
+	// where production collapses MORE versions than the reference runtime.
+	SourcesWhereGoOverMerges int
+	// SourcesWhereCMergesAndGoDoesNot is the lane's headline class: the
+	// reference runtime collapsed at least one pair and production collapsed
+	// none.
+	SourcesWhereCMergesAndGoDoesNot int
+}
+
+func (t *mergeCensusTotals) add(row mergeCensusRow) {
+	t.Sources++
+
+	t.CMergeAttempts += row.C.MergeAttempts
+	t.CMergeSuccesses += row.C.MergeSuccesses
+	t.CLinkUnionAttempts += row.C.LinkUnionAttempts
+	t.CLinkUnionDuplicate += row.C.LinkUnionDuplicate
+	t.CLinkUnionPrecedence += row.C.LinkUnionPrecedence
+	t.CLinkUnionRecursive += row.C.LinkUnionRecursive
+	t.CLinkUnionAppended += row.C.LinkUnionAppended
+	t.CLinkUnionRejected += row.C.LinkUnionRejected
+
+	t.GoAttempts += row.Go.Attempts
+	t.GoSuccesses += row.Go.Successes
+
+	t.RefuseNoGSSHead += row.Go.RefuseNoGSSHead
+	t.RefuseNoGSSHeadBoth += row.Go.RefuseNoGSSHeadBoth
+	t.RefuseNoGSSHeadOne += row.Go.RefuseNoGSSHeadOne
+	t.RefuseStatus += row.Go.RefuseStatus
+	t.RefuseScoreOrShifted += row.Go.RefuseScoreOrShifted
+	t.RefuseScoreOnly += row.Go.RefuseScoreOnly
+	t.RefuseShiftedOnly += row.Go.RefuseShiftedOnly
+	t.RefuseStateOrOffset += row.Go.RefuseStateOrOffset
+	t.RefuseCleanZero += row.Go.RefuseCleanZero
+	t.RefuseErrorCost += row.Go.RefuseErrorCost
+	t.RefuseDistinctShapes += row.Go.RefuseDistinctShapes
+	t.RefuseMergeFailed += row.Go.RefuseMergeFailed
+
+	t.LinkPayloadTests += row.Go.LinkPayloadTests
+	t.LinkPayloadDeepAccepts += row.Go.LinkPayloadDeepAccepts
+	t.LinkPayloadDeepRefusals += row.Go.LinkPayloadDeepRefusals
+	t.LinkPayloadShallowWouldAccept += row.Go.LinkPayloadShallowWouldAccept
+	t.LinkPayloadDeepWouldAccept += row.Go.LinkPayloadDeepWouldAccept
+	t.LinkPayloadPending += row.Go.LinkPayloadPending
+
+	if row.CompactAccepted {
+		t.CompactAccepted++
+		t.CompactUnionAttempt += row.Go.CompactLinkUnionAttempts
+		t.CompactUnionAppend += row.Go.CompactLinkUnionAlternateAppended
+		t.CompactUnionDup += row.Go.CompactLinkUnionDuplicateNoop
+		t.CompactUnionReject += row.Go.CompactLinkUnionRejected
+	}
+
+	if row.Go.Successes > row.C.MergeSuccesses {
+		t.SourcesWhereGoOverMerges++
+	}
+	if row.C.MergeSuccesses > 0 && row.Go.Successes == 0 {
+		t.SourcesWhereCMergesAndGoDoesNot++
+	}
+}
+
+// Ratio is the corpus-level M_p/M_c: production merge successes over the
+// reference runtime's merge successes. The lane drives it toward 1.
+func (t *mergeCensusTotals) Ratio() (float64, bool) {
+	if t.CMergeSuccesses == 0 {
+		return 0, false
+	}
+	return float64(t.GoSuccesses) / float64(t.CMergeSuccesses), true
+}
+
+func (t *mergeCensusTotals) ratioText() string {
+	ratio, ok := t.Ratio()
+	if !ok {
+		return "undefined"
+	}
+	return fmt.Sprintf("%.4f", ratio)
+}
+
+// refusalLine renders the refusal breakdown, highest class first, so the
+// dominant gate is readable without arithmetic.
+func (t *mergeCensusTotals) refusalLine() string {
+	type entry struct {
+		Name  string
+		Count uint64
+	}
+	entries := []entry{
+		{"score-or-shifted", t.RefuseScoreOrShifted},
+		{"state-or-offset", t.RefuseStateOrOffset},
+		{"clean-zero", t.RefuseCleanZero},
+		{"error-cost", t.RefuseErrorCost},
+		{"distinct-shapes", t.RefuseDistinctShapes},
+		{"status", t.RefuseStatus},
+		{"no-gss-head-both-flat", t.RefuseNoGSSHeadBoth},
+		{"no-gss-head-one-flat", t.RefuseNoGSSHeadOne},
+		{"merge-failed", t.RefuseMergeFailed},
+	}
+	sort.SliceStable(entries, func(i, j int) bool { return entries[i].Count > entries[j].Count })
+	parts := make([]string, 0, len(entries))
+	for _, item := range entries {
+		parts = append(parts, fmt.Sprintf("%s=%d", item.Name, item.Count))
+	}
+	return strings.Join(parts, " ")
+}
+
+// linkPayloadLine renders the Tier-2 accounting, whose headline number is
+// shallow-would-accept: the count of reference-runtime collapses production's
+// deep test turns into appends.
+func (t *mergeCensusTotals) linkPayloadLine() string {
+	return fmt.Sprintf(
+		"tests=%d deep-accept=%d deep-refuse=%d shallow-would-accept=%d deep-would-accept=%d pending=%d",
+		t.LinkPayloadTests, t.LinkPayloadDeepAccepts, t.LinkPayloadDeepRefusals,
+		t.LinkPayloadShallowWouldAccept, t.LinkPayloadDeepWouldAccept, t.LinkPayloadPending,
+	)
+}

--- a/cgo_harness/merge_event_census_test.go
+++ b/cgo_harness/merge_event_census_test.go
@@ -1,0 +1,472 @@
+//go:build cgo && treesitter_c_parity && gts_merge_census
+
+package cgoharness
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// Stage M0 receipts for spec.merge-time-election.v1.
+//
+// Reproduce with:
+//
+//	cd cgo_harness
+//	GOFLAGS=-buildvcs=false GTS_PARITY_ALLOW_HOST=1 \
+//	  GTS_PARITY_C_REF_BUILD_CACHE=<cache> CGO_ENABLED=1 \
+//	  go test -tags "cgo treesitter_c_parity gts_merge_census" \
+//	  -run 'TestMergeEventCensus' -count=1 -v .
+//
+// The gts_merge_census tag is what compiles the production-side census into
+// the library at all. Without it the library has no instrument, so every
+// shipped gate runs against exactly the code main ships
+// (merge_event_census_inert_test.go ratchets that).
+
+// mergeCensusOracleForTest builds the instrumented reference runtime once per
+// test binary run.
+var mergeCensusOracleCache *mergeCensusCOracle
+
+func mergeCensusOracleForTest(t *testing.T) *mergeCensusCOracle {
+	t.Helper()
+	if mergeCensusOracleCache != nil {
+		return mergeCensusOracleCache
+	}
+	repoRoot, err := mergeCensusRepoRoot()
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	oracle, err := mergeCensusBuildCOracle(repoRoot)
+	if err != nil {
+		t.Fatalf("build the instrumented reference runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		oracle.Cleanup()
+		mergeCensusOracleCache = nil
+	})
+	t.Logf(
+		"instrumented reference runtime: source=%s runtime-sha=%s patch-sha=%s driver-sha=%s",
+		oracle.RuntimeDir, oracle.RuntimeSHA[:16], oracle.PatchSHA[:16], oracle.DriverSHA[:16],
+	)
+	mergeCensusOracleCache = oracle
+	return oracle
+}
+
+// mergeCensusBaselineConstructed pins the constructed-source portion of the
+// M0 baseline. Constructed sources are compiled into this package, so every
+// host reproduces these numbers exactly.
+//
+// Every number here is a MEASUREMENT pinned after the fact, not a prediction.
+// Stage M1 must move Ratio toward 1 and must not raise
+// SourcesWhereGoOverMerges above zero; a change in any other field is a
+// change in the lane's ground truth and must be re-adjudicated, not
+// re-fitted.
+var mergeCensusBaselineConstructed = map[string]struct {
+	Sources int
+	// CMergeSuccesses is M_c, the reference runtime's collapsed pairs.
+	CMergeSuccesses uint64
+	// GoSuccesses is M_p, production's collapsed pairs.
+	GoSuccesses uint64
+	// RefuseNoGSSHead, RefuseScoreOrShifted, RefuseDistinctShapes and
+	// LinkPayloadShallowWouldAccept are the four refusal classes stage M1
+	// must answer for. The middle two are items 1 and 2 of spec section 1.2;
+	// the last is item 3's cost; the first has no counterpart in the
+	// reference runtime at all.
+	RefuseNoGSSHead               uint64
+	RefuseScoreOrShifted          uint64
+	RefuseDistinctShapes          uint64
+	LinkPayloadShallowWouldAccept uint64
+	// SourcesWhereGoOverMerges is gate G6's stop-the-line class: production
+	// collapsing MORE versions than the reference runtime.
+	SourcesWhereGoOverMerges int
+	// SourcesWhereCMergesAndGoDoesNot is the lane's headline class.
+	SourcesWhereCMergesAndGoDoesNot int
+}{
+	"apex":   {Sources: 25, CMergeSuccesses: 31, GoSuccesses: 1, RefuseNoGSSHead: 53, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 53, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 5},
+	"perl":   {Sources: 17, CMergeSuccesses: 57, GoSuccesses: 0, RefuseNoGSSHead: 43, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 0, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 7},
+	"ada":    {Sources: 23, CMergeSuccesses: 47, GoSuccesses: 2, RefuseNoGSSHead: 35, RefuseScoreOrShifted: 92, RefuseDistinctShapes: 6, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 5},
+	"kotlin": {Sources: 13, CMergeSuccesses: 54, GoSuccesses: 12, RefuseNoGSSHead: 2, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 0, LinkPayloadShallowWouldAccept: 10, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 3},
+	"python": {Sources: 26, CMergeSuccesses: 2, GoSuccesses: 0, RefuseNoGSSHead: 9, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 0, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 2},
+}
+
+// The M0 pinned aggregate over the five A3 sweep corpora's constructed
+// sources. M_p/M_c = 15/191 = 0.0785. That ratio is the lane's progress
+// number alongside D0's 32 set differences: stage M1 onward drives it toward
+// 1, and gate G6 forbids any source where production merges more than the
+// reference runtime.
+const (
+	mergeCensusBaselineCMerges  uint64 = 191
+	mergeCensusBaselineGoMerges uint64 = 15
+	// mergeCensusBaselineSources is the constructed-source denominator, the
+	// same 104 sources D0 measures.
+	mergeCensusBaselineSources = 104
+)
+
+// TestMergeEventCensusBaseline publishes the M0 baseline: how many merges the
+// reference runtime performs, how many production performs, and which gate
+// refuses the rest, for the five A3 sweep corpora and the real corpus.
+//
+// The five corpora are D0's own corpora, source for source
+// (derivationSetCensusLanguages), so the two censuses share a denominator.
+func TestMergeEventCensusBaseline(t *testing.T) {
+	if !gotreesitter.MergeEventCensusBuilt() {
+		t.Fatal("the merge-event census is not compiled into the library; build with -tags gts_merge_census")
+	}
+	oracle := mergeCensusOracleForTest(t)
+
+	grand := &mergeCensusTotals{}
+	grandConstructed := &mergeCensusTotals{}
+	var rows []string
+
+	for _, entry := range derivationSetCensusLanguages() {
+		lang := entry.Language()
+		constructed := entry.Constructed()
+		real := derivationSetLoadRealCorpus(t, entry.RealDir)
+
+		constructedTotals := &mergeCensusTotals{}
+		realTotals := &mergeCensusTotals{}
+
+		for _, group := range []struct {
+			Sources []a3CertificationSweepSource
+			Totals  *mergeCensusTotals
+			Grand   []*mergeCensusTotals
+		}{
+			{constructed, constructedTotals, []*mergeCensusTotals{grandConstructed, grand}},
+			{real, realTotals, []*mergeCensusTotals{grand}},
+		} {
+			if len(group.Sources) == 0 {
+				continue
+			}
+			cRows, err := mergeCensusRunC(oracle, entry.Name, group.Sources)
+			if err != nil {
+				t.Fatalf("%s: %v", entry.Name, err)
+			}
+			for index, source := range group.Sources {
+				row := runMergeEventCensusRow(entry.Name, lang, source.Name, source.Source, cRows[index])
+				group.Totals.add(row)
+				for _, target := range group.Grand {
+					target.add(row)
+				}
+				mergeCensusLogRow(t, row)
+			}
+		}
+
+		rows = append(rows, mergeCensusFormatTotals(entry.Name+" constructed", constructedTotals))
+		rows = append(rows, mergeCensusFormatTotals(entry.Name+" real       ", realTotals))
+
+		want, pinned := mergeCensusBaselineConstructed[entry.Name]
+		if !pinned {
+			t.Errorf("%s: no pinned constructed baseline", entry.Name)
+			continue
+		}
+		if constructedTotals.Sources != want.Sources {
+			t.Errorf("%s: constructed source count %d, want %d", entry.Name, constructedTotals.Sources, want.Sources)
+		}
+		if constructedTotals.CMergeSuccesses != want.CMergeSuccesses {
+			t.Errorf("%s: reference-runtime merges %d, want %d", entry.Name, constructedTotals.CMergeSuccesses, want.CMergeSuccesses)
+		}
+		if constructedTotals.GoSuccesses != want.GoSuccesses {
+			t.Errorf("%s: production merges %d, want %d", entry.Name, constructedTotals.GoSuccesses, want.GoSuccesses)
+		}
+		if constructedTotals.RefuseNoGSSHead != want.RefuseNoGSSHead {
+			t.Errorf("%s: no-packed-head refusals %d, want %d", entry.Name, constructedTotals.RefuseNoGSSHead, want.RefuseNoGSSHead)
+		}
+		if constructedTotals.SourcesWhereCMergesAndGoDoesNot != want.SourcesWhereCMergesAndGoDoesNot {
+			t.Errorf("%s: sources where the reference runtime merges and production does not %d, want %d", entry.Name, constructedTotals.SourcesWhereCMergesAndGoDoesNot, want.SourcesWhereCMergesAndGoDoesNot)
+		}
+		if constructedTotals.RefuseScoreOrShifted != want.RefuseScoreOrShifted {
+			t.Errorf("%s: score-or-shifted refusals %d, want %d", entry.Name, constructedTotals.RefuseScoreOrShifted, want.RefuseScoreOrShifted)
+		}
+		if constructedTotals.RefuseDistinctShapes != want.RefuseDistinctShapes {
+			t.Errorf("%s: distinct-shape refusals %d, want %d", entry.Name, constructedTotals.RefuseDistinctShapes, want.RefuseDistinctShapes)
+		}
+		if constructedTotals.LinkPayloadShallowWouldAccept != want.LinkPayloadShallowWouldAccept {
+			t.Errorf("%s: shallow-would-accept comparisons %d, want %d", entry.Name, constructedTotals.LinkPayloadShallowWouldAccept, want.LinkPayloadShallowWouldAccept)
+		}
+		if constructedTotals.SourcesWhereGoOverMerges != want.SourcesWhereGoOverMerges {
+			t.Errorf("%s: sources where production over-merges %d, want %d", entry.Name, constructedTotals.SourcesWhereGoOverMerges, want.SourcesWhereGoOverMerges)
+		}
+	}
+
+	t.Log("M0 BASELINE CENSUS -- merge events per language")
+	for _, row := range rows {
+		t.Log(row)
+	}
+	t.Log(mergeCensusFormatTotals("TOTAL constructed", grandConstructed))
+	t.Log(mergeCensusFormatTotals("TOTAL all corpora", grand))
+	t.Logf("MERGE RATIO M_p/M_c (constructed)=%s (all corpora)=%s", grandConstructed.ratioText(), grand.ratioText())
+	t.Logf("REFUSAL BREAKDOWN (constructed): %s", grandConstructed.refusalLine())
+	t.Logf("TIER-2 LINK PAYLOAD (constructed): %s", grandConstructed.linkPayloadLine())
+
+	// The pinned aggregate. A fall in M_c or a rise in M_p is the point of
+	// stages M1 onward, but the pin moves with a receipt, never silently.
+	if grandConstructed.Sources != mergeCensusBaselineSources {
+		t.Errorf("constructed source count %d, pinned at %d", grandConstructed.Sources, mergeCensusBaselineSources)
+	}
+	if grandConstructed.CMergeSuccesses != mergeCensusBaselineCMerges {
+		t.Errorf(
+			"reference-runtime merge total M_c is %d, pinned at %d -- M_c is a property of the reference runtime and must not move at all unless the pinned grammars or the pinned runtime moved",
+			grandConstructed.CMergeSuccesses, mergeCensusBaselineCMerges,
+		)
+	}
+	if grandConstructed.GoSuccesses != mergeCensusBaselineGoMerges {
+		t.Errorf(
+			"production merge total M_p is %d, pinned at %d -- a RISE is the point of stages M1 onward, but the pin must move with the receipt, never silently",
+			grandConstructed.GoSuccesses, mergeCensusBaselineGoMerges,
+		)
+	}
+
+	// Gate G6 in advance: a source where production collapses MORE versions
+	// than the reference runtime is a stop-the-line over-merge from stage M1
+	// on. M0 pins the baseline at zero so the gate has a floor.
+	if grand.SourcesWhereGoOverMerges != 0 {
+		t.Errorf(
+			"OVER-MERGE: %d sources where production merges more than the reference runtime; the M0 baseline is zero and gate G6 is stop-the-line",
+			grand.SourcesWhereGoOverMerges,
+		)
+	}
+}
+
+func mergeCensusFormatTotals(label string, t *mergeCensusTotals) string {
+	return fmt.Sprintf(
+		"%-22s sources=%3d M_c=%6d M_p=%6d ratio=%-8s c-attempts=%7d go-attempts=%7d over-merge-sources=%d c-merges-go-does-not=%d | refusals: %s | tier2: %s | compact: accepted=%d union-attempts=%d union-appends=%d",
+		label, t.Sources, t.CMergeSuccesses, t.GoSuccesses, t.ratioText(),
+		t.CMergeAttempts, t.GoAttempts, t.SourcesWhereGoOverMerges, t.SourcesWhereCMergesAndGoDoesNot,
+		t.refusalLine(), t.linkPayloadLine(),
+		t.CompactAccepted, t.CompactUnionAttempt, t.CompactUnionAppend,
+	)
+}
+
+func mergeCensusLogRow(t *testing.T, row mergeCensusRow) {
+	t.Helper()
+	if !testing.Verbose() {
+		return
+	}
+	ratio := "undefined"
+	if value, ok := row.MergeRatio(); ok {
+		ratio = fmt.Sprintf("%.4f", value)
+	}
+	t.Logf(
+		"%s/%s: M_c=%d M_p=%d ratio=%s c-status=%s c-link-union(att=%d dup=%d prec=%d rec=%d app=%d rej=%d) go-refusals(score=%d shapes=%d clean=%d state=%d cost=%d) tier2-shallow-would-accept=%d",
+		row.Language, row.Name, row.C.MergeSuccesses, row.Go.Successes, ratio, row.C.Status,
+		row.C.LinkUnionAttempts, row.C.LinkUnionDuplicate, row.C.LinkUnionPrecedence,
+		row.C.LinkUnionRecursive, row.C.LinkUnionAppended, row.C.LinkUnionRejected,
+		row.Go.RefuseScoreOrShifted, row.Go.RefuseDistinctShapes, row.Go.RefuseCleanZero,
+		row.Go.RefuseStateOrOffset, row.Go.RefuseErrorCost,
+		row.Go.LinkPayloadShallowWouldAccept,
+	)
+}
+
+// mergeCensusFooIntWitness is one source in the Foo[int](a) discriminator
+// measurement.
+type mergeCensusFooIntWitness struct {
+	Name   string
+	Source string
+	// Frame marks the bracket-free control whose counters are subtracted from
+	// every other row.
+	Frame bool
+	Note  string
+}
+
+// TestMergeEventCensusFooIntWitness takes the discriminator receipt section 3
+// of spec.merge-time-election.v1 demands before any compact collapse lands.
+//
+// The compact core defers a shallow-class precedence tie because a first-wins
+// collapse under unproven order published the wrong tree for Go `Foo[int](a)`:
+// call_expression(index_expression) against
+// type_conversion_expression(generic_type) (core.go:1989-2002). What the
+// reference runtime does with that pair was UNMEASURED. Exactly three
+// behaviours are consistent with everything known, and the work-count patch's
+// GTSLinkUnionOutcome counters discriminate them:
+//
+//  1. The reference runtime never builds the pair. The witness adds no
+//     link-union traffic. Then the deferral is not a workaround for a missing
+//     merge and the surplus arm is upstream.
+//  2. The reference runtime packs both links and elects at the pop.
+//     predecessor_link_union_alternate_appended rises. Then stage M3's pop
+//     election replaces the deferral for this class with no order proof.
+//  3. The reference runtime collapses at the same-node-pair branch.
+//     predecessor_link_union_precedence_replaced rises (precedence decides)
+//     or only predecessor_link_union_duplicate_noop rises (incumbency
+//     decides).
+//
+// The counters are parse-global, so the measurement needs a control. The
+// control is `_ = g(a)`: the same statement frame with no bracket, therefore
+// no generic-instantiation conflict at all. `_ = a[b](c)` is NOT a control:
+// it carries the SAME conflict, because `a[b]` also reads as a generic
+// instantiation. The measurement below shows the two produce identical
+// counters, which is itself part of the receipt.
+func TestMergeEventCensusFooIntWitness(t *testing.T) {
+	if !gotreesitter.MergeEventCensusBuilt() {
+		t.Fatal("the merge-event census is not compiled into the library; build with -tags gts_merge_census")
+	}
+	oracle := mergeCensusOracleForTest(t)
+
+	witnesses := []mergeCensusFooIntWitness{
+		{
+			Name: "frame_only_g_call", Source: "package p\n\nfunc f() {\n\t_ = g(a)\n}\n", Frame: true,
+			Note: "control: the same statement frame with no bracket, so no generic-instantiation conflict",
+		},
+		{
+			Name: "foo_int_a", Source: "package p\n\nfunc f() {\n\t_ = Foo[int](a)\n}\n",
+			Note: "the witness: call_expression(index_expression) against type_conversion_expression(generic_type)",
+		},
+		{
+			Name: "index_call_a_b_c", Source: "package p\n\nfunc f() {\n\t_ = a[b](c)\n}\n",
+			Note: "the same conflict written with plain identifiers, kept to show it is not a control",
+		},
+		{
+			Name: "bare_instantiation", Source: "package p\n\nfunc f() {\n\t_ = Foo[int]\n}\n",
+			Note: "the instantiation without the call, which isolates the bracket half of the conflict",
+		},
+	}
+
+	sources := make([]a3CertificationSweepSource, len(witnesses))
+	for index, witness := range witnesses {
+		sources[index] = a3CertificationSweepSource{Name: witness.Name, Source: []byte(witness.Source)}
+	}
+	cRows, err := mergeCensusRunC(oracle, "go", sources)
+	if err != nil {
+		t.Fatalf("measure the Foo[int](a) witness on the reference runtime: %v", err)
+	}
+
+	var frame mergeCensusCRow
+	for index, witness := range witnesses {
+		if witness.Frame {
+			frame = cRows[index]
+		}
+		if cRows[index].Status != "ok" {
+			t.Fatalf("%s: reference runtime status %q", witness.Name, cRows[index].Status)
+		}
+	}
+
+	lang := grammars.GoLanguage()
+	cLang, err := COracleLanguage("go")
+	if err != nil {
+		t.Fatalf("load go C oracle: %v", err)
+	}
+
+	verdicts := make([]string, len(witnesses))
+	for index, witness := range witnesses {
+		row := runMergeEventCensusRow("go", lang, witness.Name, []byte(witness.Source), cRows[index])
+		t.Logf("WITNESS %-20s -- %s", witness.Name, witness.Note)
+		t.Logf("    merges              : M_c=%d M_p=%d", row.C.MergeSuccesses, row.Go.Successes)
+		t.Logf(
+			"    reference link union: attempts=%d duplicate_noop=%d precedence_replaced=%d recursive_changed=%d alternate_appended=%d rejected=%d",
+			row.C.LinkUnionAttempts, row.C.LinkUnionDuplicate, row.C.LinkUnionPrecedence,
+			row.C.LinkUnionRecursive, row.C.LinkUnionAppended, row.C.LinkUnionRejected,
+		)
+		if !witness.Frame {
+			t.Logf(
+				"    delta over control  : attempts=%+d duplicate_noop=%+d precedence_replaced=%+d recursive_changed=%+d alternate_appended=%+d",
+				int64(row.C.LinkUnionAttempts)-int64(frame.LinkUnionAttempts),
+				int64(row.C.LinkUnionDuplicate)-int64(frame.LinkUnionDuplicate),
+				int64(row.C.LinkUnionPrecedence)-int64(frame.LinkUnionPrecedence),
+				int64(row.C.LinkUnionRecursive)-int64(frame.LinkUnionRecursive),
+				int64(row.C.LinkUnionAppended)-int64(frame.LinkUnionAppended),
+			)
+		}
+		t.Logf(
+			"    production refusals : score-or-shifted=%d distinct-shapes=%d clean-zero=%d state-or-offset=%d error-cost=%d",
+			row.Go.RefuseScoreOrShifted, row.Go.RefuseDistinctShapes, row.Go.RefuseCleanZero,
+			row.Go.RefuseStateOrOffset, row.Go.RefuseErrorCost,
+		)
+		t.Logf(
+			"    production tier 2   : tests=%d deep-refuse=%d shallow-would-accept=%d",
+			row.Go.LinkPayloadTests, row.Go.LinkPayloadDeepRefusals, row.Go.LinkPayloadShallowWouldAccept,
+		)
+		t.Logf("    reference published : %s", mergeCensusPublishedShape(cLang, []byte(witness.Source)))
+		if witness.Frame {
+			verdicts[index] = "control row; no verdict"
+		} else {
+			verdicts[index] = mergeCensusFooIntVerdict(row.C, frame)
+		}
+		t.Logf("    VERDICT: %s", verdicts[index])
+	}
+
+	t.Log("FOO[INT](A) RECEIPT -- spec.merge-time-election.v1 section 3")
+	for index, witness := range witnesses {
+		t.Logf("  %-20s %s", witness.Name, verdicts[index])
+	}
+
+	// The receipt must be decidable, not merely reported. A verdict that stays
+	// ambiguous is a real outcome and the test says so; it does not choose.
+	for index, witness := range witnesses {
+		if witness.Frame {
+			continue
+		}
+		if strings.HasPrefix(verdicts[index], "AMBIGUOUS") {
+			t.Logf("%s: the discriminator is ambiguous at this witness; stage M3 must not assume an outcome for it", witness.Name)
+		}
+	}
+}
+
+// mergeCensusPublishedShape renders the reference runtime's published tree in
+// one line, so the receipt records WHICH reading the reference runtime chose
+// beside the counters that show HOW it chose.
+func mergeCensusPublishedShape(cLang *sitter.Language, source []byte) string {
+	parser := sitter.NewParser()
+	defer parser.Close()
+	if err := parser.SetLanguage(cLang); err != nil {
+		return "<set-language error: " + err.Error() + ">"
+	}
+	tree := parser.Parse(source, nil)
+	if tree == nil {
+		return "<no tree>"
+	}
+	defer tree.Close()
+	root := tree.RootNode()
+	if root == nil {
+		return "<no root>"
+	}
+	return root.ToSexp()
+}
+
+// mergeCensusFooIntVerdict names which of the three consistent reference
+// behaviours the counters show, or states plainly that the reading is
+// ambiguous. Every count is a delta over the bracket-free control, so the
+// verdict describes the witness rather than the statement frame.
+func mergeCensusFooIntVerdict(row, frame mergeCensusCRow) string {
+	appended := int64(row.LinkUnionAppended) - int64(frame.LinkUnionAppended)
+	duplicate := int64(row.LinkUnionDuplicate) - int64(frame.LinkUnionDuplicate)
+	precedence := int64(row.LinkUnionPrecedence) - int64(frame.LinkUnionPrecedence)
+	recursive := int64(row.LinkUnionRecursive) - int64(frame.LinkUnionRecursive)
+
+	suffix := ""
+	if duplicate > 0 && appended > 0 {
+		suffix = fmt.Sprintf(
+			" The same region also adds %d duplicate no-ops, so the reference runtime collapses some pairs by incumbency while packing others; the counters are parse-global and cannot say which node each one landed on.",
+			duplicate,
+		)
+	}
+
+	switch {
+	case appended <= 0 && duplicate <= 0 && precedence <= 0 && recursive <= 0:
+		return "BEHAVIOUR 1 (pair never built): the witness adds no link-union traffic over the bracket-free control, so the reference runtime never held two links to collapse; the compact deferral is not a workaround for a missing merge and the surplus arm is upstream"
+	case precedence > 0 && appended <= 0:
+		return fmt.Sprintf(
+			"BEHAVIOUR 3 (collapsed by precedence): the witness adds %d precedence replacements and no alternate append, so strict dynamic precedence decides; compact must verify its scoreDelta accounting against the reference sum before porting the comparison",
+			precedence,
+		)
+	case appended > 0 && precedence == 0:
+		return fmt.Sprintf(
+			"BEHAVIOUR 2 (packed, elected at the pop): the witness adds %d alternate link appends and ZERO precedence replacements, so the reference runtime packs both links and the first spanning pop elects; stage M3's pop election replaces the deferral for this class with no order proof needed.%s",
+			appended, suffix,
+		)
+	case duplicate > 0 && appended <= 0 && precedence <= 0:
+		return fmt.Sprintf(
+			"BEHAVIOUR 3 (collapsed by incumbency): the witness adds %d duplicate no-ops and neither an append nor a precedence replacement, so the incumbent link survives the tie; the discriminator is version arrival order and compact must reproduce it structurally or keep the deferral",
+			duplicate,
+		)
+	default:
+		return fmt.Sprintf(
+			"AMBIGUOUS: the witness adds appends=%d duplicate=%d precedence=%d recursive=%d, which matches more than one of the three consistent behaviours; reported as ambiguous rather than chosen",
+			appended, duplicate, precedence, recursive,
+		)
+	}
+}

--- a/cgo_harness/pure_c/merge_census_oracle.c
+++ b/cgo_harness/pure_c/merge_census_oracle.c
@@ -1,0 +1,234 @@
+// Merge-event census oracle, reference-runtime side (stage M0 of
+// spec.merge-time-election.v1).
+//
+// The stage-D0 derivation-set differential reconstructs the reference
+// runtime's live version set from ts_parser_set_logger output. That method
+// cannot reach a merge event: parser.c calls ts_stack_merge at four sites
+// (parser.c:1033, :1114, :1513, :1796/:1805) and NONE of them logs. The only
+// merge-adjacent log line is "condense", which parser.c:1855 emits when
+// made_changes is set by any of removal, merge, or swap, so it cannot be
+// counted as a merge. The census therefore uses the instrumented build, which
+// the repository already carries: cgo_harness/work_count/tree_sitter_v0_25_1.patch
+// adds merge_attempts_proxy and merge_successes_proxy directly around
+// ts_stack_merge (stack.c) and the six GTSLinkUnionOutcome counters around
+// stack_node_add_link.
+//
+// This driver is compiled against the SAME runtime source the pinned C oracle
+// uses (github.com/tree-sitter/go-tree-sitter@v0.25.0/src, resolved from the
+// module cache and patched into a private snapshot) and it dlopens the SAME
+// grammar shared object the parity C-reference loader built. Both sides of
+// the census therefore run one runtime and one grammar table.
+//
+// Protocol: read a manifest of source paths, parse each with a fresh parser,
+// print one JSON object per line. A per-source failure prints a status field
+// and never aborts the batch.
+
+#include <dlfcn.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "api.h"
+#include "work_count.h"
+
+typedef const TSLanguage *(*gts_lang_fn)(void);
+
+static char *read_file(const char *path, size_t *out_len) {
+  FILE *file = fopen(path, "rb");
+  if (!file) return NULL;
+  if (fseek(file, 0, SEEK_END) != 0) {
+    fclose(file);
+    return NULL;
+  }
+  long end = ftell(file);
+  if (end < 0 || fseek(file, 0, SEEK_SET) != 0) {
+    fclose(file);
+    return NULL;
+  }
+  char *buf = malloc((size_t)end + 1u);
+  if (!buf) {
+    fclose(file);
+    return NULL;
+  }
+  size_t n = fread(buf, 1u, (size_t)end, file);
+  if (n != (size_t)end || ferror(file)) {
+    free(buf);
+    fclose(file);
+    return NULL;
+  }
+  fclose(file);
+  buf[n] = '\0';
+  *out_len = n;
+  return buf;
+}
+
+static void print_escaped(const char *value) {
+  for (const char *p = value; *p; p++) {
+    switch (*p) {
+      case '"': fputs("\\\"", stdout); break;
+      case '\\': fputs("\\\\", stdout); break;
+      case '\n': fputs("\\n", stdout); break;
+      case '\r': fputs("\\r", stdout); break;
+      case '\t': fputs("\\t", stdout); break;
+      default:
+        if ((unsigned char)*p < 0x20) {
+          printf("\\u%04x", (unsigned char)*p);
+        } else {
+          fputc(*p, stdout);
+        }
+    }
+  }
+}
+
+static void print_row(const char *path, const char *status, GTSWorkCount c,
+                      uint32_t source_len, uint32_t root_end_byte,
+                      bool root_has_error) {
+  printf("{\"schema\":\"gts-merge-census-c/v1\",\"path\":\"");
+  print_escaped(path);
+  printf("\",\"status\":\"%s\"", status);
+  printf(",\"source_bytes\":%u,\"root_end_byte\":%u,\"root_has_error\":%s",
+         source_len, root_end_byte, root_has_error ? "true" : "false");
+#define ROW(field) printf(",\"" #field "\":%llu", (unsigned long long)c.field)
+  ROW(merge_attempts_proxy);
+  ROW(merge_successes_proxy);
+  ROW(stack_version_creations_proxy);
+  ROW(shifts);
+  ROW(reductions);
+  ROW(accept_actions);
+  ROW(explicit_recover_actions);
+  ROW(reduction_pop_requests);
+  ROW(emitted_pop_paths);
+  ROW(predecessor_link_union_attempts);
+  ROW(predecessor_link_union_duplicate_noop);
+  ROW(predecessor_link_union_precedence_replaced);
+  ROW(predecessor_link_union_recursive_changed);
+  ROW(predecessor_link_union_alternate_appended);
+  ROW(predecessor_link_union_rejected);
+  ROW(alternate_predecessor_links_appended);
+  ROW(graph_link_additions_proxy);
+#undef ROW
+  printf(",\"overflow\":%s}\n", c.overflow ? "true" : "false");
+}
+
+static unsigned long long parse_u64(const char *raw) {
+  char *end = NULL;
+  unsigned long long value = strtoull(raw, &end, 10);
+  if (!raw[0] || (end && *end)) return 0;
+  return value;
+}
+
+int main(int argc, char **argv) {
+  if (argc == 2 && strcmp(argv[1], "--exact-model") == 0) {
+    // The same three self-checks the work-count oracle runs, so a census run
+    // proves the counters it reads still behave as the patch's model states.
+    bool passed = gts_work_count_validate_action_model() &&
+                  gts_work_count_validate_link_union_model() &&
+                  gts_work_count_validate_raw_census_model();
+    printf("{\"schema\":\"gts-merge-census-c-exact-model/v1\",\"passed\":%s}\n",
+           passed ? "true" : "false");
+    return passed ? 0 : 12;
+  }
+  if (argc != 5) {
+    fputs("status=c_protocol_error\n", stderr);
+    fprintf(stderr, "usage: %s <grammar-so> <symbol> <manifest> <timeout-us>\n",
+            argv[0]);
+    return 2;
+  }
+
+  unsigned long long timeout_us = parse_u64(argv[4]);
+  if (timeout_us == 0) {
+    fputs("status=c_protocol_error\n", stderr);
+    return 2;
+  }
+
+  void *handle = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+  if (!handle) {
+    fprintf(stderr, "status=c_dlopen_error %s\n", dlerror());
+    return 3;
+  }
+  // argv[2] is a comma-separated candidate list, mirroring the parity
+  // loader's parityLanguageSymbols: a grammar repository does not always name
+  // its entry point after the lock row.
+  gts_lang_fn lang_fn = NULL;
+  char *symbols = strdup(argv[2]);
+  if (!symbols) {
+    fputs("status=c_alloc_error\n", stderr);
+    return 3;
+  }
+  for (char *candidate = strtok(symbols, ","); candidate;
+       candidate = strtok(NULL, ",")) {
+    dlerror();
+    void *symbol = dlsym(handle, candidate);
+    if (symbol) {
+      lang_fn = (gts_lang_fn)symbol;
+      break;
+    }
+  }
+  free(symbols);
+  if (!lang_fn) {
+    fprintf(stderr, "status=c_dlsym_error %s\n", argv[2]);
+    return 3;
+  }
+  const TSLanguage *language = lang_fn();
+  if (!language) {
+    fputs("status=c_language_error\n", stderr);
+    return 3;
+  }
+
+  size_t manifest_len = 0;
+  char *manifest = read_file(argv[3], &manifest_len);
+  if (!manifest) {
+    fputs("status=c_manifest_error\n", stderr);
+    return 4;
+  }
+
+  char *cursor = manifest;
+  while (cursor && *cursor) {
+    char *newline = strchr(cursor, '\n');
+    if (newline) *newline = '\0';
+    char *path = cursor;
+    cursor = newline ? newline + 1 : NULL;
+    if (path[0] == '\0') continue;
+
+    size_t source_len = 0;
+    char *source = read_file(path, &source_len);
+    if (!source || source_len > UINT32_MAX) {
+      free(source);
+      print_row(path, "source_error", (GTSWorkCount){0}, 0u, 0u, false);
+      continue;
+    }
+
+    TSParser *parser = ts_parser_new();
+    if (!parser || !ts_parser_set_language(parser, language)) {
+      if (parser) ts_parser_delete(parser);
+      free(source);
+      print_row(path, "parser_error", (GTSWorkCount){0}, (uint32_t)source_len,
+                0u, false);
+      continue;
+    }
+    ts_parser_set_timeout_micros(parser, timeout_us);
+
+    gts_work_count_reset();
+    TSTree *tree =
+        ts_parser_parse_string(parser, NULL, source, (uint32_t)source_len);
+    GTSWorkCount counts = gts_work_count_snapshot();
+    if (!tree) {
+      ts_parser_delete(parser);
+      free(source);
+      print_row(path, "timeout", counts, (uint32_t)source_len, 0u, false);
+      continue;
+    }
+    TSNode root = ts_tree_root_node(tree);
+    print_row(path, "ok", counts, (uint32_t)source_len, ts_node_end_byte(root),
+              ts_node_has_error(root));
+    ts_tree_delete(tree);
+    ts_parser_delete(parser);
+    free(source);
+  }
+
+  free(manifest);
+  fflush(stdout);
+  return ferror(stdout) ? 6 : 0;
+}

--- a/docs/ci-gate-coverage.md
+++ b/docs/ci-gate-coverage.md
@@ -249,6 +249,46 @@ into that module, the same shape as the `gts_parsercorephase0` finding above.
 Given this branch's scope and the stop rules, this was noted but not
 quantified test-by-test; a dedicated audit pass is filed in the backlog.
 
+## Part 3: later additions
+
+### 3a. `merge-event-census-cgo` — wired with the census it runs (2026-08-02)
+
+Stage M0 of `spec.merge-time-election.v1` added two cgo tests,
+`TestMergeEventCensusBaseline` and `TestMergeEventCensusFooIntWitness`
+(`cgo_harness/merge_event_census_test.go`). Both sit behind the new
+`gts_merge_census` build tag, so no existing lane could reach them: every cgo
+parity lane passes a fixed `-run` allow-list AND a fixed `-tags` string, and
+`run_parity_in_docker.sh` hardcodes `-tags treesitter_c_parity` in its default
+command.
+
+Fixed in the same change that added the tests: a new `merge-event-census-cgo`
+job uses the docker runner's custom-command form to pass
+`-tags 'cgo treesitter_c_parity gts_merge_census'`, and the job is listed in
+the required `build` gate's `needs` and in its `require_success` checks. The
+census therefore blocks a merge when it fails.
+
+### 3b. The stage-D0 derivation-set differential is a DARK GATE and its pin has drifted
+
+`TestDerivationSetDifferentialBaselineCensus` and
+`TestDerivationSetDifferentialWitnessReproduction`
+(`cgo_harness/derivation_set_differential_test.go`, PR #646) need
+`-tags gts_derivation_set_census`. No workflow passes that tag. Searching
+`.github/` for `gts_derivation_set_census` returns nothing.
+
+The consequence is already measurable. On unmodified `main` at `56410214`,
+the baseline census reports 24 set differences against a pin of 32, so the
+test FAILS:
+
+```
+TOTAL SET-DIFFERENCE COUNT (constructed)=24 (all corpora)=24
+D0 baseline total set-difference count is 24, pinned at 32
+```
+
+The drift is a FALL, which is the direction stages D1 and D2 want, but it
+landed with no receipt because nothing ran the gate. Re-pinning belongs to the
+owner of that lane with the per-witness adjudication the file's own comment
+demands, so this branch reports the drift and does not re-fit the number.
+
 ## Backlog (not fixed in this branch)
 
 | Item | Severity | Why |
@@ -258,6 +298,7 @@ quantified test-by-test; a dedicated audit pass is filed in the backlog.
 | Hardcoded `/home/draco/...` absolute paths in 5 test files, including two named historical-regression tests (`TestGoZerrorsNormalizerByteIdentity`, `TestCRecoveryZerrorsTruncationAcyclic`) | High | Not just uncovered — unreachable by CI or any engineer without that exact local layout; no env var exists to opt in. |
 | `gts_parsercorephase0`-tagged surface: 277 top-level test functions across 57 root-package files, only on the order of a dozen actually executed by CI's narrow `-run` allow-lists | High (scale) | Same defect class as the two fixed items, much larger; needs a lane redesign, not a one-line change. |
 | `gts_workcount` build tag never passed by any CI job | Medium | Entire work-count differential harness (9+ files) compiled nowhere, run nowhere. |
+| `gts_derivation_set_census` build tag never passed by any CI job; its pinned baseline has already drifted from 32 to 24 on `main` | High | See 3b. The gate exists, fails on `main`, and nothing reports it. |
 | `gts_no_parsercorephase0` (emergency stub) build never compiled by CI | Medium | The fail-closed emergency route itself is untested; would only be discovered broken during an actual incident. |
 | `GTS_ADMISSION_REAL_CORPUS` in `admission_real_corpus_matrix_test.go` has the same silent-by-default shape as the gate loudened in 1b, not yet loudened itself | Low–Medium | Same fixture problem (`cgo_harness/corpus_real`), same fix shape as 1b; not touched here to keep this branch's diff minimal. |
 | `cgo_harness` module's own `gts_parsercorephase0`-style narrow-`-run`-vs-broad-tag-surface pattern (94 `treesitter_c_parity`-tagged files) | Unquantified | Flagged, not measured; separate module, separate audit warranted. |

--- a/glr.go
+++ b/glr.go
@@ -3248,7 +3248,13 @@ func tryGSSMainMergeForParser(p *Parser, a, b *glrStack) bool {
 		return tryGSSMainMergeForParserPhase(p, a, b, workCountConvergencePhaseBoundaryGSS, true)
 	}
 	workCountRecordMergeAttempt()
+	if mergeCensusEnabled {
+		mergeCensusRecordAttempt()
+	}
 	if !gssMainCanMergeForParser(p, a, b) {
+		if mergeCensusEnabled {
+			mergeCensusAttributeForParserRefusal(p, a, b)
+		}
 		return false
 	}
 	var scratch *glrMergeScratch
@@ -3258,20 +3264,31 @@ func tryGSSMainMergeForParser(p *Parser, a, b *glrStack) bool {
 	merged := gssMainMergeWithScratch(scratch, a, b)
 	if merged {
 		workCountRecordMergeSuccess()
+		if mergeCensusEnabled {
+			mergeCensusRecordSuccess()
+		}
 		a.cEverErrored = a.cEverErrored || b.cEverErrored
 		if p != nil {
 			p.mergeScratch.bumpShapePrefixEpoch()
 		}
+	} else if mergeCensusEnabled {
+		mergeCensusRecordMergeFailed()
 	}
 	return merged
 }
 
 func tryGSSMainMergeForParserPhase(p *Parser, a, b *glrStack, phase string, recordDecision bool) bool {
 	workCountRecordMergeAttempt()
+	if mergeCensusEnabled {
+		mergeCensusRecordAttempt()
+	}
 	if recordDecision {
 		workCountRecordPairCandidate(p, phase, "GSS merge entered eligibility preflight", a, b) // work-count-assembly: convergence GSS seam
 	}
 	if !gssMainCanMergeForParserPhase(p, a, b, phase) {
+		if mergeCensusEnabled {
+			mergeCensusAttributeForParserRefusal(p, a, b)
+		}
 		return false
 	}
 	var scratch *glrMergeScratch
@@ -3286,6 +3303,9 @@ func tryGSSMainMergeForParserPhase(p *Parser, a, b *glrStack, phase string, reco
 	}
 	if merged {
 		workCountRecordMergeSuccess()
+		if mergeCensusEnabled {
+			mergeCensusRecordSuccess()
+		}
 		// a survives and absorbs b, so OR the sticky wreckage bit: cEverErrored
 		// is lineage history, not current shape, and a clean survivor must not
 		// shed a merged-in recovered-wreckage lineage's error history (see
@@ -3299,6 +3319,8 @@ func tryGSSMainMergeForParserPhase(p *Parser, a, b *glrStack, phase string, reco
 			// bumpShapePrefixEpoch is nil-safe.
 			p.mergeScratch.bumpShapePrefixEpoch()
 		}
+	} else if mergeCensusEnabled {
+		mergeCensusRecordMergeFailed()
 	}
 	return merged
 }
@@ -4173,7 +4195,23 @@ func gssMainAddLinkSeenMutate(scratch *glrMergeScratch, n *gssNode, prev *gssNod
 	}
 	for i := 0; i < n.linkCount(); i++ {
 		existingPrev, existingEntry := n.link(i)
-		if !stackEntryPayloadsEquivalentIgnoringDynamicWithScratch(scratch, existingEntry, entry) {
+		if mergeCensusEnabled {
+			// Stage M0 instrument (spec.merge-time-election.v1). This loop is
+			// production's port of the reference runtime's Tier-2 link union
+			// (stack.c:199-263), and this comparison is its port of
+			// stack__subtree_is_equivalent. The census records production's DEEP
+			// verdict beside the reference runtime's SHALLOW verdict, so stage
+			// M1 knows exactly how many reference-runtime collapses the deep
+			// test turns into appends. Only the mutating union is instrumented;
+			// the preflight walkers repeat the same comparisons for the same
+			// pairs and would double count. The constant guard removes this
+			// block from the default build.
+			verdict := stackEntryPayloadsEquivalentIgnoringDynamicWithScratch(scratch, existingEntry, entry)
+			mergeCensusRecordLinkPayload(existingEntry, entry, verdict)
+			if !verdict {
+				continue
+			}
+		} else if !stackEntryPayloadsEquivalentIgnoringDynamicWithScratch(scratch, existingEntry, entry) {
 			continue
 		}
 		if existingPrev == prev {
@@ -4368,6 +4406,9 @@ func gssMainMergeWithScratch(scratch *glrMergeScratch, a, b *glrStack) bool {
 
 func tryGSSMainMergeResult(scratch *glrMergeScratch, result []glrStack, idx int, stack *glrStack) (merged bool, attempted bool) {
 	workCountRecordMergeAttempt()
+	if mergeCensusEnabled {
+		mergeCensusRecordAttempt()
+	}
 	if idx < 0 || idx >= len(result) || stack == nil {
 		return false, false
 	}
@@ -4384,6 +4425,9 @@ func tryGSSMainMergeResult(scratch *glrMergeScratch, result []glrStack, idx int,
 		if workCountInstrumentationEnabled {
 			workCountRecordGSSScoreShiftReject(workCountParserFromMergeScratch(scratch), workCountConvergencePhaseBoundaryGSS, &result[idx], stack)
 		}
+		if mergeCensusEnabled {
+			mergeCensusRecordScorePreflight()
+		}
 		return false, false
 	}
 	if cRecoveryMergeCostsDiffer(scratch, &result[idx], stack) {
@@ -4391,19 +4435,31 @@ func tryGSSMainMergeResult(scratch *glrMergeScratch, result []glrStack, idx int,
 		if workCountInstrumentationEnabled {
 			workCountRecordGSSReject(workCountParserFromMergeScratch(scratch), workCountConvergencePhaseBoundaryGSS, workCountConvergenceReasonErrorCost, "boundary merge rejected by recovery cost", &result[idx], stack)
 		}
+		if mergeCensusEnabled {
+			mergeCensusRecordErrorCost()
+		}
 		return false, false
 	}
 	if workCountInstrumentationEnabled {
 		if !gssMainCanMergeWithScratchPhase(scratch, &result[idx], stack, workCountConvergencePhaseBoundaryGSS) {
+			if mergeCensusEnabled {
+				mergeCensusRecordGateRefusal(scratch, &result[idx], stack)
+			}
 			return false, false
 		}
 	} else if !gssMainCanMergeWithScratch(scratch, &result[idx], stack) {
+		if mergeCensusEnabled {
+			mergeCensusRecordGateRefusal(scratch, &result[idx], stack)
+		}
 		return false, false
 	}
 	if (scratch == nil || scratch.perKeyCap != 1) &&
 		gssStacksHaveDistinctMaterializingShapesWithScratch(scratch, &result[idx], stack) {
 		if workCountInstrumentationEnabled {
 			workCountRecordGSSReject(workCountParserFromMergeScratch(scratch), workCountConvergencePhaseBoundaryEquivalence, workCountConvergenceReasonDistinctShape, "boundary merge retained distinct materializing shapes", &result[idx], stack)
+		}
+		if mergeCensusEnabled {
+			mergeCensusRecordDistinctShapes()
 		}
 		return false, true
 	}
@@ -4414,6 +4470,9 @@ func tryGSSMainMergeResult(scratch *glrMergeScratch, result []glrStack, idx int,
 	}
 	if merged {
 		workCountRecordMergeSuccess()
+		if mergeCensusEnabled {
+			mergeCensusRecordSuccess()
+		}
 		// result[idx] survives and absorbs stack, so OR the sticky wreckage bit:
 		// a clean survivor that merges a recovered-wreckage lineage must inherit
 		// its error history (see glrStack.cEverErrored / tryGSSMainMergeForParser).
@@ -4423,6 +4482,8 @@ func tryGSSMainMergeResult(scratch *glrMergeScratch, result []glrStack, idx int,
 			// nodes (setGSSMainLink), so every cached spine prefix may be stale.
 			scratch.bumpShapePrefixEpoch()
 		}
+	} else if mergeCensusEnabled {
+		mergeCensusRecordMergeFailed()
 	}
 	return merged, true
 }

--- a/merge_event_census.go
+++ b/merge_event_census.go
@@ -1,0 +1,311 @@
+//go:build gts_merge_census
+
+package gotreesitter
+
+import "sync"
+
+// Merge-event census, production side (stage M0 of
+// spec.merge-time-election.v1).
+//
+// The lane's thesis (finding.late-election-unifying-cause) is that the
+// reference runtime collapses duplicate stack versions AT THE MERGE and
+// carries one version forward, while this parser refuses the merge when the
+// subtree shapes differ, carries both versions to EOF, and elects at the end.
+// Nobody has taken the direct measurement: how many merges does the reference
+// runtime perform, how many does this parser perform, and which gate refuses
+// the rest. This file publishes the production half of that measurement.
+//
+// The whole file sits behind the gts_merge_census build tag. The shipped
+// build compiles merge_event_census_disabled.go instead, where
+// mergeCensusEnabled is a false constant and every hook has an empty body. A
+// constant false guard removes the guarded blocks at compile time, so the
+// shipped binary keeps the exact instruction stream it had before the census
+// existed. merge_event_census_inert_test.go is the ratchet for that claim.
+//
+// The census NEVER influences a merge decision. Every hook reads the same
+// values the gate already read and returns nothing.
+
+// mergeCensusEnabled reports whether the census is compiled in. It is a
+// constant so every guarded block is removed from the default build.
+const mergeCensusEnabled = true
+
+// MergeEventCensusCounts is one parse's production merge accounting.
+//
+// The refusal fields answer stage M1's question directly: which gate must go
+// first, and what does removing it cost. Every field name states the gate it
+// counts, not a mechanism the gate is believed to protect.
+type MergeEventCensusCounts struct {
+	// Attempts is the number of times a production merge front door was
+	// entered with a candidate pair. The three front doors are
+	// tryGSSMainMergeForParser, tryGSSMainMergeForParserPhase and
+	// tryGSSMainMergeResult. The reference runtime's equivalent is a call to
+	// ts_stack_merge (merge_attempts_proxy).
+	Attempts uint64
+	// Successes is the number of attempts that collapsed two versions into
+	// one. The reference runtime's equivalent is a ts_stack_merge call that
+	// returned true (merge_successes_proxy). Successes divided by the
+	// reference runtime's successes is the lane's progress ratio.
+	Successes uint64
+
+	// RefuseNoGSSHead counts pairs where at least one side carried no packed
+	// head. A glrStack packs lazily (ensureGSS, glr.go:466-471), so a nil head
+	// means the candidate is still in flat-slice form and was never presented
+	// to the graph at all. The reference runtime has no equivalent state: every
+	// version is a stack-node chain from creation, so this whole class is a
+	// refusal with no counterpart. RefuseNoGSSHeadBoth and RefuseNoGSSHeadOne
+	// split it, because "neither side was packed" and "one side was packed"
+	// need different work in stage M1.
+	RefuseNoGSSHead     uint64
+	RefuseNoGSSHeadBoth uint64
+	RefuseNoGSSHeadOne  uint64
+	// RefuseStatus counts pairs rejected because one side was dead, or
+	// because the accepted flags differed.
+	RefuseStatus uint64
+	// RefuseScoreOrShifted counts the score-equality gate (glr.go:3311) plus
+	// its preflight fast reject in tryGSSMainMergeResult. The reference
+	// runtime merges across dynamic-precedence differences and elects per
+	// link (stack.c:216-218), so this whole class is a refusal the reference
+	// runtime does not make. Stage M1 item 1.
+	RefuseScoreOrShifted uint64
+	// RefuseScoreOnly and RefuseShiftedOnly split the gate above so the
+	// worker who deletes it can attribute each half. RefuseShiftedOnly is the
+	// part with no reference-runtime counterpart at all: C has no shifted
+	// field.
+	RefuseScoreOnly   uint64
+	RefuseShiftedOnly uint64
+	// RefuseStateOrOffset counts the Tier-1 key mismatch: different top state
+	// or different byte offset. The reference runtime refuses these too
+	// (stack.c:709-719), so this class is agreement, not divergence.
+	RefuseStateOrOffset uint64
+	// RefuseCleanZero counts the clean-zero-error merge gate
+	// (glr.go:3317-3318). Stage M2, not M1.
+	RefuseCleanZero uint64
+	// RefuseErrorCost counts the recovery-cost rejection in
+	// tryGSSMainMergeResult. The reference runtime keys error cost into the
+	// merge test as well (stack.c:713), so this class is agreement.
+	RefuseErrorCost uint64
+	// RefuseDistinctShapes counts the distinct-materializing-shapes refusal
+	// (glr.go:4401-4407). This is the refusal the finding names: where the
+	// reference runtime packs the differing subtree as an extra link
+	// (stack.c:249-263), production declines the merge and carries both
+	// versions. Stage M1 item 2.
+	RefuseDistinctShapes uint64
+	// RefuseMergeFailed counts attempts that passed every gate and still did
+	// not collapse, because the graph mutation itself declined.
+	RefuseMergeFailed uint64
+
+	// LinkPayloadTests is the number of Tier-2 link-payload comparisons
+	// (stackEntryPayloadsEquivalentIgnoringDynamicWithScratch), the port of
+	// stack__subtree_is_equivalent (stack.c:181-198).
+	LinkPayloadTests uint64
+	// LinkPayloadDeepAccepts and LinkPayloadDeepRefusals split those tests by
+	// production's verdict.
+	LinkPayloadDeepAccepts  uint64
+	LinkPayloadDeepRefusals uint64
+	// LinkPayloadShallowWouldAccept is the actionable number: comparisons
+	// where the reference runtime's SHALLOW test accepts and production's
+	// DEEP test refuses. Every one of these turns a reference-runtime Tier-2
+	// collapse into a production append. Stage M1 item 3 removes exactly this
+	// class.
+	LinkPayloadShallowWouldAccept uint64
+	// LinkPayloadDeepWouldAccept is the opposite direction: production
+	// accepts where the shallow test refuses. A non-zero count here means
+	// adopting the shallow test alone would LOSE collapses, so it must be
+	// reported rather than assumed empty.
+	LinkPayloadDeepWouldAccept uint64
+	// LinkPayloadPending counts comparisons routed to the pending-parent
+	// branch, where no shallow comparison is defined because the payload has
+	// no materialized node yet. Reported, never folded into the two classes
+	// above.
+	LinkPayloadPending uint64
+
+	// CompactLinkUnionAttempts and the four outcome fields mirror the compact
+	// core's own always-on link-union counters (internal/parsercorephase0),
+	// snapshotted at a compact acceptance. They are recorded only when the
+	// compact route reaches an accept.
+	CompactLinkUnionAttempts           uint64
+	CompactLinkUnionDuplicateNoop      uint64
+	CompactLinkUnionPrecedenceReplaced uint64
+	CompactLinkUnionRecursiveChanged   uint64
+	CompactLinkUnionAlternateAppended  uint64
+	CompactLinkUnionRejected           uint64
+	CompactAcceptancesObserved         uint64
+}
+
+var mergeCensusState struct {
+	mu     sync.Mutex
+	counts MergeEventCensusCounts
+}
+
+// MergeEventCensusBuilt reports whether this binary carries the merge-event
+// census. Only a gts_merge_census build does.
+func MergeEventCensusBuilt() bool { return true }
+
+// MergeEventCensusReset clears the accumulated counts. Call it before the
+// parse under measurement.
+func MergeEventCensusReset() {
+	mergeCensusState.mu.Lock()
+	mergeCensusState.counts = MergeEventCensusCounts{}
+	mergeCensusState.mu.Unlock()
+}
+
+// MergeEventCensusSnapshot returns the counts accumulated since the last
+// reset.
+func MergeEventCensusSnapshot() MergeEventCensusCounts {
+	mergeCensusState.mu.Lock()
+	out := mergeCensusState.counts
+	mergeCensusState.mu.Unlock()
+	return out
+}
+
+func mergeCensusAdd(field *uint64, delta uint64) {
+	mergeCensusState.mu.Lock()
+	*field += delta
+	mergeCensusState.mu.Unlock()
+}
+
+func mergeCensusRecordAttempt() { mergeCensusAdd(&mergeCensusState.counts.Attempts, 1) }
+
+func mergeCensusRecordSuccess() { mergeCensusAdd(&mergeCensusState.counts.Successes, 1) }
+
+func mergeCensusRecordMergeFailed() { mergeCensusAdd(&mergeCensusState.counts.RefuseMergeFailed, 1) }
+
+func mergeCensusRecordDistinctShapes() {
+	mergeCensusAdd(&mergeCensusState.counts.RefuseDistinctShapes, 1)
+}
+
+func mergeCensusRecordErrorCost() { mergeCensusAdd(&mergeCensusState.counts.RefuseErrorCost, 1) }
+
+// mergeCensusRecordScorePreflight attributes the fast score reject in
+// tryGSSMainMergeResult (glr.go:4381-4386) to the same class as the gate it
+// front-runs, so the two sites never double-count differently.
+func mergeCensusRecordScorePreflight() {
+	mergeCensusState.mu.Lock()
+	mergeCensusState.counts.RefuseScoreOrShifted++
+	mergeCensusState.counts.RefuseScoreOnly++
+	mergeCensusState.mu.Unlock()
+}
+
+// mergeCensusAttributeForParserRefusal attributes one refusal by
+// gssMainCanMergeForParser, whose first gate is the recovery-cost comparison
+// and whose second is gssMainCanMergeWithScratch.
+func mergeCensusAttributeForParserRefusal(p *Parser, a, b *glrStack) {
+	if cRecoveryMergeCostsDifferForParser(p, a, b) {
+		mergeCensusRecordErrorCost()
+		return
+	}
+	var scratch *glrMergeScratch
+	if p != nil {
+		scratch = p.mergeScratch
+	}
+	mergeCensusRecordGateRefusal(scratch, a, b)
+}
+
+// mergeCensusRecordGateRefusal attributes one refusal by
+// gssMainCanMergeWithScratch. It re-evaluates the gate's own conditions in
+// the gate's own order. The gate is pure, so the attribution is exact rather
+// than inferred.
+func mergeCensusRecordGateRefusal(scratch *glrMergeScratch, a, b *glrStack) {
+	mergeCensusState.mu.Lock()
+	defer mergeCensusState.mu.Unlock()
+	counts := &mergeCensusState.counts
+	switch {
+	case a == nil || b == nil:
+		counts.RefuseStatus++
+	case a.gss.head == nil || b.gss.head == nil:
+		counts.RefuseNoGSSHead++
+		if a.gss.head == nil && b.gss.head == nil {
+			counts.RefuseNoGSSHeadBoth++
+		} else {
+			counts.RefuseNoGSSHeadOne++
+		}
+	case a.dead || b.dead || a.accepted != b.accepted:
+		counts.RefuseStatus++
+	case a.score != b.score || a.shifted != b.shifted:
+		counts.RefuseScoreOrShifted++
+		if a.score != b.score {
+			counts.RefuseScoreOnly++
+		} else {
+			counts.RefuseShiftedOnly++
+		}
+	case a.top().state != b.top().state || a.byteOffset != b.byteOffset:
+		counts.RefuseStateOrOffset++
+	default:
+		counts.RefuseCleanZero++
+	}
+	_ = scratch
+}
+
+// mergeCensusRecordLinkPayload records one Tier-2 link-payload comparison and
+// the divergence between production's deep verdict and the reference
+// runtime's shallow verdict.
+func mergeCensusRecordLinkPayload(a, b stackEntry, deep bool) {
+	pending := stackEntryPendingParent(a) != nil || stackEntryPendingParent(b) != nil
+	shallow := false
+	if !pending {
+		shallow = mergeCensusShallowEquivalent(a, b)
+	}
+	mergeCensusState.mu.Lock()
+	counts := &mergeCensusState.counts
+	counts.LinkPayloadTests++
+	if deep {
+		counts.LinkPayloadDeepAccepts++
+	} else {
+		counts.LinkPayloadDeepRefusals++
+	}
+	switch {
+	case pending:
+		counts.LinkPayloadPending++
+	case shallow && !deep:
+		counts.LinkPayloadShallowWouldAccept++
+	case deep && !shallow:
+		counts.LinkPayloadDeepWouldAccept++
+	}
+	mergeCensusState.mu.Unlock()
+}
+
+// mergeCensusShallowEquivalent is the port of the reference runtime's
+// stack__subtree_is_equivalent (stack.c:181-198): equal symbol, a
+// both-have-errors shortcut, then equal padding, size, child count and extra
+// flag.
+//
+// Two components of the reference test are deliberately absent, and their
+// absence is stated rather than hidden:
+//
+//   - External scanner state. Production's scanner is a parser singleton
+//     (glr.go:1978-1982), so the component is tautological today. Stage M2
+//     gives it a per-stack identity before it joins any key.
+//   - Padding as a separate length. The reference runtime stores padding and
+//     size; production stores start and end bytes. Equal start plus equal end
+//     is equal padding plus equal size when the two payloads follow the same
+//     predecessor, which is the only position this test is applied from. The
+//     spec records the exact mapping as open question 4.
+func mergeCensusShallowEquivalent(a, b stackEntry) bool {
+	if stackEntryNodeSymbol(a) != stackEntryNodeSymbol(b) {
+		return false
+	}
+	if stackEntryNodeHasError(a) && stackEntryNodeHasError(b) {
+		return true
+	}
+	return stackEntryNodeStartByte(a) == stackEntryNodeStartByte(b) &&
+		stackEntryNodeEndByte(a) == stackEntryNodeEndByte(b) &&
+		stackEntryNodeChildCount(a) == stackEntryNodeChildCount(b) &&
+		stackEntryNodeIsExtra(a) == stackEntryNodeIsExtra(b)
+}
+
+// mergeCensusRecordCompactLinkUnion snapshots the compact core's own
+// always-on link-union counters at a compact acceptance. The compact core
+// keeps cumulative per-parse totals, so the census stores the last observed
+// values rather than summing them.
+func mergeCensusRecordCompactLinkUnion(attempts, duplicate, precedence, recursive, alternate, rejected uint64) {
+	mergeCensusState.mu.Lock()
+	counts := &mergeCensusState.counts
+	counts.CompactAcceptancesObserved++
+	counts.CompactLinkUnionAttempts = attempts
+	counts.CompactLinkUnionDuplicateNoop = duplicate
+	counts.CompactLinkUnionPrecedenceReplaced = precedence
+	counts.CompactLinkUnionRecursiveChanged = recursive
+	counts.CompactLinkUnionAlternateAppended = alternate
+	counts.CompactLinkUnionRejected = rejected
+	mergeCensusState.mu.Unlock()
+}

--- a/merge_event_census_disabled.go
+++ b/merge_event_census_disabled.go
@@ -1,0 +1,33 @@
+//go:build !gts_merge_census
+
+package gotreesitter
+
+// Shipped build of the merge-event census (stage M0 of
+// spec.merge-time-election.v1): the census is absent.
+//
+// merge_event_census.go carries the whole instrument behind the
+// gts_merge_census build tag. This file supplies the same names with empty
+// bodies and, above all, mergeCensusEnabled as a false CONSTANT. Every census
+// block in glr.go is written as `if mergeCensusEnabled { ... }`, so the
+// compiler removes the block and its argument evaluation from the default
+// build. That is stronger than an env-var read: the shipped binary keeps the
+// exact instruction stream it had before the census existed, which
+// merge_event_census_inert_test.go ratchets.
+
+// mergeCensusEnabled is a constant false in the shipped build.
+const mergeCensusEnabled = false
+
+// MergeEventCensusBuilt reports whether this binary carries the merge-event
+// census. The shipped build never does.
+func MergeEventCensusBuilt() bool { return false }
+
+func mergeCensusRecordAttempt()                                                        {}
+func mergeCensusRecordSuccess()                                                        {}
+func mergeCensusRecordMergeFailed()                                                    {}
+func mergeCensusRecordDistinctShapes()                                                 {}
+func mergeCensusRecordErrorCost()                                                      {}
+func mergeCensusRecordScorePreflight()                                                 {}
+func mergeCensusAttributeForParserRefusal(*Parser, *glrStack, *glrStack)               {}
+func mergeCensusRecordGateRefusal(*glrMergeScratch, *glrStack, *glrStack)              {}
+func mergeCensusRecordLinkPayload(stackEntry, stackEntry, bool)                        {}
+func mergeCensusRecordCompactLinkUnion(uint64, uint64, uint64, uint64, uint64, uint64) {}

--- a/merge_event_census_inert_test.go
+++ b/merge_event_census_inert_test.go
@@ -1,0 +1,25 @@
+//go:build !gts_merge_census
+
+package gotreesitter
+
+import "testing"
+
+// TestMergeEventCensusIsAbsentFromTheDefaultBuild is the inertness ratchet for
+// the stage M0 merge-event census (spec.merge-time-election.v1).
+//
+// The census sits on the production merge path, which every language and
+// every route shares, and its link-payload hook runs a second shallow
+// comparison beside the deep one. That cost must never reach a shipped parse.
+// A build tag, not an env var, keeps it out: the default build compiles
+// merge_event_census_disabled.go, where mergeCensusEnabled is a false
+// constant, so the compiler removes every guarded block.
+//
+// This test fails the moment the default build starts carrying the census.
+func TestMergeEventCensusIsAbsentFromTheDefaultBuild(t *testing.T) {
+	if MergeEventCensusBuilt() {
+		t.Fatal("the merge-event census is compiled into the default build; it must stay behind the gts_merge_census build tag")
+	}
+	if mergeCensusEnabled {
+		t.Fatal("mergeCensusEnabled is true in the default build; every census block must be removed at compile time")
+	}
+}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -4760,6 +4760,21 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
 		Accepts: s.work.Accepts, Stats: stats, Work: s.work,
 	}
 	s.receipt.Acceptance = &s.receipt.acceptanceBacking
+	if mergeCensusEnabled {
+		// Stage M0 instrument (spec.merge-time-election.v1): the compact
+		// core's own always-on link-union counters, read from the snapshot
+		// this function already took. Removed from the default build by the
+		// constant guard.
+		compactWork := s.receipt.acceptanceBacking.CoreWork
+		mergeCensusRecordCompactLinkUnion(
+			compactWork.PredecessorLinkUnionAttempts,
+			compactWork.PredecessorLinkUnionDuplicateNoop,
+			compactWork.PredecessorLinkUnionPrecedenceReplaced,
+			compactWork.PredecessorLinkUnionRecursiveChanged,
+			compactWork.PredecessorLinkUnionAlternateAppended,
+			compactWork.PredecessorLinkUnionRejected,
+		)
+	}
 	s.publishTotals()
 	return nil
 }


### PR DESCRIPTION
Add a census that compares stack-merge events against the reference runtime.

Stage M0 of the merge-time-election lane. The lane's premise is that the
reference runtime collapses duplicate stack versions at the merge and carries
one version forward, while this parser refuses the merge when subtree shapes
differ, carries both versions, and elects at the end. Nobody had counted the
merges on both sides. This change counts them.

Zero shipped behaviour change. The whole instrument sits behind the new
`gts_merge_census` build tag, and `mergeCensusEnabled` is a false constant in
the default build, so the compiler removes every census block.

## Merge ratio, per language and aggregate

M_c is the reference runtime's collapsed pairs. M_p is production's. The
denominator is the 104 constructed sources the stage-D0 derivation-set
differential already measures, so the two censuses share one corpus.

| corpus | sources | M_c | M_p | M_p/M_c | sources where the reference merges and production does not |
|---|---|---|---|---|---|
| apex | 25 | 31 | 1 | 0.0323 | 5 |
| perl | 17 | 57 | 0 | 0.0000 | 7 |
| ada | 23 | 47 | 2 | 0.0426 | 5 |
| kotlin | 13 | 54 | 12 | 0.2222 | 3 |
| python | 26 | 2 | 0 | 0.0000 | 2 |
| **total** | **104** | **191** | **15** | **0.0785** | **22** |

Production collapses one version pair for every 12.7 the reference runtime
collapses. No source shows production merging more than the reference runtime,
so the over-merge floor is zero.

## Refusal breakdown

Production entered a merge front door 308 times and collapsed 15 pairs. The
293 refusals attribute exactly, with no residue:

| gate | count | reference runtime does the same? |
|---|---|---|
| candidate never packed into the graph | 142 | no; every reference version is a node chain from creation |
| score or shifted equality | 92 | no; the reference runtime merges across precedence differences |
| distinct materializing shapes | 59 | no; the reference runtime packs the difference as an extra link |
| top state or byte offset | 0 | yes |
| clean zero error | 0 | out of scope until stage M2 |
| recovery cost | 0 | yes |

All 142 unpacked-candidate refusals have exactly one flat side; none has two.
Only ada reaches the score gate (92 of 92). Only apex and ada reach the
shape refusal (53 and 6).

The Tier-2 link-payload test ran 41 times, accepted 29, and refused 12. In 10
of those 12 refusals the reference runtime's shallow test would have accepted,
so production's deep test turns a reference collapse into an append. All 10 are
kotlin. No comparison went the other way.

## The Foo[int](a) receipt

The census measures the witness against a bracket-free control (`_ = g(a)`),
because the counters are parse-global. `_ = a[b](c)` is not a control: it
carries the same conflict and produces identical counters.

At `_ = Foo[int](a)` the reference runtime adds, over the control, 3 alternate
link appends, 4 duplicate no-ops, 1 recursive change, and **zero precedence
replacements**. It publishes
`type_conversion_expression(generic_type(...))`.

The verdict is behaviour 2: the reference runtime builds the pair, packs both
links, and elects at the first spanning pop. It does not collapse the pair by
precedence, and it does not skip building it. The receipt also records that
duplicate no-ops fire in the same region, so some pairs there do collapse by
incumbency; the counters are parse-global and cannot say which node each one
landed on.

## Reference-side counting method

The parse logger cannot count merges. `parser.c` calls `ts_stack_merge` at four
sites and none of them logs. The only merge-adjacent line is `condense`, which
fires when any of removal, merge, or version swap changed the stack, so it
cannot be attributed. The live version count falls for removal and cap
enforcement too.

The census therefore reads the repository's own instrumented build. It applies
`cgo_harness/work_count/tree_sitter_v0_25_1.patch` to the pinned runtime source
resolved from the module cache, compiles a driver against it, and dlopens the
same grammar shared object the parity C-reference loader built. The patch
already carries `merge_attempts_proxy`, `merge_successes_proxy`, and the six
link-union outcome counters; no new C instrumentation was written. The driver
runs the patch's three counter self-models before any count is trusted.

## CI

New job `merge-event-census-cgo` runs both census tests. Every cgo parity lane
in `ci.yml` passes a fixed `--run` regex and a fixed tag string, so a
new-tagged cgo test runs nowhere unless a lane names it. This one names it, and
the job is listed in the required `build` gate's `needs` and `require_success`
checks.

## Gates

- `go test . -count=1`: pass.
- `go test . -count=1 -tags gts_merge_census`: pass. The suite is green with
  the census on and with it off, so the instrument changes no tree.
- `go test ./grammars -count=1`: pass.
- `go test ./parser_result_test/... -count=1`: pass.
- `go test -race .` over the GLR, merge, GSS and condense tests: pass.
- `GOMAXPROCS=1 go test -race ./internal/parsercorephase0`: pass.
- Admission scorecard ratchet lane, exact `-run` and env: pass.
- Five A3 certification sweeps: apex and ada pass; kotlin, perl and python skip
  for the absent `corpus_real` fixture, same as on the base commit.
- `go tool nm` on the default test binary: zero census symbols.
- benchstat, 8 runs each of three parse benchmarks: allocations identical,
  bytes per operation unchanged, times within noise.

## Pre-existing failures, not caused here

- `TestCanonicalGoBenchmarkPreflight` fails identically on unmodified `main`
  (`query_compile max stacks=0 want >=8`).
- The stage-D0 derivation-set census fails on unmodified `main` at 24 set
  differences against its pin of 32. It is a dark gate: no workflow passes
  `gts_derivation_set_census`. Reported in `docs/ci-gate-coverage.md` section
  3b and left for that lane's owner to re-pin with a receipt.
- `go vet -tags gts_no_parsercorephase0 ./...` fails identically on `main`.
