### PR TITLE
refactor(tests): Restructure tests under roottest directory

### DIFF
--- a/roottest/bench/benchmark_cpp_condition_test.go
+++ b/roottest/bench/benchmark_cpp_condition_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package bench_test
 
 import (
 	"testing"

--- a/roottest/bench/benchmark_injection_test.go
+++ b/roottest/bench/benchmark_injection_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package bench_test
 
 import (
 	"testing"

--- a/roottest/bench/benchmark_self_parse_test.go
+++ b/roottest/bench/benchmark_self_parse_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package bench_test
 
 // Benchmarks that parse gotreesitter's own source files. These files are
 // deliberately pathological: very long, dense switch/select bodies and

--- a/roottest/bench/outline_bench_test.go
+++ b/roottest/bench/outline_bench_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package bench_test
 
 import (
 	"strings"

--- a/roottest/highlight/highlight_incremental_issue23_test.go
+++ b/roottest/highlight/highlight_incremental_issue23_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package highlight_test
 
 import (
 	"testing"

--- a/roottest/highlight/highlight_markdown_injection_test.go
+++ b/roottest/highlight/highlight_markdown_injection_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package highlight_test
 
 import (
 	"testing"

--- a/roottest/highlight/injection_integration_test.go
+++ b/roottest/highlight/injection_integration_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package highlight_test
 
 import (
 	"testing"

--- a/roottest/parse/arena_slice_alias_regression_test.go
+++ b/roottest/parse/arena_slice_alias_regression_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package parse_test
 
 import (
 	"os"

--- a/roottest/parse/descendant_range_parity_test.go
+++ b/roottest/parse/descendant_range_parity_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package parse_test
 
 import (
 	"testing"

--- a/roottest/parse/imports_test.go
+++ b/roottest/parse/imports_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package parse_test
 
 import (
 	"testing"

--- a/roottest/parse/intern_observe_test.go
+++ b/roottest/parse/intern_observe_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package parse_test
 
 import (
 	"os"

--- a/roottest/parse/issue660_regression_test.go
+++ b/roottest/parse/issue660_regression_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package parse_test
 
 import (
 	"testing"

--- a/roottest/parse/js_fork_reduction_test.go
+++ b/roottest/parse/js_fork_reduction_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package parse_test
 
 import (
 	"os"

--- a/roottest/parse/parent_link_race_test.go
+++ b/roottest/parse/parent_link_race_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package parse_test
 
 import (
 	"sync"

--- a/roottest/parse/parser_arena_density_parse_test.go
+++ b/roottest/parse/parser_arena_density_parse_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package parse_test
 
 import (
 	"bytes"

--- a/roottest/parse/parser_fidl_test.go
+++ b/roottest/parse/parser_fidl_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package parse_test
 
 import (
 	"testing"

--- a/roottest/parse/parser_go_large_file_regression_test.go
+++ b/roottest/parse/parser_go_large_file_regression_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package parse_test
 
 import (
 	"os"

--- a/roottest/parse/parser_http_test.go
+++ b/roottest/parse/parser_http_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package parse_test
 
 import (
 	"testing"

--- a/roottest/parse/parser_markdown_inline_html_test.go
+++ b/roottest/parse/parser_markdown_inline_html_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package parse_test
 
 import (
 	"strings"

--- a/roottest/parse/parser_memory_budget_test.go
+++ b/roottest/parse/parser_memory_budget_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package parse_test
 
 import (
 	"bytes"

--- a/roottest/parse/parser_resync_recovery_test.go
+++ b/roottest/parse/parser_resync_recovery_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package parse_test
 
 import (
 	"testing"

--- a/roottest/query/fuzz_query_test.go
+++ b/roottest/query/fuzz_query_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package query_test
 
 import (
 	"testing"

--- a/roottest/query/query_c_parity_fixes_test.go
+++ b/roottest/query/query_c_parity_fixes_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package query_test
 
 // Focused C-parity regression tests for the tree-sitter query-engine
 // parity fixes landed on this branch:

--- a/roottest/query/query_cmake_regression_test.go
+++ b/roottest/query/query_cmake_regression_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package query_test
 
 import (
 	"reflect"

--- a/roottest/query/query_kotlin_object_declaration_test.go
+++ b/roottest/query/query_kotlin_object_declaration_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package query_test
 
 import (
 	"testing"

--- a/roottest/query/query_silent_wrong_witness_test.go
+++ b/roottest/query/query_silent_wrong_witness_test.go
@@ -1,4 +1,4 @@
-package gotreesitter_test
+package query_test
 
 // Witness suite for the query-engine "silent-wrong" correctness tranche
 // (D1, D3, D4, D5, D8). Each witness was cross-checked against the real C


### PR DESCRIPTION
## Summary

Moves all top-level test files into a dedicated roottest directory. Organizes tests by subsystem into bench, highlight, parse, and query subdirectories. Updates package names to match the new paths. This layout improves navigation and isolates test suites by domain.

## Changes

- Relocate parser and arena tests to roottest/parse with package parse_test.
- Relocate highlight and injection tests to roottest/highlight with package highlight_test.
- Relocate query and fuzz tests to roottest/query with package query_test.
- Relocate benchmark tests to roottest/bench with package bench_test.
- Update all package declarations to match the new directory structure.

## Testing

- Run `go test ./...` to verify compilation and suite execution.
- Run `go vet ./...` to confirm no stray imports or broken references.