### PR TITLE
fix(apex, parser): fix apex class_literal election parity with c oracle

### DIFF
--- a/cgo_harness/apex_generic_local_parity_test.go
+++ b/cgo_harness/apex_generic_local_parity_test.go
@@ -41,18 +41,23 @@ func TestApexCloseAngleRawCOracleParity(t *testing.T) {
 				"}\n"),
 		},
 		{
-			// Witness for issue #601: both class_literal and field_access
-			// reach acceptance as live parallel derivations (a grammar-
-			// declared conflict with no prec.dynamic tie-break), and
-			// gotreesitter's runtime accept-selection elects class_literal
-			// where the locked C oracle elects field_access.
+			// Former witness for issue #601: both class_literal and
+			// field_access used to reach acceptance as live parallel
+			// derivations (a grammar-declared conflict with no
+			// prec.dynamic tie-break), and gotreesitter's runtime
+			// accept-selection elected class_literal where the locked C
+			// oracle elects field_access. Fixed natively: a per-stack DFA
+			// relex (parser.go) stops the shared lexer from starving the
+			// field_access fork, and the certified primary-acceptance-
+			// derivation preference (parser_result.go, reusing
+			// CompactPrimaryAcceptanceDerivationCertified) now settles the
+			// resulting tie the same way the compact route already did.
 			name: "class_literal_alias",
 			source: []byte("public class C {\n" +
 				"  void m() {\n" +
 				"    Object t = RecordPage.class;\n" +
 				"  }\n" +
 				"}\n"),
-			wantDivergence: true,
 		},
 	}
 

