### PR TITLE
fix(docker): Set GIT_SSL_CAINFO to stabilize network clones

### DIFF
--- a/cgo_harness/docker/Dockerfile
+++ b/cgo_harness/docker/Dockerfile
@@ -12,6 +12,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     time \
     && rm -rf /var/lib/apt/lists/*
 
+# Debian's git links against GnuTLS. GnuTLS resolves its default "system
+# trust" through the p11-kit PKCS#11 trust module instead of reading the CA
+# bundle file directly. Under this harness's process churn (many short-lived
+# git clones per exhaustive parity run), that indirection has produced
+# intermittent "server certificate verification failed. CAfile: none" clone
+# failures against C-oracle grammar repos that need a fresh network clone.
+# Pointing git straight at the installed CA bundle skips the p11-kit lookup
+# and gives every git subprocess in the container a fixed, known-good file to
+# verify against.
+ENV GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt
+
 COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
 COPY --from=node-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \


### PR DESCRIPTION
## Summary

The parity harness encounters intermittent SSL clone failures because Debian's Git delegates trust validation to p11-kit. Short-lived container processes often miss the required initialization step. This update points Git directly at the system CA bundle to guarantee reliable clones.

## Changes

- Add `GIT_SSL_CAINFO` environment variable to the Docker image.
- Bypass the fragile p11-kit trust module lookup.
- Supply a stable certificate path for all Git subprocesses.
- Resolve recurring verification errors during exhaustive grammar parity checks.