### PR TITLE
parser: drop oversized pending stack buffers

### DIFF
--- a/glr.go
+++ b/glr.go
@@ -246,6 +246,38 @@ func resetPendingStackBufferAtBoundary(stacks []glrStack, reserve *[]glrStack) [
 	return (*reserve)[:0]
 }
 
+func (p *Parser) resetPendingStackBuffersAfterDemotion() {
+	if p == nil {
+		return
+	}
+	cold := p.forestDeclineMemo
+	if cold == nil && (cap(p.pendingForkStacks) > maxRetainedPendingStackCap ||
+		cap(p.pendingFrontierForkStacks) > maxRetainedPendingStackCap) {
+		cold = p.ensureParserColdState()
+	}
+	if cold == nil {
+		p.pendingForkStacks = resetPendingStackBufferAfterDemotion(p.pendingForkStacks, nil)
+		p.pendingFrontierForkStacks = resetPendingStackBufferAfterDemotion(p.pendingFrontierForkStacks, nil)
+		return
+	}
+	p.pendingForkStacks = resetPendingStackBufferAfterDemotion(p.pendingForkStacks, &cold.pendingForkStackReserve)
+	p.pendingFrontierForkStacks = resetPendingStackBufferAfterDemotion(p.pendingFrontierForkStacks, &cold.pendingFrontierForkStackReserve)
+}
+
+func (p *Parser) resetPendingStackBuffersAtBoundary() {
+	if p == nil {
+		return
+	}
+	cold := p.forestDeclineMemo
+	if cold == nil {
+		p.pendingForkStacks = resetPendingStackBufferAtBoundary(p.pendingForkStacks, nil)
+		p.pendingFrontierForkStacks = resetPendingStackBufferAtBoundary(p.pendingFrontierForkStacks, nil)
+		return
+	}
+	p.pendingForkStacks = resetPendingStackBufferAtBoundary(p.pendingForkStacks, &cold.pendingForkStackReserve)
+	p.pendingFrontierForkStacks = resetPendingStackBufferAtBoundary(p.pendingFrontierForkStacks, &cold.pendingFrontierForkStackReserve)
+}
+
 type glrMergeScratch struct {
 	result                    []glrStack
 	slots                     []glrMergeSlot

--- a/glr.go
+++ b/glr.go
@@ -202,7 +202,7 @@ const (
 )
 
 // resetPendingStackBuffer clears stack references before the buffer is reused.
-// Drop oversized buffers only at parse and pool boundaries.
+// Drop oversized buffers at parse and pool boundaries.
 func resetPendingStackBuffer(stacks []glrStack, dropOversized bool) []glrStack {
 	if dropOversized && cap(stacks) > maxRetainedPendingStackCap {
 		return nil
@@ -211,6 +211,39 @@ func resetPendingStackBuffer(stacks []glrStack, dropOversized bool) []glrStack {
 		clear(stacks[:cap(stacks)])
 	}
 	return stacks[:0]
+}
+
+// resetPendingStackBufferAfterDemotion bounds active-parse retention without
+// rebuilding ordinary fork capacity after each oversized burst. The reserve
+// remains reachable while an append grows stacks onto a larger backing array.
+func resetPendingStackBufferAfterDemotion(stacks []glrStack, reserve *[]glrStack) []glrStack {
+	if cap(stacks) <= maxRetainedPendingStackCap {
+		return resetPendingStackBuffer(stacks, false)
+	}
+	if reserve == nil {
+		return nil
+	}
+	if cap(*reserve) != maxRetainedPendingStackCap {
+		*reserve = make([]glrStack, 0, maxRetainedPendingStackCap)
+	} else {
+		*reserve = resetPendingStackBuffer(*reserve, false)
+	}
+	return (*reserve)[:0]
+}
+
+// resetPendingStackBufferAtBoundary releases oversized active storage and
+// scrubs a bounded reserve before the parser starts or enters a pool.
+func resetPendingStackBufferAtBoundary(stacks []glrStack, reserve *[]glrStack) []glrStack {
+	stacks = resetPendingStackBuffer(stacks, true)
+	if reserve == nil || cap(*reserve) == 0 {
+		return stacks
+	}
+	if cap(stacks) > 0 && &stacks[:1][0] == &(*reserve)[:1][0] {
+		*reserve = stacks
+		return stacks
+	}
+	*reserve = resetPendingStackBuffer(*reserve, false)
+	return (*reserve)[:0]
 }
 
 type glrMergeScratch struct {

--- a/glr.go
+++ b/glr.go
@@ -201,11 +201,10 @@ const (
 	mergeBudgetPollStride = 4096
 )
 
-// resetPendingStackBuffer releases stack references before the buffer is
-// reused. Oversized buffers are dropped with their references because scanning
-// them before dropping them only delays the same garbage collection.
-func resetPendingStackBuffer(stacks []glrStack) []glrStack {
-	if cap(stacks) > maxRetainedPendingStackCap {
+// resetPendingStackBuffer clears stack references before the buffer is reused.
+// Drop oversized buffers only at parse and pool boundaries.
+func resetPendingStackBuffer(stacks []glrStack, dropOversized bool) []glrStack {
+	if dropOversized && cap(stacks) > maxRetainedPendingStackCap {
 		return nil
 	}
 	if cap(stacks) > 0 {

--- a/glr.go
+++ b/glr.go
@@ -179,6 +179,10 @@ const (
 	// pathological GLR bursts that would otherwise allocate huge slot tables
 	// before the next memory-budget check can run.
 	maxMergeAliveStacks = 4096
+	// Keep ordinary pending-stack scratch hot, but drop pathological buffers.
+	// Clearing a million-slot empty buffer at every GSS recycle can cost more
+	// than the parse work between recycles.
+	maxRetainedPendingStackCap = maxMergeAliveStacks
 	// Keep ordinary merge scratch hot while dropping pathological buffers after
 	// the parse. glrMergeSlot is intentionally large because it owns fixed
 	// per-key survivor arrays.
@@ -196,6 +200,19 @@ const (
 	// bounding how far a pathological grind can run before it is stopped.
 	mergeBudgetPollStride = 4096
 )
+
+// resetPendingStackBuffer releases stack references before the buffer is
+// reused. Oversized buffers are dropped with their references because scanning
+// them before dropping them only delays the same garbage collection.
+func resetPendingStackBuffer(stacks []glrStack) []glrStack {
+	if cap(stacks) > maxRetainedPendingStackCap {
+		return nil
+	}
+	if cap(stacks) > 0 {
+		clear(stacks[:cap(stacks)])
+	}
+	return stacks[:0]
+}
 
 type glrMergeScratch struct {
 	result                    []glrStack

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -182,13 +182,15 @@ type forestDeclineMemoState struct {
 	retainedSourceBytes int
 }
 
-// parserColdState shares the Parser's existing lazy sidecar slot between two
+// parserColdState shares the Parser's existing lazy sidecar slot between
 // uncommon features. It preserves the hot Parser layout for ordinary parses.
 type parserColdState struct {
 	forestDeclineMemoState
-	cNodeMemoRetainedCache []cNodeMemoCacheEntry
-	cNodeMemoCollisions    uint64
-	recoveryRuntime        recoveryRuntimeTelemetry
+	cNodeMemoRetainedCache          []cNodeMemoCacheEntry
+	pendingForkStackReserve         []glrStack
+	pendingFrontierForkStackReserve []glrStack
+	cNodeMemoCollisions             uint64
+	recoveryRuntime                 recoveryRuntimeTelemetry
 }
 
 func (p *Parser) ensureParserColdState() *parserColdState {

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -1238,6 +1238,10 @@ func TestParserDemotionBoundsOversizedPendingStackBuffers(t *testing.T) {
 	if !parser.tryDemoteSingleLinearGSS(stacks, &scratch) {
 		t.Fatal("tryDemoteSingleLinearGSS() = false")
 	}
+	cold := parser.forestDeclineMemo
+	if cold == nil {
+		t.Fatal("oversized production demotion did not allocate the cold sidecar")
+	}
 	if forkBacking[0].gss.head != forkHead || frontierBacking[0].gss.head != frontierHead {
 		t.Fatal("production demotion scanned an oversized backing array")
 	}
@@ -1247,8 +1251,20 @@ func TestParserDemotionBoundsOversizedPendingStackBuffers(t *testing.T) {
 	if got := cap(parser.pendingFrontierForkStacks); got != maxRetainedPendingStackCap {
 		t.Fatalf("pending frontier capacity = %d, want %d", got, maxRetainedPendingStackCap)
 	}
+	if got := cap(cold.pendingForkStackReserve); got != maxRetainedPendingStackCap {
+		t.Fatalf("cold pending fork reserve capacity = %d, want %d", got, maxRetainedPendingStackCap)
+	}
+	if got := cap(cold.pendingFrontierForkStackReserve); got != maxRetainedPendingStackCap {
+		t.Fatalf("cold pending frontier reserve capacity = %d, want %d", got, maxRetainedPendingStackCap)
+	}
 	forkReserve := &parser.pendingForkStacks[:cap(parser.pendingForkStacks)][0]
 	frontierReserve := &parser.pendingFrontierForkStacks[:cap(parser.pendingFrontierForkStacks)][0]
+	if got := &cold.pendingForkStackReserve[:cap(cold.pendingForkStackReserve)][0]; got != forkReserve {
+		t.Fatalf("cold pending fork reserve = %p, want %p", got, forkReserve)
+	}
+	if got := &cold.pendingFrontierForkStackReserve[:cap(cold.pendingFrontierForkStackReserve)][0]; got != frontierReserve {
+		t.Fatalf("cold pending frontier reserve = %p, want %p", got, frontierReserve)
+	}
 	for len(parser.pendingForkStacks) < maxRetainedPendingStackCap {
 		parser.pendingForkStacks = append(parser.pendingForkStacks, glrStack{})
 	}
@@ -1273,6 +1289,24 @@ func TestParserDemotionBoundsOversizedPendingStackBuffers(t *testing.T) {
 	if parser.pendingForkStacks[:cap(parser.pendingForkStacks)][0].gss.head != nil ||
 		parser.pendingFrontierForkStacks[:cap(parser.pendingFrontierForkStacks)][0].gss.head != nil {
 		t.Fatal("bounded reserves retained stack references")
+	}
+}
+
+func TestParserDemotionKeepsPendingReserveSidecarLazy(t *testing.T) {
+	var scratch parserScratch
+	stacks := []glrStack{{
+		gss: buildGSSStack([]stackEntry{{state: 1}}, &scratch.gss),
+	}}
+	parser := &Parser{
+		pendingForkStacks:         make([]glrStack, 0, maxRetainedPendingStackCap),
+		pendingFrontierForkStacks: make([]glrStack, 0, maxRetainedPendingStackCap),
+	}
+
+	if !parser.tryDemoteSingleLinearGSS(stacks, &scratch) {
+		t.Fatal("tryDemoteSingleLinearGSS() = false")
+	}
+	if parser.forestDeclineMemo != nil {
+		t.Fatal("bounded production demotion allocated the cold sidecar")
 	}
 }
 

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -6,6 +6,11 @@ import (
 	"unsafe"
 )
 
+var (
+	benchmarkPendingStackBuffer      []glrStack
+	benchmarkResetPendingStackBuffer = resetPendingStackBuffer
+)
+
 func gssNodeWithExtraLinks(node gssNode, links ...gssMainLink) *gssNode {
 	n := &node
 	for _, link := range links {
@@ -1064,6 +1069,65 @@ func TestGSSScratchRecycleForParseReusesClearedSlots(t *testing.T) {
 	if scratch.peakUsed != 1 || scratch.usedTotal != 1 {
 		t.Fatalf("allocation high-water peak=%d used=%d", scratch.peakUsed, scratch.usedTotal)
 	}
+}
+
+func TestResetPendingStackBufferRetainsAndClearsSmallBuffer(t *testing.T) {
+	backing := make([]glrStack, 2)
+	backing[0].gss.head = &gssNode{}
+	backing[0].entries = []stackEntry{{state: 1}}
+	backing[1].cRec = &cRecoverState{}
+
+	got := resetPendingStackBuffer(backing[:1])
+
+	if len(got) != 0 || cap(got) != cap(backing) {
+		t.Fatalf("reset len/cap = %d/%d, want 0/%d", len(got), cap(got), cap(backing))
+	}
+	for i := range backing {
+		if backing[i].gss.head != nil || backing[i].entries != nil || backing[i].cRec != nil {
+			t.Fatalf("backing slot %d retained stack references", i)
+		}
+	}
+}
+
+func TestResetPendingStackBufferDropsOversizedBufferWithoutScan(t *testing.T) {
+	backing := make([]glrStack, 1, maxRetainedPendingStackCap+1)
+	head := &gssNode{}
+	backing[0].gss.head = head
+
+	got := resetPendingStackBuffer(backing)
+
+	if got != nil {
+		t.Fatalf("oversized reset retained cap %d, want nil", cap(got))
+	}
+	if backing[0].gss.head != head {
+		t.Fatal("oversized reset scanned the buffer before dropping it")
+	}
+}
+
+func BenchmarkResetPendingStackBuffer(b *testing.B) {
+	const count = maxRetainedPendingStackCap + 1
+	size := int64(count) * int64(unsafe.Sizeof(glrStack{}))
+
+	b.Run("drop_oversized", func(b *testing.B) {
+		backing := make([]glrStack, 0, count)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			benchmarkPendingStackBuffer = benchmarkResetPendingStackBuffer(backing)
+			if benchmarkPendingStackBuffer != nil {
+				b.Fatal("oversized buffer was retained")
+			}
+		}
+	})
+	b.Run("clear_oversized", func(b *testing.B) {
+		backing := make([]glrStack, 0, count)
+		b.SetBytes(size)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			clear(backing[:cap(backing)])
+			backing = backing[:0]
+		}
+		benchmarkPendingStackBuffer = backing
+	})
 }
 
 func TestParserRecycleDemotedGSSInvalidatesPointerHolders(t *testing.T) {

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -8,7 +8,9 @@ import (
 
 var (
 	benchmarkPendingStackBuffer      []glrStack
-	benchmarkResetPendingStackBuffer = resetPendingStackBuffer
+	benchmarkResetPendingStackBuffer = func(stacks []glrStack) []glrStack {
+		return resetPendingStackBuffer(stacks, true)
+	}
 )
 
 func gssNodeWithExtraLinks(node gssNode, links ...gssMainLink) *gssNode {
@@ -1077,7 +1079,7 @@ func TestResetPendingStackBufferRetainsAndClearsSmallBuffer(t *testing.T) {
 	backing[0].entries = []stackEntry{{state: 1}}
 	backing[1].cRec = &cRecoverState{}
 
-	got := resetPendingStackBuffer(backing[:1])
+	got := resetPendingStackBuffer(backing[:1], false)
 
 	if len(got) != 0 || cap(got) != cap(backing) {
 		t.Fatalf("reset len/cap = %d/%d, want 0/%d", len(got), cap(got), cap(backing))
@@ -1094,13 +1096,27 @@ func TestResetPendingStackBufferDropsOversizedBufferWithoutScan(t *testing.T) {
 	head := &gssNode{}
 	backing[0].gss.head = head
 
-	got := resetPendingStackBuffer(backing)
+	got := resetPendingStackBuffer(backing, true)
 
 	if got != nil {
 		t.Fatalf("oversized reset retained cap %d, want nil", cap(got))
 	}
 	if backing[0].gss.head != head {
 		t.Fatal("oversized reset scanned the buffer before dropping it")
+	}
+}
+
+func TestResetPendingStackBufferRetainsOversizedActiveCapacity(t *testing.T) {
+	backing := make([]glrStack, 1, maxRetainedPendingStackCap+1)
+	backing[0].gss.head = &gssNode{}
+
+	got := resetPendingStackBuffer(backing, false)
+
+	if len(got) != 0 || cap(got) != cap(backing) {
+		t.Fatalf("active reset len/cap = %d/%d, want 0/%d", len(got), cap(got), cap(backing))
+	}
+	if backing[0].gss.head != nil {
+		t.Fatal("active reset retained a stack reference")
 	}
 }
 
@@ -1127,6 +1143,44 @@ func BenchmarkResetPendingStackBuffer(b *testing.B) {
 			backing = backing[:0]
 		}
 		benchmarkPendingStackBuffer = backing
+	})
+	b.Run("demotion_reuse", func(b *testing.B) {
+		var pending []glrStack
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for len(pending) < count {
+				pending = append(pending, glrStack{})
+			}
+			pending = resetPendingStackBuffer(pending, false)
+			for len(pending) < count {
+				pending = append(pending, glrStack{})
+			}
+			pending = resetPendingStackBuffer(pending, false)
+		}
+		benchmarkPendingStackBuffer = pending
+	})
+	b.Run("full_lifecycle", func(b *testing.B) {
+		b.SetBytes(size)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var pending []glrStack
+			for len(pending) < count {
+				pending = append(pending, glrStack{})
+			}
+			pending = resetPendingStackBuffer(pending, false)
+			for len(pending) < count {
+				pending = append(pending, glrStack{})
+			}
+			pending = resetPendingStackBuffer(pending, false)
+			pending = resetPendingStackBuffer(pending, true)
+			for len(pending) < count {
+				pending = append(pending, glrStack{})
+			}
+			pending = resetPendingStackBuffer(pending, true)
+			benchmarkPendingStackBuffer = pending
+		}
 	})
 }
 

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -2,6 +2,9 @@ package gotreesitter
 
 import (
 	"fmt"
+	"os"
+	"runtime"
+	"strconv"
 	"testing"
 	"unsafe"
 )
@@ -1106,20 +1109,6 @@ func TestResetPendingStackBufferDropsOversizedBufferWithoutScan(t *testing.T) {
 	}
 }
 
-func TestResetPendingStackBufferRetainsOversizedActiveCapacity(t *testing.T) {
-	backing := make([]glrStack, 1, maxRetainedPendingStackCap+1)
-	backing[0].gss.head = &gssNode{}
-
-	got := resetPendingStackBuffer(backing, false)
-
-	if len(got) != 0 || cap(got) != cap(backing) {
-		t.Fatalf("active reset len/cap = %d/%d, want 0/%d", len(got), cap(got), cap(backing))
-	}
-	if backing[0].gss.head != nil {
-		t.Fatal("active reset retained a stack reference")
-	}
-}
-
 func BenchmarkResetPendingStackBuffer(b *testing.B) {
 	const count = maxRetainedPendingStackCap + 1
 	size := int64(count) * int64(unsafe.Sizeof(glrStack{}))
@@ -1144,44 +1133,147 @@ func BenchmarkResetPendingStackBuffer(b *testing.B) {
 		}
 		benchmarkPendingStackBuffer = backing
 	})
-	b.Run("demotion_reuse", func(b *testing.B) {
-		var pending []glrStack
+}
+
+func pendingStackLifecycleBenchmarkCount(b *testing.B) int {
+	b.Helper()
+	const defaultCount = maxRetainedPendingStackCap + 1
+	raw := os.Getenv("GOT_BENCH_PENDING_STACK_COUNT")
+	if raw == "" {
+		return defaultCount
+	}
+	count, err := strconv.Atoi(raw)
+	if err != nil || count <= maxRetainedPendingStackCap {
+		b.Fatalf("GOT_BENCH_PENDING_STACK_COUNT = %q, want an integer above %d", raw, maxRetainedPendingStackCap)
+	}
+	return count
+}
+
+func reportBenchmarkGCs(b *testing.B, before uint32) {
+	b.Helper()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	if b.N > 0 {
+		b.ReportMetric(float64(after.NumGC-before)/float64(b.N), "gc/op")
+	}
+}
+
+func BenchmarkPendingStackProductionLifecycle(b *testing.B) {
+	count := pendingStackLifecycleBenchmarkCount(b)
+	bytesPerCycle := int64(count) * int64(unsafe.Sizeof(glrStack{}))
+
+	b.Run("grow_drain_production_demotion_append", func(b *testing.B) {
+		parser := &Parser{}
+		var scratch parserScratch
+		stacks := make([]glrStack, 1)
+		runtime.GC()
+		var before runtime.MemStats
+		runtime.ReadMemStats(&before)
 		b.ReportAllocs()
+		b.SetBytes(bytesPerCycle)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			for len(pending) < count {
-				pending = append(pending, glrStack{})
+			for len(parser.pendingForkStacks) < count {
+				parser.pendingForkStacks = append(parser.pendingForkStacks, glrStack{})
 			}
-			pending = resetPendingStackBuffer(pending, false)
-			for len(pending) < count {
-				pending = append(pending, glrStack{})
+			parser.pendingForkStacks = parser.pendingForkStacks[:0]
+			stacks[0] = glrStack{gss: buildGSSStack([]stackEntry{{state: 1}}, &scratch.gss)}
+			if !parser.tryDemoteSingleLinearGSS(stacks, &scratch) {
+				b.Fatal("production demotion failed")
 			}
-			pending = resetPendingStackBuffer(pending, false)
+			parser.pendingForkStacks = append(parser.pendingForkStacks, glrStack{})
+			parser.pendingForkStacks = parser.pendingForkStacks[:0]
 		}
-		benchmarkPendingStackBuffer = pending
+		b.StopTimer()
+		reportBenchmarkGCs(b, before.NumGC)
+		benchmarkPendingStackBuffer = parser.pendingForkStacks
 	})
-	b.Run("full_lifecycle", func(b *testing.B) {
-		b.SetBytes(size)
+
+	b.Run("grow_drain_pool_release_reacquire_append", func(b *testing.B) {
+		pool := NewParserPool(buildArithmeticLanguage())
+		parser := pool.checkout()
+		pool.release(parser)
+		parser = nil
+		runtime.GC()
+		var before runtime.MemStats
+		runtime.ReadMemStats(&before)
 		b.ReportAllocs()
+		b.SetBytes(bytesPerCycle)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			var pending []glrStack
-			for len(pending) < count {
-				pending = append(pending, glrStack{})
+			parser = pool.checkout()
+			for len(parser.pendingForkStacks) < count {
+				parser.pendingForkStacks = append(parser.pendingForkStacks, glrStack{})
 			}
-			pending = resetPendingStackBuffer(pending, false)
-			for len(pending) < count {
-				pending = append(pending, glrStack{})
-			}
-			pending = resetPendingStackBuffer(pending, false)
-			pending = resetPendingStackBuffer(pending, true)
-			for len(pending) < count {
-				pending = append(pending, glrStack{})
-			}
-			pending = resetPendingStackBuffer(pending, true)
-			benchmarkPendingStackBuffer = pending
+			parser.pendingForkStacks = parser.pendingForkStacks[:0]
+			pool.release(parser)
+			parser = pool.checkout()
+			parser.pendingForkStacks = append(parser.pendingForkStacks, glrStack{})
+			parser.pendingForkStacks = parser.pendingForkStacks[:0]
+			pool.release(parser)
 		}
+		b.StopTimer()
+		reportBenchmarkGCs(b, before.NumGC)
+		parser = pool.checkout()
+		benchmarkPendingStackBuffer = parser.pendingForkStacks
+		pool.release(parser)
 	})
+}
+
+func TestParserDemotionBoundsOversizedPendingStackBuffers(t *testing.T) {
+	var scratch parserScratch
+	stacks := []glrStack{{
+		gss: buildGSSStack([]stackEntry{{state: 1}}, &scratch.gss),
+	}}
+	parser := &Parser{}
+	forkHead := &gssNode{}
+	forkBacking := make([]glrStack, 1, maxRetainedPendingStackCap+1)
+	forkBacking[0].gss.head = forkHead
+	parser.pendingForkStacks = forkBacking[:0]
+	frontierHead := &gssNode{}
+	frontierBacking := make([]glrStack, 1, maxRetainedPendingStackCap+1)
+	frontierBacking[0].gss.head = frontierHead
+	parser.pendingFrontierForkStacks = frontierBacking[:0]
+
+	if !parser.tryDemoteSingleLinearGSS(stacks, &scratch) {
+		t.Fatal("tryDemoteSingleLinearGSS() = false")
+	}
+	if forkBacking[0].gss.head != forkHead || frontierBacking[0].gss.head != frontierHead {
+		t.Fatal("production demotion scanned an oversized backing array")
+	}
+	if got := cap(parser.pendingForkStacks); got != maxRetainedPendingStackCap {
+		t.Fatalf("pending fork capacity = %d, want %d", got, maxRetainedPendingStackCap)
+	}
+	if got := cap(parser.pendingFrontierForkStacks); got != maxRetainedPendingStackCap {
+		t.Fatalf("pending frontier capacity = %d, want %d", got, maxRetainedPendingStackCap)
+	}
+	forkReserve := &parser.pendingForkStacks[:cap(parser.pendingForkStacks)][0]
+	frontierReserve := &parser.pendingFrontierForkStacks[:cap(parser.pendingFrontierForkStacks)][0]
+	for len(parser.pendingForkStacks) < maxRetainedPendingStackCap {
+		parser.pendingForkStacks = append(parser.pendingForkStacks, glrStack{})
+	}
+	for len(parser.pendingFrontierForkStacks) < maxRetainedPendingStackCap {
+		parser.pendingFrontierForkStacks = append(parser.pendingFrontierForkStacks, glrStack{})
+	}
+	parser.pendingForkStacks[0].gss.head = &gssNode{}
+	parser.pendingFrontierForkStacks[0].gss.head = &gssNode{}
+	parser.pendingForkStacks = parser.pendingForkStacks[:0]
+	parser.pendingFrontierForkStacks = parser.pendingFrontierForkStacks[:0]
+	stacks[0] = glrStack{gss: buildGSSStack([]stackEntry{{state: 2}}, &scratch.gss)}
+
+	if !parser.tryDemoteSingleLinearGSS(stacks, &scratch) {
+		t.Fatal("second tryDemoteSingleLinearGSS() = false")
+	}
+	if got := &parser.pendingForkStacks[:cap(parser.pendingForkStacks)][0]; got != forkReserve {
+		t.Fatalf("pending fork reserve changed from %p to %p", forkReserve, got)
+	}
+	if got := &parser.pendingFrontierForkStacks[:cap(parser.pendingFrontierForkStacks)][0]; got != frontierReserve {
+		t.Fatalf("pending frontier reserve changed from %p to %p", frontierReserve, got)
+	}
+	if parser.pendingForkStacks[:cap(parser.pendingForkStacks)][0].gss.head != nil ||
+		parser.pendingFrontierForkStacks[:cap(parser.pendingFrontierForkStacks)][0].gss.head != nil {
+		t.Fatal("bounded reserves retained stack references")
+	}
 }
 
 func TestParserRecycleDemotedGSSInvalidatesPointerHolders(t *testing.T) {

--- a/parser.go
+++ b/parser.go
@@ -453,10 +453,12 @@ type Parser struct {
 	// pendingForkStacks buffers extra stacks produced by gated multi-link GSS
 	// reductions. The dispatch loop drains them into stacks for same-token
 	// re-dispatch.
-	pendingForkStacks          []glrStack
-	pendingFrontierForkStacks  []glrStack
-	disablePostReduceForkMerge bool
-	stopActionDiag             *parseStopActionDiagnostic
+	pendingForkStacks               []glrStack
+	pendingFrontierForkStacks       []glrStack
+	pendingForkStackReserve         []glrStack
+	pendingFrontierForkStackReserve []glrStack
+	disablePostReduceForkMerge      bool
+	stopActionDiag                  *parseStopActionDiagnostic
 	// forestDeclineMemo is the lazy parser cold sidecar. It stores the bounded
 	// forest-decline memo and difficult recovery-memo operation state. Parsers
 	// that use neither feature pay no sidecar allocation.
@@ -1697,8 +1699,8 @@ func resetSnippetParser(parser *Parser) {
 	// its reuseCursor.topLevel/*Node alive, preventing arena reclamation.
 	parser.reuseCursor.releaseNodeRefs()
 	parser.reuseScratch.releaseNodeRefs()
-	parser.pendingForkStacks = resetPendingStackBuffer(parser.pendingForkStacks, true)
-	parser.pendingFrontierForkStacks = resetPendingStackBuffer(parser.pendingFrontierForkStacks, true)
+	parser.pendingForkStacks = resetPendingStackBufferAtBoundary(parser.pendingForkStacks, &parser.pendingForkStackReserve)
+	parser.pendingFrontierForkStacks = resetPendingStackBufferAtBoundary(parser.pendingFrontierForkStacks, &parser.pendingFrontierForkStackReserve)
 }
 
 // InferredRootSymbol returns the root symbol inferred during parser
@@ -4458,8 +4460,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	defer p.restoreParseModeFlags(parseFlags)
 	p.clearCurrentExternalTokenCheckpoint()
 	p.resetNormalizationStats()
-	p.pendingForkStacks = resetPendingStackBuffer(p.pendingForkStacks, true)
-	p.pendingFrontierForkStacks = resetPendingStackBuffer(p.pendingFrontierForkStacks, true)
+	p.pendingForkStacks = resetPendingStackBufferAtBoundary(p.pendingForkStacks, &p.pendingForkStackReserve)
+	p.pendingFrontierForkStacks = resetPendingStackBufferAtBoundary(p.pendingFrontierForkStacks, &p.pendingFrontierForkStackReserve)
 	if p.logger != nil {
 		p.logf(ParserLogParse, "start len=%d incremental=%t", len(source), reuse != nil || oldTree != nil)
 	}
@@ -7341,9 +7343,10 @@ func (p *Parser) recycleDemotedGSS(stacks []glrStack, scratch *parserScratch) {
 		clear(stacks[:cap(stacks)])
 		stacks[0] = live
 	}
-	// Retain active-parse capacity to avoid repeated fork-burst allocations.
-	p.pendingForkStacks = resetPendingStackBuffer(p.pendingForkStacks, false)
-	p.pendingFrontierForkStacks = resetPendingStackBuffer(p.pendingFrontierForkStacks, false)
+	// Keep one bounded reserve for later fork bursts. Drop an oversized active
+	// backing array without scanning it before the GSS slabs are recycled.
+	p.pendingForkStacks = resetPendingStackBufferAfterDemotion(p.pendingForkStacks, &p.pendingForkStackReserve)
+	p.pendingFrontierForkStacks = resetPendingStackBufferAfterDemotion(p.pendingFrontierForkStacks, &p.pendingFrontierForkStackReserve)
 	scratch.gss.recycleForParse()
 }
 

--- a/parser.go
+++ b/parser.go
@@ -4456,8 +4456,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	defer p.restoreParseModeFlags(parseFlags)
 	p.clearCurrentExternalTokenCheckpoint()
 	p.resetNormalizationStats()
-	p.pendingForkStacks = p.pendingForkStacks[:0]
-	p.pendingFrontierForkStacks = p.pendingFrontierForkStacks[:0]
+	p.pendingForkStacks = resetPendingStackBuffer(p.pendingForkStacks)
+	p.pendingFrontierForkStacks = resetPendingStackBuffer(p.pendingFrontierForkStacks)
 	if p.logger != nil {
 		p.logf(ParserLogParse, "start len=%d incremental=%t", len(source), reuse != nil || oldTree != nil)
 	}
@@ -7339,14 +7339,8 @@ func (p *Parser) recycleDemotedGSS(stacks []glrStack, scratch *parserScratch) {
 		clear(stacks[:cap(stacks)])
 		stacks[0] = live
 	}
-	if cap(p.pendingForkStacks) > 0 {
-		clear(p.pendingForkStacks[:cap(p.pendingForkStacks)])
-		p.pendingForkStacks = p.pendingForkStacks[:0]
-	}
-	if cap(p.pendingFrontierForkStacks) > 0 {
-		clear(p.pendingFrontierForkStacks[:cap(p.pendingFrontierForkStacks)])
-		p.pendingFrontierForkStacks = p.pendingFrontierForkStacks[:0]
-	}
+	p.pendingForkStacks = resetPendingStackBuffer(p.pendingForkStacks)
+	p.pendingFrontierForkStacks = resetPendingStackBuffer(p.pendingFrontierForkStacks)
 	scratch.gss.recycleForParse()
 }
 

--- a/parser.go
+++ b/parser.go
@@ -1697,6 +1697,8 @@ func resetSnippetParser(parser *Parser) {
 	// its reuseCursor.topLevel/*Node alive, preventing arena reclamation.
 	parser.reuseCursor.releaseNodeRefs()
 	parser.reuseScratch.releaseNodeRefs()
+	parser.pendingForkStacks = resetPendingStackBuffer(parser.pendingForkStacks, true)
+	parser.pendingFrontierForkStacks = resetPendingStackBuffer(parser.pendingFrontierForkStacks, true)
 }
 
 // InferredRootSymbol returns the root symbol inferred during parser
@@ -4456,8 +4458,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	defer p.restoreParseModeFlags(parseFlags)
 	p.clearCurrentExternalTokenCheckpoint()
 	p.resetNormalizationStats()
-	p.pendingForkStacks = resetPendingStackBuffer(p.pendingForkStacks)
-	p.pendingFrontierForkStacks = resetPendingStackBuffer(p.pendingFrontierForkStacks)
+	p.pendingForkStacks = resetPendingStackBuffer(p.pendingForkStacks, true)
+	p.pendingFrontierForkStacks = resetPendingStackBuffer(p.pendingFrontierForkStacks, true)
 	if p.logger != nil {
 		p.logf(ParserLogParse, "start len=%d incremental=%t", len(source), reuse != nil || oldTree != nil)
 	}
@@ -7339,8 +7341,9 @@ func (p *Parser) recycleDemotedGSS(stacks []glrStack, scratch *parserScratch) {
 		clear(stacks[:cap(stacks)])
 		stacks[0] = live
 	}
-	p.pendingForkStacks = resetPendingStackBuffer(p.pendingForkStacks)
-	p.pendingFrontierForkStacks = resetPendingStackBuffer(p.pendingFrontierForkStacks)
+	// Retain active-parse capacity to avoid repeated fork-burst allocations.
+	p.pendingForkStacks = resetPendingStackBuffer(p.pendingForkStacks, false)
+	p.pendingFrontierForkStacks = resetPendingStackBuffer(p.pendingFrontierForkStacks, false)
 	scratch.gss.recycleForParse()
 }
 

--- a/parser.go
+++ b/parser.go
@@ -453,15 +453,13 @@ type Parser struct {
 	// pendingForkStacks buffers extra stacks produced by gated multi-link GSS
 	// reductions. The dispatch loop drains them into stacks for same-token
 	// re-dispatch.
-	pendingForkStacks               []glrStack
-	pendingFrontierForkStacks       []glrStack
-	pendingForkStackReserve         []glrStack
-	pendingFrontierForkStackReserve []glrStack
-	disablePostReduceForkMerge      bool
-	stopActionDiag                  *parseStopActionDiagnostic
-	// forestDeclineMemo is the lazy parser cold sidecar. It stores the bounded
-	// forest-decline memo and difficult recovery-memo operation state. Parsers
-	// that use neither feature pay no sidecar allocation.
+	pendingForkStacks          []glrStack
+	pendingFrontierForkStacks  []glrStack
+	disablePostReduceForkMerge bool
+	stopActionDiag             *parseStopActionDiagnostic
+	// forestDeclineMemo is the lazy parser cold sidecar. It stores the forest
+	// memo, recovery state, telemetry, and bounded pending-stack reserves.
+	// Parsers that use none of these features pay no sidecar allocation.
 	// Explicit ParseForestExperimental calls intentionally ignore this memo.
 	forestDeclineMemo *parserColdState
 }
@@ -1699,8 +1697,7 @@ func resetSnippetParser(parser *Parser) {
 	// its reuseCursor.topLevel/*Node alive, preventing arena reclamation.
 	parser.reuseCursor.releaseNodeRefs()
 	parser.reuseScratch.releaseNodeRefs()
-	parser.pendingForkStacks = resetPendingStackBufferAtBoundary(parser.pendingForkStacks, &parser.pendingForkStackReserve)
-	parser.pendingFrontierForkStacks = resetPendingStackBufferAtBoundary(parser.pendingFrontierForkStacks, &parser.pendingFrontierForkStackReserve)
+	parser.resetPendingStackBuffersAtBoundary()
 }
 
 // InferredRootSymbol returns the root symbol inferred during parser
@@ -4460,8 +4457,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	defer p.restoreParseModeFlags(parseFlags)
 	p.clearCurrentExternalTokenCheckpoint()
 	p.resetNormalizationStats()
-	p.pendingForkStacks = resetPendingStackBufferAtBoundary(p.pendingForkStacks, &p.pendingForkStackReserve)
-	p.pendingFrontierForkStacks = resetPendingStackBufferAtBoundary(p.pendingFrontierForkStacks, &p.pendingFrontierForkStackReserve)
+	p.resetPendingStackBuffersAtBoundary()
 	if p.logger != nil {
 		p.logf(ParserLogParse, "start len=%d incremental=%t", len(source), reuse != nil || oldTree != nil)
 	}
@@ -7345,8 +7341,7 @@ func (p *Parser) recycleDemotedGSS(stacks []glrStack, scratch *parserScratch) {
 	}
 	// Keep one bounded reserve for later fork bursts. Drop an oversized active
 	// backing array without scanning it before the GSS slabs are recycled.
-	p.pendingForkStacks = resetPendingStackBufferAfterDemotion(p.pendingForkStacks, &p.pendingForkStackReserve)
-	p.pendingFrontierForkStacks = resetPendingStackBufferAfterDemotion(p.pendingFrontierForkStacks, &p.pendingFrontierForkStackReserve)
+	p.resetPendingStackBuffersAfterDemotion()
 	scratch.gss.recycleForParse()
 }
 

--- a/parser_pool.go
+++ b/parser_pool.go
@@ -150,8 +150,8 @@ func (pp *ParserPool) release(p *Parser) {
 	p.reuseScratch.releaseNodeRefs()
 	// Drop pending stack references and pathological retained capacity while
 	// the parser is idle in the pool.
-	p.pendingForkStacks = resetPendingStackBuffer(p.pendingForkStacks)
-	p.pendingFrontierForkStacks = resetPendingStackBuffer(p.pendingFrontierForkStacks)
+	p.pendingForkStacks = resetPendingStackBuffer(p.pendingForkStacks, true)
+	p.pendingFrontierForkStacks = resetPendingStackBuffer(p.pendingFrontierForkStacks, true)
 	// Return the recovery sub-parser so its reuseCursor *Node refs (and the
 	// arena they pin) are released while preserving its language-level caches.
 	p.clearRecoveryParser()

--- a/parser_pool.go
+++ b/parser_pool.go
@@ -150,8 +150,8 @@ func (pp *ParserPool) release(p *Parser) {
 	p.reuseScratch.releaseNodeRefs()
 	// Drop pending stack references and pathological retained capacity while
 	// the parser is idle in the pool.
-	p.pendingForkStacks = resetPendingStackBuffer(p.pendingForkStacks, true)
-	p.pendingFrontierForkStacks = resetPendingStackBuffer(p.pendingFrontierForkStacks, true)
+	p.pendingForkStacks = resetPendingStackBufferAtBoundary(p.pendingForkStacks, &p.pendingForkStackReserve)
+	p.pendingFrontierForkStacks = resetPendingStackBufferAtBoundary(p.pendingFrontierForkStacks, &p.pendingFrontierForkStackReserve)
 	// Return the recovery sub-parser so its reuseCursor *Node refs (and the
 	// arena they pin) are released while preserving its language-level caches.
 	p.clearRecoveryParser()

--- a/parser_pool.go
+++ b/parser_pool.go
@@ -150,8 +150,7 @@ func (pp *ParserPool) release(p *Parser) {
 	p.reuseScratch.releaseNodeRefs()
 	// Drop pending stack references and pathological retained capacity while
 	// the parser is idle in the pool.
-	p.pendingForkStacks = resetPendingStackBufferAtBoundary(p.pendingForkStacks, &p.pendingForkStackReserve)
-	p.pendingFrontierForkStacks = resetPendingStackBufferAtBoundary(p.pendingFrontierForkStacks, &p.pendingFrontierForkStackReserve)
+	p.resetPendingStackBuffersAtBoundary()
 	// Return the recovery sub-parser so its reuseCursor *Node refs (and the
 	// arena they pin) are released while preserving its language-level caches.
 	p.clearRecoveryParser()

--- a/parser_pool.go
+++ b/parser_pool.go
@@ -148,6 +148,10 @@ func (pp *ParserPool) release(p *Parser) {
 	// Release *Node refs so the last-used arena can be GC'd.
 	p.reuseCursor.releaseNodeRefs()
 	p.reuseScratch.releaseNodeRefs()
+	// Drop pending stack references and pathological retained capacity while
+	// the parser is idle in the pool.
+	p.pendingForkStacks = resetPendingStackBuffer(p.pendingForkStacks)
+	p.pendingFrontierForkStacks = resetPendingStackBuffer(p.pendingFrontierForkStacks)
 	// Return the recovery sub-parser so its reuseCursor *Node refs (and the
 	// arena they pin) are released while preserving its language-level caches.
 	p.clearRecoveryParser()

--- a/parser_pool_test.go
+++ b/parser_pool_test.go
@@ -7,6 +7,53 @@ import (
 	"testing"
 )
 
+func TestParserPoolReleaseScrubsPendingStackBuffers(t *testing.T) {
+	pool := NewParserPool(buildArithmeticLanguage())
+	parser := pool.checkout()
+
+	small := make([]glrStack, 1, maxRetainedPendingStackCap)
+	small[0].gss.head = &gssNode{}
+	large := make([]glrStack, 1, maxRetainedPendingStackCap+1)
+	large[0].gss.head = &gssNode{}
+	parser.pendingForkStacks = small
+	parser.pendingFrontierForkStacks = large
+
+	pool.release(parser)
+
+	if parser.pendingForkStacks == nil || len(parser.pendingForkStacks) != 0 || cap(parser.pendingForkStacks) != cap(small) {
+		t.Fatalf("pooled small pending buffer = len %d, cap %d, want len 0, cap %d", len(parser.pendingForkStacks), cap(parser.pendingForkStacks), cap(small))
+	}
+	if parser.pendingForkStacks[:cap(parser.pendingForkStacks)][0].gss.head != nil {
+		t.Fatal("pooled small pending buffer retained a stack reference")
+	}
+	if parser.pendingFrontierForkStacks != nil {
+		t.Fatalf("pooled oversized pending buffer cap = %d, want nil", cap(parser.pendingFrontierForkStacks))
+	}
+}
+
+func TestReleaseSnippetParserScrubsPendingStackBuffers(t *testing.T) {
+	parser := NewParser(buildArithmeticLanguage())
+
+	small := make([]glrStack, 1, maxRetainedPendingStackCap)
+	small[0].gss.head = &gssNode{}
+	large := make([]glrStack, 1, maxRetainedPendingStackCap+1)
+	large[0].gss.head = &gssNode{}
+	parser.pendingForkStacks = small
+	parser.pendingFrontierForkStacks = large
+
+	releaseSnippetParser(parser)
+
+	if parser.pendingForkStacks == nil || len(parser.pendingForkStacks) != 0 || cap(parser.pendingForkStacks) != cap(small) {
+		t.Fatalf("snippet small pending buffer = len %d, cap %d, want len 0, cap %d", len(parser.pendingForkStacks), cap(parser.pendingForkStacks), cap(small))
+	}
+	if parser.pendingForkStacks[:cap(parser.pendingForkStacks)][0].gss.head != nil {
+		t.Fatal("snippet small pending buffer retained a stack reference")
+	}
+	if parser.pendingFrontierForkStacks != nil {
+		t.Fatalf("snippet oversized pending buffer cap = %d, want nil", cap(parser.pendingFrontierForkStacks))
+	}
+}
+
 func TestParserPoolParseConcurrent(t *testing.T) {
 	lang := buildArithmeticLanguage()
 	pool := NewParserPool(lang)

--- a/parser_pool_test.go
+++ b/parser_pool_test.go
@@ -29,6 +29,55 @@ func TestParserPoolReleaseScrubsPendingStackBuffers(t *testing.T) {
 	if parser.pendingFrontierForkStacks != nil {
 		t.Fatalf("pooled oversized pending buffer cap = %d, want nil", cap(parser.pendingFrontierForkStacks))
 	}
+	if parser.forestDeclineMemo != nil {
+		t.Fatal("pool release allocated the cold sidecar")
+	}
+}
+
+func TestParserPoolReleaseScrubsColdPendingStackReserves(t *testing.T) {
+	pool := NewParserPool(buildArithmeticLanguage())
+	parser := pool.checkout()
+	cold := parser.ensureParserColdState()
+	forkReserve := make([]glrStack, 1, maxRetainedPendingStackCap)
+	forkReserve[0].gss.head = &gssNode{}
+	cold.pendingForkStackReserve = forkReserve[:0]
+	parser.pendingForkStacks = cold.pendingForkStackReserve
+	frontierReserve := make([]glrStack, 1, maxRetainedPendingStackCap)
+	frontierReserve[0].gss.head = &gssNode{}
+	cold.pendingFrontierForkStackReserve = frontierReserve[:0]
+	frontierBacking := make([]glrStack, 1, maxRetainedPendingStackCap+1)
+	frontierHead := &gssNode{}
+	frontierBacking[0].gss.head = frontierHead
+	parser.pendingFrontierForkStacks = frontierBacking[:0]
+
+	pool.release(parser)
+
+	if frontierBacking[0].gss.head != frontierHead {
+		t.Fatal("pool release scanned the oversized active buffer")
+	}
+	if got := cap(parser.pendingForkStacks); got != maxRetainedPendingStackCap {
+		t.Fatalf("pooled pending fork capacity = %d, want %d", got, maxRetainedPendingStackCap)
+	}
+	if got := cap(parser.pendingFrontierForkStacks); got != maxRetainedPendingStackCap {
+		t.Fatalf("pooled pending frontier capacity = %d, want %d", got, maxRetainedPendingStackCap)
+	}
+	if forkReserve[0].gss.head != nil || frontierReserve[0].gss.head != nil {
+		t.Fatal("pool release retained stack references in the cold reserves")
+	}
+	if cold.pendingForkStackReserve[:cap(cold.pendingForkStackReserve)][0].gss.head != nil ||
+		cold.pendingFrontierForkStackReserve[:cap(cold.pendingFrontierForkStackReserve)][0].gss.head != nil {
+		t.Fatal("cold reserve state retained stack references")
+	}
+
+	reacquired := pool.checkout()
+	if len(reacquired.pendingForkStacks) != 0 || len(reacquired.pendingFrontierForkStacks) != 0 {
+		t.Fatal("reacquired parser retained pending stacks")
+	}
+	if cap(reacquired.pendingForkStacks) > maxRetainedPendingStackCap ||
+		cap(reacquired.pendingFrontierForkStacks) > maxRetainedPendingStackCap {
+		t.Fatal("reacquired parser retained oversized pending capacity")
+	}
+	pool.release(reacquired)
 }
 
 func TestReleaseSnippetParserScrubsPendingStackBuffers(t *testing.T) {
@@ -51,6 +100,9 @@ func TestReleaseSnippetParserScrubsPendingStackBuffers(t *testing.T) {
 	}
 	if parser.pendingFrontierForkStacks != nil {
 		t.Fatalf("snippet oversized pending buffer cap = %d, want nil", cap(parser.pendingFrontierForkStacks))
+	}
+	if parser.forestDeclineMemo != nil {
+		t.Fatal("snippet release allocated the cold sidecar")
 	}
 }
 


### PR DESCRIPTION
## Summary

- drop empty pending-stack buffers above the existing 4096-stack emergency cap
- retain and clear ordinary buffers
- scrub both pending buffers when pooled parsers are released
- add retention, clearing, and focused benchmark coverage

## Root cause

Pending GLR queues can grow far beyond the ordinary live-stack cap. After the queue drains, GSS recycling clears the full backing capacity on every demotion even though the logical length is zero. Dropping an oversized empty buffer releases the same references without the repeated scan.

## Benchmark

Focused 4097-stack benchmark, six runs:

- drop oversized: 1.39-1.42 ns/op
- clear oversized: 1.89-2.27 us/op
- both: 0 B/op, 0 allocs/op

## Tests

- go test .
- go vet .
- targeted race test for parser pool, reset, demotion, and discard paths
- reset tests repeated 20 times