### PR TITLE
remove(hlsl, parser): retire HLSL subscript-assignment result-compatibility arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,13 @@ for tags and release notes while still in `0.x`.
   declaration whose modifier keyword carries a stray `(name=value)` argument
   list. Production, compact, forest, and incremental routes produce the same
   tree, and an isolated C-oracle parity check confirms the shape.
+- The HLSL subscript-assignment declarator member of the result-compatibility
+  dispatcher arm is retired. `structured_binding_declarator` carries a
+  negative dynamic precedence in the grammar. Native parsing already elects
+  the C-equivalent subscript-assignment expression for `Name[index] = value;`
+  without a post-parse pass. Production, compact, forest, and incremental
+  routes stay exact. The negative-number cast and unorm-buffer members of the
+  HLSL arm remain live.
 
 ## [0.49.0] - 2026-08-11
 

--- a/cgo_harness/hlsl_subscript_assignment_parity_cgo_test.go
+++ b/cgo_harness/hlsl_subscript_assignment_parity_cgo_test.go
@@ -1,0 +1,30 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import "testing"
+
+// TestHLSLSubscriptAssignmentLockedCParity checks the same
+// subscript-assignment witnesses grammars/hlsl_subscript_assignment_native_regression_test.go
+// locks against a native C tree-sitter reference parser, node by node.
+func TestHLSLSubscriptAssignmentLockedCParity(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+	}{
+		{name: "single_index_in_function", source: "void f() {\n    Foo[bar] = value;\n}\n"},
+		{name: "top_level", source: "Foo[bar] = value;\n"},
+		{name: "two_indices", source: "void f() {\n    Foo[bar, baz] = value;\n}\n"},
+		{name: "numeric_index", source: "void f() {\n    Foo[42] = value;\n}\n"},
+		{name: "call_value", source: "void f() {\n    Foo[bar] = compute(baz);\n}\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runParityCase(
+				t,
+				parityCase{name: "hlsl"},
+				test.name,
+				[]byte(test.source),
+			)
+		})
+	}
+}

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -45,6 +45,12 @@ Native Objective-C projection also owns protocol type identifiers.
 Generic result selection owns the remaining ambiguous `sizeof` operand.
 No Objective-C result-compatibility repair remains live.
 
+The HLSL dispatcher arm retires its subscript-assignment declarator member.
+`structured_binding_declarator` carries a negative dynamic precedence in the
+grammar, so a clean election already prefers the subscript-assignment
+expression natively. The negative-number cast and unorm-buffer members
+remain live.
+
 The parser covers every byte in each recovered EBNF source.
 This change removes the EBNF compatibility arm.
 

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -249,6 +249,11 @@ The assignment, generated-command, and `if`-field subpasses remain live.
 Native FIDL recovery already emits the C-equivalent versioned-layout-modifier
 error shape for stray modifier arguments.
 This change retires the FIDL dispatcher arm.
+The HLSL grammar's negative dynamic precedence on structured-binding
+declarators already makes native election prefer a subscript-assignment
+expression over a structured-binding declaration.
+This change retires the HLSL subscript-assignment member.
+The negative-number cast and unorm-buffer members remain live.
 
 Group by invariant, not language:
 
@@ -342,6 +347,7 @@ there.
 | HTTP document sections | retirement change | 1 subpass / 1 dispatcher arm | 0 | zero-rewrite exact and locked census, compatibility-free producer, compact fail-closed behavior, forest, incremental reuse, and isolated C-oracle receipts |
 | Bash command names | retirement change | 1 Bash subpass | 0 | compatibility-free producer, production, compact fallback, forest, incremental reuse, exact 25-case baseline at `83548f55`, and isolated C-oracle parity |
 | FIDL versioned layout modifiers | retirement change | 1 dispatcher arm | 0 | compatibility-free producer, production, compact fallback, forest-fail-closed, incremental reuse, and isolated C-oracle parity |
