### PR TITLE
ci: verify corpus files before the performance scan

### DIFF
--- a/.github/workflows/perf-scan-gate.yml
+++ b/.github/workflows/perf-scan-gate.yml
@@ -74,6 +74,23 @@ jobs:
           done < "$lock"
           test "$rows" -eq 206 || fail "corpus lock contains $rows language rows, want 206"
 
+      - name: Verify provisioned corpus files
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "$PERF_OUT"
+          mkdir -p "$PERF_OUT"
+          (
+            cd cgo_harness
+            GOWORK=off go run ./cmd/real_corpus_inventory \
+              -grammar-dir ../grammars/grammar_blobs \
+              -lock ../grammars/languages.lock \
+              -corpus-source-root "$PERF_CORPUS_DIR/corpus_sources" \
+              -corpus-source-lock "$PERF_CORPUS_DIR/corpus_sources.lock" \
+              -require-corpus-sources \
+              -out-json "../$PERF_OUT/source_inventory.json"
+          )
+
       - name: Restore C reference build cache
         uses: actions/cache@v4
         with:
@@ -84,7 +101,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rm -rf "$PERF_OUT"
           bash cgo_harness/docker/run_parity_in_docker.sh \
             --label perf-scan-hard-gate \
             --memory 8g \


### PR DESCRIPTION
## Summary

- Run the real-corpus inventory before the performance scan.
- Require every locked language to provide matching source files.
- Save the authenticated source inventory with the scan artifacts.
- Fail before timing when corpus staging omits extracted fixtures.

## Validation

- `GOWORK=off go test ./cmd/real_corpus_inventory ./cmd/perf_scan_budget ./cmd/perf_scan_status -count=1`
- `git diff --check`

## Campaign scope

This PR is a Q5 evidence-containment tranche.

It does not change parser routes, parser budgets, or performance measurements.

It prevents incomplete corpus staging from producing partial scan evidence.
