### PR TITLE
perf: add bounded Go reference atlas events

### DIFF
--- a/cgo_harness/reference_atlas_event_schema_test.go
+++ b/cgo_harness/reference_atlas_event_schema_test.go
@@ -5,13 +5,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
 )
 
 type referenceAtlasSchema struct {
-	Schema    string `json:"schema"`
-	Reference struct {
+	Schema               string `json:"schema"`
+	OrderedEventContract string `json:"ordered_event_contract"`
+	Reference            struct {
 		Commit string `json:"commit"`
 	} `json:"reference"`
 	Identity struct {
@@ -56,6 +58,9 @@ func TestReferenceAtlasEventSchemaIsCompleteAndHonest(t *testing.T) {
 	if schema.Schema != "gts-reference-atlas-event-schema/v1" {
 		t.Fatalf("schema = %q", schema.Schema)
 	}
+	if schema.OrderedEventContract != "gts-reference-atlas-events/v1" {
+		t.Fatalf("ordered event contract = %q", schema.OrderedEventContract)
+	}
 	if schema.Reference.Commit != "f5afe475deb7c0bae6407fb776c76824f717bb61" {
 		t.Fatalf("reference commit = %q", schema.Reference.Commit)
 	}
@@ -69,7 +74,7 @@ func TestReferenceAtlasEventSchemaIsCompleteAndHonest(t *testing.T) {
 		t.Fatal("claim limits must state the evidence boundary")
 	}
 
-	wantStatuses := map[string]bool{"aggregate_only": true, "planned": true}
+	wantStatuses := map[string]bool{"aggregate_only": true, "planned": true, "ordered": true}
 	seen := make(map[string]bool, len(schema.Events))
 	for index, event := range schema.Events {
 		if event.ID == "" || event.Phase == "" {
@@ -100,6 +105,12 @@ func validateReferenceAtlasEngine(t *testing.T, eventID, engine string, value re
 	}
 	if value.Status == "aggregate_only" && len(value.Fields) == 0 {
 		t.Fatalf("event %q %s aggregate status has no counter mapping", eventID, engine)
+	}
+	if value.Status == "ordered" {
+		wantFields := []string{"event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "event_kind", "outcome"}
+		if !reflect.DeepEqual(value.Fields, wantFields) {
+			t.Fatalf("event %q %s ordered fields=%v want=%v", eventID, engine, value.Fields, wantFields)
+		}
 	}
 	for _, field := range value.Fields {
 		if field == "" {

--- a/cgo_harness/reference_atlas_event_schema_test.go
+++ b/cgo_harness/reference_atlas_event_schema_test.go
@@ -1,0 +1,124 @@
+package cgoharness
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+type referenceAtlasSchema struct {
+	Schema    string `json:"schema"`
+	Reference struct {
+		Commit string `json:"commit"`
+	} `json:"reference"`
+	Identity struct {
+		RequiredFields           []string `json:"required_fields"`
+		SemanticKeyFields        []string `json:"semantic_key_fields"`
+		ExcludedPhysicalIdentity []string `json:"excluded_physical_identity"`
+	} `json:"identity"`
+	StatusDefinitions map[string]string     `json:"status_definitions"`
+	Events            []referenceAtlasEvent `json:"events"`
+	ClaimLimits       []string              `json:"claim_limits"`
+}
+
+type referenceAtlasEvent struct {
+	ID             string               `json:"id"`
+	Phase          string               `json:"phase"`
+	RequiredFields []string             `json:"required_fields"`
+	SemanticKey    []string             `json:"semantic_key"`
+	C              referenceAtlasEngine `json:"c"`
+	Go             referenceAtlasEngine `json:"go"`
+}
+
+type referenceAtlasEngine struct {
+	Status string   `json:"status"`
+	Fields []string `json:"fields"`
+}
+
+func TestReferenceAtlasEventSchemaIsCompleteAndHonest(t *testing.T) {
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate the reference-atlas schema test")
+	}
+	path := filepath.Join(filepath.Dir(sourceFile), "work_count", "reference_atlas_event_schema_v1.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read reference-atlas schema: %v", err)
+	}
+	var schema referenceAtlasSchema
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("decode reference-atlas schema: %v", err)
+	}
+
+	if schema.Schema != "gts-reference-atlas-event-schema/v1" {
+		t.Fatalf("schema = %q", schema.Schema)
+	}
+	if schema.Reference.Commit != "f5afe475deb7c0bae6407fb776c76824f717bb61" {
+		t.Fatalf("reference commit = %q", schema.Reference.Commit)
+	}
+	if len(schema.Identity.RequiredFields) < 5 || len(schema.Identity.SemanticKeyFields) < 4 {
+		t.Fatal("identity contract is too small to align semantic events")
+	}
+	if len(schema.Identity.ExcludedPhysicalIdentity) == 0 {
+		t.Fatal("identity contract must exclude physical engine identifiers")
+	}
+	if len(schema.ClaimLimits) < 3 {
+		t.Fatal("claim limits must state the evidence boundary")
+	}
+
+	wantStatuses := map[string]bool{"aggregate_only": true, "planned": true}
+	seen := make(map[string]bool, len(schema.Events))
+	for index, event := range schema.Events {
+		if event.ID == "" || event.Phase == "" {
+			t.Fatalf("event %d has no id or phase", index)
+		}
+		if seen[event.ID] {
+			t.Fatalf("event %q is duplicated", event.ID)
+		}
+		seen[event.ID] = true
+		if len(event.RequiredFields) < 2 || len(event.SemanticKey) < 2 {
+			t.Fatalf("event %q has an incomplete identity", event.ID)
+		}
+		validateReferenceAtlasEngine(t, event.ID, "C", event.C, wantStatuses)
+		validateReferenceAtlasEngine(t, event.ID, "Go", event.Go, wantStatuses)
+	}
+	if len(schema.Events) != 24 {
+		t.Fatalf("event count = %d, want 24", len(schema.Events))
+	}
+}
+
+func validateReferenceAtlasEngine(t *testing.T, eventID, engine string, value referenceAtlasEngine, statuses map[string]bool) {
+	t.Helper()
+	if !statuses[value.Status] {
+		t.Fatalf("event %q %s status %q is not an allowed evidence status", eventID, engine, value.Status)
+	}
+	if value.Status == "planned" && len(value.Fields) != 0 {
+		t.Fatalf("event %q %s planned status lists fields", eventID, engine)
+	}
+	if value.Status == "aggregate_only" && len(value.Fields) == 0 {
+		t.Fatalf("event %q %s aggregate status has no counter mapping", eventID, engine)
+	}
+	for _, field := range value.Fields {
+		if field == "" {
+			t.Fatalf("event %q %s contains an empty field mapping", eventID, engine)
+		}
+		if filepath.Base(field) != field && field != "MergeEventCensusCounts.Attempts" && field != "MergeEventCensusCounts.Successes" && field != "MergeEventCensusCounts.LinkPayloadDeepAccepts" && field != "MergeEventCensusCounts.LinkPayloadShallowWouldAccept" && field != "MergeEventCensusCounts.LinkPayloadTests" && field != "MergeEventCensusCounts.LinkPayloadDeepRefusals" && field != "MergeEventCensusCounts.LinkPayloadPending" {
+			// Keep qualified Go names explicit. Do not silently accept a path
+			// or a physical identifier in the semantic contract.
+			t.Fatalf("event %q %s field %q is not a semantic counter name", eventID, engine, field)
+		}
+	}
+}
+
+func Example_referenceAtlasEventSchema() {
+	_, sourceFile, _, _ := runtime.Caller(0)
+	path := filepath.Join(filepath.Dir(sourceFile), "work_count", "reference_atlas_event_schema_v1.json")
+	data, _ := os.ReadFile(path)
+	var schema referenceAtlasSchema
+	_ = json.Unmarshal(data, &schema)
+	fmt.Println(schema.Schema, len(schema.Events))
+	// Output: gts-reference-atlas-event-schema/v1 24
+}

--- a/cgo_harness/work_count/reference_atlas_event_schema_v1.json
+++ b/cgo_harness/work_count/reference_atlas_event_schema_v1.json
@@ -2,6 +2,7 @@
   "schema": "gts-reference-atlas-event-schema/v1",
   "spec": "spec.parser-graduation.v1#8.1",
   "purpose": "Define matched C and Go event names before adding event emitters.",
+  "ordered_event_contract": "gts-reference-atlas-events/v1",
   "reference": {
     "runtime": "tree-sitter-c",
     "version": "0.25.1",
@@ -35,7 +36,8 @@
   },
   "status_definitions": {
     "aggregate_only": "The engine exposes a counter, but not an ordered event record.",
-    "planned": "The contract names the event, but the current engine exposes no record."
+    "planned": "The contract names the event, but the current engine exposes no record.",
+    "ordered": "The engine emits a bounded ordered record with the contract semantic fields."
   },
   "events": [
     {
@@ -68,7 +70,7 @@
       "required_fields": ["event_seq", "parse_state", "symbol", "call_site", "outcome"],
       "semantic_key": ["parse_state", "symbol", "call_site", "event_kind"],
       "c": {"status": "aggregate_only", "fields": ["table_lookups_proxy", "action_entries_examined_proxy"]},
-      "go": {"status": "aggregate_only", "fields": ["TableLookupsProxy", "ActionEntriesExaminedProxy"]}
+      "go": {"status": "ordered", "fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "event_kind", "outcome"]}
     },
     {
       "id": "parser.shift",
@@ -76,7 +78,7 @@
       "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
       "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
       "c": {"status": "aggregate_only", "fields": ["shifts"]},
-      "go": {"status": "aggregate_only", "fields": ["Shifts"]}
+      "go": {"status": "ordered", "fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "event_kind", "outcome"]}
     },
     {
       "id": "parser.reduce",
@@ -84,7 +86,7 @@
       "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
       "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
       "c": {"status": "aggregate_only", "fields": ["reductions", "reduction_pop_requests"]},
-      "go": {"status": "aggregate_only", "fields": ["Reductions", "ReductionPopRequests"]}
+      "go": {"status": "ordered", "fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "event_kind", "outcome"]}
     },
     {
       "id": "parser.recover",
@@ -92,7 +94,7 @@
       "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
       "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
       "c": {"status": "aggregate_only", "fields": ["explicit_recover_actions"]},
-      "go": {"status": "aggregate_only", "fields": ["ExplicitRecoverActions"]}
+      "go": {"status": "ordered", "fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "event_kind", "outcome"]}
     },
     {
       "id": "parser.accept",
@@ -100,7 +102,7 @@
       "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
       "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
       "c": {"status": "aggregate_only", "fields": ["accept_actions"]},
-      "go": {"status": "aggregate_only", "fields": ["AcceptActions"]}
+      "go": {"status": "ordered", "fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "event_kind", "outcome"]}
     },
     {
       "id": "stack.copy",
@@ -148,7 +150,7 @@
       "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "call_site", "outcome"],
       "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "call_site", "event_kind"],
       "c": {"status": "aggregate_only", "fields": ["merge_attempts_proxy", "merge_successes_proxy"]},
-      "go": {"status": "aggregate_only", "fields": ["MergeEventCensusCounts.Attempts", "MergeEventCensusCounts.Successes"]}
+      "go": {"status": "ordered", "fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "event_kind", "outcome"]}
     },
     {
       "id": "link.duplicate",

--- a/cgo_harness/work_count/reference_atlas_event_schema_v1.json
+++ b/cgo_harness/work_count/reference_atlas_event_schema_v1.json
@@ -1,0 +1,240 @@
+{
+  "schema": "gts-reference-atlas-event-schema/v1",
+  "spec": "spec.parser-graduation.v1#8.1",
+  "purpose": "Define matched C and Go event names before adding event emitters.",
+  "reference": {
+    "runtime": "tree-sitter-c",
+    "version": "0.25.1",
+    "commit": "f5afe475deb7c0bae6407fb776c76824f717bb61"
+  },
+  "identity": {
+    "required_fields": [
+      "event_seq",
+      "source_start_byte",
+      "source_end_byte",
+      "parse_state",
+      "symbol",
+      "call_site",
+      "outcome"
+    ],
+    "semantic_key_fields": [
+      "source_start_byte",
+      "source_end_byte",
+      "parse_state",
+      "symbol",
+      "call_site",
+      "event_kind"
+    ],
+    "excluded_physical_identity": [
+      "go_pointer",
+      "stack_version_id",
+      "gss_node_id",
+      "arena_id",
+      "subtree_pointer"
+    ]
+  },
+  "status_definitions": {
+    "aggregate_only": "The engine exposes a counter, but not an ordered event record.",
+    "planned": "The contract names the event, but the current engine exposes no record."
+  },
+  "events": [
+    {
+      "id": "lexer.entry_result",
+      "phase": "lexing",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["lexer_front_door_calls_proxy", "raw_main_lexer_invocations"]},
+      "go": {"status": "aggregate_only", "fields": ["LexerFrontDoorCallsProxy", "RawMainLexerInvocations"]}
+    },
+    {
+      "id": "token_cache.hit_miss",
+      "phase": "lexing",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "old_tree.reuse_decision",
+      "phase": "reuse",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "action_table.lookup",
+      "phase": "dispatch",
+      "required_fields": ["event_seq", "parse_state", "symbol", "call_site", "outcome"],
+      "semantic_key": ["parse_state", "symbol", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["table_lookups_proxy", "action_entries_examined_proxy"]},
+      "go": {"status": "aggregate_only", "fields": ["TableLookupsProxy", "ActionEntriesExaminedProxy"]}
+    },
+    {
+      "id": "parser.shift",
+      "phase": "dispatch",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["shifts"]},
+      "go": {"status": "aggregate_only", "fields": ["Shifts"]}
+    },
+    {
+      "id": "parser.reduce",
+      "phase": "dispatch",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["reductions", "reduction_pop_requests"]},
+      "go": {"status": "aggregate_only", "fields": ["Reductions", "ReductionPopRequests"]}
+    },
+    {
+      "id": "parser.recover",
+      "phase": "recovery",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["explicit_recover_actions"]},
+      "go": {"status": "aggregate_only", "fields": ["ExplicitRecoverActions"]}
+    },
+    {
+      "id": "parser.accept",
+      "phase": "dispatch",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["accept_actions"]},
+      "go": {"status": "aggregate_only", "fields": ["AcceptActions"]}
+    },
+    {
+      "id": "stack.copy",
+      "phase": "stack",
+      "required_fields": ["event_seq", "parse_state", "call_site", "outcome"],
+      "semantic_key": ["parse_state", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "stack.pause",
+      "phase": "stack",
+      "required_fields": ["event_seq", "parse_state", "call_site", "outcome"],
+      "semantic_key": ["parse_state", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "stack.resume",
+      "phase": "stack",
+      "required_fields": ["event_seq", "parse_state", "call_site", "outcome"],
+      "semantic_key": ["parse_state", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "stack.halt",
+      "phase": "stack",
+      "required_fields": ["event_seq", "parse_state", "call_site", "outcome"],
+      "semantic_key": ["parse_state", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "stack.remove",
+      "phase": "stack",
+      "required_fields": ["event_seq", "parse_state", "call_site", "outcome"],
+      "semantic_key": ["parse_state", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "head.merge",
+      "phase": "merge",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["merge_attempts_proxy", "merge_successes_proxy"]},
+      "go": {"status": "aggregate_only", "fields": ["MergeEventCensusCounts.Attempts", "MergeEventCensusCounts.Successes"]}
+    },
+    {
+      "id": "link.duplicate",
+      "phase": "merge",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["predecessor_link_union_duplicate_noop"]},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "link.precedence_replace",
+      "phase": "merge",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["predecessor_link_union_precedence_replaced"]},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "link.recursive_merge",
+      "phase": "merge",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["predecessor_link_union_recursive_changed"]},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "link.append",
+      "phase": "merge",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["predecessor_link_union_alternate_appended"]},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "link.reject",
+      "phase": "merge",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["predecessor_link_union_rejected"]},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "pop.path_create",
+      "phase": "pop",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "parse_state", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "parse_state", "symbol", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["emitted_pop_paths", "emitted_pop_payloads"]},
+      "go": {"status": "aggregate_only", "fields": ["EmittedPopPaths", "EmittedPopPayloads"]}
+    },
+    {
+      "id": "child.election",
+      "phase": "election",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "subtree.lifecycle",
+      "phase": "storage",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "call_site", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["leaf_constructions_proxy", "parent_constructions_proxy"]},
+      "go": {"status": "aggregate_only", "fields": ["LeafConstructionsProxy", "ParentConstructionsProxy"]}
+    },
+    {
+      "id": "parser.progress_stop",
+      "phase": "control",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "call_site", "event_kind"],
+      "c": {"status": "planned", "fields": []},
+      "go": {"status": "planned", "fields": []}
+    },
+    {
+      "id": "tree.final_select",
+      "phase": "materialization",
+      "required_fields": ["event_seq", "source_start_byte", "source_end_byte", "symbol", "call_site", "outcome"],
+      "semantic_key": ["source_start_byte", "source_end_byte", "symbol", "event_kind"],
+      "c": {"status": "aggregate_only", "fields": ["raw_selected_internal_nodes", "raw_selected_internal_parent_occurrences", "raw_selected_internal_leaf_occurrences"]},
+      "go": {"status": "aggregate_only", "fields": ["SelectedNodes", "SelectedParentNodes", "SelectedLeafNodes"]}
+    }
+  ],
+  "claim_limits": [
+    "Aggregate counters do not prove event equality.",
+    "An event sequence is comparable only after both engines emit the same semantic key.",
+    "Physical identifiers cannot enter a cross-engine key.",
+    "A matched event receipt must record source, grammar, runtime, and build locks."
+  ]
+}

--- a/docs/reference-atlas.md
+++ b/docs/reference-atlas.md
@@ -1,6 +1,6 @@
 # C-reference atlas
 
-This document records the first G2 unit from the parser graduation campaign.
+This document records the G2 units from the parser graduation campaign.
 
 ## Unit G2.1
 
@@ -17,7 +17,7 @@ Do not treat either state as cross-engine event equality.
 The contract excludes pointers, stack identifiers, and arena identifiers.
 Use source position, parse state, symbol, call site, and event kind instead.
 
-## Exit for this unit
+## Exit for G2.1
 
 Require these conditions before adding emitters:
 
@@ -28,9 +28,26 @@ Require these conditions before adding emitters:
 - semantic keys exclude physical engine identity;
 - the reference commit remains tree-sitter C 0.25.1.
 
+## Unit G2.2
+
+The Go diagnostic build now emits a bounded ordered stream for these events:
+
+- action table lookup
+- shift
+- reduce
+- accept
+- recovery
+- head merge
+
+The stream uses source spans, parser state, grammar symbol, call site, event
+kind, and outcome. It excludes pointers, stack identifiers, and arena data.
+
+The stream is an observation surface. It does not change parser decisions.
+Aggregate counters remain the comparison authority until the C stream exists.
+
 ## Next units
 
-Add ordered Go events and C events in separate pull requests.
+Add the ordered C stream in a separate pull request.
 Use deterministic controls before reading a real corpus.
 Align events by the schema key, not by final tree shape.
 Reject a receipt when either engine drops or truncates an event stream.

--- a/docs/reference-atlas.md
+++ b/docs/reference-atlas.md
@@ -1,0 +1,36 @@
+# C-reference atlas
+
+This document records the first G2 unit from the parser graduation campaign.
+
+## Unit G2.1
+
+The event schema in `cgo_harness/work_count/reference_atlas_event_schema_v1.json`
+names the events that the C and Go engines must expose.
+
+The schema separates two states:
+
+- `aggregate_only` means that counters exist without event order;
+- `planned` means that the current engine exposes no event yet.
+
+Do not treat either state as cross-engine event equality.
+
+The contract excludes pointers, stack identifiers, and arena identifiers.
+Use source position, parse state, symbol, call site, and event kind instead.
+
+## Exit for this unit
+
+Require these conditions before adding emitters:
+
+- every event has a stable identifier;
+- both engines have an explicit status;
+- aggregate mappings name existing counters;
+- planned mappings name no counters;
+- semantic keys exclude physical engine identity;
+- the reference commit remains tree-sitter C 0.25.1.
+
+## Next units
+
+Add ordered Go events and C events in separate pull requests.
+Use deterministic controls before reading a real corpus.
+Align events by the schema key, not by final tree shape.
+Reject a receipt when either engine drops or truncates an event stream.

--- a/reference_atlas_trace.go
+++ b/reference_atlas_trace.go
@@ -1,0 +1,166 @@
+//go:build gts_workcount
+
+package gotreesitter
+
+import (
+	"math"
+	"strconv"
+)
+
+// DiagnosticReferenceAtlasEvent is one ordered Go event for the G2 atlas.
+// It contains semantic fields only. It contains no pointer or arena identity.
+type DiagnosticReferenceAtlasEvent struct {
+	EventSeq        uint64 `json:"event_seq"`
+	SourceStartByte uint32 `json:"source_start_byte"`
+	SourceEndByte   uint32 `json:"source_end_byte"`
+	ParseState      uint32 `json:"parse_state"`
+	Symbol          uint32 `json:"symbol"`
+	CallSite        string `json:"call_site"`
+	EventKind       string `json:"event_kind"`
+	Outcome         string `json:"outcome"`
+}
+
+// DiagnosticReferenceAtlasTrace is a bounded, diagnostic-only event stream.
+// Aggregate counters remain the authority until both engines emit this form.
+type DiagnosticReferenceAtlasTrace struct {
+	Contract           string                          `json:"contract"`
+	MaxEvents          uint32                          `json:"max_events"`
+	EventsSeen         uint64                          `json:"events_seen"`
+	EventsDropped      uint64                          `json:"events_dropped"`
+	ArithmeticOverflow bool                            `json:"arithmetic_overflow"`
+	Events             []DiagnosticReferenceAtlasEvent `json:"events"`
+}
+
+const (
+	DiagnosticReferenceAtlasTraceContract  = "gts-reference-atlas-events/v1"
+	DiagnosticReferenceAtlasTraceMaxEvents = 65536
+)
+
+var activeDiagnosticReferenceAtlasTrace *DiagnosticReferenceAtlasTrace
+
+// BeginDiagnosticReferenceAtlasTrace starts one bounded Go event stream.
+// Pair it with the semantic phase trace during parser instrumentation.
+func BeginDiagnosticReferenceAtlasTrace() {
+	if activeDiagnosticReferenceAtlasTrace != nil {
+		panic("gotreesitter: reference-atlas trace already active")
+	}
+	activeDiagnosticReferenceAtlasTrace = &DiagnosticReferenceAtlasTrace{
+		Contract:  DiagnosticReferenceAtlasTraceContract,
+		MaxEvents: DiagnosticReferenceAtlasTraceMaxEvents,
+		Events:    make([]DiagnosticReferenceAtlasEvent, 0, DiagnosticReferenceAtlasTraceMaxEvents),
+	}
+}
+
+// EndDiagnosticReferenceAtlasTrace returns the event stream and disables it.
+func EndDiagnosticReferenceAtlasTrace() DiagnosticReferenceAtlasTrace {
+	if activeDiagnosticReferenceAtlasTrace == nil {
+		panic("gotreesitter: reference-atlas trace is not active")
+	}
+	out := *activeDiagnosticReferenceAtlasTrace
+	out.Events = append([]DiagnosticReferenceAtlasEvent(nil), out.Events...)
+	activeDiagnosticReferenceAtlasTrace = nil
+	return out
+}
+
+func referenceAtlasTraceAppend(event DiagnosticReferenceAtlasEvent) {
+	trace := activeDiagnosticReferenceAtlasTrace
+	if trace == nil {
+		return
+	}
+	if trace.EventsSeen == math.MaxUint64 {
+		trace.ArithmeticOverflow = true
+		return
+	}
+	trace.EventsSeen++
+	event.EventSeq = trace.EventsSeen
+	if uint64(len(trace.Events)) < uint64(trace.MaxEvents) {
+		trace.Events = append(trace.Events, event)
+		return
+	}
+	if trace.EventsDropped == math.MaxUint64 {
+		trace.ArithmeticOverflow = true
+		return
+	}
+	trace.EventsDropped++
+}
+
+func referenceAtlasTraceRecordActionLookup(event DiagnosticSemanticPhaseEvent) {
+	referenceAtlasTraceAppend(DiagnosticReferenceAtlasEvent{
+		SourceStartByte: event.LookaheadStartByte,
+		SourceEndByte:   event.LookaheadEndByte,
+		ParseState:      event.State,
+		Symbol:          event.LookaheadSymbol,
+		CallSite:        referenceAtlasActionCallSite(event.Phase, event.ActionOrdinal),
+		EventKind:       "action_table.lookup",
+		Outcome:         event.Outcome,
+	})
+}
+
+func referenceAtlasTraceRecordActionExecution(event DiagnosticSemanticPhaseEvent, action ParseAction) {
+	eventKind, ok := referenceAtlasActionEventKind(action.Type)
+	if !ok {
+		return
+	}
+	symbol := event.LookaheadSymbol
+	if action.Type == ParseActionReduce {
+		symbol = uint32(action.Symbol)
+	}
+	referenceAtlasTraceAppend(DiagnosticReferenceAtlasEvent{
+		SourceStartByte: event.LookaheadStartByte,
+		SourceEndByte:   event.LookaheadEndByte,
+		ParseState:      event.State,
+		Symbol:          symbol,
+		CallSite:        referenceAtlasActionCallSite(event.Phase, event.ActionOrdinal),
+		EventKind:       eventKind,
+		Outcome:         event.Outcome,
+	})
+}
+
+func referenceAtlasActionEventKind(action ParseActionType) (string, bool) {
+	switch action {
+	case ParseActionShift:
+		return "parser.shift", true
+	case ParseActionReduce:
+		return "parser.reduce", true
+	case ParseActionAccept:
+		return "parser.accept", true
+	case ParseActionRecover:
+		return "parser.recover", true
+	default:
+		return "", false
+	}
+}
+
+func referenceAtlasActionCallSite(phase string, ordinal int16) string {
+	return phase + ":action[" + strconv.FormatInt(int64(ordinal), 10) + "]"
+}
+
+func referenceAtlasTraceRecordDecision(event DiagnosticSemanticPhaseEvent, target, candidate *glrStack) {
+	if event.Phase != workCountConvergencePhasePostReducePrimary &&
+		event.Phase != workCountConvergencePhasePostReducePending &&
+		event.Phase != workCountConvergencePhaseBoundaryGSS &&
+		event.Phase != workCountConvergencePhaseBoundaryEquivalence {
+		return
+	}
+	stack := target
+	if stack == nil {
+		stack = candidate
+	}
+	start, end, state, symbol := event.LookaheadStartByte, event.LookaheadEndByte, event.State, event.LookaheadSymbol
+	if stack != nil && stack.depth() > 0 {
+		entry := stack.top()
+		start = stackEntryNodeStartByte(entry)
+		end = stackEntryNodeEndByte(entry)
+		state = uint32(entry.state)
+		symbol = uint32(stackEntryNodeSymbol(entry))
+	}
+	referenceAtlasTraceAppend(DiagnosticReferenceAtlasEvent{
+		SourceStartByte: start,
+		SourceEndByte:   end,
+		ParseState:      state,
+		Symbol:          symbol,
+		CallSite:        event.Phase,
+		EventKind:       "head.merge",
+		Outcome:         event.Outcome,
+	})
+}

--- a/reference_atlas_trace_external_test.go
+++ b/reference_atlas_trace_external_test.go
@@ -1,0 +1,60 @@
+//go:build gts_workcount
+
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestReferenceAtlasTraceEmitsOrderedGoEventsFromProduction(t *testing.T) {
+	parser := gotreesitter.NewParser(grammars.GoLanguage())
+	parser.SetAdmissionCandidateRoute(false)
+	gotreesitter.BeginDiagnosticWorkCount()
+	gotreesitter.BeginDiagnosticSemanticPhaseTrace()
+	gotreesitter.BeginDiagnosticReferenceAtlasTrace()
+	tree, err := parser.Parse([]byte("package p\nvar x = 1\n"))
+	atlas := gotreesitter.EndDiagnosticReferenceAtlasTrace()
+	semantic := gotreesitter.EndDiagnosticSemanticPhaseTrace()
+	_ = gotreesitter.EndDiagnosticWorkCount()
+	if err != nil {
+		if tree != nil {
+			tree.Release()
+		}
+		t.Fatal(err)
+	}
+	if tree == nil {
+		t.Fatal("parse returned no tree")
+	}
+	tree.Release()
+
+	if semantic.EventsSeen == 0 || atlas.EventsSeen == 0 || atlas.EventsDropped != 0 {
+		t.Fatalf("semantic events=%d atlas events=%d dropped=%d", semantic.EventsSeen, atlas.EventsSeen, atlas.EventsDropped)
+	}
+	wantKinds := map[string]bool{
+		"action_table.lookup": true,
+		"parser.shift":        true,
+		"parser.reduce":       true,
+		"parser.accept":       true,
+	}
+	seenKinds := make(map[string]bool)
+	for index, event := range atlas.Events {
+		if event.EventSeq != uint64(index+1) || event.CallSite == "" || event.EventKind == "" {
+			t.Fatalf("invalid ordered event %d: %+v", index, event)
+		}
+		if event.SourceEndByte < event.SourceStartByte {
+			t.Fatalf("event %d has reversed span: %+v", index, event)
+		}
+		if !wantKinds[event.EventKind] {
+			t.Fatalf("unexpected event kind %q", event.EventKind)
+		}
+		seenKinds[event.EventKind] = true
+	}
+	for kind := range wantKinds {
+		if !seenKinds[kind] {
+			t.Fatalf("ordered Go trace did not emit %q", kind)
+		}
+	}
+}

--- a/reference_atlas_trace_test.go
+++ b/reference_atlas_trace_test.go
@@ -1,0 +1,87 @@
+//go:build gts_workcount
+
+package gotreesitter
+
+import (
+	"testing"
+)
+
+func TestReferenceAtlasTraceBoundsAndSequences(t *testing.T) {
+	BeginDiagnosticReferenceAtlasTrace()
+	for i := 0; i < DiagnosticReferenceAtlasTraceMaxEvents+2; i++ {
+		referenceAtlasTraceAppend(DiagnosticReferenceAtlasEvent{
+			SourceStartByte: uint32(i),
+			SourceEndByte:   uint32(i),
+			ParseState:      7,
+			Symbol:          9,
+			CallSite:        "test",
+			EventKind:       "parser.shift",
+			Outcome:         "dispatched",
+		})
+	}
+	trace := EndDiagnosticReferenceAtlasTrace()
+	if trace.Contract != DiagnosticReferenceAtlasTraceContract || trace.MaxEvents != DiagnosticReferenceAtlasTraceMaxEvents {
+		t.Fatalf("trace contract=%q max=%d", trace.Contract, trace.MaxEvents)
+	}
+	if trace.EventsSeen != uint64(DiagnosticReferenceAtlasTraceMaxEvents)+2 || trace.EventsDropped != 2 || trace.ArithmeticOverflow {
+		t.Fatalf("trace bounds: seen=%d dropped=%d overflow=%v", trace.EventsSeen, trace.EventsDropped, trace.ArithmeticOverflow)
+	}
+	if len(trace.Events) != DiagnosticReferenceAtlasTraceMaxEvents {
+		t.Fatalf("retained events=%d, want %d", len(trace.Events), DiagnosticReferenceAtlasTraceMaxEvents)
+	}
+	for index, event := range trace.Events {
+		if event.EventSeq != uint64(index+1) {
+			t.Fatalf("event %d sequence=%d", index, event.EventSeq)
+		}
+	}
+}
+
+func TestReferenceAtlasTraceMapsOrderedGoEvents(t *testing.T) {
+	BeginDiagnosticReferenceAtlasTrace()
+	lookup := DiagnosticSemanticPhaseEvent{
+		LookaheadStartByte: 4,
+		LookaheadEndByte:   7,
+		State:              11,
+		LookaheadSymbol:    13,
+		ActionOrdinal:      0,
+		Phase:              "action_cell",
+		Outcome:            "candidate",
+	}
+	referenceAtlasTraceRecordActionLookup(lookup)
+	referenceAtlasTraceRecordActionExecution(lookup, ParseAction{Type: ParseActionShift})
+	referenceAtlasTraceRecordActionExecution(lookup, ParseAction{Type: ParseActionReduce, Symbol: 17})
+	referenceAtlasTraceRecordActionExecution(lookup, ParseAction{Type: ParseActionAccept})
+	referenceAtlasTraceRecordActionExecution(lookup, ParseAction{Type: ParseActionRecover})
+	referenceAtlasTraceRecordDecision(DiagnosticSemanticPhaseEvent{
+		LookaheadStartByte: 8,
+		LookaheadEndByte:   9,
+		State:              19,
+		LookaheadSymbol:    23,
+		Phase:              workCountConvergencePhaseBoundaryGSS,
+		Outcome:            workCountConvergenceOutcomePacked,
+	}, nil, nil)
+	trace := EndDiagnosticReferenceAtlasTrace()
+
+	wantKinds := []string{
+		"action_table.lookup",
+		"parser.shift",
+		"parser.reduce",
+		"parser.accept",
+		"parser.recover",
+		"head.merge",
+	}
+	if len(trace.Events) != len(wantKinds) {
+		t.Fatalf("event count=%d want=%d", len(trace.Events), len(wantKinds))
+	}
+	for index, event := range trace.Events {
+		if event.EventSeq != uint64(index+1) || event.EventKind != wantKinds[index] || event.CallSite == "" {
+			t.Fatalf("event %d=%+v want kind=%q", index, event, wantKinds[index])
+		}
+		if event.SourceEndByte < event.SourceStartByte {
+			t.Fatalf("event %d has reversed span: %+v", index, event)
+		}
+	}
+	if trace.Events[2].Symbol != 17 {
+		t.Fatalf("reduce symbol=%d want=17", trace.Events[2].Symbol)
+	}
+}

--- a/work_count_semantic_phase_trace.go
+++ b/work_count_semantic_phase_trace.go
@@ -192,14 +192,16 @@ func semanticPhaseTraceRecordActionCell(p *Parser, stack *glrStack, state StateI
 	semanticPhaseAuditBoundary(stack, boundaryClass)
 	checkpoint := semanticPhaseScannerCheckpoint(p, tok)
 	if len(actions) == 0 {
-		semanticPhaseTraceAppend(DiagnosticSemanticPhaseEvent{
+		event := DiagnosticSemanticPhaseEvent{
 			Kind: "action_lookup", TokenOrdinal: activeWorkCountConvergence.electionOrdinal, Iteration: activeWorkCountConvergence.iteration,
 			ByteOffset: semanticPhaseStackByte(stack), State: uint32(state),
 			LookaheadSymbol: uint32(tok.Symbol), LookaheadStartByte: tok.StartByte, LookaheadEndByte: tok.EndByte,
 			LookaheadFlags: semanticPhaseLookaheadFlags(tok), LookupActionCellFingerprint: cellHash,
 			CoarseBoundaryClass: boundaryClass, ActionOrdinal: -1, ActionType: -1,
 			Phase: "action_cell", Outcome: "empty", ScannerCheckpoint: checkpoint,
-		})
+		}
+		semanticPhaseTraceAppend(event)
+		referenceAtlasTraceRecordActionLookup(event)
 		return
 	}
 	for ordinal, action := range actions {
@@ -208,14 +210,16 @@ func semanticPhaseTraceRecordActionCell(p *Parser, stack *glrStack, state StateI
 			ordinalValue = math.MaxInt16
 			trace.ArithmeticOverflow = true
 		}
-		semanticPhaseTraceAppend(DiagnosticSemanticPhaseEvent{
+		event := DiagnosticSemanticPhaseEvent{
 			Kind: "action_lookup", TokenOrdinal: activeWorkCountConvergence.electionOrdinal, Iteration: activeWorkCountConvergence.iteration,
 			ByteOffset: semanticPhaseStackByte(stack), State: uint32(state),
 			LookaheadSymbol: uint32(tok.Symbol), LookaheadStartByte: tok.StartByte, LookaheadEndByte: tok.EndByte,
 			LookaheadFlags: semanticPhaseLookaheadFlags(tok), LookupActionCellFingerprint: cellHash,
 			CoarseBoundaryClass: boundaryClass, ActionOrdinal: ordinalValue, ActionType: int16(action.Type),
 			Phase: "action_cell", Outcome: "candidate", ScannerCheckpoint: checkpoint,
-		})
+		}
+		semanticPhaseTraceAppend(event)
+		referenceAtlasTraceRecordActionLookup(event)
 	}
 }
 
@@ -246,14 +250,16 @@ func semanticPhaseTraceRecordActionExecution(p *Parser, stack *glrStack, tok Tok
 	if cycle {
 		outcome = "cycle_rejected"
 	}
-	semanticPhaseTraceAppend(DiagnosticSemanticPhaseEvent{
+	event := DiagnosticSemanticPhaseEvent{
 		Kind: "action_execution", TokenOrdinal: activeWorkCountConvergence.electionOrdinal, Iteration: activeWorkCountConvergence.iteration,
 		ByteOffset: semanticPhaseStackByte(stack), State: uint32(state),
 		LookaheadSymbol: uint32(tok.Symbol), LookaheadStartByte: tok.StartByte, LookaheadEndByte: tok.EndByte,
 		LookaheadFlags: semanticPhaseLookaheadFlags(tok), ExecutionActionCellFingerprint: cellHash, ExecutionCellRecomputed: true,
 		CoarseBoundaryClass: boundaryClass, ActionOrdinal: ordinal, ActionType: int16(action.Type),
 		Phase: phase, Outcome: outcome, ScannerCheckpoint: semanticPhaseScannerCheckpoint(p, tok),
-	})
+	}
+	semanticPhaseTraceAppend(event)
+	referenceAtlasTraceRecordActionExecution(event, action)
 }
 
 func semanticPhaseUniqueActionOrdinal(actions []ParseAction, chosen ParseAction) int {
@@ -307,7 +313,7 @@ func semanticPhaseTraceRecordDecision(p *Parser, phase, outcome, reason string, 
 	candidateClass := semanticPhaseCoarseBoundaryClass(candidate)
 	semanticPhaseAuditBoundary(target, targetClass)
 	semanticPhaseAuditBoundary(candidate, candidateClass)
-	semanticPhaseTraceAppend(DiagnosticSemanticPhaseEvent{
+	event := DiagnosticSemanticPhaseEvent{
 		Kind: "decision", TokenOrdinal: activeWorkCountConvergence.electionOrdinal, Iteration: activeWorkCountConvergence.iteration,
 		ByteOffset: semanticPhaseStackByte(stack), State: uint32(semanticPhaseStackState(stack)),
 		LookaheadSymbol: uint32(lookahead.Symbol), LookaheadStartByte: lookahead.StartByte, LookaheadEndByte: lookahead.EndByte,
@@ -315,7 +321,9 @@ func semanticPhaseTraceRecordDecision(p *Parser, phase, outcome, reason string, 
 		CoarseBoundaryClass: targetClass, CandidateBoundaryClass: candidateClass,
 		ActionOrdinal: -1, ActionType: -1, Phase: phase, Outcome: outcome, Reason: reason,
 		CandidateCountBefore: beforeValue, CandidateCountAfter: afterValue, ScannerCheckpoint: semanticPhaseScannerCheckpoint(p, lookahead),
-	})
+	}
+	semanticPhaseTraceAppend(event)
+	referenceAtlasTraceRecordDecision(event, target, candidate)
 }
 
 func semanticPhaseTraceAppend(event DiagnosticSemanticPhaseEvent) {


### PR DESCRIPTION
## Summary

Consolidate the G2 reference atlas contract and bounded Go event lane into one reviewable PR.

- Define the versioned gts-reference-atlas-events/v1 contract.
- Emit ordered semantic records for action lookup, shift, reduce, accept, recovery, and head merge.
- Bound retained events at 65,536 and count dropped records.
- Exclude pointers, stack identifiers, and arena identifiers.
- Keep the diagnostic surface off the shipped parser path.

## Validation

- Docker root test with gts_workcount: TestReferenceAtlasTrace.
- Docker cgo_harness schema test: TestReferenceAtlasEventSchemaIsCompleteAndHonest.
- git diff --check.

This PR includes the versioned contract previously tracked by PR #669.