### PR TITLE
add(outline): add declarative owner resolution to outline symbols

### DIFF
--- a/grammars/outline_owner.go
+++ b/grammars/outline_owner.go
@@ -1,0 +1,134 @@
+package grammars
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// outlineOwnerRuleCache caches OutlineOwnerRules' gated result by language
+// name, exactly like inferredTagsQueryCache caches ResolveTagsQuery's
+// inference (tags_query_infer.go). Gating loads the language's compiled
+// grammar, so caching keeps repeated calls for the same language cheap.
+var outlineOwnerRuleCache sync.Map // map[string][]gotreesitter.OutlineOwnerRule
+
+// outlineOwnerRuleTable is the per-language table of declarative outline
+// owner rules, keyed by language name. Each row is a candidate, not a
+// guarantee: OutlineOwnerRules gates every row against the language's own
+// symbol and field table (Language.SymbolByName, Language.FieldByName)
+// before returning it, exactly as inferredTagsQuery gates a shared pattern
+// against SymbolByName (tags_query_infer.go). A row whose NodeType,
+// OwnerField, or any Unwrap/NameTypes entry the language does not define is
+// left out before a caller ever sees it, so a regenerated grammar that
+// renames or drops a node type narrows coverage instead of feeding
+// gotreesitter.WithOutlineOwnerRules a shape it cannot resolve.
+//
+// See spec.outline-api.v1 section 2 for the resolution contract this table
+// feeds, and section 3's gating argument for why this table is gated by
+// symbol/field presence rather than by the blob-SHA mechanism
+// runtime_profiles.go uses: an owner rule cannot alter a parse result, so its
+// worst failure is an omission or a caught divergence, never corrupted
+// output.
+var outlineOwnerRuleTable = map[string][]gotreesitter.OutlineOwnerRule{
+	// Go: a method's receiver is the sole child of the "receiver" field's
+	// parameter_list, unwrapped through the parameter declaration, then an
+	// optional pointer and/or generic wrapper, down to the bare type name.
+	//
+	// Verified against this repository's compiled Go grammar blob by parsing
+	// value, pointer, generic-value, and generic-pointer receivers and
+	// reading Node.SExpr(lang): every shape reaches exactly one
+	// type_identifier through this Unwrap chain. A generic receiver's type
+	// ARGUMENT (the "T" in "Box[T]") sits inside "type_arguments", a node
+	// type this rule does not list in Unwrap, so the walk never reaches it
+	// and resolves the base type name alone.
+	"go": {
+		{
+			NodeType:   "method_declaration",
+			OwnerField: "receiver",
+			Unwrap:     []string{"parameter_list", "parameter_declaration", "pointer_type", "generic_type"},
+			NameTypes:  []string{"type_identifier"},
+		},
+	},
+}
+
+// OutlineOwnerRules returns the declarative owner-resolution rules for entry,
+// gated by symbol and field presence in the language's own compiled grammar:
+// a candidate row whose NodeType, OwnerField, or any Unwrap/NameTypes entry
+// the language does not define is left out. The result is nil for a
+// language with no candidate row, or none that survives gating, and
+// gotreesitter.WithOutlineOwnerRules(nil) is a no-op, so callers compose
+// unconditionally:
+//
+//	outliner, err := gotreesitter.NewOutliner(lang, query,
+//	    gotreesitter.WithOutlineOwnerRules(grammars.OutlineOwnerRules(entry)))
+//
+// Gating loads entry's compiled grammar on first call for a given language
+// name; the result is cached, so repeated calls are cheap.
+func OutlineOwnerRules(entry LangEntry) []gotreesitter.OutlineOwnerRule {
+	name := strings.TrimSpace(entry.Name)
+	if name == "" {
+		return nil
+	}
+	if cached, ok := outlineOwnerRuleCache.Load(name); ok {
+		return cached.([]gotreesitter.OutlineOwnerRule)
+	}
+
+	gated := gateOutlineOwnerRules(entry, outlineOwnerRuleTable[name])
+	outlineOwnerRuleCache.Store(name, gated)
+	return gated
+}
+
+// gateOutlineOwnerRules drops every candidate row entry's own grammar cannot
+// resolve: a NodeType or OwnerField the grammar does not define, or an
+// Unwrap/NameTypes entry that names a node type the grammar does not define.
+func gateOutlineOwnerRules(entry LangEntry, candidates []gotreesitter.OutlineOwnerRule) []gotreesitter.OutlineOwnerRule {
+	if len(candidates) == 0 {
+		return nil
+	}
+	if entry.Language == nil {
+		return nil
+	}
+	lang := entry.Language()
+	if lang == nil {
+		return nil
+	}
+
+	hasSymbol := func(symbol string) bool {
+		_, ok := lang.SymbolByName(symbol)
+		return ok
+	}
+	hasField := func(field string) bool {
+		_, ok := lang.FieldByName(field)
+		return ok
+	}
+
+	var gated []gotreesitter.OutlineOwnerRule
+	for _, rule := range candidates {
+		if !hasSymbol(rule.NodeType) || !hasField(rule.OwnerField) {
+			continue
+		}
+		if !everyOutlineOwnerTypeExists(rule.Unwrap, hasSymbol) {
+			continue
+		}
+		if !everyOutlineOwnerTypeExists(rule.NameTypes, hasSymbol) {
+			continue
+		}
+		gated = append(gated, rule)
+	}
+	return gated
+}
+
+// everyOutlineOwnerTypeExists reports whether hasSymbol accepts every entry
+// in types. An empty types list vacuously passes: this gate checks presence,
+// not shape, and a shipped row's Unwrap or NameTypes list is never empty
+// (validated at gotreesitter.NewOutliner construction for any rule a caller
+// attaches; unreachable through this table's shipped rows).
+func everyOutlineOwnerTypeExists(types []string, hasSymbol func(string) bool) bool {
+	for _, t := range types {
+		if !hasSymbol(t) {
+			return false
+		}
+	}
+	return true
+}

