### PR TITLE
perf: define G2 reference atlas event contract

### DIFF
--- a/cgo_harness/reference_atlas_event_schema_test.go
+++ b/cgo_harness/reference_atlas_event_schema_test.go
@@ -1,0 +1,124 @@
+package cgoharness
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+type referenceAtlasSchema struct {
+	Schema    string `json:"schema"`
+	Reference struct {
+		Commit string `json:"commit"`
+	} `json:"reference"`
+	Identity struct {
+		RequiredFields           []string `json:"required_fields"`
+		SemanticKeyFields        []string `json:"semantic_key_fields"`
+		ExcludedPhysicalIdentity []string `json:"excluded_physical_identity"`
+	} `json:"identity"`
+	StatusDefinitions map[string]string     `json:"status_definitions"`
+	Events            []referenceAtlasEvent `json:"events"`
+	ClaimLimits       []string              `json:"claim_limits"`
+}
+
+type referenceAtlasEvent struct {
+	ID             string               `json:"id"`
+	Phase          string               `json:"phase"`
+	RequiredFields []string             `json:"required_fields"`
+	SemanticKey    []string             `json:"semantic_key"`
+	C              referenceAtlasEngine `json:"c"`
+	Go             referenceAtlasEngine `json:"go"`
+}
+
+type referenceAtlasEngine struct {
+	Status string   `json:"status"`
+	Fields []string `json:"fields"`
+}
+
+func TestReferenceAtlasEventSchemaIsCompleteAndHonest(t *testing.T) {
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate the reference-atlas schema test")
+	}
+	path := filepath.Join(filepath.Dir(sourceFile), "work_count", "reference_atlas_event_schema_v1.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read reference-atlas schema: %v", err)
+	}
+	var schema referenceAtlasSchema
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("decode reference-atlas schema: %v", err)
+	}
+
+	if schema.Schema != "gts-reference-atlas-event-schema/v1" {
+		t.Fatalf("schema = %q", schema.Schema)
+	}
+	if schema.Reference.Commit != "f5afe475deb7c0bae6407fb776c76824f717bb61" {
+		t.Fatalf("reference commit = %q", schema.Reference.Commit)
+	}
+	if len(schema.Identity.RequiredFields) < 5 || len(schema.Identity.SemanticKeyFields) < 4 {
+		t.Fatal("identity contract is too small to align semantic events")
+	}
+	if len(schema.Identity.ExcludedPhysicalIdentity) == 0 {
+		t.Fatal("identity contract must exclude physical engine identifiers")
+	}
+	if len(schema.ClaimLimits) < 3 {
+		t.Fatal("claim limits must state the evidence boundary")
+	}
+
+	wantStatuses := map[string]bool{"aggregate_only": true, "planned": true}
+	seen := make(map[string]bool, len(schema.Events))
+	for index, event := range schema.Events {
+		if event.ID == "" || event.Phase == "" {
+			t.Fatalf("event %d has no id or phase", index)
+		}
+		if seen[event.ID] {
+			t.Fatalf("event %q is duplicated", event.ID)
+		}
+		seen[event.ID] = true
+		if len(event.RequiredFields) < 2 || len(event.SemanticKey) < 2 {
+			t.Fatalf("event %q has an incomplete identity", event.ID)
+		}
+		validateReferenceAtlasEngine(t, event.ID, "C", event.C, wantStatuses)
+		validateReferenceAtlasEngine(t, event.ID, "Go", event.Go, wantStatuses)
+	}
+	if len(schema.Events) != 24 {
+		t.Fatalf("event count = %d, want 24", len(schema.Events))
+	}
+}
+
+func validateReferenceAtlasEngine(t *testing.T, eventID, engine string, value referenceAtlasEngine, statuses map[string]bool) {
+	t.Helper()
+	if !statuses[value.Status] {
+		t.Fatalf("event %q %s status %q is not an allowed evidence status", eventID, engine, value.Status)
+	}
+	if value.Status == "planned" && len(value.Fields) != 0 {
+		t.Fatalf("event %q %s planned status lists fields", eventID, engine)
+	}
+	if value.Status == "aggregate_only" && len(value.Fields) == 0 {
+		t.Fatalf("event %q %s aggregate status has no counter mapping", eventID, engine)
+	}
+	for _, field := range value.Fields {
+		if field == "" {
+			t.Fatalf("event %q %s contains an empty field mapping", eventID, engine)
+		}
+		if filepath.Base(field) != field && field != "MergeEventCensusCounts.Attempts" && field != "MergeEventCensusCounts.Successes" && field != "MergeEventCensusCounts.LinkPayloadDeepAccepts" && field != "MergeEventCensusCounts.LinkPayloadShallowWouldAccept" && field != "MergeEventCensusCounts.LinkPayloadTests" && field != "MergeEventCensusCounts.LinkPayloadDeepRefusals" && field != "MergeEventCensusCounts.LinkPayloadPending" {
+			// Keep qualified Go names explicit. Do not silently accept a path
+			// or a physical identifier in the semantic contract.
+			t.Fatalf("event %q %s field %q is not a semantic counter name", eventID, engine, field)
+		}
+	}
+}
+
+func Example_referenceAtlasEventSchema() {
+	_, sourceFile, _, _ := runtime.Caller(0)
+	path := filepath.Join(filepath.Dir(sourceFile), "work_count", "reference_atlas_event_schema_v1.json")
+	data, _ := os.ReadFile(path)
+	var schema referenceAtlasSchema
+	_ = json.Unmarshal(data, &schema)
+	fmt.Println(schema.Schema, len(schema.Events))
+	// Output: gts-reference-atlas-event-schema/v1 24
+}

