### PR TITLE
test: Add B16.1 Swift recovery witness matrix

### DIFF
--- a/benchmark_recovery_test.go
+++ b/benchmark_recovery_test.go
@@ -4,12 +4,14 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 )
 
 func TestKDLRecoveryGarbageSuffixExact(t *testing.T) {
@@ -246,4 +248,147 @@ func BenchmarkRecoveryCorpusFile(b *testing.B) {
 	b.ReportMetric(float64(memoEntries)/float64(b.N), "memo_entries/op")
 	b.ReportMetric(float64(memoBytes)/float64(b.N), "memo_bytes/op")
 	b.ReportMetric(float64(memoCollisions)/float64(b.N), "memo_collisions/op")
+}
+
+// TestSwiftRecoveryTelemetryWitnesses records the first B16.1 witness matrix
+// for the outside-reported Swift recovery-cost and parity issues.
+//
+// Keep this test diagnostic-only. It records Go facts and tree identity for
+// one language. The locked-C parity and performance receipts remain separate.
+func TestSwiftRecoveryTelemetryWitnesses(t *testing.T) {
+	gotreesitter.EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { gotreesitter.EnableRecoveryRuntimeTelemetry(false) })
+	previousAdmissionRoute := gotreesitter.AdmissionCandidateRouteDefault()
+	gotreesitter.SetAdmissionCandidateRouteDefault(false)
+	t.Cleanup(func() { gotreesitter.SetAdmissionCandidateRouteDefault(previousAdmissionRoute) })
+
+	const swiftGrammarLockCommit = "41d6e5fe811ec94229ee71771174a8cce558dfee"
+	witnesses := []struct {
+		name         string
+		issue        string
+		path         string
+		wantHasError bool
+	}{
+		{
+			name:         "swift-586-floating-point",
+			issue:        "#586/#576",
+			path:         filepath.Join("grammars", "testdata", "swift_corpus", "stdlib_FloatingPointToString.swift"),
+			wantHasError: true,
+		},
+		{
+			name:         "swift-576-collection-algorithms",
+			issue:        "#576",
+			path:         filepath.Join("grammars", "testdata", "swift_corpus", "stdlib_CollectionAlgorithms.swift"),
+			wantHasError: true,
+		},
+		{
+			name:         "swift-clean-control",
+			issue:        "control",
+			path:         "",
+			wantHasError: false,
+		},
+	}
+
+	for _, witness := range witnesses {
+		t.Run(witness.name, func(t *testing.T) {
+			var source []byte
+			var err error
+			if witness.path == "" {
+				source = []byte("let answer = 1\n")
+			} else {
+				source, err = os.ReadFile(witness.path)
+				if err != nil {
+					t.Fatalf("read Swift witness %q: %v", witness.path, err)
+				}
+			}
+
+			lang := grammars.SwiftLanguage()
+			parser := gotreesitter.NewParser(lang)
+			started := time.Now()
+			tree, parseErr := parser.Parse(source)
+			elapsed := time.Since(started)
+			if parseErr != nil {
+				t.Fatalf("parse Swift witness: %v", parseErr)
+			}
+			if tree == nil || tree.RootNode() == nil {
+				t.Fatal("Swift witness returned a nil tree")
+			}
+			root := tree.RootNode()
+			runtime := tree.ParseRuntime()
+			memo := tree.RecoveryNodeMemoRuntime()
+			stats := parser.DebugRecoveryRuntimeStats()
+			inspection, err := benchfixtures.InspectGoTree(root, lang)
+			if err != nil {
+				tree.Release()
+				t.Fatalf("inspect Swift witness tree: %v", err)
+			}
+
+			hasError := root.HasError()
+			fullSpan := root.StartByte() == 0 && root.EndByte() == uint32(len(source))
+			if hasError != witness.wantHasError {
+				tree.Release()
+				t.Fatalf("HasError() = %v, want %v", hasError, witness.wantHasError)
+			}
+			if !fullSpan {
+				tree.Release()
+				t.Fatalf("root span = %d..%d, want 0..%d", root.StartByte(), root.EndByte(), len(source))
+			}
+			if !stats.Enabled || !stats.Completed {
+				tree.Release()
+				t.Fatalf("telemetry status = enabled:%v completed:%v, want enabled and completed", stats.Enabled, stats.Completed)
+			}
+			if witness.wantHasError && (stats.RecoveryEntryCount == 0 || stats.ErrorNodeCount == 0) {
+				tree.Release()
+				t.Fatalf("error witness lacks recovery facts: %+v", stats)
+			}
+			if !witness.wantHasError && (stats.RecoveryEntryCount != 0 || stats.ErrorNodeCount != 0 || stats.ErrorSpanBytes != 0) {
+				tree.Release()
+				t.Fatalf("clean control recorded recovery facts: %+v", stats)
+			}
+
+			sourceDigest := sha256.Sum256(source)
+			t.Logf("B16_WITNESS version=1 name=%s issue=%s source_sha256=%x source_bytes=%d grammar=swift grammar_lock_commit=%s result_class=%s full_span=%t go_deep_sha256=%s parse_wall_ns=%d measured_wall_ns=%d stop_reason=%s truncated=%t recovery_entries=%d strategy1_elections=%d cost_competitions=%d cost_walks=%d cost_walk_ns=%d error_nodes=%d error_span_bytes=%d retry_passes=%d retry_reason=%q error_mode_tokens=%d scanner_resync=%d live_versions=%d peak_live_versions=%d reduction_ceiling_hits=%d reduction_attempts_peak=%d missing_ceiling_hits=%d missing_attempts_peak=%d memo_tier=%d memo_entries=%d memo_bytes=%d memo_collisions=%d arena_bytes=%d scratch_bytes=%d entry_scratch_bytes=%d gss_bytes=%d gss_nodes=%d max_stacks=%d",
+				witness.name,
+				witness.issue,
+				sourceDigest,
+				len(source),
+				swiftGrammarLockCommit,
+				map[bool]string{true: "error", false: "clean"}[hasError],
+				fullSpan,
+				inspection.SHA256,
+				runtime.ParseWallNanos,
+				elapsed.Nanoseconds(),
+				runtime.StopReason,
+				runtime.Truncated,
+				stats.RecoveryEntryCount,
+				stats.Strategy1ElectionCount,
+				stats.RecoveryCostCompetitionCount,
+				stats.RecoveryCostWalkCount,
+				stats.RecoveryCostWalkNanos,
+				stats.ErrorNodeCount,
+				stats.ErrorSpanBytes,
+				stats.RetryPassCount,
+				stats.RetryReason,
+				stats.ErrorModeTokenCount,
+				stats.ScannerResyncCount,
+				stats.LiveVersionCount,
+				stats.PeakLiveVersionCount,
+				runtime.CRecoverReductionCandidateCeilingHits,
+				runtime.CRecoverReductionCandidateAttemptsPeak,
+				runtime.CRecoverMissingTokenCeilingHits,
+				runtime.CRecoverMissingTokenTrialAttemptsPeak,
+				memo.PeakTier,
+				memo.PeakTier.Entries(),
+				memo.PeakTier.Bytes(),
+				memo.Collisions,
+				runtime.ArenaBytesAllocated,
+				runtime.ScratchBytesAllocated,
+				runtime.EntryScratchBytesAllocated,
+				runtime.GSSBytesAllocated,
+				runtime.GSSNodesUsed,
+				runtime.MaxStacksSeen,
+			)
+			tree.Release()
+		})
+	}
 }

