### PR TITLE
improve(parser): reserve C recovery summary capacity

### DIFF
--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -2780,7 +2780,10 @@ func cEntryCountsTowardDepth(e stackEntry) bool {
 // spine: entries top-first, depth = crossings of depth-counting links,
 // deduped on (depth, state), bounded by MAX_SUMMARY_DEPTH.
 func (p *Parser) cRecordSummary(entries []stackEntry) []cStackSummaryEntry {
-	summary := make([]cStackSummaryEntry, 0, 8)
+	// cHandleError and forestEOFRecoveryCouldCompete usually record one state
+	// for each bounded depth. Reserve up to 17 entries for that common shape.
+	// Equal-depth states can exceed this hint, and append must preserve them.
+	summary := make([]cStackSummaryEntry, 0, min(len(entries), cRecoverMaxSummaryDepth+1))
 	depth := 0
 	record := func(d int, st StateID, posBytes, posRow uint32) {
 		for j := len(summary) - 1; j >= 0; j-- {

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -671,6 +671,36 @@ func TestCRecordSummaryAvoidsPositionAllocations(t *testing.T) {
 	}
 }
 
+func TestCRecordSummaryPreservesMoreThanReserveAtEqualDepth(t *testing.T) {
+	parser := &Parser{}
+	const entryCount = cRecoverMaxSummaryDepth + 8
+	entries := make([]stackEntry, entryCount)
+	nodes := make([]Node, entryCount)
+	for i := range entries {
+		nodes[i].endByte = uint32(100 + i)
+		nodes[i].endPoint = Point{Row: uint32(10 + i), Column: uint32(i)}
+		nodes[i].setExtra(true)
+		entries[i] = newStackEntryNode(StateID(i+1), &nodes[i])
+	}
+
+	got := parser.cRecordSummary(entries)
+	want := cRecordSummaryPositionTableReference(entries)
+	if len(got) != entryCount || len(got) <= cRecoverMaxSummaryDepth+1 {
+		t.Fatalf("summary len = %d, want %d entries beyond the reserve hint", len(got), entryCount)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("summary len = %d, reference len = %d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("summary[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+		if got[i].depth != 0 {
+			t.Fatalf("summary[%d].depth = %d, want equal-depth entry", i, got[i].depth)
+		}
+	}
+}
+
 func cRecordSummaryPositionTableReference(entries []stackEntry) []cStackSummaryEntry {
 	summary := make([]cStackSummaryEntry, 0, 8)
 	posBytesAt := make([]uint32, len(entries))


### PR DESCRIPTION
Stacked performance train car for #739.

PR #739 is merged. Merge commit `af095d16` integrates updated `main` into `codex/perf-train-20260820` without rewriting `56ebe06b`.

## Scope

- Reserve bounded capacity in `cRecordSummary`.
- Add a regression test for equal-depth entries beyond the reserve hint.
- Keep the change limited to `parser_recover_c.go` and `parser_recover_c_test.go`.

## Correctness

Run these focused Docker gates for the parent and candidate revisions:

- `TestCRecordSummaryAvoidsPositionAllocations` and `TestCRecordSummaryPreservesMoreThanReserveAtEqualDepth`.
- `TestKDLRecoveryGarbageSuffixExact`.
- C grammargen parity: 20 of 20 cases passed with no errors and tree parity.
- C real-corpus parity: the baseline and candidate produced identical results and exited successfully without an out-of-memory event or timeout.

## Benchmark evidence

Run `GOMAXPROCS=1 bash scripts/run_randomized_benchmarks.sh` in each worktree.

Use one process per shuffle seed, seeds 1 through 20, `-count=1`, `-benchtime=750ms`, and `-benchmem`.

The primary trio timing comparison is neutral. Benchstat marks every timing comparison as statistically inconclusive. Do not treat this change as a timing improvement.

The KDL recovery target shows significant memory improvements:

- `B/op`: 4.263 MiB to 2.787 MiB, down 34.62 percent, p=0.000.
- `allocs/op`: 36.44k to 31.30k, down 14.11 percent, p=0.000.
- KDL timing remains neutral, p=0.149.
- The recurring recovery target has neutral timing and unchanged allocations.

A separate single-process `/usr/bin/time -v` receipt reports 57,352 KiB for the parent and 56,120 KiB for the candidate. Treat this RSS difference as directional only.