--- a/grammars/outline_owner_test.go
+++ b/grammars/outline_owner_test.go
@@ -1,0 +1,101 @@
+package grammars_test
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestOutlineOwnerRulesResolvesGoReceiverThroughAccessor proves the shipped
+// Go row is not just present in the table: composed through the documented
+// call shape --
+//
+//	gotreesitter.NewOutliner(lang, query,
+//	    gotreesitter.WithOutlineOwnerRules(grammars.OutlineOwnerRules(entry)))
+//
+// -- it resolves a real method's receiver on a real parse.
+func TestOutlineOwnerRulesResolvesGoReceiverThroughAccessor(t *testing.T) {
+	entry := grammars.DetectLanguageByName("go")
+	if entry == nil {
+		t.Fatal("the go grammar is not registered")
+	}
+	lang := entry.Language()
+	query := grammars.ResolveTagsQuery(*entry)
+
+	rules := grammars.OutlineOwnerRules(*entry)
+	if len(rules) == 0 {
+		t.Fatal("OutlineOwnerRules(go) returned no rows; the shipped receiver row did not survive gating")
+	}
+
+	const src = `package demo
+
+type Registry struct{}
+
+func (r *Registry) Add(name string) {}
+`
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+
+	outliner, err := gotreesitter.NewOutliner(lang, query,
+		gotreesitter.WithOutlineOwnerRules(rules))
+	if err != nil {
+		t.Fatalf("build outliner: %v", err)
+	}
+	symbols, report := outliner.OutlineTree(tree)
+	if report.OwnerRuleMisses != 0 {
+		t.Errorf("OwnerRuleMisses = %d, want 0", report.OwnerRuleMisses)
+	}
+
+	found := false
+	for _, symbol := range symbols {
+		if symbol.Kind != "method" {
+			continue
+		}
+		found = true
+		if symbol.Owner != "Registry" {
+			t.Errorf("%s: Owner = %q, want %q", symbol.Name, symbol.Owner, "Registry")
+		}
+	}
+	if !found {
+		t.Fatal("the snippet produced no method symbol, so the accessor proof is vacuous")
+	}
+}
+
+// TestOutlineOwnerRulesGatesOnFieldPresence proves the table is gated by
+// symbol and field presence, not shipped unconditionally: a language whose
+// grammar defines "method_declaration" but no "receiver" field -- java, in
+// this fleet -- must never receive the Go row.
+func TestOutlineOwnerRulesGatesOnFieldPresence(t *testing.T) {
+	entry := grammars.DetectLanguageByName("java")
+	if entry == nil {
+		t.Fatal("the java grammar is not registered")
+	}
+	lang := entry.Language()
+	if _, ok := lang.SymbolByName("method_declaration"); !ok {
+		t.Fatal("java's grammar no longer defines method_declaration; this gating proof needs a different witness")
+	}
+	if _, ok := lang.FieldByName("receiver"); ok {
+		t.Fatal("java's grammar now defines a receiver field; this gating proof needs a different witness")
+	}
+
+	rules := grammars.OutlineOwnerRules(*entry)
+	for _, rule := range rules {
+		if rule.NodeType == "method_declaration" {
+			t.Errorf("OutlineOwnerRules(java) returned a method_declaration row despite no receiver field: %+v", rule)
+		}
+	}
+}
+
+// TestOutlineOwnerRulesEmptyForUnknownLanguage proves the accessor fails
+// closed on a LangEntry with no name and no owner-rule row, rather than
+// panicking or loading a grammar it was never asked about.
+func TestOutlineOwnerRulesEmptyForUnknownLanguage(t *testing.T) {
+	if got := grammars.OutlineOwnerRules(grammars.LangEntry{}); got != nil {
+		t.Errorf("OutlineOwnerRules(zero value) = %v, want nil", got)
+	}
+}

