### PR TITLE
release: v0.50.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.50.1] - 2026-08-14
+
+### Fixed
+
+- Restore single-language `grammar_subset` builds. Shared lexer helpers and
+  Python-derived scanner state now compile with each grammar that uses them.
+  Derivative-only builds do not register Python scanner metadata.
+
+- Add a blocking subset build sweep. Continuous integration now builds all
+  206 registered grammars with their individual `grammar_subset` tags.
+
 ## [0.50.0] - 2026-08-14
 
 ### Added
@@ -4652,7 +4663,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.50.0...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.50.1...HEAD
+[0.50.1]: https://github.com/odvcencio/gotreesitter/compare/v0.50.0...v0.50.1
 [0.50.0]: https://github.com/odvcencio/gotreesitter/compare/v0.49.0...v0.50.0
 [0.49.0]: https://github.com/odvcencio/gotreesitter/compare/v0.48.1...v0.49.0
 [0.48.1]: https://github.com/odvcencio/gotreesitter/compare/v0.48.0...v0.48.1

--- a/README.md
+++ b/README.md
@@ -789,12 +789,15 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.50.0**.
+The current release is **v0.50.1**.
 
 This release consolidates parser correctness, recovery bounds, parser-core
 bytecode, fact extraction bytecode, replay caches, randomized benchmarks, and
 V10 fleet controls. It also adds opt-in Lean 4 support and scanner corrections
 for JavaScript, TypeScript, and TSX.
+
+This patch restores single-language grammar-subset builds and checks each
+registered grammar subset in continuous integration.
 
 Detailed shipped evidence lives in [CHANGELOG.md](CHANGELOG.md). Planned minor
 releases are batched on Thursdays; the immutable-tag process and exceptions are


### PR DESCRIPTION
## Release metadata

Prepare the urgent `v0.50.1` patch release.

## Qualifying incident

Single-language `grammar_subset` builds fail in `v0.50.0`. Shared lexer and scanner symbols are unavailable in selected subsets.

## Why publish now

Downstream constrained builds cannot compile. PR #724 restores those supported build paths and adds a blocking sweep.

## Validation

- `go test ./cmd/releasegate -count=1` in Docker
- PR #724 full CI, including the 206-grammar subset sweep