### PR TITLE
release: publish v0.48.1 for issue 660

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.48.1] - 2026-08-04
+
+### Fixed
+
+- Keep anonymous separator nodes unfielded in Python import and subscript
+  forms. This restores the field-name behavior of the reference C runtime.
+  The regression was introduced in v0.48.0. (#660)
+
 ## [0.48.0] - 2026-08-01
 
 ### Added
@@ -4243,7 +4251,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.48.0...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.48.1...HEAD
+[0.48.1]: https://github.com/odvcencio/gotreesitter/compare/v0.48.0...v0.48.1
 [0.48.0]: https://github.com/odvcencio/gotreesitter/compare/v0.47.1...v0.48.0
 [0.47.1]: https://github.com/odvcencio/gotreesitter/compare/v0.47.0...v0.47.1
 [0.47.0]: https://github.com/odvcencio/gotreesitter/compare/v0.46.0...v0.47.0

--- a/README.md
+++ b/README.md
@@ -752,10 +752,9 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.48.0**. It closes six Swift real-code parse
-defects found against apple/swift-algorithms and the Swift 6.3 standard
-library. It adds a validated Swift corpus with a ratcheting regression suite.
-It also cuts incremental re-lex and compact full-parse allocation costs.
+The current release is **v0.48.1**. It restores reference-compatible field
+names for anonymous Python separator nodes. It also keeps the v0.48.0 Swift
+and parser performance improvements.
 
 Detailed shipped evidence lives in [CHANGELOG.md](CHANGELOG.md). Planned minor
 releases are batched on Thursdays; the immutable-tag process and exceptions are

--- a/issue660_regression_test.go
+++ b/issue660_regression_test.go
@@ -1,0 +1,54 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestIssue660AnonymousCommaHasNoField(t *testing.T) {
+	lang := grammars.PythonLanguage()
+	cases := []string{
+		"from a import b, c\n",
+		"import a, b\n",
+		"x[a, b]\n",
+	}
+
+	for _, useCandidate := range []bool{false, true} {
+		for _, source := range cases {
+			name := "production"
+			if useCandidate {
+				name = "candidate"
+			}
+			t.Run(name+"/"+source, func(t *testing.T) {
+				parser := gotreesitter.NewParser(lang)
+				parser.SetAdmissionCandidateRoute(useCandidate)
+				tree, err := parser.Parse([]byte(source))
+				if err != nil {
+					t.Fatalf("parse: %v", err)
+				}
+				defer tree.Release()
+				assertAnonymousCommasUnfielded(t, tree.RootNode(), lang, []byte(source))
+			})
+		}
+	}
+}
+
+func assertAnonymousCommasUnfielded(t *testing.T, parent *gotreesitter.Node, lang *gotreesitter.Language, source []byte) {
+	t.Helper()
+	if parent == nil {
+		return
+	}
+	for i := 0; i < parent.ChildCount(); i++ {
+		child := parent.Child(i)
+		if child == nil {
+			continue
+		}
+		if child.Text(source) == "," && parent.FieldNameForChild(i, lang) != "" {
+			t.Fatalf("anonymous comma at [%d,%d) has field %q in parent %s: %s",
+				child.StartByte(), child.EndByte(), parent.FieldNameForChild(i, lang), parent.Type(lang), parent.SExpr(lang))
+		}
+		assertAnonymousCommasUnfielded(t, child, lang, source)
+	}
+}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -6615,7 +6615,11 @@ func applyParentFieldToFlattenedHiddenSpan(children []*Node, fieldIDs []FieldID,
 	source := fieldSourceForInheritance(inherited)
 	hasField := flattenedSpanHasFieldID(fieldIDs, spanStart, fieldEnd, fid)
 	if inherited && hasField {
-		fillAnonymousGapsBetweenDirectFields(children, fieldIDs, fieldSources, spanStart, fieldEnd, fid)
+		// A deferred direct entry may cover separators in a repeated field.
+		// An inherited-only entry must not invent fields for anonymous gaps.
+		if hiddenParentHasDeferredDirectField(hiddenParent, fid) {
+			fillAnonymousGapsBetweenDirectFields(children, fieldIDs, fieldSources, spanStart, fieldEnd, fid)
+		}
 		normalizeMixedSourceFieldSpan(fieldIDs, fieldSources, spanStart, fieldEnd)
 		return
 	}
@@ -6633,6 +6637,24 @@ func applyParentFieldToFlattenedHiddenSpan(children []*Node, fieldIDs []FieldID,
 	}
 	applyFieldToFlattenedSpan(children, fieldIDs, fieldSources, spanStart, fieldEnd, fid, source, true)
 	normalizeMixedSourceFieldSpan(fieldIDs, fieldSources, spanStart, fieldEnd)
+}
+
+func hiddenParentHasDeferredDirectField(parent *Node, fid FieldID) bool {
+	if parent == nil || fid == 0 {
+		return false
+	}
+	fieldIDs := parent.fieldIDs()
+	fieldSources := parent.fieldSources()
+	limit := len(fieldIDs)
+	if len(fieldSources) < limit {
+		limit = len(fieldSources)
+	}
+	for i := 0; i < limit; i++ {
+		if fieldIDs[i] == fid && fieldSources[i] == fieldSourceDeferredDirect {
+			return true
+		}
+	}
+	return false
 }
 
 func fillAnonymousGapsBetweenDirectFields(

--- a/parser_reduce_fields_test.go
+++ b/parser_reduce_fields_test.go
@@ -687,7 +687,7 @@ func TestBuildReduceChildrenRepeatedDirectFieldOnHiddenPathLeavesAnonymousGapUnf
 	}
 }
 
