### PR TITLE
fix(incremental-reuse): restore compact-tree admission

### DIFF
--- a/external_scanner_quiescence.go
+++ b/external_scanner_quiescence.go
@@ -160,3 +160,11 @@ func classifyExternalScannerQuiescence(lang *Language) externalScannerQuiescence
 func externalScannerBoundaryQuiescentWithoutCheckpoint(lang *Language) bool {
 	return classifyExternalScannerQuiescence(lang) != scannerQuiescenceRefuted
 }
+
+// compactIncrementalReuseProvenForLanguage keeps the classifier's Unknown
+// result neutral only when the legacy language admission permits reuse.
+// Refuted scanners remain fail-closed.
+func compactIncrementalReuseProvenForLanguage(lang *Language) bool {
+	return externalScannerBoundaryQuiescentWithoutCheckpoint(lang) &&
+		languageSupportsIncrementalReuse(lang)
+}

--- a/external_scanner_quiescence_test.go
+++ b/external_scanner_quiescence_test.go
@@ -19,6 +19,7 @@ type quiescenceStatelessScanner struct {
 }
 
 func (quiescenceStatelessScanner) ExternalScannerIsStateless() bool { return true }
+func (quiescenceStatelessScanner) SupportsIncrementalReuse() bool   { return true }
 
 type quiescenceCheckpointScanner struct {
 	parserTestSafeExternalScanner
@@ -95,6 +96,35 @@ func TestExternalScannerBoundaryQuiescentFailsClosed(t *testing.T) {
 	}
 	if !externalScannerBoundaryQuiescentWithoutCheckpoint(&Language{}) {
 		t.Fatal("no-scanner language rejected: predicate must admit a proven boundary")
+	}
+}
+
+func TestCompactIncrementalReuseProvenForLanguage(t *testing.T) {
+	cases := []struct {
+		name string
+		lang *Language
+		want bool
+	}{
+		{name: "no scanner", lang: &Language{}, want: true},
+		{name: "stateless scanner", lang: &Language{ExternalScanner: quiescenceStatelessScanner{}}, want: true},
+		{name: "legacy admitted unknown scanner", lang: &Language{ExternalScanner: parserTestSafeExternalScanner{}}, want: true},
+		{name: "refuted scanner", lang: &Language{ExternalScanner: quiescenceOptOutScanner{}}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := compactIncrementalReuseProvenForLanguage(tc.lang); got != tc.want {
+				t.Fatalf("compactIncrementalReuseProvenForLanguage = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIncrementalReuseUnsupportedReasonIdentifiesTreeProducer(t *testing.T) {
+	if got := incrementalReuseUnsupportedReasonForTree(&Tree{compactMaterialized: true, incrementalReuseDisabled: true}); got != compactIncrementalReuseUnsupportedReason {
+		t.Fatalf("compact tree reason = %q, want %q", got, compactIncrementalReuseUnsupportedReason)
+	}
+	if got := incrementalReuseUnsupportedReasonForTree(&Tree{incrementalReuseDisabled: true}); got != forestIncrementalReuseUnsupportedReason {
+		t.Fatalf("forest tree reason = %q, want %q", got, forestIncrementalReuseUnsupportedReason)
 	}
 }
 

--- a/issue728_incremental_reuse_regression_test.go
+++ b/issue728_incremental_reuse_regression_test.go
@@ -1,0 +1,263 @@
+package gotreesitter_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+type issue728ReuseCase struct {
+	name      string
+	lang      func() *gotreesitter.Language
+	source    func(int) []byte
+	marker    []byte
+	insert    byte
+	wantReuse bool
+}
+
+func TestIssue728IncrementalReuseMeasurement(t *testing.T) {
+	cases := []issue728ReuseCase{
+		{name: "css", lang: grammars.CssLanguage, source: issue728CSSSource, marker: []byte(".c"), insert: 'c', wantReuse: true},
+		{name: "scss", lang: grammars.ScssLanguage, source: issue728SCSSSource, marker: []byte(".c"), insert: 'c', wantReuse: true},
+		{name: "typescript", lang: grammars.TypescriptLanguage, source: issue728TypeScriptSource, marker: []byte("export function f"), insert: 'f', wantReuse: true},
+		{name: "tsx", lang: grammars.TsxLanguage, source: issue728TypeScriptSource, marker: []byte("export function f"), insert: 'f', wantReuse: true},
+		{name: "toml", lang: grammars.TomlLanguage, source: issue728TOMLSource, marker: []byte("key"), insert: 'k', wantReuse: true},
+		{name: "cmake", lang: grammars.CmakeLanguage, source: issue728CMakeSource, marker: []byte("VAR"), insert: 'X', wantReuse: true},
+		{name: "sql", lang: grammars.SqlLanguage, source: issue728SQLSource, marker: []byte("AS value_"), insert: 'x', wantReuse: false},
+		{name: "ini", lang: grammars.IniLanguage, source: issue728INISource, marker: []byte("key"), insert: 'x', wantReuse: true},
+		{name: "go", lang: grammars.GoLanguage, source: issue728GoSource, marker: []byte("func f"), insert: 'f', wantReuse: true},
+	}
+	for _, tc := range cases {
+		for _, size := range []int{63 << 10, 65 << 10, 137 << 10} {
+			t.Run(fmt.Sprintf("%s/%dKiB", tc.name, size>>10), func(t *testing.T) {
+				src := tc.source(size)
+				if len(src) < size {
+					t.Fatalf("source length = %d, want at least %d bytes", len(src), size)
+				}
+				if size < 64<<10 && len(src) >= 64<<10 {
+					t.Fatalf("source length = %d, want below 64 KiB", len(src))
+				}
+				if size >= 64<<10 && len(src) < 64<<10 {
+					t.Fatalf("source length = %d, want at least 64 KiB", len(src))
+				}
+				offset := bytes.Index(src, tc.marker)
+				if offset < 0 {
+					t.Fatalf("source does not contain marker %q", tc.marker)
+				}
+				editOffset := offset + len(tc.marker)
+				edited := make([]byte, 0, len(src)+1)
+				edited = append(edited, src[:editOffset]...)
+				edited = append(edited, tc.insert)
+				edited = append(edited, src[editOffset:]...)
+				point := issue728PointAt(src, editOffset)
+
+				gotreesitter.ResetAdmissionCandidateCountersForTest()
+				parser := gotreesitter.NewParser(tc.lang())
+				parser.SetAdmissionCandidateRoute(true)
+				oldTree, err := parser.Parse(src)
+				if err != nil {
+					t.Fatalf("initial parse: %v", err)
+				}
+				defer oldTree.Release()
+				oldRouted, oldFallbacks := gotreesitter.AdmissionCandidateCounters()
+				if oldRouted != 1 || oldFallbacks != 0 {
+					t.Fatalf("candidate route counters = %d/%d, want 1/0 (reason=%q)", oldRouted, oldFallbacks, gotreesitter.AdmissionCandidateLastFallbackReason())
+				}
+				if oldTree.UsedForestFastPath() || oldTree.ParseRuntime().ForestFastPath {
+					t.Fatal("candidate fresh tree unexpectedly used the forest route")
+				}
+				oldTree.Edit(gotreesitter.InputEdit{
+					StartByte: uint32(editOffset), OldEndByte: uint32(editOffset), NewEndByte: uint32(editOffset + 1),
+					StartPoint: point, OldEndPoint: point, NewEndPoint: issue728PointAt(edited, editOffset+1),
+				})
+				newTree, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+				if err != nil {
+					t.Fatalf("incremental parse: %v", err)
+				}
+				defer newTree.Release()
+				newRouted, newFallbacks := gotreesitter.AdmissionCandidateCounters()
+				if newRouted != oldRouted || newFallbacks != oldFallbacks {
+					t.Fatalf("incremental parse changed candidate route counters: before=%d/%d after=%d/%d", oldRouted, oldFallbacks, newRouted, newFallbacks)
+				}
+				if tc.wantReuse {
+					if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" {
+						t.Fatalf("incremental reuse remained unsupported: %+v", profile)
+					}
+					if profile.ReusedBytes == 0 || profile.ReusedSubtrees == 0 || profile.NewNodesAllocated == 0 {
+						t.Fatalf("incremental reuse counters are empty: %+v", profile)
+					}
+				} else if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" || profile.ReusedBytes != 0 || profile.ReusedSubtrees != 0 || profile.ReuseRejectScannerUnquiescent == 0 {
+					t.Fatalf("checkpoint-refuted scanner was not rejected at reuse boundaries: %+v", profile)
+				}
+				if !profile.OldTreeReuseRoute || !newTree.ParseRuntime().IncrementalOldTreeReuseRoute {
+					t.Fatalf("incremental route tag is missing: profile=%+v runtime=%s", profile, newTree.ParseRuntime().Summary())
+				}
+				if newTree.UsedForestFastPath() || newTree.ParseRuntime().ForestFastPath {
+					t.Fatal("incremental result unexpectedly used the forest route")
+				}
+
+				freshParser := gotreesitter.NewParser(tc.lang())
+				freshParser.SetAdmissionCandidateRoute(false)
+				freshTree, err := freshParser.Parse(edited)
+				if err != nil {
+					t.Fatalf("fresh parse: %v", err)
+				}
+				defer freshTree.Release()
+				freshDigest := issue728TreeDigest(freshTree, tc.lang())
+				requireIncrementalDeepTreeMatchesFresh(t, newTree, freshTree, tc.lang())
+				if newTree.RootNode().HasError() != freshTree.RootNode().HasError() ||
+					newTree.RootNode().Type(tc.lang()) != freshTree.RootNode().Type(tc.lang()) ||
+					issue728TreeDigest(newTree, tc.lang()) != freshDigest {
+					t.Fatalf("incremental tree differs from fresh tree: incremental=%s fresh=%s", issue728TreeDigest(newTree, tc.lang()), freshDigest)
+				}
+				t.Logf("source=%d oldRoute={forest=%v runtimeForest=%v usedForest=%v routed=%d fallbacks=%d} profile={reusedBytes=%d reusedSubtrees=%d newNodes=%d unsupported=%v reason=%q oldTreeReuse=%v scannerRejects=%d reparseNanos=%d} newRoute={forest=%v runtimeForest=%v incrementalReuse=%v routed=%d fallbacks=%d} freshDigest=%s",
+					len(src),
+					oldTree.UsedForestFastPath(), oldTree.ParseRuntime().ForestFastPath, oldTree.UsedForestFastPath(), oldRouted, oldFallbacks,
+					profile.ReusedBytes, profile.ReusedSubtrees, profile.NewNodesAllocated, profile.ReuseUnsupported, profile.ReuseUnsupportedReason, profile.OldTreeReuseRoute, profile.ReuseRejectScannerUnquiescent, profile.ReparseNanos,
+					newTree.UsedForestFastPath(), newTree.ParseRuntime().ForestFastPath, newTree.ParseRuntime().IncrementalOldTreeReuseRoute, newRouted, newFallbacks,
+					freshDigest,
+				)
+			})
+		}
+	}
+}
+
+func TestIssue728RefutedExternalScannersFailClosed(t *testing.T) {
+	cases := []issue728ReuseCase{
+		{name: "python", lang: grammars.PythonLanguage, source: issue728PythonSource, marker: []byte("value"), insert: 'x'},
+		{name: "starlark", lang: grammars.StarlarkLanguage, source: issue728PythonSource, marker: []byte("value"), insert: 'x'},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := tc.source(8 << 10)
+			offset := bytes.Index(src, tc.marker)
+			if offset < 0 {
+				t.Fatalf("source does not contain marker %q", tc.marker)
+			}
+			edited := make([]byte, 0, len(src)+1)
+			edited = append(edited, src[:offset+len(tc.marker)]...)
+			edited = append(edited, tc.insert)
+			edited = append(edited, src[offset+len(tc.marker):]...)
+
+			gotreesitter.ResetAdmissionCandidateCountersForTest()
+			parser := gotreesitter.NewParser(tc.lang())
+			parser.SetAdmissionCandidateRoute(true)
+			oldTree, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("initial parse: %v", err)
+			}
+			defer oldTree.Release()
+			if oldTree.UsedForestFastPath() || oldTree.ParseRuntime().ForestFastPath {
+				t.Fatal("refuted scanner fixture unexpectedly used the forest route")
+			}
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte: uint32(offset + len(tc.marker)), OldEndByte: uint32(offset + len(tc.marker)), NewEndByte: uint32(offset + len(tc.marker) + 1),
+				StartPoint: issue728PointAt(src, offset+len(tc.marker)), OldEndPoint: issue728PointAt(src, offset+len(tc.marker)), NewEndPoint: issue728PointAt(edited, offset+len(tc.marker)+1),
+			})
+			incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+			if err != nil {
+				t.Fatalf("incremental parse: %v", err)
+			}
+			defer incremental.Release()
+			if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason == "" || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+				t.Fatalf("refuted scanner entered reuse: %+v", profile)
+			}
+
+			freshParser := gotreesitter.NewParser(tc.lang())
+			freshParser.SetAdmissionCandidateRoute(false)
+			freshTree, err := freshParser.Parse(edited)
+			if err != nil {
+				t.Fatalf("fresh parse: %v", err)
+			}
+			defer freshTree.Release()
+			requireIncrementalDeepTreeMatchesFresh(t, incremental, freshTree, tc.lang())
+		})
+	}
+}
+
+func issue728TreeDigest(tree *gotreesitter.Tree, lang *gotreesitter.Language) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(tree.RootNode().SExpr(lang))))
+}
+
+func issue728PointAt(src []byte, offset int) gotreesitter.Point {
+	var point gotreesitter.Point
+	for _, b := range src[:offset] {
+		if b == '\n' {
+			point.Row++
+			point.Column = 0
+		} else {
+			point.Column++
+		}
+	}
+	return point
+}
+
+func issue728FillSource(target int, line func(int) string) []byte {
+	var builder strings.Builder
+	for i := 0; builder.Len() < target; i++ {
+		builder.WriteString(line(i))
+	}
+	return []byte(builder.String())
+}
+
+func issue728CSSSource(target int) []byte {
+	return issue728FillSource(target, func(i int) string {
+		return fmt.Sprintf(".c%d { color: #012345; margin: 0px; padding: 1px; }\n", i)
+	})
+}
+
+func issue728SCSSSource(target int) []byte {
+	return issue728FillSource(target, func(i int) string {
+		return fmt.Sprintf("$color%d: #012345;\n.c%d { color: $color%d; margin: 0px; padding: 1px; }\n", i, i, i)
+	})
+}
+
+func issue728TypeScriptSource(target int) []byte {
+	return issue728FillSource(target, func(i int) string {
+		return fmt.Sprintf("export function f%d(): number { const v = %d; return v }\n", i, i)
+	})
+}
+
+func issue728TOMLSource(target int) []byte {
+	return issue728FillSource(target, func(i int) string {
+		return fmt.Sprintf("key%d = \"value-%d\"\n", i, i)
+	})
+}
+
+func issue728CMakeSource(target int) []byte {
+	return issue728FillSource(target, func(i int) string {
+		return fmt.Sprintf("set(VAR%d value-%d)\n", i, i)
+	})
+}
+
+func issue728SQLSource(target int) []byte {
+	return issue728FillSource(target, func(i int) string {
+		return fmt.Sprintf("SELECT $q$payload_%06d$q$ AS value_%06d;\n", i, i)
+	})
+}
+
+func issue728INISource(target int) []byte {
+	return issue728FillSource(target, func(i int) string {
+		return fmt.Sprintf("[section%d]\nkey%d = \"value-%d\"\n", i, i, i)
+	})
+}
+
+func issue728PythonSource(target int) []byte {
+	return issue728FillSource(target, func(i int) string {
+		return fmt.Sprintf("def f%d():\n    value = %d\n    return value\n\n", i, i)
+	})
+}
+
+func issue728GoSource(target int) []byte {
+	var builder strings.Builder
+	builder.WriteString("package main\n\n")
+	for i := 0; builder.Len() < target; i++ {
+		fmt.Fprintf(&builder, "func f%d() int { v := %d; return v }\n", i, i)
+	}
+	return []byte(builder.String())
+}

