### PR TITLE
optimize(dispatcher): Cache dispatcher transcript environment reads

### DIFF
--- a/parser_result_dispatcher_transcript.go
+++ b/parser_result_dispatcher_transcript.go
@@ -47,19 +47,40 @@ const (
 	dispatcherTranscriptEnvOut  = "GTS_DISPATCHER_TRANSCRIPT_OUT"
 )
 
+// dispatcherTranscriptEnabledOnce and dispatcherTranscriptOutputPathOnce
+// cache the two environment reads below (sync.Once), mirroring
+// admissionCensusEnabled's pattern (admission_census.go): each read happens
+// at most once per process, so every dispatcher-arm call after the first
+// pays one atomic-guarded read instead of a fresh os.Getenv.
+var (
+	dispatcherTranscriptEnabledOnce sync.Once
+	dispatcherTranscriptEnabledVal  bool
+
+	dispatcherTranscriptOutputPathOnce sync.Once
+	dispatcherTranscriptOutputPathVal  string
+)
+
 // dispatcherTranscriptEnabled reports whether GTS_DISPATCHER_TRANSCRIPT=1 is
-// set. Like dispatcherCensusEnabled, this is an uncached os.Getenv check paid
-// once per dispatcher-arm call: the only cost an ordinary parse pays when the
-// transcript is off is this one string comparison.
+// set. The read is cached after the first call (sync.Once): the only cost an
+// ordinary parse pays when the transcript is off, after process start, is
+// one atomic-guarded boolean read, not a fresh os.Getenv.
 func dispatcherTranscriptEnabled() bool {
-	return os.Getenv(dispatcherTranscriptEnvFlag) == "1"
+	dispatcherTranscriptEnabledOnce.Do(func() {
+		dispatcherTranscriptEnabledVal = os.Getenv(dispatcherTranscriptEnvFlag) == "1"
+	})
+	return dispatcherTranscriptEnabledVal
 }
 
 // dispatcherTranscriptOutputPath returns the configured JSON-lines output
 // path, or "" when unset. An enabled transcript with no output path still
 // updates the in-memory summary map; it just has nowhere to write records.
+// The read is cached after the first call (sync.Once), the same as
+// dispatcherTranscriptEnabled above.
 func dispatcherTranscriptOutputPath() string {
-	return os.Getenv(dispatcherTranscriptEnvOut)
+	dispatcherTranscriptOutputPathOnce.Do(func() {
+		dispatcherTranscriptOutputPathVal = os.Getenv(dispatcherTranscriptEnvOut)
+	})
+	return dispatcherTranscriptOutputPathVal
 }
 
 // dispatcherTranscriptSnapshot pairs one captureDispatcherFingerprint-style
@@ -329,6 +350,21 @@ func resetDispatcherTranscriptSummary() {
 	dispatcherTranscriptState.mu.Lock()
 	defer dispatcherTranscriptState.mu.Unlock()
 	dispatcherTranscriptState.counts = nil
+}
+
+// resetDispatcherTranscriptEnvCacheForTest clears
+// dispatcherTranscriptEnabled's and dispatcherTranscriptOutputPath's cached
+// reads (their sync.Once guards). It exists for tests: a fixture that sets
+// GTS_DISPATCHER_TRANSCRIPT or GTS_DISPATCHER_TRANSCRIPT_OUT with t.Setenv
+// needs the next read to see that value immediately, regardless of whether
+// an earlier test in the same binary already read and cached one; call it
+// again (for example via t.Cleanup) after the environment variable is
+// restored, so later tests re-read rather than inherit this test's value.
+func resetDispatcherTranscriptEnvCacheForTest() {
+	dispatcherTranscriptEnabledOnce = sync.Once{}
+	dispatcherTranscriptEnabledVal = false
+	dispatcherTranscriptOutputPathOnce = sync.Once{}
+	dispatcherTranscriptOutputPathVal = ""
 }
 
 // recordDispatcherArmTranscript is the sole entry point dispatcherArmCensus,