--- a/cgo_harness/work_count/reference_atlas_event_schema_v1.json
+++ b/cgo_harness/work_count/reference_atlas_event_schema_v1.json
@@ -1,0 +1,240 @@
+{
+  "schema": "gts-reference-atlas-event-schema/v1",
+  "spec": "spec.parser-graduation.v1#8.1",
+  "purpose": "Define matched C and Go event names before adding event emitters.",
+  "reference": {
+    "runtime": "tree-sitter-c",
+    "version": "0.25.1",
+    "commit": "f5afe475deb7c0bae6407fb776c76824f717bb61"
+  },
+  "identity": {
+    "required_fields": [
+      "event_seq",
+      "source_start_byte",
+      "source_end_byte",
+      "parse_state",
+      "symbol",
+      "call_site",
+      "outcome"
+    ],
+    "semantic_key_fields": [
+      "source_start_byte",
+      "source_end_byte",
+      "parse_state",
+      "symbol",
+      "call_site",
+      "event_kind"
+    ],
+    "excluded_physical_identity": [
+      "go_pointer",
+      "stack_version_id",
+      "gss_node_id",
+      "arena_id",
+      "subtree_pointer"
+    ]
+  },
+  "status_definitions": {
+    "aggregate_only": "The engine exposes a counter, but not an ordered event record.",
+    "planned": "The contract names the event, but the current engine exposes no record."
+  },
+  "events": [
+    {
+      "id": "lexer.entry_result",
+      "phase": "lexing",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["lexer_front_door_calls_proxy", "raw_main_lexer_invocations"]},
+      "go": {"status": "aggregate_only", "fields": ["LexerFrontDoorCallsProxy", "RawMainLexerInvocations"]}
+    },
+    {
+      "id": "token_cache.hit_miss",
+      "phase": "lexing",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "old_tree.reuse_decision",
+      "phase": "reuse",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "action_table.lookup",
+      "phase": "dispatch",
+      "required_fields": ["event_seq", "parse_state", "symbol", "call_site", "outcome"],
+      "semantic_key": ["parse_state", "symbol", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["table_lookups_proxy", "action_entries_examined_proxy"]},
+      "go": {"status": "aggregate_only", "fields": ["TableLookupsProxy", "ActionEntriesExaminedProxy"]}
+    },
+    {
+      "id": "parser.shift",
+      "phase": "dispatch",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["shifts"]},
+      "go": {"status": "aggregate_only", "fields": ["Shifts"]}
+    },
+    {
+      "id": "parser.reduce",
+      "phase": "dispatch",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["reductions", "reduction_pop_requests"]},
+      "go": {"status": "aggregate_only", "fields": ["Reductions", "ReductionPopRequests"]}
+    },
+    {
+      "id": "parser.recover",
+      "phase": "recovery",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["explicit_recover_actions"]},
+      "go": {"status": "aggregate_only", "fields": ["ExplicitRecoverActions"]}
+    },
+    {
+      "id": "parser.accept",
+      "phase": "dispatch",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["accept_actions"]},
+      "go": {"status": "aggregate_only", "fields": ["AcceptActions"]}
+    },
+    {
+      "id": "stack.copy",
+      "phase": "stack",
+      "required_fields": ["event_seq", "parse_state", "call_site", "outcome"],
+      "semantic_key": ["parse_state", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "stack.pause",
+      "phase": "stack",
+      "required_fields": ["event_seq", "parse_state", "call_site", "outcome"],
+      "semantic_key": ["parse_state", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "stack.resume",
+      "phase": "stack",
+      "required_fields": ["event_seq", "parse_state", "call_site", "outcome"],
+      "semantic_key": ["parse_state", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "stack.halt",
+      "phase": "stack",
+      "required_fields": ["event_seq", "parse_state", "call_site", "outcome"],
+      "semantic_key": ["parse_state", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "stack.remove",
+      "phase": "stack",
+      "required_fields": ["event_seq", "parse_state", "call_site", "outcome"],
+      "semantic_key": ["parse_state", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "head.merge",
+      "phase": "merge",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["merge_attempts_proxy", "merge_successes_proxy"]},
+      "go": {"status": "aggregate_only", "fields": ["MergeEventCensusCounts.Attempts", "MergeEventCensusCounts.Successes"]}
+    },
+    {
+      "id": "link.duplicate",
+      "phase": "merge",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["predecessor_link_union_duplicate_noop"]},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "link.precedence_replace",
+      "phase": "merge",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["predecessor_link_union_precedence_replaced"]},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "link.recursive_merge",
+      "phase": "merge",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["predecessor_link_union_recursive_changed"]},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "link.append",
+      "phase": "merge",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["predecessor_link_union_alternate_appended"]},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "link.reject",
+      "phase": "merge",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["predecessor_link_union_rejected"]},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "pop.path_create",
+      "phase": "pop",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["emitted_pop_paths", "emitted_pop_payloads"]},
+      "go": {"status": "aggregate_only", "fields": ["EmittedPopPaths", "EmittedPopPayloads"]}
+    },
+    {
+      "id": "child.election",
+      "phase": "election",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "subtree.lifecycle",
+      "phase": "storage",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["leaf_constructions_proxy", "parent_constructions_proxy"]},
+      "go": {"status": "aggregate_only", "fields": ["LeafConstructionsProxy", "ParentConstructionsProxy"]}
+    },
+    {
+      "id": "parser.progress_stop",
+      "phase": "control",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "tree.final_select",
+      "phase": "materialization",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["raw_selected_internal_nodes", "raw_selected_internal_parent_occurrences", "raw_selected_internal_leaf_occurrences"]},
+      "go": {"status": "aggregate_only", "fields": ["SelectedNodes", "SelectedParentNodes", "SelectedLeafNodes"]}
+    }
+  ],
+  "claim_limits": [
+    "Aggregate counters do not prove event equality.",
+    "An event sequence is comparable only after both engines emit the same semantic key.",
+    "Physical identifiers cannot enter a cross-engine key.",
+    "A matched event receipt must record source, grammar, runtime, and build locks."
+  ]
+}