--- a/parser.go
+++ b/parser.go
@@ -3161,7 +3161,7 @@ func (p *Parser) parseIncrementalInternalWithMergePerKeyOverride(source []byte, 
 	if oldTreeDisablesIncrementalReuse(oldTree) {
 		if timing != nil {
 			timing.reuseUnsupported = true
-			timing.reuseUnsupportedReason = forestIncrementalReuseUnsupportedReason
+			timing.reuseUnsupportedReason = incrementalReuseUnsupportedReasonForTree(oldTree)
 			if oldTree != nil && oldTree.compactMaterialized {
 				if reason := incrementalReuseUnavailableReason(ts); reason != "" {
 					timing.reuseUnsupportedReason = reason

--- a/parser_api.go
+++ b/parser_api.go
@@ -175,12 +175,22 @@ func finalizeDeferredReturnedTreeTruncation(tree *Tree, _ []byte) {
 	markTruncatedTreeHasError(tree.parseRuntime, rawRootOrNil(tree))
 }
 
-const forestIncrementalReuseUnsupportedReason = "old tree was built by GSS forest fast path"
+const (
+	forestIncrementalReuseUnsupportedReason  = "old tree was built by GSS forest fast path"
+	compactIncrementalReuseUnsupportedReason = "old tree was compact-materialized without a scanner-quiescence proof"
+)
 
 const forestRecoveryFallbackReuseReason = "forest_recovery_fallback"
 
 func oldTreeDisablesIncrementalReuse(oldTree *Tree) bool {
 	return oldTree != nil && oldTree.incrementalReuseDisabled
+}
+
+func incrementalReuseUnsupportedReasonForTree(oldTree *Tree) string {
+	if oldTree != nil && oldTree.compactMaterialized {
+		return compactIncrementalReuseUnsupportedReason
+	}
+	return forestIncrementalReuseUnsupportedReason
 }
 
 func (p *Parser) tryTokenInvariantReuseForDisabledOldTree(source []byte, oldTree *Tree, timing *incrementalParseTiming) (*Tree, bool) {
@@ -1697,7 +1707,7 @@ func (p *Parser) parseIncrementalChangedProfiled(source []byte, oldTree *Tree) (
 		if oldTree == nil || !oldTree.compactMaterialized {
 			start := time.Now()
 			tree, err := p.Parse(source)
-			return tree, profileFreshParseFallback(start, tree, forestIncrementalReuseUnsupportedReason), err
+			return tree, profileFreshParseFallback(start, tree, incrementalReuseUnsupportedReasonForTree(oldTree)), err
 		}
 		// Continue through the token-source path so a compact-tree decline keeps
 		// the same scanner reason and work attribution as an ordinary fallback.

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -3197,7 +3197,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 		}
 		defer replayStates.release()
 	}
-	incrementalReuseProven := replayStates != nil && classifyExternalScannerQuiescence(parser.language) == scannerQuiescenceProven
+	incrementalReuseProven := replayStates != nil && compactIncrementalReuseProvenForLanguage(parser.language)
 	stamp := func(id core.SubtreeID, node *Node, terminal bool) {
 		// Stamp the reconstructed state for THIS derivation id onto the node
 		// that materializes it. For a unary collapse chain the driver visits the

--- a/parsestate_reuse_bar_test.go
+++ b/parsestate_reuse_bar_test.go
@@ -75,11 +75,17 @@ func TestCompactMaterializedTreeBarsIncrementalReuse(t *testing.T) {
 			}
 			t.Fatal("compact tree was reused via the token-invariant leaf path")
 		}
-		got, err := p.ParseIncremental(newSrc, treeA)
+		got, profile, err := p.ParseIncrementalProfiled(newSrc, treeA)
 		if err != nil {
-			t.Fatalf("ParseIncremental: %v", err)
+			t.Fatalf("ParseIncrementalProfiled: %v", err)
 		}
 		defer got.Release()
+		if !profile.ReuseUnsupported {
+			t.Fatal("compact tree fallback did not report unsupported reuse")
+		}
+		if profile.ReuseUnsupportedReason != compactIncrementalReuseUnsupportedReason {
+			t.Fatalf("compact tree fallback reason = %q, want %q", profile.ReuseUnsupportedReason, compactIncrementalReuseUnsupportedReason)
+		}
 		requireFreshFallback(t, got, treeA)
 	})
 


### PR DESCRIPTION
# Issue 728 pull request closure packet

Status: Ready for pull request creation. This audit did not open a pull request.

Title: `fix(incremental-reuse): restore compact-tree admission`

## Body

Restore incremental subtree reuse on the compact-tree route for admitted external scanners.

- Reject reuse only when the scanner classifier refutes quiescence.
- Apply the existing language admission gate to compact trees.
- Report compact-tree and forest-path refusal reasons separately.
- Add regression coverage for nine languages at 63, 65, and 137 KiB.
- Keep Python and Starlark reuse fail-closed.

Closes #728

### Scope

- Commit: `13a20edaa331f973a15100def6734ae1fe213689`
- Parent: `8c17e0e942e0a68cf99a820ad0fc047bf2238cfa`
- Seven files changed:
  - `external_scanner_quiescence.go`
  - `external_scanner_quiescence_test.go`
  - `issue728_incremental_reuse_regression_test.go`
  - `parser.go`
  - `parser_api.go`
  - `parsercore_phase0_driver.go`
  - `parsestate_reuse_bar_test.go`

### Correctness

- Docker compile passed with exit code 0 and no out-of-memory event.
- Docker unit receipt passed 27 reuse cases and 2 fail-closed cases.
- Docker race receipt passed the same 29 issue cases.
- Build-tagged compact unit tests passed both compact-tree tests.
- Build-tagged compact race tests passed both compact-tree tests.
- Docker C-reference smoke passed fresh and incremental Go parity.
- C-reference maximum resident set size was 223,840 kB.
- `git diff --check` passed.

Receipts:

- Compile: `/tmp/issue728-final-artifacts/20260816T133805Z-issue728-final-compile`
- Unit: `/tmp/issue728-final-artifacts/20260816T133818Z-issue728-final-unit`
- Race: `/tmp/issue728-final-artifacts/20260816T133830Z-issue728-final-race`
- Compact unit: `/tmp/issue728-compact-gates/20260816T170003Z-compact-unit`
- Compact race: `/tmp/issue728-compact-gates/20260816T170010Z-compact-race`
- C-reference smoke: `/tmp/issue728-final-artifacts/20260816T134004Z-issue728-final-go-cgo-parity-go`

SQL, Python, and Starlark remain fail-closed where their scanner proof is absent.
The incremental trees match fresh trees in the regression cases.

### Performance evidence

The directional comparison used the primary benchmark trio, seeds 1 through 20, 750 ms per benchmark, and benchmark memory reporting.
Each input has 60 samples and six observed benchmark-order permutations.

- Before receipt: `/tmp/gotreesitter-issue728-bench-before.txt`
- After receipt: `/tmp/gotreesitter-issue728-bench-after.txt`
- Before SHA-256: `561ed252b7efc51bb1e7eb8437c0cc9b02dedad4d11ac627c9d0f19746a00359`
- After SHA-256: `b90296cab079f8f5ae46f442a50d7bd6cb922729860cb9d5d192250e813a776b`
- Full parse: `-5.14%`
- Incremental single-byte edit: `-5.30%`
- Incremental no edit: `-4.40%`
- Geometric mean: `-4.95%`

The receipts predate the later invalidated overlapping host campaigns. This pull request makes no campaign-credit claim.
Final-head C0f must establish campaign credit after the change reaches accepted main.

### Residuals

- The existing TypeScript parity qualification remains unchanged.
- This change does not claim a new full-fleet parity result.
- The final-head C0f gate remains required by the campaign.

### Release context

Release `v0.51.0` is published from main commit `8c17e0e942e0a68cf99a820ad0fc047bf2238cfa`.
