### PR TITLE
add(grammars): Add test for Forth incremental terminator deletion

### DIFF
--- a/grammars/recovery_action_materialization_native_regression_test.go
+++ b/grammars/recovery_action_materialization_native_regression_test.go
@@ -222,6 +222,64 @@ func TestRecoveryActionMaterializationRoutesStayExactOrFailClosed(t *testing.T) 
 	}
 }
 
+// TestForthIncrementalTerminatorDeletionMaterializesMissingEnd covers the
+// edit shape that actually triggers Forth recovery: removing a definition's
+// closing terminator. TestRecoveryActionMaterializationRoutesStayExactOrFailClosed
+// above only exercises an incremental edit that appends a trailing byte, so
+// it never removes a terminator. This case deletes the `;` from a terminated
+// definition and confirms the incremental route still materializes a
+// zero-width missing end_definition matching a fresh parse of the edited
+// source.
+func TestForthIncrementalTerminatorDeletionMaterializesMissingEnd(t *testing.T) {
+	language := ForthLanguage()
+	oldSource := []byte(": foo 1 2 ;\n")
+	semicolon := bytes.IndexByte(oldSource, ';')
+	if semicolon < 0 {
+		t.Fatal("fixture is missing its terminator")
+	}
+	newSource := append(append([]byte(nil), oldSource[:semicolon]...), oldSource[semicolon+1:]...)
+
+	parser := gotreesitter.NewParser(language)
+	parser.SetAdmissionCandidateRoute(false)
+	oldTree, err := parser.Parse(oldSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(oldTree.Release)
+
+	deletePoint := retiredDispatchPointAtByte(oldSource, semicolon)
+	afterPoint := retiredDispatchPointAtByte(oldSource, semicolon+1)
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte:   uint32(semicolon),
+		OldEndByte:  uint32(semicolon + 1),
+		NewEndByte:  uint32(semicolon),
+		StartPoint:  deletePoint,
+		OldEndPoint: afterPoint,
+		NewEndPoint: deletePoint,
+	})
+
+	incremental, _, err := parser.ParseIncrementalProfiled(newSource, oldTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(incremental.Release)
+	assertNoNormalizationPasses(t, incremental)
+
+	fresh, err := gotreesitter.NewParser(language).Parse(newSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(fresh.Release)
+	assertNoNormalizationPasses(t, fresh)
+	want := collapsedTokenTreeDigest(t, fresh, language)
+	assertRecoveryActionMaterializationDigest(t, "incremental-terminator-deletion", incremental, language, want)
+
+	missing := findRecoveryActionMaterializationNode(incremental.RootNode(), language, "end_definition")
+	if missing == nil || !missing.IsMissing() || missing.StartByte() != missing.EndByte() {
+		t.Fatalf("incremental end_definition = %v, want zero-width missing node", missing)
+	}
+}
+
 func assertRecoveryActionMaterializationIncremental(
 	t *testing.T,
 	language *gotreesitter.Language,


### PR DESCRIPTION
## Summary

Add a test for deleting a Forth definition terminator during incremental updates. Existing tests only append characters to strings. This new case removes the closing semicolon. The test verifies the incremental parser produces a zero-width missing node that matches a fresh parse.

## Changes

- Add `TestForthIncrementalTerminatorDeletionMaterializesMissingEnd` to the grammar recovery test suite.
- Exercise the edit shape that triggers Forth recovery by deleting the semicolon character from a terminated definition.
- Confirm the incremental route materializes a zero-width missing `end_definition` node.
- Validate the result against a fresh parse digest to ensure full parity.

## Testing

- Run `go test ./grammars -run TestForthIncrementalTerminatorDeletionMaterializesMissingEnd`.