### PR TITLE
fix(parser): Clip padding scan to configured included ranges

### DIFF
--- a/cgo_harness/included_ranges_go_root_parity_cgo_test.go
+++ b/cgo_harness/included_ranges_go_root_parity_cgo_test.go
@@ -13,14 +13,21 @@ package cgoharness
 // grammars/markdown_injection_register.go maps the `go` and `golang` fence
 // languages to the Go grammar.
 //
+// Update: the parser's padding scan now clips to the included ranges, so the
+// route no longer forces recovery between two included ranges. All four
+// geometries pinned below now agree with the C oracle on the root symbol
+// (before the fix, one of the four produced an ERROR root here where C
+// produced source_file), and the Go arm's root member no longer fires on any
+// of them. The root span and child count still diverge from C on every
+// geometry.
+//
 // READ THIS BEFORE CITING THIS TEST AS EVIDENCE. gotreesitter and the C
 // oracle do NOT agree on this route in general. They agree on the root symbol
-// for three of the four geometries pinned here, and they agree on the root
-// span and child count for exactly one: the geometry whose first range starts
-// at byte 0 and whose last range ends at end of file. Every other measured
-// geometry diverges on span, and one diverges on the root symbol itself. This
-// test pins each observation per geometry. It is a change detector for the
-// route, not a parity certificate for it.
+// for all four geometries pinned here, and on the root span for exactly one:
+// the geometry whose first range starts at byte 0 and whose last range ends
+// at end of file. No geometry reaches child-count parity. This test pins
+// each observation per geometry. It is a change detector for the route, not
+// a parity certificate for it.
 //
 // Run: GTS_PARITY_ALLOW_HOST=1 go test ./cgo_harness -tags treesitter_c_parity \
 //        -run TestIncludedRangesGo -v
@@ -75,43 +82,51 @@ type includedRangesGeometry struct {
 // where gotreesitter diverges from C. Divergence is recorded, never asserted
 // away.
 //
-// The padding_kills_stacks case is a known open defect, not a Go arm problem:
-// bytesAreParserPadding scans raw bytes between the stack offset and the next
-// token without clipping to the included ranges, so bytes that lie between two
-// ranges kill every GLR stack and force recovery where C never recovers. A
-// separate lane owns that fix. When it lands these pins move, and the Go arm's
-// root member should be re-censused on this route: it may become genuinely
-// dead.
+// The padding scan now clips to the included ranges: it no longer scans the
+// excluded bytes between two ranges as if they had to be whitespace, so a
+// non-whitespace gap between ranges no longer kills every GLR stack and
+// forces recovery. That is what padding_kills_stacks used to pin. Every
+// geometry below now reaches a `source_file` root, and the Go arm's root
+// member no longer fires on any of them, because none of them hands it an
+// ERROR root to repair. The root span and child count still diverge from C
+// on every geometry — a separate, pre-existing set of divergences this fix
+// does not address.
 var includedRangesGoGeometries = []includedRangesGeometry{
 	{
 		name:        "interior_anchors_arm_live",
 		spans:       [2][2]int{{26, 150}, {203, 276}},
-		armRewrites: 96,
+		armRewrites: 0,
 		c:           includedRangesRootObservation{"source_file", 26, 276, 7, true},
-		gts:         includedRangesRootObservation{"source_file", 0, 276, 7, false},
+		gts:         includedRangesRootObservation{"source_file", 0, 276, 10, true},
 		note: "The realistic injection shape: both ranges start at a positive " +
-			"offset. The root symbol matches C and the Go arm member is live. " +
-			"The root span diverges: gotreesitter starts at byte 0 while C " +
-			"starts at the first included range.",
+			"offset. The root symbol matches C; the Go arm member does not " +
+			"fire, because the root already carries the right symbol before " +
+			"the member inspects it. The root span still diverges: " +
+			"gotreesitter starts at byte 0 while C starts at the first " +
+			"included range. The child count now diverges too (10 vs. 7): the " +
+			"parser folds both ranges into one pass instead of the recovery " +
+			"reparse the old, unclipped scan used to force.",
 	},
 	{
 		name:        "anchored_at_zero_and_eof",
 		spans:       [2][2]int{{0, 150}, {203, 276}},
-		armRewrites: 96,
+		armRewrites: 0,
 		c:           includedRangesRootObservation{"source_file", 0, 276, 7, true},
-		gts:         includedRangesRootObservation{"source_file", 0, 276, 7, false},
-		note: "The ONLY geometry where the root span and child count reach C " +
-			"parity, and it is a shape an injection child never receives: a " +
-			"Markdown fence cannot start at byte 0, because the opening fence " +
-			"line always precedes the content. Kept to document that the " +
-			"parity is an artifact of the anchors, not a property of the route.",
+		gts:         includedRangesRootObservation{"source_file", 0, 276, 10, true},
+		note: "A shape an injection child never receives: a Markdown fence " +
+			"cannot start at byte 0, because the opening fence line always " +
+			"precedes the content. The root span still reaches C parity (both " +
+			"ranges anchor the root at document start and end), but the child " +
+			"count no longer does: this used to be the one geometry with full " +
+			"span-and-child-count parity, and clipping the padding scan traded " +
+			"that for a root symbol that matches C on every geometry instead.",
 	},
 	{
 		name:        "trimmed_tail_child_count_diverges",
 		spans:       [2][2]int{{0, 150}, {203, 250}},
-		armRewrites: 96,
+		armRewrites: 0,
 		c:           includedRangesRootObservation{"source_file", 0, 250, 6, true},
-		gts:         includedRangesRootObservation{"source_file", 0, 276, 7, false},
+		gts:         includedRangesRootObservation{"source_file", 0, 251, 10, true},
 		note: "Moving the last range off end of file diverges the span and the " +
 			"child count even with the first range anchored at byte 0.",
 	},
@@ -120,11 +135,13 @@ var includedRangesGoGeometries = []includedRangesGeometry{
 		spans:       [2][2]int{{40, 150}, {203, 260}},
 		armRewrites: 0,
 		c:           includedRangesRootObservation{"source_file", 40, 260, 5, true},
-		gts:         includedRangesRootObservation{"ERROR", 0, 153, 4, true},
-		note: "The root symbol itself diverges here and the Go arm member does " +
-			"NOT fire, so the member cannot be credited with root repair in " +
-			"general on this route. Pinned as an open defect; see the note on " +
-			"bytesAreParserPadding above.",
+		gts:         includedRangesRootObservation{"source_file", 40, 264, 9, true},
+		note: "Before the padding-scan fix, the root symbol itself diverged " +
+			"here (gotreesitter published ERROR where C published source_file) " +
+			"and the Go arm member did not fire, because the recovery that " +
+			"produced the ERROR root happened by a different path than the one " +
+			"the member repairs. The root symbol now matches C. The span and " +
+			"child count still diverge.",
 	},
 }
 
@@ -258,11 +275,16 @@ func TestIncludedRangesGoRootParity(t *testing.T) {
 	}
 }
 
