### PR TITLE
test: Add B16.2 selected retry telemetry

### DIFF
--- a/benchmark_recovery_test.go
+++ b/benchmark_recovery_test.go
@@ -345,9 +345,19 @@ func TestSwiftRecoveryTelemetryWitnesses(t *testing.T) {
 				tree.Release()
 				t.Fatalf("clean control recorded recovery facts: %+v", stats)
 			}
+			if witness.name == "swift-586-floating-point" {
+				if stats.RetryAttemptCount == 0 || stats.RetrySelectedAttempt == "" {
+					tree.Release()
+					t.Fatalf("#586 lacks selected retry facts: %+v", stats)
+				}
+				if !stats.RetrySelectedAttemptHasError || !stats.RetrySelectedAttemptFullSpan {
+					tree.Release()
+					t.Fatalf("#586 selected retry shape = has_error:%v full_span:%v, want true/true", stats.RetrySelectedAttemptHasError, stats.RetrySelectedAttemptFullSpan)
+				}
+			}
 
 			sourceDigest := sha256.Sum256(source)
-			t.Logf("B16_WITNESS version=1 name=%s issue=%s source_sha256=%x source_bytes=%d grammar=swift grammar_lock_commit=%s result_class=%s full_span=%t go_deep_sha256=%s parse_wall_ns=%d measured_wall_ns=%d stop_reason=%s truncated=%t recovery_entries=%d strategy1_elections=%d cost_competitions=%d cost_walks=%d cost_walk_ns=%d error_nodes=%d error_span_bytes=%d retry_passes=%d retry_reason=%q error_mode_tokens=%d scanner_resync=%d live_versions=%d peak_live_versions=%d reduction_ceiling_hits=%d reduction_attempts_peak=%d missing_ceiling_hits=%d missing_attempts_peak=%d memo_tier=%d memo_entries=%d memo_bytes=%d memo_collisions=%d arena_bytes=%d scratch_bytes=%d entry_scratch_bytes=%d gss_bytes=%d gss_nodes=%d max_stacks=%d",
+			t.Logf("B16_WITNESS version=2 name=%s issue=%s source_sha256=%x source_bytes=%d grammar=swift grammar_lock_commit=%s result_class=%s full_span=%t go_deep_sha256=%s parse_wall_ns=%d measured_wall_ns=%d stop_reason=%s truncated=%t recovery_entries=%d strategy1_elections=%d cost_competitions=%d cost_walks=%d cost_walk_ns=%d error_nodes=%d error_span_bytes=%d retry_passes=%d retry_reason=%q retry_attempts=%d retry_selected=%q retry_selected_has_error=%t retry_selected_full_span=%t error_mode_tokens=%d scanner_resync=%d live_versions=%d peak_live_versions=%d reduction_ceiling_hits=%d reduction_attempts_peak=%d missing_ceiling_hits=%d missing_attempts_peak=%d memo_tier=%d memo_entries=%d memo_bytes=%d memo_collisions=%d arena_bytes=%d scratch_bytes=%d entry_scratch_bytes=%d gss_bytes=%d gss_nodes=%d max_stacks=%d",
 				witness.name,
 				witness.issue,
 				sourceDigest,
@@ -369,6 +379,10 @@ func TestSwiftRecoveryTelemetryWitnesses(t *testing.T) {
 				stats.ErrorSpanBytes,
 				stats.RetryPassCount,
 				stats.RetryReason,
+				stats.RetryAttemptCount,
+				stats.RetrySelectedAttempt,
+				stats.RetrySelectedAttemptHasError,
+				stats.RetrySelectedAttemptFullSpan,
 				stats.ErrorModeTokenCount,
 				stats.ScannerResyncCount,
 				stats.LiveVersionCount,

--- a/cgo_harness/parity_swift_recovery_telemetry_test.go
+++ b/cgo_harness/parity_swift_recovery_telemetry_test.go
@@ -124,7 +124,7 @@ func TestB16SwiftRecoveryTelemetryCOracle(t *testing.T) {
 			}
 
 			sourceDigest := sha256.Sum256(source)
-			t.Logf("B16_C_WITNESS version=1 name=%s issue=%s source_sha256=%x source_bytes=%d grammar=swift grammar_lock_commit=%s c_runtime=%s@%s c_grammar_repo=%s c_grammar_commit=%s c_grammar_artifact_sha256=%s result_class=%s go_deep_sha256=%s c_deep_sha256=%s go_stop_reason=%s go_truncated=%t go_recovery_entries=%d go_strategy1_elections=%d go_cost_competitions=%d go_cost_walks=%d go_cost_walk_ns=%d go_error_nodes=%d go_error_span_bytes=%d go_retry_passes=%d go_retry_reason=%q go_memo_tier=%d go_memo_entries=%d go_memo_bytes=%d go_memo_collisions=%d go_arena_bytes=%d go_scratch_bytes=%d go_entry_scratch_bytes=%d go_gss_bytes=%d go_gss_nodes=%d go_max_stacks=%d",
+			t.Logf("B16_C_WITNESS version=2 name=%s issue=%s source_sha256=%x source_bytes=%d grammar=swift grammar_lock_commit=%s c_runtime=%s@%s c_grammar_repo=%s c_grammar_commit=%s c_grammar_artifact_sha256=%s result_class=%s go_deep_sha256=%s c_deep_sha256=%s go_stop_reason=%s go_truncated=%t go_recovery_entries=%d go_strategy1_elections=%d go_cost_competitions=%d go_cost_walks=%d go_cost_walk_ns=%d go_error_nodes=%d go_error_span_bytes=%d go_retry_passes=%d go_retry_reason=%q go_retry_attempts=%d go_retry_selected=%q go_retry_selected_has_error=%t go_retry_selected_full_span=%t go_memo_tier=%d go_memo_entries=%d go_memo_bytes=%d go_memo_collisions=%d go_arena_bytes=%d go_scratch_bytes=%d go_entry_scratch_bytes=%d go_gss_bytes=%d go_gss_nodes=%d go_max_stacks=%d",
 				witness.name,
 				witness.issue,
 				sourceDigest,
@@ -149,6 +149,10 @@ func TestB16SwiftRecoveryTelemetryCOracle(t *testing.T) {
 				goStats.ErrorSpanBytes,
 				goStats.RetryPassCount,
 				goStats.RetryReason,
+				goStats.RetryAttemptCount,
+				goStats.RetrySelectedAttempt,
+				goStats.RetrySelectedAttemptHasError,
+				goStats.RetrySelectedAttemptFullSpan,
 				goMemo.PeakTier,
 				goMemo.PeakTier.Entries(),
 				goMemo.PeakTier.Bytes(),

--- a/docs/b16-r1-retry-economy-telemetry.md
+++ b/docs/b16-r1-retry-economy-telemetry.md
@@ -1,0 +1,75 @@
+# B16.2 retry economy telemetry
+
+Status: evidence tranche
+
+Use Revision R1 of `spec.campaign.v7` as the authority.
+
+This receipt records which retry rung supplied the selected tree.
+It does not change retry routing or admit performance credit.
+
+## Schema
+
+The opt-in `RecoveryRuntimeStats` fields report the retry ladder outcome.
+
+| Field | Meaning |
+| --- | --- |
+| `RetryAttemptCount` | Retry pass slots consumed by the top-level parse. |
+| `RetrySelectedAttempt` | Logical rung that supplied the selected tree. |
+| `RetrySelectedAttemptHasError` | Error status of the selected tree. |
+| `RetrySelectedAttemptFullSpan` | Full source span status of the selected tree. |
+
+The telemetry keeps a sidecar map from each retry tree to its logical rung.
+The map exists only while recovery telemetry is enabled.
+The map is cleared when the retry ladder returns.
+
+## Locked Swift witness result
+
+Run the Go and locked-C witnesses with one test worker in Docker.
+
+| Witness | Retry passes | Selected rung | Selected error | Selected full span |
+| --- | ---: | --- | --- | --- |
+| #586 `FloatingPointToString` | 4 | `initial_merge` | true | true |
+| #576 `CollectionAlgorithms` | 0 | `initial` | true | true |
+| Swift clean control | 0 | `initial` | false | true |
+
+The #586 parse paid for four retry pass slots.
+The final selected tree came from `initial_merge`.
+The later widened and final-merge passes did not replace that tree.
+
+The #576 error witness needed no retry pass.
+The selected initial tree already covered the complete source.
+
+Both error witnesses preserve their known Swift grammar mismatch.
+The clean control keeps exact Go and C tree identity.
+
+## Interpretation
+
+The selected-rung fact identifies retry payment that may be avoidable.
+It does not prove that later rungs are redundant across the fleet.
+
+Do not skip a retry rung from this receipt alone.
+First collect the selected-rung distribution across the generic recovery cohort.
+Then compare correctness, wall time, allocation, and resident set.
+
+Keep the candidate generic.
+Do not add a Swift exception, a source hash, or a grammar-name rule.
+
+## Commands and artifacts
+
+Go witness command:
+
+```text
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build --repo-root /tmp/gotreesitter-r1-b16-retry --label b16-swift-selected-retry-facts --memory 8g --cpus 1 --gomemlimit 6GiB -- "cd /workspace && go test ./ -run '^TestSwiftRecoveryTelemetryWitnesses$' -count=1 -v -timeout 5m"
+```
+
+Go artifact: `harness_out/docker/20260811T233432Z-b16-swift-selected-retry-facts`
+
+Locked-C command:
+
+```text
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build --repo-root /tmp/gotreesitter-r1-b16-retry --label b16-swift-selected-retry-cgo --memory 8g --cpus 1 --gomemlimit 6GiB -- "cd /workspace/cgo_harness && /usr/bin/time -v go test . -tags treesitter_c_parity -run '^TestB16SwiftRecoveryTelemetryCOracle$' -count=1 -parallel 1 -timeout 5m -v"
+```
+
+Locked-C artifact: `harness_out/docker/20260811T233549Z-b16-swift-selected-retry-cgo`
+
+Both runs passed without an out-of-memory kill or a wall timeout.

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -1589,7 +1589,10 @@ func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree,
 }
 
 func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tree *Tree, origin fullParseRetryOrigin, runRetry fullParseRetryRunner) *Tree {
+	p.recordRecoveryRuntimeRetryTree(tree, "initial")
 	if certifiedAcceptedErrorRetrySkipsFresh(tree, len(source), origin) {
+		p.finishRecoveryRuntimeRetryTelemetry(tree, len(source))
+		p.clearRecoveryRuntimeRetryTrees()
 		return tree
 	}
 	maxStacksOverride := fullParseRetryMaxStacksOverrideForOrigin(tree, len(source), initialMaxStacks, origin)
@@ -1691,6 +1694,7 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 				release(*best)
 			}
 			*best = candidate
+			p.recordRecoveryRuntimeSelectedTree(candidate)
 			return
 		}
 		release(candidate)
@@ -1711,6 +1715,8 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 	// normal result compatibility; avoid paying the full retry ladder first.
 	if certifiedGSSConvergenceAcceptedErrorMergePerKey(tree, len(source)) == 0 &&
 		csharpAcceptedErrorTreeCanUseNamespaceRecovery(tree, source) {
+		p.finishRecoveryRuntimeRetryTelemetry(tree, len(source))
+		p.clearRecoveryRuntimeRetryTrees()
 		return tree
 	}
 	runRetryAttempt := func(logicalRung, operationCause string, maxStacks int, maxMergePerKeyOverride int, maxNodes int) *Tree {
@@ -1750,10 +1756,16 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 			fmt.Fprintf(os.Stderr, "RETRYDBG pass maxStacks=%d mergePerKey=%d maxNodes=%d took=%v stop=%v hasErr=%v forceClean=%v\n",
 				maxStacks, maxMergePerKeyOverride, maxNodes, time.Since(t0), stop, hasErr, p != nil && p.forceCleanRetryPass)
 		}
+		p.recordRecoveryRuntimeRetryTree(result, logicalRung)
 		return result
 	}
 
 	bestTree := tree
+	defer func() {
+		p.finishRecoveryRuntimeRetryTelemetry(bestTree, len(source))
+		p.clearRecoveryRuntimeRetryTrees()
+	}()
+	p.recordRecoveryRuntimeSelectedTree(bestTree)
 	if shouldRunInitialFullParseMergeRetry(tree, len(source), origin) {
 		if initialMergePerKey := fullParseRetryMergePerKeyOverride(tree, len(source), initialMaxStacks); initialMergePerKey != 0 {
 			mergeRetryTree := runRetryAttempt(
@@ -1877,6 +1889,7 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 						release(bestTree)
 					}
 					bestTree = retryTree
+					p.recordRecoveryRuntimeSelectedTree(bestTree)
 				} else if retryTree != bestTree {
 					release(retryTree)
 				}
@@ -1893,6 +1906,7 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 					release(bestTree)
 				}
 				bestTree = retryTree
+				p.recordRecoveryRuntimeSelectedTree(bestTree)
 			}
 		}
 	}

