### PR TITLE
Add build-tagged recovery telemetry

### DIFF
--- a/cgo_harness/benchmark_go_canonical_parity_test.go
+++ b/cgo_harness/benchmark_go_canonical_parity_test.go
@@ -13,6 +13,18 @@ import (
 	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
+const (
+	deepDigestExactDisposition   = "exact"
+	lockedCDivergenceDisposition = "locked-C divergence"
+)
+
+func goCDeepDigestDisposition(goDigest, cDigest string) string {
+	if goDigest == cDigest {
+		return deepDigestExactDisposition
+	}
+	return lockedCDivergenceDisposition
+}
+
 // BenchmarkParityGoCanonicalFull measures the same authenticated source and
 // complete warm-parser lifecycle with gotreesitter and the exact C grammar
 // loaded from languages.lock. Grammar identity and deep structural parity are
@@ -44,6 +56,27 @@ func TestCanonicalGoBenchmarkPreflight(t *testing.T) {
 func TestCanonicalGoBackendBuildTag(t *testing.T) {
 	if canonicalGoBenchmarkBackend != "production" && canonicalGoBenchmarkBackend != "candidate" {
 		t.Fatalf("canonical Go preflight requires exactly one backend tag: got %q", canonicalGoBenchmarkBackend)
+	}
+}
+
+func TestGoCDeepDigestDisposition(t *testing.T) {
+	tests := []struct {
+		name   string
+		goHash string
+		cHash  string
+		want   string
+	}{
+		{name: "equal", goHash: "same", cHash: "same", want: deepDigestExactDisposition},
+		{name: "unequal", goHash: "go", cHash: "c", want: lockedCDivergenceDisposition},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := goCDeepDigestDisposition(test.goHash, test.cHash)
+			t.Logf("Go/C deep digest pair Go=%s C=%s disposition=%s", test.goHash, test.cHash, got)
+			if got != test.want {
+				t.Fatalf("Go/C deep digest disposition = %q, want %q", got, test.want)
+			}
+		})
 	}
 }
 
@@ -162,11 +195,11 @@ func preflightCanonicalGoFixtures(tb testing.TB, fixtures []benchfixtures.Loaded
 			cTree.Close()
 			tb.Fatalf("%s C workload identity: %v", fixture.Fixture.ID, err)
 		}
