### PR TITLE
fix(parser): end convergence after clean condense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- End recovery convergence after a clean condense. Pending forks no longer
+  keep clean C initializer suffixes on the recovery merge path.
+
 ## [0.51.0] - 2026-08-16
 
 ### Added

--- a/benchmark_c_clean_suffix_test.go
+++ b/benchmark_c_clean_suffix_test.go
@@ -1,0 +1,69 @@
+package gotreesitter_test
+
+import (
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestCInitializerBoundsTransientRecoveryStacks(t *testing.T) {
+	source := cleanSuffixInitializerSource(40)
+	parser := gotreesitter.NewParser(grammars.CLanguage())
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse C initializer: %v", err)
+	}
+	t.Cleanup(tree.Release)
+	requireCompleteCInitializerTree(t, source, tree)
+	if got := tree.ParseRuntime().MaxStacksSeen; got > 8 {
+		t.Fatalf("peak stack count = %d, want at most 8", got)
+	}
+}
+
+func BenchmarkCInitializerAfterTransientRecovery(b *testing.B) {
+	source := cleanSuffixInitializerSource(40)
+	parser := gotreesitter.NewParser(grammars.CLanguage())
+	b.ReportAllocs()
+	b.SetBytes(int64(len(source)))
+	for range b.N {
+		tree, err := parser.Parse(source)
+		if err != nil {
+			b.Fatalf("parse C initializer: %v", err)
+		}
+		requireCompleteCInitializerTree(b, source, tree)
+		tree.Release()
+	}
+}
+
+func cleanSuffixInitializerSource(rows int) []byte {
+	var source strings.Builder
+	source.WriteString("static const element_t table[] = {\n")
+	for range rows {
+		source.WriteString("  {{ 0x1, 0x2, 0x3, 0x4, }},\n")
+	}
+	source.WriteString("};\n")
+	return []byte(source.String())
+}
+
+func requireCompleteCInitializerTree(tb testing.TB, source []byte, tree *gotreesitter.Tree) {
+	tb.Helper()
+	if tree == nil || tree.RootNode() == nil {
+		tb.Fatal("C initializer parse returned a nil tree")
+	}
+	root := tree.RootNode()
+	if root.StartByte() != 0 || root.EndByte() != uint32(len(source)) {
+		tb.Fatalf("root span = %d:%d, want 0:%d", root.StartByte(), root.EndByte(), len(source))
+	}
+	if root.HasError() {
+		tb.Fatal("C initializer parse returned an error tree")
+	}
+	runtime := tree.ParseRuntime()
+	if got, want := runtime.StopReason, gotreesitter.ParseStopAccepted; got != want {
+		tb.Fatalf("stop reason = %q, want %q", got, want)
+	}
+	if runtime.Truncated {
+		tb.Fatal("C initializer parse returned a truncated tree")
+	}
+}

--- a/cgo_harness/c_clean_suffix_parity_test.go
+++ b/cgo_harness/c_clean_suffix_parity_test.go
@@ -1,0 +1,19 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCInitializerAfterTransientRecoveryMatchesC(t *testing.T) {
+	var source strings.Builder
+	source.WriteString("static const element_t table[] = {\n")
+	for range 40 {
+		source.WriteString("  {{ 0x1, 0x2, 0x3, 0x4, }},\n")
+	}
+	source.WriteString("};\n")
+
+	runParityCase(t, parityCase{name: "c"}, "initializer-after-transient-recovery", []byte(source.String()))
+}

--- a/cgo_harness/kotlin_a3_certification_sweep_test.go
+++ b/cgo_harness/kotlin_a3_certification_sweep_test.go
@@ -69,6 +69,26 @@ func TestKotlinA3CompactCertificationFullCorpusSweep(t *testing.T) {
 	a3ReportSweep(t, result, kotlinA3KnownDivergences)
 }
 
+// TestKotlinRecoverySuffixSourcesMatchC keeps exact C parity for the two
+// constructed sources that use clean recovery suffix convergence.
+func TestKotlinRecoverySuffixSourcesMatchC(t *testing.T) {
+	matched := 0
+	for _, source := range kotlinA3AdversarialSources() {
+		if source.Name != "annotated_extension_property_getter_line_comment" &&
+			source.Name != "annotated_extension_property_getter_block_comment" {
+			continue
+		}
+		matched++
+		source := source
+		t.Run(source.Name, func(t *testing.T) {
+			runParityCase(t, parityCase{name: "kotlin"}, source.Name, source.Source)
+		})
+	}
+	if matched != 2 {
+		t.Fatalf("Kotlin recovery suffix sources = %d, want 2", matched)
+	}
+}
+
 // kotlinA3KnownDivergences is an already-triaged, pre-existing
 // production-route defect the tightened sweep criterion surfaced: the
 // compact route only reproduces what production already produces (verified

