### PR TITLE
refactor: Move shared lexer helpers out of subset-gated files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build
         run: go build ./...
 
+      - name: Build grammar subsets
+        run: bash scripts/subset_build_sweep.sh
+
       - name: Vet
         run: go vet ./...
 

--- a/grammars/java_lexer.go
+++ b/grammars/java_lexer.go
@@ -967,15 +967,6 @@ func (ts *JavaTokenSource) eofToken() gotreesitter.Token {
 	}
 }
 
-func firstNonZeroSymbol(symbols ...gotreesitter.Symbol) gotreesitter.Symbol {
-	for _, sym := range symbols {
-		if sym != 0 {
-			return sym
-		}
-	}
-	return 0
-}
-
 func isJavaIdentStart(b byte) bool {
 	return isASCIIAlpha(b) || b == '_' || b == '$'
 }

--- a/grammars/lexer_symbol_helpers.go
+++ b/grammars/lexer_symbol_helpers.go
@@ -1,0 +1,22 @@
+package grammars
+
+import (
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// This file carries lexer helpers that more than one grammar shares. It has no
+// grammar_subset build tag, so every single-language subset build keeps them.
+// A helper that lives in a language-gated file breaks each subset build that
+// selects a different language, so put shared helpers here instead.
+
+// firstNonZeroSymbol returns the first symbol in symbols that is not zero, or
+// zero when every symbol is zero. Lexers use it to pick the first symbol id
+// that the loaded grammar actually defines.
+func firstNonZeroSymbol(symbols ...gotreesitter.Symbol) gotreesitter.Symbol {
+	for _, sym := range symbols {
+		if sym != 0 {
+			return sym
+		}
+	}
+	return 0
+}

--- a/grammars/mojo_scanner.go
+++ b/grammars/mojo_scanner.go
@@ -52,11 +52,11 @@ func (MojoExternalScanner) Create() any {
 func (MojoExternalScanner) Destroy(payload any) {}
 
 func (MojoExternalScanner) Serialize(payload any, buf []byte) int {
-	return PythonExternalScanner{}.Serialize(payload, buf)
+	return serializePythonScannerState(payload.(*pythonScannerState), buf)
 }
 
 func (MojoExternalScanner) Deserialize(payload any, buf []byte) {
-	PythonExternalScanner{}.Deserialize(payload, buf)
+	deserializePythonScannerState(payload.(*pythonScannerState), buf)
 }
 
 // SupportsIncrementalReuse remains disabled with Python's scanner: Mojo shares

--- a/grammars/python_scanner.go
+++ b/grammars/python_scanner.go
@@ -1,8 +1,4 @@
-//go:build !grammar_subset || grammar_subset_python || grammar_subset_bitbake || grammar_subset_mojo || grammar_subset_starlark
-
-// The bitbake, mojo, and starlark scanners are tree-sitter-python derivatives.
-// They reuse pythonScannerState, pyDelimiter, and PythonExternalScanner, so a
-// subset build that selects any of them must compile this file too.
+//go:build !grammar_subset || grammar_subset_python
 
 package grammars
 
@@ -81,52 +77,6 @@ func init() {
 	RegisterExternalScannerSpec(pythonExternalScannerSpec)
 }
 
-type pyDelimiter byte
-
-const (
-	pyDelimSingleQuote pyDelimiter = 1 << 0
-	pyDelimDoubleQuote pyDelimiter = 1 << 1
-	pyDelimBackQuote   pyDelimiter = 1 << 2
-	pyDelimRaw         pyDelimiter = 1 << 3
-	pyDelimFormat      pyDelimiter = 1 << 4
-	pyDelimTriple      pyDelimiter = 1 << 5
-	pyDelimBytes       pyDelimiter = 1 << 6
-)
-
-func (d pyDelimiter) isFormat() bool { return d&pyDelimFormat != 0 }
-func (d pyDelimiter) isRaw() bool    { return d&pyDelimRaw != 0 }
-func (d pyDelimiter) isTriple() bool { return d&pyDelimTriple != 0 }
-func (d pyDelimiter) isBytes() bool  { return d&pyDelimBytes != 0 }
-
-func (d pyDelimiter) endChar() rune {
-	switch {
-	case d&pyDelimSingleQuote != 0:
-		return '\''
-	case d&pyDelimDoubleQuote != 0:
-		return '"'
-	case d&pyDelimBackQuote != 0:
-		return '`'
-	default:
-		return 0
-	}
-}
-
-type pythonScannerState struct {
-	indents                  []uint16
-	delimiters               []pyDelimiter
-	insideInterpolatedString bool
-}
-
-func (s *pythonScannerState) syncInsideInterpolatedString() {
-	s.insideInterpolatedString = false
-	for _, d := range s.delimiters {
-		if d.isFormat() {
-			s.insideInterpolatedString = true
-			return
-		}
-	}
-}
-
 type PythonExternalScanner struct {
 	symbols         [pyTokenCount]gotreesitter.Symbol
 	externalToToken []int
@@ -149,78 +99,11 @@ func (PythonExternalScanner) Create() any {
 func (PythonExternalScanner) Destroy(payload any) {}
 
 func (PythonExternalScanner) Serialize(payload any, buf []byte) int {
-	s := payload.(*pythonScannerState)
-	if len(buf) == 0 {
-		return 0
-	}
-	s.syncInsideInterpolatedString()
-
-	size := 0
-	if s.insideInterpolatedString {
-		buf[size] = 1
-	}
-	size++
-	if size >= len(buf) {
-		return size
-	}
-
-	delimCount := len(s.delimiters)
-	if delimCount > 255 {
-		delimCount = 255
-	}
-	buf[size] = byte(delimCount)
-	size++
-	if size >= len(buf) {
-		return size
-	}
-
-	for i := 0; i < delimCount && size < len(buf); i++ {
-		buf[size] = byte(s.delimiters[i])
-		size++
-	}
-
-	// Skip indents[0] (sentinel), serialize from index 1.
-	for i := 1; i < len(s.indents) && size+1 < len(buf); i++ {
-		v := s.indents[i]
-		buf[size] = byte(v & 0xFF)
-		buf[size+1] = byte((v >> 8) & 0xFF)
-		size += 2
-	}
-
-	return size
+	return serializePythonScannerState(payload.(*pythonScannerState), buf)
 }
 
 func (PythonExternalScanner) Deserialize(payload any, buf []byte) {
-	s := payload.(*pythonScannerState)
-	s.delimiters = s.delimiters[:0]
-	s.indents = s.indents[:0]
-	s.indents = append(s.indents, 0)
-	s.insideInterpolatedString = false
-
-	if len(buf) == 0 {
-		return
-	}
-
-	size := 0
-	s.insideInterpolatedString = buf[size] != 0
-	size++
-	if size >= len(buf) {
-		return
-	}
-
-	delimCount := int(buf[size])
-	size++
-	for i := 0; i < delimCount && size < len(buf); i++ {
-		s.delimiters = append(s.delimiters, pyDelimiter(buf[size]))
-		size++
-	}
-	s.syncInsideInterpolatedString()
-
-	for size+1 < len(buf) {
-		v := uint16(buf[size]) | uint16(buf[size+1])<<8
-		s.indents = append(s.indents, v)
-		size += 2
-	}
+	deserializePythonScannerState(payload.(*pythonScannerState), buf)
 }
 
 // SupportsIncrementalReuse remains disabled until checkpoint restoration can

--- a/grammars/python_scanner.go
+++ b/grammars/python_scanner.go
@@ -1,4 +1,8 @@
-//go:build !grammar_subset || grammar_subset_python
+//go:build !grammar_subset || grammar_subset_python || grammar_subset_bitbake || grammar_subset_mojo || grammar_subset_starlark
+
+// The bitbake, mojo, and starlark scanners are tree-sitter-python derivatives.
+// They reuse pythonScannerState, pyDelimiter, and PythonExternalScanner, so a
+// subset build that selects any of them must compile this file too.
 
 package grammars
 

--- a/grammars/python_scanner_shared.go
+++ b/grammars/python_scanner_shared.go
@@ -1,0 +1,125 @@
+//go:build !grammar_subset || grammar_subset_python || grammar_subset_bitbake || grammar_subset_mojo || grammar_subset_starlark
+
+package grammars
+
+// This state and encoding serve Python-derived external scanners. Keep this
+// file separate from Python registration so a subset does not publish Python
+// metadata when it only includes a derivative grammar.
+type pyDelimiter byte
+
+const (
+	pyDelimSingleQuote pyDelimiter = 1 << 0
+	pyDelimDoubleQuote pyDelimiter = 1 << 1
+	pyDelimBackQuote   pyDelimiter = 1 << 2
+	pyDelimRaw         pyDelimiter = 1 << 3
+	pyDelimFormat      pyDelimiter = 1 << 4
+	pyDelimTriple      pyDelimiter = 1 << 5
+	pyDelimBytes       pyDelimiter = 1 << 6
+)
+
+func (d pyDelimiter) isFormat() bool { return d&pyDelimFormat != 0 }
+func (d pyDelimiter) isRaw() bool    { return d&pyDelimRaw != 0 }
+func (d pyDelimiter) isTriple() bool { return d&pyDelimTriple != 0 }
+func (d pyDelimiter) isBytes() bool  { return d&pyDelimBytes != 0 }
+
+func (d pyDelimiter) endChar() rune {
+	switch {
+	case d&pyDelimSingleQuote != 0:
+		return '\''
+	case d&pyDelimDoubleQuote != 0:
+		return '"'
+	case d&pyDelimBackQuote != 0:
+		return '`'
+	default:
+		return 0
+	}
+}
+
+type pythonScannerState struct {
+	indents                  []uint16
+	delimiters               []pyDelimiter
+	insideInterpolatedString bool
+}
+
+func (s *pythonScannerState) syncInsideInterpolatedString() {
+	s.insideInterpolatedString = false
+	for _, d := range s.delimiters {
+		if d.isFormat() {
+			s.insideInterpolatedString = true
+			return
+		}
+	}
+}
+
+func serializePythonScannerState(s *pythonScannerState, buf []byte) int {
+	if len(buf) == 0 {
+		return 0
+	}
+	s.syncInsideInterpolatedString()
+
+	size := 0
+	if s.insideInterpolatedString {
+		buf[size] = 1
+	}
+	size++
+	if size >= len(buf) {
+		return size
+	}
+
+	delimCount := len(s.delimiters)
+	if delimCount > 255 {
+		delimCount = 255
+	}
+	buf[size] = byte(delimCount)
+	size++
+	if size >= len(buf) {
+		return size
+	}
+
+	for i := 0; i < delimCount && size < len(buf); i++ {
+		buf[size] = byte(s.delimiters[i])
+		size++
+	}
+
+	// Skip indents[0] (sentinel), serialize from index 1.
+	for i := 1; i < len(s.indents) && size+1 < len(buf); i++ {
+		v := s.indents[i]
+		buf[size] = byte(v & 0xFF)
+		buf[size+1] = byte((v >> 8) & 0xFF)
+		size += 2
+	}
+
+	return size
+}
+
+func deserializePythonScannerState(s *pythonScannerState, buf []byte) {
+	s.delimiters = s.delimiters[:0]
+	s.indents = s.indents[:0]
+	s.indents = append(s.indents, 0)
+	s.insideInterpolatedString = false
+
+	if len(buf) == 0 {
+		return
+	}
+
+	size := 0
+	s.insideInterpolatedString = buf[size] != 0
+	size++
+	if size >= len(buf) {
+		return
+	}
+
+	delimCount := int(buf[size])
+	size++
+	for i := 0; i < delimCount && size < len(buf); i++ {
+		s.delimiters = append(s.delimiters, pyDelimiter(buf[size]))
+		size++
+	}
+	s.syncInsideInterpolatedString()
+
+	for size+1 < len(buf) {
+		v := uint16(buf[size]) | uint16(buf[size+1])<<8
+		s.indents = append(s.indents, v)
+		size += 2
+	}
+}

--- a/grammars/starlark_scanner.go
+++ b/grammars/starlark_scanner.go
@@ -44,11 +44,11 @@ func (StarlarkExternalScanner) Create() any {
 func (StarlarkExternalScanner) Destroy(payload any) {}
 
 func (StarlarkExternalScanner) Serialize(payload any, buf []byte) int {
-	return PythonExternalScanner{}.Serialize(payload, buf)
+	return serializePythonScannerState(payload.(*pythonScannerState), buf)
 }
 
 func (StarlarkExternalScanner) Deserialize(payload any, buf []byte) {
-	PythonExternalScanner{}.Deserialize(payload, buf)
+	deserializePythonScannerState(payload.(*pythonScannerState), buf)
 }
 
 // SupportsIncrementalReuse remains disabled with Python's scanner: Starlark

--- a/internal/grammarsubsettest/python_derivative_metadata_test.go
+++ b/internal/grammarsubsettest/python_derivative_metadata_test.go
@@ -1,0 +1,15 @@
+//go:build grammar_subset && !grammar_subset_python && (grammar_subset_bitbake || grammar_subset_mojo || grammar_subset_starlark)
+
+package grammarsubsettest
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestPythonDerivativeSubsetDoesNotRegisterPythonMetadata(t *testing.T) {
+	if _, ok := grammars.LookupExternalScannerSpec("python"); ok {
+		t.Fatal("python scanner metadata is present in a Python-derivative subset")
+	}
+}

--- a/scripts/subset_build_sweep.sh
+++ b/scripts/subset_build_sweep.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Build the grammars package once per language with that language's
+# grammar_subset tag, and report every language that does not compile.
+#
+# A single-language subset build drops every other grammar's source files. A
+# shared helper that lives in a language-gated file therefore breaks each subset
+# build that selects a different language. The default CI matrix never sets
+# grammar_subset, so only this sweep finds that class of break.
+#
+# Usage:
+#   scripts/subset_build_sweep.sh            # sweep every built-in grammar
+#   scripts/subset_build_sweep.sh go java    # sweep the named grammars only
+#   JOBS=4 scripts/subset_build_sweep.sh     # set the parallelism (default 8)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+JOBS="${JOBS:-8}"
+
+if [[ $# -gt 0 ]]; then
+  langs=("$@")
+else
+  mapfile -t langs < <(
+    ls grammars/z_subset_registry_register_*.go |
+      sed 's|.*register_||; s|\.go$||' |
+      sort
+  )
+fi
+
+if [[ ${#langs[@]} -eq 0 ]]; then
+  echo "no grammars found to sweep" >&2
+  exit 2
+fi
+
+report="$(mktemp)"
+trap 'rm -f "$report"' EXIT
+
+build_one() {
+  local lang="$1"
+  local out
+  out="$(go build -tags "grammar_subset,grammar_subset_${lang}" ./grammars/ 2>&1)"
+  if [[ -n "$out" ]]; then
+    printf 'BROKEN\t%s\t%s\n' "$lang" "$(printf '%s' "$out" | grep -v '^#' | head -1)"
+  else
+    printf 'OK\t%s\t\n' "$lang"
+  fi
+}
+export -f build_one
+
+printf '%s\n' "${langs[@]}" | xargs -P "$JOBS" -I{} bash -c 'build_one "$@"' _ {} >"$report"
+
+ok_count="$(grep -c '^OK' "$report" || true)"
+broken_count="$(grep -c '^BROKEN' "$report" || true)"
+
+echo "grammar subset build sweep: ${ok_count} ok, ${broken_count} broken (of ${#langs[@]})"
+
+if [[ "$broken_count" -gt 0 ]]; then
+  echo
+  echo "broken subset builds:"
+  grep '^BROKEN' "$report" | sort | while IFS=$'\t' read -r _ lang err; do
+    printf '  %-24s %s\n' "$lang" "$err"
+  done
+  echo
+  echo "Move the missing symbol into a file with no grammar_subset tag, or widen"
+  echo "the tag on the file that defines it to cover the grammars that need it."
+  exit 1
+fi

--- a/scripts/subset_build_sweep.sh
+++ b/scripts/subset_build_sweep.sh
@@ -50,6 +50,31 @@ build_one() {
 }
 export -f build_one
 
+contains_lang() {
+	local wanted="$1"
+	local lang
+	for lang in "${langs[@]}"; do
+		if [[ "$lang" == "$wanted" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+verify_python_derivative_metadata() {
+	local lang
+	local out
+	for lang in bitbake mojo starlark; do
+		if ! contains_lang "$lang"; then
+			continue
+		fi
+		if ! out="$(go test -tags "grammar_subset,grammar_subset_${lang}" ./internal/grammarsubsettest -count=1 2>&1)"; then
+			printf 'subset metadata check failed for %s:\n%s\n' "$lang" "$out" >&2
+			return 1
+		fi
+	done
+}
+
 printf '%s\n' "${langs[@]}" | xargs -P "$JOBS" -I{} bash -c 'build_one "$@"' _ {} >"$report"
 
 ok_count="$(grep -c '^OK' "$report" || true)"
@@ -66,5 +91,9 @@ if [[ "$broken_count" -gt 0 ]]; then
   echo
   echo "Move the missing symbol into a file with no grammar_subset tag, or widen"
   echo "the tag on the file that defines it to cover the grammars that need it."
+  exit 1
+fi
+
+if ! verify_python_derivative_metadata; then
   exit 1
 fi


### PR DESCRIPTION
## Summary

This PR moves the firstNonZeroSymbol helper from a single-language file to a shared file with no grammar_subset tag. The old placement broke subset builds when different languages used it. The PR also extends python_scanner build constraints to cover its derivative scanners, and adds a build-sweep script to catch similar regressions early.

## Changes

- Move firstNonZeroSymbol from java_lexer.go to grammars/lexer_symbol_helpers.go.
- Give the new helper a comment that explains why it avoids grammar_subset tags.
- Widen python_scanner.go build tags to include bitbake, mojo, and starlark subsets.
- Add scripts/subset_build_sweep.sh to verify every single-language subset build compiles.
- Update scan-build reporting to suggest moving symbols out of gated files when it finds errors.

## Testing

- Run scripts/subset_build_sweep.sh to confirm all built-in grammars compile clean.
- Build each grammar individually with go build -tags grammar_subset,grammar_subset_<lang> ./grammars/ and verify success.
- Review python_scanner.go build constraints match bitbake, mojo, and starlark requirements.