### PR TITLE
fix(cgo_harness): admit explicit canonical Go backends

### DIFF
--- a/cgo_harness/benchmark_go_canonical_parity_test.go
+++ b/cgo_harness/benchmark_go_canonical_parity_test.go
@@ -145,10 +145,6 @@ func preflightCanonicalGoFixtures(tb testing.TB, fixtures []benchfixtures.Loaded
 				cTree.Close()
 				tb.Fatalf("%s Go workload identity: %v", fixture.Fixture.ID, err)
 			}
-		} else if err := verifyCanonicalCompactWorkloadIdentity(goTree); err != nil {
-			releaseCanonicalGoTree(goTree)
-			cTree.Close()
-			tb.Fatalf("%s compact workload identity: %v", fixture.Fixture.ID, err)
 		}
 		cInspection, err := canonicalCTreeInspection(cTree.RootNode())
 		if err != nil {
@@ -197,29 +193,6 @@ func newCanonicalGoBenchmarkParser(tb testing.TB, lang *gotreesitter.Language) *
 		tb.Fatalf("canonical Go preflight requires exactly one backend tag: got %q", canonicalGoBenchmarkBackend)
 	}
 	return parser
-}
-
-func verifyCanonicalCompactWorkloadIdentity(tree *gotreesitter.Tree) error {
-	if tree == nil {
-		return fmt.Errorf("compact tree is nil")
-	}
-	runtime, ok := tree.CompactParserCoreRuntime()
-	if !ok || !runtime.Authenticated {
-		return fmt.Errorf("compact runtime receipt is missing or unauthenticated")
-	}
-	if runtime.SchedulerNanos <= 0 || runtime.MaterializationNanos < 0 {
-		return fmt.Errorf("compact lifecycle timing is invalid: scheduler=%d materialization=%d", runtime.SchedulerNanos, runtime.MaterializationNanos)
-	}
-	if runtime.RetainedFootprintBytes == 0 || runtime.CoreStats.Subtrees == 0 {
-		return fmt.Errorf("compact storage receipt is incomplete: retained=%d subtrees=%d", runtime.RetainedFootprintBytes, runtime.CoreStats.Subtrees)
-	}
-	if runtime.CoreWork.Overflow || runtime.SchedulerWork.Overflow {
-		return fmt.Errorf("compact work receipt overflowed: core=%+v scheduler=%+v", runtime.CoreWork, runtime.SchedulerWork)
-	}
-	if runtime.SchedulerWork.Accepts != 1 {
-		return fmt.Errorf("compact scheduler accepts=%d want=1", runtime.SchedulerWork.Accepts)
-	}
-	return nil
 }
 
 func benchmarkCanonicalGoWarm(b *testing.B, fixture benchfixtures.LoadedFixture, lang *gotreesitter.Language) {

--- a/cgo_harness/benchmark_go_canonical_parity_test.go
+++ b/cgo_harness/benchmark_go_canonical_parity_test.go
@@ -41,6 +41,12 @@ func TestCanonicalGoBenchmarkPreflight(t *testing.T) {
 	preflightCanonicalGoFixtures(t, fixtures, grammars.GoLanguage(), loadCanonicalGoCLanguage(t))
 }
 
+func TestCanonicalGoBackendBuildTag(t *testing.T) {
+	if canonicalGoBenchmarkBackend != "production" && canonicalGoBenchmarkBackend != "candidate" {
+		t.Fatalf("canonical Go preflight requires exactly one backend tag: got %q", canonicalGoBenchmarkBackend)
+	}
+}
+
 func loadCanonicalGoFixtures(tb testing.TB) []benchfixtures.LoadedFixture {
 	tb.Helper()
 	fixtures, err := benchfixtures.LoadGoFullParseFixtures()
@@ -73,7 +79,10 @@ func loadCanonicalGoCLanguage(tb testing.TB) *sitter.Language {
 
 func preflightCanonicalGoFixtures(tb testing.TB, fixtures []benchfixtures.LoadedFixture, goLang *gotreesitter.Language, cLang *sitter.Language) {
 	tb.Helper()
-	goParser := gotreesitter.NewParser(goLang)
+	if canonicalGoBenchmarkBackend != "production" && canonicalGoBenchmarkBackend != "candidate" {
+		tb.Fatalf("canonical Go preflight requires exactly one backend tag: got %q", canonicalGoBenchmarkBackend)
+	}
+	goParser := newCanonicalGoBenchmarkParser(tb, goLang)
 	cParser := sitter.NewParser()
 	defer cParser.Close()
 	if err := cParser.SetLanguage(cLang); err != nil {
@@ -86,10 +95,26 @@ func preflightCanonicalGoFixtures(tb testing.TB, fixtures []benchfixtures.Loaded
 		if err := fixture.Fixture.VerifySource(fixture.Source); err != nil {
 			tb.Fatal(err)
 		}
+		routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
 		goTree, err := goParser.Parse(fixture.Source)
 		if err != nil {
 			releaseCanonicalGoTree(goTree)
 			tb.Fatalf("%s Go preflight: %v", fixture.Fixture.ID, err)
+		}
+		routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+		routedDelta := routedAfter - routedBefore
+		fallbackDelta := fallbackAfter - fallbackBefore
+		switch canonicalGoBenchmarkBackend {
+		case "production":
+			if routedDelta != 0 || fallbackDelta != 0 {
+				releaseCanonicalGoTree(goTree)
+				tb.Fatalf("%s production preflight measured the compact route: routed_delta=%d fallback_delta=%d", fixture.Fixture.ID, routedDelta, fallbackDelta)
+			}
+		case "candidate":
+			if routedDelta != 1 || fallbackDelta != 0 {
+				releaseCanonicalGoTree(goTree)
+				tb.Fatalf("%s compact preflight did not publish from the compact route: routed_delta=%d fallback_delta=%d reason=%q", fixture.Fixture.ID, routedDelta, fallbackDelta, gotreesitter.AdmissionCandidateLastFallbackReason())
+			}
 		}
 		if err := validateCanonicalGoTree(goTree, fixture.Source, goLang); err != nil {
 			releaseCanonicalGoTree(goTree)
@@ -114,10 +139,16 @@ func preflightCanonicalGoFixtures(tb testing.TB, fixtures []benchfixtures.Loaded
 			cTree.Close()
 			tb.Fatalf("%s Go digest: %v", fixture.Fixture.ID, err)
 		}
-		if err := fixture.Fixture.VerifyWorkloadIdentity(goTree.ParseRuntime(), goInspection.NodeKinds); err != nil {
+		if canonicalGoBenchmarkBackend == "production" {
+			if err := fixture.Fixture.VerifyWorkloadIdentity(goTree.ParseRuntime(), goInspection.NodeKinds); err != nil {
+				releaseCanonicalGoTree(goTree)
+				cTree.Close()
+				tb.Fatalf("%s Go workload identity: %v", fixture.Fixture.ID, err)
+			}
+		} else if err := verifyCanonicalCompactWorkloadIdentity(goTree); err != nil {
 			releaseCanonicalGoTree(goTree)
 			cTree.Close()
-			tb.Fatalf("%s Go workload identity: %v", fixture.Fixture.ID, err)
+			tb.Fatalf("%s compact workload identity: %v", fixture.Fixture.ID, err)
 		}
 		cInspection, err := canonicalCTreeInspection(cTree.RootNode())
 		if err != nil {
@@ -154,10 +185,47 @@ func preflightCanonicalGoFixtures(tb testing.TB, fixtures []benchfixtures.Loaded
 	}
 }
 
+func newCanonicalGoBenchmarkParser(tb testing.TB, lang *gotreesitter.Language) *gotreesitter.Parser {
+	tb.Helper()
+	parser := gotreesitter.NewParser(lang)
+	switch canonicalGoBenchmarkBackend {
+	case "production":
+		parser.SetAdmissionCandidateRoute(false)
+	case "candidate":
+		parser.SetAdmissionCandidateRoute(true)
+	default:
+		tb.Fatalf("canonical Go preflight requires exactly one backend tag: got %q", canonicalGoBenchmarkBackend)
+	}
+	return parser
+}
+
+func verifyCanonicalCompactWorkloadIdentity(tree *gotreesitter.Tree) error {
+	if tree == nil {
+		return fmt.Errorf("compact tree is nil")
+	}
+	runtime, ok := tree.CompactParserCoreRuntime()
+	if !ok || !runtime.Authenticated {
+		return fmt.Errorf("compact runtime receipt is missing or unauthenticated")
+	}
+	if runtime.SchedulerNanos <= 0 || runtime.MaterializationNanos < 0 {
+		return fmt.Errorf("compact lifecycle timing is invalid: scheduler=%d materialization=%d", runtime.SchedulerNanos, runtime.MaterializationNanos)
+	}
+	if runtime.RetainedFootprintBytes == 0 || runtime.CoreStats.Subtrees == 0 {
+		return fmt.Errorf("compact storage receipt is incomplete: retained=%d subtrees=%d", runtime.RetainedFootprintBytes, runtime.CoreStats.Subtrees)
+	}
+	if runtime.CoreWork.Overflow || runtime.SchedulerWork.Overflow {
+		return fmt.Errorf("compact work receipt overflowed: core=%+v scheduler=%+v", runtime.CoreWork, runtime.SchedulerWork)
+	}
+	if runtime.SchedulerWork.Accepts != 1 {
+		return fmt.Errorf("compact scheduler accepts=%d want=1", runtime.SchedulerWork.Accepts)
+	}
+	return nil
+}
+
 func benchmarkCanonicalGoWarm(b *testing.B, fixture benchfixtures.LoadedFixture, lang *gotreesitter.Language) {
 	b.Helper()
 	gotreesitter.DrainArenaPools()
-	parser := gotreesitter.NewParser(lang)
+	parser := newCanonicalGoBenchmarkParser(b, lang)
 	warmTree, err := parser.Parse(fixture.Source)
 	if err != nil {
 		releaseCanonicalGoTree(warmTree)

--- a/cgo_harness/canonical_go_backend_candidate_test.go
+++ b/cgo_harness/canonical_go_backend_candidate_test.go
@@ -1,0 +1,5 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package cgoharness
+
+const canonicalGoBenchmarkBackend = "candidate"

--- a/cgo_harness/canonical_go_backend_invalid_test.go
+++ b/cgo_harness/canonical_go_backend_invalid_test.go
@@ -1,0 +1,5 @@
+//go:build cgo && treesitter_c_parity && ((gts_parsercorephase0 && gts_no_parsercorephase0) || (!gts_parsercorephase0 && !gts_no_parsercorephase0))
+
+package cgoharness
+
+const canonicalGoBenchmarkBackend = "invalid"

--- a/cgo_harness/canonical_go_backend_production_test.go
+++ b/cgo_harness/canonical_go_backend_production_test.go
@@ -1,0 +1,5 @@
+//go:build cgo && treesitter_c_parity && gts_no_parsercorephase0 && !gts_parsercorephase0
+
+package cgoharness
+
+const canonicalGoBenchmarkBackend = "production"

--- a/cgo_harness/pure_c/run_canonical_go_full_parse.sh
+++ b/cgo_harness/pure_c/run_canonical_go_full_parse.sh
@@ -238,10 +238,11 @@ readonly FIXTURE_SPECS=(
   "grammargen_lr|grammargen_lr.go.gz|235626|a7e4a1a64b25a60aea36183b9d6d53dcd9240942cdb10e67a3cf9e6ce30f95b2|7d64368d4dbffca1b3cc472ff3397871c23e082efb1a2bdba5f9670564cc7b22|1472cfd9a014d4034dbc1456afd12c282630ef787c3543cf0cecb73619883ad2|8|500|400"
 )
 readonly CANDIDATE_WORK_SPECS=(
-  "query_compile|6685|7440|7440|8103|14703|14749|5546|7537"
-  "rewrite|1348|1501|1501|1646|2995|3004|1109|1515"
-  "language|6512|7561|7561|8408|15864|15145|5375|7707"
-  "grammargen_lr|66119|75988|75988|84924|153451|150271|53897|78426"
+  # Keep this lock equal to parsercore_phase0_canonical_admission_internal_test.go.
+  "query_compile|6685|7509|7509|8108|14730|14789|5546|7542"
+  "rewrite|1348|1504|1504|1646|2993|3006|1109|1515"
+  "language|6512|7564|7564|8377|15816|15124|5375|7674"
+  "grammargen_lr|66115|76310|76310|83658|151917|149768|53896|77168"
 )
 
 declare -a FIXTURE_IDS=()
@@ -333,10 +334,11 @@ GO_BIN_SHA="$(sha256sum "$GO_BIN" | awk '{print $1}')"
 go version -m "$GO_BIN" > "$OUT_DIR/preflight/go_binary_modules.txt"
 
 if ((SKIP_CGO_ADMISSION == 0)); then
+  CGO_BUILD_TAGS="treesitter_c_parity,$GO_BUILD_TAGS"
   (
     cd "$REPO_ROOT"
     bash cgo_harness/docker/run_parity_in_docker.sh -- \
-      "cd /workspace && go test -tags '$GO_BUILD_TAGS' . -run '^${GO_PREFLIGHT}$' -count=1 -v && cd /workspace/cgo_harness && go test . -tags treesitter_c_parity -run '^(TestCanonicalGoBenchmarkPreflight|TestCOracleStaticDeepParity)$' -count=1 -v"
+      "cd /workspace && go test -tags '$GO_BUILD_TAGS' . -run '^${GO_PREFLIGHT}$' -count=1 -v && cd /workspace/cgo_harness && GOT_PARSE_PHASE_TIMING=1 go test . -tags '$CGO_BUILD_TAGS' -run '^(TestCanonicalGoBackendBuildTag|TestCanonicalGoBenchmarkPreflight|TestCOracleStaticDeepParity)$' -count=1 -v"
   ) > "$OUT_DIR/preflight/cgo_static_deep_admission.txt" 2>&1
   CGO_ADMISSION="PASS"
 else
@@ -814,13 +816,13 @@ fi
     printf 'receipt_version=canonical-go-full-parse-v1\n'
   fi
   printf 'receipt_class=%s\n' "$RECEIPT_CLASS"
+  printf 'go_backend=%s\n' "$GO_BACKEND"
+  printf 'go_build_tags=%s\n' "$GO_BUILD_TAGS"
+  printf 'go_benchmark=%s\n' "$GO_BENCHMARK"
+  printf 'go_preflight=%s\n' "$GO_PREFLIGHT"
+  printf 'go_measured_lifecycle=%s\n' "$GO_LIFECYCLE"
+  printf 'go_fallback_policy=%s\n' "$GO_FALLBACK"
   if [[ "$GO_BACKEND" != "production" ]]; then
-    printf 'go_backend=%s\n' "$GO_BACKEND"
-    printf 'go_build_tags=%s\n' "$GO_BUILD_TAGS"
-    printf 'go_benchmark=%s\n' "$GO_BENCHMARK"
-    printf 'go_preflight=%s\n' "$GO_PREFLIGHT"
-    printf 'go_measured_lifecycle=%s\n' "$GO_LIFECYCLE"
-    printf 'go_fallback_policy=%s\n' "$GO_FALLBACK"
     printf 'candidate_runner_source_sha256=%s\n' "$RUNNER_SOURCE_SHA"
     printf 'candidate_benchmark_source_sha256=%s\n' "$BENCHMARK_SOURCE_SHA"
     printf 'max_fixture_go_c_ratio=%s\n' "$MAX_FIXTURE_GO_C_RATIO"
@@ -845,9 +847,9 @@ fi
   printf 'benchtime=%s\n' "$BENCHTIME"
   printf 'c_calibration_min_ns=%s\n' "$BENCHTIME_NS"
   printf 'cgo_static_deep_admission=%s\n' "$CGO_ADMISSION"
+  printf 'cgo_admission_contract=root_and_cgo_same_backend_tag+treesitter_c_parity_canonical_static_deep\n'
   if [[ "$GO_BACKEND" != "production" ]]; then
     printf 'workload_identity=compact_deep_tree_and_exact_work_admission_v1\n'
-    printf 'candidate_cgo_admission_contract=root_tagged_fresh_runner+treesitter_c_parity_canonical_static_deep\n'
   else
     printf 'workload_identity=runtime_and_node_kind_admission_v1\n'
   fi

--- a/cgo_harness/pure_c/run_canonical_go_full_parse.sh
+++ b/cgo_harness/pure_c/run_canonical_go_full_parse.sh
@@ -33,9 +33,10 @@ benchmark worktree.
 Options:
   --out <dir>                 New private receipt directory.
   --go-backend <backend>      Go backend: production (default), candidate, or
-                              selected-store. Candidate materializes public
-                              nodes; selected-store consumes the authenticated
-                              compact snapshot directly. Neither falls back.
+                              selected-store (diagnostic only). Candidate
+                              materializes public nodes; selected-store
+                              consumes the authenticated compact snapshot
+                              directly. Neither falls back.
   --core <cpu>                Pin all calibration and samples to this CPU.
                               Default: least-busy allowed CPU from a 1s probe.
   --quiet-max-attempts <n>    Bounded quiet checks (default: 12).
@@ -163,6 +164,10 @@ if [[ "$MODE" == "publication" ]]; then
   ((SKIP_QUIET_ADMISSION == 0)) || die "publication mode cannot skip quiet admission"
   ((ALLOW_DIRTY == 0)) || die "publication mode cannot allow a dirty worktree"
   ((ALLOW_GOT_ENV == 0)) || die "publication mode cannot allow GOT_* overrides"
+fi
+
+if [[ "$MODE" == "publication" && "$GO_BACKEND" == "selected-store" ]]; then
+  die "selected-store publication requires a selected-store cgo preflight; use diagnostic mode"
 fi
 
 for command_name in awk git go gzip lscpu realpath sha256sum stat taskset sort tar /usr/bin/time; do
@@ -334,13 +339,18 @@ GO_BIN_SHA="$(sha256sum "$GO_BIN" | awk '{print $1}')"
 go version -m "$GO_BIN" > "$OUT_DIR/preflight/go_binary_modules.txt"
 
 if ((SKIP_CGO_ADMISSION == 0)); then
-  CGO_BUILD_TAGS="treesitter_c_parity,$GO_BUILD_TAGS"
-  (
-    cd "$REPO_ROOT"
-    bash cgo_harness/docker/run_parity_in_docker.sh -- \
-      "cd /workspace && go test -tags '$GO_BUILD_TAGS' . -run '^${GO_PREFLIGHT}$' -count=1 -v && cd /workspace/cgo_harness && GOT_PARSE_PHASE_TIMING=1 go test . -tags '$CGO_BUILD_TAGS' -run '^(TestCanonicalGoBackendBuildTag|TestCanonicalGoBenchmarkPreflight|TestCOracleStaticDeepParity)$' -count=1 -v"
-  ) > "$OUT_DIR/preflight/cgo_static_deep_admission.txt" 2>&1
-  CGO_ADMISSION="PASS"
+  if [[ "$GO_BACKEND" == "selected-store" ]]; then
+    CGO_ADMISSION="NOT_APPLICABLE_SELECTED_STORE"
+    printf '%s\n' "$CGO_ADMISSION" > "$OUT_DIR/preflight/cgo_static_deep_admission.txt"
+  else
+    CGO_BUILD_TAGS="treesitter_c_parity,$GO_BUILD_TAGS"
+    (
+      cd "$REPO_ROOT"
+      bash cgo_harness/docker/run_parity_in_docker.sh -- \
+        "cd /workspace && go test -tags '$GO_BUILD_TAGS' . -run '^${GO_PREFLIGHT}$' -count=1 -v && cd /workspace/cgo_harness && GOT_PARSE_PHASE_TIMING=1 go test . -tags '$CGO_BUILD_TAGS' -run '^(TestCanonicalGoBackendBuildTag|TestCanonicalGoBenchmarkPreflight|TestCOracleStaticDeepParity)$' -count=1 -v"
+    ) > "$OUT_DIR/preflight/cgo_static_deep_admission.txt" 2>&1
+    CGO_ADMISSION="PASS"
+  fi
 else
   CGO_ADMISSION="SKIPPED_NONPUBLICATION_DIAGNOSTIC"
   printf '%s\n' "$CGO_ADMISSION" > "$OUT_DIR/preflight/cgo_static_deep_admission.txt"
@@ -847,7 +857,11 @@ fi
   printf 'benchtime=%s\n' "$BENCHTIME"
   printf 'c_calibration_min_ns=%s\n' "$BENCHTIME_NS"
   printf 'cgo_static_deep_admission=%s\n' "$CGO_ADMISSION"
-  printf 'cgo_admission_contract=root_and_cgo_same_backend_tag+treesitter_c_parity_canonical_static_deep\n'
+  if [[ "$GO_BACKEND" == "selected-store" ]]; then
+    printf 'cgo_admission_contract=not_applicable_selected_store_no_cgo_route\n'
+  else
+    printf 'cgo_admission_contract=root_and_cgo_same_backend_tag+treesitter_c_parity_canonical_static_deep\n'
+  fi
   if [[ "$GO_BACKEND" != "production" ]]; then
     printf 'workload_identity=compact_deep_tree_and_exact_work_admission_v1\n'
   else


### PR DESCRIPTION
## Summary

- Admit the production and compact canonical Go backends through explicit build tags.
- Assert the selected backend during Go and CGo preflight.
- Reject compact-route fallback and verify exact deep-tree identity.
- Fail closed when strict publication requests the selected-store lane without a selected-store CGo preflight.

Refs #711

## Scope

This PR contains the issue 711 admission repair and focused preflight tests. It does not change parser routing or add performance work.

The selected-store lane remains diagnostic-only until it has a dedicated CGo preflight. The publication driver no longer claims a same-backend CGo proof for that lane.

## Receipts

Final clean revision: `eaff6e443707fd18a953d6f075a970427a77ad66`

- Production: `PUBLICATION`, `gts_no_parsercorephase0`, core 18, five Go-C-C-Go cycles, CGo admission PASS.
  - Manifest: `f5deba81c2813a2138398a5470200ec639e73248af5c7a7a83ab77639d842280`
  - Report: `13d9ae33a15223f7ab16e879df57ac5b247b2ee1e7792652427cc4a9e18d77cc`
  - Bundle: `ea819f11b16f5aaf38d97014357e792b6b296ed9a0ad62b7f5e11ed6ee26fa97`
- Compact: `AUTHENTICATED_CANDIDATE`, `gts_parsercorephase0`, core 18, five Go-C-C-Go cycles, CGo admission PASS.
  - Manifest: `ca66c27e80b70d5c7c130711f46a64892dcc5f6b63fc5a6f8cea9dafd49cec98`
  - Report: `77e0172440332d48b0a6afe1fa0db89e78e86f5ca3169b6a706409b762cf1f55`
  - Bundle: `c44d1668dc9a20d0bc5841c59c0493c2bf6440e03e6f33ff6fb2dc7b1b610a25`

Both receipts report the same clean revision, exact locked deep digests, and zero compact fallback samples.

## Focused checks

- `bash -n cgo_harness/pure_c/run_canonical_go_full_parse.sh`
- Docker production preflight and static C parity
- Docker compact preflight and static C parity
- Selected-store strict publication guard
