### PR TITLE
release: stage v0.49.0 soak candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.49.0] - 2026-08-04
+
 ### Removed
 
 - One member of the Go result-compatibility arm is retired: the member
@@ -20,6 +22,10 @@ for tags and release notes while still in `0.x`.
   the exhaustive C-oracle fresh and incremental parity sweep stays green.
 
 ### Added
+
+- A regression guard covers issue #660.
+  It checks anonymous comma nodes in Python imports and subscripts on both
+  parser routes.
 
 - The included-ranges route now has committed test coverage.
   `Parser.SetIncludedRanges` had no test for any language, and injection
@@ -201,6 +207,15 @@ for tags and release notes while still in `0.x`.
   gap trades against how large an input the compact route can still serve,
   and is an open follow-up, not resolved by this change.
   Routing only changes; every canonical tree digest stays identical.
+
+## [0.48.1] - 2026-08-04
+
+### Fixed
+
+- Anonymous separator nodes in Python import and subscript forms stay
+  unfielded.
+  The patch restores field-name behavior from the reference C runtime.
+  This fixes [issue #660](https://github.com/odvcencio/gotreesitter/issues/660).
 
 ## [0.48.0] - 2026-08-01
 
@@ -419,11 +434,6 @@ for tags and release notes while still in `0.x`.
 - The native reduction path now sets Dart switch-expression body fields.
   It now sets the target field for nested Elixir calls.
   This change removes two inert language-local field repairs.
-
-- Inherited reduction fields now fill anonymous gaps between repeated direct
-  descendants.
-  They do not cross a leading separator without direct descendant evidence.
-  This change removes three Scala field repairs and the SQL `INTO` cleanup.
 
 - Compact graph insertion now persists exact predecessor merges across a
   bounded 16-level path.
@@ -4438,7 +4448,9 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.48.0...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.49.0...HEAD
+[0.49.0]: https://github.com/odvcencio/gotreesitter/compare/v0.48.1...v0.49.0
+[0.48.1]: https://github.com/odvcencio/gotreesitter/compare/v0.48.0...v0.48.1
 [0.48.0]: https://github.com/odvcencio/gotreesitter/compare/v0.47.1...v0.48.0
 [0.47.1]: https://github.com/odvcencio/gotreesitter/compare/v0.47.0...v0.47.1
 [0.47.0]: https://github.com/odvcencio/gotreesitter/compare/v0.46.0...v0.47.0

--- a/README.md
+++ b/README.md
@@ -752,10 +752,10 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.48.0**. It closes six Swift real-code parse
-defects found against apple/swift-algorithms and the Swift 6.3 standard
-library. It adds a validated Swift corpus with a ratcheting regression suite.
-It also cuts incremental re-lex and compact full-parse allocation costs.
+The current release is **v0.49.0**. It consolidates parser correctness,
+reference parity, recovery bounds, and compact-route work since v0.48.1.
+It also includes the issue #660 field-projection correction and its
+regression guard.
 
 Detailed shipped evidence lives in [CHANGELOG.md](CHANGELOG.md). Planned minor
 releases are batched on Thursdays; the immutable-tag process and exceptions are

--- a/issue660_regression_test.go
+++ b/issue660_regression_test.go
@@ -1,0 +1,54 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestIssue660AnonymousCommaHasNoField(t *testing.T) {
+	lang := grammars.PythonLanguage()
+	cases := []string{
+		"from a import b, c\n",
+		"import a, b\n",
+		"x[a, b]\n",
+	}
+
+	for _, useCandidate := range []bool{false, true} {
+		for _, source := range cases {
+			name := "production"
+			if useCandidate {
+				name = "candidate"
+			}
+			t.Run(name+"/"+source, func(t *testing.T) {
+				parser := gotreesitter.NewParser(lang)
+				parser.SetAdmissionCandidateRoute(useCandidate)
+				tree, err := parser.Parse([]byte(source))
+				if err != nil {
+					t.Fatalf("parse: %v", err)
+				}
+				defer tree.Release()
+				assertAnonymousCommasUnfielded(t, tree.RootNode(), lang, []byte(source))
+			})
+		}
+	}
+}
+
+func assertAnonymousCommasUnfielded(t *testing.T, parent *gotreesitter.Node, lang *gotreesitter.Language, source []byte) {
+	t.Helper()
+	if parent == nil {
+		return
+	}
+	for i := 0; i < parent.ChildCount(); i++ {
+		child := parent.Child(i)
+		if child == nil {
+			continue
+		}
+		if child.Text(source) == "," && parent.FieldNameForChild(i, lang) != "" {
+			t.Fatalf("anonymous comma at [%d,%d) has field %q in parent %s: %s",
+				child.StartByte(), child.EndByte(), parent.FieldNameForChild(i, lang), parent.Type(lang), parent.SExpr(lang))
+		}
+		assertAnonymousCommasUnfielded(t, child, lang, source)
+	}
+}


### PR DESCRIPTION
## Scope

- Graduate the accumulated `Unreleased` entries into `v0.49.0` dated 2026-08-04.
- Update the README release status and comparison links.
- Record the published `v0.48.1` issue #660 patch.
- Add a Python regression guard for anonymous separator fields on both parser routes.

## Verification

- Focused Docker test: `TestIssue660AnonymousCommaHasNoField`
- Docker release validator tests: `go test ./cmd/releasegate -count=1`
- `git diff --check`

## Soak

After merge, dispatch the full `ci.yml` workflow with `workflow_dispatch` on the exact merge commit. Start the 48-hour soak only after that run succeeds. Keep v10 performance work outside this candidate.