### PR TITLE
test(compact): trace EOF recovery histories

### DIFF
--- a/cgo_harness/eof_history_differential_test.go
+++ b/cgo_harness/eof_history_differential_test.go
@@ -1,0 +1,279 @@
+//go:build cgo && treesitter_c_parity && gts_derivation_set_census && gts_eof_history_census
+
+package cgoharness
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestEOFAcceptHistoryDifferential records the two compact EOF histories before
+// their certified drop. A bounded test-only observer records both locked-C
+// roots before selection. The test rejects a grant while the two multisets
+// lack a full bijection.
+func TestEOFAcceptHistoryDifferential(t *testing.T) {
+	if !gotreesitter.EOFAcceptHistoryCensusBuilt() {
+		t.Fatal("EOF-history census is absent; build with gts_eof_history_census")
+	}
+
+	previousForest := os.Getenv("GOT_GLR_FOREST") != "0"
+	gotreesitter.SetGLRForestEnabled(false)
+	t.Cleanup(func() { gotreesitter.SetGLRForestEnabled(previousForest) })
+
+	for _, language := range []string{"http", "robot"} {
+		language := language
+		t.Run(language, func(t *testing.T) {
+			source := []byte(grammars.ParseSmokeSample(language))
+			entry := grammars.DetectLanguageByName(language)
+			if entry == nil || entry.Language == nil {
+				t.Fatalf("load %s Go grammar", language)
+			}
+			goLanguage := entry.Language()
+			if goLanguage == nil {
+				t.Fatalf("load %s Go grammar", language)
+			}
+			cLanguage, err := COracleLanguage(language)
+			if err != nil {
+				t.Fatalf("load %s locked C grammar: %v", language, err)
+			}
+
+			gotreesitter.EOFAcceptHistoryCensusReset()
+			parser := gotreesitter.NewParser(goLanguage)
+			parser.SetAdmissionCandidateRoute(true)
+			tree, err := parser.Parse(source)
+			if err != nil {
+				t.Fatalf("parse compact route: %v", err)
+			}
+			tree.Release()
+
+			frontiers := gotreesitter.EOFAcceptHistoryCensusSnapshot()
+			if len(frontiers) != 1 {
+				t.Fatalf("pre-drop EOF frontiers=%d, want 1", len(frontiers))
+			}
+			frontier := frontiers[0]
+			if frontier.Token.Symbol != 0 || frontier.Token.StartByte != frontier.Token.EndByte {
+				t.Fatalf("frontier token is not zero-width EOF: %+v", frontier.Token)
+			}
+			if len(frontier.Heads) != 2 {
+				t.Fatalf("pre-drop compact histories=%d, want 2", len(frontier.Heads))
+			}
+
+			accepting := 0
+			noAction := 0
+			var compactShapes []string
+			var compactAcceptingShape string
+			var compactNoActionShape string
+			for _, head := range frontier.Heads {
+				if head.Accepting {
+					accepting++
+				}
+				if head.NoAction {
+					noAction++
+				}
+				if head.EnumerationErr != "" || head.EnumerationTruncated {
+					t.Fatalf("head %d enumeration: err=%q truncated=%v", head.HeaderIndex, head.EnumerationErr, head.EnumerationTruncated)
+				}
+				if len(head.Candidates) != 1 {
+					t.Fatalf("head %d exact paths=%d, want 1", head.HeaderIndex, len(head.Candidates))
+				}
+				candidate := head.Candidates[0]
+				if candidate.MaterializeErr != "" {
+					t.Fatalf("head %d materialization: %s", head.HeaderIndex, candidate.MaterializeErr)
+				}
+				compactShapes = append(compactShapes, candidate.Shape)
+				if head.Accepting {
+					compactAcceptingShape = candidate.Shape
+				}
+				if head.NoAction {
+					compactNoActionShape = candidate.Shape
+				}
+				t.Logf(
+					"G2 COMPACT language=%s head=%d accept=%v no-action=%v state=%d byte=%d score=%d branch=%d/%v sha256=%x shape=%s",
+					language, head.HeaderIndex, head.Accepting, head.NoAction,
+					head.Header.State, head.Header.ByteOffset, candidate.Score,
+					candidate.BranchOrder, candidate.HasBranchOrder, candidate.DeepSHA256, candidate.Shape,
+				)
+			}
+			if accepting != 1 || noAction != 1 {
+				t.Fatalf("pre-drop roles: accepting=%d no-action=%d, want 1/1", accepting, noAction)
+			}
+
+			cReceipt, err := cReconstructVersionSet(cLanguage, source)
+			if err != nil {
+				t.Fatalf("reconstruct locked-C versions: %v", err)
+			}
+			if cReceipt.Roots != 2 {
+				t.Fatalf("locked-C versions=%d, want 2", cReceipt.Roots)
+			}
+			if len(cReceipt.Accepts) != 2 {
+				t.Fatalf("locked-C accept events=%d, want 2", len(cReceipt.Accepts))
+			}
+			if cReceipt.Accepts[0].RecoverEOF || len(cReceipt.Accepts[0].Folds) != 0 {
+				t.Fatalf("locked-C event 0=%+v, want normal accept with no fold", cReceipt.Accepts[0])
+			}
+			if !cReceipt.Accepts[1].RecoverEOF || len(cReceipt.Accepts[1].Folds) != 1 {
+				t.Fatalf("locked-C event 1=%+v, want recover_eof with one fold", cReceipt.Accepts[1])
+			}
+			publishedShape := eofHistoryCShape(cReceipt.Published)
+			publishedMatches := 0
+			for _, shape := range compactShapes {
+				if shape == publishedShape {
+					publishedMatches++
+				}
+			}
+			if publishedMatches == 0 {
+				t.Fatalf("locked-C published root is absent from the compact pre-drop set: %s", publishedShape)
+			}
+			t.Logf(
+				"G2 C language=%s versions=%d max-live=%d winner-known=%v winner=%d published-matches=%d published=%s",
+				language, cReceipt.Roots, cReceipt.VersionCountMax,
+				cReceipt.WinnerIndexKnown, cReceipt.WinnerIndex,
+				publishedMatches, publishedShape,
+			)
+
+			cHistory := runEOFAcceptHistoryCOracle(t, language, source)
+			t.Logf("G2 C RAW language=%s\n%s", language, strings.TrimSpace(cHistory.Raw))
+			if len(cHistory.Versions) != 2 {
+				t.Fatalf("instrumented locked-C versions=%d, want 2", len(cHistory.Versions))
+			}
+			if cHistory.Published != publishedShape {
+				t.Fatalf("instrumented C publication differs from the unmodified locked-C publication: instrumented=%s unmodified=%s", cHistory.Published, publishedShape)
+			}
+			if cHistory.Summary != "GTS_C_EOF_SUMMARY captures=2 failed=0" {
+				t.Fatalf("instrumented C summary=%q", cHistory.Summary)
+			}
+
+			cShapes := make([]string, len(cHistory.Versions))
+			var cPublished *eofHistoryCVersion
+			var cLosing *eofHistoryCVersion
+			for index, version := range cHistory.Versions {
+				if version.AcceptIndex != index {
+					t.Fatalf("C capture %d has accept index %d; root/event order drifted", index, version.AcceptIndex)
+				}
+				cShapes[index] = version.Shape
+				if version.Precedence != 0 {
+					t.Fatalf("C version %d precedence=%d, want 0", index, version.Precedence)
+				}
+				if version.Shape == cHistory.Published {
+					copy := version
+					cPublished = &copy
+				} else {
+					copy := version
+					cLosing = &copy
+				}
+				t.Logf(
+					"G2 C ROOT language=%s capture=%d version=%d precedence=%d error-cost=%d shape=%s",
+					language, version.AcceptIndex, version.Version,
+					version.Precedence, version.ErrorCost, version.Shape,
+				)
+			}
+
+			compactMultiset := append([]string(nil), compactShapes...)
+			cMultiset := append([]string(nil), cShapes...)
+			sort.Strings(compactMultiset)
+			sort.Strings(cMultiset)
+			if equalStrings(compactMultiset, cMultiset) {
+				t.Fatal("pre-drop compact histories unexpectedly reached a full locked-C bijection; adjudicate before any production proposal")
+			}
+			if compactAcceptingShape != cHistory.Published {
+				t.Fatalf("compact accepting history does not equal the C-published version")
+			}
+			if cPublished == nil || cPublished.AcceptIndex != 0 {
+				t.Fatalf("published C root does not map to normal event 0: %+v", cPublished)
+			}
+			if cReceipt.Accepts[cPublished.AcceptIndex].RecoverEOF {
+				t.Fatalf("published C root maps to recover_eof: capture=%+v event=%+v", *cPublished, cReceipt.Accepts[cPublished.AcceptIndex])
+			}
+			if cLosing == nil {
+				t.Fatal("instrumented C receipt has no distinct losing version")
+			}
+			if cLosing.AcceptIndex != 1 || !cReceipt.Accepts[cLosing.AcceptIndex].RecoverEOF {
+				t.Fatalf("losing C root does not map to recover_eof event 1: capture=%+v event=%+v", *cLosing, cReceipt.Accepts[cLosing.AcceptIndex])
+			}
+			if compactNoActionShape == cLosing.Shape {
+				t.Fatal("compact no-action history unexpectedly equals the losing C version; adjudicate the new bijection")
+			}
+			if !strings.HasPrefix(cLosing.Shape, "(ERROR[") || cLosing.ErrorCost == 0 {
+				t.Fatalf("losing C version is not the expected error-cost root: %+v", *cLosing)
+			}
+			compactPayload, err := eofHistoryRootChildrenShape(compactNoActionShape)
+			if err != nil {
+				t.Fatalf("decode compact no-action payload: %v", err)
+			}
+			cPayload, err := eofHistoryRootChildrenShape(cLosing.Shape)
+			if err != nil {
+				t.Fatalf("decode losing C payload: %v", err)
+			}
+			if compactPayload != cPayload {
+				t.Fatalf("no-action payload differs before the C recovery wrapper: compact=%s C=%s", compactPayload, cPayload)
+			}
+			t.Logf(
+				"G2 BIJECTION language=%s status=REJECT cardinality=%d/%d accepting-match=true no-action-payload-match=true c-topology=normal[0]/recover_eof[1] compact-loser=%s c-loser=%s c-loser-error-cost=%d",
+				language, len(compactShapes), len(cShapes), compactNoActionShape, cLosing.Shape, cLosing.ErrorCost,
+			)
+		})
+	}
+}
+
+func eofHistoryRootChildrenShape(shape string) (string, error) {
+	if len(shape) < 2 || shape[0] != '(' || shape[len(shape)-1] != ')' {
+		return "", fmt.Errorf("invalid root shape %q", shape)
+	}
+	depth := 0
+	for index := 0; index < len(shape)-1; index++ {
+		switch shape[index] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ' ':
+			if depth == 1 {
+				return shape[index+1 : len(shape)-1], nil
+			}
+		}
+	}
+	return "", nil
+}
+
+func eofHistoryCShape(node *dsTree) string {
+	if node == nil {
+		return "(nil)"
+	}
+	var builder strings.Builder
+	var write func(*dsTree)
+	write = func(current *dsTree) {
+		if current == nil {
+			builder.WriteString("(nil)")
+			return
+		}
+		builder.WriteByte('(')
+		if current.Field != "" {
+			builder.WriteString(current.Field)
+			builder.WriteByte(':')
+		}
+		builder.WriteString(current.Type)
+		fmt.Fprintf(&builder, "[%d-%d]", current.Start, current.End)
+		if !current.Named {
+			builder.WriteString("!anon")
+		}
+		if current.Extra {
+			builder.WriteString("!extra")
+		}
+		if current.Missing {
+			builder.WriteString("!missing")
+		}
+		for _, child := range current.Children {
+			builder.WriteByte(' ')
+			write(child)
+		}
+		builder.WriteByte(')')
+	}
+	write(node)
+	return builder.String()
+}

