### PR TITLE
fix(telemetry): preserve retry attempt attribution

### DIFF
--- a/benchmark_recovery_test.go
+++ b/benchmark_recovery_test.go
@@ -63,6 +63,46 @@ func TestKDLRecoveryGarbageSuffixExact(t *testing.T) {
 	}
 }
 
+func TestRecoveryRuntimeTelemetry(t *testing.T) {
+	gotreesitter.EnableRecoveryRuntimeTelemetry(true)
+	defer gotreesitter.EnableRecoveryRuntimeTelemetry(false)
+
+	recoveryParser := gotreesitter.NewParser(grammars.KdlLanguage())
+	source := makeKDLRecoveryGarbageSource(12, 24)
+	tree, err := recoveryParser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse recovery telemetry witness: %v", err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("recovery telemetry witness returned a nil tree")
+	}
+	stats := recoveryParser.DebugRecoveryRuntimeStats()
+	tree.Release()
+	if !stats.Enabled || !stats.Completed {
+		t.Fatalf("telemetry status = enabled:%v completed:%v, want enabled and completed", stats.Enabled, stats.Completed)
+	}
+	if stats.RecoveryEntryCount == 0 {
+		t.Fatal("recovery entry count = 0, want a recovery witness")
+	}
+	if stats.ErrorNodeCount == 0 || stats.ErrorSpanBytes == 0 {
+		t.Fatalf("error shape = count:%d span:%d, want both non-zero", stats.ErrorNodeCount, stats.ErrorSpanBytes)
+	}
+	if stats.PeakLiveVersionCount == 0 {
+		t.Fatal("peak live version count = 0, want a recovery witness")
+	}
+
+	cleanParser := gotreesitter.NewParser(grammars.GoLanguage())
+	cleanTree, err := cleanParser.Parse([]byte("package p\n"))
+	if err != nil {
+		t.Fatalf("parse clean telemetry control: %v", err)
+	}
+	cleanStats := cleanParser.DebugRecoveryRuntimeStats()
+	cleanTree.Release()
+	if cleanStats.RecoveryEntryCount != 0 || cleanStats.ErrorNodeCount != 0 || cleanStats.ErrorSpanBytes != 0 {
+		t.Fatalf("clean control recorded recovery facts: %+v", cleanStats)
+	}
+}
+
 // makeKDLRecoveryGarbageSource synthesizes a KDL document that reliably
 // drives the C-recovery cost-competition machinery: a valid, node-per-line
 // KDL prefix truncated 70% of the way through, followed by a long run of

