### PR TITLE
test(grammargen): keep the ABI-14 C probe on the generated DFA

### DIFF
--- a/grammargen/language_version_stamp_test.go
+++ b/grammargen/language_version_stamp_test.go
@@ -93,20 +93,9 @@ func TestGeneratedCABI14LexModesRuntime(t *testing.T) {
 	if !hasLaterMode {
 		t.Fatal("generated grammar has no nonzero lex mode after state zero")
 	}
-	// The Go lexer reports EOF out of band, while parser.c represents it as an
-	// explicit DFA accept state. Add that mechanically equivalent edge here so
-	// this probe isolates the locked runtime's ABI-14 lex-mode indexing.
-	eofState := len(lang.LexStates)
-	lang.LexStates = append(lang.LexStates, gotreesitter.LexState{AcceptToken: 0, Skip: true, EOF: -1, Default: -1})
-	for i, mode := range lang.LexModes {
-		if mode.LexState == ^uint16(0) {
-			lang.LexModes[i].LexState = 0
-			mode.LexState = 0
-		}
-		if int(mode.LexState) < eofState {
-			lang.LexStates[mode.LexState].EOF = eofState
-		}
-	}
+	// EmitC synthesizes the EOF token at each parser-start lexer state.
+	// Keep the generated DFA unchanged so this probe exercises the ABI-14
+	// lex-mode layout rather than an artificial EOF state.
 	code, err := EmitC(g.Name, lang)
 	if err != nil {
 		t.Fatalf("EmitC: %v", err)


### PR DESCRIPTION
## Summary

Keep the ABI-14 C-runtime probe on the generated lexer DFA. EmitC already synthesizes the end-of-file token at parser-start lexer states.

The old probe injected a synthetic skip state and attached it to every lexer mode. That bypassed the current EOF contract, returned no end-of-file token, and caused the locked C parser to recover forever.

## Evidence

- Focused Docker run passed with 4 GB memory: `TestGeneratedCABI14LexModesRuntime`.
- Related ABI-14, ABI-15, language-version, and EmitC parity tests passed in Docker.
- The old probe reached 16.7 GB resident memory and was killed.
- The repaired probe completed without an out-of-memory event.

This PR changes one test file and does not change parser or code-generation behavior.

Refs #667