### PR TITLE
refactor(ada): Refactor Ada tree repairs and retire obsolete association-choice subpass

### DIFF
--- a/admission_switch_a3_arm_noop_confirmation_test.go
+++ b/admission_switch_a3_arm_noop_confirmation_test.go
@@ -45,6 +45,20 @@ import (
 // Follow-up arm-deletion PRs for perl, python, and ada must not treat this
 // finding's retirement precondition as met on this evidence.
 //
+// UPDATE: ada's array_others_choice witness now confirms. A declared-conflict
+// election policy (grammars/runtime_profiles.go "ada",
+// ConflictPolicyDeclaredReduceReduceHighestSymbol in conflict_policy.go)
+// resolves the component_choice_list/discrete_choice tie natively before the
+// parser forks, so dispatch.ada.association-choice-materialization
+// (previously materialization-owned) retired outright and
+// dispatch.ada.aggregate-kind-election no longer reshapes this witness --
+// see TestA3ArmNoOpConfirmationAdaOthersChoiceConfirms.
+// locked_positional_array_aggregate's ambiguity
+// (record_component_association_list vs positional_array_aggregate) is a
+// separate shift/reduce fork with no dynamic-precedence differentiator, a
+// table-generation gap this policy mechanism does not reach; ada's arm
+// stays load-bearing for that witness.
+//
 // UPDATE: apex's witness no longer confirms. selectCompactAcceptanceDerivation's
 // materiality gate (parsercore_phase0_driver.go,
 // compactAcceptanceElectionIsVacuous) found the class_literal_alias witness's
@@ -153,6 +167,12 @@ func TestA3ArmNoOpConfirmationPythonDoesNotConfirm(t *testing.T) {
 	}
 }
 
