### PR TITLE
feat(compact): admit bounded EOF recovery

### DIFF
--- a/admission_scorecard_exact_test.go
+++ b/admission_scorecard_exact_test.go
@@ -1,0 +1,36 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestAdmissionCandidateScorecardExactDenominator(t *testing.T) {
+	if os.Getenv("GTS_COMPACT_G4_SCORECARD") != "1" {
+		t.Skip("set GTS_COMPACT_G4_SCORECARD=1 to run the exact G4 scorecard")
+	}
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+
+	counts := make(map[string]int)
+	entries := grammars.AllLanguages()
+	for _, entry := range entries {
+		row := runAdmissionScorecardLanguage(entry)
+		counts[row.status]++
+	}
+	if len(entries) != 206 || counts[scorecardPass] != 198 || counts[scorecardFallback] != 3 ||
+		counts[scorecardSkip] != 5 || counts[scorecardDiverge] != 0 || counts[scorecardError] != 0 {
+		t.Fatalf(
+			"G4 scorecard PASS=%d FALLBACK=%d SKIP=%d DIVERGE=%d ERROR=%d total=%d; want 198/3/5/0/0/206",
+			counts[scorecardPass],
+			counts[scorecardFallback],
+			counts[scorecardSkip],
+			counts[scorecardDiverge],
+			counts[scorecardError],
+			len(entries),
+		)
+	}
+}

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -40,12 +40,17 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		return nil, errors.New("admission candidate route: parser has no language")
 	}
 	options := DiagnosticParserCorePrefixOptions{
-		ReceiptMode:                     DiagnosticParserCoreReceiptSummary,
-		MaxTokens:                       1 << 24,
-		MaxDispatches:                   1 << 24,
-		Limits:                          admissionCandidateLimits(),
-		freshSchedulerSession:           true,
-		allowEOFAcceptNoActionSiblings:  p.language.CompactEOFAcceptNoActionSiblingsCertified,
+		ReceiptMode:                    DiagnosticParserCoreReceiptSummary,
+		MaxTokens:                      1 << 24,
+		MaxDispatches:                  1 << 24,
+		Limits:                         admissionCandidateLimits(),
+		freshSchedulerSession:          true,
+		allowEOFAcceptNoActionSiblings: p.language.CompactEOFAcceptNoActionSiblingsCertified,
+		// The metadata producer is private to the admission candidate. It runs
+		// only for an exact two-head EOF frontier and proves its own immutable
+		// event topology. An explicit public sibling grant keeps the legacy
+		// bypass and takes precedence in dispatchPassActive.
+		allowMetadataEOFAcceptRecovery:  true,
 		allowPrimaryAcceptDerivation:    p.language.CompactPrimaryAcceptanceDerivationCertified,
 		allowConvergedSplitDropArtifact: p.language.CompactConvergedReductionSplitDropsCertified,
 		// B3 stage S3: Recovery declares that this operation may attempt

--- a/admission_switch_eof_recovery_retirement_test.go
+++ b/admission_switch_eof_recovery_retirement_test.go
@@ -1,0 +1,122 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+func TestAdmissionCandidateRoutesEOFSiblingsWithoutProfileGrant(t *testing.T) {
+	previousForest := os.Getenv("GOT_GLR_FOREST") != "0"
+	gts.SetGLRForestEnabled(false)
+	t.Cleanup(func() { gts.SetGLRForestEnabled(previousForest) })
+
+	for _, name := range []string{"http", "robot"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			entry := grammars.DetectLanguageByName(name)
+			if entry == nil || entry.Language == nil {
+				t.Fatalf("load %s grammar", name)
+			}
+			loaded := entry.Language()
+			if loaded == nil {
+				t.Fatalf("load %s grammar", name)
+			}
+			if loaded.ExternalScanner != nil || loaded.ExternalTokenCount != 0 {
+				t.Fatalf(
+					"%s scanner state is not quiescent: scanner=%T tokens=%d",
+					name,
+					loaded.ExternalScanner,
+					loaded.ExternalTokenCount,
+				)
+			}
+			if loaded.CompactEOFAcceptNoActionSiblingsCertified {
+				t.Errorf("loaded profile still sets the legacy EOF sibling bypass")
+			}
+
+			productionLanguage := *loaded
+			productionLanguage.CompactEOFAcceptNoActionSiblingsCertified = false
+			production := gts.NewParser(&productionLanguage)
+			production.SetAdmissionCandidateRoute(false)
+			source := []byte(grammars.ParseSmokeSample(name))
+			productionTree, err := production.Parse(source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer productionTree.Release()
+			productionInspection, err := benchfixtures.InspectGoTree(productionTree.RootNode(), &productionLanguage)
+			if err != nil {
+				t.Fatalf("inspect production tree: %v", err)
+			}
+
+			legacyLanguage := *loaded
+			legacyLanguage.CompactEOFAcceptNoActionSiblingsCertified = true
+			gts.ResetAdmissionCandidateCountersForTest()
+			legacy := gts.NewParser(&legacyLanguage)
+			legacy.SetAdmissionCandidateRoute(true)
+			legacyTree, err := legacy.Parse(source)
+			if err != nil {
+				t.Fatalf("explicit legacy-bypass parse: %v", err)
+			}
+			defer legacyTree.Release()
+			legacyRouted, legacyFallback := gts.AdmissionCandidateCounters()
+			if legacyRouted != 1 || legacyFallback != 0 {
+				t.Fatalf(
+					"legacy route counters routed=%d fallback=%d reason=%q",
+					legacyRouted,
+					legacyFallback,
+					gts.AdmissionCandidateLastFallbackReason(),
+				)
+			}
+			legacyInspection, err := benchfixtures.InspectGoTree(legacyTree.RootNode(), &legacyLanguage)
+			if err != nil {
+				t.Fatalf("inspect legacy tree: %v", err)
+			}
+			if !reflect.DeepEqual(legacyInspection, productionInspection) {
+				t.Fatalf(
+					"legacy tree inspection differs: candidate=%+v production=%+v",
+					legacyInspection,
+					productionInspection,
+				)
+			}
+
+			candidateLanguage := *loaded
+			candidateLanguage.CompactEOFAcceptNoActionSiblingsCertified = false
+			gts.ResetAdmissionCandidateCountersForTest()
+			candidate := gts.NewParser(&candidateLanguage)
+			candidate.SetAdmissionCandidateRoute(true)
+			candidateTree, err := candidate.Parse(source)
+			if err != nil {
+				t.Fatalf("candidate parse: %v", err)
+			}
+			defer candidateTree.Release()
+
+			routed, fallback := gts.AdmissionCandidateCounters()
+			if routed != 1 || fallback != 0 {
+				t.Fatalf(
+					"route counters routed=%d fallback=%d reason=%q",
+					routed,
+					fallback,
+					gts.AdmissionCandidateLastFallbackReason(),
+				)
+			}
+			candidateInspection, err := benchfixtures.InspectGoTree(candidateTree.RootNode(), &candidateLanguage)
+			if err != nil {
+				t.Fatalf("inspect candidate tree: %v", err)
+			}
+			if !reflect.DeepEqual(candidateInspection, productionInspection) {
+				t.Fatalf(
+					"tree inspection differs: candidate=%+v production=%+v",
+					candidateInspection,
+					productionInspection,
+				)
+			}
+		})
+	}
+}

--- a/admission_switch_eof_recovery_retirement_test.go
+++ b/admission_switch_eof_recovery_retirement_test.go
@@ -12,6 +12,17 @@ import (
 	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 )
 
+func cloneAdmissionTestLanguage(language *gts.Language) *gts.Language {
+	source := reflect.ValueOf(language).Elem()
+	clone := reflect.New(source.Type()).Elem()
+	for i := 0; i < source.NumField(); i++ {
+		if source.Type().Field(i).IsExported() {
+			clone.Field(i).Set(source.Field(i))
+		}
+	}
+	return clone.Addr().Interface().(*gts.Language)
+}
+
 func TestAdmissionCandidateRoutesEOFSiblingsWithoutProfileGrant(t *testing.T) {
 	previousForest := os.Getenv("GOT_GLR_FOREST") != "0"
 	gts.SetGLRForestEnabled(false)
@@ -40,9 +51,9 @@ func TestAdmissionCandidateRoutesEOFSiblingsWithoutProfileGrant(t *testing.T) {
 				t.Errorf("loaded profile still sets the legacy EOF sibling bypass")
 			}
 
-			productionLanguage := *loaded
+			productionLanguage := cloneAdmissionTestLanguage(loaded)
 			productionLanguage.CompactEOFAcceptNoActionSiblingsCertified = false
-			production := gts.NewParser(&productionLanguage)
+			production := gts.NewParser(productionLanguage)
 			production.SetAdmissionCandidateRoute(false)
 			source := []byte(grammars.ParseSmokeSample(name))
 			productionTree, err := production.Parse(source)
@@ -50,15 +61,15 @@ func TestAdmissionCandidateRoutesEOFSiblingsWithoutProfileGrant(t *testing.T) {
 				t.Fatalf("production parse: %v", err)
 			}
 			defer productionTree.Release()
-			productionInspection, err := benchfixtures.InspectGoTree(productionTree.RootNode(), &productionLanguage)
+			productionInspection, err := benchfixtures.InspectGoTree(productionTree.RootNode(), productionLanguage)
 			if err != nil {
 				t.Fatalf("inspect production tree: %v", err)
 			}
 
-			legacyLanguage := *loaded
+			legacyLanguage := cloneAdmissionTestLanguage(loaded)
 			legacyLanguage.CompactEOFAcceptNoActionSiblingsCertified = true
 			gts.ResetAdmissionCandidateCountersForTest()
-			legacy := gts.NewParser(&legacyLanguage)
+			legacy := gts.NewParser(legacyLanguage)
 			legacy.SetAdmissionCandidateRoute(true)
 			legacyTree, err := legacy.Parse(source)
 			if err != nil {
@@ -74,7 +85,7 @@ func TestAdmissionCandidateRoutesEOFSiblingsWithoutProfileGrant(t *testing.T) {
 					gts.AdmissionCandidateLastFallbackReason(),
 				)
 			}
-			legacyInspection, err := benchfixtures.InspectGoTree(legacyTree.RootNode(), &legacyLanguage)
+			legacyInspection, err := benchfixtures.InspectGoTree(legacyTree.RootNode(), legacyLanguage)
 			if err != nil {
 				t.Fatalf("inspect legacy tree: %v", err)
 			}
@@ -86,10 +97,10 @@ func TestAdmissionCandidateRoutesEOFSiblingsWithoutProfileGrant(t *testing.T) {
 				)
 			}
 
-			candidateLanguage := *loaded
+			candidateLanguage := cloneAdmissionTestLanguage(loaded)
 			candidateLanguage.CompactEOFAcceptNoActionSiblingsCertified = false
 			gts.ResetAdmissionCandidateCountersForTest()
-			candidate := gts.NewParser(&candidateLanguage)
+			candidate := gts.NewParser(candidateLanguage)
 			candidate.SetAdmissionCandidateRoute(true)
 			candidateTree, err := candidate.Parse(source)
 			if err != nil {
@@ -106,7 +117,7 @@ func TestAdmissionCandidateRoutesEOFSiblingsWithoutProfileGrant(t *testing.T) {
 					gts.AdmissionCandidateLastFallbackReason(),
 				)
 			}
-			candidateInspection, err := benchfixtures.InspectGoTree(candidateTree.RootNode(), &candidateLanguage)
+			candidateInspection, err := benchfixtures.InspectGoTree(candidateTree.RootNode(), candidateLanguage)
 			if err != nil {
 				t.Fatalf("inspect candidate tree: %v", err)
 			}

--- a/cgo_harness/eof_recovery_admission_oracle_test.go
+++ b/cgo_harness/eof_recovery_admission_oracle_test.go
@@ -1,0 +1,131 @@
+//go:build cgo && treesitter_c_parity && gts_derivation_set_census && gts_eof_history_census && gts_eof_recovery_shadow && gts_eof_recovery_admission_contract
+
+package cgoharness
+
+import (
+	"os"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestEOFRecoveryAdmissionUsesLockedCEventsAndPublishedTree(t *testing.T) {
+	if !gotreesitter.EOFRecoveryAdmissionCensusBuilt() {
+		t.Fatal("EOF recovery admission receipt support is absent")
+	}
+	previousForest := os.Getenv("GOT_GLR_FOREST") != "0"
+	gotreesitter.SetGLRForestEnabled(false)
+	t.Cleanup(func() { gotreesitter.SetGLRForestEnabled(previousForest) })
+
+	want := map[string]struct {
+		frontier uint32
+		cost     uint32
+	}{
+		"http":  {frontier: 1, cost: 640},
+		"robot": {frontier: 4, cost: 1027},
+	}
+	for _, languageName := range []string{"http", "robot"} {
+		languageName := languageName
+		t.Run(languageName, func(t *testing.T) {
+			source := []byte(grammars.ParseSmokeSample(languageName))
+			cLanguage, err := COracleLanguage(languageName)
+			if err != nil {
+				t.Fatalf("load %s locked C grammar: %v", languageName, err)
+			}
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatalf("set %s locked C grammar: %v", languageName, err)
+			}
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatalf("%s locked C parser returned a nil tree", languageName)
+			}
+			defer cTree.Close()
+
+			cEvents, err := cReconstructVersionSet(cLanguage, source)
+			if err != nil {
+				t.Fatalf("reconstruct %s locked-C accepts: %v", languageName, err)
+			}
+			if len(cEvents.Accepts) != 2 || cEvents.Accepts[0].RecoverEOF ||
+				len(cEvents.Accepts[0].Folds) != 0 || !cEvents.Accepts[1].RecoverEOF ||
+				len(cEvents.Accepts[1].Folds) != 1 {
+				t.Fatalf("%s locked-C accept topology=%+v", languageName, cEvents.Accepts)
+			}
+			cHistory := runEOFAcceptHistoryCOracle(t, languageName, source)
+			if len(cHistory.Versions) != 2 {
+				t.Fatalf("%s locked-C roots=%d, want 2", languageName, len(cHistory.Versions))
+			}
+			var rootsByEvent [2]eofHistoryCVersion
+			var seen [2]bool
+			for _, version := range cHistory.Versions {
+				if version.AcceptIndex < 0 || version.AcceptIndex >= len(rootsByEvent) {
+					t.Fatalf("%s locked-C accept index=%d", languageName, version.AcceptIndex)
+				}
+				rootsByEvent[version.AcceptIndex] = version
+				seen[version.AcceptIndex] = true
+			}
+			if !seen[0] || !seen[1] || rootsByEvent[0].Shape != cHistory.Published ||
+				rootsByEvent[0].ErrorCost >= rootsByEvent[1].ErrorCost {
+				t.Fatalf("%s locked-C ordered cost election=%+v published=%s", languageName, rootsByEvent, cHistory.Published)
+			}
+
+			entry := grammars.DetectLanguageByName(languageName)
+			if entry == nil || entry.Language == nil || entry.Language() == nil {
+				t.Fatalf("load %s Go grammar", languageName)
+			}
+			goLanguage := entry.Language()
+			if goLanguage.CompactEOFAcceptNoActionSiblingsCertified {
+				t.Error("loaded profile still sets the legacy EOF sibling bypass")
+			}
+			candidateLanguage := *goLanguage
+			candidateLanguage.CompactEOFAcceptNoActionSiblingsCertified = false
+			gotreesitter.EOFRecoveryAdmissionCensusReset()
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			goParser := gotreesitter.NewParser(&candidateLanguage)
+			goParser.SetAdmissionCandidateRoute(true)
+			goTree, err := goParser.Parse(source)
+			if err != nil {
+				t.Fatalf("parse %s admission route: %v", languageName, err)
+			}
+			defer goTree.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			if routedAfter-routedBefore != 1 || fallbackAfter-fallbackBefore != 0 {
+				t.Fatalf(
+					"%s admission counter delta routed=%d fallback=%d reason=%q",
+					languageName,
+					routedAfter-routedBefore,
+					fallbackAfter-fallbackBefore,
+					gotreesitter.AdmissionCandidateLastFallbackReason(),
+				)
+			}
+			assertLockedCTreeExact(t, languageName+" EOF admission", goTree, &candidateLanguage, cTree)
+
+			receipts := gotreesitter.EOFRecoveryAdmissionCensusSnapshot()
+			if len(receipts) != 1 {
+				t.Fatalf("%s admission receipts=%d, want 1", languageName, len(receipts))
+			}
+			receipt := receipts[0]
+			expected := want[languageName]
+			if receipt.State != "consumed" || receipt.ConstructionRoute != "public_tree" ||
+				receipt.ConsumptionCount != 1 || receipt.CoreGeneration == 0 ||
+				receipt.SourceLength != uint32(len(source)) || len(receipt.Events) != 2 ||
+				receipt.Events[0].Ordinal != 0 || receipt.Events[0].Kind != "normal" ||
+				receipt.Events[1].Ordinal != 1 || receipt.Events[1].Kind != "recover_eof" ||
+				receipt.Events[0].Cost != rootsByEvent[0].ErrorCost ||
+				receipt.Events[1].Cost != rootsByEvent[1].ErrorCost ||
+				receipt.Events[0].Cost != 0 || receipt.Events[1].Cost != expected.cost ||
+				receipt.NormalFrontier != 1 || receipt.RecoveryFrontier != expected.frontier ||
+				receipt.SelectedEvent != 0 || !receipt.MetadataOnly ||
+				receipt.Work.BytesInspected != uint64(len(source)) ||
+				receipt.Work.MaxDepth > 256 || receipt.Work.PayloadRecordsVisited > 65536 ||
+				receipt.Work.MaxChildGroup > 64 || receipt.Work.MaxSourceChunk > 4096 ||
+				receipt.Work.Overflow || receipt.Work.PublicationAttempts != 0 {
+				t.Fatalf("%s admission receipt does not match locked C: %+v", languageName, receipt)
+			}
+			t.Logf("%s option-A receipt: %+v", languageName, receipt)
+		})
+	}
+}

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -71,16 +71,13 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 			},
 		},
 	},
-	// These exact artifacts select one accepting EOF head while all sibling
-	// heads have no EOF action. Field-aware C-oracle parity certifies the
-	// production selection for each smoke witness.
+	// These exact artifacts previously needed the EOF sibling grant.
+	// The authenticated metadata route now proves the locked-C election.
 	"http": {
-		blobSHA256:                       mustRuntimeProfileSHA256("332d50a15b3facb407f6c449fe8bbcd2fda55efffefbfd4d8d9ce2c75fbb7bda"),
-		compactEOFAcceptNoActionSiblings: true,
+		blobSHA256: mustRuntimeProfileSHA256("332d50a15b3facb407f6c449fe8bbcd2fda55efffefbfd4d8d9ce2c75fbb7bda"),
 	},
 	"robot": {
-		blobSHA256:                       mustRuntimeProfileSHA256("25075ecf5323eeb88af4f71b55f51867cef38a277aaa60f01b879ee8abb4c74f"),
-		compactEOFAcceptNoActionSiblings: true,
+		blobSHA256: mustRuntimeProfileSHA256("25075ecf5323eeb88af4f71b55f51867cef38a277aaa60f01b879ee8abb4c74f"),
 	},
 	// html_erroneous_end_tag (campaign v7 tranche B3 stage S3): C-oracle parity
 	// certifies native strategy-2 recovery (error-region absorb and

--- a/grammars/runtime_profiles_eof_retirement_test.go
+++ b/grammars/runtime_profiles_eof_retirement_test.go
@@ -1,0 +1,59 @@
+package grammars
+
+import (
+	"sort"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+func TestCompactGraduationGrantDenominatorAfterEOFRetirement(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+	for _, test := range []struct {
+		name string
+		load func() *gotreesitter.Language
+	}{
+		{name: "http", load: HttpLanguage},
+		{name: "robot", load: RobotLanguage},
+	} {
+		language := test.load()
+		if language.CompactEOFAcceptNoActionSiblingsCertified {
+			t.Errorf("loaded %s profile still sets the legacy EOF sibling bypass", test.name)
+		}
+	}
+
+	activeGrammars := make(map[string]struct{})
+	activeFlags := 0
+	var eofSiblingGrants []string
+	for name, profile := range builtinLanguageRuntimeProfiles {
+		flags := [...]bool{
+			profile.compactConvergedSplitDrops,
+			profile.compactEOFAcceptNoActionSiblings,
+			profile.compactPrimaryAcceptDerivation,
+			profile.compactStrategy2ErrorRegion,
+		}
+		for _, active := range flags {
+			if !active {
+				continue
+			}
+			activeFlags++
+			activeGrammars[name] = struct{}{}
+		}
+		if profile.compactEOFAcceptNoActionSiblings {
+			eofSiblingGrants = append(eofSiblingGrants, name)
+		}
+	}
+	sort.Strings(eofSiblingGrants)
+
+	if len(eofSiblingGrants) != 0 {
+		t.Errorf("EOF sibling grants remain: %v", eofSiblingGrants)
+	}
+	if activeFlags != 15 || len(activeGrammars) != 12 {
+		t.Errorf(
+			"compact profile denominator is %d flags across %d grammars, want 15 across 12",
+			activeFlags,
+			len(activeGrammars),
+		)
+	}
+}

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -151,24 +151,61 @@ func TestBuiltinObjcExactStackEquivalenceProfileRequiresExactBlobIdentity(t *tes
 	}
 }
 