--- a/recovery_runtime_telemetry.go
+++ b/recovery_runtime_telemetry.go
@@ -7,8 +7,10 @@ import "time"
 var recoveryRuntimeTelemetryEnabled bool
 
 type recoveryRuntimeTelemetry struct {
-	stats              RecoveryRuntimeStats
-	pendingRetryReason string
+	stats                RecoveryRuntimeStats
+	pendingRetryReason   string
+	retryAttemptRungs    map[*Tree]string
+	selectedRetryAttempt string
 }
 
 // EnableRecoveryRuntimeTelemetry enables diagnostic recovery counters.
@@ -34,14 +36,20 @@ func (p *Parser) beginRecoveryRuntimeTelemetry() {
 	}
 	cold := p.ensureParserColdState()
 	state := &cold.recoveryRuntime
+	if p.fullParseRetryPassesTaken == 0 {
+		state.retryAttemptRungs = nil
+		state.selectedRetryAttempt = "initial"
+	}
 	retryReason := state.pendingRetryReason
 	if p.fullParseRetryPassesTaken == 0 {
 		retryReason = ""
 	}
 	state.stats = RecoveryRuntimeStats{
-		Enabled:        true,
-		RetryPassCount: uint64(p.fullParseRetryPassesTaken),
-		RetryReason:    retryReason,
+		Enabled:              true,
+		RetryPassCount:       uint64(p.fullParseRetryPassesTaken),
+		RetryReason:          retryReason,
+		RetryAttemptCount:    uint64(p.fullParseRetryPassesTaken),
+		RetrySelectedAttempt: state.selectedRetryAttempt,
 	}
 	state.pendingRetryReason = ""
 }
