### PR TITLE
remove(parser): retire JavaScript dynamic import repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ for tags and release notes while still in `0.x`.
 - Swift ternary expressions now come directly from the regenerated grammar
   blob. Parsing no longer runs the source-reparse compatibility pass.
 
+- JavaScript dynamic imports now retain their keyword child during parsing.
+  Parsing no longer runs the leaf-repair compatibility path.
+
 ### Fixed
 
 - End recovery convergence after a clean condense. Pending forks no longer

--- a/cgo_harness/javascript_dynamic_import_retirement_parity_test.go
+++ b/cgo_harness/javascript_dynamic_import_retirement_parity_test.go
@@ -1,0 +1,169 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestJavaScriptDynamicImportRetirementLockedCRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	language := grammars.JavascriptLanguage()
+	cLanguage, err := COracleLanguage("javascript")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name       string
+		source     []byte
+		sha256     string
+		deepDigest string
+		baseSource []byte
+	}{
+		{
+			name:       "call",
+			source:     []byte("import(\"foo\");\n"),
+			sha256:     "d8df58099982cfa08eb81abba34eeff697541da9a833e24201212a446c3dfc32",
+			deepDigest: "b1901d0041baf9c91907ae0662130263192c1f4007152f176c0a14095b03a99c",
+			baseSource: []byte("fetch(\"foo\");\n"),
+		},
+		{
+			name:       "awaited_call",
+			source:     []byte("async function f() {\n  const m = await import(\"foo\");\n  return m;\n}\n"),
+			sha256:     "ce37afad67db99de9253674850fd9f8ae5819ac22171535ba282e097e61e03f8",
+			deepDigest: "e48a5956112fb1cec0f0de5b5121beca17795ab99b29e8ad8b8c9548737bd24a",
+			baseSource: []byte("async function f() {\n  const m = await fetch(\"foo\");\n  return m;\n}\n"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := fmt.Sprintf("%x", sha256.Sum256(test.source)); got != test.sha256 {
+				t.Fatalf("source digest = %s, want %s", got, test.sha256)
+			}
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(test.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("locked C parse returned a nil tree")
+			}
+			t.Cleanup(cTree.Close)
+
+			rawParser := gotreesitter.NewParser(language)
+			rawParser.SetAdmissionCandidateRoute(false)
+			raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(raw.Release)
+			assertJavaScriptDynamicImportLockedCExact(t, "JavaScript dynamic import raw", raw, language, cTree, test.deepDigest)
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(production.Release)
+			assertJavaScriptDynamicImportLockedCExact(t, "JavaScript dynamic import production", production, language, cTree, test.deepDigest)
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactParser := gotreesitter.NewParser(language)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(compact.Release)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			if routedAfter != routedBefore+1 || fallbackAfter != fallbackBefore {
+				t.Fatalf("compact route counters routed=%d/%d fallback=%d/%d reason=%s", routedBefore, routedAfter, fallbackBefore, fallbackAfter, gotreesitter.AdmissionCandidateLastFallbackReason())
+			}
+			assertJavaScriptDynamicImportLockedCExact(t, "JavaScript dynamic import compact", compact, language, cTree, test.deepDigest)
+
+			forestParser := gotreesitter.NewParser(language)
+			forest, ok := forestParser.ParseForestExperimental(test.source)
+			if !ok || forest == nil {
+				offset, symbol, reason, _ := forestParser.ForestDeclineInfo()
+				t.Fatalf("forest declined at %d symbol=%d reason=%s", offset, symbol, reason)
+			}
+			t.Cleanup(forest.Release)
+			if !forest.ParseRuntime().ForestFastPath {
+				t.Fatal("strict forest parse did not report the forest route")
+			}
+			assertJavaScriptDynamicImportLockedCExact(t, "JavaScript dynamic import forest", forest, language, cTree, test.deepDigest)
+
+			incrementalParser := gotreesitter.NewParser(language)
+			incrementalParser.SetAdmissionCandidateRoute(false)
+			oldTree, err := incrementalParser.Parse(test.baseSource)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(oldTree.Release)
+			start := bytes.Index(test.baseSource, []byte("fetch"))
+			if start < 0 {
+				t.Fatal("incremental base has no fetch token")
+			}
+			startPoint := javaScriptDynamicImportRetirementPointAtByte(test.baseSource, start)
+			oldEndPoint := javaScriptDynamicImportRetirementPointAtByte(test.baseSource, start+len("fetch"))
+			newEndPoint := startPoint
+			newEndPoint.Column += uint32(len("import"))
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(start),
+				OldEndByte:  uint32(start + len("fetch")),
+				NewEndByte:  uint32(start + len("import")),
+				StartPoint:  startPoint,
+				OldEndPoint: oldEndPoint,
+				NewEndPoint: newEndPoint,
+			})
+			incremental, profile, err := incrementalParser.ParseIncrementalProfiled(test.source, oldTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(incremental.Release)
+			if !profile.OldTreeReuseRoute || profile.ReuseUnsupported || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+				t.Fatalf("incremental route did not reuse the old tree: %+v", profile)
+			}
+			assertJavaScriptDynamicImportLockedCExact(t, "JavaScript dynamic import incremental", incremental, language, cTree, test.deepDigest)
+		})
+	}
+}
+
+func assertJavaScriptDynamicImportLockedCExact(t *testing.T, label string, tree *gotreesitter.Tree, language *gotreesitter.Language, cTree *sitter.Tree, wantDigest string) {
+	t.Helper()
+	assertLockedCTreeExact(t, label, tree, language, cTree)
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.SHA256 != wantDigest {
+		t.Fatalf("%s deep digest = %s, want %s", label, inspection.SHA256, wantDigest)
+	}
+}
+
+func javaScriptDynamicImportRetirementPointAtByte(source []byte, offset int) gotreesitter.Point {
+	var point gotreesitter.Point
+	for index, value := range source {
+		if index == offset {
+			break
+		}
+		if value == '\n' {
+			point.Row++
+			point.Column = 0
+			continue
+		}
+		point.Column++
+	}
+	return point
+}