--- a/cgo_harness/merge_event_census_test.go
+++ b/cgo_harness/merge_event_census_test.go
@@ -87,23 +87,25 @@ var mergeCensusBaselineConstructed = map[string]struct {
 	// SourcesWhereCMergesAndGoDoesNot is the lane's headline class.
 	SourcesWhereCMergesAndGoDoesNot int
 }{
-	"apex":   {Sources: 25, CMergeSuccesses: 31, GoSuccesses: 1, RefuseNoGSSHead: 53, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 53, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 5},
-	"perl":   {Sources: 17, CMergeSuccesses: 57, GoSuccesses: 0, RefuseNoGSSHead: 43, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 0, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 7},
+	"apex": {Sources: 25, CMergeSuccesses: 31, GoSuccesses: 1, RefuseNoGSSHead: 53, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 53, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 5},
+	"perl": {Sources: 17, CMergeSuccesses: 57, GoSuccesses: 0, RefuseNoGSSHead: 43, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 0, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 7},
 	// PR #708 elects Ada aggregate conflicts before the GLR fork. This removes
 	// five no-GSS-head opportunities without changing merges or other gates.
-	"ada":    {Sources: 23, CMergeSuccesses: 47, GoSuccesses: 2, RefuseNoGSSHead: 30, RefuseScoreOrShifted: 92, RefuseDistinctShapes: 6, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 5},
-	"kotlin": {Sources: 13, CMergeSuccesses: 54, GoSuccesses: 12, RefuseNoGSSHead: 2, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 0, LinkPayloadShallowWouldAccept: 10, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 3},
+	"ada": {Sources: 23, CMergeSuccesses: 47, GoSuccesses: 2, RefuseNoGSSHead: 30, RefuseScoreOrShifted: 92, RefuseDistinctShapes: 6, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 5},
+	// Clean-suffix reset removes four redundant Kotlin merges. Exact C tree
+	// parity remains pinned by TestKotlinRecoverySuffixSourcesMatchC.
+	"kotlin": {Sources: 13, CMergeSuccesses: 54, GoSuccesses: 8, RefuseNoGSSHead: 2, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 0, LinkPayloadShallowWouldAccept: 8, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 3},
 	"python": {Sources: 26, CMergeSuccesses: 2, GoSuccesses: 0, RefuseNoGSSHead: 9, RefuseScoreOrShifted: 0, RefuseDistinctShapes: 0, LinkPayloadShallowWouldAccept: 0, SourcesWhereGoOverMerges: 0, SourcesWhereCMergesAndGoDoesNot: 2},
 }
 
 // The M0 pinned aggregate over the five A3 sweep corpora's constructed