-		if goInspection.SHA256 != cInspection.SHA256 {
+		if disposition := goCDeepDigestDisposition(goInspection.SHA256, cInspection.SHA256); disposition != deepDigestExactDisposition {
 			first := FirstDivergenceDumpV1(goTree.RootNode(), goLang, cTree.RootNode())
 			releaseCanonicalGoTree(goTree)
 			cTree.Close()
-			tb.Fatalf("%s deep parity digest mismatch Go=%s C=%s first=%s", fixture.Fixture.ID, goInspection.SHA256, cInspection.SHA256, formatRealCorpusDivergence(first))
+			tb.Fatalf("%s deep parity %s Go=%s C=%s first=%s", fixture.Fixture.ID, disposition, goInspection.SHA256, cInspection.SHA256, formatRealCorpusDivergence(first))
 		}
 		goSuiteCoverage.Merge(goInspection.NodeKinds)
 		cSuiteCoverage.Merge(cInspection.NodeKinds)

--- a/cgo_harness/parity_swift_recovery_telemetry_test.go
+++ b/cgo_harness/parity_swift_recovery_telemetry_test.go
@@ -125,8 +125,8 @@ func TestB16SwiftRecoveryTelemetryCOracle(t *testing.T) {
 
 			sourceDigest := sha256.Sum256(source)
 			resultClass := map[bool]string{true: "error", false: "clean"}[goRoot.HasError()]
-			if goInspection.SHA256 != cDigest {
-				resultClass = "locked_c_divergence"
+			if disposition := goCDeepDigestDisposition(goInspection.SHA256, cDigest); disposition != deepDigestExactDisposition {
+				resultClass = disposition
 			}
 			t.Logf("B16_C_WITNESS version=2 name=%s issue=%s source_sha256=%x source_bytes=%d grammar=swift grammar_lock_commit=%s c_runtime=%s@%s c_grammar_repo=%s c_grammar_commit=%s c_grammar_artifact_sha256=%s result_class=%s go_deep_sha256=%s c_deep_sha256=%s go_stop_reason=%s go_truncated=%t go_recovery_entries=%d go_strategy1_elections=%d go_cost_competitions=%d go_cost_walks=%d go_cost_walk_ns=%d go_error_nodes=%d go_error_span_bytes=%d go_retry_passes=%d go_retry_reason=%q go_retry_attempts=%d go_retry_selected=%q go_retry_selected_has_error=%t go_retry_selected_full_span=%t go_memo_tier=%d go_memo_entries=%d go_memo_bytes=%d go_memo_collisions=%d go_arena_bytes=%d go_scratch_bytes=%d go_entry_scratch_bytes=%d go_gss_bytes=%d go_gss_nodes=%d go_max_stacks=%d",
 				witness.name,

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -182,17 +182,6 @@ type forestDeclineMemoState struct {
 	retainedSourceBytes int
 }
 
-// parserColdState shares the Parser's existing lazy sidecar slot between
-// uncommon features. It preserves the hot Parser layout for ordinary parses.
-type parserColdState struct {
-	forestDeclineMemoState
-	cNodeMemoRetainedCache          []cNodeMemoCacheEntry
-	pendingForkStackReserve         []glrStack
-	pendingFrontierForkStackReserve []glrStack
-	cNodeMemoCollisions             uint64
-	recoveryRuntime                 recoveryRuntimeTelemetry
-}
-
 func (p *Parser) ensureParserColdState() *parserColdState {
 	if p == nil {
 		return nil
@@ -369,6 +358,11 @@ func forestProgressExtra(frontier, work, nextFrontier []*gssForestNode, curIndex
 // out-of-tree benchmarks and validation in packages that attach external
 // scanners (e.g. grammars) can drive it; not part of the stable API.
 func (p *Parser) ParseForestExperimental(source []byte) (*Tree, bool) {
+	p.resetRecoveryRuntimeTelemetryDetailed()
+	return p.parseForestExperimental(source)
+}
+
+func (p *Parser) parseForestExperimental(source []byte) (*Tree, bool) {
 	// Every other public parse entry point (parser_api.go: Parse,
 	// ParseWithTokenSource, ParseIncremental...) establishes the
 	// timeout/cancellation deadline via enterParseBudget before doing any
@@ -434,7 +428,7 @@ func (p *Parser) maybeReplaceRecoveredTreeWithForest(source []byte, tree *Tree) 
 		return tree, false
 	}
 
-	candidate, ok := p.ParseForestExperimental(source)
+	candidate, ok := p.parseForestExperimental(source)
 	if !ok || candidate == nil {
 		return tree, false
 	}

--- a/parser.go
+++ b/parser.go
@@ -1737,6 +1737,7 @@ func resetSnippetParser(parser *Parser) {
 	if parser == nil {
 		return
 	}
+	parser.clearRecoveryRuntimeTelemetryDetailed()
 	parser.finishCNodeMemoParse()
 	parser.resetCRecoveryCostCompetitionState()
 	resetGSSPrefixPath(&parser.cPrefixPath)
@@ -4565,6 +4566,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	p.reduceScratch = &scratch.reduce
 	p.mergeScratch = &scratch.merge
 	p.beginRecoveryRuntimeTelemetry()
+	p.beginRecoveryRuntimeTelemetryDetailed()
 	// budgetScratch is saved and restored, not just cleared, unlike its
 	// siblings above: a nested parseInternal call (a retry or compat-
 	// normalization sub-parse reachable from this call's own body, however
@@ -5139,6 +5141,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		recordParseRuntimeTokenStats(&parseRuntime, perfTokensConsumed, lastTokenEndByte, lastTokenSymbol, lastTokenWasEOF, tokenSourceEOFEarly)
 		recordParseRuntimeRootStats(&parseRuntime, tree, source, expectedEOFByte, p.included, scratch.audit.enabled || (arena != nil && arena.breakdownEnabled), p.language)
 		p.finishRecoveryRuntimeTelemetry(tree, stacks)
+		p.finishRecoveryRuntimeTelemetryDetailed(tree, &parseRuntime)
 		recordStopDiagnostic(parseRuntime.StopReason, tree)
 		p.copyNormalizationStats(&parseRuntime)
 		if tree != nil {
@@ -6712,7 +6715,11 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			var resumed bool
 			condenseRan = true
 			var reason ParseStopReason
-			stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
+			if recoveryRuntimeDetailedBuildEnabled {
+				stacks, resumed, tok, reason = p.cCondenseAndResumeDetailed(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
+			} else {
+				stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
+			}
 			workCountRefreshConvergenceLookahead(tok)
 			if resultMaterializationShouldStop(reason) {
 				return finalize(stacks, reason)
@@ -6874,7 +6881,11 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			var resumed bool
 			condenseRan = true
 			var reason ParseStopReason
-			stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
+			if recoveryRuntimeDetailedBuildEnabled {
+				stacks, resumed, tok, reason = p.cCondenseAndResumeDetailed(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
+			} else {
+				stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
+			}
 			if resultMaterializationShouldStop(reason) {
 				return finalize(stacks, reason)
 			}

--- a/parser_api.go
+++ b/parser_api.go
@@ -1434,6 +1434,7 @@ func (p *Parser) ParseUTF16(source []uint16) (*Tree, error) {
 // ParseUTF16Bytes parses UTF-16 source encoded as bytes with an explicit byte
 // order.
 func (p *Parser) ParseUTF16Bytes(source []byte, order UTF16ByteOrder) (*Tree, error) {
+	p.resetRecoveryRuntimeTelemetryDetailed()
 	units, err := DecodeUTF16Bytes(source, order)
 	if err != nil {
 		return nil, err
@@ -1456,6 +1457,7 @@ func (p *Parser) ParseUTF16WithTokenSourceFactory(source []uint16, factory Token
 // ParseUTF16BytesWithTokenSourceFactory parses UTF-16 bytes using a token
 // source built from the parser's canonical UTF-8 source view.
 func (p *Parser) ParseUTF16BytesWithTokenSourceFactory(source []byte, order UTF16ByteOrder, factory TokenSourceFactory) (*Tree, error) {
+	p.resetRecoveryRuntimeTelemetryDetailed()
 	units, err := DecodeUTF16Bytes(source, order)
 	if err != nil {
 		return nil, err
@@ -1479,6 +1481,7 @@ func (p *Parser) ParseWithTokenSourceStrict(source []byte, ts TokenSource) (*Tre
 // ParseWithTokenSourceFactory parses source using a freshly built custom token
 // source. The factory is also retained for recovery reparses.
 func (p *Parser) ParseWithTokenSourceFactory(source []byte, factory TokenSourceFactory) (*Tree, error) {
+	p.resetRecoveryRuntimeTelemetryDetailed()
 	if factory == nil {
 		return nil, ErrNoTokenSourceFactory
 	}
@@ -1603,6 +1606,7 @@ func (p *Parser) ParseIncrementalUTF16(source []uint16, oldTree *Tree) (*Tree, e
 // ParseIncrementalUTF16Bytes re-parses UTF-16 bytes after edits were applied
 // to oldTree.
 func (p *Parser) ParseIncrementalUTF16Bytes(source []byte, oldTree *Tree, order UTF16ByteOrder) (*Tree, error) {
+	p.resetRecoveryRuntimeTelemetryDetailed()
 	units, err := DecodeUTF16Bytes(source, order)
 	if err != nil {
 		return nil, err
@@ -1625,6 +1629,7 @@ func (p *Parser) ParseIncrementalUTF16WithTokenSourceFactory(source []uint16, ol
 // ParseIncrementalUTF16BytesWithTokenSourceFactory re-parses UTF-16 bytes using
 // a token source built from the parser's canonical UTF-8 source view.
 func (p *Parser) ParseIncrementalUTF16BytesWithTokenSourceFactory(source []byte, oldTree *Tree, order UTF16ByteOrder, factory TokenSourceFactory) (*Tree, error) {
+	p.resetRecoveryRuntimeTelemetryDetailed()
 	units, err := DecodeUTF16Bytes(source, order)
 	if err != nil {
 		return nil, err
@@ -1647,6 +1652,7 @@ func (p *Parser) ParseIncrementalWithTokenSourceStrict(source []byte, oldTree *T
 // ParseIncrementalWithTokenSourceFactory is like ParseWithTokenSourceFactory
 // for an edited old tree.
 func (p *Parser) ParseIncrementalWithTokenSourceFactory(source []byte, oldTree *Tree, factory TokenSourceFactory) (*Tree, error) {
+	p.resetRecoveryRuntimeTelemetryDetailed()
 	if factory == nil {
 		return nil, ErrNoTokenSourceFactory
 	}
@@ -1866,6 +1872,7 @@ var ErrNoTokenSource = errors.New("parser has no token source")
 // checkLanguageCompatible returns an error if the parser's language is nil or
 // incompatible with the runtime.
 func (p *Parser) checkLanguageCompatible() error {
+	p.resetRecoveryRuntimeTelemetryDetailed()
 	if p.language == nil {
 		return ErrNoLanguage
 	}

--- a/parser_cold_state.go
+++ b/parser_cold_state.go
@@ -1,0 +1,14 @@
+//go:build !gts_recovery_telemetry
+
+package gotreesitter
+
+// parserColdState shares the Parser's existing lazy sidecar slot between
+// uncommon features. It preserves the hot Parser layout for ordinary parses.
+type parserColdState struct {
+	forestDeclineMemoState
+	cNodeMemoRetainedCache          []cNodeMemoCacheEntry
+	pendingForkStackReserve         []glrStack
+	pendingFrontierForkStackReserve []glrStack
+	cNodeMemoCollisions             uint64
+	recoveryRuntime                 recoveryRuntimeTelemetry
+}

--- a/parser_cold_state_recovery_telemetry.go
+++ b/parser_cold_state_recovery_telemetry.go
@@ -1,0 +1,14 @@
+//go:build gts_recovery_telemetry
+
+package gotreesitter
+
+// parserColdState adds attempt storage only to diagnostic builds.
+type parserColdState struct {
+	forestDeclineMemoState
+	cNodeMemoRetainedCache          []cNodeMemoCacheEntry
+	pendingForkStackReserve         []glrStack
+	pendingFrontierForkStackReserve []glrStack
+	cNodeMemoCollisions             uint64
+	recoveryRuntime                 recoveryRuntimeTelemetry
+	recoveryRuntimeDetailed         *recoveryRuntimeDetailedState
+}

--- a/parser_pool.go
+++ b/parser_pool.go
@@ -111,6 +111,7 @@ func (pp *ParserPool) applyDefaults(p *Parser) {
 	p.SetIncludedRanges(pp.included)
 	p.SetGLRTrace(pp.glrTrace)
 	p.SetAmbiguityProfile(pp.ambiguityProfile)
+	p.clearRecoveryRuntimeTelemetryDetailed()
 	p.resetCRecoveryCostCompetitionState()
 	p.noTreeBenchmarkOnly = false
 	p.noTreeCheckpointBenchmarkOnly = false

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -259,11 +259,16 @@ func shouldRetryIncrementalAcceptedErrorAtBaseMergeCap(tree *Tree, sourceLen int
 // retry, and a fresh fallback would conceal an incremental correctness defect.
 func (p *Parser) retryIncrementalAcceptedErrorWithBaseMergeCap(source []byte, first *Tree, timing *incrementalParseTiming, run incrementalAcceptedErrorRetryRunner) *Tree {
 	baseCap := incrementalAcceptedErrorBaseMergeCap(p, first, source)
+	p.recordRecoveryRuntimeRetryTree(first, "initial")
+	p.recordRecoveryRuntimeRetryTreeDetailed(first, "initial", "initial_incremental_parse")
 	if baseCap == 0 || run == nil || p.fullParseRetryPassesTaken >= fullParseRetryMaxTotalPasses {
+		p.recordRecoveryRuntimeSelectedTree(first)
+		p.recordRecoveryRuntimeSelectedTreeDetailed(first)
 		return first
 	}
 
-	p.recordRecoveryRuntimeRetryTree(first, "initial")
+	p.recordRecoveryRuntimeSelectedTree(first)
+	p.recordRecoveryRuntimeSelectedTreeDetailed(first)
 	p.fullParseRetryPassesTaken++
 	p.recordRecoveryRuntimeRetry("accepted_error_under_wide_incremental_merge")
 	workCountSetNextParseAttempt("incremental_base_merge", "accepted_error_under_wide_incremental_merge")
@@ -275,10 +280,12 @@ func (p *Parser) retryIncrementalAcceptedErrorWithBaseMergeCap(source []byte, fi
 	// effective cap and therefore cannot lower the incremental default.
 	candidate := run(-baseCap, retryTiming)
 	p.recordRecoveryRuntimeRetryTree(candidate, "incremental_base_merge")
+	p.recordRecoveryRuntimeRetryTreeDetailed(candidate, "incremental_base_merge", "accepted_error_under_wide_incremental_merge")
 	adopted := candidate != nil && candidate != first && preferRetryTreeOverFirstPass(p, candidate, first)
 	result := first
 	if adopted {
 		result = candidate
+		p.recordRecoveryRuntimeCandidateReplacedDetailed(candidate)
 		first.Release()
 	} else if candidate != nil && candidate != first {
 		candidate.Release()
@@ -299,6 +306,7 @@ func (p *Parser) retryIncrementalAcceptedErrorWithBaseMergeCap(source []byte, fi
 		result.parseRuntime.IncrementalAcceptedErrorRetryCause = IncrementalRetryCauseAcceptedErrorBaseMerge
 	}
 	p.finishRecoveryRuntimeRetryTelemetry(result, len(source))
+	p.clearRecoveryRuntimeRetryTreesDetailed()
 	p.clearRecoveryRuntimeRetryTrees()
 	return result
 }
@@ -1592,8 +1600,12 @@ func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree,
 
 func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tree *Tree, origin fullParseRetryOrigin, runRetry fullParseRetryRunner) *Tree {
 	p.recordRecoveryRuntimeRetryTree(tree, "initial")
+	p.recordRecoveryRuntimeRetryTreeDetailed(tree, "initial", "initial_full_parse")
 	if certifiedAcceptedErrorRetrySkipsFresh(tree, len(source), origin) {
+		p.recordRecoveryRuntimeSelectedTree(tree)
+		p.recordRecoveryRuntimeSelectedTreeDetailed(tree)
 		p.finishRecoveryRuntimeRetryTelemetry(tree, len(source))
+		p.clearRecoveryRuntimeRetryTreesDetailed()
 		p.clearRecoveryRuntimeRetryTrees()
 		return tree
 	}
@@ -1691,12 +1703,18 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 		if candidate == nil || candidate == *best {
 			return
 		}
-		if preferRetryTree(p, candidate, *best) {
+		preferCandidate := preferRetryTree
+		if origin == fullParseRetryOriginIncremental && tree != nil && *best == tree {
+			preferCandidate = preferRetryTreeOverFirstPass
+		}
+		if preferCandidate(p, candidate, *best) {
 			if *best != candidate {
 				release(*best)
 			}
 			*best = candidate
 			p.recordRecoveryRuntimeSelectedTree(candidate)
+			p.recordRecoveryRuntimeSelectedTreeDetailed(candidate)
+			p.recordRecoveryRuntimeCandidateReplacedDetailed(candidate)
 			return
 		}
 		release(candidate)
@@ -1711,7 +1729,10 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 	// normal result compatibility; avoid paying the full retry ladder first.
 	if certifiedGSSConvergenceAcceptedErrorMergePerKey(tree, len(source)) == 0 &&
 		csharpAcceptedErrorTreeCanUseNamespaceRecovery(tree, source) {
+		p.recordRecoveryRuntimeSelectedTree(tree)
+		p.recordRecoveryRuntimeSelectedTreeDetailed(tree)
 		p.finishRecoveryRuntimeRetryTelemetry(tree, len(source))
+		p.clearRecoveryRuntimeRetryTreesDetailed()
 		p.clearRecoveryRuntimeRetryTrees()
 		return tree
 	}
@@ -1740,15 +1761,18 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 			result = runRetry(maxStacks, maxMergePerKeyOverride, maxNodes)
 		}
 		p.recordRecoveryRuntimeRetryTree(result, logicalRung)
+		p.recordRecoveryRuntimeRetryTreeDetailed(result, logicalRung, operationCause)
 		return result
 	}
 
 	bestTree := tree
 	defer func() {
 		p.finishRecoveryRuntimeRetryTelemetry(bestTree, len(source))
+		p.clearRecoveryRuntimeRetryTreesDetailed()
 		p.clearRecoveryRuntimeRetryTrees()
 	}()
 	p.recordRecoveryRuntimeSelectedTree(bestTree)
+	p.recordRecoveryRuntimeSelectedTreeDetailed(bestTree)
 	if shouldRunInitialFullParseMergeRetry(tree, len(source), origin) {
 		if initialMergePerKey := fullParseRetryMergePerKeyOverride(tree, len(source), initialMaxStacks); initialMergePerKey != 0 {
 			mergeRetryTree := runRetryAttempt(
@@ -1867,12 +1891,18 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 			// Fold the primary retry into bestTree before we overwrite
 			// nodeRetryTree, so the loser's arena is returned.
 			if retryTree != nil {
-				if preferRetryTree(p, retryTree, bestTree) {
+				preferCandidate := preferRetryTree
+				if origin == fullParseRetryOriginIncremental && tree != nil && bestTree == tree {
+					preferCandidate = preferRetryTreeOverFirstPass
+				}
+				if preferCandidate(p, retryTree, bestTree) {
 					if bestTree != retryTree {
 						release(bestTree)
 					}
 					bestTree = retryTree
 					p.recordRecoveryRuntimeSelectedTree(bestTree)
+					p.recordRecoveryRuntimeSelectedTreeDetailed(bestTree)
+					p.recordRecoveryRuntimeCandidateReplacedDetailed(bestTree)
 				} else if retryTree != bestTree {
 					release(retryTree)
 				}
@@ -1884,12 +1914,18 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 			// but truncated no-stacks tree, yet still be the evidence that
 			// selects a bounded merge or certified-pressure retry. Releasing it
 			// here clears its runtime data and silently suppresses those rungs.
-			if retryTree != nil && preferRetryTree(p, retryTree, bestTree) {
+			preferCandidate := preferRetryTree
+			if origin == fullParseRetryOriginIncremental && tree != nil && bestTree == tree {
+				preferCandidate = preferRetryTreeOverFirstPass
+			}
+			if retryTree != nil && preferCandidate(p, retryTree, bestTree) {
 				if bestTree != retryTree {
 					release(bestTree)
 				}
 				bestTree = retryTree
 				p.recordRecoveryRuntimeSelectedTree(bestTree)
+				p.recordRecoveryRuntimeSelectedTreeDetailed(bestTree)
+				p.recordRecoveryRuntimeCandidateReplacedDetailed(bestTree)
 			}
 		}
 	}
@@ -2110,9 +2146,13 @@ func (p *Parser) retryIncrementalMemoryBudgetAsPlainFullWithDFA(source []byte, t
 	full := p.parseInternal(source, p.wrapIncludedRanges(retryTS), nil, nil, arenaClassFull, nil, initialMaxStacks, 0, 0, deterministicExternalConflicts)
 	if full == nil || full.RootNode() == nil {
 		full.Release()
+		p.recordRecoveryRuntimeSelectedTree(tree)
+		p.recordRecoveryRuntimeSelectedTreeDetailed(tree)
 		return tree
 	}
 	tree.Release()
+	p.recordRecoveryRuntimeSelectedTree(full)
+	p.recordRecoveryRuntimeSelectedTreeDetailed(full)
 	if timing != nil {
 		timing.totalNanos += time.Since(retryStart).Nanoseconds()
 		timing.reuseUnsupported = true
@@ -2145,9 +2185,13 @@ func (p *Parser) retryIncrementalMemoryBudgetAsPlainFullWithTokenSource(source [
 	full := p.parseInternal(source, p.wrapIncludedRanges(ts), nil, nil, arenaClassFull, nil, initialMaxStacks, 0, 0, deterministicExternalConflicts)
 	if full == nil || full.RootNode() == nil {
 		full.Release()
+		p.recordRecoveryRuntimeSelectedTree(tree)
+		p.recordRecoveryRuntimeSelectedTreeDetailed(tree)
 		return tree
 	}
 	tree.Release()
+	p.recordRecoveryRuntimeSelectedTree(full)
+	p.recordRecoveryRuntimeSelectedTreeDetailed(full)
 	if timing != nil {
 		timing.totalNanos += time.Since(retryStart).Nanoseconds()
 		timing.reuseUnsupported = true

--- a/recovery_runtime_detailed_common.go
+++ b/recovery_runtime_detailed_common.go
@@ -1,0 +1,15 @@
+//go:build gts_recovery_telemetry
+
+package gotreesitter
+
+import "time"
+
+type recoveryRuntimeDetailedState struct {
+	attempts       RecoveryRuntimeAttempts
+	byTree         map[*Tree]int
+	activeStarted  time.Time
+	activeHeap     uint64
+	activeTotal    uint64
+	activeMallocs  uint64
+	activeCondense uint64
+}

--- a/recovery_runtime_detailed_disabled.go
+++ b/recovery_runtime_detailed_disabled.go
@@ -1,0 +1,37 @@
+//go:build !gts_recovery_telemetry
+
+package gotreesitter
+
+const recoveryRuntimeDetailedBuildEnabled = false
+
+func (p *Parser) resetRecoveryRuntimeTelemetryDetailed() {}
+
+func (p *Parser) clearRecoveryRuntimeTelemetryDetailed() {}
+
+func (p *Parser) beginRecoveryRuntimeTelemetryDetailed() {}
+
+func (p *Parser) finishRecoveryRuntimeTelemetryDetailed(*Tree, *ParseRuntime) {}
+
+func (p *Parser) recordRecoveryRuntimeRetryTreeDetailed(*Tree, string, string) {}
+
+func (p *Parser) recordRecoveryRuntimeSelectedTreeDetailed(*Tree) {}
+
+func (p *Parser) recordRecoveryRuntimeCandidateReplacedDetailed(*Tree) {}
+
+func (p *Parser) clearRecoveryRuntimeRetryTreesDetailed() {}
+
+func (p *Parser) cCondenseAndResumeDetailed(
+	stacks []glrStack,
+	source []byte,
+	tok Token,
+	nodeCount *int,
+	arena *nodeArena,
+	entryScratch *glrEntryScratch,
+	gssScratch *gssScratch,
+	trackChildErrors *bool,
+) ([]glrStack, bool, Token, ParseStopReason) {
+	return p.cCondenseAndResume(stacks, source, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+}
+
+// DebugRecoveryRuntimeAttempts returns no attempt receipt in production builds.
+func (p *Parser) DebugRecoveryRuntimeAttempts() RecoveryRuntimeAttempts { return nil }

--- a/recovery_runtime_detailed_disabled_test.go
+++ b/recovery_runtime_detailed_disabled_test.go
@@ -1,0 +1,28 @@
+//go:build !gts_recovery_telemetry
+
+package gotreesitter
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestRecoveryRuntimeDetailedProductionAPIIsInert(t *testing.T) {
+	if _, ok := reflect.TypeOf(parserColdState{}).FieldByName("recoveryRuntimeDetailed"); ok {
+		t.Fatal("production parser sidecar contains detailed telemetry storage")
+	}
+
+	EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { EnableRecoveryRuntimeTelemetry(false) })
+	parser := &Parser{}
+	if _, err := parser.Parse(nil); !errors.Is(err, ErrNoLanguage) {
+		t.Fatalf("parse error = %v, want ErrNoLanguage", err)
+	}
+	if parser.forestDeclineMemo != nil {
+		t.Fatal("production diagnostic API allocated a parser sidecar")
+	}
+	if attempts := parser.DebugRecoveryRuntimeAttempts(); len(attempts) != 0 {
+		t.Fatalf("production attempt receipt = %+v, want empty", attempts)
+	}
+}

--- a/recovery_runtime_detailed_enabled.go
+++ b/recovery_runtime_detailed_enabled.go
@@ -1,0 +1,254 @@
+//go:build gts_recovery_telemetry
+
+package gotreesitter
+
+import "runtime"
+import "time"
+
+const recoveryRuntimeDetailedBuildEnabled = true
+
+func (p *Parser) detailedRecoveryRuntimeState(create bool) *recoveryRuntimeDetailedState {
+	if p == nil || !recoveryRuntimeTelemetryEnabled {
+		return nil
+	}
+	cold := p.forestDeclineMemo
+	if cold == nil && create {
+		cold = p.ensureParserColdState()
+	}
+	if cold == nil {
+		return nil
+	}
+	state := cold.recoveryRuntimeDetailed
+	if state == nil && create {
+		state = &recoveryRuntimeDetailedState{}
+		cold.recoveryRuntimeDetailed = state
+	}
+	return state
+}
+
+func (p *Parser) resetRecoveryRuntimeTelemetryDetailed() {
+	if p == nil || !recoveryRuntimeTelemetryEnabled || p.forestDeclineMemo == nil {
+		return
+	}
+	p.clearRecoveryRuntimeTelemetryDetailed()
+}
+
+// clearRecoveryRuntimeTelemetryDetailed scrubs diagnostic state at pool boundaries.
+// Pool release must clear state even after the runtime toggle is disabled.
+func (p *Parser) clearRecoveryRuntimeTelemetryDetailed() {
+	if p == nil || p.forestDeclineMemo == nil {
+		return
+	}
+	p.forestDeclineMemo.recoveryRuntime = recoveryRuntimeTelemetry{}
+	p.forestDeclineMemo.recoveryRuntimeDetailed = nil
+}
+
+func (p *Parser) beginRecoveryRuntimeTelemetryDetailed() {
+	if p == nil || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	state := p.detailedRecoveryRuntimeState(true)
+	if state == nil {
+		return
+	}
+	if p.fullParseRetryPassesTaken == 0 {
+		state.attempts = nil
+		state.byTree = nil
+	}
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	state.activeStarted = time.Now()
+	state.activeHeap = mem.HeapAlloc
+	state.activeTotal = mem.TotalAlloc
+	state.activeMallocs = mem.Mallocs
+	state.activeCondense = 0
+}
+
+func (p *Parser) finishRecoveryRuntimeTelemetryDetailed(tree *Tree, parseRuntime *ParseRuntime) {
+	if p == nil || tree == nil || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	state := p.detailedRecoveryRuntimeState(true)
+	if state == nil {
+		return
+	}
+	attempt := RecoveryRuntimeAttemptStats{
+		Ordinal: uint32(len(state.attempts)),
+		Rung:    "initial",
+		Cause:   "initial_parse",
+	}
+	if stats := p.recoveryRuntimeTelemetryState(); stats != nil {
+		attempt.RecoveryEntryCount = stats.stats.RecoveryEntryCount
+		attempt.Strategy1ElectionCount = stats.stats.Strategy1ElectionCount
+		attempt.RecoveryCostCompetitionCount = stats.stats.RecoveryCostCompetitionCount
+		attempt.RecoveryCostWalkCount = stats.stats.RecoveryCostWalkCount
+		attempt.RecoveryCostWalkNanos = stats.stats.RecoveryCostWalkNanos
+		attempt.LiveVersions = stats.stats.LiveVersionCount
+		attempt.PeakLiveVersions = stats.stats.PeakLiveVersionCount
+	}
+	if parseRuntime != nil {
+		attempt.StopReason = parseRuntime.StopReason
+		attempt.Truncated = parseRuntime.Truncated
+		attempt.TokenSourceEOFEarly = parseRuntime.TokenSourceEOFEarly
+		attempt.WallNanos = detailedNonNegativeUint64(parseRuntime.ParseWallNanos)
+		attempt.ArenaBytesPeak = detailedNonNegativeUint64(parseRuntime.ArenaBytesAllocated)
+		attempt.ScratchBytesPeak = detailedNonNegativeUint64(parseRuntime.ScratchBytesAllocated)
+		attempt.EntryScratchBytesPeak = detailedNonNegativeUint64(parseRuntime.EntryScratchBytesAllocated)
+		attempt.GSSBytesPeak = detailedNonNegativeUint64(parseRuntime.GSSBytesAllocated)
+		attempt.GSSNodesPeak = detailedNonNegativeUint64(int64(parseRuntime.GSSNodesUsed))
+		attempt.NodesAllocated = detailedNonNegativeUint64(int64(parseRuntime.NodesAllocated))
+		attempt.MaxStacksSeen = detailedNonNegativeUint64(int64(parseRuntime.MaxStacksSeen))
+		attempt.PeakStackDepth = detailedNonNegativeUint64(int64(parseRuntime.PeakStackDepth))
+		attempt.ResultSelectionNanos = detailedNonNegativeUint64(parseRuntime.ResultSelectionNanos)
+		attempt.TransientParentMaterializationNanos = detailedNonNegativeUint64(parseRuntime.TransientParentMaterializationNanos)
+		attempt.ResultTreeBuildNanos = detailedNonNegativeUint64(parseRuntime.ResultTreeBuildNanos)
+		attempt.TransientChildMaterializationNanos = detailedNonNegativeUint64(parseRuntime.TransientChildMaterializationNanos)
+		attempt.MaterializationNanos = attempt.ResultSelectionNanos +
+			attempt.TransientParentMaterializationNanos +
+			attempt.ResultTreeBuildNanos +
+			attempt.TransientChildMaterializationNanos
+		expectedStart, expectedEnd := detailedRecoveryRuntimeExpectedRange(p, parseRuntime)
+		root := rawRootOrNil(tree)
+		attempt.AttemptFullSpan = root != nil && root.StartByte() == expectedStart && root.EndByte() == expectedEnd
+	}
+	root := rawRootOrNil(tree)
+	attempt.AttemptHasError = root != nil && root.HasError()
+	if attempt.WallNanos == 0 && !state.activeStarted.IsZero() {
+		attempt.WallNanos = detailedNonNegativeUint64(time.Since(state.activeStarted).Nanoseconds())
+	}
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	attempt.HeapAllocDeltaBytes = int64(mem.HeapAlloc) - int64(state.activeHeap)
+	if mem.TotalAlloc >= state.activeTotal {
+		attempt.TotalAllocDeltaBytes = mem.TotalAlloc - state.activeTotal
+	}
+	if mem.Mallocs >= state.activeMallocs {
+		attempt.MallocsDelta = mem.Mallocs - state.activeMallocs
+	}
+	attempt.CondenseNanos = state.activeCondense
+	state.attempts = append(state.attempts, attempt)
+	if state.byTree == nil {
+		state.byTree = make(map[*Tree]int)
+	}
+	state.byTree[tree] = len(state.attempts) - 1
+	state.activeStarted = time.Time{}
+	state.activeCondense = 0
+}
+
+func detailedRecoveryRuntimeExpectedRange(p *Parser, parseRuntime *ParseRuntime) (uint32, uint32) {
+	if p != nil && len(p.included) != 0 {
+		return p.included[0].StartByte, p.included[len(p.included)-1].EndByte
+	}
+	if parseRuntime == nil {
+		return 0, 0
+	}
+	return 0, parseRuntime.ExpectedEOFByte
+}
+
+func detailedNonNegativeUint64(value int64) uint64 {
+	if value <= 0 {
+		return 0
+	}
+	return uint64(value)
+}
+
+func (p *Parser) recordRecoveryRuntimeRetryTreeDetailed(tree *Tree, rung, cause string) {
+	if p == nil || tree == nil || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	state := p.detailedRecoveryRuntimeState(false)
+	if state == nil || state.byTree == nil {
+		return
+	}
+	index, ok := state.byTree[tree]
+	if !ok || index < 0 || index >= len(state.attempts) {
+		return
+	}
+	attempt := state.attempts[index]
+	if rung != "" {
+		attempt.Rung = rung
+	}
+	if cause != "" {
+		attempt.Cause = cause
+	}
+	state.attempts[index] = attempt
+}
+
+func (p *Parser) recordRecoveryRuntimeSelectedTreeDetailed(tree *Tree) {
+	if p == nil || tree == nil || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	state := p.detailedRecoveryRuntimeState(false)
+	if state == nil || state.byTree == nil {
+		return
+	}
+	index, ok := state.byTree[tree]
+	if !ok || index < 0 || index >= len(state.attempts) {
+		return
+	}
+	attempt := state.attempts[index]
+	attempt.CandidateSelected = true
+	state.attempts[index] = attempt
+}
+
+func (p *Parser) recordRecoveryRuntimeCandidateReplacedDetailed(tree *Tree) {
+	if p == nil || tree == nil || !recoveryRuntimeTelemetryEnabled {
+		return
+	}
+	state := p.detailedRecoveryRuntimeState(false)
+	if state == nil || state.byTree == nil {
+		return
+	}
+	index, ok := state.byTree[tree]
+	if !ok || index < 0 || index >= len(state.attempts) {
+		return
+	}
+	attempt := state.attempts[index]
+	attempt.CandidateSelected = true
+	attempt.CandidateReplacedIncumbent = true
+	state.attempts[index] = attempt
+}
+
+func (p *Parser) clearRecoveryRuntimeRetryTreesDetailed() {
+	if p == nil || p.forestDeclineMemo == nil {
+		return
+	}
+	state := p.forestDeclineMemo.recoveryRuntimeDetailed
+	if state == nil {
+		return
+	}
+	state.byTree = nil
+}
+
+func (p *Parser) cCondenseAndResumeDetailed(
+	stacks []glrStack,
+	source []byte,
+	tok Token,
+	nodeCount *int,
+	arena *nodeArena,
+	entryScratch *glrEntryScratch,
+	gssScratch *gssScratch,
+	trackChildErrors *bool,
+) ([]glrStack, bool, Token, ParseStopReason) {
+	if !recoveryRuntimeTelemetryEnabled {
+		return p.cCondenseAndResume(stacks, source, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+	}
+	started := time.Now()
+	resultStacks, resumed, resultToken, reason := p.cCondenseAndResume(stacks, source, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+	if state := p.detailedRecoveryRuntimeState(false); state != nil {
+		state.activeCondense += detailedNonNegativeUint64(time.Since(started).Nanoseconds())
+	}
+	return resultStacks, resumed, resultToken, reason
+}
+
+// DebugRecoveryRuntimeAttempts returns a copy of the tagged attempt receipt.
+func (p *Parser) DebugRecoveryRuntimeAttempts() RecoveryRuntimeAttempts {
+	if p == nil || !recoveryRuntimeTelemetryEnabled || p.forestDeclineMemo == nil || p.forestDeclineMemo.recoveryRuntimeDetailed == nil {
+		return nil
+	}
+	attempts := p.forestDeclineMemo.recoveryRuntimeDetailed.attempts
+	if len(attempts) == 0 {
+		return nil
+	}
+	return append(RecoveryRuntimeAttempts(nil), attempts...)
+}

--- a/recovery_runtime_detailed_enabled_test.go
+++ b/recovery_runtime_detailed_enabled_test.go
@@ -1,0 +1,488 @@
+//go:build gts_recovery_telemetry
+
+package gotreesitter
+
+import (
+	"errors"
+	"testing"
+)
+
+func seedRecoveryRuntimeDetailedForTest(parser *Parser) {
+	tree := &Tree{}
+	cold := parser.ensureParserColdState()
+	cold.recoveryRuntime = recoveryRuntimeTelemetry{
+		stats: RecoveryRuntimeStats{
+			Enabled:              true,
+			Completed:            true,
+			RecoveryEntryCount:   7,
+			RetrySelectedAttempt: "stale",
+		},
+		pendingRetryReason: "stale",
+	}
+	cold.recoveryRuntimeDetailed = &recoveryRuntimeDetailedState{
+		attempts: RecoveryRuntimeAttempts{{
+			Ordinal:           3,
+			Rung:              "stale",
+			Cause:             "stale",
+			CandidateSelected: true,
+		}},
+		byTree: map[*Tree]int{tree: 0},
+	}
+}
+
+func requireRecoveryRuntimeDetailedCleared(t *testing.T, parser *Parser) {
+	t.Helper()
+	if got := parser.DebugRecoveryRuntimeStats(); got != (RecoveryRuntimeStats{}) {
+		t.Fatalf("selected-tree receipt = %+v, want zero", got)
+	}
+	if got := parser.DebugRecoveryRuntimeAttempts(); len(got) != 0 {
+		t.Fatalf("attempt receipt = %+v, want empty", got)
+	}
+}
+
+func requireRecoveryRuntimeDetailedStorageCleared(t *testing.T, parser *Parser) {
+	t.Helper()
+	if parser == nil || parser.forestDeclineMemo == nil {
+		return
+	}
+	cold := parser.forestDeclineMemo
+	if cold.recoveryRuntime.stats != (RecoveryRuntimeStats{}) ||
+		cold.recoveryRuntime.pendingRetryReason != "" ||
+		cold.recoveryRuntime.retryAttempts != nil {
+		t.Fatalf("regular recovery state retained after pool release: %+v", cold.recoveryRuntime)
+	}
+	if cold.recoveryRuntimeDetailed != nil {
+		t.Fatalf("detailed recovery state retained after pool release: %+v", cold.recoveryRuntimeDetailed)
+	}
+}
+
+func seedRecoveryRuntimeDetailedAttemptForTest(parser *Parser, tree *Tree) {
+	parser.beginRecoveryRuntimeTelemetry()
+	parser.beginRecoveryRuntimeTelemetryDetailed()
+	runtime := tree.parseRuntime
+	parser.finishRecoveryRuntimeTelemetry(tree, nil)
+	parser.finishRecoveryRuntimeTelemetryDetailed(tree, &runtime)
+	parser.recordRecoveryRuntimeRetryTree(tree, "initial")
+	parser.recordRecoveryRuntimeRetryTreeDetailed(tree, "initial", "initial_parse")
+}
+
+func requireOneSelectedRecoveryRuntimeAttempt(t *testing.T, parser *Parser, wantRung string) RecoveryRuntimeAttemptStats {
+	t.Helper()
+	attempts := parser.DebugRecoveryRuntimeAttempts()
+	if len(attempts) != 1 {
+		t.Fatalf("attempt count = %d, want 1: %+v", len(attempts), attempts)
+	}
+	if !attempts[0].CandidateSelected || attempts[0].Rung != wantRung {
+		t.Fatalf("selected attempt = %+v, want selected rung %q", attempts[0], wantRung)
+	}
+	return attempts[0]
+}
+
+func detailedAcceptedErrorTreeForTest(language *Language, sourceLen int) *Tree {
+	return &Tree{
+		language: language,
+		root:     &Node{endByte: uint32(sourceLen), flags: nodeFlagHasError},
+		parseRuntime: ParseRuntime{
+			StopReason:       ParseStopAccepted,
+			SourceLen:        uint32(sourceLen),
+			ExpectedEOFByte:  uint32(sourceLen),
+			RootEndByte:      uint32(sourceLen),
+			LastTokenEndByte: uint32(sourceLen),
+			LastTokenWasEOF:  true,
+			MaxStacksSeen:    8,
+		},
+	}
+}
+
+func detailedCSharpNamespaceRecoveryTreeForTest() (*Tree, []byte) {
+	source := []byte("namespace N {}")
+	language := &Language{
+		Name:        "c_sharp",
+		SymbolNames: []string{"EOF", "compilation_unit", "namespace_declaration"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF"},
+			{Name: "compilation_unit", Visible: true, Named: true},
+			{Name: "namespace_declaration", Visible: true, Named: true},
+		},
+	}
+	arena := acquireNodeArena(arenaClassFull)
+	namespace := newLeafNodeInArena(arena, 2, true, 0, uint32(len(source)), Point{}, Point{})
+	namespace.setHasError(true)
+	root := newParentNodeInArena(arena, 1, true, []*Node{namespace}, nil, 0)
+	return &Tree{
+		language: language,
+		root:     root,
+		arena:    arena,
+		parseRuntime: ParseRuntime{
+			StopReason:       ParseStopAccepted,
+			SourceLen:        uint32(len(source)),
+			ExpectedEOFByte:  uint32(len(source)),
+			RootEndByte:      uint32(len(source)),
+			LastTokenEndByte: uint32(len(source)),
+			LastTokenWasEOF:  true,
+			MaxStacksSeen:    64,
+		},
+	}, source
+}
+
+func TestRecoveryRuntimeDetailedResetsEarlyFailures(t *testing.T) {
+	EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { EnableRecoveryRuntimeTelemetry(false) })
+
+	factoryError := errors.New("factory failed")
+	tests := []struct {
+		name   string
+		parser *Parser
+		parse  func(*Parser) error
+		want   error
+	}{
+		{
+			name:   "language",
+			parser: &Parser{},
+			parse: func(parser *Parser) error {
+				_, err := parser.Parse(nil)
+				return err
+			},
+			want: ErrNoLanguage,
+		},
+		{
+			name:   "token source",
+			parser: NewParser(buildArithmeticLanguage()),
+			parse: func(parser *Parser) error {
+				_, err := parser.ParseWithTokenSource(nil, nil)
+				return err
+			},
+			want: ErrNoTokenSource,
+		},
+		{
+			name:   "factory",
+			parser: NewParser(buildArithmeticLanguage()),
+			parse: func(parser *Parser) error {
+				_, err := parser.ParseWithTokenSourceFactory(nil, func([]byte) (TokenSource, error) {
+					return nil, factoryError
+				})
+				return err
+			},
+			want: factoryError,
+		},
+		{
+			name:   "UTF-16",
+			parser: NewParser(buildArithmeticLanguage()),
+			parse: func(parser *Parser) error {
+				_, err := parser.ParseUTF16Bytes([]byte{0x31}, UTF16LittleEndian)
+				return err
+			},
+			want: ErrInvalidUTF16ByteLength,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			seedRecoveryRuntimeDetailedForTest(test.parser)
+			if err := test.parse(test.parser); !errors.Is(err, test.want) {
+				t.Fatalf("parse error = %v, want %v", err, test.want)
+			}
+			requireRecoveryRuntimeDetailedCleared(t, test.parser)
+		})
+	}
+
+	forestLanguage := buildArithmeticLanguage()
+	forestLanguage.NativeUnaryWrapperFlattening = []UnaryWrapperFlatteningRule{{}}
+	forestParser := NewParser(forestLanguage)
+	seedRecoveryRuntimeDetailedForTest(forestParser)
+	if tree, ok := forestParser.ParseForestExperimental(nil); ok || tree != nil {
+		t.Fatalf("forest parse = tree:%v ok:%v, want nil and false", tree, ok)
+	}
+	requireRecoveryRuntimeDetailedCleared(t, forestParser)
+}
+
+func TestRecoveryRuntimeDetailedKeepsAttemptsSeparateFromSelectedTree(t *testing.T) {
+	EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { EnableRecoveryRuntimeTelemetry(false) })
+
+	parser := &Parser{}
+	initialRoot := &Node{endByte: 4, symbol: errorSymbol}
+	initialRoot.setHasError(true)
+	initial := &Tree{root: initialRoot}
+	losing := &Tree{root: &Node{endByte: 4}}
+
+	parser.beginRecoveryRuntimeTelemetry()
+	parser.beginRecoveryRuntimeTelemetryDetailed()
+	parser.recordRecoveryEntry()
+	initialRuntime := &ParseRuntime{StopReason: ParseStopAccepted, SourceLen: 4, ExpectedEOFByte: 4, ParseWallNanos: 10}
+	parser.finishRecoveryRuntimeTelemetry(initial, nil)
+	parser.finishRecoveryRuntimeTelemetryDetailed(initial, initialRuntime)
+	parser.recordRecoveryRuntimeRetryTree(initial, "initial")
+	parser.recordRecoveryRuntimeRetryTreeDetailed(initial, "initial", "initial_parse")
+	parser.recordRecoveryRuntimeSelectedTree(initial)
+	parser.recordRecoveryRuntimeSelectedTreeDetailed(initial)
+
+	parser.fullParseRetryPassesTaken = 1
+	parser.recordRecoveryRuntimeRetry("boundary_retry")
+	parser.beginRecoveryRuntimeTelemetry()
+	parser.beginRecoveryRuntimeTelemetryDetailed()
+	parser.recordRecoveryEntry()
+	parser.recordRecoveryEntry()
+	losingRuntime := &ParseRuntime{StopReason: ParseStopAccepted, SourceLen: 4, ExpectedEOFByte: 4, ParseWallNanos: 20}
+	parser.finishRecoveryRuntimeTelemetry(losing, nil)
+	parser.finishRecoveryRuntimeTelemetryDetailed(losing, losingRuntime)
+	parser.recordRecoveryRuntimeRetryTree(losing, "final_merge")
+	parser.recordRecoveryRuntimeRetryTreeDetailed(losing, "final_merge", "boundary_retry")
+	parser.finishRecoveryRuntimeRetryTelemetry(initial, 4)
+
+	stats := parser.DebugRecoveryRuntimeStats()
+	attempts := parser.DebugRecoveryRuntimeAttempts()
+	if stats.RecoveryEntryCount != 1 || stats.RetrySelectedAttempt != "initial" {
+		t.Fatalf("selected-tree receipt = %+v, want initial attempt", stats)
+	}
+	if len(attempts) != 2 || attempts[0].RecoveryEntryCount != 1 || attempts[1].RecoveryEntryCount != 2 {
+		t.Fatalf("attempt receipt = %+v, want separate 1-entry and 2-entry attempts", attempts)
+	}
+	if !attempts[0].CandidateSelected || attempts[1].CandidateSelected {
+		t.Fatalf("attempt selection = %+v, want only initial selected", attempts)
+	}
+
+	parser.fullParseRetryPassesTaken = 2
+	parser.recordRecoveryRuntimeRetry("pooled_pointer_retry")
+	parser.beginRecoveryRuntimeTelemetry()
+	parser.beginRecoveryRuntimeTelemetryDetailed()
+	parser.recordRecoveryEntry()
+	parser.recordRecoveryEntry()
+	parser.recordRecoveryEntry()
+	parser.finishRecoveryRuntimeTelemetry(losing, nil)
+	parser.finishRecoveryRuntimeTelemetryDetailed(losing, &ParseRuntime{StopReason: ParseStopAccepted, SourceLen: 4, ExpectedEOFByte: 4, ParseWallNanos: 30})
+	parser.recordRecoveryRuntimeRetryTree(losing, "secondary_node")
+	parser.recordRecoveryRuntimeRetryTreeDetailed(losing, "secondary_node", "pooled_pointer_retry")
+	parser.finishRecoveryRuntimeRetryTelemetry(initial, 4)
+
+	stats = parser.DebugRecoveryRuntimeStats()
+	attempts = parser.DebugRecoveryRuntimeAttempts()
+	if len(attempts) != 3 || attempts[2].RecoveryEntryCount != 3 {
+		t.Fatalf("pooled tree pointer collapsed attempt history: %+v", attempts)
+	}
+	if stats.RecoveryEntryCount != 1 || stats.RetrySelectedAttempt != "initial" {
+		t.Fatalf("pooled losing tree replaced selected receipt: %+v", stats)
+	}
+
+	attempts[0].Rung = "mutated"
+	if got := parser.DebugRecoveryRuntimeAttempts()[0].Rung; got == "mutated" {
+		t.Fatal("attempt API returned mutable parser storage")
+	}
+}
+
+func TestRecoveryRuntimeDetailedResetsNoEditAndParserPools(t *testing.T) {
+	EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { EnableRecoveryRuntimeTelemetry(false) })
+
+	parser := NewParser(buildArithmeticLanguage())
+	source := []byte("1+2")
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse source: %v", err)
+	}
+	if unchanged, err := parser.ParseIncremental(source, tree); err != nil || unchanged != tree {
+		t.Fatalf("no-edit parse = tree:%p err:%v, want tree:%p", unchanged, err, tree)
+	}
+	requireRecoveryRuntimeDetailedCleared(t, parser)
+
+	seedRecoveryRuntimeDetailedForTest(parser)
+	(&ParserPool{}).applyDefaults(parser)
+	requireRecoveryRuntimeDetailedCleared(t, parser)
+
+	seedRecoveryRuntimeDetailedForTest(parser)
+	resetSnippetParser(parser)
+	requireRecoveryRuntimeDetailedCleared(t, parser)
+	tree.Release()
+}
+
+func TestRecoveryRuntimeDetailedPoolReleaseClearsDisabledState(t *testing.T) {
+	EnableRecoveryRuntimeTelemetry(true)
+	parser := NewParser(buildArithmeticLanguage())
+	seedRecoveryRuntimeDetailedForTest(parser)
+	EnableRecoveryRuntimeTelemetry(false)
+
+	(&ParserPool{}).applyDefaults(parser)
+	requireRecoveryRuntimeDetailedStorageCleared(t, parser)
+
+	seedRecoveryRuntimeDetailedForTest(parser)
+	resetSnippetParser(parser)
+	requireRecoveryRuntimeDetailedStorageCleared(t, parser)
+}
+
+func TestRecoveryRuntimeDetailedCertifiedSkipSelectsReturnedTree(t *testing.T) {
+	EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { EnableRecoveryRuntimeTelemetry(false) })
+
+	const sourceLen = 128
+	language := &Language{
+		Name: "certified_skip",
+		FullParseAcceptedErrorRetryProfile: FullParseAcceptedErrorRetryProfile{
+			SkipFreshCompleteAcceptedErrorRetry: true,
+			SkipCompleteMinSourceBytes:          sourceLen,
+		},
+	}
+	tree := detailedAcceptedErrorTreeForTest(language, sourceLen)
+	parser := &Parser{}
+	seedRecoveryRuntimeDetailedAttemptForTest(parser, tree)
+	got := parser.retryFullParseForOrigin(make([]byte, sourceLen), 8, tree, fullParseRetryOriginFresh,
+		func(int, int, int) *Tree {
+			t.Fatal("certified skip ran a retry")
+			return nil
+		})
+	if got != tree {
+		t.Fatalf("returned tree = %p, want initial tree %p", got, tree)
+	}
+	requireOneSelectedRecoveryRuntimeAttempt(t, parser, "initial")
+}
+
+func TestRecoveryRuntimeDetailedCSharpSkipSelectsReturnedTree(t *testing.T) {
+	EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { EnableRecoveryRuntimeTelemetry(false) })
+
+	tree, source := detailedCSharpNamespaceRecoveryTreeForTest()
+	parser := &Parser{}
+	seedRecoveryRuntimeDetailedAttemptForTest(parser, tree)
+	got := parser.retryFullParseForOrigin(source, 8, tree, fullParseRetryOriginFresh,
+		func(int, int, int) *Tree {
+			t.Fatal("C# namespace recovery skip ran a retry")
+			return nil
+		})
+	if got != tree {
+		t.Fatalf("returned tree = %p, want initial tree %p", got, tree)
+	}
+	requireOneSelectedRecoveryRuntimeAttempt(t, parser, "initial")
+	tree.Release()
+}
+
+func TestRecoveryRuntimeDetailedIncrementalNoRetrySelectsReturnedTree(t *testing.T) {
+	EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { EnableRecoveryRuntimeTelemetry(false) })
+
+	const sourceLen = 128
+	tree := detailedAcceptedErrorTreeForTest(&Language{Name: "go"}, sourceLen)
+	tree.parseRuntime.IncrementalOldTreeReuseRoute = true
+	parser := &Parser{language: tree.language}
+	seedRecoveryRuntimeDetailedAttemptForTest(parser, tree)
+	got := parser.retryIncrementalAcceptedErrorWithBaseMergeCap(make([]byte, sourceLen), tree, nil, nil)
+	if got != tree {
+		t.Fatalf("returned tree = %p, want initial tree %p", got, tree)
+	}
+	requireOneSelectedRecoveryRuntimeAttempt(t, parser, "initial")
+}
+
+func TestRecoveryRuntimeDetailedIncrementalTieKeepsFirstPassSelected(t *testing.T) {
+	EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { EnableRecoveryRuntimeTelemetry(false) })
+
+	const sourceLen = 128
+	language := &Language{Name: "incremental_tie"}
+	initial := &Tree{
+		language: language,
+		root:     &Node{endByte: sourceLen},
+		parseRuntime: ParseRuntime{
+			StopReason:       ParseStopNoStacksAlive,
+			SourceLen:        sourceLen,
+			ExpectedEOFByte:  sourceLen,
+			RootEndByte:      sourceLen,
+			LastTokenEndByte: sourceLen,
+			LastTokenWasEOF:  true,
+			NodesAllocated:   2,
+		},
+	}
+	parser := &Parser{language: language}
+	seedRecoveryRuntimeDetailedAttemptForTest(parser, initial)
+
+	got := parser.retryFullParseForOrigin(make([]byte, sourceLen), 8, initial, fullParseRetryOriginIncremental,
+		func(int, int, int) *Tree {
+			candidate := &Tree{
+				language: language,
+				root:     &Node{endByte: sourceLen},
+				parseRuntime: ParseRuntime{
+					StopReason:       ParseStopNoStacksAlive,
+					SourceLen:        sourceLen,
+					ExpectedEOFByte:  sourceLen,
+					RootEndByte:      sourceLen,
+					LastTokenEndByte: sourceLen,
+					LastTokenWasEOF:  true,
+					NodesAllocated:   1,
+				},
+			}
+			parser.finishRecoveryRuntimeTelemetry(candidate, nil)
+			parser.finishRecoveryRuntimeTelemetryDetailed(candidate, &candidate.parseRuntime)
+			return candidate
+		})
+	if got != initial {
+		t.Fatalf("quality-tied retry = %p, want first pass %p", got, initial)
+	}
+	attempts := parser.DebugRecoveryRuntimeAttempts()
+	if len(attempts) < 2 || !attempts[0].CandidateSelected {
+		t.Fatalf("attempt selection = %+v, want first pass selected", attempts)
+	}
+	for i := 1; i < len(attempts); i++ {
+		if attempts[i].CandidateSelected {
+			t.Fatalf("quality-tied retry attempt %d selected: %+v", i, attempts[i])
+		}
+	}
+}
+
+func TestRecoveryRuntimeDetailedReplacementFactsRemainSeparate(t *testing.T) {
+	EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { EnableRecoveryRuntimeTelemetry(false) })
+
+	const sourceLen = 128
+	initial := detailedAcceptedErrorTreeForTest(&Language{Name: "replacement"}, sourceLen)
+	candidate := detailedAcceptedErrorTreeForTest(&Language{Name: "replacement"}, sourceLen)
+	parser := &Parser{}
+	parser.beginRecoveryRuntimeTelemetry()
+	parser.beginRecoveryRuntimeTelemetryDetailed()
+	parser.recordRecoveryEntry()
+	parser.finishRecoveryRuntimeTelemetry(initial, nil)
+	parser.finishRecoveryRuntimeTelemetryDetailed(initial, &initial.parseRuntime)
+	parser.recordRecoveryRuntimeRetryTree(initial, "initial")
+	parser.recordRecoveryRuntimeRetryTreeDetailed(initial, "initial", "initial_parse")
+
+	parser.fullParseRetryPassesTaken = 1
+	parser.beginRecoveryRuntimeTelemetry()
+	parser.beginRecoveryRuntimeTelemetryDetailed()
+	parser.recordRecoveryEntry()
+	parser.recordRecoveryEntry()
+	parser.recordRecoveryEntry()
+	parser.finishRecoveryRuntimeTelemetry(candidate, nil)
+	parser.finishRecoveryRuntimeTelemetryDetailed(candidate, &candidate.parseRuntime)
+	parser.recordRecoveryRuntimeRetryTree(candidate, "retry")
+	parser.recordRecoveryRuntimeRetryTreeDetailed(candidate, "retry", "replacement_retry")
+	parser.recordRecoveryRuntimeSelectedTree(candidate)
+	parser.recordRecoveryRuntimeSelectedTreeDetailed(candidate)
+	parser.recordRecoveryRuntimeCandidateReplacedDetailed(candidate)
+	parser.finishRecoveryRuntimeRetryTelemetry(candidate, sourceLen)
+
+	attempts := parser.DebugRecoveryRuntimeAttempts()
+	if len(attempts) != 2 {
+		t.Fatalf("attempt count = %d, want 2: %+v", len(attempts), attempts)
+	}
+	if attempts[0].RecoveryEntryCount != 1 || attempts[0].CandidateSelected {
+		t.Fatalf("initial attempt facts = %+v, want one entry and not selected", attempts[0])
+	}
+	if attempts[1].RecoveryEntryCount != 3 || !attempts[1].CandidateSelected || !attempts[1].CandidateReplacedIncumbent {
+		t.Fatalf("replacement attempt facts = %+v, want three entries, selected, and replaced", attempts[1])
+	}
+	if stats := parser.DebugRecoveryRuntimeStats(); stats.RecoveryEntryCount != 3 || stats.RetrySelectedAttempt != "retry" {
+		t.Fatalf("selected-tree facts = %+v, want retry facts only", stats)
+	}
+}
+
+func TestRecoveryRuntimeDetailedDisabledDoesNotWrite(t *testing.T) {
+	EnableRecoveryRuntimeTelemetry(false)
+	parser := NewParser(buildArithmeticLanguage())
+	seedRecoveryRuntimeDetailedForTest(parser)
+	beforeStats := parser.forestDeclineMemo.recoveryRuntime.stats
+	beforeAttempts := parser.forestDeclineMemo.recoveryRuntimeDetailed.attempts
+	if _, err := parser.ParseWithTokenSource(nil, nil); !errors.Is(err, ErrNoTokenSource) {
+		t.Fatalf("parse error = %v, want ErrNoTokenSource", err)
+	}
+	if got := parser.forestDeclineMemo.recoveryRuntime.stats; got != beforeStats {
+		t.Fatalf("disabled reset changed selected receipt: got %+v want %+v", got, beforeStats)
+	}
+	if got := parser.forestDeclineMemo.recoveryRuntimeDetailed.attempts; len(got) != len(beforeAttempts) {
+		t.Fatalf("disabled reset changed attempt receipt: got %+v want %+v", got, beforeAttempts)
+	}
+}

--- a/recovery_runtime_swift_telemetry_tagged_test.go
+++ b/recovery_runtime_swift_telemetry_tagged_test.go
@@ -1,0 +1,50 @@
+//go:build gts_recovery_telemetry
+
+package gotreesitter_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestSwiftRecoveryAttemptTelemetryTagged(t *testing.T) {
+	gotreesitter.EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { gotreesitter.EnableRecoveryRuntimeTelemetry(false) })
+
+	source, err := os.ReadFile(filepath.Join("grammars", "testdata", "swift_corpus", "stdlib_FloatingPointToString.swift"))
+	if err != nil {
+		t.Fatalf("read Swift issue 586 witness: %v", err)
+	}
+	parser := gotreesitter.NewParser(grammars.SwiftLanguage())
+	parser.SetAdmissionCandidateRoute(false)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse Swift issue 586 witness: %v", err)
+	}
+	defer tree.Release()
+
+	stats := parser.DebugRecoveryRuntimeStats()
+	attempts := parser.DebugRecoveryRuntimeAttempts()
+	if !stats.Enabled || !stats.Completed || stats.RetryAttemptCount == 0 {
+		t.Fatalf("selected-tree receipt = %+v, want completed retry facts", stats)
+	}
+	if len(attempts) != int(stats.RetryAttemptCount)+1 {
+		t.Fatalf("attempt count = %d, want %d: %+v", len(attempts), stats.RetryAttemptCount+1, attempts)
+	}
+	selected := 0
+	for _, attempt := range attempts {
+		if attempt.Rung == "" || attempt.Cause == "" || attempt.StopReason == "" || attempt.WallNanos == 0 {
+			t.Fatalf("incomplete attempt receipt: %+v", attempt)
+		}
+		if attempt.CandidateSelected {
+			selected++
+		}
+	}
+	if selected == 0 {
+		t.Fatalf("attempt receipt has no selected candidate: %+v", attempts)
+	}
+}

--- a/tree.go
+++ b/tree.go
@@ -813,6 +813,54 @@ type RecoveryNodeMemoRuntime struct {
 	Collisions uint32
 }
 
+// RecoveryRuntimeAttemptStats reports diagnostics for one parser attempt.
+//
+// These facts stay separate from RecoveryRuntimeStats. The latter reports the
+// selected tree. A losing attempt can still consume time and memory.
+type RecoveryRuntimeAttemptStats struct {
+	Ordinal uint32
+	Rung    string
+	Cause   string
+
+	StopReason          ParseStopReason
+	Truncated           bool
+	TokenSourceEOFEarly bool
+	AttemptHasError     bool
+	AttemptFullSpan     bool
+
+	WallNanos            uint64
+	HeapAllocDeltaBytes  int64
+	TotalAllocDeltaBytes uint64
+	MallocsDelta         uint64
+
+	RecoveryEntryCount           uint64
+	Strategy1ElectionCount       uint64
+	RecoveryCostCompetitionCount uint64
+	RecoveryCostWalkCount        uint64
+	RecoveryCostWalkNanos        uint64
+
+	MaterializationNanos                uint64
+	ResultSelectionNanos                uint64
+	TransientParentMaterializationNanos uint64
+	ResultTreeBuildNanos                uint64
+	TransientChildMaterializationNanos  uint64
+	CondenseNanos                       uint64
+
+	ArenaBytesPeak        uint64
+	ScratchBytesPeak      uint64
+	EntryScratchBytesPeak uint64
+	GSSBytesPeak          uint64
+	GSSNodesPeak          uint64
+	NodesAllocated        uint64
+	MaxStacksSeen         uint64
+	PeakStackDepth        uint64
+	LiveVersions          uint64
+	PeakLiveVersions      uint64
+
+	CandidateSelected          bool
+	CandidateReplacedIncumbent bool
+}
+
 // RecoveryRuntimeStats reports opt-in recovery facts for the most recent
 // completed parse attempt on a parser.
 //
@@ -841,6 +889,10 @@ type RecoveryRuntimeStats struct {
 	LiveVersionCount             uint64
 	PeakLiveVersionCount         uint64
 }
+
+// RecoveryRuntimeAttempts contains attempt-local facts for one parse
+// operation. Use Parser.DebugRecoveryRuntimeAttempts to read this receipt.
+type RecoveryRuntimeAttempts []RecoveryRuntimeAttemptStats
 
 // ParseRuntime captures parser-loop diagnostics for a completed tree.
 type ParseRuntime struct {


### PR DESCRIPTION
## Summary

Add detailed recovery telemetry behind an opt-in build tag.

Detailed telemetry exists only under `gts_recovery_telemetry`.
The runtime toggle remains required.

The production API returns `nil`.
Production builds store no detailed state.

Attempt-local counters remain separate from the selected-tree record.
Pool release clears tagged state after the runtime toggle is disabled.
Early-return paths record the returned selected tree.
We label unequal Go and C deep digests `locked-C divergence`.

## Validation

The focused tagged and untagged tests passed.

The Swift integration, Docker race suite, and locked-C oracle passed.
Windows, tagged-Windows, WebAssembly, and tagged-WebAssembly cross-builds passed.

Normalized Go 1.25.1 assembly matches the exact base `6d4a50d28e8b38fa1439acf279ab3e33940701fb` for all checked parser entry points.

Fixed-iteration allocation probes match the allocation counts.
The representative rows below show bytes per operation and allocations per operation.

| Fixed iterations | Base | Candidate |
| ---: | --- | --- |
| 20 | 223,489 B/op, 10 allocs | 223,489 B/op, 10 allocs |
| 40 | 111,794 B/op, 7 allocs | 111,794 B/op, 7 allocs |
| 58 | 77,130 B/op, 6 allocs | 77,131 B/op, 6 allocs |
| 63 | 71,017 B/op, 5 allocs | 71,017 B/op, 5 allocs |
| 84 | 53,287 B/op, 5 allocs | 53,287 B/op, 5 allocs |
| 100 | 44,778 B/op, 5 allocs | 44,777 B/op, 5 allocs |

The one-byte differences reflect arena amortization at different iteration counts.
Allocation counts match in every row.

## Benchmark note

R4 was incomplete.
Its verifier incorrectly required identical output order across binaries with different test registries.
The partial run provides no campaign evidence.

This PR contains one commit and 14 files.
It claims no cloud or campaign performance credit.
Final-head C0f remains required.

Refs #586