### PR TITLE
Compact raw-shape records with a bounded hash cache

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -120,6 +120,7 @@ type nodeArena struct {
 	rawShapeSlabCursor              int
 	rawShapeChildSlabs              []rawShapeChildSlab
 	rawShapeChildSlabCursor         int
+	rawShapeHashCache               []rawShapeHashCacheEntry
 	compactCheckpointLeafSlabs      []compactCheckpointLeafSlab
 	compactCheckpointLeafSlabCursor int
 	finalChildSidecars              []finalChildSidecar
@@ -552,6 +553,7 @@ func (a *nodeArena) reset() {
 	a.resetPendingChildEntrySlabs()
 	a.resetRawShapeSlabs()
 	a.resetRawShapeChildSlabs()
+	a.resetRawShapeHashCache()
 	a.resetFinalChildSidecars()
 	a.resetCompactCheckpointLeafSlabs()
 	a.resetNodeFieldMetadataSlabs()
@@ -820,6 +822,13 @@ func (a *nodeArena) resetRawShapeChildSlabs() {
 		slab.used = 0
 	}
 	a.rawShapeChildSlabCursor = 0
+}
+
+func (a *nodeArena) resetRawShapeHashCache() {
+	if a == nil || len(a.rawShapeHashCache) == 0 {
+		return
+	}
+	clear(a.rawShapeHashCache)
 }
 
 func (a *nodeArena) resetFinalChildSidecars() {
@@ -1804,6 +1813,13 @@ func (a *nodeArena) rawShapeChildBytesAllocated() int64 {
 	return total
 }
 
+func (a *nodeArena) rawShapeHashCacheBytesAllocated() int64 {
+	if a == nil {
+		return 0
+	}
+	return rawShapeHashCacheBytesForCap(cap(a.rawShapeHashCache))
+}
+
 func (a *nodeArena) pendingChildEntryCapacity() uint64 {
 	if a == nil {
 		return 0
@@ -1860,6 +1876,7 @@ func (a *nodeArena) recomputeAllocatedBytes() {
 		a.pendingChildEntryBytesAllocated() +
 		a.rawShapeBytesAllocated() +
 		a.rawShapeChildBytesAllocated() +
+		a.rawShapeHashCacheBytesAllocated() +
 		a.finalChildSidecarBytesAllocated() +
 		a.compactCheckpointLeafBytesAllocated() +
 		a.childSliceBytesAllocated() +
@@ -2218,6 +2235,7 @@ func (a *nodeArena) collectArenaBreakdown() *ArenaBreakdown {
 		PendingChildEntryBytesAllocated:     a.pendingChildEntryBytesAllocated(),
 		RawShapeBytesAllocated:              a.rawShapeBytesAllocated(),
 		RawShapeChildBytesAllocated:         a.rawShapeChildBytesAllocated(),
+		RawShapeHashCacheBytesAllocated:     a.rawShapeHashCacheBytesAllocated(),
 		FinalChildSidecarBytesAllocated:     a.finalChildSidecarBytesAllocated(),
 		CompactCheckpointLeafBytesAllocated: a.compactCheckpointLeafBytesAllocated(),
 		PendingChildEntriesAllocated:        a.pendingChildEntriesAllocated,

--- a/benchmark_warm_reuse_test.go
+++ b/benchmark_warm_reuse_test.go
@@ -129,6 +129,10 @@ func TestArenaGCRetentionAfterRelease(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read parser_test.go: %v", err)
 	}
+	runtime.GC()
+	runtime.GC()
+	var baseline runtime.MemStats
+	runtime.ReadMemStats(&baseline)
 
 	parser := gotreesitter.NewParser(grammars.GoLanguage())
 	tree, parseErr := parser.Parse(src)
@@ -136,6 +140,8 @@ func TestArenaGCRetentionAfterRelease(t *testing.T) {
 		t.Fatalf("parse: %v", parseErr)
 	}
 	tree.Release()
+	parser = nil
+	src = nil
 
 	// Run GC three times: first pass marks, second pass sweeps, third confirms.
 	runtime.GC()
@@ -144,15 +150,24 @@ func TestArenaGCRetentionAfterRelease(t *testing.T) {
 
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
+	retainedBytes := int64(ms.HeapAlloc) - int64(baseline.HeapAlloc)
+	if retainedBytes < 0 {
+		retainedBytes = 0
+	}
 
 	// 60 MB is well above the expected ~12-20 MB post-fix but far below the
 	// ~545 MB retained by reset implementations that leave stale node pointers.
+	// Compare against a pre-parse baseline so unrelated suite allocations do
+	// not turn this arena-lifecycle test into a flaky absolute-heap gate.
 	const maxRetainedBytes = 60 * 1024 * 1024
-	if ms.HeapAlloc > maxRetainedBytes {
-		t.Fatalf("HeapAlloc after parse+release+GC = %d MB, want < %d MB\n"+
+	if retainedBytes > maxRetainedBytes {
+		t.Fatalf("HeapAlloc retained after parse+release+GC = %d MB (baseline=%d MB, final=%d MB), want < %d MB\n"+
 			"Hint: arena slab backing arrays may not be fully cleared on reset,\n"+
 			"leaving stale *Node pointers that prevent GC collection.",
-			ms.HeapAlloc/1024/1024, maxRetainedBytes/1024/1024)
+			retainedBytes/1024/1024,
+			baseline.HeapAlloc/1024/1024,
+			ms.HeapAlloc/1024/1024,
+			maxRetainedBytes/1024/1024)
 	}
 }
 

--- a/cgo_harness/cmd/parse_gap_report/main.go
+++ b/cgo_harness/cmd/parse_gap_report/main.go
@@ -194,6 +194,7 @@ type runtimeStats struct {
 	ArenaFieldB                           int64         `json:"arena_field_b,omitempty"`
 	ArenaRawShapeB                        int64         `json:"arena_raw_shape_b,omitempty"`
 	ArenaRawShapeChildB                   int64         `json:"arena_raw_shape_child_b,omitempty"`
+	ArenaRawShapeHashCacheB               int64         `json:"arena_raw_shape_hash_cache_b,omitempty"`
 	ArenaCapacityWaste                    uint64        `json:"arena_capacity_waste,omitempty"`
 	FinalChildRangeDrains                 uint64        `json:"final_child_range_drains,omitempty"`
 	PublicNodesMaterialized               uint64        `json:"public_nodes_materialized,omitempty"`
@@ -1186,6 +1187,7 @@ func statsFromGoTree(r *runner, tree *gotreesitter.Tree, queryCaptures, cursorNo
 			breakdown.FieldSourceBytesAllocated
 		stats.ArenaRawShapeB = breakdown.RawShapeBytesAllocated
 		stats.ArenaRawShapeChildB = breakdown.RawShapeChildBytesAllocated
+		stats.ArenaRawShapeHashCacheB = breakdown.RawShapeHashCacheBytesAllocated
 		stats.ArenaLiveB = arenaLiveBytes(breakdown, rt.ExternalScannerCheckpointBytesAllocated)
 		stats.ArenaCapacityWaste = breakdown.NodeCapacityWaste
 		stats.MergeScratchAllocatedB = breakdown.MergeScratchBytesAllocated
@@ -1289,6 +1291,7 @@ func arenaLiveBytes(b gotreesitter.ArenaBreakdown, externalScannerCheckpointByte
 		b.PendingChildEntryBytesAllocated +
 		b.RawShapeBytesAllocated +
 		b.RawShapeChildBytesAllocated +
+		b.RawShapeHashCacheBytesAllocated +
 		b.FinalChildSidecarBytesAllocated +
 		b.CompactCheckpointLeafBytesAllocated +
 		b.ChildSliceBytesAllocated +

--- a/cgo_harness/cmd/parse_gap_report/main_test.go
+++ b/cgo_harness/cmd/parse_gap_report/main_test.go
@@ -317,6 +317,7 @@ func TestArenaLiveBytesIncludesEveryRuntimeArenaComponent(t *testing.T) {
 		PendingChildEntryBytesAllocated:     5,
 		RawShapeBytesAllocated:              6,
 		RawShapeChildBytesAllocated:         7,
+		RawShapeHashCacheBytesAllocated:     13,
 		FinalChildSidecarBytesAllocated:     8,
 		CompactCheckpointLeafBytesAllocated: 9,
 		ChildSliceBytesAllocated:            10,
@@ -325,7 +326,7 @@ func TestArenaLiveBytesIncludesEveryRuntimeArenaComponent(t *testing.T) {
 	}
 	runtime := gotreesitter.ParseRuntime{
 		ExternalScannerCheckpointBytesAllocated: 13,
-		ArenaBytesAllocated:                     105,
+		ArenaBytesAllocated:                     118,
 	}
 	if got, want := arenaLiveBytes(breakdown, runtime.ExternalScannerCheckpointBytesAllocated), runtime.ArenaBytesAllocated; got != want {
 		t.Fatalf("arenaLiveBytes = %d, runtime arena total = %d", got, want)

--- a/glr.go
+++ b/glr.go
@@ -993,9 +993,11 @@ func materializingShapeEntryHashWithScratch(scratch *glrMergeScratch, h uint64, 
 		scratch.arena == nil {
 		return h
 	}
-	if shape, ok := rawShapeForStackEntry(scratch.arena, entry); ok {
-		h ^= shape.contentHash
-		h *= gssHashPrime
+	if ref := stackEntryRawShapeRef(entry); ref != 0 {
+		if shapeHash, ok := scratch.arena.rawShapeHash(ref); ok {
+			h ^= shapeHash
+			h *= gssHashPrime
+		}
 	}
 	return h
 }
@@ -3642,9 +3644,11 @@ func stackEntryPayloadsEquivalentIgnoringDynamicWithScratch(scratch *glrMergeScr
 			scratch.language != nil &&
 			scratch.language.ExactStackNodeEquivalenceCertified &&
 			scratch.arena != nil {
-			aShape, aOK := rawShapeForStackEntry(scratch.arena, a)
-			bShape, bOK := rawShapeForStackEntry(scratch.arena, b)
-			if aOK && bOK && aShape.contentHash != bShape.contentHash {
+			aRef := stackEntryRawShapeRef(a)
+			bRef := stackEntryRawShapeRef(b)
+			aHash, aOK := scratch.arena.rawShapeHash(aRef)
+			bHash, bOK := scratch.arena.rawShapeHash(bRef)
+			if aOK && bOK && aHash != bHash {
 				return false
 			}
 		}

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -1914,13 +1914,13 @@ func forestRawStackEntriesExactEqualRec(arena *nodeArena, a, b stackEntry, depth
 	if !stackEntryHasNode(a) {
 		return forestRawEqual
 	}
-	aShape, aHasShape := rawShapeForStackEntry(arena, a)
-	bShape, bHasShape := rawShapeForStackEntry(arena, b)
+	_, aHasShape := rawShapeForStackEntry(arena, a)
+	_, bHasShape := rawShapeForStackEntry(arena, b)
 	if aHasShape != bHasShape {
 		return forestRawUnknown
 	}
 	if aHasShape {
-		return forestRawShapesExactEqualRec(arena, aShape, bShape, depth+1)
+		return forestRawShapesExactEqualRec(arena, stackEntryRawShapeRef(a), stackEntryRawShapeRef(b), depth+1)
 	}
 	if stackEntryNodeSymbol(a) != stackEntryNodeSymbol(b) ||
 		stackEntryNodeStartByte(a) != stackEntryNodeStartByte(b) ||
@@ -1933,17 +1933,27 @@ func forestRawStackEntriesExactEqualRec(arena *nodeArena, a, b stackEntry, depth
 	return forestRawEqual
 }
 
-func forestRawShapesExactEqualRec(arena *nodeArena, a, b *rawShape, depth int) forestRawEquality {
-	if arena == nil || a == nil || b == nil || depth > maxTreeWalkDepth {
+func forestRawShapesExactEqualRec(arena *nodeArena, aRef, bRef rawShapeRef, depth int) forestRawEquality {
+	if arena == nil || aRef == 0 || bRef == 0 || depth > maxTreeWalkDepth {
 		return forestRawUnknown
 	}
-	if a.symbol != b.symbol || a.productionID != b.productionID || a.childCount != b.childCount {
+	a, aOK := arena.rawShapeForRef(aRef)
+	b, bOK := arena.rawShapeForRef(bRef)
+	if !aOK || !bOK {
+		return forestRawUnknown
+	}
+	if a.symbol != b.symbol || a.productionID != b.productionID || a.childCount() != b.childCount() {
 		return forestRawDifferent
 	}
-	if a.contentHash != b.contentHash {
-		// contentHash folds in strictly more than this function inspects
+	aHash, aHashOK := arena.rawShapeHash(aRef)
+	bHash, bHashOK := arena.rawShapeHash(bRef)
+	if !aHashOK || !bHashOK {
+		return forestRawUnknown
+	}
+	if aHash != bHash {
+		// The 64-bit digest folds in strictly more than this function inspects
 		// (symbol, productionID, childCount, and every descendant's symbol,
-		// span and contentHash — see rawShapeComputeContentHash), so a
+		// span and digest — see rawShapeComputeContentHash), so a
 		// mismatch proves the subtrees differ somewhere without descending.
 		// This is the fast path on shapes with many raw-distinct alternatives
 		// (the common case here): only a genuine hash MATCH falls through to
@@ -1953,7 +1963,7 @@ func forestRawShapesExactEqualRec(arena *nodeArena, a, b *rawShape, depth int) f
 	}
 	aChildren := arena.rawShapeChildren(a)
 	bChildren := arena.rawShapeChildren(b)
-	if len(aChildren) != int(a.childCount) || len(bChildren) != int(b.childCount) || len(aChildren) != len(bChildren) {
+	if len(aChildren) != a.childCount() || len(bChildren) != b.childCount() || len(aChildren) != len(bChildren) {
 		return forestRawUnknown
 	}
 	for i := range aChildren {
@@ -1979,12 +1989,7 @@ func forestRawShapesExactEqualRec(arena *nodeArena, a, b *rawShape, depth int) f
 			}
 			continue
 		}
-		aChild, aOK := arena.rawShapeForRef(aRef)
-		bChild, bOK := arena.rawShapeForRef(bRef)
-		if !aOK || !bOK {
-			return forestRawUnknown
-		}
-		if eq := forestRawShapesExactEqualRec(arena, aChild, bChild, depth+1); eq != forestRawEqual {
+		if eq := forestRawShapesExactEqualRec(arena, aRef, bRef, depth+1); eq != forestRawEqual {
 			return eq
 		}
 	}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -3240,7 +3240,7 @@ func (p *Parser) compareRawStackEntriesRec(arena *nodeArena, a, b stackEntry, de
 	ac, bc := stackEntryNodeChildCount(a), stackEntryNodeChildCount(b)
 	if aHasShape && bHasShape {
 		as, bs = aShape.symbol, bShape.symbol
-		ac, bc = int(aShape.childCount), int(bShape.childCount)
+		ac, bc = aShape.childCount(), bShape.childCount()
 	}
 	if as != bs {
 		if as < bs {
@@ -3275,7 +3275,7 @@ func (p *Parser) compareRawStackEntriesRec(arena *nodeArena, a, b stackEntry, de
 			continue
 		}
 		if rawStackEntryChildPairHashEqual(arena, achild, bchild) {
-			// Bottom-up fingerprint match (see rawShape.contentHash /
+			// Bottom-up fingerprint match (see the raw-shape hash /
 			// rawShapeComputeContentHash): this child's subtree is treated as
 			// interchangeable with its counterpart under the same
 			// negligible-collision hash tradeoff documented on
@@ -3303,9 +3303,9 @@ func (p *Parser) compareRawStackEntriesRec(arena *nodeArena, a, b stackEntry, de
 // equal (cmp==0) under compareRawStackEntriesRec, in O(1) and without walking
 // their subtrees. This is not a proof of equality — it is a probabilistic
 // shortcut: it requires BOTH sides to carry a captured raw shape with
-// matching symbol, childCount and contentHash (see
+// matching symbol, child count, and shape hash (see
 // rawShapeComputeContentHash), AND matching start/end spans on the entries
-// themselves, and then accepts that combination as sufficient. contentHash is
+// themselves, and then accepts that combination as sufficient. The shape hash is
 // a 64-bit FNV-1a fingerprint, so a match here carries the same
 // negligible-collision (~2^-64) risk of a false positive that the package's
 // existing GSS merge-key hashing already accepts for equivalence decisions
@@ -3334,7 +3334,9 @@ func rawStackEntryChildPairHashEqual(arena *nodeArena, a, b stackEntry) bool {
 	if !bHasShape {
 		return false
 	}
-	if aShape.symbol != bShape.symbol || aShape.childCount != bShape.childCount || aShape.contentHash != bShape.contentHash {
+	aHash, aHashOK := arena.rawShapeHash(stackEntryRawShapeRef(a))
+	bHash, bHashOK := arena.rawShapeHash(stackEntryRawShapeRef(b))
+	if !aHashOK || !bHashOK || aShape.symbol != bShape.symbol || aShape.childCount() != bShape.childCount() || aHash != bHash {
 		return false
 	}
 	return stackEntryNodeStartByte(a) == stackEntryNodeStartByte(b) && stackEntryNodeEndByte(a) == stackEntryNodeEndByte(b)

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -256,7 +256,7 @@ func nativeRecoveredStructureHasIsolatedErrorReceipt(root *Node) bool {
 		return false
 	}
 	shape, ok := root.ownerArena.rawShapeForRef(root.rawShape)
-	if !ok || shape.symbol != root.symbol || int(shape.childCount) != resultChildCount(root) {
+	if !ok || shape.symbol != root.symbol || shape.childCount() != resultChildCount(root) {
 		return false
 	}
 	rawChildren := root.ownerArena.rawShapeChildren(shape)

--- a/parser_runtime_test.go
+++ b/parser_runtime_test.go
@@ -1210,6 +1210,7 @@ func assertParseRuntimeArenaBreakdown(t *testing.T, tree *Tree, rt ParseRuntime)
 		arenaBreakdown.PendingChildEntryBytesAllocated +
 		arenaBreakdown.RawShapeBytesAllocated +
 		arenaBreakdown.RawShapeChildBytesAllocated +
+		arenaBreakdown.RawShapeHashCacheBytesAllocated +
 		arenaBreakdown.FinalChildSidecarBytesAllocated +
 		arenaBreakdown.CompactCheckpointLeafBytesAllocated +
 		arenaBreakdown.ChildSliceBytesAllocated +

--- a/raw_shape.go
+++ b/raw_shape.go
@@ -7,55 +7,28 @@ type rawShapeRef uint32
 const rawShapeRefIndexBits = 20
 
 type rawShape struct {
-	// Keep the 8-byte fields first. This holds the sidecar header to 24 bytes
-	// on 64-bit targets instead of 32 bytes lost to alignment padding; large
-	// GLR parses retain millions of these headers.
+	// The child count is encoded in the range's low 16 bits, so do not store it
+	// again. Large GLR parses retain millions of these headers.
 	childRange   rawShapeChildRange
 	symbol       Symbol
 	productionID uint16
-	childCount   uint16
-	// contentHash is a bottom-up structural fingerprint over (symbol,
-	// productionID, childCount) plus every child's (symbol, span, and — when
-	// the child itself has a captured raw shape — the child's own
-	// contentHash). Computed once in captureRawShape, when the shape is
-	// captured (children are always captured strictly before their parent, so
-	// every child's contentHash is already populated — this is one linear
-	// pass, not a recursive walk).
-	//
-	// The two existing consumers trust this hash in OPPOSITE directions:
-	//
-	//   - forestRawShapesExactEqualRec (glr_forest.go) trusts a MISMATCH: a
-	//     different hash proves the two shapes are not exactly
-	//     interchangeable (the contrapositive of "equal inputs hash
-	//     equally"), so it fast-rejects without a walk. A MATCH is never
-	//     trusted by itself — it still falls through to the existing exact
-	//     recursive walk as a collision safety net. So this consumer's use of
-	//     the hash never changes what it returns, only whether a fast-reject
-	//     or a full walk produces that answer; it is a provably
-	//     answer-preserving optimization.
-	//
-	//   - rawStackEntryChildPairHashEqual (parser_reduce.go, feeding
-	//     compareRawStackEntriesRec) trusts a MATCH: hash equality plus
-	//     matching symbol/childCount/span is treated as sufficient on its own
-	//     to skip the walk and declare the pair equal, with no fallback
-	//     verification. This is a probabilistic shortcut, not a proof (see
-	//     that function's doc comment) — it accepts the same
-	//     negligible-collision (~2^-64 FNV-1a) tradeoff already used for this
-	//     package's GSS merge-key hashing (see rawShapeComputeContentHash
-	//     below and glr_gss.go). A MISMATCH there falls through to the real
-	//     recursive comparison, unaffected. This direction is the inverse of
-	//     forestRawShapesExactEqualRec's, so a hash collision could change
-	//     this consumer's answer for one child pair; the effect is limited to
-	//     ambiguity tie-break/ordering choices and never touches memory
-	//     safety.
-	//
-	// See the forest link-cap eviction path (glr_forest.go
-	// forestCapReplacementIndex): on shapes with a long shared prefix (e.g.
-	// C# designer-style repeated-statement blocks), that path re-derives the
-	// same "is this exactly the resident's shape" question for every new
-	// alternative, and without this fingerprint each question re-walks the
-	// whole accumulated subtree.
-	contentHash uint64
+}
+
+// rawShapeHashCacheEntry keeps the original 64-bit shape fingerprint outside
+// the per-shape header. A direct-mapped cache bounds its memory cost while
+// preserving the old hash width and collision behavior.
+type rawShapeHashCacheEntry struct {
+	ref  rawShapeRef
+	hash uint64
+}
+
+const rawShapeHashCacheSize = 1 << 15
+
+func rawShapeHashCacheBytesForCap(n int) int64 {
+	if n <= 0 {
+		return 0
+	}
+	return int64(n) * int64(unsafe.Sizeof(rawShapeHashCacheEntry{}))
 }
 
 type rawShapeChild struct {
@@ -186,6 +159,7 @@ func (a *nodeArena) reclaimRawShapeStorage() {
 	// regression on ordinary files.
 	a.resetRawShapeSlabs()
 	a.resetRawShapeChildSlabs()
+	a.resetRawShapeHashCache()
 	a.recomputeAllocatedBytes()
 }
 
@@ -247,6 +221,17 @@ func (r rawShapeChildRange) start() int {
 	return int((uint64(r) >> 16) & 0xffffffff)
 }
 
+func (r rawShapeChildRange) count() int {
+	return int(uint16(uint64(r)))
+}
+
+func (s *rawShape) childCount() int {
+	if s == nil {
+		return 0
+	}
+	return s.childRange.count()
+}
+
 func (a *nodeArena) rawShapeForRef(ref rawShapeRef) (*rawShape, bool) {
 	if a == nil || ref == 0 {
 		return nil, false
@@ -263,13 +248,55 @@ func (a *nodeArena) rawShapeForRef(ref rawShapeRef) (*rawShape, bool) {
 	return &slab.data[entryIdx], true
 }
 
+func rawShapeHashCacheIndex(ref rawShapeRef) int {
+	// Multiplication spreads sequential references across the direct-mapped
+	// cache while keeping lookup to one integer operation.
+	return int((uint32(ref) * 2654435761) & (rawShapeHashCacheSize - 1))
+}
+
+func (a *nodeArena) ensureRawShapeHashCache() {
+	if a == nil || len(a.rawShapeHashCache) != 0 {
+		return
+	}
+	a.rawShapeHashCache = make([]rawShapeHashCacheEntry, rawShapeHashCacheSize)
+	a.allocatedBytes += rawShapeHashCacheBytesForCap(cap(a.rawShapeHashCache))
+}
+
+func (a *nodeArena) storeRawShapeHash(ref rawShapeRef, hash uint64) {
+	if a == nil || ref == 0 {
+		return
+	}
+	a.ensureRawShapeHashCache()
+	a.rawShapeHashCache[rawShapeHashCacheIndex(ref)] = rawShapeHashCacheEntry{ref: ref, hash: hash}
+}
+
+func (a *nodeArena) rawShapeHash(ref rawShapeRef) (uint64, bool) {
+	if a == nil || ref == 0 {
+		return 0, false
+	}
+	if len(a.rawShapeHashCache) != 0 {
+		cached := a.rawShapeHashCache[rawShapeHashCacheIndex(ref)]
+		if cached.ref == ref {
+			return cached.hash, true
+		}
+	}
+	shape, ok := a.rawShapeForRef(ref)
+	if !ok {
+		return 0, false
+	}
+	children := a.rawShapeChildren(shape)
+	hash := rawShapeComputeContentHash(a, ref, shape.symbol, shape.productionID, uint16(shape.childCount()), children)
+	a.storeRawShapeHash(ref, hash)
+	return hash, true
+}
+
 func (a *nodeArena) rawShapeChildren(shape *rawShape) []rawShapeChild {
-	if a == nil || shape == nil || shape.childCount == 0 || shape.childRange == 0 {
+	if a == nil || shape == nil || shape.childCount() == 0 || shape.childRange == 0 {
 		return nil
 	}
 	slabIdx := shape.childRange.slabIndex()
 	start := shape.childRange.start()
-	count := int(shape.childCount)
+	count := shape.childCount()
 	if slabIdx < 0 || slabIdx >= len(a.rawShapeChildSlabs) {
 		return nil
 	}
@@ -360,12 +387,11 @@ func (p *Parser) captureRawShape(gssScratch *gssScratch, arena *nodeArena, symbo
 	if count > 0xffff {
 		count = 0xffff
 	}
-	shape.childCount = uint16(count)
 	if count == 0 {
 		return ref
 	}
 	childRange := arena.allocRawShapeChildren(count)
-	children := arena.rawShapeChildren(&rawShape{childRange: childRange, childCount: uint16(count)})
+	children := arena.rawShapeChildren(&rawShape{childRange: childRange})
 	out := 0
 	for i := start; i < end && out < count; i++ {
 		entry := entries[i]
@@ -376,21 +402,24 @@ func (p *Parser) captureRawShape(gssScratch *gssScratch, arena *nodeArena, symbo
 		out++
 	}
 	shape.childRange = childRange
-	shape.contentHash = rawShapeComputeContentHash(arena, symbol, productionID, uint16(count), children[:out])
+	// Cache the same 64-bit digest used by the previous inline field. The
+	// bounded cache may evict it later, so rawShapeHash can recompute it from
+	// the lossless sidecar without changing collision behavior.
+	arena.storeRawShapeHash(ref, rawShapeComputeContentHash(arena, ref, symbol, productionID, uint16(count), children[:out]))
 	return ref
 }
 
 // rawShapeComputeContentHash builds the bottom-up structural fingerprint
-// documented on rawShape.contentHash. It folds in the same fields the exact
+// documented on the raw-shape hash cache. It folds in the same fields the exact
 // raw-shape comparators inspect (symbol, productionID, childCount, and per
 // child: whether it has a node, its symbol, its span, and — recursively —
-// its own already-computed contentHash when it has a captured shape,
+// its own already-computed hash when it has a captured shape,
 // otherwise its own child count as a coarse stand-in for a leaf's shape).
 // Reusing the package's existing 64-bit FNV-1a combiner (gssHashSeed/
 // gssHashPrime/gssNilNodeSentinel, glr_gss.go) keeps this consistent with the
 // GSS merge-key hashing that already accepts the same negligible-collision
 // tradeoff for equivalence decisions.
-func rawShapeComputeContentHash(arena *nodeArena, symbol Symbol, productionID uint16, childCount uint16, children []rawShapeChild) uint64 {
+func rawShapeComputeContentHash(arena *nodeArena, parentRef rawShapeRef, symbol Symbol, productionID uint16, childCount uint16, children []rawShapeChild) uint64 {
 	h := gssHashSeed
 	h ^= uint64(symbol)
 	h *= gssHashPrime
@@ -409,9 +438,9 @@ func rawShapeComputeContentHash(arena *nodeArena, symbol Symbol, productionID ui
 		h *= gssHashPrime
 		h ^= (uint64(stackEntryNodeStartByte(entry)) << 32) | uint64(stackEntryNodeEndByte(entry))
 		h *= gssHashPrime
-		if ref := children[i].shapeRef(); ref != 0 && arena != nil {
-			if childShape, ok := arena.rawShapeForRef(ref); ok {
-				h ^= childShape.contentHash
+		if ref := children[i].shapeRef(); ref != 0 && ref < parentRef && arena != nil {
+			if childHash, ok := arena.rawShapeHash(ref); ok {
+				h ^= childHash
 				h *= gssHashPrime
 				continue
 			}
@@ -507,7 +536,7 @@ func rawStackEntryContainsShape(arena *nodeArena, entry stackEntry, depth int) b
 		return false
 	}
 	if shape, ok := rawShapeForStackEntry(arena, entry); ok {
-		if shape.childCount > 0 {
+		if shape.childCount() > 0 {
 			return true
 		}
 	}

--- a/raw_shape_diag.go
+++ b/raw_shape_diag.go
@@ -122,7 +122,7 @@ func (p *Parser) emitRawShapeDiagEntry(arena *nodeArena, label string, entry sta
 	shapeChildCount := -1
 	if shape, ok := rawShapeForStackEntry(arena, entry); ok {
 		shapeProductionID = shape.productionID
-		shapeChildCount = int(shape.childCount)
+		shapeChildCount = shape.childCount()
 	}
 	fmt.Fprintf(os.Stderr,
 		"GLR-RAW-SHAPE %s depth=%d symbol=%d name=%s span=%d:%d children=%d shape_ref=%d shape_pid=%d shape_children=%d named=%t meta_named=%t visible=%t hidden=%t invisible=%t extra=%t missing=%t error=%t kind=%s\n",
@@ -189,7 +189,7 @@ func (p *Parser) emitRawShapeDiagEntry(arena *nodeArena, label string, entry sta
 
 func rawShapeDiagEntryChildCount(arena *nodeArena, entry stackEntry) int {
 	if shape, ok := rawShapeForStackEntry(arena, entry); ok {
-		return int(shape.childCount)
+		return shape.childCount()
 	}
 	return stackEntryNodeChildCount(entry)
 }

--- a/raw_shape_reclaim_test.go
+++ b/raw_shape_reclaim_test.go
@@ -20,7 +20,6 @@ func TestReclaimRawShapeStorageClearsArenaPayloadRefs(t *testing.T) {
 		t.Fatal("allocRawShape returned no shape")
 	}
 	shape.childRange = arena.allocRawShapeChildren(1)
-	shape.childCount = 1
 	shapeLimit := maxRetainedRawShapeCapacityForClass(arena.class)
 	for i := 1; i < shapeLimit+defaultRawShapeSlabCap(arena.class); i++ {
 		if _, allocated := arena.allocRawShape(); allocated == nil {
@@ -105,12 +104,12 @@ func TestParseReclaimsRawShapeStorageAfterAccounting(t *testing.T) {
 		t.Fatalf("MaxStacksSeen = %d, want > 1 (this test requires a genuinely forking parse)", rt.MaxStacksSeen)
 	}
 	breakdown := assertParseRuntimeArenaBreakdown(t, tree, rt)
-	parseRawBytes := breakdown.RawShapeBytesAllocated + breakdown.RawShapeChildBytesAllocated
+	parseRawBytes := breakdown.RawShapeBytesAllocated + breakdown.RawShapeChildBytesAllocated + breakdown.RawShapeHashCacheBytesAllocated
 	if parseRawBytes == 0 {
 		t.Fatal("parse-time raw-shape bytes = 0, want captured allocation once the parse has forked")
 	}
 	assertTreeRawShapeStorageReclaimed(t, tree)
-	retainedRawBytes := tree.arena.rawShapeBytesAllocated() + tree.arena.rawShapeChildBytesAllocated()
+	retainedRawBytes := tree.arena.rawShapeBytesAllocated() + tree.arena.rawShapeChildBytesAllocated() + tree.arena.rawShapeHashCacheBytesAllocated()
 	if got, want := tree.ParseRuntime().ArenaBytesAllocated-tree.arena.allocatedBytes, parseRawBytes-retainedRawBytes; got != want {
 		t.Fatalf("retained arena reduction = %d, want reclaimed raw-shape allocation %d", got, want)
 	}
@@ -141,12 +140,12 @@ func TestParseReclaimsRawShapeStorageAccountsForZeroOnSingleStackParse(t *testin
 		t.Fatalf("MaxStacksSeen = %d, want <= 1 (arithmetic grammar has no GLR conflicts)", rt.MaxStacksSeen)
 	}
 	breakdown := assertParseRuntimeArenaBreakdown(t, tree, rt)
-	parseRawBytes := breakdown.RawShapeBytesAllocated + breakdown.RawShapeChildBytesAllocated
+	parseRawBytes := breakdown.RawShapeBytesAllocated + breakdown.RawShapeChildBytesAllocated + breakdown.RawShapeHashCacheBytesAllocated
 	if parseRawBytes != 0 {
 		t.Fatalf("parse-time raw-shape bytes = %d, want 0 on a pure single-stack parse (elision should skip every capture)", parseRawBytes)
 	}
 	assertTreeRawShapeStorageReclaimed(t, tree)
-	retainedRawBytes := tree.arena.rawShapeBytesAllocated() + tree.arena.rawShapeChildBytesAllocated()
+	retainedRawBytes := tree.arena.rawShapeBytesAllocated() + tree.arena.rawShapeChildBytesAllocated() + tree.arena.rawShapeHashCacheBytesAllocated()
 	if got, want := tree.ParseRuntime().ArenaBytesAllocated-tree.arena.allocatedBytes, parseRawBytes-retainedRawBytes; got != want {
 		t.Fatalf("retained arena reduction = %d, want reclaimed raw-shape allocation %d", got, want)
 	}
@@ -245,10 +244,10 @@ func BenchmarkReturnedTreeRawShapeRetention(b *testing.B) {
 			b.Fatal(err)
 		}
 		if breakdown, ok := tree.ArenaBreakdown(); ok {
-			parseRawBytes += breakdown.RawShapeBytesAllocated + breakdown.RawShapeChildBytesAllocated
+			parseRawBytes += breakdown.RawShapeBytesAllocated + breakdown.RawShapeChildBytesAllocated + breakdown.RawShapeHashCacheBytesAllocated
 		}
 		if tree.arena != nil {
-			retainedRawBytes += tree.arena.rawShapeBytesAllocated() + tree.arena.rawShapeChildBytesAllocated()
+			retainedRawBytes += tree.arena.rawShapeBytesAllocated() + tree.arena.rawShapeChildBytesAllocated() + tree.arena.rawShapeHashCacheBytesAllocated()
 		}
 		tree.Release()
 	}

--- a/raw_shape_test.go
+++ b/raw_shape_test.go
@@ -17,7 +17,7 @@ const (
 )
 
 func TestRawShapeHeaderLayoutStaysCompact(t *testing.T) {
-	if got, want := unsafe.Sizeof(rawShape{}), uintptr(24); got != want {
+	if got, want := unsafe.Sizeof(rawShape{}), uintptr(16); got != want {
 		t.Fatalf("rawShape header size = %d bytes, want %d", got, want)
 	}
 	if got, want := unsafe.Sizeof(rawShapeChild{}), uintptr(16); got != want {
@@ -37,6 +37,36 @@ func TestRawShapeChildPacksShapeRefAndRestoresCurrentState(t *testing.T) {
 	}
 	if got := entry.state; got != 41 {
 		t.Fatalf("restored state = %d, want current node state 41", got)
+	}
+}
+
+func TestRawShapeHashCacheRecomputesAfterEviction(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser := testRawShapeParser()
+
+	leaf := newLeafNodeInArena(arena, 3, true, 0, 1, Point{}, Point{Column: 1})
+	ref := parser.captureRawShape(nil, arena, 1, 0, []stackEntry{newStackEntryNode(0, leaf)}, 0, 1)
+	if ref == 0 {
+		t.Fatal("captureRawShape returned no reference")
+	}
+	want, ok := arena.rawShapeHash(ref)
+	if !ok {
+		t.Fatal("rawShapeHash failed before eviction")
+	}
+
+	// Consecutive references cover every slot because the cache multiplier is
+	// odd. Use references outside the arena so no real shape is overwritten.
+	const fakeRefBase = rawShapeRef(2 << 20)
+	for i := 0; i < rawShapeHashCacheSize; i++ {
+		arena.storeRawShapeHash(fakeRefBase+rawShapeRef(i), uint64(i+1))
+	}
+	got, ok := arena.rawShapeHash(ref)
+	if !ok {
+		t.Fatal("rawShapeHash failed after eviction")
+	}
+	if got != want {
+		t.Fatalf("recomputed raw-shape hash = %#x, want %#x", got, want)
 	}
 }
 
@@ -1460,7 +1490,7 @@ func TestRawShapeRebuiltAcceptRootUsesSplicedChildren(t *testing.T) {
 	if !ok {
 		t.Fatal("rebuilt root raw shape missing")
 	}
-	if got := int(shape.childCount); got != 2 {
+	if got := shape.childCount(); got != 2 {
 		t.Fatalf("rebuilt root raw child count = %d, want 2", got)
 	}
 }

--- a/tree.go
+++ b/tree.go
@@ -1324,6 +1324,7 @@ type ArenaBreakdown struct {
 	PendingChildEntryBytesAllocated     int64
 	RawShapeBytesAllocated              int64
 	RawShapeChildBytesAllocated         int64
+	RawShapeHashCacheBytesAllocated     int64
 	FinalChildSidecarBytesAllocated     int64
 	CompactCheckpointLeafBytesAllocated int64
 	PendingChildEntriesAllocated        uint64


### PR DESCRIPTION
## Summary

- Reduce each raw-shape header from 24 bytes to 16 bytes.
- Derive child count from the existing child-range encoding.
- Preserve the existing 64-bit shape fingerprint.
- Store fingerprints in a bounded direct-mapped cache.
- Recompute fingerprints after cache eviction.
- Report cache memory in arena diagnostics.

## Scope

This tranche targets parser-side raw-shape storage during ambiguous recovery. It does not change public tree ownership, normalization routes, or compact result storage.

## Test gate correction

- Measure the arena retention test against a pre-parse heap baseline.
- Clear parser and source references before garbage collection.
- Isolate suite allocations left by the existing Swift recovery witness lane.
- Change no parser behavior and claim no performance credit.

## Evidence

- Focused raw-shape and reclamation tests pass on the host.
- The same focused tests pass in Docker.
- Parse-gap report accounting tests pass with the cache field.
- C# issue 454 convergence tests pass in Docker.
- C# real-corpus parity remains at the current baseline: 24/25 no-error, 20/25 S-expression, and 20/25 deep parity.
- The 20-seed C# recovery benchmark reports 315.5 MiB to 308.5 MiB per operation, a 2.22% reduction.
- The same benchmark reports 4,638 to 4,635 allocations per operation.
- Timing trends from 1.258 seconds to 1.236 seconds per operation, but the result is not significant.
- The combined 20-seed benchmark set shows host drift, so this PR claims no broad timing credit.

## Safety

- Cache memory is included in arena accounting.
- Reclamation clears cache entries and all raw-shape references.
- Cache eviction has a focused recomputation test.
- Hash width and collision behavior remain unchanged.

Refs: universal-parser-frontier Q5 raw-shape storage tranche.
