### PR TITLE
update(grammars, parity-tests): Update tags-query inference and add C-oracle outline tests

### DIFF
--- a/cgo_harness/outline_differential_test.go
+++ b/cgo_harness/outline_differential_test.go
@@ -1,0 +1,695 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+// Outline C-oracle differential (spec.outline-api.v1, gate G-2).
+//
+// The cgo harness already binds the official C tree-sitter runtime and its
+// query engine (parity_query_exact_test.go:14, :215). The outline projection
+// (outline.go, package gotreesitter) is built entirely from tags-query
+// captures: resolve the query through grammars.ResolveTagsQuery, run it, and
+// feed the resulting candidates through one fixed stage C-F builder
+// (collectOutlineCandidates -> filterOutlineCandidates -> buildOutlineForest
+// in outline.go) regardless of which engine produced the captures. So
+// running the SAME resolved tags query through BOTH query engines over the
+// SAME parsed source and diffing the capture streams exactly -- pattern
+// index, capture name, node type, start byte, end byte, capture text -- is a
+// direct fleet probe of outline correctness: exact capture parity implies
+// exact outline parity, because the builder that turns captures into an
+// outline forest is shared and reads nothing else. This file never
+// reconstructs the outline forest on the C side; capture-stream equality is
+// the whole gate, per that argument.
+//
+// Gating tiers:
+//
+//   - CoreNine: the nine languages grammars/registry_test.go:280-291 proves
+//     have a compilable tags query (go, python, javascript, typescript, tsx,
+//     rust, java, c, cpp). HARD-asserted: a capture-stream divergence, a
+//     query compile failure against the locked C grammar, or an
+//     unexpectedly empty tags query fails the test. No language in this
+//     tier is ever special-cased or skipped for a real divergence.
+//
+//   - FleetCensus: every OTHER registered language with a resolvable tags
+//     query. LOG-ONLY -- nothing in this half of the file calls t.Error or
+//     t.Fatal for a divergence. Breadth is controlled by GTS_PARITY_MODE
+//     exactly like the rest of the harness (parityMode, parity_cgo_test.go
+//     :192-204): a small representative set by default, the top-50
+//     correctness lock set for GTS_PARITY_MODE=top50, and the full
+//     206-language registry for GTS_PARITY_MODE=exhaustive. The run ends
+//     with one printed census table: the ratchet baseline for a later
+//     stage (spec G-3), not a gate itself.
+//
+// Two outcomes are explicitly NOT divergence and NOT parity (spec.outline
+// -api.v1 section 6, honest limits (a) and (b)): a language with no
+// resolvable tags query is "vacuous" (nothing ran), and a resolved query
+// that fails to compile against one engine's grammar is
+// "query_incompatible" (an inferred query is generated from the Go
+// grammar's symbol table and is not guaranteed to compile against the
+// pinned C grammar). Both get their own census bucket so vacuity or a
+// compile gap can never masquerade as parity.
+//
+// Run:
+//
+//	go test . -tags treesitter_c_parity -run '^TestOutlineOracleDifferential$' -count=1 -v
+//	GTS_PARITY_MODE=top50 go test . -tags treesitter_c_parity -run '^TestOutlineOracleDifferential$' -count=1 -v -timeout 60m
+//	GTS_PARITY_MODE=exhaustive go test . -tags treesitter_c_parity -run '^TestOutlineOracleDifferential$' -count=1 -v -timeout 60m
+//
+// Outside the docker harness (cgo_harness/docker/run_parity_in_docker.sh),
+// set GTS_PARITY_ALLOW_HOST=1 for a focused local run; see
+// testmain_cgo_test.go for the host-execution gate this file inherits from
+// the rest of the package.
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// outlineDifferentialCoreLanguages is the exact core-nine list
+// grammars.TestCoreLanguagesHaveCompilableTagsQuery pins (registry_test.go
+// :280-291). Keep this byte-for-byte identical to that test's "core" slice;
+// the two lists describe the same fleet floor from two different gates.
+var outlineDifferentialCoreLanguages = []string{
+	"go",
+	"python",
+	"javascript",
+	"typescript",
+	"tsx",
+	"rust",
+	"java",
+	"c",
+	"cpp",
+}
+
+var outlineDifferentialCoreSet = func() map[string]bool {
+	out := make(map[string]bool, len(outlineDifferentialCoreLanguages))
+	for _, name := range outlineDifferentialCoreLanguages {
+		out[name] = true
+	}
+	return out
+}()
+
+// outlineDiffStatus classifies one language's differential outcome for the
+// census table.
+type outlineDiffStatus string
+
+const (
+	// outlineDiffEqual: the two capture streams are identical in every
+	// compared field.
+	outlineDiffEqual outlineDiffStatus = "equal"
+	// outlineDiffDiverged: both engines produced a tree and ran the query;
+	// the capture streams differ. A real finding -- never special-cased.
+	outlineDiffDiverged outlineDiffStatus = "diverged"
+	// outlineDiffVacuous: the language has no resolvable tags query, so
+	// neither engine ran a query. Nothing to compare; not parity.
+	outlineDiffVacuous outlineDiffStatus = "vacuous"
+	// outlineDiffQueryIncompatible: the resolved tags query -- the same
+	// string on both sides -- failed to compile against one engine's
+	// grammar. Not a capture-level divergence and not parity.
+	outlineDiffQueryIncompatible outlineDiffStatus = "query_incompatible"
+	// outlineDiffSkipped: the comparison could not run for a reason
+	// unrelated to query or outline correctness (no C reference for this
+	// language/ABI, unsupported Go parse backend, operator exclusion).
+	outlineDiffSkipped outlineDiffStatus = "skipped"
+)
+
+// outlineDiffResult is one language's differential outcome.
+type outlineDiffResult struct {
+	language      string
+	fixtureSource string // "smoke_sample" or "corpus_sources"
+	fixtureBytes  int
+	goMatches     int
+	cMatches      int
+	goCaptures    int
+	cCaptures     int
+	mismatches    int // count of differing (match, capture) positions
+	status        outlineDiffStatus
+	skipEligible  bool // true only for infra reasons the hard tier may also skip on
+	detail        string
+	firstDiff     string
+	outlineReport string // sanity-only Outliner receipt; never gates
+}
+
+func TestOutlineOracleDifferential(t *testing.T) {
+	t.Run("CoreNine", testOutlineDifferentialCoreNine)
+	t.Run("FleetCensus", testOutlineDifferentialFleetCensus)
+}
+
+// testOutlineDifferentialCoreNine HARD-asserts capture-stream parity for the
+// core nine languages. See the file comment for exactly what counts as a
+// pass; every failure path reports language, fixture, and (for a real
+// divergence) the first differing capture on both sides.
+func testOutlineDifferentialCoreNine(t *testing.T) {
+	for _, name := range outlineDifferentialCoreLanguages {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			scheduleParityMemoryScavenge(t)
+			entry, ok := parityEntriesByName[name]
+			if !ok {
+				t.Fatalf("core outline language %q is not registered in grammars.AllLanguages", name)
+			}
+			result := runOutlineDifferentialLanguage(entry)
+			logOutlineDifferentialResult(t, result)
+
+			switch result.status {
+			case outlineDiffEqual:
+				return
+			case outlineDiffSkipped:
+				if result.skipEligible {
+					t.Skipf("%s: %s", name, result.detail)
+					return
+				}
+				t.Fatalf("core outline language %q could not be compared: %s", name, result.detail)
+			case outlineDiffVacuous:
+				t.Fatalf("core outline language %q resolved an empty tags query; "+
+					"grammars/registry_test.go:280-291 guarantees a compilable core-nine query", name)
+			case outlineDiffQueryIncompatible:
+				t.Fatalf("core outline language %q: the tags query that compiles against the Go grammar "+
+					"failed to compile against the locked C grammar: %s", name, result.detail)
+			case outlineDiffDiverged:
+				t.Fatalf("core outline language %q: C-oracle capture-stream divergence "+
+					"(%d mismatched position(s); go_matches=%d/go_captures=%d c_matches=%d/c_captures=%d, fixture=%s %dB)\n"+
+					"first mismatch: %s",
+					name, result.mismatches, result.goMatches, result.goCaptures, result.cMatches, result.cCaptures,
+					result.fixtureSource, result.fixtureBytes, result.firstDiff)
+			}
+		})
+	}
+}
+
+// testOutlineDifferentialFleetCensus runs the SAME differential, LOG-ONLY,
+// over every registered language outside the core nine that has a
+// resolvable tags query. Breadth follows GTS_PARITY_MODE exactly like the
+// rest of the harness: smoke by default, top50, or exhaustive for the full
+// registry. Nothing in this subtest calls t.Error or t.Fatal for a
+// divergence; the printed census table is the ratchet baseline for a later
+// stage, not a gate.
+func testOutlineDifferentialFleetCensus(t *testing.T) {
+	scheduleParityMemoryScavenge(t)
+
+	entries := grammars.AllLanguages()
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if outlineDifferentialCoreSet[entry.Name] {
+			continue
+		}
+		if !outlineDifferentialFleetIncluded(entry.Name) {
+			continue
+		}
+		names = append(names, entry.Name)
+	}
+	sort.Strings(names)
+
+	if len(names) == 0 {
+		t.Skip("no non-core languages selected for the outline fleet census at this GTS_PARITY_MODE")
+	}
+
+	rows := make([]outlineDiffResult, 0, len(names))
+	for _, name := range names {
+		name := name
+		entry, ok := parityEntriesByName[name]
+		if !ok {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			result := runOutlineDifferentialLanguage(entry)
+			rows = append(rows, result)
+			logOutlineDifferentialResult(t, result)
+			// LOG-ONLY by design: no t.Error, no t.Fatal, for any status
+			// including "diverged". See the file comment.
+		})
+	}
+
+	t.Log(formatOutlineDifferentialCensusTable(rows))
+}
+
+// outlineDifferentialFleetIncluded controls fleet-census breadth. It mirrors
+// parityIncludeStructuralLanguage (parity_cgo_test.go:231-242): smoke mode
+// runs the harness's small representative set, top50 mode runs the top-50
+// correctness lock set, and exhaustive mode runs the full registry -- the
+// true fleet differential the spec describes. An operator exclusion
+// (GTS_PARITY_SKIP_LANGS) still gets a census row so the skip stays visible
+// instead of silently shrinking the table.
+func outlineDifferentialFleetIncluded(name string) bool {
+	if parityLanguageExcluded(name) {
+		return true
+	}
+	if parityRunExhaustive() {
+		return true
+	}
+	if parityMode() == "top50" {
+		return top50ParityLanguageSet[name]
+	}
+	return smokeParityLanguages[name]
+}
+
+// runOutlineDifferentialLanguage runs the differential for one language. It
+// never touches *testing.T: callers decide whether a non-equal status fails
+// the build (CoreNine) or is only logged (FleetCensus).
+func runOutlineDifferentialLanguage(entry grammars.LangEntry) outlineDiffResult {
+	result := outlineDiffResult{language: entry.Name}
+
+	if parityLanguageExcluded(entry.Name) {
+		result.status = outlineDiffSkipped
+		result.skipEligible = true
+		result.detail = "excluded via GTS_PARITY_SKIP_LANGS"
+		return result
+	}
+
+	tagsQuery := grammars.ResolveTagsQuery(entry)
+	if strings.TrimSpace(tagsQuery) == "" {
+		result.status = outlineDiffVacuous
+		result.detail = "no resolvable tags query"
+		return result
+	}
+
+	support, ok := paritySupportForName(entry.Name)
+	if !ok || support.Backend == grammars.ParseBackendUnsupported {
+		reason := "no parse support report"
+		if ok {
+			reason = support.Reason
+		}
+		result.status = outlineDiffSkipped
+		result.detail = "go parse unsupported: " + reason
+		return result
+	}
+
+	source, provenance := outlineDifferentialFixture(entry)
+	src := []byte(source)
+	result.fixtureSource = provenance
+	result.fixtureBytes = len(src)
+
+	goTree, goLang, err := parseWithGo(parityCase{name: entry.Name, source: source}, src, nil)
+	if err != nil {
+		result.status = outlineDiffSkipped
+		result.detail = "go parse error: " + err.Error()
+		return result
+	}
+	defer releaseGoTree(goTree)
+
+	// Sanity aside, non-gating: run the Go core Outliner over the SAME tree
+	// and record its receipt. This runs whenever the Go parse succeeds,
+	// independent of whether the C-oracle comparison below can run at all.
+	result.outlineReport = outlineDifferentialSanityReport(goLang, tagsQuery, goTree)
+
+	cLang, err := ParityCLanguage(entry.Name)
+	if err != nil {
+		if reason := parityReferenceSkipReason(err); reason != "" {
+			result.status = outlineDiffSkipped
+			result.skipEligible = true
+			result.detail = "no C reference parser: " + reason
+			return result
+		}
+		result.status = outlineDiffSkipped
+		result.detail = "load C parser: " + err.Error()
+		return result
+	}
+
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		if reason := parityReferenceSkipReason(err); reason != "" {
+			result.status = outlineDiffSkipped
+			result.skipEligible = true
+			result.detail = "C SetLanguage: " + reason
+			return result
+		}
+		result.status = outlineDiffSkipped
+		result.detail = "C SetLanguage: " + err.Error()
+		return result
+	}
+	cTree := cParser.Parse(src, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		result.status = outlineDiffSkipped
+		result.detail = "C parser returned no tree"
+		return result
+	}
+	defer cTree.Close()
+
+	goQuery, err := gotreesitter.NewQuery(tagsQuery, goLang)
+	if err != nil {
+		result.status = outlineDiffQueryIncompatible
+		result.detail = "Go NewQuery: " + err.Error()
+		return result
+	}
+
+	// sitter.NewQuery returns a concrete *QueryError, not the error
+	// interface (query.go:199 in the go-tree-sitter module). Give it its
+	// own variable: reusing "err" here would let := re-declare only cQuery
+	// while boxing a (possibly nil) *QueryError into the pre-existing
+	// error-typed "err" variable, which is never a nil interface even when
+	// the underlying pointer is nil -- a classic Go footgun that would make
+	// every successful C compile look like a query_incompatible failure.
+	cQuery, cQueryErr := sitter.NewQuery(cLang, tagsQuery)
+	if cQueryErr != nil {
+		result.status = outlineDiffQueryIncompatible
+		result.detail = "C NewQuery: " + cQueryErr.Error()
+		return result
+	}
+	defer cQuery.Close()
+
+	goMatches := outlineDiffGoQueryMatches(goLang, goTree, goQuery, src)
+	cMatches := outlineDiffCQueryMatches(cQuery, cTree, src)
+
+	result.goMatches = len(goMatches)
+	result.cMatches = len(cMatches)
+	result.goCaptures = outlineDiffCaptureTotal(goMatches)
+	result.cCaptures = outlineDiffCaptureTotal(cMatches)
+
+	if reflect.DeepEqual(goMatches, cMatches) {
+		result.status = outlineDiffEqual
+		return result
+	}
+
+	result.status = outlineDiffDiverged
+	result.mismatches = outlineDiffMismatchCount(goMatches, cMatches)
+	result.firstDiff = outlineDiffFirstMismatch(goMatches, cMatches)
+	return result
+}
+
+// outlineDiffGoQueryMatches runs a compiled Go query over a Go tree and
+// reduces it to the same neutral shape assertExactQueryParity compares
+// (collectGoExactQueryMatches, parity_query_exact_test.go:504-536), minus
+// the *testing.T dependency: this differential decides per-tier how a
+// compile or run failure is reported, so the collector itself never fails a
+// test.
+func outlineDiffGoQueryMatches(lang *gotreesitter.Language, tree *gotreesitter.Tree, q *gotreesitter.Query, source []byte) []exactQueryMatch {
+	cursor := q.Exec(tree.RootNode(), lang, source)
+	var matches []exactQueryMatch
+	for {
+		m, ok := cursor.NextMatch()
+		if !ok {
+			break
+		}
+		snap := exactQueryMatch{PatternIndex: m.PatternIndex}
+		for _, c := range m.Captures {
+			if c.Node == nil {
+				continue
+			}
+			snap.Captures = append(snap.Captures, exactQueryCapture{
+				Name:      c.Name,
+				Type:      c.Node.Type(lang),
+				Named:     c.Node.IsNamed(),
+				StartByte: c.Node.StartByte(),
+				EndByte:   c.Node.EndByte(),
+				Text:      c.Text(source),
+			})
+		}
+		matches = append(matches, snap)
+	}
+	return matches
+}
+
+// outlineDiffCQueryMatches is the C-side counterpart of
+// outlineDiffGoQueryMatches; see collectCExactQueryMatches
+// (parity_query_exact_test.go:538-579) for the pattern this mirrors.
+func outlineDiffCQueryMatches(q *sitter.Query, tree *sitter.Tree, source []byte) []exactQueryMatch {
+	cursor := sitter.NewQueryCursor()
+	defer cursor.Close()
+
+	names := q.CaptureNames()
+	iter := cursor.Matches(q, tree.RootNode(), source)
+
+	var matches []exactQueryMatch
+	for {
+		m := iter.Next()
+		if m == nil {
+			break
+		}
+		snap := exactQueryMatch{PatternIndex: int(m.PatternIndex)}
+		for _, c := range m.Captures {
+			name := ""
+			if int(c.Index) < len(names) {
+				name = names[c.Index]
+			}
+			start := uint32(c.Node.StartByte())
+			end := uint32(c.Node.EndByte())
+			snap.Captures = append(snap.Captures, exactQueryCapture{
+				Name:      name,
+				Type:      c.Node.Kind(),
+				Named:     c.Node.IsNamed(),
+				StartByte: start,
+				EndByte:   end,
+				Text:      string(source[start:end]),
+			})
+		}
+		matches = append(matches, snap)
+	}
+	return matches
+}
+
+func outlineDiffCaptureTotal(matches []exactQueryMatch) int {
+	total := 0
+	for _, m := range matches {
+		total += len(m.Captures)
+	}
+	return total
+}
+
+// outlineDiffMismatchCount counts capture-stream positions where the two
+// sequences disagree: a missing/extra match, a pattern-index disagreement,
+// or a missing/extra/differing capture within an otherwise-aligned match.
+// It is a magnitude indicator for the census table, not a formal edit
+// distance.
+func outlineDiffMismatchCount(goMatches, cMatches []exactQueryMatch) int {
+	n := len(goMatches)
+	if len(cMatches) > n {
+		n = len(cMatches)
+	}
+	count := 0
+	for i := 0; i < n; i++ {
+		if i >= len(goMatches) || i >= len(cMatches) {
+			count++
+			continue
+		}
+		g, c := goMatches[i], cMatches[i]
+		if g.PatternIndex != c.PatternIndex {
+			count++
+		}
+		capN := len(g.Captures)
+		if len(c.Captures) > capN {
+			capN = len(c.Captures)
+		}
+		for j := 0; j < capN; j++ {
+			if j >= len(g.Captures) || j >= len(c.Captures) {
+				count++
+				continue
+			}
+			if g.Captures[j] != c.Captures[j] {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+// outlineDiffFirstMismatch returns a precise, human-readable description of
+// the first position where the two capture streams disagree, with both
+// sides' values. Empty when the streams are identical (never called in that
+// case, since it is only invoked after reflect.DeepEqual reports false).
+func outlineDiffFirstMismatch(goMatches, cMatches []exactQueryMatch) string {
+	n := len(goMatches)
+	if len(cMatches) > n {
+		n = len(cMatches)
+	}
+	for i := 0; i < n; i++ {
+		if i >= len(goMatches) {
+			return fmt.Sprintf("match[%d]: absent on Go side; C has pattern=%d captures=%d",
+				i, cMatches[i].PatternIndex, len(cMatches[i].Captures))
+		}
+		if i >= len(cMatches) {
+			return fmt.Sprintf("match[%d]: absent on C side; Go has pattern=%d captures=%d",
+				i, goMatches[i].PatternIndex, len(goMatches[i].Captures))
+		}
+		g, c := goMatches[i], cMatches[i]
+		if g.PatternIndex != c.PatternIndex {
+			return fmt.Sprintf("match[%d]: pattern index Go=%d C=%d", i, g.PatternIndex, c.PatternIndex)
+		}
+		capN := len(g.Captures)
+		if len(c.Captures) > capN {
+			capN = len(c.Captures)
+		}
+		for j := 0; j < capN; j++ {
+			if j >= len(g.Captures) {
+				return fmt.Sprintf("match[%d] capture[%d]: absent on Go side; C=%s", i, j, formatOutlineDiffCapture(c.Captures[j]))
+			}
+			if j >= len(c.Captures) {
+				return fmt.Sprintf("match[%d] capture[%d]: absent on C side; Go=%s", i, j, formatOutlineDiffCapture(g.Captures[j]))
+			}
+			if gc, cc := g.Captures[j], c.Captures[j]; gc != cc {
+				return fmt.Sprintf("match[%d] capture[%d]: Go=%s C=%s", i, j, formatOutlineDiffCapture(gc), formatOutlineDiffCapture(cc))
+			}
+		}
+	}
+	return ""
+}
+
+func formatOutlineDiffCapture(c exactQueryCapture) string {
+	return fmt.Sprintf("{name:%s type:%s named:%v start:%d end:%d text:%q}",
+		c.Name, c.Type, c.Named, c.StartByte, c.EndByte, c.Text)
+}
+
+// outlineDifferentialMaxFixtureBytes caps the opportunistic real-corpus
+// fixture so the differential's per-file cost stays modest even at
+// exhaustive breadth.
+const outlineDifferentialMaxFixtureBytes = 48 * 1024
+
+// outlineDifferentialFixture picks one fixture for a language, following the
+// harness's existing corpus-then-smoke-sample convention (compare
+// realCorpusBenchmarkRoot, benchmark_real_corpus_parity_test.go:337-357):
+// prefer a small file from a real corpus_sources/<name> checkout when one is
+// present, and fall back to the language's dedicated smoke sample
+// (grammars.ParseSmokeSample) -- the same fixture parityCases already uses
+// for every registered language (parity_cgo_test.go:75-84). corpus_sources
+// is a set of git submodules that are not always checked out; the fallback
+// keeps this differential runnable with zero external state.
+func outlineDifferentialFixture(entry grammars.LangEntry) (source, provenance string) {
+	if src, ok := outlineDifferentialCorpusFixture(entry); ok {
+		return src, "corpus_sources"
+	}
+	return grammars.ParseSmokeSample(entry.Name), "smoke_sample"
+}
+
+func outlineDifferentialCorpusRoot() string {
+	for _, candidate := range []string{
+		"corpus_sources",
+		filepath.Join("cgo_harness", "corpus_sources"),
+		filepath.Join("..", "cgo_harness", "corpus_sources"),
+	} {
+		if st, err := os.Stat(candidate); err == nil && st.IsDir() {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// outlineDifferentialCorpusFixture returns the first modestly-sized file
+// under corpus_sources/<name> matching the language's registered extensions,
+// in lexical walk order (deterministic). It is a best-effort lookup: any
+// absence (no corpus root, no per-language subdir, no matching file) simply
+// returns false so the caller falls back to the smoke sample.
+func outlineDifferentialCorpusFixture(entry grammars.LangEntry) (string, bool) {
+	root := outlineDifferentialCorpusRoot()
+	if root == "" {
+		return "", false
+	}
+	dir := filepath.Join(root, entry.Name)
+	if st, err := os.Stat(dir); err != nil || !st.IsDir() {
+		return "", false
+	}
+
+	exts := make(map[string]bool, len(entry.Extensions))
+	for _, ext := range entry.Extensions {
+		exts[strings.ToLower(ext)] = true
+	}
+
+	var chosen string
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if len(exts) > 0 && !exts[strings.ToLower(filepath.Ext(path))] {
+			return nil
+		}
+		info, statErr := d.Info()
+		if statErr != nil || info.Size() == 0 || info.Size() > outlineDifferentialMaxFixtureBytes {
+			return nil
+		}
+		chosen = path
+		return filepath.SkipAll
+	})
+	if chosen == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(chosen)
+	if err != nil || len(data) == 0 {
+		return "", false
+	}
+	return string(data), true
+}
+
+// outlineDifferentialSanityReport runs the Go core Outliner over the Go tree
+// and formats its OutlineReport. Diagnostic only -- see the file comment --
+// and never influences outlineDiffResult.status.
+func outlineDifferentialSanityReport(lang *gotreesitter.Language, tagsQuery string, tree *gotreesitter.Tree) string {
+	outliner, err := gotreesitter.NewOutliner(lang, tagsQuery)
+	if err != nil {
+		return fmt.Sprintf("NewOutliner error: %v", err)
+	}
+	symbols, report := outliner.OutlineTree(tree)
+	return fmt.Sprintf(
+		"symbols=%d omitted=%d(no_name=%d dup=%d name_conflict=%d conflict=%d overlap=%d bad_name_range=%d multi_def=%d) "+
+			"owner_rule_misses=%d decline=%q truncated=%v tree_has_error=%v",
+		len(symbols), report.Omitted(), report.OmittedNoName, report.OmittedDuplicate, report.OmittedNameConflict,
+		report.OmittedConflict, report.OmittedOverlap, report.OmittedInvalidNameRange, report.OmittedMultipleDefinitions,
+		report.OwnerRuleMisses, report.DeclineReason, report.Truncated, report.TreeHasError,
+	)
+}
+
+func logOutlineDifferentialResult(t *testing.T, r outlineDiffResult) {
+	t.Helper()
+	t.Logf("outline differential %-14s status=%-18s fixture=%s(%dB) go_matches=%d c_matches=%d go_captures=%d c_captures=%d mismatches=%d",
+		r.language, r.status, r.fixtureSource, r.fixtureBytes, r.goMatches, r.cMatches, r.goCaptures, r.cCaptures, r.mismatches)
+	if r.detail != "" {
+		t.Logf("  detail: %s", r.detail)
+	}
+	if r.firstDiff != "" {
+		t.Logf("  first mismatch: %s", r.firstDiff)
+	}
+	if r.outlineReport != "" {
+		t.Logf("  outline report (sanity, non-gating): %s", r.outlineReport)
+	}
+}
+
+// formatOutlineDifferentialCensusTable renders the fleet census's one
+// summary table: the ratchet baseline for a later stage (spec.outline-api.v1
+// gate G-3). Log-only: printing this table is the entire contract here, it
+// never drives a pass/fail decision.
+func formatOutlineDifferentialCensusTable(rows []outlineDiffResult) string {
+	counts := make(map[outlineDiffStatus]int, 8)
+	for _, r := range rows {
+		counts[r.status]++
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "\nOutline C-oracle differential fleet census (log-only, mode=%s, languages=%d)\n", parityMode(), len(rows))
+	fmt.Fprintf(&b, "%-16s %-18s %9s %9s %9s %10s  %s\n", "language", "status", "go_match", "c_match", "mismatch", "fixture_B", "detail")
+	for _, r := range rows {
+		fmt.Fprintf(&b, "%-16s %-18s %9d %9d %9d %10d  %s\n",
+			r.language, r.status, r.goMatches, r.cMatches, r.mismatches, r.fixtureBytes, outlineDiffTableDetail(r.detail, 64))
+	}
+	fmt.Fprintf(&b, "\nsummary: equal=%d diverged=%d vacuous=%d query_incompatible=%d skipped=%d total=%d\n",
+		counts[outlineDiffEqual], counts[outlineDiffDiverged], counts[outlineDiffVacuous],
+		counts[outlineDiffQueryIncompatible], counts[outlineDiffSkipped], len(rows))
+	return b.String()
+}
+
+func outlineDiffTruncate(s string, limit int) string {
+	if len(s) <= limit {
+		return s
+	}
+	if limit <= 3 {
+		return s[:limit]
+	}
+	return s[:limit-3] + "..."
+}
+
+// outlineDiffTableDetail flattens a (possibly multi-line) detail string --
+// for example a *QueryError message, which spells its own "Impossible
+// pattern:\n<snippet>\n<caret>" body -- to one space-joined line before
+// truncating it, so a census row never spills across the fixed-width table.
+// The full, unflattened detail still reaches the per-language log line (see
+// logOutlineDifferentialResult); only the table row is flattened.
+func outlineDiffTableDetail(detail string, limit int) string {
+	flat := strings.Join(strings.Fields(detail), " ")
+	return outlineDiffTruncate(flat, limit)
+}

--- a/grammars/outline_coverage_witness_test.go
+++ b/grammars/outline_coverage_witness_test.go
@@ -1,0 +1,322 @@
+package grammars
+
+import (
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// outlineWitnessCase pins one language's real coverage as DATA: a tiny
+// source snippet and one symbol -- exact name, exact kind -- that the
+// language's resolved tags query MUST produce through the real Outliner
+// pipeline (gotreesitter.NewOutliner + OutlineTree, the same mechanism
+// grammars.ExtractOutline is specified to delegate to). A pattern that only
+// "compiles" but never fires (the class of defect the C-oracle sweep found
+// in seven core-nine rows, spec.outline-api.v1 G-2) cannot pass this test:
+// an empty or wrong result fails loudly instead of hiding behind a
+// non-empty query string.
+//
+// Every case here is a language this change either moved out of query-empty
+// (T3/T4) or corrected from a vacuous/degraded shared-inference match
+// (non-empty query, zero or wrong captures) to a real one. The source
+// snippets and expected symbols were verified against this repository's
+// OWN compiled grammar blobs before being written here (Node.SExpr(lang)
+// plus an isolated single-pattern firing test), never against upstream
+// tree-sitter.
+type outlineWitnessCase struct {
+	Language string
+	Source   string
+	WantName string
+	WantKind string
+	// WantNodeType, when set, additionally pins the captured definition
+	// node's grammar type, catching a kind-normalization or refinement
+	// change that a name+kind check alone could miss.
+	WantNodeType string
+}
+
+var outlineWitnessCases = []outlineWitnessCase{
+	// --- moved out of query-empty (T3/T4 -> T1/T2) ---
+	{
+		Language: "php",
+		Source: "<?php\n" +
+			"class Person {\n" +
+			"    function greet() {\n" +
+			"        return \"hi\";\n" +
+			"    }\n" +
+			"}\n",
+		WantName: "greet", WantKind: "method",
+	},
+	{
+		Language: "erlang",
+		Source:   "-module(m).\n\nadd(A, B) ->\n    A + B.\n",
+		WantName: "add", WantKind: "function",
+	},
+	{
+		Language: "ocaml",
+		Source:   "let add a b = a + b\n",
+		WantName: "add", WantKind: "function",
+	},
+	{
+		Language: "bash",
+		Source:   "greet() {\n  echo \"hi\"\n}\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "fish",
+		Source:   "function greet\n    echo \"hi\"\nend\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "graphql",
+		Source:   "type Query {\n  hero: String\n}\n",
+		WantName: "Query", WantKind: "type",
+	},
+	{
+		Language: "hcl",
+		Source:   "resource \"aws_instance\" \"web\" {\n  ami = \"abc\"\n}\n",
+		WantName: "web", WantKind: "block",
+	},
+	{
+		Language: "cmake",
+		Source:   "function(greet name)\n  message(STATUS \"${name}\")\nendfunction()\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "powershell",
+		Source:   "function Greet {\n    param($Name)\n}\n",
+		WantName: "Greet", WantKind: "function",
+	},
+	{
+		Language: "sql",
+		Source:   "CREATE TABLE users (\n  id INT PRIMARY KEY\n);\n",
+		WantName: "users", WantKind: "type",
+	},
+	{
+		Language: "proto",
+		Source:   "syntax = \"proto3\";\n\nmessage Person {\n  string name = 1;\n}\n",
+		WantName: "Person", WantKind: "message",
+	},
+	{
+		Language: "clojure",
+		Source:   "(defn greet [name]\n  (str \"hi \" name))\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "commonlisp",
+		Source:   "(defun greet (name)\n  (format nil \"hi ~a\" name))\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "scheme",
+		Source:   "(define (greet name)\n  (string-append \"hi \" name))\n",
+		WantName: "greet", WantKind: "function",
+	},
+
+	// --- corrected from a vacuous or wrong shared-inference match ---
+	{
+		Language: "ruby",
+		Source:   "class Person\n  def greet\n    \"hi\"\n  end\nend\n",
+		WantName: "greet", WantKind: "method",
+	},
+	{
+		Language: "kotlin",
+		Source: "class Person {\n" +
+			"    fun greet(): String {\n" +
+			"        return \"hi\"\n" +
+			"    }\n" +
+			"}\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "swift",
+		Source: "class Person {\n" +
+			"    func greet() -> String {\n" +
+			"        return \"hi\"\n" +
+			"    }\n" +
+			"}\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "scala",
+		Source:   "class Person {\n  def greet(): String = \"hi\"\n}\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "dart",
+		Source: "class Person {\n" +
+			"  String greet() {\n" +
+			"    return \"hi\";\n" +
+			"  }\n" +
+			"}\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "zig",
+		Source:   "pub fn greet() void {\n    return;\n}\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "elixir",
+		Source: "defmodule Greeter do\n" +
+			"  def greet(name) do\n" +
+			"    name\n" +
+			"  end\n" +
+			"end\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "julia",
+		Source:   "function greet(name)\n    return name\nend\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "groovy",
+		Source:   "String greet() {\n    return \"hi\"\n}\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "solidity",
+		Source: "pragma solidity ^0.8.0;\n\n" +
+			"contract Greeter {\n" +
+			"    function greet() public pure returns (string memory) {\n" +
+			"        return \"hi\";\n" +
+			"    }\n" +
+			"}\n",
+		WantName: "Greeter", WantKind: "class",
+	},
+	{
+		Language: "nim",
+		Source:   "proc greet(name: string): string =\n  return name\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "crystal",
+		Source:   "class Person\n  def greet\n    \"hi\"\n  end\nend\n",
+		WantName: "greet", WantKind: "method",
+	},
+	{
+		Language: "d",
+		Source:   "string greet() {\n    return \"hi\";\n}\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "v",
+		Source:   "fn greet() string {\n\treturn 'hi'\n}\n",
+		WantName: "greet", WantKind: "function",
+	},
+	{
+		Language: "thrift",
+		Source:   "service Greeter {\n  string greet(1: string name);\n}\n",
+		WantName: "Greeter", WantKind: "service",
+	},
+	{
+		// Lua: the shared table's function_definition row was found dead
+		// (0 matches, C-side "Impossible pattern") via the cgo_harness
+		// FleetCensus C-oracle sweep, not this repository's own reasoning;
+		// see the "lua" entry comment in tags_query_infer.go.
+		Language: "lua",
+		Source:   "function obj.method(self)\n    return self\nend\n",
+		WantName: "method", WantKind: "method",
+	},
+}
+
+// TestOutlineCoverageWitnesses runs every outlineWitnessCase through the
+// real core Outliner (gotreesitter.NewOutliner, OutlineTree) and asserts
+// the named symbol is present, in exactly the reported kind, somewhere in
+// the resulting forest. It is the fail-closed complement to
+// TestOutlineTierCensus: the census proves a query is non-empty text, this
+// proves the query actually PRODUCES the definition it claims to.
+func TestOutlineCoverageWitnesses(t *testing.T) {
+	for _, tc := range outlineWitnessCases {
+		tc := tc
+		t.Run(tc.Language, func(t *testing.T) {
+			entry := DetectLanguageByName(tc.Language)
+			if entry == nil {
+				t.Fatalf("language %q is not registered", tc.Language)
+			}
+			if entry.Language == nil {
+				t.Fatalf("language %q has no loader", tc.Language)
+			}
+			lang := entry.Language()
+			if lang == nil {
+				t.Fatalf("language %q loader returned nil", tc.Language)
+			}
+
+			query := ResolveTagsQuery(*entry)
+			if strings.TrimSpace(query) == "" {
+				t.Fatalf("language %q resolved an empty tags query", tc.Language)
+			}
+
+			source := []byte(tc.Source)
+			support := EvaluateParseSupport(*entry, lang)
+			parser := gotreesitter.NewParser(lang)
+			var tree *gotreesitter.Tree
+			var err error
+			if support.Backend == ParseBackendTokenSource && entry.TokenSourceFactory != nil {
+				tree, err = parser.ParseWithTokenSource(source, entry.TokenSourceFactory(source, lang))
+			} else {
+				tree, err = parser.Parse(source)
+			}
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if tree == nil || tree.RootNode() == nil {
+				t.Fatal("parse produced a nil tree")
+			}
+
+			outliner, err := gotreesitter.NewOutliner(lang, query)
+			if err != nil {
+				t.Fatalf("build outliner: %v", err)
+			}
+
+			symbols, report := outliner.OutlineTree(tree)
+			got, gotType, found := findOutlineWitness(symbols, tc.WantName, tc.WantKind)
+			if !found {
+				t.Fatalf("%s: expected a %q symbol named %q, not found in forest %s\nreport=%+v",
+					tc.Language, tc.WantKind, tc.WantName, describeOutlineSymbols(symbols), report)
+			}
+			if tc.WantNodeType != "" && gotType != tc.WantNodeType {
+				t.Errorf("%s: symbol %q kind %q has NodeType %q, want %q", tc.Language, tc.WantName, tc.WantKind, gotType, tc.WantNodeType)
+			}
+			_ = got
+		})
+	}
+}
+
+// findOutlineWitness searches the whole forest, nested symbols included,
+// for a symbol with the exact name and kind. It returns the matched
+// symbol's NodeType alongside the found flag.
+func findOutlineWitness(symbols []gotreesitter.OutlineSymbol, name, kind string) (gotreesitter.OutlineSymbol, string, bool) {
+	for _, sym := range symbols {
+		if sym.Name == name && sym.Kind == kind {
+			return sym, sym.NodeType, true
+		}
+		if found, nodeType, ok := findOutlineWitness(sym.Children, name, kind); ok {
+			return found, nodeType, true
+		}
+	}
+	return gotreesitter.OutlineSymbol{}, "", false
+}
+
+// describeOutlineSymbols renders a compact "kind:name" forest for a test
+// failure message.
+func describeOutlineSymbols(symbols []gotreesitter.OutlineSymbol) string {
+	var b strings.Builder
+	var walk func([]gotreesitter.OutlineSymbol, int)
+	walk = func(list []gotreesitter.OutlineSymbol, depth int) {
+		for _, sym := range list {
+			b.WriteString(strings.Repeat("  ", depth))
+			b.WriteString(sym.Kind)
+			b.WriteString(":")
+			b.WriteString(sym.Name)
+			b.WriteString("\n")
+			walk(sym.Children, depth+1)
+		}
+	}
+	walk(symbols, 0)
+	if b.Len() == 0 {
+		return "(empty)"
+	}
+	return "\n" + b.String()
+}

--- a/grammars/registry_test.go
+++ b/grammars/registry_test.go
@@ -331,8 +331,13 @@ func TestInferredTagsQueryCoverage(t *testing.T) {
 	}
 
 	// Core set (9) is explicit. Inference should expand this materially.
-	if withTags < 30 {
-		t.Fatalf("expected inferred tags query coverage to be >=30 languages, got %d", withTags)
+	// Floor raised 2026-08-11 (workstream D coverage growth pass) from 30 to
+	// 84, the measured tags-query-non-empty count (T1 83 + T2 1) recorded in
+	// testdata/outline_census/baseline.json. Any language that drops out of
+	// this count without a stated reason and a baseline update fails here
+	// first.
+	if withTags < 84 {
+		t.Fatalf("expected inferred tags query coverage to be >=84 languages, got %d", withTags)
 	}
 }
 

--- a/grammars/tags_query_infer.go
+++ b/grammars/tags_query_infer.go
@@ -14,12 +14,634 @@ var (
 	inferredTagsQueryCache sync.Map // map[string]string
 )
 
+// inferredTagsQueryOverrides holds two kinds of entries, both per-language
+// data, exactly like the pre-existing Go row:
+//
+//  1. Precision overrides: the shared inference table either misses a
+//     language's conventional shapes or misnames them (a field-constrained
+//     query resolves what a positional pattern cannot, e.g. the Go override
+//     already does for the return-type overcapture bug). These use `name:`
+//     and other field constraints verified against this repository's
+//     compiled grammars, not against upstream tree-sitter, because a
+//     grammargen/ts2go-compiled blob's field map is the fact that matters
+//     here.
+//
+//  2. Golden-fixture freezes: python, javascript, typescript, tsx, java,
+//     rust, c, cpp, and c_sharp each already carry a committed, exact-match
+//     golden fixture in the core package (outline_golden_test.go,
+//     testdata/outline/**). Those files sit outside grammars/ and are out of
+//     scope for a grammars-data change, and TestOutlineGoldens compares full
+//     JSON including DefinitionKinds() -- which is the compiled query's
+//     static capture-name list, so even an unmatched new pattern changes it.
+//     Any shared-inferredTagsQueryPatterns edit that a frozen language's
+//     grammar happens to satisfy would silently move that language's golden
+//     output. Snapshotting each one's pre-change resolved query here removes
+//     that whole risk class: overrides short-circuit inference (see
+//     inferredTagsQuery below) before the shared table is ever consulted, so
+//     these nine stay byte-identical no matter what the shared table gains.
+//     Each snapshot is the exact string ResolveTagsQuery produced before
+//     this change; verified unchanged by TestOutlineGoldens continuing to
+//     pass. A future change that also updates the goldens in the same
+//     commit is free to replace any of these with a real fix.
+//
+//  3. Impossible-pattern fixes (2026-08-11, cgo_harness C-oracle exhaustive
+//     sweep, cgo_harness/outline_differential_test.go): tree-sitter's C
+//     ts_query_new statically rejects a pattern whose child node type can
+//     never occur at that position in the grammar's rules ("Impossible
+//     pattern"), and rejects the WHOLE multi-pattern query atomically --
+//     one bad line drops every valid line for that language on the C side.
+//     gotreesitter's Go NewQuery has no equivalent static check, so a dead
+//     line "compiled" here while producing zero matches, silently masking
+//     the C incompatibility. Because C reports only the FIRST impossible
+//     pattern it hits, an initial hand-reported list (from a first C-oracle
+//     pass) undercounted: fixing pattern 1 in a language's query routinely
+//     exposed pattern 2 on the next compile attempt. Every row below was
+//     therefore run against BOTH sides before being trusted fixed: Go side
+//     via SExpr(lang) dumps of this repository's own compiled grammar
+//     blobs plus an isolated single-pattern gotreesitter.NewQuery/Execute
+//     firing test (0 matches = dead), C side via
+//
+//     CGO_ENABLED=1 GTS_PARITY_ALLOW_HOST=1 go test -tags "cgo treesitter_c_parity" \
+//     ./cgo_harness -run 'TestOutlineOracleDifferential/CoreNine' -v
+//
+//     which now reports status=equal for all nine core languages (go,
+//     python, javascript, typescript, tsx, rust, java, c, cpp) -- zero
+//     query_incompatible, zero diverged. Final dead/corrected rows, all
+//     confirmed 0-match on Go and "Impossible pattern" on C before the fix,
+//     and firing correctly (or simply absent, superseded by a working row)
+//     after it:
+//     - javascript: (method_definition (identifier) @name) -- every JS
+//     method_definition names through property_identifier,
+//     computed_property_name, or private_property_identifier, never a
+//     bare identifier.
+//     - typescript, tsx: (function_declaration (type_identifier) @name);
+//     (class_declaration (identifier) @name); (interface_declaration
+//     (identifier) @name); (enum_declaration (type_identifier) @name).
+//     The pattern is consistent: function/enum name through (identifier)
+//     only, class/interface name through (type_identifier) only -- never
+//     the other spelling, for any of the four.
+//     - java: (class_declaration (type_identifier) @name);
+//     (interface_declaration (type_identifier) @name); (enum_declaration
+//     (type_identifier) @name). Java's own-name child is (identifier)
+//     only for all three; type_identifier appears solely inside
+//     type_parameters/superclass/super_interfaces/extends/implements
+//     clauses, never as the declaration's own name.
+//     - c, cpp: (function_definition (identifier) @name) and
+//     (function_definition (field_identifier) @name) -- a
+//     function_definition's name is always wrapped one level inside
+//     function_declarator, never a bare direct child; the two wrapped
+//     rows already cover both spellings. cpp's (type_definition
+//     (identifier) @name) -- a typedef's target is always
+//     (type_identifier) in this grammar family, never plain identifier.
+//     - rust, c, cpp: (call_expression (field_identifier) @name) for a
+//     method-call reference like "obj.method()" -- field_identifier is
+//     always nested one level inside field_expression, never a bare
+//     direct child of call_expression. Corrected in place (not deleted)
+//     to (call_expression (field_expression (field_identifier) @name))
+//     @reference.call, which fires correctly on the same witness.
+//     Every row above is either a removal (a working alternate spelling
+//     already covers the same capture name) or, for the three
+//     field_identifier reference corrections, a reference.* capture:
+//     OutlineTree's collectOutlineCandidates discards any match without a
+//     definition.* capture before it is ever counted (outline.go), and
+//     DefinitionKinds() filters CaptureNames() to the "definition." prefix
+//     (isOutlineDefinitionCapture). So none of this can move Symbols, any
+//     OutlineReport counter, or DefinitionKinds() for a frozen language --
+//     confirmed by TestOutlineGoldens continuing to pass byte for byte
+//     after every edit in this list.
+//     python and c_sharp were checked against the same method (real
+//     source, SExpr dump, isolated single-pattern firing test, and the
+//     CoreNine C-oracle run above) and carry no structurally-impossible
+//     row. c_sharp's method_declaration name/return-type collision is a
+//     real, already-documented ambiguity (see the c_sharp golden fixture
+//     purpose string), not a dead pattern, and is left exactly as shipped.
 var inferredTagsQueryOverrides = map[string]string{
 	"go": strings.Join([]string{
 		"(function_declaration name: (identifier) @name) @definition.function",
 		"(method_declaration name: (field_identifier) @name) @definition.method",
 		"(call_expression function: (identifier) @name) @reference.call",
 		"(call_expression function: (selector_expression field: (field_identifier) @name)) @reference.call",
+	}, "\n"),
+
+	// --- golden-fixture freezes (see comment above) ---
+
+	"python": strings.Join([]string{
+		"(function_definition (identifier) @name) @definition.function",
+		"(class_definition (identifier) @name) @definition.class",
+		"(call (identifier) @name) @reference.call",
+		"(call (attribute (identifier) @name)) @reference.call",
+	}, "\n"),
+	"javascript": strings.Join([]string{
+		"(function_declaration (identifier) @name) @definition.function",
+		"(method_definition (property_identifier) @name) @definition.method",
+		"(class_declaration (identifier) @name) @definition.class",
+		"(call_expression (identifier) @name) @reference.call",
+		"(call_expression (member_expression (property_identifier) @name)) @reference.call",
+	}, "\n"),
+	"typescript": strings.Join([]string{
+		"(function_declaration (identifier) @name) @definition.function",
+		"(method_definition (property_identifier) @name) @definition.method",
+		"(class_declaration (type_identifier) @name) @definition.class",
+		"(interface_declaration (type_identifier) @name) @definition.interface",
+		"(enum_declaration (identifier) @name) @definition.type",
+		"(call_expression (identifier) @name) @reference.call",
+		"(call_expression (member_expression (property_identifier) @name)) @reference.call",
+	}, "\n"),
+	"tsx": strings.Join([]string{
+		"(function_declaration (identifier) @name) @definition.function",
+		"(method_definition (property_identifier) @name) @definition.method",
+		"(class_declaration (type_identifier) @name) @definition.class",
+		"(interface_declaration (type_identifier) @name) @definition.interface",
+		"(enum_declaration (identifier) @name) @definition.type",
+		"(call_expression (identifier) @name) @reference.call",
+		"(call_expression (member_expression (property_identifier) @name)) @reference.call",
+	}, "\n"),
+	"java": strings.Join([]string{
+		"(method_declaration (identifier) @name) @definition.method",
+		"(class_declaration (identifier) @name) @definition.class",
+		"(interface_declaration (identifier) @name) @definition.interface",
+		"(enum_declaration (identifier) @name) @definition.type",
+		"(constructor_declaration (identifier) @name) @definition.constructor",
+		"(method_invocation (identifier) @name) @reference.call",
+	}, "\n"),
+	"rust": strings.Join([]string{
+		"(function_item (identifier) @name) @definition.function",
+		"(function_signature_item (identifier) @name) @definition.function",
+		"(struct_item (type_identifier) @name) @definition.type",
+		"(enum_item (type_identifier) @name) @definition.type",
+		"(trait_item (type_identifier) @name) @definition.type",
+		"(call_expression (identifier) @name) @reference.call",
+		"(call_expression (field_expression (field_identifier) @name)) @reference.call",
+		"(call_expression (scoped_identifier (identifier) @name)) @reference.call",
+		"(macro_invocation (identifier) @name) @reference.call",
+	}, "\n"),
+	"c": strings.Join([]string{
+		"(function_definition (function_declarator (identifier) @name)) @definition.function",
+		"(function_definition (function_declarator (field_identifier) @name)) @definition.function",
+		"(type_definition (type_identifier) @name) @definition.type",
+		"(struct_specifier (type_identifier) @name) @definition.type",
+		"(call_expression (identifier) @name) @reference.call",
+		"(call_expression (field_expression (field_identifier) @name)) @reference.call",
+	}, "\n"),
+	"cpp": strings.Join([]string{
+		"(function_definition (function_declarator (identifier) @name)) @definition.function",
+		"(function_definition (function_declarator (field_identifier) @name)) @definition.function",
+		"(type_definition (type_identifier) @name) @definition.type",
+		"(class_specifier (type_identifier) @name) @definition.class",
+		"(struct_specifier (type_identifier) @name) @definition.type",
+		"(call_expression (identifier) @name) @reference.call",
+		"(call_expression (field_expression (field_identifier) @name)) @reference.call",
+	}, "\n"),
+	"c_sharp": strings.Join([]string{
+		"(method_declaration (identifier) @name) @definition.method",
+		"(class_declaration (identifier) @name) @definition.class",
+		"(interface_declaration (identifier) @name) @definition.interface",
+		"(enum_declaration (identifier) @name) @definition.type",
+		"(constructor_declaration (identifier) @name) @definition.constructor",
+	}, "\n"),
+
+	// --- stage-5 coverage growth overrides (2026-08-11) ---
+	//
+	// Every row below was verified against this repository's OWN compiled
+	// grammar blob, not upstream tree-sitter: a real snippet was parsed,
+	// Node.SExpr(lang) was read to confirm the exact child shape, and the
+	// candidate pattern was run in isolation through gotreesitter.NewTagger
+	// to confirm it fires exactly once per definition with the expected
+	// name text and no duplicate/conflicting capture. None of these touch a
+	// golden-frozen language.
+
+	// PHP: the grammar has no plain "identifier" symbol at all (verified:
+	// SymbolByName("identifier") absent) -- every name-bearing leaf is
+	// "name" instead, which is why every shared-table pattern silently
+	// gated PHP to an empty query. All seven shapes below are direct
+	// children of their definition node in this grammar; enum_declaration
+	// keeps the definition.type suffix on purpose so the existing
+	// outlineKindRefinement row ("enum_declaration" -> "enum") applies
+	// without a new table entry.
+	"php": strings.Join([]string{
+		"(function_definition (name) @name) @definition.function",
+		"(method_declaration (name) @name) @definition.method",
+		"(class_declaration (name) @name) @definition.class",
+		"(interface_declaration (name) @name) @definition.interface",
+		"(trait_declaration (name) @name) @definition.trait",
+		"(enum_declaration (name) @name) @definition.type",
+		"(enum_case (name) @name) @definition.enum_member",
+	}, "\n"),
+
+	// Erlang: function clauses nest the name one level inside
+	// function_clause; a bare record_decl's own name is its only direct
+	// atom child (field atoms sit inside their own record_field wrapper,
+	// never a direct child of record_decl, so there is no ambiguity to
+	// anchor against). definition.record is used directly rather than
+	// definition.type plus an outlineKindRefinement row: the core
+	// outline.go tables are out of scope for this change, and
+	// "record_decl" is Erlang-unique (verified via SymbolByName across
+	// every registered language) so a direct kind loses nothing.
+	"erlang": strings.Join([]string{
+		"(fun_decl (function_clause (atom) @name)) @definition.function",
+		"(record_decl (atom) @name) @definition.record",
+	}, "\n"),
+
+	// OCaml: "name"/"pattern" fields resolve type_binding and let_binding
+	// precisely (verified present via lang.FieldNames); module_binding and
+	// class_binding do not carry a "name" field in this grammar, so those
+	// two stay positional (verified: exactly one direct name-shaped child,
+	// with no other candidate at that depth). let_binding covers both
+	// functions and plain values -- OCaml's grammar does not distinguish
+	// them structurally -- so "function" is used uniformly, matching the
+	// upstream tree-sitter-ocaml tags convention.
+	"ocaml": strings.Join([]string{
+		"(type_definition (type_binding name: (type_constructor) @name)) @definition.type",
+		"(value_definition (let_binding pattern: (value_name) @name)) @definition.function",
+		"(module_definition (module_binding (module_name) @name)) @definition.module",
+		"(exception_definition (constructor_declaration (constructor_name) @name)) @definition.exception",
+		"(class_definition (class_binding (class_name) @name)) @definition.class",
+		"(method_definition (method_name) @name) @definition.method",
+	}, "\n"),
+
+	// Bash and fish both expose a "name" field on function_definition.
+	"bash": "(function_definition name: (word) @name) @definition.function",
+	"fish": "(function_definition name: (word) @name) @definition.function",
+
+	// GraphQL: no fields at all in this grammar (verified: lang.FieldNames
+	// is empty), so every row is positional. Each definition node's own
+	// "name" is always its first-reachable direct or one-level-nested
+	// (name) node; member names (enum values) sit one level deeper still
+	// and cannot collide with the parent's own name capture because the
+	// parent pattern only looks at direct children.
+	// enum_type_definition uses definition.enum directly (not
+	// definition.type plus a refinement row): the core outline.go tables
+	// are out of scope for this change, and "enum_type_definition" is
+	// GraphQL-unique (verified via SymbolByName across every registered
+	// language), so a direct kind loses nothing.
+	"graphql": strings.Join([]string{
+		"(object_type_definition (name) @name) @definition.type",
+		"(interface_type_definition (name) @name) @definition.interface",
+		"(enum_type_definition (name) @name) @definition.enum",
+		"(enum_value_definition (enum_value (name) @name)) @definition.enum_member",
+		"(input_object_type_definition (name) @name) @definition.type",
+		"(union_type_definition (name) @name) @definition.union",
+		"(scalar_type_definition (name) @name) @definition.scalar",
+		"(directive_definition (name) @name) @definition.directive",
+	}, "\n"),
+
+	// Ruby: class/module name through the "constant" node type; the "left"
+	// field on assignment excludes a plain read of a constant on the right
+	// -- verified both directions with "CONST = 1" and "x = CONST" snippets
+	// -- so only genuine constant bindings are captured.
+	"ruby": strings.Join([]string{
+		"(class (constant) @name) @definition.class",
+		"(module (constant) @name) @definition.module",
+		"(method (identifier) @name) @definition.method",
+		"(singleton_method (identifier) @name) @definition.method",
+		"(assignment left: (constant) @name) @definition.constant",
+	}, "\n"),
+
+	// Kotlin: class_declaration is reused for classes, interfaces, AND enum
+	// classes, distinguished only by an anonymous keyword token or body
+	// node type -- there is no per-shape node type the way Java has. The
+	// three rows below are mutually exclusive by construction: "interface"
+	// only ever appears on an interface; enum_class_body only ever appears
+	// on an enum class; requiring (class_body), which enum classes never
+	// carry, keeps the plain "class" row from also firing (and thereby
+	// conflicting) on an enum class. Verified on interface+class+enum-class
+	// source together with zero OmittedConflict. Function/method names use
+	// "simple_identifier", never "identifier", which is why the shared
+	// table's function_declaration rows never fired for Kotlin.
+	"kotlin": strings.Join([]string{
+		`(class_declaration "interface" (type_identifier) @name) @definition.interface`,
+		"(class_declaration (type_identifier) @name (enum_class_body)) @definition.enum",
+		`(class_declaration "class" (type_identifier) @name (class_body)) @definition.class`,
+		"(object_declaration (type_identifier) @name) @definition.object",
+		"(function_declaration (simple_identifier) @name) @definition.function",
+		"(enum_entry (simple_identifier) @name) @definition.enum_member",
+		"(type_alias (type_identifier) @name) @definition.type",
+	}, "\n"),
+
+	// Swift: the same class_declaration reuse as Kotlin (class, struct, AND
+	// enum all parse as class_declaration), disambiguated the same way by
+	// keyword token plus body node type. Constructors (init_declaration)
+	// carry no name distinct from the fixed "init" keyword, so -- as with
+	// Kotlin -- they are not captured; there is nothing to name that is not
+	// already guessing.
+	"swift": strings.Join([]string{
+		"(protocol_declaration (type_identifier) @name) @definition.interface",
+		`(class_declaration "class" (type_identifier) @name (class_body)) @definition.class`,
+		`(class_declaration "struct" (type_identifier) @name (class_body)) @definition.struct`,
+		"(class_declaration (type_identifier) @name (enum_class_body)) @definition.enum",
+		"(protocol_function_declaration (simple_identifier) @name) @definition.method",
+		"(function_declaration (simple_identifier) @name) @definition.function",
+		"(enum_entry (simple_identifier) @name) @definition.enum_member",
+	}, "\n"),
+
+	// Scala: trait/class/object/enum/function/def all carry an explicit
+	// "name:" field (verified via lang.FieldNames and firing witnesses),
+	// so every row below is field-constrained and unambiguous by
+	// construction; no anchor or body-shape disambiguation is needed the
+	// way Kotlin and Swift require.
+	"scala": strings.Join([]string{
+		"(trait_definition name: (identifier) @name) @definition.interface",
+		"(class_definition name: (identifier) @name) @definition.class",
+		"(object_definition name: (identifier) @name) @definition.object",
+		"(enum_definition name: (identifier) @name) @definition.enum",
+		"(function_declaration name: (identifier) @name) @definition.function",
+		"(function_definition name: (identifier) @name) @definition.function",
+		"(simple_enum_case (identifier) @name) @definition.enum_member",
+	}, "\n"),
+
+	// Dart: class_definition already fires through the shared table, but
+	// method/constructor/getter names live under function_signature /
+	// constructor_signature / getter_signature -- none of which the shared
+	// table names -- and enum_declaration's own name needs anchoring away
+	// from enum_body's member identifiers (verified: enum_constant's
+	// identifier sits one level deeper, inside enum_body, never a direct
+	// child of enum_declaration, so no anchor is actually required, but the
+	// direct-child requirement alone is what keeps this safe).
+	"dart": strings.Join([]string{
+		"(class_definition (identifier) @name) @definition.class",
+		"(enum_declaration (identifier) @name) @definition.type",
+		"(enum_constant (identifier) @name) @definition.enum_member",
+		"(mixin_declaration (identifier) @name) @definition.mixin",
+		"(function_signature (identifier) @name) @definition.function",
+		"(constructor_signature (identifier) @name) @definition.constructor",
+		"(getter_signature (identifier) @name) @definition.method",
+	}, "\n"),
+
+	// Zig: struct/enum literals carry no name of their own -- the name
+	// comes from the surrounding "const X = struct {...}" variable
+	// binding, so the pattern anchors on variable_declaration and checks
+	// the value's shape. function_declaration needs the leading anchor
+	// because a user-defined return type parses as a second, later
+	// (identifier) sibling (e.g. "fn init(...) Point"); without the anchor
+	// the two identifiers share one span with different names and both are
+	// dropped as OmittedNameConflict -- verified both with and without the
+	// anchor on that exact shape.
+	"zig": strings.Join([]string{
+		"(variable_declaration (identifier) @name (struct_declaration)) @definition.type",
+		"(variable_declaration (identifier) @name (enum_declaration)) @definition.enum",
+		"(function_declaration . (identifier) @name) @definition.function",
+	}, "\n"),
+
+	// Elixir: defmodule/def/defp/defmacro are ordinary calls, not distinct
+	// node types (the grammar has no "module"/"function definition" node
+	// at all) -- the same shape as Clojure. #eq?/#any-of? predicates on the
+	// call's own head identifier are the only way to name the construct
+	// without guessing; verified the predicate engine matches this
+	// repository's compiled grammar output (anchors and #eq?/#any-of? all
+	// fire as expected).
+	"elixir": strings.Join([]string{
+		`(call (identifier) @_head (arguments (alias) @name)) @definition.module (#eq? @_head "defmodule")`,
+		`(call (identifier) @_head (arguments (call (identifier) @name))) @definition.function (#any-of? @_head "def" "defp" "defmacro")`,
+		// Carried over from the shared table's generic call reference so an
+		// override does not regress reference coverage the shared inference
+		// already gave Elixir (every construct, defmodule/def included, is
+		// itself a "call" node in this grammar).
+		"(call (identifier) @name) @reference.call",
+	}, "\n"),
+
+	// Julia: every definition wraps its name one to two levels deep
+	// (module_definition direct; struct/abstract through type_head;
+	// function through a call-shaped signature, mirroring how a Julia
+	// function header actually parses). const_statement is anchored to the
+	// assignment's first child so a constant that reads another constant
+	// on its right-hand side is never mistaken for a second definition.
+	"julia": strings.Join([]string{
+		"(module_definition (identifier) @name) @definition.module",
+		"(struct_definition (type_head (identifier) @name)) @definition.type",
+		"(abstract_definition (type_head (identifier) @name)) @definition.type",
+		"(function_definition (signature (call_expression (identifier) @name))) @definition.function",
+		"(const_statement (assignment . (identifier) @name)) @definition.constant",
+	}, "\n"),
+
+	// Groovy: class_definition already fires through the shared table, but
+	// function_definition needs the trailing anchor -- a typed method like
+	// "String greet()" parses return type and name as two sibling
+	// (identifier) nodes in that order, so an unanchored pattern captures
+	// "String" (or drops both to OmittedNameConflict once both identifiers
+	// match); anchoring the name immediately before parameter_list
+	// resolves it to the actual method/function name in both the typed and
+	// untyped ("def standalone()") cases.
+	"groovy": strings.Join([]string{
+		"(class_definition (identifier) @name) @definition.class",
+		"(function_definition (identifier) @name . (parameter_list)) @definition.function",
+	}, "\n"),
+
+	// Solidity: contract/interface/library/struct/enum/function/modifier/
+	// event all carry a "name:" field (verified via lang.FieldNames and a
+	// firing witness covering all seven). Constructors are intentionally
+	// not captured: constructor_definition has no name distinct from the
+	// fixed "constructor" keyword.
+	"solidity": strings.Join([]string{
+		"(contract_declaration name: (identifier) @name) @definition.class",
+		"(interface_declaration name: (identifier) @name) @definition.interface",
+		"(library_declaration name: (identifier) @name) @definition.class",
+		"(struct_declaration name: (identifier) @name) @definition.type",
+		"(enum_declaration name: (identifier) @name) @definition.type",
+		"(function_definition name: (identifier) @name) @definition.function",
+		"(modifier_definition name: (identifier) @name) @definition.method",
+		"(event_definition name: (identifier) @name) @definition.event",
+	}, "\n"),
+
+	// Nim: type_declaration wraps the symbol name in type_symbol_declaration
+	// one level deep, then the type's own shape (object_declaration versus
+	// enum_declaration) as a second direct child -- both are checked so an
+	// object type and an enum type resolve to different kinds without
+	// touching the language-neutral refinement table. proc/func/method all
+	// carry a direct (identifier) name child with no return-type collision
+	// (the return type sits inside its own type_expression wrapper).
+	"nim": strings.Join([]string{
+		"(type_declaration (type_symbol_declaration (identifier) @name) (object_declaration)) @definition.type",
+		"(type_declaration (type_symbol_declaration (identifier) @name) (enum_declaration)) @definition.enum",
+		"(proc_declaration (identifier) @name) @definition.function",
+		"(func_declaration (identifier) @name) @definition.function",
+		"(method_declaration (identifier) @name) @definition.method",
+		"(const_section (variable_declaration (symbol_declaration_list (symbol_declaration (identifier) @name)))) @definition.constant",
+		// Carried over from the shared table's generic call reference so an
+		// override does not regress reference coverage the shared inference
+		// already gave Nim (the smoke sample is a single bare call with no
+		// definitions at all, so this is what makes Nim's Tagger output
+		// non-empty on that fixture).
+		"(call (identifier) @name) @reference.call",
+	}, "\n"),
+
+	// Crystal: module_def/class_def/struct_def/const_assign all name
+	// through a direct "constant" child, and because def/class_def/
+	// struct_def/enum_def are distinct sibling node types (not one node
+	// reused three ways, unlike Kotlin/Swift) there is no cross-kind
+	// conflict to guard against. enum_def is the one exception -- its own
+	// name and every member share the flat "constant" child shape, so only
+	// the leading anchor distinguishes the enum's own name; members are not
+	// captured (same structural limit as Thrift's enum_definition).
+	"crystal": strings.Join([]string{
+		"(module_def (constant) @name) @definition.module",
+		"(class_def (constant) @name) @definition.class",
+		"(struct_def (constant) @name) @definition.struct",
+		"(enum_def . (constant) @name) @definition.enum",
+		"(method_def (identifier) @name) @definition.method",
+		"(const_assign (constant) @name) @definition.constant",
+	}, "\n"),
+
+	// D: interface/class/function already fire through the shared table
+	// (return types wrap in their own "type" node, never colliding with
+	// the name identifier); struct_declaration is not in the shared table
+	// at all, and enum_member needs its own row since the shared table has
+	// no enum-member concept.
+	"d": strings.Join([]string{
+		"(interface_declaration (identifier) @name) @definition.interface",
+		"(class_declaration (identifier) @name) @definition.class",
+		"(struct_declaration (identifier) @name) @definition.struct",
+		"(enum_declaration (identifier) @name) @definition.type",
+		"(enum_member (identifier) @name) @definition.enum_member",
+		"(function_declaration (identifier) @name) @definition.function",
+	}, "\n"),
+
+	// V: interface/function(including methods, whose receiver is a nested
+	// "receiver" node and never collides with the direct-child function
+	// name) already fire through the shared table. struct_declaration and
+	// const_declaration are not in the shared table; const_declaration
+	// nests its name one level inside const_definition.
+	"v": strings.Join([]string{
+		"(interface_declaration (identifier) @name) @definition.interface",
+		"(struct_declaration (identifier) @name) @definition.struct",
+		"(enum_declaration (identifier) @name) @definition.type",
+		"(enum_field_definition (identifier) @name) @definition.enum_member",
+		"(function_declaration (identifier) @name) @definition.function",
+		"(const_declaration (const_definition (identifier) @name)) @definition.constant",
+	}, "\n"),
+
+	// Thrift: the shared table only ever reached the one function_definition
+	// pattern (service methods), because it happens to also be shaped like
+	// a generic "function_definition". struct/service/exception each name
+	// through a direct, unambiguous first identifier child (body members
+	// nest one level deeper and never collide); enum_definition repeats
+	// its own name and every member as flat sibling identifiers with no
+	// wrapping node at all, so -- as with Crystal -- only the leading
+	// anchor is used and members are not captured. typedef_identifier is a
+	// dedicated node type with no ambiguity.
+	"thrift": strings.Join([]string{
+		"(struct_definition (identifier) @name) @definition.type",
+		"(enum_definition . (identifier) @name) @definition.enum",
+		"(service_definition (identifier) @name) @definition.service",
+		"(typedef_definition (typedef_identifier) @name) @definition.type",
+		"(exception_definition (identifier) @name) @definition.exception",
+		"(function_definition (identifier) @name) @definition.method",
+	}, "\n"),
+
+	// HCL / Terraform: every top-level construct is the same generic
+	// "block" node (resource, variable, module, output, provider, locals,
+	// terraform, data, ...); there is no per-kind node type to distinguish
+	// them, and this grammar carries no fields at all. The name is
+	// whichever label (a quoted string) sits immediately before
+	// block_start -- always the LAST label regardless of how many labels
+	// the block type takes (one for "variable", two for "resource"), which
+	// is also Terraform's own addressing convention (TYPE.NAME). The
+	// zero-label row (locals, terraform, ...) falls back to the block's own
+	// type identifier. Recursive: nested blocks (e.g. "lifecycle {}" inside
+	// a resource) get their own definition.block symbol nested as a child
+	// by the outliner's ordinary byte-containment logic, with no new code.
+	"hcl": strings.Join([]string{
+		"(block (identifier) (string_lit (template_literal) @name) . (block_start)) @definition.block",
+		"(block (identifier) @name . (block_start)) @definition.block",
+	}, "\n"),
+
+	// CMake: function()/macro() define their own name as the FIRST
+	// argument in argument_list, with the parameter names following as
+	// more arguments of the identical shape -- the leading anchor is
+	// required, or the pattern also captures every parameter name at the
+	// same span (verified: without the anchor, "greet" and "name" would
+	// both bind to the definition and drop via OmittedNameConflict).
+	"cmake": strings.Join([]string{
+		"(function_def (function_command (function) (argument_list . (argument (unquoted_argument) @name)))) @definition.function",
+		"(macro_def (macro_command (macro) (argument_list . (argument (unquoted_argument) @name)))) @definition.macro",
+	}, "\n"),
+
+	// PowerShell: function_name is a dedicated node type. class_statement's
+	// own name is a direct (simple_name) child; a method's simple_name
+	// sits one level inside class_method_definition instead, so the two
+	// never collide. enum_statement's own name is likewise its own direct
+	// (simple_name) child, distinct from each enum_member's nested one;
+	// it uses definition.enum directly (not definition.type plus a
+	// refinement row, since the core outline.go tables are out of scope
+	// for this change). "enum_statement" is shared verbatim by Fortran,
+	// PowerShell, and Smithy (verified via SymbolByName across every
+	// registered language), all three for a genuine enum construct, so a
+	// direct kind here loses nothing a refinement row would have added.
+	"powershell": strings.Join([]string{
+		"(function_statement (function_name) @name) @definition.function",
+		"(class_statement (simple_name) @name) @definition.class",
+		"(class_method_definition (simple_name) @name) @definition.method",
+		"(enum_statement (simple_name) @name) @definition.enum",
+		"(enum_member (simple_name) @name) @definition.enum_member",
+	}, "\n"),
+
+	// SQL: create_index_statement and create_trigger_statement carry a
+	// "name:" field that picks out the index/trigger identifier from a
+	// second, unfielded identifier (the target table); the rest have no
+	// field and are positional, verified as the sole direct-child
+	// identifier for each (parameter, return-type, and body identifiers
+	// all nest at least one level deeper).
+	"sql": strings.Join([]string{
+		"(create_table_statement (identifier) @name) @definition.type",
+		"(create_view_statement (identifier) @name) @definition.type",
+		"(create_function_statement (identifier) @name) @definition.function",
+		"(create_index_statement name: (identifier) @name) @definition.index",
+		"(create_type_statement (identifier) @name) @definition.type",
+		"(create_sequence (identifier) @name) @definition.sequence",
+		"(create_trigger_statement name: (identifier) @name) @definition.trigger",
+	}, "\n"),
+
+	// Protobuf: message/enum/service/rpc each wrap their name in a
+	// dedicated *_name node, and enum_field is a direct, unambiguous child
+	// of enum_body. definition.enum is used directly (not definition.type
+	// plus refinement) because the bare node type "enum" is used as an
+	// anonymous keyword token by 47 other grammars in this fleet -- adding
+	// it to outlineKindRefinement would be a cross-language keyword
+	// collision, not the genuine convention the refinement table is for.
+	"proto": strings.Join([]string{
+		"(message (message_name (identifier) @name)) @definition.message",
+		"(enum (enum_name (identifier) @name)) @definition.enum",
+		"(enum_field (identifier) @name) @definition.enum_member",
+		"(service (service_name (identifier) @name)) @definition.service",
+		"(rpc (rpc_name (identifier) @name)) @definition.rpc",
+	}, "\n"),
+
+	// Clojure, Common Lisp, and Scheme: none of these grammars gives a
+	// definition its own node type (defn/def/defun-with-macro-body/define
+	// are just s-expression lists), except Common Lisp's "defun", which
+	// does get a dedicated node with a "function_name" field. The other
+	// two are matched with #eq?/#any-of? predicates on the head symbol,
+	// verified against this repository's compiled grammar output.
+	"clojure": strings.Join([]string{
+		`(list_lit . (sym_lit (sym_name) @_head) . (sym_lit (sym_name) @name) (#any-of? @_head "defn" "defn-")) @definition.function`,
+		`(list_lit . (sym_lit (sym_name) @_head) . (sym_lit (sym_name) @name) (#eq? @_head "def")) @definition.variable`,
+		`(list_lit . (sym_lit (sym_name) @_head) . (sym_lit (sym_name) @name) (#eq? @_head "defmacro")) @definition.macro`,
+	}, "\n"),
+	"commonlisp": strings.Join([]string{
+		"(defun (defun_header function_name: (sym_lit) @name)) @definition.function",
+		`(list_lit . (sym_lit) @_head . (sym_lit) @name) @definition.variable (#eq? @_head "defvar")`,
+		`(list_lit . (sym_lit) @_head . (sym_lit) @name) @definition.variable (#eq? @_head "defparameter")`,
+	}, "\n"),
+	"scheme": strings.Join([]string{
+		`(list . (symbol) @_head . (list . (symbol) @name)) @definition.function (#eq? @_head "define")`,
+		`(list . (symbol) @_head . (symbol) @name) @definition.variable (#eq? @_head "define")`,
+	}, "\n"),
+
+	// Lua: found via the cgo_harness C-oracle fleet census (log-only
+	// FleetCensus subtest, GTS_PARITY_MODE=top50), not the CoreNine sweep --
+	// Lua is not one of the core nine. The shared table's
+	// "(function_definition (identifier) @name) @definition.function" row
+	// gates in because Lua's grammar DEFINES a "function_definition" symbol,
+	// but no production ever reaches it (verified: 0 matches on a real
+	// firing witness with three function definitions), so it is an
+	// impossible pattern on the C side, exactly like the core-nine dead
+	// rows above. All of Lua's real function definitions -- free functions,
+	// "local function", and "function table.field(...)" method syntax --
+	// go through function_declaration; the dot_index_expression row picks
+	// the LAST identifier (the field/method name, not the table) via the
+	// trailing anchor, verified against "function obj.method(self) ... end".
+	"lua": strings.Join([]string{
+		"(function_declaration (identifier) @name) @definition.function",
+		"(function_declaration (dot_index_expression (identifier) @name .)) @definition.method",
 	}, "\n"),
 }
 
@@ -54,6 +676,12 @@ var inferredTagsQueryPatterns = []tagsQueryPattern{
 	{Query: "(trait_item (type_identifier) @name) @definition.type", Symbols: []string{"trait_item", "type_identifier"}},
 	{Query: "(class_specifier (type_identifier) @name) @definition.class", Symbols: []string{"class_specifier", "type_identifier"}},
 	{Query: "(struct_specifier (type_identifier) @name) @definition.type", Symbols: []string{"struct_specifier", "type_identifier"}},
+	// A bare "type_alias" node (not wrapped in type_declaration, unlike Go's
+	// shape above) whose first named child is the alias name. Verified
+	// identical direct-child shape in Kotlin, Dart, and templ; the pattern
+	// still fails closed for grammars that nest the name deeper (Gleam wraps
+	// it in type_name, so it simply never matches there).
+	{Query: "(type_alias (type_identifier) @name) @definition.type", Symbols: []string{"type_alias", "type_identifier"}},
 
 	// Constants and variables.
 	{Query: "(const_spec (identifier) @name) @definition.constant", Symbols: []string{"const_spec", "identifier"}},

--- a/grammars/testdata/outline_census/baseline.json
+++ b/grammars/testdata/outline_census/baseline.json
@@ -4,10 +4,10 @@
   "real_corpus_root": "/home/draco/work/gotreesitter-corpora/corpus_sources",
   "real_corpus_root_exists": true,
   "counts_by_tier": {
-    "T1": 69,
+    "T1": 83,
     "T2": 1,
-    "T3": 16,
-    "T4": 120
+    "T3": 10,
+    "T4": 112
   },
   "rows": [
     {
@@ -84,13 +84,10 @@
     },
     {
       "language": "bash",
-      "tier": "T3",
-      "tags_query_non_empty": false,
+      "tier": "T1",
+      "tags_query_non_empty": true,
       "smoke_capture_count": 0,
-      "real_corpus_present": false,
-      "candidate_symbols": [
-        "function_definition"
-      ]
+      "real_corpus_present": true
     },
     {
       "language": "bass",
@@ -200,17 +197,22 @@
     },
     {
       "language": "clojure",
-      "tier": "T4",
-      "tags_query_non_empty": false,
-      "smoke_capture_count": 0,
-      "real_corpus_present": false
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 3,
+      "smoke_capture_names": [
+        "_head",
+        "definition.variable",
+        "name"
+      ],
+      "real_corpus_present": true
     },
     {
       "language": "cmake",
-      "tier": "T4",
-      "tags_query_non_empty": false,
+      "tier": "T1",
+      "tags_query_non_empty": true,
       "smoke_capture_count": 0,
-      "real_corpus_present": false
+      "real_corpus_present": true
     },
     {
       "language": "cobol",
@@ -228,10 +230,14 @@
     },
     {
       "language": "commonlisp",
-      "tier": "T4",
-      "tags_query_non_empty": false,
-      "smoke_capture_count": 0,
-      "real_corpus_present": false
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
     },
     {
       "language": "cooklang",
@@ -326,7 +332,11 @@
       "language": "dart",
       "tier": "T1",
       "tags_query_non_empty": true,
-      "smoke_capture_count": 0,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
       "real_corpus_present": true
     },
     {
@@ -448,8 +458,11 @@
       "language": "elixir",
       "tier": "T1",
       "tags_query_non_empty": true,
-      "smoke_capture_count": 6,
+      "smoke_capture_count": 12,
       "smoke_capture_names": [
+        "_head",
+        "definition.function",
+        "definition.module",
         "name",
         "reference.call"
       ],
@@ -488,13 +501,10 @@
     },
     {
       "language": "erlang",
-      "tier": "T3",
-      "tags_query_non_empty": false,
+      "tier": "T1",
+      "tags_query_non_empty": true,
       "smoke_capture_count": 0,
-      "real_corpus_present": false,
-      "candidate_symbols": [
-        "call"
-      ]
+      "real_corpus_present": true
     },
     {
       "language": "facility",
@@ -533,13 +543,10 @@
     },
     {
       "language": "fish",
-      "tier": "T3",
-      "tags_query_non_empty": false,
+      "tier": "T1",
+      "tags_query_non_empty": true,
       "smoke_capture_count": 0,
-      "real_corpus_present": false,
-      "candidate_symbols": [
-        "function_definition"
-      ]
+      "real_corpus_present": true
     },
     {
       "language": "foam",
@@ -669,13 +676,14 @@
     },
     {
       "language": "graphql",
-      "tier": "T3",
-      "tags_query_non_empty": false,
-      "smoke_capture_count": 0,
-      "real_corpus_present": false,
-      "candidate_symbols": [
-        "type_definition"
-      ]
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.type",
+        "name"
+      ],
+      "real_corpus_present": true
     },
     {
       "language": "groovy",
@@ -727,10 +735,10 @@
     },
     {
       "language": "hcl",
-      "tier": "T4",
-      "tags_query_non_empty": false,
+      "tier": "T1",
+      "tags_query_non_empty": true,
       "smoke_capture_count": 0,
-      "real_corpus_present": false
+      "real_corpus_present": true
     },
     {
       "language": "heex",
@@ -864,7 +872,11 @@
       "language": "julia",
       "tier": "T1",
       "tags_query_non_empty": true,
-      "smoke_capture_count": 0,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.module",
+        "name"
+      ],
       "real_corpus_present": true
     },
     {
@@ -895,7 +907,11 @@
       "language": "kotlin",
       "tier": "T1",
       "tags_query_non_empty": true,
-      "smoke_capture_count": 0,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
       "real_corpus_present": true
     },
     {
@@ -1079,17 +1095,14 @@
     },
     {
       "language": "ocaml",
-      "tier": "T3",
-      "tags_query_non_empty": false,
-      "smoke_capture_count": 0,
-      "real_corpus_present": false,
-      "candidate_symbols": [
-        "method_definition",
-        "class_definition",
-        "constructor_declaration",
-        "type_definition",
-        "method_invocation"
-      ]
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.function",
+        "name"
+      ],
+      "real_corpus_present": true
     },
     {
       "language": "odin",
@@ -1128,17 +1141,10 @@
     },
     {
       "language": "php",
-      "tier": "T3",
-      "tags_query_non_empty": false,
+      "tier": "T1",
+      "tags_query_non_empty": true,
       "smoke_capture_count": 0,
-      "real_corpus_present": false,
-      "candidate_symbols": [
-        "function_definition",
-        "method_declaration",
-        "class_declaration",
-        "interface_declaration",
-        "enum_declaration"
-      ]
+      "real_corpus_present": true
     },
     {
       "language": "pkl",
@@ -1149,10 +1155,10 @@
     },
     {
       "language": "powershell",
-      "tier": "T4",
-      "tags_query_non_empty": false,
+      "tier": "T1",
+      "tags_query_non_empty": true,
       "smoke_capture_count": 0,
-      "real_corpus_present": false
+      "real_corpus_present": true
     },
     {
       "language": "prisma",
@@ -1184,10 +1190,10 @@
     },
     {
       "language": "proto",
-      "tier": "T4",
-      "tags_query_non_empty": false,
+      "tier": "T1",
+      "tags_query_non_empty": true,
       "smoke_capture_count": 0,
-      "real_corpus_present": false
+      "real_corpus_present": true
     },
     {
       "language": "pug",
@@ -1214,7 +1220,8 @@
       "smoke_capture_count": 0,
       "real_corpus_present": false,
       "candidate_symbols": [
-        "class_declaration"
+        "class_declaration",
+        "type_alias"
       ]
     },
     {
@@ -1302,7 +1309,11 @@
       "language": "ruby",
       "tier": "T1",
       "tags_query_non_empty": true,
-      "smoke_capture_count": 0,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.method",
+        "name"
+      ],
       "real_corpus_present": true
     },
     {
@@ -1320,19 +1331,25 @@
       "language": "scala",
       "tier": "T1",
       "tags_query_non_empty": true,
-      "smoke_capture_count": 2,
+      "smoke_capture_count": 4,
       "smoke_capture_names": [
         "definition.function",
+        "definition.object",
         "name"
       ],
       "real_corpus_present": true
     },
     {
       "language": "scheme",
-      "tier": "T4",
-      "tags_query_non_empty": false,
-      "smoke_capture_count": 0,
-      "real_corpus_present": false
+      "tier": "T1",
+      "tags_query_non_empty": true,
+      "smoke_capture_count": 3,
+      "smoke_capture_names": [
+        "_head",
+        "definition.variable",
+        "name"
+      ],
+      "real_corpus_present": true
     },
     {
       "language": "scss",
@@ -1364,10 +1381,10 @@
     },
     {
       "language": "sql",
-      "tier": "T4",
-      "tags_query_non_empty": false,
+      "tier": "T1",
+      "tags_query_non_empty": true,
       "smoke_capture_count": 0,
-      "real_corpus_present": false
+      "real_corpus_present": true
     },
     {
       "language": "squirrel",
@@ -1443,7 +1460,11 @@
       "language": "thrift",
       "tier": "T1",
       "tags_query_non_empty": true,
-      "smoke_capture_count": 0,
+      "smoke_capture_count": 2,
+      "smoke_capture_names": [
+        "definition.type",
+        "name"
+      ],
       "real_corpus_present": true
     },
     {


### PR DESCRIPTION
## Summary

Expands inferred tags-query coverage to over 80 languages, introduces a C-oracle differential gate to validate capture-stream parity, and adds coverage witnesses to ensure queries fire correctly. Resolves multiple structurally impossible patterns that silently masked C incompatibilities and raises coverage thresholds accordingly. Preserves byte-identical output for nine frozen core-language goldens while eliminating dead query rows.

## Changes

- Add TestOutlineOracleDifferential to compare Go and C capture streams exactly. It runs as a hard gate for CoreNine languages and logs a wide fleet census. It distinguishes equal, diverged, vacuous, incompatible, and skipped outcomes.
- Add TestOutlineCoverageWitnesses to run real snippets through the core Outliner pipeline. It asserts that named symbols exist in the forest. It fails loudly when inferred queries produce zero matches.
- Expand inferredTagsQueryOverrides with 30+ precision overrides. It uses field-constrained syntax and positional anchors to match compiled grammar shapes. Each row verifies zero-match removal and successful compilation.
- Freeze golden fixtures for nine core languages. It short-circuits inference so future shared-table edits cannot alter existing golden outputs.
- Correct seven structurally impossible patterns across javascript, typescript, tsx, java, c, cpp, rust, and lua. Every fix verifies zero-match removal on Go and successful compilation on C.
- Raise TestInferredTagsQueryCoverage floor from 30 to 84. It matches the measured non-empty query count recorded in testdata/outline_census/baseline.json.

## Testing

- go test ./grammars -run '^TestOutlineCoverageWitnesses$' -count=1 -v
- go test ./grammars -run '^TestInferredTagsQueryCoverage$' -count=1 -v
- go test ./cgo_harness -tags treesitter_c_parity -run '^TestOutlineOracleDifferential$' -count=1 -v