--- a/cgo_harness/parity_swift_recovery_telemetry_test.go
+++ b/cgo_harness/parity_swift_recovery_telemetry_test.go
@@ -1,0 +1,167 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// TestB16SwiftRecoveryTelemetryCOracle records the locked-C identity for the
+// Swift witnesses. Keep this correctness receipt separate from benchmarks.
+func TestB16SwiftRecoveryTelemetryCOracle(t *testing.T) {
+	previousAdmissionRoute := gotreesitter.AdmissionCandidateRouteDefault()
+	gotreesitter.SetAdmissionCandidateRouteDefault(false)
+	t.Cleanup(func() { gotreesitter.SetAdmissionCandidateRouteDefault(previousAdmissionRoute) })
+	gotreesitter.EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { gotreesitter.EnableRecoveryRuntimeTelemetry(false) })
+
+	identity, err := COracleIdentity("swift")
+	if err != nil {
+		t.Fatalf("load Swift C oracle identity: %v", err)
+	}
+	cLang, err := ParityCLanguage("swift")
+	if err != nil {
+		t.Fatalf("load Swift C language: %v", err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatalf("set Swift C language: %v", err)
+	}
+
+	witnesses := []struct {
+		name         string
+		issue        string
+		path         string
+		wantHasError bool
+	}{
+		{
+			name:         "swift-586-floating-point",
+			issue:        "#586/#576",
+			path:         filepath.Join("..", "grammars", "testdata", "swift_corpus", "stdlib_FloatingPointToString.swift"),
+			wantHasError: true,
+		},
+		{
+			name:         "swift-576-collection-algorithms",
+			issue:        "#576",
+			path:         filepath.Join("..", "grammars", "testdata", "swift_corpus", "stdlib_CollectionAlgorithms.swift"),
+			wantHasError: true,
+		},
+		{
+			name:         "swift-clean-control",
+			issue:        "control",
+			path:         "",
+			wantHasError: false,
+		},
+	}
+
+	for _, witness := range witnesses {
+		t.Run(witness.name, func(t *testing.T) {
+			var source []byte
+			if witness.path == "" {
+				source = []byte("let answer = 1\n")
+			} else {
+				source, err = os.ReadFile(witness.path)
+				if err != nil {
+					t.Fatalf("read Swift witness %q: %v", witness.path, err)
+				}
+			}
+
+			goLang := grammars.SwiftLanguage()
+			goParser := gotreesitter.NewParser(goLang)
+			goTree, parseErr := goParser.Parse(source)
+			if parseErr != nil {
+				t.Fatalf("parse Swift witness with Go: %v", parseErr)
+			}
+			if goTree == nil || goTree.RootNode() == nil {
+				t.Fatal("Go Swift witness returned no tree")
+			}
+			goRoot := goTree.RootNode()
+			goRuntime := goTree.ParseRuntime()
+			goMemo := goTree.RecoveryNodeMemoRuntime()
+			goStats := goParser.DebugRecoveryRuntimeStats()
+			goInspection, err := benchfixtures.InspectGoTree(goRoot, goLang)
+			if err != nil {
+				goTree.Release()
+				t.Fatalf("inspect Go Swift witness: %v", err)
+			}
+
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				goTree.Release()
+				t.Fatal("C Swift witness returned no tree")
+			}
+			cRoot := cTree.RootNode()
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				cTree.Close()
+				goTree.Release()
+				t.Fatalf("inspect C Swift witness: %v", err)
+			}
+
+			if goRoot.HasError() != witness.wantHasError || cRoot.HasError() != witness.wantHasError {
+				cTree.Close()
+				goTree.Release()
+				t.Fatalf("HasError() = Go:%v C:%v, want %v/%v", goRoot.HasError(), cRoot.HasError(), witness.wantHasError, witness.wantHasError)
+			}
+			if goRoot.StartByte() != 0 || goRoot.EndByte() != uint32(len(source)) || cRoot.StartByte() != 0 || cRoot.EndByte() != uint(len(source)) {
+				cTree.Close()
+				goTree.Release()
+				t.Fatalf("root span = Go:%d..%d C:%d..%d, want 0..%d", goRoot.StartByte(), goRoot.EndByte(), cRoot.StartByte(), cRoot.EndByte(), len(source))
+			}
+			if !goStats.Enabled || !goStats.Completed {
+				cTree.Close()
+				goTree.Release()
+				t.Fatalf("telemetry status = enabled:%v completed:%v, want enabled and completed", goStats.Enabled, goStats.Completed)
+			}
+
+			sourceDigest := sha256.Sum256(source)
+			t.Logf("B16_C_WITNESS version=1 name=%s issue=%s source_sha256=%x source_bytes=%d grammar=swift grammar_lock_commit=%s c_runtime=%s@%s c_grammar_repo=%s c_grammar_commit=%s c_grammar_artifact_sha256=%s result_class=%s go_deep_sha256=%s c_deep_sha256=%s go_stop_reason=%s go_truncated=%t go_recovery_entries=%d go_strategy1_elections=%d go_cost_competitions=%d go_cost_walks=%d go_cost_walk_ns=%d go_error_nodes=%d go_error_span_bytes=%d go_retry_passes=%d go_retry_reason=%q go_memo_tier=%d go_memo_entries=%d go_memo_bytes=%d go_memo_collisions=%d go_arena_bytes=%d go_scratch_bytes=%d go_entry_scratch_bytes=%d go_gss_bytes=%d go_gss_nodes=%d go_max_stacks=%d",
+				witness.name,
+				witness.issue,
+				sourceDigest,
+				len(source),
+				identity.GrammarCommit,
+				identity.RuntimeVersion,
+				identity.RuntimeCommit,
+				identity.GrammarRepo,
+				identity.GrammarCommit,
+				identity.GrammarArtifactSHA256,
+				map[bool]string{true: "error", false: "clean"}[goRoot.HasError()],
+				goInspection.SHA256,
+				cDigest,
+				goRuntime.StopReason,
+				goRuntime.Truncated,
+				goStats.RecoveryEntryCount,
+				goStats.Strategy1ElectionCount,
+				goStats.RecoveryCostCompetitionCount,
+				goStats.RecoveryCostWalkCount,
+				goStats.RecoveryCostWalkNanos,
+				goStats.ErrorNodeCount,
+				goStats.ErrorSpanBytes,
+				goStats.RetryPassCount,
+				goStats.RetryReason,
+				goMemo.PeakTier,
+				goMemo.PeakTier.Entries(),
+				goMemo.PeakTier.Bytes(),
+				goMemo.Collisions,
+				goRuntime.ArenaBytesAllocated,
+				goRuntime.ScratchBytesAllocated,
+				goRuntime.EntryScratchBytesAllocated,
+				goRuntime.GSSBytesAllocated,
+				goRuntime.GSSNodesUsed,
+				goRuntime.MaxStacksSeen,
+			)
+			cTree.Close()
+			goTree.Release()
+		})
+	}
+}