+| HLSL subscript-assignment declarator | retirement change | 1 HLSL member | 0 | negative dynamic precedence election, compatibility-free producer, production, compact fallback, forest, incremental reuse, and isolated C-oracle parity |
 
 Mark a row merged only after CI and merge evidence exist. Detailed per-entry
 receipts stay in the JSON registry and durable run findings stay in Hyphae.

--- a/grammars/hlsl_subscript_assignment_native_regression_test.go
+++ b/grammars/hlsl_subscript_assignment_native_regression_test.go
@@ -1,0 +1,138 @@
+//go:build !grammar_subset
+
+package grammars
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// hlslSubscriptAssignmentFixtures cover `Name[index] = value;`, a construct
+// the grammar's declared conflict lets read two ways: a subscript
+// assignment expression, or a C++-style structured-binding declaration
+// (`Name` as the type, `[index]` as the binding list). The grammar assigns
+// structured_binding_declarator a negative dynamic precedence, so a clean,
+// unambiguous election always prefers the subscript assignment.
+var hlslSubscriptAssignmentFixtures = []struct {
+	name   string
+	source string
+}{
+	{
+		name:   "single_index_in_function",
+		source: "void f() {\n    Foo[bar] = value;\n}",
+	},
+	{
+		name:   "top_level",
+		source: "Foo[bar] = value;",
+	},
+	{
+		name:   "two_indices",
+		source: "void f() {\n    Foo[bar, baz] = value;\n}",
+	},
+	{
+		name:   "numeric_index",
+		source: "void f() {\n    Foo[42] = value;\n}",
+	},
+	{
+		name:   "call_value",
+		source: "void f() {\n    Foo[bar] = compute(baz);\n}",
+	},
+}
+
+// TestHLSLSubscriptAssignmentNeedsNoResultCompatibility proves the native
+// parser already elects the C-compatible subscript-assignment shape for
+// `Name[index] = value;` without any post-parse compatibility pass: the
+// compatibility-free route (ParseNoResultCompatibilityBenchmarkOnly) and the
+// production route (Parse) build byte-identical trees, and production
+// performs zero normalization rewrites.
+func TestHLSLSubscriptAssignmentNeedsNoResultCompatibility(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	language := HlslLanguage()
+	for _, fixture := range hlslSubscriptAssignmentFixtures {
+		fixture := fixture
+		t.Run(fixture.name, func(t *testing.T) {
+			source := []byte(fixture.source)
+
+			raw, err := gotreesitter.NewParser(language).
+				ParseNoResultCompatibilityBenchmarkOnly(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(raw.Release)
+			assertNoNormalizationPasses(t, raw)
+			assertHLSLSubscriptAssignmentShape(t, raw, language)
+
+			production, err := gotreesitter.NewParser(language).Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(production.Release)
+			assertNoNormalizationPasses(t, production)
+			assertHLSLSubscriptAssignmentShape(t, production, language)
+
+			want := collapsedTokenTreeDigest(t, production, language)
+			if got := collapsedTokenTreeDigest(t, raw, language); got != want {
+				t.Fatalf("compatibility-free digest=%s production=%s", got, want)
+			}
+		})
+	}
+}
+
+// assertHLSLSubscriptAssignmentShape locks the exact election the C oracle
+// makes: an error-free assignment_expression wrapping a subscript_expression,
+// never a structured-binding declaration.
+func assertHLSLSubscriptAssignmentShape(t *testing.T, tree *gotreesitter.Tree, language *gotreesitter.Language) {
+	t.Helper()
+	root := tree.RootNode()
+	if root == nil || root.HasError() {
+		t.Fatalf("root = %v, want error-free tree", root)
+	}
+	assign := findHLSLNodeByType(root, language, "assignment_expression")
+	if assign == nil {
+		t.Fatalf("assignment_expression not found in %s", root.SExpr(language))
+	}
+	if got, want := assign.ChildCount(), 3; got != want {
+		t.Fatalf("assignment_expression child count = %d, want %d", got, want)
+	}
+	subscript := assign.Child(0)
+	if subscript == nil || subscript.Type(language) != "subscript_expression" {
+		t.Fatalf("assignment left child = %#v, want subscript_expression", subscript)
+	}
+	if binding := findHLSLNodeByType(root, language, "structured_binding_declarator"); binding != nil {
+		t.Fatalf("found structured_binding_declarator in %s, want none", root.SExpr(language))
+	}
+}
+
+func findHLSLNodeByType(root *gotreesitter.Node, lang *gotreesitter.Language, typ string) *gotreesitter.Node {
+	if root == nil {
+		return nil
+	}
+	if root.Type(lang) == typ {
+		return root
+	}
+	for i := 0; i < root.ChildCount(); i++ {
+		if found := findHLSLNodeByType(root.Child(i), lang, typ); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// TestHLSLSubscriptAssignmentRetiredDispatchArmRoutes proves production,
+// compact, forest, and incremental routes all build the same tree for the
+// subscript-assignment witnesses with no result compatibility pass involved.
+func TestHLSLSubscriptAssignmentRetiredDispatchArmRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	language := HlslLanguage()
+	for _, fixture := range hlslSubscriptAssignmentFixtures {
+		fixture := fixture
+		t.Run(fixture.name, func(t *testing.T) {
+			baseSource := []byte(fixture.source)
+			for _, receipt := range retiredDispatchRouteReceiptsAllowCompactFallback(t, language, baseSource) {
+				assertNoNormalizationPasses(t, receipt.tree)
+				assertHLSLSubscriptAssignmentShape(t, receipt.tree, language)
+			}
+		})
+	}
+}

--- a/parser_result_hlsl.go
+++ b/parser_result_hlsl.go
@@ -7,7 +7,6 @@ func normalizeHLSLCompatibility(root *Node, source []byte, lang *Language) {
 	walkResultTreePostorder(root, func(n *Node) {
 		normalizeHLSLCastNegativeNumber(n, source, lang)
 		normalizeHLSLUnormBufferDeclaration(n, source, lang)
-		normalizeHLSLSubscriptAssignmentDeclaration(n, source, lang)
 	})
 }
 
@@ -136,61 +135,6 @@ func normalizeHLSLUnormBufferDeclaration(stmt *Node, source []byte, lang *Langua
 	stmt.setNamed(symbolIsNamed(lang, declSym))
 	stmt.setHasError(true)
 	replaceNodeChildrenUnfielded(stmt, []*Node{templateType, name, semi})
-}
-
-func normalizeHLSLSubscriptAssignmentDeclaration(stmt *Node, source []byte, lang *Language) {
-	if stmt == nil || stmt.Type(lang) != "declaration" || resultChildCount(stmt) != 3 || int(stmt.endByte) > len(source) {
-		return
-	}
-	typeIdent := resultChildAt(stmt, 0)
-	init := resultChildAt(stmt, 1)
-	semi := resultChildAt(stmt, 2)
-	if typeIdent == nil || init == nil || semi == nil ||
-		typeIdent.Type(lang) != "type_identifier" || init.Type(lang) != "init_declarator" || semi.Type(lang) != ";" ||
-		resultChildCount(init) != 3 {
-		return
-	}
-	binding := resultChildAt(init, 0)
-	eq := resultChildAt(init, 1)
-	value := resultChildAt(init, 2)
-	if binding == nil || eq == nil || value == nil ||
-		binding.Type(lang) != "structured_binding_declarator" || eq.Type(lang) != "=" || resultChildCount(binding) != 3 {
-		return
-	}
-	open := resultChildAt(binding, 0)
-	index := resultChildAt(binding, 1)
-	close := resultChildAt(binding, 2)
-	if open == nil || index == nil || close == nil || open.Type(lang) != "[" || close.Type(lang) != "]" {
-		return
-	}
-	exprStmtSym, ok := symbolByName(lang, "expression_statement")
-	if !ok {
-		return
-	}
-	assignSym, ok := symbolByName(lang, "assignment_expression")
-	if !ok {
-		return
-	}
-	subscriptSym, ok := symbolByName(lang, "subscript_expression")
-	if !ok {
-		return
-	}
-	subscriptArgsSym, ok := symbolByName(lang, "subscript_argument_list")
-	if !ok {
-		return
-	}
-	identifierSym, ok := symbolByName(lang, "identifier")
-	if !ok {
-		return
-	}
-
-	base := hlslCloneLeafAs(typeIdent, identifierSym, symbolIsNamed(lang, identifierSym))
-	args := newParentNodeInArena(stmt.ownerArena, subscriptArgsSym, symbolIsNamed(lang, subscriptArgsSym), []*Node{open, index, close}, nil, 0)
-	subscript := newParentNodeInArena(stmt.ownerArena, subscriptSym, symbolIsNamed(lang, subscriptSym), []*Node{base, args}, nil, 0)
-	assignment := newParentNodeInArena(stmt.ownerArena, assignSym, symbolIsNamed(lang, assignSym), []*Node{subscript, eq, value}, nil, 0)
-	stmt.symbol = exprStmtSym
-	stmt.setNamed(symbolIsNamed(lang, exprStmtSym))
-	replaceNodeChildrenUnfielded(stmt, []*Node{assignment, semi})
 }
 
 func hlslSingleChildOfType(n *Node, lang *Language, typ string) *Node {

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -1422,12 +1422,14 @@
       "languages": [
         "hlsl"
       ],
-      "purpose": "Reconcile HLSL recovery and returned-tree shape.",
+      "purpose": "Reconcile HLSL derivation election and returned-tree shape: the negative-number cast rewrite and the unorm buffer template-argument repair. The subscript-assignment member retired 2026-08-12.",
       "authoritative_owner": "scheduler_action_semantics",
       "witnesses": [
-        "cgo_harness/parity_cgo_test.go"
+        "cgo_harness/parity_cgo_test.go",
+        "grammars/hlsl_subscript_assignment_native_regression_test.go",
+        "cgo_harness/hlsl_subscript_assignment_parity_cgo_test.go"
       ],
-      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "retirement_condition": "One member retired 2026-08-12: the subscript-assignment declarator repair. `structured_binding_declarator` carries a negative dynamic precedence in the grammar, so a clean, unambiguous election already prefers the subscript-assignment expression natively; production, compact, forest, incremental, and C-oracle receipts are exact with no post-parse pass. The cast-negative-number and unorm-buffer members stay live: both still rewrite the tree to reach the C-equivalent shape. Delete a remaining member only after scheduler_action_semantics or derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
       "route_coverage": {
         "production": "shared_result_compatibility_tail",
         "compact": "shared_result_compatibility_tail",


### PR DESCRIPTION
## Summary

Retires the post-parse compatibility rewrite for HLSL `Name[index] = value;` assignments. Native parsing already selects the correct assignment-expression shape because the grammar assigns negative dynamic precedence to structured-binding declarators. This removal strips dead dispatcher logic while keeping production, compact, forest, and incremental routes byte-identical to prior output.

## Changes

- Drop the `normalizeHLSLSubscriptAssignmentDeclaration` function and its dispatcher hook to stop rewriting matched declarations.
- Add regression tests proving native parsing and all compilation routes emit identical trees for subscript-assignment witnesses.
- Add CGO parity harness tests locking the new witnesses to the C tree-sitter reference node-by-node.
- Update CHANGELOG, documentation, retirement registry, and ownership metadata to record the retirement.
- Keep the negative-number cast and unorm-buffer template members active since they still require tree rewrites.

## Testing

- Run the new regression suite: `cd grammars && go test -run 'TestHLSLSubscriptAssignment' -v`
- Validate CGO parity for HLSL: `bash cgo_harness/docker/run_single_grammar_parity.sh hlsl`
- Baseline performance with randomized benchmarks: `bash scripts/run_randomized_benchmarks.sh --output /tmp/pr-hlsl-subscript-bench.txt`