### PR TITLE
perf(parser): arena C recovery summaries

### DIFF
--- a/glr_forest.go
+++ b/glr_forest.go
@@ -2183,11 +2183,12 @@ func forestNodeBestLinearStack(p *Parser, arena *nodeArena, node *gssForestNode)
 // those languages (only `make`, 1 file) is too thin to validate empirically.
 // So for those languages this keeps the original, unconditionally-conservative
 // behavior (any structurally-reachable pop-back declines the forest).
-func (p *Parser) forestEOFRecoveryCouldCompete(idx *gssForestIndex, arena *nodeArena, eofByte uint32, relaxForCleanAcceptLanguages bool) bool {
+func (p *Parser) forestEOFRecoveryCouldCompete(idx *gssForestIndex, arena *nodeArena, eofByte uint32, relaxForCleanAcceptLanguages bool) (bool, ParseStopReason) {
 	if p == nil || idx == nil || idx.len() == 0 {
-		return false
+		return false, ParseStopNone
 	}
 	var gssScratch gssScratch
+	gssScratch.summaryBudgetOwner = &forestGSSSummaryBudgetOwner{arena: arena, scratch: &gssScratch}
 	var entryScratch glrEntryScratch
 	trackChildErrors := false
 	// cRecoverToState (parser_recover_c.go) tags a freshly-recovered fork with
@@ -2229,12 +2230,21 @@ func (p *Parser) forestEOFRecoveryCouldCompete(idx *gssForestIndex, arena *nodeA
 		if node == nil || node.byteOffset != eofByte {
 			continue
 		}
+		if reason := p.forestMemoryBudgetStopReason(arena, false, &gssScratch); reason != ParseStopNone {
+			return false, reason
+		}
 		stack, ok := forestNodeBestLinearStack(p, arena, node)
 		if !ok {
 			continue
 		}
 		entries := cStackEntriesTopFirst(&stack, &gssScratch)
-		summary := p.cRecordSummary(entries)
+		summary, reason := p.cRecordSummaryWithScratch(entries, &gssScratch, arena)
+		if reason != ParseStopNone {
+			return false, reason
+		}
+		if reason := p.forestMemoryBudgetStopReason(arena, false, &gssScratch); reason != ParseStopNone {
+			return false, reason
+		}
 		for _, entry := range summary {
 			if entry.state == cErrorState || entry.posBytes == stack.byteOffset {
 				continue
@@ -2249,10 +2259,10 @@ func (p *Parser) forestEOFRecoveryCouldCompete(idx *gssForestIndex, arena *nodeA
 			if relaxForCleanAcceptLanguages && fork.cRecoveryUnvalidatedMarker {
 				continue
 			}
-			return true
+			return true, ParseStopNone
 		}
 	}
-	return false
+	return false, ParseStopNone
 }
 
 // forestAcceptedIsCleanCompleteParse reports whether the forest's chosen accept
@@ -3870,13 +3880,20 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 			// corpus here — the C argument is airtight, but we stay conservative.
 			cleanAcceptBeatsRecovery := !recoverActive &&
 				p.forestAcceptedIsCleanCompleteParse(arena, accepted, source)
-			if accepted != nil && !cleanAcceptBeatsRecovery && (recoverActive || p.errorCostCompetitionEnabled()) && p.forestEOFRecoveryCouldCompete(&curIndex, arena, tok.StartByte, !recoverActive) {
-				p.recordForestDecline(forestDeclineEOFRecoveryConflict, tok, nil)
-				if progress.enabled {
-					progress.emit(time.Now(), "forest_decline", iter, tokens, tok, true, nil, 0, 0, 0, false, 0, 0,
-						forestProgressExtra(frontier, work, nextFrontier, curIndex, nextIndex, processEpoch, recoverCount, reducer, accepted, "decline_reason="+forestDeclineEOFRecoveryConflict))
+			if accepted != nil && !cleanAcceptBeatsRecovery && (recoverActive || p.errorCostCompetitionEnabled()) {
+				competes, reason := p.forestEOFRecoveryCouldCompete(&curIndex, arena, tok.StartByte, !recoverActive)
+				if reason != ParseStopNone {
+					p.recordForestDecline(string(reason), tok, nil)
+					return nil, false
 				}
-				return nil, false
+				if competes {
+					p.recordForestDecline(forestDeclineEOFRecoveryConflict, tok, nil)
+					if progress.enabled {
+						progress.emit(time.Now(), "forest_decline", iter, tokens, tok, true, nil, 0, 0, 0, false, 0, 0,
+							forestProgressExtra(frontier, work, nextFrontier, curIndex, nextIndex, processEpoch, recoverCount, reducer, accepted, "decline_reason="+forestDeclineEOFRecoveryConflict))
+					}
+					return nil, false
+				}
 			}
 			if progress.enabled {
 				progress.beginDetail(time.Now(), "forest_collect_root_begin", "forest_collect_root_end", iter, tokens, tok, true, nil, 0, 0, 0, true, 0, 0,
@@ -4100,7 +4117,25 @@ func (p *Parser) forestMemoryBudgetExceeded(arena *nodeArena, final bool) bool {
 	// scratchAllocatedVolume is a nil-safe no-op here today; it is included
 	// for unit consistency with the production watermark rather than because
 	// it currently contributes anything.
-	return p.runtimeMemoryBudgetStopReason(arenaAllocatedVolume(arena)+scratchAllocatedVolume(p.budgetScratch)) == ParseStopMemoryBudget
+	return p.forestMemoryBudgetStopReason(arena, final, nil) != ParseStopNone
+}
+
+func (p *Parser) forestMemoryBudgetStopReason(arena *nodeArena, final bool, summaryScratch *gssScratch) ParseStopReason {
+	if arena != nil && arena.budgetExhausted() {
+		return p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceArena)
+	}
+	if summaryScratch != nil {
+		if reason := summaryScratch.summaryBudgetStopReason(); reason != ParseStopNone {
+			return p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceScratch)
+		}
+	}
+	if final {
+		if p.runtimeMemoryBudgetStopReasonNow() == ParseStopMemoryBudget {
+			return ParseStopMemoryBudget
+		}
+		return ParseStopNone
+	}
+	return p.runtimeMemoryBudgetStopReason(arenaAllocatedVolume(arena) + scratchAllocatedVolume(p.budgetScratch))
 }
 
 // maxForestNoLookaheadSteps bounds consecutive no-lookahead re-lex steps at one

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -43,11 +43,17 @@ func resetGSSNodeHashPendingForPool(pending *[]*gssNode) bool {
 }
 
 const (
-	defaultGSSNodeSlabCap      = 4 * 1024
-	fullParseGSSNodeSlabCap    = 32 * 1024
-	maxRetainedGSSNodes        = 256 * 1024
-	maxRetainedGSSStackEntries = 4 * 1024
+	defaultGSSNodeSlabCap              = 4 * 1024
+	fullParseGSSNodeSlabCap            = 32 * 1024
+	maxRetainedGSSNodes                = 256 * 1024
+	maxRetainedGSSStackEntries         = 4 * 1024
+	cRecoverSummaryChunkInitialEntries = 256
+	cRecoverSummaryChunkMaxEntries     = 4 * 1024
+	maxRetainedGSSSummaryBytes         = 1 << 20
+	maxRetainedGSSSummaryChunks        = 16
+)
 
+const (
 	gssAggCostValid uint8 = 1 << iota
 	gssAggVisValid
 )
@@ -170,23 +176,53 @@ type gssStack struct {
 	head *gssNode
 }
 
+type gssSummaryChunk struct {
+	data      []cStackSummaryEntry
+	used      int
+	dedicated bool
+}
+
+type gssSummaryBudgetOwner interface {
+	summaryBudgetState() (budgetBytes, baselineBytes, allocatedBytes int64)
+}
+
+type forestGSSSummaryBudgetOwner struct {
+	arena   *nodeArena
+	scratch *gssScratch
+}
+
+func (o *forestGSSSummaryBudgetOwner) summaryBudgetState() (int64, int64, int64) {
+	if o == nil || o.arena == nil {
+		return 0, 0, 0
+	}
+	allocated := o.arena.allocatedBytes
+	if o.scratch != nil {
+		allocated += o.scratch.allocatedBytes
+	}
+	return o.arena.budgetBytes, o.arena.budgetBaselineBytes, allocated
+}
+
 type gssScratch struct {
-	slabs             []gssNodeSlab
-	slabCursor        int
-	initialCap        int
-	skipClear         bool
-	usedTotal         int
-	peakUsed          int
-	allocatedBytes    int64
-	singleStackMode   bool
-	singleStackAllocs uint64
-	multiStackAllocs  uint64
-	demotions         uint64
-	nodesDemoted      uint64
-	audit             *runtimeAudit
-	frontier          conflictReduceFrontierScratch
-	recoveryElection  cRecoverElectionScratch
-	stackEntries      []stackEntry
+	slabs               []gssNodeSlab
+	slabCursor          int
+	initialCap          int
+	skipClear           bool
+	usedTotal           int
+	peakUsed            int
+	allocatedBytes      int64
+	singleStackMode     bool
+	singleStackAllocs   uint64
+	multiStackAllocs    uint64
+	demotions           uint64
+	nodesDemoted        uint64
+	audit               *runtimeAudit
+	frontier            conflictReduceFrontierScratch
+	recoveryElection    cRecoverElectionScratch
+	stackEntries        []stackEntry
+	summaryChunks       []gssSummaryChunk
+	summaryChunkCursor  int
+	summaryNextChunkCap int
+	summaryBudgetOwner  gssSummaryBudgetOwner
 	// everForked latches true the first time this parse observes more than
 	// one live GLR stack (see the singleStackMode writers in parser.go, and
 	// the explicit early latch at the "len(actions) > 1" conflict-fork
@@ -208,6 +244,159 @@ type gssScratch struct {
 	// captureRawShape's doc comment (raw_shape.go) for the full argument, and
 	// spore.2026-07-12.hazel.rawshape-elision-rca for the originating RCA.
 	everForked bool
+}
+
+func gssSummaryBytesForCap(n int) (int64, bool) {
+	if n < 0 {
+		return 0, false
+	}
+	size := uint64(unsafe.Sizeof(cStackSummaryEntry{}))
+	if size == 0 || uint64(n) > uint64(^uint64(0)>>1)/size {
+		return 0, false
+	}
+	return int64(uint64(n) * size), true
+}
+
+func (s *gssScratch) summaryBudgetAllows(additional int64) bool {
+	if s == nil || additional < 0 {
+		return false
+	}
+	owner := s.summaryBudgetOwner
+	if owner == nil {
+		return true
+	}
+	budget, baseline, allocated := owner.summaryBudgetState()
+	if budget <= 0 {
+		return true
+	}
+	used := allocated - baseline
+	if used < 0 {
+		used = 0
+	}
+	remaining := budget - used
+	return remaining > additional
+}
+
+func (s *gssScratch) summaryBudgetStopReason() ParseStopReason {
+	if s == nil || s.summaryBudgetOwner == nil {
+		return ParseStopNone
+	}
+	budget, baseline, allocated := s.summaryBudgetOwner.summaryBudgetState()
+	if budget <= 0 || allocated < baseline {
+		return ParseStopNone
+	}
+	if allocated-baseline >= budget {
+		return ParseStopMemoryBudget
+	}
+	return ParseStopNone
+}
+
+// allocRecoverySummary reserves one contiguous, immutable summary region.
+// A parse never reuses a region until its owning parser scratch is released.
+func (s *gssScratch) allocRecoverySummary(count int) ([]cStackSummaryEntry, ParseStopReason) {
+	if count == 0 {
+		return nil, ParseStopNone
+	}
+	if s == nil || count < 0 {
+		return nil, ParseStopMemoryBudget
+	}
+	if reason := s.summaryBudgetStopReason(); reason != ParseStopNone {
+		return nil, reason
+	}
+	if s.summaryNextChunkCap <= 0 {
+		s.summaryNextChunkCap = cRecoverSummaryChunkInitialEntries
+	}
+	for scanned := 0; scanned < len(s.summaryChunks); scanned++ {
+		chunkIndex := (s.summaryChunkCursor + scanned) % len(s.summaryChunks)
+		chunk := &s.summaryChunks[chunkIndex]
+		if !chunk.dedicated && len(chunk.data)-chunk.used >= count {
+			start := chunk.used
+			chunk.used += count
+			s.summaryChunkCursor = chunkIndex
+			return chunk.data[start : start+count : start+count], ParseStopNone
+		}
+	}
+
+	capacity := count
+	dedicated := count > cRecoverSummaryChunkMaxEntries
+	if !dedicated {
+		capacity = s.summaryNextChunkCap
+		for capacity < count && capacity < cRecoverSummaryChunkMaxEntries {
+			capacity *= 2
+		}
+		if capacity < count {
+			capacity = count
+			dedicated = true
+		}
+	}
+	bytes, ok := gssSummaryBytesForCap(capacity)
+	if !ok || !s.summaryBudgetAllows(bytes) {
+		return nil, ParseStopMemoryBudget
+	}
+	maxInt64 := int64(^uint64(0) >> 1)
+	if s.allocatedBytes > maxInt64-bytes {
+		return nil, ParseStopMemoryBudget
+	}
+	chunk := gssSummaryChunk{data: make([]cStackSummaryEntry, capacity), used: count, dedicated: dedicated}
+	s.summaryChunks = append(s.summaryChunks, chunk)
+	s.summaryChunkCursor = len(s.summaryChunks) - 1
+	if !dedicated {
+		if capacity >= cRecoverSummaryChunkMaxEntries {
+			s.summaryNextChunkCap = cRecoverSummaryChunkMaxEntries
+		} else {
+			s.summaryNextChunkCap = capacity * 2
+		}
+	}
+	s.allocatedBytes += bytes
+	return chunk.data[:count:count], ParseStopNone
+}
+
+// resetRecoverySummary drops dedicated and excess chunks after the parse.
+// Callers must clear all live stacks and pending buffers before gssScratch.reset.
+func (s *gssScratch) resetRecoverySummary() {
+	if s == nil {
+		return
+	}
+	write := 0
+	retainedBytes := 0
+	for read := range s.summaryChunks {
+		chunk := s.summaryChunks[read]
+		clear(chunk.data)
+		chunk.used = 0
+		bytes, ok := gssSummaryBytesForCap(cap(chunk.data))
+		keep := write < maxRetainedGSSSummaryChunks && !chunk.dedicated && ok && bytes <= int64(maxRetainedGSSSummaryBytes-retainedBytes)
+		if keep {
+			retainedBytes += int(bytes)
+			s.summaryChunks[write] = chunk
+			write++
+			continue
+		}
+		chunk.data = nil
+		s.summaryChunks[read] = chunk
+	}
+	for i := write; i < len(s.summaryChunks); i++ {
+		s.summaryChunks[i] = gssSummaryChunk{}
+	}
+	s.summaryChunks = s.summaryChunks[:write]
+	if write == 0 {
+		s.summaryChunks = nil
+	} else if cap(s.summaryChunks) > maxRetainedGSSSummaryChunks {
+		retained := make([]gssSummaryChunk, write)
+		copy(retained, s.summaryChunks)
+		s.summaryChunks = retained
+	}
+	s.summaryChunkCursor = 0
+	if write == 0 {
+		s.summaryNextChunkCap = cRecoverSummaryChunkInitialEntries
+	} else {
+		capacity := cap(s.summaryChunks[write-1].data)
+		if capacity >= cRecoverSummaryChunkMaxEntries {
+			s.summaryNextChunkCap = cRecoverSummaryChunkMaxEntries
+		} else {
+			s.summaryNextChunkCap = capacity * 2
+		}
+	}
+	s.summaryBudgetOwner = nil
 }
 
 // rawShapeElisionDisabledForDiagnostics forces every reduction to capture its
@@ -828,8 +1017,9 @@ func (s *gssScratch) reset() {
 		s.demotions = 0
 		s.nodesDemoted = 0
 		s.skipClear = false
+		s.resetRecoverySummary()
 		s.peakUsed = 0
-		s.allocatedBytes = s.frontier.allocatedBytes() + s.recoveryElection.allocatedBytes() + stackEntryBytesForCap(cap(s.stackEntries))
+		s.recomputeAllocatedBytes()
 		s.audit = nil
 		return
 	}
@@ -892,6 +1082,7 @@ func (s *gssScratch) reset() {
 	s.multiStackAllocs = 0
 	s.demotions = 0
 	s.nodesDemoted = 0
+	s.resetRecoverySummary()
 	s.audit = nil
 	s.recomputeAllocatedBytes()
 }
@@ -948,6 +1139,12 @@ func (s *gssScratch) recomputeAllocatedBytes() {
 	for i := range s.slabs {
 		total += gssNodeBytesForCap(len(s.slabs[i].data))
 		total += gssReachMarkBytesForCap(len(s.slabs[i].reachMarks))
+	}
+	for i := range s.summaryChunks {
+		bytes, ok := gssSummaryBytesForCap(cap(s.summaryChunks[i].data))
+		if ok {
+			total += bytes
+		}
 	}
 	total += s.frontier.allocatedBytes()
 	total += s.recoveryElection.allocatedBytes()

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -34,6 +34,124 @@ func TestGSSNodeLayoutSizeBudget(t *testing.T) {
 	}
 }
 
+func TestCRecoverSummaryArenaCrossesChunkBoundary(t *testing.T) {
+	parser := &Parser{}
+	var scratch gssScratch
+	entries := recoverySummaryTestEntries(1)
+	for i := 0; i < cRecoverSummaryChunkInitialEntries; i++ {
+		if _, reason := parser.cRecordSummaryWithScratch(entries, &scratch, nil); reason != ParseStopNone {
+			t.Fatalf("summary %d stopped: %s", i, reason)
+		}
+	}
+	if len(scratch.summaryChunks) != 1 || scratch.summaryChunks[0].used != cRecoverSummaryChunkInitialEntries {
+		t.Fatalf("first summary chunk = %#v, want full first chunk", scratch.summaryChunks)
+	}
+	if _, reason := parser.cRecordSummaryWithScratch(entries, &scratch, nil); reason != ParseStopNone {
+		t.Fatalf("boundary summary stopped: %s", reason)
+	}
+	if len(scratch.summaryChunks) != 2 || scratch.summaryChunks[1].used != 1 {
+		t.Fatalf("summary arena did not cross chunk boundary: %#v", scratch.summaryChunks)
+	}
+	firstSlot := &scratch.summaryChunks[0].data[0]
+	scratch.reset()
+	reused, reason := parser.cRecordSummaryWithScratch(entries, &scratch, nil)
+	if reason != ParseStopNone {
+		t.Fatalf("retained summary stopped: %s", reason)
+	}
+	if len(reused) != 1 || &reused[0] != firstSlot {
+		t.Fatal("retained summary arena did not restart at its first reusable chunk")
+	}
+}
+
+func TestCRecoverSummaryArenaReusesMixedRetainedChunks(t *testing.T) {
+	var scratch gssScratch
+	for _, count := range []int{cRecoverSummaryChunkInitialEntries, 2 * cRecoverSummaryChunkInitialEntries, 4 * cRecoverSummaryChunkInitialEntries} {
+		if _, reason := scratch.allocRecoverySummary(count); reason != ParseStopNone {
+			t.Fatalf("initial chunk allocation %d stopped: %s", count, reason)
+		}
+	}
+	if len(scratch.summaryChunks) != 3 {
+		t.Fatalf("initial chunk count = %d, want 3", len(scratch.summaryChunks))
+	}
+	first := &scratch.summaryChunks[0].data[0]
+	third := &scratch.summaryChunks[2].data[0]
+	scratch.reset()
+
+	large, reason := scratch.allocRecoverySummary(4 * cRecoverSummaryChunkInitialEntries)
+	if reason != ParseStopNone {
+		t.Fatalf("retained large allocation stopped: %s", reason)
+	}
+	if &large[0] != third {
+		t.Fatal("large allocation did not reuse the retained 1024-entry chunk")
+	}
+	small, reason := scratch.allocRecoverySummary(1)
+	if reason != ParseStopNone {
+		t.Fatalf("retained small allocation stopped: %s", reason)
+	}
+	if &small[0] != first {
+		t.Fatal("small allocation did not wrap to the retained 256-entry chunk")
+	}
+	if len(scratch.summaryChunks) != 3 || scratch.summaryChunks[0].used != 1 || scratch.summaryChunks[2].used != 4*cRecoverSummaryChunkInitialEntries {
+		t.Fatalf("mixed retained chunks changed unexpectedly: %#v", scratch.summaryChunks)
+	}
+}
+
+func TestCRecoverSummaryArenaResetCapsRetainedChunks(t *testing.T) {
+	backing := make([]gssSummaryChunk, maxRetainedGSSSummaryChunks+4)
+	for i := range backing {
+		backing[i].data = make([]cStackSummaryEntry, 1)
+		backing[i].used = 1
+	}
+	var scratch gssScratch
+	scratch.summaryChunks = backing
+	scratch.recomputeAllocatedBytes()
+	scratch.reset()
+	if len(scratch.summaryChunks) != maxRetainedGSSSummaryChunks || cap(scratch.summaryChunks) != maxRetainedGSSSummaryChunks {
+		t.Fatalf("retained summary descriptors = len %d cap %d, want %d", len(scratch.summaryChunks), cap(scratch.summaryChunks), maxRetainedGSSSummaryChunks)
+	}
+	for i := 0; i < maxRetainedGSSSummaryChunks; i++ {
+		if scratch.summaryChunks[i].data == nil || scratch.summaryChunks[i].used != 0 {
+			t.Fatalf("retained chunk %d = %#v, want cleared storage", i, scratch.summaryChunks[i])
+		}
+	}
+	for i := maxRetainedGSSSummaryChunks; i < len(backing); i++ {
+		if backing[i].data != nil {
+			t.Fatalf("dropped chunk %d retained storage", i)
+		}
+	}
+}
+
+func TestCRecoverSummaryArenaAllocatesOversizedSummary(t *testing.T) {
+	parser := &Parser{}
+	var scratch gssScratch
+	entries := recoverySummaryTestEntries(cRecoverSummaryChunkMaxEntries + 1)
+	summary, reason := parser.cRecordSummaryWithScratch(entries, &scratch, nil)
+	if reason != ParseStopNone {
+		t.Fatalf("oversized summary stopped: %s", reason)
+	}
+	if len(scratch.summaryChunks) != 1 || cap(scratch.summaryChunks[0].data) != len(entries) {
+		t.Fatalf("oversized summary chunk = %#v, want exact capacity %d", scratch.summaryChunks, len(entries))
+	}
+	if cap(summary) != len(summary) {
+		t.Fatalf("summary capacity = %d, want fenced capacity %d", cap(summary), len(summary))
+	}
+}
+
+func TestCRecoverSummaryArenaStopsAtMemoryBudget(t *testing.T) {
+	parser := &Parser{}
+	scratch := &parserScratch{}
+	scratch.setBudget(int64(unsafe.Sizeof(cStackSummaryEntry{}))*cRecoverSummaryChunkInitialEntries - 1)
+	entries := recoverySummaryTestEntries(1)
+	summary, reason := parser.cRecordSummaryWithScratch(entries, &scratch.gss, nil)
+	if reason != ParseStopMemoryBudget {
+		t.Fatalf("summary stop reason = %s, want %s", reason, ParseStopMemoryBudget)
+	}
+	if summary != nil || len(scratch.gss.summaryChunks) != 0 {
+		t.Fatalf("budget stop allocated or truncated summary: summary=%v chunks=%d", summary, len(scratch.gss.summaryChunks))
+	}
+	scratch.clearBudget()
+}
+
 func TestGSSStackPushCloneAndTruncate(t *testing.T) {
 	var scratch gssScratch
 	base := newGSSStack(1, &scratch)

--- a/parser_pool_test.go
+++ b/parser_pool_test.go
@@ -34,6 +34,26 @@ func TestParserPoolReleaseScrubsPendingStackBuffers(t *testing.T) {
 	}
 }
 
+func TestCRecoverSummaryArenaResetsAtParseBoundary(t *testing.T) {
+	parser := &Parser{}
+	scratch := acquireParserScratch()
+	entries := recoverySummaryTestEntries(1)
+	if _, reason := parser.cRecordSummaryWithScratch(entries, &scratch.gss, nil); reason != ParseStopNone {
+		t.Fatalf("summary stopped: %s", reason)
+	}
+	if len(scratch.gss.summaryChunks) == 0 || scratch.gss.summaryChunks[0].used == 0 {
+		t.Fatal("summary arena did not allocate before release")
+	}
+	releaseParserScratch(scratch, false)
+	reacquired := acquireParserScratch()
+	defer releaseParserScratch(reacquired, false)
+	for _, chunk := range reacquired.gss.summaryChunks {
+		if chunk.used != 0 {
+			t.Fatal("summary chunk retained live slots after parser-scratch release")
+		}
+	}
+}
+
 func TestParserPoolReleaseScrubsColdPendingStackReserves(t *testing.T) {
 	pool := NewParserPool(buildArithmeticLanguage())
 	parser := pool.checkout()

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -1243,18 +1243,21 @@ type cRecoverState struct {
 	extraRecoveries uint32
 }
 
+var cRecoverStateCloneObserver func()
+
 func (r *cRecoverState) clone() *cRecoverState {
 	if r == nil {
 		return nil
+	}
+	if observer := cRecoverStateCloneObserver; observer != nil {
+		observer()
 	}
 	cp := &cRecoverState{
 		openErr:         r.openErr,
 		group:           r.group,
 		groupOrder:      r.groupOrder,
 		extraRecoveries: r.extraRecoveries,
-	}
-	if len(r.summary) > 0 {
-		cp.summary = append([]cStackSummaryEntry(nil), r.summary...)
+		summary:         r.summary,
 	}
 	return cp
 }
@@ -2780,21 +2783,58 @@ func cEntryCountsTowardDepth(e stackEntry) bool {
 // spine: entries top-first, depth = crossings of depth-counting links,
 // deduped on (depth, state), bounded by MAX_SUMMARY_DEPTH.
 func (p *Parser) cRecordSummary(entries []stackEntry) []cStackSummaryEntry {
-	// cHandleError and forestEOFRecoveryCouldCompete usually record one state
-	// for each bounded depth. Reserve up to 17 entries for that common shape.
-	// Equal-depth states can exceed this hint, and append must preserve them.
-	summary := make([]cStackSummaryEntry, 0, min(len(entries), cRecoverMaxSummaryDepth+1))
+	summary, _ := p.cRecordSummaryWithScratch(entries, nil, nil)
+	return summary
+}
+
+// cRecordSummaryWithScratch records a summary in parse-scoped GSS scratch.
+// It builds the usual bounded shape inline, then reserves only the final size.
+func (p *Parser) cRecordSummaryWithScratch(entries []stackEntry, gssScratch *gssScratch, arena *nodeArena) ([]cStackSummaryEntry, ParseStopReason) {
+	if len(entries) == 0 {
+		return nil, ParseStopNone
+	}
+	if gssScratch != nil {
+		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+			return nil, reason
+		}
+	}
+	var inline [cRecoverMaxSummaryDepth + 1]cStackSummaryEntry
+	summary := inline[:0]
+	var dynamic []cStackSummaryEntry
+	var reason ParseStopReason
+	reserveDynamic := func() bool {
+		if dynamic != nil {
+			return true
+		}
+		if gssScratch != nil {
+			dynamic, reason = gssScratch.allocRecoverySummary(len(entries))
+			if reason != ParseStopNone {
+				return false
+			}
+			dynamic = dynamic[:len(summary)]
+		} else {
+			dynamic = make([]cStackSummaryEntry, len(entries))
+			dynamic = dynamic[:len(summary)]
+		}
+		copy(dynamic, summary)
+		summary = dynamic
+		return true
+	}
 	depth := 0
-	record := func(d int, st StateID, posBytes, posRow uint32) {
+	record := func(d int, st StateID, posBytes, posRow uint32) bool {
 		for j := len(summary) - 1; j >= 0; j-- {
 			if int(summary[j].depth) < d {
 				break
 			}
 			if int(summary[j].depth) == d && summary[j].state == st {
-				return
+				return true
 			}
 		}
+		if dynamic == nil && len(summary) == cap(summary) && !reserveDynamic() {
+			return false
+		}
 		summary = append(summary, cStackSummaryEntry{depth: uint8(d), state: st, posBytes: posBytes, posRow: posRow})
+		return true
 	}
 	// A node-bearing entry owns its position. Node-less discontinuities use the
 	// next payload below them. The cached index advances monotonically, so this
@@ -2820,7 +2860,9 @@ func (p *Parser) cRecordSummary(entries []stackEntry) []cStackSummaryEntry {
 				posRow = stackEntryNodeEndPoint(entries[nextPayload]).Row
 			}
 		}
-		record(depth, entry.state, posBytes, posRow)
+		if !record(depth, entry.state, posBytes, posRow) {
+			return nil, p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceScratch)
+		}
 		if cEntryCountsTowardDepth(entry) {
 			depth++
 			if depth > cRecoverMaxSummaryDepth {
@@ -2828,7 +2870,23 @@ func (p *Parser) cRecordSummary(entries []stackEntry) []cStackSummaryEntry {
 			}
 		}
 	}
-	return summary
+	if dynamic != nil {
+		return dynamic[:len(summary):len(summary)], ParseStopNone
+	}
+	if gssScratch != nil {
+		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+			return nil, reason
+		}
+		out, reason := gssScratch.allocRecoverySummary(len(summary))
+		if reason != ParseStopNone {
+			return nil, p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceScratch)
+		}
+		copy(out, summary)
+		return out[:len(summary):len(summary)], ParseStopNone
+	}
+	out := make([]cStackSummaryEntry, len(summary))
+	copy(out, summary)
+	return out[:len(out):len(out)], ParseStopNone
 }
 
 // ---------------------------------------------------------------------------
@@ -3010,7 +3068,6 @@ func (p *Parser) cReductionCandidatesForAction(source []byte, start glrStack, ac
 		return nil, reason
 	}
 	fork := start.cloneWithScratch(gssScratch)
-	fork.cRec = start.cRec.clone()
 	var dummy bool
 	deferParentLinks := p.reduceScratch != nil && p.reduceScratch.transientParents != nil
 	p.applyAction(source, &fork, act, tok, &dummy, nodeCount, arena, entryScratch, gssScratch, nil, deferParentLinks, trackChildErrors)
@@ -3400,7 +3457,11 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 				}
 			}
 		}
-		v.cRec = &cRecoverState{summary: p.cRecordSummary(entries), group: group, groupOrder: uint32(vi)}
+		summary, reason := p.cRecordSummaryWithScratch(entries, gssScratch, arena)
+		if reason != ParseStopNone {
+			return cRecHalted, false, reason
+		}
+		v.cRec = &cRecoverState{summary: summary, group: group, groupOrder: uint32(vi)}
 		v.cRecoverMissingGroup = nil
 	}
 

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -2665,3 +2665,180 @@ func TestCAcceptRootRebuildPreservesCandidateFields(t *testing.T) {
 		t.Fatalf("root field sources = %v, want %v", got, want)
 	}
 }