-func TestBuildReduceChildrenInheritedFieldFillsRepeatedDirectAnonymousGaps(t *testing.T) {
+func TestBuildReduceChildrenInheritedFieldLeavesRepeatedDirectAnonymousGapsUnfielded(t *testing.T) {
 	lang := &Language{
 		SymbolNames: []string{"EOF", "_hidden_inner", ".", "identifier", "visible_parent"},
 		SymbolMetadata: []SymbolMetadata{
@@ -742,11 +742,17 @@ func TestBuildReduceChildrenInheritedFieldFillsRepeatedDirectAnonymousGaps(t *te
 		t.Fatalf("child count = %d, want %d", got, want)
 	}
 	for index := range children {
-		if got, want := fieldIDs[index], FieldID(1); got != want {
-			t.Fatalf("field %d = %d, want %d", index, got, want)
+		wantField := FieldID(1)
+		wantSource := uint8(fieldSourceDirect)
+		if index == 1 || index == 3 {
+			wantField = 0
+			wantSource = fieldSourceNone
 		}
-		if got, want := fieldSourceAt(fieldSources, index), uint8(fieldSourceDirect); got != want {
-			t.Fatalf("field source %d = %d, want %d", index, got, want)
+		if got := fieldIDs[index]; got != wantField {
+			t.Fatalf("field %d = %d, want %d", index, got, wantField)
+		}
+		if got := fieldSourceAt(fieldSources, index); got != wantSource {
+			t.Fatalf("field source %d = %d, want %d", index, got, wantSource)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Publish v0.48.1 as an urgent correctness patch for issue #660.

## Scope

- Stop inherited-only field entries from labeling anonymous separator nodes.
- Preserve deferred direct repeated fields, including Scala `path` separators.
- Add production and candidate-route coverage for Python imports and subscripts.
- Update the changelog and the README release status.

## Verification

- Docker root regression and field-reduction tests: pass.
- Docker `go test ./grammars/... -count=1`: pass.
- Python real-corpus C parity: 25 of 25 samples pass with deep parity enabled.
- The full root package retention gate fails on both v0.48.0 and this branch at `TestArenaGCRetentionAfterRelease` with 82 MB versus a 60 MB limit. The failure is pre-existing and unrelated to this patch.

This branch starts at the immutable v0.48.0 tag. It excludes the unresolved main-branch performance work.