--- a/parser_result_dispatcher_transcript_test.go
+++ b/parser_result_dispatcher_transcript_test.go
@@ -80,6 +80,8 @@ func TestDispatcherArmTranscriptRecordsKnownFiringWitness(t *testing.T) {
 	t.Setenv("GTS_DISPATCHER_TRANSCRIPT", "1")
 	outPath := filepath.Join(t.TempDir(), "transcript.jsonl")
 	t.Setenv("GTS_DISPATCHER_TRANSCRIPT_OUT", outPath)
+	resetDispatcherTranscriptEnvCacheForTest()
+	t.Cleanup(resetDispatcherTranscriptEnvCacheForTest)
 
 	lang, source, root, boolValue := hyprlangTranscriptFixture()
 	ctx := resultCompatibilityContext{root: root, source: source, lang: lang}
@@ -157,6 +159,8 @@ func TestDispatcherArmTranscriptDisabledRecordsNothing(t *testing.T) {
 	t.Setenv("GTS_DISPATCHER_TRANSCRIPT", "")
 	outPath := filepath.Join(t.TempDir(), "transcript.jsonl")
 	t.Setenv("GTS_DISPATCHER_TRANSCRIPT_OUT", outPath)
+	resetDispatcherTranscriptEnvCacheForTest()
+	t.Cleanup(resetDispatcherTranscriptEnvCacheForTest)
 
 	lang, source, root, boolValue := hyprlangTranscriptFixture()
 	ctx := resultCompatibilityContext{root: root, source: source, lang: lang}
@@ -188,13 +192,19 @@ func TestDispatcherArmTranscriptDisabledRecordsNothing(t *testing.T) {
 // matching GTS_DISPATCHER_CENSUS's existing contract
 // (TestDispatcherCensusRequiresExactOne).
 func TestDispatcherTranscriptRequiresExactOne(t *testing.T) {
+	t.Cleanup(resetDispatcherTranscriptEnvCacheForTest)
 	for _, value := range []string{"", "0", "false", "2"} {
 		t.Setenv("GTS_DISPATCHER_TRANSCRIPT", value)
+		// dispatcherTranscriptEnabled caches its read (sync.Once); reset
+		// before each value so this loop still exercises a fresh read every
+		// iteration instead of pinning the first iteration's result.
+		resetDispatcherTranscriptEnvCacheForTest()
 		if dispatcherTranscriptEnabled() {
 			t.Fatalf("GTS_DISPATCHER_TRANSCRIPT=%q enabled the transcript", value)
 		}
 	}
 	t.Setenv("GTS_DISPATCHER_TRANSCRIPT", "1")
+	resetDispatcherTranscriptEnvCacheForTest()
 	if !dispatcherTranscriptEnabled() {
 		t.Fatal("GTS_DISPATCHER_TRANSCRIPT=1 did not enable the transcript")
 	}


### PR DESCRIPTION
## Summary

Caches GTS_DISPATCHER_TRANSCRIPT and GTS_DISPATCHER_TRANSCRIPT_OUT environment reads behind sync.Once guards. Subsequent dispatcher-arm calls pay one atomic check instead of repeating os.Getenv lookups. Adds a test helper to flush the cache and updates affected tests so environment toggles work reliably across iterations.

## Changes

- Introduce sync.Once variables for transcript enabled state and output path.
- Guard os.Getenv calls in dispatcherTranscriptEnabled and dispatcherTranscriptOutputPath to reduce dispatch overhead.
- Add resetDispatcherTranscriptEnvCacheForTest to clear sync.Once guards in unit tests.
- Apply the reset helper in existing transcript tests to prevent cached values from bleeding across iterations.

## Testing

- Run go test ./grammargen -run '^TestDispatcher.*Transcript$' -count=1 to verify all transcript tests pass.
- Run scripts/run_randomized_benchmarks.sh to confirm no regression on full parse or incremental edit benchmarks.
- Execute cgo_harness/docker/run_single_grammar_parity.sh <grammar> to validate parser correctness remains intact.