### PR TITLE
fix(cgo_harness): reconcile Ada merge census baseline

### DIFF
--- a/cgo_harness/merge_event_census_test.go
+++ b/cgo_harness/merge_event_census_test.go
@@ -89,7 +89,9 @@ var mergeCensusBaselineConstructed = map[string]struct {
 }{
 	"apex":   {Sources: 25, CMergeSuccesses: 31, GoSuccesses: 1, RefuseNoGSSHead: 53, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 53, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 5},
 	"perl":   {Sources: 17, CMergeSuccesses: 57, GoSuccesses: 0, RefuseNoGSSHead: 43, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 0, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 7},
-	"ada":    {Sources: 23, CMergeSuccesses: 47, GoSuccesses: 2, RefuseNoGSSHead: 35, RefuseScoreOrShifted: 92, RefuseDistinctShapes: 6, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 5},
+	// PR #708 elects Ada aggregate conflicts before the GLR fork. This removes
+	// five no-GSS-head opportunities without changing merges or other gates.
+	"ada":    {Sources: 23, CMergeSuccesses: 47, GoSuccesses: 2, RefuseNoGSSHead: 30, RefuseScoreOrShifted: 92, RefuseDistinctShapes: 6, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 5},
 	"kotlin": {Sources: 13, CMergeSuccesses: 54, GoSuccesses: 12, RefuseNoGSSHead: 2, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 0, LinkPayloadShallowWouldAccept: 10, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 3},
 	"python": {Sources: 26, CMergeSuccesses: 2, GoSuccesses: 0, RefuseNoGSSHead: 9, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 0, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 2},
 }


### PR DESCRIPTION
## Summary

- Change the Ada no-GSS-head baseline from 35 to 30.
- Keep all merge counts and other refusal classes unchanged.
- Restore the merge-event census gate after pull request 708.

## Cause

Pull request 708 elects Ada aggregate conflicts before the generalized LR fork.
This removes five no-GSS-head opportunities without changing parser results.

This baseline drift existed on `main` before pull request 713.

Refs #708

## Validation

- Focused merge-event census passed in Docker.
- `TestMergeEventCensusBaseline` passed.
- `TestMergeEventCensusFooIntWitness` passed.
- The run had no out-of-memory event or timeout.
