### PR TITLE
perf(parser): seed recovery reduction versions

### DIFF
--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -2948,8 +2948,10 @@ func (p *Parser) cCollectPotentialReductions(state StateID, lookaheadSym Symbol,
 // that dead-end keep their pre-reduction shape (C leaves them in place).
 // With anyLookahead false, dead-end versions are dropped (C removes them).
 // EOF is symbol 0, so callers must pass anyLookahead explicitly instead of
-// overloading lookaheadSym == 0.
-func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookaheadSym Symbol, anyLookahead bool, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) ([]glrStack, bool, ParseStopReason) {
+// overloading lookaheadSym == 0. The caller seed supplies reusable initial
+// capacity for the returned version set; growth beyond that capacity remains
+// ordinary append growth.
+func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookaheadSym Symbol, anyLookahead bool, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool, callerSeed []glrStack) ([]glrStack, bool, ParseStopReason) {
 	oldDisablePostReduceForkMerge := p.disablePostReduceForkMerge
 	p.disablePostReduceForkMerge = true
 	defer func() {
@@ -2965,7 +2967,7 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 		return nil, false, reason
 	}
 
-	versions := []glrStack{start}
+	versions := append(callerSeed[:0], start)
 	canShift := false
 	var reduces []ParseAction
 	var singletonCandidate glrStack
@@ -3363,7 +3365,8 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	// 1. Close in-progress productions: reductions reachable on any symbol.
 	// Promote the error stack to the graph-structured stack before reductions.
 	// Recovery forks then share the immutable prefix instead of copying each deep linear stack.
-	versions, _, reason := p.cDoAllPotentialReductions(source, s.cloneWithScratch(gssScratch), 0, true, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+	var outerResultSeed [2]glrStack
+	versions, _, reason := p.cDoAllPotentialReductions(source, s.cloneWithScratch(gssScratch), 0, true, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors, outerResultSeed[:0])
 	if reason != ParseStopNone {
 		return cRecHalted, false, reason
 	}
@@ -3373,6 +3376,7 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	// C keeps every version that survives do_all_potential_reductions on the
 	// lookahead (the copied version plus its reduction forks).
 	var missingVersions []glrStack
+	var missingProbeSeed [2]glrStack
 	if !p.isGraphQLRecoveryTripleQuote(tok.Symbol) {
 		missingTokenTrialAttempts := 0
 	missingTokenSearch:
@@ -3438,7 +3442,7 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 				if cand.dead {
 					continue
 				}
-				reduced, canShift, reason := p.cDoAllPotentialReductions(source, cand, tok.Symbol, false, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+				reduced, canShift, reason := p.cDoAllPotentialReductions(source, cand, tok.Symbol, false, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors, missingProbeSeed[:0])
 				if reason != ParseStopNone {
 					return cRecHalted, false, reason
 				}

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -1197,7 +1197,7 @@ func TestCDoAllPotentialReductionsCollapsesSamePopTargetSlicesByCParentSelection
 	start := glrStack{gss: gssStack{head: rightNode}, byteOffset: 2}
 
 	nodeCount := 0
-	versions, canShift, reason := parser.cDoAllPotentialReductions(nil, start, 0, true, Token{}, &nodeCount, arena, nil, &scratch, nil)
+	versions, canShift, reason := parser.cDoAllPotentialReductions(nil, start, 0, true, Token{}, &nodeCount, arena, nil, &scratch, nil, nil)
 	if reason != ParseStopNone {
 		t.Fatalf("cDoAllPotentialReductions stop reason = %v, want none", reason)
 	}
@@ -1263,7 +1263,7 @@ func TestCDoAllPotentialReductionsCollapsesSamePopWithTrailingExtra(t *testing.T
 	start := glrStack{gss: gssStack{head: head}, byteOffset: 3}
 
 	nodeCount := 0
-	versions, canShift, reason := parser.cDoAllPotentialReductions(nil, start, 0, true, Token{}, &nodeCount, arena, nil, &scratch, nil)
+	versions, canShift, reason := parser.cDoAllPotentialReductions(nil, start, 0, true, Token{}, &nodeCount, arena, nil, &scratch, nil, nil)
 	if reason != ParseStopNone {
 		t.Fatalf("cDoAllPotentialReductions stop reason = %v, want none", reason)
 	}
@@ -1471,7 +1471,7 @@ func TestCDoAllPotentialReductionsKeepsShiftableOriginalWithReductionFork(t *tes
 	start.pushEntry(newStackEntryNode(3, leaf), nil, nil)
 
 	nodeCount := 0
-	versions, canShift, reason := parser.cDoAllPotentialReductions(nil, start, 0, true, Token{}, &nodeCount, arena, nil, nil, nil)
+	versions, canShift, reason := parser.cDoAllPotentialReductions(nil, start, 0, true, Token{}, &nodeCount, arena, nil, nil, nil, nil)
 	if reason != ParseStopNone {
 		t.Fatalf("cDoAllPotentialReductions stop reason = %v, want none", reason)
 	}
@@ -1491,6 +1491,145 @@ func TestCDoAllPotentialReductionsKeepsShiftableOriginalWithReductionFork(t *tes
 		t.Fatalf("reduction fork top entry = %+v, want reduced parent symbol", top)
 	}
 }
+
+func cCallerSeedShiftableParserAndStack(arena *nodeArena) (*Parser, glrStack) {
+	lang := &Language{
+		TokenCount:  2,
+		StateCount:  10,
+		SymbolCount: 5,
+		ParseTable: [][]uint16{
+			nil,
+			{0, 0, 0, 0, 2},
+			nil,
+			{0, 1},
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		},
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{
+				{Type: ParseActionReduce, Symbol: 4, ChildCount: 1},
+				{Type: ParseActionShift, State: 8},
+			}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 9}}},
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "end", Visible: true, Named: true},
+			{Name: "tok", Visible: true, Named: true},
+			{Name: "leaf", Visible: true, Named: true},
+			{Name: "unused", Visible: true, Named: true},
+			{Name: "parent", Visible: true, Named: true},
+		},
+	}
+	parser := &Parser{language: lang, denseLimit: len(lang.ParseTable)}
+	leaf := newLeafNodeInArena(arena, 2, true, 0, 1, Point{}, Point{Column: 1})
+	start := newGLRStack(1)
+	start.pushEntry(newStackEntryNode(3, leaf), nil, nil)
+	return parser, start
+}
+
+func cCallerSeedFallbackParserAndStack(arena *nodeArena) (*Parser, glrStack) {
+	lang := &Language{
+		TokenCount:  4,
+		StateCount:  12,
+		SymbolCount: 7,
+		ParseTable:  make([][]uint16, 12),
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 4, ChildCount: 1}}},
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 5, ChildCount: 1}}},
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 6, ChildCount: 1}}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 9}}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 10}}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 11}}},
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "end", Visible: true, Named: true},
+			{Name: "a", Visible: true, Named: true},
+			{Name: "b", Visible: true, Named: true},
+			{Name: "c", Visible: true, Named: true},
+			{Name: "parent_a", Visible: true, Named: true},
+			{Name: "parent_b", Visible: true, Named: true},
+			{Name: "parent_c", Visible: true, Named: true},
+		},
+	}
+	lang.ParseTable[1] = []uint16{0, 0, 0, 0, 4, 5, 6}
+	lang.ParseTable[3] = []uint16{0, 1, 2, 3}
+	parser := &Parser{language: lang, denseLimit: len(lang.ParseTable)}
+	leaf := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
+	start := newGLRStack(1)
+	start.pushEntry(newStackEntryNode(3, leaf), nil, nil)
+	return parser, start
+}
+
+func TestCDoAllPotentialReductionsCallerSeedFirstFork(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser, start := cCallerSeedShiftableParserAndStack(arena)
+	var callerSeed [2]glrStack
+	nodeCount := 0
+	versions, canShift, reason := parser.cDoAllPotentialReductions(nil, start, 0, true, Token{}, &nodeCount, arena, nil, nil, nil, callerSeed[:0])
+	if reason != ParseStopNone {
+		t.Fatalf("cDoAllPotentialReductions stop reason = %v, want none", reason)
+	}
+	if !canShift || len(versions) != 2 {
+		t.Fatalf("caller-seeded versions: canShift=%v len=%d, want true/2", canShift, len(versions))
+	}
+	if &versions[0] != &callerSeed[0] || &versions[1] != &callerSeed[1] {
+		t.Fatal("first reduction fork did not preserve caller-seed ownership")
+	}
+	if got, want := versions[0].top().state, StateID(3); got != want {
+		t.Fatalf("caller-seeded version[0] state = %d, want original state %d", got, want)
+	}
+	if got, want := versions[1].top().state, StateID(9); got != want {
+		t.Fatalf("caller-seeded version[1] state = %d, want reduction state %d", got, want)
+	}
+}
+
+func TestCDoAllPotentialReductionsCallerSeedFallback(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser, start := cCallerSeedFallbackParserAndStack(arena)
+	var callerSeed [2]glrStack
+	nodeCount := 0
+	versions, canShift, reason := parser.cDoAllPotentialReductions(nil, start, 0, true, Token{}, &nodeCount, arena, nil, nil, nil, callerSeed[:0])
+	if reason != ParseStopNone {
+		t.Fatalf("cDoAllPotentialReductions stop reason = %v, want none", reason)
+	}
+	if canShift || len(versions) != 3 {
+		t.Fatalf("fallback versions: canShift=%v len=%d, want false/3", canShift, len(versions))
+	}
+	if &versions[0] == &callerSeed[0] || &versions[1] == &callerSeed[1] {
+		t.Fatal("fallback growth retained an alias to the caller seed")
+	}
+	seedByteOffset := callerSeed[0].byteOffset
+	versions[0].byteOffset++
+	if callerSeed[0].byteOffset != seedByteOffset {
+		t.Fatal("fallback result still aliases caller-seed storage")
+	}
+}
+
+func TestCAppendReductionVersionCallerSeedFirstAppendAllocatesZero(t *testing.T) {
+	parser := &Parser{}
+	var callerSeed [2]glrStack
+	candidate := glrStack{byteOffset: 1}
+	allocs := testing.AllocsPerRun(1000, func() {
+		versions := callerSeed[:1]
+		versions[0] = glrStack{}
+		out, appended := parser.cAppendReductionVersion(versions, candidate, 0)
+		if !appended || len(out) != 2 {
+			t.Fatalf("caller-seeded append: appended=%v len=%d, want true/2", appended, len(out))
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("caller-seeded first append allocations = %v, want zero", allocs)
+	}
+}
+
 func TestCDoAllPotentialReductionsDistinguishesEOFFromAnyLookahead(t *testing.T) {
 	lang := &Language{
 		TokenCount:  2,
@@ -1517,7 +1656,7 @@ func TestCDoAllPotentialReductionsDistinguishesEOFFromAnyLookahead(t *testing.T)
 	defer arena.Release()
 
 	nodeCount := 0
-	versions, canShift, reason := parser.cDoAllPotentialReductions(nil, newGLRStack(1), 0, true, Token{}, &nodeCount, arena, nil, nil, nil)
+	versions, canShift, reason := parser.cDoAllPotentialReductions(nil, newGLRStack(1), 0, true, Token{}, &nodeCount, arena, nil, nil, nil, nil)
 	if reason != ParseStopNone {
 		t.Fatalf("cDoAllPotentialReductions stop reason = %v, want none", reason)
 	}
@@ -1525,7 +1664,7 @@ func TestCDoAllPotentialReductionsDistinguishesEOFFromAnyLookahead(t *testing.T)
 		t.Fatalf("any-lookahead reductions: canShift=%v versions=%d, want true/1", canShift, len(versions))
 	}
 
-	versions, canShift, reason = parser.cDoAllPotentialReductions(nil, newGLRStack(1), 0, false, Token{}, &nodeCount, arena, nil, nil, nil)
+	versions, canShift, reason = parser.cDoAllPotentialReductions(nil, newGLRStack(1), 0, false, Token{}, &nodeCount, arena, nil, nil, nil, nil)
 	if reason != ParseStopNone {
 		t.Fatalf("cDoAllPotentialReductions stop reason = %v, want none", reason)
 	}
@@ -1533,7 +1672,7 @@ func TestCDoAllPotentialReductionsDistinguishesEOFFromAnyLookahead(t *testing.T)
 		t.Fatalf("exact EOF reductions on non-EOF state: canShift=%v versions=%d, want false/0", canShift, len(versions))
 	}
 
-	versions, canShift, reason = parser.cDoAllPotentialReductions(nil, newGLRStack(2), 0, false, Token{}, &nodeCount, arena, nil, nil, nil)
+	versions, canShift, reason = parser.cDoAllPotentialReductions(nil, newGLRStack(2), 0, false, Token{}, &nodeCount, arena, nil, nil, nil, nil)
 	if reason != ParseStopNone {
 		t.Fatalf("cDoAllPotentialReductions stop reason = %v, want none", reason)
 	}


### PR DESCRIPTION
## What does this PR do?

This PR seeds two caller-local `[2]glrStack` buffers in C-style GLR recovery.
It preserves ordinary append growth when recovery needs more versions.

## Why this approach?

The seed removes the first reduction-version backing-array allocation.
The fallback keeps multi-fork behavior unchanged.
The change adds no pool, parser field, or shared state.

## Identity

- Base commit: `f60aee0ae93c3f525d210e18c788560d48aa7aa0`.
- Commit: `db43c4a55cdd65b2a0f275186fceaaa0513f966c`.
- Approved diff SHA-256: `335876e3564b7872cc705c2ff37e7cc430f012a387ee4d8f812669f44a0a9db9`.
- Changed paths: `parser_recover_c.go`, `parser_recover_c_test.go`.
- Candidate worktree: `/home/draco/work/gts-perf-p9-20260821`.
- Candidate receipt: `/home/draco/work/gts-perf-p9-20260821/harness_out/p9/p9-candidate-receipt.txt`.
- Receipt SHA-256: `25c7dc44f4cc5aaf9f044fd126a2bc98047a31ad4b0a2a794744f8de4fb16b85`.
- Artifact manifest SHA-256: `900c45bbd7318e4243dd8288d686eb246375619d5720a74d246668dcdc3e4d57`.
- Source manifest SHA-256: `bcb6045d7c55fda89fda6905f36a222673ee7b2e541577db21e196a0571ae673`.

## Correctness

- [x] Focused recovery tests passed in Docker.
- [x] Existing same-pop, shift-fork, and end-of-file tests passed in Docker.
- [x] Exhaustive KDL C/cgo parity passed in Docker, one grammar at a time.
- [x] Memory and ceiling controls passed without an out-of-memory or timeout result.
- [x] The controls recorded zero missing-token ceiling hits.
- [x] The 719-file evidence limitation is documented below.
- [x] Grammargen validation is not applicable because this PR changes no grammargen code.

The exhaustive parity command was:

```text
GOMAXPROCS=1 GTS_PARITY_MODE=exhaustive go test -tags cgo,treesitter_c_parity -run '^TestParityFreshParse$/kdl$' -count=1 -v .
```

## Performance

- [x] Benchmarks used `GOMAXPROCS=1`, one process, 20 shuffle seeds, `-benchtime=750ms`, and `-benchmem`.
- [x] KDL B/op changed from `1.456 MiB` to `1.208 MiB`, or `-17.01%`.
- [x] KDL allocations per operation changed from `23.83k` to `22.17k`, or `-6.99%`.
- [x] The focused helper allocation profile changed by `-30.3%`.
- [x] Full parse timing changed from `6.308 ms` to `6.303 ms`, with `p=0.277`.
- [x] Incremental edit timing changed from `779.4 ns` to `767.6 ns`, or `-1.51%`.
- [x] Incremental no-edit timing changed from `2.552 ns` to `2.590 ns`, or `+1.51%`.
- [x] Twenty isolated RSS processes passed.
- [x] RSS median changed by `-4.02%`; RSS maximum changed by `-5.08%`.

## Maintainability

- [x] The diff contains only the two approved paths.
- [x] The change adds no dependency and no generated file.
- [x] The tests cover seed ownership, fallback growth, and zero first-append allocation.

## Self-review

- [x] I reviewed the complete two-path diff.
- [x] I checked the staged diff with `git diff --check`.
- [x] I checked the Buckley trailers against the approved diff digest and statistics.

## Evidence limitation

The 719-file cohort did not run.
No deterministic manifest, path list, source revision, or selector can reconstruct that cohort.
The 214-file corpus cannot substitute for the 719-file cohort.

## Review hold

Sol approved the candidate with no P0-P3 findings.
Keep this PR as a non-draft review hold.
Do not merge this PR until CI and independent review complete.
