### PR TITLE
docs: record T0 tail cards

### DIFF
--- a/docs/t0-tail-cards.md
+++ b/docs/t0-tail-cards.md
@@ -58,14 +58,14 @@ It uses the same V10 scoreboard and performs no new run.
 
 The top 20 contains four evidence groups:
 
-- Initial, temporary, or standard memo activity appears in 12 rows.
-- No recovery memo fact appears in five rows.
+- Initial, temporary, or standard memo activity appears in 13 rows.
+- Two large rows have no recovery memo fact.
 - Two zero-byte HTTP rows fall below the 1,000 nanosecond hygiene threshold.
 - Three small-input rows need a size series before mechanism attribution.
 
 The memo-bearing rows support one recovery-materialization hypothesis.
 They do not prove one implementation mechanism or justify a parser change.
-The next T0 tranche must compare memo activity with file size, retry count, and materialization lifetime.
+The card matrix in `docs/t0-top20-clean-file-cards.md` defines the next evidence gate.
 
 ## Evidence boundary
 

--- a/docs/t0-tail-cards.md
+++ b/docs/t0-tail-cards.md
@@ -3,8 +3,8 @@
 This receipt closes the six R1 tail cards from the accepted V10 epoch.
 It uses existing evidence only. It changes no parser code and runs no new experiment.
 
-Source epoch: `20260808T202958Z-v10-full-5003ffba`  
-Source revision: `5003ffba01e2aee44043e71360c00f5aa93e6e8b`  
+Source epoch: `20260808T202958Z-v10-full-5003ffba`
+Source revision: `5003ffba01e2aee44043e71360c00f5aa93e6e8b`
 Source scoreboard: `harness_out/gcp/20260808T202958Z-v10-full-5003ffba/gts-v10-full/results/scoreboard/scoreboard.json`
 
 R1 counts the Scala 56–58x pair as one card. The table therefore has six cards.

--- a/docs/t0-tail-cards.md
+++ b/docs/t0-tail-cards.md
@@ -28,6 +28,45 @@ The Perl card remains not-actionable. Its single 1.2 MB witness cannot separate 
 No card qualifies as hygiene or fixed-candidate.
 Named files remain witnesses. They are not code selectors.
 
