### PR TITLE
remove(parser): retire Kotlin interpolated call repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ for tags and release notes while still in `0.x`.
 - JavaScript dynamic imports now retain their keyword child during parsing.
   Parsing no longer runs the leaf-repair compatibility path.
 
+- Kotlin interpolated calls now retain their call-expression wrapper during
+  reduction. Parsing no longer runs the wrapper-repair compatibility path.
+
 ### Fixed
 
 - End recovery convergence after a clean condense. Pending forks no longer

--- a/cgo_harness/kotlin_interpolated_call_retirement_parity_test.go
+++ b/cgo_harness/kotlin_interpolated_call_retirement_parity_test.go
@@ -1,0 +1,154 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const (
+	kotlinInterpolatedCallSourceSHA256 = "2ab0943ca4d948edded0764c76ad9a30a923c1b5e8ecfb331b912a9d4aca2df1"
+	kotlinInterpolatedCallDeepDigest   = "90414cc78a28a6c37d28fe79c2423259cad62080e0284a5b4c51dd4818dd47ee"
+)
+
+func TestKotlinInterpolatedCallRetirementLockedCRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	language := grammars.KotlinLanguage()
+	source := []byte("package demo\n\nfun f() {\n  val time = if (true) \"${Instant.now()} \" else \"\"\n}\n")
+	if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != kotlinInterpolatedCallSourceSHA256 {
+		t.Fatalf("source digest=%s, want %s", got, kotlinInterpolatedCallSourceSHA256)
+	}
+	cLanguage, err := COracleLanguage("kotlin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("locked C parse returned a nil tree")
+	}
+	t.Cleanup(cTree.Close)
+
+	rawParser := gotreesitter.NewParser(language)
+	rawParser.SetAdmissionCandidateRoute(false)
+	raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(raw.Release)
+	if raw.ParseRuntime().ForestFastPath {
+		t.Fatal("raw production-pinned parse reported the forest route")
+	}
+	assertKotlinInterpolatedCallLockedCExact(t, "raw", raw, language, cTree)
+
+	productionParser := gotreesitter.NewParser(language)
+	productionParser.SetAdmissionCandidateRoute(false)
+	production, err := productionParser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(production.Release)
+	if production.ParseRuntime().ForestFastPath {
+		t.Fatal("production-pinned parse reported the forest route")
+	}
+	assertKotlinInterpolatedCallLockedCExact(t, "production", production, language, cTree)
+
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	compactParser := gotreesitter.NewParser(language)
+	compactParser.SetAdmissionCandidateRoute(true)
+	compact, err := compactParser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(compact.Release)
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter != routedBefore+1 || fallbackAfter != fallbackBefore {
+		t.Fatalf("compact route counters routed=%d/%d fallback=%d/%d reason=%s", routedBefore, routedAfter, fallbackBefore, fallbackAfter, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+	assertKotlinInterpolatedCallLockedCExact(t, "compact", compact, language, cTree)
+
+	forestParser := gotreesitter.NewParser(language)
+	forest, ok := forestParser.ParseForestExperimental(source)
+	if !ok || forest == nil {
+		offset, symbol, reason, _ := forestParser.ForestDeclineInfo()
+		t.Fatalf("forest declined at %d symbol=%d reason=%s", offset, symbol, reason)
+	}
+	t.Cleanup(forest.Release)
+	if !forest.ParseRuntime().ForestFastPath {
+		t.Fatal("strict forest did not report the forest route")
+	}
+	assertKotlinInterpolatedCallLockedCExact(t, "forest", forest, language, cTree)
+
+	baseSource := bytes.Replace(source, []byte("Instant"), []byte("Moments"), 1)
+	incrementalParser := gotreesitter.NewParser(language)
+	incrementalParser.SetAdmissionCandidateRoute(false)
+	oldTree, err := incrementalParser.Parse(baseSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(oldTree.Release)
+	start := bytes.Index(baseSource, []byte("Moments"))
+	if start < 0 {
+		t.Fatal("incremental base has no Moments token")
+	}
+	point := kotlinInterpolatedCallParityPointAtByte(baseSource, start)
+	oldEnd, newEnd := point, point
+	oldEnd.Column += uint32(len("Moments"))
+	newEnd.Column += uint32(len("Instant"))
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte: uint32(start), OldEndByte: uint32(start + len("Moments")), NewEndByte: uint32(start + len("Instant")),
+		StartPoint: point, OldEndPoint: oldEnd, NewEndPoint: newEnd,
+	})
+	incremental, profile, err := incrementalParser.ParseIncrementalProfiled(source, oldTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(incremental.Release)
+	if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+		t.Fatalf("incremental fallback receipt changed: %+v", profile)
+	}
+	assertKotlinInterpolatedCallLockedCExact(t, "incremental-fresh-fallback", incremental, language, cTree)
+}
+
+func assertKotlinInterpolatedCallLockedCExact(t *testing.T, route string, tree *gotreesitter.Tree, language *gotreesitter.Language, cTree *sitter.Tree) {
+	t.Helper()
+	assertLockedCTreeExact(t, "Kotlin interpolated call "+route, tree, language, cTree)
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.SHA256 != kotlinInterpolatedCallDeepDigest {
+		t.Fatalf("%s deep digest=%s, want %s", route, inspection.SHA256, kotlinInterpolatedCallDeepDigest)
+	}
+	if tree.ParseRuntime().NormalizationNodesRewritten != 0 {
+		t.Fatalf("%s reports %d normalization rewrites", route, tree.ParseRuntime().NormalizationNodesRewritten)
+	}
+}
+
+func kotlinInterpolatedCallParityPointAtByte(source []byte, offset int) gotreesitter.Point {
+	var point gotreesitter.Point
+	for index, value := range source {
+		if index == offset {
+			break
+		}
+		if value == '\n' {
+			point.Row++
+			point.Column = 0
+			continue
+		}
+		point.Column++
+	}
+	return point
+}