--- a/docs/reference-atlas.md
+++ b/docs/reference-atlas.md
@@ -1,0 +1,36 @@
+# C-reference atlas
+
+This document records the first G2 unit from the parser graduation campaign.
+
+## Unit G2.1
+
+The event schema in `cgo_harness/work_count/reference_atlas_event_schema_v1.json`
+names the events that the C and Go engines must expose.
+
+The schema separates two states:
+
+- `aggregate_only` means that counters exist without event order;
+- `planned` means that the current engine exposes no event yet.
+
+Do not treat either state as cross-engine event equality.
+
+The contract excludes pointers, stack identifiers, and arena identifiers.
+Use source position, parse state, symbol, call site, and event kind instead.
+
+## Exit for this unit
+
+Require these conditions before adding emitters:
+
+- every event has a stable identifier;
+- both engines have an explicit status;
+- aggregate mappings name existing counters;
+- planned mappings name no counters;
+- semantic keys exclude physical engine identity;
+- the reference commit remains tree-sitter C 0.25.1.
+
+## Next units
+
+Add ordered Go events and C events in separate pull requests.
+Use deterministic controls before reading a real corpus.
+Align events by the schema key, not by final tree shape.
+Reject a receipt when either engine drops or truncates an event stream.


### PR DESCRIPTION
## Summary

- Define the G2 C-reference atlas event vocabulary.
- Map current aggregate counters and mark missing ordered events as planned.
- Validate semantic keys and evidence limits in the harness.

## Campaign position

This pull request implements G2.1 from the parser graduation proposal.
It changes no parser behavior, route, public API, or benchmark result.
It does not claim cross-engine event equality.

## Validation

- Focused Docker test passes.
- Git diff checks pass.
- The reference runtime is pinned to tree-sitter C 0.25.1.

## Follow-up

Add ordered Go and C event emitters in separate units.
Run deterministic controls before reading the real corpus.
Complete M0 before starting merge-time election M1.