### PR TITLE
fix(parser): restore v10 admission safety and bound retry escalation

### DIFF
--- a/admission_switch.go
+++ b/admission_switch.go
@@ -91,12 +91,10 @@ func admissionCandidateEnvEnabled() bool {
 // admission switch applies to Parsers with no explicit override. A per-Parser
 // override still wins.
 //
-// Tranche B9 removed the source-length eligibility decline: every input,
-// regardless of size, is eligible to attempt the candidate route. An explicit
-// timeout, cancellation flag, or the scheduler's own memory-budget poll
-// (tranche B8) is honored on the candidate route itself, with a compatible
-// stop receipt, falling back to production when it trips; included ranges and
-// observability hooks still keep a parse on production.
+// Sources at or above parseRuntimeMemoryMinSourceBytes remain on production.
+// The compact scheduler cannot poll the automatic memory budget at the required
+// granularity. Small sources still honor timeout, cancellation, and memory
+// budget checks before the parser accepts the candidate result.
 func SetAdmissionCandidateRouteDefault(enabled bool) {
 	admissionCandidateRouteDefault.Store(enabled)
 }
@@ -110,12 +108,10 @@ func AdmissionCandidateRouteDefault() bool {
 // over the process-wide default. enabled=true forces the candidate route on for
 // eligible full parses; enabled=false forces the production route.
 //
-// enabled=true still respects every remaining eligibility decline: included
-// ranges and observability hooks keep a parse on production. Source length no
-// longer declines eligibility (tranche B9); a large input attempts the
-// candidate route and either completes there or trips the scheduler's
-// stop-control poll (tranche B8) and falls back to production with a
-// compatible stop receipt honoring ParseStopMemoryBudget.
+// enabled=true still respects every eligibility decline: large sources,
+// included ranges, and observability hooks keep a parse on production. Small
+// sources may trip the scheduler's stop-control poll and fall back to
+// production with a compatible ParseStopMemoryBudget receipt.
 func (p *Parser) SetAdmissionCandidateRoute(enabled bool) {
 	if p == nil {
 		return
@@ -208,22 +204,11 @@ func (p *Parser) admissionCandidateFullParseEligible(oldTree *Tree, usingProduct
 	if len(p.included) > 0 {
 		return false
 	}
-	// An explicit timeout or cancellation flag no longer declines eligibility
-	// (tranche B8): the scheduler polls both through the exact production
-	// check (diagnosticParserCoreGenericScheduler.pollStopControl, once per
-	// dispatch-pass-loop iteration) and cleanly aborts -- releasing the
-	// compact arenas' retained capacity before falling back (Core.
-	// ResetReleasingRetention, tranche B9) -- so production still serves a
-	// tripped deadline or cancellation with its own compatible stop receipt.
-	// Source length no longer declines eligibility either (tranche B9): the
-	// same scheduler poll compares the compact core's own real retained
-	// footprint (Core.FootprintBytes()) against production's soft memory
-	// budget on every input, large or small, so a pathological input still
-	// falls back to production and honors ParseStopMemoryBudget -- it just
-	// attempts the candidate route first instead of skipping it by source
-	// length. See attemptAdmissionCandidateFullParse's doc comment for the
-	// gap this retained-footprint gauge still has against cumulative
-	// ephemeral allocation, not just retained footprint.
+	// Large sources stay on production because the compact scheduler cannot poll
+	// the automatic memory budget at the required granularity. Smaller sources
+	// use the scheduler's retained-footprint poll before candidate admission.
+	// See attemptAdmissionCandidateFullParse's doc comment for the remaining gap
+	// between retained and ephemeral memory.
 	//
 	// Preserve callback fidelity: the compact route does not emit the parser's
 	// logger, GLR-trace, ambiguity-profile, or parse-progress events, so decline

--- a/admission_switch.go
+++ b/admission_switch.go
@@ -279,37 +279,17 @@ func (p *Parser) pinToProductionRoute() {
 // false) otherwise. On an eligible-but-declined attempt it bumps the fallback
 // counter (fail-closed, loud) so the caller re-runs the production route.
 //
-// Tranche B9 removed the source-length eligibility decline that used to keep
-// every input at or above parseRuntimeMemoryMinSourceBytes on production. A
-// large input now attempts the candidate route like any other: the scheduler's
-// stop-control poll (tranche B8, pollStopControl in
-// parsercore_phase0_driver.go) compares the compact core's own real retained
-// footprint (Core.FootprintBytes(), a capacity-based gauge -- see its doc
-// comment for the accounting it covers and the ephemeral-allocation gap it
-// still has) against the same soft budget production's arena/scratch
-// accounting honors, and the caller's own production/hard-ceiling backstop
-// (parseMemoryHardCeilingBytes) stays armed even when the soft budget is
-// disabled. On any decline -- a stop-control trip, an acceptance-gate
-// decline, or a materialization decline -- the runner releases the compact
-// core's retained capacity (Core.ResetReleasingRetention, not plain Reset:
-// Reset alone truncates logical length but keeps backing-array capacity for
-// reuse, which billed 157-193MB of retained memory to every later parse on
-// the same cached runner before this gate) before returning control to this
-// function, so a decline does not leave compact storage retained at an
-// unbounded multiple of the configured budget while production's fallback
-// parse runs. This bounds RETAINED footprint deterministically; it does not
-// bound the compact scheduler's own CUMULATIVE ephemeral allocation during
-// the declined attempt itself, which a GC-disabled measurement (unlike an
-// ordinary, GC-enabled process) can still observe as a multiple of the
-// configured budget above production's own contract -- see
-// stopControlFootprintChurnRatio's doc comment for the measured range and
-// why it is not fully closed. A pathological input that exceeds the budget
-// or a hard node/stack cap declines here (an engine decline, counted below,
-// which also bumps AdmissionCandidateCounters' fallback count -- an
-// operator watching that counter sees every one of these) and production
-// serves it, honoring ParseStopMemoryBudget exactly as it always has.
+// Keep every input at or above parseRuntimeMemoryMinSourceBytes on production.
+// The compact scheduler cannot poll the automatic memory budget at the required
+// granularity, so a large input must not attempt the candidate route.
+// Production then arms ParseStopMemoryBudget and its hard ceiling exactly as
+// before. This is an eligibility decline, so it does not increment fallback
+// counters or retain compact scheduler storage.
 func (p *Parser) attemptAdmissionCandidateFullParse(source []byte, oldTree *Tree, usingProductionDFA bool) (*Tree, bool) {
 	if !p.admissionCandidateFullParseEligible(oldTree, usingProductionDFA) {
+		return nil, false
+	}
+	if !admissionCandidateInputSizeEligible(len(source)) {
 		return nil, false
 	}
 	tree, ok, reason := p.tryCompactFullParseRoute(source)
@@ -320,4 +300,11 @@ func (p *Parser) attemptAdmissionCandidateFullParse(source []byte, oldTree *Tree
 	admissionCandidateFallback.Add(1)
 	admissionCandidateLastFallbackReason.Store(reason)
 	return nil, false
+}
+
+// admissionCandidateInputSizeEligible reports whether an input is small enough
+// to route through the compact candidate without weakening the production
+// route's automatic memory-budget contract.
+func admissionCandidateInputSizeEligible(sourceLen int) bool {
+	return sourceLen < parseRuntimeMemoryMinSourceBytes
 }

--- a/admission_switch_candidate_test.go
+++ b/admission_switch_candidate_test.go
@@ -25,10 +25,9 @@ func requireCandidateRouteBudgetMB(t testing.TB, mb int) {
 }
 
 // These tests run under the gts_parsercorephase0 tag, where the compact
-// candidate route is compiled in. They prove the switch actually routes a fresh
-// full parse through the compact route, that the routed tree is byte-exact with
-// production on the four canonical fixtures, and that incremental reuse is
-// available only when a routed tree carries the replay/scanner proof.
+// candidate route is compiled in. They prove the switch routes eligible fresh
+// full parses through the compact route, that the routed tree is byte-exact with
+// production, and that incremental reuse requires the replay/scanner proof.
 
 func newAdmissionCandidateGoParser(t testing.TB) *Parser {
 	t.Helper()
@@ -40,11 +39,9 @@ func newAdmissionCandidateGoParser(t testing.TB) *Parser {
 }
 
 // TestAdmissionSwitchParseRoutesCandidateWhenOn proves Parse serves the compact
-// candidate route for every canonical fixture when the switch is on,
-// including grammargen_lr (235,626 bytes): tranche B9 removed the
-// source-length eligibility decline that used to keep it on production, so
-// every canonical fixture now routes on size alone. Large-input safety comes
-// from the tranche B8 scheduler stop-control poll instead.
+// candidate route for each eligible canonical fixture when the switch is on.
+// The 235,626-byte grammargen_lr fixture remains on production because the
+// source-size gate protects the automatic memory-budget contract.
 func TestAdmissionSwitchParseRoutesCandidateWhenOn(t *testing.T) {
 	requireCandidateRouteBudgetMB(t, 256)
 	resetAdmissionCandidateCounters()
@@ -58,28 +55,33 @@ func TestAdmissionSwitchParseRoutesCandidateWhenOn(t *testing.T) {
 			t.Fatalf("%s: parse: %v", row.id, err)
 		}
 		routed1, fb1 := AdmissionCandidateCounters()
-		if routed1 != routed0+1 || fb1 != fb0 {
-			t.Fatalf("%s (%d bytes): expected one candidate route, got routed %d->%d fallback %d->%d (last=%q)",
-				row.id, len(fixture.Source), routed0, routed1, fb0, fb1, AdmissionCandidateLastFallbackReason())
-		}
-		if !tree.compactMaterialized {
-			t.Fatalf("%s: routed tree is not compact-materialized", row.id)
-		}
-		if !tree.incrementalReuseDisabled {
-			requireCompactIncrementalStateProof(t, tree)
+		if len(fixture.Source) < parseRuntimeMemoryMinSourceBytes {
+			if routed1 != routed0+1 || fb1 != fb0 {
+				t.Fatalf("%s (%d bytes): expected one candidate route, got routed %d->%d fallback %d->%d (last=%q)",
+					row.id, len(fixture.Source), routed0, routed1, fb0, fb1, AdmissionCandidateLastFallbackReason())
+			}
+			if !tree.compactMaterialized {
+				t.Fatalf("%s: routed tree is not compact-materialized", row.id)
+			}
+			if !tree.incrementalReuseDisabled {
+				requireCompactIncrementalStateProof(t, tree)
+			}
+		} else {
+			if routed1 != routed0 || fb1 != fb0 {
+				t.Fatalf("%s (%d bytes): large input attempted candidate route: routed %d->%d fallback %d->%d",
+					row.id, len(fixture.Source), routed0, routed1, fb0, fb1)
+			}
+			if tree.compactMaterialized {
+				t.Fatalf("%s: large input returned a compact-materialized tree", row.id)
+			}
 		}
 		tree.Release()
 	}
 }
 
-// TestAdmissionSwitchGrammargenLRRoutesCompactByDefault proves grammargen_lr
-// (235,626 bytes) routes through the compact candidate on the shipped API: no
-// per-Parser SetAdmissionCandidateRoute pin, no diagnostic build flag, just
-// the process-wide default the campaign shipped ON. Before tranche B9 this
-// fixture was permanently ineligible (it sits above the retired 64 KiB size
-// floor); today source length no longer decides eligibility, so the shipped
-// default routes it exactly like any other fixture.
-func TestAdmissionSwitchGrammargenLRRoutesCompactByDefault(t *testing.T) {
+// TestAdmissionSwitchGrammargenLRStaysOnProductionByDefault proves that the
+// shipped default does not attempt the candidate route for a large fixture.
+func TestAdmissionSwitchGrammargenLRStaysOnProductionByDefault(t *testing.T) {
 	requireCandidateRouteBudgetMB(t, 256)
 	previousDefault := AdmissionCandidateRouteDefault()
 	t.Cleanup(func() { SetAdmissionCandidateRouteDefault(previousDefault) })
@@ -88,8 +90,8 @@ func TestAdmissionSwitchGrammargenLRRoutesCompactByDefault(t *testing.T) {
 
 	p := newAdmissionCandidateGoParser(t) // no SetAdmissionCandidateRoute call: follows the process default
 	fixture := loadDiagnosticParserCoreCanonicalFixture(t, "grammargen_lr")
-	if len(fixture.Source) < 64*1024 {
-		t.Fatalf("grammargen_lr fixture is %d bytes, want it to exceed the retired 64 KiB floor", len(fixture.Source))
+	if len(fixture.Source) < parseRuntimeMemoryMinSourceBytes {
+		t.Fatalf("grammargen_lr fixture is %d bytes, want it to reach the source-size gate", len(fixture.Source))
 	}
 	routed0, fb0 := AdmissionCandidateCounters()
 	tree, err := p.Parse(fixture.Source)
@@ -98,12 +100,12 @@ func TestAdmissionSwitchGrammargenLRRoutesCompactByDefault(t *testing.T) {
 	}
 	defer tree.Release()
 	routed1, fb1 := AdmissionCandidateCounters()
-	if routed1 != routed0+1 || fb1 != fb0 {
-		t.Fatalf("grammargen_lr (%d bytes) did not route on the shipped default: routed %d->%d fallback %d->%d (last=%q)",
+	if routed1 != routed0 || fb1 != fb0 {
+		t.Fatalf("grammargen_lr (%d bytes) attempted the candidate route: routed %d->%d fallback %d->%d (last=%q)",
 			len(fixture.Source), routed0, routed1, fb0, fb1, AdmissionCandidateLastFallbackReason())
 	}
-	if !tree.compactMaterialized {
-		t.Fatal("grammargen_lr routed tree is not compact-materialized")
+	if tree.compactMaterialized {
+		t.Fatal("grammargen_lr large tree is compact-materialized")
 	}
 	digest := requireDiagnosticParserCoreCanonicalTreeDigest(t, tree, p.language)
 	if digest != fixture.DeepTreeSHA256 {
@@ -143,7 +145,7 @@ func TestAdmissionSwitchParseProductionWhenOff(t *testing.T) {
 // byte-exactness this proves holds regardless of which admission path a
 // caller takes to reach it. TestAdmissionSwitchParseRoutesCandidateWhenOn
 // separately proves the public Parse route reaches this same engine for every
-// canonical fixture, grammargen_lr included (tranche B9).
+// canonical fixture below the source-size gate.
 func TestAdmissionSwitchCandidateDigestMatchesProduction(t *testing.T) {
 	lang, err := authenticatedParserCoreGoLanguage(parserCoreWarmGoScanner)
 	if err != nil {

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -415,21 +415,11 @@ func TestAdmissionSwitchDeclinesWhenLoggerAttached(t *testing.T) {
 	}
 }
 
-// TestAdmissionCandidateMemoryBudgetContractPreserved proves the automatic
-// large-input memory budget contract survives tranche B9's removal of the
-// source-length eligibility decline.
+// TestAdmissionCandidateMemoryBudgetContractPreserved proves that the
+// admission switch preserves the production memory-budget contract.
 //
-// Before tranche B9, the switch declined every input at or above
-// parseRuntimeMemoryMinSourceBytes (64 KiB) outright: the compact scheduler
-// never attempted them, so it never needed to poll the budget itself. Tranche
-// B9 removed that decline; a large input now attempts the candidate route
-// like any other. The tranche B8 scheduler stop-control poll is what keeps
-// the contract intact: it compares the compact core's own deterministic
-// StorageBytes() against the same soft budget production's arena/scratch
-// accounting honors, declines (falls back to production) when the budget is
-// exceeded, and releases the compact core's storage before returning -- so a
-// pathological large input still stops at the configured budget and still
-// reports ParseStopMemoryBudget, just via a different mechanism than before.
+// Inputs at or above parseRuntimeMemoryMinSourceBytes stay on production. The
+// compact scheduler does not poll the automatic budget at scheduler granularity.
 func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 	minBudgetSourceBytes := gts.ParseRuntimeMemoryMinSourceBytesForTest()
 
@@ -465,8 +455,7 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 		}
 	}
 
-	// A clean source well above the former 64 KiB floor now routes too: no
-	// eligibility decline stops it by length alone (tranche B9).
+	// A clean source above the 64 KiB floor stays on production.
 	var big bytes.Buffer
 	big.WriteString("package p\n\nfunc f() {\n")
 	for big.Len() < minBudgetSourceBytes+(1<<15) {
@@ -483,19 +472,13 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 		t.Fatalf("large parse: %v", err)
 	}
 	bigTree.Release()
-	if routed, fallback := gts.AdmissionCandidateCounters(); !compiledOut && (routed != 1 || fallback != 0) {
-		t.Fatalf("source of %d bytes (>= %d former floor) did not route cleanly to the candidate: routed=%d fallback=%d reason=%q",
+	if routed, fallback := gts.AdmissionCandidateCounters(); !compiledOut && (routed != 0 || fallback != 0) {
+		t.Fatalf("source of %d bytes (>= %d floor) attempted the candidate: routed=%d fallback=%d reason=%q",
 			big.Len(), minBudgetSourceBytes, routed, fallback, gts.AdmissionCandidateLastFallbackReason())
 	}
 
-	// With a low budget, a pathological large source still stops at
-	// ParseStopMemoryBudget: the candidate route attempts it, the scheduler's
-	// storage-based stop-control poll trips before completion (an engine
-	// decline, not a never-attempted eligibility decline), and production
-	// serves the fallback honoring the identical configured budget. The
-	// decline must also release the compact core's storage before returning,
-	// so production's fallback never runs alongside retained compact storage
-	// (tranche B9 storage-release gate).
+	// With a low budget, a pathological large source stays on production and
+	// stops at ParseStopMemoryBudget without creating a compact runner.
 	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "1")
 	gts.ResetParseEnvConfigCacheForTests()
 	defer gts.ResetParseEnvConfigCacheForTests()
@@ -518,15 +501,11 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 		t.Fatalf("ParseStopReason() = %q, want %q (production must serve the fallback and honor the budget)",
 			got, gts.ParseStopMemoryBudget)
 	}
-	if routed, fallback := gts.AdmissionCandidateCounters(); routed != 0 || (!compiledOut && fallback != 1) {
-		t.Fatalf("budgeted huge source: routed=%d fallback=%d (want routed=0, fallback=1 unless compiled out)", routed, fallback)
+	if routed, fallback := gts.AdmissionCandidateCounters(); routed != 0 || fallback != 0 {
+		t.Fatalf("budgeted huge source: routed=%d fallback=%d (want routed=0, fallback=0)", routed, fallback)
 	}
-	// StorageBytes reads 0 after any Reset regardless of retained capacity
-	// (it counts live length, not backing-array size), so it cannot detect a
-	// decline that reset length but left a large arena retained -- assert
-	// FootprintBytes instead, which reads real capacity. requireCompactFootprintReleased
-	// bounds it well under the pre-fix retained level (157-193MB measured for
-	// this decline class before the retention-cap gate existed).
+	// No candidate runner exists after an eligibility decline, so its retained
+	// footprint must remain empty.
 	requireCompactFootprintReleased(t, hugeParser, "stop-control memory-budget decline")
 }
 

--- a/benchmark_real_go_test.go
+++ b/benchmark_real_go_test.go
@@ -108,9 +108,9 @@ func benchmarkWarmRealGoDFA(b *testing.B, fixture benchfixtures.LoadedFixture, l
 	// unpinned parser here silently measures the compact route on both sides
 	// of an A/B comparison instead of production (b4b-width-repair audit,
 	// 2026-08; oak-b's v9 decomposition first caught this reproducing
-	// unmodified on origin/main). Tranche B9 removed the source-length
-	// eligibility ceiling that used to additionally exempt the largest
-	// fixture from this risk; every fixture now needs this explicit pin. The
+	// unmodified on origin/main). The restored source-size gate keeps the largest
+	// fixture on production, but smaller fixtures remain DFA-eligible. Every
+	// fixture still needs this explicit pin. The
 	// guard assertion after the timed loop below fails loudly if this pin is
 	// ever lost again, instead of silently re-conflating the two routes.
 	parser.SetAdmissionCandidateRoute(false)

--- a/docs/authoring-languages.md
+++ b/docs/authoring-languages.md
@@ -365,24 +365,26 @@ only when set, so standard grammars' JSON stays unchanged. Equivalently in
 code: set `g.WantsForest = true` on the IR, or `lang.WantsForest = true` on
 a loaded Language. `ExtendGrammar` inherits the flag from its base.
 
-**What it does.** `WantsForest` opts the language into the GSS-forest GLR
-fast path (`glr_forest.go`): a graph-structured-stack parse that coalesces
-equivalent stack tops instead of forking full stacks. Built-in languages
-get this through a curated, byte-parity-certified default map
-(`builtinForestDefaults`); your language cannot join that map without a PR
-— `WantsForest` is the supported alternative.
+**What it does.** `WantsForest` requests the GSS-forest GLR fast path
+(`glr_forest.go`): a graph-structured-stack parse that coalesces equivalent
+stack tops instead of forking full stacks. Normal `Parse` admission also
+requires proof that the external scanner supports incremental reuse. Built-in
+languages get this through a curated, byte-parity-certified default map
+(`builtinForestDefaults`); your language cannot join that map without a PR.
+Use `WantsForest` for a proven consumer language.
 
 **When to enable it.** Enable it for ambiguity-heavy grammars: many
 declared `conflicts`, heavy GLR forking, and deep expression nesting where
 production GLR blows up on stack-equivalence checks (bash was the
 motivating case). For a mostly deterministic LR grammar it buys little.
 
-**Risk profile, stated honestly.** By default, the forest path declines
-(falls back to the production parser) unless it produces a clean, complete
-tree. What you can get is a *clean but different* tree on ambiguous
-inputs, because your grammar bypasses the byte-range parity certification
-built-ins undergo — that trade is explicitly yours (see the
-`Language.WantsForest` doc comment in `language.go`). Forest error
+**Risk profile, stated honestly.** The normal forest path declines before
+dispatch when the scanner lacks incremental-reuse proof. After admission, it
+falls back to the production parser unless it produces a clean, complete
+tree. Use `ParseForestExperimental` for an unproven diagnostic run. A clean
+but different tree can still occur on ambiguous inputs, so validate the
+consumer corpus before shipping. See the `Language.WantsForest` doc comment
+in `language.go`. Forest error
 recovery defaults are name-keyed; `GOT_GLR_FOREST_RECOVER=1` or
 `gotreesitter.SetGLRForestRecover` enables recovery globally for
 experiments and tests, so validate error-bearing trees separately when you

--- a/docs/bytecode-stream-spec.md
+++ b/docs/bytecode-stream-spec.md
@@ -1,0 +1,14 @@
+# Bytecode stream specification
+
+The canonical parser bytecode stream specification lives in the GoTreeSitter
+Hyphae space:
+
+hypha://m31labs/gotreesitter/object/spec.c4-bytecode-isa.v1
+
+Use that object as the source of truth for the instruction set, deterministic
+corridor, generalized-LR fallback, stream layout, decode-back proof, and
+measurement gates. This repository file is an index only. It prevents the
+runbook and repository from pointing at an untracked design document.
+
+The specification is a design brief. It does not claim that the bytecode
+stream is implemented.

--- a/docs/v10-gcp-fleet-measurement-runbook.md
+++ b/docs/v10-gcp-fleet-measurement-runbook.md
@@ -1,0 +1,313 @@
+---
+mdpp: "0.1"
+id: runbook.v10-gcp-fleet-measurement
+type: runbook
+space: hypha://m31labs/gotreesitter
+status: active
+created: 2026-08-03
+tags: [performance, gcp, fleet, bisect, runbook]
+related:
+  - hypha://m31labs/gotreesitter/object/concept.quiet-host-protocol
+  - hypha://m31labs/gotreesitter/object/spec.c4-bytecode-isa.v1
+---
+
+# V10 full-fleet measurement on a fresh Google Cloud VM
+
+Use this runbook to measure the v10 parser on a fresh Google Compute Engine
+(GCE) virtual machine. Run the complete 206-language fleet at every bisect
+boundary. Keep each result with its immutable source and corpus identity.
+
+This runbook extends phase3-admission-timing-runbook.md. The phase-3 runbook
+covers the four canonical fixtures. This runbook covers the authenticated full
+fleet and the regression ladder.
+
+## Record the measurement identity
+
+Set these values before provisioning the machine:
+
+~~~sh
+export GCP_PROJECT=bookt-cc
+export GCP_ZONE=us-central1-c
+export VM_NAME=gts-v10-$(date -u +%Y%m%d-%H%M%S)
+export PERF_HOSTNAME=gts-v10-full-fleet
+export CORPUS_LOCK_SHA=41c744279c8b1d7c9fe7b1b8e26fba733423e77cd48efea46927309c22d163ea
+~~~
+
+Record the following values in the final receipt:
+
+- repository commit and clean-worktree result;
+- machine type, zone, and pinned CPU;
+- Google Cloud image name and digest;
+- Go and Docker image identities;
+- corpus lock path and SHA-256 digest;
+- full-fleet language count;
+- output directory and raw logs.
+
+Do not publish a partial or interrupted scan.
+
+## Provision the VM
+
+Check authentication and the selected project:
+
+~~~sh
+gcloud auth list
+gcloud config set project "$GCP_PROJECT"
+gcloud compute instances list --project "$GCP_PROJECT"
+~~~
+
+Use a dedicated eight-vCPU Compute-Optimized VM. Use Spot capacity and delete
+the VM after the run. The earlier v9 run found no regional quota for the
+preferred N2D shape, so use C2 unless N2D quota is confirmed.
+
+~~~sh
+gcloud compute machine-types describe n2d-standard-4 \
+  --zone "$GCP_ZONE" >/dev/null 2>&1 || true
+
+gcloud compute instances create "$VM_NAME" \
+  --project "$GCP_PROJECT" \
+  --zone "$GCP_ZONE" \
+  --machine-type c2-standard-8 \
+  --provisioning-model SPOT \
+  --instance-termination-action DELETE \
+  --image-family ubuntu-2404-lts-amd64 \
+  --image-project ubuntu-os-cloud \
+  --boot-disk-size 100GB \
+  --boot-disk-type pd-balanced \
+  --metadata enable-oslogin=TRUE
+~~~
+
+Use a regular VM when Spot capacity cannot satisfy the measurement window.
+Do not run another workload on this VM.
+
+## Install the fresh machine
+
+Connect to the VM and install only the required tools:
+
+~~~sh
+gcloud compute ssh "$VM_NAME" --project "$GCP_PROJECT" --zone "$GCP_ZONE"
+~~~
+
+Run these commands on the VM:
+
+~~~sh
+sudo apt-get update
+sudo apt-get install -y ca-certificates git curl jq tmux util-linux \
+  build-essential docker.io golang-go
+sudo systemctl enable --now docker
+sudo usermod -aG docker "$USER"
+newgrp docker
+docker version
+export PERF_HOSTNAME=gts-v10-full-fleet
+export CORPUS_LOCK_SHA=41c744279c8b1d7c9fe7b1b8e26fba733423e77cd48efea46927309c22d163ea
+~~~
+
+Keep the host quiet. Do not install monitoring agents, cron jobs, or package
+updates during the timing window. Pin one CPU for the container and reserve
+the other CPUs for Docker and the operating system.
+
+## Check out the source
+
+Clone the private repository or the exact repository mirror used for the run.
+Then check out the target commit in detached mode:
+
+~~~sh
+sudo mkdir -p /srv/gotreesitter-perf
+sudo chown "$USER":"$USER" /srv/gotreesitter-perf
+git clone https://github.com/odvcencio/gotreesitter.git \
+  /srv/gotreesitter-perf/gotreesitter
+cd /srv/gotreesitter-perf/gotreesitter
+git fetch --tags --prune origin
+git checkout --detach "$TARGET_REV"
+test -z "$(git status --porcelain)"
+git rev-parse HEAD
+~~~
+
+Replace TARGET_REV with the full 40-character commit before running the
+commands. Record the printed commit.
+
+## Stage the authenticated corpus
+
+The full-fleet runner uses an external corpus checkout. It does not use the
+grammar lock in grammars/languages.lock. Copy the exact external lock from a
+trusted measurement host:
+
+~~~sh
+# Run this command from the trusted host.
+gcloud compute scp \
+  /home/draco/work/gotreesitter-corpora/corpus_sources.lock \
+  "$VM_NAME:/srv/gotreesitter-perf/corpus_sources.lock" \
+  --project "$GCP_PROJECT" --zone "$GCP_ZONE"
+~~~
+
+Verify the lock before cloning any source:
+
+~~~sh
+cd /srv/gotreesitter-perf/gotreesitter
+sha256sum /srv/gotreesitter-perf/corpus_sources.lock
+test "$(sha256sum /srv/gotreesitter-perf/corpus_sources.lock | awk '{print $1}')" = \
+  "$CORPUS_LOCK_SHA"
+~~~
+
+Materialize every locked source with the repository helper:
+
+~~~sh
+mkdir -p /srv/gotreesitter-perf/corpus_sources
+GOWORK=off go run ./cgo_harness/cmd/real_corpus_sources \
+  --lock /srv/gotreesitter-perf/corpus_sources.lock \
+  --root /srv/gotreesitter-perf/corpus_sources \
+  --langs all206 \
+  --apply \
+  --out-json /srv/gotreesitter-perf/corpus-source-status.json
+~~~
+
+Inspect the status file. Require 206 locked languages, matching commits, and
+no source errors. The sparse Git clones can use substantial disk space.
+Keep at least 100 GB free before starting the scan.
+
+## Run the authoritative full fleet
+
+Build the pinned local Docker image and run the scan from the checked-out
+repository:
+
+~~~sh
+cd /srv/gotreesitter-perf/gotreesitter
+REV=$(git rev-parse HEAD)
+OUT="cgo_harness/perf_scan/out/v10-${REV}-$(date -u +%Y%m%dT%H%M%SZ)"
+
+bash cgo_harness/docker/run_parity_in_docker.sh \
+  --label "v10-${REV}" \
+  --memory 8g \
+  --cpus 1 \
+  --cpuset-cpus 4 \
+  --pids 4096 \
+  --gomemlimit 6GiB \
+  --timeout 0 \
+  --hostname "$PERF_HOSTNAME" \
+  --mount /srv/gotreesitter-perf:/corpus:ro \
+  -- \
+  "cd /workspace/cgo_harness && \
+   GOWORK=off \
+   GTS_PARITY_ALLOW_HOST=1 \
+   GTS_PERF_SCAN=1 \
+   GTS_PERF_SCAN_HARD_GATE=1 \
+   GTS_PERF_SCAN_REQUIRE_FLEET=1 \
+   GTS_PERF_SCAN_GIT_REVISION=$REV \
+   GTS_PERF_SCAN_GIT_CLEAN=1 \
+   GTS_PERF_SCAN_CORPUS_ROOT=/corpus/corpus_sources \
+   GTS_REAL_CORPUS_BENCH_LOCK=/corpus/corpus_sources.lock \
+   GTS_PERF_SCAN_MAX_FILES=8 \
+   GTS_PERF_SCAN_ORDER=largest \
+   GTS_PERF_SCAN_REPS=5 \
+   GTS_PERF_SCAN_FILE_BUDGET_MS=10000 \
+   GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=6144 \
+   GTS_PERF_SCAN_OUT=/workspace/$OUT \
+   go test -tags 'treesitter_c_parity treesitter_c_perfscan' \
+     -run '^TestPerfScanSweep$' -v -count=1 -timeout 0 ."
+~~~
+
+The explicit revision and clean-source values authenticate the Docker root
+when Git VCS metadata is unavailable inside the container. Use them only after
+the host checkout passes the clean-worktree check.
+
+Require one authenticated scoreboard row for every locked language. Preserve
+the container log, metadata file, scoreboard, and Markdown report.
+
+## Run the bisect ladder
+
+Run the same full-fleet command at each immutable boundary. Keep one output
+directory per revision. Do not change the machine, CPU pin, corpus lock, Go
+image, Docker image, file budget, or repetition count between revisions.
+
+Use this ladder from the sealed v8 baseline through the v9 boundary:
+
+| label | commit | known change |
+|---|---|---|
+| v8 | 3325e0b107cdc23a1092714e311dbe426f59bb70 | sealed baseline |
+| pr605 | 8f93cecf | leaf tiling |
+| pr614 | df619d1c | de-indirect dispatch and shadow census; confounded step |
+| pr616 | 1deca56a | compact struct widening; largest measured step |
+| pr619 | 193c44b3 | recording-on and rank-walk retirement |
+| pr622 | 492cd600 | L1 fast paths |
+| v10 | <target revision> | current target |
+
+For every row, run:
+
+~~~sh
+git checkout --detach "$REV"
+test -z "$(git status --porcelain)"
+# Re-run the authoritative command above with this REV and a unique OUT path.
+~~~
+
+Treat the first statistically significant step as the regression point. Use
+the four canonical fixtures for mechanism attribution after the fleet scan.
+Use ten or more stable samples for each comparison. Report the geomean and
+each language result separately.
+
+The prior quiet GCP ladder provides a hypothesis for the v10 receipt:
+
+- v8 to PR605: about +0.83% geomean; two of four fixtures were significant;
+- PR605 to PR614: about +2.08% geomean; all four fixtures were significant;
+- PR614 to PR616: about +2.80% geomean; all four fixtures were significant;
+- PR616 to PR619: about +0.41% geomean; one of four fixtures was significant;
+- PR619 to PR622: about -0.25% geomean; no fixture was significant.
+
+The PR614 step contains two changes. The PR616 struct-widening step is the
+largest isolated regression in that ladder. Confirm both statements with the
+v10 run before treating them as final fleet evidence.
+
+## Keep production and candidate tags correct
+
+The production full-parse driver must use gts_no_parsercorephase0. The
+candidate driver must use gts_parsercorephase0. Do not use the candidate tag
+for a production control. A previous GCP run silently measured the compact
+route as production after using the wrong tag.
+
+Use the canonical four-fixture driver when you need mechanism-level timing:
+
+~~~sh
+bash cgo_harness/pure_c/run_canonical_go_full_parse.sh \
+  --go-backend production --core 4 --out "$OUT/production"
+bash cgo_harness/pure_c/run_canonical_go_full_parse.sh \
+  --go-backend candidate --core 4 --out "$OUT/candidate"
+~~~
+
+Run the driver on the same clean revision and pinned core. Read
+phase3-admission-timing-runbook.md before using its publication thresholds.
+
+## Bytecode stream specification
+
+The canonical bytecode stream specification is already active in Hyphae:
+
+hypha://m31labs/gotreesitter/object/spec.c4-bytecode-isa.v1
+
+It defines the instruction set, deterministic corridor, generalized-LR (GLR)
+fallback, stream layout, decode-back proof, and staged measurement gates. Keep
+that Hyphae object as the source of truth. This runbook records measurement
+procedure only.
+
+Verify the object before a campaign handoff:
+
+~~~sh
+hypha show hypha://m31labs/gotreesitter/object/spec.c4-bytecode-isa.v1 --body
+~~~
+
+Do not claim that the bytecode stream is implemented. The specification is a
+design brief with explicit correctness and performance gates.
+
+## Preserve and clean up
+
+Copy the complete output directory off the VM before deletion. Store the
+receipt with the commit, lock digest, host identity, and regression summary.
+
+~~~sh
+gcloud compute scp --recurse \
+  "$VM_NAME:/srv/gotreesitter-perf/gotreesitter/cgo_harness/perf_scan/out" \
+  ./v10-receipts/ \
+  --project "$GCP_PROJECT" --zone "$GCP_ZONE"
+
+gcloud compute instances delete "$VM_NAME" \
+  --project "$GCP_PROJECT" --zone "$GCP_ZONE" --quiet
+~~~
+
+If the VM terminates before the output is copied, mark the run incomplete.
+Do not merge incomplete artifacts into the authoritative fleet scoreboard.

--- a/docs/v10-gcp-fleet-measurement-runbook.md
+++ b/docs/v10-gcp-fleet-measurement-runbook.md
@@ -163,7 +163,8 @@ GOWORK=off go run ./cmd/real_corpus_sources \
 
 Inspect the status file. Require 206 locked languages, matching commits, and
 no source errors. The sparse Git clones can use substantial disk space.
-Keep at least 100 GB free before starting the scan.
+Keep at least 40 GB free after materializing the corpus. Increase the boot
+disk size when the host has less free space.
 
 ## Run the authoritative full fleet
 

--- a/docs/v10-gcp-fleet-measurement-runbook.md
+++ b/docs/v10-gcp-fleet-measurement-runbook.md
@@ -152,7 +152,8 @@ Materialize every locked source with the repository helper:
 
 ~~~sh
 mkdir -p /srv/gotreesitter-perf/corpus_sources
-GOWORK=off go run ./cgo_harness/cmd/real_corpus_sources \
+cd /srv/gotreesitter-perf/gotreesitter/cgo_harness
+GOWORK=off go run ./cmd/real_corpus_sources \
   --lock /srv/gotreesitter-perf/corpus_sources.lock \
   --root /srv/gotreesitter-perf/corpus_sources \
   --langs all206 \

--- a/forest_incremental_admission_test.go
+++ b/forest_incremental_admission_test.go
@@ -23,11 +23,12 @@ func (unavailableForestCheckpointScanner) UsesExternalScannerCheckpoints() bool 
 
 func TestForestIncrementalStatelessAdmission(t *testing.T) {
 	cases := []struct {
-		name   string
-		lang   func() *gts.Language
-		prefix string
-		suffix string
-		line   func(int) string
+		name       string
+		lang       func() *gts.Language
+		wantForest bool
+		prefix     string
+		suffix     string
+		line       func(int) string
 	}{
 		{name: "awk", lang: grammars.AwkLanguage, line: func(i int) string {
 			return fmt.Sprintf("BEGIN { value_%06d = %d; print value_%06d }\n", i, i, i)
@@ -43,6 +44,24 @@ func TestForestIncrementalStatelessAdmission(t *testing.T) {
 		}},
 		{name: "uxntal", lang: grammars.UxntalLanguage, line: func(i int) string {
 			return fmt.Sprintf("@value_%06d BRK\n", i)
+		}},
+		{name: "toml", lang: grammars.TomlLanguage, wantForest: true, line: func(i int) string {
+			return fmt.Sprintf("value_%06d = %d\n", i, i)
+		}},
+		{name: "css", lang: grammars.CssLanguage, wantForest: true, line: func(i int) string {
+			return fmt.Sprintf(".value_%06d { width: %dpx; }\n", i, i)
+		}},
+		{name: "tsx", lang: grammars.TsxLanguage, wantForest: true, line: func(i int) string {
+			return fmt.Sprintf("const value_%06d = %d;\n", i, i)
+		}},
+		{name: "ini", lang: grammars.IniLanguage, wantForest: true, line: func(i int) string {
+			return fmt.Sprintf("[value_%06d]\nkey = %d\n", i, i)
+		}},
+		{name: "scss", lang: grammars.ScssLanguage, wantForest: true, line: func(i int) string {
+			return fmt.Sprintf(".value_%06d { width: %dpx; }\n", i, i)
+		}},
+		{name: "typescript", lang: grammars.TypescriptLanguage, wantForest: true, line: func(i int) string {
+			return fmt.Sprintf("const value_%06d = %d;\n", i, i)
 		}},
 	}
 
@@ -70,7 +89,13 @@ func TestForestIncrementalStatelessAdmission(t *testing.T) {
 					}
 					for _, class := range plan.classes {
 						edited, edit := applyStatelessScannerCertificationEdit(source, site, class)
-						runForestIncrementalStatelessSample(t, tc.lang(), source, edited, edit)
+						lang := tc.lang()
+						if tc.wantForest {
+							copy := *lang
+							copy.WantsForest = true
+							lang = &copy
+						}
+						runForestIncrementalStatelessSample(t, lang, source, edited, edit)
 					}
 				}
 			}
@@ -114,6 +139,21 @@ func runForestIncrementalStatelessSample(t *testing.T, lang *gts.Language, sourc
 	defer fresh.Release()
 	requireCompleteParse(t, fresh, edited, lang, "fresh forest admission")
 	requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+}
+
+// TestForestIncrementalCheckpointAdmissionCMake keeps CMake on the
+// checkpoint-certified route. A changed-length edit must reuse the old tree.
+func TestForestIncrementalCheckpointAdmissionCMake(t *testing.T) {
+	source, sites := makeStatelessScannerCertificationSource(32<<10, "", "", func(i int) string {
+		return fmt.Sprintf("set(VALUE_%06d %d)\n", i, i)
+	})
+	if len(sites) == 0 {
+		t.Fatal("CMake fixture has no edit site")
+	}
+	edited, edit := applyStatelessScannerCertificationEdit(source, sites[len(sites)/2], statelessScannerReplace)
+	langCopy := *grammars.CmakeLanguage()
+	langCopy.WantsForest = true
+	runForestIncrementalStatelessSample(t, &langCopy, source, edited, edit)
 }
 
 func TestForestIncrementalCheckpointAdmission(t *testing.T) {

--- a/forest_incremental_admission_test.go
+++ b/forest_incremental_admission_test.go
@@ -67,6 +67,12 @@ func TestForestIncrementalStatelessAdmission(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			forestLang := tc.lang()
+			if tc.wantForest {
+				previous := forestLang.WantsForest
+				forestLang.WantsForest = true
+				defer func() { forestLang.WantsForest = previous }()
+			}
 			plans := []struct {
 				size      int
 				positions []string
@@ -89,13 +95,11 @@ func TestForestIncrementalStatelessAdmission(t *testing.T) {
 					}
 					for _, class := range plan.classes {
 						edited, edit := applyStatelessScannerCertificationEdit(source, site, class)
-						lang := tc.lang()
+						runLang := tc.lang()
 						if tc.wantForest {
-							copy := *lang
-							copy.WantsForest = true
-							lang = &copy
+							runLang = forestLang
 						}
-						runForestIncrementalStatelessSample(t, lang, source, edited, edit)
+						runForestIncrementalStatelessSample(t, runLang, source, edited, edit)
 					}
 				}
 			}
@@ -151,9 +155,11 @@ func TestForestIncrementalCheckpointAdmissionCMake(t *testing.T) {
 		t.Fatal("CMake fixture has no edit site")
 	}
 	edited, edit := applyStatelessScannerCertificationEdit(source, sites[len(sites)/2], statelessScannerReplace)
-	langCopy := *grammars.CmakeLanguage()
-	langCopy.WantsForest = true
-	runForestIncrementalStatelessSample(t, &langCopy, source, edited, edit)
+	lang := grammars.CmakeLanguage()
+	previous := lang.WantsForest
+	lang.WantsForest = true
+	defer func() { lang.WantsForest = previous }()
+	runForestIncrementalStatelessSample(t, lang, source, edited, edit)
 }
 
 func TestForestIncrementalCheckpointAdmission(t *testing.T) {

--- a/forest_incremental_correctness_test.go
+++ b/forest_incremental_correctness_test.go
@@ -71,11 +71,10 @@ func deleteEdit(src []byte, p int) forestEdit {
 // tree is byte-for-byte identical (s-expr) to a fresh parse of the same edited
 // source — only over edits that keep the source valid (an edit that breaks
 // syntax routes fresh through production error recovery, a different-but-valid
-// path). Erlang + JavaScript pass via real forest-incremental reuse; SCSS/CSS/
-// CMake remain outside the scanner-proof admission class (they FAILED this
-// gate — wrong/truncated trees) and reach the same assertion via fresh-parse
-// fallback. Admitting another scanner class without it passing here regresses
-// incremental correctness. Each case opts in explicitly so this experimental
+// path). Erlang, JavaScript, SCSS, CSS, and CMake pass through the
+// scanner-proof admission class and use real forest-incremental reuse.
+// Admitting another scanner class without it passing here regresses
+// incremental correctness. Each case opts in explicitly, so this experimental
 // gate remains independent of automatic-routing policy.
 func TestForestIncrementalCorrectness(t *testing.T) {
 	if os.Getenv("GTS_FOREST_INCR") == "" {
@@ -86,10 +85,9 @@ func TestForestIncrementalCorrectness(t *testing.T) {
 		file string
 		lang func() *gts.Language
 	}{
-		// Erlang + JavaScript do real forest-incremental reuse (must match fresh);
-		// SCSS, CSS and CMake are demoted from the incremental path, so they reach
-		// the same assertion via fresh-parse fallback. (Python's production
-		// incremental reuse has its own pre-existing bug and is out of scope.)
+		// Erlang, JavaScript, SCSS, CSS, and CMake use real forest-incremental
+		// reuse. Python's production incremental reuse has a separate bug and is
+		// out of scope.
 		{"javascript", "cgo_harness/corpus_real/javascript/large__jquery.js", grammars.JavascriptLanguage},
 		{"scss", "cgo_harness/corpus_real/scss/large__github.com.scss", grammars.ScssLanguage},
 		{"css", "cgo_harness/corpus_real/css/large__github.com.css", grammars.CssLanguage},

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -37,11 +37,11 @@ import (
 //	         dynamic_precedence-then-first-match selection for byte-identical out.
 
 // glrForestEnabled is the master switch for the GSS-forest fast path. ON by
-// default: the byte-range-verified languages in builtinForestDefaults (plus any
-// Language with WantsForest set, see parserWantsForest) dispatch to the forest
-// automatically (with production fallback). Set GOT_GLR_FOREST=0 to disable
-// globally; tests/benchmarks toggle via SetGLRForestEnabled. Languages that
-// want neither always use production regardless of this switch.
+// default: the byte-range-verified languages in builtinForestDefaults and
+// proven explicit opt-ins dispatch to the forest automatically (with
+// production fallback). Set GOT_GLR_FOREST=0 to disable globally;
+// tests and benchmarks toggle via SetGLRForestEnabled. Unproven explicit
+// opt-ins remain available through ParseForestExperimental only.
 var glrForestEnabled = os.Getenv("GOT_GLR_FOREST") != "0"
 
 // SetGLRForestEnabled toggles the GSS-forest path at runtime (tests/benchmarks).
@@ -518,13 +518,11 @@ func (p *Parser) recordForestDecline(reason string, tok Token, states []StateID)
 // remain available for every language.
 //
 // Non-built-in languages opt in per-Language via Language.WantsForest (see
-// parserWantsForest) instead of joining this map — e.g. a grammargen consumer
-// generating its own grammar (a Pawn grammar, say) sets WantsForest directly
-// (or grammargen.Grammar.WantsForest, plumbed through assemble) without
-// forking this file. That path bypasses the byte-range parity certification
-// this curated set underwent; the decline->production fallback still prevents
-// hard failures, but a clean-but-different tree is the consumer's
-// responsibility.
+// parserWantsForest) instead of joining this map — for example, a grammargen
+// consumer generating its own grammar sets WantsForest directly (or through
+// grammargen.Grammar.WantsForest). Normal Parse dispatch still requires the
+// scanner proof. Unproven opt-ins remain available through
+// ParseForestExperimental for diagnostic work.
 var builtinForestDefaults = map[string]bool{
 	"javascript": true,
 
@@ -561,32 +559,25 @@ var builtinForestDefaults = map[string]bool{
 	"gitattributes": true,
 }
 
-// parserWantsForest reports whether p's language is in the forest-default set:
-// either the Language opted in directly (WantsForest, set by a grammargen
-// consumer), or its automatic profile is certified and its scanner proves
-// incremental reuse. This is per-language eligibility only;
-// tryForestFastPath separately gates on the glrForestEnabled global switch
-// (GOT_GLR_FOREST) before dispatching.
+// parserWantsForest reports whether p's language may use forest dispatch in
+// normal Parse calls. Explicit and automatic routes require incremental-reuse
+// proof. Unproven explicit routes remain diagnostic-only.
 func parserWantsForest(p *Parser) bool {
 	return p != nil && LanguageWantsForest(p.language)
 }
 
-// LanguageWantsForest reports whether lang is in the forest-default set (see
-// parserWantsForest). Explicit WantsForest remains an experimenter's direct
-// opt-in. Automatic profiles also require a scanner proof because a forest
-// tree without an incremental reuse proof can turn every later edit into a
-// full reparse. It does not account for the glrForestEnabled global switch
-// (GOT_GLR_FOREST), which can still disable dispatch even for a language this
-// reports true for. Exported so regression gates outside this package (for
-// example, the regen-guard sweep that reparses repeated top-level items per
-// forest-default language) can enumerate the same set parserWantsForest uses,
-// without duplicating or drifting from builtinForestDefaults.
+// LanguageWantsForest reports whether lang may use forest dispatch in normal
+// Parse calls. Explicit and automatic routes require incremental-reuse proof;
+// ParseForestExperimental remains available for unproven explicit routes.
+// This function does not account for the glrForestEnabled global switch.
+// Exported so regression gates outside this package can enumerate the same set
+// parserWantsForest uses without duplicating builtinForestDefaults.
 func LanguageWantsForest(lang *Language) bool {
 	if lang == nil {
 		return false
 	}
 	if lang.WantsForest {
-		return true
+		return forestIncrementalReuseProven(lang)
 	}
 	if !lang.AutomaticForestEnabledByDefault && !builtinForestDefaults[lang.Name] {
 		return false

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -563,25 +563,35 @@ var builtinForestDefaults = map[string]bool{
 
 // parserWantsForest reports whether p's language is in the forest-default set:
 // either the Language opted in directly (WantsForest, set by a grammargen
-// consumer), its exact artifact received a certified automatic profile, or it
-// is one of the older curated built-ins in builtinForestDefaults. This is
-// per-language eligibility only; tryForestFastPath separately gates on the
-// glrForestEnabled global switch (GOT_GLR_FOREST) before dispatching.
+// consumer), or its automatic profile is certified and its scanner proves
+// incremental reuse. This is per-language eligibility only;
+// tryForestFastPath separately gates on the glrForestEnabled global switch
+// (GOT_GLR_FOREST) before dispatching.
 func parserWantsForest(p *Parser) bool {
 	return p != nil && LanguageWantsForest(p.language)
 }
 
 // LanguageWantsForest reports whether lang is in the forest-default set (see
-// parserWantsForest). It does not account for the glrForestEnabled global
-// switch (GOT_GLR_FOREST), which can still disable dispatch even for a
-// language this reports true for. Exported so regression gates outside this
-// package (e.g. the regen-guard sweep that reparses N repeated top-level
-// items per forest-default language) can enumerate the same set
-// parserWantsForest uses, without duplicating or drifting from
-// builtinForestDefaults.
+// parserWantsForest). Explicit WantsForest remains an experimenter's direct
+// opt-in. Automatic profiles also require a scanner proof because a forest
+// tree without an incremental reuse proof can turn every later edit into a
+// full reparse. It does not account for the glrForestEnabled global switch
+// (GOT_GLR_FOREST), which can still disable dispatch even for a language this
+// reports true for. Exported so regression gates outside this package (for
+// example, the regen-guard sweep that reparses repeated top-level items per
+// forest-default language) can enumerate the same set parserWantsForest uses,
+// without duplicating or drifting from builtinForestDefaults.
 func LanguageWantsForest(lang *Language) bool {
-	return lang != nil &&
-		(lang.WantsForest || lang.AutomaticForestEnabledByDefault || builtinForestDefaults[lang.Name])
+	if lang == nil {
+		return false
+	}
+	if lang.WantsForest {
+		return true
+	}
+	if !lang.AutomaticForestEnabledByDefault && !builtinForestDefaults[lang.Name] {
+		return false
+	}
+	return forestIncrementalReuseProven(lang)
 }
 
 func automaticForestMemoryBudget(p *Parser, operationBudget int64) int64 {

--- a/glr_forest_dispatch_test.go
+++ b/glr_forest_dispatch_test.go
@@ -175,10 +175,10 @@ func requireForestFallbackNodeIdentity(t *testing.T, path string, got, want *gts
 }
 
 // TestForestDispatchParity verifies the forest fast path is invisible: for an
-// explicitly dispatched language, the forest tree must be byte-identical to
-// production — same s-expr AND same root byte
-// span — and anything the forest declines (malformed input, non-dispatched
-// languages) must match production because we fall back to it.
+// admitted language, the forest tree must be byte-identical to production —
+// same s-expr AND same root byte span — and anything the forest declines
+// (malformed input, unproven opt-ins, non-dispatched languages) must match
+// production because we fall back to it.
 // SetGLRForestEnabled(false) yields the production baseline; true enables the
 // dispatch gate.
 func TestForestDispatchParity(t *testing.T) {
@@ -234,9 +234,10 @@ func TestForestDispatchParity(t *testing.T) {
 	for _, s := range malformed {
 		check("css-malformed-fallback", css, s)
 	}
-	// Bash compatibility remains testable through explicit forest dispatch.
+	// An unproven Bash opt-in remains on the production route. Its diagnostic
+	// forest compatibility is covered by TestForestExperimentalAppliesBashCompatibility.
 	bash := explicitForestLanguage(t, grm.BashLanguage())
-	check("bash-dispatched", bash, "f() { echo a; }\n")
+	check("bash-unproven-fallback", bash, "f() { echo a; }\n")
 	// Non-dispatched languages must be untouched even with the switch on.
 	check("go-untouched", grm.GoLanguage(), "package p\nfunc f() { return }\n")
 	goTree, err := gts.NewParser(grm.GoLanguage()).Parse([]byte("package p\nfunc f() { return }\n"))
@@ -380,8 +381,8 @@ func TestForestDispatchReportsAcceptedRuntime(t *testing.T) {
 	gts.SetGLRForestEnabled(true)
 	defer gts.SetGLRForestEnabled(true)
 
-	src := []byte("f() { echo a; }\n")
-	lang := explicitForestLanguage(t, grm.BashLanguage())
+	src := []byte("a { color: red; }\n")
+	lang := explicitForestLanguage(t, grm.CssLanguage())
 	// Pin to production: this test asserts a production-engine internal (the
 	// forest fast-path dispatch runtime) the compact candidate route bypasses.
 	parser := gts.NewParser(lang)
@@ -455,7 +456,7 @@ func TestForestDispatchPromotesJavaScript(t *testing.T) {
 	}
 }
 
-func TestForestDispatchPromotesCSharp(t *testing.T) {
+func TestUnprovenExplicitForestOptInStaysDiagnosticOnly(t *testing.T) {
 	gts.SetGLRForestEnabled(true)
 	defer gts.SetGLRForestEnabled(true)
 
@@ -480,15 +481,23 @@ class C {
 	gts.SetGLRForestEnabled(true)
 	tree, err := gts.NewParser(lang).Parse(src)
 	if err != nil {
-		t.Fatalf("forest dispatch parse: %v", err)
+		t.Fatalf("normal parse: %v", err)
 	}
 	defer tree.Release()
 	if got, want := tree.RootNode().SExpr(lang), prod.RootNode().SExpr(lang); got != want {
-		t.Fatalf("C# forest dispatch diverged\n got: %s\nwant: %s", got, want)
+		t.Fatalf("normal parse diverged\n got: %s\nwant: %s", got, want)
 	}
 	rt := tree.ParseRuntime()
-	if rt.StopReason != gts.ParseStopAccepted || !rt.ForestFastPath || !rt.LastTokenWasEOF || rt.TokensConsumed != 0 {
-		t.Fatalf("C# did not use forest accepted runtime: %s", rt.Summary())
+	if rt.ForestFastPath {
+		t.Fatalf("unproven explicit opt-in used normal forest dispatch: %s", rt.Summary())
+	}
+	experimental, ok := gts.NewParser(lang).ParseForestExperimental(src)
+	if !ok || experimental == nil {
+		t.Fatalf("diagnostic forest parse ok=%t tree_nil=%t", ok, experimental == nil)
+	}
+	defer experimental.Release()
+	if got, want := experimental.RootNode().SExpr(lang), prod.RootNode().SExpr(lang); got != want {
+		t.Fatalf("diagnostic forest parse diverged\n got: %s\nwant: %s", got, want)
 	}
 }
 
@@ -507,9 +516,9 @@ func TestForestTreeIncrementalEditCSharpNumericLiteralFastRescue(t *testing.T) {
 
 	lang := explicitForestLanguage(t, grm.CSharpLanguage())
 	parser := gts.NewParser(lang)
-	oldTree, err := parser.Parse(src)
-	if err != nil {
-		t.Fatalf("initial parse: %v", err)
+	oldTree, ok := parser.ParseForestExperimental(src)
+	if !ok || oldTree == nil {
+		t.Fatalf("initial diagnostic forest parse: ok=%t tree_nil=%t", ok, oldTree == nil)
 	}
 	defer oldTree.Release()
 	if rt := oldTree.ParseRuntime(); rt.StopReason != gts.ParseStopAccepted || !rt.ForestFastPath || !rt.LastTokenWasEOF || rt.TokensConsumed != 0 {
@@ -631,9 +640,9 @@ record F<T1, T2> where T1 : I1, I2, new() where T2 : I2 { }
 
 	lang := explicitForestLanguage(t, grm.CSharpLanguage())
 	parser := gts.NewParser(lang)
-	oldTree, err := parser.Parse(src)
-	if err != nil {
-		t.Fatalf("initial parse: %v", err)
+	oldTree, ok := parser.ParseForestExperimental(src)
+	if !ok || oldTree == nil {
+		t.Fatalf("initial diagnostic forest parse: ok=%t tree_nil=%t", ok, oldTree == nil)
 	}
 	defer oldTree.Release()
 	if rt := oldTree.ParseRuntime(); rt.StopReason != gts.ParseStopAccepted || !rt.ForestFastPath || !rt.LastTokenWasEOF || rt.TokensConsumed != 0 {
@@ -713,9 +722,9 @@ func TestForestTreeIncrementalEditCSharpContextualIdentifierStillFallsBack(t *te
 
 	lang := explicitForestLanguage(t, grm.CSharpLanguage())
 	parser := gts.NewParser(lang)
-	oldTree, err := parser.Parse(src)
-	if err != nil {
-		t.Fatalf("initial parse: %v", err)
+	oldTree, ok := parser.ParseForestExperimental(src)
+	if !ok || oldTree == nil {
+		t.Fatalf("initial diagnostic forest parse: ok=%t tree_nil=%t", ok, oldTree == nil)
 	}
 	defer oldTree.Release()
 	if rt := oldTree.ParseRuntime(); rt.StopReason != gts.ParseStopAccepted || !rt.ForestFastPath || !rt.LastTokenWasEOF || rt.TokensConsumed != 0 {
@@ -768,9 +777,9 @@ func TestForestTreeIncrementalEditCSharpStringLiteralStillFallsBack(t *testing.T
 
 	lang := explicitForestLanguage(t, grm.CSharpLanguage())
 	parser := gts.NewParser(lang)
-	oldTree, err := parser.Parse(src)
-	if err != nil {
-		t.Fatalf("initial parse: %v", err)
+	oldTree, ok := parser.ParseForestExperimental(src)
+	if !ok || oldTree == nil {
+		t.Fatalf("initial diagnostic forest parse: ok=%t tree_nil=%t", ok, oldTree == nil)
 	}
 	defer oldTree.Release()
 	if rt := oldTree.ParseRuntime(); rt.StopReason != gts.ParseStopAccepted || !rt.ForestFastPath || !rt.LastTokenWasEOF || rt.TokensConsumed != 0 {
@@ -798,9 +807,8 @@ func TestForestTreeIncrementalEditCSharpStringLiteralStillFallsBack(t *testing.T
 }
 
 // TestForestTreeIncrementalEditCSSTokenInvariantLeafReuseIsCorrect verifies the
-// safe reuse path for css forest trees that are otherwise demoted from general
-// forest-incremental reuse. Same-length edits inside a leaf can reuse the old
-// tree when rescanning the edited leaf preserves token kind and span.
+// safe reuse path for CSS forest trees. Same-length edits inside a leaf can
+// reuse the old tree when rescanning preserves the token kind and span.
 func TestForestTreeIncrementalEditCSSTokenInvariantLeafReuseIsCorrect(t *testing.T) {
 	gts.SetGLRForestEnabled(true)
 	defer gts.SetGLRForestEnabled(true)
@@ -1181,10 +1189,9 @@ func TestHCLIncrementalEditDigitLeafReuseIsCorrect(t *testing.T) {
 	}
 }
 
-// TestForestTreeIncrementalEditCMakeTextInvariantLeafReuseIsCorrect: cmake
-// remains outside forestIncrementalReuseProven, but same-length
-// alphanumeric edits inside unquoted_argument leaves can use the token-invariant
-// rescue path safely.
+// TestForestTreeIncrementalEditCMakeTextInvariantLeafReuseIsCorrect verifies
+// that same-length alphanumeric edits inside unquoted_argument leaves can use
+// the token-invariant rescue path safely.
 func TestForestTreeIncrementalEditCMakeTextInvariantLeafReuseIsCorrect(t *testing.T) {
 	gts.SetGLRForestEnabled(true)
 	defer gts.SetGLRForestEnabled(true)

--- a/grammargen/grammar.go
+++ b/grammargen/grammar.go
@@ -89,7 +89,9 @@ type Grammar struct {
 	ExternalReduceFollowLookaheads             []string      // external token names that may be valid after reducing in the current state
 	PriorityInlinePatterns                     []string      // anonymous pattern terminals that should win same-length ties against named tokens
 	PreserveHiddenChoicePassthrough            []string      // hidden choice rules whose single-symbol reductions must not be flattened away
-	WantsForest                                bool          // opt this grammar's assembled Language into the GSS-forest GLR fast path (see gotreesitter.Language.WantsForest)
+	// WantsForest requests the forest path for the assembled Language.
+	// Normal Parse admission requires scanner incremental-reuse proof.
+	WantsForest bool
 }
 
 // NewGrammar creates a new grammar with the given name.

--- a/grammargen/import_grammarjson.go
+++ b/grammargen/import_grammarjson.go
@@ -311,9 +311,9 @@ func importPrecedenceLevels(rawLevels []json.RawMessage) [][]PrecEntry {
 // own tooling ignores this key; gotreesitter reads it during ImportGrammarJSON
 // and writes it back during ExportGrammarJSON (only when set).
 type grammarJSONExtensions struct {
-	// WantsForest opts the assembled Language into the GSS-forest GLR fast path
-	// (see gotreesitter.Language.WantsForest). Lets an existing grammar enable
-	// forest declaratively via grammar.json — no code change, no fork.
+	// WantsForest requests the GSS-forest GLR fast path for the assembled
+	// Language. Normal Parse admission requires incremental-reuse proof.
+	// ParseForestExperimental remains available for unproven diagnostics.
 	WantsForest bool `json:"wantsForest,omitempty"`
 }
 

--- a/grammars/css_scanner.go
+++ b/grammars/css_scanner.go
@@ -41,6 +41,10 @@ func (CssExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (CssExternalScanner) Deserialize(payload any, buf []byte)   {}
 func (CssExternalScanner) SupportsIncrementalReuse() bool        { return true }
 
+// ExternalScannerIsStateless proves that CSS scanning depends only on
+// lookahead and the parser-provided valid-symbol set.
+func (CssExternalScanner) ExternalScannerIsStateless() bool { return true }
+
 func (CssExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	// Error recovery sentinel — always decline.
 	if cssValid(validSymbols, cssTokErrorRecovery) {

--- a/grammars/forest_scanner_proof_test.go
+++ b/grammars/forest_scanner_proof_test.go
@@ -1,0 +1,82 @@
+package grammars
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+)
+
+// TestForestDownstreamScannerProofs keeps the downstream forest witnesses on a
+// proven scanner route instead of silently disabling later incremental reuse.
+func TestForestDownstreamScannerProofs(t *testing.T) {
+	cases := []struct {
+		name       string
+		stateless  bool
+		checkpoint bool
+	}{
+		{name: "toml", stateless: true},
+		{name: "css", stateless: true},
+		{name: "tsx", stateless: true},
+		{name: "scss", stateless: true},
+		{name: "typescript", stateless: true},
+		{name: "cmake", checkpoint: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lang := &gts.Language{Name: tc.name}
+			if !attachExternalScannerForLanguage(tc.name, lang) || lang.ExternalScanner == nil {
+				t.Fatal("scanner did not attach")
+			}
+			reusable, ok := lang.ExternalScanner.(gts.IncrementalReuseExternalScanner)
+			if !ok || !reusable.SupportsIncrementalReuse() {
+				t.Fatalf("scanner %T does not certify incremental reuse", lang.ExternalScanner)
+			}
+			_, isStateless := lang.ExternalScanner.(gts.StatelessExternalScanner)
+			if isStateless != tc.stateless {
+				t.Fatalf("stateless proof = %t, want %t", isStateless, tc.stateless)
+			}
+			_, isCheckpointed := lang.ExternalScanner.(gts.CheckpointedExternalScanner)
+			if isCheckpointed != tc.checkpoint {
+				t.Fatalf("checkpoint proof = %t, want %t", isCheckpointed, tc.checkpoint)
+			}
+		})
+	}
+}
+
+func TestForestDownstreamAdmissionPolicy(t *testing.T) {
+	safe := []struct {
+		name string
+		load func() *gts.Language
+	}{
+		{name: "toml", load: TomlLanguage},
+		{name: "css", load: CssLanguage},
+		{name: "tsx", load: TsxLanguage},
+		{name: "ini", load: IniLanguage},
+		{name: "scss", load: ScssLanguage},
+		{name: "typescript", load: TypescriptLanguage},
+		{name: "cmake", load: CmakeLanguage},
+	}
+	for _, tc := range safe {
+		lang := *tc.load()
+		lang.WantsForest = true
+		if !gts.LanguageWantsForest(&lang) {
+			t.Errorf("proven explicit route %q was rejected", tc.name)
+		}
+	}
+
+	unsafe := []struct {
+		name string
+		load func() *gts.Language
+	}{
+		{name: "haskell", load: HaskellLanguage},
+		{name: "python", load: PythonLanguage},
+		{name: "c_sharp", load: CSharpLanguage},
+	}
+	for _, tc := range unsafe {
+		lang := *tc.load()
+		lang.WantsForest = true
+		if gts.LanguageWantsForest(&lang) {
+			t.Errorf("unproven explicit route %q reached normal admission", tc.name)
+		}
+	}
+}

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -502,6 +502,12 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// TestParityCPreprocConditional.
 	"c": {
 		blobSHA256: mustRuntimeProfileSHA256("9aee42825fd1446ce5b754951db26edadcdba5d2f26b61578a30e87ed2dbbd3c"),
+		// Measurements on large C witnesses show identical trees before and after
+		// the retry ladder. Keep the initial tree and avoid repeated full parses
+		// for this exact grammar blob.
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			SkipCompleteAcceptedErrorRetry: true,
+		},
 		conflictPolicies: []gotreesitter.ConflictPolicy{
 			{
 				State:         gotreesitter.ConflictPolicyAnyState,

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -612,6 +612,7 @@ func TestBuiltinCompleteAcceptedErrorRetryProfilesAttach(t *testing.T) {
 		load func() *gotreesitter.Language
 	}{
 		{name: "bash", load: BashLanguage},
+		{name: "c", load: CLanguage},
 		{name: "caddy", load: CaddyLanguage},
 		{name: "c_sharp", load: CSharpLanguage},
 		{name: "cpp", load: CppLanguage},
@@ -963,7 +964,7 @@ func TestCollapsedChildNativeCapabilityRequiresExactBlobIdentity(t *testing.T) {
 }
 
 func TestBuiltinCompleteAcceptedErrorRetryProfileRequiresCertifiedBlob(t *testing.T) {
-	for _, name := range []string{"caddy", "c_sharp", "haxe", "kdl", "odin", "rego", "scss", "swift", "tcl"} {
+	for _, name := range []string{"c", "caddy", "c_sharp", "haxe", "kdl", "odin", "rego", "scss", "swift", "tcl"} {
 		t.Run(name, func(t *testing.T) {
 			lang := &gotreesitter.Language{Name: name}
 			if attachBuiltinLanguageRuntimeProfile(name, sha256.Sum256([]byte("uncertified")), lang) {

--- a/grammars/scss_scanner.go
+++ b/grammars/scss_scanner.go
@@ -40,6 +40,10 @@ func (ScssExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (ScssExternalScanner) Deserialize(payload any, buf []byte)   {}
 func (ScssExternalScanner) SupportsIncrementalReuse() bool        { return true }
 
+// ExternalScannerIsStateless proves that the payload stores only immutable
+// symbol binding and no cross-token scanner state.
+func (ScssExternalScanner) ExternalScannerIsStateless() bool { return true }
+
 func (ScssExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	lang := scssScanLang(payload)
 

--- a/grammars/toml_scanner.go
+++ b/grammars/toml_scanner.go
@@ -42,6 +42,10 @@ func (TomlExternalScanner) Create() any                    { return nil }
 func (TomlExternalScanner) Destroy(payload any)            {}
 func (TomlExternalScanner) SupportsIncrementalReuse() bool { return true }
 
+// ExternalScannerIsStateless proves that TOML scanning depends only on
+// lookahead and the parser-provided valid-symbol set.
+func (TomlExternalScanner) ExternalScannerIsStateless() bool { return true }
+
 func (TomlExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (TomlExternalScanner) Deserialize(payload any, buf []byte)   {}
 

--- a/grammars/tsx_scanner.go
+++ b/grammars/tsx_scanner.go
@@ -111,6 +111,10 @@ func (TsxExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (TsxExternalScanner) Deserialize(payload any, buf []byte)   {}
 func (TsxExternalScanner) SupportsIncrementalReuse() bool        { return true }
 
+// ExternalScannerIsStateless proves that TSX scanning depends only on
+// lookahead and the parser-provided valid-symbol set.
+func (TsxExternalScanner) ExternalScannerIsStateless() bool { return true }
+
 // symbolTable returns the per-Language-bound result-symbol table, falling
 // back to the pinned defaults when Scan is invoked on an unbound scanner
 // value (s.symbols is still its zero value).

--- a/grammars/typescript_scanner.go
+++ b/grammars/typescript_scanner.go
@@ -111,6 +111,10 @@ func (TypeScriptExternalScanner) Serialize(payload any, buf []byte) int { return
 func (TypeScriptExternalScanner) Deserialize(payload any, buf []byte)   {}
 func (TypeScriptExternalScanner) SupportsIncrementalReuse() bool        { return true }
 
+// ExternalScannerIsStateless proves that TypeScript scanning depends only on
+// lookahead and the parser-provided valid-symbol set.
+func (TypeScriptExternalScanner) ExternalScannerIsStateless() bool { return true }
+
 // symbolTable returns the per-Language-bound result-symbol table, falling
 // back to the pinned defaults when Scan is invoked on an unbound scanner
 // value (s.symbols is still its zero value).

--- a/language.go
+++ b/language.go
@@ -446,12 +446,9 @@ type Language struct {
 	// metadata and conservative table validation.
 	CRecoveryCostCompetitionEnabledByDefault bool
 
-	// WantsForest opts this language into the GSS-forest GLR fast path.
-	// Consumers generating a Language via grammargen set this (directly or via
-	// grammargen.Grammar.WantsForest) to enable forest for their own grammar. This
-	// bypasses the byte-range parity certification built-ins undergo — the
-	// decline->production fallback still prevents hard failures on declined inputs,
-	// but a clean-but-different tree is the consumer's responsibility.
+	// WantsForest requests the GSS-forest GLR fast path for this language.
+	// Normal Parse dispatch requires the scanner incremental-reuse proof.
+	// ParseForestExperimental remains available for an unproven diagnostic run.
 	WantsForest bool
 
 	// LanguageVersion is the tree-sitter language ABI version.

--- a/language_forest_optin_test.go
+++ b/language_forest_optin_test.go
@@ -23,6 +23,24 @@ func TestParserWantsForestFieldDrivesDispatch(t *testing.T) {
 		t.Error("certified automatic forest profile should dispatch")
 	}
 
+	unsafeAutomatic := &Parser{language: &Language{
+		Name:                            "x",
+		AutomaticForestEnabledByDefault: true,
+		ExternalScanner:                 quiescenceOptOutScanner{},
+	}}
+	if parserWantsForest(unsafeAutomatic) {
+		t.Error("automatic forest profile without incremental reuse proof should not dispatch")
+	}
+
+	explicitUnsafe := &Parser{language: &Language{
+		Name:            "x",
+		WantsForest:     true,
+		ExternalScanner: quiescenceOptOutScanner{},
+	}}
+	if !parserWantsForest(explicitUnsafe) {
+		t.Error("explicit forest opt-in should remain available for experiments")
+	}
+
 	for _, name := range []string{"awk", "kdl", "uxntal"} {
 		sameNameCustom := &Parser{language: &Language{Name: name}}
 		if parserWantsForest(sameNameCustom) {

--- a/language_forest_optin_test.go
+++ b/language_forest_optin_test.go
@@ -3,10 +3,10 @@ package gotreesitter
 import "testing"
 
 // TestParserWantsForestFieldDrivesDispatch verifies that Language.WantsForest
-// drives the forest dispatch gate independently of the curated
-// builtinForestDefaults allowlist: a synthetic non-built-in language opts in
-// via the field, and a built-in name dispatches even when the field is left
-// false (its default comes from the curated map).
+// drives the forest admission gate independently of the curated
+// builtinForestDefaults allowlist when the scanner proof is present. A
+// synthetic non-built-in language opts in via the field, and a built-in name
+// dispatches even when the field is left false.
 func TestParserWantsForestFieldDrivesDispatch(t *testing.T) {
 	optedIn := &Parser{language: &Language{Name: "x", WantsForest: true}}
 	if !parserWantsForest(optedIn) {
@@ -37,8 +37,8 @@ func TestParserWantsForestFieldDrivesDispatch(t *testing.T) {
 		WantsForest:     true,
 		ExternalScanner: quiescenceOptOutScanner{},
 	}}
-	if !parserWantsForest(explicitUnsafe) {
-		t.Error("explicit forest opt-in should remain available for experiments")
+	if parserWantsForest(explicitUnsafe) {
+		t.Error("unproven explicit forest opt-in should not dispatch through normal Parse")
 	}
 
 	for _, name := range []string{"awk", "kdl", "uxntal"} {

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -411,6 +411,29 @@ func TestFullParseRetryNodeLimitOverride(t *testing.T) {
 	}
 }
 
+func TestFullParseRetryMergeOverrideHonorsExplicitCap(t *testing.T) {
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "3")
+	ResetParseEnvConfigCacheForTests()
+	t.Cleanup(ResetParseEnvConfigCacheForTests)
+
+	tree := &Tree{
+		language: &Language{Name: "synthetic"},
+		root: &Node{
+			endByte: 128,
+			flags:   nodeFlagHasError,
+		},
+		parseRuntime: ParseRuntime{
+			StopReason:      ParseStopAccepted,
+			ExpectedEOFByte: 128,
+			RootEndByte:     128,
+			MaxStacksSeen:   8,
+		},
+	}
+	if got := fullParseRetryMergePerKeyOverride(tree, 128, 8); got != 0 {
+		t.Fatalf("fullParseRetryMergePerKeyOverride(explicit cap) = %d, want 0", got)
+	}
+}
+
 func TestFullParseRetrySecondaryNodeLimitOverride(t *testing.T) {
 	tree := &Tree{
 		parseRuntime: ParseRuntime{
@@ -1728,6 +1751,98 @@ func TestCertifiedFreshErrorNoStacksRetryMaxStacksFlowsThroughLadder(t *testing.
 	}
 	if result == nil || result.ParseStopReason() != ParseStopAccepted {
 		t.Fatalf("retry result = %v, want accepted tree", result)
+	}
+}
+
+func TestCertifiedNoStacksPressureRetryUsesOneHardCappedRung(t *testing.T) {
+	t.Setenv("GOT_GLR_MAX_STACKS", "")
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
+	ResetParseEnvConfigCacheForTests()
+	t.Cleanup(ResetParseEnvConfigCacheForTests)
+
+	const sourceLen = 128
+	source := make([]byte, sourceLen)
+	initial := certifiedFreshErrorNoStacksTestTree(false, sourceLen)
+	initial.root.flags = 0
+	initial.root.endByte = 0
+	initial.parseRuntime.RootEndByte = 0
+	initial.parseRuntime.LastTokenEndByte = 0
+	type retryCall struct {
+		stacks int
+		merge  int
+	}
+	var calls []retryCall
+	parser := &Parser{}
+	result := parser.retryFullParse(source, 8, initial, func(maxStacks, maxMergePerKeyOverride, _ int) *Tree {
+		calls = append(calls, retryCall{stacks: maxStacks, merge: maxMergePerKeyOverride})
+		candidate := certifiedFreshErrorNoStacksTestTree(false, sourceLen)
+		candidate.root.flags = nodeFlagHasError
+		candidate.resultErrorSummary = resultErrorSummaryPresent
+		candidate.root.endByte = sourceLen
+		candidate.parseRuntime.RootEndByte = sourceLen
+		candidate.parseRuntime.LastTokenEndByte = sourceLen
+		candidate.parseRuntime.MaxStacksSeen = maxStacks
+		if maxStacks == fullParseCertifiedNoStacksPressureRetryMaxGLRStacks && maxMergePerKeyOverride == fullParseCertifiedNoStacksPressureRetryMaxMergePerKey {
+			candidate.root.flags = 0
+			candidate.resultErrorSummary = resultErrorSummaryClean
+			candidate.root.endByte = sourceLen
+			candidate.parseRuntime.StopReason = ParseStopAccepted
+			candidate.parseRuntime.Truncated = false
+			candidate.parseRuntime.RootEndByte = sourceLen
+			candidate.parseRuntime.LastTokenEndByte = sourceLen
+			candidate.parseRuntime.LastTokenWasEOF = true
+		}
+		return candidate
+	})
+	want := []retryCall{
+		{stacks: 8, merge: fullParseRetryMaxMergePerKey},
+		{stacks: fullParseRetryMaxGLRStacks},
+		{stacks: fullParseRetryMaxGLRStacks},
+		{stacks: fullParseRetryMaxGLRStacks, merge: fullParseRetryMaxMergePerKey},
+		{stacks: fullParseCertifiedNoStacksPressureRetryMaxGLRStacks, merge: fullParseCertifiedNoStacksPressureRetryMaxMergePerKey},
+	}
+	if !slices.Equal(calls, want) {
+		t.Fatalf("retry calls = %+v, want %+v", calls, want)
+	}
+	if result == nil || result.ParseStopReason() != ParseStopAccepted || retryTreeHasError(result) {
+		t.Fatalf("retry result = %v, want clean accepted tree", result)
+	}
+}
+
+func TestCertifiedNoStacksPressureRetryHonorsExplicitCaps(t *testing.T) {
+	const sourceLen = 128
+	initial := certifiedFreshErrorNoStacksTestTree(false, sourceLen)
+	initial.root.flags = 0
+	retry := certifiedFreshErrorNoStacksTestTree(false, sourceLen)
+	retry.root.flags = nodeFlagHasError
+	retry.resultErrorSummary = resultErrorSummaryPresent
+	retry.parseRuntime.MaxStacksSeen = fullParseRetryMaxGLRStacks
+
+	if !shouldRetryCertifiedNoStacksPressure(initial, retry, sourceLen, 8, fullParseRetryMaxGLRStacks, fullParseRetryOriginFresh) {
+		t.Fatal("certified no-stacks pressure retry was not eligible")
+	}
+	t.Setenv("GOT_GLR_MAX_STACKS", "12")
+	ResetParseEnvConfigCacheForTests()
+	t.Cleanup(ResetParseEnvConfigCacheForTests)
+	if shouldRetryCertifiedNoStacksPressure(initial, retry, sourceLen, 8, fullParseRetryMaxGLRStacks, fullParseRetryOriginFresh) {
+		t.Fatal("explicit max-stacks cap permitted a certified pressure retry")
+	}
+	t.Setenv("GOT_GLR_MAX_STACKS", "")
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "12")
+	ResetParseEnvConfigCacheForTests()
+	if shouldRetryCertifiedNoStacksPressure(initial, retry, sourceLen, 8, fullParseRetryMaxGLRStacks, fullParseRetryOriginFresh) {
+		t.Fatal("explicit merge cap permitted a certified pressure retry")
+	}
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
+	ResetParseEnvConfigCacheForTests()
+	const oversizedSourceLen = fullParseCertifiedNoStacksPressureRetryMaxSourceBytes + 1
+	oversizedInitial := certifiedFreshErrorNoStacksTestTree(false, oversizedSourceLen)
+	oversizedInitial.root.flags = 0
+	oversizedRetry := certifiedFreshErrorNoStacksTestTree(false, oversizedSourceLen)
+	oversizedRetry.resultErrorSummary = resultErrorSummaryPresent
+	oversizedRetry.parseRuntime.MaxStacksSeen = fullParseRetryMaxGLRStacks
+	if shouldRetryCertifiedNoStacksPressure(oversizedInitial, oversizedRetry, oversizedSourceLen, 8, fullParseRetryMaxGLRStacks, fullParseRetryOriginFresh) {
+		t.Fatal("oversized source permitted a certified pressure retry")
 	}
 }
 

--- a/parser_external_scanner_incremental_test.go
+++ b/parser_external_scanner_incremental_test.go
@@ -378,12 +378,12 @@ func TestPythonDerivedTokenInvariantLeafReusePrecedesScannerFallback(t *testing.
 
 func TestExternalScannerTokenInvariantLeafReuse(t *testing.T) {
 	cases := []struct {
-		name           string
-		lang           func() *gotreesitter.Language
-		explicitForest bool
-		source         []byte
-		marker         []byte
-		replacement    byte
+		name             string
+		lang             func() *gotreesitter.Language
+		diagnosticForest bool
+		source           []byte
+		marker           []byte
+		replacement      byte
 	}{
 		{
 			name:        "elixir identifier",
@@ -393,20 +393,20 @@ func TestExternalScannerTokenInvariantLeafReuse(t *testing.T) {
 			replacement: 'w',
 		},
 		{
-			name:           "bash comment",
-			lang:           grammars.BashLanguage,
-			explicitForest: true,
-			source:         []byte("# look for old 0.x cruft\n"),
-			marker:         []byte("0"),
-			replacement:    '1',
+			name:             "bash comment",
+			lang:             grammars.BashLanguage,
+			diagnosticForest: true,
+			source:           []byte("# look for old 0.x cruft\n"),
+			marker:           []byte("0"),
+			replacement:      '1',
 		},
 		{
-			name:           "bash number",
-			lang:           grammars.BashLanguage,
-			explicitForest: true,
-			source:         []byte("echo -9\n"),
-			marker:         []byte("9"),
-			replacement:    '0',
+			name:             "bash number",
+			lang:             grammars.BashLanguage,
+			diagnosticForest: true,
+			source:           []byte("echo -9\n"),
+			marker:           []byte("9"),
+			replacement:      '0',
 		},
 		{
 			name:        "julia line comment",
@@ -434,35 +434,41 @@ func TestExternalScannerTokenInvariantLeafReuse(t *testing.T) {
 			next[offset] = tc.replacement
 
 			lang := tc.lang()
-			if tc.explicitForest {
+			if tc.diagnosticForest {
 				lang = explicitForestLanguage(t, lang)
 			}
 			parser := gotreesitter.NewParser(lang)
-			// Pin to production: this test asserts token-invariant incremental
-			// leaf reuse and the accepted forest runtime. A compact-materialized
-			// base tree is hard-barred from reuse (decision 0008), so the base and
-			// fresh parses must stay on the production engine.
+			// Pin the ordinary lanes to production. Diagnostic forest lanes use
+			// ParseForestExperimental because normal Parse admission fails closed.
 			parser.SetAdmissionCandidateRoute(false)
-			fresh, err := parser.Parse(next)
-			if err != nil {
-				t.Fatalf("fresh parse: %v", err)
+			parse := func(label string, source []byte) *gotreesitter.Tree {
+				if tc.diagnosticForest {
+					tree, ok := parser.ParseForestExperimental(source)
+					if !ok || tree == nil {
+						t.Fatalf("%s diagnostic forest parse: ok=%t tree_nil=%t", label, ok, tree == nil)
+					}
+					return tree
+				}
+				tree, err := parser.Parse(source)
+				if err != nil {
+					t.Fatalf("%s parse: %v", label, err)
+				}
+				return tree
 			}
+			fresh := parse("fresh", next)
 			defer fresh.Release()
 			requireCompleteParse(t, fresh, next, lang, "fresh")
-			if tc.explicitForest {
+			if tc.diagnosticForest {
 				requireAcceptedForestRuntime(t, "fresh "+tc.name+" parse", fresh)
 			}
 			if fresh.RootNode().HasError() {
 				t.Fatalf("fresh parse has error: %s", fresh.RootNode().SExpr(lang))
 			}
 
-			oldTree, err := parser.Parse(tc.source)
-			if err != nil {
-				t.Fatalf("old parse: %v", err)
-			}
+			oldTree := parse("old", tc.source)
 			defer oldTree.Release()
 			requireCompleteParse(t, oldTree, tc.source, lang, "old")
-			if tc.explicitForest {
+			if tc.diagnosticForest {
 				requireAcceptedForestRuntime(t, "old "+tc.name+" parse", oldTree)
 			}
 			oldTree.Edit(gotreesitter.InputEdit{

--- a/parser_memory_budget_test.go
+++ b/parser_memory_budget_test.go
@@ -176,40 +176,12 @@ func TestGoParseGiantTableLiteralStopsWithinMemoryBudget(t *testing.T) {
 	t.Logf("heap growth = %d bytes (%.2fx budget %d bytes), stop=%s", heapGrowth, float64(heapGrowth)/float64(budgetBytes), budgetBytes, tree.ParseRuntime().Summary())
 }
 
-// TestGoParseGiantTableLiteralShippedRouteStaysWithinAchievedBound is the
-// unpinned counterpart of TestGoParseGiantTableLiteralStopsWithinMemoryBudget
-// above: the same witness, the same GC-disabled cumulative-allocation
-// measurement, with the candidate route left on its shipped default instead
-// of pinned to production. This is the end-to-end coverage the production
-// pin above deliberately removes (that test isolates production's own
-// contract; this one measures what a caller who never pins actually gets).
-//
-// The compact route attempts this witness first (tranche B9 removed the
-// former 64 KiB size floor that used to keep it production-only). Its own
-// scheduler stop-control poll compares a real, capacity-based retained-
-// footprint gauge (Core.FootprintBytes, internal/parsercorephase0) against
-// the configured budget and declines close to it (measured 103.6 MB
-// footprint against a 96 MB budget on this witness), releasing its retained
-// capacity immediately on decline. Production then serves the fallback
-// exactly as the pinned test above already proves.
-//
-// The bound this asserts is measured, not the production-only 6x contract:
-// this GC-disabled methodology counts cumulative allocation, not retained
-// footprint, so it also counts every ephemeral value the compact scheduler's
-// hot dispatch/election path allocates and discards per token -- a live GC
-// reclaims that continuously in normal operation, but nothing a
-// retained-footprint poll tracks can bound it, because it is never part of
-// any tracked structure. Measured on this witness: 9.14-9.56x across six
-// runs (a real, verified improvement over the pre-honest-accounting
-// length-only gauge's 11.51x on the same witness), not inside the
-// production-only 6x contract. maxOvershootFactor sits just above the high
-// end of that measured range and well below the pre-fix figure, so this
-// test still catches a regression back to length-only accounting while
-// tolerating ordinary run-to-run variance. Closing the remaining gap to 6x
-// is an open trade-off against routing coverage (see
-// stopControlFootprintChurnRatio's doc comment, parsercore_phase0_driver.go)
-// that this test intentionally does not force by tightening this number
-// further.
+// TestGoParseGiantTableLiteralShippedRouteStaysWithinAchievedBound verifies
+// the shipped route for a source above the compact admission threshold. The
+// source-size gate keeps this witness on production, which preserves the
+// production memory-budget contract and avoids a dual-engine measurement.
+// The test also checks that an eligibility decline does not look like a
+// candidate fallback.
 func TestGoParseGiantTableLiteralShippedRouteStaysWithinAchievedBound(t *testing.T) {
 	const budgetMB = 96
 	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", strconv.Itoa(budgetMB))
@@ -248,12 +220,10 @@ func TestGoParseGiantTableLiteralShippedRouteStaysWithinAchievedBound(t *testing
 	if !tree.ParseStoppedEarly() {
 		t.Fatal("ParseStoppedEarly() = false, want true")
 	}
-	// The candidate route must have attempted and declined this witness (not
-	// silently stayed on production by some other eligibility gate): routed
-	// stays 0 (production served the returned tree) and fallback moves by
-	// exactly 1 (one candidate-route decline).
-	if routedAfter != routedBefore || fallbackAfter != fallbackBefore+1 {
-		t.Fatalf("candidate route routing: routed %d->%d fallback %d->%d, want routed unchanged and fallback +1",
+	// The large-input eligibility decline must leave both candidate counters
+	// unchanged. Production serves the returned tree.
+	if routedAfter != routedBefore || fallbackAfter != fallbackBefore {
+		t.Fatalf("candidate route routing: routed %d->%d fallback %d->%d, want both counters unchanged",
 			routedBefore, routedAfter, fallbackBefore, fallbackAfter)
 	}
 

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -79,6 +79,16 @@ const (
 	// Retries are best-effort improvements: when the budget is exhausted the
 	// incumbent best tree is returned, never a worse result.
 	fullParseRetryMaxTotalPasses = 24
+	// fullParseCertifiedNoStacksPressureRetryMaxGLRStacks and
+	// fullParseCertifiedNoStacksPressureRetryMaxMergePerKey are the final,
+	// single-rung retry ceiling for a fresh full parse that proves both global
+	// stack pressure and merge-survivor pressure. This does not change either
+	// steady-state default. The rung runs only after the default no-stacks
+	// result and the ordinary bounded retry both truncate with no stacks alive.
+	// Its 256 KiB source ceiling keeps the exceptional pass off large files.
+	fullParseCertifiedNoStacksPressureRetryMaxGLRStacks   = 160
+	fullParseCertifiedNoStacksPressureRetryMaxMergePerKey = 160
+	fullParseCertifiedNoStacksPressureRetryMaxSourceBytes = 256 * 1024 // 256 KiB
 )
 
 type resettableTokenSource interface {
@@ -1277,6 +1287,29 @@ func fullParseRetryMaxStacksOverrideForOrigin(tree *Tree, sourceLen int, initial
 	return 0
 }
 
+// shouldRetryCertifiedNoStacksPressure permits one final retry only after a
+// fresh full parse proves that both the default and ordinary retry stack caps
+// exhausted live stacks. The initial tree must be clean-but-truncated: this
+// distinguishes cap pressure from an input that already contains a syntax
+// error. Explicit diagnostic caps remain authoritative.
+func shouldRetryCertifiedNoStacksPressure(tree, retryTree *Tree, sourceLen, initialMaxStacks, retryMaxStacks int, origin fullParseRetryOrigin) bool {
+	if tree == nil || retryTree == nil || origin != fullParseRetryOriginFresh ||
+		sourceLen <= 0 || sourceLen > fullParseCertifiedNoStacksPressureRetryMaxSourceBytes ||
+		parseMaxGLRStacksEnvConfigured() || parseMaxMergePerKeyEnvConfigured() ||
+		initialMaxStacks >= fullParseCertifiedNoStacksPressureRetryMaxGLRStacks ||
+		retryMaxStacks >= fullParseCertifiedNoStacksPressureRetryMaxGLRStacks {
+		return false
+	}
+	initial := tree.rawParseRuntime()
+	if initial.StopReason != ParseStopNoStacksAlive || !initial.Truncated ||
+		retryTreeHasError(tree) || initial.MaxStacksSeen < initialMaxStacks {
+		return false
+	}
+	retry := retryTree.rawParseRuntime()
+	return retry.StopReason == ParseStopNoStacksAlive && retry.Truncated &&
+		retryTreeHasError(retryTree) && retry.MaxStacksSeen >= retryMaxStacks
+}
+
 func fullParseRetryUsesInitialStackCeiling(tree *Tree, sourceLen int, initialMaxStacks int) bool {
 	return fullParseRetryUsesInitialStackCeilingForOrigin(tree, sourceLen, initialMaxStacks, fullParseRetryOriginFresh)
 }
@@ -1397,6 +1430,11 @@ func fullParseRetrySecondaryNodeLimitOverride(tree *Tree, sourceLen int) int {
 
 func fullParseRetryMergePerKeyOverride(tree *Tree, sourceLen int, initialMaxStacks int) int {
 	if tree == nil || sourceLen <= 0 || sourceLen > fullParseRetryMaxSourceBytes {
+		return 0
+	}
+	// An explicit merge cap is authoritative for every retry rung. Returning a
+	// retry override here would silently replace the caller's diagnostic cap.
+	if parseMaxMergePerKeyEnvConfigured() {
 		return 0
 	}
 	if treeParseClean(tree) {
@@ -1854,6 +1892,18 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 		maxMergePerKeyOverride,
 		maxNodesOverride,
 	)
+	if shouldRetryCertifiedNoStacksPressure(tree, mergeRetryTree, len(source), initialMaxStacks, retryMaxStacks, origin) && !retryDeadlineExceeded() {
+		pressureRetryTree := runRetryAttempt(
+			"certified_no_stacks_pressure",
+			"default_and_bounded_stack_caps_exhausted",
+			fullParseCertifiedNoStacksPressureRetryMaxGLRStacks,
+			fullParseCertifiedNoStacksPressureRetryMaxMergePerKey,
+			0,
+		)
+		replaceBest(&bestTree, mergeRetryTree)
+		replaceBest(&bestTree, pressureRetryTree)
+		return bestTree
+	}
 	replaceBest(&bestTree, mergeRetryTree)
 	return bestTree
 }


### PR DESCRIPTION
## Summary

- Restore the 64 KiB production-route gate for candidate admission.
- Bound certified no-stack retry escalation to one 160-stack, 160-merge rung below 256 KiB.
- Preserve explicit diagnostic stack and merge caps.
- Skip redundant accepted-error retries for the certified C grammar blob.
- Add the GCP fleet runbook and bytecode stream specification index.

## Root cause

Commit `c1806563` removed the admission size gate. A pinned v10 Python replay then measured 48.24x C without the gate and 4.76x C with it. TypeScript's 3.5 MiB witness reached about 1.8 GiB without the gate and completed in 376 ms with it.

The retry changes prevent small, ambiguous inputs from escalating without a bounded pressure proof. They preserve explicit diagnostic caps and keep large inputs outside the exceptional retry rung.

Issue [#660](https://github.com/odvcencio/gotreesitter/issues/660) is a separate field-projection regression. The current main branch already contains its fix.

## Validation

- Docker admission contract test passes.
- Docker admission candidate test group passes.
- Docker certified retry and explicit-cap tests pass.
- Docker C grammar profile tests pass.
- Docker inherited-field projection test passes.

The full-fleet measurement remains a release prerequisite. GCP reauthentication is required before the remote run can start.