### PR TITLE
parser APIs: add strict batch helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ if errors.Is(err, gotreesitter.ErrParseStoppedEarly) {
 Strict variants are available for full parse, incremental parse, token-source
 parse, factory parse, `ParseWith`, and `ParserPool`.
 
+`grammars.ParseFilePooledStrict` returns a pooled `*BoundTree` only after a
+complete parse. The caller must call `Release` on a returned tree. It returns
+`nil` and an error for parser setup failures, parse failures, and early stops.
+
+`Tagger.TagStrict` returns tags only after a complete parse. It releases its
+internal tree before it returns. It returns `nil` and an error for parser
+failures and early stops.
+
 High-level analysis can use `WithHighlighterTimeoutMicros` or
 `WithTaggerTimeoutMicros` to bound parser work. The
 `HighlightIncrementalStrict` and `TagIncrementalStrict` methods return the

--- a/grammars/parse_file.go
+++ b/grammars/parse_file.go
@@ -58,8 +58,21 @@ func ParseFile(filename string, source []byte) (*gotreesitter.BoundTree, error) 
 
 // ParseFilePooled is like ParseFile but reuses a per-language ParserPool
 // to avoid allocating a new parser on every call. It is safe for concurrent use.
+// Parser safety stops return a partial tree without an error; use
+// ParseFilePooledStrict when partial output is not valid.
 // The caller must call Release() on the returned BoundTree.
 func ParseFilePooled(filename string, source []byte) (*gotreesitter.BoundTree, error) {
+	return parseFilePooled(filename, source, false)
+}
+
+// ParseFilePooledStrict is like ParseFilePooled, but rejects a partial tree when
+// the parser stops before it accepts all input. It releases the partial tree and
+// returns an error that wraps gotreesitter.ErrParseStoppedEarly.
+func ParseFilePooledStrict(filename string, source []byte) (*gotreesitter.BoundTree, error) {
+	return parseFilePooled(filename, source, true)
+}
+
+func parseFilePooled(filename string, source []byte, strict bool) (*gotreesitter.BoundTree, error) {
 	entry := DetectLanguage(filename)
 	if entry == nil {
 		return nil, fmt.Errorf("unsupported file type: %s", filename)
@@ -72,11 +85,20 @@ func ParseFilePooled(filename string, source []byte) (*gotreesitter.BoundTree, e
 	var err error
 	if entry.TokenSourceFactory != nil {
 		ts := entry.TokenSourceFactory(source, lang)
-		tree, err = pp.ParseWithTokenSource(source, ts)
+		if strict {
+			tree, err = pp.ParseWithTokenSourceStrict(source, ts)
+		} else {
+			tree, err = pp.ParseWithTokenSource(source, ts)
+		}
+	} else if strict {
+		tree, err = pp.ParseStrict(source)
 	} else {
 		tree, err = pp.Parse(source)
 	}
 	if err != nil {
+		if tree != nil {
+			tree.Release()
+		}
 		return nil, fmt.Errorf("parse %s: %w", filename, err)
 	}
 

--- a/grammars/registry_lifecycle_test.go
+++ b/grammars/registry_lifecycle_test.go
@@ -1,6 +1,7 @@
 package grammars
 
 import (
+	"bytes"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -220,5 +221,41 @@ func TestParseFilePooledReplacesPoolForReplacedLanguage(t *testing.T) {
 	}
 	if got := secondPool.Language(); got != pythonLang {
 		t.Fatalf("replacement pool language = %p, want %p", got, pythonLang)
+	}
+}
+
+func TestParseFilePooledStrictRejectsStoppedTree(t *testing.T) {
+	preserveRegistryState(t)
+	const name = "zz_pool_strict"
+	preserveParserPool(t, name)
+
+	entry := DetectLanguage("sample.go")
+	if entry == nil {
+		t.Fatal("Go language is not registered")
+	}
+	entry.Name = name
+	entry.Extensions = []string{".zz-pool-strict"}
+	Register(*entry)
+
+	lang := entry.Language()
+	poolsMu.Lock()
+	pools[name] = gotreesitter.NewParserPool(lang, gotreesitter.WithParserPoolTimeoutMicros(1))
+	poolsMu.Unlock()
+
+	source := append([]byte("package p\n"), bytes.Repeat([]byte("var value int\n"), 10_000)...)
+	tree, err := ParseFilePooledStrict("sample.zz-pool-strict", source)
+	if tree != nil {
+		tree.Release()
+		t.Fatal("ParseFilePooledStrict returned a partial tree")
+	}
+	if !errors.Is(err, gotreesitter.ErrParseStoppedEarly) {
+		t.Fatalf("ParseFilePooledStrict error = %v, want ErrParseStoppedEarly", err)
+	}
+	var stopped *gotreesitter.ParseStoppedEarlyError
+	if !errors.As(err, &stopped) {
+		t.Fatalf("ParseFilePooledStrict error type = %T, want *ParseStoppedEarlyError", err)
+	}
+	if stopped.Reason != gotreesitter.ParseStopTimeout {
+		t.Fatalf("stop reason = %q, want %q", stopped.Reason, gotreesitter.ParseStopTimeout)
 	}
 }

--- a/parse_dispatch.go
+++ b/parse_dispatch.go
@@ -24,6 +24,21 @@ func dispatchParse(p *Parser, source []byte, oldTree *Tree, tsFactory func([]byt
 	return tree
 }
 
+// dispatchParseStrict preserves parser errors and reports early stops.
+func dispatchParseStrict(p *Parser, source []byte, oldTree *Tree, tsFactory func([]byte) TokenSource) (*Tree, error) {
+	if tsFactory != nil {
+		ts := tsFactory(source)
+		if oldTree != nil {
+			return p.ParseIncrementalWithTokenSourceStrict(source, oldTree, ts)
+		}
+		return p.ParseWithTokenSourceStrict(source, ts)
+	}
+	if oldTree != nil {
+		return p.ParseIncrementalStrict(source, oldTree)
+	}
+	return p.ParseStrict(source)
+}
+
 func dispatchParseUTF16(p *Parser, source []uint16, oldTree *Tree, tsFactory func([]byte) TokenSource, lang *Language) *Tree {
 	var tree *Tree
 	var err error

--- a/tagger.go
+++ b/tagger.go
@@ -99,14 +99,17 @@ func (tg *Tagger) TagStrict(source []byte) ([]Tag, error) {
 		return nil, nil
 	}
 
-	tree := tg.parse(source, nil)
+	tree, err := tg.parseStrict(source, nil)
+	if err != nil {
+		if tree != nil {
+			tree.Release()
+		}
+		return nil, err
+	}
 	if tree == nil {
 		return nil, nil
 	}
 	defer tree.Release()
-	if err := parseStoppedEarlyError(tree); err != nil {
-		return nil, err
-	}
 	if tree.RootNode() == nil {
 		return nil, nil
 	}
@@ -218,6 +221,10 @@ func (tg *Tagger) TagIncrementalUTF16Bytes(source []byte, oldTree *Tree, order U
 
 func (tg *Tagger) parse(source []byte, oldTree *Tree) *Tree {
 	return dispatchParse(tg.parser, source, oldTree, tg.tokenSourceFactory, tg.lang)
+}
+
+func (tg *Tagger) parseStrict(source []byte, oldTree *Tree) (*Tree, error) {
+	return dispatchParseStrict(tg.parser, source, oldTree, tg.tokenSourceFactory)
 }
 
 func (tg *Tagger) parseUTF16(source []uint16, oldTree *Tree) *Tree {

--- a/tagger.go
+++ b/tagger.go
@@ -91,6 +91,29 @@ func (tg *Tagger) Tag(source []byte) []Tag {
 	return tg.tagTree(tree)
 }
 
+// TagStrict is like Tag, but rejects a partial tree when parsing stops before
+// it accepts all input. It releases the partial tree and returns an error that
+// wraps ErrParseStoppedEarly.
+func (tg *Tagger) TagStrict(source []byte) ([]Tag, error) {
+	if len(source) == 0 {
+		return nil, nil
+	}
+
+	tree := tg.parse(source, nil)
+	if tree == nil {
+		return nil, nil
+	}
+	defer tree.Release()
+	if err := parseStoppedEarlyError(tree); err != nil {
+		return nil, err
+	}
+	if tree.RootNode() == nil {
+		return nil, nil
+	}
+
+	return tg.tagTree(tree), nil
+}
+
 // TagUTF16 parses UTF-16 source and returns all tags with UTF-16 ranges.
 func (tg *Tagger) TagUTF16(source []uint16) []UTF16Tag {
 	if len(source) == 0 {

--- a/tagger_test.go
+++ b/tagger_test.go
@@ -49,6 +49,36 @@ func TestTagIncrementalStrictReportsTimeout(t *testing.T) {
 	}
 }
 
+func TestTagStrictReportsTimeout(t *testing.T) {
+	tagger, err := NewTagger(buildArithmeticLanguage(), "",
+		WithTaggerTimeoutMicros(100),
+		WithTaggerTokenSourceFactory(func(source []byte) TokenSource {
+			return &slowArithmeticTokenSource{
+				delay: 2 * time.Millisecond,
+				tokens: []Token{
+					{Symbol: 1, StartByte: 0, EndByte: 1},
+					{Symbol: 0, StartByte: 1, EndByte: 1},
+				},
+			}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tags, err := tagger.TagStrict([]byte("1"))
+	var stopped *ParseStoppedEarlyError
+	if !errors.As(err, &stopped) {
+		t.Fatalf("error = %v, want ParseStoppedEarlyError", err)
+	}
+	if stopped.Reason != ParseStopTimeout {
+		t.Fatalf("stop reason = %q, want %q", stopped.Reason, ParseStopTimeout)
+	}
+	if tags != nil {
+		t.Fatalf("tags = %#v, want nil", tags)
+	}
+}
+
 func TestTaggerBasic(t *testing.T) {
 	lang := queryTestLanguage()
 

--- a/tagger_test.go
+++ b/tagger_test.go
@@ -50,7 +50,8 @@ func TestTagIncrementalStrictReportsTimeout(t *testing.T) {
 }
 
 func TestTagStrictReportsTimeout(t *testing.T) {
-	tagger, err := NewTagger(buildArithmeticLanguage(), "",
+	query := `(expression) @definition.expression`
+	tagger, err := NewTagger(buildArithmeticLanguage(), query,
 		WithTaggerTimeoutMicros(100),
 		WithTaggerTokenSourceFactory(func(source []byte) TokenSource {
 			return &slowArithmeticTokenSource{
@@ -76,6 +77,35 @@ func TestTagStrictReportsTimeout(t *testing.T) {
 	}
 	if tags != nil {
 		t.Fatalf("tags = %#v, want nil", tags)
+	}
+
+	// Make query execution observable. A stopped strict parse must return
+	// before it reaches tagTree, even when the tag query is non-empty.
+	tagger.query = nil
+	if tags, err := tagger.TagStrict([]byte("1")); !errors.Is(err, ErrParseStoppedEarly) || tags != nil {
+		t.Fatalf("second strict call = tags %#v, err %v; want no tags and ErrParseStoppedEarly", tags, err)
+	}
+
+	complete, err := NewTagger(buildArithmeticLanguage(), query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tags, err = complete.TagStrict([]byte("1"))
+	if err != nil {
+		t.Fatalf("complete strict call error = %v", err)
+	}
+	if len(tags) != 1 || tags[0].Kind != "definition.expression" || tags[0].Name != "1" {
+		t.Fatalf("complete strict tags = %#v, want one expression tag for 1", tags)
+	}
+}
+
+func TestTagStrictPropagatesParserError(t *testing.T) {
+	tagger, err := NewTagger(nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tags, err := tagger.TagStrict([]byte("1")); !errors.Is(err, ErrNoLanguage) || tags != nil {
+		t.Fatalf("TagStrict = tags %#v, err %v; want nil tags and ErrNoLanguage", tags, err)
 	}
 }
 


### PR DESCRIPTION
Batch consumers must reject trees that stop before all input is accepted. The pooled grammar parser and one-shot tagger exposed only editor-style APIs. Those APIs return partial output without an error.

This change adds ParseFilePooledStrict and TagStrict. Both reject a stopped parse, release the partial tree, return the typed parser stop error, and skip query work. Existing ParseFilePooled and Tag behavior stays unchanged.

Test proof:
- Focused grammar and tagger tests passed 10 times on the host.
- The same tests passed 10 times in the required 8 GiB Docker harness.
- Docker reported exit code 0, no out-of-memory kill, and no wall timeout.

The required buckley command was not installed. Git created the commits.