+
+func recoverySummaryTestEntries(count int) []stackEntry {
+	entries := make([]stackEntry, count)
+	for i := range entries {
+		entries[i] = stackEntry{state: StateID(i + 1)}
+	}
+	return entries
+}
+
+func runCHandleErrorForSummaryTest(t *testing.T, gss *gssScratch) *cRecoverState {
+	t.Helper()
+	parser := cRecoveryElectionTestParser()
+	arena := acquireNodeArena(arenaClassFull)
+	t.Cleanup(arena.Release)
+	stacks := []glrStack{newGLRStack(2)}
+	var entries glrEntryScratch
+	trackChildErrors := false
+	nodeCount := 0
+	_, _, reason := parser.cHandleError(
+		&stacks,
+		0,
+		[]byte("x"),
+		Token{Symbol: 2, StartByte: 0, EndByte: 1, EndPoint: Point{Column: 1}},
+		&nodeCount,
+		arena,
+		&entries,
+		gss,
+		&trackChildErrors,
+	)
+	if reason != ParseStopNone {
+		t.Fatalf("cHandleError stop reason = %s, want %s", reason, ParseStopNone)
+	}
+	for i := range stacks {
+		if stacks[i].cRec != nil {
+			return stacks[i].cRec
+		}
+	}
+	t.Fatalf("cHandleError produced no recovery state: %#v", stacks)
+	return nil
+}
+
+func forestEOFRecoveryTestParser() *Parser {
+	parser := cRecoveryElectionTestParser()
+	parser.language.ParseTable[2] = []uint16{1, 1}
+	return parser
+}
+
+func TestCRecoverSummaryArenaSurvivesHandleErrorReturn(t *testing.T) {
+	var scratch gssScratch
+	first := runCHandleErrorForSummaryTest(t, &scratch)
+	if len(first.summary) == 0 {
+		t.Fatal("cHandleError recorded an empty summary")
+	}
+	want := first.summary[0]
+	if first.summary[0] != want {
+		t.Fatalf("summary changed before cHandleError returned: got=%v want=%v", first.summary[0], want)
+	}
+	if first.group == nil {
+		t.Fatal("cHandleError did not attach a recovery group")
+	}
+}
+
+func TestCRecoverSummaryArenaDoesNotReuseLiveGroupStorage(t *testing.T) {
+	var scratch gssScratch
+	first := runCHandleErrorForSummaryTest(t, &scratch)
+	second := runCHandleErrorForSummaryTest(t, &scratch)
+	if len(first.summary) == 0 || len(second.summary) == 0 {
+		t.Fatal("cHandleError recorded an empty summary")
+	}
+	if &first.summary[0] == &second.summary[0] {
+		t.Fatal("summary arena reused live group storage")
+	}
+	firstState := first.summary[0].state
+	second.summary[0].state++
+	if first.summary[0].state != firstState {
+		t.Fatal("mutating a later summary changed live group storage")
+	}
+}
+
+func TestCRecoverStateCloneSharesImmutableSummary(t *testing.T) {
+	var scratch gssScratch
+	original := runCHandleErrorForSummaryTest(t, &scratch)
+	clone := original.clone()
+	if clone == original {
+		t.Fatal("clone returned the original recovery state")
+	}
+	if len(clone.summary) != len(original.summary) || &clone.summary[0] != &original.summary[0] {
+		t.Fatal("recovery-state clone copied immutable summary storage")
+	}
+}
+
+func TestForestEOFRecoverySummaryArenaLifetime(t *testing.T) {
+	parser := forestEOFRecoveryTestParser()
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	leaf := newLeafNodeInArena(arena, 1, true, 0, 3, Point{}, Point{Column: 3})
+	base := &gssForestNode{state: 1, byteOffset: 0}
+	node := &gssForestNode{
+		state:      2,
+		byteOffset: 4,
+		links:      []gssLink{{prev: base, subtree: newStackEntryNode(2, leaf)}},
+	}
+	var index gssForestIndex
+	index.init(1)
+	index.set(gssForestKey{state: 2, byteOffset: 4}, node)
+	competes, reason := parser.forestEOFRecoveryCouldCompete(&index, arena, 4, true)
+	if reason != ParseStopNone {
+		t.Fatalf("forest EOF recovery stop reason = %s, want %s", reason, ParseStopNone)
+	}
+	if !competes {
+		t.Fatal("forest EOF recovery path did not evaluate a competing recovery")
+	}
+}
+
+func TestForestEOFRecoverySummaryArenaBudgetStopsBeforeAllocation(t *testing.T) {
+	parser := forestEOFRecoveryTestParser()
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	arena.setBudget(1)
+	leaf := newLeafNodeInArena(arena, 1, true, 0, 3, Point{}, Point{Column: 3})
+	base := &gssForestNode{state: 1, byteOffset: 0}
+	node := &gssForestNode{
+		state:      2,
+		byteOffset: 4,
+		links:      []gssLink{{prev: base, subtree: newStackEntryNode(2, leaf)}},
+	}
+	var index gssForestIndex
+	index.init(1)
+	index.set(gssForestKey{state: 2, byteOffset: 4}, node)
+	competes, reason := parser.forestEOFRecoveryCouldCompete(&index, arena, 4, true)
+	if reason != ParseStopMemoryBudget {
+		t.Fatalf("forest EOF budget reason = %s, want %s", reason, ParseStopMemoryBudget)
+	}
+	if competes {
+		t.Fatal("forest EOF budget stop reported a recovery competitor")
+	}
+}
+
+func TestCReductionCandidateDoesNotDoubleCloneRecoveryState(t *testing.T) {
+	parser := newCRecoverySyntheticReduceParser()
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	var entryScratch glrEntryScratch
+	var scratch gssScratch
+	leaf := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
+	start := newGLRStack(1)
+	start.pushEntry(newStackEntryNode(2, leaf), &entryScratch, &scratch)
+	start.cRec = &cRecoverState{summary: []cStackSummaryEntry{{depth: 0, state: 1}}, group: &cRecGroup{}}
+	cloneCalls := 0
+	previousObserver := cRecoverStateCloneObserver
+	cRecoverStateCloneObserver = func() { cloneCalls++ }
+	defer func() { cRecoverStateCloneObserver = previousObserver }()
+	nodeCount := 0
+	candidates, reason := parser.cReductionCandidatesForAction(
+		nil,
+		start,
+		ParseAction{Type: ParseActionReduce, Symbol: 4, ChildCount: 1},
+		Token{},
+		&nodeCount,
+		arena,
+		&entryScratch,
+		&scratch,
+		nil,
+	)
+	if reason != ParseStopNone {
+		t.Fatalf("reduction candidate stop reason = %s, want %s", reason, ParseStopNone)
+	}
+	if len(candidates) == 0 || candidates[0].cRec == nil {
+		t.Fatal("reduction candidate lost its recovery state")
+	}
+	if cloneCalls != 1 {
+		t.Fatalf("cReductionCandidatesForAction cloned recovery state %d times, want 1", cloneCalls)
+	}
+	if &candidates[0].cRec.summary[0] != &start.cRec.summary[0] {
+		t.Fatal("reduction candidate did not preserve shared immutable recovery summary")
+	}
+}