+## Top-20 clean-file census
+
+This census ranks clean, full-span, measured rows by the existing full-parse ratio.
+It uses the same V10 scoreboard and performs no new run.
+
+| Rank | Language | File | Ratio | Bytes | Memo tier | Disposition |
+|---:|---|---|---:|---:|---|---|
+| 1 | Python | `Lib/test/test_logging.py` | 209.170723x | 276,682 | initial | recovery candidate |
+| 2 | Elixir | `lib/elixir/lib/enum.ex` | 121.410147x | 154,291 | temporary | recovery candidate |
+| 3 | Python | `Lib/test/test_socket.py` | 108.118260x | 288,768 | initial | recovery candidate |
+| 4 | Scala | `src/compiler/scala/tools/nsc/typechecker/Implicits.scala` | 58.538671x | 103,233 | temporary | recovery candidate |
+| 5 | Scala | `src/compiler/scala/tools/nsc/typechecker/Namers.scala` | 55.995092x | 102,961 | temporary | recovery candidate |
+| 6 | Elixir | `lib/elixir/lib/macro.ex` | 42.503260x | 96,618 | temporary | recovery candidate |
+| 7 | Perl | `dist/Module-CoreList/lib/Module/CoreList.pm` | 40.899346x | 1,266,636 | none | no mechanism fact |
+| 8 | HTTP | `spec/examples/dotenv/with_dotenv.http` | 35.727088x | 0 | none | hygiene; exclude from ratio credit |
+| 9 | HTTP | `spec/examples/dotenv/without_dotenv.http` | 32.834630x | 0 | none | hygiene; exclude from ratio credit |
+| 10 | Solidity | `test/utils/Packing.t.sol` | 30.709653x | 44,712 | initial | recovery candidate |
+| 11 | Common Lisp | `src/code/external-formats/enc-cn-tbl.lisp` | 27.175048x | 959,740 | none | no mechanism fact |
+| 12 | Requirements | `test/integration/targets/ansible-test-integration-constraints/ansible_collections/ns/col/tests/integration/requirements.txt` | 24.254181x | 9 | none | tiny-input candidate |
+| 13 | TOML | `.prettierrc.toml` | 23.040623x | 21 | none | tiny-input candidate |
+| 14 | Solidity | `contracts/governance/Governor.sol` | 22.572329x | 31,997 | initial | recovery candidate |
+| 15 | Enforce | `4_world/entities/dayzplayerimplement.c` | 22.170520x | 104,908 | standard | recovery candidate |
+| 16 | Enforce | `4_world/entities/manbase/dayzplayer/dayzplayercfgbase.c` | 21.968405x | 194,135 | standard | recovery candidate |
+| 17 | Liquid | `performance/tests/tribble/blog.liquid` | 21.734392x | 1,133 | initial | recovery candidate |
+| 18 | Requirements | `test/integration/targets/ansible-test-units-constraints/ansible_collections/ns/col/tests/unit/requirements.txt` | 21.626286x | 9 | none | tiny-input candidate |
+| 19 | Enforce | `4_world/systems/inventory/dayzplayerinventory.c` | 21.493946x | 108,051 | standard | recovery candidate |
+| 20 | PureScript | `src/Data/EuclideanRing.purs` | 21.303608x | 4,059 | initial | recovery candidate |
+
+The top 20 contains four evidence groups:
+
+- Initial, temporary, or standard memo activity appears in 12 rows.
+- No recovery memo fact appears in five rows.
+- Two zero-byte HTTP rows fall below the 1,000 nanosecond hygiene threshold.
+- Three small-input rows need a size series before mechanism attribution.
+
+The memo-bearing rows support one recovery-materialization hypothesis.
+They do not prove one implementation mechanism or justify a parser change.
+The next T0 tranche must compare memo activity with file size, retry count, and materialization lifetime.
+
 ## Evidence boundary
 
 All selected rows have `axes.full.status=ok`, clean full-span trees, and no root error.

--- a/docs/t0-tail-cards.md
+++ b/docs/t0-tail-cards.md
@@ -1,0 +1,37 @@
+# T0 tail cards
+
+This receipt closes the six R1 tail cards from the accepted V10 epoch.
+It uses existing evidence only. It changes no parser code and runs no new experiment.
+
+Source epoch: `20260808T202958Z-v10-full-5003ffba`  
+Source revision: `5003ffba01e2aee44043e71360c00f5aa93e6e8b`  
+Source scoreboard: `harness_out/gcp/20260808T202958Z-v10-full-5003ffba/gts-v10-full/results/scoreboard/scoreboard.json`
+
+R1 counts the Scala 56–58x pair as one card. The table therefore has six cards.
+
+| Card | Witnesses | Ratios | Disposition | First attributable mechanism |
+|---:|---|---:|---|---|
+| 1 | Python `Lib/test/test_logging.py` | 209.170723x | grouped with card 2 | Initial recovery-node memo; 128 entries and 3,072 bytes |
+| 2 | Python `Lib/test/test_socket.py` | 108.118260x | grouped with card 1 | Initial recovery-node memo; 128 entries and 3,072 bytes |
+| 3 | Elixir `lib/elixir/lib/enum.ex` | 121.410147x | grouped with card 4 | Temporary recovery-node memo; 262,144 entries and 6,291,456 bytes |
+| 4 | Elixir `lib/elixir/lib/macro.ex` | 42.503260x | grouped with card 3 | Temporary recovery-node memo; 262,144 entries and 6,291,456 bytes |
+| 5 | Scala `Implicits.scala`, `Namers.scala` | 58.538671x, 55.995092x | grouped | Temporary recovery-node memo; 262,144 entries and 6,291,456 bytes each |
+| 6 | Perl `Module/CoreList.pm` | 40.899346x | not-actionable | No mechanism facts; R1 requires a size series |
+
+## Interpretation
+
+The Python, Elixir, and Scala cards form one recovery-memo mechanism cohort.
+The evidence supports a grouped recovery candidate, not a parser change.
+
+The Perl card remains not-actionable. Its single 1.2 MB witness cannot separate scale cost from parser, tree, or materialization cost.
+
+No card qualifies as hygiene or fixed-candidate.
+Named files remain witnesses. They are not code selectors.
+
+## Evidence boundary
+
+All selected rows have `axes.full.status=ok`, clean full-span trees, and no root error.
+The source rows and per-language receipts remain in the accepted V10 artifact.
+The signed Hyphae receipt is `hypha-receipt:2026-08-12:codex-t0-tail-cards`.
+
+The next step is T1 mechanism work after B8f and C0f gates close.

