### PR TITLE
feat: add B16 recovery telemetry

### DIFF
--- a/benchmark_recovery_test.go
+++ b/benchmark_recovery_test.go
@@ -63,6 +63,46 @@ func TestKDLRecoveryGarbageSuffixExact(t *testing.T) {
 	}
 }
 
+func TestRecoveryRuntimeTelemetry(t *testing.T) {
+	gotreesitter.EnableRecoveryRuntimeTelemetry(true)
+	defer gotreesitter.EnableRecoveryRuntimeTelemetry(false)
+
+	recoveryParser := gotreesitter.NewParser(grammars.KdlLanguage())
+	source := makeKDLRecoveryGarbageSource(12, 24)
+	tree, err := recoveryParser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse recovery telemetry witness: %v", err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("recovery telemetry witness returned a nil tree")
+	}
+	stats := recoveryParser.DebugRecoveryRuntimeStats()
+	tree.Release()
+	if !stats.Enabled || !stats.Completed {
+		t.Fatalf("telemetry status = enabled:%v completed:%v, want enabled and completed", stats.Enabled, stats.Completed)
+	}
+	if stats.RecoveryEntryCount == 0 {
+		t.Fatal("recovery entry count = 0, want a recovery witness")
+	}
+	if stats.ErrorNodeCount == 0 || stats.ErrorSpanBytes == 0 {
+		t.Fatalf("error shape = count:%d span:%d, want both non-zero", stats.ErrorNodeCount, stats.ErrorSpanBytes)
+	}
+	if stats.PeakLiveVersionCount == 0 {
+		t.Fatal("peak live version count = 0, want a recovery witness")
+	}
+
+	cleanParser := gotreesitter.NewParser(grammars.GoLanguage())
+	cleanTree, err := cleanParser.Parse([]byte("package p\n"))
+	if err != nil {
+		t.Fatalf("parse clean telemetry control: %v", err)
+	}
+	cleanStats := cleanParser.DebugRecoveryRuntimeStats()
+	cleanTree.Release()
+	if cleanStats.RecoveryEntryCount != 0 || cleanStats.ErrorNodeCount != 0 || cleanStats.ErrorSpanBytes != 0 {
+		t.Fatalf("clean control recorded recovery facts: %+v", cleanStats)
+	}
+}
+
 // makeKDLRecoveryGarbageSource synthesizes a KDL document that reliably
 // drives the C-recovery cost-competition machinery: a valid, node-per-line
 // KDL prefix truncated 70% of the way through, followed by a long run of

