### PR TITLE
fix(grammars): stop C inventing a comma in three-enumerator enums

### DIFF
--- a/cgo_harness/c_enum_missing_comma_parity_test.go
+++ b/cgo_harness/c_enum_missing_comma_parity_test.go
@@ -1,0 +1,49 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"os"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// TestCEnumThreeValuedEnumeratorsLeadingTriviaMatchesCReference locks the
+// reduced PR #739 witness against the pinned C parser. Leading trivia selects
+// the production GLR route, so this case must not rely on the forest fallback.
+func TestCEnumThreeValuedEnumeratorsLeadingTriviaMatchesCReference(t *testing.T) {
+	const src = "\ntypedef enum { A = 0, B = 1, C = MAX } t;"
+	source := []byte(src)
+	restoreForest := os.Getenv("GOT_GLR_FOREST") != "0"
+	gotreesitter.SetGLRForestEnabled(false)
+	t.Cleanup(func() { gotreesitter.SetGLRForestEnabled(restoreForest) })
+
+	cLang, err := ParityCLanguage("c")
+	if err != nil {
+		t.Fatalf("load locked C parser: %v", err)
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatalf("set locked C language: %v", err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("locked C parser returned no tree")
+	}
+	t.Cleanup(cTree.Close)
+
+	production := false
+	goTree, goLang, err := parseWithGo(parityCase{
+		name:           "c",
+		source:         src,
+		candidateRoute: &production,
+	}, source, nil)
+	if err != nil {
+		t.Fatalf("parse C with Go production: %v", err)
+	}
+	t.Cleanup(func() { releaseGoTree(goTree) })
+	assertLockedCTreeExact(t, "PR #739 C enum witness", goTree, goLang, cTree)
+}

--- a/cgo_harness/parity_swift_condition_field_regression_test.go
+++ b/cgo_harness/parity_swift_condition_field_regression_test.go
@@ -120,15 +120,20 @@ func TestParitySwiftConditionFieldFamily(t *testing.T) {
 
 func assertSwiftConditionTreeExact(t *testing.T, goTree *gotreesitter.Tree, goLang *gotreesitter.Language, cTree *sitter.Tree) {
 	t.Helper()
+	assertLockedCTreeExact(t, "Swift condition witness", goTree, goLang, cTree)
+}
+
+func assertLockedCTreeExact(t *testing.T, label string, goTree *gotreesitter.Tree, goLang *gotreesitter.Language, cTree *sitter.Tree) {
+	t.Helper()
 	goRoot := goTree.RootNode()
 	cRoot := cTree.RootNode()
 	if goRoot.HasError() || cRoot.HasError() {
-		t.Fatalf("condition witness has an error node: Go=%v C=%v", goRoot.HasError(), cRoot.HasError())
+		t.Fatalf("%s has an error node: Go=%v C=%v", label, goRoot.HasError(), cRoot.HasError())
 	}
 	if diff := FirstDivergenceDumpV1(goRoot, goLang, cRoot); diff != nil {
-		t.Fatalf("node or field divergence: %+v", diff)
+		t.Fatalf("%s node or field divergence: %+v", label, diff)
 	}
-	if diff := firstSwiftConditionFlagDivergence(goRoot, goLang, cRoot, "/source_file"); diff != nil {
+	if diff := firstLockedCTreeFlagDivergence(goRoot, goLang, cRoot, "/"+goRoot.Type(goLang)); diff != nil {
 		t.Fatal(diff)
 	}
 	goInspection, err := benchfixtures.InspectGoTree(goRoot, goLang)
@@ -142,10 +147,10 @@ func assertSwiftConditionTreeExact(t *testing.T, goTree *gotreesitter.Tree, goLa
 	if goInspection.SHA256 != cDigest {
 		t.Fatalf("deep digest Go=%s C=%s", goInspection.SHA256, cDigest)
 	}
-	t.Logf("exact symbols, fields, spans, points, flags, and deep digest %s", goInspection.SHA256)
+	t.Logf("%s: exact symbols, fields, spans, points, flags, and deep digest %s", label, goInspection.SHA256)
 }
 
-func firstSwiftConditionFlagDivergence(goNode *gotreesitter.Node, goLang *gotreesitter.Language, cNode *sitter.Node, path string) error {
+func firstLockedCTreeFlagDivergence(goNode *gotreesitter.Node, goLang *gotreesitter.Language, cNode *sitter.Node, path string) error {
 	if goNode == nil || cNode == nil {
 		return fmt.Errorf("%s: nil mismatch Go=%v C=%v", path, goNode == nil, cNode == nil)
 	}
@@ -159,7 +164,7 @@ func firstSwiftConditionFlagDivergence(goNode *gotreesitter.Node, goLang *gotree
 		goChild := goNode.Child(i)
 		cChild := cNode.Child(uint(i))
 		childPath := fmt.Sprintf("%s/%s[%d]", path, goChild.Type(goLang), i)
-		if err := firstSwiftConditionFlagDivergence(goChild, goLang, cChild, childPath); err != nil {
+		if err := firstLockedCTreeFlagDivergence(goChild, goLang, cChild, childPath); err != nil {
 			return err
 		}
 	}

--- a/grammars/c_enum_missing_comma_pin_test.go
+++ b/grammars/c_enum_missing_comma_pin_test.go
@@ -1,0 +1,92 @@
+package grammars
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// Pin for a MISSING comma that the Go engine invents inside a three-enumerator
+// enum when the construct is the first declaration in the file and any trivia
+// precedes it.
+//
+// C tree-sitter parses the source below with no MISSING node and no error. The
+// Go engine inserts a zero-width `,` between the last enumerator and the
+// closing brace, and marks enumerator_list, enum_specifier, type_definition,
+// and translation_unit as containing an error. Every other node matches the C
+// tree exactly, so the whole divergence is that one invented token and the
+// error state it propagates.
+//
+// The trigger is narrow and worth recording precisely:
+//
+//   - the enum must be the first declaration in the file, and some trivia must
+//     precede it. A single leading space, tab, newline, or comment is enough.
+//     With the enum at byte 0 the tree is correct, and with any declaration
+//     ahead of it the tree is correct.
+//   - exactly three enumerators. Two are fine and four are fine.
+//   - every enumerator carries `= value`. Bare enumerators are fine, and a
+//     trailing comma after the last enumerator is fine.
+//
+// Leading trivia is not the cause. It decides which parser runs. With the enum
+// at byte 0 the GSS-forest fast path accepts the parse and reports
+// ForestFastPath=true with zero iterations. Leading trivia makes that path
+// decline, the production GLR parser runs instead, and it enters recovery
+// (CRecoveryEnteredErrorState=true, CRecoverMissingTokenTrialAttemptsPeak=1)
+// and keeps a missing-token trial that C never needs. The fast path is
+// therefore masking the defect on the inputs it happens to accept.
+//
+// Found by differential testing against the pinned C oracle over a 1,567-file
+// corpus: /usr/include/KHR/khrplatform.h was the only file where the oracle
+// parsed completely clean and the Go engine invented a token. Reduced from
+// 11,131 bytes to the 42 below.
+//
+// This pin is self-healing: it PASSES automatically once the invented comma
+// disappears.
+func TestCleanRegressionPinCEnumThreeValuedEnumerators(t *testing.T) {
+	const src = "\ntypedef enum { A = 0, B = 1, C = MAX } t;"
+
+	tree, lang := pinParse(t, "c", src)
+	defer tree.Release()
+
+	root := tree.RootNode()
+	if got := root.Type(lang); got != "translation_unit" {
+		t.Fatalf("c: root type = %q, want translation_unit", got)
+	}
+	// The enumerator_list must still cover the whole brace-delimited run; the
+	// divergence is an extra child, not a reshaped span.
+	list := pinFind(root, lang, "enumerator_list")
+	if list == nil {
+		t.Fatal("c: no enumerator_list node")
+	}
+	if got, want := int(list.StartByte()), 14; got != want {
+		t.Fatalf("c: enumerator_list starts at %d, want %d", got, want)
+	}
+	if got, want := int(list.EndByte()), 39; got != want {
+		t.Fatalf("c: enumerator_list ends at %d, want %d", got, want)
+	}
+
+	const wantMissing = 0 // C tree-sitter invents nothing here.
+	if got := pinCountMissing(root); got == wantMissing {
+		return // fix landed — pin now green.
+	} else {
+		t.Skipf("KNOWN DIVERGENCE (c enum three valued enumerators): Go invents %d "+
+			"MISSING node(s), C invents %d — the production GLR parser keeps a "+
+			"missing-comma trial that the forest fast path never runs; see file "+
+			"comment", got, wantMissing)
+	}
+}
+
+// pinCountMissing reports how many nodes in the tree are MISSING.
+func pinCountMissing(n *gotreesitter.Node) int {
+	if n == nil {
+		return 0
+	}
+	count := 0
+	if n.IsMissing() {
+		count++
+	}
+	for i := 0; i < n.ChildCount(); i++ {
+		count += pinCountMissing(n.Child(i))
+	}
+	return count
+}

--- a/grammars/c_enum_missing_comma_pin_test.go
+++ b/grammars/c_enum_missing_comma_pin_test.go
@@ -19,26 +19,33 @@ import (
 //
 // The trigger is narrow and worth recording precisely:
 //
-//   - the enum must be the first declaration in the file, and some trivia must
-//     precede it. A single leading space, tab, newline, or comment is enough.
-//     With the enum at byte 0 the tree is correct, and with any declaration
-//     ahead of it the tree is correct.
-//   - exactly three enumerators. Two are fine and four are fine.
-//   - every enumerator carries `= value`. Bare enumerators are fine, and a
-//     trailing comma after the last enumerator is fine.
+//   - exactly three enumerators. Two are fine and four are fine. Three is the
+//     only count that diverges: it is the count where the losing fork is also
+//     the last fork. With four, a later fork promotes the stack to a packed GSS
+//     and the merge that keeps the folded history succeeds.
+//   - some trivia must precede the enum. A single space, tab, newline, or
+//     comment is enough.
 //
-// Leading trivia is not the cause. It decides which parser runs. With the enum
-// at byte 0 the GSS-forest fast path accepts the parse and reports
-// ForestFastPath=true with zero iterations. Leading trivia makes that path
-// decline, the production GLR parser runs instead, and it enters recovery
-// (CRecoveryEnteredErrorState=true, CRecoverMissingTokenTrialAttemptsPeak=1)
-// and keeps a missing-token trial that C never needs. The fast path is
-// therefore masking the defect on the inputs it happens to accept.
+// The trivia does not cause the defect. The production GLR parser builds the
+// wrong tree at every offset. What trivia changes is whether the wrong tree
+// escapes: maybeReplaceRecoveredTreeWithForest (glr_forest.go) re-parses any
+// errored production root through the forest engine and swaps in the clean
+// result, but it declines when the candidate root does not start at byte 0.
+// Leading trivia moves the root to byte 1, the repair declines, and the broken
+// tree reaches the caller.
 //
-// Found by differential testing against the pinned C oracle over a 1,567-file
-// corpus: /usr/include/KHR/khrplatform.h was the only file where the oracle
-// parsed completely clean and the Go engine invented a token. Reduced from
-// 11,131 bytes to the 42 below.
+// Root cause. Upstream tree-sitter never executes SHIFT_REPEAT at a conflict
+// cell (lib/src/parser.c, `if (action.shift.repetition) break;`); it folds the
+// repetition first and re-dispatches. gotreesitter implements the same rule as
+// cRepetitionSkipConflictChoice but opts language "c" out (conflict_policy.go).
+// C therefore forks at the cell, and convergence then fails: C forces cap-one
+// merging, the GSS merge refuses because one stack is demoted-linear, and the
+// cap-one depth tiebreak keeps the deeper unfolded branch. The parse dead-ends
+// on `}` and recovery invents the comma. The parse table itself matches
+// upstream byte for byte, so this is a runtime and profile defect.
+//
+// A bare three-enumerator enum (no `= value`) diverges too, with an ERROR wrap
+// instead of an invented comma. This pin covers the valued form.
 //
 // This pin is self-healing: it PASSES automatically once the invented comma
 // disappears.

--- a/grammars/c_enum_missing_comma_pin_test.go
+++ b/grammars/c_enum_missing_comma_pin_test.go
@@ -97,3 +97,62 @@ func pinCountMissing(n *gotreesitter.Node) int {
 	}
 	return count
 }
+
+// Pin for a second C divergence in the same family as the enum comma above,
+// which the enumerator-list fold does NOT repair.
+//
+// C tree-sitter parses this reduced form of libc-test's tls_align_dlopen.c
+// with no error. The Go engine wraps a fragment of `t[i].align` in an ERROR
+// node and marks every enclosing statement as containing an error, while every
+// node span stays identical to the C tree.
+//
+// It is the same convergence failure, reached a different way. Both
+// GOT_FAITHFUL_CONDENSE=1 and GOT_GLR_MAX_MERGE_PER_KEY=2 clear it, so the
+// correct reading exists and cap-one merging discards it. Unlike the enum
+// case, the fork is not at a repetition conflict cell: adding a
+// ConflictPolicyRepetitionReduce row for sized_type_specifier_repeat1(342),
+// _declaration_specifiers_repeat1(336), _field_declaration_declarator_repeat1(344),
+// argument_list_repeat1(354), or declaration_repeat1(332) leaves it unchanged.
+// Folding cannot reach it, so the repair belongs in the merge itself:
+// gssMainCanMergeWithScratch refuses when one candidate is in demoted-linear
+// form (nil head) instead of promoting it, and the cap-one depth tiebreak then
+// keeps the wrong branch.
+//
+// Like the enum pin, this needs leading trivia to be observable at all:
+// maybeReplaceRecoveredTreeWithForest silently repairs an errored production
+// root, but declines when the root does not start at byte 0.
+//
+// This pin is self-healing: it PASSES once the ERROR disappears.
+func TestCleanRegressionPinCStructMemberSubscriptField(t *testing.T) {
+	tree, _ := pinParse(t, "c", tlsAlignFixture)
+	defer tree.Release()
+
+	root := tree.RootNode()
+	if got, want := int(root.EndByte()), len(tlsAlignFixture); got != want {
+		t.Fatalf("c: parse covers %d of %d bytes", got, want)
+	}
+	if !root.HasError() {
+		return // fix landed - pin now green.
+	}
+	t.Skip("KNOWN DIVERGENCE (c struct member subscript field): the Go engine " +
+		"wraps a field access fragment in ERROR where C parses clean; cap-one " +
+		"merging discards the correct branch and no repetition fold reaches it; " +
+		"see file comment")
+}
+
+const tlsAlignFixture = `
+{
+	struct {
+		char *name;
+		unsigned size;
+		unsigned align;
+		unsigned long addr;
+	} *t;
+	if (!t)
+		t_error("dlsym failed\n");
+	else for (i = 0; i < 4; i++) {
+		if (t[i].addr & (t[i].align-1))
+			t_error("bad alignment: %s, size: %u, align: %u, addr: 0x%lx\n",
+				t[i].name, t[i].size, t[i].align, t[i].addr);
+	}
+}`

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -544,6 +544,22 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 				Kind:          gotreesitter.ConflictPolicyRepetitionShift,
 				ReduceSymbols: []gotreesitter.Symbol{324, 326},
 			},
+			// Fold aux_sym_enumerator_list_repeat1 at its conflict cell instead
+			// of forking. Upstream never executes SHIFT_REPEAT at a conflict cell
+			// (lib/src/parser.c, `if (action.shift.repetition) break;`): it
+			// reduces, renumbers, and re-dispatches the same lookahead. C is
+			// opted out of the engine-wide equivalent (cRepetitionSkipOptOut in
+			// conflict_policy.go), so an enumerator list forks and then depends
+			// on cap-one convergence. When one branch is in demoted-linear form
+			// the GSS merge refuses, the depth tiebreak keeps the unfolded
+			// branch, and a three-enumerator list dead-ends on `}` and invents a
+			// comma. Folding this one symbol restores the upstream order.
+			{
+				State:         gotreesitter.ConflictPolicyAnyState,
+				Lookahead:     gotreesitter.ConflictPolicyAnyLookahead,
+				Kind:          gotreesitter.ConflictPolicyRepetitionReduce,
+				ReduceSymbols: []gotreesitter.Symbol{343},
+			},
 		},
 	},
 	// QL declares conflicts: [[$.simpleId, $.className], ...]. An upper-case

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -569,7 +569,7 @@ func TestBuiltinCConflictPolicyAttachesWildcard(t *testing.T) {
 	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
 
 	lang := CLanguage()
-	if got, want := len(lang.ConflictPolicies), 1; got != want {
+	if got, want := len(lang.ConflictPolicies), 2; got != want {
 		t.Fatalf("c ConflictPolicies = %d rows, want %d", got, want)
 	}
 	policy := lang.ConflictPolicies[0]
@@ -577,6 +577,17 @@ func TestBuiltinCConflictPolicyAttachesWildcard(t *testing.T) {
 		policy.Kind != gotreesitter.ConflictPolicyRepetitionShift || len(policy.ReduceSymbols) != 2 ||
 		policy.ReduceSymbols[0] != 324 || policy.ReduceSymbols[1] != 326 {
 		t.Fatalf("c conflict policy = %+v, want wildcard repetition-shift over translation_unit_repeat1(324)/preproc_if_repeat1(326)", policy)
+	}
+	// C is held out of the engine-wide repetition fold
+	// (cRepetitionSkipConflictChoice), so it carves out the symbols that are
+	// proven safe one row at a time, the way haskell does. This row folds
+	// aux_sym_enumerator_list_repeat1 and stops a three-enumerator list from
+	// inventing a comma; see grammars/c_enum_missing_comma_pin_test.go.
+	fold := lang.ConflictPolicies[1]
+	if fold.State != gotreesitter.ConflictPolicyAnyState || fold.Lookahead != gotreesitter.ConflictPolicyAnyLookahead ||
+		fold.Kind != gotreesitter.ConflictPolicyRepetitionReduce || len(fold.ReduceSymbols) != 1 ||
+		fold.ReduceSymbols[0] != 343 {
+		t.Fatalf("c conflict policy[1] = %+v, want wildcard repetition-reduce over enumerator_list_repeat1(343)", fold)
 	}
 }
 


### PR DESCRIPTION
Fix a C parse defect that invents a comma inside a three-enumerator enum, and pin it.

## The defect

C tree-sitter parses the source below with no MISSING node and no error. gotreesitter inserted a zero-width `,` between the last enumerator and the closing brace and marked four ancestors as containing an error. Every other node already matched the C tree exactly.

    typedef enum { A = 0, B = 1, C = MAX } t;

Found by differential testing against the pinned C oracle over a 1,567 file corpus. `/usr/include/KHR/khrplatform.h` was the only file in that corpus where the oracle parsed completely clean and the Go engine invented a token. It reduced from 11,131 bytes to 42.

## Cause

Upstream never executes a repetition SHIFT at a conflict cell (`lib/src/parser.c`, `if (action.shift.repetition) break;`). It reduces, renumbers, and re-dispatches the same lookahead from the folded state.

gotreesitter implements that rule engine wide as `cRepetitionSkipConflictChoice`, and holds C out of it (`cRepetitionSkipOptOut`) because an eager fold before the first error reshapes what recovery later consumes on an error-dense corpus. The held-out C parser therefore forks at the cell. Convergence then fails in three steps: C forces cap-one merging, the GSS merge refuses because one branch is in demoted-linear form, and the cap-one depth tiebreak keeps the deeper unfolded branch. The parse dead-ends on `}` and recovery invents the comma.

Three enumerators is the only count that fails. Two never reach the conflict cell. With four, a later fork promotes the stack to a packed GSS, the merge succeeds, and the folded history survives.

The parse table matches upstream byte for byte, so this is a runtime and profile defect, not a grammargen defect.

## Fix

Add one `ConflictPolicyRepetitionReduce` row for `aux_sym_enumerator_list_repeat1` to the `c` runtime profile. This does not lift the opt-out. It carves out one symbol that is proven safe, which is what `haskell` already does with three rows for the same reason.

## Measurements

Corpus of 1,567 C files, both engines compared against the pinned C oracle, baseline and candidate both built from the same commit:

- divergences 452 to 449
- 3 files become byte-exact against the oracle: `khrplatform.h`, `rawmidi.h`, `xkb.h`
- 0 regressions

A second population: 23 files whose defects are normally hidden because `maybeReplaceRecoveredTreeWithForest` declines when the root does not start at byte 0. Re-measured with one byte of leading trivia so the repair cannot mask them: 2 fixed, 0 regressed.

Full suite matches the baseline failure set. `TestBuiltinCConflictPolicyAttachesWildcard` asserted C had exactly one policy row; it now asserts both rows, including the new kind and symbol.

## Pin

`TestCleanRegressionPinCEnumThreeValuedEnumerators` is self-healing in the style of the existing `regex any_character` pin: it passes once the invented comma disappears. It passes with this fix and skips with a KNOWN DIVERGENCE message without it.