--- a/docs/t0-top20-clean-file-cards.md
+++ b/docs/t0-top20-clean-file-cards.md
@@ -1,0 +1,88 @@
+# T0 top-20 clean-file cards
+
+Status: evidence specification
+
+Use the accepted V10 epoch as the source.
+This document adds no parser change and runs no new experiment.
+
+## Locked source
+
+- Epoch: `20260808T202958Z-v10-full-5003ffba`
+- Go revision: `5003ffba01e2aee44043e71360c00f5aa93e6e8b`
+- Scoreboard: `results/scoreboard/scoreboard.json`
+- Corpus lock: `41c744279c8b1d7c9fe7b1b8e26fba733423e77cd48efea46927309c22d163ea`
+- C runtime: `0.25.1@f5afe475deb7c0bae6407fb776c76824f717bb61`
+
+All rows have a clean, full-span Go tree and an accepted full-parse result.
+The table reports the measured file ratio and the existing memo tier.
+The `Go ns/byte` value is a diagnostic scale indicator.
+
+## Card matrix
+
+| Card | Language | File | Bytes | Ratio | Go ns/byte | Memo tier | Current class |
+| ---: | --- | --- | ---: | ---: | ---: | --- | --- |
+| 1 | Python | `Lib/test/test_logging.py` | 276682 | 209 | 28674 | initial | memo candidate |
+| 2 | Elixir | `lib/elixir/lib/enum.ex` | 154291 | 121 | 16274 | temporary | memo candidate |
+| 3 | Python | `Lib/test/test_socket.py` | 288768 | 108 | 14544 | initial | memo candidate |
+| 4 | Scala | `src/compiler/scala/tools/nsc/typechecker/Implicits.scala` | 103233 | 59 | 14336 | temporary | memo candidate |
+| 5 | Scala | `src/compiler/scala/tools/nsc/typechecker/Namers.scala` | 102961 | 56 | 13342 | temporary | memo candidate |
+| 6 | Elixir | `lib/elixir/lib/macro.ex` | 96618 | 43 | 6429 | temporary | memo candidate |
+| 7 | Perl | `dist/Module-CoreList/lib/Module/CoreList.pm` | 1266636 | 41 | 6001 | none | large no-memo candidate |
+| 8 | HTTP | `spec/examples/dotenv/with_dotenv.http` | 0 | 36 | 17542 | none | hygiene |
+| 9 | HTTP | `spec/examples/dotenv/without_dotenv.http` | 0 | 33 | 16877 | none | hygiene |
+| 10 | Solidity | `test/utils/Packing.t.sol` | 44712 | 31 | 4701 | initial | memo candidate |
+| 11 | Common Lisp | `src/code/external-formats/enc-cn-tbl.lisp` | 959740 | 27 | 4891 | none | large no-memo candidate |
+| 12 | Requirements | `test/integration/targets/ansible-test-integration-constraints/ansible_collections/ns/col/tests/integration/requirements.txt` | 9 | 24 | 3223 | none | tiny input |
+| 13 | TOML | `.prettierrc.toml` | 21 | 23 | 2890 | none | tiny input |
+| 14 | Solidity | `contracts/governance/Governor.sol` | 31997 | 23 | 1732 | initial | memo candidate |
+| 15 | Enforce | `4_world/entities/dayzplayerimplement.c` | 104908 | 22 | 2551 | standard | memo candidate |
+| 16 | Enforce | `4_world/entities/manbase/dayzplayer/dayzplayercfgbase.c` | 194135 | 22 | 8928 | standard | memo candidate |
+| 17 | Liquid | `performance/tests/tribble/blog.liquid` | 1133 | 22 | 810 | initial | memo candidate |
+| 18 | Requirements | `test/integration/targets/ansible-test-units-constraints/ansible_collections/ns/col/tests/unit/requirements.txt` | 9 | 22 | 3035 | none | tiny input |
+| 19 | Enforce | `4_world/systems/inventory/dayzplayerinventory.c` | 108051 | 21 | 2947 | standard | memo candidate |
+| 20 | PureScript | `src/Data/EuclideanRing.purs` | 4059 | 21 | 2790 | initial | memo candidate |
+
+The memo cohort contains 13 rows.
+The large no-memo cohort contains two rows.
+The hygiene cohort contains two rows.
+The tiny-input cohort contains three rows.
+
+## Evidence gates
+
+Do not infer generated status from a file path.
+The V10 scoreboard does not record source-generation provenance.
+
+Complete one card only when its receipt contains these facts:
+
+- source provenance, with a manifest or repository proof;
+- file size and source digest;
+- locked-C and Go deep-tree identity;
+- retry pass count and selected retry rung;
+- peak memo tier, entries, bytes, and collisions;
+- parser arena, scratch, and graph-stack allocation facts;
+- materialization time and retained lifetime facts;
+- maximum resident set size under the same process contract.
+
+Keep hygiene and tiny-input rows out of mechanism credit.
+Use the two large no-memo rows as negative controls.
+Use the 13 memo rows as the first recovery-materialization cohort.
+
+## Generated-file hypothesis
+
+The current data supports a memo-bearing cohort.
+It does not prove that generated files cause the scaling shape.
+
+Test the hypothesis with a size series that preserves grammar and source class.
+Compare at least three sizes for each selected source class.
+Record whether memo tier, retry work, and materialization lifetime scale together.
+
+Accept one generic mechanism only when the same predicate explains the cohort.
+Reject the mechanism when large no-memo controls show the same shape.
+Reject the mechanism when the result requires a language or file exception.
+
+## Next bounded tranche
+
+First collect the missing runtime facts for cards 1, 2, 4, 5, 6, 7, 10, 11, 14, 15, 16, 19, and 20.
+Keep cards 8, 9, 12, 13, and 18 as hygiene or scale controls.
+Use the B16 selected-rung telemetry for retry attribution.
+Do not admit a performance change until the card matrix has a generic predicate.


### PR DESCRIPTION
## Summary

Record the Phase 1 T0 tail cards and the top-20 clean-file card matrix from the accepted V10 epoch.

This pull request changes documentation only. It runs no new fleet experiment.

## Current matrix

- 13 rows have initial, standard, or temporary recovery-memo activity.
- 2 large rows have no recovery-memo fact and serve as negative controls.
- 2 zero-byte HTTP rows are hygiene and receive no ratio credit.
- 3 tiny-input rows require a size series before attribution.

The matrix requires source provenance, retry facts, memo facts, allocation facts, materialization lifetime, and resident set before mechanism selection. It does not infer generated status from file paths.

## Checks

- `git diff --check`
- All selected rows have `axes.full.status=ok` in the accepted V10 scoreboard.
- The signed Hyphae receipt is `hypha-receipt:2026-08-11:t0-top20-card-matrix-v2`.

## Next gate

Collect runtime facts for the 13 memo-bearing rows and retain the large no-memo rows as controls. Do not claim performance credit until one generic predicate explains the cohort.