--- a/grammars/apex_class_literal_election_native_regression_test.go
+++ b/grammars/apex_class_literal_election_native_regression_test.go
@@ -1,0 +1,254 @@
+//go:build !grammar_subset
+
+package grammars
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// Apex's class_literal (seq(_unannotated_type, ".", ci("class"))) and
+// field_access (seq(choice(primary_expression, super),
+// _property_navigation, choice(identifier, this))) both reach a live GLR
+// fork on `Type.class`: the grammar declares no dynamic precedence between
+// the _unannotated_type and primary_expression readings of the leading
+// name, so both the class-literal and field-access derivations complete as
+// fully valid, differently-shaped parses of the same bytes. The locked C
+// oracle always keeps field_access. This is fixed natively at two points
+// for the classic engine (production, compact's fallback target, and
+// incremental all share it), neither apex-specific:
+//
+//   - relexTokenForStackLexState (parser.go) now also runs, unconditionally,
+//     right before a multi-stack no-action kill: the shared lexer's
+//     keyword-versus-identifier choice used to starve the field_access
+//     fork of the plain `identifier` token its state needs for the
+//     trailing `class` text, because a sibling fork's state only needed
+//     the `class` keyword. The per-stack DFA re-probe now gives a
+//     starved fork its own tokenization before killing it, exactly as the
+//     faithful C-recovery port already does for its own gated languages.
+//   - stackCompareForResultSelectionWithRawShape (parser_result.go) now
+//     skips the raw-shape/symbol-id fallback tie-break for languages
+//     certified CompactPrimaryAcceptanceDerivationCertified (apex among
+//     them): that fallback broke the resulting tie on raw grammar symbol
+//     id, an artifact of compiler assignment order unrelated to which
+//     production C actually prefers. Skipping it lets the existing
+//     branchOrder tie-break -- which already encodes "never took a
+//     GLR-forked conflict branch," the same signal the compact route's own
+//     certified primary-derivation election already trusts -- decide
+//     instead.
+//
+// The GSS-forest experimental fast path (ParseForestExperimental) is a
+// separate engine with its own dispatch loop and does not share either fix
+// site; it is not in apex's automatic-dispatch set
+// (glr_forest.go builtinForestDefaults), so no ordinary Parse call reaches
+// it for this language, but an explicit ParseForestExperimental call still
+// needs the compat arm below. dispatch.apex therefore stays live, narrowed
+// to that one remaining route -- see TestApexClassLiteralForestStillNeedsResultCompatibility.
+var (
+	apexClassLiteralAliasFixture = []byte(
+		"public class C {\n" +
+			"  void m() {\n" +
+			"    Object t = RecordPage.class;\n" +
+			"  }\n" +
+			"}",
+	)
+	apexQualifiedClassLiteralAliasFixture = []byte(
+		"public class C {\n" +
+			"  void m() {\n" +
+			"    Object t = Outer.Inner.class;\n" +
+			"  }\n" +
+			"}",
+	)
+	apexPlainFieldAccessFixture = []byte(
+		"public class C {\n" +
+			"  void m() {\n" +
+			"    Object t = RecordPage.someField;\n" +
+			"  }\n" +
+			"}",
+	)
+)
+
+func TestApexClassLiteralElectionNeedsNoResultCompatibility(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	language := ApexLanguage()
+
+	for _, fixture := range [][]byte{apexClassLiteralAliasFixture, apexQualifiedClassLiteralAliasFixture} {
+		tree, err := gotreesitter.NewParser(language).ParseNoResultCompatibilityBenchmarkOnly(fixture)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(tree.Release)
+		assertNoNormalizationPasses(t, tree)
+		assertApexClassLiteralIsFieldAccess(t, "compatibility-free", tree.RootNode(), language)
+
+		production, err := gotreesitter.NewParser(language).Parse(fixture)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(production.Release)
+		if runtime := production.ParseRuntime(); runtime.NormalizationNodesRewritten != 0 {
+			t.Fatalf("production normalization rewrote %d nodes", runtime.NormalizationNodesRewritten)
+		}
+		assertApexClassLiteralIsFieldAccess(t, "production", production.RootNode(), language)
+	}
+}
+
+// TestApexClassLiteralElectionRoutesMatch checks the three routes this fix
+// covers: production, compact (which falls back to production for this
+// witness -- see the comment below -- rather than routing directly), and
+// incremental. The forest fast path is exercised separately: see
+// TestApexClassLiteralForestStillNeedsResultCompatibility.
+func TestApexClassLiteralElectionRoutesMatch(t *testing.T) {
+	language := ApexLanguage()
+
+	tests := []struct {
+		name    string
+		fixture []byte
+	}{
+		{"bare_class_literal_alias", apexClassLiteralAliasFixture},
+		{"qualified_class_literal_alias", apexQualifiedClassLiteralAliasFixture},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			baseSource := test.fixture
+			source := append(append([]byte(nil), baseSource...), '\n')
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(source)
+			if err != nil {
+				t.Fatalf("production parse failed: %v", err)
+			}
+			t.Cleanup(production.Release)
+			assertApexClassLiteralIsFieldAccess(t, "production", production.RootNode(), language)
+
+			// Allow the compact route to fall back to production rather than
+			// requiring it to route directly: both fixtures' two tied
+			// derivations (field_access vs. class_literal) are not
+			// byte-identical, so the compact route's own, separate R1
+			// materiality gate (compactAcceptanceElectionIsVacuous,
+			// parsercore_phase0_driver.go) declines them and falls back to
+			// production on every parse -- documented there as a
+			// pre-existing, orthogonal cost this fix does not touch. The
+			// fallback still serves production's tree, which this fix makes
+			// C-exact, so the route's final output is correct either way.
+			compactParser := gotreesitter.NewParser(language)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.Parse(source)
+			if err != nil {
+				t.Fatalf("compact parse failed: %v", err)
+			}
+			t.Cleanup(compact.Release)
+			assertApexClassLiteralIsFieldAccess(t, "compact", compact.RootNode(), language)
+
+			oldParser := gotreesitter.NewParser(language)
+			oldParser.SetAdmissionCandidateRoute(false)
+			oldTree, err := oldParser.Parse(baseSource)
+			if err != nil {
+				t.Fatalf("incremental base parse failed: %v", err)
+			}
+			t.Cleanup(oldTree.Release)
+			endPoint := retiredDispatchPointAtByte(baseSource, len(baseSource))
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(len(baseSource)),
+				OldEndByte:  uint32(len(baseSource)),
+				NewEndByte:  uint32(len(source)),
+				StartPoint:  endPoint,
+				OldEndPoint: endPoint,
+				NewEndPoint: gotreesitter.Point{Row: endPoint.Row + 1},
+			})
+			incremental, err := oldParser.ParseIncremental(source, oldTree)
+			if err != nil {
+				t.Fatalf("incremental parse failed: %v", err)
+			}
+			t.Cleanup(incremental.Release)
+			assertApexClassLiteralIsFieldAccess(t, "incremental", incremental.RootNode(), language)
+		})
+	}
+}
+
+// TestApexClassLiteralForestStillNeedsResultCompatibility documents and
+// guards the one route this fix does not cover. ParseForestExperimental is
+// a separate engine (glr_forest.go) with its own dispatch loop and
+// accept-time tie-break; it is not apex's automatic-dispatch route (apex is
+// not in builtinForestDefaults), so no ordinary Parse call reaches it, but
+// an explicit ParseForestExperimental call still needs
+// normalizeApexClassLiteralAccess to reach the C-native field_access shape.
+// If this test starts failing (the forest route stops rewriting), the
+// forest engine has been fixed natively too: update this test and dispatch.apex
+// can retire for good.
+func TestApexClassLiteralForestStillNeedsResultCompatibility(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	language := ApexLanguage()
+	source := append(append([]byte(nil), apexClassLiteralAliasFixture...), '\n')
+
+	forestParser := gotreesitter.NewParser(language)
+	forest, ok := forestParser.ParseForestExperimental(source)
+	if !ok {
+		t.Fatal("forest route declined")
+	}
+	t.Cleanup(forest.Release)
+	if !forest.ParseRuntime().ForestFastPath {
+		t.Fatal("forest parse did not report the forest route")
+	}
+	assertApexClassLiteralIsFieldAccess(t, "forest", forest.RootNode(), language)
+
+	runtime := forest.ParseRuntime()
+	rewrote := false
+	if runtime.NormalizationPasses != nil {
+		for _, pass := range *runtime.NormalizationPasses {
+			if pass.Name == "dispatch.apex.class-literal-alias" && pass.NodesRewritten > 0 {
+				rewrote = true
+			}
+		}
+	}
+	if !rewrote {
+		t.Fatal("forest route no longer needs normalizeApexClassLiteralAccess: " +
+			"the forest engine now elects field_access natively too -- " +
+			"dispatch.apex can retire (delete parser_result_apex.go and its " +
+			"dispatcher case) instead of staying live for this route alone")
+	}
+}
+
+// TestApexPlainFieldAccessUnaffected is a negative control: a bare
+// (non-".class") field access was never ambiguous and must keep resolving
+// to field_access without exercising the election this fix touches.
+func TestApexPlainFieldAccessUnaffected(t *testing.T) {
+	language := ApexLanguage()
+	tree, err := gotreesitter.NewParser(language).Parse(apexPlainFieldAccessFixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(tree.Release)
+	assertApexClassLiteralIsFieldAccess(t, "production", tree.RootNode(), language)
+}
+
+// assertApexClassLiteralIsFieldAccess locates the outermost field_access
+// node and requires its trailing field to be a plain identifier -- the
+// C-native reading for both `Type.class` and a plain `Type.field` access. A
+// regression back to the old election would surface a class_literal node
+// instead.
+func assertApexClassLiteralIsFieldAccess(
+	t *testing.T,
+	route string,
+	root *gotreesitter.Node,
+	language *gotreesitter.Language,
+) {
+	t.Helper()
+	if root == nil || root.HasError() {
+		t.Fatalf("%s root = %v", route, root)
+	}
+	if bad := findRecoveryActionMaterializationNode(root, language, "class_literal"); bad != nil {
+		t.Fatalf("%s tree still contains a class_literal node: %s", route, root.SExpr(language))
+	}
+	access := findRecoveryActionMaterializationNode(root, language, "field_access")
+	if access == nil || access.ChildCount() != 3 {
+		t.Fatalf("%s field_access = %v, want exactly 3 children: %s", route, access, root.SExpr(language))
+	}
+	field := access.Child(2)
+	if field.Type(language) != "identifier" {
+		t.Fatalf("%s field_access trailing child = %q, want %q: %s", route, field.Type(language), "identifier", root.SExpr(language))
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -6088,6 +6088,37 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					continue
 				}
 				if len(stacks) > 1 {
+					// A GLR fork can leave sibling stacks in states that need
+					// different tokenizations of the same bytes: a keyword
+					// literal versus the grammar's generic word token, a
+					// dedicated operator token versus a shared one, and so
+					// on. This engine lexes one token per iteration for
+					// every live stack (see updateParserStateTokenSource),
+					// so a stack whose state needs the other reading is
+					// starved unless it gets a chance at its own lex mode
+					// first. relexTokenForStackLexState is the same
+					// span-exact, action-verified DFA probe the faithful
+					// C-recovery port already uses for this (issue #454)
+					// and the compact route runs unconditionally
+					// (relexTokenForState); it is a no-op whenever the
+					// re-lex does not land a different, action-bearing
+					// symbol at the identical byte span, so a stack that
+					// genuinely has no other reading is killed exactly as
+					// before.
+					if reTok, ok := p.relexTokenForStackLexState(source, currentState, tok); ok {
+						if p.glrTrace {
+							fmt.Printf("  stack[%d] STACK-RELEX: sym=%d -> sym=%d [%d-%d] in state=%d\n",
+								si, tok.Symbol, reTok.Symbol, reTok.StartByte, reTok.EndByte, currentState)
+						}
+						stackRelexRestoreTok = tok
+						stackRelexActive = true
+						tok = reTok
+						if actionTiming != nil {
+							ns := recordNoActionTiming()
+							actionTiming.actionNoActionRelexNanos += ns
+						}
+						goto retryAction
+					}
 					if p.glrTrace {
 						fmt.Printf("  stack[%d] KILLED: no action for sym=%d in state=%d (multiple stacks)\n", si, tok.Symbol, currentState)
 					}

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -4965,7 +4965,20 @@ func (p *Parser) newRecoveryParentNodeInArena(arena *nodeArena, sym Symbol, name
 // This is not Scala-specific. Any grammar where one byte sequence lexes as
 // different symbols depending on parse state has the same exposure: `+ - ! ~`
 // as unary or binary, `/` as divide or regex start, `<` as comparison or type
-// bracket.
+// bracket, a keyword literal or the grammar's generic word token. Apex's
+// `Type.class` is the word-token witness: `class_literal`'s _unannotated_type
+// reading and `field_access`'s primary_expression reading both stay live GLR
+// forks through the trailing `.`, one needing the `class` keyword and the
+// other needing plain `identifier` for the same bytes; the shared lexer
+// promotes the keyword, and the field_access fork used to die here with no
+// alternative. This function has two callers: the C-recovery port above
+// (parser.go, gated by errorCostCompetitionEnabled -- a no-action stack there
+// pauses instead of dying if the re-lex fails) and the plain multi-stack
+// dispatch loop (parser.go, ungated -- a no-action stack there is killed
+// instead of dying if the re-lex fails). Both callers restore the shared
+// token for every sibling stack via the same stackRelexRestoreTok /
+// stackRelexActive pair, so a re-lex never leaks sideways to a stack that
+// does accept the original symbol.
 //
 // The re-lex is deliberately narrow, so it cannot disturb the lockstep token
 // loop the rest of the engine relies on:

--- a/parser_result.go
+++ b/parser_result.go
@@ -598,7 +598,20 @@ func stackCompareForResultSelectionWithRawShape(p *Parser, arena *nodeArena, a, 
 	if cmp := compareAcceptedStackTreeOrderPreference(p, arena, a, b); cmp != 0 {
 		return cmp
 	}
-	if useRawShape {
+	// The raw-shape/symbol-id fallback below is a last-resort ordering with no
+	// grammar-authored basis: compareRawStackEntriesRec breaks ties on raw
+	// numeric Symbol id, an artifact of grammar-compiler assignment order that
+	// carries no relationship to which production the C oracle actually
+	// prefers. A CompactPrimaryAcceptanceDerivationCertified language has
+	// already proven (via the compact route's own primary-derivation election,
+	// admission_switch_candidate.go) that C keeps whichever accepted
+	// derivation never took a GLR-forked conflict branch; skipping the
+	// symbol-id fallback for exactly these certified languages lets that same
+	// signal -- already present below as the branchOrder tie-break, lower
+	// (never-forked) wins -- decide instead, rather than losing to an
+	// unrelated ordering first. This changes nothing for every uncertified
+	// language.
+	if useRawShape && (p == nil || p.language == nil || !p.language.CompactPrimaryAcceptanceDerivationCertified) {
 		if cmp := compareAcceptedStackRawShapePreference(p, arena, a, b); cmp != 0 {
 			return cmp
 		}

--- a/parser_result_apex.go
+++ b/parser_result_apex.go
@@ -1,5 +1,34 @@
 package gotreesitter
 
+// normalizeApexClassLiteralAccess retags a raw class_literal(type_identifier,
+// ".", "class") node to the field_access(identifier, ".", identifier) shape
+// the locked C oracle elects for `Type.class` (issue #601): the grammar's
+// class_literal and field_access productions both stay live GLR alternatives
+// through the trailing `.`, one needing the `class` keyword and the other
+// needing the plain `identifier` token for the same bytes, with no
+// grammar-authored dynamic precedence between them.
+//
+// The classic engine (production, and therefore also compact's fallback
+// target and incremental) now elects field_access natively and never reaches
+// this function for the shape it matches: a per-stack DFA re-probe
+// (relexTokenForStackLexState, parser.go) stops the shared lexer from
+// starving the field_access fork, and a certified primary-derivation
+// preference at accept-time result selection
+// (stackCompareForResultSelectionWithRawShape, parser_result.go) settles the
+// resulting tie the way the compact route's own certified election already
+// did. This function stays live solely for the GSS-forest experimental fast
+// path (ParseForestExperimental), a separate engine with its own dispatch
+// loop and accept-time tie-break that neither fix reaches; apex is not in
+// that engine's automatic-dispatch set, so no ordinary Parse call needs this
+// function anymore. See
+// grammars/apex_class_literal_election_native_regression_test.go
+// (TestApexClassLiteralForestStillNeedsResultCompatibility), which fails
+// loudly once the forest engine no longer needs this rewrite either.
+//
+// This is also, independent of the above, narrower than the C oracle's own
+// rule: it matches only an unqualified leading type name. A qualified one
+// (`Outer.Inner.class`) never matched here even before the classic-engine
+// fix and keeps its own, separate, pre-existing gap on the forest route.
 func normalizeApexClassLiteralAccess(root *Node, source []byte, lang *Language) {
 	if root == nil || lang == nil || lang.Name != "apex" {
 		return

--- a/parser_result_test/materialization_subpass_census_test.go
+++ b/parser_result_test/materialization_subpass_census_test.go
@@ -275,6 +275,22 @@ func materializationSubpassProbes() []materializationSubpassProbe {
 			},
 		},
 		{
+			// The producer now elects field_access natively (a per-stack DFA
+			// relex, parser.go, plus a certified primary-derivation
+			// preference at accept-time result selection, parser_result.go),
+			// so raw and result now match and this pass no longer rewrites
+			// on the production route. Both digests moved: the producer fix
+			// also carries the "object"/"field" field assignments the old
+			// post-parse retag never reconstructed (retagResultRoot only
+			// relabels a node's symbol), so this digest is the first one
+			// verified against the locked C oracle with field comparison on
+			// (cgo_harness/apex_generic_local_parity_test.go
+			// TestApexCloseAngleRawCOracleParity/class_literal_alias). The
+			// pass still checks and still rewrites for the
+			// ParseForestExperimental route, which has its own, separate
+			// dispatch loop this fix does not reach -- see
+			// grammars/apex_class_literal_election_native_regression_test.go
+			// TestApexClassLiteralForestStillNeedsResultCompatibility.
 			name:     "apex_class_literal_alias",
 			language: grammars.ApexLanguage,
 			source: "public class C {\n" +
@@ -282,13 +298,9 @@ func materializationSubpassProbes() []materializationSubpassProbe {
 				"    Object t = RecordPage.class;\n" +
 				"  }\n" +
 				"}\n",
-			wantRawDigest:    "a7ce1bb2fb703f6c85a85bac1116a31f9d14f03cd4560f8fe81f518b19d36f33",
-			wantResultDigest: "691872382855aafce9519a115ca30ac191c4a118d4ab7170e88e0193fd2f5bb6",
+			wantRawDigest:    "35a8cb0bdcf84a752c313b3c9cf296d4bf2acaac240646e0b32578c858832096",
+			wantResultDigest: "35a8cb0bdcf84a752c313b3c9cf296d4bf2acaac240646e0b32578c858832096",
 			expectedSubpasses: []string{
-				"dispatch.apex",
-				"dispatch.apex.class-literal-alias",
-			},
-			rewrittenSubpasses: []string{
 				"dispatch.apex",
 				"dispatch.apex.class-literal-alias",
 			},

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -158,24 +158,26 @@
           "files": [
             "parser_result_apex.go"
           ],
-          "purpose": "Materialize the field-access aliases for an Apex class literal.",
+          "purpose": "Retags a raw class_literal(type_identifier, \".\", \"class\") node to the C-native field_access(identifier, \".\", identifier) shape for `Type.class`. Inert for production, compact, and incremental since a per-stack DFA relex (parser.go) and a certified primary-derivation preference at accept-time result selection (parser_result.go) made the classic engine elect field_access natively; still reached by the GSS-forest experimental fast path, a separate engine this fix does not cover.",
           "authoritative_owner": "derivation_election_selection",
           "witnesses": [
             "parser_result_test/materialization_subpass_census_test.go",
             "cgo_harness/apex_generic_local_parity_test.go",
-            "cgo_harness/apex_a3_certification_sweep_test.go"
+            "cgo_harness/apex_a3_certification_sweep_test.go",
+            "grammars/apex_class_literal_election_native_regression_test.go"
           ]
         }
       ],
       "languages": [
         "apex"
       ],
-      "purpose": "Reconcile Apex returned-tree aliases, fields, and spans.",
+      "purpose": "Reconciles Apex returned-tree aliases, fields, and spans, including the class_literal/field_access election. The election is now natively C-exact on production, compact, and incremental; this arm stays live only because the GSS-forest experimental fast path (ParseForestExperimental, not in apex's automatic-dispatch set) still needs the retag. See the class-literal-alias subpass for detail.",
       "authoritative_owner": "derivation_election_selection",
       "witnesses": [
         "cgo_harness/parity_cgo_test.go",
         "cgo_harness/apex_generic_local_parity_test.go",
-        "cgo_harness/apex_a3_certification_sweep_test.go"
+        "cgo_harness/apex_a3_certification_sweep_test.go",
+        "grammars/apex_class_literal_election_native_regression_test.go"
       ],
       "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
       "route_coverage": {


### PR DESCRIPTION
## Summary

Aligns Apex GLR derivation selection with the locked C oracle for `Type.class`. The grammar declares both `class_literal` and `field_access` as live parallel paths. This branch adds a per-stack DFA relex to prevent lexical starvation and refines the accept-time tie-breaker to match C behavior.

## Changes

- Add a per-stack DFA relex before killing a no-action stack. Starved forks now receive their required token type instead of failing due to shared lexer state.
- Skip raw-shape fallback in accept-time comparison for certified languages. The branch-order signal now prefers the non-forked derivation to match the C oracle.
- Update documentation for normalizeApexClassLiteralAccess. The function now serves only the GSS-forest experimental fast path.
- Add regression tests for production, compact, and incremental routes. Include negative controls and explicit forest-route guards.
- Update parity harness and materialization census to reflect the corrected tree shape.

## Testing

- Run `bash cgo_harness/docker/run_single_grammar_parity.sh apex` to verify C oracle parity.
- Run `go test ./grammars -run TestApexClassLiteralElection -v` to execute the native regression suite.
- Run `go test ./parser_result_test -run TestMaterializationSubpassCensus -v` to validate census updates.

## Related Issues

- Refs #601

## Review Focus

Focus on the per-stack relex logic in parser.go and the certification gate in parser_result.go. Verify that apex parity tests pass locally before review.