--- a/compat_ownership_test.go
+++ b/compat_ownership_test.go
@@ -26,6 +26,9 @@ const (
 	resultCompatJavaScriptImportPositive      = "143936b2a62b44eb779dda835b09abe0c26cc6d5"
 	resultCompatJavaScriptImportProducerFix   = "eee20b8a54a1608b47cce0ab7fb934651e204d66"
 	resultCompatJavaScriptImportFunction      = "normalizeJavaScriptTypeScriptDynamicImportLeafWithSymbolChanged"
+	resultCompatKotlinCallPositive            = "a321147042b7374a52570865d6ec44e1771669a4"
+	resultCompatKotlinCallProducerFix         = "b06804219dc0b27a0804d769a5cc24626568387d"
+	resultCompatKotlinCallFunction            = "normalizeKotlinInterpolatedCallExpressions"
 )
 
 var resultCompatRetiredCommitPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
@@ -240,6 +243,20 @@ func assertRetiredSubpassProvenance(t *testing.T, entry resultCompatOwnershipEnt
 		}
 		if strings.Contains(string(data), resultCompatJavaScriptImportFunction) {
 			t.Errorf("%s remains in production source", resultCompatJavaScriptImportFunction)
+		}
+	case "dispatch.kotlin.interpolated-call-expressions":
+		if got, want := entry.PositiveControlCommit, resultCompatKotlinCallPositive; got != want {
+			t.Errorf("%s positive_control_commit = %q, want %q", entry.ID, got, want)
+		}
+		if got, want := entry.ProducerFixCommit, resultCompatKotlinCallProducerFix; got != want {
+			t.Errorf("%s producer_fix_commit = %q, want %q", entry.ID, got, want)
+		}
+		data, err := os.ReadFile("parser_result_kotlin.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(data), resultCompatKotlinCallFunction) {
+			t.Errorf("%s remains in production source", resultCompatKotlinCallFunction)
 		}
 	}
 }