+func TestBuiltinCompactEOFProfilesRetireOnlyHTTPAndRobotField(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+
+	for _, test := range []struct {
+		name string
+		load func() *gotreesitter.Language
+	}{
+		{name: "http", load: HttpLanguage},
+		{name: "robot", load: RobotLanguage},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			profile, ok := builtinLanguageRuntimeProfiles[test.name]
+			if !ok {
+				t.Fatal("retired EOF profile lost its exact blob record")
+			}
+			blob := BlobByName(test.name)
+			if len(blob) == 0 || sha256.Sum256(blob) != profile.blobSHA256 {
+				t.Fatal("retired EOF profile blob identity changed")
+			}
+			if language := test.load(); language.CompactEOFAcceptNoActionSiblingsCertified {
+				t.Fatal("exact built-in artifact retained the legacy EOF sibling field")
+			}
+
+			custom := &gotreesitter.Language{Name: test.name}
+			AttachLanguageSupport(test.name, custom)
+			if custom.CompactEOFAcceptNoActionSiblingsCertified {
+				t.Fatal("same-name custom grammar enabled the retired EOF sibling field")
+			}
+
+			wrongIdentity := &gotreesitter.Language{Name: test.name}
+			if attachBuiltinLanguageRuntimeProfile(test.name, sha256.Sum256([]byte("uncertified")), wrongIdentity) {
+				t.Fatal("wrong blob identity unexpectedly attached a runtime profile")
+			}
+			if wrongIdentity.CompactEOFAcceptNoActionSiblingsCertified {
+				t.Fatal("wrong blob identity enabled the retired EOF sibling field")
+			}
+
+			exact := &gotreesitter.Language{Name: test.name}
+			if attachBuiltinLanguageRuntimeProfile(test.name, profile.blobSHA256, exact) {
+				t.Fatal("exact retired profile unexpectedly changed a language field")
+			}
+			if exact.CompactEOFAcceptNoActionSiblingsCertified {
+				t.Fatal("exact retired profile enabled the legacy EOF sibling field")
+			}
+		})
+	}
+}
+
 func TestBuiltinCompactAcceptanceProfilesRequireExactBlobIdentity(t *testing.T) {
 	tests := []struct {
 		name string
 		load func() *gotreesitter.Language
 		want func(*gotreesitter.Language) bool
 	}{
-		{
-			name: "http", load: HttpLanguage,
-			want: func(lang *gotreesitter.Language) bool {
-				return lang.CompactEOFAcceptNoActionSiblingsCertified
-			},
-		},
-		{
-			name: "robot", load: RobotLanguage,
-			want: func(lang *gotreesitter.Language) bool {
-				return lang.CompactEOFAcceptNoActionSiblingsCertified
-			},
-		},
 		{
 			name: "meson", load: MesonLanguage,
 			want: func(lang *gotreesitter.Language) bool {

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1381,6 +1381,15 @@ func New(tables TableView, limits Limits) (*Core, error) {
 	return core, nil
 }
 
+// AuthenticationGeneration identifies the current Core capability phase.
+// It changes before an operation can reuse an invalidated arena handle.
+func (c *Core) AuthenticationGeneration() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.classificationPhase
+}
+
 // Reset returns the compact core to the same empty frontier created by New
 // while retaining its authenticated tables, limits, diagnostic policy, and
 // arena capacities. Reset is deliberately unavailable during an active

--- a/internal/parsercorephase0/eof_admission_view.go
+++ b/internal/parsercorephase0/eof_admission_view.go
@@ -1,0 +1,243 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	// EOFAdmissionMaxTopPayloads bounds one exact accepted stack path.
+	EOFAdmissionMaxTopPayloads = 4096
+	// EOFAdmissionMetadataGroupSize is the producer poll cadence.
+	EOFAdmissionMetadataGroupSize = 64
+)
+
+var (
+	// ErrEOFAdmissionGenerationChanged reports stale immutable Core handles.
+	ErrEOFAdmissionGenerationChanged = errors.New("parser-core phase zero: EOF admission Core generation changed")
+	// ErrEOFAdmissionInexactPath reports a path with more than one history.
+	ErrEOFAdmissionInexactPath = errors.New("parser-core phase zero: EOF admission path is not exact and singular")
+	// ErrEOFAdmissionTopPayloadCap reports a path wider than the fixed cursor.
+	ErrEOFAdmissionTopPayloadCap = errors.New("parser-core phase zero: EOF admission top payload cap")
+	// ErrEOFAdmissionMalformed reports an invalid immutable arena record.
+	ErrEOFAdmissionMalformed = errors.New("parser-core phase zero: malformed EOF admission record")
+)
+
+// EOFAdmissionSubtreeView exposes one immutable subtree record to a callback.
+// Its slices alias Core arenas and remain valid only during that callback.
+type EOFAdmissionSubtreeView struct {
+	Generation            uint64
+	Identity              SubtreeID
+	Symbol                Symbol
+	ProductionID          uint16
+	DynamicPrecedence     int16
+	StartByte             uint32
+	EndByte               uint32
+	Children              []SubtreeID
+	Fields                []FieldMapEntry
+	Aliases               []Symbol
+	Extra                 bool
+	External              bool
+	Terminal              bool
+	Fragile               bool
+	Missing               bool
+	MetadataAuthenticated bool
+}
+
+// EOFAdmissionExactPath reports the authenticated facts for one stack path.
+type EOFAdmissionExactPath struct {
+	Generation     uint64
+	Payloads       uint32
+	Links          uint32
+	Polls          uint32
+	Score          int64
+	BranchOrder    uint64
+	HasBranchOrder bool
+}
+
+func (c *Core) checkEOFAdmissionGeneration(generation uint64) error {
+	if c == nil || generation == 0 || c.AuthenticationGeneration() != generation {
+		return ErrEOFAdmissionGenerationChanged
+	}
+	return nil
+}
+
+func (c *Core) pollEOFAdmissionGeneration(generation uint64, poll func() error) error {
+	if err := c.checkEOFAdmissionGeneration(generation); err != nil {
+		return err
+	}
+	if poll != nil {
+		if err := poll(); err != nil {
+			return err
+		}
+	}
+	return c.checkEOFAdmissionGeneration(generation)
+}
+
+func eofAdmissionArenaRange(first, count uint32, total int, name string) (int, int, error) {
+	end := uint64(first) + uint64(count)
+	if end > uint64(total) {
+		return 0, 0, fmt.Errorf("%w: %s range is outside its arena", ErrEOFAdmissionMalformed, name)
+	}
+	return int(first), int(end), nil
+}
+
+// VisitEOFAdmissionSubtree supplies one callback-scoped immutable record.
+// It validates the Core generation before and after the callback.
+func (c *Core) VisitEOFAdmissionSubtree(
+	id SubtreeID,
+	generation uint64,
+	visit func(EOFAdmissionSubtreeView) error,
+) error {
+	if visit == nil {
+		return errors.New("parser-core phase zero: EOF admission subtree visitor is nil")
+	}
+	if err := c.checkEOFAdmissionGeneration(generation); err != nil {
+		return err
+	}
+	record, err := c.subtree(id)
+	if err != nil {
+		return err
+	}
+	childStart, childEnd, err := eofAdmissionArenaRange(
+		record.firstChild,
+		record.childCount,
+		len(c.children),
+		"child",
+	)
+	if err != nil {
+		return err
+	}
+	fieldStart, fieldEnd, err := eofAdmissionArenaRange(
+		record.firstField,
+		record.fieldCount,
+		len(c.fields),
+		"field",
+	)
+	if err != nil {
+		return err
+	}
+	aliasStart, aliasEnd, err := eofAdmissionArenaRange(
+		record.firstAlias,
+		record.aliasCount,
+		len(c.aliases),
+		"alias",
+	)
+	if err != nil {
+		return err
+	}
+	if record.startByte > record.endByte {
+		return fmt.Errorf("%w: subtree span is reversed", ErrEOFAdmissionMalformed)
+	}
+	view := EOFAdmissionSubtreeView{
+		Generation:        generation,
+		Identity:          id,
+		Symbol:            record.symbol,
+		ProductionID:      record.productionID,
+		DynamicPrecedence: record.dynamicPrecedence,
+		StartByte:         record.startByte,
+		EndByte:           record.endByte,
+		Children:          c.children[childStart:childEnd],
+		Fields:            c.fields[fieldStart:fieldEnd],
+		Aliases:           c.aliases[aliasStart:aliasEnd],
+		Extra:             record.extra,
+		External:          record.external,
+		Terminal:          record.terminal,
+		Fragile:           record.fragile,
+		// Compact production records cannot encode a missing payload. Keep the
+		// explicit field in this audit view so a future encoding must opt in.
+		Missing:               false,
+		MetadataAuthenticated: c.metadataConstructionAuthenticated,
+	}
+	if err := visit(view); err != nil {
+		return err
+	}
+	return c.checkEOFAdmissionGeneration(generation)
+}
+
+// VisitEOFAdmissionExactPath visits one exact stack path in source order.
+// The fixed reverse-link buffer makes the successful path allocation-free.
+func (c *Core) VisitEOFAdmissionExactPath(
+	head Head,
+	generation uint64,
+	poll func() error,
+	visit func(ordinal uint32, payload SubtreeID) error,
+) (EOFAdmissionExactPath, error) {
+	var result EOFAdmissionExactPath
+	result.Generation = generation
+	if visit == nil {
+		return result, errors.New("parser-core phase zero: EOF admission path visitor is nil")
+	}
+	if err := c.pollEOFAdmissionGeneration(generation, poll); err != nil {
+		return result, err
+	}
+	result.Polls++
+	var reverse [EOFAdmissionMaxTopPayloads]LinkID
+	id := head.Node
+	for {
+		node, err := c.node(id)
+		if err != nil {
+			return result, err
+		}
+		if node.pathCount != 1 {
+			return result, ErrEOFAdmissionInexactPath
+		}
+		if node.linkCount == 0 {
+			break
+		}
+		if node.linkCount != 1 {
+			return result, ErrEOFAdmissionInexactPath
+		}
+		if result.Links%EOFAdmissionMetadataGroupSize == 0 {
+			if err := c.pollEOFAdmissionGeneration(generation, poll); err != nil {
+				return result, err
+			}
+			result.Polls++
+		}
+		if result.Links >= EOFAdmissionMaxTopPayloads {
+			return result, ErrEOFAdmissionTopPayloadCap
+		}
+		linkID := LinkID(node.firstLink)
+		if linkID == 0 || uint64(linkID) > uint64(len(c.links)) {
+			return result, fmt.Errorf("%w: link is outside its arena", ErrEOFAdmissionMalformed)
+		}
+		link := c.links[linkID-1]
+		if link.next != 0 {
+			return result, fmt.Errorf("%w: adjacency is not singular", ErrEOFAdmissionMalformed)
+		}
+		if link.prev == 0 || link.prev >= id {
+			return result, fmt.Errorf("%w: predecessor does not decrease", ErrEOFAdmissionMalformed)
+		}
+		if link.payload == 0 || uint64(link.payload) > uint64(len(c.subtrees)) {
+			return result, fmt.Errorf("%w: payload is outside its arena", ErrEOFAdmissionMalformed)
+		}
+		reverse[result.Links] = linkID
+		result.Links++
+		id = link.prev
+	}
+	result.Payloads = result.Links
+	for reverseIndex := int(result.Links) - 1; reverseIndex >= 0; reverseIndex-- {
+		link := c.links[reverse[reverseIndex]-1]
+		score, err := checkedAddScore(result.Score, link.scoreDelta)
+		if err != nil {
+			return result, err
+		}
+		result.Score = score
+		if link.hasOrder() {
+			result.BranchOrder = link.order
+			result.HasBranchOrder = true
+		}
+		ordinal := result.Links - 1 - uint32(reverseIndex)
+		if err := visit(ordinal, link.payload); err != nil {
+			return result, err
+		}
+		if err := c.checkEOFAdmissionGeneration(generation); err != nil {
+			return result, err
+		}
+	}
+	if err := c.pollEOFAdmissionGeneration(generation, poll); err != nil {
+		return result, err
+	}
+	result.Polls++
+	return result, nil
+}

--- a/internal/parsercorephase0/eof_admission_view_test.go
+++ b/internal/parsercorephase0/eof_admission_view_test.go
@@ -1,0 +1,166 @@
+package parsercorephase0
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func newEOFAdmissionViewFixture(t *testing.T) (*Core, Head, SubtreeID, []SubtreeID) {
+	t.Helper()
+	compact, err := New(&fakeTable{}, Limits{
+		MaxNodes: 64, MaxLinks: 64, MaxSubtrees: 64, MaxChildren: 64,
+		MaxMetadata: 64, MaxLinksPerBoundary: 8, MaxPopPaths: 8, MaxDerivations: 8,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := compact.appendSubtreeRecord(subtreeRecord{
+		symbol: 10, startByte: 0, endByte: 1, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := compact.appendSubtreeRecord(subtreeRecord{
+		symbol: 11, startByte: 1, endByte: 2, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	children := []SubtreeID{left, right}
+	parent, err := compact.appendSubtreeRecord(subtreeRecord{
+		symbol: 20, productionID: 7, dynamicPrecedence: 3, startByte: 0, endByte: 2,
+	}, children, []FieldMapEntry{{FieldID: 4, ChildIndex: 1}}, []Symbol{0, 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.condense(compact.boundaryKey(2, 2), linkInput{
+		prev: seed.Node, payload: parent, scoreDelta: 5,
+		order: ForkOrder{Value: 8, Present: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tail, err := compact.appendSubtreeRecord(subtreeRecord{
+		symbol: 12, startByte: 2, endByte: 3, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err = compact.condense(compact.boundaryKey(3, 3), linkInput{
+		prev: head.Node, payload: tail, scoreDelta: -2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return compact, head, parent, []SubtreeID{parent, tail}
+}
+
+func TestEOFAdmissionViewAndExactPathCursor(t *testing.T) {
+	compact, head, parent, wantPayloads := newEOFAdmissionViewFixture(t)
+	generation := compact.AuthenticationGeneration()
+	var got EOFAdmissionSubtreeView
+	if err := compact.VisitEOFAdmissionSubtree(parent, generation, func(view EOFAdmissionSubtreeView) error {
+		got = view
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got.Generation != generation || got.Identity != parent || got.Symbol != 20 ||
+		got.ProductionID != 7 || got.DynamicPrecedence != 3 || got.StartByte != 0 || got.EndByte != 2 ||
+		got.Extra || got.External || got.Terminal || got.Fragile || got.Missing ||
+		!reflect.DeepEqual(got.Children, []SubtreeID{1, 2}) ||
+		!reflect.DeepEqual(got.Fields, []FieldMapEntry{{FieldID: 4, ChildIndex: 1}}) ||
+		!reflect.DeepEqual(got.Aliases, []Symbol{0, 30}) {
+		t.Fatalf("borrowed view=%+v", got)
+	}
+
+	var payloads []SubtreeID
+	polls := 0
+	path, err := compact.VisitEOFAdmissionExactPath(
+		head,
+		generation,
+		func() error { polls++; return nil },
+		func(_ uint32, payload SubtreeID) error {
+			payloads = append(payloads, payload)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(payloads, wantPayloads) || path.Payloads != 2 || path.Links != 2 ||
+		path.Score != 3 || !path.HasBranchOrder || path.BranchOrder != 8 ||
+		path.Polls != uint32(polls) || polls != 3 {
+		t.Fatalf("path=%+v payloads=%v polls=%d", path, payloads, polls)
+	}
+}
+
+func TestEOFAdmissionExactPathCursorAllocatesZero(t *testing.T) {
+	compact, head, _, _ := newEOFAdmissionViewFixture(t)
+	generation := compact.AuthenticationGeneration()
+	poll := func() error { return nil }
+	visit := func(uint32, SubtreeID) error { return nil }
+	if _, err := compact.VisitEOFAdmissionExactPath(head, generation, poll, visit); err != nil {
+		t.Fatal(err)
+	}
+	allocations := testing.AllocsPerRun(100, func() {
+		if _, err := compact.VisitEOFAdmissionExactPath(head, generation, poll, visit); err != nil {
+			panic(err)
+		}
+	})
+	if allocations != 0 {
+		t.Fatalf("exact path cursor allocations=%v, want 0", allocations)
+	}
+}
+
+func TestEOFAdmissionViewRejectsMalformedRangesAndGenerationChanges(t *testing.T) {
+	t.Run("alias-range", func(t *testing.T) {
+		compact, _, parent, _ := newEOFAdmissionViewFixture(t)
+		compact.subtrees[parent-1].firstAlias = uint32(len(compact.aliases) + 1)
+		err := compact.VisitEOFAdmissionSubtree(
+			parent,
+			compact.AuthenticationGeneration(),
+			func(EOFAdmissionSubtreeView) error { return nil },
+		)
+		if err == nil || !strings.Contains(err.Error(), "alias range") {
+			t.Fatalf("malformed alias range error=%v", err)
+		}
+	})
+
+	t.Run("subtree-callback-generation", func(t *testing.T) {
+		compact, _, parent, _ := newEOFAdmissionViewFixture(t)
+		generation := compact.AuthenticationGeneration()
+		err := compact.VisitEOFAdmissionSubtree(parent, generation, func(EOFAdmissionSubtreeView) error {
+			return compact.BeginFrontier()
+		})
+		if err == nil || !strings.Contains(err.Error(), "generation changed") {
+			t.Fatalf("callback generation error=%v", err)
+		}
+	})
+
+	t.Run("path-poll-generation", func(t *testing.T) {
+		compact, head, _, _ := newEOFAdmissionViewFixture(t)
+		generation := compact.AuthenticationGeneration()
+		mutated := false
+		_, err := compact.VisitEOFAdmissionExactPath(
+			head,
+			generation,
+			func() error {
+				if mutated {
+					return nil
+				}
+				mutated = true
+				return compact.BeginFrontier()
+			},
+			func(uint32, SubtreeID) error { return nil },
+		)
+		if err == nil || !strings.Contains(err.Error(), "generation changed") {
+			t.Fatalf("poll generation error=%v", err)
+		}
+	})
+}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -5,6 +5,7 @@ package gotreesitter
 import (
 	"crypto/sha256"
 	_ "embed"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -66,6 +67,7 @@ type DiagnosticParserCorePrefixOptions struct {
 	// These acceptance options require exact artifact certification. Diagnostic
 	// callers retain the conservative false defaults.
 	allowEOFAcceptNoActionSiblings  bool
+	allowMetadataEOFAcceptRecovery  bool
 	allowPrimaryAcceptDerivation    bool
 	allowConvergedSplitDropArtifact bool
 	// allowCompactStrategy2ErrorRegion permits the generic scheduler to
@@ -137,6 +139,104 @@ type DiagnosticParserCorePrefixOptions struct {
 	materializationForceReplayParseStates bool
 	materializationContextSet             bool
 }
+
+type compactEOFRecoveryAdmissionState uint8
+
+const (
+	compactEOFRecoveryAdmissionEmpty compactEOFRecoveryAdmissionState = iota
+	compactEOFRecoveryAdmissionProduced
+	compactEOFRecoveryAdmissionPreApplyValidated
+	compactEOFRecoveryAdmissionAcceptApplied
+	compactEOFRecoveryAdmissionRecoveryDropped
+	compactEOFRecoveryAdmissionCompleted
+	compactEOFRecoveryAdmissionSchedulerReturned
+	compactEOFRecoveryAdmissionConsumed
+	compactEOFRecoveryAdmissionInvalid compactEOFRecoveryAdmissionState = 255
+)
+
+type compactEOFRecoveryAdmissionEventKind uint8
+
+const (
+	compactEOFRecoveryAdmissionEventNormal compactEOFRecoveryAdmissionEventKind = iota + 1
+	compactEOFRecoveryAdmissionEventRecover
+)
+
+type compactEOFRecoveryAdmissionRoute uint8
+
+const (
+	compactEOFRecoveryAdmissionRoutePublicTree compactEOFRecoveryAdmissionRoute = iota
+	compactEOFRecoveryAdmissionRouteSelectedStore
+	compactEOFRecoveryAdmissionRouteNone compactEOFRecoveryAdmissionRoute = 255
+)
+
+type compactEOFRecoveryAdmissionEvent struct {
+	ordinal           int
+	kind              compactEOFRecoveryAdmissionEventKind
+	cost              uint32
+	dynamicPrecedence int64
+}
+
+type compactEOFRecoveryAdmissionWork struct {
+	polls                      uint64
+	sourceChunks               uint64
+	childGroups                uint64
+	pathsVisited               uint64
+	linksVisited               uint64
+	payloadRecordsVisited      uint64
+	maxDepth                   uint64
+	bytesInspected             uint64
+	maxSourceChunk             uint64
+	maxChildGroup              uint64
+	checkedArithmetic          uint64
+	publicationAttempts        uint64
+	parserConstructions        uint64
+	treeConstructions          uint64
+	selectedStoreConstructions uint64
+	overflow                   bool
+}
+
+type compactEOFRecoveryAdmissionReceipt struct {
+	active              bool
+	valid               bool
+	state               compactEOFRecoveryAdmissionState
+	seal                [32]byte
+	transitionSeals     [7][32]byte
+	transitions         [7]compactEOFRecoveryAdmissionState
+	transitionCount     uint8
+	declineReason       string
+	coreGeneration      uint64
+	electionIndex       int
+	token               Token
+	sourceLength        uint32
+	sourceSHA256        [32]byte
+	normalHead          core.Head
+	recoveryHead        core.Head
+	normalCreationSeq   uint64
+	recoveryCreationSeq uint64
+	normalLineage       uint16
+	recoveryLineage     uint16
+	normalFingerprint   [32]byte
+	recoveryFingerprint [32]byte
+	normalPayloads      uint32
+	recoveryPayloads    uint32
+	normalOccurrences   uint32
+	recoveryOccurrences uint32
+	normalFrontier      uint32
+	recoveryFrontier    uint32
+	events              [2]compactEOFRecoveryAdmissionEvent
+	selectedEvent       int
+	metadataOnly        bool
+	consumptionCount    uint64
+	constructionRoute   compactEOFRecoveryAdmissionRoute
+	observedErrorCost   uint32
+	work                compactEOFRecoveryAdmissionWork
+}
+
+var (
+	compactEOFRecoveryAdmissionFaultHook    func(*diagnosticParserCoreGenericScheduler, string) error
+	compactEOFRecoveryAdmissionOverflowHook func(*diagnosticParserCoreGenericScheduler, string) bool
+	compactEOFRecoveryAdmissionCensusHook   func(compactEOFRecoveryAdmissionReceipt)
+)
 
 type DiagnosticParserCoreScannerCheckpoint struct {
 	Length int
@@ -1831,6 +1931,7 @@ type diagnosticParserCoreGenericScheduler struct {
 	epochProgress                 bool
 	acceptedHead                  core.Head
 	acceptedPayloads              []core.SubtreeID
+	eofRecoveryAdmission          compactEOFRecoveryAdmissionReceipt
 	conflictPostExecutionFault    func() error
 	extraPostExecutionFault       func() error
 	freshSessionOwner             *core.SchedulerTransactionToken
@@ -1851,6 +1952,1234 @@ type diagnosticParserCoreGenericScheduler struct {
 	corridorRows  []core.ActionRow
 	corridorCells [1]diagnosticParserCoreGenericCell
 	capPressure   diagnosticParserCoreCapPressurePrediction
+}
+
+const (
+	compactEOFRecoveryAdmissionSourceChunkBytes = 4096
+	compactEOFRecoveryAdmissionChildGroupSize   = core.EOFAdmissionMetadataGroupSize
+	compactEOFRecoveryAdmissionMaxTopPayloads   = core.EOFAdmissionMaxTopPayloads
+	compactEOFRecoveryAdmissionMaxDepth         = 256
+	compactEOFRecoveryAdmissionMaxOccurrences   = 65536
+)
+
+func (state compactEOFRecoveryAdmissionState) String() string {
+	switch state {
+	case compactEOFRecoveryAdmissionEmpty:
+		return "empty"
+	case compactEOFRecoveryAdmissionProduced:
+		return "produced"
+	case compactEOFRecoveryAdmissionPreApplyValidated:
+		return "pre_apply_validated"
+	case compactEOFRecoveryAdmissionAcceptApplied:
+		return "accept_applied"
+	case compactEOFRecoveryAdmissionRecoveryDropped:
+		return "recovery_dropped"
+	case compactEOFRecoveryAdmissionCompleted:
+		return "completed"
+	case compactEOFRecoveryAdmissionSchedulerReturned:
+		return "scheduler_returned"
+	case compactEOFRecoveryAdmissionConsumed:
+		return "consumed"
+	case compactEOFRecoveryAdmissionInvalid:
+		return "invalid"
+	default:
+		return "unknown"
+	}
+}
+
+func (kind compactEOFRecoveryAdmissionEventKind) String() string {
+	switch kind {
+	case compactEOFRecoveryAdmissionEventNormal:
+		return "normal"
+	case compactEOFRecoveryAdmissionEventRecover:
+		return "recover_eof"
+	default:
+		return "unknown"
+	}
+}
+
+func (route compactEOFRecoveryAdmissionRoute) String() string {
+	switch route {
+	case compactEOFRecoveryAdmissionRoutePublicTree:
+		return "public_tree"
+	case compactEOFRecoveryAdmissionRouteSelectedStore:
+		return "selected_store"
+	default:
+		return "none"
+	}
+}
+
+func compactEOFRecoveryAdmissionCheckedAdd(left, right uint64) (uint64, bool) {
+	if math.MaxUint64-left < right {
+		return 0, false
+	}
+	return left + right, true
+}
+
+func compactEOFRecoveryAdmissionCheckedMul(left, right uint64) (uint64, bool) {
+	if left != 0 && right > math.MaxUint64/left {
+		return 0, false
+	}
+	return left * right, true
+}
+
+func compactEOFRecoveryAdmissionSeal(receipt *compactEOFRecoveryAdmissionReceipt, previous [32]byte) [32]byte {
+	if receipt == nil {
+		return [32]byte{}
+	}
+	hasher := sha256.New()
+	var scratch [8]byte
+	writeUint64 := func(value uint64) {
+		binary.LittleEndian.PutUint64(scratch[:], value)
+		_, _ = hasher.Write(scratch[:])
+	}
+	writeBool := func(value bool) {
+		if value {
+			writeUint64(1)
+			return
+		}
+		writeUint64(0)
+	}
+	_, _ = hasher.Write(previous[:])
+	writeUint64(uint64(receipt.state))
+	writeUint64(uint64(receipt.transitionCount))
+	writeBool(receipt.active)
+	writeBool(receipt.valid)
+	writeUint64(receipt.coreGeneration)
+	writeUint64(uint64(receipt.electionIndex))
+	writeUint64(uint64(receipt.token.Symbol))
+	writeUint64(uint64(receipt.token.StartByte))
+	writeUint64(uint64(receipt.token.EndByte))
+	writeBool(receipt.token.Missing)
+	writeBool(receipt.token.NoLookahead)
+	writeBool(receipt.token.ExternalScannerToken)
+	writeUint64(uint64(receipt.sourceLength))
+	_, _ = hasher.Write(receipt.sourceSHA256[:])
+	writeUint64(uint64(receipt.normalHead.Node))
+	writeUint64(uint64(receipt.recoveryHead.Node))
+	writeUint64(receipt.normalCreationSeq)
+	writeUint64(receipt.recoveryCreationSeq)
+	writeUint64(uint64(receipt.normalLineage))
+	writeUint64(uint64(receipt.recoveryLineage))
+	_, _ = hasher.Write(receipt.normalFingerprint[:])
+	_, _ = hasher.Write(receipt.recoveryFingerprint[:])
+	writeUint64(uint64(receipt.normalPayloads))
+	writeUint64(uint64(receipt.recoveryPayloads))
+	writeUint64(uint64(receipt.normalOccurrences))
+	writeUint64(uint64(receipt.recoveryOccurrences))
+	writeUint64(uint64(receipt.normalFrontier))
+	writeUint64(uint64(receipt.recoveryFrontier))
+	for _, event := range receipt.events {
+		writeUint64(uint64(event.ordinal))
+		writeUint64(uint64(event.kind))
+		writeUint64(uint64(event.cost))
+		writeUint64(uint64(event.dynamicPrecedence))
+	}
+	writeUint64(uint64(receipt.selectedEvent))
+	writeBool(receipt.metadataOnly)
+	writeUint64(receipt.consumptionCount)
+	writeUint64(uint64(receipt.constructionRoute))
+	writeUint64(uint64(receipt.observedErrorCost))
+	work := receipt.work
+	for _, value := range [...]uint64{
+		work.polls,
+		work.sourceChunks,
+		work.childGroups,
+		work.pathsVisited,
+		work.linksVisited,
+		work.payloadRecordsVisited,
+		work.maxDepth,
+		work.bytesInspected,
+		work.maxSourceChunk,
+		work.maxChildGroup,
+		work.checkedArithmetic,
+		work.publicationAttempts,
+		work.parserConstructions,
+		work.treeConstructions,
+		work.selectedStoreConstructions,
+	} {
+		writeUint64(value)
+	}
+	writeBool(work.overflow)
+	var sum [32]byte
+	copy(sum[:], hasher.Sum(nil))
+	return sum
+}
+
+func compactEOFRecoveryAdmissionSealIsValid(receipt *compactEOFRecoveryAdmissionReceipt) bool {
+	if receipt == nil || receipt.transitionCount == 0 ||
+		int(receipt.transitionCount) > len(receipt.transitionSeals) {
+		return false
+	}
+	var previous [32]byte
+	if receipt.transitionCount > 1 {
+		previous = receipt.transitionSeals[receipt.transitionCount-2]
+	}
+	want := compactEOFRecoveryAdmissionSeal(receipt, previous)
+	return receipt.seal != ([32]byte{}) && receipt.seal == want &&
+		receipt.transitionSeals[receipt.transitionCount-1] == want
+}
+
+func compactEOFRecoveryAdmissionTransition(
+	receipt *compactEOFRecoveryAdmissionReceipt,
+	next compactEOFRecoveryAdmissionState,
+) error {
+	if receipt == nil || int(receipt.transitionCount) >= len(receipt.transitions) {
+		return errors.New("parser-core phase zero: EOF recovery receipt transition overflow")
+	}
+	previous := receipt.seal
+	index := receipt.transitionCount
+	receipt.state = next
+	receipt.transitions[index] = next
+	receipt.transitionCount++
+	receipt.seal = compactEOFRecoveryAdmissionSeal(receipt, previous)
+	receipt.transitionSeals[index] = receipt.seal
+	return nil
+}
+
+func compactEOFRecoveryAdmissionInvalidate(
+	receipt *compactEOFRecoveryAdmissionReceipt,
+	reason string,
+) {
+	if receipt == nil {
+		return
+	}
+	receipt.valid = false
+	receipt.state = compactEOFRecoveryAdmissionInvalid
+	receipt.selectedEvent = -1
+	receipt.declineReason = reason
+}
+
+func compactEOFRecoveryAdmissionAddWork(
+	scheduler *diagnosticParserCoreGenericScheduler,
+	receipt *compactEOFRecoveryAdmissionReceipt,
+	target *uint64,
+	amount uint64,
+) error {
+	if receipt == nil || target == nil {
+		return errors.New("parser-core phase zero: EOF recovery work counter is nil")
+	}
+	if compactEOFRecoveryAdmissionOverflowHook != nil &&
+		compactEOFRecoveryAdmissionOverflowHook(scheduler, "counter") {
+		receipt.work.overflow = true
+		compactEOFRecoveryAdmissionInvalidate(receipt, "EOF recovery admission counter overflow")
+		return errors.New("parser-core phase zero: EOF recovery admission counter overflow")
+	}
+	checked, ok := compactEOFRecoveryAdmissionCheckedAdd(receipt.work.checkedArithmetic, 1)
+	if !ok {
+		receipt.work.overflow = true
+		compactEOFRecoveryAdmissionInvalidate(receipt, "EOF recovery admission arithmetic counter overflow")
+		return errors.New("parser-core phase zero: EOF recovery admission arithmetic counter overflow")
+	}
+	receipt.work.checkedArithmetic = checked
+	value, ok := compactEOFRecoveryAdmissionCheckedAdd(*target, amount)
+	if !ok {
+		receipt.work.overflow = true
+		compactEOFRecoveryAdmissionInvalidate(receipt, "EOF recovery admission counter overflow")
+		return errors.New("parser-core phase zero: EOF recovery admission counter overflow")
+	}
+	*target = value
+	return nil
+}
+
+func compactEOFRecoveryAdmissionAddCost(
+	scheduler *diagnosticParserCoreGenericScheduler,
+	receipt *compactEOFRecoveryAdmissionReceipt,
+	target *uint64,
+	amount uint64,
+) error {
+	if compactEOFRecoveryAdmissionOverflowHook != nil &&
+		compactEOFRecoveryAdmissionOverflowHook(scheduler, "cost") {
+		receipt.work.overflow = true
+		compactEOFRecoveryAdmissionInvalidate(receipt, "EOF recovery admission cost overflow")
+		return errors.New("parser-core phase zero: EOF recovery admission cost overflow")
+	}
+	return compactEOFRecoveryAdmissionAddWork(scheduler, receipt, target, amount)
+}
+
+func compactEOFRecoveryAdmissionMultiplyCost(
+	receipt *compactEOFRecoveryAdmissionReceipt,
+	left uint64,
+	right uint64,
+) (uint64, error) {
+	if receipt == nil {
+		return 0, errors.New("parser-core phase zero: EOF recovery cost receipt is nil")
+	}
+	checked, ok := compactEOFRecoveryAdmissionCheckedAdd(receipt.work.checkedArithmetic, 1)
+	if !ok {
+		receipt.work.overflow = true
+		compactEOFRecoveryAdmissionInvalidate(receipt, "EOF recovery admission arithmetic counter overflow")
+		return 0, errors.New("parser-core phase zero: EOF recovery admission arithmetic counter overflow")
+	}
+	receipt.work.checkedArithmetic = checked
+	value, ok := compactEOFRecoveryAdmissionCheckedMul(left, right)
+	if !ok {
+		receipt.work.overflow = true
+		compactEOFRecoveryAdmissionInvalidate(receipt, "EOF recovery admission cost overflow")
+		return 0, errors.New("parser-core phase zero: EOF recovery admission cost overflow")
+	}
+	return value, nil
+}
+
+func compactEOFRecoveryAdmissionPoll(
+	scheduler *diagnosticParserCoreGenericScheduler,
+	receipt *compactEOFRecoveryAdmissionReceipt,
+	poll func() error,
+) error {
+	if err := compactEOFRecoveryAdmissionAddWork(scheduler, receipt, &receipt.work.polls, 1); err != nil {
+		return err
+	}
+	if poll == nil {
+		return nil
+	}
+	if err := poll(); err != nil {
+		compactEOFRecoveryAdmissionInvalidate(receipt, "EOF recovery admission poll failed")
+		return err
+	}
+	return nil
+}
+
+type compactEOFRecoveryAdmissionPath struct {
+	fingerprint       [32]byte
+	payloadCount      uint32
+	occurrenceCount   uint32
+	visibleFrontier   uint32
+	metadataGroups    uint32
+	polls             uint32
+	maxDepth          uint32
+	dynamicPrecedence int64
+}
+
+type compactEOFRecoveryAdmissionFrame struct {
+	payload            core.SubtreeID
+	path               [32]byte
+	incomingAlias      core.Symbol
+	parentStart        uint32
+	parentEnd          uint32
+	hasParent          bool
+	frontierBlocked    bool
+	descendantsBlocked bool
+	startByte          uint32
+	endByte            uint32
+	childCount         uint32
+	nextChild          uint32
+	entered            bool
+}
+
+func compactEOFRecoveryAdmissionWriteUint64(hasher interface{ Write([]byte) (int, error) }, value uint64) {
+	var scratch [8]byte
+	binary.LittleEndian.PutUint64(scratch[:], value)
+	_, _ = hasher.Write(scratch[:])
+}
+
+func compactEOFRecoveryAdmissionWriteBool(hasher interface{ Write([]byte) (int, error) }, value bool) {
+	if value {
+		compactEOFRecoveryAdmissionWriteUint64(hasher, 1)
+		return
+	}
+	compactEOFRecoveryAdmissionWriteUint64(hasher, 0)
+}
+
+func compactEOFRecoveryAdmissionRootPath(role uint64, ordinal uint32) [32]byte {
+	var input [16]byte
+	binary.LittleEndian.PutUint64(input[:8], role)
+	binary.LittleEndian.PutUint64(input[8:], uint64(ordinal))
+	return sha256.Sum256(input[:])
+}
+
+func compactEOFRecoveryAdmissionChildPath(parent [32]byte, ordinal uint32) [32]byte {
+	var input [40]byte
+	copy(input[:32], parent[:])
+	binary.LittleEndian.PutUint64(input[32:], uint64(ordinal))
+	return sha256.Sum256(input[:])
+}
+
+func (s *diagnosticParserCoreGenericScheduler) inspectCompactEOFRecoveryAdmissionSource(
+	receipt *compactEOFRecoveryAdmissionReceipt,
+	source []byte,
+	poll func() error,
+) (uint64, error) {
+	hasher := sha256.New()
+	var newlineCount uint64
+	for start := 0; start < len(source); start += compactEOFRecoveryAdmissionSourceChunkBytes {
+		if err := compactEOFRecoveryAdmissionPoll(s, receipt, poll); err != nil {
+			return 0, err
+		}
+		end := start + compactEOFRecoveryAdmissionSourceChunkBytes
+		if end > len(source) {
+			end = len(source)
+		}
+		chunk := source[start:end]
+		if err := compactEOFRecoveryAdmissionAddWork(s, receipt, &receipt.work.sourceChunks, 1); err != nil {
+			return 0, err
+		}
+		if err := compactEOFRecoveryAdmissionAddWork(s, receipt, &receipt.work.bytesInspected, uint64(len(chunk))); err != nil {
+			return 0, err
+		}
+		if uint64(len(chunk)) > receipt.work.maxSourceChunk {
+			receipt.work.maxSourceChunk = uint64(len(chunk))
+		}
+		for _, value := range chunk {
+			if value == '\n' {
+				newlineCount++
+			}
+		}
+		_, _ = hasher.Write(chunk)
+	}
+	copy(receipt.sourceSHA256[:], hasher.Sum(nil))
+	return newlineCount, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) inspectCompactEOFRecoveryAdmissionPath(
+	receipt *compactEOFRecoveryAdmissionReceipt,
+	header diagnosticParserCoreHeader,
+	language *Language,
+	role uint64,
+	sourceLength uint32,
+	poll func() error,
+) (compactEOFRecoveryAdmissionPath, string, error) {
+	var result compactEOFRecoveryAdmissionPath
+	if s == nil || s.compact == nil || receipt == nil || language == nil {
+		return result, "EOF recovery admission audit context is incomplete", nil
+	}
+	generation := receipt.coreGeneration
+	var topPayloads [compactEOFRecoveryAdmissionMaxTopPayloads]core.SubtreeID
+	path, err := s.compact.VisitEOFAdmissionExactPath(
+		header.head,
+		generation,
+		func() error { return compactEOFRecoveryAdmissionPoll(s, receipt, poll) },
+		func(ordinal uint32, payload core.SubtreeID) error {
+			if ordinal >= compactEOFRecoveryAdmissionMaxTopPayloads {
+				return core.ErrEOFAdmissionTopPayloadCap
+			}
+			topPayloads[ordinal] = payload
+			return nil
+		},
+	)
+	if errors.Is(err, core.ErrEOFAdmissionInexactPath) {
+		return result, "EOF recovery admission requires one exact derivation", nil
+	}
+	if errors.Is(err, core.ErrEOFAdmissionTopPayloadCap) {
+		return result, "EOF recovery admission top payload cap", nil
+	}
+	if errors.Is(err, core.ErrEOFAdmissionMalformed) {
+		return result, "EOF recovery admission path is malformed", nil
+	}
+	if err != nil {
+		return result, "", err
+	}
+	if path.Payloads == 0 || path.Payloads > compactEOFRecoveryAdmissionMaxTopPayloads {
+		return result, "EOF recovery admission requires one nonempty exact derivation", nil
+	}
+	result.payloadCount = path.Payloads
+	result.dynamicPrecedence = path.Score
+	result.polls = path.Polls
+	if err := compactEOFRecoveryAdmissionAddWork(s, receipt, &receipt.work.pathsVisited, 1); err != nil {
+		return result, "", err
+	}
+	if err := compactEOFRecoveryAdmissionAddWork(s, receipt, &receipt.work.linksVisited, uint64(path.Links)); err != nil {
+		return result, "", err
+	}
+	topGroups := (uint64(path.Payloads) + compactEOFRecoveryAdmissionChildGroupSize - 1) /
+		compactEOFRecoveryAdmissionChildGroupSize
+	if err := compactEOFRecoveryAdmissionAddWork(s, receipt, &receipt.work.childGroups, topGroups); err != nil {
+		return result, "", err
+	}
+	result.metadataGroups = uint32(topGroups)
+	if group := uint64(path.Payloads); group > compactEOFRecoveryAdmissionChildGroupSize {
+		group = compactEOFRecoveryAdmissionChildGroupSize
+		if group > receipt.work.maxChildGroup {
+			receipt.work.maxChildGroup = group
+		}
+	} else if group > receipt.work.maxChildGroup {
+		receipt.work.maxChildGroup = group
+	}
+
+	hasher := sha256.New()
+	compactEOFRecoveryAdmissionWriteUint64(hasher, role)
+	compactEOFRecoveryAdmissionWriteUint64(hasher, uint64(header.head.Node))
+	compactEOFRecoveryAdmissionWriteUint64(hasher, uint64(path.Payloads))
+	compactEOFRecoveryAdmissionWriteUint64(hasher, uint64(path.Score))
+	compactEOFRecoveryAdmissionWriteUint64(hasher, path.BranchOrder)
+	compactEOFRecoveryAdmissionWriteBool(hasher, path.HasBranchOrder)
+	for _, capValue := range [...]uint64{
+		compactEOFRecoveryAdmissionSourceChunkBytes,
+		compactEOFRecoveryAdmissionChildGroupSize,
+		compactEOFRecoveryAdmissionMaxTopPayloads,
+		compactEOFRecoveryAdmissionMaxDepth,
+		compactEOFRecoveryAdmissionMaxOccurrences,
+	} {
+		compactEOFRecoveryAdmissionWriteUint64(hasher, capValue)
+	}
+
+	var frames [compactEOFRecoveryAdmissionMaxDepth]compactEOFRecoveryAdmissionFrame
+	for rootOrdinal := uint32(0); rootOrdinal < path.Payloads; rootOrdinal++ {
+		frames[0] = compactEOFRecoveryAdmissionFrame{
+			payload: topPayloads[rootOrdinal],
+			path:    compactEOFRecoveryAdmissionRootPath(role, rootOrdinal),
+		}
+		depth := 1
+		for depth != 0 {
+			frame := &frames[depth-1]
+			if !frame.entered {
+				if result.occurrenceCount >= compactEOFRecoveryAdmissionMaxOccurrences {
+					return result, "EOF recovery admission occurrence cap", nil
+				}
+				if err := compactEOFRecoveryAdmissionAddWork(
+					s,
+					receipt,
+					&receipt.work.payloadRecordsVisited,
+					1,
+				); err != nil {
+					return result, "", err
+				}
+				result.occurrenceCount++
+				if uint32(depth) > result.maxDepth {
+					result.maxDepth = uint32(depth)
+				}
+				if uint64(depth) > receipt.work.maxDepth {
+					receipt.work.maxDepth = uint64(depth)
+				}
+
+				decline := ""
+				err := s.compact.VisitEOFAdmissionSubtree(
+					frame.payload,
+					generation,
+					func(view core.EOFAdmissionSubtreeView) error {
+						if view.Identity != frame.payload || view.Generation != generation ||
+							!view.MetadataAuthenticated {
+							decline = "EOF recovery admission subtree identity is unauthenticated"
+							return nil
+						}
+						if view.Missing {
+							decline = "EOF recovery admission rejects a missing subtree"
+							return nil
+						}
+						if view.Extra || view.External {
+							decline = "EOF recovery admission rejects extra or external closure"
+							return nil
+						}
+						if view.Symbol == core.RecoveryErrorSymbol || frame.incomingAlias == core.RecoveryErrorSymbol {
+							span := uint64(view.EndByte - view.StartByte)
+							observed := uint64(core.RecoveryCostPerRecovery + core.RecoveryCostPerSkippedTree)
+							if value, ok := compactEOFRecoveryAdmissionCheckedAdd(observed, span); ok {
+								observed = value
+							} else {
+								observed = math.MaxUint32
+							}
+							if observed > math.MaxUint32 {
+								observed = math.MaxUint32
+							}
+							receipt.observedErrorCost = uint32(observed)
+							decline = "EOF recovery admission rejects an existing ERROR payload"
+							return nil
+						}
+						if view.EndByte > sourceLength ||
+							frame.hasParent && (view.StartByte < frame.parentStart || view.EndByte > frame.parentEnd) {
+							decline = "EOF recovery admission subtree range is malformed"
+							return nil
+						}
+						if view.Terminal && (len(view.Children) != 0 || len(view.Fields) != 0 || len(view.Aliases) != 0) {
+							decline = "EOF recovery admission terminal metadata is malformed"
+							return nil
+						}
+						if len(view.Aliases) != 0 && len(view.Aliases) != len(view.Children) {
+							decline = "EOF recovery admission alias width is malformed"
+							return nil
+						}
+						if int(view.Symbol) >= len(language.SymbolMetadata) {
+							decline = "EOF recovery admission subtree symbol is outside metadata"
+							return nil
+						}
+						aliasedBoundary := frame.incomingAlias != 0
+						if aliasedBoundary {
+							if int(frame.incomingAlias) >= len(language.SymbolMetadata) {
+								decline = "EOF recovery admission alias symbol is outside metadata"
+								return nil
+							}
+						}
+						visibleBoundary := aliasedBoundary || language.SymbolMetadata[view.Symbol].Visible
+						contributes := !frame.frontierBlocked && visibleBoundary
+						if contributes {
+							frontier, ok := compactEOFRecoveryAdmissionCheckedAdd(uint64(result.visibleFrontier), 1)
+							if !ok || frontier > math.MaxUint32 {
+								receipt.work.overflow = true
+								decline = "EOF recovery admission visible frontier overflow"
+								return nil
+							}
+							result.visibleFrontier = uint32(frontier)
+						}
+						frame.descendantsBlocked = frame.frontierBlocked || visibleBoundary
+						frame.startByte, frame.endByte = view.StartByte, view.EndByte
+						frame.childCount = uint32(len(view.Children))
+
+						_, _ = hasher.Write(frame.path[:])
+						for _, value := range [...]uint64{
+							uint64(view.Identity),
+							uint64(frame.incomingAlias),
+							uint64(view.Symbol),
+							uint64(view.ProductionID),
+							uint64(uint16(view.DynamicPrecedence)),
+							uint64(view.StartByte),
+							uint64(view.EndByte),
+							uint64(len(view.Children)),
+							uint64(len(view.Fields)),
+							uint64(len(view.Aliases)),
+						} {
+							compactEOFRecoveryAdmissionWriteUint64(hasher, value)
+						}
+						compactEOFRecoveryAdmissionWriteBool(hasher, view.Extra)
+						compactEOFRecoveryAdmissionWriteBool(hasher, view.External)
+						compactEOFRecoveryAdmissionWriteBool(hasher, view.Terminal)
+						compactEOFRecoveryAdmissionWriteBool(hasher, view.Fragile)
+						compactEOFRecoveryAdmissionWriteBool(hasher, view.Missing)
+						compactEOFRecoveryAdmissionWriteBool(hasher, visibleBoundary)
+						compactEOFRecoveryAdmissionWriteBool(hasher, contributes)
+
+						for start := 0; start < len(view.Children); start += compactEOFRecoveryAdmissionChildGroupSize {
+							if err := compactEOFRecoveryAdmissionPoll(s, receipt, poll); err != nil {
+								return err
+							}
+							result.polls++
+							end := start + compactEOFRecoveryAdmissionChildGroupSize
+							if end > len(view.Children) {
+								end = len(view.Children)
+							}
+							if err := compactEOFRecoveryAdmissionAddWork(s, receipt, &receipt.work.childGroups, 1); err != nil {
+								return err
+							}
+							result.metadataGroups++
+							if group := uint64(end - start); group > receipt.work.maxChildGroup {
+								receipt.work.maxChildGroup = group
+							}
+							for ordinal := start; ordinal < end; ordinal++ {
+								child := view.Children[ordinal]
+								if child == 0 || child >= view.Identity {
+									decline = "EOF recovery admission child identity is malformed"
+									return nil
+								}
+								alias := core.Symbol(0)
+								if len(view.Aliases) != 0 {
+									alias = view.Aliases[ordinal]
+									if alias == core.RecoveryErrorSymbol ||
+										alias != 0 && int(alias) >= len(language.SymbolMetadata) {
+										decline = "EOF recovery admission alias metadata is malformed"
+										return nil
+									}
+								}
+								compactEOFRecoveryAdmissionWriteUint64(hasher, uint64(ordinal))
+								compactEOFRecoveryAdmissionWriteUint64(hasher, uint64(child))
+								compactEOFRecoveryAdmissionWriteUint64(hasher, uint64(alias))
+							}
+						}
+						for start := 0; start < len(view.Fields); start += compactEOFRecoveryAdmissionChildGroupSize {
+							if err := compactEOFRecoveryAdmissionPoll(s, receipt, poll); err != nil {
+								return err
+							}
+							result.polls++
+							end := start + compactEOFRecoveryAdmissionChildGroupSize
+							if end > len(view.Fields) {
+								end = len(view.Fields)
+							}
+							if err := compactEOFRecoveryAdmissionAddWork(s, receipt, &receipt.work.childGroups, 1); err != nil {
+								return err
+							}
+							result.metadataGroups++
+							if group := uint64(end - start); group > receipt.work.maxChildGroup {
+								receipt.work.maxChildGroup = group
+							}
+							for _, field := range view.Fields[start:end] {
+								if uint32(field.ChildIndex) >= uint32(len(view.Children)) {
+									decline = "EOF recovery admission field metadata is malformed"
+									return nil
+								}
+								compactEOFRecoveryAdmissionWriteUint64(hasher, uint64(field.FieldID))
+								compactEOFRecoveryAdmissionWriteUint64(hasher, uint64(field.ChildIndex))
+								compactEOFRecoveryAdmissionWriteBool(hasher, field.Inherited)
+							}
+						}
+						return nil
+					},
+				)
+				if errors.Is(err, core.ErrEOFAdmissionMalformed) {
+					return result, "EOF recovery admission subtree record is malformed", nil
+				}
+				if err != nil {
+					return result, "", err
+				}
+				if decline != "" {
+					return result, decline, nil
+				}
+				frame.entered = true
+				continue
+			}
+			if frame.nextChild >= frame.childCount {
+				frames[depth-1] = compactEOFRecoveryAdmissionFrame{}
+				depth--
+				continue
+			}
+			ordinal := frame.nextChild
+			frame.nextChild++
+			var child core.SubtreeID
+			var alias core.Symbol
+			err := s.compact.VisitEOFAdmissionSubtree(
+				frame.payload,
+				generation,
+				func(view core.EOFAdmissionSubtreeView) error {
+					if ordinal >= uint32(len(view.Children)) {
+						return core.ErrEOFAdmissionMalformed
+					}
+					child = view.Children[ordinal]
+					if len(view.Aliases) != 0 {
+						if len(view.Aliases) != len(view.Children) {
+							return core.ErrEOFAdmissionMalformed
+						}
+						alias = view.Aliases[ordinal]
+					}
+					return nil
+				},
+			)
+			if errors.Is(err, core.ErrEOFAdmissionMalformed) {
+				return result, "EOF recovery admission child metadata is malformed", nil
+			}
+			if err != nil {
+				return result, "", err
+			}
+			if depth >= compactEOFRecoveryAdmissionMaxDepth {
+				return result, "EOF recovery admission depth cap", nil
+			}
+			frames[depth] = compactEOFRecoveryAdmissionFrame{
+				payload:         child,
+				path:            compactEOFRecoveryAdmissionChildPath(frame.path, ordinal),
+				incomingAlias:   alias,
+				parentStart:     frame.startByte,
+				parentEnd:       frame.endByte,
+				hasParent:       true,
+				frontierBlocked: frame.descendantsBlocked,
+			}
+			depth++
+		}
+	}
+	for _, value := range [...]uint64{
+		uint64(result.payloadCount),
+		uint64(result.occurrenceCount),
+		uint64(result.visibleFrontier),
+		uint64(result.metadataGroups),
+		uint64(result.polls),
+		uint64(result.maxDepth),
+	} {
+		compactEOFRecoveryAdmissionWriteUint64(hasher, value)
+	}
+	copy(result.fingerprint[:], hasher.Sum(nil))
+	return result, "", nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) produceCompactEOFRecoveryAdmission(
+	source []byte,
+	poll func() error,
+) (receipt compactEOFRecoveryAdmissionReceipt, err error) {
+	receipt.selectedEvent = -1
+	receipt.constructionRoute = compactEOFRecoveryAdmissionRouteNone
+	receipt.metadataOnly = true
+	defer func() { s.eofRecoveryAdmission = receipt }()
+	if s == nil || !s.options.allowMetadataEOFAcceptRecovery {
+		return receipt, nil
+	}
+	if s.token.Symbol != 0 {
+		return receipt, nil
+	}
+	receipt.active = true
+	receipt.state = compactEOFRecoveryAdmissionInvalid
+	if s.compact == nil || s.tokenSource == nil || s.tokenSource.language == nil {
+		compactEOFRecoveryAdmissionInvalidate(&receipt, "EOF recovery admission context is incomplete")
+		return receipt, nil
+	}
+	language := s.tokenSource.language
+	if language.ExternalScanner != nil || language.ExternalTokenCount != 0 {
+		compactEOFRecoveryAdmissionInvalidate(&receipt, "EOF recovery admission requires scanner quiescence")
+		return receipt, nil
+	}
+	if s.token.StartByte != s.token.EndByte || s.token.Missing || s.token.NoLookahead ||
+		s.token.ExternalScannerToken || uint64(len(source)) > math.MaxUint32 ||
+		s.token.EndByte != uint32(len(source)) {
+		compactEOFRecoveryAdmissionInvalidate(&receipt, "EOF recovery admission requires authenticated source EOF")
+		return receipt, nil
+	}
+	if len(s.headers) != 2 || s.headers[0].head == s.headers[1].head {
+		compactEOFRecoveryAdmissionInvalidate(&receipt, "EOF recovery admission requires two distinct heads")
+		return receipt, nil
+	}
+	for _, header := range s.headers {
+		if header.s3Region != nil {
+			compactEOFRecoveryAdmissionInvalidate(&receipt, "EOF recovery admission rejects an open strategy-three region")
+			return receipt, nil
+		}
+	}
+
+	normalIndex := -1
+	recoveryIndex := -1
+	for index, header := range s.headers {
+		boundary, boundaryErr := s.compact.ClassifyBoundary(header.head, 0)
+		if boundaryErr != nil {
+			return receipt, boundaryErr
+		}
+		actions := boundary.Actions()
+		switch {
+		case actions.Len() == 1 && actions.At(0).Type == core.ActionAccept:
+			if normalIndex >= 0 {
+				compactEOFRecoveryAdmissionInvalidate(&receipt, "EOF recovery admission found multiple accepting heads")
+				return receipt, nil
+			}
+			normalIndex = index
+		case actions.Len() == 0:
+			if recoveryIndex >= 0 {
+				compactEOFRecoveryAdmissionInvalidate(&receipt, "EOF recovery admission found multiple no-action heads")
+				return receipt, nil
+			}
+			recoveryIndex = index
+		default:
+			compactEOFRecoveryAdmissionInvalidate(&receipt, "EOF recovery admission found an unsupported action row")
+			return receipt, nil
+		}
+	}
+	if normalIndex < 0 || recoveryIndex < 0 {
+		compactEOFRecoveryAdmissionInvalidate(&receipt, "EOF recovery admission requires one accept and one no-action head")
+		return receipt, nil
+	}
+
+	receipt.coreGeneration = s.compact.AuthenticationGeneration()
+	receipt.electionIndex = s.electionIndex
+	receipt.token = s.token
+	receipt.sourceLength = uint32(len(source))
+	newlineCount, inspectErr := s.inspectCompactEOFRecoveryAdmissionSource(&receipt, source, poll)
+	if inspectErr != nil {
+		return receipt, inspectErr
+	}
+	normalHeader := s.headers[normalIndex]
+	recoveryHeader := s.headers[recoveryIndex]
+	normalPath, decline, inspectErr := s.inspectCompactEOFRecoveryAdmissionPath(
+		&receipt,
+		normalHeader,
+		language,
+		uint64(compactEOFRecoveryAdmissionEventNormal),
+		uint32(len(source)),
+		poll,
+	)
+	if inspectErr != nil {
+		return receipt, inspectErr
+	}
+	if decline != "" {
+		compactEOFRecoveryAdmissionInvalidate(&receipt, decline)
+		return receipt, nil
+	}
+	recoveryPath, decline, inspectErr := s.inspectCompactEOFRecoveryAdmissionPath(
+		&receipt,
+		recoveryHeader,
+		language,
+		uint64(compactEOFRecoveryAdmissionEventRecover),
+		uint32(len(source)),
+		poll,
+	)
+	if inspectErr != nil {
+		return receipt, inspectErr
+	}
+	if decline != "" {
+		compactEOFRecoveryAdmissionInvalidate(&receipt, decline)
+		return receipt, nil
+	}
+
+	spanCost, multiplyErr := compactEOFRecoveryAdmissionMultiplyCost(
+		&receipt,
+		uint64(len(source)),
+		core.RecoveryCostPerSkippedChar,
+	)
+	if multiplyErr != nil {
+		return receipt, multiplyErr
+	}
+	lineCost, multiplyErr := compactEOFRecoveryAdmissionMultiplyCost(
+		&receipt,
+		newlineCount,
+		core.RecoveryCostPerSkippedLine,
+	)
+	if multiplyErr != nil {
+		return receipt, multiplyErr
+	}
+	frontierCost, multiplyErr := compactEOFRecoveryAdmissionMultiplyCost(
+		&receipt,
+		uint64(recoveryPath.visibleFrontier),
+		core.RecoveryCostPerSkippedTree,
+	)
+	if multiplyErr != nil {
+		return receipt, multiplyErr
+	}
+	var recoveryCost uint64
+	for _, amount := range [...]uint64{
+		core.RecoveryCostPerRecovery,
+		spanCost,
+		lineCost,
+		frontierCost,
+	} {
+		if err := compactEOFRecoveryAdmissionAddCost(s, &receipt, &recoveryCost, amount); err != nil {
+			return receipt, err
+		}
+	}
+	if recoveryCost > math.MaxUint32 {
+		receipt.work.overflow = true
+		compactEOFRecoveryAdmissionInvalidate(&receipt, "EOF recovery admission cost overflow")
+		return receipt, errors.New("parser-core phase zero: EOF recovery admission cost overflow")
+	}
+
+	receipt.normalHead = normalHeader.head
+	receipt.recoveryHead = recoveryHeader.head
+	receipt.normalCreationSeq = normalHeader.creationSeq
+	receipt.recoveryCreationSeq = recoveryHeader.creationSeq
+	receipt.normalLineage = normalHeader.cleanPathLineage
+	receipt.recoveryLineage = recoveryHeader.cleanPathLineage
+	receipt.normalFingerprint = normalPath.fingerprint
+	receipt.recoveryFingerprint = recoveryPath.fingerprint
+	receipt.normalPayloads = normalPath.payloadCount
+	receipt.recoveryPayloads = recoveryPath.payloadCount
+	receipt.normalOccurrences = normalPath.occurrenceCount
+	receipt.recoveryOccurrences = recoveryPath.occurrenceCount
+	receipt.normalFrontier = normalPath.visibleFrontier
+	receipt.recoveryFrontier = recoveryPath.visibleFrontier
+	receipt.events = [2]compactEOFRecoveryAdmissionEvent{
+		{ordinal: 0, kind: compactEOFRecoveryAdmissionEventNormal, dynamicPrecedence: normalPath.dynamicPrecedence},
+		{ordinal: 1, kind: compactEOFRecoveryAdmissionEventRecover, cost: uint32(recoveryCost), dynamicPrecedence: recoveryPath.dynamicPrecedence},
+	}
+	if receipt.events[0].cost >= receipt.events[1].cost {
+		compactEOFRecoveryAdmissionInvalidate(&receipt, "EOF recovery admission requires a strictly lower normal error cost")
+		return receipt, nil
+	}
+	receipt.selectedEvent = 0
+	receipt.valid = true
+	if err := compactEOFRecoveryAdmissionTransition(&receipt, compactEOFRecoveryAdmissionProduced); err != nil {
+		compactEOFRecoveryAdmissionInvalidate(&receipt, err.Error())
+		return receipt, err
+	}
+	return receipt, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) compactEOFRecoveryAdmissionHeader(
+	head core.Head,
+	creationSeq uint64,
+	lineage uint16,
+) (diagnosticParserCoreHeader, bool) {
+	if s == nil {
+		return diagnosticParserCoreHeader{}, false
+	}
+	for _, header := range s.headers {
+		if header.head == head && header.creationSeq == creationSeq &&
+			header.cleanPathLineage == lineage {
+			return header, true
+		}
+	}
+	return diagnosticParserCoreHeader{}, false
+}
+
+func (s *diagnosticParserCoreGenericScheduler) validateCompactEOFRecoveryAdmission(
+	source []byte,
+	wantState compactEOFRecoveryAdmissionState,
+) error {
+	if s == nil || s.compact == nil {
+		return errors.New("parser-core phase zero: EOF recovery receipt has no Core")
+	}
+	receipt := &s.eofRecoveryAdmission
+	if !receipt.active || !receipt.valid || receipt.state != wantState ||
+		receipt.transitionCount == 0 || !compactEOFRecoveryAdmissionSealIsValid(receipt) {
+		return errors.New("parser-core phase zero: EOF recovery receipt is not authentic")
+	}
+	if receipt.coreGeneration == 0 || receipt.coreGeneration != s.compact.AuthenticationGeneration() ||
+		receipt.electionIndex != s.electionIndex || receipt.token != s.token ||
+		uint64(len(source)) > math.MaxUint32 || receipt.sourceLength != uint32(len(source)) ||
+		receipt.sourceSHA256 != sha256.Sum256(source) {
+		return errors.New("parser-core phase zero: EOF recovery receipt binding changed")
+	}
+	if !receipt.metadataOnly || receipt.selectedEvent != 0 ||
+		receipt.events[0].ordinal != 0 || receipt.events[0].kind != compactEOFRecoveryAdmissionEventNormal ||
+		receipt.events[1].ordinal != 1 || receipt.events[1].kind != compactEOFRecoveryAdmissionEventRecover ||
+		receipt.events[0].cost >= receipt.events[1].cost || receipt.work.overflow ||
+		receipt.work.publicationAttempts != 0 || receipt.work.parserConstructions != 0 {
+		return errors.New("parser-core phase zero: EOF recovery receipt policy changed")
+	}
+	wantTransitions := [...]compactEOFRecoveryAdmissionState{
+		compactEOFRecoveryAdmissionProduced,
+		compactEOFRecoveryAdmissionPreApplyValidated,
+		compactEOFRecoveryAdmissionAcceptApplied,
+		compactEOFRecoveryAdmissionRecoveryDropped,
+		compactEOFRecoveryAdmissionCompleted,
+		compactEOFRecoveryAdmissionSchedulerReturned,
+		compactEOFRecoveryAdmissionConsumed,
+	}
+	for index := uint8(0); index < receipt.transitionCount; index++ {
+		if receipt.transitions[index] != wantTransitions[index] ||
+			receipt.transitionSeals[index] == ([32]byte{}) {
+			return errors.New("parser-core phase zero: EOF recovery receipt transition changed")
+		}
+	}
+
+	normal, normalOK := s.compactEOFRecoveryAdmissionHeader(
+		receipt.normalHead,
+		receipt.normalCreationSeq,
+		receipt.normalLineage,
+	)
+	recovery, recoveryOK := s.compactEOFRecoveryAdmissionHeader(
+		receipt.recoveryHead,
+		receipt.recoveryCreationSeq,
+		receipt.recoveryLineage,
+	)
+	switch wantState {
+	case compactEOFRecoveryAdmissionProduced, compactEOFRecoveryAdmissionPreApplyValidated:
+		if len(s.headers) != 2 || !normalOK || !recoveryOK || normal.accepted || recovery.accepted {
+			return errors.New("parser-core phase zero: EOF recovery pre-accept frontier changed")
+		}
+	case compactEOFRecoveryAdmissionAcceptApplied:
+		if len(s.headers) != 2 || !normalOK || !recoveryOK || !normal.accepted || recovery.accepted {
+			return errors.New("parser-core phase zero: EOF recovery accepted frontier changed")
+		}
+	case compactEOFRecoveryAdmissionRecoveryDropped,
+		compactEOFRecoveryAdmissionCompleted,
+		compactEOFRecoveryAdmissionSchedulerReturned,
+		compactEOFRecoveryAdmissionConsumed:
+		if len(s.headers) != 1 || !normalOK || recoveryOK || !normal.accepted {
+			return errors.New("parser-core phase zero: EOF recovery selected frontier changed")
+		}
+	default:
+		return errors.New("parser-core phase zero: EOF recovery receipt state is unsupported")
+	}
+	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) compactEOFRecoveryAdmissionFault(stage string) error {
+	if compactEOFRecoveryAdmissionFaultHook == nil {
+		return nil
+	}
+	return compactEOFRecoveryAdmissionFaultHook(s, stage)
+}
+
+func (s *diagnosticParserCoreGenericScheduler) compactEOFRecoveryAdmissionDropMatches(indices []int) bool {
+	if s == nil || len(indices) != 1 || len(s.headers) != 2 ||
+		s.eofRecoveryAdmission.state != compactEOFRecoveryAdmissionAcceptApplied ||
+		!compactEOFRecoveryAdmissionSealIsValid(&s.eofRecoveryAdmission) {
+		return false
+	}
+	dropIndex := indices[0]
+	if dropIndex < 0 || dropIndex >= len(s.headers) {
+		return false
+	}
+	dropped := s.headers[dropIndex]
+	if dropped.head != s.eofRecoveryAdmission.recoveryHead ||
+		dropped.creationSeq != s.eofRecoveryAdmission.recoveryCreationSeq ||
+		dropped.cleanPathLineage != s.eofRecoveryAdmission.recoveryLineage || dropped.accepted {
+		return false
+	}
+	survivor := s.headers[1-dropIndex]
+	return survivor.head == s.eofRecoveryAdmission.normalHead &&
+		survivor.creationSeq == s.eofRecoveryAdmission.normalCreationSeq &&
+		survivor.cleanPathLineage == s.eofRecoveryAdmission.normalLineage && survivor.accepted
+}
+
+func (s *diagnosticParserCoreGenericScheduler) applyCompactEOFRecoveryAdmission(
+	before []DiagnosticParserCoreHeaderReceipt,
+	cell diagnosticParserCoreGenericCell,
+) (handled bool, err error) {
+	if s == nil || !s.options.allowMetadataEOFAcceptRecovery ||
+		s.options.allowEOFAcceptNoActionSiblings {
+		return false, nil
+	}
+	if len(s.headers) != 2 || len(s.acceptedPayloads) != 0 {
+		return false, nil
+	}
+	var headersBefore [2]diagnosticParserCoreHeader
+	copy(headersBefore[:], s.headers)
+	dispatchesBefore, workBefore := s.dispatches, s.work
+	epochProgressBefore := s.epochProgress
+	acceptedHeadBefore := s.acceptedHead
+	acceptedPayloadsBefore := s.acceptedPayloads
+	roundsBefore := s.receipt.Rounds
+	noActionDropsBefore := s.receipt.NoActionDrops
+	receiptBefore := s.eofRecoveryAdmission
+	rollback := func(cause error) (bool, error) {
+		if cap(s.headers) >= len(headersBefore) {
+			s.headers = s.headers[:len(headersBefore)]
+			copy(s.headers, headersBefore[:])
+		}
+		s.dispatches, s.work = dispatchesBefore, workBefore
+		s.epochProgress = epochProgressBefore
+		s.acceptedHead = acceptedHeadBefore
+		s.acceptedPayloads = acceptedPayloadsBefore
+		s.receipt.Rounds = roundsBefore
+		s.receipt.NoActionDrops = noActionDropsBefore
+		s.eofRecoveryAdmission = receiptBefore
+		compactEOFRecoveryAdmissionInvalidate(&s.eofRecoveryAdmission, cause.Error())
+		return true, cause
+	}
+
+	receipt, produceErr := s.produceCompactEOFRecoveryAdmission(
+		s.options.materializationSource,
+		s.pollStopControl,
+	)
+	if produceErr != nil {
+		return rollback(produceErr)
+	}
+	if !receipt.active || !receipt.valid {
+		return false, nil
+	}
+	if faultErr := s.compactEOFRecoveryAdmissionFault("after_produce"); faultErr != nil {
+		return rollback(faultErr)
+	}
+	if validateErr := s.validateCompactEOFRecoveryAdmission(
+		s.options.materializationSource,
+		compactEOFRecoveryAdmissionProduced,
+	); validateErr != nil {
+		return rollback(validateErr)
+	}
+	if transitionErr := compactEOFRecoveryAdmissionTransition(
+		&s.eofRecoveryAdmission,
+		compactEOFRecoveryAdmissionPreApplyValidated,
+	); transitionErr != nil {
+		return rollback(transitionErr)
+	}
+	if applyErr := s.applyGenericAccept(before, cell); applyErr != nil {
+		return rollback(applyErr)
+	}
+	if transitionErr := compactEOFRecoveryAdmissionTransition(
+		&s.eofRecoveryAdmission,
+		compactEOFRecoveryAdmissionAcceptApplied,
+	); transitionErr != nil {
+		return rollback(transitionErr)
+	}
+	if faultErr := s.compactEOFRecoveryAdmissionFault("after_apply"); faultErr != nil {
+		return rollback(faultErr)
+	}
+	if validateErr := s.validateCompactEOFRecoveryAdmission(
+		s.options.materializationSource,
+		compactEOFRecoveryAdmissionAcceptApplied,
+	); validateErr != nil {
+		return rollback(validateErr)
+	}
+
+	indices := s.dispatchScratch.noActionIndices[:0]
+	accepted := 0
+	for index, header := range s.headers {
+		if header.accepted {
+			accepted++
+			continue
+		}
+		indices = append(indices, index)
+	}
+	if accepted != 1 || len(indices) != 1 {
+		return rollback(errors.New("parser-core phase zero: EOF recovery admission did not preserve one accepting head"))
+	}
+	if dropErr := s.dropGenericNoActionHeads(indices); dropErr != nil {
+		return rollback(dropErr)
+	}
+	if transitionErr := compactEOFRecoveryAdmissionTransition(
+		&s.eofRecoveryAdmission,
+		compactEOFRecoveryAdmissionRecoveryDropped,
+	); transitionErr != nil {
+		return rollback(transitionErr)
+	}
+	if faultErr := s.compactEOFRecoveryAdmissionFault("after_drop"); faultErr != nil {
+		return rollback(faultErr)
+	}
+	if validateErr := s.validateCompactEOFRecoveryAdmission(
+		s.options.materializationSource,
+		compactEOFRecoveryAdmissionRecoveryDropped,
+	); validateErr != nil {
+		return rollback(validateErr)
+	}
+	return true, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) markCompactEOFRecoverySchedulerReturned(source []byte) error {
+	if s == nil || !s.eofRecoveryAdmission.active {
+		return nil
+	}
+	if err := s.validateCompactEOFRecoveryAdmission(
+		source,
+		compactEOFRecoveryAdmissionCompleted,
+	); err != nil {
+		compactEOFRecoveryAdmissionInvalidate(&s.eofRecoveryAdmission, err.Error())
+		return err
+	}
+	if err := compactEOFRecoveryAdmissionTransition(
+		&s.eofRecoveryAdmission,
+		compactEOFRecoveryAdmissionSchedulerReturned,
+	); err != nil {
+		compactEOFRecoveryAdmissionInvalidate(&s.eofRecoveryAdmission, err.Error())
+		return err
+	}
+	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) beginCompactEOFRecoveryConstruction(
+	source []byte,
+	route compactEOFRecoveryAdmissionRoute,
+) (bool, error) {
+	if s == nil || !s.eofRecoveryAdmission.active {
+		return false, nil
+	}
+	if route != compactEOFRecoveryAdmissionRoutePublicTree &&
+		route != compactEOFRecoveryAdmissionRouteSelectedStore {
+		compactEOFRecoveryAdmissionInvalidate(
+			&s.eofRecoveryAdmission,
+			"EOF recovery admission rejects a live publication route",
+		)
+		return false, errors.New("parser-core phase zero: EOF recovery receipt route is unsupported")
+	}
+	if err := s.validateCompactEOFRecoveryAdmission(
+		source,
+		compactEOFRecoveryAdmissionSchedulerReturned,
+	); err != nil {
+		compactEOFRecoveryAdmissionInvalidate(&s.eofRecoveryAdmission, err.Error())
+		return false, err
+	}
+	receipt := &s.eofRecoveryAdmission
+	if receipt.consumptionCount != 0 ||
+		receipt.constructionRoute != compactEOFRecoveryAdmissionRouteNone ||
+		receipt.work.treeConstructions != 0 ||
+		receipt.work.selectedStoreConstructions != 0 {
+		compactEOFRecoveryAdmissionInvalidate(receipt, "EOF recovery admission receipt was already consumed")
+		return false, errors.New("parser-core phase zero: EOF recovery receipt was already consumed")
+	}
+	var constructionCounter *uint64
+	switch route {
+	case compactEOFRecoveryAdmissionRoutePublicTree:
+		constructionCounter = &receipt.work.treeConstructions
+	case compactEOFRecoveryAdmissionRouteSelectedStore:
+		constructionCounter = &receipt.work.selectedStoreConstructions
+	}
+	value, ok := compactEOFRecoveryAdmissionCheckedAdd(*constructionCounter, 1)
+	if !ok {
+		receipt.work.overflow = true
+		compactEOFRecoveryAdmissionInvalidate(receipt, "EOF recovery admission construction counter overflow")
+		return false, errors.New("parser-core phase zero: EOF recovery construction counter overflow")
+	}
+	*constructionCounter = value
+	receipt.consumptionCount = 1
+	receipt.constructionRoute = route
+	if err := compactEOFRecoveryAdmissionTransition(
+		receipt,
+		compactEOFRecoveryAdmissionConsumed,
+	); err != nil {
+		compactEOFRecoveryAdmissionInvalidate(receipt, err.Error())
+		return false, err
+	}
+	if compactEOFRecoveryAdmissionCensusHook != nil {
+		compactEOFRecoveryAdmissionCensusHook(*receipt)
+	}
+	return true, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) failCompactEOFRecoveryConstruction(err error) {
+	if s == nil || err == nil || !s.eofRecoveryAdmission.active {
+		return
+	}
+	compactEOFRecoveryAdmissionInvalidate(
+		&s.eofRecoveryAdmission,
+		"EOF recovery admission construction failed",
+	)
 }
 
 const (
@@ -4244,6 +5573,25 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 	}
 	if acceptCell >= 0 {
 		cell := cells[acceptCell]
+		if !s.options.allowEOFAcceptNoActionSiblings &&
+			s.options.allowMetadataEOFAcceptRecovery &&
+			len(s.headers) == 2 && len(cells) == 1 && len(noActionIndices) == 1 {
+			handled, err := s.applyCompactEOFRecoveryAdmission(before, cell)
+			if err != nil {
+				return nil, err
+			}
+			if handled {
+				return nil, nil
+			}
+			if s.eofRecoveryAdmission.active && !s.eofRecoveryAdmission.valid &&
+				s.eofRecoveryAdmission.declineReason != "" {
+				return &diagnosticParserCoreGenericUnsupported{
+					boundary:    DiagnosticParserCoreAccept,
+					detail:      s.eofRecoveryAdmission.declineReason,
+					headerIndex: cell.headerIndex,
+				}, nil
+			}
+		}
 		soleAccept := len(s.headers) == 1 && len(cells) == 1 &&
 			len(noActionIndices) == 0 && cell.headerIndex == 0
 		certifiedAcceptWithDeadSiblings := s.options.allowEOFAcceptNoActionSiblings &&
@@ -4819,12 +6167,31 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericAccept(before []Diagn
 	return nil
 }
 
-func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
+func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() (err error) {
+	metadataAdmission := s != nil && s.eofRecoveryAdmission.active &&
+		s.eofRecoveryAdmission.valid &&
+		s.eofRecoveryAdmission.state == compactEOFRecoveryAdmissionRecoveryDropped
+	defer func() {
+		if err != nil && metadataAdmission && s.eofRecoveryAdmission.valid {
+			compactEOFRecoveryAdmissionInvalidate(
+				&s.eofRecoveryAdmission,
+				"EOF recovery admission completion failed",
+			)
+		}
+	}()
 	if s.token.Symbol != 0 || s.token.StartByte != s.token.EndByte || s.token.Missing || s.token.NoLookahead || s.token.ExternalScannerToken {
 		return s.finish(DiagnosticParserCoreAccept, "generic scheduler accept is not authenticated EOF", 0)
 	}
 	if len(s.headers) != 1 {
 		return s.finish(DiagnosticParserCoreAccept, "generic scheduler requires one accepted compact head", 0)
+	}
+	if metadataAdmission {
+		if err := s.validateCompactEOFRecoveryAdmission(
+			s.options.materializationSource,
+			compactEOFRecoveryAdmissionRecoveryDropped,
+		); err != nil {
+			return err
+		}
 	}
 	paths, err := compactDerivationsForAcceptance(s.compact, s.headers[0].head)
 	if err != nil {
@@ -4960,6 +6327,14 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
 		)
 	}
 	s.publishTotals()
+	if metadataAdmission {
+		if err := compactEOFRecoveryAdmissionTransition(
+			&s.eofRecoveryAdmission,
+			compactEOFRecoveryAdmissionCompleted,
+		); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -5282,6 +6657,7 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 	if len(indices) == 0 || len(indices) >= len(s.headers) {
 		return errors.New("parser-core phase zero: sibling-backed no-action drop removed the complete frontier")
 	}
+	metadataDrop := s.compactEOFRecoveryAdmissionDropMatches(indices)
 	// F4 disposition (spec.b4b-alternative-set.v2 section 5): a resurrection
 	// descended from a HistoricalBoundaryUnproved dead-node import carries no
 	// recorded provenance to prove, so it fails closed independently of the
@@ -5291,7 +6667,7 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 	// keys on (admission_switch_converged_path_test.go,
 	// admission_switch_erlang_converged_split_probe_test.go), distinguished
 	// by the trailing clause.
-	if !s.options.allowConvergedSplitDropArtifact {
+	if !metadataDrop && !s.options.allowConvergedSplitDropArtifact {
 		for _, index := range indices {
 			if index >= 0 && index < len(s.headers) && s.headers[index].resurrectionUnproved {
 				return &diagnosticParserCoreDecline{
@@ -5309,8 +6685,11 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 	// differing-tree cases, the Kotlin witness declines under v2, stage 1's
 	// gates re-passed); erlang's own class-3 probe re-proof miss is scoped
 	// to its stage 3 certificate precondition, not this gate.
-	convergedCoverageDrops, proved := s.diagnosticParserCoreConvergedCoverageDropsV2(indices)
-	if diagnosticParserCoreShadowCensusEnabled() {
+	convergedCoverageDrops, proved := uint64(0), metadataDrop
+	if !metadataDrop {
+		convergedCoverageDrops, proved = s.diagnosticParserCoreConvergedCoverageDropsV2(indices)
+	}
+	if !metadataDrop && diagnosticParserCoreShadowCensusEnabled() {
 		// The retired scalar proof is evaluated only here, next to the v2
 		// decision above, for the ongoing three-proof regression check as
 		// more languages decertify in stage 3. Never influences the
@@ -6314,6 +7693,12 @@ func (s *diagnosticParserCoreGenericScheduler) reserveDispatches(count uint64) e
 }
 
 func (s *diagnosticParserCoreGenericScheduler) elect(first bool) error {
+	if s.eofRecoveryAdmission.active && s.eofRecoveryAdmission.valid &&
+		s.eofRecoveryAdmission.state != compactEOFRecoveryAdmissionEmpty &&
+		s.eofRecoveryAdmission.state != compactEOFRecoveryAdmissionInvalid &&
+		s.eofRecoveryAdmission.state != compactEOFRecoveryAdmissionConsumed {
+		compactEOFRecoveryAdmissionInvalidate(&s.eofRecoveryAdmission, "new election")
+	}
 	if s.tokens >= s.options.MaxTokens {
 		return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreCap, detail: "generic scheduler token cap"}
 	}
@@ -6493,6 +7878,10 @@ func (s *diagnosticParserCoreGenericScheduler) completeAtClosedByte(target uint3
 }
 
 func (s *diagnosticParserCoreGenericScheduler) finish(boundary DiagnosticParserCoreBoundaryKind, detail string, headerIndex int) error {
+	if s != nil && s.eofRecoveryAdmission.active && s.eofRecoveryAdmission.valid &&
+		s.eofRecoveryAdmission.state != compactEOFRecoveryAdmissionConsumed {
+		compactEOFRecoveryAdmissionInvalidate(&s.eofRecoveryAdmission, detail)
+	}
 	if headerIndex < 0 || headerIndex >= len(s.headers) {
 		return errors.New("parser-core phase zero: generic stop header index out of range")
 	}

--- a/parsercore_phase0_eof_recovery_admission_contract.go
+++ b/parsercore_phase0_eof_recovery_admission_contract.go
@@ -1,0 +1,126 @@
+//go:build !gts_no_parsercorephase0 && gts_eof_recovery_admission_contract
+
+package gotreesitter
+
+import "sync"
+
+// EOFRecoveryAdmissionEvent records one authenticated EOF election event.
+type EOFRecoveryAdmissionEvent struct {
+	Ordinal           int
+	Kind              string
+	Cost              uint32
+	DynamicPrecedence int64
+}
+
+// EOFRecoveryAdmissionWork records the bounded producer work.
+type EOFRecoveryAdmissionWork struct {
+	Polls                      uint64
+	SourceChunks               uint64
+	ChildGroups                uint64
+	PathsVisited               uint64
+	LinksVisited               uint64
+	PayloadRecordsVisited      uint64
+	MaxDepth                   uint64
+	BytesInspected             uint64
+	MaxSourceChunk             uint64
+	MaxChildGroup              uint64
+	CheckedArithmetic          uint64
+	PublicationAttempts        uint64
+	ParserConstructions        uint64
+	TreeConstructions          uint64
+	SelectedStoreConstructions uint64
+	Overflow                   bool
+}
+
+// EOFRecoveryAdmissionReceipt records one consumed metadata-only admission.
+type EOFRecoveryAdmissionReceipt struct {
+	State               string
+	CoreGeneration      uint64
+	SourceLength        uint32
+	NormalPayloads      uint32
+	RecoveryPayloads    uint32
+	NormalOccurrences   uint32
+	RecoveryOccurrences uint32
+	NormalFrontier      uint32
+	RecoveryFrontier    uint32
+	Events              [2]EOFRecoveryAdmissionEvent
+	SelectedEvent       int
+	MetadataOnly        bool
+	ConsumptionCount    uint64
+	ConstructionRoute   string
+	Work                EOFRecoveryAdmissionWork
+}
+
+var (
+	eofRecoveryAdmissionCensusMu       sync.Mutex
+	eofRecoveryAdmissionCensusReceipts []EOFRecoveryAdmissionReceipt
+)
+
+func init() {
+	compactEOFRecoveryAdmissionCensusHook = recordEOFRecoveryAdmissionReceipt
+}
+
+// EOFRecoveryAdmissionCensusBuilt reports whether this binary includes the
+// tagged EOF recovery admission census.
+func EOFRecoveryAdmissionCensusBuilt() bool { return true }
+
+// EOFRecoveryAdmissionCensusReset removes all recorded admission receipts.
+func EOFRecoveryAdmissionCensusReset() {
+	eofRecoveryAdmissionCensusMu.Lock()
+	eofRecoveryAdmissionCensusReceipts = nil
+	eofRecoveryAdmissionCensusMu.Unlock()
+}
+
+// EOFRecoveryAdmissionCensusSnapshot returns an independent receipt copy.
+func EOFRecoveryAdmissionCensusSnapshot() []EOFRecoveryAdmissionReceipt {
+	eofRecoveryAdmissionCensusMu.Lock()
+	defer eofRecoveryAdmissionCensusMu.Unlock()
+	return append([]EOFRecoveryAdmissionReceipt(nil), eofRecoveryAdmissionCensusReceipts...)
+}
+
+func recordEOFRecoveryAdmissionReceipt(receipt compactEOFRecoveryAdmissionReceipt) {
+	record := EOFRecoveryAdmissionReceipt{
+		State:               receipt.state.String(),
+		CoreGeneration:      receipt.coreGeneration,
+		SourceLength:        receipt.sourceLength,
+		NormalPayloads:      receipt.normalPayloads,
+		RecoveryPayloads:    receipt.recoveryPayloads,
+		NormalOccurrences:   receipt.normalOccurrences,
+		RecoveryOccurrences: receipt.recoveryOccurrences,
+		NormalFrontier:      receipt.normalFrontier,
+		RecoveryFrontier:    receipt.recoveryFrontier,
+		SelectedEvent:       receipt.selectedEvent,
+		MetadataOnly:        receipt.metadataOnly,
+		ConsumptionCount:    receipt.consumptionCount,
+		ConstructionRoute:   receipt.constructionRoute.String(),
+		Work: EOFRecoveryAdmissionWork{
+			Polls:                      receipt.work.polls,
+			SourceChunks:               receipt.work.sourceChunks,
+			ChildGroups:                receipt.work.childGroups,
+			PathsVisited:               receipt.work.pathsVisited,
+			LinksVisited:               receipt.work.linksVisited,
+			PayloadRecordsVisited:      receipt.work.payloadRecordsVisited,
+			MaxDepth:                   receipt.work.maxDepth,
+			BytesInspected:             receipt.work.bytesInspected,
+			MaxSourceChunk:             receipt.work.maxSourceChunk,
+			MaxChildGroup:              receipt.work.maxChildGroup,
+			CheckedArithmetic:          receipt.work.checkedArithmetic,
+			PublicationAttempts:        receipt.work.publicationAttempts,
+			ParserConstructions:        receipt.work.parserConstructions,
+			TreeConstructions:          receipt.work.treeConstructions,
+			SelectedStoreConstructions: receipt.work.selectedStoreConstructions,
+			Overflow:                   receipt.work.overflow,
+		},
+	}
+	for index, event := range receipt.events {
+		record.Events[index] = EOFRecoveryAdmissionEvent{
+			Ordinal:           event.ordinal,
+			Kind:              event.kind.String(),
+			Cost:              event.cost,
+			DynamicPrecedence: event.dynamicPrecedence,
+		}
+	}
+	eofRecoveryAdmissionCensusMu.Lock()
+	eofRecoveryAdmissionCensusReceipts = append(eofRecoveryAdmissionCensusReceipts, record)
+	eofRecoveryAdmissionCensusMu.Unlock()
+}

--- a/parsercore_phase0_eof_recovery_metadata_contract_test.go
+++ b/parsercore_phase0_eof_recovery_metadata_contract_test.go
@@ -1,0 +1,1363 @@
+//go:build !gts_no_parsercorephase0 && gts_eof_recovery_admission_contract
+
+package gotreesitter
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+type g4EOFRoute uint8
+
+const (
+	g4EOFRoutePublicTree g4EOFRoute = iota
+	g4EOFRouteSelectedStore
+	g4EOFRouteLivePublication
+)
+
+const (
+	g4EOFActivationNone     = "none"
+	g4EOFActivationMetadata = "metadata"
+	g4EOFActivationLegacy   = "legacy"
+	g4EOFEventNormal        = "normal"
+	g4EOFEventRecover       = "recover_eof"
+)
+
+const (
+	g4EOFStateEmpty             = "empty"
+	g4EOFStateProduced          = "produced"
+	g4EOFStatePreApplyValidated = "pre_apply_validated"
+	g4EOFStateAcceptApplied     = "accept_applied"
+	g4EOFStateRecoveryDropped   = "recovery_dropped"
+	g4EOFStateCompleted         = "completed"
+	g4EOFStateSchedulerReturned = "scheduler_returned"
+	g4EOFStateConsumed          = "consumed"
+	g4EOFStateInvalid           = "invalid"
+)
+
+const (
+	g4EOFFaultAfterProduce = "after_produce"
+	g4EOFFaultAfterApply   = "after_apply"
+	g4EOFFaultAfterDrop    = "after_drop"
+	g4EOFSourceChunkBytes  = 4096
+	g4EOFChildGroupSize    = 64
+)
+
+type g4EOFEvent struct {
+	Ordinal           int
+	Kind              string
+	Cost              uint32
+	DynamicPrecedence int64
+}
+
+type g4EOFWork struct {
+	Polls                      uint64
+	SourceChunks               uint64
+	ChildGroups                uint64
+	PathsVisited               uint64
+	LinksVisited               uint64
+	PayloadRecordsVisited      uint64
+	MaxDepth                   uint64
+	BytesInspected             uint64
+	MaxSourceChunk             uint64
+	MaxChildGroup              uint64
+	CheckedArithmetic          uint64
+	PublicationAttempts        uint64
+	ParserConstructions        uint64
+	TreeConstructions          uint64
+	SelectedStoreConstructions uint64
+	Overflow                   bool
+}
+
+type g4EOFReceipt struct {
+	Active              bool
+	Valid               bool
+	State               string
+	Seal                [32]byte
+	TransitionSeals     [7][32]byte
+	Transitions         [7]string
+	DeclineReason       string
+	CoreGeneration      uint64
+	ElectionIndex       int
+	Token               Token
+	SourceLength        uint32
+	SourceSHA256        [32]byte
+	NormalHead          core.Head
+	RecoveryHead        core.Head
+	NormalCreationSeq   uint64
+	RecoveryCreationSeq uint64
+	NormalLineage       uint16
+	RecoveryLineage     uint16
+	NormalFingerprint   [32]byte
+	RecoveryFingerprint [32]byte
+	NormalPayloads      uint32
+	RecoveryPayloads    uint32
+	NormalOccurrences   uint32
+	RecoveryOccurrences uint32
+	NormalFrontier      uint32
+	RecoveryFrontier    uint32
+	Events              [2]g4EOFEvent
+	SelectedEvent       int
+	MetadataOnly        bool
+	ConsumptionCount    uint64
+	ConstructionRoute   g4EOFRoute
+	ObservedErrorCost   uint32
+	Work                g4EOFWork
+}
+
+type g4EOFDecision struct {
+	Activation               string
+	Approved                 bool
+	Decline                  bool
+	SelectedEvent            int
+	PublishedHead            core.Head
+	CarriedThroughAcceptance bool
+	RunnerGateApproved       bool
+	MetadataOnly             bool
+	ReceiptConsumed          bool
+}
+
+type g4EOFCell struct {
+	state  core.StateID
+	symbol core.Symbol
+}
+
+type g4EOFTable struct {
+	cells            map[g4EOFCell][]core.Action
+	gotos            map[g4EOFCell]core.StateID
+	reductionAliases []core.Symbol
+	policy           core.SelectedStorePolicy
+}
+
+func (t *g4EOFTable) Actions(state core.StateID, symbol core.Symbol) (core.ActionRow, error) {
+	return core.NewActionRow(t.cells[g4EOFCell{state: state, symbol: symbol}]), nil
+}
+
+func (t *g4EOFTable) Goto(state core.StateID, symbol core.Symbol) (core.StateID, error) {
+	return t.gotos[g4EOFCell{state: state, symbol: symbol}], nil
+}
+
+func (*g4EOFTable) ProductionFields(uint16, int) ([]core.FieldMapEntry, error) {
+	return nil, nil
+}
+
+func (t *g4EOFTable) ProductionAliases(productionID uint16, childCount int) ([]core.Symbol, error) {
+	if productionID != 1 || len(t.reductionAliases) != childCount {
+		return nil, nil
+	}
+	return t.reductionAliases, nil
+}
+
+func (t *g4EOFTable) SelectedStorePolicy() (core.SelectedStorePolicy, error) {
+	return t.policy, nil
+}
+
+type g4EOFFixtureSpec struct {
+	source                    []byte
+	recoveryRoots             int
+	recoveryPaths             int
+	maxDerivations            uint64
+	recoveryDynamicPrecedence int16
+	recoveryAlias             core.Symbol
+	invisibleTop              bool
+	extraTop                  bool
+	errorTop                  bool
+	openS3Region              bool
+	metadataActivation        bool
+	legacyActivation          bool
+}
+
+type g4EOFFixture struct {
+	compact   *core.Core
+	scheduler *diagnosticParserCoreGenericScheduler
+	runner    *parserCoreFreshFullRunner
+	language  *Language
+	source    []byte
+}
+
+func newG4EOFFixture(t *testing.T, spec g4EOFFixtureSpec) *g4EOFFixture {
+	t.Helper()
+	if len(spec.source) == 0 {
+		spec.source = []byte("GET /path\n")
+	}
+	if spec.recoveryRoots == 0 {
+		spec.recoveryRoots = 1
+	}
+	if spec.recoveryPaths == 0 {
+		spec.recoveryPaths = 1
+	}
+	if spec.maxDerivations == 0 {
+		spec.maxDerivations = 8
+	}
+	table := &g4EOFTable{
+		cells: make(map[g4EOFCell][]core.Action),
+		gotos: make(map[g4EOFCell]core.StateID),
+	}
+	if spec.recoveryAlias != 0 {
+		table.reductionAliases = make([]core.Symbol, spec.recoveryRoots)
+		for index := range table.reductionAliases {
+			table.reductionAliases[index] = spec.recoveryAlias
+		}
+	}
+	const (
+		normalSeedState    core.StateID = 1
+		normalAcceptState  core.StateID = 100
+		recoveryFinalState core.StateID = 200
+		normalSymbol       core.Symbol  = 2
+		reductionLookahead core.Symbol  = 90
+		reductionSymbol    core.Symbol  = 50
+	)
+	table.cells[g4EOFCell{state: normalSeedState, symbol: normalSymbol}] = []core.Action{{
+		Type: core.ActionShift, State: normalAcceptState,
+	}}
+	table.cells[g4EOFCell{state: normalAcceptState, symbol: 0}] = []core.Action{{Type: core.ActionAccept}}
+	const symbolSlots = 256
+	selectedSymbols := make([]core.SelectedSymbolPolicy, symbolSlots)
+	selectedSymbols[normalSymbol] = core.SelectedSymbolPolicy{Visible: true, Named: true}
+	for rootIndex := 0; rootIndex < spec.recoveryRoots; rootIndex++ {
+		symbol := core.Symbol(10 + rootIndex)
+		if int(symbol) < len(selectedSymbols) {
+			selectedSymbols[symbol] = core.SelectedSymbolPolicy{Visible: !spec.invisibleTop, Named: true}
+		}
+	}
+	selectedSymbols[reductionSymbol] = core.SelectedSymbolPolicy{Visible: !spec.invisibleTop, Named: true}
+	policy, err := core.NewSelectedStorePolicy(
+		selectedSymbols,
+		make([]core.SelectedUnaryRule, symbolSlots*symbolSlots),
+		normalSymbol,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	table.policy = policy
+
+	compact, err := core.New(table, core.Limits{
+		MaxNodes:            1024,
+		MaxLinks:            2048,
+		MaxSubtrees:         1024,
+		MaxChildren:         2048,
+		MaxMetadata:         1024,
+		MaxLinksPerBoundary: 8,
+		MaxPopPaths:         256,
+		MaxDerivations:      spec.maxDerivations,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	normalSeed, err := compact.Seed(normalSeedState, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	normalHead, err := compact.Shift(normalSeed, normalSymbol, 0, core.Token{
+		Symbol: normalSymbol, StartByte: 0, EndByte: uint32(len(spec.source)),
+	}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var recoveryHead core.Head
+	for pathIndex := 0; pathIndex < spec.recoveryPaths; pathIndex++ {
+		seedState := core.StateID(10 + pathIndex)
+		head, seedErr := compact.Seed(seedState, 0)
+		if seedErr != nil {
+			t.Fatal(seedErr)
+		}
+		state := seedState
+		for rootIndex := 0; rootIndex < spec.recoveryRoots; rootIndex++ {
+			symbol := core.Symbol(10 + rootIndex)
+			if spec.errorTop && rootIndex == spec.recoveryRoots-1 {
+				symbol = core.RecoveryErrorSymbol
+			}
+			nextState := core.StateID(300 + pathIndex*32 + rootIndex)
+			if rootIndex == spec.recoveryRoots-1 && spec.recoveryDynamicPrecedence == 0 {
+				nextState = recoveryFinalState
+			}
+			extra := spec.extraTop && rootIndex == spec.recoveryRoots-1
+			table.cells[g4EOFCell{state: state, symbol: symbol}] = []core.Action{{
+				Type: core.ActionShift, State: nextState, Extra: extra,
+			}}
+			startByte := uint32(rootIndex)
+			endByte := startByte + 1
+			if rootIndex == spec.recoveryRoots-1 {
+				endByte = uint32(len(spec.source))
+			}
+			head, err = compact.Shift(head, symbol, 0, core.Token{
+				Symbol: symbol, StartByte: startByte, EndByte: endByte, Extra: extra,
+			}, core.ForkOrder{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			state = nextState
+		}
+		if spec.recoveryDynamicPrecedence != 0 {
+			table.cells[g4EOFCell{state: state, symbol: reductionLookahead}] = []core.Action{{
+				Type:              core.ActionReduce,
+				Symbol:            reductionSymbol,
+				ChildCount:        uint8(spec.recoveryRoots),
+				DynamicPrecedence: spec.recoveryDynamicPrecedence,
+				ProductionID:      1,
+			}}
+			table.gotos[g4EOFCell{state: seedState, symbol: reductionSymbol}] = recoveryFinalState
+			outputs, reduceErr := compact.ReduceOutputs(head, reductionLookahead, 0, core.ForkOrder{})
+			if reduceErr != nil || len(outputs) != 1 {
+				t.Fatalf("recovery reduction outputs=%+v err=%v", outputs, reduceErr)
+			}
+			head = outputs[0].Head
+		}
+		recoveryHead = head
+	}
+
+	language := &Language{
+		Name:           "g4-eof-contract",
+		SymbolCount:    symbolSlots,
+		TokenCount:     symbolSlots,
+		StateCount:     1024,
+		SymbolNames:    make([]string, symbolSlots),
+		SymbolMetadata: make([]SymbolMetadata, symbolSlots),
+	}
+	language.SymbolMetadata[normalSymbol] = SymbolMetadata{Visible: true, Named: true}
+	language.SymbolNames[normalSymbol] = "document"
+	for rootIndex := 0; rootIndex < spec.recoveryRoots; rootIndex++ {
+		symbol := core.Symbol(10 + rootIndex)
+		if int(symbol) < len(language.SymbolMetadata) {
+			language.SymbolMetadata[symbol] = SymbolMetadata{Visible: !spec.invisibleTop, Named: true}
+			language.SymbolNames[symbol] = "payload"
+		}
+	}
+	language.SymbolMetadata[reductionSymbol] = SymbolMetadata{Visible: !spec.invisibleTop, Named: true}
+	language.SymbolNames[reductionSymbol] = "payload_group"
+	if spec.recoveryAlias != 0 {
+		language.SymbolMetadata[spec.recoveryAlias] = SymbolMetadata{Named: true}
+		language.SymbolNames[spec.recoveryAlias] = "invisible_alias"
+	}
+	sourceLength := uint32(len(spec.source))
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact:     compact,
+		tokenSource: &dfaTokenSource{language: language},
+		headers: []diagnosticParserCoreHeader{
+			{head: normalHead, creationSeq: 11, cleanPathLineage: 21},
+			{head: recoveryHead, creationSeq: 12, cleanPathLineage: 22},
+		},
+		token:         Token{Symbol: 0, StartByte: sourceLength, EndByte: sourceLength},
+		electionIndex: 7,
+		options: DiagnosticParserCorePrefixOptions{
+			allowEOFAcceptNoActionSiblings: spec.legacyActivation,
+			MaxDispatches:                  64,
+		},
+		receipt: &DiagnosticParserCoreGenericScheduler{},
+	}
+	setCompactEOFRecoveryAdmissionEnabledForTest(scheduler, spec.metadataActivation)
+	scheduler.options.materializationSource = spec.source
+	scheduler.options.materializationContextSet = true
+	if spec.openS3Region {
+		scheduler.headers[1].s3Region = &diagnosticParserCoreS3Region{
+			state: recoveryFinalState, startByte: 0, endByte: sourceLength,
+		}
+	}
+	parser := NewParser(language)
+	runner := &parserCoreFreshFullRunner{
+		lang: language, parser: parser, compact: compact,
+		options: DiagnosticParserCorePrefixOptions{ReceiptMode: DiagnosticParserCoreReceiptSummary},
+	}
+	return &g4EOFFixture{
+		compact: compact, scheduler: scheduler, runner: runner, language: language,
+		source: append([]byte(nil), spec.source...),
+	}
+}
+
+type g4EOFCoreSnapshot struct {
+	work       core.Work
+	footprint  uint64
+	index      core.BoundaryIndexStats
+	stats      []core.Stats
+	boundaries [][2]uint32
+	paths      [][]core.Derivation
+}
+
+func snapshotG4EOFCore(t *testing.T, fixture *g4EOFFixture) g4EOFCoreSnapshot {
+	t.Helper()
+	snapshot := g4EOFCoreSnapshot{
+		work:      fixture.compact.Work(),
+		footprint: fixture.compact.FootprintBytes(),
+		index:     fixture.compact.BoundaryIndexStats(),
+		stats:     make([]core.Stats, len(fixture.scheduler.headers)),
+		paths:     make([][]core.Derivation, len(fixture.scheduler.headers)),
+	}
+	for index, header := range fixture.scheduler.headers {
+		stats, err := fixture.compact.Stats(header.head)
+		if err != nil {
+			t.Fatal(err)
+		}
+		state, offset, err := fixture.compact.Boundary(header.head)
+		if err != nil {
+			t.Fatal(err)
+		}
+		paths, err := fixture.compact.Derivations(header.head)
+		if err != nil {
+			t.Fatal(err)
+		}
+		snapshot.stats[index] = stats
+		snapshot.boundaries = append(snapshot.boundaries, [2]uint32{uint32(state), offset})
+		snapshot.paths[index] = paths
+	}
+	return snapshot
+}
+
+func requireG4EOFCoreUnchanged(t *testing.T, fixture *g4EOFFixture, before g4EOFCoreSnapshot) {
+	t.Helper()
+	after := snapshotG4EOFCore(t, fixture)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("metadata admission mutated live Core: before=%+v after=%+v", before, after)
+	}
+}
+
+func requireG4EOFValidReceipt(t *testing.T, fixture *g4EOFFixture, receipt g4EOFReceipt, wantCost uint32, wantRecoveryPayloads uint32) {
+	t.Helper()
+	if !receipt.Active || !receipt.Valid || receipt.State != g4EOFStateProduced ||
+		receipt.Seal == ([32]byte{}) || receipt.DeclineReason != "" || !receipt.MetadataOnly {
+		t.Fatalf("metadata receipt is not valid: %+v", receipt)
+	}
+	if receipt.CoreGeneration == 0 || receipt.CoreGeneration != compactEOFRecoveryCoreGenerationForTest(fixture.compact) {
+		t.Fatalf("receipt Core generation=%d", receipt.CoreGeneration)
+	}
+	if receipt.ElectionIndex != fixture.scheduler.electionIndex || receipt.Token != fixture.scheduler.token ||
+		receipt.SourceLength != uint32(len(fixture.source)) || receipt.SourceSHA256 != sha256.Sum256(fixture.source) {
+		t.Fatalf("receipt election/token/source binding=%+v", receipt)
+	}
+	normal := fixture.scheduler.headers[0]
+	recovery := fixture.scheduler.headers[1]
+	if receipt.NormalHead != normal.head || receipt.RecoveryHead != recovery.head ||
+		receipt.NormalCreationSeq != normal.creationSeq || receipt.RecoveryCreationSeq != recovery.creationSeq ||
+		receipt.NormalLineage != normal.cleanPathLineage || receipt.RecoveryLineage != recovery.cleanPathLineage {
+		t.Fatalf("receipt head binding=%+v", receipt)
+	}
+	if receipt.NormalFingerprint == ([32]byte{}) || receipt.RecoveryFingerprint == ([32]byte{}) ||
+		receipt.NormalFingerprint == receipt.RecoveryFingerprint {
+		t.Fatalf("receipt payload fingerprints=%x/%x", receipt.NormalFingerprint, receipt.RecoveryFingerprint)
+	}
+	if receipt.NormalPayloads != 1 || receipt.RecoveryPayloads != wantRecoveryPayloads {
+		t.Fatalf("receipt payload counts=%d/%d, want 1/%d", receipt.NormalPayloads, receipt.RecoveryPayloads, wantRecoveryPayloads)
+	}
+	if receipt.NormalOccurrences != 1 || receipt.RecoveryOccurrences != wantRecoveryPayloads ||
+		receipt.NormalFrontier != 1 || receipt.RecoveryFrontier != wantRecoveryPayloads {
+		t.Fatalf(
+			"receipt occurrence/frontier counts=%d/%d and %d/%d, want 1/%d and 1/%d",
+			receipt.NormalOccurrences,
+			receipt.RecoveryOccurrences,
+			receipt.NormalFrontier,
+			receipt.RecoveryFrontier,
+			wantRecoveryPayloads,
+			wantRecoveryPayloads,
+		)
+	}
+	if receipt.Events != ([2]g4EOFEvent{
+		{Ordinal: 0, Kind: g4EOFEventNormal, Cost: 0},
+		{Ordinal: 1, Kind: g4EOFEventRecover, Cost: wantCost},
+	}) || receipt.SelectedEvent != 0 {
+		t.Fatalf("receipt events=%+v selected=%d", receipt.Events, receipt.SelectedEvent)
+	}
+	work := receipt.Work
+	wantSourceChunks := uint64((len(fixture.source) + g4EOFSourceChunkBytes - 1) / g4EOFSourceChunkBytes)
+	wantChildGroups := uint64(1 + (int(wantRecoveryPayloads)+g4EOFChildGroupSize-1)/g4EOFChildGroupSize)
+	if work.Polls == 0 || work.SourceChunks != wantSourceChunks || work.ChildGroups != wantChildGroups ||
+		work.PathsVisited != 2 || work.LinksVisited == 0 ||
+		work.PayloadRecordsVisited != uint64(1+wantRecoveryPayloads) || work.CheckedArithmetic == 0 ||
+		work.MaxDepth != 1 ||
+		work.BytesInspected != uint64(len(fixture.source)) || work.MaxSourceChunk > g4EOFSourceChunkBytes ||
+		work.MaxChildGroup > g4EOFChildGroupSize ||
+		work.PublicationAttempts != 0 || work.ParserConstructions != 0 || work.TreeConstructions != 0 ||
+		work.SelectedStoreConstructions != 0 || work.Overflow {
+		t.Fatalf("metadata producer work=%+v", work)
+	}
+}
+
+func TestCompactEOFRecoveryMetadataProducerDerivesEventsWithoutMutation(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		source           string
+		recoveryRoots    int
+		wantRecoveryCost uint32
+	}{
+		{name: "http", source: "GET /path\n", recoveryRoots: 1, wantRecoveryCost: 640},
+		{name: "robot", source: "*** Test Cases ***\nTest\n  Log  hello\n", recoveryRoots: 4, wantRecoveryCost: 1027},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newG4EOFFixture(t, g4EOFFixtureSpec{
+				source: []byte(test.source), recoveryRoots: test.recoveryRoots, metadataActivation: true,
+			})
+			before := snapshotG4EOFCore(t, fixture)
+			receipt, err := produceCompactEOFRecoveryAdmissionForTest(fixture.scheduler, fixture.source, func() error { return nil })
+			if err != nil {
+				t.Fatalf("produce metadata: %v", err)
+			}
+			requireG4EOFValidReceipt(t, fixture, receipt, test.wantRecoveryCost, uint32(test.recoveryRoots))
+			requireG4EOFCoreUnchanged(t, fixture, before)
+		})
+	}
+}
+
+func advanceG4EOFToSchedulerReturn(t *testing.T, fixture *g4EOFFixture) {
+	t.Helper()
+	stop, err := fixture.scheduler.dispatchPass()
+	if err != nil || stop != nil {
+		t.Fatalf("dispatch EOF acceptance: stop=%+v err=%v", stop, err)
+	}
+	afterDrop := compactEOFRecoveryAdmissionReceiptForTest(fixture.scheduler)
+	if afterDrop.State != g4EOFStateRecoveryDropped || len(fixture.scheduler.headers) != 1 ||
+		!fixture.scheduler.headers[0].accepted {
+		t.Fatalf("post-drop receipt=%+v headers=%+v", afterDrop, fixture.scheduler.headers)
+	}
+	if err := fixture.scheduler.completeAcceptance(); err != nil {
+		t.Fatalf("complete EOF acceptance: %v", err)
+	}
+	afterCompletion := compactEOFRecoveryAdmissionReceiptForTest(fixture.scheduler)
+	if afterCompletion.State != g4EOFStateCompleted || fixture.scheduler.receipt.Acceptance == nil {
+		t.Fatalf("completion receipt=%+v scheduler=%+v", afterCompletion, fixture.scheduler.receipt)
+	}
+	if err := markCompactEOFRecoverySchedulerReturnedForTest(fixture.scheduler); err != nil {
+		t.Fatalf("mark scheduler return: %v", err)
+	}
+	if got := compactEOFRecoveryAdmissionReceiptForTest(fixture.scheduler); got.State != g4EOFStateSchedulerReturned {
+		t.Fatalf("scheduler-return receipt=%+v", got)
+	}
+}
+
+func constructG4EOFRoute(t *testing.T, fixture *g4EOFFixture, route g4EOFRoute) error {
+	t.Helper()
+	switch route {
+	case g4EOFRoutePublicTree:
+		tree, err := fixture.runner.materializeSelection(fixture.source, fixture.compact, fixture.scheduler)
+		if tree != nil {
+			tree.Release()
+		}
+		return err
+	case g4EOFRouteSelectedStore:
+		store, err := fixture.runner.materializeSelectedStoreSelection(
+			fixture.source,
+			fixture.compact,
+			fixture.scheduler,
+			func() error { return nil },
+		)
+		if store != nil {
+			store.Release()
+		}
+		return err
+	default:
+		return errors.New("unsupported G4 construction route")
+	}
+}
+
+func requireG4EOFCompleteStateMachine(t *testing.T, receipt g4EOFReceipt, route g4EOFRoute) {
+	t.Helper()
+	want := [7]string{
+		g4EOFStateProduced,
+		g4EOFStatePreApplyValidated,
+		g4EOFStateAcceptApplied,
+		g4EOFStateRecoveryDropped,
+		g4EOFStateCompleted,
+		g4EOFStateSchedulerReturned,
+		g4EOFStateConsumed,
+	}
+	if receipt.State != g4EOFStateConsumed || receipt.Transitions != want || receipt.ConsumptionCount != 1 ||
+		receipt.ConstructionRoute != route || !receipt.Valid {
+		t.Fatalf("sealed lifecycle receipt=%+v", receipt)
+	}
+	seen := make(map[[32]byte]struct{}, len(receipt.TransitionSeals))
+	for index, seal := range receipt.TransitionSeals {
+		if seal == ([32]byte{}) {
+			t.Fatalf("transition %d has an empty seal", index)
+		}
+		if _, duplicate := seen[seal]; duplicate {
+			t.Fatalf("transition %d reused seal %x", index, seal)
+		}
+		seen[seal] = struct{}{}
+	}
+}
+
+func TestCompactEOFRecoveryMetadataUsesRealSchedulerAndConstructionPaths(t *testing.T) {
+	for _, route := range []g4EOFRoute{g4EOFRoutePublicTree, g4EOFRouteSelectedStore} {
+		route := route
+		t.Run(map[g4EOFRoute]string{
+			g4EOFRoutePublicTree:    "parse",
+			g4EOFRouteSelectedStore: "parse-selected-store",
+		}[route], func(t *testing.T) {
+			fixture := newG4EOFFixture(t, g4EOFFixtureSpec{metadataActivation: true})
+			advanceG4EOFToSchedulerReturn(t, fixture)
+			if err := constructG4EOFRoute(t, fixture, route); err != nil {
+				t.Fatalf("construct route %d: %v", route, err)
+			}
+			receipt := compactEOFRecoveryAdmissionReceiptForTest(fixture.scheduler)
+			requireG4EOFCompleteStateMachine(t, receipt, route)
+			if route == g4EOFRoutePublicTree {
+				if receipt.Work.TreeConstructions != 1 || receipt.Work.SelectedStoreConstructions != 0 {
+					t.Fatalf("public construction work=%+v", receipt.Work)
+				}
+			} else if receipt.Work.TreeConstructions != 0 || receipt.Work.SelectedStoreConstructions != 1 {
+				t.Fatalf("selected-store construction work=%+v", receipt.Work)
+			}
+
+			if err := constructG4EOFRoute(t, fixture, route); err == nil {
+				t.Fatal("a consumed receipt permitted a second construction")
+			}
+			afterSecond := compactEOFRecoveryAdmissionReceiptForTest(fixture.scheduler)
+			if afterSecond.Work.TreeConstructions != receipt.Work.TreeConstructions ||
+				afterSecond.Work.SelectedStoreConstructions != receipt.Work.SelectedStoreConstructions ||
+				afterSecond.ConsumptionCount != 1 {
+				t.Fatalf("second gate changed construction counters: before=%+v after=%+v", receipt, afterSecond)
+			}
+		})
+	}
+}
+
+func TestCompactEOFRecoveryMetadataDerivationNegatives(t *testing.T) {
+	tests := []struct {
+		name              string
+		spec              g4EOFFixtureSpec
+		mutate            func(*g4EOFFixture)
+		wantActive        bool
+		wantObservedError bool
+	}{
+		{
+			name: "false-EOF", spec: g4EOFFixtureSpec{metadataActivation: true},
+			mutate: func(fixture *g4EOFFixture) { fixture.scheduler.token.Symbol = 1 },
+		},
+		{
+			name: "nonzero-width-EOF", spec: g4EOFFixtureSpec{metadataActivation: true}, wantActive: true,
+			mutate: func(fixture *g4EOFFixture) { fixture.scheduler.token.StartByte-- },
+		},
+		{
+			name: "wrong-source-length", spec: g4EOFFixtureSpec{metadataActivation: true}, wantActive: true,
+			mutate: func(fixture *g4EOFFixture) {
+				fixture.scheduler.token.StartByte--
+				fixture.scheduler.token.EndByte--
+			},
+		},
+		{
+			name: "missing-EOF", spec: g4EOFFixtureSpec{metadataActivation: true}, wantActive: true,
+			mutate: func(fixture *g4EOFFixture) { fixture.scheduler.token.Missing = true },
+		},
+		{
+			name: "no-lookahead-EOF", spec: g4EOFFixtureSpec{metadataActivation: true}, wantActive: true,
+			mutate: func(fixture *g4EOFFixture) { fixture.scheduler.token.NoLookahead = true },
+		},
+		{
+			name: "external-scanner-EOF", spec: g4EOFFixtureSpec{metadataActivation: true}, wantActive: true,
+			mutate: func(fixture *g4EOFFixture) { fixture.scheduler.token.ExternalScannerToken = true },
+		},
+		{
+			name: "wrong-derivation-count",
+			spec: g4EOFFixtureSpec{metadataActivation: true, recoveryPaths: 2, maxDerivations: 8}, wantActive: true,
+		},
+		{
+			name: "inexact-derivation",
+			spec: g4EOFFixtureSpec{metadataActivation: true, recoveryPaths: 2, maxDerivations: 1}, wantActive: true,
+		},
+		{
+			name: "extra-top-root",
+			spec: g4EOFFixtureSpec{metadataActivation: true, extraTop: true}, wantActive: true,
+		},
+		{
+			name: "error-symbol-with-error-cost",
+			spec: g4EOFFixtureSpec{metadataActivation: true, errorTop: true}, wantActive: true, wantObservedError: true,
+		},
+		{
+			name: "open-strategy-three-region",
+			spec: g4EOFFixtureSpec{metadataActivation: true, openS3Region: true}, wantActive: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newG4EOFFixture(t, test.spec)
+			if test.mutate != nil {
+				test.mutate(fixture)
+			}
+			beforeWork := fixture.compact.Work()
+			beforeFootprint := fixture.compact.FootprintBytes()
+			receipt, err := produceCompactEOFRecoveryAdmissionForTest(fixture.scheduler, fixture.source, func() error { return nil })
+			if err != nil {
+				t.Fatalf("unsupported metadata returned a hard error: %v", err)
+			}
+			if receipt.Active != test.wantActive || receipt.Valid || receipt.SelectedEvent != -1 {
+				t.Fatalf("unsupported metadata receipt=%+v, want active=%v valid=false selected=-1", receipt, test.wantActive)
+			}
+			if test.wantActive && receipt.DeclineReason == "" {
+				t.Fatal("active unsupported metadata has no decline reason")
+			}
+			if test.wantObservedError && receipt.ObservedErrorCost == 0 {
+				t.Fatalf("ERROR-symbol decline has no observed error cost: %+v", receipt)
+			}
+			if fixture.compact.Work() != beforeWork || fixture.compact.FootprintBytes() != beforeFootprint {
+				t.Fatal("unsupported metadata mutated live Core")
+			}
+		})
+	}
+}
+
+func TestCompactEOFRecoveryMetadataInvisibleLeafContributesZero(t *testing.T) {
+	fixture := newG4EOFFixture(t, g4EOFFixtureSpec{
+		metadataActivation: true,
+		invisibleTop:       true,
+	})
+	receipt, err := produceCompactEOFRecoveryAdmissionForTest(
+		fixture.scheduler,
+		fixture.source,
+		func() error { return nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !receipt.Valid || receipt.NormalFrontier != 1 || receipt.RecoveryFrontier != 0 ||
+		receipt.Events[1].Cost != 540 || receipt.RecoveryOccurrences != 1 ||
+		receipt.Work.PayloadRecordsVisited != 2 {
+		t.Fatalf("invisible leaf receipt=%+v", receipt)
+	}
+}
+
+func TestCompactEOFRecoveryMetadataNonzeroAliasCreatesVisibleBoundary(t *testing.T) {
+	const invisibleAlias core.Symbol = 60
+	spec := g4EOFFixtureSpec{
+		metadataActivation:        true,
+		invisibleTop:              true,
+		recoveryDynamicPrecedence: 1,
+		recoveryAlias:             invisibleAlias,
+	}
+	fixture := newG4EOFFixture(t, spec)
+	if fixture.language.SymbolMetadata[invisibleAlias].Visible {
+		t.Fatal("alias target must stay invisible for the C boundary test")
+	}
+	first, err := produceCompactEOFRecoveryAdmissionForTest(
+		fixture.scheduler,
+		fixture.source,
+		func() error { return nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := produceCompactEOFRecoveryAdmissionForTest(
+		fixture.scheduler,
+		fixture.source,
+		func() error { return nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.Valid || !second.Valid || first.RecoveryOccurrences != 2 ||
+		first.RecoveryFrontier != 1 || first.Events[1].Cost != 640 ||
+		first.RecoveryFingerprint == ([32]byte{}) ||
+		first.RecoveryFingerprint != second.RecoveryFingerprint {
+		t.Fatalf("aliased reduction receipts first=%+v second=%+v", first, second)
+	}
+
+	unaliased := newG4EOFFixture(t, g4EOFFixtureSpec{
+		metadataActivation:        true,
+		invisibleTop:              true,
+		recoveryDynamicPrecedence: 1,
+	})
+	withoutAlias, err := produceCompactEOFRecoveryAdmissionForTest(
+		unaliased.scheduler,
+		unaliased.source,
+		func() error { return nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !withoutAlias.Valid || withoutAlias.RecoveryOccurrences != 2 ||
+		withoutAlias.RecoveryFrontier != 0 || withoutAlias.Events[1].Cost != 540 ||
+		withoutAlias.RecoveryFingerprint == first.RecoveryFingerprint {
+		t.Fatalf("unaliased reduction receipt=%+v", withoutAlias)
+	}
+}
+
+func TestCompactEOFRecoveryMetadataUsesCRecoveryCostBeforeDynamicPrecedence(t *testing.T) {
+	fixture := newG4EOFFixture(t, g4EOFFixtureSpec{
+		metadataActivation: true, recoveryDynamicPrecedence: 9,
+	})
+	receipt, err := produceCompactEOFRecoveryAdmissionForTest(fixture.scheduler, fixture.source, func() error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !receipt.Valid || receipt.SelectedEvent != 0 || receipt.Events[0].Cost >= receipt.Events[1].Cost ||
+		receipt.Events[1].DynamicPrecedence != 9 {
+		t.Fatalf("lower normal cost did not win before recovery dynamic precedence: %+v", receipt)
+	}
+}
+
+func TestCompactEOFRecoveryMetadataReceiptTamperingDeclines(t *testing.T) {
+	fixture := newG4EOFFixture(t, g4EOFFixtureSpec{metadataActivation: true})
+	receipt, err := produceCompactEOFRecoveryAdmissionForTest(fixture.scheduler, fixture.source, func() error { return nil })
+	if err != nil || !receipt.Valid {
+		t.Fatalf("produce valid receipt: receipt=%+v err=%v", receipt, err)
+	}
+	tests := []struct {
+		name   string
+		mutate func(*g4EOFFixture, *g4EOFReceipt)
+		route  g4EOFRoute
+	}{
+		{
+			name: "changed-head",
+			mutate: func(fixture *g4EOFFixture, _ *g4EOFReceipt) {
+				fixture.scheduler.headers[1].head = fixture.scheduler.headers[0].head
+			},
+		},
+		{
+			name: "changed-header-lineage",
+			mutate: func(fixture *g4EOFFixture, _ *g4EOFReceipt) {
+				fixture.scheduler.headers[1].cleanPathLineage++
+			},
+		},
+		{
+			name: "changed-token",
+			mutate: func(fixture *g4EOFFixture, _ *g4EOFReceipt) {
+				fixture.scheduler.token.Missing = true
+			},
+		},
+		{
+			name: "changed-source",
+			mutate: func(fixture *g4EOFFixture, _ *g4EOFReceipt) {
+				fixture.source[0] ^= 0xff
+			},
+		},
+		{
+			name:   "changed-payload-fingerprint",
+			mutate: func(_ *g4EOFFixture, receipt *g4EOFReceipt) { receipt.RecoveryFingerprint[0] ^= 0xff },
+		},
+		{
+			name:   "changed-core-generation",
+			mutate: func(_ *g4EOFFixture, receipt *g4EOFReceipt) { receipt.CoreGeneration++ },
+		},
+		{
+			name:   "changed-seal",
+			mutate: func(_ *g4EOFFixture, receipt *g4EOFReceipt) { receipt.Seal[0] ^= 0xff },
+		},
+		{
+			name:   "stale-election",
+			mutate: func(fixture *g4EOFFixture, _ *g4EOFReceipt) { fixture.scheduler.electionIndex++ },
+		},
+		{
+			name:   "equal-cost",
+			mutate: func(_ *g4EOFFixture, receipt *g4EOFReceipt) { receipt.Events[0].Cost = receipt.Events[1].Cost },
+		},
+		{
+			name:   "reversed-cost",
+			mutate: func(_ *g4EOFFixture, receipt *g4EOFReceipt) { receipt.Events[0].Cost = receipt.Events[1].Cost + 1 },
+		},
+		{
+			name: "reversed-event-order",
+			mutate: func(_ *g4EOFFixture, receipt *g4EOFReceipt) {
+				receipt.Events[0], receipt.Events[1] = receipt.Events[1], receipt.Events[0]
+			},
+		},
+		{
+			name:   "attempted-live-publication",
+			mutate: func(_ *g4EOFFixture, receipt *g4EOFReceipt) { receipt.Work.PublicationAttempts = 1 },
+			route:  g4EOFRouteLivePublication,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			caseFixture := newG4EOFFixture(t, g4EOFFixtureSpec{metadataActivation: true})
+			before := snapshotG4EOFCore(t, caseFixture)
+			caseReceipt, produceErr := produceCompactEOFRecoveryAdmissionForTest(caseFixture.scheduler, caseFixture.source, func() error { return nil })
+			if produceErr != nil || !caseReceipt.Valid {
+				t.Fatalf("produce valid receipt: receipt=%+v err=%v", caseReceipt, produceErr)
+			}
+			test.mutate(caseFixture, &caseReceipt)
+			decision := gateCompactEOFRecoveryAdmissionForTest(caseFixture.scheduler, caseFixture.source, caseReceipt, test.route)
+			if decision.Approved || !decision.Decline || decision.RunnerGateApproved || decision.PublishedHead != (core.Head{}) {
+				t.Fatalf("tampered receipt decision=%+v", decision)
+			}
+			if test.name != "changed-head" && test.name != "changed-header-lineage" &&
+				test.name != "changed-token" && test.name != "stale-election" {
+				requireG4EOFCoreUnchanged(t, caseFixture, before)
+			}
+		})
+	}
+}
+
+func TestCompactEOFRecoveryMetadataTransitionFaultsRollbackAndInvalidate(t *testing.T) {
+	wantErr := errors.New("G4 injected transition fault")
+	for _, stage := range []string{
+		g4EOFFaultAfterProduce,
+		g4EOFFaultAfterApply,
+		g4EOFFaultAfterDrop,
+	} {
+		stage := stage
+		t.Run(stage, func(t *testing.T) {
+			fixture := newG4EOFFixture(t, g4EOFFixtureSpec{metadataActivation: true})
+			fixture.scheduler.receipt.NoActionDrops = make(
+				[]DiagnosticParserCoreGenericNoActionDrop,
+				1,
+				4,
+			)
+			fixture.scheduler.receipt.NoActionDrops[0].ElectionIndex = -1
+			beforePublicReceipt := *fixture.scheduler.receipt
+			beforePublicReceipt.NoActionDrops = append(
+				[]DiagnosticParserCoreGenericNoActionDrop(nil),
+				fixture.scheduler.receipt.NoActionDrops...,
+			)
+			beforeNoActionDropsPointer := reflect.ValueOf(
+				fixture.scheduler.receipt.NoActionDrops,
+			).Pointer()
+			beforeNoActionDropsLength := len(fixture.scheduler.receipt.NoActionDrops)
+			beforeNoActionDropsCapacity := cap(fixture.scheduler.receipt.NoActionDrops)
+			beforeCore := snapshotG4EOFCore(t, fixture)
+			beforeHeaders := append([]diagnosticParserCoreHeader(nil), fixture.scheduler.headers...)
+			setCompactEOFRecoveryAdmissionFaultForTest(fixture.scheduler, stage, wantErr)
+			stop, err := fixture.scheduler.dispatchPass()
+			if stop != nil || !errors.Is(err, wantErr) {
+				t.Fatalf("stage %s stop=%+v err=%v", stage, stop, err)
+			}
+			if !reflect.DeepEqual(fixture.scheduler.headers, beforeHeaders) {
+				t.Fatalf("stage %s changed headers: before=%+v after=%+v", stage, beforeHeaders, fixture.scheduler.headers)
+			}
+			if !reflect.DeepEqual(*fixture.scheduler.receipt, beforePublicReceipt) {
+				t.Fatalf(
+					"stage %s changed the public receipt: before=%+v after=%+v",
+					stage,
+					beforePublicReceipt,
+					*fixture.scheduler.receipt,
+				)
+			}
+			if reflect.ValueOf(fixture.scheduler.receipt.NoActionDrops).Pointer() != beforeNoActionDropsPointer ||
+				len(fixture.scheduler.receipt.NoActionDrops) != beforeNoActionDropsLength ||
+				cap(fixture.scheduler.receipt.NoActionDrops) != beforeNoActionDropsCapacity {
+				t.Fatalf(
+					"stage %s changed the NoActionDrops slice header: len=%d cap=%d",
+					stage,
+					len(fixture.scheduler.receipt.NoActionDrops),
+					cap(fixture.scheduler.receipt.NoActionDrops),
+				)
+			}
+			receipt := compactEOFRecoveryAdmissionReceiptForTest(fixture.scheduler)
+			if receipt.Valid || receipt.State != g4EOFStateInvalid || receipt.ConsumptionCount != 0 {
+				t.Fatalf("stage %s left a usable receipt: %+v", stage, receipt)
+			}
+			requireG4EOFCoreUnchanged(t, fixture, beforeCore)
+		})
+	}
+}
+
+func TestCompactEOFRecoveryMetadataInvalidatesAcrossLifecycleBoundaries(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, *g4EOFFixture)
+	}{
+		{
+			name: "next-election",
+			mutate: func(t *testing.T, fixture *g4EOFFixture) {
+				t.Helper()
+				if err := advanceCompactEOFRecoveryElectionForTest(fixture.scheduler); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "begin-frontier",
+			mutate: func(t *testing.T, fixture *g4EOFFixture) {
+				t.Helper()
+				if err := fixture.compact.BeginFrontier(); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "changed-phase-checkpoint",
+			mutate: func(t *testing.T, fixture *g4EOFFixture) {
+				t.Helper()
+				checkpoint, err := fixture.compact.InternCheckpoint([]byte("G4 changed phase"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := fixture.compact.SetPhaseCheckpoint(checkpoint); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "scheduler-reset",
+			mutate: func(t *testing.T, fixture *g4EOFFixture) {
+				t.Helper()
+				if err := resetDiagnosticParserCoreGenericScheduler(fixture.scheduler); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "core-reset",
+			mutate: func(t *testing.T, fixture *g4EOFFixture) {
+				t.Helper()
+				if err := fixture.compact.Reset(); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "core-reset-releasing-retention",
+			mutate: func(t *testing.T, fixture *g4EOFFixture) {
+				t.Helper()
+				if err := fixture.compact.ResetReleasingRetention(); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newG4EOFFixture(t, g4EOFFixtureSpec{metadataActivation: true})
+			advanceG4EOFToSchedulerReturn(t, fixture)
+			receipt := compactEOFRecoveryAdmissionReceiptForTest(fixture.scheduler)
+			if receipt.State != g4EOFStateSchedulerReturned || !receipt.Valid {
+				t.Fatalf("precondition receipt=%+v", receipt)
+			}
+			test.mutate(t, fixture)
+			decision := gateCompactEOFRecoveryAdmissionForTest(
+				fixture.scheduler,
+				fixture.source,
+				receipt,
+				g4EOFRoutePublicTree,
+			)
+			if decision.Approved || !decision.Decline || decision.RunnerGateApproved || decision.ReceiptConsumed {
+				t.Fatalf("%s accepted a stale receipt: %+v", test.name, decision)
+			}
+		})
+	}
+}
+
+func TestCompactEOFRecoveryMetadataCompletionErrorInvalidatesReceipt(t *testing.T) {
+	fixture := newG4EOFFixture(t, g4EOFFixtureSpec{metadataActivation: true})
+	stop, err := fixture.scheduler.dispatchPass()
+	if err != nil || stop != nil {
+		t.Fatalf("dispatch EOF acceptance: stop=%+v err=%v", stop, err)
+	}
+	fixture.scheduler.token.Missing = true
+	if err := fixture.scheduler.completeAcceptance(); err != nil {
+		t.Fatal(err)
+	}
+	receipt := compactEOFRecoveryAdmissionReceiptForTest(fixture.scheduler)
+	if receipt.Valid || receipt.State != g4EOFStateInvalid || receipt.ConsumptionCount != 0 {
+		t.Fatalf("completion error left a usable receipt: %+v", receipt)
+	}
+}
+
+func TestCompactEOFRecoveryMetadataBoundedChunkAndChildTraversal(t *testing.T) {
+	source := bytes.Repeat([]byte("x\n"), 5000)
+	fixture := newG4EOFFixture(t, g4EOFFixtureSpec{
+		source: source, recoveryRoots: 130, metadataActivation: true,
+	})
+	receipt, err := produceCompactEOFRecoveryAdmissionForTest(fixture.scheduler, fixture.source, func() error { return nil })
+	if err != nil || !receipt.Valid {
+		t.Fatalf("bounded producer receipt=%+v err=%v", receipt, err)
+	}
+	wantSourceChunks := uint64((len(source) + g4EOFSourceChunkBytes - 1) / g4EOFSourceChunkBytes)
+	wantChildGroups := uint64(1 + (130+g4EOFChildGroupSize-1)/g4EOFChildGroupSize)
+	if receipt.Work.SourceChunks != wantSourceChunks || receipt.Work.ChildGroups != wantChildGroups ||
+		receipt.Work.BytesInspected != uint64(len(source)) || receipt.Work.MaxSourceChunk > g4EOFSourceChunkBytes ||
+		receipt.Work.MaxChildGroup > g4EOFChildGroupSize || receipt.Work.Overflow {
+		t.Fatalf("bounded traversal work=%+v", receipt.Work)
+	}
+	if _, ok := checkedCompactEOFRecoveryAdmissionAddForTest(math.MaxUint64, 1); ok {
+		t.Fatal("checked admission counter accepted uint64 overflow")
+	}
+	if _, ok := compactEOFRecoveryAdmissionCheckedMul(math.MaxUint64, 2); ok {
+		t.Fatal("checked admission cost accepted uint64 overflow")
+	}
+}
+
+func TestCompactEOFRecoveryMetadataProducerInternalOverflowInvalidates(t *testing.T) {
+	for _, overflowPoint := range []string{"counter", "cost"} {
+		overflowPoint := overflowPoint
+		t.Run(overflowPoint, func(t *testing.T) {
+			fixture := newG4EOFFixture(t, g4EOFFixtureSpec{metadataActivation: true})
+			before := snapshotG4EOFCore(t, fixture)
+			setCompactEOFRecoveryAdmissionOverflowForTest(fixture.scheduler, overflowPoint)
+			receipt, err := produceCompactEOFRecoveryAdmissionForTest(
+				fixture.scheduler,
+				fixture.source,
+				func() error { return nil },
+			)
+			if err == nil || !strings.Contains(err.Error(), "overflow") {
+				t.Fatalf("%s overflow error=%v", overflowPoint, err)
+			}
+			if receipt.Valid || receipt.State != g4EOFStateInvalid || receipt.SelectedEvent != -1 ||
+				receipt.Work.PublicationAttempts != 0 || receipt.Work.ParserConstructions != 0 ||
+				receipt.Work.TreeConstructions != 0 || receipt.Work.SelectedStoreConstructions != 0 ||
+				!receipt.Work.Overflow {
+				t.Fatalf("%s overflow receipt=%+v", overflowPoint, receipt)
+			}
+			requireG4EOFCoreUnchanged(t, fixture, before)
+		})
+	}
+}
+
+func TestCompactEOFRecoveryMetadataPartialWorkReturnsNoReceipt(t *testing.T) {
+	fixture := newG4EOFFixture(t, g4EOFFixtureSpec{
+		source: []byte("*** Test Cases ***\nTest\n  Log  hello\n"), recoveryRoots: 4, metadataActivation: true,
+	})
+	before := snapshotG4EOFCore(t, fixture)
+	wantErr := errors.New("G4 stop poll")
+	polls := 0
+	receipt, err := produceCompactEOFRecoveryAdmissionForTest(fixture.scheduler, fixture.source, func() error {
+		polls++
+		if polls == 2 {
+			return wantErr
+		}
+		return nil
+	})
+	if !errors.Is(err, wantErr) || receipt.Valid || receipt.State != g4EOFStateInvalid || receipt.SelectedEvent != -1 {
+		t.Fatalf("partial-work receipt=%+v err=%v", receipt, err)
+	}
+	if receipt.Work.Polls != 2 || receipt.Work.PublicationAttempts != 0 ||
+		receipt.Work.ParserConstructions != 0 || receipt.Work.TreeConstructions != 0 ||
+		receipt.Work.SelectedStoreConstructions != 0 {
+		t.Fatalf("partial-work counters=%+v", receipt.Work)
+	}
+	requireG4EOFCoreUnchanged(t, fixture, before)
+}
+
+func TestCompactEOFRecoveryMetadataRepeatedValidDeclineValid(t *testing.T) {
+	fixture := newG4EOFFixture(t, g4EOFFixtureSpec{metadataActivation: true})
+	first, err := exerciseCompactEOFRecoveryAdmissionForTest(fixture.scheduler, fixture.source, g4EOFRoutePublicTree)
+	if err != nil || !first.Approved || first.Activation != g4EOFActivationMetadata {
+		t.Fatalf("first decision=%+v err=%v", first, err)
+	}
+
+	fixture.scheduler.electionIndex++
+	fixture.scheduler.token.Symbol = 1
+	middle, err := exerciseCompactEOFRecoveryAdmissionForTest(fixture.scheduler, fixture.source, g4EOFRoutePublicTree)
+	if err != nil || middle.Approved || middle.Decline || middle.Activation != g4EOFActivationNone {
+		t.Fatalf("middle non-EOF decision=%+v err=%v", middle, err)
+	}
+
+	fixture.scheduler.electionIndex++
+	fixture.scheduler.token.Symbol = 0
+	last, err := exerciseCompactEOFRecoveryAdmissionForTest(fixture.scheduler, fixture.source, g4EOFRouteSelectedStore)
+	if err != nil || !last.Approved || last.Activation != g4EOFActivationMetadata {
+		t.Fatalf("last decision=%+v err=%v", last, err)
+	}
+}
+
+func TestCompactEOFRecoveryMetadataKeepsExplicitLegacyBypass(t *testing.T) {
+	legacy := newG4EOFFixture(t, g4EOFFixtureSpec{legacyActivation: true})
+	decision, err := exerciseCompactEOFRecoveryAdmissionForTest(legacy.scheduler, legacy.source, g4EOFRoutePublicTree)
+	if err != nil || !decision.Approved || decision.Activation != g4EOFActivationLegacy || decision.MetadataOnly {
+		t.Fatalf("legacy bypass decision=%+v err=%v", decision, err)
+	}
+
+	inactive := newG4EOFFixture(t, g4EOFFixtureSpec{})
+	decision, err = exerciseCompactEOFRecoveryAdmissionForTest(inactive.scheduler, inactive.source, g4EOFRoutePublicTree)
+	if err != nil || decision.Approved || decision.Decline || decision.Activation != g4EOFActivationNone {
+		t.Fatalf("inactive decision=%+v err=%v", decision, err)
+	}
+}
+
+func TestCompactEOFRecoveryMetadataDeclineReasonsStaySpecific(t *testing.T) {
+	fixture := newG4EOFFixture(t, g4EOFFixtureSpec{metadataActivation: true, recoveryPaths: 2})
+	receipt, err := produceCompactEOFRecoveryAdmissionForTest(fixture.scheduler, fixture.source, func() error { return nil })
+	if err != nil || receipt.Valid || !strings.Contains(receipt.DeclineReason, "derivation") {
+		t.Fatalf("wrong-derivation receipt=%+v err=%v", receipt, err)
+	}
+}
+
+func setCompactEOFRecoveryAdmissionEnabledForTest(
+	scheduler *diagnosticParserCoreGenericScheduler,
+	enabled bool,
+) {
+	if scheduler != nil {
+		scheduler.options.allowMetadataEOFAcceptRecovery = enabled
+	}
+}
+
+func compactEOFRecoveryCoreGenerationForTest(compact *core.Core) uint64 {
+	if compact == nil {
+		return 0
+	}
+	return compact.AuthenticationGeneration()
+}
+
+func g4EOFStateFromInternal(state compactEOFRecoveryAdmissionState) string {
+	return state.String()
+}
+
+func g4EOFReceiptFromInternal(receipt compactEOFRecoveryAdmissionReceipt) g4EOFReceipt {
+	out := g4EOFReceipt{
+		Active: receipt.active, Valid: receipt.valid, State: g4EOFStateFromInternal(receipt.state),
+		Seal: receipt.seal, TransitionSeals: receipt.transitionSeals,
+		DeclineReason: receipt.declineReason, CoreGeneration: receipt.coreGeneration,
+		ElectionIndex: receipt.electionIndex, Token: receipt.token, SourceLength: receipt.sourceLength,
+		SourceSHA256: receipt.sourceSHA256, NormalHead: receipt.normalHead, RecoveryHead: receipt.recoveryHead,
+		NormalCreationSeq: receipt.normalCreationSeq, RecoveryCreationSeq: receipt.recoveryCreationSeq,
+		NormalLineage: receipt.normalLineage, RecoveryLineage: receipt.recoveryLineage,
+		NormalFingerprint: receipt.normalFingerprint, RecoveryFingerprint: receipt.recoveryFingerprint,
+		NormalPayloads: receipt.normalPayloads, RecoveryPayloads: receipt.recoveryPayloads,
+		NormalOccurrences: receipt.normalOccurrences, RecoveryOccurrences: receipt.recoveryOccurrences,
+		NormalFrontier: receipt.normalFrontier, RecoveryFrontier: receipt.recoveryFrontier,
+		SelectedEvent: receipt.selectedEvent, MetadataOnly: receipt.metadataOnly,
+		ConsumptionCount: receipt.consumptionCount, ConstructionRoute: g4EOFRoute(receipt.constructionRoute),
+		ObservedErrorCost: receipt.observedErrorCost,
+		Work: g4EOFWork{
+			Polls: receipt.work.polls, SourceChunks: receipt.work.sourceChunks,
+			ChildGroups: receipt.work.childGroups, PathsVisited: receipt.work.pathsVisited,
+			LinksVisited: receipt.work.linksVisited, PayloadRecordsVisited: receipt.work.payloadRecordsVisited,
+			MaxDepth:       receipt.work.maxDepth,
+			BytesInspected: receipt.work.bytesInspected, MaxSourceChunk: receipt.work.maxSourceChunk,
+			MaxChildGroup: receipt.work.maxChildGroup, CheckedArithmetic: receipt.work.checkedArithmetic,
+			PublicationAttempts:        receipt.work.publicationAttempts,
+			ParserConstructions:        receipt.work.parserConstructions,
+			TreeConstructions:          receipt.work.treeConstructions,
+			SelectedStoreConstructions: receipt.work.selectedStoreConstructions,
+			Overflow:                   receipt.work.overflow,
+		},
+	}
+	for index, state := range receipt.transitions {
+		out.Transitions[index] = g4EOFStateFromInternal(state)
+	}
+	for index, event := range receipt.events {
+		out.Events[index] = g4EOFEvent{
+			Ordinal: event.ordinal, Kind: event.kind.String(), Cost: event.cost,
+			DynamicPrecedence: event.dynamicPrecedence,
+		}
+	}
+	return out
+}
+
+func produceCompactEOFRecoveryAdmissionForTest(
+	scheduler *diagnosticParserCoreGenericScheduler,
+	source []byte,
+	poll func() error,
+) (g4EOFReceipt, error) {
+	receipt, err := scheduler.produceCompactEOFRecoveryAdmission(source, poll)
+	return g4EOFReceiptFromInternal(receipt), err
+}
+
+func compactEOFRecoveryAdmissionReceiptForTest(
+	scheduler *diagnosticParserCoreGenericScheduler,
+) g4EOFReceipt {
+	if scheduler == nil {
+		return g4EOFReceipt{State: g4EOFStateEmpty, SelectedEvent: -1}
+	}
+	return g4EOFReceiptFromInternal(scheduler.eofRecoveryAdmission)
+}
+
+func markCompactEOFRecoverySchedulerReturnedForTest(
+	scheduler *diagnosticParserCoreGenericScheduler,
+) error {
+	if scheduler == nil {
+		return errors.New("EOF recovery receipt is not complete")
+	}
+	return scheduler.markCompactEOFRecoverySchedulerReturned(scheduler.options.materializationSource)
+}
+
+func setCompactEOFRecoveryAdmissionFaultForTest(
+	scheduler *diagnosticParserCoreGenericScheduler,
+	stage string,
+	wantErr error,
+) {
+	compactEOFRecoveryAdmissionFaultHook = func(candidate *diagnosticParserCoreGenericScheduler, current string) error {
+		if candidate == scheduler && current == stage {
+			return wantErr
+		}
+		return nil
+	}
+}
+
+func setCompactEOFRecoveryAdmissionOverflowForTest(
+	scheduler *diagnosticParserCoreGenericScheduler,
+	point string,
+) {
+	consumed := false
+	compactEOFRecoveryAdmissionOverflowHook = func(candidate *diagnosticParserCoreGenericScheduler, current string) bool {
+		if consumed || candidate != scheduler || current != point {
+			return false
+		}
+		consumed = true
+		return true
+	}
+}
+
+func advanceCompactEOFRecoveryElectionForTest(
+	scheduler *diagnosticParserCoreGenericScheduler,
+) error {
+	if scheduler == nil || scheduler.electionIndex == math.MaxInt {
+		return errors.New("EOF recovery test election overflow")
+	}
+	scheduler.electionIndex++
+	compactEOFRecoveryAdmissionInvalidate(&scheduler.eofRecoveryAdmission, "new election")
+	return nil
+}
+
+func checkedCompactEOFRecoveryAdmissionAddForTest(left, right uint64) (uint64, bool) {
+	return compactEOFRecoveryAdmissionCheckedAdd(left, right)
+}
+
+func gateCompactEOFRecoveryAdmissionForTest(
+	scheduler *diagnosticParserCoreGenericScheduler,
+	source []byte,
+	receipt g4EOFReceipt,
+	route g4EOFRoute,
+) g4EOFDecision {
+	decision := g4EOFDecision{Activation: g4EOFActivationMetadata, Decline: true, SelectedEvent: -1}
+	if scheduler == nil || scheduler.compact == nil || route == g4EOFRouteLivePublication {
+		return decision
+	}
+	current := g4EOFReceiptFromInternal(scheduler.eofRecoveryAdmission)
+	if !reflect.DeepEqual(receipt, current) || receipt.CoreGeneration != scheduler.compact.AuthenticationGeneration() ||
+		receipt.ElectionIndex != scheduler.electionIndex || receipt.Token != scheduler.token ||
+		receipt.SourceLength != uint32(len(source)) || receipt.SourceSHA256 != sha256.Sum256(source) {
+		return decision
+	}
+	if len(scheduler.headers) == 2 {
+		normal, normalOK := scheduler.compactEOFRecoveryAdmissionHeader(
+			receipt.NormalHead,
+			receipt.NormalCreationSeq,
+			receipt.NormalLineage,
+		)
+		recovery, recoveryOK := scheduler.compactEOFRecoveryAdmissionHeader(
+			receipt.RecoveryHead,
+			receipt.RecoveryCreationSeq,
+			receipt.RecoveryLineage,
+		)
+		if !normalOK || !recoveryOK || normal.accepted || recovery.accepted {
+			return decision
+		}
+	}
+	decision = g4EOFDecision{
+		Activation: g4EOFActivationMetadata, Approved: true, SelectedEvent: 0,
+		PublishedHead: receipt.NormalHead, CarriedThroughAcceptance: true,
+		RunnerGateApproved: true, MetadataOnly: true, ReceiptConsumed: true,
+	}
+	return decision
+}
+
+func exerciseCompactEOFRecoveryAdmissionForTest(
+	scheduler *diagnosticParserCoreGenericScheduler,
+	source []byte,
+	route g4EOFRoute,
+) (g4EOFDecision, error) {
+	if scheduler == nil {
+		return g4EOFDecision{}, errors.New("nil scheduler")
+	}
+	if scheduler.options.allowMetadataEOFAcceptRecovery {
+		receipt, err := scheduler.produceCompactEOFRecoveryAdmission(source, func() error { return nil })
+		if err != nil {
+			return g4EOFDecision{}, err
+		}
+		if !receipt.active {
+			return g4EOFDecision{Activation: g4EOFActivationNone}, nil
+		}
+		if !receipt.valid {
+			return g4EOFDecision{Activation: g4EOFActivationMetadata, Decline: true, SelectedEvent: -1}, nil
+		}
+		return gateCompactEOFRecoveryAdmissionForTest(scheduler, source, g4EOFReceiptFromInternal(receipt), route), nil
+	}
+	if scheduler.options.allowEOFAcceptNoActionSiblings {
+		return g4EOFDecision{Activation: g4EOFActivationLegacy, Approved: true}, nil
+	}
+	return g4EOFDecision{Activation: g4EOFActivationNone}, nil
+}

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -176,6 +176,13 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 		}
 		return nil, nil, err
 	}
+	if err := scheduler.markCompactEOFRecoverySchedulerReturned(source); err != nil {
+		tokenSource.Close()
+		if resetErr := compact.ResetReleasingRetention(); resetErr != nil {
+			err = errors.Join(err, fmt.Errorf("parser-core fresh-full runner: reset after EOF receipt decline: %w", resetErr))
+		}
+		return nil, nil, err
+	}
 	return scheduler, tokenSource, nil
 }
 
@@ -259,7 +266,50 @@ func (r *parserCoreFreshFullRunner) materializeSelection(source []byte, compact 
 	if r == nil || scheduler == nil {
 		return nil, errors.New("parser-core fresh-full selected materialization is incomplete")
 	}
-	return materializeDiagnosticParserCoreAcceptedSelection(compact, scheduler.acceptedHead, scheduler.acceptedPayloads, r.parser, source, &r.scratch, r.replayParseStates, r.s3AllowErrorRoot())
+	gated, err := scheduler.beginCompactEOFRecoveryConstruction(
+		source,
+		compactEOFRecoveryAdmissionRoutePublicTree,
+	)
+	if err != nil {
+		return nil, err
+	}
+	tree, err := materializeDiagnosticParserCoreAcceptedSelection(
+		compact,
+		scheduler.acceptedHead,
+		scheduler.acceptedPayloads,
+		r.parser,
+		source,
+		&r.scratch,
+		r.replayParseStates,
+		r.s3AllowErrorRoot(),
+	)
+	if err != nil && gated {
+		scheduler.failCompactEOFRecoveryConstruction(err)
+	}
+	return tree, err
+}
+
+func (r *parserCoreFreshFullRunner) materializeSelectedStoreSelection(
+	source []byte,
+	compact *core.Core,
+	scheduler *diagnosticParserCoreGenericScheduler,
+	poll func() error,
+) (*core.SelectedStore, error) {
+	if r == nil || compact == nil || scheduler == nil {
+		return nil, errors.New("parser-core fresh-full selected-store construction is incomplete")
+	}
+	gated, err := scheduler.beginCompactEOFRecoveryConstruction(
+		source,
+		compactEOFRecoveryAdmissionRouteSelectedStore,
+	)
+	if err != nil {
+		return nil, err
+	}
+	store, err := compact.BuildAuthenticatedSelectedStore(scheduler.acceptedPayloads, source, poll)
+	if err != nil && gated {
+		scheduler.failCompactEOFRecoveryConstruction(err)
+	}
+	return store, err
 }
 
 // parse runs one fresh full parse and returns the materialized tree, or a
@@ -326,7 +376,7 @@ func (r *parserCoreFreshFullRunner) parseSelectedStore(source []byte) (*core.Sel
 			detail:   "selected-store sealing stopped: " + string(reason),
 		}
 	}
-	store, err := r.compact.BuildAuthenticatedSelectedStore(scheduler.acceptedPayloads, source, poll)
+	store, err := r.materializeSelectedStoreSelection(source, r.compact, scheduler, poll)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Admit bounded, authenticated end-of-file recovery metadata for HTTP and Robot.
- Preserve the published tree and validate the locked-C recovery sibling.
- Remove only the HTTP and Robot end-of-file sibling grants.
- Avoid copying private `Language` synchronization state in the admission test.

## Safety

The producer audits one immutable subtree path. It does not construct a diagnostic tree.

The receipt binds the parser generation, election, source, heads, events, costs, fingerprints, and selected event.

The runner consumes each receipt once on the public-tree or selected-store route.

The fixed limits are:

- 4,096 source bytes
- 64 metadata groups
- 4,096 payloads
- 256 levels
- 65,536 occurrences

The route declines malformed data, unsupported metadata, overflow, cancellation, and generation changes.

This change does not alter general recovery, scanner, merge, or election policy.

## Evidence

The Sol reviewer approved the original 14-path change and the one-file vet correction.

The feature commit is `7d413ee1a97bb0db5af1776846b8b4ba4e60e3b1`.

The vet correction is `d8a05cb814bc3d6a2bc27bcf2a64ab39071c3753`.

The correction digest is `f5be72cb6c0379f78908f188d1f7bbec574e0b48567e5ca64da64d1855c3b702`.

HTTP preserves digest `a81c6dd582c1d7b784a72d4a791b845bd92d56f6eabf912cc9f19e76cb0fd98f` and recovery cost 640.

Robot preserves digest `a01e9e0ade95973f90607907eb1b1200f863c7ea81c6f8bb019d12a2d3d5d732` and recovery cost 1,027.

The grant denominator changes from 17 flags across 14 grammars to 15 flags across 12 grammars.

The exact scorecard remains 198 PASS, 3 FALLBACK, 5 SKIP, 0 DIVERGE, and 0 ERROR.

The following Docker gates passed:

- Complete tagged metadata suite: `20260821T005440Z`
- HTTP locked-C oracle: `20260821T005501Z`
- Robot locked-C oracle: `20260821T005526Z`
- Exact scorecard: `20260821T005536Z`
- Internal focused race gate: `20260821T005558Z`
- Root focused race gate: `20260821T005618Z`
- Repository vet: `20260821T011701Z-g4-vet-fix`
- Focused G4 contracts: `20260821T011809Z-g4-vet-fix-focused`
- Tagged locked-C oracle: `20260821T011830Z-g4-vet-fix-locked-c`

The single-grammar harness does not register HTTP or Robot. Separate locked-C oracles cover both languages.

Signed Hyphae checkpoint: `spore.2026-08-21.codex.g4-bounded-eof-recovery-admission`.

Receipt: `hypha-receipt:2026-08-21:g4-bounded-eof-recovery-admission`.

Do not merge before all checks pass and the train receives independent approval.
