### PR TITLE
update(harness,diagnostics,docs): Update T0 harness, canonical routing, and compact diagnostics

### DIFF
--- a/grammars/java_lexer.go
+++ b/grammars/java_lexer.go
@@ -967,15 +967,6 @@ func (ts *JavaTokenSource) eofToken() gotreesitter.Token {
 	}
 }
 
-func firstNonZeroSymbol(symbols ...gotreesitter.Symbol) gotreesitter.Symbol {
-	for _, sym := range symbols {
-		if sym != 0 {
-			return sym
-		}
-	}
-	return 0
-}
-
 func isJavaIdentStart(b byte) bool {
 	return isASCIIAlpha(b) || b == '_' || b == '$'
 }

--- a/grammars/lexer_symbol_helpers.go
+++ b/grammars/lexer_symbol_helpers.go
@@ -1,0 +1,22 @@
+package grammars
+
+import (
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// This file carries lexer helpers that more than one grammar shares. It has no
+// grammar_subset build tag, so every single-language subset build keeps them.
+// A helper that lives in a language-gated file breaks each subset build that
+// selects a different language, so put shared helpers here instead.
+
+// firstNonZeroSymbol returns the first symbol in symbols that is not zero, or
+// zero when every symbol is zero. Lexers use it to pick the first symbol id
+// that the loaded grammar actually defines.
+func firstNonZeroSymbol(symbols ...gotreesitter.Symbol) gotreesitter.Symbol {
+	for _, sym := range symbols {
+		if sym != 0 {
+			return sym
+		}
+	}
+	return 0
+}

--- a/grammars/python_scanner.go
+++ b/grammars/python_scanner.go
@@ -1,4 +1,8 @@
-//go:build !grammar_subset || grammar_subset_python
+//go:build !grammar_subset || grammar_subset_python || grammar_subset_bitbake || grammar_subset_mojo || grammar_subset_starlark
+
+// The bitbake, mojo, and starlark scanners are tree-sitter-python derivatives.
+// They reuse pythonScannerState, pyDelimiter, and PythonExternalScanner, so a
+// subset build that selects any of them must compile this file too.
 
 package grammars
 

--- a/scripts/subset_build_sweep.sh
+++ b/scripts/subset_build_sweep.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Build the grammars package once per language with that language's
+# grammar_subset tag, and report every language that does not compile.
+#
+# A single-language subset build drops every other grammar's source files. A
+# shared helper that lives in a language-gated file therefore breaks each subset
+# build that selects a different language. The default CI matrix never sets
+# grammar_subset, so only this sweep finds that class of break.
+#
+# Usage:
+#   scripts/subset_build_sweep.sh            # sweep every built-in grammar
+#   scripts/subset_build_sweep.sh go java    # sweep the named grammars only
+#   JOBS=4 scripts/subset_build_sweep.sh     # set the parallelism (default 8)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+JOBS="${JOBS:-8}"
+
+if [[ $# -gt 0 ]]; then
+  langs=("$@")
+else
+  mapfile -t langs < <(
+    ls grammars/z_subset_registry_register_*.go |
+      sed 's|.*register_||; s|\.go$||' |
+      sort
+  )
+fi
+
+if [[ ${#langs[@]} -eq 0 ]]; then
+  echo "no grammars found to sweep" >&2
+  exit 2
+fi
+
+report="$(mktemp)"
+trap 'rm -f "$report"' EXIT
+
+build_one() {
+  local lang="$1"
+  local out
+  out="$(go build -tags "grammar_subset,grammar_subset_${lang}" ./grammars/ 2>&1)"
+  if [[ -n "$out" ]]; then
+    printf 'BROKEN\t%s\t%s\n' "$lang" "$(printf '%s' "$out" | grep -v '^#' | head -1)"
+  else
+    printf 'OK\t%s\t\n' "$lang"
+  fi
+}
+export -f build_one
+
+printf '%s\n' "${langs[@]}" | xargs -P "$JOBS" -I{} bash -c 'build_one "$@"' _ {} >"$report"
+
+ok_count="$(grep -c '^OK' "$report" || true)"
+broken_count="$(grep -c '^BROKEN' "$report" || true)"
+
+echo "grammar subset build sweep: ${ok_count} ok, ${broken_count} broken (of ${#langs[@]})"
+
+if [[ "$broken_count" -gt 0 ]]; then
+  echo
+  echo "broken subset builds:"
+  grep '^BROKEN' "$report" | sort | while IFS=$'\t' read -r _ lang err; do
+    printf '  %-24s %s\n' "$lang" "$err"
+  done
+  echo
+  echo "Move the missing symbol into a file with no grammar_subset tag, or widen"
+  echo "the tag on the file that defines it to cover the grammars that need it."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Upgrades the T0 card harness to v2, captures authenticated compact-runtime diagnostics, and tightens canonical parity benchmark routing. It also records current-head rechecks across multiple evidence certificates and stabilizes child-build isolation in the CGO harness.

## Changes

- Upgrade T0 card harness to v2 and introduce `cmd/t0_card_child` to collect authenticated runtime facts, admission routing deltas, and peak RSS.
- Parameterize canonical parity benchmarks behind `production` and `candidate` build tags, and validate admission counters during preflight to guarantee backend correctness.
- Move `compactRuntime` from `ParseRuntime` to `nodeArena` to preserve hot-path allocations while retaining scheduled and materialization timings for audit.
- Refactor admission route equality tests to use a typed `wantProductionErr` expectation and clarify fail-closed decline contracts in doc comments.
- Document current-head recheck outcomes for A0, B0, B15, and C0E/C0F attribution receipts without altering parser routes or grants.
- Isolate `safe.directory` Git configuration in `cgo_harness` child builds and adopt detached worktrees for reproducible test execution.
- Extract `firstNonZeroSymbol` into `grammars/lexer_symbol_helpers.go` and update subset build constraints for Python-scanner derivatives (Bitbake, Mojo, Starlark).
- Add `EvidenceRefs` to the compatibility ownership registry and enforce path validation rules for live entries.

## Testing

- Run `bash scripts/run_randomized_benchmarks.sh --output /tmp/gotreesitter-bench.txt` to establish stable performance baselines.
- Execute `bash cgo_harness/docker/run_parity_in_docker.sh -- "cd /workspace && go test ./grammargen -run '^TestResultCompatibilityOwnershipRegistry$' -count=1"` to validate registry changes.
- Run `bash cgo_harness/docker/run_single_grammar_parity.sh go` to confirm canonical parity preflight gates pass under both backend tags.
- Set `GTS_T0_CARD=1` and run `go test ./cgo_harness -run '^TestT0RuntimeFactsCard$' -v -timeout=30s` to verify the T0 child binary and receipt schema.

## Review Focus

Focus on the new T0 card receipt schema validation, the canonical backend routing assertions, and the arena-backed compact diagnostics layout.