### PR TITLE
test(parser): pin normalization retirement provenance

### DIFF
--- a/compat_ownership_provenance_test.go
+++ b/compat_ownership_provenance_test.go
@@ -1,0 +1,257 @@
+package gotreesitter
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const resultCompatAuthoritativeMainCommit = "bb09ff6978cb2e46d98b805c0e2f6bb7d4429e24"
+
+// These are zero-based registry indexes. Keep this map explicit so a later
+// ledger regeneration cannot silently restore a parallel retirement commit.
+var resultCompatCorrectedRetiredCommits = map[int]string{
+	1:  "2ef4802f2dbb853486d852cc9c1909e2a26f0199",
+	5:  "2ef4802f2dbb853486d852cc9c1909e2a26f0199",
+	8:  "2ef4802f2dbb853486d852cc9c1909e2a26f0199",
+	12: "84aee737500e7b9e0365725fb7af18e059e9d9e5",
+	15: "16d4873e62d7eeff43cf61b552465e27eda87536",
+	18: "05cd86a0bb925078f833b69bac21effa3fcca657",
+	23: "ff3acd87af32d98ed0d05ddfe16d5430abbbcb4a",
+	24: "062fb1a130c15c030192bc23cdd0dd7eed6af18f",
+	25: "7c07270b3e98b691df5e9c8c6d10151cb8918b62",
+	26: "2ef4802f2dbb853486d852cc9c1909e2a26f0199",
+	28: "9e2a7d8668f99e6f3eb43f6a74f4d449451943b2",
+	29: "3f2a9256d72a838bb62a39ccf4af2e7cc1724dbb",
+	30: "e12abef4da826db0bef291127ef4ab62ae4071e2",
+	37: "2427094ae0629d0bd5c6a2fe2c2e801cbc709d3a",
+	39: "a5c853591fd84b1d004692b9f96651ad433d699d",
+	40: "2427094ae0629d0bd5c6a2fe2c2e801cbc709d3a",
+	44: "84aee737500e7b9e0365725fb7af18e059e9d9e5",
+	49: "db34ebb495d1cd0c6540428c7045ac032ac41a22",
+	50: "3f2a9256d72a838bb62a39ccf4af2e7cc1724dbb",
+	51: "db34ebb495d1cd0c6540428c7045ac032ac41a22",
+	52: "29b6e302701058e2ed101941c6da5f52a98dfe9a",
+	53: "84aee737500e7b9e0365725fb7af18e059e9d9e5",
+	56: "84aee737500e7b9e0365725fb7af18e059e9d9e5",
+	64: "0d84d2eb5e597420de90d7d275b945e9b15ba7df",
+	68: "0d84d2eb5e597420de90d7d275b945e9b15ba7df",
+	78: "af6dce4cf9dc323fba10155fdcab6a84a25e3927",
+	80: "db34ebb495d1cd0c6540428c7045ac032ac41a22",
+	82: "27b0f624032680f6246bb4ee307883a2b874afb9",
+	84: "d212e7c52fffc56182b138b08bb29ee7c490aa11",
+	85: "8ced58fd8591aa18490d2720cf579e107f472711",
+	87: "93ab17820fd007b5808f2ab6b62e22f79df179d1",
+}
+
+type resultCompatRetirementFixture struct {
+	AncestorOfMain bool
+	EntryIDs       []string
+}
+
+// Docker worktrees can lack the host repository metadata. This fixture keeps
+// the provenance gate deterministic when local Git history is unavailable.
+var resultCompatRetirementFixtures = map[string]resultCompatRetirementFixture{
+	"05cd86a0bb925078f833b69bac21effa3fcca657": {true, []string{"dispatch.d"}},
+	"062fb1a130c15c030192bc23cdd0dd7eed6af18f": {true, []string{"dispatch.enforce"}},
+	"0d84d2eb5e597420de90d7d275b945e9b15ba7df": {true, []string{"dispatch.robot", "dispatch.scheme"}},
+	"144b30c9ee085406335f4549272e1ae843427993": {true, []string{"dispatch.erlang"}},
+	"16d4873e62d7eeff43cf61b552465e27eda87536": {true, []string{"dispatch.crystal"}},
+	"2427094ae0629d0bd5c6a2fe2c2e801cbc709d3a": {true, []string{"dispatch.hurl", "dispatch.ini"}},
+	"27b0f624032680f6246bb4ee307883a2b874afb9": {true, []string{"generic.trailing-extra-trivia"}},
+	"29b6e302701058e2ed101941c6da5f52a98dfe9a": {true, []string{"dispatch.objc"}},
+	"2ef4802f2dbb853486d852cc9c1909e2a26f0199": {true, []string{"dispatch.angular", "dispatch.bibtex", "dispatch.chatito", "dispatch.eds"}},
+	"305e32b0bd796a47cfbd566ec596cd8d01ceb124": {true, []string{"dispatch.ql"}},
+	"31bc9f1ed88bc930d22d0c2eaedc84195604cce1": {true, []string{"generic.terminal-leaf"}},
+	"3f2a9256d72a838bb62a39ccf4af2e7cc1724dbb": {true, []string{"dispatch.forth", "dispatch.luau"}},
+	"49d776674b2f599fa162874bbf74dc119fa9e7d4": {true, []string{"dispatch.hcl"}},
+	"4ac19d4446b4b41daa236465a5316d624214343c": {true, []string{"dispatch.linkerscript"}},
+	"22f506d9b633b9b83f405ca1d7d2770527b9a8cd": {true, []string{"fixpoint.returned-tree-second-pass.html"}},
+	"6f9047d75b4406e2aadf8eeb1a47ebca752734b5": {true, []string{"dispatch.cpon"}},
+	"7c07270b3e98b691df5e9c8c6d10151cb8918b62": {true, []string{"dispatch.ebnf"}},
+	"84aee737500e7b9e0365725fb7af18e059e9d9e5": {true, []string{"dispatch.shared_trailing_span", "dispatch.just", "dispatch.nginx", "dispatch.pascal"}},
+	"8ced58fd8591aa18490d2720cf579e107f472711": {true, []string{"fixpoint.returned-tree-second-pass"}},
+	"8d0648f5e97fb75e4934aab90f0de4b0e3c7e821": {true, []string{"dispatch.javascript.dynamic-import"}},
+	"9e2a7d8668f99e6f3eb43f6a74f4d449451943b2": {true, []string{"dispatch.fsharp"}},
+	"93ab17820fd007b5808f2ab6b62e22f79df179d1": {true, []string{"fixpoint.returned-tree-second-pass.javascript"}},
+	"a0e65e32a892ac33fe7481cf0837cb033e562a1c": {true, []string{"dispatch.http"}},
+	"a5c853591fd84b1d004692b9f96651ad433d699d": {true, []string{"dispatch.hyprlang"}},
+	"aadc2fed64f072499f8cc9485f7cd86db2a274c3": {true, []string{"dispatch.haskell"}},
+	"af6dce4cf9dc323fba10155fdcab6a84a25e3927": {true, []string{"dispatch.typst"}},
+	"af90246a860bf2c6a1632b7b4f5573e6b0b57339": {true, []string{"dispatch.cue", "dispatch.gitcommit", "dispatch.r"}},
+	"c73670f0a4af1c6d9ba9572fb04eef2795bdfd26": {true, []string{"dispatch.rescript"}},
+	"c79ee1ca40a332739374652beb02df9df5280e83": {true, []string{"dispatch.html", "dispatch.ocaml", "dispatch.ruby"}},
+	"d212e7c52fffc56182b138b08bb29ee7c490aa11": {true, []string{"generic.collapsed-named-leaf"}},
+	"d9c712131e152529b2e21e048c792db0a5b358c1": {true, []string{"dispatch.arduino"}},
+	"dcb14a971284eedf064a08963455e940427f7dcc": {true, []string{"dispatch.kotlin.interpolated-call-expressions"}},
+	"db34ebb495d1cd0c6540428c7045ac032ac41a22": {true, []string{"dispatch.lua", "dispatch.make", "dispatch.zig"}},
+	"ddaed36e558d60d0e8e96bb9f6c59c0fb63c3b97": {true, []string{"dispatch.swift.ternary"}},
+	"e12abef4da826db0bef291127ef4ab62ae4071e2": {true, []string{"dispatch.fidl"}},
+	"ff3acd87af32d98ed0d05ddfe16d5430abbbcb4a": {true, []string{"dispatch.elixir"}},
+	"252a2513688945de445f02addfc6ce9680196577": {true, []string{"dispatch.squirrel"}},
+}
+
+func TestResultCompatibilityRetiredCommitProvenance(t *testing.T) {
+	registry := loadResultCompatOwnershipRegistry(t)
+	if got, want := len(registry.Entries), 88; got != want {
+		t.Fatalf("registry entries = %d, want %d", got, want)
+	}
+	if got, want := len(resultCompatCorrectedRetiredCommits), 31; got != want {
+		t.Fatalf("corrected retired commit rows = %d, want %d", got, want)
+	}
+	for index, wantCommit := range resultCompatCorrectedRetiredCommits {
+		if index < 0 || index >= len(registry.Entries) {
+			t.Fatalf("corrected registry index %d is outside the registry", index)
+		}
+		entry := registry.Entries[index]
+		if entry.Status != "retired" {
+			t.Errorf("registry index %d (%s) status = %q, want retired", index, entry.ID, entry.Status)
+		}
+		if entry.RetiredCommit != wantCommit {
+			t.Errorf("registry index %d (%s) retired_commit = %q, want %q", index, entry.ID, entry.RetiredCommit, wantCommit)
+		}
+	}
+	for index, entry := range registry.Entries {
+		if entry.Status == "retired" && entry.ProducerFixCommit != "" && entry.ProducerFixCommit == entry.RetiredCommit {
+			t.Errorf("registry index %d (%s) uses producer_fix_commit %s as retired_commit", index, entry.ID, entry.RetiredCommit)
+		}
+	}
+
+	for index, entry := range registry.Entries {
+		if entry.Status != "retired" {
+			continue
+		}
+		if entry.RetiredCommit == "" {
+			t.Errorf("registry index %d (%s) has no retired_commit", index, entry.ID)
+			continue
+		}
+		fixture, ok := resultCompatRetirementFixtures[entry.RetiredCommit]
+		if !ok || !fixture.AncestorOfMain || !containsString(fixture.EntryIDs, entry.ID) {
+			t.Errorf("retirement fixture lacks ancestor and deletion evidence for registry index %d (%s), commit %s", index, entry.ID, entry.RetiredCommit)
+		}
+	}
+
+	repo, ok := resultCompatGitRepository()
+	if !ok {
+		t.Log("local Git history is unavailable; used the deterministic retirement fixture")
+		return
+	}
+	for index, entry := range registry.Entries {
+		if entry.Status != "retired" {
+			continue
+		}
+		if err := resultCompatRequireAncestor(repo, entry.RetiredCommit); err != nil {
+			t.Errorf("registry index %d (%s) retired_commit %s is not an ancestor of authoritative main %s: %v", index, entry.ID, entry.RetiredCommit, resultCompatAuthoritativeMainCommit, err)
+			continue
+		}
+		if evidence, err := resultCompatRetirementDiffEvidence(repo, entry); err != nil {
+			t.Errorf("registry index %d (%s) retired_commit %s has no local retirement diff: %v", index, entry.ID, entry.RetiredCommit, err)
+		} else if evidence == "" {
+			t.Errorf("registry index %d (%s) retired_commit %s has no removed function, row, label, or file", index, entry.ID, entry.RetiredCommit)
+		}
+	}
+}
+
+func resultCompatGitRepository() (string, bool) {
+	command := exec.Command("git", "rev-parse", "--show-toplevel")
+	command.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	out, err := command.Output()
+	if err != nil {
+		return "", false
+	}
+	repo := strings.TrimSpace(string(out))
+	if repo == "" {
+		return "", false
+	}
+	repo = filepath.Clean(repo)
+	probe := exec.Command("git", "-C", repo, "rev-parse", "--verify", resultCompatAuthoritativeMainCommit+"^{commit}")
+	probe.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if _, err := probe.Output(); err != nil {
+		return "", false
+	}
+	return repo, true
+}
+
+func resultCompatRequireAncestor(repo, commit string) error {
+	command := exec.Command("git", "-C", repo, "merge-base", "--is-ancestor", commit, resultCompatAuthoritativeMainCommit)
+	command.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if output, err := command.CombinedOutput(); err != nil {
+		return fmt.Errorf("git merge-base: %w (%s)", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func resultCompatRetirementDiffEvidence(repo string, entry resultCompatOwnershipEntry) (string, error) {
+	paths := append([]string{}, entry.Files...)
+	paths = append(paths, resultCompatOwnershipRegistryPath, "parser_result_compat.go")
+	paths = uniqueStrings(paths)
+	args := []string{"-C", repo, "diff-tree", "--no-commit-id", "--no-ext-diff", "--no-renames", "--unified=0", "-p", entry.RetiredCommit + "^", entry.RetiredCommit, "--"}
+	args = append(args, paths...)
+	command := exec.Command("git", args...)
+	command.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	out, err := command.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git diff-tree: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	diff := string(out)
+	for _, line := range strings.Split(diff, "\n") {
+		if !strings.HasPrefix(line, "-") || strings.HasPrefix(line, "---") {
+			continue
+		}
+		for _, function := range entry.Functions {
+			if strings.Contains(line, function) {
+				return "removed function " + function, nil
+			}
+		}
+		if strings.Contains(line, entry.ID) {
+			return "removed registry or census label " + entry.ID, nil
+		}
+		for _, language := range entry.Languages {
+			if strings.Contains(line, strconv.Quote(language)) {
+				return "removed language label " + language, nil
+			}
+		}
+	}
+
+	nameArgs := []string{"-C", repo, "diff-tree", "--no-commit-id", "--no-ext-diff", "--no-renames", "--name-status", "-r", entry.RetiredCommit + "^", entry.RetiredCommit, "--"}
+	nameArgs = append(nameArgs, paths...)
+	nameCommand := exec.Command("git", nameArgs...)
+	nameCommand.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	nameOut, nameErr := nameCommand.CombinedOutput()
+	if nameErr != nil {
+		return "", fmt.Errorf("git diff-tree name-status: %w (%s)", nameErr, strings.TrimSpace(string(nameOut)))
+	}
+	for _, line := range strings.Split(string(nameOut), "\n") {
+		fields := strings.Split(line, "\t")
+		if len(fields) >= 2 && fields[0] == "D" && containsString(entry.Files, fields[1]) {
+			return "removed registered file " + fields[1], nil
+		}
+	}
+	return "", nil
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	return result
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -134,7 +134,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "b67d12a13bdd4eb8e4b27e9e77b28934c398b8b2",
+      "retired_commit": "2ef4802f2dbb853486d852cc9c1909e2a26f0199",
       "receipt_refs": [
         "grammars/recovery_action_materialization_native_regression_test.go",
         "cgo_harness/inert_recovery_materialization_parity_cgo_test.go"
@@ -273,7 +273,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "b67d12a13bdd4eb8e4b27e9e77b28934c398b8b2",
+      "retired_commit": "2ef4802f2dbb853486d852cc9c1909e2a26f0199",
       "receipt_refs": [
         "grammars/recovery_action_materialization_native_regression_test.go",
         "cgo_harness/inert_recovery_materialization_parity_cgo_test.go"
@@ -378,7 +378,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "b67d12a13bdd4eb8e4b27e9e77b28934c398b8b2",
+      "retired_commit": "2ef4802f2dbb853486d852cc9c1909e2a26f0199",
       "receipt_refs": [
         "grammars/recovery_action_materialization_native_regression_test.go",
         "cgo_harness/inert_recovery_materialization_parity_cgo_test.go"
@@ -508,7 +508,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "2e0ed636316e82eaaea2b3c89aecd957a80af499",
+      "retired_commit": "84aee737500e7b9e0365725fb7af18e059e9d9e5",
       "receipt_refs": [
         "grammars/trailing_span_native_regression_test.go",
         "parsercore_phase0_generic_extra_internal_test.go",
@@ -615,7 +615,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "0b64c6fc02d8a606f919a6a68ae6c6811d2f16ad",
+      "retired_commit": "16d4873e62d7eeff43cf61b552465e27eda87536",
       "receipt_refs": [
         "grammars/crystal_opener_span_native_regression_test.go",
         "cgo_harness/crystal_opener_span_parity_cgo_test.go"
@@ -720,7 +720,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "6a650454e5698d64a0148629cfa444b3dbce6877",
+      "retired_commit": "05cd86a0bb925078f833b69bac21effa3fcca657",
       "receipt_refs": [
         "grammars/d_module_span_native_regression_test.go",
         "grammars/d_call_expression_native_regression_test.go",
@@ -866,7 +866,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "5baffc7237200733e46bf9881cd81bfc3581ccf3",
+      "retired_commit": "ff3acd87af32d98ed0d05ddfe16d5430abbbcb4a",
       "receipt_refs": [
         "grammars/elixir_extras_and_pairs_native_regression_test.go",
         "cgo_harness/elixir_extras_and_pairs_retirement_parity_cgo_test.go"
@@ -899,7 +899,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "172177ea09f2dec718a85a4e3f65aee92f8bb20d",
+      "retired_commit": "062fb1a130c15c030192bc23cdd0dd7eed6af18f",
       "receipt_refs": [
         "grammars/enforce_const_param_native_regression_test.go",
         "cgo_harness/enforce_const_param_retirement_parity_cgo_test.go"
@@ -932,7 +932,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "29b6e302701058e2ed101941c6da5f52a98dfe9a",
+      "retired_commit": "7c07270b3e98b691df5e9c8c6d10151cb8918b62",
       "receipt_refs": [
         "grammars/ebnf_native_regression_test.go",
         "cgo_harness/ebnf_retirement_parity_test.go"
@@ -965,7 +965,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "b67d12a13bdd4eb8e4b27e9e77b28934c398b8b2",
+      "retired_commit": "2ef4802f2dbb853486d852cc9c1909e2a26f0199",
       "receipt_refs": [
         "grammars/recovery_action_materialization_native_regression_test.go",
         "cgo_harness/inert_recovery_materialization_parity_cgo_test.go"
@@ -1032,7 +1032,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "c2721bc558cde4be27f1b8c4fcc131975d52741c",
+      "retired_commit": "9e2a7d8668f99e6f3eb43f6a74f4d449451943b2",
       "receipt_refs": [
         "grammars/fsharp_unary_wrapper_native_regression_test.go",
         "cgo_harness/fsharp_unary_wrapper_retirement_parity_test.go"
@@ -1065,7 +1065,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "44f95347952fdf2b50eb7a70479d2aa6545941de",
+      "retired_commit": "3f2a9256d72a838bb62a39ccf4af2e7cc1724dbb",
       "receipt_refs": [
         "grammars/recovery_action_materialization_native_regression_test.go",
         "cgo_harness/recovery_action_materialization_parity_cgo_test.go"
@@ -1098,7 +1098,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "a2f14f5abe9277b4c6a5cec821fa8696914561aa",
+      "retired_commit": "e12abef4da826db0bef291127ef4ab62ae4071e2",
       "receipt_refs": [
         "grammars/fidl_versioned_layout_modifier_native_regression_test.go",
         "cgo_harness/fidl_versioned_layout_modifier_parity_cgo_test.go"
@@ -1389,7 +1389,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "bcb9d1d27c8f71aa4490412eaec43d120be726ff",
+      "retired_commit": "2427094ae0629d0bd5c6a2fe2c2e801cbc709d3a",
       "receipt_refs": [
         "grammars/expected_root_fallback_native_regression_test.go",
         "cgo_harness/expected_root_fallback_parity_cgo_test.go"
@@ -1452,7 +1452,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "1adc7c8694000b0b670f0ca05cc8b8d7b6588cd3",
+      "retired_commit": "a5c853591fd84b1d004692b9f96651ad433d699d",
       "receipt_refs": [
         "grammars/type_projection_native_regression_test.go",
         "cgo_harness/type_projection_retirement_parity_test.go"
@@ -1485,7 +1485,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "bcb9d1d27c8f71aa4490412eaec43d120be726ff",
+      "retired_commit": "2427094ae0629d0bd5c6a2fe2c2e801cbc709d3a",
       "receipt_refs": [
         "grammars/expected_root_fallback_native_regression_test.go",
         "cgo_harness/expected_root_fallback_parity_cgo_test.go"
@@ -1609,7 +1609,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "2e0ed636316e82eaaea2b3c89aecd957a80af499",
+      "retired_commit": "84aee737500e7b9e0365725fb7af18e059e9d9e5",
       "receipt_refs": [
         "grammars/trailing_span_native_regression_test.go",
         "cgo_harness/retired_dispatch_arm_parity_test.go"
@@ -1788,7 +1788,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "617dd66e8a6e2c270b1f98be021861b838fdff74",
+      "retired_commit": "db34ebb495d1cd0c6540428c7045ac032ac41a22",
       "receipt_refs": [
         "grammars/field_projection_native_regression_test.go",
         "parser_reduce_fields_test.go",
@@ -1822,7 +1822,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "44f95347952fdf2b50eb7a70479d2aa6545941de",
+      "retired_commit": "3f2a9256d72a838bb62a39ccf4af2e7cc1724dbb",
       "receipt_refs": [
         "grammars/recovery_action_materialization_native_regression_test.go",
         "cgo_harness/recovery_action_materialization_parity_cgo_test.go"
@@ -1856,7 +1856,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "617dd66e8a6e2c270b1f98be021861b838fdff74",
+      "retired_commit": "db34ebb495d1cd0c6540428c7045ac032ac41a22",
       "receipt_refs": [
         "grammars/field_projection_native_regression_test.go",
         "parser_reduce_fields_test.go",
@@ -1891,7 +1891,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "d84aff3d1fa3031e911317ce342e2c6d10697f20",
+      "retired_commit": "29b6e302701058e2ed101941c6da5f52a98dfe9a",
       "receipt_refs": [
         "parser_result_objc_test.go",
         "grammars/objc_sizeof_native_regression_test.go",
@@ -1925,7 +1925,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "2e0ed636316e82eaaea2b3c89aecd957a80af499",
+      "retired_commit": "84aee737500e7b9e0365725fb7af18e059e9d9e5",
       "receipt_refs": [
         "grammars/trailing_span_native_regression_test.go",
         "cgo_harness/retired_dispatch_arm_parity_test.go"
@@ -2023,7 +2023,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "2e0ed636316e82eaaea2b3c89aecd957a80af499",
+      "retired_commit": "84aee737500e7b9e0365725fb7af18e059e9d9e5",
       "receipt_refs": [
         "grammars/trailing_span_native_regression_test.go",
         "cgo_harness/retired_dispatch_arm_parity_test.go"
@@ -2276,7 +2276,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "9fe391d597f7cf1e129abeea2c5b68219392edd6",
+      "retired_commit": "0d84d2eb5e597420de90d7d275b945e9b15ba7df",
       "receipt_refs": [
         "grammars/robot_scheme_skipped_error_native_regression_test.go",
         "cgo_harness/robot_scheme_skipped_error_parity_cgo_test.go"
@@ -2404,7 +2404,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "9fe391d597f7cf1e129abeea2c5b68219392edd6",
+      "retired_commit": "0d84d2eb5e597420de90d7d275b945e9b15ba7df",
       "receipt_refs": [
         "grammars/robot_scheme_skipped_error_native_regression_test.go",
         "cgo_harness/robot_scheme_skipped_error_parity_cgo_test.go"
@@ -2711,7 +2711,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "e6f1f05a42440756319a9f04fde41cdedd27815f",
+      "retired_commit": "af6dce4cf9dc323fba10155fdcab6a84a25e3927",
       "receipt_refs": [
         "grammars/typst_indent_native_regression_test.go",
         "cgo_harness/typst_indent_parity_cgo_test.go"
@@ -2772,7 +2772,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "617dd66e8a6e2c270b1f98be021861b838fdff74",
+      "retired_commit": "db34ebb495d1cd0c6540428c7045ac032ac41a22",
       "receipt_refs": [
         "grammars/field_projection_native_regression_test.go",
         "cgo_harness/retired_dispatch_arm_parity_test.go"
@@ -2835,7 +2835,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "242453ea94d36fc2ee36b87076bcaae9a2ac234e",
+      "retired_commit": "27b0f624032680f6246bb4ee307883a2b874afb9",
       "receipt_refs": [
         "parser_result_trailing_extra_native_test.go",
         "grammars/trailing_extra_native_regression_test.go",
@@ -2914,7 +2914,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "7fe7aac5c32c1d63d50b50022fd6bc5afaeb9b90",
+      "retired_commit": "d212e7c52fffc56182b138b08bb29ee7c490aa11",
       "receipt_refs": [
         "parser_collapsed_child_policy_test.go",
         "parser_collapsed_child_policy_external_test.go",
@@ -2984,7 +2984,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "d82f9c2cadb81242cb324ba751aa2805038d4b60",
+      "retired_commit": "8ced58fd8591aa18490d2720cf579e107f472711",
       "receipt_refs": [
         "parser_result_scala_fixpoint_retirement_test.go",
         "parser_result_scala_produced_span_test.go",
@@ -3088,7 +3088,7 @@
         "c_oracle": "retired_exact_receipt"
       },
       "status": "retired",
-      "retired_commit": "34a224bc6e98f49276bc06235c85c497127d1790",
+      "retired_commit": "93ab17820fd007b5808f2ab6b62e22f79df179d1",
       "receipt_refs": [
         "parser_result_javascript_typescript_test.go",
         "glr_forest_dispatch_test.go",


### PR DESCRIPTION
## Summary
- Correct 31 retired commit hashes in the compatibility registry.
- Add provenance checks for retired entries and deterministic Docker fixtures.

## Evidence
- Base: bb09ff6978cb2e46d98b805c0e2f6bb7d4429e24
- Head: af808932a1c80b2307937cc4c643dd12bed48943
- Tree identity: 151e2d7a393a894fc03e1377fc7c9426e108d01b
- Diff identity: 2ee70c39e42ef73e6cb5806d3b1402dd149d20e6947aa616aca879fee2c073d6
- Coverage: 52/52 retired entries, 36/36 live parents, 9/9 inner subpasses.
- Ledger SHA: ed974ee769367f9af6ca093f88a2079b068daf98b17ad724bb1786f637f0654a
- Julia amendment: spore.2026-08-21.codex.normalization-n57-julia-registration-provenance-amendment
- Docker gate: harness_out/docker/20260821T094944Z-normalization-completion-provenance-focused
- Trailer parse: Buckley-Change-Hash and Buckley-Stats both parse successfully.

## Review hold
Sol marked the candidate COMPLETE. No P0, P1, or P2 findings remain. Keep this pull request open as a non-merge review hold.

P3 disclosures:
1. Docker worktrees lack host Git history, so the test uses deterministic retirement fixtures.
2. The fixture path does not replace host Git ancestor and deletion-diff evidence.
3. The prior commit embedded a large patch in its message; this amendment removes it and preserves the exact tree and diff.

Do not merge.