@@ -108,8 +116,65 @@ func (p *Parser) finishRecoveryRuntimeTelemetry(tree *Tree, stacks []glrStack) {
 		return
 	}
 	state.stats.Completed = true
+	state.stats.RetryAttemptCount = uint64(p.fullParseRetryPassesTaken)
+	state.stats.RetrySelectedAttempt = state.selectedRetryAttempt
 	p.recordRecoveryLiveVersions(stacks)
 	state.stats.ErrorNodeCount, state.stats.ErrorSpanBytes = recoveryRuntimeErrorStats(rawRootOrNil(tree))
+}
+
+func (p *Parser) recordRecoveryRuntimeRetryTree(tree *Tree, rung string) {
+	if p == nil || tree == nil || rung == "" || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	state := p.recoveryRuntimeTelemetryState()
+	if state == nil {
+		return
+	}
+	if state.retryAttemptRungs == nil {
+		state.retryAttemptRungs = make(map[*Tree]string)
+	}
+	state.retryAttemptRungs[tree] = rung
+}
+
+func (p *Parser) recordRecoveryRuntimeSelectedTree(tree *Tree) {
+	if p == nil || tree == nil || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	state := p.recoveryRuntimeTelemetryState()
+	if state == nil || state.retryAttemptRungs == nil {
+		return
+	}
+	if rung := state.retryAttemptRungs[tree]; rung != "" {
+		state.selectedRetryAttempt = rung
+		state.stats.RetrySelectedAttempt = rung
+	}
+}
+
+func (p *Parser) finishRecoveryRuntimeRetryTelemetry(tree *Tree, sourceLen int) {
+	if p == nil || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	state := p.recoveryRuntimeTelemetryState()
+	if state == nil {
+		return
+	}
+	state.stats.RetryAttemptCount = uint64(p.fullParseRetryPassesTaken)
+	state.stats.RetrySelectedAttempt = state.selectedRetryAttempt
+	root := rawRootOrNil(tree)
+	if root == nil {
+		return
+	}
+	state.stats.RetrySelectedAttemptHasError = root.HasError()
+	state.stats.RetrySelectedAttemptFullSpan = root.StartByte() == 0 && root.EndByte() == uint32(sourceLen)
+}
+
+func (p *Parser) clearRecoveryRuntimeRetryTrees() {
+	if p == nil || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	if state := p.recoveryRuntimeTelemetryState(); state != nil {
+		state.retryAttemptRungs = nil
+	}
 }
 
 func recoveryRuntimeErrorStats(root *Node) (count uint64, span uint32) {

--- a/tree.go
+++ b/tree.go
@@ -832,6 +832,10 @@ type RecoveryRuntimeStats struct {
 	ErrorSpanBytes               uint32
 	RetryPassCount               uint64
 	RetryReason                  string
+	RetryAttemptCount            uint64
+	RetrySelectedAttempt         string
+	RetrySelectedAttemptHasError bool
+	RetrySelectedAttemptFullSpan bool
 	ErrorModeTokenCount          uint64
 	ScannerResyncCount           uint64
 	LiveVersionCount             uint64


### PR DESCRIPTION
## Summary

Add opt-in telemetry that records the retry rung that supplies the selected tree.

- Record retry candidates without changing parser routing.
- Expose retry count, selected rung, error status, and full-span status.
- Extend the Swift #586 and #576 witnesses and locked-C receipt.
- Document the first result: #586 consumed four retry passes, but `initial_merge` supplied the selected tree.

## Validation

- Focused Go telemetry and layout tests passed in Docker.
- Swift Go witness passed in Docker.
- Locked-C Swift witness passed in Docker.
- No performance credit is claimed.