### PR TITLE
Document v0.51.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.51.0] - 2026-08-16
+
+### Added
+
+- Add `grammars.ParseFilePooledStrict`. It rejects a partial tree and returns
+  the parser stop error.
+
+- Add `Tagger.TagStrict`. It returns tags only after a complete parse and
+  preserves parser errors.
+
+### Changed
+
+- Bound pending fork-stack retention. Keep a bounded reserve during parsing,
+  and drop oversized storage at parse and parser-pool boundaries.
+
+- Separate C-runtime recovery walk, convergence, and fallback state. Reset
+  these states across parse, retry, snippet, pool, and iteration boundaries.
+
+- Provision dense reach marks when generalized LR (GLR) slabs grow. Owned nodes
+  no longer use the pointer-map fallback.
+
+### Fixed
+
+- Clear stale C-runtime recovery state after a clean condense. A clean suffix
+  no longer inherits an active recovery-cost gate.
+
+### Tests
+
+- Align the Application Binary Interface version 14 (ABI-14) lexer-mode probe
+  with generated end-of-file behavior. The probe now checks the emitted layout
+  without injecting an end-of-file state.
+
+### CI
+
+- [PR #732](https://github.com/odvcencio/gotreesitter/pull/732) remains open.
+  It separates query-fleet smoke tests from regular shards and is not part of
+  this release.
+
+### Open work
+
+The following items remain open:
+
+- [Issue #454](https://github.com/odvcencio/gotreesitter/issues/454) tracks
+  downstream field reports.
+
+- [Issue #576](https://github.com/odvcencio/gotreesitter/issues/576) tracks
+  Swift recovery divergence.
+
+- [Issue #586](https://github.com/odvcencio/gotreesitter/issues/586) tracks
+  shared GLR error-cost bounds.
+
+- [Issue #728](https://github.com/odvcencio/gotreesitter/issues/728) tracks
+  external-scanner incremental reuse.
+
 ## [0.50.1] - 2026-08-14
 
 ### Fixed
@@ -4663,7 +4717,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.50.1...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.51.0...HEAD
+[0.51.0]: https://github.com/odvcencio/gotreesitter/compare/v0.50.1...v0.51.0
 [0.50.1]: https://github.com/odvcencio/gotreesitter/compare/v0.50.0...v0.50.1
 [0.50.0]: https://github.com/odvcencio/gotreesitter/compare/v0.49.0...v0.50.0
 [0.49.0]: https://github.com/odvcencio/gotreesitter/compare/v0.48.1...v0.49.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,11 +39,11 @@ for tags and release notes while still in `0.x`.
   with generated end-of-file behavior. The probe now checks the emitted layout
   without injecting an end-of-file state.
 
-### CI
+### Continuous integration (CI)
 
-- [PR #732](https://github.com/odvcencio/gotreesitter/pull/732) remains open.
-  It separates query-fleet smoke tests from regular shards and is not part of
-  this release.
+- [Pull request (PR) #732](https://github.com/odvcencio/gotreesitter/pull/732)
+  remains open. Its CI-only change separates query-fleet smoke tests from
+  regular shards and is not part of this release.
 
 ### Open work
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,9 @@ for tags and release notes while still in `0.x`.
 
 ### Continuous integration (CI)
 
-- [Pull request (PR) #732](https://github.com/odvcencio/gotreesitter/pull/732)
-  remains open. Its CI-only change separates query-fleet smoke tests from
-  regular shards and is not part of this release.
+- The project merged [pull request (PR) #732](https://github.com/odvcencio/gotreesitter/pull/732).
+  Its CI-only change separates query-fleet smoke tests from regular shards and
+  is not part of this release.
 
 ### Open work
 

--- a/README.md
+++ b/README.md
@@ -803,9 +803,9 @@ This release adds strict pooled file parsing and strict one-shot tagging. It
 also bounds generalized LR (GLR) recovery state retention and resets recovery
 state across parser lifecycle boundaries.
 
-Pull request #732 remains open. Its continuous-integration-only change
-separates query-fleet smoke tests from regular shards and is not part of this
-release.
+The project merged [pull request #732](https://github.com/odvcencio/gotreesitter/pull/732).
+Its continuous-integration-only change separates query-fleet smoke tests from
+regular shards and is not part of this release.
 
 Detailed shipped evidence lives in [CHANGELOG.md](CHANGELOG.md). Standard minor
 releases may ship on any day after the exact commit on `main` passes the full

--- a/README.md
+++ b/README.md
@@ -797,15 +797,15 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.50.1**.
+The current release is **v0.51.0**.
 
-This release consolidates parser correctness, recovery bounds, parser-core
-bytecode, fact extraction bytecode, replay caches, randomized benchmarks, and
-V10 fleet controls. It also adds opt-in Lean 4 support and scanner corrections
-for JavaScript, TypeScript, and TSX.
+This release adds strict pooled file parsing and strict one-shot tagging. It
+also bounds generalized LR (GLR) recovery state retention and resets recovery
+state across parser lifecycle boundaries.
 
-This patch restores single-language grammar-subset builds and checks each
-registered grammar subset in continuous integration.
+Pull request #732 remains open. Its continuous-integration-only change
+separates query-fleet smoke tests from regular shards and is not part of this
+release.
 
 Detailed shipped evidence lives in [CHANGELOG.md](CHANGELOG.md). Planned minor
 releases are batched on Thursdays; the immutable-tag process and exceptions are

--- a/README.md
+++ b/README.md
@@ -807,9 +807,12 @@ Pull request #732 remains open. Its continuous-integration-only change
 separates query-fleet smoke tests from regular shards and is not part of this
 release.
 
-Detailed shipped evidence lives in [CHANGELOG.md](CHANGELOG.md). Planned minor
-releases are batched on Thursdays; the immutable-tag process and exceptions are
-documented in [docs/releasing.md](docs/releasing.md).
+Detailed shipped evidence lives in [CHANGELOG.md](CHANGELOG.md). Standard minor
+releases may ship on any day after the exact commit on `main` passes the full
+hosted continuous integration workflow. Require complete correctness and
+performance evidence; do not use a calendar delay as a replacement for release
+evidence. The immutable-tag process and urgent-patch exception are documented in
+[docs/releasing.md](docs/releasing.md).
 
 ### Now — cleanup, ownership, and explainability
 


### PR DESCRIPTION
## Summary

Document the final v0.51.0 release metadata.

- Rebase the accepted metadata commits onto `main`.
- Mark pull request #732 as merged.
- Retain the continuous-integration-only release note.
- Keep issues #454, #576, #586, and #728 open.
- Change only `CHANGELOG.md` and `README.md`.

## Assertions

- Base branch: `main`.
- Base SHA: `28d7c45e24d56dd065abf12fdf10e4073a03ea7c`.
- Head SHA: `e39ffc494891b3a3515abdbc52c7d74c2baf5385`.
- Pull request #732 is merged.
- The release date is `2026-08-16`.
- The release version is `v0.51.0`.
- The comparison links use `v0.50.1...v0.51.0` and `v0.51.0...HEAD`.
- The diff adds no unsupported performance claim.
- No issue-closing reference appears.

## Validation

- `go test ./cmd/releasegate -count=1`
- `git diff --check`
- Exact file-scope and metadata assertions pass.
- GitHub reports issues #454, #576, #586, and #728 as open.