### PR TITLE
perf(parser): avoid singleton recovery candidate allocation

### DIFF
--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -2968,6 +2968,7 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 	versions := []glrStack{start}
 	canShift := false
 	var reduces []ParseAction
+	var singletonCandidate glrStack
 	v := 0
 	candidateAttempts := 0
 	for iter := 0; ; iter++ {
@@ -3012,12 +3013,18 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 				p.crecoveryReductionCandidateCeilingHits++
 				return versions, canShift, ParseStopNone
 			}
-			actionCandidates, reason := p.cReductionCandidatesForAction(source, versions[v], act, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+			actionCandidates, hasSingletonCandidate, reason := p.cReductionCandidatesForActionInto(source, versions[v], act, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors, &singletonCandidate)
 			if reason != ParseStopNone {
 				return versions, canShift, reason
 			}
 			actionReductionVersion := -1
-			if len(actionCandidates) > 0 {
+			if hasSingletonCandidate {
+				var appended bool
+				versions, appended = p.cAppendReductionVersion(versions, singletonCandidate, v)
+				if appended {
+					actionReductionVersion = len(versions) - 1
+				}
+			} else if len(actionCandidates) > 0 {
 				versions, actionReductionVersion = p.cAppendActionReductionVersions(versions, actionCandidates, v, arena)
 			}
 			// C overwrites reduction_version for every reduce action, including
@@ -3060,19 +3067,37 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 }
 
 func (p *Parser) cReductionCandidatesForAction(source []byte, start glrStack, act ParseAction, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) ([]glrStack, ParseStopReason) {
+	var singletonCandidate glrStack
+	candidates, hasSingletonCandidate, reason := p.cReductionCandidatesForActionInto(source, start, act, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors, &singletonCandidate)
+	if hasSingletonCandidate {
+		return []glrStack{singletonCandidate}, reason
+	}
+	return candidates, reason
+}
+
+func (p *Parser) cReductionCandidatesForActionInto(source []byte, start glrStack, act ParseAction, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool, singletonCandidate *glrStack) ([]glrStack, bool, ParseStopReason) {
 	p.pendingForkStacks = p.pendingForkStacks[:0]
 	defer func() {
 		p.pendingForkStacks = p.pendingForkStacks[:0]
 	}()
 	if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
-		return nil, reason
+		return nil, false, reason
 	}
 	fork := start.cloneWithScratch(gssScratch)
 	var dummy bool
 	deferParentLinks := p.reduceScratch != nil && p.reduceScratch.transientParents != nil
 	p.applyAction(source, &fork, act, tok, &dummy, nodeCount, arena, entryScratch, gssScratch, nil, deferParentLinks, trackChildErrors)
 	if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
-		return nil, reason
+		return nil, false, reason
+	}
+	if len(p.pendingForkStacks) == 0 {
+		if fork.dead {
+			return nil, false, ParseStopNone
+		}
+		// The caller consumes this value synchronously. The append helper copies
+		// it into versions and never retains the caller-owned slot.
+		*singletonCandidate = fork
+		return nil, true, ParseStopNone
 	}
 	candidates := make([]glrStack, 0, 1+len(p.pendingForkStacks))
 	if !fork.dead {
@@ -3081,14 +3106,14 @@ func (p *Parser) cReductionCandidatesForAction(source []byte, start glrStack, ac
 	for i := range p.pendingForkStacks {
 		if i&15 == 0 {
 			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
-				return candidates, reason
+				return candidates, false, reason
 			}
 		}
 		if !p.pendingForkStacks[i].dead {
 			candidates = append(candidates, p.pendingForkStacks[i])
 		}
 	}
-	return candidates, ParseStopNone
+	return candidates, false, ParseStopNone
 }
 
 func (p *Parser) cAppendActionReductionVersions(versions []glrStack, candidates []glrStack, originalVersion int, arena *nodeArena) ([]glrStack, int) {


### PR DESCRIPTION
## Summary

Use one caller-owned `glrStack` slot for singleton recovery candidates with no pending fork. Keep the existing exact-capacity append path for multi-fork reductions.

## Binding

- Commit: `1455c93c325163f97edf2ef93971ee914f89712e`
- Base and `origin/main`: `9531af46a1aabdb81b8affe76ce4ead4c7362309`
- Production path: `parser_recover_c.go` only
- Production diff SHA-256: `8f682ebad7e00be4043d03cc6c281abff75aa5f2870954b42d8a40bdd62a1a0a`
- Signed Hyphae receipt: `hypha-receipt:2026-08-21:p8-singleton-recovery-train-v1`
- Receipt content hash: `caedb73aeb3fd6129a52547ce36f6032f8266e0ba7d06272bec4fd01aef62e4c`

## Gates

- Final focused Docker correctness gate passed:
  `harness_out/p8/20260821T040005Z-p8-final-correctness/`
- Direct exhaustive KDL C/cgo parity passed on candidate and exact base.
- The requested single-grammar script was attempted on candidate and exact base. Both failed during grammar generation; five-minute retries were OOM-killed.
- Recovered exact temporary C-oracle source replay produced the same baseline divergence on both sides: Go root child count 1, C root child count 86. This shared divergence is excluded from the candidate regression gate.
- Twenty paired randomized Docker processes: KDL B/op -23.47%, allocations/op -14.92%, KDL time p=0.565; the primary timing trio had no significant regression.
- Ten one-CPU RSS samples are recorded in the freeze artifact.

## Evidence

- Freeze: `harness_out/p8/p8-freeze.txt`, SHA-256 `6771da1a66b40f431544b3ae1312f18d4167b5004f27748c210680470dd4aab0`
- Artifact index: `harness_out/p8/p8-artifact-sha256-r3.txt`, SHA-256 `328887220a71b5fc719903295a54216e800063162e99b59f6fb7c5bf6c4062eb`
- The 719-file recovery cohort remains an unreconstructable proof limitation. No manifest, path list, source revision, or deterministic selector was found. The 214-file green corpus is not a substitute for that cohort.

Terminal Sol review approved this train with no P0-P3 findings. CI run 32445839373 is queued at this freeze. Do not merge before terminal exact-head CI and independent train approval.