--- a/outline.go
+++ b/outline.go
@@ -83,12 +83,13 @@ type OutlinerOption func(*Outliner)
 // A later call REPLACES the rules an earlier call set; the option does not
 // accumulate.
 //
-// Owner resolution is NOT applied in this change. The outliner validates and
-// retains the rules, every OutlineSymbol.Owner stays empty, and
-// OutlineReport.OwnerRuleMisses stays zero. Owner reads a child field name, and
-// field-name projection became trustworthy only after the field-projection
-// alignment change; ownership therefore ships in its own change, behind its own
-// differential gate.
+// OutlineTree applies the attached rules to every symbol: a rule whose
+// NodeType matches resolves OutlineSymbol.Owner when its OwnerField is
+// present on the node and its Unwrap/NameTypes walk reaches exactly one
+// accepted terminal node (resolveOutlineOwner, outline_owner.go). Any other
+// outcome leaves Owner empty and, for a NodeType a rule did match, increments
+// OutlineReport.OwnerRuleMisses. A NodeType no attached rule names never
+// touches Owner or OwnerRuleMisses at all.
 //
 // What construction checks today: every rule must name a NodeType and an
 // OwnerField, because a rule missing either can never resolve an owner.
@@ -96,9 +97,10 @@ type OutlinerOption func(*Outliner)
 // What construction does NOT check today: it accepts an empty NameTypes list,
 // a blank entry inside Unwrap or NameTypes, and a NodeType or OwnerField the
 // language does not define. Each of those fails closed at resolution time and