--- a/docs/b16-r1-recovery-evidence-brief.md
+++ b/docs/b16-r1-recovery-evidence-brief.md
@@ -1,0 +1,225 @@
+# B16/R1 recovery evidence brief
+
+Status: design brief
+
+This brief starts the first performance family after the C0f attribution receipt.
+It does not change parser routing, grammar admission, or recovery behavior.
+
+## Authority and evidence
+
+Use Revision R1 of `spec.campaign.v7` as the campaign authority.
+
+Use V10 epoch `20260808T202958Z-v10-full-5003ffba` as the fleet baseline.
+
+The baseline contains 1,435 rows across 206 languages.
+The measured signal contains 1,315 rows.
+
+The C0f receipt reports these recovery-priority facts:
+
+- Error rows own 72.2586 percent of measured Go time.
+- The error cohort has a 92.6307 percent local Go gap.
+- The measured Go-to-C ratio is 10.950130x by total time.
+- The C0f receipt remains partially gated because several runtime facts are absent.
+
+The 72.2586 percent share sets priority.
+It does not provide performance credit.
+
+The fleet credit gate remains:
+
+```text
+projected_saved_go_time / total_measured_signal_go_time >= 0.02
+```
+
+Select cohorts with runtime facts.
+Do not select cohorts by language or file identity.
+
+## Outside-validated witnesses
+
+Use issue [#586](https://github.com/odvcencio/gotreesitter/issues/586) as a recovery-cost witness.
+It records a Swift failure with high retry and recovery pressure.
+
+PR #666 already provides a useful generic result on that witness:
+
+- Time improved by 9.96 percent after the recovery-stack change.
+- Allocated bytes improved by 59.65 percent.
+- Mean resident set size improved by 22.09 percent.
+- Generic recovery cost remains active.
+
+Treat those values as historical evidence.
+Reproduce them on the current branch before using them as a B16 receipt.
+
+Use issue [#576](https://github.com/odvcencio/gotreesitter/issues/576) as a recovery-parity witness set.
+Its umbrella includes `unsafe`, `__consuming`, `associatedtype`, optional binding, and comparison cases.
+
+Do not add a Swift-specific parser fix.
+Record each grammar or oracle divergence against the generic recovery path.
+
+## Work order
+
+### B16.0 — instrument the runtime facts
+
+Add diagnostic counters without changing parser decisions.
+Keep the counters off the public hot path when diagnostics are disabled.
+
+Record these facts per completed parse and per retry attempt:
+
+- Recovery entry count.
+- Recovery cost competition count.
+- Recovery cost walk count and elapsed time.
+- Reduction candidate attempts and peak attempts.
+- Missing-token trial attempts and peak attempts.
+- Error-node count and error-byte span.
+- Recovery retry count and retry reason.
+- Retry stack ceiling and selected attempt.
+- Scanner error-mode entries and resynchronization events.
+- Recovery-node memo tier, entries, bytes, and collisions.
+- Live version count and peak live version count.
+- GLR stack iterations and merge counts.
+- Transient parent and child materialization counts and time.
+- Final tree materialization time.
+- Arena, scratch, entry-scratch, and GSS allocation bytes.
+- Stop reason and memory-budget source.
+
+Use existing runtime fields when they provide the same fact.
+Do not create duplicate counters with different meanings.
+
+Publish the counter schema with units, reset scope, and overflow behavior.
+Keep counters monotonic within one parse attempt.
+Reset them at the top-level parse boundary.
+
+### B16.1 — build the witness matrix
+
+Run one language at a time in Docker.
+Start with the Swift #586 witness and one representative error-cohort file.
+Add one clean control from the same language when available.
+
+For every witness, capture:
+
+- Go and locked-C tree identity.
+- Source digest and grammar digest.
+- Parse class and full-span status.
+- All B16 runtime facts.
+- Wall time, allocations, and maximum resident set size.
+- The exact command, revision, image, and environment.
+
+Keep correctness and performance receipts separate.
+Do not run a fleet scan for this tranche.
+
+### B16.2 — classify the first generic cohort
+
+Use observed runtime facts to assign each witness to one or more diagnostic cohorts.
+Use these tentative cohort names only when the data supports them:
+
+- Retry economy: repeated accepted-error or no-stack retry work dominates.
+- Recovery cost: error-cost walks or candidate competition dominate.
+- Materialization lifetime: recovery memo or transient tree work dominates.
+- Scanner boundary: error-mode lexing or scanner resynchronization dominates.
+- Stop overhead: a generic stop signature dominates without a correctness failure.
+
+Do not merge cohorts because they share a language or file extension.
+Do not infer a cohort from a ratio alone.
+
+The first candidate must explain both time and memory.
+The candidate must preserve the locked-C tree.
+
+### B16.3 — formulate one generic mechanism
+
+Write one mechanism proposal for the largest weighted cohort.
+State the C behavior that the mechanism preserves.
+State the Go state that the mechanism removes, shares, or bounds.
+
+Define the change as a small, reversible tranche.
+Keep the change generic across grammars.
+
+Reject the proposal when it needs any of these conditions:
+
+- A language-name branch.
+- A blob digest admission exception.
+- A driver-local exception.
+- A new grammar profile grant.
+- A changed locked-C result.
+- An unbounded memory structure.
+- A default-off feature without a fusion or table-replacement design.
+
+### B16.4 — validate the candidate
+
+Run the smallest parity suite that covers the changed recovery path.
+Run the Swift witness in isolation.
+Run the recovery benchmark with randomized order.
+
+Use these stable settings for every comparison:
+
+- `GOMAXPROCS=1`.
+- One process per explicit shuffle seed.
+- Twenty shuffle seeds.
+- `-count=1`.
+- `-benchtime=750ms`.
+- `-benchmem`.
+
+Use `scripts/run_randomized_benchmarks.sh` for the primary benchmark comparison.
+Do not use fixed-order output as comparison evidence.
+
+Keep the candidate only when all gates pass:
+
+- Locked-C tree identity remains exact.
+- The target cohort improves in `ns/op`.
+- Allocated bytes do not regress materially.
+- Allocation count does not regress materially.
+- Maximum resident set size does not regress.
+- No crash, stop, out-of-memory failure, or retention failure appears.
+
+Record rejected candidates as tombstones with the failed gate.
+
+### B16.5 — earn fleet credit
+
+Project saved Go time from measured runtime facts.
+Use the C0f signal denominator.
+
+Admit performance credit only when the projected saving reaches two percent.
+Then rerun the affected cohort and the full C6f epoch.
+
+The affected cohort must hold or improve every C6f class metric.
+The sealed C0e board remains a separate regression gate.
+
+## Acceptance receipt
+
+Close B16.0 when the counter schema and reset rules are documented.
+
+Close B16.1 when the witness matrix contains the Swift and control receipts.
+
+Close B16.2 when every admitted cohort has a runtime-fact predicate.
+
+Close B16.3 when one generic mechanism has a parity-preserving design.
+
+Close B16.4 when the randomized comparison and isolated parity gates pass.
+
+Close B16.5 only after the projected saving reaches two percent and the C6f epoch holds.
+
+Every receipt must include:
+
+- The source revision.
+- The source and grammar digests.
+- The exact command.
+- The result class.
+- The C parity result.
+- The performance result.
+- The memory result.
+- The rejected alternatives.
+
+## Stop conditions
+
+Return to the brief when the counters cannot distinguish recovery from materialization.
+
+Return to A8 when the first C and Go live-version divergence remains unexplained.
+
+Return to T1 when the top-20 clean cards expose a separate generic mechanism.
+
+Do not spend B16 time on broad clean-path tuning.
+Do not spend B16 time on new blob-SHA certificates.
+Do not spend B16 time on the kill ledger.
+
+## Current decision
+
+Start B16 design now because C0f confirms that the error cohort owns 72.2586 percent of measured Go time.
+
+Hold performance credit until the missing runtime facts and the two percent projection gate close.

--- a/docs/b16-r1-recovery-evidence-brief.md
+++ b/docs/b16-r1-recovery-evidence-brief.md
@@ -2,6 +2,8 @@
 
 Status: design brief
 
+The B16.0 implementation receipt is in `docs/b16-r1-recovery-telemetry.md`.
+
 This brief starts the first performance family after the C0f attribution receipt.
 It does not change parser routing, grammar admission, or recovery behavior.
 

--- a/docs/b16-r1-recovery-telemetry.md
+++ b/docs/b16-r1-recovery-telemetry.md
@@ -1,0 +1,42 @@
+# B16.0 recovery telemetry
+
+Status: implementation tranche
+
+This tranche records missing recovery facts for one completed parse attempt.
+It does not change parser routing, grammar admission, or recovery decisions.
+
+Enable the facts with `gotreesitter.EnableRecoveryRuntimeTelemetry(true)`.
+Disable the facts after the diagnostic run.
+
+The default path does not allocate the recovery telemetry sidecar.
+The default path does not write the new counters.
+
+Read the latest facts with `Parser.DebugRecoveryRuntimeStats()`.
+The result describes the most recent completed parse attempt on that parser.
+
+| Field | Unit | Reset and meaning |
+| --- | --- | --- |
+| `RecoveryEntryCount` | calls | Count `cHandleError` entries in this attempt. |
+| `Strategy1ElectionCount` | calls | Count strategy-1 recovery elections. |
+| `RecoveryCostCompetitionCount` | calls | Count recovery cost comparisons after header checks. |
+| `RecoveryCostWalkCount` | calls | Count non-clean recovery cost walks. |
+| `RecoveryCostWalkNanos` | nanoseconds | Sum the measured recovery cost walk time. |
+| `ErrorNodeCount` | nodes | Count final error and missing nodes. |
+| `ErrorSpanBytes` | bytes | Report the envelope from the first error start to the last error end. |
+| `RetryPassCount` | passes | Report the parser retry count when this attempt began. |
+| `RetryReason` | stable text | Report the reason for the retry that started this attempt. |
+| `ErrorModeTokenCount` | tokens | Count engine-generated error-mode lookaheads. |
+| `ScannerResyncCount` | events | Count custom token-source resynchronizations. |
+| `LiveVersionCount` | versions | Report live parser versions at finalization. |
+| `PeakLiveVersionCount` | versions | Report the largest live version set seen during recovery. |
+
+Counters reset at the start of `parseInternal`.
+Counters increase monotonically during one attempt.
+The implementation does not saturate counters before `uint64` overflow.
+
+Use existing runtime fields for stack iterations, merges, materialization,
+allocation, stop reasons, and memory-budget sources.
+Use `Tree.RecoveryNodeMemoRuntime()` for memo tier and collision facts.
+
+The focused witness covers a KDL recovery input and a Go clean control.
+The test checks the recovery entry, error shape, and live-version facts.

--- a/glr.go
+++ b/glr.go
@@ -2090,6 +2090,9 @@ func cStackErrorCostForMergeCached(scratch *glrMergeScratch, lang *Language, s *
 	if cost, ok := cStackCleanZeroErrorCostForMerge(scratch, s); ok {
 		return cost
 	}
+	if recoveryRuntimeParser(scratch) != nil {
+		return recoveryRuntimeCostWalk(scratch, lang, s)
+	}
 	return cStackErrorCostForMergeWithScratch(scratch, lang, s)
 }
 
@@ -2100,6 +2103,7 @@ func cRecoveryMergeCostsDiffer(scratch *glrMergeScratch, a, b *glrStack) bool {
 	if !stacksHeaderEquivalent(a, b) {
 		return false
 	}
+	recordRecoveryCostCompetition(scratch)
 	return cStackErrorCostForMergeCached(scratch, scratch.language, a) != cStackErrorCostForMergeCached(scratch, scratch.language, b)
 }
 
@@ -2121,9 +2125,10 @@ func cRecoveryMergeCostsDifferForParser(p *Parser, a, b *glrStack) bool {
 	scratch := p.mergeScratch
 	if scratch == nil {
 		local := glrMergeScratch{
-			language:      p.language,
-			trace:         p.glrTrace,
-			cRecoveryCost: true,
+			language:         p.language,
+			trace:            p.glrTrace,
+			cRecoveryCost:    true,
+			cErrorCostParser: p,
 		}
 		return cRecoveryMergeCostsDiffer(&local, a, b)
 	}

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -188,6 +188,7 @@ type parserColdState struct {
 	forestDeclineMemoState
 	cNodeMemoRetainedCache []cNodeMemoCacheEntry
 	cNodeMemoCollisions    uint64
+	recoveryRuntime        recoveryRuntimeTelemetry
 }
 
 func (p *Parser) ensureParserColdState() *parserColdState {

--- a/parser.go
+++ b/parser.go
@@ -4437,6 +4437,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	defer releaseParserScratch(scratch, deferParentLinks)
 	p.reduceScratch = &scratch.reduce
 	p.mergeScratch = &scratch.merge
+	p.beginRecoveryRuntimeTelemetry()
 	// budgetScratch is saved and restored, not just cleared, unlike its
 	// siblings above: a nested parseInternal call (a retry or compat-
 	// normalization sub-parse reachable from this call's own body, however
@@ -5002,6 +5003,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		recordParseRuntimeMaterializationTiming(&parseRuntime, materializationTimingRef, materializationTiming)
 		recordParseRuntimeTokenStats(&parseRuntime, perfTokensConsumed, lastTokenEndByte, lastTokenSymbol, lastTokenWasEOF, tokenSourceEOFEarly)
 		recordParseRuntimeRootStats(&parseRuntime, tree, source, expectedEOFByte, p.included, scratch.audit.enabled || (arena != nil && arena.breakdownEnabled), p.language)
+		p.finishRecoveryRuntimeTelemetry(tree, stacks)
 		recordStopDiagnostic(parseRuntime.StopReason, tree)
 		p.copyNormalizationStats(&parseRuntime)
 		if tree != nil {

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -787,6 +787,7 @@ func (p *Parser) cRecoverAcquireToken(ts TokenSource, stacks []glrStack, source 
 	if p.cRecoverCustomResyncActive {
 		p.cRecoverCustomResyncActive = false
 		if skipper, ok := ts.(interface{ SkipToByte(uint32) Token }); ok {
+			p.recordRecoveryScannerResync()
 			return skipper.SkipToByte(p.cRecoverCustomResyncByte)
 		}
 	}
@@ -910,6 +911,7 @@ func (p *Parser) cRecoverResumeLookahead(source []byte, s *glrStack, tok Token) 
 	p.cRecoverSharedTokenErrorModeLexed = true
 	p.cRecoverCustomResyncActive = true
 	p.cRecoverCustomResyncByte = relexed.EndByte
+	p.recordRecoveryErrorModeToken()
 	return relexed, true
 }
 
@@ -983,6 +985,7 @@ func (p *Parser) cRecoverInternalErrorModeToken(ts TokenSource, stacks []glrStac
 	p.cRecoverSharedTokenErrorModeLexed = true
 	p.cRecoverCustomResyncActive = true
 	p.cRecoverCustomResyncByte = tok.EndByte
+	p.recordRecoveryErrorModeToken()
 	return tok, true
 }
 
@@ -3187,6 +3190,7 @@ func (p *Parser) cTerminalNextState(state StateID, sym Symbol) (StateID, ParseAc
 // missing-token versions and strategy-1 recoveries) — the caller must force a
 // re-dispatch pass for the same token.
 func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) (cRecoverOutcome, bool, ParseStopReason) {
+	p.recordRecoveryEntry()
 	// C-recovery reads raw shapes unconditionally once it runs (see
 	// cSelectReplacementParentEntry / compareRawStackEntries), and its
 	// version-spawning (cRecoverToState and friends) creates multi-stack
@@ -3453,6 +3457,7 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 			v.dead = true
 		}
 	}
+	p.recordRecoveryLiveVersions(*stacks)
 	return outcome, needsRedispatch, ParseStopNone
 }
 
@@ -3693,6 +3698,7 @@ func (p *Parser) cRecoverElectionLookaheadSymbol(source []byte, member *glrStack
 //   - entries are deduped on (depth, state) at first encounter, mirroring
 //     ts_stack_record_summary's record-time dedup across the merged paths.
 func (p *Parser) cRecoverStrategy1Election(stacks *[]glrStack, group *cRecGroup, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) (didRecover, forked bool, reason ParseStopReason) {
+	p.recordStrategy1Election()
 	checkStop := func() ParseStopReason {
 		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 			return reason
@@ -3836,6 +3842,7 @@ func (p *Parser) cRecoverStrategy1Election(stacks *[]glrStack, group *cRecGroup,
 				}
 				fork.branchOrder = (*stacks)[mi].branchOrder
 				*stacks = append(*stacks, fork)
+				p.recordRecoveryLiveVersions(*stacks)
 				if nodeCount != nil {
 					*nodeCount = *nodeCount + 1
 				}

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -266,6 +266,7 @@ func (p *Parser) retryIncrementalAcceptedErrorWithBaseMergeCap(source []byte, fi
 	}
 
 	p.fullParseRetryPassesTaken++
+	p.recordRecoveryRuntimeRetry("accepted_error_under_wide_incremental_merge")
 	workCountSetNextParseAttempt("incremental_base_merge", "accepted_error_under_wide_incremental_merge")
 	var retryTiming *incrementalParseTiming
 	if timing != nil {
@@ -1721,6 +1722,7 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 				return nil
 			}
 			p.fullParseRetryPassesTaken++
+			p.recordRecoveryRuntimeRetry(operationCause)
 		}
 		var t0 time.Time
 		if retryDebug {

--- a/recovery_runtime_telemetry.go
+++ b/recovery_runtime_telemetry.go
@@ -1,0 +1,176 @@
+package gotreesitter
+
+import "time"
+
+// recoveryRuntimeTelemetryEnabled gates the recovery facts that are absent
+// from the normal parser runtime. Keep the default path free of these writes.
+var recoveryRuntimeTelemetryEnabled bool
+
+type recoveryRuntimeTelemetry struct {
+	stats              RecoveryRuntimeStats
+	pendingRetryReason string
+}
+
+// EnableRecoveryRuntimeTelemetry enables diagnostic recovery counters.
+//
+// Use this function for single-threaded profiling and witness collection.
+// Disable it after the diagnostic run to restore the default path.
+func EnableRecoveryRuntimeTelemetry(enabled bool) {
+	recoveryRuntimeTelemetryEnabled = enabled
+}
+
+// DebugRecoveryRuntimeStats returns the latest recovery facts for parser p.
+// The method returns zero values when telemetry is disabled or no parse ran.
+func (p *Parser) DebugRecoveryRuntimeStats() RecoveryRuntimeStats {
+	if p == nil || !recoveryRuntimeTelemetryEnabled || p.forestDeclineMemo == nil {
+		return RecoveryRuntimeStats{}
+	}
+	return p.forestDeclineMemo.recoveryRuntime.stats
+}
+
+func (p *Parser) beginRecoveryRuntimeTelemetry() {
+	if p == nil || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	cold := p.ensureParserColdState()
+	state := &cold.recoveryRuntime
+	retryReason := state.pendingRetryReason
+	if p.fullParseRetryPassesTaken == 0 {
+		retryReason = ""
+	}
+	state.stats = RecoveryRuntimeStats{
+		Enabled:        true,
+		RetryPassCount: uint64(p.fullParseRetryPassesTaken),
+		RetryReason:    retryReason,
+	}
+	state.pendingRetryReason = ""
+}
+
+func (p *Parser) recoveryRuntimeTelemetryState() *recoveryRuntimeTelemetry {
+	if p == nil || !recoveryRuntimeTelemetryEnabled || p.forestDeclineMemo == nil {
+		return nil
+	}
+	return &p.forestDeclineMemo.recoveryRuntime
+}
+
+func (p *Parser) recordRecoveryRuntimeRetry(reason string) {
+	if p == nil || !recoveryRuntimeTelemetryEnabled || reason == "" {
+		return
+	}
+	cold := p.ensureParserColdState()
+	cold.recoveryRuntime.pendingRetryReason = reason
+}
+
+func (p *Parser) recordRecoveryEntry() {
+	if state := p.recoveryRuntimeTelemetryState(); state != nil {
+		state.stats.RecoveryEntryCount++
+	}
+}
+
+func (p *Parser) recordStrategy1Election() {
+	if state := p.recoveryRuntimeTelemetryState(); state != nil {
+		state.stats.Strategy1ElectionCount++
+	}
+}
+
+func (p *Parser) recordRecoveryErrorModeToken() {
+	if state := p.recoveryRuntimeTelemetryState(); state != nil {
+		state.stats.ErrorModeTokenCount++
+	}
+}
+
+func (p *Parser) recordRecoveryScannerResync() {
+	if state := p.recoveryRuntimeTelemetryState(); state != nil {
+		state.stats.ScannerResyncCount++
+	}
+}
+
+func (p *Parser) recordRecoveryLiveVersions(stacks []glrStack) {
+	state := p.recoveryRuntimeTelemetryState()
+	if state == nil {
+		return
+	}
+	var live uint64
+	for i := range stacks {
+		if !stacks[i].dead && !stacks[i].accepted {
+			live++
+		}
+	}
+	state.stats.LiveVersionCount = live
+	if live > state.stats.PeakLiveVersionCount {
+		state.stats.PeakLiveVersionCount = live
+	}
+}
+
+func (p *Parser) finishRecoveryRuntimeTelemetry(tree *Tree, stacks []glrStack) {
+	state := p.recoveryRuntimeTelemetryState()
+	if state == nil {
+		return
+	}
+	state.stats.Completed = true
+	p.recordRecoveryLiveVersions(stacks)
+	state.stats.ErrorNodeCount, state.stats.ErrorSpanBytes = recoveryRuntimeErrorStats(rawRootOrNil(tree))
+}
+
+func recoveryRuntimeErrorStats(root *Node) (count uint64, span uint32) {
+	if root == nil {
+		return 0, 0
+	}
+	var local [64]*Node
+	stack := local[:0]
+	stack = append(stack, root)
+	minStart := ^uint32(0)
+	var maxEnd uint32
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if n == nil {
+			continue
+		}
+		if n.IsError() || n.IsMissing() {
+			count++
+			if n.StartByte() < minStart {
+				minStart = n.StartByte()
+			}
+			if n.EndByte() > maxEnd {
+				maxEnd = n.EndByte()
+			}
+		}
+		for i := n.ChildCount() - 1; i >= 0; i-- {
+			stack = append(stack, n.Child(i))
+		}
+	}
+	if count == 0 {
+		return 0, 0
+	}
+	return count, maxEnd - minStart
+}
+
+func recoveryRuntimeParser(scratch *glrMergeScratch) *Parser {
+	if !recoveryRuntimeTelemetryEnabled || scratch == nil {
+		return nil
+	}
+	return scratch.cErrorCostParser
+}
+
+func recordRecoveryCostCompetition(scratch *glrMergeScratch) {
+	if p := recoveryRuntimeParser(scratch); p != nil {
+		if state := p.recoveryRuntimeTelemetryState(); state != nil {
+			state.stats.RecoveryCostCompetitionCount++
+		}
+	}
+}
+
+func recoveryRuntimeCostWalk(scratch *glrMergeScratch, lang *Language, stack *glrStack) uint32 {
+	p := recoveryRuntimeParser(scratch)
+	if p == nil {
+		return cStackErrorCostForMergeWithScratch(scratch, lang, stack)
+	}
+	start := time.Now()
+	cost := cStackErrorCostForMergeWithScratch(scratch, lang, stack)
+	if state := p.recoveryRuntimeTelemetryState(); state != nil {
+		state.stats.RecoveryCostWalkCount++
+		state.stats.RecoveryCostWalkNanos += uint64(time.Since(start).Nanoseconds())
+	}
+	return cost
+}

--- a/tree.go
+++ b/tree.go
@@ -813,6 +813,31 @@ type RecoveryNodeMemoRuntime struct {
 	Collisions uint32
 }
 
+// RecoveryRuntimeStats reports opt-in recovery facts for the most recent
+// completed parse attempt on a parser.
+//
+// The default value reports no facts. Enable the telemetry before parsing.
+// Existing tree runtime fields and RecoveryNodeMemoRuntime provide the other
+// B16 facts, including materialization, allocation, stop, and memo metrics.
+type RecoveryRuntimeStats struct {
+	Enabled   bool
+	Completed bool
+
+	RecoveryEntryCount           uint64
+	Strategy1ElectionCount       uint64
+	RecoveryCostCompetitionCount uint64
+	RecoveryCostWalkCount        uint64
+	RecoveryCostWalkNanos        uint64
+	ErrorNodeCount               uint64
+	ErrorSpanBytes               uint32
+	RetryPassCount               uint64
+	RetryReason                  string
+	ErrorModeTokenCount          uint64
+	ScannerResyncCount           uint64
+	LiveVersionCount             uint64
+	PeakLiveVersionCount         uint64
+}
+
 // ParseRuntime captures parser-loop diagnostics for a completed tree.
 type ParseRuntime struct {
 	StopReason     ParseStopReason


### PR DESCRIPTION
## Summary

Add the first B16.0 recovery telemetry tranche.

- Add an opt-in RecoveryRuntimeStats diagnostic surface.
- Count recovery entries, strategy elections, cost walks, scanner events, retries, and live versions.
- Record final error count and error span.
- Preserve existing parser decisions, routing, grammar admission, and hot layouts.
- Document reset scope, units, overflow behavior, and existing metric sources.

## Evidence boundary

The sidecar remains disabled by default.
This tranche describes the most recent completed parse attempt on one parser.
It does not run a fleet experiment or admit performance credit.

## Validation

- git diff --check
- Docker focused recovery witness
- Docker hot-layout ratchet
- Docker KDL recovery regression

The next B16 tranche will collect the Swift issue 586 witness and one same-language control.