### PR TITLE
Close B14 parser-core hygiene gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ Thumbs.db
 
 # Private working notes
 .claude/
+.codex/
 docs/blog-outlines/
 docs/plans/
 docs/superpowers/

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -6,8 +6,9 @@
 // (memory budget, deadline, cancellation) bounds a large input instead of a
 // source-length eligibility decline.
 //
-// The engine consumes a dependency-neutral TableView. It does not own a
-// lexer, an external-scanner election, recovery, retries, or included
+// The engine consumes a dependency-neutral TableView. It owns compact stack
+// advancement and the admitted error-region recovery stages. It does not own
+// lexer selection, external-scanner election, retry policy, or included
 // ranges. Incremental parsing stays on the production engine.
 //
 // The engine fails closed. A decline at any eligibility check, or during


### PR DESCRIPTION
## Summary

- Ignore private `.codex/` working files.
- Align the compact parser package comment with its current ownership.

## Verification

- `GOWORK=off go test ./internal/parsercorephase0 -count=1`
- `git diff --check origin/main...HEAD`

## Campaign

This PR contains the B14 hygiene tranche only. It changes no parser behavior,
benchmark code, or performance claim. It supports the universal parser
frontier plan and remains subject to the normal review and continuous
integration gates.