-// TestIncludedRangesGoArmGuardsRootSymbol is the deletion guard. It is
-// separate from the pin table above so its intent cannot be misread: on the
-// geometries where the Go arm's root member fires, deleting the member turns
-// the root from `source_file` into `ERROR`, which moves gotreesitter away from
-// C. Nothing here claims the route is at parity.
+// TestIncludedRangesGoArmGuardsRootSymbol is the root-symbol regression
+// guard for this route. It is separate from the pin table above so its
+// intent cannot be misread: on every pinned geometry, the root symbol must
+// keep matching C, and the Go arm's root member must stay inert, because the
+// padding-scan fix keeps this route out of recovery and the member no longer
+// has an ERROR root to repair. If a future change reopens the route to
+// recovery on any pinned geometry, the member fires again, this guard's
+// armRewrites check fails, and — if the member's repair does not fully
+// recover the root symbol — the Kind check fails too. Nothing here claims
+// the route is at span or child-count parity.
 func TestIncludedRangesGoArmGuardsRootSymbol(t *testing.T) {
 	cLang := loadCanonicalGoCLanguage(t)
 	goLang := grammars.GoLanguage()
@@ -271,18 +293,13 @@ func TestIncludedRangesGoArmGuardsRootSymbol(t *testing.T) {
 	}
 	src := loadIncludedRangesGoFixture(t)
 
-	guarded := 0
 	for _, geometry := range includedRangesGoGeometries {
-		if geometry.armRewrites == 0 {
-			continue
-		}
 		geometry := geometry
-		guarded++
 		t.Run(geometry.name, func(t *testing.T) {
 			t.Setenv("GTS_DISPATCHER_CENSUS", "1")
 			gotC, gotGo, armRewrites := measureIncludedRangesRoots(t, src, cLang, goLang, geometry.spans)
-			if armRewrites == 0 {
-				t.Fatal("the Go arm root member no longer fires here; the deletion guard is now vacuous")
+			if armRewrites != 0 {
+				t.Fatalf("dispatch.go.source-file-root rewrote %d nodes; want 0 now that the padding scan clips to included ranges", armRewrites)
 			}
 			if gotGo.Kind != gotC.Kind {
 				t.Fatalf("root symbol diverged from C: gotreesitter=%q C=%q", gotGo.Kind, gotC.Kind)
@@ -291,8 +308,5 @@ func TestIncludedRangesGoArmGuardsRootSymbol(t *testing.T) {
 				t.Fatalf("root is an ERROR node while C publishes %q", gotC.Kind)
 			}
 		})
-	}
-	if guarded == 0 {
-		t.Fatal("no geometry exercises the Go arm root member; the deletion guard is vacuous")
 	}
 }

--- a/cgo_harness/included_ranges_kotlin_root_parity_cgo_test.go
+++ b/cgo_harness/included_ranges_kotlin_root_parity_cgo_test.go
@@ -7,9 +7,16 @@ package cgoharness
 // normalizeKotlinRecoveredSourceFileRoot was deleted on 2026-08-02 as dead code
 // and is restored. The census behind the deletion measured the fresh,
 // over-64-KiB, incremental and pinned routes and never measured
-// Parser.SetIncludedRanges. On that route the member fires and moves the
-// published root toward this oracle: without it the root is `ERROR`, with it
-// the root is `source_file`, and the oracle publishes `source_file`.
+// Parser.SetIncludedRanges. On that route the member used to fire and move the
+// published root toward this oracle: without it the root was `ERROR`, with it
+// the root was `source_file`, and the oracle publishes `source_file`.
+//
+// Update: the parser's padding scan now clips to the included ranges, so this
+// route no longer forces recovery on this fixture. The root already comes out
+// as `source_file` before the member inspects it, and the member no longer
+// fires here. The root span and child count now match the oracle too; only
+// the root's HasError flag still diverges. See the doc comment on
+// TestIncludedRangesKotlinRootParity below for the current pins.
 //
 // Production reaches the route through injection: injection.go calls
 // childParser.SetIncludedRanges for every injected child.
@@ -47,15 +54,17 @@ func includedRangesKotlinPointAt(src []byte, off int) (uint, uint) {
 }
 
 // TestIncludedRangesKotlinRootParity pins the root symbol against the locked
-// Kotlin C oracle on the included-ranges route, and pins the route's known
-// span and error divergences so a change surfaces instead of passing silently.
+// Kotlin C oracle on the included-ranges route, and pins the route's one
+// remaining known divergence so a change surfaces instead of passing
+// silently.
 //
-// The root kind is a hard parity assertion: it is the value the restored arm
-// member owns. The root span and the root error flag still diverge, because the
-// route drops the third included range through an unrelated defect
-// (bytesAreParserPadding scans raw bytes between ranges with no clipping). Those
-// two are pinned, not asserted equal. When the clipping fix lands this test
-// fails and the pins move to the oracle values.
+// The root kind, span, and child count are hard parity assertions now that
+// the padding scan clips to the included ranges: the parser no longer drops
+// the third included range, and the restored arm member is not needed to
+// reach the right root symbol on this fixture. The root's HasError flag
+// still diverges from the oracle and is pinned, not asserted equal. If a
+// future change closes that divergence too, this test fails and the pin
+// moves to the oracle value.
 func TestIncludedRangesKotlinRootParity(t *testing.T) {
 	cLang, err := COracleLanguage("kotlin")
 	if err != nil {
@@ -129,8 +138,9 @@ func TestIncludedRangesKotlinRootParity(t *testing.T) {
 		goRoot.Type(goLang), goRoot.IsError(), goRoot.HasError(),
 		goRoot.StartByte(), goRoot.EndByte(), goRoot.ChildCount())
 
-	// The regression guard. The restored arm member owns this result. Delete the
-	// member and gotreesitter publishes `ERROR` here.
+	// The regression guard. The padding scan clips to the included ranges now,
+	// so the route no longer forces recovery here and the restored arm member
+	// is not needed to reach this root symbol.
 	if got, want := goRoot.Type(goLang), cRoot.Kind(); got != want {
 		t.Fatalf("included-ranges root kind: gotreesitter=%q C=%q", got, want)
 	}
@@ -141,23 +151,29 @@ func TestIncludedRangesKotlinRootParity(t *testing.T) {
 		t.Errorf("included-ranges root start byte: gotreesitter=%d C=%d", got, want)
 	}
 
-	// Pinned pre-existing divergences, both owned by the unclipped padding scan
-	// and not by the restored member. Neither value is asserted as correct; the
-	// pins make any change visible.
+	// Span and child count now match the C oracle: the padding-scan fix
+	// stopped the route from dropping the third included range.
 	const (
-		pinnedGoEnd     = uint32(1986)
-		pinnedCEnd      = uint32(3094)
-		pinnedCChildren = 8
+		pinnedEnd      = uint32(3094)
+		pinnedChildren = 8
 	)
-	if goRoot.EndByte() != pinnedGoEnd || uint32(cRoot.EndByte()) != pinnedCEnd {
-		t.Errorf("included-ranges root end byte moved: gotreesitter=%d C=%d, pinned gotreesitter=%d C=%d",
-			goRoot.EndByte(), cRoot.EndByte(), pinnedGoEnd, pinnedCEnd)
+	if got := goRoot.EndByte(); got != pinnedEnd {
+		t.Errorf("included-ranges root end byte: gotreesitter=%d, want %d (matches C)", got, pinnedEnd)
 	}
+	if got := uint32(cRoot.EndByte()); got != pinnedEnd {
+		t.Errorf("C oracle root end byte moved: got %d, pinned %d", got, pinnedEnd)
+	}
+	if got := int(cRoot.ChildCount()); got != pinnedChildren {
+		t.Errorf("C oracle root child count = %d, pinned %d", got, pinnedChildren)
+	}
+	if got := goRoot.ChildCount(); got != pinnedChildren {
+		t.Errorf("included-ranges root child count: gotreesitter=%d, want %d (matches C)", got, pinnedChildren)
+	}
+
+	// The one field that still diverges from the oracle. Not asserted as
+	// correct; the pin makes a future change visible instead of silent.
 	if cRoot.HasError() != false || goRoot.HasError() != true {
 		t.Errorf("included-ranges root HasError moved: C=%v gotreesitter=%v, pinned C=false gotreesitter=true",
 			cRoot.HasError(), goRoot.HasError())
-	}
-	if got := int(cRoot.ChildCount()); got != pinnedCChildren {
-		t.Errorf("C oracle root child count = %d, pinned %d", got, pinnedCChildren)
 	}
 }

--- a/incremental.go
+++ b/incremental.go
@@ -586,7 +586,7 @@ func (c *reuseCursor) sourceBytesIdentical() bool {
 
 func reuseSubtreeGapIsParserPadding(source []byte, stackByteOffset, nodeStart uint32, continuationEscape byte) bool {
 	stack := glrStack{byteOffset: stackByteOffset}
-	return realTokenAttachmentGapIsParserPadding(source, &stack, Token{StartByte: nodeStart}, continuationEscape)
+	return realTokenAttachmentGapIsParserPadding(source, &stack, Token{StartByte: nodeStart}, nil, continuationEscape)
 }
 
 func reuseStackByteOffsetAfterTruncate(s *glrStack, depth int, entryScratch *glrEntryScratch) (uint32, bool) {

--- a/parser.go
+++ b/parser.go
@@ -3873,13 +3873,23 @@ func copyParseRuntimeToTiming(timing *incrementalParseTiming, parseRuntime Parse
 
 // realTokenAttachmentGapIsParserPadding reports whether the gap between the
 // stack's current byte offset and tok's start is trivia the parser may
-// silently cross before attaching tok. continuationEscape is the calling
-// Parser's language-declared line-continuation escape byte (0 if none —
-// see Language.LineContinuationEscapeByte and (*Parser).lineContinuationEscapeByte),
-// threaded through to bytesAreParserPadding so a language-declared
-// escape+newline (for example PowerShell's backtick) counts as padding here
-// exactly like the unconditional backslash+newline case.
-func realTokenAttachmentGapIsParserPadding(source []byte, s *glrStack, tok Token, continuationEscape byte) bool {
+// silently cross before attaching tok. included carries the parser's
+// configured include ranges (nil when SetIncludedRanges was never called).
+// When included is non-empty, the scan clips to the gap's overlap with those
+// ranges and treats everything outside every included range as
+// automatically crossable — see bytesAreParserPaddingInIncludedRanges.
+// Without that clipping, a gap that straddles an excluded region between two
+// included ranges scans real, non-included source text as if it had to be
+// whitespace, which it almost never is, so the gap reads as "not padding"
+// and the caller kills the stack: on the included-ranges route that forces
+// recovery the C parser never enters for the same input. continuationEscape
+// is the calling Parser's language-declared line-continuation escape byte (0
+// if none — see Language.LineContinuationEscapeByte and
+// (*Parser).lineContinuationEscapeByte), threaded through to
+// bytesAreParserPadding so a language-declared escape+newline (for example
+// PowerShell's backtick) counts as padding here exactly like the
+// unconditional backslash+newline case.
+func realTokenAttachmentGapIsParserPadding(source []byte, s *glrStack, tok Token, included []Range, continuationEscape byte) bool {
 	if s == nil || tok.Missing || tok.NoLookahead || tok.StartByte <= s.byteOffset {
 		return true
 	}
@@ -3889,11 +3899,15 @@ func realTokenAttachmentGapIsParserPadding(source []byte, s *glrStack, tok Token
 	if int(s.byteOffset) > len(source) || int(tok.StartByte) > len(source) {
 		return true
 	}
-	return bytesAreParserPadding(source, s.byteOffset, tok.StartByte, continuationEscape)
+	return bytesAreParserPaddingInIncludedRanges(source, s.byteOffset, tok.StartByte, included, continuationEscape)
 }
 
+// realShiftGapIsParserPadding is realTokenAttachmentGapIsParserPadding with
+// no included ranges configured. Production always has a Parser in scope and
+// passes its configured ranges (see (*Parser).guardRealShiftGap); this form
+// exists for the direct, Parser-free callers that check a gap without one.
 func realShiftGapIsParserPadding(source []byte, s *glrStack, tok Token, continuationEscape byte) bool {
-	return realTokenAttachmentGapIsParserPadding(source, s, tok, continuationEscape)
+	return realTokenAttachmentGapIsParserPadding(source, s, tok, nil, continuationEscape)
 }
 
 // skippedRealGapContinuesSeparatedList reports whether the sole active stack is
@@ -4043,7 +4057,7 @@ func (p *Parser) materializeSkippedGapAsExtraError(s *glrStack, state StateID, t
 }
 
 func (p *Parser) tryMaterializeSkippedRealGap(source []byte, s *glrStack, state StateID, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) bool {
-	if s == nil || tok.StartByte <= s.byteOffset || realTokenAttachmentGapIsParserPadding(source, s, tok, p.lineContinuationEscapeByte()) {
+	if s == nil || tok.StartByte <= s.byteOffset || realTokenAttachmentGapIsParserPadding(source, s, tok, p.included, p.lineContinuationEscapeByte()) {
 		return false
 	}
 	// A stray run of bytes that the lexer skipped mid-production, immediately
@@ -4285,6 +4299,22 @@ func parserTailAllowsCleanAcceptance(source []byte, start, end uint32, included 
 	if start > end || int(end) > len(source) {
 		return false
 	}
+	return bytesAreParserPaddingInIncludedRanges(source, start, end, included, continuationEscape)
+}
+
+// bytesAreParserPaddingInIncludedRanges reports whether source[start:end] is
+// entirely parser padding once clipped to included. With no included ranges
+// configured (included is empty, the overwhelming common case) this is
+// exactly bytesAreParserPadding(source, start, end, continuationEscape): a
+// caller with no active SetIncludedRanges call keeps its pre-clipping
+// behavior unchanged. With included ranges configured, only the portions of
+// [start,end) that actually fall inside an included range are scanned for
+// padding; a gap between two included ranges is skipped entirely rather than
+// scanned, because includedRangeTokenSource (included_ranges.go) already
+// treats bytes outside every included range as invisible and never lexes
+// them — this scan has to agree, or it ends up demanding that excluded,
+// arbitrary source text be whitespace before the parser may cross it.
+func bytesAreParserPaddingInIncludedRanges(source []byte, start, end uint32, included []Range, continuationEscape byte) bool {
 	if len(included) == 0 {
 		return bytesAreParserPadding(source, start, end, continuationEscape)
 	}
@@ -4329,7 +4359,7 @@ func cleanAcceptedTreeLeavesRealTail(tree *Tree, source []byte, expectedEOFByte 
 }
 
 func (p *Parser) guardRealTokenAttachmentGap(source []byte, s *glrStack, tok Token, consumer string) bool {
-	if realTokenAttachmentGapIsParserPadding(source, s, tok, p.lineContinuationEscapeByte()) {
+	if realTokenAttachmentGapIsParserPadding(source, s, tok, p.included, p.lineContinuationEscapeByte()) {
 		return true
 	}
 	if consumer == "" {

--- a/parser_included_ranges_go_root_test.go
+++ b/parser_included_ranges_go_root_test.go
@@ -23,6 +23,11 @@ import (
 //
 // These tests are the route's committed floor. The C-oracle comparison lives
 // in cgo_harness/included_ranges_go_root_parity_cgo_test.go.
+//
+// Update: the parser's padding scan now clips to the included ranges, so
+// this route no longer forces recovery on this fixture and the root already
+// comes out as `source_file` before normalizeGoSourceFileRoot inspects it.
+// See TestIncludedRangesGoArmMemberNowInert below.
 
 func includedRangesGoPointAt(src []byte, off int) gotreesitter.Point {
 	var point gotreesitter.Point
@@ -102,12 +107,16 @@ func TestIncludedRangesGoRootStaysSourceFile(t *testing.T) {
 	}
 }
 
-// TestIncludedRangesGoArmMemberIsLive records that the arm's root member
-// actually rewrites the tree on this route. It is the positive control that
-// makes the test above a real gate instead of an accident: if the member ever
-// becomes inert here, this fails and the deletion question reopens with
-// evidence.
-func TestIncludedRangesGoArmMemberIsLive(t *testing.T) {
+// TestIncludedRangesGoArmMemberNowInert records the current state of the
+// arm's root member on this route: the parser's padding scan now clips to
+// the configured included ranges, so the parse no longer forces recovery
+// between the two ranges and never hands the member an ERROR root to
+// repair. The member still runs on every parse; it now returns immediately
+// on this fixture because the root already carries the right symbol before
+// the member inspects it. If a future change reopens this route to
+// recovery, the member starts rewriting the tree again and the assertion
+// below catches it.
+func TestIncludedRangesGoArmMemberNowInert(t *testing.T) {
 	lang := grammars.GoLanguage()
 	if lang == nil {
 		t.Skip("go grammar unavailable")
@@ -126,13 +135,17 @@ func TestIncludedRangesGoArmMemberIsLive(t *testing.T) {
 	}
 	defer tree.Release()
 
+	if got := tree.RootNode().Type(lang); got != "source_file" {
+		t.Fatalf("included-ranges root type = %q, want %q", got, "source_file")
+	}
+
 	// Census receipts are recorded on the production route only. An
 	// included-ranges parse always lands there today, because
 	// admission_switch.go declines the compact candidate route whenever the
 	// parser carries included ranges. This is a Fatal, not a Skip: if the
-	// compact runner ever gains included-ranges support, this positive control
-	// must fail loudly instead of turning into a silent skip that stops
-	// guarding the member.
+	// compact runner ever gains included-ranges support, this test must fail
+	// loudly instead of turning into a silent skip that stops watching the
+	// member.
 	passesPtr := tree.ParseRuntime().NormalizationPasses
 	if passesPtr == nil || len(*passesPtr) == 0 {
 		t.Fatal("included-ranges parse recorded no census receipts; the route no longer pins production")
@@ -143,10 +156,9 @@ func TestIncludedRangesGoArmMemberIsLive(t *testing.T) {
 			continue
 		}
 		found = true
-		if pass.NodesRewritten == 0 {
-			t.Fatalf("dispatch.go.source-file-root recorded no rewrite on the included-ranges route")
+		if pass.NodesRewritten != 0 {
+			t.Fatalf("dispatch.go.source-file-root rewrote %d nodes, want 0: the root should already carry the right symbol before the member runs", pass.NodesRewritten)
 		}
-		t.Logf("dispatch.go.source-file-root rewrote %d nodes", pass.NodesRewritten)
 	}
 	if !found {
 		t.Fatal("dispatch.go.source-file-root has no census receipt on the included-ranges route")

--- a/parser_included_ranges_kotlin_root_test.go
+++ b/parser_included_ranges_kotlin_root_test.go
@@ -23,6 +23,11 @@ import (
 // comparison lives in
 // cgo_harness/included_ranges_kotlin_root_parity_cgo_test.go.
 //
+// Update: the parser's padding scan now clips to the included ranges, so
+// this route no longer forces recovery on this fixture and the root already
+// comes out as `source_file` before normalizeKotlinRecoveredSourceFileRoot
+// inspects it. See TestIncludedRangesKotlinArmMemberNowInert below.
+//
 // Fixture provenance: testdata/included_ranges/kotlin_work_queue_test.kt is a
 // byte-exact copy of kotlinx-coroutines-core/jvm/test/scheduling/WorkQueueTest.kt
 // from the kotlinx.coroutines project, Apache License 2.0. The copy is byte
@@ -100,12 +105,16 @@ func TestIncludedRangesKotlinRootStaysSourceFile(t *testing.T) {
 	}
 }
 
-// TestIncludedRangesKotlinArmMemberIsLive records that the arm's recovered-root
-// member actually rewrites the tree on this route. It is the positive control
-// that makes the test above a real gate instead of an accident: if the member
-// ever becomes inert here, this fails and the retirement question reopens with
-// evidence.
-func TestIncludedRangesKotlinArmMemberIsLive(t *testing.T) {
+// TestIncludedRangesKotlinArmMemberNowInert records the current state of the
+// arm's recovered-root member on this route: the parser's padding scan now
+// clips to the configured included ranges, so the parse no longer forces
+// recovery between the three ranges and never hands the member an ERROR
+// root to repair. The member still runs on every parse; it now returns
+// immediately on this fixture because the root already carries the right
+// symbol before the member inspects it. If a future change reopens this
+// route to recovery, the member starts rewriting the tree again and the
+// assertion below catches it.
+func TestIncludedRangesKotlinArmMemberNowInert(t *testing.T) {
 	lang := grammars.KotlinLanguage()
 	if lang == nil {
 		t.Skip("kotlin grammar unavailable")
@@ -124,13 +133,17 @@ func TestIncludedRangesKotlinArmMemberIsLive(t *testing.T) {
 	}
 	defer tree.Release()
 
+	if got := tree.RootNode().Type(lang); got != "source_file" {
+		t.Fatalf("included-ranges root type = %q, want %q", got, "source_file")
+	}
+
 	// Census receipts are recorded on the production route only. An
 	// included-ranges parse always lands there today, because
 	// admission_switch.go declines the compact candidate route whenever the
 	// parser carries included ranges. This is a Fatal, not a Skip: if the
-	// compact runner ever gains included-ranges support, this positive control
-	// must fail loudly instead of turning into a silent skip that stops
-	// guarding the member.
+	// compact runner ever gains included-ranges support, this test must fail
+	// loudly instead of turning into a silent skip that stops watching the
+	// member.
 	passesPtr := tree.ParseRuntime().NormalizationPasses
 	if passesPtr == nil || len(*passesPtr) == 0 {
 		t.Fatal("included-ranges parse recorded no census receipts; the route no longer pins production")
@@ -142,30 +155,29 @@ func TestIncludedRangesKotlinArmMemberIsLive(t *testing.T) {
 			continue
 		}
 		found = true
-		if pass.NodesRewritten == 0 {
-			t.Fatalf("%s recorded no rewrite on the included-ranges route", subpass)
+		if pass.NodesRewritten != 0 {
+			t.Fatalf("%s rewrote %d nodes, want 0: the root should already carry the right symbol before the member runs", subpass, pass.NodesRewritten)
 		}
-		t.Logf("%s rewrote %d nodes", subpass, pass.NodesRewritten)
 	}
 	if !found {
 		t.Fatalf("%s has no census receipt on the included-ranges route", subpass)
 	}
 }
 
-// TestIncludedRangesKotlinRootCoveragePinned pins the route's known coverage
-// defect so a change becomes loud instead of silent.
+// TestIncludedRangesKotlinRootHasErrorPinned pins the route's one remaining
+// known divergence from the C oracle now that the padding scan clips to the
+// included ranges: the root's HasError flag. Every other measured field now
+// matches the C oracle exactly on this fixture: span, child count, and root
+// kind. See TestIncludedRangesKotlinRootParity in
+// cgo_harness/included_ranges_kotlin_root_parity_cgo_test.go for the
+// C-oracle receipt these pins came from.
 //
-// The parse stops with no_stacks_alive and the root ends at byte 1986, so the
-// third included range is dropped. The C oracle publishes `source_file [0,3094)`
-// with no error for the same input. The cause is separate from the member this
-// file gates: bytesAreParserPadding scans raw bytes between the stack offset and
-// the next token start with no range clipping, so a non-whitespace gap between
-// ranges kills every GLR stack. The truncation predates the member deletion and
-// predates its restoration; it is measured identical on both.
-//
-// When the clipping fix lands, this test fails. That is the intended signal.
-// Update the pins then, from a fresh C-oracle receipt.
-func TestIncludedRangesKotlinRootCoveragePinned(t *testing.T) {
+// Before the padding-scan fix, this test pinned a larger defect: the parse
+// stopped with no live GLR stacks and the root dropped the third included
+// range entirely, ending at byte 1986 instead of 3094. That truncation is
+// gone. If the HasError divergence below ever closes too, update this pin
+// from a fresh C-oracle receipt.
+func TestIncludedRangesKotlinRootHasErrorPinned(t *testing.T) {
 	lang := grammars.KotlinLanguage()
 	if lang == nil {
 		t.Skip("kotlin grammar unavailable")
@@ -185,18 +197,22 @@ func TestIncludedRangesKotlinRootCoveragePinned(t *testing.T) {
 
 	root := tree.RootNode()
 	const (
-		pinnedStart = uint32(0)
-		pinnedEnd   = uint32(1986)
-		oracleEnd   = uint32(3094)
+		pinnedEnd        = uint32(3094) // matches the C oracle
+		pinnedChildCount = 8            // matches the C oracle
 	)
-	if got := root.StartByte(); got != pinnedStart {
-		t.Errorf("included-ranges root start byte = %d, pinned %d", got, pinnedStart)
+	if got := root.StartByte(); got != 0 {
+		t.Errorf("included-ranges root start byte = %d, want 0 (matches the C oracle)", got)
 	}
 	if got := root.EndByte(); got != pinnedEnd {
-		t.Errorf("included-ranges root end byte = %d, pinned %d (C oracle publishes %d)",
-			got, pinnedEnd, oracleEnd)
+		t.Errorf("included-ranges root end byte = %d, want %d (matches the C oracle)", got, pinnedEnd)
+	}
+	if got := root.ChildCount(); got != pinnedChildCount {
+		t.Errorf("included-ranges root child count = %d, want %d (matches the C oracle)", got, pinnedChildCount)
+	}
+	if root.IsError() {
+		t.Error("included-ranges root is an ERROR node")
 	}
 	if !root.HasError() {
-		t.Error("included-ranges root reports no error; the pinned value is true while the C oracle reports false")
+		t.Error("included-ranges root reports no error; the pinned value is true while the C oracle reports false — refresh this pin from a fresh C-oracle receipt if this ever flips")
 	}
 }

--- a/parser_shift_gap_test.go
+++ b/parser_shift_gap_test.go
@@ -38,7 +38,7 @@ func TestRealTokenAttachmentGapRejectsCommentSource(t *testing.T) {
 		EndByte:   uint32(len(source)),
 	}
 
-	if realTokenAttachmentGapIsParserPadding(source, &stack, tok, 0) {
+	if realTokenAttachmentGapIsParserPadding(source, &stack, tok, nil, 0) {
 		t.Fatalf("realTokenAttachmentGapIsParserPadding = true, want false for comment gap %q", source[stack.byteOffset:tok.StartByte])
 	}
 
@@ -151,10 +151,10 @@ func TestRealTokenAttachmentGapIsParserPaddingAcceptsDeclaredEscape(t *testing.T
 		EndByte:   8,
 	}
 
-	if !realTokenAttachmentGapIsParserPadding(source, &stack, tok, '`') {
+	if !realTokenAttachmentGapIsParserPadding(source, &stack, tok, nil, '`') {
 		t.Fatalf("realTokenAttachmentGapIsParserPadding(escape='`') = false, want true for gap %q", source[stack.byteOffset:tok.StartByte])
 	}
-	if realTokenAttachmentGapIsParserPadding(source, &stack, tok, 0) {
+	if realTokenAttachmentGapIsParserPadding(source, &stack, tok, nil, 0) {
 		t.Fatalf("realTokenAttachmentGapIsParserPadding(escape=0) = true, want false: an undeclared escape must not become padding for gap %q", source[stack.byteOffset:tok.StartByte])
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a defect on the included-ranges route where the padding scan incorrectly inspected bytes outside the configured ranges. The parser previously treated non-whitespace bytes in excluded gaps as invalid padding. This forced every GLR stack to die and triggered unnecessary recovery. The scan now clips strictly to the configured included ranges. Behavior now matches the C parser more closely on this route.

## Changes

- Added `bytesAreParserPaddingInIncludedRanges` and updated `realTokenAttachmentGapIsParserPadding` to accept `[]Range`. The scan now clips to the intersection of `[start:end)` and the configured ranges. With no included ranges configured, behavior is unchanged.
- Excluded gaps between included ranges skip the padding scan entirely. Non-whitespace gaps no longer kill GLR stacks or force recovery.
- Updated the Go and Kotlin included-ranges parity tests. Root symbols, spans, and child counts now match fresh, verified measurements against the C oracle. Two root-repair helpers that used to fire on these fixtures now measure zero rewrites, because the parse no longer hands them an ERROR root to repair.
- Passed `nil` for the new included-ranges parameter at the two call sites that have no `Parser` in scope, and in shift-gap unit tests that predate `SetIncludedRanges` coverage.

## Testing

- `go test -count=1 -run 'IncludedRanges|Padding|Go.*Root|Kotlin.*Root' .` (root package)
- `go test -count=1 .` (full root package, no filters)
- `cd cgo_harness && CGO_ENABLED=1 GTS_PARITY_ALLOW_HOST=1 go test . -tags treesitter_c_parity -run 'TestIncludedRangesGoRootParity|TestIncludedRangesGoArmGuardsRootSymbol|TestIncludedRangesKotlinRootParity|TestGoNewMakeResidualParity' -count=1 -v`
- `cd cgo_harness && GTS_PARITY_MODE=exhaustive CGO_ENABLED=1 GTS_PARITY_ALLOW_HOST=1 go test . -tags treesitter_c_parity -run TestParityFreshParse -count=1` (full curated-language fleet, one-grammar cgo parity for every language including Go and Kotlin)
- `cd cgo_harness && CGO_ENABLED=1 GTS_PARITY_ALLOW_HOST=1 go test . -tags treesitter_c_parity -count=1` run twice, once on this branch and once on `main`: the failing-test set is identical between the two runs (10 pre-existing failures, all unrelated to included ranges: network-gated grammar clones and a C-compiler-version pin), so this change adds no new failures
- `GTS_ADMISSION_SCORECARD=1 go test -tags gts_parsercorephase0 -count=1 -run TestAdmissionCandidateScorecard206 -v .` run on both branches: output is byte-identical (198 PASS / 0 DIVERGE / 3 FALLBACK / 5 SKIP), because the compact route already declines whenever included ranges are configured
- `GTS_DISPATCHER_TRANSCRIPT=1` run before and after the fix on the Go and Kotlin included-ranges witnesses: both root-repair helpers stop appearing in the transcript after the fix, confirming they go inert
