### PR TITLE
Fix repeated direct field projection on flattened spans

### DIFF
--- a/cgo_harness/parity_swift_condition_field_regression_test.go
+++ b/cgo_harness/parity_swift_condition_field_regression_test.go
@@ -1,0 +1,167 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"fmt"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestParitySwiftConditionFieldFamily(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "issue-590-condition-list",
+			source: "func f() {\n" +
+				"  if let first = first, let second = second {\n" +
+				"    return\n" +
+				"  }\n" +
+				"}\n",
+		},
+		{
+			name: "issue-591-else-if-binding",
+			source: "func f(_ i: Index, _ limit: Index) -> Index? {\n" +
+				"  if (limit < i) {\n" +
+				"    if let idx = make(i) {\n" +
+				"      return idx\n" +
+				"    } else {\n" +
+				"      return nil\n" +
+				"    }\n" +
+				"  } else if let idx = make(i) {\n" +
+				"    return idx\n" +
+				"  } else {\n" +
+				"    return nil\n" +
+				"  }\n" +
+				"}\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := []byte(test.source)
+			cLang, err := ParityCLanguage("swift")
+			if err != nil {
+				t.Fatalf("load locked Swift C parser: %v", err)
+			}
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatalf("set locked Swift C language: %v", err)
+			}
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("locked Swift C parser returned no tree")
+			}
+			t.Cleanup(cTree.Close)
+
+			for _, route := range []struct {
+				name      string
+				candidate bool
+			}{
+				{name: "production", candidate: false},
+				{name: "compact", candidate: true},
+			} {
+				route := route
+				t.Run("fresh-"+route.name, func(t *testing.T) {
+					candidate := route.candidate
+					goTree, goLang, err := parseWithGo(parityCase{
+						name:           "swift",
+						source:         test.source,
+						candidateRoute: &candidate,
+					}, source, nil)
+					if err != nil {
+						t.Fatalf("parse Swift with Go: %v", err)
+					}
+					t.Cleanup(func() { releaseGoTree(goTree) })
+					assertSwiftConditionTreeExact(t, goTree, goLang, cTree)
+				})
+
+				t.Run("incremental-"+route.name, func(t *testing.T) {
+					oldSource := append(append([]byte(nil), source...), '\n')
+					candidate := route.candidate
+					oldTree, goLang, err := parseWithGo(parityCase{
+						name:           "swift",
+						source:         string(oldSource),
+						candidateRoute: &candidate,
+					}, oldSource, nil)
+					if err != nil {
+						t.Fatalf("parse old Swift tree with Go: %v", err)
+					}
+					oldTree.Edit(gotreesitter.InputEdit{
+						StartByte:   uint32(len(source)),
+						OldEndByte:  uint32(len(oldSource)),
+						NewEndByte:  uint32(len(source)),
+						StartPoint:  pointAtOffset(source, len(source)),
+						OldEndPoint: pointAtOffset(oldSource, len(oldSource)),
+						NewEndPoint: pointAtOffset(source, len(source)),
+					})
+					goTree, _, err := parseWithGo(parityCase{
+						name:           "swift",
+						source:         test.source,
+						candidateRoute: &candidate,
+					}, source, oldTree)
+					releaseGoTree(oldTree)
+					if err != nil {
+						t.Fatalf("parse Swift incrementally with Go: %v", err)
+					}
+					t.Cleanup(func() { releaseGoTree(goTree) })
+					assertSwiftConditionTreeExact(t, goTree, goLang, cTree)
+				})
+			}
+		})
+	}
+}
+
+func assertSwiftConditionTreeExact(t *testing.T, goTree *gotreesitter.Tree, goLang *gotreesitter.Language, cTree *sitter.Tree) {
+	t.Helper()
+	goRoot := goTree.RootNode()
+	cRoot := cTree.RootNode()
+	if goRoot.HasError() || cRoot.HasError() {
+		t.Fatalf("condition witness has an error node: Go=%v C=%v", goRoot.HasError(), cRoot.HasError())
+	}
+	if diff := FirstDivergenceDumpV1(goRoot, goLang, cRoot); diff != nil {
+		t.Fatalf("node or field divergence: %+v", diff)
+	}
+	if diff := firstSwiftConditionFlagDivergence(goRoot, goLang, cRoot, "/source_file"); diff != nil {
+		t.Fatal(diff)
+	}
+	goInspection, err := benchfixtures.InspectGoTree(goRoot, goLang)
+	if err != nil {
+		t.Fatalf("inspect Go deep tree: %v", err)
+	}
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatalf("inspect C deep tree: %v", err)
+	}
+	if goInspection.SHA256 != cDigest {
+		t.Fatalf("deep digest Go=%s C=%s", goInspection.SHA256, cDigest)
+	}
+	t.Logf("exact symbols, fields, spans, points, flags, and deep digest %s", goInspection.SHA256)
+}
+
+func firstSwiftConditionFlagDivergence(goNode *gotreesitter.Node, goLang *gotreesitter.Language, cNode *sitter.Node, path string) error {
+	if goNode == nil || cNode == nil {
+		return fmt.Errorf("%s: nil mismatch Go=%v C=%v", path, goNode == nil, cNode == nil)
+	}
+	if goNode.IsMissing() != cNode.IsMissing() {
+		return fmt.Errorf("%s: missing Go=%v C=%v", path, goNode.IsMissing(), cNode.IsMissing())
+	}
+	if goNode.IsError() != cNode.IsError() {
+		return fmt.Errorf("%s: error Go=%v C=%v", path, goNode.IsError(), cNode.IsError())
+	}
+	for i := 0; i < goNode.ChildCount(); i++ {
+		goChild := goNode.Child(i)
+		cChild := cNode.Child(uint(i))
+		childPath := fmt.Sprintf("%s/%s[%d]", path, goChild.Type(goLang), i)
+		if err := firstSwiftConditionFlagDivergence(goChild, goLang, cChild, childPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -6056,7 +6056,7 @@ func appendFlattenedHiddenChildrenWithFieldScratch(scratch *reduceBuildScratch, 
 			if idx < 0 || idx >= len(scratch.repeatCount) || scratch.repeatCount[idx] < 2 {
 				continue
 			}
-			applyFieldToFlattenedSpan(scratch.nodes, scratch.fieldIDs, scratch.fieldSources, nodeStart, len(scratch.nodes), fid, scratch.repeatSource[idx], false)
+			applyRepeatedDirectFieldToFlattenedSpan(scratch.nodes, scratch.fieldIDs, scratch.fieldSources, nodeStart, len(scratch.nodes), fid, scratch.repeatSource[idx])
 		}
 		scratch.repeatTouched = scratch.repeatTouched[:touchedStart]
 		normalizeMixedSourceFieldSpan(scratch.fieldIDs, scratch.fieldSources, nodeStart, len(scratch.nodes))
@@ -6725,7 +6725,7 @@ func appendFlattenedHiddenChildrenWithFieldsScratch(scratch *hiddenFieldRepeatSc
 		if span.count < 2 {
 			continue
 		}
-		applyFieldToFlattenedSpan(dst, fieldDst, fieldSrcDst, nodeStart, out, span.fieldID, span.source, false)
+		applyRepeatedDirectFieldToFlattenedSpan(dst, fieldDst, fieldSrcDst, nodeStart, out, span.fieldID, span.source)
 	}
 	normalizeMixedSourceFieldSpan(fieldDst, fieldSrcDst, nodeStart, out)
 	scratch.end(repeatedStart)
@@ -6918,19 +6918,28 @@ func applyFieldToFlattenedSpan(children []*Node, fieldIDs []FieldID, fieldSource
 	if fid == 0 || fieldIDs == nil || start >= end {
 		return
 	}
+	if flattenedSpanHasFieldID(fieldIDs, start, end, fid) {
+		return
+	}
 	inherited := source == fieldSourceInherited
 	conflictCount, multipleKinds := flattenedSpanConflictSummary(children, fieldIDs, start, end, fid)
 	if !multipleKinds && conflictCount >= 2 {
-		assignFieldToFlattenedSpanTargets(children, fieldIDs, fieldSources, start, end, fid, source, false, false)
+		assignAllUnassignedFlattenedFields(children, fieldIDs, fieldSources, start, end, fid, source, false)
 		return
 	}
 	if !multipleKinds && conflictCount == 1 && preferNamed {
-		if assignFieldToFlattenedSpanTargets(children, fieldIDs, fieldSources, start, end, fid, source, true, true) {
-			return
+		existingDirect := false
+		for i := start; i < end; i++ {
+			if fieldIDs[i] != 0 && fieldIDs[i] != fid && fieldSourceIsDirect(fieldSourceAt(fieldSources, i)) {
+				existingDirect = true
+				break
+			}
 		}
-	}
-	if flattenedSpanHasFieldID(fieldIDs, start, end, fid) {
-		return
+		if !existingDirect || !fieldSourceIsDirect(source) {
+			if assignFieldToFlattenedSpanTargets(children, fieldIDs, fieldSources, start, end, fid, source, true, true) {
+				return
+			}
+		}
 	}
 	if inherited && !preferNamed {
 		if countEligibleNamedFieldTargets(children, fieldIDs, start, end) > 1 {
@@ -6942,6 +6951,40 @@ func applyFieldToFlattenedSpan(children []*Node, fieldIDs []FieldID, fieldSource
 		return
 	}
 	assignFirstInheritedFieldToFlattenedSpan(children, fieldIDs, fieldSources, start, end, fid, source, preferNamed, inherited)
+}
+
+// Repeated direct fields may resolve inherited conflicts across their full span.
+// Keep this carry path separate from generic duplicate-safe field projection.
+func applyRepeatedDirectFieldToFlattenedSpan(children []*Node, fieldIDs []FieldID, fieldSources []uint8, start, end int, fid FieldID, source uint8) {
+	if fid == 0 || fieldIDs == nil || start >= end {
+		return
+	}
+	if !flattenedSpanHasFieldID(fieldIDs, start, end, fid) {
+		applyFieldToFlattenedSpan(children, fieldIDs, fieldSources, start, end, fid, source, false)
+		return
+	}
+	conflictCount, multipleKinds := flattenedSpanConflictSummary(children, fieldIDs, start, end, fid)
+	if multipleKinds || conflictCount < 2 {
+		return
+	}
+	if source == fieldSourceProjectedDirect {
+		source = fieldSourceDirect
+	}
+	for i := start; i < end; i++ {
+		if !flattenedFieldTargetEligible(children[i], false) {
+			continue
+		}
+		if fieldIDs[i] == fid {
+			if i < len(fieldSources) && fieldSources[i] == fieldSourceProjectedDirect {
+				fieldSources[i] = source
+			}
+			continue
+		}
+		if fieldIDs[i] != 0 && fieldSourceIsDirect(fieldSourceAt(fieldSources, i)) {
+			continue
+		}
+		assignFlattenedField(fieldIDs, fieldSources, i, fid, source)
+	}
 }
 
 func assignFieldToFlattenedSpanTargets(children []*Node, fieldIDs []FieldID, fieldSources []uint8, start, end int, fid FieldID, source uint8, requireNamed, firstOnly bool) bool {

--- a/parser_reduce_fields_test.go
+++ b/parser_reduce_fields_test.go
@@ -727,6 +727,129 @@ func TestBuildReduceChildrenDirectFieldPrefersNamedTargetsOnFlattenedSpan(t *tes
 	}
 }
 
+func TestBuildReduceChildrenDirectFieldProjectsAroundExistingDirectField(t *testing.T) {
+	lang := &Language{
+		SymbolNames: []string{"EOF", "_hidden", "left", "=", "right", "root"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false},
+			{Name: "_hidden", Visible: false},
+			{Name: "left", Visible: true, Named: true},
+			{Name: "=", Visible: true},
+			{Name: "right", Visible: true, Named: true},
+			{Name: "root", Visible: true, Named: true},
+		},
+		FieldNames:     []string{"", "condition", "inner"},
+		FieldMapSlices: [][2]uint16{{0, 1}},
+		FieldMapEntries: []FieldMapEntry{
+			{FieldID: 1, ChildIndex: 0},
+		},
+	}
+	parser := NewParser(lang)
+	arena := newNodeArena(arenaClassFull)
+	left := newLeafNodeInArena(arena, 2, true, 0, 1, Point{}, Point{Column: 1})
+	equal := newLeafNodeInArena(arena, 3, false, 1, 2, Point{Column: 1}, Point{Column: 2})
+	right := newLeafNodeInArena(arena, 4, true, 2, 3, Point{Column: 2}, Point{Column: 3})
+	hidden := newParentNodeInArenaWithFieldSources(
+		arena,
+		1,
+		false,
+		[]*Node{left, equal, right},
+		[]FieldID{2, 0, 0},
+		[]uint8{fieldSourceDirect, fieldSourceNone, fieldSourceNone},
+		0,
+	)
+
+	children, fieldIDs, fieldSources := parser.buildReduceChildren(
+		[]stackEntry{newStackEntryNode(0, hidden)}, 0, 1, 1, 5, 0, arena,
+	)
+	if len(children) != 3 || len(fieldIDs) != 3 {
+		t.Fatalf("children=%d fields=%d, want three each", len(children), len(fieldIDs))
+	}
+	wantIDs := []FieldID{2, 1, 1}
+	wantSources := []uint8{fieldSourceDirect, fieldSourceDirect, fieldSourceDirect}
+	for i := range wantIDs {
+		if children[i] == nil {
+			t.Fatalf("child[%d] is nil", i)
+		}
+		if children[i].StartByte() != uint32(i) || children[i].EndByte() != uint32(i+1) {
+			t.Fatalf("child[%d] span=[%d,%d), want [%d,%d)", i, children[i].StartByte(), children[i].EndByte(), i, i+1)
+		}
+		if fieldIDs[i] != wantIDs[i] || fieldSourceAt(fieldSources, i) != wantSources[i] {
+			t.Fatalf("child[%d] field=%d source=%d, want field=%d source=%d", i, fieldIDs[i], fieldSourceAt(fieldSources, i), wantIDs[i], wantSources[i])
+		}
+	}
+	root := newParentNodeInArenaWithFieldSources(arena, 5, true, children, fieldIDs, fieldSources, 0)
+	if root.StartByte() != 0 || root.EndByte() != 3 || root.StartPoint() != (Point{}) || root.EndPoint() != (Point{Column: 3}) {
+		t.Fatalf("root span=[%d,%d) points=%v..%v, want [0,3) points 0..3", root.StartByte(), root.EndByte(), root.StartPoint(), root.EndPoint())
+	}
+	wantFields := []string{"inner", "condition", "condition"}
+	for i, want := range wantFields {
+		if got := root.FieldNameForChild(i, lang); got != want {
+			t.Fatalf("child[%d] field name=%q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestApplyFieldToFlattenedSpanPreservesRepeatedDirectConflict(t *testing.T) {
+	tests := []struct {
+		name  string
+		named []bool
+	}{
+		{name: "named-anonymous-named-anonymous", named: []bool{true, false, true, false}},
+		{name: "anonymous-named-anonymous-named", named: []bool{false, true, false, true}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			arena := newNodeArena(arenaClassFull)
+			children := make([]*Node, len(test.named))
+			for i, named := range test.named {
+				children[i] = newLeafNodeInArena(arena, Symbol(i+1), named, uint32(i), uint32(i+1), Point{Column: uint32(i)}, Point{Column: uint32(i + 1)})
+			}
+			fieldIDs := []FieldID{0, 2, 2, 0}
+			fieldSources := []uint8{fieldSourceNone, fieldSourceDirect, fieldSourceDirect, fieldSourceNone}
+
+			applyFieldToFlattenedSpan(children, fieldIDs, fieldSources, 0, len(children), 1, fieldSourceDirect, true)
+
+			want := []FieldID{1, 2, 2, 1}
+			for i, wantID := range want {
+				if fieldIDs[i] != wantID {
+					t.Fatalf("fieldIDs[%d] = %d, want %d", i, fieldIDs[i], wantID)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyFieldToFlattenedSpanDoesNotDuplicateExistingFieldID(t *testing.T) {
+	tests := []struct {
+		name  string
+		named []bool
+	}{
+		{name: "incoming-anonymous-conflict-named", named: []bool{false, true, false}},
+		{name: "incoming-named-conflict-anonymous", named: []bool{true, false, true}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			arena := newNodeArena(arenaClassFull)
+			children := make([]*Node, len(test.named))
+			for i, named := range test.named {
+				children[i] = newLeafNodeInArena(arena, Symbol(i+1), named, uint32(i), uint32(i+1), Point{Column: uint32(i)}, Point{Column: uint32(i + 1)})
+			}
+			fieldIDs := []FieldID{0, 2, 1}
+			fieldSources := []uint8{fieldSourceNone, fieldSourceNone, fieldSourceDirect}
+
+			applyFieldToFlattenedSpan(children, fieldIDs, fieldSources, 0, len(children), 1, fieldSourceDirect, true)
+
+			want := []FieldID{0, 2, 1}
+			for i, wantID := range want {
+				if fieldIDs[i] != wantID {
+					t.Fatalf("fieldIDs[%d] = %d, want %d", i, fieldIDs[i], wantID)
+				}
+			}
+		})
+	}
+}
+
 func TestBuildReduceChildrenRepeatedDirectFieldOnHiddenPathLeavesAnonymousGapUnfielded(t *testing.T) {
 	lang := &Language{
 		SymbolNames: []string{"EOF", "_hidden_inner", ".", "identifier", "visible_parent"},


### PR DESCRIPTION
## Summary

Preserve repeated direct field assignments on flattened spans.

This tranche:

- Keeps direct field assignments when a flattened span repeats a field.
- Rejects duplicate assignments for the same direct field.
- Prevents inherited projection from replacing an already resolved direct field.
- Adds focused Swift witnesses for issues #590 and #591.

## Correctness evidence

- The focused direct-field test suite passes.
- The locked-C Docker witness passes for both Swift witnesses.
- Fresh and incremental routes pass for production and compact parsing.
- The #590 deep digest is `f9b26a3b9b7a881e53dbe70a512733c98b6c77f86ab7550a04924b370035df63`.
- The #591 deep digest is `018cecb4cb76ff3c7bbecb40546c1832fdfcaa644debd1c489c634a762b91c84`.
- Go and locked-C trees match in symbols, fields, spans, points, flags, and deep digest.
- The timed test binary used `165,760 kB` maximum resident set size.

The Docker wrapper reported higher peaks while compiling the fresh clone. The timed binary excludes compiler and linker memory.

## Scope

- Base: `3484b1b3598383b6f9b84f91d0588c49f22e6bc6`.
- Commit: `b84dffb68ffa2230379868e1c0355ea7a0f64cb0`.
- Files changed: three.
- Commits: one.
- No diagnostic timing or performance credit is claimed.
- This PR does not include Grammargen error-row, B16, telemetry, or benchmark-lock work.

Residual Swift work remains for issues #574, #575, #576, and #578.

Refs #576
