### PR TITLE
add(parser): Add dispatcher transcript for action-effect tracing

### DIFF
--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -336,28 +336,54 @@ func nativeRecoveredStructureHasIsolatedErrorReceipt(root *Node) bool {
 // when the flag is unset, and every dispatcher arm already performs at least
 // one full-tree walk of its own, so even the closure indirection paid when
 // the flag is set is in the noise relative to the arm's own cost.
+//
+// parser_result_dispatcher_transcript.go extends this same probe under its
+// own flag, GTS_DISPATCHER_TRANSCRIPT=1: where this census answers "did the
+// arm change the tree?", the transcript answers "what did it change, and
+// where?" for every invocation that did. dispatcherArmCensus,
+// dispatcherArmSubpassCensus, and materializationSubpassCensus.run below each
+// check both flags, but the disabled and census-only branches are exactly
+// the code that shipped before the transcript existed.
 func dispatcherCensusEnabled() bool {
 	return os.Getenv("GTS_DISPATCHER_CENSUS") == "1"
 }
 
 // dispatcherArmCensus runs fn (the body of one dispatcher-arm switch case)
-// and, only when census instrumentation is enabled, records whether fn
-// changed ctx.root's structural fingerprint under armID via
-// (*Parser).recordNormalizationMetric. armID matches the corresponding
-// "dispatch.<name>" / "predicate.<name>" id in
-// testdata/result_compat_ownership_v1.json so census receipts trace directly
+// and, only when census or transcript instrumentation is enabled, snapshots
+// ctx.root's structural fingerprint before and after fn runs. When the
+// census is enabled it records whether fn changed the fingerprint under
+// armID via (*Parser).recordNormalizationMetric. When the transcript is
+// enabled and fn changed the fingerprint, it also records a transcript
+// effect record (see recordDispatcherArmTranscript). armID matches the
+// corresponding "dispatch.<name>" / "predicate.<name>" id in
+// testdata/result_compat_ownership_v1.json so both receipts trace directly
 // back to the registry entry they measure.
 func dispatcherArmCensus(ctx resultCompatibilityContext, armID string, fn func()) {
-	if !dispatcherCensusEnabled() {
+	census := dispatcherCensusEnabled()
+	transcript := dispatcherTranscriptEnabled()
+	if !census && !transcript {
 		fn()
 		return
 	}
-	before := captureDispatcherFingerprint(ctx.root)
+	if !transcript {
+		before := captureDispatcherFingerprint(ctx.root)
+		fn()
+		after := captureDispatcherFingerprint(ctx.root)
+		visited, rewritten := diffDispatcherFingerprint(before, after)
+		if ctx.parser != nil {
+			ctx.parser.recordNormalizationMetric(armID, 1, 1, visited, rewritten)
+		}
+		return
+	}
+	before := captureDispatcherTranscriptSnapshot(ctx.root)
 	fn()
-	after := captureDispatcherFingerprint(ctx.root)
-	visited, rewritten := diffDispatcherFingerprint(before, after)
-	if ctx.parser != nil {
+	after := captureDispatcherTranscriptSnapshot(ctx.root)
+	visited, rewritten := diffDispatcherFingerprint(before.signatures, after.signatures)
+	if census && ctx.parser != nil {
 		ctx.parser.recordNormalizationMetric(armID, 1, 1, visited, rewritten)
+	}
+	if rewritten > 0 {
+		recordDispatcherArmTranscript(ctx.lang, armID, before, after)
 	}
 }
 
@@ -365,23 +391,38 @@ func dispatcherArmCensus(ctx resultCompatibilityContext, armID string, fn func()
 // arm. The parent arm supplies its enabled state, so each subpass avoids
 // another environment lookup.
 type materializationSubpassCensus struct {
-	ctx     resultCompatibilityContext
-	enabled bool
+	ctx        resultCompatibilityContext
+	enabled    bool // census: GTS_DISPATCHER_CENSUS=1
+	transcript bool // transcript: GTS_DISPATCHER_TRANSCRIPT=1
 }
 
-// run invokes fn and records its exact tree mutation receipt when the parent
-// dispatcher census is enabled.
+// run invokes fn and, when the parent dispatcher census or transcript is
+// enabled, records its exact tree mutation receipt (census) and/or a
+// transcript effect record (transcript; see recordDispatcherArmTranscript).
 func (c materializationSubpassCensus) run(subpassID string, fn func()) {
-	if !c.enabled {
+	if !c.enabled && !c.transcript {
 		fn()
 		return
 	}
-	before := captureDispatcherFingerprint(c.ctx.root)
+	if !c.transcript {
+		before := captureDispatcherFingerprint(c.ctx.root)
+		fn()
+		after := captureDispatcherFingerprint(c.ctx.root)
+		visited, rewritten := diffDispatcherFingerprint(before, after)
+		if c.ctx.parser != nil {
+			c.ctx.parser.recordNormalizationMetric(subpassID, 1, 1, visited, rewritten)
+		}
+		return
+	}
+	before := captureDispatcherTranscriptSnapshot(c.ctx.root)
 	fn()
-	after := captureDispatcherFingerprint(c.ctx.root)
-	visited, rewritten := diffDispatcherFingerprint(before, after)
-	if c.ctx.parser != nil {
+	after := captureDispatcherTranscriptSnapshot(c.ctx.root)
+	visited, rewritten := diffDispatcherFingerprint(before.signatures, after.signatures)
+	if c.enabled && c.ctx.parser != nil {
 		c.ctx.parser.recordNormalizationMetric(subpassID, 1, 1, visited, rewritten)
+	}
+	if rewritten > 0 {
+		recordDispatcherArmTranscript(c.ctx.lang, subpassID, before, after)
 	}
 }
 
@@ -393,17 +434,31 @@ func dispatcherArmSubpassCensus(
 	fn func(materializationSubpassCensus),
 ) {
 	enabled := dispatcherCensusEnabled()
-	census := materializationSubpassCensus{ctx: ctx, enabled: enabled}
-	if !enabled {
+	transcript := dispatcherTranscriptEnabled()
+	census := materializationSubpassCensus{ctx: ctx, enabled: enabled, transcript: transcript}
+	if !enabled && !transcript {
 		fn(census)
 		return
 	}
-	before := captureDispatcherFingerprint(ctx.root)
+	if !transcript {
+		before := captureDispatcherFingerprint(ctx.root)
+		fn(census)
+		after := captureDispatcherFingerprint(ctx.root)
+		visited, rewritten := diffDispatcherFingerprint(before, after)
+		if ctx.parser != nil {
+			ctx.parser.recordNormalizationMetric(armID, 1, 1, visited, rewritten)
+		}
+		return
+	}
+	before := captureDispatcherTranscriptSnapshot(ctx.root)
 	fn(census)
-	after := captureDispatcherFingerprint(ctx.root)
-	visited, rewritten := diffDispatcherFingerprint(before, after)
-	if ctx.parser != nil {
+	after := captureDispatcherTranscriptSnapshot(ctx.root)
+	visited, rewritten := diffDispatcherFingerprint(before.signatures, after.signatures)
+	if enabled && ctx.parser != nil {
 		ctx.parser.recordNormalizationMetric(armID, 1, 1, visited, rewritten)
+	}
+	if rewritten > 0 {
+		recordDispatcherArmTranscript(ctx.lang, armID, before, after)
 	}
 }
 

--- a/parser_result_dispatcher_transcript.go
+++ b/parser_result_dispatcher_transcript.go
@@ -1,0 +1,387 @@
+package gotreesitter
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+)
+
+// --- A7 dispatcher-arm action-effect transcript ---
+//
+// dispatcherArmCensus and dispatcherArmSubpassCensus (parser_result_compat.go)
+// already answer "did this arm change the tree?" under GTS_DISPATCHER_CENSUS=1.
+// This file answers the next question the cohort model needs: *what kind* of
+// change did the arm make, and *where*? Grouping arms by shared producer
+// defect (election picks the wrong shape, recovery retags the root, an extra
+// reattaches to the wrong parent, ...) is a hypothesis until a transcript of
+// real invocations backs it: two arms belong in the same cohort only if their
+// recorded effects actually look alike.
+//
+// The transcript reuses the same iterative preorder walk and the same
+// dispatcherNodeSignature that dispatcherArmCensus's fingerprint already
+// uses, and adds one thing: a root-relative child-index path alongside each
+// signature, so a changed invocation can name which node it first diverged
+// at, not only that something changed.
+//
+// It is a strictly separate, independently gated instrument.
+// GTS_DISPATCHER_TRANSCRIPT=1 turns it on regardless of GTS_DISPATCHER_CENSUS,
+// and GTS_DISPATCHER_CENSUS=1 alone never pays any cost from this file: the
+// disabled and census-only branches in dispatcherArmCensus,
+// dispatcherArmSubpassCensus, and materializationSubpassCensus.run are
+// untouched by this instrument and keep calling the original
+// captureDispatcherFingerprint.
+//
+// Output: one JSON object per line (JSON Lines) appended to the file named
+// by GTS_DISPATCHER_TRANSCRIPT_OUT, one line per dispatcher-arm or -subpass
+// invocation that changed ctx.root. Records are append-only for the life of
+// the process: nothing here truncates a pre-existing file, so a caller that
+// wants a clean run removes the file first. dispatcherTranscriptSummary
+// exposes the same records' arm-ID -> count totals from memory, without
+// re-reading the file, for a caller that only needs the aggregate (for
+// example, "did dispatch.hyprlang fire at all against this corpus?").
+
+// dispatcherTranscriptEnvFlag and dispatcherTranscriptEnvOut name the two
+// environment variables that gate and target this instrument.
+const (
+	dispatcherTranscriptEnvFlag = "GTS_DISPATCHER_TRANSCRIPT"
+	dispatcherTranscriptEnvOut  = "GTS_DISPATCHER_TRANSCRIPT_OUT"
+)
+
+// dispatcherTranscriptEnabled reports whether GTS_DISPATCHER_TRANSCRIPT=1 is
+// set. Like dispatcherCensusEnabled, this is an uncached os.Getenv check paid
+// once per dispatcher-arm call: the only cost an ordinary parse pays when the
+// transcript is off is this one string comparison.
+func dispatcherTranscriptEnabled() bool {
+	return os.Getenv(dispatcherTranscriptEnvFlag) == "1"
+}
+
+// dispatcherTranscriptOutputPath returns the configured JSON-lines output
+// path, or "" when unset. An enabled transcript with no output path still
+// updates the in-memory summary map; it just has nowhere to write records.
+func dispatcherTranscriptOutputPath() string {
+	return os.Getenv(dispatcherTranscriptEnvOut)
+}
+
+// dispatcherTranscriptSnapshot pairs one captureDispatcherFingerprint-style
+// preorder signature per node with the root-relative child-index path that
+// reaches it (path[0] selects a child of the root, path[1] a child of that
+// child, and so on; the root itself has an empty, non-nil path). Building
+// this is strictly more expensive than captureDispatcherFingerprint (one
+// extra int slice per node), so it is only ever produced on the
+// GTS_DISPATCHER_TRANSCRIPT=1 path.
+type dispatcherTranscriptSnapshot struct {
+	signatures []dispatcherNodeSignature
+	paths      [][]int
+}
+
+// captureDispatcherTranscriptSnapshot walks root in the same iterative
+// preorder captureDispatcherFingerprint uses (parser_result_compat.go; same
+// node signature, same child order) and records each node's path alongside
+// its signature. The two functions must keep visiting nodes in the same
+// order: firstDivergentTranscriptPath compares this snapshot's signatures
+// against a plain captureDispatcherFingerprint-shaped slice position by
+// position, exactly as diffDispatcherFingerprint does.
+func captureDispatcherTranscriptSnapshot(root *Node) dispatcherTranscriptSnapshot {
+	if root == nil {
+		return dispatcherTranscriptSnapshot{}
+	}
+	type pending struct {
+		entry   stackEntry
+		arena   *nodeArena
+		fieldID FieldID
+		path    []int
+	}
+	snap := dispatcherTranscriptSnapshot{
+		signatures: make([]dispatcherNodeSignature, 0, 64),
+		paths:      make([][]int, 0, 64),
+	}
+	stack := make([]pending, 0, 64)
+	stack = append(stack, pending{
+		entry: newStackEntryNode(root.parseState, root),
+		arena: root.ownerArena,
+		path:  []int{},
+	})
+	for len(stack) > 0 {
+		top := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if !stackEntryHasNode(top.entry) {
+			continue
+		}
+		childCount := stackEntryNodeChildCount(top.entry)
+		snap.signatures = append(snap.signatures, dispatcherNodeSignature{
+			symbol:       stackEntryNodeSymbol(top.entry),
+			startByte:    stackEntryNodeStartByte(top.entry),
+			endByte:      stackEntryNodeEndByte(top.entry),
+			startPoint:   stackEntryNodeStartPoint(top.entry),
+			endPoint:     stackEntryNodeEndPoint(top.entry),
+			parseState:   stackEntryNodeParseState(top.entry),
+			preGotoState: stackEntryNodePreGotoState(top.entry),
+			childCount:   int32(childCount),
+			fieldID:      top.fieldID,
+			flags:        dispatcherFingerprintEntryFlags(top.entry),
+		})
+		snap.paths = append(snap.paths, top.path)
+		for i := childCount - 1; i >= 0; i-- {
+			child, childArena, fieldID, ok := dispatcherFingerprintChild(top.entry, top.arena, i)
+			if !ok {
+				continue
+			}
+			childPath := make([]int, len(top.path)+1)
+			copy(childPath, top.path)
+			childPath[len(top.path)] = i
+			stack = append(stack, pending{entry: child, arena: childArena, fieldID: fieldID, path: childPath})
+		}
+	}
+	return snap
+}
+
+// dispatcherTranscriptRecord is one JSON-lines entry: one dispatcher-arm (or
+// -subpass) invocation that changed the tree.
+type dispatcherTranscriptRecord struct {
+	Language string                 `json:"language"`
+	Arm      string                 `json:"arm"`
+	NodePath []int                  `json:"node_path"`
+	Effect   dispatcherEffectRecord `json:"effect"`
+}
+
+// dispatcherEffectRecord is the compact before/after description of the
+// first node (in preorder) whose signature differs between the snapshot
+// taken immediately before a dispatcher arm ran and the one taken
+// immediately after. Every change kind is a separate, omitempty field so a
+// cohort's shared shape is visible at a glance across many JSON-lines
+// records: a cohort whose members only ever set NodeType reads differently
+// from one that only ever moves a Field.
+//
+// Inserted and Removed mark the case where the divergence is a pure length
+// change (the tree gained or lost a node at this position and every node
+// before it is identical): NodeType and Span then describe the one side
+// that exists, and the other change kinds do not apply.
+type dispatcherEffectRecord struct {
+	Inserted        bool                    `json:"inserted,omitempty"`
+	Removed         bool                    `json:"removed,omitempty"`
+	NodeType        *dispatcherStringChange `json:"node_type,omitempty"`
+	Span            *dispatcherSpanChange   `json:"span,omitempty"`
+	Error           *dispatcherBoolChange   `json:"error,omitempty"`
+	Missing         *dispatcherBoolChange   `json:"missing,omitempty"`
+	ChildCountDelta int32                   `json:"child_count_delta,omitempty"`
+	Field           *dispatcherStringChange `json:"field,omitempty"`
+}
+
+// dispatcherStringChange records a before/after pair of display strings
+// (a node type name or a field name).
+type dispatcherStringChange struct {
+	Before string `json:"before"`
+	After  string `json:"after"`
+}
+
+// dispatcherBoolChange records a before/after pair for one node flag.
+type dispatcherBoolChange struct {
+	Before bool `json:"before"`
+	After  bool `json:"after"`
+}
+
+// dispatcherSpanChange records a before/after byte range [start, end).
+type dispatcherSpanChange struct {
+	Before [2]uint32 `json:"before"`
+	After  [2]uint32 `json:"after"`
+}
+
+// firstDivergentTranscriptPath locates the earliest preorder position where
+// before and after disagree, using exactly diffDispatcherFingerprint's own
+// notion of "changed" (see that function's comment for the same caveat: a
+// structural insertion or deletion shifts every later position, so the
+// reported node is not always the literal node an arm edited, but its
+// position is exact and reproducible from the two snapshots). beforeSig or
+// afterSig is nil when the position only exists in the other snapshot (a
+// pure insertion/deletion at the tail).
+func firstDivergentTranscriptPath(before, after dispatcherTranscriptSnapshot) (path []int, beforeSig, afterSig *dispatcherNodeSignature, found bool) {
+	shorter := len(before.signatures)
+	if len(after.signatures) < shorter {
+		shorter = len(after.signatures)
+	}
+	for i := 0; i < shorter; i++ {
+		if before.signatures[i] != after.signatures[i] {
+			b, a := before.signatures[i], after.signatures[i]
+			return before.paths[i], &b, &a, true
+		}
+	}
+	if len(before.signatures) > shorter {
+		b := before.signatures[shorter]
+		return before.paths[shorter], &b, nil, true
+	}
+	if len(after.signatures) > shorter {
+		a := after.signatures[shorter]
+		return after.paths[shorter], nil, &a, true
+	}
+	return nil, nil, nil, false
+}
+
+// dispatcherSymbolTypeName resolves a raw Symbol to its display type name,
+// matching (*Node).Type's convention (tree.go): the ERROR symbol reports
+// "ERROR", and an out-of-range symbol reports "".
+func dispatcherSymbolTypeName(lang *Language, sym Symbol) string {
+	if lang == nil {
+		return ""
+	}
+	if sym == errorSymbol {
+		return "ERROR"
+	}
+	if int(sym) >= 0 && int(sym) < len(lang.SymbolNames) {
+		return unescapePunctuationSymbolName(lang.SymbolNames[sym])
+	}
+	return ""
+}
+
+// dispatcherFieldName resolves a raw FieldID to its display name, matching
+// (*Node).FieldNameForChild's convention (tree.go): field 0 ("no field") and
+// an out-of-range field both report "".
+func dispatcherFieldName(lang *Language, fieldID FieldID) string {
+	if lang == nil || fieldID == 0 || int(fieldID) >= len(lang.FieldNames) {
+		return ""
+	}
+	return lang.FieldNames[fieldID]
+}
+
+// buildDispatcherEffectRecord reduces a pair of node signatures (or one
+// signature and a nil, for a pure insertion/deletion) to the compact change
+// description the transcript records.
+func buildDispatcherEffectRecord(lang *Language, before, after *dispatcherNodeSignature) dispatcherEffectRecord {
+	var eff dispatcherEffectRecord
+	switch {
+	case before == nil && after != nil:
+		eff.Inserted = true
+		eff.NodeType = &dispatcherStringChange{After: dispatcherSymbolTypeName(lang, after.symbol)}
+		eff.Span = &dispatcherSpanChange{After: [2]uint32{after.startByte, after.endByte}}
+		return eff
+	case after == nil && before != nil:
+		eff.Removed = true
+		eff.NodeType = &dispatcherStringChange{Before: dispatcherSymbolTypeName(lang, before.symbol)}
+		eff.Span = &dispatcherSpanChange{Before: [2]uint32{before.startByte, before.endByte}}
+		return eff
+	case before == nil || after == nil:
+		// Both absent: firstDivergentTranscriptPath never produces this: it
+		// is guarded here only so this function never dereferences a nil.
+		return eff
+	}
+	if before.symbol != after.symbol {
+		eff.NodeType = &dispatcherStringChange{
+			Before: dispatcherSymbolTypeName(lang, before.symbol),
+			After:  dispatcherSymbolTypeName(lang, after.symbol),
+		}
+	}
+	if before.startByte != after.startByte || before.endByte != after.endByte {
+		eff.Span = &dispatcherSpanChange{
+			Before: [2]uint32{before.startByte, before.endByte},
+			After:  [2]uint32{after.startByte, after.endByte},
+		}
+	}
+	if beforeErr, afterErr := before.flags&nodeFlagHasError != 0, after.flags&nodeFlagHasError != 0; beforeErr != afterErr {
+		eff.Error = &dispatcherBoolChange{Before: beforeErr, After: afterErr}
+	}
+	if beforeMissing, afterMissing := before.flags&nodeFlagMissing != 0, after.flags&nodeFlagMissing != 0; beforeMissing != afterMissing {
+		eff.Missing = &dispatcherBoolChange{Before: beforeMissing, After: afterMissing}
+	}
+	if before.childCount != after.childCount {
+		eff.ChildCountDelta = after.childCount - before.childCount
+	}
+	if before.fieldID != after.fieldID {
+		eff.Field = &dispatcherStringChange{
+			Before: dispatcherFieldName(lang, before.fieldID),
+			After:  dispatcherFieldName(lang, after.fieldID),
+		}
+	}
+	return eff
+}
+
+// dispatcherTranscriptState is the process-wide, mutex-guarded home for the
+// summary count map this instrument keeps. There is deliberately no
+// process-wide open *os.File: appendDispatcherTranscriptLine opens, writes,
+// and closes the output file per record. That only pays a cost on the
+// already-expensive GTS_DISPATCHER_TRANSCRIPT=1 path and needs no shutdown
+// hook to flush.
+var dispatcherTranscriptState struct {
+	mu     sync.Mutex
+	counts map[string]uint64
+}
+
+// dispatcherTranscriptSummary returns a snapshot of how many transcript
+// records this process has recorded so far, keyed by dispatcher arm/subpass
+// ID (the same "dispatch.<name>" / "dispatch.<name>.<subpass>" IDs the
+// records themselves carry as Arm, matching
+// testdata/result_compat_ownership_v1.json's entry IDs). It is safe to call
+// whether or not GTS_DISPATCHER_TRANSCRIPT is set: the map is empty when the
+// transcript never ran.
+func dispatcherTranscriptSummary() map[string]uint64 {
+	dispatcherTranscriptState.mu.Lock()
+	defer dispatcherTranscriptState.mu.Unlock()
+	out := make(map[string]uint64, len(dispatcherTranscriptState.counts))
+	for k, v := range dispatcherTranscriptState.counts {
+		out[k] = v
+	}
+	return out
+}
+
+// resetDispatcherTranscriptSummary clears the in-memory summary count map.
+// It exists for tests: GTS_DISPATCHER_TRANSCRIPT fixtures in this package
+// share the map across the whole test binary, so a test that asserts an
+// exact count resets first.
+func resetDispatcherTranscriptSummary() {
+	dispatcherTranscriptState.mu.Lock()
+	defer dispatcherTranscriptState.mu.Unlock()
+	dispatcherTranscriptState.counts = nil
+}
+
+// recordDispatcherArmTranscript is the sole entry point dispatcherArmCensus,
+// dispatcherArmSubpassCensus, and materializationSubpassCensus.run call once
+// they already know (GTS_DISPATCHER_TRANSCRIPT=1, and
+// diffDispatcherFingerprint found a rewrite) that a transcript record
+// belongs to this invocation. It locates the first divergent node, builds
+// the compact effect record, always updates the in-memory summary, and
+// appends one JSON line to GTS_DISPATCHER_TRANSCRIPT_OUT when that path is
+// set.
+func recordDispatcherArmTranscript(lang *Language, armID string, before, after dispatcherTranscriptSnapshot) {
+	path, beforeSig, afterSig, found := firstDivergentTranscriptPath(before, after)
+	if !found {
+		return
+	}
+	languageName := ""
+	if lang != nil {
+		languageName = lang.Name
+	}
+	record := dispatcherTranscriptRecord{
+		Language: languageName,
+		Arm:      armID,
+		NodePath: path,
+		Effect:   buildDispatcherEffectRecord(lang, beforeSig, afterSig),
+	}
+
+	dispatcherTranscriptState.mu.Lock()
+	if dispatcherTranscriptState.counts == nil {
+		dispatcherTranscriptState.counts = make(map[string]uint64)
+	}
+	dispatcherTranscriptState.counts[armID]++
+	dispatcherTranscriptState.mu.Unlock()
+
+	outPath := dispatcherTranscriptOutputPath()
+	if outPath == "" {
+		return
+	}
+	line, err := json.Marshal(record)
+	if err != nil {
+		return
+	}
+	line = append(line, '\n')
+	appendDispatcherTranscriptLine(outPath, line)
+}
+
+// appendDispatcherTranscriptLine opens outPath in append mode, writes line,
+// and closes it. Errors are swallowed: this is a diagnostic sink, and it
+// must never turn a bad path or a full disk into a parse failure.
+func appendDispatcherTranscriptLine(outPath string, line []byte) {
+	f, err := os.OpenFile(outPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = f.Write(line)
+}

--- a/parser_result_dispatcher_transcript_test.go
+++ b/parser_result_dispatcher_transcript_test.go
@@ -1,0 +1,343 @@
+package gotreesitter
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// hyprlangTranscriptFixture builds the same known-firing witness as
+// TestNormalizeHyprlangBooleanAssignmentValues (parser_result_hyprlang_test.go):
+// a hand-built hyprlang tree with one boolean-valued assignment
+// ("resize_on_border = true") and one non-boolean assignment
+// ("name = myBezier"). dispatch.hyprlang (runLanguageResultCompatibility's
+// "hyprlang" case) retags the first assignment's string value node to a
+// boolean node with one anonymous child, and leaves the second alone. It is
+// named as the recommended first SA-T cohort proof in the normalization
+// backlog plan, so it doubles as this file's dispatcher-arm witness.
+func hyprlangTranscriptFixture() (lang *Language, source []byte, root, boolValue *Node) {
+	lang = &Language{
+		Name: "hyprlang",
+		SymbolNames: []string{
+			"EOF", "configuration", "assignment", "name", "=", "string", "boolean",
+			"true", "false", "on", "off", "yes", "no",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF"},
+			{Name: "configuration", Visible: true, Named: true},
+			{Name: "assignment", Visible: true, Named: true},
+			{Name: "name", Visible: true, Named: true},
+			{Name: "=", Visible: true, Named: false},
+			{Name: "string", Visible: true, Named: true},
+			{Name: "boolean", Visible: true, Named: true},
+			{Name: "true", Visible: true, Named: false},
+			{Name: "false", Visible: true, Named: false},
+			{Name: "on", Visible: true, Named: false},
+			{Name: "off", Visible: true, Named: false},
+			{Name: "yes", Visible: true, Named: false},
+			{Name: "no", Visible: true, Named: false},
+		},
+	}
+	source = []byte("resize_on_border = true\nname = myBezier\n")
+	arena := newNodeArena(arenaClassFull)
+	boolName := newLeafNodeInArena(arena, 3, true, 0, 16, Point{}, Point{Column: 16})
+	boolEquals := newLeafNodeInArena(arena, 4, false, 17, 18, Point{Column: 17}, Point{Column: 18})
+	boolValue = newLeafNodeInArena(arena, 5, true, 18, 23, Point{Column: 18}, Point{Column: 23})
+	boolAssignment := newParentNodeInArena(arena, 2, true, []*Node{boolName, boolEquals, boolValue}, nil, 0)
+	stringName := newLeafNodeInArena(arena, 3, true, 24, 28, Point{Row: 1}, Point{Row: 1, Column: 4})
+	stringEquals := newLeafNodeInArena(arena, 4, false, 29, 30, Point{Row: 1, Column: 5}, Point{Row: 1, Column: 6})
+	stringValue := newLeafNodeInArena(arena, 5, true, 30, 39, Point{Row: 1, Column: 6}, Point{Row: 1, Column: 15})
+	stringAssignment := newParentNodeInArena(arena, 2, true, []*Node{stringName, stringEquals, stringValue}, nil, 0)
+	root = newParentNodeInArena(arena, 1, true, []*Node{boolAssignment, stringAssignment}, nil, 0)
+	return lang, source, root, boolValue
+}
+
+// jsonLines splits raw JSON-lines content into its non-empty lines.
+func jsonLines(t *testing.T, raw []byte) [][]byte {
+	t.Helper()
+	var lines [][]byte
+	for _, line := range bytes.Split(raw, []byte("\n")) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// TestDispatcherArmTranscriptRecordsKnownFiringWitness runs dispatch.hyprlang
+// (a known-firing arm: it always retags a boolean-valued assignment) through
+// the real dispatcher switch with GTS_DISPATCHER_TRANSCRIPT=1 and asserts a
+// transcript record appears in the JSON-lines output with the shape the
+// cohort-proof instrument promises: language, arm, a node path into the
+// changed subtree, and a compact node-type/child-count effect.
+func TestDispatcherArmTranscriptRecordsKnownFiringWitness(t *testing.T) {
+	resetDispatcherTranscriptSummary()
+	t.Setenv("GTS_DISPATCHER_CENSUS", "")
+	t.Setenv("GTS_DISPATCHER_TRANSCRIPT", "1")
+	outPath := filepath.Join(t.TempDir(), "transcript.jsonl")
+	t.Setenv("GTS_DISPATCHER_TRANSCRIPT_OUT", outPath)
+
+	lang, source, root, boolValue := hyprlangTranscriptFixture()
+	ctx := resultCompatibilityContext{root: root, source: source, lang: lang}
+
+	if result := runLanguageResultCompatibility(ctx); result.stopReason != ParseStopNone {
+		t.Fatalf("dispatcher returned stop reason %v, want none", result.stopReason)
+	}
+
+	// The witness fired exactly as it does with no instrumentation at all
+	// (TestNormalizeHyprlangBooleanAssignmentValues): the transcript never
+	// alters normalization, it only observes it.
+	if got, want := boolValue.Type(lang), "boolean"; got != want {
+		t.Fatalf("bool value type = %q, want %q", got, want)
+	}
+	if got, want := boolValue.ChildCount(), 1; got != want {
+		t.Fatalf("bool value child count = %d, want %d", got, want)
+	}
+
+	raw, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read transcript output: %v", err)
+	}
+	lines := jsonLines(t, raw)
+	if len(lines) != 1 {
+		t.Fatalf("transcript recorded %d lines for dispatch.hyprlang's single case body, want 1: %s", len(lines), raw)
+	}
+
+	var rec dispatcherTranscriptRecord
+	if err := json.Unmarshal(lines[0], &rec); err != nil {
+		t.Fatalf("unmarshal transcript line %s: %v", lines[0], err)
+	}
+
+	if rec.Language != "hyprlang" {
+		t.Errorf("record language = %q, want %q", rec.Language, "hyprlang")
+	}
+	if rec.Arm != "dispatch.hyprlang" {
+		t.Errorf("record arm = %q, want %q", rec.Arm, "dispatch.hyprlang")
+	}
+	if want := []int{0, 2}; !slices.Equal(rec.NodePath, want) {
+		t.Errorf("record node_path = %v, want %v (root -> first assignment -> its value child)", rec.NodePath, want)
+	}
+	if rec.Effect.NodeType == nil {
+		t.Fatal("record effect has no node_type change, want string -> boolean")
+	}
+	if rec.Effect.NodeType.Before != "string" || rec.Effect.NodeType.After != "boolean" {
+		t.Errorf("record node_type = %+v, want {Before:string After:boolean}", rec.Effect.NodeType)
+	}
+	if rec.Effect.ChildCountDelta != 1 {
+		t.Errorf("record child_count_delta = %d, want 1 (the synthesized boolean child)", rec.Effect.ChildCountDelta)
+	}
+	if rec.Effect.Span != nil {
+		t.Errorf("record span = %+v, want nil: the retagged node's byte range does not move", rec.Effect.Span)
+	}
+	if rec.Effect.Error != nil || rec.Effect.Missing != nil {
+		t.Errorf("record error=%+v missing=%+v, want both nil: this witness carries no recovery flags", rec.Effect.Error, rec.Effect.Missing)
+	}
+	if rec.Effect.Inserted || rec.Effect.Removed {
+		t.Errorf("record inserted=%v removed=%v, want both false: the changed node still exists on both sides", rec.Effect.Inserted, rec.Effect.Removed)
+	}
+
+	summary := dispatcherTranscriptSummary()
+	if summary["dispatch.hyprlang"] != 1 {
+		t.Errorf("summary count map[dispatch.hyprlang] = %d, want 1: %v", summary["dispatch.hyprlang"], summary)
+	}
+}
+
+// TestDispatcherArmTranscriptDisabledRecordsNothing runs the identical
+// witness with GTS_DISPATCHER_TRANSCRIPT unset and asserts: no output file
+// is created, the summary count map stays empty, and the normalizer's
+// result is byte-for-byte the same as the enabled run above — the
+// instrument is diagnostic-only and never changes behavior.
+func TestDispatcherArmTranscriptDisabledRecordsNothing(t *testing.T) {
+	resetDispatcherTranscriptSummary()
+	t.Setenv("GTS_DISPATCHER_CENSUS", "")
+	t.Setenv("GTS_DISPATCHER_TRANSCRIPT", "")
+	outPath := filepath.Join(t.TempDir(), "transcript.jsonl")
+	t.Setenv("GTS_DISPATCHER_TRANSCRIPT_OUT", outPath)
+
+	lang, source, root, boolValue := hyprlangTranscriptFixture()
+	ctx := resultCompatibilityContext{root: root, source: source, lang: lang}
+
+	if result := runLanguageResultCompatibility(ctx); result.stopReason != ParseStopNone {
+		t.Fatalf("dispatcher returned stop reason %v, want none", result.stopReason)
+	}
+
+	if got, want := boolValue.Type(lang), "boolean"; got != want {
+		t.Fatalf("bool value type = %q, want %q (same result as with the flag on)", got, want)
+	}
+	if got, want := boolValue.ChildCount(), 1; got != want {
+		t.Fatalf("bool value child count = %d, want %d (same result as with the flag on)", got, want)
+	}
+	if child := boolValue.Child(0); child == nil || child.Type(lang) != "true" || child.IsNamed() {
+		t.Fatalf("bool child = %#v, want anonymous true (same result as with the flag on)", child)
+	}
+
+	if _, err := os.Stat(outPath); !os.IsNotExist(err) {
+		t.Fatalf("transcript output file exists with the flag off (stat err = %v); the instrument must write nothing when disabled", err)
+	}
+	if summary := dispatcherTranscriptSummary(); len(summary) != 0 {
+		t.Fatalf("summary count map is non-empty with the flag off: %v", summary)
+	}
+}
+
+// TestDispatcherTranscriptRequiresExactOne locks in GTS_DISPATCHER_TRANSCRIPT's
+// gating contract: only the exact string "1" turns the instrument on,
+// matching GTS_DISPATCHER_CENSUS's existing contract
+// (TestDispatcherCensusRequiresExactOne).
+func TestDispatcherTranscriptRequiresExactOne(t *testing.T) {
+	for _, value := range []string{"", "0", "false", "2"} {
+		t.Setenv("GTS_DISPATCHER_TRANSCRIPT", value)
+		if dispatcherTranscriptEnabled() {
+			t.Fatalf("GTS_DISPATCHER_TRANSCRIPT=%q enabled the transcript", value)
+		}
+	}
+	t.Setenv("GTS_DISPATCHER_TRANSCRIPT", "1")
+	if !dispatcherTranscriptEnabled() {
+		t.Fatal("GTS_DISPATCHER_TRANSCRIPT=1 did not enable the transcript")
+	}
+}
+
+// TestCaptureDispatcherTranscriptSnapshotPaths pins the path convention
+// (root-relative child-index chain, root itself is []) against a small hand
+// built tree, independent of any real dispatcher arm.
+func TestCaptureDispatcherTranscriptSnapshotPaths(t *testing.T) {
+	arena := newNodeArena(arenaClassFull)
+	leaf1 := newLeafNodeInArena(arena, 10, true, 0, 3, Point{Column: 0}, Point{Column: 3})
+	leaf2 := newLeafNodeInArena(arena, 11, true, 3, 6, Point{Column: 3}, Point{Column: 6})
+	root := newParentNodeInArena(arena, 1, true, []*Node{leaf1, leaf2}, nil, 0)
+
+	snap := captureDispatcherTranscriptSnapshot(root)
+	if len(snap.signatures) != 3 || len(snap.paths) != 3 {
+		t.Fatalf("snapshot visited %d signatures / %d paths, want 3/3 (root + 2 leaves)", len(snap.signatures), len(snap.paths))
+	}
+	want := [][]int{{}, {0}, {1}}
+	for i, wantPath := range want {
+		if !slices.Equal(snap.paths[i], wantPath) {
+			t.Errorf("paths[%d] = %v, want %v", i, snap.paths[i], wantPath)
+		}
+	}
+}
+
+// TestFirstDivergentTranscriptPath exercises the shapes a divergence can
+// take: a same-length interior mismatch, a real child insertion (which, for
+// this signature shape, always surfaces as an interior mismatch on the
+// inserted node's parent), the trailing-only-length fallback branch in
+// isolation, and no divergence at all.
+func TestFirstDivergentTranscriptPath(t *testing.T) {
+	build := func() (root, leaf1, leaf2 *Node) {
+		arena := newNodeArena(arenaClassFull)
+		leaf1 = newLeafNodeInArena(arena, 10, true, 0, 3, Point{Column: 0}, Point{Column: 3})
+		leaf2 = newLeafNodeInArena(arena, 11, true, 3, 6, Point{Column: 3}, Point{Column: 6})
+		root = newParentNodeInArena(arena, 1, true, []*Node{leaf1, leaf2}, nil, 0)
+		return root, leaf1, leaf2
+	}
+
+	t.Run("interior mismatch", func(t *testing.T) {
+		root, _, leaf2 := build()
+		before := captureDispatcherTranscriptSnapshot(root)
+		leaf2.symbol = 99
+		after := captureDispatcherTranscriptSnapshot(root)
+
+		path, b, a, found := firstDivergentTranscriptPath(before, after)
+		if !found {
+			t.Fatal("expected a divergence")
+		}
+		if !slices.Equal(path, []int{1}) {
+			t.Errorf("path = %v, want [1]", path)
+		}
+		if b == nil || a == nil {
+			t.Fatalf("expected both sides present, got before=%v after=%v", b, a)
+		}
+		if b.symbol != 11 || a.symbol != 99 {
+			t.Errorf("signatures = before %d after %d, want 11 -> 99", b.symbol, a.symbol)
+		}
+	})
+
+	t.Run("child inserted under root", func(t *testing.T) {
+		// Appending a child always changes its parent's own childCount, and
+		// the parent (here, root) appears earlier in preorder than the new
+		// child, so the interior-mismatch scan (above) finds root itself,
+		// not a trailing-only divergence. This is the shape every real
+		// dispatcher-arm insertion takes: an ancestor's signature always
+		// changes at or before the inserted node's position.
+		root, _, _ := build()
+		before := captureDispatcherTranscriptSnapshot(root)
+		extra := newLeafNodeInArena(root.ownerArena, 12, true, 6, 9, Point{Column: 6}, Point{Column: 9})
+		root.children = append(root.children, extra)
+		after := captureDispatcherTranscriptSnapshot(root)
+
+		path, b, a, found := firstDivergentTranscriptPath(before, after)
+		if !found {
+			t.Fatal("expected a divergence")
+		}
+		if !slices.Equal(path, []int{}) {
+			t.Errorf("path = %v, want [] (root itself, whose child_count changed)", path)
+		}
+		if b == nil || a == nil {
+			t.Fatalf("expected both sides present, got before=%v after=%v", b, a)
+		}
+		if b.childCount != 2 || a.childCount != 3 {
+			t.Errorf("root child counts = before %d after %d, want 2 -> 3", b.childCount, a.childCount)
+		}
+	})
+
+	t.Run("trailing-only length divergence", func(t *testing.T) {
+		// firstDivergentTranscriptPath's trailing-only branch: every
+		// position in the common prefix compares equal, and only the
+		// longer snapshot's own length exposes the change. Built directly
+		// (rather than from a tree mutation) because, for this signature
+		// shape, an ordinary insertion is always caught earlier as an
+		// interior mismatch on the inserted node's parent (see the
+		// preceding subtest) — this subtest instead pins the fallback
+		// branch's own contract.
+		before := dispatcherTranscriptSnapshot{
+			signatures: []dispatcherNodeSignature{{symbol: 1, childCount: 1}, {symbol: 10}},
+			paths:      [][]int{{}, {0}},
+		}
+		after := dispatcherTranscriptSnapshot{
+			signatures: []dispatcherNodeSignature{{symbol: 1, childCount: 1}, {symbol: 10}, {symbol: 12}},
+			paths:      [][]int{{}, {0}, {0, 0}},
+		}
+
+		path, b, a, found := firstDivergentTranscriptPath(before, after)
+		if !found {
+			t.Fatal("expected a divergence")
+		}
+		if !slices.Equal(path, []int{0, 0}) {
+			t.Errorf("path = %v, want [0 0]", path)
+		}
+		if b != nil {
+			t.Errorf("before signature = %+v, want nil (pure insertion)", b)
+		}
+		if a == nil || a.symbol != 12 {
+			t.Errorf("after signature = %v, want symbol 12", a)
+		}
+
+		// Symmetric removal: after is the shorter snapshot this time.
+		path, b, a, found = firstDivergentTranscriptPath(after, before)
+		if !found {
+			t.Fatal("expected a divergence")
+		}
+		if !slices.Equal(path, []int{0, 0}) {
+			t.Errorf("path = %v, want [0 0]", path)
+		}
+		if a != nil {
+			t.Errorf("after signature = %+v, want nil (pure removal)", a)
+		}
+		if b == nil || b.symbol != 12 {
+			t.Errorf("before signature = %v, want symbol 12", b)
+		}
+	})
+
+	t.Run("no divergence", func(t *testing.T) {
+		root, _, _ := build()
+		before := captureDispatcherTranscriptSnapshot(root)
+		after := captureDispatcherTranscriptSnapshot(root)
+		if _, _, _, found := firstDivergentTranscriptPath(before, after); found {
+			t.Fatal("expected no divergence for two snapshots of the same unmodified tree")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Introduces an independent diagnostic instrument that records what tree mutations dispatcher arms produce, rather than only whether they do. Captures pre/post snapshots with root-relative child-index paths, serializes compact change descriptions to JSON Lines, and tracks per-arm invocation counts in memory. Stays completely off-path when GTS_DISPATCHER_TRANSCRIPT is unset.

## Changes

- Introduce `dispatcherTranscriptSnapshot` and `captureDispatcherTranscriptSnapshot` to walk the tree alongside fingerprint logic while recording root-relative child-index paths for every node.
- Extend `dispatcherArmCensus`, `dispatcherArmSubpassCensus`, and `materializationSubpassCensus.run` to evaluate both `GTS_DISPATCHER_CENSUS` and `GTS_DISPATCHER_TRANSCRIPT`, routing to the appropriate snapshot builder and recorder without extra allocation when neither flag is set.
- Implement `firstDivergentTranscriptPath` and `buildDispatcherEffectRecord` to locate the earliest preorder mismatch and emit a compact `dispatcherEffectRecord` that captures node type shifts, byte span changes, error/missing flag toggles, child count deltas, and field remappings.
- Provide append-only JSON Lines output targeting the path set in `GTS_DISPATCHER_TRANSCRIPT_OUT` and thread-safe in-memory summary tracking exposed via `dispatcherTranscriptSummary`.
- Add comprehensive tests covering known-firing witness output, disabled-mode isolation, exact `"1"` gating contract, snapshot path indexing, and divergence boundary conditions.

## Testing

- Run `go test ./... -run "TestDispatcherArm|TestCaptureDispatcher|TestFirstDivergent" -count=1` to verify transcript generation, disabled isolation, and divergence detection.

## Review Focus

Focus on the snapshot path indexing convention and the `firstDivergentTranscriptPath` fallback branches to ensure path reproducibility matches the preorder traversal order used elsewhere in the dispatcher.