--- a/cgo_harness/javascript_election_local_parity_test.go
+++ b/cgo_harness/javascript_election_local_parity_test.go
@@ -24,10 +24,7 @@ func mustReadCorpusFile(t *testing.T, path string) []byte {
 
 // TestJavaScriptElectionRawCOracleParity compares the raw production tree
 // (compat tail off) against the locked C oracle for dispatch.javascript's
-// live rewrites: dynamic `import(...)` leaf retyping
-// (normalizeJavaScriptTypeScriptDynamicImportLeafWithSymbolChanged) and the
-// top-level object-literal reconstruction
-// (normalizeJavaScriptTopLevelObjectLiterals).
+// remaining live top-level object-literal rewrite.
 func TestJavaScriptElectionRawCOracleParity(t *testing.T) {
 	goLang := grammars.JavascriptLanguage()
 	tests := []struct {
@@ -51,8 +48,8 @@ func TestJavaScriptElectionRawCOracleParity(t *testing.T) {
 		{
 			// dispatcher census witness (parser_result_test/dispatcher_census_test.go
 			// over cgo_harness/corpus_real/javascript): dispatch.javascript
-			// rewrites 7 positions in this exact file; the two dynamic-import
-			// witnesses above show no rewrites, so this is the live-firing shape.
+			// rewrites 7 positions in this exact file. The two dynamic-import
+			// witnesses above remain native, so this is the live-firing shape.
 			//
 			// For `{ key: value }` at the start of a statement, the C oracle
 			// forks between labeled_statement and an object-literal pair, then

--- a/compat_ownership_test.go
+++ b/compat_ownership_test.go
@@ -16,15 +16,16 @@ import (
 )
 
 const (
-	resultCompatOwnershipRegistryPath        = "testdata/result_compat_ownership_v1.json"
-	resultCompatDispatcherCensusEvidencePath = "parser_result_test/dispatcher_census_test.go"
-	resultCompatCOracleEvidencePath          = "cgo_harness/parity_cgo_test.go"
-	resultCompatBaselineEvidenceScope        = "baseline_corpus_wide_only"
-	resultCompatSwiftTernaryRetiredCommit    = "ddaed36e558d60d0e8e96bb9f6c59c0fb63c3b97"
-	resultCompatSwiftTernaryProducerFix      = "71180718521aa6cf53fa4122a50998a7a2ef8020"
-	resultCompatJavaScriptImportPositive     = "143936b2a62b44eb779dda835b09abe0c26cc6d5"
-	resultCompatJavaScriptImportProducerFix  = "eee20b8a54a1608b47cce0ab7fb934651e204d66"
-	resultCompatJavaScriptImportFunction     = "normalizeJavaScriptTypeScriptDynamicImportLeafWithSymbolChanged"
+	resultCompatOwnershipRegistryPath         = "testdata/result_compat_ownership_v1.json"
+	resultCompatDispatcherCensusEvidencePath  = "parser_result_test/dispatcher_census_test.go"
+	resultCompatCOracleEvidencePath           = "cgo_harness/parity_cgo_test.go"
+	resultCompatBaselineEvidenceScope         = "baseline_corpus_wide_only"
+	resultCompatSwiftTernaryRetiredCommit     = "ddaed36e558d60d0e8e96bb9f6c59c0fb63c3b97"
+	resultCompatSwiftTernaryProducerFix       = "71180718521aa6cf53fa4122a50998a7a2ef8020"
+	resultCompatJavaScriptImportRetiredCommit = "8d0648f5e97fb75e4934aab90f0de4b0e3c7e821"
+	resultCompatJavaScriptImportPositive      = "143936b2a62b44eb779dda835b09abe0c26cc6d5"
+	resultCompatJavaScriptImportProducerFix   = "eee20b8a54a1608b47cce0ab7fb934651e204d66"
+	resultCompatJavaScriptImportFunction      = "normalizeJavaScriptTypeScriptDynamicImportLeafWithSymbolChanged"
 )
 
 var resultCompatRetiredCommitPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
@@ -224,6 +225,9 @@ func assertRetiredSubpassProvenance(t *testing.T, entry resultCompatOwnershipEnt
 			t.Errorf("%s producer_fix_commit = %q, want producer commit %q", entry.ID, got, want)
 		}
 	case "dispatch.javascript.dynamic-import":
+		if got, want := entry.RetiredCommit, resultCompatJavaScriptImportRetiredCommit; got != want {
+			t.Errorf("%s retired_commit = %q, want deletion commit %q", entry.ID, got, want)
+		}
 		if got, want := entry.PositiveControlCommit, resultCompatJavaScriptImportPositive; got != want {
 			t.Errorf("%s positive_control_commit = %q, want %q", entry.ID, got, want)
 		}

--- a/compat_ownership_test.go
+++ b/compat_ownership_test.go
@@ -22,6 +22,9 @@ const (
 	resultCompatBaselineEvidenceScope        = "baseline_corpus_wide_only"
 	resultCompatSwiftTernaryRetiredCommit    = "ddaed36e558d60d0e8e96bb9f6c59c0fb63c3b97"
 	resultCompatSwiftTernaryProducerFix      = "71180718521aa6cf53fa4122a50998a7a2ef8020"
+	resultCompatJavaScriptImportPositive     = "143936b2a62b44eb779dda835b09abe0c26cc6d5"
+	resultCompatJavaScriptImportProducerFix  = "eee20b8a54a1608b47cce0ab7fb934651e204d66"
+	resultCompatJavaScriptImportFunction     = "normalizeJavaScriptTypeScriptDynamicImportLeafWithSymbolChanged"
 )
 
 var resultCompatRetiredCommitPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
@@ -173,7 +176,7 @@ func TestResultCompatibilityOwnershipRegistry(t *testing.T) {
 				if !resultCompatRetiredCommitPattern.MatchString(entry.ProducerFixCommit) {
 					t.Errorf("%s producer_fix_commit = %q, want a lowercase 40-character commit hash", entry.ID, entry.ProducerFixCommit)
 				}
-				assertSwiftTernaryRetirementProvenance(t, entry)
+				assertRetiredSubpassProvenance(t, entry)
 			}
 		default:
 			t.Errorf("%s has unsupported status %q", entry.ID, entry.Status)
@@ -210,16 +213,30 @@ func assertRetiredOwnershipReceiptRefs(t *testing.T, entry resultCompatOwnership
 	assertOwnershipEvidencePaths(t, entry.ID+" retirement receipt_refs", entry.ReceiptRefs)
 }
 
-func assertSwiftTernaryRetirementProvenance(t *testing.T, entry resultCompatOwnershipEntry) {
+func assertRetiredSubpassProvenance(t *testing.T, entry resultCompatOwnershipEntry) {
 	t.Helper()
-	if entry.ID != "dispatch.swift.ternary" {
-		return
-	}
-	if got, want := entry.RetiredCommit, resultCompatSwiftTernaryRetiredCommit; got != want {
-		t.Errorf("%s retired_commit = %q, want deletion commit %q", entry.ID, got, want)
-	}
-	if got, want := entry.ProducerFixCommit, resultCompatSwiftTernaryProducerFix; got != want {
-		t.Errorf("%s producer_fix_commit = %q, want producer commit %q", entry.ID, got, want)
+	switch entry.ID {
+	case "dispatch.swift.ternary":
+		if got, want := entry.RetiredCommit, resultCompatSwiftTernaryRetiredCommit; got != want {
+			t.Errorf("%s retired_commit = %q, want deletion commit %q", entry.ID, got, want)
+		}
+		if got, want := entry.ProducerFixCommit, resultCompatSwiftTernaryProducerFix; got != want {
+			t.Errorf("%s producer_fix_commit = %q, want producer commit %q", entry.ID, got, want)
+		}
+	case "dispatch.javascript.dynamic-import":
+		if got, want := entry.PositiveControlCommit, resultCompatJavaScriptImportPositive; got != want {
+			t.Errorf("%s positive_control_commit = %q, want %q", entry.ID, got, want)
+		}
+		if got, want := entry.ProducerFixCommit, resultCompatJavaScriptImportProducerFix; got != want {
+			t.Errorf("%s producer_fix_commit = %q, want %q", entry.ID, got, want)
+		}
+		data, err := os.ReadFile("parser_result_javascript_typescript.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(data), resultCompatJavaScriptImportFunction) {
+			t.Errorf("%s remains in production source", resultCompatJavaScriptImportFunction)
+		}
 	}
 }
 

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -20,9 +20,9 @@ The v1 registry freezes the current source and registry:
 - zero generic passes after language dispatch;
 - zero post-finalization second-pass fixpoint arms.
 
-The registry contains 36 live entries and 50 retired entries. The live entries
+The registry contains 36 live entries and 51 retired entries. The live entries
 name 39 language labels. Shared switch arms account for the label difference.
-The retired count includes the Swift ternary subpass.
+The retired count includes the Swift ternary and JavaScript dynamic-import subpasses.
 The registry covers
 only this documented internal result-compatibility tier. Scheduler experiments
 and other engine research belong in their owning subsystem's durable traces.
@@ -30,6 +30,9 @@ and other engine research belong in their owning subsystem's durable traces.
 Native parsing already recovers a FIDL versioned-layout-modifier declaration
 into the C-equivalent error shape. This change retires the FIDL dispatcher
 arm.
+
+The generic collapsed-child reducer retains the JavaScript dynamic-import
+token. The JavaScript arm remains live for its other registered repairs.
 
 R2 of `docs/root-normalization-retirement.md` retired three dispatcher arms:
 OCaml's collapsed named-leaf restoration, Ruby's top-level module bound

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -352,6 +352,7 @@ there.
 | FIDL versioned layout modifiers | retirement change | 1 dispatcher arm | 0 | compatibility-free producer, production, compact fallback, forest-fail-closed, incremental reuse, and isolated C-oracle parity |
 | HLSL subscript-assignment declarator | retirement change | 1 HLSL member | 0 | negative dynamic precedence election, compatibility-free producer, production, compact fallback, forest, incremental reuse, and isolated C-oracle parity |
 | Swift ternary source reparse | retirement change | 1 Swift subpass | 0 | exact 16-case manifest, native producer, production, compact fallback, forest fail-closed behavior, incremental fresh fallback, and isolated C-oracle parity |
+| JavaScript dynamic-import token child | retirement change | 1 JavaScript subpass | 0 | exact historical controls, generic collapsed-child producer, production, direct compact, strict forest, edited incremental reuse, and isolated C-oracle parity |
 
 Mark a row merged only after CI and merge evidence exist. Detailed per-entry
 receipts stay in the JSON registry and durable run findings stay in Hyphae.

--- a/grammars/javascript_dynamic_import_retirement_test.go
+++ b/grammars/javascript_dynamic_import_retirement_test.go
@@ -1,0 +1,276 @@
+//go:build !grammar_subset
+
+package grammars
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+const (
+	javaScriptDynamicImportPositiveControlCommit = "143936b2a62b44eb779dda835b09abe0c26cc6d5"
+	javaScriptDynamicImportProducerFixCommit     = "eee20b8a54a1608b47cce0ab7fb934651e204d66"
+	javaScriptDynamicImportBlobSHA256            = "6706f93890f24d8ea90d6a140df5dde29c02ec8a3213bae16e8cc4df37e33ee0"
+)
+
+func TestJavaScriptDynamicImportRetirementRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	tests := []struct {
+		name       string
+		source     []byte
+		sha256     string
+		deepDigest string
+		baseSource []byte
+	}{
+		{
+			name:       "call",
+			source:     []byte("import(\"foo\");\n"),
+			sha256:     "d8df58099982cfa08eb81abba34eeff697541da9a833e24201212a446c3dfc32",
+			deepDigest: "b1901d0041baf9c91907ae0662130263192c1f4007152f176c0a14095b03a99c",
+			baseSource: []byte("fetch(\"foo\");\n"),
+		},
+		{
+			name:       "awaited_call",
+			source:     []byte("async function f() {\n  const m = await import(\"foo\");\n  return m;\n}\n"),
+			sha256:     "ce37afad67db99de9253674850fd9f8ae5819ac22171535ba282e097e61e03f8",
+			deepDigest: "e48a5956112fb1cec0f0de5b5121beca17795ab99b29e8ad8b8c9548737bd24a",
+			baseSource: []byte("async function f() {\n  const m = await fetch(\"foo\");\n  return m;\n}\n"),
+		},
+	}
+	blob, err := os.ReadFile("grammar_blobs/javascript.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256(blob)); got != javaScriptDynamicImportBlobSHA256 {
+		t.Fatalf("JavaScript blob digest = %s, want %s", got, javaScriptDynamicImportBlobSHA256)
+	}
+	language := JavascriptLanguage()
+	reusable, ok := language.ExternalScanner.(gotreesitter.IncrementalReuseExternalScanner)
+	if !ok || !reusable.SupportsIncrementalReuse() {
+		t.Fatalf("JavaScript scanner does not certify incremental reuse: %T", language.ExternalScanner)
+	}
+	stateless, ok := language.ExternalScanner.(gotreesitter.StatelessExternalScanner)
+	if !ok || !stateless.ExternalScannerIsStateless() {
+		t.Fatalf("JavaScript scanner does not certify stateless operation: %T", language.ExternalScanner)
+	}
+	preserving, ok := language.ExternalScanner.(gotreesitter.FailurePreservingExternalScanner)
+	if !ok || !preserving.PreservesStateOnScanFailure() {
+		t.Fatalf("JavaScript scanner does not preserve state after a failed scan: %T", language.ExternalScanner)
+	}
+	for _, symbol := range language.ExternalSymbols {
+		index := int(symbol)
+		if index >= 0 && index < len(language.SymbolNames) && language.SymbolNames[index] == "import" {
+			t.Fatalf("dynamic import uses external scanner symbol %d", symbol)
+		}
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := fmt.Sprintf("%x", sha256.Sum256(test.source)); got != test.sha256 {
+				t.Fatalf("source digest = %s, want %s", got, test.sha256)
+			}
+			for _, forestEnabled := range []bool{true, false} {
+				name := "forest_enabled"
+				if !forestEnabled {
+					name = "forest_disabled"
+				}
+				t.Run(name, func(t *testing.T) {
+					gotreesitter.SetGLRForestEnabled(forestEnabled)
+					t.Cleanup(func() { gotreesitter.SetGLRForestEnabled(true) })
+					rawParser := gotreesitter.NewParser(language)
+					rawParser.SetAdmissionCandidateRoute(false)
+					raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(test.source)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer raw.Release()
+					productionParser := gotreesitter.NewParser(language)
+					productionParser.SetAdmissionCandidateRoute(false)
+					production, err := productionParser.Parse(test.source)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer production.Release()
+					if got := requireJavaScriptDynamicImportRetirementTree(t, "raw", raw, language); got != test.deepDigest {
+						t.Fatalf("raw digest = %s, want %s", got, test.deepDigest)
+					}
+					if got := requireJavaScriptDynamicImportRetirementTree(t, "production", production, language); got != test.deepDigest {
+						t.Fatalf("production digest = %s, want %s", got, test.deepDigest)
+					}
+				})
+			}
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactParser := gotreesitter.NewParser(language)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(compact.Release)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			if routedAfter != routedBefore+1 || fallbackAfter != fallbackBefore {
+				t.Fatalf("compact route counters routed=%d/%d fallback=%d/%d reason=%s", routedBefore, routedAfter, fallbackBefore, fallbackAfter, gotreesitter.AdmissionCandidateLastFallbackReason())
+			}
+			if got := requireJavaScriptDynamicImportRetirementTree(t, "compact", compact, language); got != test.deepDigest {
+				t.Fatalf("compact digest = %s, want %s", got, test.deepDigest)
+			}
+
+			forestParser := gotreesitter.NewParser(language)
+			forest, ok := forestParser.ParseForestExperimental(test.source)
+			if !ok || forest == nil {
+				offset, symbol, reason, _ := forestParser.ForestDeclineInfo()
+				t.Fatalf("forest declined at %d symbol=%d reason=%s", offset, symbol, reason)
+			}
+			t.Cleanup(forest.Release)
+			if !forest.ParseRuntime().ForestFastPath {
+				t.Fatal("strict forest parse did not report the forest route")
+			}
+			if got := requireJavaScriptDynamicImportRetirementTree(t, "strict-forest", forest, language); got != test.deepDigest {
+				t.Fatalf("strict forest digest = %s, want %s", got, test.deepDigest)
+			}
+
+			incrementalParser := gotreesitter.NewParser(language)
+			incrementalParser.SetAdmissionCandidateRoute(false)
+			oldTree, err := incrementalParser.Parse(test.baseSource)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(oldTree.Release)
+			start := bytes.Index(test.baseSource, []byte("fetch"))
+			if start < 0 {
+				t.Fatal("incremental base has no fetch token")
+			}
+			startPoint := javaScriptDynamicImportPointAtByte(test.baseSource, start)
+			oldEndPoint := javaScriptDynamicImportPointAtByte(test.baseSource, start+len("fetch"))
+			newEndPoint := startPoint
+			newEndPoint.Column += uint32(len("import"))
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(start),
+				OldEndByte:  uint32(start + len("fetch")),
+				NewEndByte:  uint32(start + len("import")),
+				StartPoint:  startPoint,
+				OldEndPoint: oldEndPoint,
+				NewEndPoint: newEndPoint,
+			})
+			incremental, profile, err := incrementalParser.ParseIncrementalProfiled(test.source, oldTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(incremental.Release)
+			if !profile.OldTreeReuseRoute || profile.ReuseUnsupported || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+				t.Fatalf("incremental route did not reuse the old tree: %+v", profile)
+			}
+			if got := requireJavaScriptDynamicImportRetirementTree(t, "incremental", incremental, language); got != test.deepDigest {
+				t.Fatalf("incremental digest = %s, want %s", got, test.deepDigest)
+			}
+		})
+	}
+}
+
+func TestJavaScriptDynamicImportRetirementSurvivorCensus(t *testing.T) {
+	const source = "function foo() {\n  //      ^ definition.function\n}\n\nfoo()\n// <- reference.call\n\n{ source: $ => repeat($._expression) }\n// ^ definition.function\n//              ^ reference.call\n\nlet plus1 = x => x + 1\n//   ^ definition.function\n\nlet plus2 = function(x) { return x + 2 }\n//   ^ definition.function\n\nfunction *gen() { }\n//         ^ definition.function\n\nasync function* foo() { yield 1; }\n//               ^ definition.function\n"
+	const sourceSHA256 = "0bbd2cdb0a0492055e442c44b533797386ec9c8aeb7ce8a4d0f5f5a4681e3b90"
+	if got := fmt.Sprintf("%x", sha256.Sum256([]byte(source))); got != sourceSHA256 {
+		t.Fatalf("survivor source digest = %s, want %s", got, sourceSHA256)
+	}
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	gotreesitter.SetGLRForestEnabled(true)
+	t.Cleanup(func() { gotreesitter.SetGLRForestEnabled(true) })
+	parser := gotreesitter.NewParser(JavascriptLanguage())
+	parser.SetAdmissionCandidateRoute(false)
+	tree, err := parser.Parse([]byte(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(tree.Release)
+	if tree.ParseRuntime().NormalizationPasses == nil {
+		t.Fatal("JavaScript survivor census has no pass records")
+	}
+	for _, pass := range *tree.ParseRuntime().NormalizationPasses {
+		if pass.Name != "dispatch.javascript" {
+			continue
+		}
+		if pass.Checked == 0 || pass.Run == 0 || pass.NodesVisited == 0 {
+			t.Fatalf("JavaScript survivor pass did not run: %+v", pass)
+		}
+		if pass.NodesRewritten != 7 {
+			t.Fatalf("JavaScript survivor rewrites = %d, want 7", pass.NodesRewritten)
+		}
+		return
+	}
+	t.Fatal("JavaScript survivor census has no dispatch.javascript record")
+}
+
+func requireJavaScriptDynamicImportRetirementTree(t *testing.T, route string, tree *gotreesitter.Tree, language *gotreesitter.Language) string {
+	t.Helper()
+	if tree.RootNode().HasError() {
+		t.Fatalf("%s tree has an error node", route)
+	}
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	imports := javaScriptDynamicImportNodes(tree.RootNode(), language)
+	if len(imports) != 1 {
+		t.Fatalf("%s dynamic import count = %d", route, len(imports))
+	}
+	runtime := tree.ParseRuntime()
+	if imports[0].ChildCount() != 1 {
+		t.Fatalf("%s import children = %d, want 1", route, imports[0].ChildCount())
+	}
+	child := imports[0].Child(0)
+	if child == nil || child.IsNamed() || child.Type(language) != "import" || child.StartByte() != imports[0].StartByte() || child.EndByte() != imports[0].EndByte() {
+		t.Fatalf("%s import child is not the native anonymous full-span token: parent=%v child=%v", route, imports[0], child)
+	}
+	t.Logf("%s digest=%s import_children=%d forest=%t rewrites=%d",
+		route,
+		inspection.SHA256,
+		imports[0].ChildCount(),
+		runtime.ForestFastPath,
+		runtime.NormalizationNodesRewritten,
+	)
+	if runtime.NormalizationPasses != nil {
+		for _, pass := range *runtime.NormalizationPasses {
+			if pass.Name == "dispatch.javascript" {
+				if pass.NodesRewritten != 0 {
+					t.Fatalf("%s dispatch.javascript rewrites = %d, want 0", route, pass.NodesRewritten)
+				}
+				t.Logf("%s pass=%s checked=%d run=%d visited=%d rewritten=%d", route, pass.Name, pass.Checked, pass.Run, pass.NodesVisited, pass.NodesRewritten)
+			}
+		}
+	}
+	return inspection.SHA256
+}
+
+func javaScriptDynamicImportPointAtByte(source []byte, offset int) gotreesitter.Point {
+	var point gotreesitter.Point
+	for index, value := range source {
+		if index == offset {
+			break
+		}
+		if value == '\n' {
+			point.Row++
+			point.Column = 0
+			continue
+		}
+		point.Column++
+	}
+	return point
+}
+
+func javaScriptDynamicImportNodes(root *gotreesitter.Node, language *gotreesitter.Language) []*gotreesitter.Node {
+	var nodes []*gotreesitter.Node
+	gotreesitter.Walk(root, func(node *gotreesitter.Node, _ int) gotreesitter.WalkAction {
+		if node.IsNamed() && node.Type(language) == "import" {
+			nodes = append(nodes, node)
+		}
+		return gotreesitter.WalkContinue
+	})
+	return nodes
+}

--- a/parser_result_javascript_typescript.go
+++ b/parser_result_javascript_typescript.go
@@ -46,13 +46,6 @@ func normalizeJavaScriptCompatibility(root *Node, source []byte, p *Parser, lang
 	normalizeJavaScriptProgramStart(root, lang)
 
 	poller := parseStopPoller{check: p.activeParseStopCheck(), memoryBudgetParser: p}
-	// Fused walk handles empty_statement, statement keywords (if/while),
-	// optional-chain leaves, call_expression precedence, and builds unary/
-	// binary candidate indexes — six separate full-tree walks collapsed into
-	// one walk + indexed rewrites.
-	if _, reason := normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root, source, lang, &poller); resultMaterializationShouldStop(reason) {
-		return reason
-	}
 	if reason := normalizeJavaScriptTrailingContinueComments(root, source, lang, &poller); resultMaterializationShouldStop(reason) {
 		return reason
 	}
@@ -131,8 +124,8 @@ func normalizeTypeScriptTreeCompatibilityWithParser(root *Node, source []byte, p
 	var syntaxStats javaScriptTypeScriptSyntaxNormalizationStats
 	var haveSyntaxStats bool
 	var syntaxStopReason ParseStopReason
-	// ts_compat_index_walk drives the fused walk: dynamic-import leaf
-	// retyping plus building the TypeScript-compatibility candidate index.
+	// ts_compat_index_walk drives the fused TypeScript-compatibility candidate
+	// index walk.
 	// Renamed from ts_statement_keyword_leaves by the wave11 compat-sunset
 	// (juniper), which removed the walk's empty_statement, existential_type,
 	// statement-keyword, call-precedence, and unary/binary-precedence-
@@ -817,12 +810,12 @@ type javaScriptTypeScriptSyntaxNormalizationStats struct {
 // unary/binary-precedence-rotation handling: a census over ~23MB of real
 // JS/TS/TSX (undici.js, TypeScript's own checker.ts/parser.ts/utilities.ts,
 // real TSX) plus the 5003ac64 regression snippets and independent adversarial
-// precedence chains showed zero rewrites from any of those six passes —
-// later grammargen table fixes made the GLR tables produce the already-
+// precedence chains showed zero rewrites from any of those six passes.
+// Later grammargen table fixes made the GLR tables produce the already-
 // correct shape directly, so the post-hoc rewrite passes had become dead
-// weight on every JS/TS/TSX parse. What remains — dynamic-import leaf
-// retyping and the TypeScript-compatibility candidate index — still does
-// real, live work and keeps the exact same containment discipline.
+// weight on every JS/TS/TSX parse. The parser now also retains dynamic-import
+// token children. The TypeScript-compatibility candidate index remains live
+// and keeps the same containment discipline.
 func normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root *Node, source []byte, lang *Language, poller *parseStopPoller) (javaScriptTypeScriptSyntaxNormalizationStats, ParseStopReason) {
 	var stats javaScriptTypeScriptSyntaxNormalizationStats
 	if root == nil || lang == nil {
@@ -841,10 +834,6 @@ func normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStat
 	optionalChainTokenSym, hasOptionalChainTokenSym := symbolByName(lang, "?.")
 	optionalChainTokenNamed := hasOptionalChainTokenSym && symbolIsNamed(lang, optionalChainTokenSym)
 	enableOptionalChain := hasOptionalChainSym && bytes.Contains(source, []byte("?."))
-	dynamicImportSym, hasDynamicImport := lang.symbolByNameAndNamed("import", true)
-	importKeywordSym, hasImportKeyword := lang.symbolByNameAndNamed("import", false)
-	enableDynamicImport := hasDynamicImport && hasImportKeyword && bytes.Contains(source, []byte("import"))
-
 	var typeScriptCtx *typeScriptNormalizationContext
 	if lang.Name == "typescript" || lang.Name == "tsx" {
 		sourceFlags := typeScriptCompatSourceFlagsFor(source)
@@ -856,7 +845,6 @@ func normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStat
 	index, reason := rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBinaryIndex(
 		root, source, lang,
 		optionalChainSym, optionalChainTokenSym, optionalChainTokenNamed, enableOptionalChain,
-		dynamicImportSym, importKeywordSym, enableDynamicImport,
 		typeScriptCtx,
 		poller,
 	)
@@ -867,13 +855,13 @@ func normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStat
 }
 
 // rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBinaryIndex
-// walks the whole JS/TS/TSX result tree once, doing dynamic-import leaf
-// retyping and building the TypeScript-compatibility candidate index (see
+// walks the TypeScript/TSX result tree once and builds the compatibility
+// candidate index. See
 // normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats's
 // doc comment for the wave11 census that removed this walk's former
 // empty_statement, existential_type, statement-keyword, call-precedence, and
 // unary/binary-precedence-rotation work — all confirmed dead: zero rewrites
-// across the census corpus).
+// across the census corpus.
 func rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBinaryIndex(
 	root *Node,
 	source []byte,
@@ -882,9 +870,6 @@ func rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBina
 	optionalChainTokenSym Symbol,
 	optionalChainTokenNamed bool,
 	enableOptionalChain bool,
-	dynamicImportSym Symbol,
-	importKeywordSym Symbol,
-	enableDynamicImport bool,
 	typeScriptCtx *typeScriptNormalizationContext,
 	poller *parseStopPoller,
 ) (javaScriptTypeScriptUnaryBinaryPrecedenceIndex, ParseStopReason) {
@@ -896,7 +881,7 @@ func rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBina
 	// is nothing to do; returning early avoids materializing final-ref
 	// children for callers (e.g. mock-lang unit tests) that exercise only
 	// other compat passes.
-	if !enableDynamicImport && typeScriptCtx == nil {
+	if typeScriptCtx == nil {
 		return index, ParseStopNone
 	}
 	index.builds = 1
@@ -952,9 +937,6 @@ func rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBina
 			}
 		}
 		index.nodesVisited++
-		if enableDynamicImport && n.symbol == dynamicImportSym {
-			normalizeJavaScriptTypeScriptDynamicImportLeafWithSymbolChanged(n, importKeywordSym)
-		}
 		collectTypeScriptCompatibilityNodeCandidate(&index.typeScriptCompatibility, n, typeScriptCtx)
 
 		if n.childIndex <= finalChildSidecarIndexBase && n.ownerArena != nil {
@@ -1056,15 +1038,6 @@ func rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBina
 	}
 	walk(root)
 	return index, stopReason
-}
-
-func normalizeJavaScriptTypeScriptDynamicImportLeafWithSymbolChanged(node *Node, importKeywordSym Symbol) bool {
-	if node == nil || resultChildCount(node) != 0 || node.endByte <= node.startByte {
-		return false
-	}
-	child := newLeafNodeInArena(node.ownerArena, importKeywordSym, false, node.startByte, node.endByte, node.startPoint, node.endPoint)
-	replaceNodeChildrenUnfielded(node, cloneNodeSliceInArena(node.ownerArena, []*Node{child}))
-	return true
 }
 
 type javaScriptTypeScriptPrecedenceCandidate struct {

--- a/parser_result_javascript_typescript_compat_test.go
+++ b/parser_result_javascript_typescript_compat_test.go
@@ -99,26 +99,38 @@ func TestNormalizeJavaScriptTopLevelExpressionStatementBoundsSnapToChildren(t *t
 	}
 }
 
-// newDeferredCompatDynamicImportFixture builds a minimal "program" root with
-// one childless dynamic-import leaf (named "import", symbol 2) over source
-// "import". normalizeJavaScriptTypeScriptDynamicImportLeafWithSymbolChanged
-// (still live — not part of the wave11 compat-sunset's six confirmed-dead
-// classes) retypes it into a single-child node the same way the removed
-// empty_statement leaf-retype used to, so it's the fixture below's stand-in
-// observable marker for "did deferred JS/TS compat actually run".
+// newDeferredCompatDynamicImportFixture builds a small TypeScript context.
+// Its childless dynamic-import leaf exercises TypeScript's separate candidate
+// normalizer. This marker shows that deferred TypeScript compatibility ran.
 func newDeferredCompatDynamicImportFixture() (*Language, *Node, *Node) {
 	lang := &Language{
-		Name:        "typescript",
-		SymbolNames: []string{"EOF", "program", "import", "import"},
+		Name: "typescript",
+		SymbolNames: []string{
+			"EOF", "program", "import", "import", "call_expression",
+			"type_arguments", "arguments", "predefined_type",
+			"binary_expression", ">", "parenthesized_expression", "<",
+			"identifier", "member_expression", "sequence_expression",
+		},
 		SymbolMetadata: []SymbolMetadata{
 			{Name: "EOF", Visible: false, Named: false},
 			{Name: "program", Visible: true, Named: true},
-			{Name: "import", Visible: true, Named: true},
 			{Name: "import", Visible: true, Named: false},
+			{Name: "import", Visible: true, Named: true},
+			{Name: "call_expression", Visible: true, Named: true},
+			{Name: "type_arguments", Visible: true, Named: true},
+			{Name: "arguments", Visible: true, Named: true},
+			{Name: "predefined_type", Visible: true, Named: true},
+			{Name: "binary_expression", Visible: true, Named: true},
+			{Name: ">", Visible: true, Named: false},
+			{Name: "parenthesized_expression", Visible: true, Named: true},
+			{Name: "<", Visible: true, Named: false},
+			{Name: "identifier", Visible: true, Named: true},
+			{Name: "member_expression", Visible: true, Named: true},
+			{Name: "sequence_expression", Visible: true, Named: true},
 		},
 	}
 	arena := newNodeArena(arenaClassFull)
-	stmt := newLeafNodeInArena(arena, 2, true, 0, 6, Point{}, Point{Column: 6})
+	stmt := newLeafNodeInArena(arena, 3, true, 0, 6, Point{}, Point{Column: 6})
 	root := newParentNodeInArena(arena, 1, true, []*Node{stmt}, nil, 0)
 	return lang, root, stmt
 }

--- a/parser_result_javascript_typescript_memory_budget_test.go
+++ b/parser_result_javascript_typescript_memory_budget_test.go
@@ -5,132 +5,77 @@ import (
 	"testing"
 )
 
-// This file regression-tests the 2026-07-13 jstswalk-containment-gap fix,
-// the JS/TS analogue of the 2026-07-12 gocompat-walk-containment-gap fix
-// (see parser_result_go_compat_memory_budget_test.go): the JS/TS fused
-// compat walk (rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBinaryIndex,
-// driven by normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats)
-// had ZERO stop polling of any kind before this fix — no timeout,
-// cancellation, or memory-budget check — so it ran to completion (ballooning
-// heap growth via its own per-node bookkeeping) regardless of the parse's
-// configured runtime memory budget. The fix wires a *parseStopPoller with
-// memoryBudgetParser set into the walk (mirroring the Go compat walk's
-// poller.memoryBudgetParser hook, parser_result_go_compat.go) and checks the
-// poller once per node visited, throttled to the same ~1024-node stride
-// (parseStopPollMask) walkGoCompatSubtree uses.
-//
-// wave11 (juniper) swapped this file's fixture shape from a wide
-// unary_expression tree to a wide dynamic-import-leaf tree: the fused walk's
-// unary/binary candidate-index bookkeeping this file used to exercise for
-// its heap-growth trigger was one of six rewrite classes the wave11 census
-// confirmed dead (zero rewrites across ~23MB of real JS/TS/TSX, the 5003ac64
-// regression snippets, and independent adversarial precedence chains) and
-// was removed along with empty_statement, existential_type, statement-
-// keyword, and call-precedence handling. Dynamic-import leaf retyping
-// (normalizeJavaScriptTypeScriptDynamicImportLeafWithSymbolChanged) is still
-// live, unconditional per matching leaf, and — like the old unary_expression
-// shape — does real, non-idempotent per-leaf allocation (a new leaf node
-// plus a new one-element children slice per import() call) genuinely
-// proportional to tree size, so it reproduces the same containment-gap
-// trigger shape.
-//
-// buildJSTSCompatWideDynamicImportTree below models the trigger shape
-// without an end-to-end multi-hundred-MB reproduction: a wide, flat tree of
-// many real, distinct dynamic-import leaf children, calibrated so unbounded
-// work is clearly larger than a small configured budget while staying well
-// under ~1GiB for test safety.
+// This file tests the TypeScript candidate-index memory boundary. The fused
+// walk polls for cancellation and memory pressure as it collects candidates.
+// A wide dynamic-import tree gives the index bounded, repeatable work.
 
 const (
-	testJSTSCompatProgramSym       Symbol = 1
-	testJSTSCompatDynamicImportSym Symbol = 2 // named "import" (dynamic import() call)
-	// Symbol 3 is the unnamed "import" (the retyped leaf child's symbol),
-	// resolved internally via lang.symbolByNameAndNamed("import", false).
+	testTSCompatProgramSym       Symbol = 1
+	testTSCompatDynamicImportSym Symbol = 3 // named "import" (dynamic import() call)
+	// Symbol 2 is the anonymous "import" token.
 )
 
-// buildJSTSCompatWideDynamicImportTree builds a "program" root with
-// numImport distinct, childless dynamic-import leaf children (no node
-// sharing — an ordinary tree, unlike the historical Go DAG/cycle defect) and
-// a minimal *Language whose symbol table matches, so
-// rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBinaryIndex
-// (via normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats)
-// resolves the named/unnamed "import" pair the same way it would for a real
-// grammar. The returned source is a small fixed buffer containing "import"
-// (enough to pass the walk's enableDynamicImport source-level gate); nothing
-// in this path reads source at the individual leaf offsets.
-func buildJSTSCompatWideDynamicImportTree(numImport int) (*Node, *Language, []byte) {
+// buildTypeScriptCompatWideDynamicImportTree builds a wide TypeScript tree.
+// Each childless dynamic-import leaf becomes an index candidate.
+func buildTypeScriptCompatWideDynamicImportTree(numImport int) (*Node, *Language, []byte) {
 	arena := newNodeArena(arenaClassFull)
 	children := make([]*Node, numImport)
 	for i := 0; i < numImport; i++ {
 		off := uint32(i)
-		children[i] = newLeafNodeInArena(arena, testJSTSCompatDynamicImportSym, true, off, off+1, Point{}, Point{})
+		children[i] = newLeafNodeInArena(arena, testTSCompatDynamicImportSym, true, off, off+1, Point{}, Point{})
 	}
-	root := newParentNodeInArena(arena, testJSTSCompatProgramSym, true, cloneNodeSliceInArena(arena, children), nil, 0)
+	root := newParentNodeInArena(arena, testTSCompatProgramSym, true, cloneNodeSliceInArena(arena, children), nil, 0)
 
 	lang := &Language{
-		Name:        "javascript",
-		SymbolNames: []string{"EOF", "program", "import", "import"},
+		Name: "typescript",
+		SymbolNames: []string{
+			"EOF", "program", "import", "import", "call_expression",
+			"type_arguments", "arguments", "predefined_type",
+			"binary_expression", ">", "parenthesized_expression", "<",
+			"identifier", "member_expression", "sequence_expression",
+		},
 		SymbolMetadata: []SymbolMetadata{
 			{Name: "EOF", Visible: false, Named: false},
 			{Name: "program", Visible: true, Named: true},
-			{Name: "import", Visible: true, Named: true},
 			{Name: "import", Visible: true, Named: false},
+			{Name: "import", Visible: true, Named: true},
+			{Name: "call_expression", Visible: true, Named: true},
+			{Name: "type_arguments", Visible: true, Named: true},
+			{Name: "arguments", Visible: true, Named: true},
+			{Name: "predefined_type", Visible: true, Named: true},
+			{Name: "binary_expression", Visible: true, Named: true},
+			{Name: ">", Visible: true, Named: false},
+			{Name: "parenthesized_expression", Visible: true, Named: true},
+			{Name: "<", Visible: true, Named: false},
+			{Name: "identifier", Visible: true, Named: true},
+			{Name: "member_expression", Visible: true, Named: true},
+			{Name: "sequence_expression", Visible: true, Named: true},
 		},
 	}
 	return root, lang, []byte("import")
 }
 
-// TestJSTSFusedWalkUnboundedBaselineCompletes establishes the baseline: with
-// no memory-budget parser wired into the poller (poller == nil — the pre-fix
-// shape, since the fused walk previously had no poller parameter at all), the
-// walk runs to completion and visits every child regardless of tree size.
-// This is the control for TestJSTSFusedWalkStopsOnMemoryBudget below.
-func TestJSTSFusedWalkUnboundedBaselineCompletes(t *testing.T) {
+func TestTypeScriptCandidateIndexUnboundedBaselineCompletes(t *testing.T) {
 	const numImport = 2000000
-	root, lang, source := buildJSTSCompatWideDynamicImportTree(numImport)
+	root, lang, source := buildTypeScriptCompatWideDynamicImportTree(numImport)
 
 	stats, reason := normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root, source, lang, nil)
 	if reason != ParseStopNone {
 		t.Fatalf("reason = %q, want %q (unbounded walk must not stop)", reason, ParseStopNone)
 	}
-	// indexNodesVisited counts every node the fused walk visited: root, plus
-	// every dynamic-import leaf, plus the single replacement keyword-leaf
-	// child normalizeJavaScriptTypeScriptDynamicImportLeafWithSymbolChanged
-	// gives each import leaf in place (the walk recurses into it too, since
-	// the retype mutates the leaf's own children rather than replacing it at
-	// the parent) — so 1 + 2*numImport, not 1 + numImport. An unbounded walk
-	// must visit all of them.
-	if got, want := stats.indexNodesVisited, uint64(2*numImport+1); got != want {
+	if got, want := stats.indexNodesVisited, uint64(numImport+1); got != want {
 		t.Fatalf("indexNodesVisited = %d, want %d (unbounded walk must visit every node)", got, want)
 	}
-	// Every dynamic-import leaf must actually have been retyped: proof the
-	// walk did real, non-idempotent per-node work the whole way through, not
-	// just cheap traversal.
-	for i := 0; i < numImport; i++ {
-		child := resultChildAt(root, i)
-		if got, want := resultChildCount(child), 1; got != want {
-			t.Fatalf("import leaf %d child count = %d, want %d (unbounded walk must retype every leaf)", i, got, want)
-		}
+	if got := stats.typeScriptCompatibility.len(); got != numImport {
+		t.Fatalf("candidate count = %d, want %d", got, numImport)
 	}
 }
 
-// TestJSTSFusedWalkStopsOnMemoryBudget is the core regression: wiring a
-// tiny-budget *Parser into the poller (parseStopPoller.memoryBudgetParser,
-// the fused-walk-side fix) must make the walk (a) return
-// ParseStopMemoryBudget, (b) stop well before the last child is reached
-// (proving it bailed out mid-walk rather than finishing then reporting the
-// budget as an afterthought), and (c) keep total heap growth within a
-// generous multiple of the configured budget — even though an unbounded walk
-// over the identical tree (see the baseline test above) would keep going
-// regardless.
-func TestJSTSFusedWalkStopsOnMemoryBudget(t *testing.T) {
+func TestTypeScriptCandidateIndexStopsOnMemoryBudget(t *testing.T) {
 	const numImport = 2000000
-	root, lang, source := buildJSTSCompatWideDynamicImportTree(numImport)
+	root, lang, source := buildTypeScriptCompatWideDynamicImportTree(numImport)
 
-	const budgetBytes = 1 << 20 // 1MiB: comfortably smaller than the growth
-	// this walk's own per-leaf retyping allocates (a new leaf node plus a new
-	// one-element children slice per dynamic-import leaf, across all
-	// numImport children) if it ran to completion, so the trip must land
-	// partway through, not at the end.
+	const budgetBytes = 1 << 20 // The candidate index exceeds this budget.
 	parser := newGoCompatBudgetTestParser(budgetBytes)
 	parser.language = lang
 
@@ -152,11 +97,8 @@ func TestJSTSFusedWalkStopsOnMemoryBudget(t *testing.T) {
 	if stats.indexNodesVisited == 0 {
 		t.Fatal("indexNodesVisited = 0, want some real work done before the trip")
 	}
-	// 2*numImport+1 is the full unbounded node-visit count (see the baseline
-	// test's doc comment: root + every import leaf + every replacement
-	// keyword-leaf child).
-	if stats.indexNodesVisited >= uint64(2*numImport+1) {
-		t.Fatalf("indexNodesVisited = %d, want a partial prefix < %d (walk must have stopped before reaching the end)", stats.indexNodesVisited, 2*numImport+1)
+	if stats.indexNodesVisited >= uint64(numImport+1) {
+		t.Fatalf("indexNodesVisited = %d, want a partial prefix < %d", stats.indexNodesVisited, numImport+1)
 	}
 
 	growth := int64(0)
@@ -165,48 +107,15 @@ func TestJSTSFusedWalkStopsOnMemoryBudget(t *testing.T) {
 	}
 	const maxOvershoot = 20 * budgetBytes
 	t.Logf("nodesVisited=%d/%d heap growth=%d bytes (budget=%d, %.2fx)",
-		stats.indexNodesVisited, 2*numImport+1, growth, int64(budgetBytes), float64(growth)/float64(budgetBytes))
+		stats.indexNodesVisited, numImport+1, growth, int64(budgetBytes), float64(growth)/float64(budgetBytes))
 	if growth > maxOvershoot {
 		t.Fatalf("heap growth = %d bytes, want <= %d (20x budget=%d)", growth, maxOvershoot, int64(budgetBytes))
 	}
 }
 
-// TestNormalizeJavaScriptCompatibilityPropagatesMemoryBudgetStop exercises the
-// full production entry point (normalizeJavaScriptCompatibility) instead of
-// normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats
-// directly, confirming the poller wiring done inside normalizeJavaScriptCompatibility
-// reaches all the way from a *Parser's configured budget to the returned
-// ParseStopReason, and that resultMaterializationStopReason (what
-// finalizeResultRoot consults afterward) reliably reports the trip via the
-// shared compatMemoryBudgetTripped sticky latch.
-func TestNormalizeJavaScriptCompatibilityPropagatesMemoryBudgetStop(t *testing.T) {
-	const numImport = 2000000
-	root, lang, source := buildJSTSCompatWideDynamicImportTree(numImport)
-
-	const budgetBytes = 1 << 20
-	parser := newGoCompatBudgetTestParser(budgetBytes)
-	parser.language = lang
-
-	reason := normalizeJavaScriptCompatibility(root, source, parser, lang)
-	if reason != ParseStopMemoryBudget {
-		t.Fatalf("normalizeJavaScriptCompatibility reason = %q, want %q", reason, ParseStopMemoryBudget)
-	}
-	if !parser.compatMemoryBudgetTripped {
-		t.Fatal("compatMemoryBudgetTripped = false, want true")
-	}
-	if got := parser.resultMaterializationStopReason(nil); got != ParseStopMemoryBudget {
-		t.Fatalf("resultMaterializationStopReason() = %q, want %q after a JS/TS compat memory-budget trip", got, ParseStopMemoryBudget)
-	}
-}
-
-// TestNormalizeTypeScriptTreeCompatibilityPropagatesMemoryBudgetStop is the
-// TypeScript-side counterpart of the JavaScript test above, exercising
-// normalizeTypeScriptTreeCompatibilityWithParser's fast (non-metrics) path —
-// the one every real TypeScript/TSX parse takes.
 func TestNormalizeTypeScriptTreeCompatibilityPropagatesMemoryBudgetStop(t *testing.T) {
 	const numImport = 2000000
-	root, lang, source := buildJSTSCompatWideDynamicImportTree(numImport)
-	lang.Name = "typescript"
+	root, lang, source := buildTypeScriptCompatWideDynamicImportTree(numImport)
 
 	const budgetBytes = 1 << 20
 	parser := newGoCompatBudgetTestParser(budgetBytes)
@@ -220,6 +129,6 @@ func TestNormalizeTypeScriptTreeCompatibilityPropagatesMemoryBudgetStop(t *testi
 		t.Fatal("compatMemoryBudgetTripped = false, want true")
 	}
 	if got := parser.resultMaterializationStopReason(nil); got != ParseStopMemoryBudget {
-		t.Fatalf("resultMaterializationStopReason() = %q, want %q after a JS/TS compat memory-budget trip", got, ParseStopMemoryBudget)
+		t.Fatalf("resultMaterializationStopReason() = %q, want %q after a TypeScript compatibility memory-budget trip", got, ParseStopMemoryBudget)
 	}
 }

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -1546,7 +1546,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "eee20b8a54a1608b47cce0ab7fb934651e204d66",
+      "retired_commit": "8d0648f5e97fb75e4934aab90f0de4b0e3c7e821",
       "positive_control_commit": "143936b2a62b44eb779dda835b09abe0c26cc6d5",
       "producer_fix_commit": "eee20b8a54a1608b47cce0ab7fb934651e204d66",
       "receipt_refs": [

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -9,7 +9,7 @@
     "post_finalization_arms": 0,
     "post_finalization_languages": 0,
     "live_entries": 36,
-    "retired_entries": 50
+    "retired_entries": 51
   },
   "live_evidence_baseline": {
     "scope": "baseline_corpus_wide_only",
@@ -1518,6 +1518,41 @@
       },
       "status": "live",
       "evidence_scope": "baseline_corpus_wide_only"
+    },
+    {
+      "id": "dispatch.javascript.dynamic-import",
+      "kind": "dispatcher_subpass",
+      "functions": [
+        "normalizeJavaScriptTypeScriptDynamicImportLeafWithSymbolChanged"
+      ],
+      "files": [
+        "parser_result_javascript_typescript.go"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "purpose": "Historical: add the anonymous import token below a childless named dynamic-import node after materialization.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "grammars/javascript_dynamic_import_retirement_test.go",
+        "cgo_harness/javascript_dynamic_import_retirement_parity_test.go"
+      ],
+      "retirement_condition": "Satisfied: the generic collapsed-child reducer retains the anonymous import token. Production, direct compact, strict forest, edited incremental, and locked C routes are exact.",
+      "route_coverage": {
+        "production": "retired_exact_receipt",
+        "compact": "retired_exact_receipt",
+        "forest": "retired_exact_receipt",
+        "incremental": "retired_exact_receipt",
+        "c_oracle": "retired_exact_receipt"
+      },
+      "status": "retired",
+      "retired_commit": "eee20b8a54a1608b47cce0ab7fb934651e204d66",
+      "positive_control_commit": "143936b2a62b44eb779dda835b09abe0c26cc6d5",
+      "producer_fix_commit": "eee20b8a54a1608b47cce0ab7fb934651e204d66",
+      "receipt_refs": [
+        "grammars/javascript_dynamic_import_retirement_test.go",
+        "cgo_harness/javascript_dynamic_import_retirement_parity_test.go"
+      ]
     },
     {
       "id": "dispatch.julia",

--- a/transient_children_test.go
+++ b/transient_children_test.go
@@ -254,29 +254,10 @@ func TestTransientChildFinalizationAbortReturnsErrorTree(t *testing.T) {
 }
 
 func TestTransientChildReturnedTreeMaterializationUsesRawRoot(t *testing.T) {
-	// Observable marker: a childless dynamic-import leaf (named "import"),
-	// retyped into a single-child node by
-	// normalizeJavaScriptTypeScriptDynamicImportLeafWithSymbolChanged when
-	// deferred TS compat runs. Mirrors newDeferredCompatDynamicImportFixture
-	// in parser_result_javascript_typescript_compat_test.go: this test used
-	// to use an empty_statement leaf as its marker, but the wave11
-	// compat-sunset (juniper) removed empty_statement leaf-retype as one of
-	// six confirmed-dead JS/TS rewrite classes (zero rewrites across a
-	// ~23MB real JS/TS/TSX census).
-	lang := &Language{
-		Name:        "typescript",
-		SymbolNames: []string{"EOF", "program", "import", "import"},
-		SymbolMetadata: []SymbolMetadata{
-			{Name: "EOF", Visible: false, Named: false},
-			{Name: "program", Visible: true, Named: true},
-			{Name: "import", Visible: true, Named: true},
-			{Name: "import", Visible: true, Named: false},
-		},
-	}
-
-	arena := newNodeArena(arenaClassFull)
-	stmt := newLeafNodeInArena(arena, 2, true, 0, 6, Point{}, Point{Column: 6})
-	root := newParentNodeInArena(arena, 1, true, []*Node{stmt}, nil, 0)
+	// The TypeScript candidate path adds the child after deferred compatibility.
+	// This marker proves that transient materialization keeps the raw root.
+	lang, root, stmt := newDeferredCompatDynamicImportFixture()
+	arena := root.ownerArena
 	tree := newTreeWithArenas(root, []byte("import"), lang, arena, nil)
 	tree.deferResultCompatibility()
 


### PR DESCRIPTION
## Summary

- Remove only the JavaScript dynamic-import leaf repair.
- Keep the remaining `dispatch.javascript` repairs live.
- Pin the historical control, generic producer fix, and retirement commit.
- Increase the retired-entry count from 50 to 51.

## Evidence

Two parser-produced controls reproduce the historical repair at `143936b2`.

Generic commit `eee20b8a` retains the anonymous `import` child during reduction.

Raw production, production, direct compact, strict forest, and edited incremental routes now produce the same deep tree.

The locked C oracle matches symbols, fields, spans, points, flags, `HasError`, and both pinned digests.

The JavaScript survivor source still records seven compatibility rewrites. TypeScript survivor and memory-limit tests remain green.

## Verification

- Focused Go routes: `20260820T224930Z-n17-review-go-routes-v2`
- Registry and survivor tests: `20260820T224943Z-n17-review-registry-survivors`
- Locked-C routes: `20260820T225012Z-n17-review-locked-c-v2`
- JavaScript single-grammar parity: 25 of 25 deep matches
- Provenance registry gate: `20260820T230735Z-n17-provenance-registry`
- Narrow Canopy: no production reference to the removed helper
- `git diff --check`: pass

## Review state

Sol xhigh approved the deletion patch. The second commit applies its provenance correction.

Hyphae receipt: `spore.2026-08-20.gotreesitter-normalization-n17-javascript-dynamic-import-retirement`.

Do not merge until continuous integration is terminal green. Require an independent train review before merge.