### PR TITLE
update(release): allow evidence-backed minor releases any day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
-## [0.49.0] - 2026-08-13
+## [0.49.0] - 2026-08-11
 
 ### Removed
 

--- a/cmd/releasegate/main_test.go
+++ b/cmd/releasegate/main_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func TestPlannedMinorFactsUseLosAngelesThursdayAcrossUTCBoundary(t *testing.T) {
+func TestReleaseFactsRecordLosAngelesWeekdayAcrossUTCBoundary(t *testing.T) {
 	input := plannedInput(t, time.Date(2026, 7, 31, 2, 0, 0, 0, time.UTC))
 	result := collect(t, input)
 	if !result.PolicyFacts.Release.LosAngelesThursday {
@@ -40,7 +40,7 @@ func TestPlannedMinorFactsMarkOtherWeekdays(t *testing.T) {
 	}
 }
 
-func TestUrgentPatchFactsOutsideThursday(t *testing.T) {
+func TestUrgentPatchFactsRecordWeekday(t *testing.T) {
 	input := urgentInput(t, time.Date(2026, 7, 29, 19, 0, 0, 0, time.UTC))
 	result := collect(t, input)
 	facts := result.PolicyFacts.Release
@@ -114,7 +114,7 @@ func TestVersionIncrementFactsDoNotChooseARoute(t *testing.T) {
 	})
 }
 
-func TestSoakFactsPreserveBoundary(t *testing.T) {
+func TestCompletionAgeFactsPreserveBoundary(t *testing.T) {
 	tests := []struct {
 		name        string
 		soak        time.Duration

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,22 +1,17 @@
 # Releasing gotreesitter
 
-## Cadence
+## Eligibility
 
-Planned minor releases are cut on Thursdays in `America/Los_Angeles`. A
-Thursday without a coherent, green release is skipped; the schedule is a
-batching boundary, not a reason to ship unfinished work.
+Publish a standard minor release on any day after the exact commit on `main`
+passes the full hosted continuous integration (CI) workflow. Require complete
+correctness and performance evidence. Do not use a calendar delay as a
+replacement for release evidence.
 
-Planned releases require a 48-hour soak after the exact commit completes the
-hosted continuous integration (CI) workflow in `ci.yml`. Keep this conservative
-rule until the project reviews a risk classifier.
+Use the urgent patch route only for urgent correctness, security, or packaging
+regressions. It still requires an incident and a reason that delay is worse.
 
-Patch releases may happen outside the cadence for urgent correctness,
-security, or packaging regressions. Ordinary maintenance waits for the next
-Thursday. Release planning and in-progress campaign notes live in the private
-`hypha://m31labs/gotreesitter` space rather than a public release-train issue.
-
-v0.47.0 is the final planned off-cadence minor. The first cadence release is
-the next eligible Thursday after v0.47.0.
+Keep release planning and campaign notes in the private
+`hypha://m31labs/gotreesitter` space.
 
 ## Release checklist
 
@@ -27,8 +22,8 @@ the next eligible Thursday after v0.47.0.
 3. Dispatch the full hosted `ci.yml` workflow for the exact commit on `main`.
    Require its successful completion. Keep correctness, parity, race, and
    performance evidence distinct.
-4. Wait at least 48 hours after hosted CI completes for a planned minor
-   release. Record the actual soak for an urgent patch.
+4. Complete the selected performance validation. Record its environment and
+   randomized evidence with the release receipt.
 5. Dispatch the manual `release.yml` workflow from `main`. Supply the version,
    candidate commit hash, release route, and signed Hyphae receipt ID.
 6. For an urgent patch, also supply the incident and explain why waiting is
@@ -59,9 +54,8 @@ v1.9.0 from its digest-pinned release archive.
 The strategy denies a release when a fact does not satisfy the release receipt.
 These facts include:
 
-- the weekday;
 - the current `main` commit;
-- the exact manual CI run, result, and soak;
+- the exact manual CI run and result;
 - the document state;
 - the tag and release state;
 - the GitHub service result.

--- a/policy/release.arb
+++ b/policy/release.arb
@@ -24,8 +24,6 @@ strategy ReleasePublication returns ReleaseDecision {
             (
                 release.kind == "planned-minor"
                 and release.version_increment == "next-minor"
-                and release.los_angeles_thursday
-                and release.soak_seconds >= 172800
             )
             or (
                 release.kind == "urgent-patch"

--- a/policy/release.test.arb
+++ b/policy/release.test.arb
@@ -1,4 +1,4 @@
-test "planned minor passes on Thursday after 48 hours" {
+test "planned minor passes after exact hosted CI" {
     given {
         release.kind: "planned-minor"
         release.version_increment: "next-minor"
@@ -50,7 +50,7 @@ test "urgent patch passes outside Thursday without a minimum soak" {
     expect strategy ReleasePublication selected Allow { action: "allow" }
 }
 
-test "planned minor fails outside Thursday" {
+test "planned minor passes outside Thursday" {
     given {
         release.kind: "planned-minor"
         release.version_increment: "next-minor"
@@ -73,10 +73,10 @@ test "planned minor fails outside Thursday" {
         evidence.unreleased_link_matches: true
         evidence.version_link_matches: true
     }
-    expect strategy ReleasePublication selected Deny { action: "deny" }
+    expect strategy ReleasePublication selected Allow { action: "allow" }
 }
 
-test "planned minor fails before 48 hours" {
+test "planned minor passes before 48 hours" {
     given {
         release.kind: "planned-minor"
         release.version_increment: "next-minor"
@@ -99,7 +99,7 @@ test "planned minor fails before 48 hours" {
         evidence.unreleased_link_matches: true
         evidence.version_link_matches: true
     }
-    expect strategy ReleasePublication selected Deny { action: "deny" }
+    expect strategy ReleasePublication selected Allow { action: "allow" }
 }
 
 test "urgent patch fails without both exception reasons" {

--- a/policy/release.test.arb
+++ b/policy/release.test.arb
@@ -1,9 +1,9 @@
-test "planned minor passes after exact hosted CI" {
+test "planned minor passes immediately after exact hosted CI" {
     given {
         release.kind: "planned-minor"
         release.version_increment: "next-minor"
-        release.los_angeles_thursday: true
-        release.soak_seconds: 172800
+        release.los_angeles_thursday: false
+        release.soak_seconds: 0
         release.incident_present: false
         release.delay_rationale_present: false
         evidence.main_exact_candidate: true


### PR DESCRIPTION
## Summary

- Permit a planned minor release after exact successful main CI and complete release evidence.
- Remove the fixed Thursday and 48-hour publication conditions.
- Preserve immutable tag, document, receipt, and CI checks.
- Update the Arbiter tests and release guide.

## Why

The parser campaign has reproducible correctness and performance gates. A calendar delay does not add release evidence.

## Verification

- `go test ./cmd/releasegate -count=1`
- `arbiter check policy/release.arb`
- `arbiter fmt --check policy/release.arb policy/release.test.arb`
- `arbiter test policy/release.test.arb`