--- a/parser_scratch.go
+++ b/parser_scratch.go
@@ -49,6 +49,7 @@ func (s *parserScratch) setBudget(bytes int64) {
 	s.budgetBytes = bytes
 	s.budgetBaselineBytes = s.allocatedBytes()
 	s.gssBaselineBytes = s.gss.allocatedBytes
+	s.gss.summaryBudgetOwner = s
 	s.merge.budgetBytes = bytes
 }
 
@@ -60,6 +61,14 @@ func (s *parserScratch) clearBudget() {
 	s.budgetBaselineBytes = 0
 	s.gssBaselineBytes = 0
 	s.merge.budgetBytes = 0
+	s.gss.summaryBudgetOwner = nil
+}
+
+func (s *parserScratch) summaryBudgetState() (int64, int64, int64) {
+	if s == nil {
+		return 0, 0, 0
+	}
+	return s.budgetBytes, s.budgetBaselineBytes, s.allocatedBytes()
 }
 
 func (s *parserScratch) allocatedBytes() int64 {


### PR DESCRIPTION
## Summary

- Add a parse-scoped arena for C recovery summaries.
- Reuse retained chunks and share immutable summaries across recovery clones.
- Stop before the parser exceeds its memory budget.

## Validation

- Focused Docker tests pass at the rebased commit.
- The exact KDL recovery fixture passes.
- The CPU-pinned campaign covers 20 seeds on each side.
- KDL bytes per operation (B/op) and allocations per operation (allocs/op) improve.
- The primary benchmark trio has no meaningful regression.
- Five RSS samples per side show no crash, timeout, swap, or out-of-memory event.

## Review

- Keep this pull request open until terminal checks turn green.
- Require the independent train review before merge.