--- a/compat_ownership_test.go
+++ b/compat_ownership_test.go
@@ -26,6 +26,7 @@ const (
 	resultCompatJavaScriptImportPositive      = "143936b2a62b44eb779dda835b09abe0c26cc6d5"
 	resultCompatJavaScriptImportProducerFix   = "eee20b8a54a1608b47cce0ab7fb934651e204d66"
 	resultCompatJavaScriptImportFunction      = "normalizeJavaScriptTypeScriptDynamicImportLeafWithSymbolChanged"
+	resultCompatKotlinCallRetiredCommit       = "dcb14a971284eedf064a08963455e940427f7dcc"
 	resultCompatKotlinCallPositive            = "a321147042b7374a52570865d6ec44e1771669a4"
 	resultCompatKotlinCallProducerFix         = "b06804219dc0b27a0804d769a5cc24626568387d"
 	resultCompatKotlinCallFunction            = "normalizeKotlinInterpolatedCallExpressions"
@@ -245,6 +246,9 @@ func assertRetiredSubpassProvenance(t *testing.T, entry resultCompatOwnershipEnt
 			t.Errorf("%s remains in production source", resultCompatJavaScriptImportFunction)
 		}
 	case "dispatch.kotlin.interpolated-call-expressions":
+		if got, want := entry.RetiredCommit, resultCompatKotlinCallRetiredCommit; got != want {
+			t.Errorf("%s retired_commit = %q, want deletion commit %q", entry.ID, got, want)
+		}
 		if got, want := entry.PositiveControlCommit, resultCompatKotlinCallPositive; got != want {
 			t.Errorf("%s positive_control_commit = %q, want %q", entry.ID, got, want)
 		}

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -20,9 +20,9 @@ The v1 registry freezes the current source and registry:
 - zero generic passes after language dispatch;
 - zero post-finalization second-pass fixpoint arms.
 
-The registry contains 36 live entries and 51 retired entries. The live entries
+The registry contains 36 live entries and 52 retired entries. The live entries
 name 39 language labels. Shared switch arms account for the label difference.
-The retired count includes the Swift ternary and JavaScript dynamic-import subpasses.
+The retired count includes the Swift ternary, JavaScript dynamic-import, and Kotlin interpolated-call subpasses.
 The registry covers
 only this documented internal result-compatibility tier. Scheduler experiments
 and other engine research belong in their owning subsystem's durable traces.
@@ -33,6 +33,9 @@ arm.
 
 The generic collapsed-child reducer retains the JavaScript dynamic-import
 token. The JavaScript arm remains live for its other registered repairs.
+
+Generic reduction preserves the hidden named Kotlin call wrapper. The Kotlin
+arm remains live for its other registered repairs.
 
 R2 of `docs/root-normalization-retirement.md` retired three dispatcher arms:
 OCaml's collapsed named-leaf restoration, Ruby's top-level module bound

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -175,6 +175,8 @@ PR #471 retired the Lua, Make, and Zig field-projection arms.
 PR #472 retired the trailing-span family.
 The regenerated Swift grammar blob now emits native ternary expressions.
 This change retires the Swift ternary source-reparse subpass.
+Generic reduction now preserves the hidden named Kotlin call wrapper.
+This change retires the Kotlin interpolated-call subpass.
 Shared root finalization now owns the leading-trivia root family.
 This change removes seven language-local repairs and retires Squirrel's arm.
 Pinned alias maps now own the CUE, Git Commit, and R collapsed children.

--- a/grammars/kotlin_interpolated_call_retirement_test.go
+++ b/grammars/kotlin_interpolated_call_retirement_test.go
@@ -1,0 +1,244 @@
+//go:build !grammar_subset
+
+package grammars
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+const (
+	kotlinInterpolatedCallPositiveControlCommit = "a321147042b7374a52570865d6ec44e1771669a4"
+	kotlinInterpolatedCallProducerFixCommit     = "b06804219dc0b27a0804d769a5cc24626568387d"
+	kotlinInterpolatedCallBlobSHA256            = "643a3e6b60d07846dd972849b612159ff9bf09734b09fb00013229c8593a8c78"
+	kotlinInterpolatedCallSourceSHA256          = "2ab0943ca4d948edded0764c76ad9a30a923c1b5e8ecfb331b912a9d4aca2df1"
+	kotlinInterpolatedCallDeepDigest            = "90414cc78a28a6c37d28fe79c2423259cad62080e0284a5b4c51dd4818dd47ee"
+)
+
+func TestKotlinInterpolatedCallRetirementRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	blob, err := os.ReadFile("grammar_blobs/kotlin.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256(blob)); got != kotlinInterpolatedCallBlobSHA256 {
+		t.Fatalf("Kotlin blob digest=%s, want %s", got, kotlinInterpolatedCallBlobSHA256)
+	}
+	language := KotlinLanguage()
+	source := []byte("package demo\n\nfun f() {\n  val time = if (true) \"${Instant.now()} \" else \"\"\n}\n")
+	if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != kotlinInterpolatedCallSourceSHA256 {
+		t.Fatalf("source digest=%s, want %s", got, kotlinInterpolatedCallSourceSHA256)
+	}
+
+	rawParser := gotreesitter.NewParser(language)
+	rawParser.SetAdmissionCandidateRoute(false)
+	raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(raw.Release)
+	if raw.ParseRuntime().ForestFastPath {
+		t.Fatal("raw production-pinned parse reported the forest route")
+	}
+	requireKotlinInterpolatedCallRetirementTree(t, "raw", raw, language)
+
+	productionParser := gotreesitter.NewParser(language)
+	productionParser.SetAdmissionCandidateRoute(false)
+	production, err := productionParser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(production.Release)
+	if production.ParseRuntime().ForestFastPath {
+		t.Fatal("production-pinned parse reported the forest route")
+	}
+	requireKotlinInterpolatedCallRetirementTree(t, "production", production, language)
+
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	compactParser := gotreesitter.NewParser(language)
+	compactParser.SetAdmissionCandidateRoute(true)
+	compact, err := compactParser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(compact.Release)
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter != routedBefore+1 || fallbackAfter != fallbackBefore {
+		t.Fatalf("compact route counters routed=%d/%d fallback=%d/%d reason=%s", routedBefore, routedAfter, fallbackBefore, fallbackAfter, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+	requireKotlinInterpolatedCallRetirementTree(t, "compact", compact, language)
+
+	forestParser := gotreesitter.NewParser(language)
+	forest, ok := forestParser.ParseForestExperimental(source)
+	if !ok || forest == nil {
+		offset, symbol, reason, _ := forestParser.ForestDeclineInfo()
+		t.Fatalf("forest declined at %d symbol=%d reason=%s", offset, symbol, reason)
+	}
+	t.Cleanup(forest.Release)
+	if !forest.ParseRuntime().ForestFastPath {
+		t.Fatal("strict forest did not report the forest route")
+	}
+	requireKotlinInterpolatedCallRetirementTree(t, "forest", forest, language)
+
+	baseSource := bytes.Replace(source, []byte("Instant"), []byte("Moments"), 1)
+	incrementalParser := gotreesitter.NewParser(language)
+	incrementalParser.SetAdmissionCandidateRoute(false)
+	oldTree, err := incrementalParser.Parse(baseSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(oldTree.Release)
+	start := bytes.Index(baseSource, []byte("Moments"))
+	if start < 0 {
+		t.Fatal("incremental base has no Moments token")
+	}
+	point := kotlinInterpolatedCallPointAtByte(baseSource, start)
+	oldEnd, newEnd := point, point
+	oldEnd.Column += uint32(len("Moments"))
+	newEnd.Column += uint32(len("Instant"))
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte: uint32(start), OldEndByte: uint32(start + len("Moments")), NewEndByte: uint32(start + len("Instant")),
+		StartPoint: point, OldEndPoint: oldEnd, NewEndPoint: newEnd,
+	})
+	incremental, profile, err := incrementalParser.ParseIncrementalProfiled(source, oldTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(incremental.Release)
+	if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+		t.Fatalf("incremental route-extinction receipt changed: %+v", profile)
+	}
+	requireKotlinInterpolatedCallRetirementTree(t, "incremental-fresh-fallback", incremental, language)
+}
+
+func TestKotlinInterpolatedCallRetirementNegativeControls(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	tests := []struct {
+		name   string
+		source []byte
+		sha256 string
+	}{
+		{
+			name:   "identifier_interpolation",
+			source: []byte("package demo\n\nfun f() {\n  val time = \"$value\"\n}\n"),
+			sha256: "3daf6da36aeb0744626526bfe40e65481fd976a807fddaa65fcbe8ee8f36bedc",
+		},
+		{
+			name:   "call_outside_interpolation",
+			source: []byte("package demo\n\nfun f() {\n  val time = Instant.now()\n}\n"),
+			sha256: "783d4aff9596d45dbb46a53935cdd72fbeb51a935a2d0d8b44153ac223e1aadf",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := fmt.Sprintf("%x", sha256.Sum256(test.source)); got != test.sha256 {
+				t.Fatalf("source digest=%s, want %s", got, test.sha256)
+			}
+			language := KotlinLanguage()
+			rawParser := gotreesitter.NewParser(language)
+			rawParser.SetAdmissionCandidateRoute(false)
+			raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(raw.Release)
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(production.Release)
+			rawInspection, err := benchfixtures.InspectGoTree(raw.RootNode(), language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			productionInspection, err := benchfixtures.InspectGoTree(production.RootNode(), language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if rawInspection.SHA256 != productionInspection.SHA256 {
+				t.Fatalf("raw/production mismatch: raw=%s production=%s", rawInspection.SHA256, productionInspection.SHA256)
+			}
+			requireNoKotlinInterpolatedCallRewrite(t, "production", production)
+		})
+	}
+}
+
+func requireKotlinInterpolatedCallRetirementTree(t *testing.T, route string, tree *gotreesitter.Tree, language *gotreesitter.Language) {
+	t.Helper()
+	if tree.RootNode() == nil || tree.RootNode().HasError() {
+		t.Fatalf("%s returned an invalid tree", route)
+	}
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.SHA256 != kotlinInterpolatedCallDeepDigest {
+		t.Fatalf("%s deep digest=%s, want %s", route, inspection.SHA256, kotlinInterpolatedCallDeepDigest)
+	}
+	interpolated := kotlinInterpolatedCallFirstNode(tree.RootNode(), language, "interpolated_expression")
+	if interpolated == nil || interpolated.ChildCount() != 1 {
+		t.Fatalf("%s has no single-child interpolated expression: %s", route, tree.RootNode().SExpr(language))
+	}
+	call := interpolated.Child(0)
+	if call == nil || call.Type(language) != "call_expression" || call.ChildCount() != 2 {
+		t.Fatalf("%s does not contain the native call expression: %s", route, interpolated.SExpr(language))
+	}
+	requireNoKotlinInterpolatedCallRewrite(t, route, tree)
+}
+
+func kotlinInterpolatedCallFirstNode(root *gotreesitter.Node, language *gotreesitter.Language, nodeType string) *gotreesitter.Node {
+	var match *gotreesitter.Node
+	gotreesitter.Walk(root, func(node *gotreesitter.Node, _ int) gotreesitter.WalkAction {
+		if node.Type(language) == nodeType {
+			match = node
+			return gotreesitter.WalkStop
+		}
+		return gotreesitter.WalkContinue
+	})
+	return match
+}
+
+func requireNoKotlinInterpolatedCallRewrite(t *testing.T, route string, tree *gotreesitter.Tree) {
+	t.Helper()
+	runtime := tree.ParseRuntime()
+	if runtime.NormalizationNodesRewritten != 0 {
+		t.Fatalf("%s reports %d normalization rewrites", route, runtime.NormalizationNodesRewritten)
+	}
+	if runtime.NormalizationPasses == nil {
+		return
+	}
+	for _, pass := range *runtime.NormalizationPasses {
+		if pass.Name != "dispatch.kotlin" {
+			continue
+		}
+		if pass.Checked != 1 || pass.Run != 1 || pass.NodesRewritten != 0 {
+			t.Fatalf("%s Kotlin census=%+v, want one run and zero rewrites", route, pass)
+		}
+		return
+	}
+	t.Fatalf("%s has no dispatch.kotlin census row", route)
+}
+
+func kotlinInterpolatedCallPointAtByte(source []byte, offset int) gotreesitter.Point {
+	var point gotreesitter.Point
+	for index, value := range source {
+		if index == offset {
+			break
+		}
+		if value == '\n' {
+			point.Row++
+			point.Column = 0
+			continue
+		}
+		point.Column++
+	}
+	return point
+}

--- a/parser_result_kotlin.go
+++ b/parser_result_kotlin.go
@@ -15,7 +15,6 @@ func normalizeKotlinCompatibilityWithCensus(
 	census.run("dispatch.kotlin.recovered-source-file-root", func() {
 		normalizeKotlinRecoveredSourceFileRoot(root, source, lang)
 	})
-	normalizeKotlinInterpolatedCallExpressions(root, lang)
 	normalizeKotlinGenericCallTypeArguments(root, source, lang)
 	normalizeKotlinPrefixComparisonExpressions(root, source, lang)
 	normalizeKotlinRawStringTrailingContent(root, source, lang)
@@ -761,35 +760,4 @@ func kotlinRecoveredTopLevelFunction(arena *nodeArena, children []*Node, idx int
 	fn := newParentNodeInArena(funKeyword.ownerArena, fnSym, symbolIsNamed(lang, fnSym), fnChildren, nil, 0)
 	fn.setHasError(true)
 	return fn, true
-}
-
-func normalizeKotlinInterpolatedCallExpressions(root *Node, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "kotlin" {
-		return
-	}
-	callExpressionSym, ok := lang.symbolByNameAndNamed("call_expression", true)
-	if !ok {
-		callExpressionSym, ok = symbolByName(lang, "call_expression")
-		if !ok {
-			return
-		}
-	}
-	callExpressionNamed := symbolIsNamed(lang, callExpressionSym)
-
-	walkResultTree(root, func(n *Node) {
-		if n == nil || symbolTypeName(lang, n.symbol) != "interpolated_expression" || resultChildCount(n) != 2 {
-			return
-		}
-		first := resultChildAt(n, 0)
-		second := resultChildAt(n, 1)
-		if first == nil || second == nil ||
-			symbolTypeName(lang, first.symbol) != "navigation_expression" ||
-			symbolTypeName(lang, second.symbol) != "call_suffix" {
-			return
-		}
-		arena := n.ownerArena
-		callChildren := cloneNodeSliceInArena(arena, []*Node{first, second})
-		call := newParentNodeInArena(arena, callExpressionSym, callExpressionNamed, callChildren, nil, 0)
-		replaceNodeChildrenUnfielded(n, cloneNodeSliceInArena(arena, []*Node{call}))
-	})
 }

--- a/parser_result_kotlin_test.go
+++ b/parser_result_kotlin_test.go
@@ -2,68 +2,6 @@ package gotreesitter
 
 import "testing"
 
-func TestNormalizeKotlinInterpolatedCallExpressionWrapsCallSuffix(t *testing.T) {
-	lang := testKotlinCompatibilityLanguage()
-	arena := newNodeArena(arenaClassFull)
-	navigation := newLeafNodeInArena(arena, 3, true, 0, 11, Point{}, Point{Column: 11})
-	callSuffix := newLeafNodeInArena(arena, 4, true, 11, 13, Point{Column: 11}, Point{Column: 13})
-	interpolated := newParentNodeInArena(arena, 2, true, []*Node{navigation, callSuffix}, nil, 0)
-	root := newParentNodeInArena(arena, 1, true, []*Node{interpolated}, nil, 0)
-
-	normalizeKotlinCompatibility(root, []byte("Instant.now()"), lang)
-
-	if got, want := interpolated.ChildCount(), 1; got != want {
-		t.Fatalf("interpolated_expression child count = %d, want %d", got, want)
-	}
-	call := interpolated.Child(0)
-	if call == nil || call.Type(lang) != "call_expression" {
-		t.Fatalf("interpolated_expression child = %v, want call_expression", call)
-	}
-	if got, want := call.StartByte(), uint32(0); got != want {
-		t.Fatalf("call_expression.StartByte() = %d, want %d", got, want)
-	}
-	if got, want := call.EndByte(), uint32(13); got != want {
-		t.Fatalf("call_expression.EndByte() = %d, want %d", got, want)
-	}
-	if got, want := call.ChildCount(), 2; got != want {
-		t.Fatalf("call_expression child count = %d, want %d", got, want)
-	}
-	if got := call.Child(0); got != navigation {
-		t.Fatalf("call_expression child[0] = %v, want original navigation_expression", got)
-	}
-	if got := call.Child(1); got != callSuffix {
-		t.Fatalf("call_expression child[1] = %v, want original call_suffix", got)
-	}
-	if navigation.Parent() != call {
-		t.Fatal("navigation_expression parent was not updated to call_expression")
-	}
-	if callSuffix.Parent() != call {
-		t.Fatal("call_suffix parent was not updated to call_expression")
-	}
-}
-
-func testKotlinCompatibilityLanguage() *Language {
-	return &Language{
-		Name: "kotlin",
-		SymbolNames: []string{
-			"EOF",
-			"source_file",
-			"interpolated_expression",
-			"navigation_expression",
-			"call_suffix",
-			"call_expression",
-		},
-		SymbolMetadata: []SymbolMetadata{
-			{Name: "EOF", Visible: false, Named: false},
-			{Name: "source_file", Visible: true, Named: true},
-			{Name: "interpolated_expression", Visible: true, Named: true},
-			{Name: "navigation_expression", Visible: true, Named: true},
-			{Name: "call_suffix", Visible: true, Named: true},
-			{Name: "call_expression", Visible: true, Named: true},
-		},
-	}
-}
-
 func kotlinGenericCallTestLanguage() *Language {
 	return &Language{
 		Name: "kotlin",

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -1752,7 +1752,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "b06804219dc0b27a0804d769a5cc24626568387d",
+      "retired_commit": "dcb14a971284eedf064a08963455e940427f7dcc",
       "positive_control_commit": "a321147042b7374a52570865d6ec44e1771669a4",
       "producer_fix_commit": "b06804219dc0b27a0804d769a5cc24626568387d",
       "receipt_refs": [

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -9,7 +9,7 @@
     "post_finalization_arms": 0,
     "post_finalization_languages": 0,
     "live_entries": 36,
-    "retired_entries": 51
+    "retired_entries": 52
   },
   "live_evidence_baseline": {
     "scope": "baseline_corpus_wide_only",
@@ -1706,7 +1706,7 @@
       "languages": [
         "kotlin"
       ],
-      "purpose": "Reconcile Kotlin derivation selection and returned-tree shape. Member normalizeKotlinRecoveredSourceFileRoot was retired as dead code on 2026-08-02 and RESTORED on 2026-08-03: that census measured the fresh, over-64-KiB, incremental and pinned routes and never measured Parser.SetIncludedRanges. On the included-ranges route the member fires and moves the published ROOT toward the reference runtime. Witness testdata/included_ranges/kotlin_work_queue_test.kt with ranges [0,795), [883,1987) and [2019,3094): without the member the root is ERROR, with the member the root is source_file, and the locked Kotlin C oracle publishes source_file [0,3094). The member's effect is a root retag, and its DOWNSTREAM consequence is not always toward the reference runtime: on kotlinx-coroutines-core/common/test/DelayTest.kt with three ranges, the retag alone is necessary and sufficient to make a later stage flatten a clean class_declaration into root-level members (7 children become 12) where main and the C oracle both keep the class_declaration. Do not read the root receipt as a whole-tree improvement. The member is correct today; re-evaluate it after the unclipped padding scan in bytesAreParserPadding gains range clipping, because that defect is why the route enters recovery at all. The members normalizeKotlinGenericCallTypeArguments and normalizeKotlinPrefixComparisonExpressions stay load-bearing.",
+      "purpose": "Reconcile Kotlin derivation selection and returned-tree shape. Member normalizeKotlinRecoveredSourceFileRoot was retired as dead code on 2026-08-02 and RESTORED on 2026-08-03: that census measured the fresh, over-64-KiB, incremental and pinned routes and never measured Parser.SetIncludedRanges. On the included-ranges route the member fires and moves the published ROOT toward the reference runtime. Witness testdata/included_ranges/kotlin_work_queue_test.kt with ranges [0,795), [883,1987) and [2019,3094): without the member the root is ERROR, with the member the root is source_file, and the locked Kotlin C oracle publishes source_file [0,3094). The member's effect is a root retag, and its DOWNSTREAM consequence is not always toward the reference runtime: on kotlinx-coroutines-core/common/test/DelayTest.kt with three ranges, the retag alone is necessary and sufficient to make a later stage flatten a clean class_declaration into root-level members (7 children become 12) where main and the C oracle both keep the class_declaration. Do not read the root receipt as a whole-tree improvement. The member is correct today; re-evaluate it after the unclipped padding scan in bytesAreParserPadding gains range clipping, because that defect is why the route enters recovery at all. The generic-call and prefix-comparison members remain necessary. The interpolated-call member is retired because generic reduction preserves its hidden named wrapper.",
       "authoritative_owner": "derivation_election_selection",
       "witnesses": [
         "cgo_harness/parity_cgo_test.go",
@@ -1724,6 +1724,41 @@
       },
       "status": "live",
       "evidence_scope": "baseline_corpus_wide_only"
+    },
+    {
+      "id": "dispatch.kotlin.interpolated-call-expressions",
+      "kind": "dispatcher_subpass",
+      "functions": [
+        "normalizeKotlinInterpolatedCallExpressions"
+      ],
+      "files": [
+        "parser_result_kotlin.go"
+      ],
+      "languages": [
+        "kotlin"
+      ],
+      "purpose": "Historical: wrap a navigation expression and its call suffix in a call_expression below an interpolated_expression node.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "grammars/kotlin_interpolated_call_retirement_test.go",
+        "cgo_harness/kotlin_interpolated_call_retirement_parity_test.go"
+      ],
+      "retirement_condition": "Satisfied: generic reduction preserves the hidden named wrapper and emits the aliased call_expression node. Production, direct compact, strict forest, the Kotlin incremental fresh fallback, and locked C are exact.",
+      "route_coverage": {
+        "production": "retired_exact_receipt",
+        "compact": "retired_exact_receipt",
+        "forest": "retired_exact_receipt",
+        "incremental": "retired_exact_receipt",
+        "c_oracle": "retired_exact_receipt"
+      },
+      "status": "retired",
+      "retired_commit": "b06804219dc0b27a0804d769a5cc24626568387d",
+      "positive_control_commit": "a321147042b7374a52570865d6ec44e1771669a4",
+      "producer_fix_commit": "b06804219dc0b27a0804d769a5cc24626568387d",
+      "receipt_refs": [
+        "grammars/kotlin_interpolated_call_retirement_test.go",
+        "cgo_harness/kotlin_interpolated_call_retirement_parity_test.go"
+      ]
     },
     {
       "id": "dispatch.lua",


### PR DESCRIPTION
## Summary

- Retire only `dispatch.kotlin.interpolated-call-expressions`.
- Preserve the Kotlin dispatcher and every sibling repair.
- Pin the deletion commit separately from the generic producer fix.

## Producer proof

Owner `a321147042b7374a52570865d6ec44e1771669a4` introduced the historical wrapper repair.

Generic producer commit `b06804219dc0b27a0804d769a5cc24626568387d` now preserves the hidden named wrapper during reduction.

Restoring the old invisible-wrapper rule reproduces the historical raw shape.

The source SHA-256 is `2ab0943ca4d948edded0764c76ad9a30a923c1b5e8ecfb331b912a9d4aca2df1`.

The grammar blob SHA-256 is `643a3e6b60d07846dd972849b612159ff9bf09734b09fb00013229c8593a8c78`.

## Route evidence

Production, direct compact, and strict forest routes are exact.

Kotlin old-tree reuse reports `external_scanner_unsupported` and does not run.

The documented fresh fallback is exact and records zero member rewrites.

The locked-C route is exact for fields, spans, points, flags, and `HasError`.

The Kotlin 25-case corpus keeps the same clean, deep-parity, and type-divergence results.

## Registry

The denominator is:

- 35 dispatcher arms
- 36 live entries
- 52 retired entries
- 39 live labels

The deletion commit is `dcb14a971284eedf064a08963455e940427f7dcc`.

The provenance commit is `87d94074907db414a653ba18295a4f2ee979d93e`.

## Verification

- Exact producer boundary: `20260821T011217Z-n23-boundary-b068-native`
- Old invariant control: `20260821T011237Z-n23-boundary-b068-old-invisible-wrapper`
- Final routes and locked C: `20260821T011356Z-n23-final-route-and-c`
- Fresh review registry gate: `20260821T012012Z-n23-review-fresh-registry-provenance`
- Final provenance gate: `20260821T013217Z-n23-provenance-followup`

The final source manifest SHA-256 is `ee4733a57da50332119e1785d35799fafde22465c4282360e989d49a6b0de91d`.

The Sol reviewer approved the deletion and the fresh registry evidence.

Signed Hyphae checkpoint: `spore.2026-08-21.codex.n23-kotlin-interpolated-call-retirement`.

Receipt: `hypha-receipt:2026-08-21:n23-kotlin-interpolated-call-retirement`.

Hyphae alignment is `directly_aligned` at 0.73 with `initiative.universal-parser-frontier`.

Do not merge before terminal continuous integration and independent train approval.