-// sources. M_p/M_c = 15/191 = 0.0785. That ratio is the lane's progress
+// sources. M_p/M_c = 11/191 = 0.0576. That ratio is the lane's progress
 // number alongside D0's 32 set differences: stage M1 onward drives it toward
 // 1, and gate G6 forbids any source where production merges more than the
 // reference runtime.
 const (
 	mergeCensusBaselineCMerges  uint64 = 191
-	mergeCensusBaselineGoMerges uint64 = 15
+	mergeCensusBaselineGoMerges uint64 = 11
 	// mergeCensusBaselineSources is the constructed-source denominator, the
 	// same 104 sources D0 measures.
 	mergeCensusBaselineSources = 104

--- a/glr.go
+++ b/glr.go
@@ -293,13 +293,10 @@ type glrMergeScratch struct {
 	// cRecoveryCostWalk enables the expensive per-candidate error-cost walks.
 	cRecoveryCostWalk bool
 	// cRecoveryConvergence enables faithful cap-one convergence during an active
-	// recovery episode or its pending-fork suffix. Fallback suppression has its
-	// own latch because the clean pending-fork suffix must not inherit the old
-	// active-cost fallback policy.
+	// recovery episode. A clean suffix returns to the ordinary merge path.
 	cRecoveryConvergence bool
 	// cRecoveryFallbackSuppression suppresses the non-GSS fallback after an
-	// active recovery-cost episode, without extending that policy into a clean
-	// pending-fork convergence suffix.
+	// active recovery-cost episode.
 	cRecoveryFallbackSuppression bool
 	// cRecoveryCost preserves source compatibility for the main-branch merge
 	// tests. Parser paths use the three split fields above.

--- a/parser.go
+++ b/parser.go
@@ -240,24 +240,18 @@ type Parser struct {
 	// sizing rationale is measured against.
 	crecoveryReductionCandidateAttemptsPeak uint64
 	crecoveryMissingTokenTrialAttemptsPeak  uint64
-	// crecoveryCostCompetitionRelevant enables recovery convergence and pending
-	// fork handling for the active recovery frontier. It starts false for a
+	// crecoveryCostCompetitionRelevant enables recovery convergence for the
+	// active recovery frontier. It starts false for a
 	// fresh full parse and flips true on the first event that can make costs
 	// nonzero or unequal: a stack pausing (cPaused), cHandleError running, an
 	// error/missing node being pushed, or — conservatively — any parse that can
 	// REUSE subtrees from an old tree. Reused subtrees may carry error nodes
 	// without a new pause in this pass. A clean condense clears the active cost
-	// state; a separate latch keeps cap-one convergence only after a pending
-	// recovery fork proves that the suffix needs it.
+	// state.
 	crecoveryCostCompetitionRelevant bool
 	// crecoveryCostCompetitionWalkEnabled enables the expensive recovery-cost
-	// walks for the current recovery episode. A clean condense clears this gate
-	// without changing the pending-fork convergence latch.
+	// walks for the current recovery episode. A clean condense clears this gate.
 	crecoveryCostCompetitionWalkEnabled bool
-	// crecoveryCostCompetitionConvergenceEnabled keeps faithful cap-one
-	// convergence active after a pending recovery fork has been observed. This
-	// is separate from the one-cycle cost walk and the active cost state.
-	crecoveryCostCompetitionConvergenceEnabled bool
 	// Recovery-memo tier and operation fields occupy existing Parser padding.
 	// Keep larger recovery-only state in the lazy cold sidecar at the tail.
 	cNodeMemoPeakTier          RecoveryNodeMemoTier
@@ -1105,8 +1099,7 @@ func (p *Parser) syncCRecoveryMergeScratch(scratch *glrMergeScratch) {
 		return
 	}
 	scratch.cRecoveryCostWalk = p.crecoveryCostCompetitionWalkEnabled
-	scratch.cRecoveryConvergence = p.crecoveryCostCompetitionRelevant ||
-		p.crecoveryCostCompetitionConvergenceEnabled
+	scratch.cRecoveryConvergence = p.crecoveryCostCompetitionRelevant
 	scratch.cRecoveryFallbackSuppression = p.crecoveryCostCompetitionRelevant
 }
 
@@ -1126,21 +1119,7 @@ func (p *Parser) resetCRecoveryCostCompetitionState() {
 	}
 	p.crecoveryCostCompetitionRelevant = false
 	p.crecoveryCostCompetitionWalkEnabled = false
-	p.crecoveryCostCompetitionConvergenceEnabled = false
 	p.syncCRecoveryMergeScratch(p.mergeScratch)
-}
-
-// clearCRecoveryMergeScratchEpisode clears transient walk and fallback state
-// while retaining the convergence latch that the clean suffix established.
-func clearCRecoveryMergeScratchEpisode(p *Parser, scratch *glrMergeScratch) {
-	if scratch == nil {
-		return
-	}
-	scratch.cRecoveryCostWalk = false
-	scratch.cRecoveryFallbackSuppression = false
-	if p == nil || !p.crecoveryCostCompetitionConvergenceEnabled {
-		scratch.cRecoveryConvergence = false
-	}
 }
 
 // clearCRecoveryCostIfClean ends recovery-cost walks after condense removes a
@@ -1160,13 +1139,10 @@ func (p *Parser) clearCRecoveryCostIfClean(stacks []glrStack, trackChildErrors *
 				return
 			}
 		}