--- a/benchmark_recovery_test.go
+++ b/benchmark_recovery_test.go
@@ -69,7 +69,10 @@ func TestRecoveryRuntimeTelemetry(t *testing.T) {
 	gotreesitter.EnableRecoveryRuntimeTelemetry(true)
 	defer gotreesitter.EnableRecoveryRuntimeTelemetry(false)
 
-	recoveryParser := gotreesitter.NewParser(grammars.KdlLanguage())
+	recoveryLanguage := *grammars.KdlLanguage()
+	recoveryLanguage.AutomaticForestEnabledByDefault = false
+	recoveryParser := gotreesitter.NewParser(&recoveryLanguage)
+	recoveryParser.SetAdmissionCandidateRoute(false)
 	source := makeKDLRecoveryGarbageSource(12, 24)
 	tree, err := recoveryParser.Parse(source)
 	if err != nil {
@@ -94,6 +97,7 @@ func TestRecoveryRuntimeTelemetry(t *testing.T) {
 	}
 
 	cleanParser := gotreesitter.NewParser(grammars.GoLanguage())
+	cleanParser.SetAdmissionCandidateRoute(false)
 	cleanTree, err := cleanParser.Parse([]byte("package p\n"))
 	if err != nil {
 		t.Fatalf("parse clean telemetry control: %v", err)

--- a/benchmark_recovery_test.go
+++ b/benchmark_recovery_test.go
@@ -345,9 +345,19 @@ func TestSwiftRecoveryTelemetryWitnesses(t *testing.T) {
 				tree.Release()
 				t.Fatalf("clean control recorded recovery facts: %+v", stats)
 			}
+			if witness.name == "swift-586-floating-point" {
+				if stats.RetryAttemptCount == 0 || stats.RetrySelectedAttempt == "" {
+					tree.Release()
+					t.Fatalf("#586 lacks selected retry facts: %+v", stats)
+				}
+				if !stats.RetrySelectedAttemptHasError || !stats.RetrySelectedAttemptFullSpan {
+					tree.Release()
+					t.Fatalf("#586 selected retry shape = has_error:%v full_span:%v, want true/true", stats.RetrySelectedAttemptHasError, stats.RetrySelectedAttemptFullSpan)
+				}
+			}
 
 			sourceDigest := sha256.Sum256(source)
-			t.Logf("B16_WITNESS version=1 name=%s issue=%s source_sha256=%x source_bytes=%d grammar=swift grammar_lock_commit=%s result_class=%s full_span=%t go_deep_sha256=%s parse_wall_ns=%d measured_wall_ns=%d stop_reason=%s truncated=%t recovery_entries=%d strategy1_elections=%d cost_competitions=%d cost_walks=%d cost_walk_ns=%d error_nodes=%d error_span_bytes=%d retry_passes=%d retry_reason=%q error_mode_tokens=%d scanner_resync=%d live_versions=%d peak_live_versions=%d reduction_ceiling_hits=%d reduction_attempts_peak=%d missing_ceiling_hits=%d missing_attempts_peak=%d memo_tier=%d memo_entries=%d memo_bytes=%d memo_collisions=%d arena_bytes=%d scratch_bytes=%d entry_scratch_bytes=%d gss_bytes=%d gss_nodes=%d max_stacks=%d",
+			t.Logf("B16_WITNESS version=2 name=%s issue=%s source_sha256=%x source_bytes=%d grammar=swift grammar_lock_commit=%s result_class=%s full_span=%t go_deep_sha256=%s parse_wall_ns=%d measured_wall_ns=%d stop_reason=%s truncated=%t recovery_entries=%d strategy1_elections=%d cost_competitions=%d cost_walks=%d cost_walk_ns=%d error_nodes=%d error_span_bytes=%d retry_passes=%d retry_reason=%q retry_attempts=%d retry_selected=%q retry_selected_has_error=%t retry_selected_full_span=%t error_mode_tokens=%d scanner_resync=%d live_versions=%d peak_live_versions=%d reduction_ceiling_hits=%d reduction_attempts_peak=%d missing_ceiling_hits=%d missing_attempts_peak=%d memo_tier=%d memo_entries=%d memo_bytes=%d memo_collisions=%d arena_bytes=%d scratch_bytes=%d entry_scratch_bytes=%d gss_bytes=%d gss_nodes=%d max_stacks=%d",
 				witness.name,
 				witness.issue,
 				sourceDigest,
@@ -369,6 +379,10 @@ func TestSwiftRecoveryTelemetryWitnesses(t *testing.T) {
 				stats.ErrorSpanBytes,
 				stats.RetryPassCount,
 				stats.RetryReason,
+				stats.RetryAttemptCount,
+				stats.RetrySelectedAttempt,
+				stats.RetrySelectedAttemptHasError,
+				stats.RetrySelectedAttemptFullSpan,
 				stats.ErrorModeTokenCount,
 				stats.ScannerResyncCount,
 				stats.LiveVersionCount,

--- a/benchmark_recovery_test.go
+++ b/benchmark_recovery_test.go
@@ -4,12 +4,14 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 )
 
 func TestKDLRecoveryGarbageSuffixExact(t *testing.T) {
@@ -246,4 +248,147 @@ func BenchmarkRecoveryCorpusFile(b *testing.B) {
 	b.ReportMetric(float64(memoEntries)/float64(b.N), "memo_entries/op")
 	b.ReportMetric(float64(memoBytes)/float64(b.N), "memo_bytes/op")
 	b.ReportMetric(float64(memoCollisions)/float64(b.N), "memo_collisions/op")
+}
+
+// TestSwiftRecoveryTelemetryWitnesses records the first B16.1 witness matrix
+// for the outside-reported Swift recovery-cost and parity issues.
+//
+// Keep this test diagnostic-only. It records Go facts and tree identity for
+// one language. The locked-C parity and performance receipts remain separate.
+func TestSwiftRecoveryTelemetryWitnesses(t *testing.T) {
+	gotreesitter.EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { gotreesitter.EnableRecoveryRuntimeTelemetry(false) })
+	previousAdmissionRoute := gotreesitter.AdmissionCandidateRouteDefault()
+	gotreesitter.SetAdmissionCandidateRouteDefault(false)
+	t.Cleanup(func() { gotreesitter.SetAdmissionCandidateRouteDefault(previousAdmissionRoute) })
+
+	const swiftGrammarLockCommit = "41d6e5fe811ec94229ee71771174a8cce558dfee"
+	witnesses := []struct {
+		name         string
+		issue        string
+		path         string
+		wantHasError bool
+	}{
+		{
+			name:         "swift-586-floating-point",
+			issue:        "#586/#576",
+			path:         filepath.Join("grammars", "testdata", "swift_corpus", "stdlib_FloatingPointToString.swift"),
+			wantHasError: true,
+		},
+		{
+			name:         "swift-576-collection-algorithms",
+			issue:        "#576",
+			path:         filepath.Join("grammars", "testdata", "swift_corpus", "stdlib_CollectionAlgorithms.swift"),
+			wantHasError: true,
+		},
+		{
+			name:         "swift-clean-control",
+			issue:        "control",
+			path:         "",
+			wantHasError: false,
+		},
+	}
+
+	for _, witness := range witnesses {
+		t.Run(witness.name, func(t *testing.T) {
+			var source []byte
+			var err error
+			if witness.path == "" {
+				source = []byte("let answer = 1\n")
+			} else {
+				source, err = os.ReadFile(witness.path)
+				if err != nil {
+					t.Fatalf("read Swift witness %q: %v", witness.path, err)
+				}
+			}
+
+			lang := grammars.SwiftLanguage()
+			parser := gotreesitter.NewParser(lang)
+			started := time.Now()
+			tree, parseErr := parser.Parse(source)
+			elapsed := time.Since(started)
+			if parseErr != nil {
+				t.Fatalf("parse Swift witness: %v", parseErr)
+			}
+			if tree == nil || tree.RootNode() == nil {
+				t.Fatal("Swift witness returned a nil tree")
+			}
+			root := tree.RootNode()
+			runtime := tree.ParseRuntime()
+			memo := tree.RecoveryNodeMemoRuntime()
+			stats := parser.DebugRecoveryRuntimeStats()
+			inspection, err := benchfixtures.InspectGoTree(root, lang)
+			if err != nil {
+				tree.Release()
+				t.Fatalf("inspect Swift witness tree: %v", err)
+			}
+
+			hasError := root.HasError()
+			fullSpan := root.StartByte() == 0 && root.EndByte() == uint32(len(source))
+			if hasError != witness.wantHasError {
+				tree.Release()
+				t.Fatalf("HasError() = %v, want %v", hasError, witness.wantHasError)
+			}
+			if !fullSpan {
+				tree.Release()
+				t.Fatalf("root span = %d..%d, want 0..%d", root.StartByte(), root.EndByte(), len(source))
+			}
+			if !stats.Enabled || !stats.Completed {
+				tree.Release()
+				t.Fatalf("telemetry status = enabled:%v completed:%v, want enabled and completed", stats.Enabled, stats.Completed)
+			}
+			if witness.wantHasError && (stats.RecoveryEntryCount == 0 || stats.ErrorNodeCount == 0) {
+				tree.Release()
+				t.Fatalf("error witness lacks recovery facts: %+v", stats)
+			}
+			if !witness.wantHasError && (stats.RecoveryEntryCount != 0 || stats.ErrorNodeCount != 0 || stats.ErrorSpanBytes != 0) {
+				tree.Release()
+				t.Fatalf("clean control recorded recovery facts: %+v", stats)
+			}
+
+			sourceDigest := sha256.Sum256(source)
+			t.Logf("B16_WITNESS version=1 name=%s issue=%s source_sha256=%x source_bytes=%d grammar=swift grammar_lock_commit=%s result_class=%s full_span=%t go_deep_sha256=%s parse_wall_ns=%d measured_wall_ns=%d stop_reason=%s truncated=%t recovery_entries=%d strategy1_elections=%d cost_competitions=%d cost_walks=%d cost_walk_ns=%d error_nodes=%d error_span_bytes=%d retry_passes=%d retry_reason=%q error_mode_tokens=%d scanner_resync=%d live_versions=%d peak_live_versions=%d reduction_ceiling_hits=%d reduction_attempts_peak=%d missing_ceiling_hits=%d missing_attempts_peak=%d memo_tier=%d memo_entries=%d memo_bytes=%d memo_collisions=%d arena_bytes=%d scratch_bytes=%d entry_scratch_bytes=%d gss_bytes=%d gss_nodes=%d max_stacks=%d",
+				witness.name,
+				witness.issue,
+				sourceDigest,
+				len(source),
+				swiftGrammarLockCommit,
+				map[bool]string{true: "error", false: "clean"}[hasError],
+				fullSpan,
+				inspection.SHA256,
+				runtime.ParseWallNanos,
+				elapsed.Nanoseconds(),
+				runtime.StopReason,
+				runtime.Truncated,
+				stats.RecoveryEntryCount,
+				stats.Strategy1ElectionCount,
+				stats.RecoveryCostCompetitionCount,
+				stats.RecoveryCostWalkCount,
+				stats.RecoveryCostWalkNanos,
+				stats.ErrorNodeCount,
+				stats.ErrorSpanBytes,
+				stats.RetryPassCount,
+				stats.RetryReason,
+				stats.ErrorModeTokenCount,
+				stats.ScannerResyncCount,
+				stats.LiveVersionCount,
+				stats.PeakLiveVersionCount,
+				runtime.CRecoverReductionCandidateCeilingHits,
+				runtime.CRecoverReductionCandidateAttemptsPeak,
+				runtime.CRecoverMissingTokenCeilingHits,
+				runtime.CRecoverMissingTokenTrialAttemptsPeak,
+				memo.PeakTier,
+				memo.PeakTier.Entries(),
+				memo.PeakTier.Bytes(),
+				memo.Collisions,
+				runtime.ArenaBytesAllocated,
+				runtime.ScratchBytesAllocated,
+				runtime.EntryScratchBytesAllocated,
+				runtime.GSSBytesAllocated,
+				runtime.GSSNodesUsed,
+				runtime.MaxStacksSeen,
+			)
+			tree.Release()
+		})
+	}
 }

--- a/cgo_harness/parity_swift_recovery_telemetry_test.go
+++ b/cgo_harness/parity_swift_recovery_telemetry_test.go
@@ -124,7 +124,7 @@ func TestB16SwiftRecoveryTelemetryCOracle(t *testing.T) {
 			}
 
 			sourceDigest := sha256.Sum256(source)
-			t.Logf("B16_C_WITNESS version=1 name=%s issue=%s source_sha256=%x source_bytes=%d grammar=swift grammar_lock_commit=%s c_runtime=%s@%s c_grammar_repo=%s c_grammar_commit=%s c_grammar_artifact_sha256=%s result_class=%s go_deep_sha256=%s c_deep_sha256=%s go_stop_reason=%s go_truncated=%t go_recovery_entries=%d go_strategy1_elections=%d go_cost_competitions=%d go_cost_walks=%d go_cost_walk_ns=%d go_error_nodes=%d go_error_span_bytes=%d go_retry_passes=%d go_retry_reason=%q go_memo_tier=%d go_memo_entries=%d go_memo_bytes=%d go_memo_collisions=%d go_arena_bytes=%d go_scratch_bytes=%d go_entry_scratch_bytes=%d go_gss_bytes=%d go_gss_nodes=%d go_max_stacks=%d",
+			t.Logf("B16_C_WITNESS version=2 name=%s issue=%s source_sha256=%x source_bytes=%d grammar=swift grammar_lock_commit=%s c_runtime=%s@%s c_grammar_repo=%s c_grammar_commit=%s c_grammar_artifact_sha256=%s result_class=%s go_deep_sha256=%s c_deep_sha256=%s go_stop_reason=%s go_truncated=%t go_recovery_entries=%d go_strategy1_elections=%d go_cost_competitions=%d go_cost_walks=%d go_cost_walk_ns=%d go_error_nodes=%d go_error_span_bytes=%d go_retry_passes=%d go_retry_reason=%q go_retry_attempts=%d go_retry_selected=%q go_retry_selected_has_error=%t go_retry_selected_full_span=%t go_memo_tier=%d go_memo_entries=%d go_memo_bytes=%d go_memo_collisions=%d go_arena_bytes=%d go_scratch_bytes=%d go_entry_scratch_bytes=%d go_gss_bytes=%d go_gss_nodes=%d go_max_stacks=%d",
 				witness.name,
 				witness.issue,
 				sourceDigest,
@@ -149,6 +149,10 @@ func TestB16SwiftRecoveryTelemetryCOracle(t *testing.T) {
 				goStats.ErrorSpanBytes,
 				goStats.RetryPassCount,
 				goStats.RetryReason,
+				goStats.RetryAttemptCount,
+				goStats.RetrySelectedAttempt,
+				goStats.RetrySelectedAttemptHasError,
+				goStats.RetrySelectedAttemptFullSpan,
 				goMemo.PeakTier,
 				goMemo.PeakTier.Entries(),
 				goMemo.PeakTier.Bytes(),

--- a/cgo_harness/parity_swift_recovery_telemetry_test.go
+++ b/cgo_harness/parity_swift_recovery_telemetry_test.go
@@ -124,6 +124,10 @@ func TestB16SwiftRecoveryTelemetryCOracle(t *testing.T) {
 			}
 
 			sourceDigest := sha256.Sum256(source)
+			resultClass := map[bool]string{true: "error", false: "clean"}[goRoot.HasError()]
+			if goInspection.SHA256 != cDigest {
+				resultClass = "locked_c_divergence"
+			}
 			t.Logf("B16_C_WITNESS version=2 name=%s issue=%s source_sha256=%x source_bytes=%d grammar=swift grammar_lock_commit=%s c_runtime=%s@%s c_grammar_repo=%s c_grammar_commit=%s c_grammar_artifact_sha256=%s result_class=%s go_deep_sha256=%s c_deep_sha256=%s go_stop_reason=%s go_truncated=%t go_recovery_entries=%d go_strategy1_elections=%d go_cost_competitions=%d go_cost_walks=%d go_cost_walk_ns=%d go_error_nodes=%d go_error_span_bytes=%d go_retry_passes=%d go_retry_reason=%q go_retry_attempts=%d go_retry_selected=%q go_retry_selected_has_error=%t go_retry_selected_full_span=%t go_memo_tier=%d go_memo_entries=%d go_memo_bytes=%d go_memo_collisions=%d go_arena_bytes=%d go_scratch_bytes=%d go_entry_scratch_bytes=%d go_gss_bytes=%d go_gss_nodes=%d go_max_stacks=%d",
 				witness.name,
 				witness.issue,
@@ -135,7 +139,7 @@ func TestB16SwiftRecoveryTelemetryCOracle(t *testing.T) {
 				identity.GrammarRepo,
 				identity.GrammarCommit,
 				identity.GrammarArtifactSHA256,
-				map[bool]string{true: "error", false: "clean"}[goRoot.HasError()],
+				resultClass,
 				goInspection.SHA256,
 				cDigest,
 				goRuntime.StopReason,

--- a/cgo_harness/parity_swift_recovery_telemetry_test.go
+++ b/cgo_harness/parity_swift_recovery_telemetry_test.go
@@ -1,0 +1,167 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// TestB16SwiftRecoveryTelemetryCOracle records the locked-C identity for the
+// Swift witnesses. Keep this correctness receipt separate from benchmarks.
+func TestB16SwiftRecoveryTelemetryCOracle(t *testing.T) {
+	previousAdmissionRoute := gotreesitter.AdmissionCandidateRouteDefault()
+	gotreesitter.SetAdmissionCandidateRouteDefault(false)
+	t.Cleanup(func() { gotreesitter.SetAdmissionCandidateRouteDefault(previousAdmissionRoute) })
+	gotreesitter.EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { gotreesitter.EnableRecoveryRuntimeTelemetry(false) })
+
+	identity, err := COracleIdentity("swift")
+	if err != nil {
+		t.Fatalf("load Swift C oracle identity: %v", err)
+	}
+	cLang, err := ParityCLanguage("swift")
+	if err != nil {
+		t.Fatalf("load Swift C language: %v", err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatalf("set Swift C language: %v", err)
+	}
+
+	witnesses := []struct {
+		name         string
+		issue        string
+		path         string
+		wantHasError bool
+	}{
+		{
+			name:         "swift-586-floating-point",
+			issue:        "#586/#576",
+			path:         filepath.Join("..", "grammars", "testdata", "swift_corpus", "stdlib_FloatingPointToString.swift"),
+			wantHasError: true,
+		},
+		{
+			name:         "swift-576-collection-algorithms",
+			issue:        "#576",
+			path:         filepath.Join("..", "grammars", "testdata", "swift_corpus", "stdlib_CollectionAlgorithms.swift"),
+			wantHasError: true,
+		},
+		{
+			name:         "swift-clean-control",
+			issue:        "control",
+			path:         "",
+			wantHasError: false,
+		},
+	}
+
+	for _, witness := range witnesses {
+		t.Run(witness.name, func(t *testing.T) {
+			var source []byte
+			if witness.path == "" {
+				source = []byte("let answer = 1\n")
+			} else {
+				source, err = os.ReadFile(witness.path)
+				if err != nil {
+					t.Fatalf("read Swift witness %q: %v", witness.path, err)
+				}
+			}
+
+			goLang := grammars.SwiftLanguage()
+			goParser := gotreesitter.NewParser(goLang)
+			goTree, parseErr := goParser.Parse(source)
+			if parseErr != nil {
+				t.Fatalf("parse Swift witness with Go: %v", parseErr)
+			}
+			if goTree == nil || goTree.RootNode() == nil {
+				t.Fatal("Go Swift witness returned no tree")
+			}
+			goRoot := goTree.RootNode()
+			goRuntime := goTree.ParseRuntime()
+			goMemo := goTree.RecoveryNodeMemoRuntime()
+			goStats := goParser.DebugRecoveryRuntimeStats()
+			goInspection, err := benchfixtures.InspectGoTree(goRoot, goLang)
+			if err != nil {
+				goTree.Release()
+				t.Fatalf("inspect Go Swift witness: %v", err)
+			}
+
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				goTree.Release()
+				t.Fatal("C Swift witness returned no tree")
+			}
+			cRoot := cTree.RootNode()
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				cTree.Close()
+				goTree.Release()
+				t.Fatalf("inspect C Swift witness: %v", err)
+			}
+
+			if goRoot.HasError() != witness.wantHasError || cRoot.HasError() != witness.wantHasError {
+				cTree.Close()
+				goTree.Release()
+				t.Fatalf("HasError() = Go:%v C:%v, want %v/%v", goRoot.HasError(), cRoot.HasError(), witness.wantHasError, witness.wantHasError)
+			}
+			if goRoot.StartByte() != 0 || goRoot.EndByte() != uint32(len(source)) || cRoot.StartByte() != 0 || cRoot.EndByte() != uint(len(source)) {
+				cTree.Close()
+				goTree.Release()
+				t.Fatalf("root span = Go:%d..%d C:%d..%d, want 0..%d", goRoot.StartByte(), goRoot.EndByte(), cRoot.StartByte(), cRoot.EndByte(), len(source))
+			}
+			if !goStats.Enabled || !goStats.Completed {
+				cTree.Close()
+				goTree.Release()
+				t.Fatalf("telemetry status = enabled:%v completed:%v, want enabled and completed", goStats.Enabled, goStats.Completed)
+			}
+
+			sourceDigest := sha256.Sum256(source)
+			t.Logf("B16_C_WITNESS version=1 name=%s issue=%s source_sha256=%x source_bytes=%d grammar=swift grammar_lock_commit=%s c_runtime=%s@%s c_grammar_repo=%s c_grammar_commit=%s c_grammar_artifact_sha256=%s result_class=%s go_deep_sha256=%s c_deep_sha256=%s go_stop_reason=%s go_truncated=%t go_recovery_entries=%d go_strategy1_elections=%d go_cost_competitions=%d go_cost_walks=%d go_cost_walk_ns=%d go_error_nodes=%d go_error_span_bytes=%d go_retry_passes=%d go_retry_reason=%q go_memo_tier=%d go_memo_entries=%d go_memo_bytes=%d go_memo_collisions=%d go_arena_bytes=%d go_scratch_bytes=%d go_entry_scratch_bytes=%d go_gss_bytes=%d go_gss_nodes=%d go_max_stacks=%d",
+				witness.name,
+				witness.issue,
+				sourceDigest,
+				len(source),
+				identity.GrammarCommit,
+				identity.RuntimeVersion,
+				identity.RuntimeCommit,
+				identity.GrammarRepo,
+				identity.GrammarCommit,
+				identity.GrammarArtifactSHA256,
+				map[bool]string{true: "error", false: "clean"}[goRoot.HasError()],
+				goInspection.SHA256,
+				cDigest,
+				goRuntime.StopReason,
+				goRuntime.Truncated,
+				goStats.RecoveryEntryCount,
+				goStats.Strategy1ElectionCount,
+				goStats.RecoveryCostCompetitionCount,
+				goStats.RecoveryCostWalkCount,
+				goStats.RecoveryCostWalkNanos,
+				goStats.ErrorNodeCount,
+				goStats.ErrorSpanBytes,
+				goStats.RetryPassCount,
+				goStats.RetryReason,
+				goMemo.PeakTier,
+				goMemo.PeakTier.Entries(),
+				goMemo.PeakTier.Bytes(),
+				goMemo.Collisions,
+				goRuntime.ArenaBytesAllocated,
+				goRuntime.ScratchBytesAllocated,
+				goRuntime.EntryScratchBytesAllocated,
+				goRuntime.GSSBytesAllocated,
+				goRuntime.GSSNodesUsed,
+				goRuntime.MaxStacksSeen,
+			)
+			cTree.Close()
+			goTree.Release()
+		})
+	}
+}

--- a/docs/b16-r1-recovery-telemetry.md
+++ b/docs/b16-r1-recovery-telemetry.md
@@ -1,0 +1,42 @@
+# B16.0 recovery telemetry
+
+Status: implementation tranche
+
+This tranche records missing recovery facts for one completed parse attempt.
+It does not change parser routing, grammar admission, or recovery decisions.
+
+Enable the facts with `gotreesitter.EnableRecoveryRuntimeTelemetry(true)`.
+Disable the facts after the diagnostic run.
+
+The default path does not allocate the recovery telemetry sidecar.
+The default path does not write the new counters.
+
+Read the latest facts with `Parser.DebugRecoveryRuntimeStats()`.
+The result describes the most recent completed parse attempt on that parser.
+
+| Field | Unit | Reset and meaning |
+| --- | --- | --- |
+| `RecoveryEntryCount` | calls | Count `cHandleError` entries in this attempt. |
+| `Strategy1ElectionCount` | calls | Count strategy-1 recovery elections. |
+| `RecoveryCostCompetitionCount` | calls | Count recovery cost comparisons after header checks. |
+| `RecoveryCostWalkCount` | calls | Count non-clean recovery cost walks. |
+| `RecoveryCostWalkNanos` | nanoseconds | Sum the measured recovery cost walk time. |
+| `ErrorNodeCount` | nodes | Count final error and missing nodes. |
+| `ErrorSpanBytes` | bytes | Report the envelope from the first error start to the last error end. |
+| `RetryPassCount` | passes | Report the parser retry count when this attempt began. |
+| `RetryReason` | stable text | Report the reason for the retry that started this attempt. |
+| `ErrorModeTokenCount` | tokens | Count engine-generated error-mode lookaheads. |
+| `ScannerResyncCount` | events | Count custom token-source resynchronizations. |
+| `LiveVersionCount` | versions | Report live parser versions at finalization. |
+| `PeakLiveVersionCount` | versions | Report the largest live version set seen during recovery. |
+
+Counters reset at the start of `parseInternal`.
+Counters increase monotonically during one attempt.
+The implementation does not saturate counters before `uint64` overflow.
+
+Use existing runtime fields for stack iterations, merges, materialization,
+allocation, stop reasons, and memory-budget sources.
+Use `Tree.RecoveryNodeMemoRuntime()` for memo tier and collision facts.
+
+The focused witness covers a KDL recovery input and a Go clean control.
+The test checks the recovery entry, error shape, and live-version facts.

--- a/docs/b16-r1-retry-economy-telemetry.md
+++ b/docs/b16-r1-retry-economy-telemetry.md
@@ -1,0 +1,75 @@
+# B16.2 retry economy telemetry
+
+Status: evidence tranche
+
+Use Revision R1 of `spec.campaign.v7` as the authority.
+
+This receipt records which retry rung supplied the selected tree.
+It does not change retry routing or admit performance credit.
+
+## Schema
+
+The opt-in `RecoveryRuntimeStats` fields report the retry ladder outcome.
+
+| Field | Meaning |
+| --- | --- |
+| `RetryAttemptCount` | Retry pass slots consumed by the top-level parse. |
+| `RetrySelectedAttempt` | Logical rung that supplied the selected tree. |
+| `RetrySelectedAttemptHasError` | Error status of the selected tree. |
+| `RetrySelectedAttemptFullSpan` | Full source span status of the selected tree. |
+
+The telemetry keeps a sidecar map from each retry tree to its logical rung.
+The map exists only while recovery telemetry is enabled.
+The map is cleared when the retry ladder returns.
+
+## Locked Swift witness result
+
+Run the Go and locked-C witnesses with one test worker in Docker.
+
+| Witness | Retry passes | Selected rung | Selected error | Selected full span |
+| --- | ---: | --- | --- | --- |
+| #586 `FloatingPointToString` | 4 | `initial_merge` | true | true |
+| #576 `CollectionAlgorithms` | 0 | `initial` | true | true |
+| Swift clean control | 0 | `initial` | false | true |
+
+The #586 parse paid for four retry pass slots.
+The final selected tree came from `initial_merge`.
+The later widened and final-merge passes did not replace that tree.
+
+The #576 error witness needed no retry pass.
+The selected initial tree already covered the complete source.
+
+Both error witnesses preserve their known Swift grammar mismatch.
+The clean control keeps exact Go and C tree identity.
+
+## Interpretation
+
+The selected-rung fact identifies retry payment that may be avoidable.
+It does not prove that later rungs are redundant across the fleet.
+
+Do not skip a retry rung from this receipt alone.
+First collect the selected-rung distribution across the generic recovery cohort.
+Then compare correctness, wall time, allocation, and resident set.
+
+Keep the candidate generic.
+Do not add a Swift exception, a source hash, or a grammar-name rule.
+
+## Commands and artifacts
+
+Go witness command:
+
+```text
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build --repo-root /tmp/gotreesitter-r1-b16-retry --label b16-swift-selected-retry-facts --memory 8g --cpus 1 --gomemlimit 6GiB -- "cd /workspace && go test ./ -run '^TestSwiftRecoveryTelemetryWitnesses$' -count=1 -v -timeout 5m"
+```
+
+Go artifact: `harness_out/docker/20260811T233432Z-b16-swift-selected-retry-facts`
+
+Locked-C command:
+
+```text
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build --repo-root /tmp/gotreesitter-r1-b16-retry --label b16-swift-selected-retry-cgo --memory 8g --cpus 1 --gomemlimit 6GiB -- "cd /workspace/cgo_harness && /usr/bin/time -v go test . -tags treesitter_c_parity -run '^TestB16SwiftRecoveryTelemetryCOracle$' -count=1 -parallel 1 -timeout 5m -v"
+```
+
+Locked-C artifact: `harness_out/docker/20260811T233549Z-b16-swift-selected-retry-cgo`
+
+Both runs passed without an out-of-memory kill or a wall timeout.

--- a/glr.go
+++ b/glr.go
@@ -2090,6 +2090,9 @@ func cStackErrorCostForMergeCached(scratch *glrMergeScratch, lang *Language, s *
 	if cost, ok := cStackCleanZeroErrorCostForMerge(scratch, s); ok {
 		return cost
 	}
+	if recoveryRuntimeParser(scratch) != nil {
+		return recoveryRuntimeCostWalk(scratch, lang, s)
+	}
 	return cStackErrorCostForMergeWithScratch(scratch, lang, s)
 }
 
@@ -2100,6 +2103,7 @@ func cRecoveryMergeCostsDiffer(scratch *glrMergeScratch, a, b *glrStack) bool {
 	if !stacksHeaderEquivalent(a, b) {
 		return false
 	}
+	recordRecoveryCostCompetition(scratch)
 	return cStackErrorCostForMergeCached(scratch, scratch.language, a) != cStackErrorCostForMergeCached(scratch, scratch.language, b)
 }
 
@@ -2121,9 +2125,10 @@ func cRecoveryMergeCostsDifferForParser(p *Parser, a, b *glrStack) bool {
 	scratch := p.mergeScratch
 	if scratch == nil {
 		local := glrMergeScratch{
-			language:      p.language,
-			trace:         p.glrTrace,
-			cRecoveryCost: true,
+			language:         p.language,
+			trace:            p.glrTrace,
+			cRecoveryCost:    true,
+			cErrorCostParser: p,
 		}
 		return cRecoveryMergeCostsDiffer(&local, a, b)
 	}

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -188,6 +188,7 @@ type parserColdState struct {
 	forestDeclineMemoState
 	cNodeMemoRetainedCache []cNodeMemoCacheEntry
 	cNodeMemoCollisions    uint64
+	recoveryRuntime        recoveryRuntimeTelemetry
 }
 
 func (p *Parser) ensureParserColdState() *parserColdState {

--- a/parser.go
+++ b/parser.go
@@ -4467,6 +4467,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	defer releaseParserScratch(scratch, deferParentLinks)
 	p.reduceScratch = &scratch.reduce
 	p.mergeScratch = &scratch.merge
+	p.beginRecoveryRuntimeTelemetry()
 	// budgetScratch is saved and restored, not just cleared, unlike its
 	// siblings above: a nested parseInternal call (a retry or compat-
 	// normalization sub-parse reachable from this call's own body, however
@@ -5032,6 +5033,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		recordParseRuntimeMaterializationTiming(&parseRuntime, materializationTimingRef, materializationTiming)
 		recordParseRuntimeTokenStats(&parseRuntime, perfTokensConsumed, lastTokenEndByte, lastTokenSymbol, lastTokenWasEOF, tokenSourceEOFEarly)
 		recordParseRuntimeRootStats(&parseRuntime, tree, source, expectedEOFByte, p.included, scratch.audit.enabled || (arena != nil && arena.breakdownEnabled), p.language)
+		p.finishRecoveryRuntimeTelemetry(tree, stacks)
 		recordStopDiagnostic(parseRuntime.StopReason, tree)
 		p.copyNormalizationStats(&parseRuntime)
 		if tree != nil {

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -787,6 +787,7 @@ func (p *Parser) cRecoverAcquireToken(ts TokenSource, stacks []glrStack, source 
 	if p.cRecoverCustomResyncActive {
 		p.cRecoverCustomResyncActive = false
 		if skipper, ok := ts.(interface{ SkipToByte(uint32) Token }); ok {
+			p.recordRecoveryScannerResync()
 			return skipper.SkipToByte(p.cRecoverCustomResyncByte)
 		}
 	}
@@ -910,6 +911,7 @@ func (p *Parser) cRecoverResumeLookahead(source []byte, s *glrStack, tok Token) 
 	p.cRecoverSharedTokenErrorModeLexed = true
 	p.cRecoverCustomResyncActive = true
 	p.cRecoverCustomResyncByte = relexed.EndByte
+	p.recordRecoveryErrorModeToken()
 	return relexed, true
 }
 
@@ -983,6 +985,7 @@ func (p *Parser) cRecoverInternalErrorModeToken(ts TokenSource, stacks []glrStac
 	p.cRecoverSharedTokenErrorModeLexed = true
 	p.cRecoverCustomResyncActive = true
 	p.cRecoverCustomResyncByte = tok.EndByte
+	p.recordRecoveryErrorModeToken()
 	return tok, true
 }
 
@@ -3187,6 +3190,7 @@ func (p *Parser) cTerminalNextState(state StateID, sym Symbol) (StateID, ParseAc
 // missing-token versions and strategy-1 recoveries) — the caller must force a
 // re-dispatch pass for the same token.
 func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) (cRecoverOutcome, bool, ParseStopReason) {
+	p.recordRecoveryEntry()
 	// C-recovery reads raw shapes unconditionally once it runs (see
 	// cSelectReplacementParentEntry / compareRawStackEntries), and its
 	// version-spawning (cRecoverToState and friends) creates multi-stack
@@ -3453,6 +3457,7 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 			v.dead = true
 		}
 	}
+	p.recordRecoveryLiveVersions(*stacks)
 	return outcome, needsRedispatch, ParseStopNone
 }
 
@@ -3693,6 +3698,7 @@ func (p *Parser) cRecoverElectionLookaheadSymbol(source []byte, member *glrStack
 //   - entries are deduped on (depth, state) at first encounter, mirroring
 //     ts_stack_record_summary's record-time dedup across the merged paths.
 func (p *Parser) cRecoverStrategy1Election(stacks *[]glrStack, group *cRecGroup, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) (didRecover, forked bool, reason ParseStopReason) {
+	p.recordStrategy1Election()
 	checkStop := func() ParseStopReason {
 		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 			return reason
@@ -3836,6 +3842,7 @@ func (p *Parser) cRecoverStrategy1Election(stacks *[]glrStack, group *cRecGroup,
 				}
 				fork.branchOrder = (*stacks)[mi].branchOrder
 				*stacks = append(*stacks, fork)
+				p.recordRecoveryLiveVersions(*stacks)
 				if nodeCount != nil {
 					*nodeCount = *nodeCount + 1
 				}

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -266,6 +266,7 @@ func (p *Parser) retryIncrementalAcceptedErrorWithBaseMergeCap(source []byte, fi
 	}
 
 	p.fullParseRetryPassesTaken++
+	p.recordRecoveryRuntimeRetry("accepted_error_under_wide_incremental_merge")
 	workCountSetNextParseAttempt("incremental_base_merge", "accepted_error_under_wide_incremental_merge")
 	var retryTiming *incrementalParseTiming
 	if timing != nil {
@@ -1721,6 +1722,7 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 				return nil
 			}
 			p.fullParseRetryPassesTaken++
+			p.recordRecoveryRuntimeRetry(operationCause)
 		}
 		var t0 time.Time
 		if retryDebug {

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -1589,7 +1589,10 @@ func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree,
 }
 
 func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tree *Tree, origin fullParseRetryOrigin, runRetry fullParseRetryRunner) *Tree {
+	p.recordRecoveryRuntimeRetryTree(tree, "initial")
 	if certifiedAcceptedErrorRetrySkipsFresh(tree, len(source), origin) {
+		p.finishRecoveryRuntimeRetryTelemetry(tree, len(source))
+		p.clearRecoveryRuntimeRetryTrees()
 		return tree
 	}
 	maxStacksOverride := fullParseRetryMaxStacksOverrideForOrigin(tree, len(source), initialMaxStacks, origin)
@@ -1691,6 +1694,7 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 				release(*best)
 			}
 			*best = candidate
+			p.recordRecoveryRuntimeSelectedTree(candidate)
 			return
 		}
 		release(candidate)
@@ -1711,6 +1715,8 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 	// normal result compatibility; avoid paying the full retry ladder first.
 	if certifiedGSSConvergenceAcceptedErrorMergePerKey(tree, len(source)) == 0 &&
 		csharpAcceptedErrorTreeCanUseNamespaceRecovery(tree, source) {
+		p.finishRecoveryRuntimeRetryTelemetry(tree, len(source))
+		p.clearRecoveryRuntimeRetryTrees()
 		return tree
 	}
 	runRetryAttempt := func(logicalRung, operationCause string, maxStacks int, maxMergePerKeyOverride int, maxNodes int) *Tree {
@@ -1750,10 +1756,16 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 			fmt.Fprintf(os.Stderr, "RETRYDBG pass maxStacks=%d mergePerKey=%d maxNodes=%d took=%v stop=%v hasErr=%v forceClean=%v\n",
 				maxStacks, maxMergePerKeyOverride, maxNodes, time.Since(t0), stop, hasErr, p != nil && p.forceCleanRetryPass)
 		}
+		p.recordRecoveryRuntimeRetryTree(result, logicalRung)
 		return result
 	}
 
 	bestTree := tree
+	defer func() {
+		p.finishRecoveryRuntimeRetryTelemetry(bestTree, len(source))
+		p.clearRecoveryRuntimeRetryTrees()
+	}()
+	p.recordRecoveryRuntimeSelectedTree(bestTree)
 	if shouldRunInitialFullParseMergeRetry(tree, len(source), origin) {
 		if initialMergePerKey := fullParseRetryMergePerKeyOverride(tree, len(source), initialMaxStacks); initialMergePerKey != 0 {
 			mergeRetryTree := runRetryAttempt(
@@ -1877,6 +1889,7 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 						release(bestTree)
 					}
 					bestTree = retryTree
+					p.recordRecoveryRuntimeSelectedTree(bestTree)
 				} else if retryTree != bestTree {
 					release(retryTree)
 				}
@@ -1893,6 +1906,7 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 					release(bestTree)
 				}
 				bestTree = retryTree
+				p.recordRecoveryRuntimeSelectedTree(bestTree)
 			}
 		}
 	}

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -265,6 +265,7 @@ func (p *Parser) retryIncrementalAcceptedErrorWithBaseMergeCap(source []byte, fi
 		return first
 	}
 
+	p.recordRecoveryRuntimeRetryTree(first, "initial")
 	p.fullParseRetryPassesTaken++
 	p.recordRecoveryRuntimeRetry("accepted_error_under_wide_incremental_merge")
 	workCountSetNextParseAttempt("incremental_base_merge", "accepted_error_under_wide_incremental_merge")
@@ -275,6 +276,7 @@ func (p *Parser) retryIncrementalAcceptedErrorWithBaseMergeCap(source []byte, fi
 	// A negative override is an exact cap. Positive overrides only widen the
 	// effective cap and therefore cannot lower the incremental default.
 	candidate := run(-baseCap, retryTiming)
+	p.recordRecoveryRuntimeRetryTree(candidate, "incremental_base_merge")
 	adopted := candidate != nil && candidate != first && preferRetryTreeOverFirstPass(p, candidate, first)
 	result := first
 	if adopted {
@@ -298,6 +300,8 @@ func (p *Parser) retryIncrementalAcceptedErrorWithBaseMergeCap(source []byte, fi
 		result.parseRuntime.IncrementalAcceptedErrorRetryMergePerKey = baseCap
 		result.parseRuntime.IncrementalAcceptedErrorRetryCause = IncrementalRetryCauseAcceptedErrorBaseMerge
 	}
+	p.finishRecoveryRuntimeRetryTelemetry(result, len(source))
+	p.clearRecoveryRuntimeRetryTrees()
 	return result
 }
 

--- a/recovery_runtime_telemetry.go
+++ b/recovery_runtime_telemetry.go
@@ -1,0 +1,176 @@
+package gotreesitter
+
+import "time"
+
+// recoveryRuntimeTelemetryEnabled gates the recovery facts that are absent
+// from the normal parser runtime. Keep the default path free of these writes.
+var recoveryRuntimeTelemetryEnabled bool
+
+type recoveryRuntimeTelemetry struct {
+	stats              RecoveryRuntimeStats
+	pendingRetryReason string
+}
+
+// EnableRecoveryRuntimeTelemetry enables diagnostic recovery counters.
+//
+// Use this function for single-threaded profiling and witness collection.
+// Disable it after the diagnostic run to restore the default path.
+func EnableRecoveryRuntimeTelemetry(enabled bool) {
+	recoveryRuntimeTelemetryEnabled = enabled
+}
+
+// DebugRecoveryRuntimeStats returns the latest recovery facts for parser p.
+// The method returns zero values when telemetry is disabled or no parse ran.
+func (p *Parser) DebugRecoveryRuntimeStats() RecoveryRuntimeStats {
+	if p == nil || !recoveryRuntimeTelemetryEnabled || p.forestDeclineMemo == nil {
+		return RecoveryRuntimeStats{}
+	}
+	return p.forestDeclineMemo.recoveryRuntime.stats
+}
+
+func (p *Parser) beginRecoveryRuntimeTelemetry() {
+	if p == nil || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	cold := p.ensureParserColdState()
+	state := &cold.recoveryRuntime
+	retryReason := state.pendingRetryReason
+	if p.fullParseRetryPassesTaken == 0 {
+		retryReason = ""
+	}
+	state.stats = RecoveryRuntimeStats{
+		Enabled:        true,
+		RetryPassCount: uint64(p.fullParseRetryPassesTaken),
+		RetryReason:    retryReason,
+	}
+	state.pendingRetryReason = ""
+}
+
+func (p *Parser) recoveryRuntimeTelemetryState() *recoveryRuntimeTelemetry {
+	if p == nil || !recoveryRuntimeTelemetryEnabled || p.forestDeclineMemo == nil {
+		return nil
+	}
+	return &p.forestDeclineMemo.recoveryRuntime
+}
+
+func (p *Parser) recordRecoveryRuntimeRetry(reason string) {
+	if p == nil || !recoveryRuntimeTelemetryEnabled || reason == "" {
+		return
+	}
+	cold := p.ensureParserColdState()
+	cold.recoveryRuntime.pendingRetryReason = reason
+}
+
+func (p *Parser) recordRecoveryEntry() {
+	if state := p.recoveryRuntimeTelemetryState(); state != nil {
+		state.stats.RecoveryEntryCount++
+	}
+}
+
+func (p *Parser) recordStrategy1Election() {
+	if state := p.recoveryRuntimeTelemetryState(); state != nil {
+		state.stats.Strategy1ElectionCount++
+	}
+}
+
+func (p *Parser) recordRecoveryErrorModeToken() {
+	if state := p.recoveryRuntimeTelemetryState(); state != nil {
+		state.stats.ErrorModeTokenCount++
+	}
+}
+
+func (p *Parser) recordRecoveryScannerResync() {
+	if state := p.recoveryRuntimeTelemetryState(); state != nil {
+		state.stats.ScannerResyncCount++
+	}
+}
+
+func (p *Parser) recordRecoveryLiveVersions(stacks []glrStack) {
+	state := p.recoveryRuntimeTelemetryState()
+	if state == nil {
+		return
+	}
+	var live uint64
+	for i := range stacks {
+		if !stacks[i].dead && !stacks[i].accepted {
+			live++
+		}
+	}
+	state.stats.LiveVersionCount = live
+	if live > state.stats.PeakLiveVersionCount {
+		state.stats.PeakLiveVersionCount = live
+	}
+}
+
+func (p *Parser) finishRecoveryRuntimeTelemetry(tree *Tree, stacks []glrStack) {
+	state := p.recoveryRuntimeTelemetryState()
+	if state == nil {
+		return
+	}
+	state.stats.Completed = true
+	p.recordRecoveryLiveVersions(stacks)
+	state.stats.ErrorNodeCount, state.stats.ErrorSpanBytes = recoveryRuntimeErrorStats(rawRootOrNil(tree))
+}
+
+func recoveryRuntimeErrorStats(root *Node) (count uint64, span uint32) {
+	if root == nil {
+		return 0, 0
+	}
+	var local [64]*Node
+	stack := local[:0]
+	stack = append(stack, root)
+	minStart := ^uint32(0)
+	var maxEnd uint32
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if n == nil {
+			continue
+		}
+		if n.IsError() || n.IsMissing() {
+			count++
+			if n.StartByte() < minStart {
+				minStart = n.StartByte()
+			}
+			if n.EndByte() > maxEnd {
+				maxEnd = n.EndByte()
+			}
+		}
+		for i := n.ChildCount() - 1; i >= 0; i-- {
+			stack = append(stack, n.Child(i))
+		}
+	}
+	if count == 0 {
+		return 0, 0
+	}
+	return count, maxEnd - minStart
+}
+
+func recoveryRuntimeParser(scratch *glrMergeScratch) *Parser {
+	if !recoveryRuntimeTelemetryEnabled || scratch == nil {
+		return nil
+	}
+	return scratch.cErrorCostParser
+}
+
+func recordRecoveryCostCompetition(scratch *glrMergeScratch) {
+	if p := recoveryRuntimeParser(scratch); p != nil {
+		if state := p.recoveryRuntimeTelemetryState(); state != nil {
+			state.stats.RecoveryCostCompetitionCount++
+		}
+	}
+}
+
+func recoveryRuntimeCostWalk(scratch *glrMergeScratch, lang *Language, stack *glrStack) uint32 {
+	p := recoveryRuntimeParser(scratch)
+	if p == nil {
+		return cStackErrorCostForMergeWithScratch(scratch, lang, stack)
+	}
+	start := time.Now()
+	cost := cStackErrorCostForMergeWithScratch(scratch, lang, stack)
+	if state := p.recoveryRuntimeTelemetryState(); state != nil {
+		state.stats.RecoveryCostWalkCount++
+		state.stats.RecoveryCostWalkNanos += uint64(time.Since(start).Nanoseconds())
+	}
+	return cost
+}

--- a/recovery_runtime_telemetry.go
+++ b/recovery_runtime_telemetry.go
@@ -6,11 +6,15 @@ import "time"
 // from the normal parser runtime. Keep the default path free of these writes.
 var recoveryRuntimeTelemetryEnabled bool
 
+type recoveryRuntimeAttempt struct {
+	stats RecoveryRuntimeStats
+	rung  string
+}
+
 type recoveryRuntimeTelemetry struct {
-	stats                RecoveryRuntimeStats
-	pendingRetryReason   string
-	retryAttemptRungs    map[*Tree]string
-	selectedRetryAttempt string
+	stats              RecoveryRuntimeStats
+	pendingRetryReason string
+	retryAttempts      map[*Tree]recoveryRuntimeAttempt
 }
 
 // EnableRecoveryRuntimeTelemetry enables diagnostic recovery counters.
@@ -37,19 +41,16 @@ func (p *Parser) beginRecoveryRuntimeTelemetry() {
 	cold := p.ensureParserColdState()
 	state := &cold.recoveryRuntime
 	if p.fullParseRetryPassesTaken == 0 {
-		state.retryAttemptRungs = nil
-		state.selectedRetryAttempt = "initial"
+		state.retryAttempts = nil
 	}
 	retryReason := state.pendingRetryReason
 	if p.fullParseRetryPassesTaken == 0 {
 		retryReason = ""
 	}
 	state.stats = RecoveryRuntimeStats{
-		Enabled:              true,
-		RetryPassCount:       uint64(p.fullParseRetryPassesTaken),
-		RetryReason:          retryReason,
-		RetryAttemptCount:    uint64(p.fullParseRetryPassesTaken),
-		RetrySelectedAttempt: state.selectedRetryAttempt,
+		Enabled:        true,
+		RetryPassCount: uint64(p.fullParseRetryPassesTaken),
+		RetryReason:    retryReason,
 	}
 	state.pendingRetryReason = ""
 }
@@ -117,9 +118,14 @@ func (p *Parser) finishRecoveryRuntimeTelemetry(tree *Tree, stacks []glrStack) {
 	}
 	state.stats.Completed = true
 	state.stats.RetryAttemptCount = uint64(p.fullParseRetryPassesTaken)
-	state.stats.RetrySelectedAttempt = state.selectedRetryAttempt
 	p.recordRecoveryLiveVersions(stacks)
 	state.stats.ErrorNodeCount, state.stats.ErrorSpanBytes = recoveryRuntimeErrorStats(rawRootOrNil(tree))
+	if tree != nil {
+		if state.retryAttempts == nil {
+			state.retryAttempts = make(map[*Tree]recoveryRuntimeAttempt)
+		}
+		state.retryAttempts[tree] = recoveryRuntimeAttempt{stats: state.stats}
+	}
 }
 
 func (p *Parser) recordRecoveryRuntimeRetryTree(tree *Tree, rung string) {
@@ -130,10 +136,15 @@ func (p *Parser) recordRecoveryRuntimeRetryTree(tree *Tree, rung string) {
 	if state == nil {
 		return
 	}
-	if state.retryAttemptRungs == nil {
-		state.retryAttemptRungs = make(map[*Tree]string)
+	if state.retryAttempts == nil {
+		state.retryAttempts = make(map[*Tree]recoveryRuntimeAttempt)
 	}
-	state.retryAttemptRungs[tree] = rung
+	attempt, ok := state.retryAttempts[tree]
+	if !ok {
+		attempt = recoveryRuntimeAttempt{}
+	}
+	attempt.rung = rung
+	state.retryAttempts[tree] = attempt
 }
 
 func (p *Parser) recordRecoveryRuntimeSelectedTree(tree *Tree) {
@@ -141,12 +152,11 @@ func (p *Parser) recordRecoveryRuntimeSelectedTree(tree *Tree) {
 		return
 	}
 	state := p.recoveryRuntimeTelemetryState()
-	if state == nil || state.retryAttemptRungs == nil {
+	if state == nil || state.retryAttempts == nil {
 		return
 	}
-	if rung := state.retryAttemptRungs[tree]; rung != "" {
-		state.selectedRetryAttempt = rung
-		state.stats.RetrySelectedAttempt = rung
+	if attempt := state.retryAttempts[tree]; attempt.rung != "" {
+		state.stats.RetrySelectedAttempt = attempt.rung
 	}
 }
 
@@ -158,8 +168,12 @@ func (p *Parser) finishRecoveryRuntimeRetryTelemetry(tree *Tree, sourceLen int) 
 	if state == nil {
 		return
 	}
+	if attempt, ok := state.retryAttempts[tree]; ok {
+		state.stats = attempt.stats
+		state.stats.RetrySelectedAttempt = attempt.rung
+	}
+	state.stats.RetryPassCount = uint64(p.fullParseRetryPassesTaken)
 	state.stats.RetryAttemptCount = uint64(p.fullParseRetryPassesTaken)
-	state.stats.RetrySelectedAttempt = state.selectedRetryAttempt
 	root := rawRootOrNil(tree)
 	if root == nil {
 		return
@@ -173,7 +187,7 @@ func (p *Parser) clearRecoveryRuntimeRetryTrees() {
 		return
 	}
 	if state := p.recoveryRuntimeTelemetryState(); state != nil {
-		state.retryAttemptRungs = nil
+		state.retryAttempts = nil
 	}
 }
 

--- a/recovery_runtime_telemetry.go
+++ b/recovery_runtime_telemetry.go
@@ -141,7 +141,11 @@ func (p *Parser) recordRecoveryRuntimeRetryTree(tree *Tree, rung string) {
 	}
 	attempt, ok := state.retryAttempts[tree]
 	if !ok {
-		attempt = recoveryRuntimeAttempt{}
+		// A parser may run more than one retry ladder, for example when an
+		// external scanner requests a repeat. The selected tree from the prior
+		// ladder remains the incumbent, so seed this new attempt record from
+		// its immutable snapshot instead of replacing it with zero values.
+		attempt = recoveryRuntimeAttempt{stats: state.stats}
 	}
 	attempt.rung = rung
 	state.retryAttempts[tree] = attempt
@@ -168,7 +172,7 @@ func (p *Parser) finishRecoveryRuntimeRetryTelemetry(tree *Tree, sourceLen int) 
 	if state == nil {
 		return
 	}
-	if attempt, ok := state.retryAttempts[tree]; ok {
+	if attempt, ok := state.retryAttempts[tree]; ok && attempt.stats.Enabled {
 		state.stats = attempt.stats
 		state.stats.RetrySelectedAttempt = attempt.rung
 	}

--- a/recovery_runtime_telemetry.go
+++ b/recovery_runtime_telemetry.go
@@ -7,8 +7,10 @@ import "time"
 var recoveryRuntimeTelemetryEnabled bool
 
 type recoveryRuntimeTelemetry struct {
-	stats              RecoveryRuntimeStats
-	pendingRetryReason string
+	stats                RecoveryRuntimeStats
+	pendingRetryReason   string
+	retryAttemptRungs    map[*Tree]string
+	selectedRetryAttempt string
 }
 
 // EnableRecoveryRuntimeTelemetry enables diagnostic recovery counters.
@@ -34,14 +36,20 @@ func (p *Parser) beginRecoveryRuntimeTelemetry() {
 	}
 	cold := p.ensureParserColdState()
 	state := &cold.recoveryRuntime
+	if p.fullParseRetryPassesTaken == 0 {
+		state.retryAttemptRungs = nil
+		state.selectedRetryAttempt = "initial"
+	}
 	retryReason := state.pendingRetryReason
 	if p.fullParseRetryPassesTaken == 0 {
 		retryReason = ""
 	}
 	state.stats = RecoveryRuntimeStats{
-		Enabled:        true,
-		RetryPassCount: uint64(p.fullParseRetryPassesTaken),
-		RetryReason:    retryReason,
+		Enabled:              true,
+		RetryPassCount:       uint64(p.fullParseRetryPassesTaken),
+		RetryReason:          retryReason,
+		RetryAttemptCount:    uint64(p.fullParseRetryPassesTaken),
+		RetrySelectedAttempt: state.selectedRetryAttempt,
 	}
 	state.pendingRetryReason = ""
 }
@@ -108,8 +116,65 @@ func (p *Parser) finishRecoveryRuntimeTelemetry(tree *Tree, stacks []glrStack) {
 		return
 	}
 	state.stats.Completed = true
+	state.stats.RetryAttemptCount = uint64(p.fullParseRetryPassesTaken)
+	state.stats.RetrySelectedAttempt = state.selectedRetryAttempt
 	p.recordRecoveryLiveVersions(stacks)
 	state.stats.ErrorNodeCount, state.stats.ErrorSpanBytes = recoveryRuntimeErrorStats(rawRootOrNil(tree))
+}
+
+func (p *Parser) recordRecoveryRuntimeRetryTree(tree *Tree, rung string) {
+	if p == nil || tree == nil || rung == "" || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	state := p.recoveryRuntimeTelemetryState()
+	if state == nil {
+		return
+	}
+	if state.retryAttemptRungs == nil {
+		state.retryAttemptRungs = make(map[*Tree]string)
+	}
+	state.retryAttemptRungs[tree] = rung
+}
+
+func (p *Parser) recordRecoveryRuntimeSelectedTree(tree *Tree) {
+	if p == nil || tree == nil || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	state := p.recoveryRuntimeTelemetryState()
+	if state == nil || state.retryAttemptRungs == nil {
+		return
+	}
+	if rung := state.retryAttemptRungs[tree]; rung != "" {
+		state.selectedRetryAttempt = rung
+		state.stats.RetrySelectedAttempt = rung
+	}
+}
+
+func (p *Parser) finishRecoveryRuntimeRetryTelemetry(tree *Tree, sourceLen int) {
+	if p == nil || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	state := p.recoveryRuntimeTelemetryState()
+	if state == nil {
+		return
+	}
+	state.stats.RetryAttemptCount = uint64(p.fullParseRetryPassesTaken)
+	state.stats.RetrySelectedAttempt = state.selectedRetryAttempt
+	root := rawRootOrNil(tree)
+	if root == nil {
+		return
+	}
+	state.stats.RetrySelectedAttemptHasError = root.HasError()
+	state.stats.RetrySelectedAttemptFullSpan = root.StartByte() == 0 && root.EndByte() == uint32(sourceLen)
+}
+
+func (p *Parser) clearRecoveryRuntimeRetryTrees() {
+	if p == nil || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	if state := p.recoveryRuntimeTelemetryState(); state != nil {
+		state.retryAttemptRungs = nil
+	}
 }
 
 func recoveryRuntimeErrorStats(root *Node) (count uint64, span uint32) {

--- a/recovery_runtime_telemetry_test.go
+++ b/recovery_runtime_telemetry_test.go
@@ -33,4 +33,15 @@ func TestRecoveryRuntimeTelemetryKeepsSelectedAttemptRecord(t *testing.T) {
 	if stats.RetryAttemptCount != 1 || stats.RetryPassCount != 1 {
 		t.Fatalf("retry counts = attempts:%d passes:%d, want 1/1", stats.RetryAttemptCount, stats.RetryPassCount)
 	}
+
+	// A scanner can request a second retry ladder with the first ladder's
+	// selected tree as its incumbent. The new ladder must not replace its
+	// attempt-local snapshot with zero values.
+	parser.clearRecoveryRuntimeRetryTrees()
+	parser.recordRecoveryRuntimeRetryTree(initial, "initial")
+	parser.finishRecoveryRuntimeRetryTelemetry(initial, 4)
+	stats = parser.DebugRecoveryRuntimeStats()
+	if stats.RecoveryEntryCount != 1 || !stats.Enabled || !stats.Completed {
+		t.Fatalf("repeated-ladder selected stats = enabled:%v completed:%v entries:%d, want true/true/1", stats.Enabled, stats.Completed, stats.RecoveryEntryCount)
+	}
 }

--- a/recovery_runtime_telemetry_test.go
+++ b/recovery_runtime_telemetry_test.go
@@ -1,0 +1,36 @@
+package gotreesitter
+
+import "testing"
+
+func TestRecoveryRuntimeTelemetryKeepsSelectedAttemptRecord(t *testing.T) {
+	EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { EnableRecoveryRuntimeTelemetry(false) })
+
+	parser := &Parser{}
+	initial := &Tree{root: &Node{endByte: 4}}
+	losingRetry := &Tree{root: &Node{endByte: 4}}
+
+	parser.beginRecoveryRuntimeTelemetry()
+	parser.recordRecoveryEntry()
+	parser.finishRecoveryRuntimeTelemetry(initial, nil)
+	parser.recordRecoveryRuntimeRetryTree(initial, "initial")
+
+	parser.fullParseRetryPassesTaken = 1
+	parser.beginRecoveryRuntimeTelemetry()
+	parser.recordRecoveryEntry()
+	parser.recordRecoveryEntry()
+	parser.finishRecoveryRuntimeTelemetry(losingRetry, nil)
+	parser.recordRecoveryRuntimeRetryTree(losingRetry, "final_merge")
+
+	parser.finishRecoveryRuntimeRetryTelemetry(initial, 4)
+	stats := parser.DebugRecoveryRuntimeStats()
+	if stats.RecoveryEntryCount != 1 {
+		t.Fatalf("selected attempt recovery entries = %d, want 1", stats.RecoveryEntryCount)
+	}
+	if stats.RetrySelectedAttempt != "initial" {
+		t.Fatalf("selected attempt = %q, want initial", stats.RetrySelectedAttempt)
+	}
+	if stats.RetryAttemptCount != 1 || stats.RetryPassCount != 1 {
+		t.Fatalf("retry counts = attempts:%d passes:%d, want 1/1", stats.RetryAttemptCount, stats.RetryPassCount)
+	}
+}

--- a/tree.go
+++ b/tree.go
@@ -832,6 +832,10 @@ type RecoveryRuntimeStats struct {
 	ErrorSpanBytes               uint32
 	RetryPassCount               uint64
 	RetryReason                  string
+	RetryAttemptCount            uint64
+	RetrySelectedAttempt         string
+	RetrySelectedAttemptHasError bool
+	RetrySelectedAttemptFullSpan bool
 	ErrorModeTokenCount          uint64
 	ScannerResyncCount           uint64
 	LiveVersionCount             uint64

--- a/tree.go
+++ b/tree.go
@@ -813,6 +813,31 @@ type RecoveryNodeMemoRuntime struct {
 	Collisions uint32
 }
 
+// RecoveryRuntimeStats reports opt-in recovery facts for the most recent
+// completed parse attempt on a parser.
+//
+// The default value reports no facts. Enable the telemetry before parsing.
+// Existing tree runtime fields and RecoveryNodeMemoRuntime provide the other
+// B16 facts, including materialization, allocation, stop, and memo metrics.
+type RecoveryRuntimeStats struct {
+	Enabled   bool
+	Completed bool
+
+	RecoveryEntryCount           uint64
+	Strategy1ElectionCount       uint64
+	RecoveryCostCompetitionCount uint64
+	RecoveryCostWalkCount        uint64
+	RecoveryCostWalkNanos        uint64
+	ErrorNodeCount               uint64
+	ErrorSpanBytes               uint32
+	RetryPassCount               uint64
+	RetryReason                  string
+	ErrorModeTokenCount          uint64
+	ScannerResyncCount           uint64
+	LiveVersionCount             uint64
+	PeakLiveVersionCount         uint64
+}
+
 // ParseRuntime captures parser-loop diagnostics for a completed tree.
 type ParseRuntime struct {
 	StopReason     ParseStopReason


### PR DESCRIPTION
## Summary

Restore the reusable recovery telemetry from closed pull request #683.

- Store one immutable record for each completed retry attempt.
- Keep selected-tree counters with the attempt that produced the tree.
- Report total retry counts separately.
- Label unequal Go and C deep digests as `locked_c_divergence`.
- Keep telemetry disabled by default.

## Scope

This pull request contains one evidence and reliability tranche.

- Update recovery telemetry state.
- Cover the incremental retry path.
- Add a focused selected-attempt regression test.
- Classify Swift C-oracle digest mismatches.

This pull request does not change parser routing, parser semantics, storage, or performance behavior. It does not claim performance credit.

## Evidence

Base head: `aa8c172fd00938c6680191d16c8a72ea0b2d6200`.

Focused Docker test:

`go test . -run '^TestRecoveryRuntimeTelemetryKeepsSelectedAttemptRecord$' -count=1 -v`

- Passed.
- No out-of-memory event.
- No timeout.
- Container log SHA-256: `a8f938103c4191e427d5f7c341e5b823af5e5877ba84c2ea8121cadbf4a69cb7`.

Swift C-oracle witness:

`go test ./cgo_harness -tags treesitter_c_parity -run '^TestB16SwiftRecoveryTelemetryCOracle$' -count=1 -parallel 1 -timeout 5m -v`

- Issue #586 witness: `locked_c_divergence`.
- Issue #576 witness: `locked_c_divergence`.
- Clean control: `clean`.
- No out-of-memory event.
- No timeout.
- Container log SHA-256: `4ed46cbcf38a6badb8e88f37c827a901c03c652dd12d10411ae9f70f817275aa`.

## Follow-up

- Refs #586.
- Refs #576.
- Keep both issues open until a generic parser fix proves locked-C parity.
- Run authoritative C0f only after this pull request merges.
- Give no performance credit to this telemetry tranche.