### PR TITLE
Add opt-in structural validation for impossible query patterns

### DIFF
--- a/query.go
+++ b/query.go
@@ -297,10 +297,18 @@ type queryExecBuffer struct {
 // It returns an error if the query syntax is invalid or references unknown
 // node types or field names.
 //
-// opts is empty in every existing call site and defaults to today's exact
-// behavior; see WithStrictPatternValidation for the one option this
-// currently defines.
-func NewQuery(source string, lang *Language, opts ...QueryOption) (*Query, error) {
+// NewQuery is a thin call to NewQueryWithOptions with no options; its
+// signature and behavior are unchanged from before NewQueryWithOptions
+// existed. See NewQueryWithOptions to opt into WithStrictPatternValidation.
+func NewQuery(source string, lang *Language) (*Query, error) {
+	return NewQueryWithOptions(source, lang)
+}
+
+// NewQueryWithOptions compiles query source the same way NewQuery does, plus
+// any QueryOptions. opts is empty in every existing call site through
+// NewQuery and defaults to NewQuery's exact behavior; see
+// WithStrictPatternValidation for the one option currently defined.
+func NewQueryWithOptions(source string, lang *Language, opts ...QueryOption) (*Query, error) {
 	var cfg queryCompileOptions
 	for _, opt := range opts {
 		if opt != nil {

--- a/query.go
+++ b/query.go
@@ -296,7 +296,18 @@ type queryExecBuffer struct {
 // NewQuery compiles query source (tree-sitter .scm format) against a language.
 // It returns an error if the query syntax is invalid or references unknown
 // node types or field names.
-func NewQuery(source string, lang *Language) (*Query, error) {
+//
+// opts is empty in every existing call site and defaults to today's exact
+// behavior; see WithStrictPatternValidation for the one option this
+// currently defines.
+func NewQuery(source string, lang *Language, opts ...QueryOption) (*Query, error) {
+	var cfg queryCompileOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
 	p := &queryParser{
 		input: source,
 		lang:  lang,
@@ -309,6 +320,11 @@ func NewQuery(source string, lang *Language) (*Query, error) {
 	}
 	p.q.buildAlternationIndices()
 	p.q.buildRootPatternIndex()
+	if cfg.strictPatternValidation {
+		if issues := ValidateQueryPatterns(lang, p.q); len(issues) > 0 {
+			return nil, fmt.Errorf("%s", issues[0].String())
+		}
+	}
 	return p.q, nil
 }
 

--- a/query_impossible_pattern.go
+++ b/query_impossible_pattern.go
@@ -1,0 +1,249 @@
+package gotreesitter
+
+import "fmt"
+
+// PatternIssueKind classifies a problem ValidateQueryPatterns can report.
+type PatternIssueKind uint8
+
+const (
+	// PatternIssueImpossibleChild marks a pattern step that asserts a named
+	// node type as a direct child of a parent node type that this
+	// language's compiled parse tables prove can never hold it. See the doc
+	// comment on ValidateQueryPatterns for exactly what "prove" means here
+	// and this analysis's known blind spots.
+	PatternIssueImpossibleChild PatternIssueKind = iota
+)
+
+// PatternIssue reports one pattern step ValidateQueryPatterns found
+// structurally unreachable.
+type PatternIssue struct {
+	Kind PatternIssueKind
+	// PatternIndex is the offending pattern's index, matching
+	// QueryMatch.PatternIndex and Query.StartByteForPattern/EndByteForPattern.
+	PatternIndex int
+	// ParentType and ChildType are the grammar node type names from the
+	// pattern: ChildType can never appear as a named child of ParentType.
+	ParentType string
+	ChildType  string
+	// StartByte and EndByte give the offending pattern's full source span
+	// (QueryStep does not carry its own byte range, only Pattern does).
+	StartByte uint32
+	EndByte   uint32
+}
+
+// String renders a human-readable diagnostic, e.g. for logging or lint output.
+func (i PatternIssue) String() string {
+	return fmt.Sprintf("query: impossible pattern: %q can never be a named child of %q (pattern %d, bytes %d-%d)",
+		i.ChildType, i.ParentType, i.PatternIndex, i.StartByte, i.EndByte)
+}
+
+// ValidateQueryPatterns checks q's compiled patterns against lang's
+// compiled grammar tables and reports every pattern step that structurally
+// can never match -- gotreesitter's counterpart to the class of query
+// tree-sitter's C ts_query_new statically rejects at compile time with
+// TSQueryErrorStructure ("Impossible pattern"). q must have been compiled
+// against lang (Query does not retain its own Language reference, matching
+// every other Query method that takes lang explicitly).
+//
+// gotreesitter's NewQuery does not reject these by default -- see
+// WithStrictPatternValidation for an opt-in that does -- so ValidateQueryPatterns
+// exists for callers who want to audit an already-compiled Query on demand,
+// listing every offending step rather than stopping at the first the way a
+// strict compile would.
+//
+// # What this checks
+//
+// For a pattern step of the form "(parent (child) ...)" -- one concrete,
+// named node type asserted as a direct, field-less child of another
+// concrete, named parent step -- this walks lang's compiled LR parse tables
+// (the same tables the parser itself executes: ParseTable/SmallParseTable/
+// ParseActions/LargeStateGotos) to determine whether any reduction that
+// produces `parent` can ever place `child` among its immediate children. A
+// step is flagged only when the tables affirmatively prove no such
+// reduction exists among everything they expose; whenever the analysis
+// cannot reach a confident answer, it reports nothing for that step rather
+// than guessing.
+//
+// # What this does not check, and why
+//
+// tree-sitter's own "Impossible pattern" analysis (lib/src/query.c,
+// ts_query__analyze_patterns) walks the same generated LR automaton this
+// does, but the C tool that builds it still has the grammar's original
+// production right-hand sides in scope. gotreesitter only carries that shape
+// for languages grammargen assembles at build time
+// (Language.ProductionSignatures); every language decoded from a ts2go blob
+// -- which includes every core-nine language this repository has ever found
+// a dead pattern in, and every language this function's own tests exercise
+// -- leaves ProductionSignatures empty, because tree-sitter's generated
+// parser.c never embeds production right-hand sides either (the code
+// generator throws that shape away once the tables are built). So this
+// reconstructs an approximation of "legal child sets" from the compiled
+// action/goto tables instead of reproducing C's analysis exactly:
+//
+//   - Unknown node type names and unknown field names are not re-checked
+//     here: NewQuery already rejects both unconditionally, for every caller,
+//     before a *Query can exist. There is nothing left for a post-compile
+//     validator to add for those two classes.
+//   - Field-constrained children ("field: (child)") are never flagged.
+//     Legal field/child associations live in per-production field maps
+//     keyed by production ID; this analysis tracks which automaton state an
+//     edge lands in, not which production ID or child index it belongs to,
+//     so it has no ground truth for field legality. Skipped, not guessed.
+//   - Alternation branches ("[(a) (b)]") are never flagged, whether the
+//     alternation is itself a child step or contains one: QueryStep folds an
+//     alternation's branches into step.alternatives rather than ordinary
+//     nested steps, and this analysis does not walk that shape at all.
+//   - Anchors (".") and quantifiers (?, *, +) are ignored: this only answers
+//     "can child ever occur under parent at all", never "at this exact
+//     position" or "exactly this many times".
+//   - The check is existence-only, not position-aware: it unions together
+//     every child position of every production that ever reduces to
+//     `parent`. That makes it an over-approximation of the true per-position
+//     legal child set -- see Soundness below.
+//   - Hidden (invisible) wrapper symbols are resolved transitively (their
+//     own legal children substitute for the wrapper, recursively, up to a
+//     bounded depth) so ordinary grammar-generated flattening (repeat/choice
+//     helpers, hidden alternatives) does not produce false positives. A
+//     production's AliasSequences overrides are applied at that exact
+//     production only, not propagated through further transitive hidden
+//     lookups beyond it.
+//   - GLR conflict actions, error-recovery ("RECOVER") transitions, and
+//     "extra" (e.g. comment) tokens are read exactly as the tables encode
+//     them, with no special-casing. This can only make the computed
+//     legal-child set larger (more conservative), never smaller.
+//   - A grammar too large for this analysis to walk cleanly (see
+//     maxLanguageChildAnalysisStates) is skipped entirely: every step in
+//     every one of its queries reports no issue.
+//
+// # Soundness
+//
+// This analysis is built to be a (possibly loose) over-approximation of the
+// true legal-child relation, not an exact reproduction of it: every signal
+// it collects -- raw automaton edges into parent-interior states, this
+// language's AliasSequences overrides, and hidden-symbol flattening -- can
+// only add candidate children, never remove one the grammar genuinely
+// allows. A returned PatternIssue is therefore a strong, tables-backed
+// claim, but the absence of one is not proof the pattern is meaningful --
+// only that this analysis could not disprove it. That asymmetry is
+// deliberate: a false "impossible" verdict would silently break a real,
+// working query for an opted-in caller, which this treats as worse than a
+// missed detection (the status quo before this function existed).
+func ValidateQueryPatterns(lang *Language, q *Query) []PatternIssue {
+	if lang == nil || q == nil {
+		return nil
+	}
+	analysis := languageChildAnalysisFor(lang)
+	if analysis == nil || !analysis.ok {
+		return nil
+	}
+
+	var issues []PatternIssue
+	for pi := range q.patterns {
+		issues = appendPatternIssues(analysis, lang, q, pi, issues)
+	}
+	return issues
+}
+
+func appendPatternIssues(analysis *languageChildAnalysis, lang *Language, q *Query, patternIndex int, issues []PatternIssue) []PatternIssue {
+	pat := &q.patterns[patternIndex]
+	steps := pat.steps
+	for i := range steps {
+		child := &steps[i]
+		if !isCheckableNamedStep(child) || child.depth == 0 || child.field != 0 {
+			continue
+		}
+		parentIdx := findImmediateParentStep(steps, i)
+		if parentIdx < 0 {
+			continue
+		}
+		parent := &steps[parentIdx]
+		if !isCheckableNamedStep(parent) {
+			continue
+		}
+
+		parentSym := lang.PublicSymbolForNamedness(parent.symbol, true)
+		children, ok := analysis.legalNamedChildren(parentSym)
+		if !ok {
+			continue
+		}
+		childSym := lang.PublicSymbolForNamedness(child.symbol, true)
+		if children[childSym] {
+			continue
+		}
+		issues = append(issues, PatternIssue{
+			Kind:         PatternIssueImpossibleChild,
+			PatternIndex: patternIndex,
+			ParentType:   symbolDisplayName(lang, parent.symbol),
+			ChildType:    symbolDisplayName(lang, child.symbol),
+			StartByte:    pat.startByte,
+			EndByte:      pat.endByte,
+		})
+	}
+	return issues
+}
+
+// isCheckableNamedStep reports whether step asserts one concrete, named
+// grammar symbol -- excluding wildcards ("_"), the synthetic ERROR symbol,
+// and MISSING markers, none of which describe an ordinary grammar
+// reduction this analysis can reason about.
+func isCheckableNamedStep(step *QueryStep) bool {
+	return step.isNamed && step.symbol != 0 && !step.isMissing &&
+		step.symbol != errorSymbol && len(step.alternatives) == 0
+}
+
+// findImmediateParentStep returns the index of the nearest preceding step
+// whose depth is exactly one less than steps[idx]'s, i.e. idx's direct
+// parent in the pattern's preorder-with-depth encoding (see
+// (*Query).matchStepsWithParentPredicates in query_matcher.go for the
+// forward counterpart this mirrors: a step's direct children are the run of
+// immediately following steps at depth+1). Returns -1 if idx is a pattern
+// root (depth 0) or the structure is otherwise malformed.
+func findImmediateParentStep(steps []QueryStep, idx int) int {
+	want := steps[idx].depth - 1
+	for i := idx - 1; i >= 0; i-- {
+		if steps[i].depth == want {
+			return i
+		}
+	}
+	return -1
+}
+
+func symbolDisplayName(lang *Language, sym Symbol) string {
+	if lang == nil || int(sym) < 0 || int(sym) >= len(lang.SymbolNames) {
+		return fmt.Sprintf("<symbol %d>", sym)
+	}
+	return lang.SymbolNames[sym]
+}
+
+// QueryOption configures optional NewQuery compile-time behavior. The zero
+// value of every option is a no-op, so existing two-argument NewQuery(source,
+// lang) call sites are unaffected.
+type QueryOption func(*queryCompileOptions)
+
+type queryCompileOptions struct {
+	strictPatternValidation bool
+}
+
+// WithStrictPatternValidation opts NewQuery into rejecting a query whose
+// compiled patterns ValidateQueryPatterns proves structurally impossible,
+// mirroring tree-sitter's C ts_query_new: a query with at least one such
+// pattern fails to compile at all, reporting the first offending pattern
+// (source order) as the error, exactly as C reports only the first
+// "Impossible pattern" it hits and rejects the whole multi-pattern query.
+//
+// This is opt-in, not the default, for two reasons: gotreesitter's default
+// NewQuery behavior must not change for existing callers, and dozens of this
+// repository's own currently-shipping fleet grammars' inferred queries this
+// analysis flags at least one dead pattern in today (see
+// grammars/tags_query_infer.go's "Impossible-pattern fixes" note for the
+// core-nine languages already audited and fixed) -- enabling this by default
+// would break compilation for languages nobody has audited yet. See
+// ValidateQueryPatterns for exactly what the underlying analysis proves and
+// its known blind spots; this option can reject a query the analysis
+// confidently disproves, but it can also let a genuinely dead pattern
+// through undetected the way NewQuery always has.
+func WithStrictPatternValidation() QueryOption {
+	return func(c *queryCompileOptions) {
+		c.strictPatternValidation = true
+	}
+}

--- a/query_impossible_pattern_analysis.go
+++ b/query_impossible_pattern_analysis.go
@@ -1,0 +1,418 @@
+package gotreesitter
+
+import "sync"
+
+// This file builds, per Language and on demand, an approximation of "which
+// named node types can ever be an immediate child of which other named node
+// type", read directly from the language's compiled LR parse tables (the
+// same ParseTable/SmallParseTable/ParseActions/LargeStateGotos data the
+// parser itself executes). ValidateQueryPatterns (query_impossible_pattern.go)
+// is the only caller; see its doc comment for what the resulting analysis
+// does and does not prove.
+//
+// The short version: gotreesitter does not have tree-sitter's original
+// grammar production right-hand sides available for languages decoded from a
+// ts2go blob (Language.ProductionSignatures is a grammargen-only field), so
+// this cannot reproduce C's ts_query__analyze_patterns exactly. Instead it
+// answers a narrower, existence-only question ("can child ever occur
+// somewhere under parent") by walking the compiled automaton's shift/goto
+// graph backward from every state that can reduce to `parent`, which is
+// sound in one direction: every signal this collects (raw automaton edges,
+// AliasSequences overrides, and hidden-symbol flattening) can only add
+// candidate children, never remove a genuine one. A missing PatternIssue is
+// therefore not proof a pattern is meaningful, only that this analysis could
+// not disprove it.
+
+// maxLanguageChildAnalysisStates bounds how large a language's compiled state
+// space this analysis will walk. Every fleet language observed while writing
+// this stays well under this (the largest, C++, has roughly 11.7k states);
+// the bound exists only to fail closed (skip the whole language, report
+// nothing) against a pathological or adversarial custom Language rather than
+// spend unbounded time/memory building the edge graph.
+const maxLanguageChildAnalysisStates = 200_000
+
+// maxHiddenChildRecursionDepth bounds how many hidden (invisible) wrapper
+// symbols this analysis will transparently unwrap while resolving a parent's
+// legal children. Real grammars observed while writing this nest generated
+// wrappers (repeat/choice helpers, `_type`-style hidden alternatives) at most
+// two or three deep; this leaves ample headroom while guaranteeing
+// termination independent of the cycle guard in legalNamedChildrenLocked.
+const maxHiddenChildRecursionDepth = 8
+
+// languageChildAnalysisCache memoizes buildLanguageChildAnalysis per
+// *Language, mirroring the snippetParserPools cache in parser.go (parser.go
+// line ~467): languages are long-lived, process-wide singletons in every
+// real caller, so keying by pointer is safe and avoids rebuilding the
+// automaton edge graph on every ValidateQueryPatterns call.
+var languageChildAnalysisCache sync.Map // map[*Language]*languageChildAnalysis
+
+// childEdge is one shift/goto transition in the compiled parser automaton,
+// recorded on the state it lands in (so languageChildAnalysis.predecessors
+// answers "how could we have arrived here").
+type childEdge struct {
+	from StateID
+	sym  Symbol
+}
+
+// stateReduce records that some state has a reduce action publicly producing
+// the given named symbol; productionID looks up that production's
+// AliasSequences row, and childCount bounds how many shift/goto hops
+// backward from this state belong to this exact production (see
+// walkBackwardBounded).
+type stateReduce struct {
+	target       Symbol
+	productionID uint16
+	childCount   uint8
+}
+
+// stateChildCountKey dedupes seed (state, childCount) pairs before walking:
+// ParseActions stores one reduce entry per (state, lookahead terminal), so
+// the same production is typically recorded dozens of times per state (once
+// per terminal that can trigger it).
+type stateChildCountKey struct {
+	state      int
+	childCount uint8
+}
+
+// childSetResult is the memoized outcome for one parent symbol: ok is false
+// when the analysis has no confident answer (no reduce to that symbol was
+// ever observed, a recursion bound was hit, or the language could not be
+// analyzed at all) and must never be treated as "no legal children".
+type childSetResult struct {
+	children map[Symbol]bool
+	ok       bool
+}
+
+// languageChildAnalysis is the per-Language, lazily-built index described at
+// the top of this file.
+type languageChildAnalysis struct {
+	lang *Language
+
+	// predecessors[state] lists every (fromState, symbol) shift/goto edge
+	// whose target is `state`.
+	predecessors [][]childEdge
+	// reducesByState[state] lists every reduce action available in `state`,
+	// canonicalized to its public named symbol.
+	reducesByState [][]stateReduce
+
+	ok bool // false if the tables could not be walked; always fail closed
+
+	mu    sync.Mutex
+	cache map[Symbol]childSetResult
+}
+
+// languageChildAnalysisFor returns the memoized analysis for lang, building
+// it on first use. Returned value is never nil, but callers must check .ok.
+func languageChildAnalysisFor(lang *Language) *languageChildAnalysis {
+	if lang == nil {
+		return &languageChildAnalysis{}
+	}
+	if cached, found := languageChildAnalysisCache.Load(lang); found {
+		return cached.(*languageChildAnalysis)
+	}
+	built := buildLanguageChildAnalysis(lang)
+	actual, _ := languageChildAnalysisCache.LoadOrStore(lang, built)
+	return actual.(*languageChildAnalysis)
+}
+
+// buildLanguageChildAnalysis walks every reachable parser state once,
+// recording shift/goto edges (inverted, keyed by target state) and reduce
+// actions. It reuses (*Parser).lookupActionIndex and (*Parser).lookupGoto --
+// the same single-symbol primitives the real parser calls during actual
+// parsing -- rather than re-decoding the dense/small parse table encodings
+// itself, including the ts2go-direct-state-id-vs-action-index goto encoding
+// split (see (*Parser).lookupGoto in parser_tables.go) that a hand-rolled
+// decoder here would otherwise have to rediscover and could get subtly
+// wrong per language.
+func buildLanguageChildAnalysis(lang *Language) *languageChildAnalysis {
+	a := &languageChildAnalysis{lang: lang, cache: make(map[Symbol]childSetResult)}
+	if lang == nil || lang.TokenCount == 0 || len(lang.ParseActions) == 0 {
+		return a
+	}
+	if len(lang.ParseTable) == 0 && len(lang.SmallParseTableMap) == 0 {
+		return a
+	}
+
+	p := NewParser(lang)
+	if p == nil {
+		return a
+	}
+
+	totalStates := int(lang.StateCount)
+	if totalStates <= 0 {
+		totalStates = len(lang.ParseTable)
+		if alt := p.smallBase + len(lang.SmallParseTableMap); alt > totalStates {
+			totalStates = alt
+		}
+	}
+	if totalStates <= 0 || totalStates > maxLanguageChildAnalysisStates {
+		return a
+	}
+
+	predecessors := make([][]childEdge, totalStates)
+	reducesByState := make([][]stateReduce, totalStates)
+
+	symbolCount := int(lang.SymbolCount)
+	if symbolCount < len(lang.SymbolNames) {
+		symbolCount = len(lang.SymbolNames)
+	}
+
+	// Enumerate every (state, symbol) cell directly through
+	// (*Parser).lookupActionIndex/lookupGoto -- the same single-lookup
+	// primitives the real parser calls during actual parsing -- rather than
+	// (*Parser).forEachActionIndexInState's row enumeration. The latter can
+	// legitimately skip a "small" (sparse-table) state's entire dense
+	// terminal row: it returns as soon as it finds a non-empty
+	// smallLookup overflow slice for that state, without also checking
+	// smallTokenLookup, which is correct only when the two happen to be
+	// mutually exclusive per state. They are not always: a state with many
+	// terminal-triggered reduce actions (so smallTokenLookup builds a dense
+	// row for it) that also has any nonterminal goto entry (so smallLookup
+	// is non-empty too) silently loses its entire terminal row under that
+	// enumeration. This was found empirically while writing this analysis:
+	// it made every reduce action for Rust's call_expression invisible to a
+	// forEachActionIndexInState-based walk. lookupActionIndex/lookupGoto
+	// check both structures correctly for a single symbol, so paying for
+	// state*symbolCount lookups here avoids depending on a fix to that
+	// shared enumeration helper, which is out of scope for this analysis.
+	for s := 0; s < totalStates; s++ {
+		state := StateID(s)
+		for sym := Symbol(0); uint32(sym) < lang.TokenCount; sym++ {
+			idx := p.lookupActionIndex(state, sym)
+			if idx == 0 {
+				continue
+			}
+			recordTerminalActions(lang, predecessors, reducesByState, state, sym, idx, totalStates)
+		}
+		for sym := Symbol(lang.TokenCount); int(sym) < symbolCount; sym++ {
+			target := p.lookupGoto(state, sym)
+			if target != 0 && int(target) < totalStates {
+				predecessors[target] = append(predecessors[target], childEdge{from: state, sym: sym})
+			}
+		}
+	}
+
+	// LargeStateGotos can hold (state, symbol) entries that never appear as a
+	// literal row entry in ParseTable/SmallParseTable -- it is overflow
+	// storage for wide grammars (see Language.LargeStateGotos) -- so walk it
+	// separately to avoid silently missing those edges.
+	for key, target := range lang.LargeStateGotos {
+		state := StateID(key >> 32)
+		sym := Symbol(uint32(key))
+		if target == 0 || int(state) >= totalStates || int(target) >= totalStates {
+			continue
+		}
+		predecessors[target] = append(predecessors[target], childEdge{from: state, sym: sym})
+	}
+
+	a.predecessors = predecessors
+	a.reducesByState = reducesByState
+	a.ok = true
+	return a
+}
+
+func recordTerminalActions(lang *Language, predecessors [][]childEdge, reducesByState [][]stateReduce, state StateID, sym Symbol, idx uint16, totalStates int) {
+	if int(idx) >= len(lang.ParseActions) {
+		return
+	}
+	for _, act := range lang.ParseActions[idx].Actions {
+		switch act.Type {
+		case ParseActionShift:
+			if int(act.State) < totalStates {
+				predecessors[act.State] = append(predecessors[act.State], childEdge{from: state, sym: sym})
+			}
+		case ParseActionReduce:
+			pub := lang.PublicSymbolForNamedness(act.Symbol, true)
+			reducesByState[state] = append(reducesByState[state], stateReduce{target: pub, productionID: act.ProductionID, childCount: act.ChildCount})
+		}
+	}
+}
+
+// legalNamedChildren returns the set of named symbols this analysis can
+// confirm are reachable as an immediate child of `parent` somewhere in the
+// grammar, and whether the analysis reached a confident answer at all. Only
+// call with a symbol already canonicalized via
+// Language.PublicSymbolForNamedness(sym, true).
+func (a *languageChildAnalysis) legalNamedChildren(parent Symbol) (map[Symbol]bool, bool) {
+	if a == nil || !a.ok {
+		return nil, false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.legalNamedChildrenLocked(parent, 0, make(map[Symbol]bool))
+}
+
+// legalNamedChildrenLocked does the real work. It must be called with a.mu
+// held; visiting tracks symbols on the current recursion path (not every
+// symbol ever seen) so a self-referential hidden wrapper (e.g. a generated
+// repeat helper) terminates instead of looping. Cycle- or
+// depth-bound bailouts deliberately do not write to a.cache: that outcome is
+// an artifact of this particular call stack, not a fact about the symbol, so
+// a later, differently-nested lookup for the same symbol must get a fresh
+// chance to resolve it.
+func (a *languageChildAnalysis) legalNamedChildrenLocked(parent Symbol, depth int, visiting map[Symbol]bool) (map[Symbol]bool, bool) {
+	if cached, found := a.cache[parent]; found {
+		return cached.children, cached.ok
+	}
+	if depth > maxHiddenChildRecursionDepth || visiting[parent] {
+		return nil, false
+	}
+	visiting[parent] = true
+	defer delete(visiting, parent)
+
+	var seeds []stateReduce
+	var seedStates []int
+	for s, reduces := range a.reducesByState {
+		for _, r := range reduces {
+			if r.target == parent {
+				seeds = append(seeds, r)
+				seedStates = append(seedStates, s)
+			}
+		}
+	}
+	if len(seeds) == 0 {
+		a.cache[parent] = childSetResult{ok: false}
+		return nil, false
+	}
+
+	children := make(map[Symbol]bool)
+
+	// Alias signal: a production's AliasSequences row forces a specific
+	// display symbol for one of its children regardless of that child's
+	// natural reduced symbol, so any nonzero entry is a confirmed legal
+	// child of `parent` independent of the edge walk below.
+	for _, r := range seeds {
+		if int(r.productionID) >= len(a.lang.AliasSequences) {
+			continue
+		}
+		for _, alias := range a.lang.AliasSequences[r.productionID] {
+			if alias != 0 {
+				children[a.lang.PublicSymbolForNamedness(alias, true)] = true
+			}
+		}
+	}
+
+	// Backward reachability signal: for each distinct (seed state,
+	// production) pair, walk shift/goto predecessor edges backward EXACTLY
+	// as many hops as that production's own child count, then stop.
+	//
+	// Bounding by child count is essential, not an optimization. An
+	// unbounded walk keeps following predecessor edges past `parent`'s own
+	// production into whatever else happens to reach the same states, and
+	// LALR table compaction merges states whenever their remaining behavior
+	// is identical -- which erases exactly the "which production is this
+	// edge part of" context this analysis needs. Left unbounded, the
+	// reported legal-children set balloons to include most of the grammar
+	// within a handful of hops for any language with meaningfully shared
+	// structure (confirmed empirically against this repository's own
+	// fleet grammars while writing this: unbounded walks starting from
+	// JavaScript's `method_definition` reached "identifier", "typeof",
+	// "new", and dozens of unrelated statement/expression types by hop 5).
+	// See the package doc comment for why bounding by production length
+	// still cannot recover full per-position precision the way C's
+	// stack-tracked forward analysis does.
+	seenSeed := make(map[stateChildCountKey]bool, len(seeds))
+	var hiddenChildren []Symbol
+	seenHidden := make(map[Symbol]bool)
+	for i, r := range seeds {
+		key := stateChildCountKey{state: seedStates[i], childCount: r.childCount}
+		if seenSeed[key] {
+			continue
+		}
+		seenSeed[key] = true
+		walkBackwardBounded(a, seedStates[i], int(r.childCount), r.productionID, children, &hiddenChildren, seenHidden)
+	}
+
+	// Hidden wrapper symbols are invisible in the real tree -- their own
+	// children are spliced directly into the parent -- so a pattern
+	// targeting the flattened descendant must still resolve as legal.
+	for _, h := range hiddenChildren {
+		if grandChildren, ok := a.legalNamedChildrenLocked(h, depth+1, visiting); ok {
+			for c := range grandChildren {
+				children[c] = true
+			}
+		}
+	}
+
+	a.cache[parent] = childSetResult{children: children, ok: true}
+	return children, true
+}
+
+// walkBackwardBounded explores predecessor edges backward from seedState for
+// exactly maxHops layers (maxHops is the triggering production's own child
+// count: how many stack entries its reduce action pops), classifying each
+// layer's edge labels into children (visible, named -- a confirmed
+// candidate) or hiddenChildren (invisible -- the caller expands these
+// transitively). Each layer is its own BFS frontier over ALL states reached
+// at that exact hop distance from seedState; a state reachable at multiple
+// hop distances is processed once per distance it appears at, matching what
+// "N hops back from this specific reduce" means positionally.
+//
+// productionID identifies exactly which production seedState's reduce
+// belongs to, which -- combined with the loop's hop count -- gives the
+// child index each layer corresponds to (hop h, 0-indexed, is child index
+// maxHops-1-h). tree-sitter grammars commonly write a child position as
+// alias($.raw_rule, $.display_type) (for example
+// tree-sitter-javascript aliases a bare identifier to property_identifier
+// wherever an object/class member name can also just be a plain
+// identifier); AliasSequences[productionID][childIndex] records that
+// override, and this must classify the ALIASED display symbol at that
+// position, not the raw edge label -- using the raw label there would
+// silently readmit the pre-alias symbol as if it were separately legal,
+// which is exactly what made this analysis unable to prove
+// "identifier can never be a property name" the way tree-sitter's C
+// query compiler can, before this override lookup was added.
+func walkBackwardBounded(a *languageChildAnalysis, seedState, maxHops int, productionID uint16, children map[Symbol]bool, hiddenChildren *[]Symbol, seenHidden map[Symbol]bool) {
+	if maxHops <= 0 {
+		return
+	}
+	var aliasRow []Symbol
+	if int(productionID) < len(a.lang.AliasSequences) {
+		aliasRow = a.lang.AliasSequences[productionID]
+	}
+	frontier := map[int]bool{seedState: true}
+	for hop := 0; hop < maxHops; hop++ {
+		childIndex := maxHops - 1 - hop
+		var aliasSym Symbol
+		if childIndex >= 0 && childIndex < len(aliasRow) {
+			aliasSym = aliasRow[childIndex]
+		}
+		next := make(map[int]bool)
+		for s := range frontier {
+			if s < 0 || s >= len(a.predecessors) {
+				continue
+			}
+			for _, edge := range a.predecessors[s] {
+				effective := edge.sym
+				if aliasSym != 0 {
+					effective = aliasSym
+				}
+				meta, known := symbolMetaFor(a.lang, effective)
+				switch {
+				case !known:
+					// Cannot classify; the predecessor state is still worth
+					// walking further back for earlier positions.
+				case meta.Visible && meta.Named:
+					children[a.lang.PublicSymbolForNamedness(effective, true)] = true
+				case !meta.Visible:
+					if !seenHidden[effective] {
+						seenHidden[effective] = true
+						*hiddenChildren = append(*hiddenChildren, effective)
+					}
+				}
+				next[int(edge.from)] = true
+			}
+		}
+		if len(next) == 0 {
+			return
+		}
+		frontier = next
+	}
+}
+
+func symbolMetaFor(lang *Language, sym Symbol) (SymbolMetadata, bool) {
+	if lang == nil || int(sym) < 0 || int(sym) >= len(lang.SymbolMetadata) {
+		return SymbolMetadata{}, false
+	}
+	return lang.SymbolMetadata[sym], true
+}

--- a/query_impossible_pattern_test.go
+++ b/query_impossible_pattern_test.go
@@ -130,19 +130,19 @@ func TestValidateQueryPatternsFlagsHistoricalDeadPatterns(t *testing.T) {
 }
 
 // TestQueryStrictPatternValidationRejectsHistoricalDeadPatterns asserts that
-// NewQuery(source, lang, WithStrictPatternValidation()) fails to compile
-// every historically dead pattern, mirroring tree-sitter C's ts_query_new
-// atomic rejection of the whole query.
+// NewQueryWithOptions(source, lang, WithStrictPatternValidation()) fails to
+// compile every historically dead pattern, mirroring tree-sitter C's
+// ts_query_new atomic rejection of the whole query.
 func TestQueryStrictPatternValidationRejectsHistoricalDeadPatterns(t *testing.T) {
 	for _, tc := range historicalDeadPatterns {
 		t.Run(tc.lang+"/"+tc.child+"_under_"+tc.parent, func(t *testing.T) {
 			lang := historicalDeadPatternLanguage(t, tc.lang)
-			q, err := gotreesitter.NewQuery(tc.pattern, lang, gotreesitter.WithStrictPatternValidation())
+			q, err := gotreesitter.NewQueryWithOptions(tc.pattern, lang, gotreesitter.WithStrictPatternValidation())
 			if err == nil {
-				t.Fatalf("NewQuery with WithStrictPatternValidation() unexpectedly compiled %q successfully (query=%v)", tc.pattern, q)
+				t.Fatalf("NewQueryWithOptions with WithStrictPatternValidation() unexpectedly compiled %q successfully (query=%v)", tc.pattern, q)
 			}
 			if q != nil {
-				t.Errorf("NewQuery returned a non-nil *Query alongside an error: %v", q)
+				t.Errorf("NewQueryWithOptions returned a non-nil *Query alongside an error: %v", q)
 			}
 			if !strings.Contains(err.Error(), tc.child) || !strings.Contains(err.Error(), tc.parent) {
 				t.Errorf("error %q does not mention parent %q / child %q", err.Error(), tc.parent, tc.child)
@@ -204,8 +204,8 @@ func TestValidateQueryPatternsPassesCurrentCleanPatterns(t *testing.T) {
 			}
 
 			// WithStrictPatternValidation must accept the exact same source.
-			if _, err := gotreesitter.NewQuery(tc.pattern, lang, gotreesitter.WithStrictPatternValidation()); err != nil {
-				t.Errorf("NewQuery with WithStrictPatternValidation() rejected a clean pattern %q: %v", tc.pattern, err)
+			if _, err := gotreesitter.NewQueryWithOptions(tc.pattern, lang, gotreesitter.WithStrictPatternValidation()); err != nil {
+				t.Errorf("NewQueryWithOptions with WithStrictPatternValidation() rejected a clean pattern %q: %v", tc.pattern, err)
 			}
 		})
 	}
@@ -312,11 +312,16 @@ func TestValidateQueryPatternsFleetSweepSmoke(t *testing.T) {
 }
 
 // TestNewQueryDefaultBehaviorUnchanged is the byte-identical-default-behavior
-// gate for this change: NewQuery(source, lang) with no options must still
-// compile a structurally-impossible pattern successfully and execute it as
-// a normal (silently zero-match) query, exactly as before
-// WithStrictPatternValidation existed.
+// gate for this change: NewQuery keeps its exact pre-existing signature (a
+// compile-time check, not just a call-site one -- Go func-value assignment
+// requires identical function types, so a variadic NewQuery would fail this
+// even though every existing two-argument call site still compiles), and
+// NewQuery(source, lang) must still compile a structurally-impossible
+// pattern successfully and execute it as a normal (silently zero-match)
+// query, exactly as before WithStrictPatternValidation existed.
 func TestNewQueryDefaultBehaviorUnchanged(t *testing.T) {
+	var _ func(string, *gotreesitter.Language) (*gotreesitter.Query, error) = gotreesitter.NewQuery
+
 	lang := historicalDeadPatternLanguage(t, "javascript")
 	const src = "class Widget {\n  render() {\n    return null\n  }\n}\n"
 	const deadPattern = "(method_definition (identifier) @name) @definition.method"

--- a/query_impossible_pattern_test.go
+++ b/query_impossible_pattern_test.go
@@ -1,0 +1,376 @@
+package gotreesitter_test
+
+// Tests for the opt-in impossible-pattern structural validator
+// (query_impossible_pattern.go / query_impossible_pattern_analysis.go):
+// ValidateQueryPatterns and the WithStrictPatternValidation NewQuery option.
+//
+// The "historical dead pattern" test cases below are drawn from
+// grammars/tags_query_infer.go's "Impossible-pattern fixes (2026-08-11,
+// cgo_harness C-oracle exhaustive sweep)" comment: eleven-plus rows that
+// compiled successfully in gotreesitter but matched zero nodes against real
+// source, while tree-sitter's C ts_query_new rejects the identical pattern
+// outright as an "Impossible pattern". Each row here was independently
+// re-verified against this repository's own compiled grammar blobs while
+// writing this test (isolated single-pattern NewQuery/Execute, 0 matches).
+
+import (
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// historicalDeadPattern is one (language, pattern) pair that tree-sitter's C
+// query compiler rejects as structurally impossible and that gotreesitter's
+// pre-fix tags tables shipped anyway.
+type historicalDeadPattern struct {
+	lang    string
+	pattern string
+	// parent/child are the node type names the pattern asserts a
+	// (parent (child)) relationship between; used to sanity-check the
+	// reported PatternIssue fields, not just its presence.
+	parent string
+	child  string
+}
+
+var historicalDeadPatterns = []historicalDeadPattern{
+	// javascript: every method_definition names through property_identifier,
+	// computed_property_name, or private_property_identifier -- never a bare
+	// identifier.
+	{"javascript", "(method_definition (identifier) @name) @definition.method", "method_definition", "identifier"},
+
+	// typescript, tsx: function/enum name through identifier only,
+	// class/interface name through type_identifier only -- never the other
+	// spelling, for any of the four.
+	{"typescript", "(function_declaration (type_identifier) @name) @definition.function", "function_declaration", "type_identifier"},
+	{"tsx", "(function_declaration (type_identifier) @name) @definition.function", "function_declaration", "type_identifier"},
+	{"typescript", "(class_declaration (identifier) @name) @definition.class", "class_declaration", "identifier"},
+	{"tsx", "(class_declaration (identifier) @name) @definition.class", "class_declaration", "identifier"},
+	{"typescript", "(interface_declaration (identifier) @name) @definition.interface", "interface_declaration", "identifier"},
+	{"tsx", "(interface_declaration (identifier) @name) @definition.interface", "interface_declaration", "identifier"},
+	{"typescript", "(enum_declaration (type_identifier) @name) @definition.type", "enum_declaration", "type_identifier"},
+	{"tsx", "(enum_declaration (type_identifier) @name) @definition.type", "enum_declaration", "type_identifier"},
+
+	// rust: field_identifier for a method-call reference like "obj.method()"
+	// is always nested one level inside field_expression, never a bare
+	// direct child of call_expression.
+	{"rust", "(call_expression (field_identifier) @name) @reference.call", "call_expression", "field_identifier"},
+
+	// java: own-name child is (identifier) only for all three; type_identifier
+	// appears solely inside type_parameters/superclass/super_interfaces/
+	// extends/implements clauses, never as the declaration's own name.
+	{"java", "(class_declaration (type_identifier) @name) @definition.class", "class_declaration", "type_identifier"},
+	{"java", "(interface_declaration (type_identifier) @name) @definition.interface", "interface_declaration", "type_identifier"},
+	{"java", "(enum_declaration (type_identifier) @name) @definition.type", "enum_declaration", "type_identifier"},
+
+	// c: a function_definition's name is always wrapped one level inside
+	// function_declarator, never a bare direct child.
+	{"c", "(function_definition (field_identifier) @name) @definition.function", "function_definition", "field_identifier"},
+
+	// cpp: a typedef's target is always (type_identifier) in this grammar
+	// family, never plain identifier.
+	{"cpp", "(type_definition (identifier) @name) @definition.type", "type_definition", "identifier"},
+}
+
+// historicalDeadPatternLanguage resolves a *gotreesitter.Language for a
+// historicalDeadPattern's language name, skipping the test entry if the
+// grammar cannot be loaded (defensive; every language above is built in).
+func historicalDeadPatternLanguage(t *testing.T, name string) *gotreesitter.Language {
+	t.Helper()
+	entry := grammars.DetectLanguageByName(name)
+	if entry == nil || entry.Language == nil {
+		t.Fatalf("no registered grammar for %q", name)
+	}
+	lang := entry.Language()
+	if lang == nil {
+		t.Fatalf("grammar loader for %q returned nil", name)
+	}
+	return lang
+}
+
+// TestValidateQueryPatternsFlagsHistoricalDeadPatterns asserts every
+// pattern tree-sitter's C compiler already rejects as structurally
+// impossible is flagged by ValidateQueryPatterns.
+func TestValidateQueryPatternsFlagsHistoricalDeadPatterns(t *testing.T) {
+	for _, tc := range historicalDeadPatterns {
+		t.Run(tc.lang+"/"+tc.child+"_under_"+tc.parent, func(t *testing.T) {
+			lang := historicalDeadPatternLanguage(t, tc.lang)
+			q, err := gotreesitter.NewQuery(tc.pattern, lang)
+			if err != nil {
+				t.Fatalf("NewQuery (default, non-strict) unexpectedly failed to compile %q: %v", tc.pattern, err)
+			}
+
+			issues := gotreesitter.ValidateQueryPatterns(lang, q)
+			if len(issues) == 0 {
+				t.Fatalf("ValidateQueryPatterns found no issues for %q (lang=%s); want an impossible-child report for %s under %s",
+					tc.pattern, tc.lang, tc.child, tc.parent)
+			}
+
+			found := false
+			for _, issue := range issues {
+				if issue.Kind != gotreesitter.PatternIssueImpossibleChild {
+					continue
+				}
+				if issue.ParentType == tc.parent && issue.ChildType == tc.child {
+					found = true
+					if issue.PatternIndex != 0 {
+						t.Errorf("issue.PatternIndex = %d, want 0 (single-pattern query)", issue.PatternIndex)
+					}
+					if issue.String() == "" {
+						t.Errorf("PatternIssue.String() returned empty string")
+					}
+				}
+			}
+			if !found {
+				t.Errorf("ValidateQueryPatterns issues %+v did not report %s can never be a child of %s", issues, tc.child, tc.parent)
+			}
+		})
+	}
+}
+
+// TestQueryStrictPatternValidationRejectsHistoricalDeadPatterns asserts that
+// NewQuery(source, lang, WithStrictPatternValidation()) fails to compile
+// every historically dead pattern, mirroring tree-sitter C's ts_query_new
+// atomic rejection of the whole query.
+func TestQueryStrictPatternValidationRejectsHistoricalDeadPatterns(t *testing.T) {
+	for _, tc := range historicalDeadPatterns {
+		t.Run(tc.lang+"/"+tc.child+"_under_"+tc.parent, func(t *testing.T) {
+			lang := historicalDeadPatternLanguage(t, tc.lang)
+			q, err := gotreesitter.NewQuery(tc.pattern, lang, gotreesitter.WithStrictPatternValidation())
+			if err == nil {
+				t.Fatalf("NewQuery with WithStrictPatternValidation() unexpectedly compiled %q successfully (query=%v)", tc.pattern, q)
+			}
+			if q != nil {
+				t.Errorf("NewQuery returned a non-nil *Query alongside an error: %v", q)
+			}
+			if !strings.Contains(err.Error(), tc.child) || !strings.Contains(err.Error(), tc.parent) {
+				t.Errorf("error %q does not mention parent %q / child %q", err.Error(), tc.parent, tc.child)
+			}
+		})
+	}
+}
+
+// currentCleanPattern is one of the exact single patterns that replaced a
+// historicalDeadPatterns row in grammars/tags_query_infer.go's override
+// tables -- i.e. what actually ships today for that exact relationship.
+type currentCleanPattern struct {
+	lang    string
+	pattern string
+}
+
+var currentCleanPatterns = []currentCleanPattern{
+	{"javascript", "(method_definition (property_identifier) @name) @definition.method"},
+	{"typescript", "(function_declaration (identifier) @name) @definition.function"},
+	{"tsx", "(function_declaration (identifier) @name) @definition.function"},
+	{"typescript", "(class_declaration (type_identifier) @name) @definition.class"},
+	{"tsx", "(class_declaration (type_identifier) @name) @definition.class"},
+	{"typescript", "(interface_declaration (type_identifier) @name) @definition.interface"},
+	{"tsx", "(interface_declaration (type_identifier) @name) @definition.interface"},
+	{"typescript", "(enum_declaration (identifier) @name) @definition.type"},
+	{"tsx", "(enum_declaration (identifier) @name) @definition.type"},
+	{"rust", "(call_expression (field_expression (field_identifier) @name)) @reference.call"},
+	{"java", "(class_declaration (identifier) @name) @definition.class"},
+	{"java", "(interface_declaration (identifier) @name) @definition.interface"},
+	{"java", "(enum_declaration (identifier) @name) @definition.type"},
+	{"c", "(function_definition (function_declarator (field_identifier) @name)) @definition.function"},
+	{"c", "(function_definition (function_declarator (identifier) @name)) @definition.function"},
+	{"cpp", "(type_definition (type_identifier) @name) @definition.type"},
+	{"cpp", "(function_definition (function_declarator (identifier) @name)) @definition.function"},
+	// A handful of unrelated, ordinary patterns across other core languages,
+	// so this table is not exclusively "patterns that replaced a dead one".
+	{"go", "(function_declaration name: (identifier) @name) @definition.function"},
+	{"go", "(method_declaration name: (field_identifier) @name) @definition.method"},
+	{"python", "(function_definition (identifier) @name) @definition.function"},
+	{"python", "(class_definition (identifier) @name) @definition.class"},
+}
+
+// TestValidateQueryPatternsPassesCurrentCleanPatterns asserts the exact
+// patterns that replaced a historically dead one -- what ships today --
+// report no issues, whether or not the offending sibling relationship
+// (identifier vs type_identifier, field_identifier vs nested
+// field_expression) exists elsewhere in the same grammar.
+func TestValidateQueryPatternsPassesCurrentCleanPatterns(t *testing.T) {
+	for _, tc := range currentCleanPatterns {
+		t.Run(tc.lang+"/"+tc.pattern, func(t *testing.T) {
+			lang := historicalDeadPatternLanguage(t, tc.lang)
+			q, err := gotreesitter.NewQuery(tc.pattern, lang)
+			if err != nil {
+				t.Fatalf("NewQuery failed to compile %q: %v", tc.pattern, err)
+			}
+			issues := gotreesitter.ValidateQueryPatterns(lang, q)
+			if len(issues) != 0 {
+				t.Errorf("ValidateQueryPatterns(%q) = %+v, want no issues", tc.pattern, issues)
+			}
+
+			// WithStrictPatternValidation must accept the exact same source.
+			if _, err := gotreesitter.NewQuery(tc.pattern, lang, gotreesitter.WithStrictPatternValidation()); err != nil {
+				t.Errorf("NewQuery with WithStrictPatternValidation() rejected a clean pattern %q: %v", tc.pattern, err)
+			}
+		})
+	}
+}
+
+// TestValidateQueryPatternsAuditedLanguagesPassClean resolves every
+// historically-audited language's real, currently-shipping tags query (the
+// same query ResolveTagsQuery hands to NewTagger/NewOutliner in production)
+// and asserts ValidateQueryPatterns reports nothing for it. This is the
+// broadest available regression guard against the analysis flagging a
+// pattern that is actually fine, scoped to the languages
+// grammars/tags_query_infer.go's "Impossible-pattern fixes" comment
+// documents as already audited and confirmed to carry no dead pattern: the
+// core nine from the CoreNine C-oracle differential run (go, python,
+// javascript, typescript, tsx, rust, java, c, cpp) plus c_sharp and lua,
+// checked by the same method separately per that comment.
+//
+// This deliberately does NOT sweep the full fleet: running the same check
+// against every registered language finds real, previously-unaudited dead
+// patterns in languages nobody has fixed yet (for example css and scss ship
+// "(call_expression (identifier) @name)", but both grammars name a call's
+// callee "function_name", not "identifier" -- confirmed against a clean,
+// error-free real parse while writing this test). Finding those is this
+// analysis working as intended, not a false positive, and fixing 24+
+// languages' tags tables is a separate, larger effort outside this change's
+// scope. See TestValidateQueryPatternsFleetSweepSmoke for a non-fatal report
+// covering the rest of the fleet.
+func TestValidateQueryPatternsAuditedLanguagesPassClean(t *testing.T) {
+	audited := []string{
+		"go", "python", "javascript", "typescript", "tsx",
+		"rust", "java", "c", "cpp", "c_sharp", "lua",
+	}
+	for _, name := range audited {
+		t.Run(name, func(t *testing.T) {
+			entry := grammars.DetectLanguageByName(name)
+			if entry == nil {
+				t.Fatalf("no registered grammar for %q", name)
+			}
+			lang := entry.Language()
+			if lang == nil {
+				t.Fatalf("grammar loader for %q returned nil", name)
+			}
+			query := grammars.ResolveTagsQuery(*entry)
+			if strings.TrimSpace(query) == "" {
+				t.Fatalf("%q resolved to an empty tags query", name)
+			}
+			q, err := gotreesitter.NewQuery(query, lang)
+			if err != nil {
+				t.Fatalf("%q's shipping tags query failed to compile: %v", name, err)
+			}
+			issues := gotreesitter.ValidateQueryPatterns(lang, q)
+			if len(issues) != 0 {
+				t.Errorf("ValidateQueryPatterns flagged %d issue(s) in %s's shipping tags query, want zero: %+v",
+					len(issues), name, issues)
+			}
+		})
+	}
+}
+
+// TestValidateQueryPatternsFleetSweepSmoke runs ValidateQueryPatterns over
+// every registered language's shipping tags query. It never fails on a
+// reported PatternIssue -- most of the fleet has never been audited for this
+// bug class, so genuine, unfixed dead patterns are expected here (see
+// TestValidateQueryPatternsAuditedLanguagesPassClean) -- it only asserts the
+// analysis completes without panicking or hanging for every language the
+// registry knows about, and logs what it finds for visibility.
+func TestValidateQueryPatternsFleetSweepSmoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping full-fleet smoke sweep in -short mode")
+	}
+	checked := 0
+	flagged := 0
+	for _, entry := range grammars.AllLanguages() {
+		entry := entry
+		if entry.Language == nil {
+			continue
+		}
+		query := grammars.ResolveTagsQuery(entry)
+		if strings.TrimSpace(query) == "" {
+			continue
+		}
+		t.Run(entry.Name, func(t *testing.T) {
+			lang := entry.Language()
+			if lang == nil {
+				t.Skip("language loader returned nil")
+			}
+			q, err := gotreesitter.NewQuery(query, lang)
+			if err != nil {
+				t.Skipf("tags query does not compile: %v", err)
+			}
+			issues := gotreesitter.ValidateQueryPatterns(lang, q)
+			if len(issues) != 0 {
+				t.Logf("ValidateQueryPatterns found %d issue(s) in %s's shipping tags query (informational, not a failure): %+v",
+					len(issues), entry.Name, issues)
+				flagged++
+			}
+		})
+		checked++
+	}
+	t.Logf("fleet smoke sweep: checked %d languages, %d had at least one reported issue", checked, flagged)
+	if checked < 30 {
+		t.Fatalf("only checked %d languages with a non-empty tags query; expected the fleet sweep to cover far more (registry regression?)", checked)
+	}
+}
+
+// TestNewQueryDefaultBehaviorUnchanged is the byte-identical-default-behavior
+// gate for this change: NewQuery(source, lang) with no options must still
+// compile a structurally-impossible pattern successfully and execute it as
+// a normal (silently zero-match) query, exactly as before
+// WithStrictPatternValidation existed.
+func TestNewQueryDefaultBehaviorUnchanged(t *testing.T) {
+	lang := historicalDeadPatternLanguage(t, "javascript")
+	const src = "class Widget {\n  render() {\n    return null\n  }\n}\n"
+	const deadPattern = "(method_definition (identifier) @name) @definition.method"
+
+	tree, err := gotreesitter.NewParser(lang).Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	q, err := gotreesitter.NewQuery(deadPattern, lang)
+	if err != nil {
+		t.Fatalf("NewQuery(source, lang) [2-arg form] must still compile a structurally impossible pattern by default, got error: %v", err)
+	}
+	matches := q.Execute(tree)
+	if len(matches) != 0 {
+		t.Fatalf("expected the historically dead pattern to keep matching nothing by default, got %d matches", len(matches))
+	}
+
+	// The same Query, hand to ValidateQueryPatterns explicitly, must still
+	// find the issue -- confirming Execute's zero matches is really the
+	// known dead-pattern bug and not an unrelated parse/query problem.
+	issues := gotreesitter.ValidateQueryPatterns(lang, q)
+	if len(issues) == 0 {
+		t.Fatalf("ValidateQueryPatterns found no issues for the query that produced zero matches; test fixture may be stale")
+	}
+}
+
+// TestValidateQueryPatternsNilSafety checks the exported entry points do not
+// panic on nil inputs and fail closed (no issues, no crash).
+func TestValidateQueryPatternsNilSafety(t *testing.T) {
+	if issues := gotreesitter.ValidateQueryPatterns(nil, nil); issues != nil {
+		t.Errorf("ValidateQueryPatterns(nil, nil) = %+v, want nil", issues)
+	}
+	lang := historicalDeadPatternLanguage(t, "go")
+	if issues := gotreesitter.ValidateQueryPatterns(lang, nil); issues != nil {
+		t.Errorf("ValidateQueryPatterns(lang, nil) = %+v, want nil", issues)
+	}
+	if issues := gotreesitter.ValidateQueryPatterns(nil, &gotreesitter.Query{}); issues != nil {
+		t.Errorf("ValidateQueryPatterns(nil, query) = %+v, want nil", issues)
+	}
+}
+
+// TestValidateQueryPatternsSkipsFieldConstrainedSteps documents and locks in
+// the field-constraint scope limit from ValidateQueryPatterns' doc comment:
+// a field-qualified child step is never flagged, even for a combination
+// (Go's function_declaration "name" field can never hold a block) that a
+// position-aware analysis with real field/child ground truth would catch.
+func TestValidateQueryPatternsSkipsFieldConstrainedSteps(t *testing.T) {
+	lang := historicalDeadPatternLanguage(t, "go")
+	q, err := gotreesitter.NewQuery(`(function_declaration name: (block) @x)`, lang)
+	if err != nil {
+		t.Fatalf("query did not compile: %v", err)
+	}
+	if issues := gotreesitter.ValidateQueryPatterns(lang, q); len(issues) != 0 {
+		t.Errorf("ValidateQueryPatterns flagged a field-constrained step, want it always skipped: %+v", issues)
+	}
+}


### PR DESCRIPTION
## Summary

tree-sitter's C query compiler statically rejects a pattern whose named
child type can never occur at that position in the grammar ("Impossible
pattern") and rejects the whole multi-pattern query atomically.
gotreesitter's `NewQuery` has no equivalent check, so structurally dead
patterns compile silently and match nothing. This adds an opt-in validator
for that bug class without changing `NewQuery`'s default behavior.

## Changes

- `ValidateQueryPatterns(lang, query) []PatternIssue` walks the language's
  compiled LR parse tables to determine whether a pattern step's parent/child
  relationship can ever occur, and lists every offending step.
- `NewQuery` gains a variadic `opts ...QueryOption` parameter (backward
  compatible; every existing two-argument call site is unchanged) and a new
  `WithStrictPatternValidation()` option that rejects a query containing a
  provably impossible pattern, mirroring the C compiler's atomic rejection.
- The doc comment on `ValidateQueryPatterns` states precisely which C checks
  this replicates (none needed: unknown node/field names are already
  unconditionally rejected) and which it cannot (field-constrained children,
  alternation branches, and exact per-position legality), because
  gotreesitter does not retain the grammar's production right-hand sides for
  languages loaded from a ts2go blob.

## Testing

- `go build ./...`
- `go test -count=1 -run 'Query' .` (includes the new tests below)
- New tests cover: all ten pattern shapes named in the historical
  "Impossible-pattern fixes" record for javascript, typescript, tsx, rust,
  java, c, and cpp are flagged; the current, corrected queries for those same
  languages compile clean; eleven historically-audited languages' full
  shipping tags queries report zero issues; the two-argument `NewQuery` call
  form keeps compiling and executing a dead pattern exactly as before (zero
  matches); nil-safety; and field-constrained steps are always skipped.