-		if len(p.pendingForkStacks) != 0 || len(p.pendingFrontierForkStacks) != 0 {
-			p.crecoveryCostCompetitionConvergenceEnabled = true
-		}
 	}
 	p.crecoveryCostCompetitionWalkEnabled = false
 	p.crecoveryCostCompetitionRelevant = false
-	clearCRecoveryMergeScratchEpisode(p, p.mergeScratch)
+	p.syncCRecoveryMergeScratch(p.mergeScratch)
 }
 
 func stopCondenseGatingString(errorCostCompetitionEnabled, anyReduced, condenseRelevant, condenseRan, condenseResumed bool, stacks []glrStack) string {
@@ -4653,7 +4629,6 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		initialCostRelevant := incrementalOldTreeMayCarryErrorCost(reuse, oldTree)
 		p.crecoveryCostCompetitionRelevant = initialCostRelevant
 		p.crecoveryCostCompetitionWalkEnabled = initialCostRelevant
-		p.crecoveryCostCompetitionConvergenceEnabled = false
 		p.cRecoverSharedTokenErrorModeLexed = false
 		p.cRecoverCustomResyncActive = false
 		p.cRecoverCustomResyncByte = 0

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -167,64 +167,6 @@ func TestCRecoveryCostCompetitionDisabledInNoTreeModes(t *testing.T) {
 	}
 }
 