+// TestA3ArmNoOpConfirmationAdaDoesNotConfirm covers Ada's still-load-bearing
+// witness. locked_positional_array_aggregate's ambiguity
+// (record_component_association_list vs positional_array_aggregate, a
+// shift/reduce fork with no dynamic-precedence differentiator) is a
+// table-generation gap, not a runtime election policy; the arm still
+// reshapes the compact route's tree for it.
 func TestA3ArmNoOpConfirmationAdaDoesNotConfirm(t *testing.T) {
 	lang := grammars.AdaLanguage()
 	if !lang.CompactPrimaryAcceptanceDerivationCertified || !lang.CompactConvergedReductionSplitDropsCertified {
@@ -160,10 +180,25 @@ func TestA3ArmNoOpConfirmationAdaDoesNotConfirm(t *testing.T) {
 	}
 	for _, tt := range []struct{ name, source string }{
 		{"locked_positional_array_aggregate", "package P is\n   type A is array (1 .. 3) of Boolean;\n   V : constant A := (1, 2, 3);\nend;\n"},
-		{"array_others_choice", "procedure P is\nbegin\n   A := (others => 0);\nend;\n"},
 	} {
 		assertA3ArmNoOp(t, "ada/"+tt.name, lang, []byte(tt.source), false)
 	}
+}
+
+// TestA3ArmNoOpConfirmationAdaOthersChoiceConfirms is the corrected receipt
+// for Ada's other tied-election witness. array_others_choice's ambiguity
+// (component_choice_list vs discrete_choice, a declared reduce-reduce
+// conflict with no dynamic precedence) is now resolved natively by a
+// declared-conflict election policy before the parser forks
+// (grammars/runtime_profiles.go "ada"), so the compact route's raw and
+// tailed trees are identical: the arm is confirmed inert on this witness.
+func TestA3ArmNoOpConfirmationAdaOthersChoiceConfirms(t *testing.T) {
+	lang := grammars.AdaLanguage()
+	if !lang.CompactPrimaryAcceptanceDerivationCertified || !lang.CompactConvergedReductionSplitDropsCertified {
+		t.Fatal("ada did not receive its A3 certification")
+	}
+	source := "procedure P is\nbegin\n   A := (others => 0);\nend;\n"
+	assertA3ArmNoOp(t, "ada/array_others_choice", lang, []byte(source), true)
 }
 
 // TestA3ArmNoOpConfirmationTrivialWitnessesAreVacuouslyNoOp documents the

--- a/cgo_harness/ada_a3_certification_sweep_test.go
+++ b/cgo_harness/ada_a3_certification_sweep_test.go
@@ -48,11 +48,6 @@ func TestAdaA3CompactCertificationFullCorpusSweep(t *testing.T) {
 // reproduces what production already produces (verified directly, with the
 // compact route disabled) on each of these witnesses.
 //
-// attribute_constraint is family D: Ada's grammar declares
-// prec.dynamic(1, discriminant_constraint) over index_constraint with an
-// explicit grammar comment choosing it, and Go's reduceForkWindowPreference
-// still picks index_constraint.
-//
 // This list carried six family-M entries before PR #638:
 // locked_positional_array_aggregate, array_others_choice,
 // named_array_aggregate, mixed_positional_named_aggregate,
@@ -64,15 +59,21 @@ func TestAdaA3CompactCertificationFullCorpusSweep(t *testing.T) {
 // ratchet in a3ReportSweep now fails this test if a remaining entry stops
 // matching a live divergence.
 //
+// attribute_constraint (family D) carried a divergence at its
+// index_constraint[2] node: dispatch.ada.constraint-kind-election
+// (parser_result_ada.go) used to rename ANY tick-bearing
+// discriminant_constraint to index_constraint, including named associations
+// ("F => Pkg.Obj'Access") for which index_constraint is never a legal
+// reading (index_constraint's discrete_range list carries no
+// discriminant_selector_name/'=>' pair) -- both the compact and production
+// routes ran that same shared post-parse rewrite, so both agreed with each
+// other while diverging from the C oracle, which needs no rewrite at all
+// here (the raw parse already elects discriminant_constraint). Gating the
+// rewrite on the single-positional-association shape removed the entry.
+//
 // Not tied elections, not this gate's scope; repair lanes are tracked
 // separately.
-var adaA3KnownDivergences = []a3KnownDivergence{
-	{
-		Witness:   "attribute_constraint",
-		FirstPath: "/compilation/compilation_unit[0]/subprogram_body[0]/handled_sequence_of_statements[3]/assignment_statement[0]/expression[2]/term[0]/allocator[0]/index_constraint[2]",
-		GoValue:   "index_constraint", CValue: "discriminant_constraint", Family: "D",
-	},
-}
+var adaA3KnownDivergences = []a3KnownDivergence{}
 
 // adaA3TiedElectionWitnesses reuses the three witnesses already vetted in
 // ada_election_local_parity_test.go (TestAdaElectionRawCOracleParity),
@@ -98,9 +99,13 @@ func adaA3TiedElectionWitnesses() []a3CertificationSweepSource {
 				"end;\n"),
 		},
 		{
+			// The finding's second "ada aggregate". Formerly a
 			// dispatch.ada.aggregate-kind-election +
-			// dispatch.ada.association-choice-materialization witness. The
-			// finding's second "ada aggregate".
+			// dispatch.ada.association-choice-materialization witness; the
+			// latter subpass retired once a declared-conflict election
+			// policy resolved the underlying component_choice_list vs
+			// discrete_choice tie natively (grammars/runtime_profiles.go
+			// "ada").
 			Name: "array_others_choice",
 			Source: []byte("procedure P is\n" +
 				"begin\n" +

--- a/cgo_harness/ada_constraint_kind_election_parity_test.go
+++ b/cgo_harness/ada_constraint_kind_election_parity_test.go
@@ -18,27 +18,24 @@ import (
 // production route (compat tail on, dispatch.ada.constraint-kind-election in
 // parser_result_ada.go included).
 //
-// The two routes disagree with the C oracle in opposite directions,
-// depending on the constraint shape:
-//
-//   - Named associations ("F => Pkg.Obj'Access") are unambiguous: the raw
-//     route already matches the C oracle, and the production route diverges
-//     because the compatibility pass renames discriminant_constraint to
-//     index_constraint and drops the discriminant_association wrapper
-//     regardless.
+//   - Named associations ("F => Pkg.Obj'Access") are unambiguous
+//     (index_constraint's discrete_range list carries no
+//     discriminant_selector_name/'=>' pair, so index_constraint is never a
+//     legal reading here): both routes match the C oracle. The subpass now
+//     gates its rewrite on the single-positional-association shape, so it no
+//     longer engages on a named association at all.
 //   - Positional (unnamed) constraint values that are
 //     'Access/'Delta/'Digits/'Mod attribute references, outside an
 //     allocator (object declarations, subtype declarations, record
-//     component declarations), go the other way: the raw route elects
+//     component declarations), stay load-bearing: the raw route elects
 //     discriminant_constraint wrapping a discriminant_association where the
 //     C oracle elects index_constraint directly, and the production route's
-//     rewrite produces the exact C shape.
+//     rewrite produces the exact C shape, subtype_mark/prefix/selector_name
+//     fields included.
 //
-// dispatch.ada.constraint-kind-election is therefore load-bearing for the
-// positional attribute-reference shapes even though it regresses the
-// named-association shapes; the two shapes need separate handling (for
-// example, gating on whether the discriminant_association carries a
-// name/arrow pair) rather than a single on/off subpass.
+// dispatch.ada.constraint-kind-election remains load-bearing for the
+// positional attribute-reference shapes; it is a no-op producer for every
+// other shape this suite exercises.
 func TestAdaConstraintKindElectionCParity(t *testing.T) {
 	goLang := grammars.AdaLanguage()
 	cLang, err := COracleLanguage("ada")
@@ -59,18 +56,18 @@ func TestAdaConstraintKindElectionCParity(t *testing.T) {
 		note                   string
 	}{
 		{
-			name:                   "named_allocator_witness_regresses",
+			name:                   "named_allocator_witness_unaffected",
 			source:                 "procedure P is\nbegin\n   A := new T (F => Pkg.Obj'Access);\nend;\n",
 			wantRawMismatch:        false,
-			wantProductionMismatch: true,
-			note:                   "named association is unambiguous (discriminant_association is the only legal shape); the subpass renames discriminant_constraint to index_constraint and drops the association wrapper anyway.",
+			wantProductionMismatch: false,
+			note:                   "named association is unambiguous (discriminant_association is the only legal shape); the subpass no longer engages on a multi-child (named) association.",
 		},
 		{
-			name:                   "named_object_decl_regresses",
+			name:                   "named_object_decl_unaffected",
 			source:                 "procedure P is\n   X : Rec (F => Pkg.Obj'Access);\nbegin\n   null;\nend;\n",
 			wantRawMismatch:        false,
-			wantProductionMismatch: true,
-			note:                   "same named-association regression outside an allocator.",
+			wantProductionMismatch: false,
+			note:                   "same named-association shape outside an allocator.",
 		},
 		{
 			name:                   "positional_object_decl_access_load_bearing",

--- a/cgo_harness/ada_election_local_parity_test.go
+++ b/cgo_harness/ada_election_local_parity_test.go
@@ -57,17 +57,24 @@ func TestAdaElectionRawCOracleParity(t *testing.T) {
 		{
 			// dispatch.ada.aggregate-kind-election +
 			// dispatch.ada.association-choice-materialization witness
-			// ("ada_array_others_choice"). Both component_choice_list and
-			// discrete_choice reach acceptance as live parallel
-			// derivations; gotreesitter's runtime accept-selection elects
-			// component_choice_list where the locked C oracle elects
-			// discrete_choice.
+			// ("ada_array_others_choice"). Ada's grammar declares
+			// conflicts: [[$.component_choice_list, $.discrete_choice]]: a
+			// bare "others" choice reduces as either component_choice_list
+			// (record reading) or discrete_choice (array reading), both
+			// plain REDUCE with no dynamic precedence. The declared-conflict
+			// election policy (grammars/runtime_profiles.go "ada",
+			// ConflictPolicyDeclaredReduceReduceHighestSymbol in
+			// conflict_policy.go) folds the row to the discrete_choice
+			// reading before the GLR engine ever forks, which in turn
+			// determines the outer named_array_aggregate reading (no
+			// separate outer-shape ambiguity remains once the inner choice
+			// is settled), so the raw production tree now matches C
+			// natively.
 			name: "array_others_choice",
 			source: []byte("procedure P is\n" +
 				"begin\n" +
 				"   A := (others => 0);\n" +
 				"end;\n"),
-			wantDivergence: true,
 		},
 	}
 

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -301,10 +301,29 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// Full-corpus field-aware C-oracle verification certifies both
 	// mechanisms for this exact blob (A3 certification workstream,
 	// spec.campaign.v7).
+	//
+	// Ada's grammar declares conflicts: [[$.component_choice_list,
+	// $.discrete_choice], ...] (tree-sitter-ada grammar.js): a bare
+	// "others" choice reduces the shared token as either component_choice_list
+	// (162... record-aggregate reading, RM 4.3.1) or discrete_choice
+	// (array-aggregate reading, RM 3.8.1), both plain REDUCE actions with no
+	// dynamic precedence on either alternative. The locked C oracle keeps
+	// the discrete_choice reading; this row-scoped fold (state/lookahead
+	// wildcarded, matched only by the declared-conflict symbol pair,
+	// component_choice_list=195, discrete_choice=255 in this blob) reproduces
+	// that natively, the same mechanism ql's signatureExpr election uses.
 	"ada": {
 		blobSHA256:                     mustRuntimeProfileSHA256("32f2dd8f0053ffb7e6b7014f6ff2eb7025287c0d5fcdab6ce1f6a694c2d8899e"),
 		compactConvergedSplitDrops:     true,
 		compactPrimaryAcceptDerivation: true,
+		conflictPolicies: []gotreesitter.ConflictPolicy{
+			{
+				State:         gotreesitter.ConflictPolicyAnyState,
+				Lookahead:     gotreesitter.ConflictPolicyAnyLookahead,
+				Kind:          gotreesitter.ConflictPolicyDeclaredReduceReduceHighestSymbol,
+				ReduceSymbols: []gotreesitter.Symbol{195, 255},
+			},
+		},
 	},
 	// Swift's low-pressure accepted-error parses select the same tree across
 	// the retry ladder. High-pressure parses still benefit from the first

--- a/parser_result_ada.go
+++ b/parser_result_ada.go
@@ -15,11 +15,7 @@ func normalizeAdaCompatibilityWithCensus(
 	if root == nil || lang == nil || lang.Name != "ada" || len(source) == 0 {
 		return
 	}
-	recordAggSym, recordAggNamed, ok := symbolMeta(lang, "record_aggregate")
-	if !ok {
-		return
-	}
-	namedArrayAggSym, namedArrayAggNamed, ok := symbolMeta(lang, "named_array_aggregate")
+	recordAggSym, _, ok := symbolMeta(lang, "record_aggregate")
 	if !ok {
 		return
 	}
@@ -27,23 +23,7 @@ func normalizeAdaCompatibilityWithCensus(
 	if !ok {
 		return
 	}
-	recordAssocListSym, recordAssocListNamed, ok := symbolMeta(lang, "record_component_association_list")
-	if !ok {
-		return
-	}
-	arrayAssocSym, arrayAssocNamed, ok := symbolMeta(lang, "array_component_association")
-	if !ok {
-		return
-	}
-	componentChoiceListSym, componentChoiceListNamed, ok := symbolMeta(lang, "component_choice_list")
-	if !ok {
-		return
-	}
-	discreteChoiceListSym, discreteChoiceListNamed, ok := symbolMeta(lang, "discrete_choice_list")
-	if !ok {
-		return
-	}
-	discreteChoiceSym, discreteChoiceNamed, ok := symbolMeta(lang, "discrete_choice")
+	recordAssocListSym, _, ok := symbolMeta(lang, "record_component_association_list")
 	if !ok {
 		return
 	}
@@ -87,6 +67,29 @@ func normalizeAdaCompatibilityWithCensus(
 	if !ok {
 		return
 	}
+	// subtypeMarkFieldID/prefixFieldID/selectorNameFieldID mirror the field
+	// names the C oracle attaches when it elects the discrete_range reading
+	// of a bare attribute-reference constraint natively: grammar.js's
+	// _subtype_indication rule wraps its (hidden) subtype_mark alternative
+	// in field('subtype_mark', ...), and that field propagates onto every
+	// inlined child of the hidden _attribute_reference/_name chain
+	// (selected_component, tick, attribute_designator all carry it);
+	// selected_component's own rule separately fields its prefix/selector_name
+	// children at every nesting level. adaAttributeReferenceChildren and
+	// adaSelectedComponentNode fabricate these nodes by hand, so they must
+	// set the same fields explicitly to match the natively-parsed shape.
+	subtypeMarkFieldID, ok := lang.FieldByName("subtype_mark")
+	if !ok {
+		return
+	}
+	prefixFieldID, ok := lang.FieldByName("prefix")
+	if !ok {
+		return
+	}
+	selectorNameFieldID, ok := lang.FieldByName("selector_name")
+	if !ok {
+		return
+	}
 
 	walkResultTree(root, func(n *Node) {
 		if n == nil || int(n.endByte) > len(source) || n.startByte > n.endByte {
@@ -101,71 +104,91 @@ func normalizeAdaCompatibilityWithCensus(
 		switch n.symbol {
 		case discriminantConstraintSym:
 			census.run("dispatch.ada.constraint-kind-election", func() {
-				if mid.symbol == discriminantAssociationSym && bytes.Contains(text, []byte("'")) {
-					assocChildren := resultChildSliceForMutation(mid)
-					if len(assocChildren) == 0 {
-						return
-					}
-					if len(assocChildren) == 1 && assocChildren[0] != nil && assocChildren[0].symbol == expressionSym {
-						if rebuilt := adaAttributeReferenceChildren(n.ownerArena, source, assocChildren[0], selectedComponentSym, selectedComponentNamed, tickSym, tickNamed, attributeDesignatorSym, attributeDesignatorNamed, identifierSym, identifierNamed, dotSym, dotNamed, accessSym, accessNamed); len(rebuilt) > 0 {
-							assocChildren = rebuilt
-						} else if exprChildren := resultChildSliceForMutation(assocChildren[0]); len(exprChildren) > 0 {
-							assocChildren = exprChildren
-						}
-					}
-					out := make([]*Node, 0, len(assocChildren)+2)
-					out = append(out, children[0])
-					out = append(out, assocChildren...)
-					out = append(out, children[2])
-					n.symbol = indexConstraintSym
-					n.setNamed(indexConstraintNamed)
-					replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, out))
-					nodeInitEquivVersion(n)
+				if mid.symbol != discriminantAssociationSym || !bytes.Contains(text, []byte("'")) {
+					return
 				}
-			})
-		case namedArrayAggSym:
-			census.run("dispatch.ada.aggregate-kind-election", func() {
-				if mid.symbol == arrayAssocSym && bytes.Contains(text, []byte("=>")) && !adaAggregateTextStartsOthers(text) {
-					n.symbol = recordAggSym
-					n.setNamed(recordAggNamed)
-					mid.symbol = recordAssocListSym
-					mid.setNamed(recordAssocListNamed)
-					normalizeAdaRecordAssociationChoicesWithCensus(mid, componentChoiceListSym, componentChoiceListNamed, discreteChoiceListSym, discreteChoiceSym, expressionSym, census)
-					nodeInitEquivVersion(n)
-					nodeInitEquivVersion(mid)
+				assocChildren := resultChildSliceForMutation(mid)
+				// index_constraint's discrete_range list never carries a
+				// discriminant_selector_name/'=>' pair (that shape is only
+				// legal for discriminant_constraint's own association list),
+				// so a named or multi-child association can never be the
+				// index_constraint reading: only the single positional bare
+				// expression is a rebuild candidate.
+				if len(assocChildren) != 1 || assocChildren[0] == nil || assocChildren[0].symbol != expressionSym {
+					return
 				}
+				rebuiltIsAttributeReference := false
+				rebuilt := adaAttributeReferenceChildren(n.ownerArena, source, assocChildren[0], selectedComponentSym, selectedComponentNamed, tickSym, tickNamed, attributeDesignatorSym, attributeDesignatorNamed, identifierSym, identifierNamed, dotSym, dotNamed, accessSym, accessNamed, prefixFieldID, selectorNameFieldID)
+				if len(rebuilt) > 0 {
+					assocChildren = rebuilt
+					rebuiltIsAttributeReference = true
+				} else if exprChildren := resultChildSliceForMutation(assocChildren[0]); len(exprChildren) > 0 {
+					assocChildren = exprChildren
+				}
+				out := make([]*Node, 0, len(assocChildren)+2)
+				out = append(out, children[0])
+				out = append(out, assocChildren...)
+				out = append(out, children[2])
+				n.symbol = indexConstraintSym
+				n.setNamed(indexConstraintNamed)
+				replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, out))
+				if rebuiltIsAttributeReference {
+					// The hidden _subtype_indication/_attribute_reference
+					// chain (grammar.js) pushes field('subtype_mark', ...)
+					// onto every inlined child; the rebuilt (selected
+					// component, tick, attribute_designator) triple sits at
+					// out[1:len(rebuilt)+1].
+					for i := 1; i <= len(rebuilt); i++ {
+						setNodeChildFieldDirect(n, i, subtypeMarkFieldID)
+					}
+				}
+				nodeInitEquivVersion(n)
 			})
 		case recordAggSym:
+			// Only the positional-list reading survives here.
+			// record_component_association_list's positional alternative
+			// ("expr, expr, ...", RM 4.3.1) and positional_array_aggregate's
+			// own leading alternative are a declared grammar.js conflict
+			// ([$.record_component_association_list,
+			// $.positional_array_aggregate]) with no dynamic-precedence
+			// differentiator; this is a shift/reduce fork the engine still
+			// resolves to the record reading (an F-A/F-B table-generation
+			// gap, not a runtime election policy this file can fix -- see
+			// dispatch.ada's registry entry).
+			//
+			// The "others"-choice reading that used to share this case
+			// (record_aggregate <-> named_array_aggregate, gated on whether
+			// the association text started with "others") is gone: that
+			// election was driven entirely by the component_choice_list vs
+			// discrete_choice tie (RM 4.3.1 vs RM 3.8.1 for a bare "others"),
+			// which is now resolved natively before the GLR engine forks
+			// (grammars/runtime_profiles.go "ada",
+			// ConflictPolicyDeclaredReduceReduceHighestSymbol in
+			// conflict_policy.go) -- the raw parse already produces the
+			// correct outer aggregate kind, so this file never sees the
+			// wrong one to repair.
 			census.run("dispatch.ada.aggregate-kind-election", func() {
-				switch {
-				case mid.symbol == recordAssocListSym && bytes.Contains(text, []byte("=>")) && adaAggregateTextStartsOthers(text):
-					n.symbol = namedArrayAggSym
-					n.setNamed(namedArrayAggNamed)
-					mid.symbol = arrayAssocSym
-					mid.setNamed(arrayAssocNamed)
-					normalizeAdaArrayAssociationChoicesWithCensus(mid, componentChoiceListSym, discreteChoiceListSym, discreteChoiceListNamed, discreteChoiceSym, discreteChoiceNamed, census)
-					nodeInitEquivVersion(n)
-					nodeInitEquivVersion(mid)
-				case mid.symbol == recordAssocListSym && !bytes.Contains(text, []byte("=>")) && bytes.Contains(text, []byte(",")):
-					listChildren := resultChildSliceForMutation(mid)
-					if len(listChildren) == 0 {
-						return
-					}
-					out := make([]*Node, 0, len(listChildren)+2)
-					out = append(out, children[0])
-					out = append(out, listChildren...)
-					out = append(out, children[2])
-					n.symbol = positionalArrayAggSym
-					n.setNamed(positionalArrayAggNamed)
-					replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, out))
-					nodeInitEquivVersion(n)
+				if mid.symbol != recordAssocListSym || bytes.Contains(text, []byte("=>")) || !bytes.Contains(text, []byte(",")) {
+					return
 				}
+				listChildren := resultChildSliceForMutation(mid)
+				if len(listChildren) == 0 {
+					return
+				}
+				out := make([]*Node, 0, len(listChildren)+2)
+				out = append(out, children[0])
+				out = append(out, listChildren...)
+				out = append(out, children[2])
+				n.symbol = positionalArrayAggSym
+				n.setNamed(positionalArrayAggNamed)
+				replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, out))
+				nodeInitEquivVersion(n)
 			})
 		}
 	})
 }
 
-func adaAttributeReferenceChildren(arena *nodeArena, source []byte, expr *Node, selectedComponentSym Symbol, selectedComponentNamed bool, tickSym Symbol, tickNamed bool, attributeDesignatorSym Symbol, attributeDesignatorNamed bool, identifierSym Symbol, identifierNamed bool, dotSym Symbol, dotNamed bool, accessSym Symbol, accessNamed bool) []*Node {
+func adaAttributeReferenceChildren(arena *nodeArena, source []byte, expr *Node, selectedComponentSym Symbol, selectedComponentNamed bool, tickSym Symbol, tickNamed bool, attributeDesignatorSym Symbol, attributeDesignatorNamed bool, identifierSym Symbol, identifierNamed bool, dotSym Symbol, dotNamed bool, accessSym Symbol, accessNamed bool, prefixFieldID, selectorNameFieldID FieldID) []*Node {
 	if expr == nil || expr.startByte >= expr.endByte || int(expr.endByte) > len(source) {
 		return nil
 	}
@@ -176,7 +199,7 @@ func adaAttributeReferenceChildren(arena *nodeArena, source []byte, expr *Node, 
 	}
 	tickStart := expr.startByte + uint32(tickOffset)
 	tickEnd := tickStart + 1
-	selected := adaSelectedComponentNode(arena, source, expr.startByte, tickStart, selectedComponentSym, selectedComponentNamed, identifierSym, identifierNamed, dotSym, dotNamed)
+	selected := adaSelectedComponentNode(arena, source, expr.startByte, tickStart, selectedComponentSym, selectedComponentNamed, identifierSym, identifierNamed, dotSym, dotNamed, prefixFieldID, selectorNameFieldID)
 	if selected == nil {
 		return nil
 	}
@@ -186,7 +209,12 @@ func adaAttributeReferenceChildren(arena *nodeArena, source []byte, expr *Node, 
 	return cloneNodeSliceIfArena(arena, []*Node{selected, tick, attr})
 }
 
-func adaSelectedComponentNode(arena *nodeArena, source []byte, start, end uint32, selectedComponentSym Symbol, selectedComponentNamed bool, identifierSym Symbol, identifierNamed bool, dotSym Symbol, dotNamed bool) *Node {
+// adaSelectedComponentNode rebuilds the selected_component chain a native
+// parse would produce for a dotted prefix (`Pkg.Sub.Obj`), including the
+// prefix/selector_name fields grammar.js's selected_component rule attaches
+// to every nesting level (field('prefix', $._name) '.'
+// field('selector_name', ...)).
+func adaSelectedComponentNode(arena *nodeArena, source []byte, start, end uint32, selectedComponentSym Symbol, selectedComponentNamed bool, identifierSym Symbol, identifierNamed bool, dotSym Symbol, dotNamed bool, prefixFieldID, selectorNameFieldID FieldID) *Node {
 	if start >= end || int(end) > len(source) {
 		return nil
 	}
@@ -198,7 +226,7 @@ func adaSelectedComponentNode(arena *nodeArena, source []byte, start, end uint32
 		return newLeafNodeInArena(arena, identifierSym, identifierNamed, start, end, startPoint, endPoint)
 	}
 	dotStart := start + uint32(dotOffset)
-	left := adaSelectedComponentNode(arena, source, start, dotStart, selectedComponentSym, selectedComponentNamed, identifierSym, identifierNamed, dotSym, dotNamed)
+	left := adaSelectedComponentNode(arena, source, start, dotStart, selectedComponentSym, selectedComponentNamed, identifierSym, identifierNamed, dotSym, dotNamed, prefixFieldID, selectorNameFieldID)
 	if left == nil {
 		return nil
 	}
@@ -206,109 +234,8 @@ func adaSelectedComponentNode(arena *nodeArena, source []byte, start, end uint32
 	rightStart := dotStart + 1
 	rightPoint := dot.endPoint
 	right := newLeafNodeInArena(arena, identifierSym, identifierNamed, rightStart, end, rightPoint, advancePointByBytes(rightPoint, source[rightStart:end]))
-	return newParentNodeInArena(arena, selectedComponentSym, selectedComponentNamed, []*Node{left, dot, right}, nil, 0)
-}
-
-func normalizeAdaRecordAssociationChoices(assoc *Node, componentChoiceListSym Symbol, componentChoiceListNamed bool, discreteChoiceListSym, discreteChoiceSym, expressionSym Symbol) {
-	normalizeAdaRecordAssociationChoicesWithCensus(
-		assoc,
-		componentChoiceListSym,
-		componentChoiceListNamed,
-		discreteChoiceListSym,
-		discreteChoiceSym,
-		expressionSym,
-		materializationSubpassCensus{},
-	)
-}
-
-func normalizeAdaRecordAssociationChoicesWithCensus(
-	assoc *Node,
-	componentChoiceListSym Symbol,
-	componentChoiceListNamed bool,
-	discreteChoiceListSym Symbol,
-	discreteChoiceSym Symbol,
-	expressionSym Symbol,
-	census materializationSubpassCensus,
-) {
-	walkResultTree(assoc, func(n *Node) {
-		if n == nil || n.symbol != discreteChoiceListSym {
-			return
-		}
-		census.run("dispatch.ada.association-choice-materialization", func() {
-			n.symbol = componentChoiceListSym
-			n.setNamed(componentChoiceListNamed)
-			children := resultChildSliceForMutation(n)
-			if len(children) == 1 && children[0] != nil && children[0].symbol == discreteChoiceSym {
-				innerChildren := resultChildSliceForMutation(children[0])
-				if len(innerChildren) == 1 && innerChildren[0] != nil {
-					replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, []*Node{innerChildren[0]}))
-				}
-			}
-			adaCollapseSingleChildChoiceWrappers(n, expressionSym)
-			nodeInitEquivVersion(n)
-		})
-	})
-}
-
-func adaCollapseSingleChildChoiceWrappers(choiceList *Node, firstWrapperSym Symbol) {
-	children := resultChildSliceForMutation(choiceList)
-	if len(children) != 1 || children[0] == nil || children[0].symbol != firstWrapperSym {
-		return
-	}
-	for {
-		children = resultChildSliceForMutation(choiceList)
-		if len(children) != 1 || children[0] == nil {
-			return
-		}
-		wrapper := children[0]
-		innerChildren := resultChildSliceForMutation(wrapper)
-		if len(innerChildren) != 1 || innerChildren[0] == nil {
-			return
-		}
-		inner := innerChildren[0]
-		if wrapper.startByte != inner.startByte || wrapper.endByte != inner.endByte {
-			return
-		}
-		replaceNodeChildrenUnfielded(choiceList, cloneNodeSliceIfArena(choiceList.ownerArena, []*Node{inner}))
-	}
-}
-
-func normalizeAdaArrayAssociationChoices(assoc *Node, componentChoiceListSym, discreteChoiceListSym Symbol, discreteChoiceListNamed bool, discreteChoiceSym Symbol, discreteChoiceNamed bool) {
-	normalizeAdaArrayAssociationChoicesWithCensus(
-		assoc,
-		componentChoiceListSym,
-		discreteChoiceListSym,
-		discreteChoiceListNamed,
-		discreteChoiceSym,
-		discreteChoiceNamed,
-		materializationSubpassCensus{},
-	)
-}
-
-func normalizeAdaArrayAssociationChoicesWithCensus(
-	assoc *Node,
-	componentChoiceListSym Symbol,
-	discreteChoiceListSym Symbol,
-	discreteChoiceListNamed bool,
-	discreteChoiceSym Symbol,
-	discreteChoiceNamed bool,
-	census materializationSubpassCensus,
-) {
-	walkResultTree(assoc, func(n *Node) {
-		if n == nil || n.symbol != componentChoiceListSym {
-			return
-		}
-		census.run("dispatch.ada.association-choice-materialization", func() {
-			n.symbol = discreteChoiceListSym
-			n.setNamed(discreteChoiceListNamed)
-			children := resultChildSliceForMutation(n)
-			if len(children) == 1 && children[0] != nil && children[0].symbol != discreteChoiceSym {
-				wrapper := newParentNodeInArena(n.ownerArena, discreteChoiceSym, discreteChoiceNamed, []*Node{children[0]}, nil, 0)
-				replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, []*Node{wrapper}))
-			}
-			nodeInitEquivVersion(n)
-		})
-	})
+	fieldIDs := []FieldID{prefixFieldID, 0, selectorNameFieldID}
+	return newParentNodeInArena(arena, selectedComponentSym, selectedComponentNamed, []*Node{left, dot, right}, fieldIDs, 0)
 }
 
 func adaTrimmedNodeText(n *Node, source []byte) []byte {
@@ -316,19 +243,4 @@ func adaTrimmedNodeText(n *Node, source []byte) []byte {
 		return nil
 	}
 	return bytes.TrimSpace(source[n.startByte:n.endByte])
-}
-
-func adaAggregateTextStartsOthers(text []byte) bool {
-	if len(text) < len("others") || !bytes.EqualFold(text[:len("others")], []byte("others")) {
-		return false
-	}
-	if len(text) == len("others") {
-		return true
-	}
-	switch text[len("others")] {
-	case ' ', '\t', '\r', '\n', '=':
-		return true
-	default:
-		return false
-	}
 }

--- a/parser_result_test/materialization_subpass_census_test.go
+++ b/parser_result_test/materialization_subpass_census_test.go
@@ -220,27 +220,23 @@ func materializationSubpassProbes() []materializationSubpassProbe {
 				"begin\n" +
 				"   A := (others => 0);\n" +
 				"end;\n",
-			// Both digests moved with the inherited-field projection repair
-			// (PR #638). The old digests pinned a "name" field on
-			// named_array_aggregate that the C runtime never assigns. C
-			// receipt, taken with field comparison on: the production route
-			// now reports 0 mismatches against the locked C oracle. The raw
-			// route keeps only the 6 pre-existing aggregate-kind and
-			// association-choice election mismatches that
-			// dispatch.ada.aggregate-kind-election and
-			// dispatch.ada.association-choice-materialization repair, and 0
-			// field mismatches.
-			wantRawDigest:    "ad2718a1e309fadba012881bc82689ff1dabec69814106b0dcbe3a39b6d70b27",
+			// Ada's grammar declares conflicts: [[$.component_choice_list,
+			// $.discrete_choice], ...]. A bare "others" choice used to elect
+			// component_choice_list (record reading) where the C oracle
+			// elects discrete_choice (array reading), both plain REDUCE
+			// with no dynamic precedence; the outer named_array_aggregate
+			// reading follows from the inner choice, so the same tie drove
+			// both mismatches. The declared-conflict election policy
+			// (grammars/runtime_profiles.go "ada",
+			// ConflictPolicyDeclaredReduceReduceHighestSymbol) now folds
+			// that row before the GLR engine forks, so the raw route
+			// already matches the C oracle and dispatch.ada.aggregate-kind-election
+			// / dispatch.ada.association-choice-materialization are no
+			// longer engaged on this witness at all.
+			wantRawDigest:    "95edae06bdbba04a19749854656b7c439a334cf9ae7bba367ed762386cf28d15",
 			wantResultDigest: "95edae06bdbba04a19749854656b7c439a334cf9ae7bba367ed762386cf28d15",
 			expectedSubpasses: []string{
 				"dispatch.ada",
-				"dispatch.ada.aggregate-kind-election",
-				"dispatch.ada.association-choice-materialization",
-			},
-			rewrittenSubpasses: []string{
-				"dispatch.ada",
-				"dispatch.ada.aggregate-kind-election",
-				"dispatch.ada.association-choice-materialization",
 			},
 		},
 		{
@@ -250,13 +246,15 @@ func materializationSubpassProbes() []materializationSubpassProbe {
 				"begin\n" +
 				"   A := new T (F => Pkg.Obj'Access);\n" +
 				"end;\n",
+			// Named associations are unambiguous (index_constraint is never
+			// a legal reading for a discriminant_selector_name/'=>' pair);
+			// dispatch.ada.constraint-kind-election now gates its rewrite on
+			// the single-positional-association shape, so it no longer
+			// rewrites this named witness (it still runs, and visits the
+			// discriminant_constraint node, hence it stays checked).
 			wantRawDigest:    "a35538112ad4ae10df6d5544c7f0a58f3e6a3ecb5fd5fb842808d0e31ac27ac2",
-			wantResultDigest: "d0006efd9f34dce85ac48330642b378dc2b5f995004c9c11a20aee98ac6be8a2",
+			wantResultDigest: "a35538112ad4ae10df6d5544c7f0a58f3e6a3ecb5fd5fb842808d0e31ac27ac2",
 			expectedSubpasses: []string{
-				"dispatch.ada",
-				"dispatch.ada.constraint-kind-election",
-			},
-			rewrittenSubpasses: []string{
 				"dispatch.ada",
 				"dispatch.ada.constraint-kind-election",
 			},

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -76,25 +76,8 @@
           "files": [
             "parser_result_ada.go"
           ],
-          "purpose": "Select the record, named-array, or positional-array aggregate type.",
+          "purpose": "Select the positional-array aggregate reading over the record aggregate reading for an unnamed comma-separated association list.",
           "authoritative_owner": "derivation_election_selection",
-          "witnesses": [
-            "parser_result_test/materialization_subpass_census_test.go",
-            "cgo_harness/ada_election_local_parity_test.go",
-            "cgo_harness/ada_a3_certification_sweep_test.go"
-          ]
-        },
-        {
-          "id": "dispatch.ada.association-choice-materialization",
-          "functions": [
-            "normalizeAdaArrayAssociationChoicesWithCensus",
-            "normalizeAdaRecordAssociationChoicesWithCensus"
-          ],
-          "files": [
-            "parser_result_ada.go"
-          ],
-          "purpose": "Construct the selected record or array association-choice wrappers.",
-          "authoritative_owner": "materialization",
           "witnesses": [
             "parser_result_test/materialization_subpass_census_test.go",
             "cgo_harness/ada_election_local_parity_test.go",
@@ -105,7 +88,7 @@
       "languages": [
         "ada"
       ],
-      "purpose": "Reconcile Ada returned-tree fields, aliases, and spans.",
+      "purpose": "Reconcile Ada returned-tree fields, aliases, and spans. dispatch.ada.association-choice-materialization retired: the component_choice_list/discrete_choice tie it repaired (record vs array reading of a bare \"others\" choice) is now resolved natively by a declared-conflict election policy before the parser forks (grammars/runtime_profiles.go \"ada\"), so the arm's raw output already matches the C oracle for every registered witness and the post-parse wrapper conversion is unreachable.",
       "authoritative_owner": "derivation_election_selection",
       "witnesses": [
         "cgo_harness/parity_cgo_test.go",
@@ -113,7 +96,7 @@
         "cgo_harness/ada_constraint_kind_election_parity_test.go",
         "cgo_harness/ada_a3_certification_sweep_test.go"
       ],
-      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
       "route_coverage": {
         "production": "shared_result_compatibility_tail",
         "compact": "shared_result_compatibility_tail",


### PR DESCRIPTION
## Summary

Replace post-parse tree repairs with native grammar resolution for Ada aggregate conflicts. This branch adds a declared-conflict election policy that settles the record-vs-array tie before parsing, retires the unreachable association-choice materialization pass, and narrows the constraint-kind-election rewrite to prevent regressions on named associations.

## Changes

- Add a declared-conflict election policy for Ada's component_choice_list versus discrete_choice tie in grammars/runtime_profiles.go. The policy folds the ambiguous reduce row into discrete_choice before the GLR engine forks.
- Remove the dispatch.ada.association-choice-materialization subpass and all related node-construction helpers from parser_result_ada.go. The post-parse wrapper is now unreachable because the raw parse produces the correct tree.
- Restrict dispatch.ada.constraint-kind-election to gate its rewrite on single-positional-association shapes. Named associations no longer trigger the rewrite, which prevents a regression against the C oracle.
- Pass prefix and selector_name field identifiers into the attribute-reference rebuild chain. The repaired nodes now explicitly carry the fields that the C oracle assigns natively through the hidden _subtype_indication rule.
- Update Ada parity tests, A3 certification sweeps, and materialization census probes to reflect the native resolution and the removed subpasses.
- Refresh testdata/result_compat_ownership_v1.json to document the retirement condition and update the dispatch.ada group purpose.

## Testing

- Run `bash cgo_harness/docker/run_single_grammar_parity.sh ada` to verify full C-oracle parity.
- Run `bash scripts/run_randomized_benchmarks.sh --output /tmp/perf-bench.txt` with stable settings to confirm no performance regression.