### PR TITLE
fix(glr): provision dense marks after GSS slab growth

### DIFF
--- a/glr_gss.go
+++ b/glr_gss.go
@@ -280,27 +280,59 @@ func (s *gssScratch) ensureReachMarks() {
 	}
 }
 
-func reachMarkInGSSSlab(slab *gssNodeSlab, nodePtr, nodeSize uintptr) (*uint32, bool) {
-	if slab == nil || len(slab.data) == 0 || len(slab.reachMarks) != len(slab.data) {
-		return nil, false
+func gssNodeIndexInSlab(slab *gssNodeSlab, nodePtr, nodeSize uintptr) (int, bool) {
+	if slab == nil || len(slab.data) == 0 || nodeSize == 0 {
+		return 0, false
 	}
 	base := uintptr(unsafe.Pointer(&slab.data[0]))
 	if nodePtr < base {
-		return nil, false
+		return 0, false
 	}
 	delta := nodePtr - base
 	if delta%nodeSize != 0 {
-		return nil, false
+		return 0, false
 	}
 	index := delta / nodeSize
 	if index >= uintptr(len(slab.data)) {
+		return 0, false
+	}
+	return int(index), true
+}
+
+func (s *gssScratch) ensureReachMarksForSlab(index int) bool {
+	if s == nil || index < 0 || index >= len(s.slabs) {
+		return false
+	}
+	slab := &s.slabs[index]
+	if len(slab.data) == 0 {
+		return false
+	}
+	if cap(slab.reachMarks) < len(slab.data) {
+		slab.reachMarks = make([]uint32, len(slab.data))
+	} else if len(slab.reachMarks) != len(slab.data) {
+		slab.reachMarks = slab.reachMarks[:len(slab.data)]
+	} else {
+		return true
+	}
+	s.recomputeAllocatedBytes()
+	return true
+}
+
+func (s *gssScratch) reachMarkForSlab(index int, nodePtr, nodeSize uintptr) (*uint32, bool) {
+	if s == nil || index < 0 || index >= len(s.slabs) {
 		return nil, false
 	}
-	return &slab.reachMarks[index], true
+	slab := &s.slabs[index]
+	nodeIndex, ok := gssNodeIndexInSlab(slab, nodePtr, nodeSize)
+	if !ok || !s.ensureReachMarksForSlab(index) {
+		return nil, false
+	}
+	return &slab.reachMarks[nodeIndex], true
 }
 
 // reachMarkFor returns the external mark for n when n belongs to this GSS
-// scratch. Nodes built without this scratch use the preflight map fallback.
+// scratch. A slab that grows after preflight acquisition provisions its marks
+// on first use, so owned nodes do not fall back to a pointer map.
 func (s *gssScratch) reachMarkFor(n *gssNode, hint *int) (*uint32, bool) {
 	if s == nil || n == nil {
 		return nil, false
@@ -308,7 +340,7 @@ func (s *gssScratch) reachMarkFor(n *gssNode, hint *int) (*uint32, bool) {
 	nodePtr := uintptr(unsafe.Pointer(n))
 	nodeSize := unsafe.Sizeof(gssNode{})
 	if hint != nil && *hint >= 0 && *hint < len(s.slabs) {
-		if mark, ok := reachMarkInGSSSlab(&s.slabs[*hint], nodePtr, nodeSize); ok {
+		if mark, ok := s.reachMarkForSlab(*hint, nodePtr, nodeSize); ok {
 			return mark, true
 		}
 	}
@@ -316,7 +348,7 @@ func (s *gssScratch) reachMarkFor(n *gssNode, hint *int) (*uint32, bool) {
 		if hint != nil && i == *hint {
 			continue
 		}
-		if mark, ok := reachMarkInGSSSlab(&s.slabs[i], nodePtr, nodeSize); ok {
+		if mark, ok := s.reachMarkForSlab(i, nodePtr, nodeSize); ok {
 			if hint != nil {
 				*hint = i
 			}

--- a/glr_gss_dense_reach_test.go
+++ b/glr_gss_dense_reach_test.go
@@ -41,7 +41,7 @@ func TestGSSPreflightDenseReachMarks(t *testing.T) {
 	}
 }
 
-func TestGSSPreflightDenseReachMarksFallbackAfterSlabGrowth(t *testing.T) {
+func TestGSSPreflightDenseReachMarksAfterSlabGrowth(t *testing.T) {
 	var owner gssScratch
 	owner.slabs = []gssNodeSlab{{data: make([]gssNode, 1)}}
 	owner.slabCursor = 0
@@ -50,13 +50,16 @@ func TestGSSPreflightDenseReachMarksFallbackAfterSlabGrowth(t *testing.T) {
 	merge := &glrMergeScratch{gssOwner: &owner}
 	p := acquirePreflightForScratch(merge)
 
-	// Allocate a second slab after mark provisioning. The new slab must use
-	// the documented map fallback until the next preflight acquisition.
+	// Allocate a second slab after mark provisioning. The first reach walk must
+	// provision marks for the new slab instead of using the pointer-map fallback.
 	head := owner.allocNode(stackEntry{state: 2}, root, 2)
 	if got := p.canReach(head, root); !got {
-		t.Fatal("slab-growth fallback rejected a reachable chain")
+		t.Fatal("slab-growth dense reach rejected a reachable chain")
 	}
-	if p.reachSeen == nil {
-		t.Fatal("slab-growth fallback did not use the visited map")
+	if p.reachSeen != nil {
+		t.Fatal("slab growth allocated the visited map instead of dense marks")
+	}
+	if mark, ok := owner.reachMarkFor(head, &p.reachSlabHint); !ok || *mark != p.reachGeneration {
+		t.Fatalf("slab-growth mark = %v, %v; want current generation", mark, ok)
 	}
 }


### PR DESCRIPTION
## Summary

Provision dense reach marks when a GSS slab grows after preflight acquisition.
Keep the 64-byte `gssNode` layout unchanged.
Remove the pointer-map fallback for nodes owned by the active GSS scratch.

## Reason

The preflight marks existing slabs when it starts.
Later slab growth left new nodes without marks and forced a visited pointer map.
This path adds avoidable memory and keeps B8f open.

## Validation

- `GOWORK=off go test . -run '^TestGSSPreflightDenseReachMarks' -count=1`
- Docker focused dense-mark tests passed.
- Docker real C# GLR liveness test passed.
- Both Docker runs reported no out-of-memory event and no wall timeout.

## Scope

This pull request changes no parser route or semantic result.
It makes no performance claim and earns no performance credit.
Require full CI and a final-head C0f rerun before accepting B8f closure.