-// will inflate OwnerRuleMisses rather than produce a wrong Owner. Gating rules
-// on symbol and field presence belongs with the ownership change, which owns
-// the per-language table.
+// inflates OwnerRuleMisses rather than producing a wrong Owner. A caller that
+// wants those rows filtered out ahead of time, so a stale rule costs nothing
+// at resolution either, gates its own table on symbol and field presence the
+// way grammars.OutlineOwnerRules does.
 func WithOutlineOwnerRules(rules []OutlineOwnerRule) OutlinerOption {
 	return func(o *Outliner) {
 		o.ownerRules = nil
@@ -260,11 +262,12 @@ func (o *Outliner) OutlineTree(tree *Tree) ([]OutlineSymbol, OutlineReport) {
 
 	report.TreeHasError = root.HasError()
 
-	candidates, truncated := o.collectOutlineCandidates(root, tree.Source(), &report)
+	source := tree.Source()
+	candidates, truncated := o.collectOutlineCandidates(root, source, &report)
 	report.Truncated = truncated
 
 	kept := filterOutlineCandidates(candidates, &report)
-	symbols := buildOutlineForest(kept, &report)
+	symbols := buildOutlineForest(kept, o.ownerRules, o.lang, source, &report)
 	report.Symbols = countOutlineSymbols(symbols)
 	return symbols, report
 }
@@ -309,6 +312,13 @@ type outlineCandidate struct {
 	nodeType  string
 	rng       Range
 	nameRange Range
+	// node is the captured definition node itself, kept only so a surviving
+	// candidate can resolve its Owner once buildOutlineForest accepts it. No
+	// filter or sort keys off this field, and no OutlineSymbol field repeats
+	// it: symbols already spend Range for the same span, and Node exposes no
+	// other data OutlineSymbol does not already carry through Kind, Name,
+	// NodeType, Range, and NameRange.
+	node *Node
 }
 
 // collectOutlineCandidates runs the tags query and reduces each match to at
@@ -382,6 +392,7 @@ func (o *Outliner) collectOutlineCandidates(root *Node, source []byte, report *O
 			kind:     normalizeOutlineKind(defCapture, nodeType),
 			nodeType: nodeType,
 			rng:      defNode.Range(),
+			node:     defNode,
 		}
 		if hasName {
 			candidate.name = nameText
@@ -553,7 +564,16 @@ func outlineRangeContains(outer, inner Range) bool {
 // Materialization runs in reverse index order. Every child has a higher sorted
 // index than its parent, so each parent finds its children already built. The
 // pass is iterative and allocates one slice per parent that has children.
-func buildOutlineForest(candidates []outlineCandidate, report *OutlineReport) []OutlineSymbol {
+//
+// Materialization is also where Owner resolves, through resolveOutlineOwner
+// (outline_owner.go). Owner reads only the candidate's own node, so resolving
+// it here -- once per accepted candidate, alongside the rest of the symbol's
+// fields -- is equivalent to resolving it in a separate pass over the built
+// forest, without a second walk. ownerRules and lang may be nil, exactly as
+// they are whenever no WithOutlineOwnerRules call attached a table; both
+// resolveOutlineOwner and its test-only caller (runOutlineRules) rely on that
+// nil case costing nothing beyond the nil check.
+func buildOutlineForest(candidates []outlineCandidate, ownerRules map[string][]OutlineOwnerRule, lang *Language, source []byte, report *OutlineReport) []OutlineSymbol {
 	if len(candidates) == 0 {
 		return nil
 	}
@@ -616,6 +636,7 @@ func buildOutlineForest(candidates []outlineCandidate, report *OutlineReport) []
 			NodeType:  candidate.nodeType,
 			Range:     candidate.rng,
 			NameRange: candidate.nameRange,
+			Owner:     resolveOutlineOwner(ownerRules, candidate.node, candidate.nodeType, lang, source, report),
 		}
 		if kids := childrenOf[idx]; len(kids) > 0 {
 			symbol.Children = make([]OutlineSymbol, 0, len(kids))

--- a/outline_api_test.go
+++ b/outline_api_test.go
@@ -302,13 +302,27 @@ func TestOutlineTreeIsSafeForConcurrentUse(t *testing.T) {
 	}
 }
 
-// TestOutlineOwnerStaysEmpty is the stage-1 ownership proof. It supplies the
-// exact Go receiver rule from the specification, outlines a fixture whose
-// methods all carry receivers, and asserts that every Owner is still empty and
-// that no owner-rule miss was recorded. Ownership is field-derived and ships in
-// its own change, behind its own differential gate.
-func TestOutlineOwnerStaysEmpty(t *testing.T) {
+// outlineGoFixtureOwners names, for each committed Go outline fixture, the
+// "Name=Owner" pairs collectOutlineOwners must read back once
+// outlineGoReceiverRule resolves every method symbol's receiver. Every
+// committed Go fixture uses a pointer receiver;
+// TestOutlineOwnerResolvesEveryGoReceiverShape below covers the value and
+// generic shapes this committed set does not exercise.
+var outlineGoFixtureOwners = map[string][]string{
+	"go/service.go.fixture":  {"Add=Registry", "Name=Registry"},
+	"go/broken.go.fixture":   {"After=Holder"},
+	"go/counters.go.fixture": {"Value=Holder"},
+}
+
+// TestOutlineOwnerResolvesGoReceiver is the ownership proof. It supplies the
+// exact Go receiver rule from the specification, outlines every committed Go
+// fixture, and asserts that ownership resolves the receiver type of every
+// method, changes no other field, and records no miss.
+func TestOutlineOwnerResolvesGoReceiver(t *testing.T) {
 	for _, fixture := range outlineGoldenFixtures {
+		if fixture.Language != "go" {
+			continue
+		}
 		fixture := fixture
 		t.Run(fixture.File, func(t *testing.T) {
 			tree, lang, query := loadOutlineFixture(t, fixture.Language, fixture.File)
@@ -329,23 +343,122 @@ func TestOutlineOwnerStaysEmpty(t *testing.T) {
 			if ruledReport != plainReport {
 				t.Errorf("owner rules changed the receipt: %+v with rules, %+v without", ruledReport, plainReport)
 			}
-			if !outlineSymbolsEqual(ruled, plain) {
-				t.Error("owner rules changed the symbol forest; stage 1 must not resolve ownership")
-			}
 			if ruledReport.OwnerRuleMisses != 0 {
-				t.Errorf("OwnerRuleMisses = %d, want 0 while ownership does not run", ruledReport.OwnerRuleMisses)
+				t.Errorf("OwnerRuleMisses = %d, want 0: every method in this fixture carries a resolvable receiver", ruledReport.OwnerRuleMisses)
 			}
-			owners := collectOutlineOwners(ruled)
-			if len(owners) != 0 {
-				t.Errorf("Owner is populated on %d symbols (%v); stage 1 must leave it empty", len(owners), owners)
+			if !outlineSymbolsEqual(stripOutlineOwners(ruled), plain) {
+				t.Error("owner rules changed a field other than Owner")
+			}
+
+			want := outlineGoFixtureOwners[fixture.File]
+			got := collectOutlineOwners(ruled)
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("owners = %v, want %v", got, want)
 			}
 		})
 	}
 }
 
-// TestOutlineGoFixtureHasReceiverMethods proves the ownership test above is
-// not vacuous: the Go fixture really does hold methods whose receiver field a
-// later owner rule would read.
+// TestOutlineOwnerResolvesEveryGoReceiverShape extends the fixture proof
+// above to the receiver shapes no committed Go fixture exercises: a value
+// receiver, a generic type's value receiver, and a generic type's pointer
+// receiver. It parses a small snippet directly instead of reading a
+// committed fixture, so covering all four shapes costs no fixture edit.
+func TestOutlineOwnerResolvesEveryGoReceiverShape(t *testing.T) {
+	const src = `package shapes
+
+type Value struct{}
+type Box[T any] struct{ item T }
+
+func (v Value) ByValue() int { return 0 }
+func (v *Value) ByPointer() int { return 0 }
+func (b Box[T]) GenericByValue() int { return 0 }
+func (b *Box[T]) GenericByPointer() int { return 0 }
+`
+	entry := grammars.DetectLanguageByName("go")
+	if entry == nil {
+		t.Fatal("the go grammar is not registered")
+	}
+	lang := entry.Language()
+	query := grammars.ResolveTagsQuery(*entry)
+
+	parser := gts.NewParser(lang)
+	tree, err := parser.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+
+	outliner, err := gts.NewOutliner(lang, query,
+		gts.WithOutlineOwnerRules([]gts.OutlineOwnerRule{outlineGoReceiverRule}))
+	if err != nil {
+		t.Fatalf("build outliner: %v", err)
+	}
+	symbols, report := outliner.OutlineTree(tree)
+	if report.OwnerRuleMisses != 0 {
+		t.Errorf("OwnerRuleMisses = %d, want 0", report.OwnerRuleMisses)
+	}
+
+	want := map[string]string{
+		"ByValue":          "Value",
+		"ByPointer":        "Value",
+		"GenericByValue":   "Box",
+		"GenericByPointer": "Box",
+	}
+	got := map[string]string{}
+	for _, symbol := range symbols {
+		if symbol.Kind == "method" {
+			got[symbol.Name] = symbol.Owner
+		}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("owners = %v, want %v", got, want)
+	}
+}
+
+// TestOutlineOwnerRuleFailsClosedWhenFieldIsAbsent is the fail-closed witness:
+// a rule whose NodeType matches a symbol but whose OwnerField the language
+// does not carry must leave Owner empty and count the miss, never guess.
+// Java's grammar names its method node "method_declaration" too, exactly
+// like Go's, but carries no "receiver" field, so applying the Go receiver
+// rule to real Java source is a genuine matched-node-type, absent-field
+// miss, not a constructed one.
+func TestOutlineOwnerRuleFailsClosedWhenFieldIsAbsent(t *testing.T) {
+	tree, lang, query := loadOutlineFixture(t, "java", "java/Service.java")
+
+	outliner, err := gts.NewOutliner(lang, query,
+		gts.WithOutlineOwnerRules([]gts.OutlineOwnerRule{outlineGoReceiverRule}))
+	if err != nil {
+		t.Fatalf("build outliner with owner rules: %v", err)
+	}
+	symbols, report := outliner.OutlineTree(tree)
+
+	methodSymbols := 0
+	var check func([]gts.OutlineSymbol)
+	check = func(list []gts.OutlineSymbol) {
+		for _, symbol := range list {
+			if symbol.NodeType == "method_declaration" {
+				methodSymbols++
+				if symbol.Owner != "" {
+					t.Errorf("%s: Owner = %q, want empty: java carries no receiver field", symbol.Name, symbol.Owner)
+				}
+			}
+			check(symbol.Children)
+		}
+	}
+	check(symbols)
+
+	if methodSymbols == 0 {
+		t.Fatal("the fixture holds no method_declaration symbol, so this fail-closed proof is vacuous")
+	}
+	if report.OwnerRuleMisses != methodSymbols {
+		t.Errorf("OwnerRuleMisses = %d, want %d (one per method_declaration symbol)", report.OwnerRuleMisses, methodSymbols)
+	}
+}
+
+// TestOutlineGoFixtureHasReceiverMethods proves
+// TestOutlineOwnerResolvesGoReceiver is not vacuous: the Go fixture really
+// does hold methods whose receiver field the owner rule reads.
 func TestOutlineGoFixtureHasReceiverMethods(t *testing.T) {
 	tree, lang, query := loadOutlineFixture(t, "go", "go/service.go.fixture")
 	outliner, err := gts.NewOutliner(lang, query)
@@ -589,6 +702,22 @@ func collectOutlineOwners(symbols []gts.OutlineSymbol) []string {
 			out = append(out, symbol.Name+"="+symbol.Owner)
 		}
 		out = append(out, collectOutlineOwners(symbol.Children)...)
+	}
+	return out
+}
+
+// stripOutlineOwners returns a deep copy of symbols with every Owner cleared,
+// so a forest resolved with owner rules attached can compare structurally
+// equal, via outlineSymbolsEqual, to the same forest resolved without them.
+func stripOutlineOwners(symbols []gts.OutlineSymbol) []gts.OutlineSymbol {
+	if len(symbols) == 0 {
+		return nil
+	}
+	out := make([]gts.OutlineSymbol, len(symbols))
+	for i, symbol := range symbols {
+		symbol.Owner = ""
+		symbol.Children = stripOutlineOwners(symbol.Children)
+		out[i] = symbol
 	}
 	return out
 }

--- a/outline_coupling_test.go
+++ b/outline_coupling_test.go
@@ -16,6 +16,7 @@ import (
 // file must be added here or the scan will not cover it.
 var outlineSourceFiles = []string{
 	"outline.go",
+	"outline_owner.go",
 	"outline_report.go",
 }
 

--- a/outline_golden_test.go
+++ b/outline_golden_test.go
@@ -221,6 +221,11 @@ func outlineGoldenSymbolsOf(symbols []gts.OutlineSymbol) []outlineGoldenSymbol {
 // Query uses that query instead, which is how the omission counters get pinned
 // end to end: the shared inference cannot produce a duplicate or a conflict on
 // demand, but an explicit query can, and it exercises the identical code path.
+//
+// Every fixture attaches grammars.OutlineOwnerRules(entry), the same table a
+// real caller composes. This is a no-op for every language without a row in
+// that table -- WithOutlineOwnerRules(nil) leaves Owner empty exactly as
+// before -- and resolves real Owner values for the languages that do.
 func outlineForFixture(t *testing.T, fixture outlineGoldenFixture) outlineGoldenFile {
 	t.Helper()
 
@@ -253,7 +258,8 @@ func outlineForFixture(t *testing.T, fixture outlineGoldenFixture) outlineGolden
 	}
 	defer tree.Release()
 
-	outliner, err := gts.NewOutliner(lang, query)
+	outliner, err := gts.NewOutliner(lang, query,
+		gts.WithOutlineOwnerRules(grammars.OutlineOwnerRules(*entry)))
 	if err != nil {
 		t.Fatalf("%s: build outliner: %v", fixture.File, err)
 	}
@@ -345,7 +351,7 @@ func TestOutlineGoldenAccounting(t *testing.T) {
 				t.Errorf("%s: fixture outline is truncated; raise the work budget or shrink the fixture", path)
 			}
 			if golden.Report.OwnerRuleMisses != 0 {
-				t.Errorf("%s: owner rules do not run in this change, so OwnerRuleMisses must stay 0, got %d",
+				t.Errorf("%s: every committed fixture's owner-rule-eligible symbols carry a resolvable owner, so OwnerRuleMisses must stay 0, got %d",
 					path, golden.Report.OwnerRuleMisses)
 			}
 			if golden.Report.Symbols == 0 && golden.Report.Omitted() == 0 {

--- a/outline_internal_test.go
+++ b/outline_internal_test.go
@@ -26,11 +26,18 @@ func outlineTestCandidate(order int, kind, name string, start, end, nameStart, n
 }
 
 // runOutlineRules drives the two pure stages the way OutlineTree does, so the
-// unit cases exercise the shipped code path rather than a copy of it.
+// unit cases exercise the shipped code path rather than a copy of it. These
+// cases build candidates with outlineTestCandidate, which sets no node and no
+// owner rule table, so buildOutlineForest's owner resolution is the
+// documented no-op case throughout this file. The owner-resolving tests
+// (TestOutlineOwnerResolves*, TestOutlineOwnerRuleFailsClosedWhenFieldIsAbsent
+// in outline_api_test.go) exercise resolution itself, over real parsed nodes;
+// resolveOutlineOwnerRule's walk needs a real Node, which only a parsed tree
+// provides.
 func runOutlineRules(candidates []outlineCandidate) ([]OutlineSymbol, OutlineReport) {
 	var report OutlineReport
 	kept := filterOutlineCandidates(candidates, &report)
-	symbols := buildOutlineForest(kept, &report)
+	symbols := buildOutlineForest(kept, nil, nil, nil, &report)
 	report.Symbols = countOutlineSymbols(symbols)
 	return symbols, report
 }

--- a/outline_owner.go
+++ b/outline_owner.go
@@ -1,0 +1,106 @@
+package gotreesitter
+
+// resolveOutlineOwner resolves the non-lexical Owner of one definition node
+// against the rules registered for its NodeType.
+//
+// A NodeType with no rule leaves Owner empty and never touches
+// report.OwnerRuleMisses: the rule set makes no claim about that shape, so
+// there is nothing to miss. A NodeType WITH one or more rules tries each row
+// in order and returns the first Owner a row resolves. When every row for a
+// matched NodeType fails -- the field is absent, the unwrap chain runs out,
+// or it does not end at exactly one accepted terminal node --
+// report.OwnerRuleMisses counts the symbol once and Owner stays empty.
+//
+// rules, node, and lang may all be nil or empty; each case is a miss-free
+// "no rule applies" outcome, exactly like a NodeType absent from rules. This
+// keeps the call safe from buildOutlineForest, which always calls it, even
+// when no WithOutlineOwnerRules call ever attached a table.
+func resolveOutlineOwner(rules map[string][]OutlineOwnerRule, node *Node, nodeType string, lang *Language, source []byte, report *OutlineReport) string {
+	if len(rules) == 0 {
+		return ""
+	}
+	rows, ok := rules[nodeType]
+	if !ok || len(rows) == 0 {
+		return ""
+	}
+	if node != nil && lang != nil {
+		for _, rule := range rows {
+			if owner, resolved := resolveOutlineOwnerRule(rule, node, lang, source); resolved {
+				return owner
+			}
+		}
+	}
+	report.OwnerRuleMisses++
+	return ""
+}
+
+// resolveOutlineOwnerRule applies one rule to one definition node. It reads
+// the node's OwnerField, then walks that field's subtree through
+// collectOutlineOwnerNameNodes. The rule resolves an Owner only when the walk
+// reaches EXACTLY ONE node whose type is in NameTypes; any other count --
+// zero, or more than one -- is a failure. Owner is the matched node's raw
+// text: no directive and no trimming rewrites it, unlike Name.
+func resolveOutlineOwnerRule(rule OutlineOwnerRule, node *Node, lang *Language, source []byte) (string, bool) {
+	field := node.ChildByFieldName(rule.OwnerField, lang)
+	if field == nil {
+		return "", false
+	}
+	matches := collectOutlineOwnerNameNodes(field, rule, lang)
+	if len(matches) != 1 {
+		return "", false
+	}
+	text := matches[0].Text(source)
+	if text == "" {
+		return "", false
+	}
+	return text, true
+}
+
+// collectOutlineOwnerNameNodes walks from start and returns every node the
+// walk reaches whose type is in rule.NameTypes.
+//
+// The walk descends only through a node whose type is in rule.Unwrap, and it
+// never descends past a NameTypes match: a matched node's own children are
+// never visited. A node whose type is in neither list ends that branch of the
+// walk without contributing a match. Together these two stopping rules mean a
+// NameTypes node reachable only through a type the rule does not list in
+// Unwrap is never reached and never counted -- for example, a generic
+// receiver's type ARGUMENT sits inside a node type ("type_arguments" in the
+// shipped Go rule) that Unwrap does not name, so it cannot be mistaken for
+// the receiver's own type name.
+func collectOutlineOwnerNameNodes(start *Node, rule OutlineOwnerRule, lang *Language) []*Node {
+	var matches []*Node
+	var walk func(n *Node)
+	walk = func(n *Node) {
+		if n == nil {
+			return
+		}
+		t := n.Type(lang)
+		if outlineOwnerTypeListHas(rule.NameTypes, t) {
+			matches = append(matches, n)
+			return
+		}
+		if !outlineOwnerTypeListHas(rule.Unwrap, t) {
+			return
+		}
+		count := n.NamedChildCount()
+		for i := 0; i < count; i++ {
+			walk(n.NamedChild(i))
+		}
+	}
+	walk(start)
+	return matches
+}
+
+// outlineOwnerTypeListHas reports whether nodeType appears in list. An
+// OutlineOwnerRule's Unwrap and NameTypes lists hold a handful of entries, so
+// a linear scan on every resolution attempt costs less than building and
+// discarding a map.
+func outlineOwnerTypeListHas(list []string, nodeType string) bool {
+	for _, candidate := range list {
+		if candidate == nodeType {
+			return true
+		}
+	}
+	return false
+}

--- a/outline_report.go
+++ b/outline_report.go
@@ -33,10 +33,10 @@ type OutlineSymbol struct {
 	// counted.
 	NameRange Range
 	// Owner is the non-lexical owner name, for example the receiver type of
-	// a method. It is always empty in this change. Owner resolution runs
-	// from declarative OutlineOwnerRule rows and lands in a later change;
-	// see WithOutlineOwnerRules. Lexical containment never sets Owner --
-	// that information lives in Children.
+	// a Go method. It is set only when a declarative OutlineOwnerRule
+	// attached through WithOutlineOwnerRules matches this symbol's NodeType
+	// and resolves a single identifier; otherwise it is "". Lexical
+	// containment never sets Owner -- that information lives in Children.
 	Owner string
 	// Children holds the definitions lexically nested in this one, in source
 	// order. Nesting comes from byte containment of Range, never from the
@@ -129,7 +129,8 @@ type OutlineReport struct {
 	OmittedMultipleDefinitions int
 	// OwnerRuleMisses counts symbols where an owner rule matched the node
 	// type but the field or the normalization did not resolve a single
-	// name. It is always zero until owner resolution ships.
+	// name. It is zero whenever no attached rule names a symbol's NodeType,
+	// including whenever WithOutlineOwnerRules was never called.
 	OwnerRuleMisses int
 	// DeclineReason names why the outliner produced nothing, or is empty
 	// when it ran the query. See the OutlineDecline constants. An empty
@@ -185,9 +186,8 @@ func (r OutlineReport) Candidates() int {
 // Owner stays empty.
 //
 // Rules are data. The core holds no rule rows; the grammars package owns the
-// per-language table and passes it through WithOutlineOwnerRules.
-//
-// Owner resolution is not applied in this change. See WithOutlineOwnerRules.
+// per-language table (grammars.OutlineOwnerRules) and passes it through
+// WithOutlineOwnerRules.
 type OutlineOwnerRule struct {
 	// NodeType is the definition node type the rule applies to, for example
 	// "method_declaration".

--- a/testdata/outline/go/broken.go.fixture.golden.json
+++ b/testdata/outline/go/broken.go.fixture.golden.json
@@ -73,7 +73,7 @@
         "start_point": "14:17",
         "end_point": "14:22"
       },
-      "owner": ""
+      "owner": "Holder"
     }
   ]
 }

--- a/testdata/outline/go/service.go.fixture.golden.json
+++ b/testdata/outline/go/service.go.fixture.golden.json
@@ -55,7 +55,7 @@
         "start_point": "18:19",
         "end_point": "18:22"
       },
-      "owner": ""
+      "owner": "Registry"
     },
     {
       "kind": "method",
@@ -73,7 +73,7 @@
         "start_point": "23:19",
         "end_point": "23:23"
       },
-      "owner": ""
+      "owner": "Registry"
     },
     {
       "kind": "function",


### PR DESCRIPTION
## Summary

This change implements declarative owner resolution for outline symbols. It replaces the empty placeholder with a runtime walker that applies per-language rules against parsed definition nodes. Every shipped rule gates on the language grammar, so missing nodes or fields fail closed without panicking.

## Changes

- Add grammars.OutlineOwnerRules accessor to expose per-language rule tables. Gating checks symbol and field presence before returning rows.
- Implement resolveOutlineOwner and collectOutlineOwnerNameNodes to walk definition subtrees through Unwrap types and stop at NameTypes matches.
- Pass captured definition nodes through buildOutlineForest so materialization populates OutlineSymbol.Owner using attached rules.
- Update documentation and reporting counters to reflect active ownership resolution and accurate miss tracking.
- Expand test coverage to validate Go receivers across value, pointer, and generic shapes, verify fail-closed behavior on absent fields, and refresh golden fixtures.

## Testing

- Run go test ./... -run '^TestOutline$' to verify owner resolution against all fixtures.
- Run bash cgo_harness/docker/run_single_grammar_parity.sh go to ensure full-parse correctness matches downstream expectations.