-func TestCRecoveryCleanCondenseRetainsPendingConvergence(t *testing.T) {
-	parser := &Parser{
-		crecoveryCostCompetitionRelevant:    true,
-		crecoveryCostCompetitionWalkEnabled: true,
-		pendingForkStacks:                   []glrStack{{}},
-		mergeScratch:                        &glrMergeScratch{cRecoveryCostWalk: true, cRecoveryConvergence: true, cRecoveryFallbackSuppression: true},
-	}
-	trackChildErrors := false
-
-	parser.clearCRecoveryCostIfClean([]glrStack{{}}, &trackChildErrors)
-
-	if !parser.crecoveryCostCompetitionConvergenceEnabled {
-		t.Fatal("clean condense did not retain convergence after a pending fork")
-	}
-	if parser.crecoveryCostCompetitionRelevant {
-		t.Fatal("clean condense kept the active recovery cost state")
-	}
-	if parser.crecoveryCostCompetitionWalkEnabled {
-		t.Fatal("clean condense kept the recovery cost walk enabled")
-	}
-	if parser.mergeScratch.cRecoveryCostWalk || parser.mergeScratch.cRecoveryFallbackSuppression || !parser.mergeScratch.cRecoveryConvergence {
-		t.Fatalf("clean condense mishandled active scratch walk=%t convergence=%t fallback=%t", parser.mergeScratch.cRecoveryCostWalk, parser.mergeScratch.cRecoveryConvergence, parser.mergeScratch.cRecoveryFallbackSuppression)
-	}
-	parser.pendingForkStacks = nil
-	parser.markCRecoveryCostCompetitionRelevant()
-	parser.clearCRecoveryCostIfClean([]glrStack{{}}, &trackChildErrors)
-	if !parser.crecoveryCostCompetitionConvergenceEnabled {
-		t.Fatal("clean condense cleared the established convergence latch")
-	}
-	if !parser.mergeScratch.cRecoveryConvergence {
-		t.Fatal("clean condense cleared an established active convergence latch")
-	}
-}
-
-func TestCRecoveryCleanCondenseDropsIdleConvergenceState(t *testing.T) {
-	parser := &Parser{
-		crecoveryCostCompetitionRelevant:    true,
-		crecoveryCostCompetitionWalkEnabled: true,
-		mergeScratch:                        &glrMergeScratch{cRecoveryCostWalk: true, cRecoveryConvergence: true, cRecoveryFallbackSuppression: true},
-	}
-	trackChildErrors := false
-
-	parser.clearCRecoveryCostIfClean([]glrStack{{}}, &trackChildErrors)
-
-	if parser.crecoveryCostCompetitionConvergenceEnabled {
-		t.Fatal("clean condense retained idle convergence state")
-	}
-	if parser.crecoveryCostCompetitionRelevant {
-		t.Fatal("clean condense kept the active recovery cost state")
-	}
-	if parser.crecoveryCostCompetitionWalkEnabled {
-		t.Fatal("clean condense kept the recovery cost walk enabled")
-	}
-	if parser.mergeScratch.cRecoveryCostWalk || parser.mergeScratch.cRecoveryConvergence || parser.mergeScratch.cRecoveryFallbackSuppression {
-		t.Fatal("clean condense kept recovery scratch state")
-	}
-}
-
 func TestCRecoveryCleanCondenseSingleStackSynchronizesMergeScratch(t *testing.T) {
 	parser := &Parser{
 		errorCostCompetition:                true,
@@ -283,39 +225,22 @@ func TestCRecoveryCleanCondenseSingleStackSynchronizesMergeScratch(t *testing.T)
 func TestCRecoveryCostWalkIsOneCycle(t *testing.T) {
 	parser := &Parser{errorCostCompetition: true, mergeScratch: &glrMergeScratch{}}
 	parser.markCRecoveryCostCompetitionRelevant()
-	if !parser.crecoveryCostCompetitionWalkEnabled || parser.crecoveryCostCompetitionConvergenceEnabled {
-		t.Fatal("recovery start published convergence before a pending fork")
+	if !parser.crecoveryCostCompetitionWalkEnabled {
+		t.Fatal("recovery start did not enable the cost walk")
 	}
 	parser.syncCRecoveryMergeScratch(parser.mergeScratch)
-	if !parser.mergeScratch.cRecoveryCostWalk {
-		t.Fatal("recovery start did not publish the active cost walk")
+	if !parser.mergeScratch.cRecoveryCostWalk || !parser.mergeScratch.cRecoveryConvergence {
+		t.Fatal("recovery start did not publish active recovery state")
 	}
 
 	trackChildErrors := false
+	parser.pendingForkStacks = []glrStack{newGLRStack(1)}
 	parser.clearCRecoveryCostIfClean([]glrStack{{}}, &trackChildErrors)
-	if parser.crecoveryCostCompetitionRelevant || parser.crecoveryCostCompetitionWalkEnabled || parser.crecoveryCostCompetitionConvergenceEnabled {
-		t.Fatal("clean recovery exit retained the active walk")
+	if parser.crecoveryCostCompetitionRelevant || parser.crecoveryCostCompetitionWalkEnabled {
+		t.Fatal("clean recovery exit retained active state with a pending fork")
 	}
 	if parser.mergeScratch.cRecoveryCostWalk || parser.mergeScratch.cRecoveryConvergence || parser.mergeScratch.cRecoveryFallbackSuppression {
 		t.Fatal("clean recovery exit retained scratch state")
-	}
-
-	parser.markCRecoveryCostCompetitionRelevant()
-	parser.pendingForkStacks = []glrStack{newGLRStack(1)}
-	parser.clearCRecoveryCostIfClean([]glrStack{{}}, &trackChildErrors)
-	if !parser.crecoveryCostCompetitionConvergenceEnabled {
-		t.Fatal("clean recovery exit discarded the pending-fork convergence latch")
-	}
-	parser.syncCRecoveryMergeScratch(parser.mergeScratch)
-	if parser.mergeScratch.cRecoveryCostWalk || parser.mergeScratch.cRecoveryFallbackSuppression || !parser.mergeScratch.cRecoveryConvergence {
-		t.Fatalf("pending-fork convergence latch did not reach merge scratch walk=%t convergence=%t fallback=%t", parser.mergeScratch.cRecoveryCostWalk, parser.mergeScratch.cRecoveryConvergence, parser.mergeScratch.cRecoveryFallbackSuppression)
-	}
-
-	parser.pendingForkStacks = nil
-	scratch := parserScratch{merge: *parser.mergeScratch}
-	parser.prepareParseStacksForIteration([]glrStack{newGLRStack(1)}, &scratch, nil, arenaClassFull, 0, 0, false, nil, nil)
-	if scratch.merge.cRecoveryCostWalk || scratch.merge.cRecoveryConvergence || scratch.merge.cRecoveryFallbackSuppression {
-		t.Fatalf("single-stack preparation retained scratch state walk=%t convergence=%t fallback=%t", scratch.merge.cRecoveryCostWalk, scratch.merge.cRecoveryConvergence, scratch.merge.cRecoveryFallbackSuppression)
 	}
 }
 
@@ -329,9 +254,8 @@ func TestCRecoveryParseRetryPoolAndSnippetResetsClearState(t *testing.T) {
 	parser.mergeScratch = scratch
 	parser.crecoveryCostCompetitionRelevant = true
 	parser.crecoveryCostCompetitionWalkEnabled = true
-	parser.crecoveryCostCompetitionConvergenceEnabled = true
 	parser.resetCRecoveryCostCompetitionState()
-	if parser.crecoveryCostCompetitionRelevant || parser.crecoveryCostCompetitionWalkEnabled || parser.crecoveryCostCompetitionConvergenceEnabled || scratch.cRecoveryCostWalk || scratch.cRecoveryConvergence || scratch.cRecoveryFallbackSuppression {
+	if parser.crecoveryCostCompetitionRelevant || parser.crecoveryCostCompetitionWalkEnabled || scratch.cRecoveryCostWalk || scratch.cRecoveryConvergence || scratch.cRecoveryFallbackSuppression {
 		t.Fatal("retry reset retained recovery state before parse")
 	}
 
@@ -340,7 +264,6 @@ func TestCRecoveryParseRetryPoolAndSnippetResetsClearState(t *testing.T) {
 	parser.recoveryInitialOnly = true
 	parser.crecoveryCostCompetitionRelevant = true
 	parser.crecoveryCostCompetitionWalkEnabled = true
-	parser.crecoveryCostCompetitionConvergenceEnabled = true
 
 	tree, err := parser.Parse([]byte("1+2"))
 	if err != nil {
@@ -349,8 +272,8 @@ func TestCRecoveryParseRetryPoolAndSnippetResetsClearState(t *testing.T) {
 	if tree != nil {
 		tree.Release()
 	}
-	if parser.crecoveryCostCompetitionRelevant || parser.crecoveryCostCompetitionWalkEnabled || parser.crecoveryCostCompetitionConvergenceEnabled {
-		t.Fatalf("parse start retained recovery state relevant=%t walk=%t convergence=%t", parser.crecoveryCostCompetitionRelevant, parser.crecoveryCostCompetitionWalkEnabled, parser.crecoveryCostCompetitionConvergenceEnabled)
+	if parser.crecoveryCostCompetitionRelevant || parser.crecoveryCostCompetitionWalkEnabled {
+		t.Fatalf("parse start retained recovery state relevant=%t walk=%t", parser.crecoveryCostCompetitionRelevant, parser.crecoveryCostCompetitionWalkEnabled)
 	}
 	parser.errorCostCompetition = true
 	parser.recoveryInitialOnly = false
@@ -358,32 +281,29 @@ func TestCRecoveryParseRetryPoolAndSnippetResetsClearState(t *testing.T) {
 	parser.mergeScratch = scratch
 	parser.crecoveryCostCompetitionRelevant = true
 	parser.crecoveryCostCompetitionWalkEnabled = true
-	parser.crecoveryCostCompetitionConvergenceEnabled = true
 	parser.resetCRecoveryCostCompetitionState()
-	if parser.crecoveryCostCompetitionRelevant || parser.crecoveryCostCompetitionWalkEnabled || parser.crecoveryCostCompetitionConvergenceEnabled || scratch.cRecoveryCostWalk || scratch.cRecoveryConvergence || scratch.cRecoveryFallbackSuppression {
+	if parser.crecoveryCostCompetitionRelevant || parser.crecoveryCostCompetitionWalkEnabled || scratch.cRecoveryCostWalk || scratch.cRecoveryConvergence || scratch.cRecoveryFallbackSuppression {
 		t.Fatal("retry reset retained recovery state")
 	}
 
 	parser.crecoveryCostCompetitionRelevant = true
 	parser.crecoveryCostCompetitionWalkEnabled = true
-	parser.crecoveryCostCompetitionConvergenceEnabled = true
 	scratch.cRecoveryCostWalk = true
 	scratch.cRecoveryConvergence = true
 	scratch.cRecoveryFallbackSuppression = true
 	pool := &ParserPool{language: parser.language}
 	pool.applyDefaults(parser)
-	if parser.crecoveryCostCompetitionRelevant || parser.crecoveryCostCompetitionWalkEnabled || parser.crecoveryCostCompetitionConvergenceEnabled || scratch.cRecoveryCostWalk || scratch.cRecoveryConvergence || scratch.cRecoveryFallbackSuppression {
+	if parser.crecoveryCostCompetitionRelevant || parser.crecoveryCostCompetitionWalkEnabled || scratch.cRecoveryCostWalk || scratch.cRecoveryConvergence || scratch.cRecoveryFallbackSuppression {
 		t.Fatal("parser pool reset retained recovery state")
 	}
 
 	parser.crecoveryCostCompetitionRelevant = true
 	parser.crecoveryCostCompetitionWalkEnabled = true
-	parser.crecoveryCostCompetitionConvergenceEnabled = true
 	scratch.cRecoveryCostWalk = true
 	scratch.cRecoveryConvergence = true
 	scratch.cRecoveryFallbackSuppression = true
 	resetSnippetParser(parser)
-	if parser.crecoveryCostCompetitionRelevant || parser.crecoveryCostCompetitionWalkEnabled || parser.crecoveryCostCompetitionConvergenceEnabled || scratch.cRecoveryCostWalk || scratch.cRecoveryConvergence || scratch.cRecoveryFallbackSuppression {
+	if parser.crecoveryCostCompetitionRelevant || parser.crecoveryCostCompetitionWalkEnabled || scratch.cRecoveryCostWalk || scratch.cRecoveryConvergence || scratch.cRecoveryFallbackSuppression {
 		t.Fatal("snippet reset retained recovery state")
 	}
 
@@ -1845,7 +1765,7 @@ func TestRecoveryMemoTelemetryPreservesAMD64HotLayouts(t *testing.T) {
 	if got, want := unsafe.Sizeof(Tree{}), uintptr(3240); got != want {
 		t.Fatalf("Tree size = %d, want %d", got, want)
 	}
-	if got, want := unsafe.Offsetof(Parser{}.cNodeMemoPeakTier), unsafe.Offsetof(Parser{}.crecoveryCostCompetitionRelevant)+3; got != want {
+	if got, want := unsafe.Offsetof(Parser{}.cNodeMemoPeakTier), unsafe.Offsetof(Parser{}.crecoveryCostCompetitionRelevant)+2; got != want {
 		t.Fatalf("Parser memo peak offset = %d, want %d", got, want)
 	}
 	if got, want := unsafe.Offsetof(Parser{}.fullParseRetryPassesTaken), uintptr(984); got != want {


### PR DESCRIPTION
## What does this PR do?

This change returns clean suffixes to ordinary merging after condense removes all active recovery state.
It deletes the separate pending-fork convergence latch.

Before this change, parsing stayed correct but used avoidable CPU time and memory.

## Why this approach?

The pending-fork latch kept cap-one convergence active after recovery costs became irrelevant.
This retained hundreds of equivalent stacks on a valid generated C initializer.

The active recovery state already owns this decision.
Keeping a second latch created a stale authority path.

## Correctness

- [x] Focused package tests pass for the changed recovery boundary.
- [x] Exact C-runtime parity passes for the generated C initializer.
- [x] Exact C-runtime parity passes for the two affected Kotlin fixtures.
- [x] The merge census passes with the new counts.
- [x] The Docker smoke parity ring passes.
- [x] The focused race test and `go vet` pass.

The generated regression test requires:

- a complete, accepted tree;
- no error nodes;
- an exact source span;
- no truncation;
- at most eight live stacks.

The baseline reached 413 live stacks. The candidate reached four.

## Performance

The benchmark uses generated input, 20 shuffle seeds, `GOMAXPROCS=1`, a 750 ms duration, and `-benchmem`.

| Metric | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| Time | 1.261 s/op | 2.193 ms/op | -99.83% |
| Bytes | 70.7 MiB/op | 190 KiB/op | -99.74% |
| Allocations | 221,190/op | 1,339/op | -99.39% |

`benchstat` reports `p=0.000` for all three metrics.
Absolute times varied on the test host, but the result groups stayed separate.

- [x] Used the repository's stable benchmark settings.
- [x] Included before and after numbers.
- [x] The Docker parity ring completed without an out-of-memory failure.

## Maintainability

- [x] No unnecessary abstractions or unrelated cleanup.
- [x] Harness changes are limited to required parity proof.
- [x] No new dependencies.

The change deletes one parser field, one helper, and tests for the old mechanism.

## Self-review

- [x] Reviewed the full diff.
- [x] Reviewed the recovery boundary with independent performance and minimality lenses.
- [x] No unresolved uncertainty remains.

## Due diligence

- [x] Read the changed parser and merge paths.
- [x] Kept the existing parser state pattern.
- [x] Validated the affected grammars against the C runtime.