--- a/docs/b16-r1-swift-witness-matrix.md
+++ b/docs/b16-r1-swift-witness-matrix.md
@@ -1,0 +1,90 @@
+# B16.1 Swift recovery witness matrix
+
+Status: complete
+
+Source revision: `61f5f2ba05c79f8145db934a95ba2318ff256389`
+
+Use Revision R1 of `spec.campaign.v7` as the authority.
+
+This receipt covers one-language Swift evidence for issues [#586](https://github.com/odvcencio/gotreesitter/issues/586) and [#576](https://github.com/odvcencio/gotreesitter/issues/576).
+It keeps correctness evidence separate from performance evidence.
+
+## Locked inputs
+
+- Grammar repository: `https://github.com/alex-pinkus/tree-sitter-swift`
+- Grammar lock commit: `41d6e5fe811ec94229ee71771174a8cce558dfee`
+- C runtime: `0.25.1@f5afe475deb7c0bae6407fb776c76824f717bb61`
+- C grammar artifact SHA-256: `2a9f14046d4ca88b6db1316ee5f48b876aea1700e3c09811b3c87257fe827c5c`
+- Go route: production route, with `GTS_ADMISSION_CANDIDATE=0`
+
+## Correctness and telemetry receipt
+
+Run the Go and locked-C witnesses in one Docker container.
+The container ran one test process with one test worker.
+
+| Witness | Bytes | Source SHA-256 | Go tree SHA-256 | C tree SHA-256 | Result | Full span |
+| --- | ---: | --- | --- | --- | --- | --- |
+| #586 FloatingPointToString | 104681 | `ec96801e5237dff8da773f617a8a2f36e95b6a0a7c94b581855a451cd6507fdc` | `ec51c633a3f99515cc0cd1c0cff435a44ddc7db8e83705977d28f78bdfb0fc0e` | `ab96dddf088487acc700d72af9342c338901504dcf1d32b9644e9f6f6638190d` | Go error / C error | yes |
+| #576 CollectionAlgorithms | 24056 | `1aae0051b0bfb50e17c7ac94961ee7cab7332367dcc16e827d2482be7a2dc5a1` | `79cf919059aa656c0d01a9a9f01d658e98e4e13d174de4bbf6560def035cb285` | `132d332f511f12735d80e846f52ec1fddf5f3d0dcd7a097779640a7710497487` | Go error / C error | yes |
+| Same-language clean control | 15 | `e7d7fe1c6039c1a9d12e23c3c997369c94daf40c244b22c4b174ffc437ee74f9` | `aaee5a3b2142b81d29e96896bedb9a51fca1c42ca98b83b6c9c6198d20740b0e` | `aaee5a3b2142b81d29e96896bedb9a51fca1c42ca98b83b6c9c6198d20740b0e` | Go clean / C clean | yes |
+
+The two error witnesses preserve the known upstream Swift grammar mismatch.
+The clean control has exact Go and C tree identity.
+
+The B16 runtime facts are:
+
+| Witness | Recovery entries | Strategy 1 elections | Cost competitions | Cost walks | Error nodes | Error span | Retry passes | Peak live versions | Memo tier / entries |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| #586 FloatingPointToString | 394 | 1635 | 743866 | 1487732 | 378 | 104680 | 4 | 32 | temporary / 262144 |
+| #576 CollectionAlgorithms | 29 | 99 | 6203 | 12406 | 29 | 10977 | 0 | 11 | standard / 16384 |
+| Same-language clean control | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | initial / 128 |
+
+The #586 retry reason is `best_retry_result_requires_merge_width`.
+Both error witnesses record zero error-mode tokens and zero scanner resynchronizations.
+The largest observed reduction-attempt peaks are 11 for #586 and 9 for #576.
+The largest observed missing-token trial peaks are 15 for #586 and 11 for #576.
+
+These facts support the generic recovery-cost cohort.
+They do not support a Swift scanner change or a Swift-specific parser repair.
+
+## Isolated performance receipt
+
+Run each benchmark in a separate Docker container.
+Use one explicit benchmark iteration with `GOMAXPROCS=1`.
+Disable the admission candidate route.
+Set the recovery timeout to two minutes.
+
+| Witness | `ns/op` | `B/op` | `allocs/op` | Memo bytes/op | Maximum resident set size |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| #586 FloatingPointToString | 12747857551 | 924653488 | 2826965 | 6291456 | 600640 KiB |
+| #576 CollectionAlgorithms | 81483990 | 46425792 | 25626 | 393216 | 584800 KiB |
+
+These are baseline measurements.
+They are not a before-and-after comparison and earn no fleet performance credit.
+The resident set includes the loaded Swift grammar.
+
+## Commands and artifacts
+
+Correctness command:
+
+```text
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build --repo-root /tmp/gotreesitter-r1-b16-witness --label b16-swift-telemetry-cgo-committed -- "cd /workspace/cgo_harness && /usr/bin/time -v go test . -tags treesitter_c_parity -run '^TestB16SwiftRecoveryTelemetryCOracle$' -count=1 -parallel 1 -timeout 5m -v"
+```
+
+Artifact: `harness_out/docker/20260811T232146Z-b16-swift-telemetry-cgo-committed`
+
+The Go diagnostic command used the same Docker runner and ran `TestSwiftRecoveryTelemetryWitnesses`.
+
+The #586 performance artifact is `harness_out/docker/20260811T232210Z-b16-swift-586-perf-committed`.
+The #576 performance artifact is `harness_out/docker/20260811T232232Z-b16-swift-576-perf-committed`.
+
+All three runs completed without an out-of-memory kill or a wall timeout.
+
+## Boundary and next step
+
+This receipt closes B16.1.
+It does not close B16.2 or admit performance credit.
+
+Use the #586 facts to classify the first generic recovery cohort.
+Keep the retry, cost-walk, and memo signals separate until a mechanism explains both time and memory.
+Run the next candidate against the same Swift witnesses and a non-Swift error control.


### PR DESCRIPTION
## Summary

Add the B16.1 Swift witness matrix for issues #586 and #576.

- Record Go recovery telemetry for the #586 and #576 corpus witnesses.
- Record locked-C tree identity and grammar provenance.
- Keep the same-language clean control in the matrix.
- Record isolated baseline time, allocation, and maximum resident set size facts.
- Keep correctness and performance receipts separate.

## Result

The #586 witness shows repeated generic recovery cost walks, bounded retry work, and temporary memo pressure.
The #576 witness shows the same generic shape at a smaller scale.
Neither witness shows scanner error-mode or scanner resynchronization activity.
No parser route or recovery behavior changes in this pull request.

Depends on #679.

Refs #576
Refs #586