### PR TITLE
perf(parser): integrate bounded replay page pools

### DIFF
--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -7,6 +7,7 @@ type resultRootBuild struct {
 	reuseState            *parseReuseState
 	linkScratch           *[]*Node
 	lang                  *Language
+	budgetScratch         *parserScratch
 	expectedRootSymbol    Symbol
 	hasExpectedRoot       bool
 	shouldWireParentLinks bool
@@ -22,14 +23,28 @@ type resultRootBuild struct {
 
 func newResultRootBuild(p *Parser, source []byte, arena *nodeArena, oldTree *Tree, reuseState *parseReuseState, linkScratch *[]*Node) resultRootBuild {
 	build := resultRootBuild{
-		parser:                p,
-		source:                source,
-		arena:                 arena,
-		reuseState:            reuseState,
-		linkScratch:           linkScratch,
+		parser:      p,
+		source:      source,
+		arena:       arena,
+		reuseState:  reuseState,
+		linkScratch: linkScratch,
+		budgetScratch: func() *parserScratch {
+			if p != nil {
+				return p.budgetScratch
+			}
+			return nil
+		}(),
 		shouldWireParentLinks: oldTree == nil,
 	}
 	if p != nil {
+		if build.budgetScratch != nil {
+			build.replayAdvancePages = build.budgetScratch.advancePages
+			build.replayAdvancePageUsed = build.budgetScratch.advancePageUsed
+			build.replayAdvanceFrames = build.budgetScratch.advanceFrames
+			build.replayStack.closePages = build.budgetScratch.closePages
+			build.replayStack.closePageUsed = build.budgetScratch.closePageUsed
+			build.replayStack.closeFrames = build.budgetScratch.closeFrames
+		}
 		build.lang = p.language
 		if p.hasRootSymbol {
 			build.expectedRootSymbol = p.rootSymbol
@@ -245,6 +260,8 @@ const syntheticRootReplayCloseMemoMaxEntries = 1 << 18
 
 // Fixed pages avoid stream-growth copies and bound frame storage to 4 MiB.
 const syntheticRootReplayAdvancePageFrames = 1 << 14
+const syntheticRootReplayAdvancePageBytes = syntheticRootReplayAdvancePageFrames * 4
+const syntheticRootReplayClosePageBytes = syntheticRootReplayClosePageFrames * 4
 const syntheticRootReplayAdvanceMaxPages = syntheticRootReplayAdvanceStreamMaxFrames / syntheticRootReplayAdvancePageFrames
 const syntheticRootReplayAdvanceSpanOffsetBits = 14
 const syntheticRootReplayAdvanceSpanPageBits = 6
@@ -716,7 +733,7 @@ func (b *resultRootBuild) syntheticRootReplayAdvanceToken(frontier []syntheticRo
 			start := span.offset()
 			end := start + count
 			if pageIndex >= 0 && pageIndex < len(b.replayAdvancePages) && start >= 0 && end >= start && end <= syntheticRootReplayAdvancePageFrames {
-				cached := b.replayAdvancePages[pageIndex][start:end]
+				cached := b.replayAdvancePages[pageIndex][start:end:end]
 				perfRecordSyntheticReplayAdvanceCacheHit()
 				perfRecordSyntheticReplayAdvanceOutput(len(cached), false)
 				return cached
@@ -780,7 +797,12 @@ func (b *resultRootBuild) syntheticRootReplayStoreAdvance(key syntheticRootRepla
 			perfRecordSyntheticReplayAdvanceCacheCapSkip()
 			return
 		}
-		b.replayAdvancePages = append(b.replayAdvancePages, new([syntheticRootReplayAdvancePageFrames]syntheticRootReplayFrame))
+		if b.budgetScratch != nil {
+			b.budgetScratch.advancePages = append(b.budgetScratch.advancePages, new([syntheticRootReplayAdvancePageFrames]syntheticRootReplayFrame))
+			b.replayAdvancePages = b.budgetScratch.advancePages
+		} else {
+			b.replayAdvancePages = append(b.replayAdvancePages, new([syntheticRootReplayAdvancePageFrames]syntheticRootReplayFrame))
+		}
 		used = 0
 	}
 	pageIndex := len(b.replayAdvancePages) - 1
@@ -788,6 +810,10 @@ func (b *resultRootBuild) syntheticRootReplayStoreAdvance(key syntheticRootRepla
 	b.replayAdvanceMemo[key] = newSyntheticRootReplayAdvanceSpan(pageIndex, used, len(frames))
 	b.replayAdvancePageUsed = uint16(used + len(frames))
 	b.replayAdvanceFrames += uint32(len(frames))
+	if b.budgetScratch != nil {
+		b.budgetScratch.advancePageUsed = b.replayAdvancePageUsed
+		b.budgetScratch.advanceFrames = b.replayAdvanceFrames
+	}
 	perfRecordSyntheticReplayAdvanceCacheStore()
 }
 
@@ -879,7 +905,12 @@ func (b *resultRootBuild) syntheticRootReplayStoreClose(key syntheticRootReplayC
 		if len(store.closePages) >= syntheticRootReplayCloseMaxPages {
 			return nil, false
 		}
-		store.closePages = append(store.closePages, new([syntheticRootReplayClosePageFrames]syntheticRootReplayFrame))
+		if b.budgetScratch != nil {
+			store.closePages = append(b.budgetScratch.closePages, new([syntheticRootReplayClosePageFrames]syntheticRootReplayFrame))
+			b.budgetScratch.closePages = store.closePages
+		} else {
+			store.closePages = append(store.closePages, new([syntheticRootReplayClosePageFrames]syntheticRootReplayFrame))
+		}
 		used = 0
 	}
 	pageIndex := len(store.closePages) - 1
@@ -888,6 +919,10 @@ func (b *resultRootBuild) syntheticRootReplayStoreClose(key syntheticRootReplayC
 	store.closeMemo[key] = newSyntheticRootReplayCloseSpan(pageIndex, used, len(frames))
 	store.closePageUsed = uint16(end)
 	store.closeFrames += uint32(len(frames))
+	if b.budgetScratch != nil {
+		b.budgetScratch.closePageUsed = store.closePageUsed
+		b.budgetScratch.closeFrames = store.closeFrames
+	}
 	perfRecordSyntheticReplayCloseMemoStore()
 	return store.closePages[pageIndex][used:end:end], true
 }

--- a/parser_scratch.go
+++ b/parser_scratch.go
@@ -1,12 +1,21 @@
 package gotreesitter
 
-import "sync"
+import (
+	"sync"
+	"unsafe"
+)
 
 // Keep enough compatibility traversal storage for ordinary generated files
 // without retaining multi-megabyte backing arrays after unusually wide trees.
 const maxRetainedGoCompatFrames = 16 * 1024
 
 type parserScratch struct {
+	advancePages             []*[syntheticRootReplayAdvancePageFrames]syntheticRootReplayFrame
+	closePages               []*[syntheticRootReplayClosePageFrames]syntheticRootReplayFrame
+	advancePageUsed          uint16
+	closePageUsed            uint16
+	advanceFrames            uint32
+	closeFrames              uint32
 	merge                    glrMergeScratch
 	entries                  glrEntryScratch
 	gss                      gssScratch
@@ -75,7 +84,27 @@ func (s *parserScratch) allocatedBytes() int64 {
 	if s == nil {
 		return 0
 	}
-	return s.entries.allocatedBytes + s.gss.allocatedBytes + s.merge.allocatedBytes() + s.transientChildren.allocatedBytes + s.transientParents.allocatedBytes
+	return s.entries.allocatedBytes + s.gss.allocatedBytes + s.merge.allocatedBytes() + s.transientChildren.allocatedBytes + s.transientParents.allocatedBytes + int64(len(s.advancePages))*int64(unsafe.Sizeof([syntheticRootReplayAdvancePageFrames]syntheticRootReplayFrame{})) + int64(len(s.closePages))*int64(unsafe.Sizeof([syntheticRootReplayClosePageFrames]syntheticRootReplayFrame{}))
+}
+
+func (s *parserScratch) resetReplayPages() {
+	if s == nil {
+		return
+	}
+	if cap(s.advancePages) > 1 {
+		clear(s.advancePages[:cap(s.advancePages)][1:])
+	}
+	if cap(s.closePages) > 1 {
+		clear(s.closePages[:cap(s.closePages)][1:])
+	}
+	if len(s.advancePages) > 0 {
+		s.advancePages = s.advancePages[:1:1]
+	}
+	if len(s.closePages) > 0 {
+		s.closePages = s.closePages[:1:1]
+	}
+	s.advancePageUsed, s.closePageUsed = 0, 0
+	s.advanceFrames, s.closeFrames = 0, 0
 }
 
 func (s *parserScratch) budgetExhausted() bool {
@@ -198,6 +227,7 @@ func releaseParserScratch(s *parserScratch, skipGSSClear bool) {
 	s.relexSnapshotInUse = false
 	s.trackChildErrors = false
 	s.materializeStopPollCount = 0
+	s.resetReplayPages()
 	s.entries.reset()
 	s.gss.skipClear = skipGSSClear
 	s.gss.audit = nil

--- a/parser_scratch_pagepool_test.go
+++ b/parser_scratch_pagepool_test.go
@@ -1,0 +1,401 @@
+package gotreesitter
+
+import (
+	"reflect"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+func newReplayAdvancePage() *[syntheticRootReplayAdvancePageFrames]syntheticRootReplayFrame {
+	return new([syntheticRootReplayAdvancePageFrames]syntheticRootReplayFrame)
+}
+
+func newReplayClosePage() *[syntheticRootReplayClosePageFrames]syntheticRootReplayFrame {
+	return new([syntheticRootReplayClosePageFrames]syntheticRootReplayFrame)
+}
+
+func seedReplayPageZero(s *parserScratch) {
+	s.advancePages = append(s.advancePages, newReplayAdvancePage())
+	s.closePages = append(s.closePages, newReplayClosePage())
+}
+
+func replayPageFrames() []syntheticRootReplayFrame {
+	frames := make([]syntheticRootReplayFrame, syntheticRootReplayMaxFrontier)
+	for i := range frames {
+		frames[i].top = uint32(i + 1)
+	}
+	return frames
+}
+
+func exerciseReplayPages(b *resultRootBuild, frames []syntheticRootReplayFrame) {
+	for i := 0; i < syntheticRootReplayAdvancePageFrames/syntheticRootReplayMaxFrontier+1; i++ {
+		b.syntheticRootReplayStoreAdvance(
+			syntheticRootReplayAdvanceKey{top: uint32(i + 1), lookahead: Symbol(1)},
+			frames,
+		)
+		b.syntheticRootReplayStoreClose(
+			syntheticRootReplayCloseKey{top: uint32(i + 1), lookahead: Symbol(1)},
+			frames,
+		)
+	}
+}
+
+func TestParserScratchReplayPagesResetDeterministically(t *testing.T) {
+	s := &parserScratch{
+		advancePages:    make([]*[syntheticRootReplayAdvancePageFrames]syntheticRootReplayFrame, 2, 4),
+		closePages:      make([]*[syntheticRootReplayClosePageFrames]syntheticRootReplayFrame, 2, 4),
+		advancePageUsed: 7,
+		closePageUsed:   9,
+		advanceFrames:   7,
+		closeFrames:     9,
+	}
+	page0Advance := newReplayAdvancePage()
+	page0Close := newReplayClosePage()
+	page1Advance := newReplayAdvancePage()
+	page1Close := newReplayClosePage()
+	s.advancePages[0] = page0Advance
+	s.advancePages[1] = page1Advance
+	s.closePages[0] = page0Close
+	s.closePages[1] = page1Close
+	advanceBacking := s.advancePages[:cap(s.advancePages)]
+	closeBacking := s.closePages[:cap(s.closePages)]
+
+	s.resetReplayPages()
+
+	if len(s.advancePages) != 1 || cap(s.advancePages) != 1 ||
+		len(s.closePages) != 1 || cap(s.closePages) != 1 {
+		t.Fatalf("retained page shape: advance %d/%d close %d/%d", len(s.advancePages), cap(s.advancePages), len(s.closePages), cap(s.closePages))
+	}
+	if s.advancePages[0] != page0Advance || s.closePages[0] != page0Close {
+		t.Fatal("page zero was not retained")
+	}
+	if s.advancePageUsed != 0 || s.closePageUsed != 0 || s.advanceFrames != 0 || s.closeFrames != 0 {
+		t.Fatal("replay page counters were not reset")
+	}
+	if advanceBacking[1] != nil || advanceBacking[2] != nil || advanceBacking[3] != nil ||
+		closeBacking[1] != nil || closeBacking[2] != nil || closeBacking[3] != nil {
+		t.Fatal("hidden replay page pointers were retained")
+	}
+	if page1Advance == nil || page1Close == nil {
+		t.Fatal("test did not seed excess pages")
+	}
+}
+
+func TestParserScratchReplayPageFrameShape(t *testing.T) {
+	frameType := reflect.TypeOf(syntheticRootReplayFrame{})
+	for i := 0; i < frameType.NumField(); i++ {
+		switch frameType.Field(i).Type.Kind() {
+		case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+			t.Fatalf("replay frame field %q contains pointer data", frameType.Field(i).Name)
+		}
+	}
+	if got := unsafe.Sizeof(syntheticRootReplayFrame{}); got != unsafe.Sizeof(uint32(0)) {
+		t.Fatalf("frame size %d", got)
+	}
+	if unsafe.Sizeof([syntheticRootReplayAdvancePageFrames]syntheticRootReplayFrame{}) != syntheticRootReplayAdvancePageBytes {
+		t.Fatal("advance page accounting drift")
+	}
+	if unsafe.Sizeof([syntheticRootReplayClosePageFrames]syntheticRootReplayFrame{}) != syntheticRootReplayClosePageBytes {
+		t.Fatal("close page accounting drift")
+	}
+}
+
+func TestParserScratchReplayPoolCheckoutShape(t *testing.T) {
+	s := acquireParserScratch()
+	seedReplayPageZero(s)
+	s.advancePages = append(s.advancePages, newReplayAdvancePage())
+	s.closePages = append(s.closePages, newReplayClosePage())
+	s.advancePageUsed = 17
+	s.closePageUsed = 19
+	s.advanceFrames = 17
+	s.closeFrames = 19
+	releaseParserScratch(s, false)
+
+	// sync.Pool may return a different scratch object or no retained page.
+	// Check only the release contract, never pointer identity.
+	reacquired := acquireParserScratch()
+	if len(reacquired.advancePages) > 1 || cap(reacquired.advancePages) > 1 ||
+		len(reacquired.closePages) > 1 || cap(reacquired.closePages) > 1 {
+		t.Fatalf("reacquired replay page shape: advance %d/%d close %d/%d", len(reacquired.advancePages), cap(reacquired.advancePages), len(reacquired.closePages), cap(reacquired.closePages))
+	}
+	if reacquired.advancePageUsed != 0 || reacquired.closePageUsed != 0 ||
+		reacquired.advanceFrames != 0 || reacquired.closeFrames != 0 {
+		t.Fatal("reacquired scratch retained replay counters")
+	}
+	releaseParserScratch(reacquired, false)
+}
+
+func TestParserScratchReplayBudgetBaselineExemptsRetainedPages(t *testing.T) {
+	s := &parserScratch{}
+	seedReplayPageZero(s)
+	baselineBytes := s.allocatedBytes()
+	pageBytes := int64(unsafe.Sizeof([syntheticRootReplayAdvancePageFrames]syntheticRootReplayFrame{}))
+	s.setBudget(pageBytes)
+
+	if got := s.budgetBaselineBytes; got != baselineBytes {
+		t.Fatalf("budget baseline = %d, want seeded-page bytes %d", got, baselineBytes)
+	}
+	if got := s.allocatedBytes(); got != baselineBytes {
+		t.Fatalf("seeded-page allocation = %d, want baseline %d", got, baselineBytes)
+	}
+	if s.budgetExhausted() {
+		t.Fatal("retained page baseline incorrectly exhausted the budget")
+	}
+
+	s.advancePages = append(s.advancePages, newReplayAdvancePage())
+	if got := s.allocatedBytes() - baselineBytes; got != pageBytes {
+		t.Fatalf("new advance page growth = %d, want %d", got, pageBytes)
+	}
+	if !s.budgetExhausted() {
+		t.Fatal("exact new-page growth did not exhaust the budget")
+	}
+}
+
+func TestSyntheticRootReplayAdvanceTokenCacheHitIsAppendIsolated(t *testing.T) {
+	s := &parserScratch{}
+	p := newRootFrameReplayParser(newRootFrameReplayGapLanguage())
+	p.budgetScratch = s
+	b := newResultRootBuild(p, []byte("\n"), nil, nil, nil, nil)
+	initial := b.syntheticRootReplayPush(syntheticRootReplayFrame{}, b.lang.InitialState)
+	frame := b.syntheticRootReplayPush(initial, 3)
+	var frameScratch [2][syntheticRootReplayMaxFrontier]syntheticRootReplayFrame
+	var setScratch [2]syntheticRootReplayFrameSetScratch
+	key := syntheticRootReplayAdvanceKey{top: frame.top, lookahead: Symbol(2)}
+
+	first := b.syntheticRootReplayAdvanceToken(
+		[]syntheticRootReplayFrame{frame},
+		key.lookahead,
+		frameScratch[0][:0],
+		frameScratch[1][:0],
+		&setScratch[0],
+		&setScratch[1],
+	)
+	if len(first) == 0 {
+		t.Fatal("production transition returned no frames")
+	}
+	span, ok := b.replayAdvanceMemo[key]
+	if !ok || span.count() != len(first) {
+		t.Fatalf("advance cache span = %v, want count %d", span, len(first))
+	}
+	pageCount := len(b.replayAdvancePages)
+	frameCount := b.replayAdvanceFrames
+
+	second := b.syntheticRootReplayAdvanceToken(
+		[]syntheticRootReplayFrame{frame},
+		key.lookahead,
+		frameScratch[0][:0],
+		frameScratch[1][:0],
+		&setScratch[0],
+		&setScratch[1],
+	)
+	if len(second) != len(first) || cap(second) != len(second) {
+		t.Fatalf("cached transition shape = %d/%d, want %d/%d", len(second), cap(second), len(first), len(first))
+	}
+	want := append([]syntheticRootReplayFrame(nil), second...)
+	appended := append(second, syntheticRootReplayFrame{top: ^uint32(0)})
+	if len(appended) != len(second)+1 {
+		t.Fatalf("append-isolated result length = %d, want %d", len(appended), len(second)+1)
+	}
+	for i, wantFrame := range want {
+		if second[i] != wantFrame {
+			t.Fatalf("cached result changed at %d: got %+v want %+v", i, second[i], wantFrame)
+		}
+	}
+
+	third := b.syntheticRootReplayAdvanceToken(
+		[]syntheticRootReplayFrame{frame},
+		key.lookahead,
+		frameScratch[0][:0],
+		frameScratch[1][:0],
+		&setScratch[0],
+		&setScratch[1],
+	)
+	if len(third) != len(want) || cap(third) != len(third) {
+		t.Fatalf("later cached transition shape = %d/%d, want %d/%d", len(third), cap(third), len(want), len(want))
+	}
+	for i, wantFrame := range want {
+		if third[i] != wantFrame {
+			t.Fatalf("later cached result changed at %d: got %+v want %+v", i, third[i], wantFrame)
+		}
+	}
+	if len(b.replayAdvancePages) != pageCount || b.replayAdvanceFrames != frameCount || len(b.replayAdvanceMemo) != 1 {
+		t.Fatalf("cache hit changed storage: pages=%d/%d frames=%d/%d memo=%d", len(b.replayAdvancePages), pageCount, b.replayAdvanceFrames, frameCount, len(b.replayAdvanceMemo))
+	}
+}
+
+func TestParserScratchReplayProductionCountersMatchBeforeRelease(t *testing.T) {
+	s := acquireParserScratch()
+	p := newRootFrameReplayParser(newRootFrameReplayGapLanguage())
+	p.budgetScratch = s
+	b := newResultRootBuild(p, []byte("source"), nil, nil, nil, nil)
+	exerciseReplayPages(&b, replayPageFrames())
+	if len(s.advancePages) < 2 || len(s.closePages) < 2 || s.advanceFrames == 0 || s.closeFrames == 0 {
+		t.Fatalf("production replay pages were not exercised: advance=%d/%d close=%d/%d", len(s.advancePages), s.advanceFrames, len(s.closePages), s.closeFrames)
+	}
+	if s.advancePageUsed != b.replayAdvancePageUsed || s.advanceFrames != b.replayAdvanceFrames ||
+		s.closePageUsed != b.replayStack.closePageUsed || s.closeFrames != b.replayStack.closeFrames {
+		t.Fatalf("scratch and builder counters diverged: scratch=%d/%d/%d/%d builder=%d/%d/%d/%d", s.advancePageUsed, s.advanceFrames, s.closePageUsed, s.closeFrames, b.replayAdvancePageUsed, b.replayAdvanceFrames, b.replayStack.closePageUsed, b.replayStack.closeFrames)
+	}
+	// Drop the builder value before release. Do not inspect either object after
+	// releaseParserScratch; the pool contract is checked by the next test.
+	b = resultRootBuild{}
+	releaseParserScratch(s, false)
+}
+
+func TestParserScratchReplayBuilderStateDoesNotEnterPagePool(t *testing.T) {
+	s := acquireParserScratch()
+	p := newRootFrameReplayParser(newRootFrameReplayGapLanguage())
+	p.budgetScratch = s
+	source := []byte("source")
+	node := &Node{}
+	links := []*Node{node}
+	b := &resultRootBuild{}
+	*b = newResultRootBuild(p, source, nil, nil, nil, &links)
+	b.replayStack.nodes = append(b.replayStack.nodes, syntheticRootReplayStackNode{state: 3})
+	b.replayStack.intern = map[syntheticRootReplayStackKey]uint32{{state: 3}: 1}
+	b.replayStack.closeMemo = map[syntheticRootReplayCloseKey]syntheticRootReplayCloseSpan{{top: 1}: 0}
+	b.replayAdvanceMemo = map[syntheticRootReplayAdvanceKey]syntheticRootReplayAdvanceSpan{{top: 1}: 0}
+	b.replayGapLexMemo = map[syntheticRootReplayGapLexKey]syntheticRootReplayGapToken{{state: 3}: {symbol: 1}}
+	exerciseReplayPages(b, replayPageFrames())
+	if len(b.replayStack.nodes) == 0 || len(b.replayStack.intern) == 0 || len(b.replayStack.closeMemo) == 0 ||
+		len(b.replayAdvanceMemo) == 0 || len(b.replayGapLexMemo) == 0 || len(b.source) == 0 || len(links) != 1 || links[0] == nil {
+		t.Fatal("builder-owned replay state was not populated")
+	}
+	s.nodeLinks = append(s.nodeLinks, node)
+	if len(s.advancePages) < 2 || len(s.closePages) < 2 {
+		t.Fatal("page pool did not receive production replay pages")
+	}
+
+	// A finalizer on the builder proves that the page pool does not retain the
+	// builder, its maps, its source slice, or its link slice after release.
+	builderFinalized := make(chan struct{})
+	nodeFinalized := make(chan struct{})
+	runtime.SetFinalizer(node, func(*Node) { close(nodeFinalized) })
+	runtime.SetFinalizer(b, func(*resultRootBuild) { close(builderFinalized) })
+	runtime.KeepAlive(node)
+	b = nil
+	links = nil
+	node = nil
+	source = nil
+	releaseParserScratch(s, false)
+	builderDone, nodeDone := false, false
+	for i := 0; i < 20; i++ {
+		runtime.GC()
+		select {
+		case <-builderFinalized:
+			builderDone = true
+		case <-nodeFinalized:
+			nodeDone = true
+		case <-time.After(10 * time.Millisecond):
+		}
+		if builderDone && nodeDone {
+			return
+		}
+	}
+	t.Fatalf("page pool retained builder-owned replay state: builderFinalized=%t nodeFinalized=%t", builderDone, nodeDone)
+}
+
+func TestParserScratchReplayTwoGrammarReuse(t *testing.T) {
+	s := &parserScratch{}
+	seedReplayPageZero(s)
+	firstParser := newRootFrameReplayParser(newRootFrameReplayGapLanguage())
+	firstParser.budgetScratch = s
+	firstBuilder := newResultRootBuild(firstParser, []byte("\n"), nil, nil, nil, nil)
+	exerciseReplayPages(&firstBuilder, replayPageFrames())
+	page0Advance := s.advancePages[0]
+	page0Close := s.closePages[0]
+	if len(s.advancePages) < 2 || len(s.closePages) < 2 {
+		t.Fatal("first grammar did not exercise replay page growth")
+	}
+
+	s.resetReplayPages()
+	secondParser := newRootFrameReplayParser(newRootFrameReplayReduceLanguage())
+	secondParser.budgetScratch = s
+	secondBuilder := newResultRootBuild(secondParser, nil, nil, nil, nil, nil)
+	exerciseReplayPages(&secondBuilder, replayPageFrames())
+	if s.advancePages[0] != page0Advance || s.closePages[0] != page0Close {
+		t.Fatal("second grammar did not reuse retained page zero")
+	}
+	if len(s.advancePages) < 2 || len(s.closePages) < 2 || s.advanceFrames == 0 || s.closeFrames == 0 {
+		t.Fatal("second grammar did not exercise replay page growth")
+	}
+}
+
+func TestParserScratchReplayConcurrentProductionPages(t *testing.T) {
+	const workers = 4
+	var wg sync.WaitGroup
+	errs := make(chan string, workers)
+	for worker := 0; worker < workers; worker++ {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lang := newRootFrameReplayGapLanguage()
+			if worker&1 != 0 {
+				lang = newRootFrameReplayReduceLanguage()
+			}
+			s := &parserScratch{}
+			p := newRootFrameReplayParser(lang)
+			p.budgetScratch = s
+			b := newResultRootBuild(p, []byte("source"), nil, nil, nil, nil)
+			exerciseReplayPages(&b, replayPageFrames())
+			if len(s.advancePages) < 2 || len(s.closePages) < 2 || s.advanceFrames == 0 || s.closeFrames == 0 {
+				errs <- "concurrent worker did not exercise both replay page stores"
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+}
+
+type nestedBudgetScratchTokenSource struct {
+	parser   *Parser
+	delegate TokenSource
+	called   bool
+}
+
+func (s *nestedBudgetScratchTokenSource) Next() Token {
+	if !s.called {
+		s.called = true
+		tree, err := s.parser.Parse([]byte("1+2"))
+		if err != nil {
+			panic(err)
+		}
+		if tree != nil {
+			tree.Release()
+		}
+	}
+	return s.delegate.Next()
+}
+
+func TestParserScratchReplayNestedBudgetScratchRestoresProductionScope(t *testing.T) {
+	lang := buildArithmeticLanguage()
+	p := NewParser(lang)
+	sentinel := &parserScratch{}
+	p.budgetScratch = sentinel
+	source := []byte("1+2")
+	delegate := newDFATokenSourceDirect(
+		NewLexer(lang.LexStates, source),
+		lang,
+		p.lookupActionIndex,
+		p.hasKeywordState,
+		p.externalValidByState,
+		p.externalValidMaskByState,
+	)
+	ts := &nestedBudgetScratchTokenSource{parser: p, delegate: delegate}
+	tree := p.parseInternal(source, ts, nil, nil, arenaClassFull, nil, 0, 0, 0, false)
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("nested-scope parse returned no tree")
+	}
+	tree.Release()
+	if p.budgetScratch != sentinel {
+		t.Fatal("nested parse did not restore the outer budget scratch")
+	}
+	p.budgetScratch = nil
+}


### PR DESCRIPTION
## Summary

Move bounded replay page storage into parser scratch state. Reuse retained page zero, clear excess pages on release, count page memory in parser budgets, and cap cached token slices.

The commit contains exactly three approved files:
- parser_scratch.go
- parser_result_root_build.go
- parser_scratch_pagepool_test.go

Commit: d835ba2f22d29318c160c02f6f336d878af51aa5

## Terminal evidence

Evidence root: /home/draco/work/gts-perf-p11-full-evidence-20260821
Receipt SHA-256: dfc191501e489ce6e92807131ae0ae23de7900d6d35b157b402c12215c52fa74
Evidence manifest SHA-256: 9ca522626ef0e226a3a0429e78696246856ff62dad0874be384e4ac20dc4647f
Source manifest SHA-256: 4f50d387e0972b9115a91b405041db8d4428fbdebc11a44f4867f06288588bcc

Candidate source SHA-256 values:
- parser_scratch.go: 6a251824d97ce1e50dfba9a81c90653b48d1a5f96ba55e1b28d7ee463676ed01
- parser_result_root_build.go: b09ae2a4c2fad78a570a72d444a28532e9329f44a36c0e0974cc68dfd92733a7
- parser_scratch_pagepool_test.go: 982e7f35c52446a7b5cebda2bec619bc3c19175b229e48dbcb335209627e6345

## Benchmark headline

| Benchmark | Base | Candidate | Change |
| --- | ---: | ---: | ---: |
| Full Go parse | 9.675 ms | 8.492 ms | -12.23% |
| Incremental single-byte edit | 1.154 us | 1.056 us | -8.49% |
| Incremental no-edit | 3.868 ns | 3.346 ns | -13.48% |
| KDL recovery | 41.29 ms | 36.37 ms | -11.92% |
| Recovery corpus | 402.7 us | 362.3 us | -10.02% |

Full Go B/op fell 4.51%. KDL recovery B/op fell 12.55%. Twenty randomized seeds completed for each source identity.

## Gates

- Focused Docker correctness: PASS.
- Focused Docker race: PASS.
- Go real-corpus smoke: 25/25 no-error, S-expression, and deep parity: PASS.
- KDL, Hurl, and INI runtime C parity: PASS.
- Cached KDL substitute: 5/5 exact Go-to-C and base-to-candidate rows: PASS.
- Memory budgets at zero, sub-page, one-page, and multi-page cases: PASS.
- Long-lived RSS and heap: 20 large-to-small forced-GC pairs per identity: PASS. Candidate timed max RSS was 30,284 kB versus base 30,420 kB.

## KDL generation limitation

The generated KDL real-corpus command timed out at 120 seconds on both base and candidate after 1 import, 0 generated files, and 0 eligible samples. Candidate max RSS was 2,491,064 kB; base was 2,684,368 kB; both were OOM-free. The pinned cached language artifact and corpus provide the runtime substitute, which passed all five fixtures.

This PR does not recertify a new directional C-ratio claim. Existing runtime C parity remains covered, but no new C-ratio result is used for acceptance.

No unrelated files, evidence files, commits, or generated artifacts are included in the commit.