### PR TITLE
test(cgo_harness): repair C replacement-loop ownership

### DIFF
--- a/cgo_harness/benchmark_c_baseline_test.go
+++ b/cgo_harness/benchmark_c_baseline_test.go
@@ -99,7 +99,11 @@ func BenchmarkCTreeSitterGoParseIncrementalSingleByteEdit(b *testing.B) {
 	if tree == nil || tree.RootNode() == nil {
 		b.Fatal("initial parse returned nil root")
 	}
-	defer tree.Close()
+	defer func() {
+		if tree != nil {
+			tree.Close()
+		}
+	}()
 
 	edit := sitter.InputEdit{
 		StartByte:      uint(editAt),
@@ -140,7 +144,11 @@ func BenchmarkCTreeSitterGoParseIncrementalNoEdit(b *testing.B) {
 	if tree == nil || tree.RootNode() == nil {
 		b.Fatal("initial parse returned nil root")
 	}
-	defer tree.Close()
+	defer func() {
+		if tree != nil {
+			tree.Close()
+		}
+	}()
 
 	b.ReportAllocs()
 	b.SetBytes(int64(len(src)))
@@ -170,7 +178,11 @@ func BenchmarkCTreeSitterGoParseIncrementalRandomSingleByteEdit(b *testing.B) {
 	if tree == nil || tree.RootNode() == nil {
 		b.Fatal("initial parse returned nil root")
 	}
-	defer tree.Close()
+	defer func() {
+		if tree != nil {
+			tree.Close()
+		}
+	}()
 
 	seed := uint32(0x9e3779b9)
 	b.ReportAllocs()

--- a/cgo_harness/benchmark_c_semantic_admission_test.go
+++ b/cgo_harness/benchmark_c_semantic_admission_test.go
@@ -1,0 +1,228 @@
+//go:build cgo && treesitter_c_bench
+
+package cgoharness
+
+import (
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// TestGeneratedGoBenchmarkSemanticAdmission proves the generated benchmark
+// source against fresh and incremental Go and C trees in both edit directions.
+func TestGeneratedGoBenchmarkSemanticAdmission(t *testing.T) {
+	goLang := grammars.GoLanguage()
+	goParser := gotreesitter.NewParser(goLang)
+	cParser := newOracleCTreeSitterParser(t)
+	defer cParser.Close()
+
+	source := makeGoBenchmarkSource(500)
+	sites := makeGoBenchmarkEditSites(source)
+	if len(sites) == 0 {
+		t.Fatal("generated benchmark source has no edit site")
+	}
+	site := sites[0]
+	edited := append([]byte(nil), source...)
+	toggleDigitAt(edited, site.offset)
+
+	directions := []struct {
+		name string
+		from []byte
+		to   []byte
+	}{
+		{name: "forward", from: source, to: edited},
+		{name: "reverse", from: edited, to: source},
+	}
+	for _, direction := range directions {
+		direction := direction
+		t.Run(direction.name, func(t *testing.T) {
+			goFresh, err := goParser.Parse(direction.to)
+			if err != nil {
+				t.Fatalf("fresh Go parse: %v", err)
+			}
+			defer goFresh.Release()
+			cFresh := parseOracleCTree(t, cParser, nil, direction.to, "fresh C")
+			defer cFresh.Close()
+			assertGeneratedSemanticPair(t, "fresh", direction.to, goFresh, cFresh, goLang)
+
+			goOld, err := goParser.Parse(direction.from)
+			if err != nil {
+				t.Fatalf("old Go parse: %v", err)
+			}
+			goOld.Edit(generatedGoBenchmarkEdit(direction.from, direction.to, site))
+			goIncremental, err := goParser.ParseIncremental(direction.to, goOld)
+			if err != nil {
+				t.Fatalf("incremental Go parse: %v", err)
+			}
+			if goIncremental != goOld {
+				goOld.Release()
+			}
+			defer goIncremental.Release()
+			cOld := parseOracleCTree(t, cParser, nil, direction.from, "old C")
+			cEdit := generatedCTreeSitterEdit(direction.from, direction.to, site)
+			cOld.Edit(&cEdit)
+			cIncremental := parseOracleCTree(t, cParser, cOld, direction.to, "incremental C")
+			cOld.Close()
+			defer cIncremental.Close()
+
+			assertGeneratedSemanticPair(t, "incremental", direction.to, goIncremental, cIncremental, goLang)
+			assertGeneratedTreeEquivalent(t, "Go incremental/fresh Go", goIncremental, goFresh, goLang)
+			assertGeneratedCTreeEquivalent(t, "C incremental/fresh C", cIncremental, cFresh)
+		})
+	}
+}
+
+func generatedGoBenchmarkEdit(from, to []byte, site benchmarkEditSite) gotreesitter.InputEdit {
+	return gotreesitter.InputEdit{
+		StartByte:   uint32(site.offset),
+		OldEndByte:  uint32(site.offset + 1),
+		NewEndByte:  uint32(site.offset + 1),
+		StartPoint:  pointAtOffset(from, site.offset),
+		OldEndPoint: pointAtOffset(from, site.offset+1),
+		NewEndPoint: pointAtOffset(to, site.offset+1),
+	}
+}
+
+func generatedCTreeSitterEdit(from, to []byte, site benchmarkEditSite) sitter.InputEdit {
+	start := pointAtOffset(from, site.offset)
+	oldEnd := pointAtOffset(from, site.offset+1)
+	newEnd := pointAtOffset(to, site.offset+1)
+	return sitter.InputEdit{
+		StartByte:      uint(site.offset),
+		OldEndByte:     uint(site.offset + 1),
+		NewEndByte:     uint(site.offset + 1),
+		StartPosition:  sitter.Point{Row: uint(start.Row), Column: uint(start.Column)},
+		OldEndPosition: sitter.Point{Row: uint(oldEnd.Row), Column: uint(oldEnd.Column)},
+		NewEndPosition: sitter.Point{Row: uint(newEnd.Row), Column: uint(newEnd.Column)},
+	}
+}
+
+func assertGeneratedSemanticPair(tb testing.TB, phase string, source []byte, goTree *gotreesitter.Tree, cTree *sitter.Tree, goLang *gotreesitter.Language) {
+	tb.Helper()
+	goRoot := goTree.RootNode()
+	cRoot := cTree.RootNode()
+	if goRoot == nil || cRoot == nil {
+		tb.Fatalf("%s root is nil", phase)
+	}
+	if got, want := goRoot.StartByte(), uint32(0); got != want {
+		tb.Fatalf("%s Go root start=%d want=%d", phase, got, want)
+	}
+	if got, want := goRoot.EndByte(), uint32(len(source)); got != want {
+		tb.Fatalf("%s Go root end=%d want=%d", phase, got, want)
+	}
+	if got, want := cRoot.StartByte(), uint(0); got != want {
+		tb.Fatalf("%s C root start=%d want=%d", phase, got, want)
+	}
+	if got, want := cRoot.EndByte(), uint(len(source)); got != want {
+		tb.Fatalf("%s C root end=%d want=%d", phase, got, want)
+	}
+	if goRoot.HasError() != cRoot.HasError() {
+		tb.Fatalf("%s root error mismatch: Go=%v C=%v", phase, goRoot.HasError(), cRoot.HasError())
+	}
+	goInspection, err := benchfixtures.InspectGoTree(goRoot, goLang)
+	if err != nil {
+		tb.Fatalf("%s Go deep digest: %v", phase, err)
+	}
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		tb.Fatalf("%s C deep digest: %v", phase, err)
+	}
+	if goInspection.SHA256 != cDigest {
+		tb.Fatalf("%s deep digest mismatch: Go=%s C=%s", phase, goInspection.SHA256, cDigest)
+	}
+	goSExpr := generatedGoNamedSExpr(goRoot, goLang)
+	cSExpr := generatedCNamedSExpr(cRoot)
+	if goSExpr != cSExpr {
+		tb.Fatalf("%s named S-expression mismatch\nGo: %s\nC: %s", phase, goSExpr, cSExpr)
+	}
+}
+
+func assertGeneratedTreeEquivalent(tb testing.TB, phase string, got, want *gotreesitter.Tree, lang *gotreesitter.Language) {
+	tb.Helper()
+	if got.RootNode().StartByte() != want.RootNode().StartByte() || got.RootNode().EndByte() != want.RootNode().EndByte() || got.RootNode().HasError() != want.RootNode().HasError() {
+		tb.Fatalf("%s root semantic mismatch", phase)
+	}
+	gotDigest, err := benchfixtures.InspectGoTree(got.RootNode(), lang)
+	if err != nil {
+		tb.Fatalf("%s got digest: %v", phase, err)
+	}
+	wantDigest, err := benchfixtures.InspectGoTree(want.RootNode(), lang)
+	if err != nil {
+		tb.Fatalf("%s want digest: %v", phase, err)
+	}
+	if gotDigest.SHA256 != wantDigest.SHA256 {
+		tb.Fatalf("%s deep digest mismatch: got=%s want=%s", phase, gotDigest.SHA256, wantDigest.SHA256)
+	}
+	if generatedGoNamedSExpr(got.RootNode(), lang) != generatedGoNamedSExpr(want.RootNode(), lang) {
+		tb.Fatalf("%s named S-expression mismatch", phase)
+	}
+}
+
+func assertGeneratedCTreeEquivalent(tb testing.TB, phase string, got, want *sitter.Tree) {
+	tb.Helper()
+	if got.RootNode().StartByte() != want.RootNode().StartByte() || got.RootNode().EndByte() != want.RootNode().EndByte() || got.RootNode().HasError() != want.RootNode().HasError() {
+		tb.Fatalf("%s root semantic mismatch", phase)
+	}
+	gotDigest, err := COracleDeepDigest(got)
+	if err != nil {
+		tb.Fatalf("%s got digest: %v", phase, err)
+	}
+	wantDigest, err := COracleDeepDigest(want)
+	if err != nil {
+		tb.Fatalf("%s want digest: %v", phase, err)
+	}
+	if gotDigest != wantDigest {
+		tb.Fatalf("%s deep digest mismatch: got=%s want=%s", phase, gotDigest, wantDigest)
+	}
+	if generatedCNamedSExpr(got.RootNode()) != generatedCNamedSExpr(want.RootNode()) {
+		tb.Fatalf("%s named S-expression mismatch", phase)
+	}
+}
+
+func generatedGoNamedSExpr(node *gotreesitter.Node, lang *gotreesitter.Language) string {
+	var b strings.Builder
+	var visit func(*gotreesitter.Node)
+	visit = func(current *gotreesitter.Node) {
+		if current == nil {
+			return
+		}
+		b.WriteByte('(')
+		b.WriteString(current.Type(lang))
+		for i := 0; i < current.ChildCount(); i++ {
+			child := current.Child(i)
+			if child != nil && child.IsNamed() {
+				b.WriteByte(' ')
+				visit(child)
+			}
+		}
+		b.WriteByte(')')
+	}
+	visit(node)
+	return b.String()
+}
+
+func generatedCNamedSExpr(node *sitter.Node) string {
+	var b strings.Builder
+	var visit func(*sitter.Node)
+	visit = func(current *sitter.Node) {
+		if current == nil || !current.IsNamed() {
+			return
+		}
+		b.WriteByte('(')
+		b.WriteString(current.Kind())
+		for i := uint(0); i < current.ChildCount(); i++ {
+			child := current.Child(i)
+			if child != nil && child.IsNamed() {
+				b.WriteByte(' ')
+				visit(child)
+			}
+		}
+		b.WriteByte(')')
+	}
+	visit(node)
+	return b.String()
+}


### PR DESCRIPTION
## Summary

Repair ownership in the three C replacement-loop benchmarks.

The old deferred method value retained the first tree. Each loop also closed that tree during replacement. The deferred call could therefore close the same tree twice.

This change makes the deferred closure read the final tree. Each replaced tree closes once. The final tree closes once.

Add generated semantic admission for fresh and incremental Go and C trees. Test both edit directions.

## Verification

- Base: `de4fe455d3a9778b8a9b09347908e860a1f6b7f8`
- Commit: `a9e76f7e9c10b47d842408054839f0762db6db4e`
- Changed files: exactly two files under `cgo_harness/`
- `git diff --check`: passed
- Docker focus gate: passed; four benchmarks; `benchtime=1x`; exit code 0; no signal; no allocator diagnostic; no out-of-memory stop
- Docker semantic gate: passed; fresh and incremental Go equals C; forward and reverse edits; root spans; error flags; deep digests; named S-expressions
- Matrix: 120/120 processes passed; 20 seeds; separate process per lane; `GOMAXPROCS=1`; `count=1`; `benchtime=750ms`; `benchmem`; CPU 4; one CPU quota; 3 GiB; no added swap

## Directional disposition

The matrix uses the generated Go benchmark control only. It does not establish performance for a broad real-world corpus.

- Full parse: median Go/C `1.480362744549`; the `<=2x` goal passes.
- Single-byte edit: median Go/C `0.004239870483`; the `<=1x` goal passes.
- No-edit: median Go/C `0.000013923967`; the `<=1x` goal passes.

Median full-parse resident set size was 47,578 KiB for Go and 15,760 KiB for C. The edit values were 47,262 KiB and 16,000 KiB. The no-edit values were 46,460 KiB and 13,440 KiB.

## Open performance work

The representative profile goals remain open. The next candidate targets repeated raw-shape content hashing under `stackEntryNodeParseState` during `early_newline` reparse.

Require deep semantic parity in both directions, zero allocation for no-edit, no ownership regression, at least 10% lower early-newline reparse time, and no more than 5% regression in the three matrix lanes. Stop on any semantic, parity, signal, memory, allocation, or resident-set failure.

## Evidence disclosures

- P3: The immutable report and receipt describe the pre-commit attribution run. They retain `source.commit=de4fe455...` and `no_commit=true`, `no_push=true`, and `no_pull_request=true`. Those fields are historical evidence, not the current Git state.
- P3: The canonical parity run includes a known Python external-scanner full-parse fallback. The generated-control semantic gate is the scoped admission gate for this repair.
- P3: Attribution profiles and the 20-seed raw matrix remain outside this source commit. The PR includes only the harness repair and semantic admission test.

## Signed evidence hashes

- Report: `bf2158e14fe38a5e7ece1dc7119f6a93577c7afefc42722b05ca2267a37e505d`
- Artifact manifest: `3d764704d19d29da76ab5411084e53261936811869e1f396305253fbb8c4748c`
- Final manifest: `baa342b6c82613e68745c9d91e2534de3a7b4d7d51c5a9d97de5aeda5997b6a1`
- Receipt: `7fe3303da0c0496b8c9d5cd29815bba2b399388a2f5e1a8ec67e27a07463e7ef`
- Receipt signature: `7530df4d735777e04df4f73fd81602fc4b353443bc8c1edcfc1a52c7b57eded8`
- Receipt public key: `e5b9d74370dc7323750bba7f57e50173b0d0ca75e14579dbfdedadc6fa63d0df`

The signed receipt verifies with OpenSSL. The attribution artifacts are available at `/home/draco/work/gts-p12-attribution-evidence-20260821/repair/` on the evidence host.