--- a/cgo_harness/eof_history_oracle_builder_test.go
+++ b/cgo_harness/eof_history_oracle_builder_test.go
@@ -1,0 +1,251 @@
+//go:build cgo && treesitter_c_parity && gts_derivation_set_census && gts_eof_history_census
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const eofHistoryRuntimeParserSHA256 = "5e8ae76a9ff12d09d22b1a489124061e82c686a4721470e42f0648c02401080c"
+
+type eofHistoryCVersion struct {
+	AcceptIndex int
+	Version     int
+	Precedence  int
+	ErrorCost   uint32
+	Shape       string
+}
+
+type eofHistoryCReceipt struct {
+	Versions  []eofHistoryCVersion
+	Published string
+	Summary   string
+	Raw       string
+}
+
+func runEOFAcceptHistoryCOracle(t *testing.T, language string, source []byte) eofHistoryCReceipt {
+	t.Helper()
+	identity, err := COracleIdentity(language)
+	if err != nil {
+		t.Fatalf("load %s C oracle identity: %v", language, err)
+	}
+	if identity.BindingVersion != COracleBindingVersion || identity.BindingCommit != COracleBindingCommit ||
+		identity.RuntimeCommit != COracleRuntimeCommit {
+		t.Fatalf("%s C oracle identity is not locked: %+v", language, identity)
+	}
+
+	parityCRefState.mu.Lock()
+	entry, ok := parityCRefState.lock[language]
+	parityCRefState.mu.Unlock()
+	if !ok {
+		t.Fatalf("parity lock has no %s entry", language)
+	}
+	symbol, err := eofHistorySharedLanguageSymbol(identity.GrammarArtifactPath, parityLanguageSymbols(entry))
+	if err != nil {
+		t.Fatalf("resolve %s C language symbol: %v", language, err)
+	}
+
+	artifact := buildEOFAcceptHistoryRuntime(t)
+	command := exec.Command(artifact, identity.GrammarArtifactPath, symbol)
+	command.Stdin = bytes.NewReader(source)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run %s EOF-history C oracle: %v: %s", language, err, strings.TrimSpace(string(output)))
+	}
+	receipt, err := parseEOFAcceptHistoryCOutput(string(output))
+	if err != nil {
+		t.Fatalf("parse %s EOF-history C receipt: %v\n%s", language, err, output)
+	}
+	return receipt
+}
+
+func buildEOFAcceptHistoryRuntime(t *testing.T) string {
+	t.Helper()
+	var module struct {
+		Path    string
+		Version string
+		Dir     string
+	}
+	command := exec.Command("go", "list", "-m", "-json", "github.com/tree-sitter/go-tree-sitter")
+	output, err := command.Output()
+	if err != nil {
+		t.Fatalf("locate locked C binding source: %v", err)
+	}
+	if err := json.Unmarshal(output, &module); err != nil {
+		t.Fatalf("decode locked C binding module: %v", err)
+	}
+	if module.Path != COracleBindingModule || module.Version != COracleBindingVersion || module.Dir == "" {
+		t.Fatalf("unexpected locked C binding source: %+v", module)
+	}
+
+	buildRoot := t.TempDir()
+	runtimeRoot := filepath.Join(buildRoot, "runtime")
+	if err := eofHistoryCopyTree(filepath.Join(module.Dir, "src"), filepath.Join(runtimeRoot, "src")); err != nil {
+		t.Fatalf("copy runtime src: %v", err)
+	}
+	if err := eofHistoryCopyTree(filepath.Join(module.Dir, "include"), filepath.Join(runtimeRoot, "include")); err != nil {
+		t.Fatalf("copy runtime include: %v", err)
+	}
+
+	parserPath := filepath.Join(runtimeRoot, "src", "parser.c")
+	parserSource, err := os.ReadFile(parserPath)
+	if err != nil {
+		t.Fatalf("read runtime parser.c: %v", err)
+	}
+	parserHash := sha256.Sum256(parserSource)
+	if got := hex.EncodeToString(parserHash[:]); got != eofHistoryRuntimeParserSHA256 {
+		t.Fatalf("runtime parser.c sha256=%s, want %s", got, eofHistoryRuntimeParserSHA256)
+	}
+	patched, err := eofHistoryPatchRuntimeParser(string(parserSource))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(parserPath, 0o644); err != nil {
+		t.Fatalf("make copied parser.c writable: %v", err)
+	}
+	if err := os.WriteFile(parserPath, []byte(patched), 0o644); err != nil {
+		t.Fatalf("write diagnostic parser.c: %v", err)
+	}
+
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	driver := filepath.Join(repoRoot, "cgo_harness", "pure_c", "eof_history_oracle.c")
+	artifact := filepath.Join(buildRoot, "eof_history_oracle")
+	compile := exec.Command(
+		"cc",
+		"-O2", "-DNDEBUG", "-std=c11", "-D_POSIX_C_SOURCE=200112L", "-D_DEFAULT_SOURCE",
+		"-DGTS_EOF_HISTORY_CENSUS",
+		"-I", filepath.Join(runtimeRoot, "include"),
+		"-I", filepath.Join(runtimeRoot, "src"),
+		filepath.Join(runtimeRoot, "src", "lib.c"), driver,
+		"-Wl,--export-dynamic", "-ldl", "-o", artifact,
+	)
+	if output, err := compile.CombinedOutput(); err != nil {
+		t.Fatalf("compile diagnostic C runtime: %v: %s", err, strings.TrimSpace(string(output)))
+	}
+	return artifact
+}
+
+func eofHistoryPatchRuntimeParser(source string) (string, error) {
+	includeNeedle := "#include \"./wasm_store.h\"\n"
+	includeReplacement := includeNeedle + "\n#ifdef GTS_EOF_HISTORY_CENSUS\n" +
+		"void gts_eof_history_capture_root(const TSLanguage *, Subtree, uint32_t, uint32_t);\n" +
+		"#endif\n"
+	if strings.Count(source, includeNeedle) != 1 {
+		return "", fmt.Errorf("runtime parser.c has %d wasm_store include seams, want 1", strings.Count(source, includeNeedle))
+	}
+	source = strings.Replace(source, includeNeedle, includeReplacement, 1)
+
+	acceptNeedle := "    self->accept_count++;\n\n    if (self->finished_tree.ptr) {"
+	acceptReplacement := "    self->accept_count++;\n" +
+		"#ifdef GTS_EOF_HISTORY_CENSUS\n" +
+		"    gts_eof_history_capture_root(self->language, root, self->accept_count - 1, version);\n" +
+		"#endif\n\n    if (self->finished_tree.ptr) {"
+	if strings.Count(source, acceptNeedle) != 1 {
+		return "", fmt.Errorf("runtime parser.c has %d accept capture seams, want 1", strings.Count(source, acceptNeedle))
+	}
+	return strings.Replace(source, acceptNeedle, acceptReplacement, 1), nil
+}
+
+func eofHistoryCopyTree(source, destination string) error {
+	return filepath.WalkDir(source, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(destination, relative)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("runtime source contains unsupported symlink %s", path)
+		}
+		input, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		output, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o444)
+		if err != nil {
+			_ = input.Close()
+			return err
+		}
+		_, copyErr := io.Copy(output, input)
+		inputCloseErr := input.Close()
+		outputCloseErr := output.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		if inputCloseErr != nil {
+			return inputCloseErr
+		}
+		return outputCloseErr
+	})
+}
+
+func eofHistorySharedLanguageSymbol(sharedObject string, candidates []string) (string, error) {
+	command := exec.Command("nm", "-D", "--defined-only", sharedObject)
+	output, err := command.Output()
+	if err != nil {
+		return "", err
+	}
+	defined := make(map[string]bool)
+	for _, line := range strings.Split(string(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 0 {
+			defined[fields[len(fields)-1]] = true
+		}
+	}
+	for _, candidate := range candidates {
+		if defined[candidate] {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("no accepted language symbol in %v", candidates)
+}
+
+func parseEOFAcceptHistoryCOutput(raw string) (eofHistoryCReceipt, error) {
+	receipt := eofHistoryCReceipt{Raw: raw}
+	for _, line := range strings.Split(strings.TrimSpace(raw), "\n") {
+		switch {
+		case strings.HasPrefix(line, "GTS_C_EOF_HISTORY "):
+			shapeAt := strings.Index(line, " shape=")
+			if shapeAt < 0 {
+				return receipt, fmt.Errorf("history line lacks shape: %q", line)
+			}
+			var version eofHistoryCVersion
+			if _, err := fmt.Sscanf(
+				line[:shapeAt],
+				"GTS_C_EOF_HISTORY accept=%d version=%d precedence=%d error_cost=%d",
+				&version.AcceptIndex, &version.Version, &version.Precedence, &version.ErrorCost,
+			); err != nil {
+				return receipt, fmt.Errorf("decode history line: %w", err)
+			}
+			version.Shape = line[shapeAt+len(" shape="):]
+			receipt.Versions = append(receipt.Versions, version)
+		case strings.HasPrefix(line, "GTS_C_EOF_PUBLISHED shape="):
+			receipt.Published = strings.TrimPrefix(line, "GTS_C_EOF_PUBLISHED shape=")
+		case strings.HasPrefix(line, "GTS_C_EOF_SUMMARY "):
+			receipt.Summary = line
+		}
+	}
+	if len(receipt.Versions) == 0 || receipt.Published == "" || receipt.Summary == "" {
+		return receipt, fmt.Errorf("incomplete C receipt: versions=%d published=%v summary=%v", len(receipt.Versions), receipt.Published != "", receipt.Summary != "")
+	}
+	return receipt, nil
+}

--- a/cgo_harness/pure_c/eof_history_oracle.c
+++ b/cgo_harness/pure_c/eof_history_oracle.c
@@ -1,0 +1,151 @@
+#include <dlfcn.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tree_sitter/api.h"
+#include "subtree.h"
+#include "tree.h"
+
+enum {
+  GTS_EOF_HISTORY_MAX_INPUT = 1024 * 1024,
+  GTS_EOF_HISTORY_MAX_NODES = 100000,
+  GTS_EOF_HISTORY_MAX_DEPTH = 512,
+};
+
+static uint32_t gts_eof_history_capture_count;
+static bool gts_eof_history_capture_failed;
+
+static void gts_eof_history_write_node(
+  TSNode node,
+  const char *field,
+  uint32_t depth,
+  uint32_t *nodes
+) {
+  if (depth > GTS_EOF_HISTORY_MAX_DEPTH || ++*nodes > GTS_EOF_HISTORY_MAX_NODES) {
+    gts_eof_history_capture_failed = true;
+    fputs("<cap>", stdout);
+    return;
+  }
+  fputc('(', stdout);
+  if (field && field[0]) {
+    fputs(field, stdout);
+    fputc(':', stdout);
+  }
+  fputs(ts_node_type(node), stdout);
+  fprintf(stdout, "[%u-%u]", ts_node_start_byte(node), ts_node_end_byte(node));
+  if (!ts_node_is_named(node)) fputs("!anon", stdout);
+  if (ts_node_is_extra(node)) fputs("!extra", stdout);
+  if (ts_node_is_missing(node)) fputs("!missing", stdout);
+  if (ts_node_is_error(node)) fputs("!error", stdout);
+  if (ts_node_has_error(node)) fputs("!has-error", stdout);
+
+  uint32_t child_count = ts_node_child_count(node);
+  for (uint32_t index = 0; index < child_count; index++) {
+    fputc(' ', stdout);
+    const char *child_field = ts_node_field_name_for_child(node, index);
+    gts_eof_history_write_node(ts_node_child(node, index), child_field, depth + 1, nodes);
+  }
+  fputc(')', stdout);
+}
+
+// The diagnostic runtime calls this function after it constructs each accept
+// root and before ts_parser__select_tree sees that root. Retaining the subtree
+// gives the temporary TSTree sole extra ownership. Deleting the tree releases
+// that ownership before the parser resumes.
+void gts_eof_history_capture_root(
+  const TSLanguage *language,
+  Subtree root,
+  uint32_t accept_index,
+  uint32_t version
+) {
+  ts_subtree_retain(root);
+  TSTree *tree = ts_tree_new(root, language, NULL, 0);
+  uint32_t nodes = 0;
+  fprintf(
+    stdout,
+    "GTS_C_EOF_HISTORY accept=%u version=%u precedence=%d error_cost=%u shape=",
+    accept_index,
+    version,
+    ts_subtree_dynamic_precedence(root),
+    ts_subtree_error_cost(root)
+  );
+  gts_eof_history_write_node(ts_tree_root_node(tree), NULL, 0, &nodes);
+  fputc('\n', stdout);
+  fflush(stdout);
+  ts_tree_delete(tree);
+  gts_eof_history_capture_count++;
+}
+
+static unsigned char *gts_eof_history_read_stdin(uint32_t *length) {
+  unsigned char *source = malloc(GTS_EOF_HISTORY_MAX_INPUT + 1);
+  if (!source) return NULL;
+  size_t size = fread(source, 1, GTS_EOF_HISTORY_MAX_INPUT + 1, stdin);
+  if (ferror(stdin) || size > GTS_EOF_HISTORY_MAX_INPUT) {
+    free(source);
+    return NULL;
+  }
+  source[size] = 0;
+  *length = (uint32_t)size;
+  return source;
+}
+
+int main(int argc, char **argv) {
+  if (argc != 3) {
+    fprintf(stderr, "usage: %s <grammar.so> <language-symbol>\n", argv[0]);
+    return 2;
+  }
+
+  void *grammar = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+  if (!grammar) {
+    fprintf(stderr, "dlopen: %s\n", dlerror());
+    return 3;
+  }
+  const TSLanguage *(*language_fn)(void) =
+    (const TSLanguage *(*)(void))dlsym(grammar, argv[2]);
+  if (!language_fn) {
+    fprintf(stderr, "dlsym %s: %s\n", argv[2], dlerror());
+    dlclose(grammar);
+    return 4;
+  }
+
+  uint32_t source_length = 0;
+  unsigned char *source = gts_eof_history_read_stdin(&source_length);
+  if (!source) {
+    fputs("read source: failed or exceeded cap\n", stderr);
+    dlclose(grammar);
+    return 5;
+  }
+
+  TSParser *parser = ts_parser_new();
+  if (!parser || !ts_parser_set_language(parser, language_fn())) {
+    fputs("set language: failed\n", stderr);
+    free(source);
+    if (parser) ts_parser_delete(parser);
+    dlclose(grammar);
+    return 6;
+  }
+  TSTree *tree = ts_parser_parse_string(parser, NULL, (const char *)source, source_length);
+  if (!tree) {
+    fputs("parse: no tree\n", stderr);
+    free(source);
+    ts_parser_delete(parser);
+    dlclose(grammar);
+    return 7;
+  }
+
+  uint32_t published_nodes = 0;
+  fputs("GTS_C_EOF_PUBLISHED shape=", stdout);
+  gts_eof_history_write_node(ts_tree_root_node(tree), NULL, 0, &published_nodes);
+  fputc('\n', stdout);
+  fprintf(stdout, "GTS_C_EOF_SUMMARY captures=%u failed=%u\n",
+          gts_eof_history_capture_count, gts_eof_history_capture_failed ? 1u : 0u);
+
+  ts_tree_delete(tree);
+  ts_parser_delete(parser);
+  free(source);
+  dlclose(grammar);
+  return gts_eof_history_capture_failed ? 8 : 0;
+}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -4212,6 +4212,12 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				boundary: DiagnosticParserCoreAccept, detail: "generic scheduler requires a sole homogeneous accept frontier", headerIndex: cell.headerIndex,
 			}, nil
 		}
+		if certifiedAcceptWithDeadSiblings {
+			// The G2 EOF-history census observes the complete frontier before
+			// acceptance canonicalization removes its no-action siblings. The
+			// default build supplies an empty inlined stub.
+			s.censusEOFAcceptHistoryFrontier(cell.headerIndex, noActionIndices)
+		}
 		if err := s.applyGenericAccept(before, cell); err != nil {
 			return nil, err
 		}

--- a/parsercore_phase0_eof_history_census.go
+++ b/parsercore_phase0_eof_history_census.go
@@ -1,0 +1,234 @@
+//go:build !gts_no_parsercorephase0 && gts_eof_history_census
+
+package gotreesitter
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// EOFAcceptHistoryCandidate is one exact compact path at the authenticated
+// EOF frontier, before the scheduler drops a no-action sibling.
+type EOFAcceptHistoryCandidate struct {
+	FoldIndex      int
+	Score          int64
+	BranchOrder    uint64
+	HasBranchOrder bool
+	PayloadCount   int
+	Shape          string
+	DeepSHA256     [32]byte
+	MaterializeErr string
+}
+
+// EOFAcceptHistoryHead is one live compact history at the pre-drop frontier.
+type EOFAcceptHistoryHead struct {
+	HeaderIndex          int
+	Accepting            bool
+	NoAction             bool
+	Header               DiagnosticParserCoreHeaderReceipt
+	Candidates           []EOFAcceptHistoryCandidate
+	EnumerationTruncated bool
+	EnumerationErr       string
+}
+
+// EOFAcceptHistoryFrontier records all compact histories at one certified
+// EOF-sibling boundary. The census does not mutate or retain a live head.
+type EOFAcceptHistoryFrontier struct {
+	ElectionIndex     int
+	Token             Token
+	AcceptHeaderIndex int
+	Heads             []EOFAcceptHistoryHead
+}
+
+var (
+	eofAcceptHistoryCensusMu        sync.Mutex
+	eofAcceptHistoryCensusFrontiers []EOFAcceptHistoryFrontier
+)
+
+// EOFAcceptHistoryCensusBuilt reports whether this binary includes the G2
+// diagnostic census.
+func EOFAcceptHistoryCensusBuilt() bool { return true }
+
+// EOFAcceptHistoryCensusReset removes all recorded diagnostic frontiers.
+func EOFAcceptHistoryCensusReset() {
+	eofAcceptHistoryCensusMu.Lock()
+	eofAcceptHistoryCensusFrontiers = nil
+	eofAcceptHistoryCensusMu.Unlock()
+}
+
+// EOFAcceptHistoryCensusSnapshot returns an independent copy of the recorded
+// frontiers. Candidate slices and shape strings do not alias the live census.
+func EOFAcceptHistoryCensusSnapshot() []EOFAcceptHistoryFrontier {
+	eofAcceptHistoryCensusMu.Lock()
+	defer eofAcceptHistoryCensusMu.Unlock()
+	out := make([]EOFAcceptHistoryFrontier, len(eofAcceptHistoryCensusFrontiers))
+	for index, frontier := range eofAcceptHistoryCensusFrontiers {
+		out[index] = frontier
+		out[index].Heads = make([]EOFAcceptHistoryHead, len(frontier.Heads))
+		for headIndex, head := range frontier.Heads {
+			out[index].Heads[headIndex] = head
+			out[index].Heads[headIndex].Candidates = append([]EOFAcceptHistoryCandidate(nil), head.Candidates...)
+		}
+	}
+	return out
+}
+
+func (s *diagnosticParserCoreGenericScheduler) censusEOFAcceptHistoryFrontier(
+	acceptHeaderIndex int,
+	noActionIndices []int,
+) {
+	record := EOFAcceptHistoryFrontier{
+		ElectionIndex:     s.electionIndex,
+		Token:             s.token,
+		AcceptHeaderIndex: acceptHeaderIndex,
+		Heads:             make([]EOFAcceptHistoryHead, len(s.headers)),
+	}
+	noAction := make(map[int]bool, len(noActionIndices))
+	for _, index := range noActionIndices {
+		noAction[index] = true
+	}
+	for index, header := range s.headers {
+		headRecord := EOFAcceptHistoryHead{
+			HeaderIndex: index,
+			Accepting:   index == acceptHeaderIndex,
+			NoAction:    noAction[index],
+		}
+		receipt, err := diagnosticParserCoreHeaderReceipt(s.compact, header)
+		if err != nil {
+			headRecord.EnumerationErr = err.Error()
+			record.Heads[index] = headRecord
+			continue
+		}
+		headRecord.Header = receipt
+		paths, err := s.compact.Derivations(header.head)
+		if errors.Is(err, core.ErrDerivationEnumerationCap) {
+			headRecord.EnumerationTruncated = true
+			record.Heads[index] = headRecord
+			continue
+		}
+		if err != nil {
+			headRecord.EnumerationErr = err.Error()
+			record.Heads[index] = headRecord
+			continue
+		}
+		order := eofAcceptHistoryFoldOrder(paths)
+		for foldIndex, pathIndex := range order {
+			path := paths[pathIndex]
+			candidate := EOFAcceptHistoryCandidate{
+				FoldIndex:      foldIndex,
+				Score:          path.Score,
+				BranchOrder:    path.BranchOrder,
+				HasBranchOrder: path.HasBranchOrder,
+				PayloadCount:   len(path.Payloads),
+			}
+			if !s.options.materializationContextSet || s.options.materializationParser == nil {
+				candidate.MaterializeErr = "no materialization context"
+				headRecord.Candidates = append(headRecord.Candidates, candidate)
+				continue
+			}
+			tree, err := materializeDiagnosticParserCoreAcceptedSelection(
+				s.compact,
+				header.head,
+				path.Payloads,
+				s.options.materializationParser,
+				s.options.materializationSource,
+				nil,
+				s.options.materializationForceReplayParseStates,
+				false,
+			)
+			if err != nil {
+				candidate.MaterializeErr = err.Error()
+				headRecord.Candidates = append(headRecord.Candidates, candidate)
+				continue
+			}
+			candidate.Shape = eofAcceptHistoryTreeShape(s.options.materializationParser.language, tree.RootNode())
+			candidate.DeepSHA256 = sha256.Sum256([]byte(candidate.Shape))
+			tree.Release()
+			headRecord.Candidates = append(headRecord.Candidates, candidate)
+		}
+		record.Heads[index] = headRecord
+	}
+
+	eofAcceptHistoryCensusMu.Lock()
+	eofAcceptHistoryCensusFrontiers = append(eofAcceptHistoryCensusFrontiers, record)
+	eofAcceptHistoryCensusMu.Unlock()
+}
+
+func eofAcceptHistoryFoldOrder(paths []core.Derivation) []int {
+	order := make([]int, len(paths))
+	for index := range paths {
+		order[index] = index
+	}
+	sort.SliceStable(order, func(left, right int) bool {
+		leftPath := paths[order[left]]
+		rightPath := paths[order[right]]
+		if leftPath.HasBranchOrder != rightPath.HasBranchOrder {
+			return !leftPath.HasBranchOrder
+		}
+		return leftPath.HasBranchOrder && leftPath.BranchOrder < rightPath.BranchOrder
+	})
+	return order
+}
+
+func eofAcceptHistoryTreeShape(language *Language, node *Node) string {
+	var builder strings.Builder
+	eofAcceptHistoryWriteNode(&builder, language, node, "")
+	return builder.String()
+}
+
+func eofAcceptHistoryWriteNode(builder *strings.Builder, language *Language, node *Node, field string) {
+	if node == nil {
+		builder.WriteString("(nil)")
+		return
+	}
+	builder.WriteByte('(')
+	if field != "" {
+		builder.WriteString(field)
+		builder.WriteByte(':')
+	}
+	builder.WriteString(node.Type(language))
+	builder.WriteByte('[')
+	builder.WriteString(strconv.FormatUint(uint64(node.StartByte()), 10))
+	builder.WriteByte('-')
+	builder.WriteString(strconv.FormatUint(uint64(node.EndByte()), 10))
+	builder.WriteByte(']')
+	if !node.IsNamed() {
+		builder.WriteString("!anon")
+	}
+	if node.IsExtra() {
+		builder.WriteString("!extra")
+	}
+	if node.IsMissing() {
+		builder.WriteString("!missing")
+	}
+	if node.IsError() {
+		builder.WriteString("!error")
+	}
+	if node.HasError() {
+		builder.WriteString("!has-error")
+	}
+	for index := 0; index < node.ChildCount(); index++ {
+		builder.WriteByte(' ')
+		child := node.Child(index)
+		fieldName := ""
+		if child != nil {
+			fieldName = node.FieldNameForChild(index, language)
+		}
+		eofAcceptHistoryWriteNode(builder, language, child, fieldName)
+	}
+	builder.WriteByte(')')
+}
+
+func (candidate EOFAcceptHistoryCandidate) String() string {
+	if candidate.MaterializeErr != "" {
+		return fmt.Sprintf("fold=%d score=%d materialize=%q", candidate.FoldIndex, candidate.Score, candidate.MaterializeErr)
+	}
+	return fmt.Sprintf("fold=%d score=%d sha256=%x", candidate.FoldIndex, candidate.Score, candidate.DeepSHA256)
+}

--- a/parsercore_phase0_eof_history_census_disabled.go
+++ b/parsercore_phase0_eof_history_census_disabled.go
@@ -1,0 +1,11 @@
+//go:build !gts_no_parsercorephase0 && !gts_eof_history_census
+
+package gotreesitter
+
+// The shipped build omits the G2 EOF-history census. The inliner removes this
+// empty call from the compact scheduler.
+func (s *diagnosticParserCoreGenericScheduler) censusEOFAcceptHistoryFrontier(_ int, _ []int) {}
+
+// EOFAcceptHistoryCensusBuilt reports whether this binary includes the G2
+// diagnostic census.
+func EOFAcceptHistoryCensusBuilt() bool { return false }


### PR DESCRIPTION
## Scope

This PR adds tagged end-of-file history diagnostics for the compact parser.

It records both compact histories before the scheduler drops the no-action sibling.

It also records both locked-C roots before C selects one root.

This PR changes no grant, admission rule, or production route.

## Result

HTTP and Robot each have two compact histories and two locked-C roots.

The two root sets are not bijective.

The compact loser is clean. The C loser is an `ERROR` root from `recover_eof`.

The C error costs are 640 for HTTP and 1027 for Robot.

This result rejects a grant change until compact reproduces the recovery root.

## Review

The independent Sol reviewer found no P0, P1, or P2 issue.

The reviewer approved this local diagnostic-only checkpoint.

The approval does not approve a grant or a production route.

## Verification

- Tagged Docker differential: `harness_out/docker/20260820T193110Z-compact-g2-event-topology`; PASS.
- Default frontier gate: `harness_out/docker/20260820T193133Z-compact-g2-event-topology-default`; PASS.
- `git diff --cached --check`; PASS before the local Buckley commit.
- Buckley change hash: `sha256:60109bfc3dd7bd068d84ff2564838be2ee9468b0e23faee1a67eb64b5531bd37`.

## Durable receipt

- Spore: `spore.2026-08-20.codex.g2-eof-history-rejection`.
- Receipt: `hypha-receipt:2026-08-20:g2-eof-history-rejection`.
