### PR TITLE
Add compact alternative-set storage

### DIFF
--- a/cgo_harness/compact_g18_alternative_set_contract_test.go
+++ b/cgo_harness/compact_g18_alternative_set_contract_test.go
@@ -1,0 +1,1030 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+const (
+	g18AlternativeSetTargetManifestSHA256 = "3a659138e3aac82563e5fdf46aeb3041a685d6311f32dfd6660c0337b02dbb0d"
+	g18AlternativeSetFlagDenominator      = 15
+	g18AlternativeSetGrammarDenominator   = 12
+)
+
+var g18AlternativeSetRouteGrammars = []string{
+	"go", "erlang", "haskell", "javascript", "bash", "perl", "ada", "python",
+}
+
+type g18AlternativeSetTarget struct {
+	grammar       string
+	name          string
+	source        []byte
+	sourceSHA256  string
+	load          func() *gotreesitter.Language
+	wantReason    string
+	wantCensus    gotreesitter.DiagnosticParserCoreThreeProofCensusTotals
+	wantAdaImport bool
+}
+
+type g18CohortVerifierTelemetryProvider interface {
+	DiagnosticDropCohortVerifierTelemetryForTest() []byte
+}
+
+// g18CohortVerifierReceiptProvider exposes one diagnostic receipt per election.
+// The future parser must publish this data beside aggregate telemetry.
+type g18CohortVerifierReceiptProvider interface {
+	DiagnosticDropCohortVerifierReceiptsForTest() []byte
+}
+
+// g18DiagnosticDropCohortReceiptProvider is owned by the diagnostic runner.
+// It must expose canonical bytes from that runner's own Core instance.
+type g18DiagnosticProvider interface {
+	DiagnosticDropCohortSessionForTest() (func() (uint64, uint64, error), func() (uint64, uint64, []byte, error), func(), error)
+}
+
+type g18DiagnosticProviderCompileContract struct{}
+
+func (*g18DiagnosticProviderCompileContract) DiagnosticDropCohortSessionForTest() (func() (uint64, uint64, error), func() (uint64, uint64, []byte, error), func(), error) {
+	return func() (uint64, uint64, error) { return 0, 0, nil }, func() (uint64, uint64, []byte, error) { return 1, 1, []byte("contract"), nil }, func() {}, nil
+}
+
+var _ g18DiagnosticProvider = (*g18DiagnosticProviderCompileContract)(nil)
+
+// g18CertificateAdmissionActivator is private and test-only. Production
+// profile flags never enable it. The returned restore function must run after
+// one parser attempt and before the parser is reused.
+type g18CertificateAdmissionActivator interface {
+	DiagnosticEnableDropCohortCertificateAdmissionForTest() func()
+}
+
+// g18CertificateAdmissionSuppressor is a one-shot, test-only seam. Only the
+// missing-certificate fallback test may call it.
+type g18CertificateAdmissionSuppressor interface {
+	DiagnosticSuppressDropCohortCertificateForTest()
+}
+
+type g18CertificateAdmissionNegativeProvider interface {
+	DiagnosticInvalidateDropCohortCertificateForTest()
+}
+
+type g18CohortVerifierReceipt struct {
+	ArenaOwner     uint64 `json:"arena_owner"`
+	ArenaEpoch     uint64 `json:"arena_epoch"`
+	CohortSequence uint64 `json:"cohort_sequence"`
+	Verdict        string `json:"verdict"`
+	Classification string `json:"classification"`
+}
+
+type g18CohortVerifierTelemetry struct {
+	Schema                      string            `json:"schema"`
+	ArenaOwner                  uint64            `json:"arena_owner"`
+	ArenaEpoch                  uint64            `json:"arena_epoch"`
+	VerifierElections           uint64            `json:"verifier_elections"`
+	VerifierProofs              uint64            `json:"verifier_proofs"`
+	VerifierDeclines            uint64            `json:"verifier_declines"`
+	ProfileBypasses             uint64            `json:"profile_bypasses"`
+	ActionIdentityDeclines      uint64            `json:"action_identity_declines"`
+	DerivationIdentityDeclines  uint64            `json:"derivation_identity_declines"`
+	DeclineReasons              map[string]uint64 `json:"decline_reasons"`
+	AuthenticatedHistoryImports uint64            `json:"authenticated_history_imports"`
+	UnprovedHistoryImports      uint64            `json:"unproved_history_imports"`
+	ProducerWrites              map[string]uint64 `json:"producer_writes"`
+}
+
+// TestG18AlternativeSetCurrentFallbackCharacterization pins current main.
+// Each shipped grant routes and matches locked C. A grant-free clone must use
+// the exact fallback and census recorded before the future design changes it.
+func TestG18AlternativeSetCurrentFallbackCharacterization(t *testing.T) {
+	restoreCensus := gotreesitter.SetDiagnosticParserCoreShadowCensusEnabledForTest(true)
+	defer restoreCensus()
+
+	groups := make(map[string][]g18AlternativeSetTarget)
+	for _, target := range g18AlternativeSetTargets(t) {
+		groups[target.grammar] = append(groups[target.grammar], target)
+	}
+	for _, grammar := range g18AlternativeSetRouteGrammars {
+		grammar := grammar
+		t.Run(grammar, func(t *testing.T) {
+			for _, target := range groups[grammar] {
+				target := target
+				t.Run(target.name, func(t *testing.T) {
+					runG18AlternativeSetCurrentFallback(t, target)
+				})
+			}
+		})
+	}
+}
+
+func runG18AlternativeSetCurrentFallback(t *testing.T, target g18AlternativeSetTarget) {
+	t.Helper()
+	if got := fmt.Sprintf("%x", sha256.Sum256(target.source)); got != target.sourceSHA256 {
+		t.Fatalf("source SHA-256 = %s, want %s", got, target.sourceSHA256)
+	}
+
+	cLanguage, err := COracleLanguage(target.grammar)
+	if err != nil {
+		t.Fatalf("load %s locked C language: %v", target.grammar, err)
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatalf("set %s locked C language: %v", target.grammar, err)
+	}
+	cTree := cParser.Parse(target.source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatalf("%s locked C parse returned no root", target.grammar)
+	}
+	t.Cleanup(cTree.Close)
+
+	grantedLanguage := g18CloneLanguage(target.load())
+	if !grantedLanguage.CompactConvergedReductionSplitDropsCertified {
+		t.Fatal("shipped profile does not carry the converged-split grant")
+	}
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	grantedParser := gotreesitter.NewParser(grantedLanguage)
+	grantedParser.SetAdmissionCandidateRoute(true)
+	grantedTree, err := grantedParser.Parse(target.source)
+	if err != nil {
+		t.Fatalf("granted compact parse: %v", err)
+	}
+	t.Cleanup(grantedTree.Release)
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter != routedBefore+1 || fallbackAfter != fallbackBefore {
+		t.Fatalf("granted counters = %d/%d to %d/%d; want routed +1; reason=%q", routedBefore, fallbackBefore, routedAfter, fallbackAfter, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+	assertG18LockedCExact(t, "granted compact", grantedTree, grantedLanguage, cTree)
+
+	grantFreeLanguage := g18CloneLanguage(target.load())
+	grantFreeLanguage.CompactConvergedReductionSplitDropsCertified = false
+	productionParser := gotreesitter.NewParser(grantFreeLanguage)
+	productionParser.SetAdmissionCandidateRoute(false)
+	productionTree, err := productionParser.Parse(target.source)
+	if err != nil {
+		t.Fatalf("grant-free production parse: %v", err)
+	}
+	t.Cleanup(productionTree.Release)
+	gotreesitter.DiagnosticParserCoreShadowCensusResetForTest()
+	routedBefore, fallbackBefore = gotreesitter.AdmissionCandidateCounters()
+	candidateParser := gotreesitter.NewParser(grantFreeLanguage)
+	candidateParser.SetAdmissionCandidateRoute(true)
+	defaultTelemetryProvider, ok := any(candidateParser).(g18CohortVerifierTelemetryProvider)
+	if !ok {
+		t.Log("RED boundary: candidate parser does not yet publish default-disabled verifier telemetry")
+	}
+	var defaultTelemetry []byte
+	if ok {
+		defaultTelemetry = append([]byte(nil), defaultTelemetryProvider.DiagnosticDropCohortVerifierTelemetryForTest()...)
+	}
+	candidateTree, err := candidateParser.Parse(target.source)
+	if err != nil {
+		t.Fatalf("grant-free candidate parse: %v", err)
+	}
+	t.Cleanup(candidateTree.Release)
+	routedAfter, fallbackAfter = gotreesitter.AdmissionCandidateCounters()
+	reason := gotreesitter.AdmissionCandidateLastFallbackReason()
+	if routedAfter != routedBefore || fallbackAfter != fallbackBefore+1 {
+		t.Fatalf("grant-free counters = %d/%d to %d/%d; want fallback +1; reason=%q", routedBefore, fallbackBefore, routedAfter, fallbackAfter, reason)
+	}
+	if ok && string(defaultTelemetryProvider.DiagnosticDropCohortVerifierTelemetryForTest()) != string(defaultTelemetry) {
+		t.Fatalf("default-disabled verifier telemetry changed: before=%s after=%s", defaultTelemetry, defaultTelemetryProvider.DiagnosticDropCohortVerifierTelemetryForTest())
+	}
+	if !strings.Contains(reason, target.wantReason) {
+		t.Fatalf("grant-free reason = %q, want substring %q", reason, target.wantReason)
+	}
+	census := gotreesitter.DiagnosticParserCoreThreeProofCensusSnapshotForTest()
+	if census != target.wantCensus {
+		t.Fatalf("grant-free census = %+v, want %+v", census, target.wantCensus)
+	}
+	assertG18GoTreesExact(t, candidateTree, productionTree, grantFreeLanguage)
+	assertG18LockedCExact(t, "grant-free fallback", candidateTree, grantFreeLanguage, cTree)
+	t.Logf("grant-free route=0/1 reason=%q census=%+v", reason, census)
+	if target.wantAdaImport && !strings.Contains(reason, "unproved historical boundary resurrection") {
+		t.Fatalf("Ada fallback did not reach the F4 history veto: %q", reason)
+	}
+}
+
+// TestG18AlternativeSetCertificateRED states the future behavior. Every
+// grant-free source must route directly, match locked C, and publish the exact
+// cohort-verifier telemetry. Current main fails this contract by design.
+func TestG18AlternativeSetCertificateRED(t *testing.T) {
+	groups := make(map[string][]g18AlternativeSetTarget)
+	for _, target := range g18AlternativeSetTargets(t) {
+		groups[target.grammar] = append(groups[target.grammar], target)
+	}
+	for _, grammar := range g18AlternativeSetRouteGrammars {
+		grammar := grammar
+		t.Run(grammar, func(t *testing.T) {
+			for _, target := range groups[grammar] {
+				target := target
+				t.Run(target.name, func(t *testing.T) {
+					runG18AlternativeSetFutureContractRED(t, target)
+				})
+			}
+		})
+	}
+}
+
+func runG18AlternativeSetFutureContractRED(t *testing.T, target g18AlternativeSetTarget) {
+	t.Helper()
+	if got := fmt.Sprintf("%x", sha256.Sum256(target.source)); got != target.sourceSHA256 {
+		t.Fatalf("source SHA-256 = %s, want %s", got, target.sourceSHA256)
+	}
+	cLanguage, err := COracleLanguage(target.grammar)
+	if err != nil {
+		t.Fatalf("load %s locked C language: %v", target.grammar, err)
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatalf("set %s locked C language: %v", target.grammar, err)
+	}
+	cTree := cParser.Parse(target.source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatalf("%s locked C parse returned no root", target.grammar)
+	}
+	t.Cleanup(cTree.Close)
+
+	language := g18CloneLanguage(target.load())
+	language.CompactConvergedReductionSplitDropsCertified = false
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	parser := gotreesitter.NewParser(language)
+	parser.SetAdmissionCandidateRoute(true)
+	activator, ok := any(parser).(g18CertificateAdmissionActivator)
+	if !ok {
+		t.Errorf("RED: parser does not expose the private certificate-admission activation seam")
+		return
+	}
+	restoreAdmission := activator.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+	var restoreOnce sync.Once
+	restore := func() { restoreOnce.Do(restoreAdmission) }
+	t.Cleanup(restore)
+	tree, err := parser.Parse(target.source)
+	if err != nil {
+		t.Fatalf("future grant-free parse: %v", err)
+	}
+	t.Cleanup(tree.Release)
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter != routedBefore+1 || fallbackAfter != fallbackBefore {
+		t.Errorf(
+			"RED: grant-free counters = %d/%d to %d/%d; want direct route +1 with no fallback; reason=%q",
+			routedBefore,
+			fallbackBefore,
+			routedAfter,
+			fallbackAfter,
+			gotreesitter.AdmissionCandidateLastFallbackReason(),
+		)
+	}
+	if err := g18LockedCExactError(tree, language, cTree); err != nil {
+		t.Errorf("RED: grant-free direct tree differs from locked C: %v", err)
+	}
+
+	provider, ok := any(parser).(g18CohortVerifierTelemetryProvider)
+	if !ok {
+		t.Errorf("RED: parser does not publish drop-cohort verifier telemetry")
+		return
+	}
+	var telemetry g18CohortVerifierTelemetry
+	if err := json.Unmarshal(provider.DiagnosticDropCohortVerifierTelemetryForTest(), &telemetry); err != nil {
+		t.Fatalf("decode drop-cohort verifier telemetry: %v", err)
+	}
+	g18RequireFutureVerifierTelemetry(t, target, telemetry)
+	telemetryBeforeRestore := append([]byte(nil), provider.DiagnosticDropCohortVerifierTelemetryForTest()...)
+	// Restore the private seam before the cached parser runs again. The next
+	// candidate attempt must fall back and must not consume the certificate.
+	restore()
+	routedBefore, fallbackBefore = gotreesitter.AdmissionCandidateCounters()
+	secondTree, secondErr := parser.Parse(target.source)
+	if secondErr != nil {
+		t.Fatalf("restored candidate parse: %v", secondErr)
+	}
+	secondTree.Release()
+	routedAfter, fallbackAfter = gotreesitter.AdmissionCandidateCounters()
+	if routedAfter != routedBefore || fallbackAfter != fallbackBefore+1 {
+		t.Errorf("RED: restored activation leaked across cached parser run: routed=%d/%d fallback=%d/%d", routedBefore, routedAfter, fallbackBefore, fallbackAfter)
+	}
+	if got := string(provider.DiagnosticDropCohortVerifierTelemetryForTest()); got != string(telemetryBeforeRestore) {
+		t.Fatalf("restored-disabled verifier telemetry changed: before=%s after=%s", telemetryBeforeRestore, got)
+	}
+}
+
+func g18RequireFutureVerifierTelemetry(t *testing.T, target g18AlternativeSetTarget, telemetry g18CohortVerifierTelemetry) {
+	t.Helper()
+	if telemetry.Schema != "gts-drop-cohort-verifier/v1" || telemetry.ArenaOwner == 0 ||
+		telemetry.ArenaEpoch == 0 || telemetry.VerifierElections == 0 ||
+		telemetry.VerifierProofs != telemetry.VerifierElections ||
+		telemetry.VerifierDeclines != 0 || telemetry.ProfileBypasses != 0 ||
+		telemetry.ActionIdentityDeclines != 0 || telemetry.DerivationIdentityDeclines != 0 ||
+		telemetry.UnprovedHistoryImports != 0 {
+		t.Fatalf("future verifier telemetry = %+v, want one proof per election", telemetry)
+	}
+	for reason, count := range telemetry.DeclineReasons {
+		if count != 0 {
+			t.Fatalf("future positive decline reason %q=%d", reason, count)
+		}
+	}
+	if len(telemetry.ProducerWrites) == 0 {
+		t.Fatal("future verifier telemetry has no producer-path writes")
+	}
+	allowedProducers := map[string]bool{
+		"reduction_establishment": true,
+		"linear_canonicalizer":    true,
+		"mapped_canonicalizer":    true,
+		"sibling_adoption":        true,
+		"conflict_reconciliation": true,
+		"dead_history_import":     true,
+	}
+	for producer, count := range telemetry.ProducerWrites {
+		if !allowedProducers[producer] {
+			t.Fatalf("future verifier published unknown producer %q=%d", producer, count)
+		}
+		if count == 0 {
+			t.Fatalf("future verifier producer write %q = %d", producer, count)
+		}
+	}
+	if telemetry.ProducerWrites["reduction_establishment"] == 0 {
+		t.Fatal("future verifier telemetry has no reduction establishment")
+	}
+	if target.wantAdaImport && telemetry.AuthenticatedHistoryImports == 0 {
+		t.Fatal("Ada future verifier telemetry has no authenticated history import")
+	}
+	if target.wantAdaImport && telemetry.ProducerWrites["dead_history_import"] == 0 {
+		t.Fatal("Ada future verifier telemetry has no dead history producer write")
+	}
+	if !target.wantAdaImport && telemetry.AuthenticatedHistoryImports != 0 {
+		t.Fatalf("unexpected authenticated history imports = %d", telemetry.AuthenticatedHistoryImports)
+	}
+}
+
+func TestG18CertificateAdmissionMissingFallsBackRED(t *testing.T) {
+	runG18CertificateAdmissionDeclineRED(t, false, func(t *testing.T, parser *gotreesitter.Parser) {
+		suppressor, ok := any(parser).(g18CertificateAdmissionSuppressor)
+		if !ok {
+			t.Fatal("RED: missing one-shot certificate suppression seam")
+		}
+		suppressor.DiagnosticSuppressDropCohortCertificateForTest()
+	})
+}
+
+func TestG18CertificateAdmissionInvalidFallsBackRED(t *testing.T) {
+	runG18CertificateAdmissionDeclineRED(t, true, nil)
+}
+
+func runG18CertificateAdmissionDeclineRED(t *testing.T, invalid bool, prepare func(*testing.T, *gotreesitter.Parser)) {
+	targets := g18AlternativeSetTargets(t)
+	if len(targets) == 0 {
+		t.Fatal("missing G18 target")
+	}
+	target := targets[0]
+	language := g18CloneLanguage(target.load())
+	language.CompactConvergedReductionSplitDropsCertified = false
+	parser := gotreesitter.NewParser(language)
+	parser.SetAdmissionCandidateRoute(true)
+	activator, ok := any(parser).(g18CertificateAdmissionActivator)
+	if !ok {
+		t.Fatal("RED: missing private certificate activation seam")
+	}
+	restore := activator.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+	var restoreAdmissionOnce sync.Once
+	restoreAdmission := func() { restoreAdmissionOnce.Do(restore) }
+	t.Cleanup(restoreAdmission)
+	if prepare != nil {
+		prepare(t, parser)
+	}
+	if invalid {
+		invalidator, ok := any(parser).(g18CertificateAdmissionNegativeProvider)
+		if !ok {
+			t.Fatal("RED: missing invalid-certificate test hook")
+		}
+		invalidator.DiagnosticInvalidateDropCohortCertificateForTest()
+	}
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	tree, err := parser.Parse(target.source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree.Release()
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter != routedBefore || fallbackAfter != fallbackBefore+1 {
+		t.Fatalf("certificate decline route=%d/%d fallback=%d/%d, want unchanged route and fallback +1", routedBefore, routedAfter, fallbackBefore, fallbackAfter)
+	}
+}
+
+func TestG18CertificateAdmissionNonCandidateAndDiagnosticIgnoreRED(t *testing.T) {
+	targets := g18AlternativeSetTargets(t)
+	if len(targets) == 0 {
+		t.Fatal("missing G18 target")
+	}
+	language := g18CloneLanguage(targets[0].load())
+	parser := gotreesitter.NewParser(language)
+	parser.SetAdmissionCandidateRoute(false)
+	activator, ok := any(parser).(g18CertificateAdmissionActivator)
+	if !ok {
+		t.Fatal("RED: missing private certificate activation seam")
+	}
+	restore := activator.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+	t.Cleanup(restore)
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	tree, err := parser.Parse(targets[0].source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree.Release()
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter != routedBefore || fallbackAfter != fallbackBefore {
+		t.Fatalf("non-candidate parser consumed certificate: routed=%d/%d fallback=%d/%d", routedBefore, routedAfter, fallbackBefore, fallbackAfter)
+	}
+}
+
+func TestG18CertificateAdmissionDiagnosticRunnerIgnoresRED(t *testing.T) {
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	// The diagnostic runner owns this snapshot. The dedicated API must expose
+	// canonical bytes from the same runner Core before bounded execution.
+	parser := gotreesitter.NewParser(grammars.GoLanguage())
+	provider, ok := any(parser).(g18DiagnosticProvider)
+	if !ok {
+		t.Errorf("RED: production parser lacks primitive diagnostic drop-cohort session provider")
+		return
+	}
+	run, snapshot, closeSession, err := provider.DiagnosticDropCohortSessionForTest()
+	if err != nil {
+		t.Fatalf("diagnostic session: %v", err)
+	}
+	if run == nil || snapshot == nil || closeSession == nil {
+		t.Fatalf("diagnostic provider returned a nil session closure")
+	}
+	var closeOnce sync.Once
+	guardedClose := func() { closeOnce.Do(closeSession) }
+	defer guardedClose()
+	ownerBefore, generationBefore, telemetryBefore, err := snapshot()
+	if err != nil {
+		t.Fatalf("diagnostic snapshot before: %v", err)
+	}
+	routeDelta, fallbackDelta, err := run()
+	if err != nil {
+		t.Fatalf("diagnostic runner: %v", err)
+	}
+	ownerAfter, generationAfter, telemetryAfter, err := snapshot()
+	if err != nil {
+		t.Fatalf("diagnostic snapshot after: %v", err)
+	}
+	if ownerAfter != ownerBefore || generationAfter != generationBefore {
+		t.Fatalf("diagnostic session swapped Core identity")
+	}
+	if routeDelta != 0 || fallbackDelta != 0 {
+		t.Fatalf("diagnostic session changed route/fallback: %d/%d", routeDelta, fallbackDelta)
+	}
+	if string(telemetryAfter) != string(telemetryBefore) {
+		t.Fatalf("diagnostic runner verifier telemetry changed: before=%s after=%s", telemetryBefore, telemetryAfter)
+	}
+	guardedClose()
+	guardedClose()
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter != routedBefore || fallbackAfter != fallbackBefore {
+		t.Fatalf("diagnostic runner consumed certificate state: route=%d/%d fallback=%d/%d", routedBefore, routedAfter, fallbackBefore, fallbackAfter)
+	}
+}
+
+// TestG18AlternativeSetKotlinFutureDeclineTelemetryRED binds both opposite
+// controls to the future real verifier. Current main does not publish this
+// telemetry. The future verifier must record both identity decline classes.
+func TestG18AlternativeSetKotlinFutureDeclineTelemetryRED(t *testing.T) {
+	tests := []struct {
+		name         string
+		source       []byte
+		sourceSHA256 string
+	}{
+		{
+			name:         "annotated_getter_line",
+			source:       []byte("@Deprecated(\"old\")\nval Int.double: Int\n    get() = this * 2\n// trailing\n"),
+			sourceSHA256: "7aad51909730adbec84060f5445384ff82c9517e3603fb0da86c9ac2397548b7",
+		},
+		{
+			name:         "annotated_getter_block",
+			source:       []byte("@Deprecated(\"old\")\nval Int.double: Int\n    get() = this * 2\n/* trailing */\n"),
+			sourceSHA256: "3c745d430894c3c739f217b807f747a4bd2f521173b441e625e4ca109b773ec2",
+		},
+	}
+	cLanguage, err := COracleLanguage("kotlin")
+	if err != nil {
+		t.Fatalf("load Kotlin locked C language: %v", err)
+	}
+	var actionDeclines uint64
+	var derivationDeclines uint64
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			if got := fmt.Sprintf("%x", sha256.Sum256(test.source)); got != test.sourceSHA256 {
+				t.Fatalf("source SHA-256 = %s, want %s", got, test.sourceSHA256)
+			}
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatalf("set Kotlin locked C language: %v", err)
+			}
+			cTree := cParser.Parse(test.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("Kotlin locked C parse returned no root")
+			}
+			t.Cleanup(cTree.Close)
+
+			language := g18CloneLanguage(grammars.KotlinLanguage())
+			language.CompactConvergedReductionSplitDropsCertified = false
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			parser := gotreesitter.NewParser(language)
+			parser.SetAdmissionCandidateRoute(true)
+			activator, ok := any(parser).(g18CertificateAdmissionActivator)
+			if !ok {
+				t.Fatal("RED: missing Kotlin certificate-admission activation seam")
+			}
+			restoreAdmission := activator.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+			var restoreOnce sync.Once
+			restore := func() { restoreOnce.Do(restoreAdmission) }
+			t.Cleanup(restore)
+			tree, err := parser.Parse(test.source)
+			if err != nil {
+				t.Fatalf("Kotlin future decline parse: %v", err)
+			}
+			t.Cleanup(tree.Release)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			if routedAfter != routedBefore || fallbackAfter != fallbackBefore+1 {
+				t.Fatalf("Kotlin future decline counters = %d/%d to %d/%d; want fallback +1", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+			}
+			assertG18LockedCExact(t, "Kotlin future decline", tree, language, cTree)
+
+			provider, ok := any(parser).(g18CohortVerifierTelemetryProvider)
+			if !ok {
+				t.Errorf("RED: parser does not publish Kotlin verifier decline telemetry")
+				return
+			}
+			var telemetry g18CohortVerifierTelemetry
+			if err := json.Unmarshal(provider.DiagnosticDropCohortVerifierTelemetryForTest(), &telemetry); err != nil {
+				t.Fatalf("decode Kotlin verifier telemetry: %v", err)
+			}
+			if telemetry.Schema != "gts-drop-cohort-verifier/v1" || telemetry.ArenaOwner == 0 ||
+				telemetry.ArenaEpoch == 0 || telemetry.VerifierElections == 0 ||
+				telemetry.VerifierProofs+telemetry.VerifierDeclines != telemetry.VerifierElections ||
+				telemetry.VerifierProofs != 0 || telemetry.VerifierDeclines == 0 ||
+				telemetry.ProfileBypasses != 0 {
+				t.Fatalf("Kotlin future decline telemetry = %+v", telemetry)
+			}
+			classified := telemetry.ActionIdentityDeclines + telemetry.DerivationIdentityDeclines
+			if classified != telemetry.VerifierDeclines ||
+				telemetry.DeclineReasons["action_identity_mismatch"] != telemetry.ActionIdentityDeclines ||
+				telemetry.DeclineReasons["derivation_identity_mismatch"] != telemetry.DerivationIdentityDeclines {
+				t.Fatalf("Kotlin decline classification = %+v", telemetry)
+			}
+			for reason, count := range telemetry.DeclineReasons {
+				if reason != "action_identity_mismatch" && reason != "derivation_identity_mismatch" && count != 0 {
+					t.Fatalf("Kotlin unclassified decline reason %q=%d", reason, count)
+				}
+			}
+			var classifiedReasons uint64
+			for _, reason := range []string{"action_identity_mismatch", "derivation_identity_mismatch"} {
+				classifiedReasons += telemetry.DeclineReasons[reason]
+			}
+			if classifiedReasons != telemetry.VerifierDeclines {
+				t.Fatalf("Kotlin decline reason total=%d, declines=%d", classifiedReasons, telemetry.VerifierDeclines)
+			}
+			if telemetry.VerifierElections != 1 {
+				t.Fatalf("Kotlin control elections=%d, want exactly one", telemetry.VerifierElections)
+			}
+			receiptProvider, ok := any(parser).(g18CohortVerifierReceiptProvider)
+			if !ok {
+				t.Errorf("RED: parser does not publish per-election Kotlin verifier receipts")
+				return
+			}
+			var receipts []g18CohortVerifierReceipt
+			if err := json.Unmarshal(receiptProvider.DiagnosticDropCohortVerifierReceiptsForTest(), &receipts); err != nil {
+				t.Fatalf("decode Kotlin verifier receipts: %v", err)
+			}
+			if len(receipts) != int(telemetry.VerifierElections) {
+				t.Fatalf("Kotlin verifier receipts=%d, elections=%d", len(receipts), telemetry.VerifierElections)
+			}
+			var receiptDeclines uint64
+			var receiptActionDeclines uint64
+			var receiptDerivationDeclines uint64
+			for index, receipt := range receipts {
+				if receipt.ArenaOwner != telemetry.ArenaOwner || receipt.ArenaEpoch != telemetry.ArenaEpoch ||
+					receipt.CohortSequence == 0 {
+					t.Fatalf("Kotlin receipt %d has invalid cohort identity: %+v", index, receipt)
+				}
+				switch receipt.Verdict {
+				case "proved":
+					if receipt.Classification != "" {
+						t.Fatalf("Kotlin proof receipt %d has a decline classification: %+v", index, receipt)
+					}
+				case "declined":
+					if receipt.Classification != "action_identity_mismatch" && receipt.Classification != "derivation_identity_mismatch" {
+						t.Fatalf("Kotlin decline receipt %d has one unknown or missing classification: %+v", index, receipt)
+					}
+					receiptDeclines++
+					if receipt.Classification == "action_identity_mismatch" {
+						receiptActionDeclines++
+					} else {
+						receiptDerivationDeclines++
+					}
+				default:
+					t.Fatalf("Kotlin receipt %d has verdict %q, want proved or declined", index, receipt.Verdict)
+				}
+			}
+			if receiptDeclines != telemetry.VerifierDeclines ||
+				receiptActionDeclines != telemetry.ActionIdentityDeclines ||
+				receiptDerivationDeclines != telemetry.DerivationIdentityDeclines {
+				t.Fatalf("Kotlin receipt census=%d/%d/%d, telemetry=%d/%d/%d", receiptDeclines, receiptActionDeclines, receiptDerivationDeclines, telemetry.VerifierDeclines, telemetry.ActionIdentityDeclines, telemetry.DerivationIdentityDeclines)
+			}
+			actionDeclines += telemetry.ActionIdentityDeclines
+			derivationDeclines += telemetry.DerivationIdentityDeclines
+		})
+	}
+	if actionDeclines == 0 || derivationDeclines == 0 {
+		t.Fatalf(
+			"RED: Kotlin decline telemetry action=%d derivation=%d, want both classes",
+			actionDeclines,
+			derivationDeclines,
+		)
+	}
+}
+
+// TestG18AlternativeSetKotlinOppositeControls keeps the known unsafe side of
+// the class-3 boundary. The current proof must decline. A forced profile grant
+// must route and differ from locked C.
+func TestG18AlternativeSetKotlinOppositeControls(t *testing.T) {
+	restoreCensus := gotreesitter.SetDiagnosticParserCoreShadowCensusEnabledForTest(true)
+	defer restoreCensus()
+
+	tests := []struct {
+		name         string
+		source       []byte
+		sourceSHA256 string
+	}{
+		{
+			name:         "annotated_getter_line",
+			source:       []byte("@Deprecated(\"old\")\nval Int.double: Int\n    get() = this * 2\n// trailing\n"),
+			sourceSHA256: "7aad51909730adbec84060f5445384ff82c9517e3603fb0da86c9ac2397548b7",
+		},
+		{
+			name:         "annotated_getter_block",
+			source:       []byte("@Deprecated(\"old\")\nval Int.double: Int\n    get() = this * 2\n/* trailing */\n"),
+			sourceSHA256: "3c745d430894c3c739f217b807f747a4bd2f521173b441e625e4ca109b773ec2",
+		},
+	}
+	cLanguage, err := COracleLanguage("kotlin")
+	if err != nil {
+		t.Fatalf("load Kotlin locked C language: %v", err)
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			if got := fmt.Sprintf("%x", sha256.Sum256(test.source)); got != test.sourceSHA256 {
+				t.Fatalf("source SHA-256 = %s, want %s", got, test.sourceSHA256)
+			}
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatalf("set Kotlin locked C language: %v", err)
+			}
+			cTree := cParser.Parse(test.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("Kotlin locked C parse returned no root")
+			}
+			t.Cleanup(cTree.Close)
+
+			declinedLanguage := g18CloneLanguage(grammars.KotlinLanguage())
+			if declinedLanguage.CompactConvergedReductionSplitDropsCertified {
+				t.Fatal("Kotlin unexpectedly carries the split grant")
+			}
+			gotreesitter.DiagnosticParserCoreShadowCensusResetForTest()
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			declinedParser := gotreesitter.NewParser(declinedLanguage)
+			declinedParser.SetAdmissionCandidateRoute(true)
+			declinedTree, err := declinedParser.Parse(test.source)
+			if err != nil {
+				t.Fatalf("declined parse: %v", err)
+			}
+			t.Cleanup(declinedTree.Release)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			if routedAfter != routedBefore || fallbackAfter != fallbackBefore+1 {
+				t.Fatalf("Kotlin no-grant counters = %d/%d to %d/%d; want fallback +1", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+			}
+			if reason := gotreesitter.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "lacks alternative-set coverage") {
+				t.Fatalf("Kotlin no-grant reason = %q", reason)
+			}
+			wantCensus := gotreesitter.DiagnosticParserCoreThreeProofCensusTotals{
+				Elections: 1, V1Proved: 1, Class3V1ProvesV2Declines: 1,
+				SpillElections: 1, SpillObserved: 1, MaxBranchOrdinalObserved: 1,
+			}
+			census := gotreesitter.DiagnosticParserCoreThreeProofCensusSnapshotForTest()
+			if census != wantCensus {
+				t.Fatalf("Kotlin no-grant census = %+v, want %+v", census, wantCensus)
+			}
+			assertG18LockedCExact(t, "Kotlin declined fallback", declinedTree, declinedLanguage, cTree)
+			t.Logf("Kotlin no-grant route=0/1 census=%+v", census)
+
+			forcedLanguage := g18CloneLanguage(grammars.KotlinLanguage())
+			forcedLanguage.CompactConvergedReductionSplitDropsCertified = true
+			routedBefore, fallbackBefore = gotreesitter.AdmissionCandidateCounters()
+			forcedParser := gotreesitter.NewParser(forcedLanguage)
+			forcedParser.SetAdmissionCandidateRoute(true)
+			forcedTree, err := forcedParser.Parse(test.source)
+			if err != nil {
+				t.Fatalf("forced compact parse: %v", err)
+			}
+			t.Cleanup(forcedTree.Release)
+			routedAfter, fallbackAfter = gotreesitter.AdmissionCandidateCounters()
+			if routedAfter != routedBefore+1 || fallbackAfter != fallbackBefore {
+				t.Fatalf("Kotlin forced counters = %d/%d to %d/%d; want routed +1", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+			}
+			if diff := FirstDivergenceDumpV1(forcedTree.RootNode(), forcedLanguage, cTree.RootNode()); diff == nil {
+				t.Fatal("forced Kotlin split grant unexpectedly matches locked C")
+			} else {
+				t.Logf("forced Kotlin split grant remains unsafe: %+v", diff)
+			}
+		})
+	}
+}
+
+func g18AlternativeSetTargets(t *testing.T) []g18AlternativeSetTarget {
+	t.Helper()
+	goFixtures, err := benchfixtures.LoadGoFullParseFixtures()
+	if err != nil {
+		t.Fatalf("load Go fixtures: %v", err)
+	}
+	if len(goFixtures) != 4 {
+		t.Fatalf("Go fixture count = %d, want 4", len(goFixtures))
+	}
+	coverageReason := "lacks alternative-set coverage by one non-blended survivor"
+	historyReason := "descends from an unproved historical boundary resurrection"
+	targets := []g18AlternativeSetTarget{
+		{
+			grammar: "go", name: goFixtures[0].Fixture.ID, source: goFixtures[0].Source,
+			sourceSHA256: goFixtures[0].Fixture.SHA256, load: grammars.GoLanguage, wantReason: coverageReason,
+			wantCensus: gotreesitter.DiagnosticParserCoreThreeProofCensusTotals{
+				Elections: 3, ScalarProved: 2, V1Proved: 2, V2Proved: 2,
+				SpillElections: 3, SpillObserved: 1, MaxBranchOrdinalObserved: 1,
+			},
+		},
+		{
+			grammar: "go", name: goFixtures[1].Fixture.ID, source: goFixtures[1].Source,
+			sourceSHA256: goFixtures[1].Fixture.SHA256, load: grammars.GoLanguage, wantReason: coverageReason,
+			wantCensus: gotreesitter.DiagnosticParserCoreThreeProofCensusTotals{
+				Elections: 3, ScalarProved: 2, V1Proved: 2, V2Proved: 2,
+				SpillElections: 3, SpillObserved: 1, MaxBranchOrdinalObserved: 1,
+			},
+		},
+		{
+			grammar: "go", name: goFixtures[2].Fixture.ID, source: goFixtures[2].Source,
+			sourceSHA256: goFixtures[2].Fixture.SHA256, load: grammars.GoLanguage, wantReason: coverageReason,
+			wantCensus: gotreesitter.DiagnosticParserCoreThreeProofCensusTotals{
+				Elections: 4, ScalarProved: 3, V1Proved: 4, V2Proved: 3,
+				Class3V1ProvesV2Declines: 1, SpillElections: 4, MaxBranchOrdinalObserved: 1,
+			},
+		},
+		{
+			grammar: "go", name: goFixtures[3].Fixture.ID, source: goFixtures[3].Source,
+			sourceSHA256: goFixtures[3].Fixture.SHA256, load: grammars.GoLanguage, wantReason: coverageReason,
+			wantCensus: gotreesitter.DiagnosticParserCoreThreeProofCensusTotals{
+				Elections: 1, V1Proved: 1, Class3V1ProvesV2Declines: 1,
+				SpillElections: 1, MaxBranchOrdinalObserved: 1,
+			},
+		},
+		g18SimpleAlternativeSetTarget(
+			"erlang", "macro_function_clauses",
+			"-module(m).\n-define(FN, foo(0) -> zero; foo(N) when N > 0 -> pos; foo(_) -> neg).\n?FN.\n",
+			"796647c2730c3f3d9d88abb589d606df700c2806396a8b79769fe89f65a5bea0", grammars.ErlangLanguage, true,
+		),
+		g18SimpleAlternativeSetTarget(
+			"erlang", "macro_expanded_top_level_function",
+			"-module(m).\n-define(FN1, bar(1) -> one).\n?FN1.\n",
+			"36f66cda874299c4f9de7aa86bd5653c6d18cfd218d68d249c806acb39eb046e", grammars.ErlangLanguage, true,
+		),
+		g18SimpleAlternativeSetTarget(
+			"haskell", "smoke", grammars.ParseSmokeSample("haskell"),
+			"8e46b697006a890d6629efa91e5be5ba778ecf5c1315b3dd3b2265f2549bc854", grammars.HaskellLanguage, false,
+		),
+		{
+			grammar: "javascript", name: "functions",
+			source:       g18ReadSource(t, filepath.Join("..", "testdata", "compact_converged_split", "javascript.js")),
+			sourceSHA256: "0bbd2cdb0a0492055e442c44b533797386ec9c8aeb7ce8a4d0f5f5a4681e3b90",
+			load:         grammars.JavascriptLanguage, wantReason: coverageReason,
+			wantCensus: gotreesitter.DiagnosticParserCoreThreeProofCensusTotals{
+				Elections: 1, V1Proved: 1, Class3V1ProvesV2Declines: 1,
+				SpillElections: 1, SpillObserved: 1, MaxBranchOrdinalObserved: 1,
+			},
+		},
+		{
+			grammar: "bash", name: "converged_split",
+			source:       g18ReadSource(t, filepath.Join("..", "testdata", "compact_converged_split", "bash.sh")),
+			sourceSHA256: "cccefdfff900acc9873a16805c244725b08d0bf85e15c7dacc3886ba8d5c7b4c",
+			load:         grammars.BashLanguage, wantReason: coverageReason,
+			wantCensus: gotreesitter.DiagnosticParserCoreThreeProofCensusTotals{
+				Elections: 3, ScalarProved: 2, V1Proved: 3, V2Proved: 2,
+				Class3V1ProvesV2Declines: 1, SpillElections: 3, SpillObserved: 1, MaxBranchOrdinalObserved: 1,
+			},
+		},
+		g18SimpleAlternativeSetTarget(
+			"perl", "push_two", "push @found, $_;\n",
+			"08ac06c62278aa8bb26361629ac930bbbfbe5031da04a54ee3aeec4875ce0b3b", grammars.PerlLanguage, true,
+		),
+		g18SimpleAlternativeSetTarget(
+			"perl", "push_three", "push @found, $a, $b;\n",
+			"7be8389f1e6981c2e1e6324357df96ffb34063e9ea6811b8c332143e76015cd1", grammars.PerlLanguage, true,
+		),
+		{
+			grammar: "ada", name: "positional_array",
+			source:       []byte("package P is\n   type A is array (1 .. 3) of Boolean;\n   V : constant A := (1, 2, 3);\nend;\n"),
+			sourceSHA256: "cce847719840bac903a5e52bd6d7b31d9f67a28353706ae3fc82ac07d0511e9b",
+			load:         grammars.AdaLanguage, wantReason: historyReason, wantAdaImport: true,
+			wantCensus: gotreesitter.DiagnosticParserCoreThreeProofCensusTotals{
+				Elections: 1, ScalarProved: 1, V1Proved: 1, V2Proved: 1, SpillElections: 1,
+			},
+		},
+		{
+			grammar: "python", name: "greet",
+			source:       []byte("def greet(name):\n    return f\"hello {name}\"\n\nprint(greet(\"world\"))\n"),
+			sourceSHA256: "d29a356c8115cbf7b87f6644c6ff6f8b1fa530f7dcbd0fbc200f2ac9400827dd",
+			load:         grammars.PythonLanguage, wantReason: coverageReason,
+			wantCensus: gotreesitter.DiagnosticParserCoreThreeProofCensusTotals{
+				Elections: 2, ScalarProved: 1, V1Proved: 2, V2Proved: 1,
+				Class3V1ProvesV2Declines: 1, SpillElections: 2, SpillObserved: 1, MaxBranchOrdinalObserved: 1,
+			},
+		},
+	}
+	g18AssertTargetManifest(t, targets)
+	return targets
+}
+
+func g18SimpleAlternativeSetTarget(
+	grammar, name, source, sourceSHA256 string,
+	load func() *gotreesitter.Language,
+	spilled bool,
+) g18AlternativeSetTarget {
+	spill := uint64(0)
+	if spilled {
+		spill = 1
+	}
+	return g18AlternativeSetTarget{
+		grammar: grammar, name: name, source: []byte(source), sourceSHA256: sourceSHA256, load: load,
+		wantReason: "lacks alternative-set coverage by one non-blended survivor",
+		wantCensus: gotreesitter.DiagnosticParserCoreThreeProofCensusTotals{
+			Elections: 1, V1Proved: 1, Class3V1ProvesV2Declines: 1,
+			SpillElections: 1, SpillObserved: spill, MaxBranchOrdinalObserved: 1,
+		},
+	}
+}
+
+func g18AssertTargetManifest(t *testing.T, targets []g18AlternativeSetTarget) {
+	t.Helper()
+	if len(g18AlternativeSetRouteGrammars) != 8 {
+		t.Fatalf("future route grammar groups=%d, want 8", len(g18AlternativeSetRouteGrammars))
+	}
+	if g18AlternativeSetFlagDenominator != 15 || g18AlternativeSetGrammarDenominator != 12 {
+		t.Fatalf(
+			"locked denominator=%d/%d, want 15/12",
+			g18AlternativeSetFlagDenominator,
+			g18AlternativeSetGrammarDenominator,
+		)
+	}
+	if len(targets) != 13 {
+		t.Fatalf("target manifest has %d cases, want 13", len(targets))
+	}
+	keys := make(map[string]bool, len(targets))
+	hashes := make(map[string]bool, len(targets))
+	manifestHash := sha256.New()
+	for _, target := range targets {
+		key := target.grammar + "/" + target.name
+		if keys[key] {
+			t.Fatalf("duplicate target key %q", key)
+		}
+		keys[key] = true
+		if hashes[target.sourceSHA256] {
+			t.Fatalf("duplicate target source SHA-256 %q", target.sourceSHA256)
+		}
+		hashes[target.sourceSHA256] = true
+		for _, value := range []string{target.grammar, target.name, target.sourceSHA256} {
+			_, _ = manifestHash.Write([]byte(value))
+			_, _ = manifestHash.Write([]byte{0})
+		}
+	}
+	if got := fmt.Sprintf("%x", manifestHash.Sum(nil)); got != g18AlternativeSetTargetManifestSHA256 {
+		t.Fatalf("target manifest SHA-256 = %s, want %s", got, g18AlternativeSetTargetManifestSHA256)
+	}
+}
+
+func g18ReadSource(t *testing.T, path string) []byte {
+	t.Helper()
+	source, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return source
+}
+
+// g18CloneLanguage copies exported configuration only. It does not copy the
+// private synchronization and atomic state in Language.
+func g18CloneLanguage(language *gotreesitter.Language) *gotreesitter.Language {
+	source := reflect.ValueOf(language).Elem()
+	clone := reflect.New(source.Type()).Elem()
+	for index := 0; index < source.NumField(); index++ {
+		if source.Type().Field(index).IsExported() {
+			clone.Field(index).Set(source.Field(index))
+		}
+	}
+	return clone.Addr().Interface().(*gotreesitter.Language)
+}
+
+func assertG18GoTreesExact(t *testing.T, left, right *gotreesitter.Tree, language *gotreesitter.Language) {
+	t.Helper()
+	leftInspection, err := benchfixtures.InspectGoTree(left.RootNode(), language)
+	if err != nil {
+		t.Fatalf("inspect left Go tree: %v", err)
+	}
+	rightInspection, err := benchfixtures.InspectGoTree(right.RootNode(), language)
+	if err != nil {
+		t.Fatalf("inspect right Go tree: %v", err)
+	}
+	if leftInspection.SHA256 != rightInspection.SHA256 {
+		t.Fatalf("Go tree inspections differ: left=%+v right=%+v", leftInspection, rightInspection)
+	}
+}
+
+func assertG18LockedCExact(
+	t *testing.T,
+	label string,
+	tree *gotreesitter.Tree,
+	language *gotreesitter.Language,
+	cTree *sitter.Tree,
+) {
+	t.Helper()
+	if err := g18LockedCExactError(tree, language, cTree); err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+	goInspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatalf("%s inspect Go tree: %v", label, err)
+	}
+	t.Logf("%s locked-C deep digest=%s", label, goInspection.SHA256)
+}
+
+func g18LockedCExactError(tree *gotreesitter.Tree, language *gotreesitter.Language, cTree *sitter.Tree) error {
+	goRoot := tree.RootNode()
+	cRoot := cTree.RootNode()
+	if diff := FirstDivergenceDumpV1(goRoot, language, cRoot); diff != nil {
+		return fmt.Errorf("node or field divergence: %+v", diff)
+	}
+	if err := g18FirstLockedCFlagDifference(goRoot, language, cRoot, "/"+goRoot.Type(language)); err != nil {
+		return fmt.Errorf("flag divergence: %w", err)
+	}
+	goInspection, err := benchfixtures.InspectGoTree(goRoot, language)
+	if err != nil {
+		return fmt.Errorf("inspect Go tree: %w", err)
+	}
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		return fmt.Errorf("inspect C tree: %w", err)
+	}
+	if goInspection.SHA256 != cDigest {
+		return fmt.Errorf("deep digest Go=%s C=%s", goInspection.SHA256, cDigest)
+	}
+	return nil
+}
+
+func g18FirstLockedCFlagDifference(
+	goNode *gotreesitter.Node,
+	language *gotreesitter.Language,
+	cNode *sitter.Node,
+	path string,
+) error {
+	if goNode == nil || cNode == nil {
+		return fmt.Errorf("%s: nil mismatch Go=%v C=%v", path, goNode == nil, cNode == nil)
+	}
+	if goNode.IsMissing() != cNode.IsMissing() {
+		return fmt.Errorf("%s: missing Go=%v C=%v", path, goNode.IsMissing(), cNode.IsMissing())
+	}
+	if goNode.IsError() != cNode.IsError() {
+		return fmt.Errorf("%s: error Go=%v C=%v", path, goNode.IsError(), cNode.IsError())
+	}
+	for index := 0; index < goNode.ChildCount(); index++ {
+		goChild := goNode.Child(index)
+		cChild := cNode.Child(uint(index))
+		childPath := fmt.Sprintf("%s/%s[%d]", path, goChild.Type(language), index)
+		if err := g18FirstLockedCFlagDifference(goChild, language, cChild, childPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/docs/compact-g18-alternative-set-design.md
+++ b/docs/compact-g18-alternative-set-design.md
@@ -1,0 +1,726 @@
+# G18 drop-cohort certificate design
+
+Revision v20 binds wrap, cap, allocation, and per-election receipt checks to real `Core` and `Parser` instances.
+It also freezes the one-shot missing-certificate suppression seam and authenticated Slice B compatibility wrappers.
+
+## Decision scope
+
+G18 covers the converged-split no-action family. This family owns eight active profile flags.
+
+The family ranking is:
+
+| Rank | Producer family | Flags | Grammars |
+| ---: | --- | ---: | --- |
+| 1 | Converged-split no-action | 8 | Go, Erlang, Haskell, JavaScript, Bash, Perl, Ada, Python |
+| 2 | Primary acceptance | 6 | Kotlin, Apex, Meson, Perl, Ada, Python |
+| 3 | Strategy-2 error region | 1 | HTML |
+
+The denominator stays at 15 flags across 12 grammars. G18 does not change a runtime profile.
+
+## Private certificate admission activation
+
+Keep certificate admission disabled by default. Keep every runtime profile flag
+unchanged. Add one private test-only activation seam on the root parser:
+
+```text
+DiagnosticEnableDropCohortCertificateAdmissionForTest() func()
+```
+
+The seam returns a restore function. Activate it only on the candidate parser
+for one test parse. Run the restore function before the parser enters a cached
+second parse. The same `Parser` type may implement the seam in every build.
+The disabled state, rather than interface absence, selects the existing fallback.
+Snapshot telemetry on the candidate parser before its disabled parse.
+
+Do not consume a certificate when activation is disabled. Do not consume a
+certificate when the certificate is missing or invalid. Each decline requires
+an unchanged route counter and fallback plus one; these outcomes are exclusive.
+The restored cached parse uses the same exact counter rule.
+A production parser must expose a literal primitive-only session method. It
+returns run, snapshot, close, and error values. The closures share one Core.
+The provider must return non-nil run, snapshot, and close closures. The test
+guards close with one local once gate and may call it repeatedly. The snapshot
+returns owner, generation, and canonical receipt bytes. The RED
+fails at the missing production method. Test-local named interfaces, constant
+snapshots, and standalone Core constructors are forbidden.
+Do not substitute ordinary scheduler elections or parser result fields.
+Snapshot this API before and after bounded execution, and require exact equality.
+The runner must ignore the
+activation state. A non-candidate parser and production route must also ignore
+it. The Kotlin future control enables the seam before parsing and
+restores it with idempotent cleanup.
+
+The missing-certificate fallback test may call one test-only seam once:
+
+```text
+DiagnosticSuppressDropCohortCertificateForTest()
+```
+
+This call suppresses only the positive certificate for that test. Keep the
+call out of the positive, invalid-certificate, non-candidate, and diagnostic
+tests. Keep corruption tests separate from the missing-certificate case.
+
+Slice C must provide three distinct exported, test-only compatibility methods:
+
+```text
+G18AdoptUpdatedReductionSiblingOwned(
+    SchedulerTransactionToken, source, head, rank, lineage, set,
+    set_blended, converged, resurrection, DropCohortProducerMutationClass,
+) (adopted, error)
+
+G18ReconcileGenericConflictOutputsOwned(
+    SchedulerTransactionToken, source, outputs,
+    DropCohortProducerMutationClass,
+) (kept, adopted, error)
+
+G18CanonicalizeOwned(
+    SchedulerTransactionToken, DropCohortProducerMutationClass,
+) error
+```
+
+Each method must validate and forward the active `SchedulerTransactionToken`
+and the intended producer mutation class. The packet uses direct compile-time
+interfaces with these exact signatures. It uses no reflection and no arity
+fallback. Conflict reconciliation passes its class through the sibling-adoption
+path and records one class only. A missing method is a runtime RED seam, not a
+compile-time substitute and not a token-validation bypass.
+The linear and mapped canonicalizer tests use the same owned adapter and pass
+their distinct mutation classes. They never call canonicalization scratch
+directly for authentic telemetry.
+
+The current fallback characterization runs with activation disabled and
+requires the existing fallback and unchanged verifier telemetry. The future
+direct-route contract differs only by enabling this private seam. It then requires the direct route and complete
+producer and verifier telemetry. Neither test changes a grammar flag, profile,
+grammar allowlist, or grammar blob.
+
+The design applies to parser data only. It does not use grammar names, source text, or blob hashes.
+
+## Locked denominator and scorecard
+
+The locked denominator is 15 flags across 12 grammars.
+
+The eight G18 route groups cover 13 locked-C target cases. The remaining seven flags stay in the existing primary and strategy families.
+
+Use this scorecard tuple:
+
+`(PASS, FALLBACK, SKIP, FAIL, DEFECT, TOTAL) = (198, 3, 5, 0, 0, 206)`
+
+The total is `198 + 3 + 5 + 0 = 206`. Keep the denominator and the scorecard unchanged at the RED boundary.
+
+## Current behavior
+
+`RecordReductionLineageOwned` records an event and a branch. The scheduler then carries that set through these paths:
+
+- The linear canonicalizer.
+- The mapped canonicalizer.
+- Sibling adoption.
+- Conflict reconciliation.
+- A dead-node history import.
+
+`dropGenericNoActionHeads` makes the final drop decision. The current proof requires exact event and branch containment.
+
+The current proof has two limits:
+
+- An inline set has no arena identity.
+- A branch does not identify its action and derivation.
+
+The profile grant bypasses those limits. It does not prove parser ownership.
+
+## Control manifest
+
+The contract pins each source with Secure Hash Algorithm 256 (SHA-256). Source hashes authenticate tests only.
+
+The ordered 13-case manifest digest is:
+
+`3a659138e3aac82563e5fdf46aeb3041a685d6311f32dfd6660c0337b02dbb0d`
+
+| Grammar | Control | Source SHA-256 |
+| --- | --- | --- |
+| Go | `query_compile` | `b788ee19b0075f0b9b567a9f93ea657e715bc8a6a40a99d3ca5c761404e71894` |
+| Go | `rewrite` | `74c0705f8729670559492fb5460a01b2a1a2a109928e1aeb52736e485e8ff097` |
+| Go | `language` | `009aa9fd5352c712f3839670c7df8a9b00ae878ee20dc88131a438b2d5edfd9a` |
+| Go | `grammargen_lr` | `a7e4a1a64b25a60aea36183b9d6d53dcd9240942cdb10e67a3cf9e6ce30f95b2` |
+| Erlang | Macro function clauses | `796647c2730c3f3d9d88abb589d606df700c2806396a8b79769fe89f65a5bea0` |
+| Erlang | Macro top-level function | `36f66cda874299c4f9de7aa86bd5653c6d18cfd218d68d249c806acb39eb046e` |
+| Haskell | Smoke source | `8e46b697006a890d6629efa91e5be5ba778ecf5c1315b3dd3b2265f2549bc854` |
+| JavaScript | Functions | `0bbd2cdb0a0492055e442c44b533797386ec9c8aeb7ce8a4d0f5f5a4681e3b90` |
+| Bash | Converged split | `cccefdfff900acc9873a16805c244725b08d0bf85e15c7dacc3886ba8d5c7b4c` |
+| Perl | Two-argument push | `08ac06c62278aa8bb26361629ac930bbbfbe5031da04a54ee3aeec4875ce0b3b` |
+| Perl | Three-argument push | `7be8389f1e6981c2e1e6324357df96ffb34063e9ea6811b8c332143e76015cd1` |
+| Ada | Positional array | `cce847719840bac903a5e52bd6d7b31d9f67a28353706ae3fc82ac07d0511e9b` |
+| Python | Greeting function | `d29a356c8115cbf7b87f6644c6ff6f8b1fa530f7dcbd0fbc200f2ac9400827dd` |
+
+The opposite controls are two Kotlin annotated getters:
+
+- `7aad51909730adbec84060f5445384ff82c9517e3603fb0da86c9ac2397548b7`
+- `3c745d430894c3c739f217b807f747a4bd2f521173b441e625e4ca109b773ec2`
+
+A forced split grant makes both Kotlin trees differ from locked C. The future verifier must decline both controls.
+
+## Current fallback characterization
+
+The current characterization test removes one grant from an exported-field clone. It keeps certificate admission disabled and requires the existing fallback.
+
+The test also requires these results:
+
+- The fallback tree equals the production tree.
+- The fallback tree equals locked C.
+- The fallback reason matches the current proof failure.
+- The current census matches the pinned values.
+
+This characterization is not a future admission contract. It must stay separate from the RED test.
+
+The future test uses the same clone and source, then enables only the private
+certificate-admission seam. It requires the direct route and verifier proof.
+The test restores the seam before a cached second parse and requires fallback.
+It also tests missing or invalid certificates, non-candidate parsers, and
+diagnostic runners. Each negative case must ignore certificate admission.
+
+The current census is:
+
+| Control group | Elections | Scalar | v1 | v2 | Class 3 | Spill | Maximum branch | Stop |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| Go query and rewrite | 3 | 2 | 2 | 2 | 0 | 1 | 1 | Later election lacks coverage |
+| Go language | 4 | 3 | 4 | 3 | 1 | 0 | Branch mismatch |
+| Go grammar generator | 1 | 0 | 1 | 0 | 1 | 0 | 1 | Branch mismatch |
+| Erlang macros | 1 | 0 | 1 | 0 | 1 | 1 | 1 | Branch mismatch |
+| Haskell smoke | 1 | 0 | 1 | 0 | 1 | 0 | 1 | Branch mismatch |
+| JavaScript functions | 1 | 0 | 1 | 0 | 1 | 1 | 1 | Branch mismatch |
+| Bash source | 3 | 2 | 3 | 2 | 1 | 1 | 1 | Branch mismatch |
+| Perl pushes | 1 | 0 | 1 | 0 | 1 | 1 | 1 | Branch mismatch |
+| Ada array | 1 | 1 | 1 | 1 | 0 | 0 | 0 | F4 history veto |
+| Python greeting | 2 | 1 | 2 | 1 | 1 | 1 | 1 | Branch mismatch |
+| Kotlin getters | 1 | 0 | 1 | 0 | 1 | 1 | 1 | Required decline |
+
+## Certificate identity
+
+Create one certificate arena for each `Core` instance. Give the arena a nonzero owner capability.
+
+Allocate the owner when `Core.New` creates the instance. Use one process-wide atomic monotonic counter.
+
+Concurrent `Core.New` calls must receive unique owners. Test 32 concurrent real `Core` instances.
+
+Run the owner test with the race detector in Docker. Keep this gate separate from parser parity.
+
+Run the concurrent owner contract with the Go race detector in Docker after implementation.
+
+Reject `Core.New` before the owner counter can wrap. Do not derive the owner from a pointer.
+
+Keep the owner stable for the life of the `Core` instance. Give each scheduler session a nonzero epoch.
+
+Increase the arena epoch in these cases:
+
+- A new scheduler session starts.
+- `Core.Reset` starts a reused session.
+
+Reject the session before an epoch can wrap. Do not reuse epoch zero.
+
+Increase a nonzero cohort sequence for each split action. Reject the action before its sequence can wrap.
+
+The certificate ID is this tuple:
+
+`(arena owner, arena epoch, cohort sequence)`
+
+Match the owner before any certificate lookup. Then match the epoch and sequence.
+
+Count every owner-check attempt in `owner_checked_lookups`. Increment the counter before the owner comparison. Include successful local proofs, foreign-owner rejections, and reset-stale rejections. Do not count certificate-store reads.
+
+Do not access an inline value, a spill entry, a map, or an interner before the owner matches.
+
+Two arenas can have equal epochs, equal sequences, and equal payloads. Their certificates are still different.
+
+Do not copy a certificate between parser arenas.
+
+## Real Core contract surface
+
+The RED contract binds a future API on the real `Core` instance. A test-only model cannot satisfy this contract.
+
+Keep every `Core` method signature within the internal package boundary. Use
+fixed-width primitive vectors, handles, digests, byte slices, and internal
+`core.Head` values. Keep JSON snapshots and convenience adapters in the root
+tests. The compile contract must prove that an internal provider can satisfy
+the root adapter without importing the root package.
+
+Use these operations and exact primitive argument classes:
+
+```text
+DiagnosticDropCohortArenaIdentityForTest() (uint64, uint64)
+DiagnosticDropCohortSnapshotForTest() []byte
+DiagnosticDropCohortOwnerWrapProbeForTest() (uint64, uint64, error)
+DiagnosticDropCohortEpochWrapProbeForTest() (uint64, uint64, error)
+DiagnosticDropCohortSequenceWrapProbeForTest() (uint64, uint64, error)
+DiagnosticDropCohortLimitsForTest() (uint16, uint16)
+DiagnosticDropCohortSetLimitsForTest(uint16, uint16) error
+DiagnosticDropCohortBeginForTest(uint16, uint32, [7]uint64) ([3]uint64, error)
+DiagnosticDropCohortWriteForTest([3]uint64, core.Head, uint16, [14]int64, [32]byte, []byte) error
+DiagnosticDropCohortFinalizeForTest([3]uint64) error
+DiagnosticDropCohortMarkUnprovedForTest([3]uint64) error
+DiagnosticDropCohortRollbackForTest([3]uint64) error
+```
+
+The scheduler test surface binds opaque handles to real summary-receipt headers. It then calls the real drop method:
+
+```text
+DiagnosticBindDropCohortReferencesForTest([][3]uint64, []uint16) error
+DiagnosticDropGenericNoActionHeadsForTest([]int) (string, error)
+DiagnosticDropGenericNoActionHeadsNonDestructiveForTest([]int) (string, uint64, [32]byte, error)
+DiagnosticDropGenericNoActionHeadsVerifierStateDigestForTest() [32]byte
+```
+
+The root adapter exposes the private activation seam separately from this
+Core surface. Reset the seam with its returned function after every parse.
+Prove that a cached parser run after restore has no certificate admission.
+
+The state-changing methods must mutate the next arena snapshot. A static JSON response does not satisfy this contract.
+
+The non-destructive verifier hook must execute the real verifier, return one invocation number, and restore the exact bound headers, receipt, and certificate state. Its returned digest must equal the verifier-state digest after restoration. It must not publish telemetry.
+
+Each wrap probe uses the production atomic counter with a scoped test value. It must accept `MaxUint64`, reject zero, return an overflow error, and restore the arena snapshot.
+
+The limit getter must return `MaxDropCohorts = 4,096` and `MaxDropCohortMembers = 32`. The setter must apply both limits before preflight. A rejected cap reservation must leave every store and byte total unchanged.
+
+The owner-check counter is named `owner_checked_lookups` in the snapshot. Count every owner-check attempt before comparison. Include successful local proofs, foreign-owner rejections, and reset-stale rejections. Do not count certificate-store reads.
+
+The real verifier allocation test binds exactly two real summary headers. It warms the non-destructive verifier, then requires 1,001 valid invocations and zero allocations. The extra invocation is `AllocsPerRun` warm-up.
+
+Use the real parser heads in every verifier call. Do not use a test-only head or certificate model.
+
+## Action identity
+
+Derive the action identity from the exact dispatch row. Record these values:
+
+- The parser state.
+- The lookahead symbol.
+- The action ordinal.
+- The action type.
+- The target state.
+- The reduced symbol.
+- The production ID.
+- The child count.
+- The dynamic precedence.
+- The extra flags.
+- The repetition flag.
+- The no-lookahead context.
+- The selected dispatch class.
+
+Use the decoded action values. Do not infer identity from the output tree.
+
+Mutate each action field independently. Require an action identity decline for every mutation.
+
+## Derivation identity
+
+Intern an exact semantic derivation record. A digest alone is not an identity.
+
+The record contains:
+
+- The root symbol.
+- The stack depth.
+- The production and token payload sequence.
+- The child sequence.
+- The field assignments.
+- The aliases.
+- The byte and point checkpoints.
+- The recovery, extra, missing, and external flags.
+
+Resolve a digest collision with full record equality. Keep each interned ID local to its arena epoch.
+
+Test two unequal records with one forced equal digest. The verifier must decline that pair.
+
+Test two byte-equal records with that digest. The verifier must accept that pair.
+
+## Certificate members
+
+Map each branch to one action and one derivation:
+
+`branch -> (action identity, derivation identity)`
+
+The branch is diagnostic data. It cannot replace either identity.
+
+A certificate records one of these states:
+
+- Building.
+- Complete.
+- Overflowed.
+- Blended.
+- Unproved.
+
+Record `expected_members` when the producer reserves the certificate. Increase `written_members` after each complete member write.
+
+Expose the certificate only after finalization. Finalization requires equal, nonzero expected and written counts.
+
+Reject a partial certificate. Reject a duplicate member. Do not count a duplicate as a successful write.
+
+An overflow changes the state to overflowed. A branch conflict changes the state to blended.
+
+An unauthenticated import changes the state to unproved. These states are terminal.
+
+Only a complete certificate can prove a drop.
+
+The RED contract performs each transition on a real `Core` arena. A test-only reference model cannot satisfy this contract.
+
+## Compatible cohort merge
+
+Merge two building certificates only when their full cohort IDs are equal. Apply these rules:
+
+1. Match the arena owner before a lookup.
+2. Reject a complete or terminal certificate.
+3. Reject a partial source.
+4. Reject a duplicate member.
+5. Reject a shared branch with different action or derivation data.
+6. Add disjoint branches to the building result.
+7. Finalize only after the written count equals the expected count.
+
+Mark the result as blended when a shared branch conflicts. Do not publish a partial merge.
+
+Do not union certificates from different cohorts. A flat union cannot prove a drop.
+
+## Full verifier predicate
+
+Evaluate all requested drops as one transaction. Admit the drop only when all conditions are true:
+
+1. The drop list is nonempty and does not contain every head.
+2. Each index is unique and in range.
+3. Each certificate uses the current nonzero arena owner.
+4. Each certificate uses the current nonzero arena epoch.
+5. Each certificate uses the same nonzero cohort sequence.
+6. Each certificate is complete and nonempty.
+7. Each expected count equals its written count.
+8. No certificate is stale, overflowed, blended, or unproved.
+9. At least one head survives.
+10. A surviving certificate contains each dropped action and derivation pair.
+11. Every dropped head passes the same predicate.
+
+Ignore the branch only after the action and derivation identities match. Reject the complete drop when one candidate fails.
+
+Keep the metadata recovery proof separate. A cohort certificate cannot replace that proof.
+
+## Caps and accounting
+
+Add `MaxDropCohorts` and `MaxDropCohortMembers` to the compact limits. Use these default hard caps:
+
+- 4,096 cohorts per scheduler session.
+- 32 members per cohort.
+
+Bound derivation records with `MaxDerivations`. Bound record bytes with the existing memory budget.
+
+Preflight one reservation before the first write. The reservation covers these seven stores:
+
+- Action identity records.
+- Derivation identity records.
+- Certificate references.
+- Certificate maps.
+- Derivation interners.
+- Transaction journals.
+- Cohort records.
+
+Check every count and byte addition for overflow. Check every hard cap and the parser memory budget.
+
+Apply each diagnostic preflight cap to one retained-footprint store. Fail before writes when one requested store exceeds its cap.
+
+Do not write any store until the complete reservation succeeds. A failed preflight leaves all stores unchanged.
+
+Charge every reserved value before producer writes begin. Release the charge on an exact rollback.
+
+On a later member overflow, mark the certificate overflowed. Do not publish a partial proof.
+
+Use fixed record layouts for exact accounting:
+
+- An action record contains the 14 signed identity values.
+- A derivation header contains the digest, offset, and length.
+- A reference contains the cohort handle, real head, and branch.
+- A map slot contains the hash, index, and used flag.
+- An interner slot contains the digest, index, and used flag.
+- A journal entry contains the store, index, and old value.
+- A cohort record contains the handle, state, counts, and spill flag.
+
+Use `unsafe.Sizeof` on mirrored layouts in the RED contract. Add the derivation payload bytes to each derivation header.
+
+Set each map and interner capacity to the smallest power of two that is at least twice the expected member count.
+
+`StorageBytes` counts reserved logical slots after preflight. `FootprintBytes` counts the retained capacity for those reservations.
+
+Require the exact per-store vectors and their exact totals. Do not permit an unclassified byte.
+
+Keep the warm verifier path at zero allocations. Poll the memory budget after each bounded producer write.
+
+## Transaction and lifecycle rules
+
+Add these values to the scheduler transaction journal:
+
+- The arena owner.
+- The arena epoch.
+- The cohort arena length.
+- The next cohort sequence.
+- Every certificate state.
+- Every expected and written member count.
+- Every accounting counter.
+- The derivation interner length.
+- The certificate reference writes.
+- The telemetry counters.
+
+Rollback must restore all values exactly. Do not retain a certificate from a rejected action.
+
+Support sequential cohorts in one scheduler transaction. Give each cohort a new sequence.
+
+Support nested cohort construction. Keep the outer certificate building while the inner certificate completes.
+
+Do not merge nested or sequential cohorts. Finalize each cohort against its own expected count.
+
+`Core.Reset` clears logical lengths and increases the arena epoch. It can retain allocated capacity.
+
+A reused parser starts a new epoch. All old certificate references must fail closed.
+
+Do not store a certificate in a materialized `Tree`. A certificate belongs to one scheduler session.
+
+An incremental old tree cannot carry a certificate. A fresh compact attempt must build a new certificate.
+
+A future incremental import requires authenticated reconstruction from current parser data. Until then, decline the import.
+
+## Dead-node history imports
+
+Import dead-node history only when the producer supplies all of these values:
+
+- The current arena owner.
+- The current arena epoch.
+- The exact cohort sequence.
+- A complete action identity.
+- A complete interned derivation record.
+
+Count this result as an authenticated history import. Keep the Ada F4 veto for every other history import.
+
+An unproved import clears the certificate and sets the unproved state. It must not authorize a drop.
+
+## Telemetry contract
+
+Publish test telemetry with schema `gts-drop-cohort-verifier/v1`. Include these fields:
+
+- `arena_owner`
+- `arena_epoch`
+- `verifier_elections`
+- `verifier_proofs`
+- `verifier_declines`
+- `profile_bypasses`
+- `action_identity_declines`
+- `derivation_identity_declines`
+- `authenticated_history_imports`
+- `unproved_history_imports`
+- `producer_writes`
+
+Record producer writes for these paths:
+
+- Reduction establishment.
+- The linear canonicalizer.
+- The mapped canonicalizer.
+- Sibling adoption.
+- Conflict reconciliation.
+- A dead-node history import.
+
+Publish arena telemetry with schema `gts-drop-cohort-certificate-arena/v2`. Include these fields:
+
+- The owner and epoch.
+- A count for each certificate state.
+- The expected and written member totals.
+- Every producer write count.
+- Every reserved accounting class.
+- The count of every owner-check attempt before comparison in `owner_checked_lookups`.
+- The inline, spill, map, and interner read counts.
+
+It exposes these operations on a real `Core`:
+
+- Read the arena identity.
+- Read a complete arena snapshot.
+- Begin a cohort with per-store caps.
+- Write a member for a real parser head.
+- Finalize a cohort.
+- Mark an import as unproved.
+- Roll back a cohort.
+- Verify one drop request with real parser heads.
+
+The scheduler test hook binds certificate handles to valid summary-receipt headers. It then calls `dropGenericNoActionHeads` without another decision path.
+
+The bind step copies opaque handles only. It does not validate an owner, epoch, sequence, state, action, or derivation.
+
+Use this hook for the equal-session foreign inline, foreign spill, and reset-stale tests.
+
+The behavior API uses primitive arrays in its method signatures. Production does not depend on test-local types.
+
+A static JSON response cannot pass the contract. Each operation must change the next snapshot as specified.
+
+For a foreign or stale verifier call, count the owner-check attempt before comparison. Reject the handle before any inline, spill, map, or interner read. Only the owner-check counter may increase.
+
+Snapshot telemetry immediately before and after each real producer call. Require only that producer counter to increase by one.
+
+Require every other producer counter to stay unchanged. Cover all six registered producer paths.
+
+The real `Parser` route tests must read verifier telemetry. They must also match locked C.
+
+The real `Parser` must also expose `DiagnosticDropCohortVerifierReceiptsForTest() []byte`. Decode its JSON array as one receipt per election. Each receipt contains `arena_owner`, `arena_epoch`, `cohort_sequence`, `verdict`, and one `classification` string.
+
+Each diagnostic receipt records the full cohort ID, the verdict, and one decline reason. Production can keep aggregate counters only.
+
+The future target controls require one proof for each future election. They do not pin the current fallback census.
+
+They require a nonzero election count, `proofs == elections`, zero profile bypasses, and zero declines.
+
+The Ada target requires an authenticated history import. All other target controls require zero history imports.
+
+The two Kotlin controls must decline. Constrain each control to one election. Require `proofs + declines == elections` for each control.
+
+Require exactly one classified identity reason in every declined receipt. Reject an unclassified or multiply classified decline.
+
+Their combined telemetry must record both action and derivation identity declines.
+
+## RED tests
+
+The future RED test removes every target grant. It then uses the real parser candidate route.
+
+Each target must produce these results:
+
+- The candidate routes directly.
+- The fallback counter does not change.
+- The tree equals locked C.
+- The parser publishes exact verifier telemetry.
+
+The current characterization compares the grant-free fallback tree directly with locked C.
+
+Current main fails before direct admission and does not publish telemetry. This failure is intentional.
+
+The safety packet also tests these cases:
+
+- A valid blended survivor.
+- A valid unproved history import.
+- A foreign inline certificate.
+- A foreign spilled certificate.
+- A reset-stale spilled certificate.
+- Equal-epoch and equal-sequence arenas with identical payloads.
+- An arena A certificate accepted in arena A.
+- An arena B certificate rejected in arena A.
+- Two concurrent real arenas with unique owners.
+- An atomic owner counter wrap.
+- A Kotlin action mismatch.
+- A Kotlin derivation mismatch.
+- A cohort conflict.
+- An arena reset and reuse.
+- An epoch wrap.
+- A cohort sequence wrap.
+- A cohort cap.
+- A member cap.
+- The exact 32-member default.
+- Cohort and member cap overflow with atomic preflight.
+- A partial finalization.
+- A duplicate member.
+- An exact rollback.
+- A sequential cohort.
+- A nested cohort.
+- An atomic preflight for every store class.
+- Exact storage and retained-footprint vectors.
+- Every action identity field mutation.
+- Equal-digest unequal derivation records.
+- Full derivation record equality.
+- Zero allocations in the real future verifier.
+
+The producer-path tests call reduction establishment, both owned canonicalizers,
+sibling adoption, conflict reconciliation, and dead-node history import.
+
+Each future producer test requires telemetry from the real certificate arena. The current passing tests remain current-state characterizations.
+
+## Review run set
+
+Run these focused Docker commands from the packet worktree:
+
+```sh
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build -- \
+  "cd /workspace && go test ./internal/parsercorephase0 -run '^TestG18HistoricalAlternativeSetProducerPath$' -count=1"
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build -- \
+  "cd /workspace && go test ./internal/parsercorephase0 -run '^TestG18HistoricalAlternativeSetCertificateTelemetryRED$' -count=1"
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build -- \
+  "cd /workspace/cgo_harness && go test . -tags cgo,treesitter_c_parity -run '^TestG18AlternativeSetCurrentFallbackCharacterization$' -count=1"
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build -- \
+  "cd /workspace/cgo_harness && go test . -tags cgo,treesitter_c_parity -run '^TestG18AlternativeSetCertificateRED$' -count=1"
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build -- \
+  "cd /workspace/cgo_harness && go test . -tags cgo,treesitter_c_parity -run '^TestG18AlternativeSetKotlinOppositeControls$' -count=1"
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build -- \
+  "cd /workspace/cgo_harness && go test . -tags cgo,treesitter_c_parity -run '^TestG18AlternativeSetKotlinFutureDeclineTelemetryRED$' -count=1"
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build -- \
+  "cd /workspace && go test . -tags gts_parsercorephase0 -run '^TestG18Current' -count=1"
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build -- \
+  "cd /workspace && go test . -tags gts_parsercorephase0 -run '^TestG18Future' -count=1"
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build -- \
+  "cd /workspace && go test -race . -tags gts_parsercorephase0 -run '^TestG18FutureConcurrentArenaOwnerAllocationRED$' -count=1"
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build -- \
+  "cd /workspace && go test . -tags gts_parsercorephase0 -run '^TestG18Reference' -count=1"
+bash cgo_harness/docker/run_parity_in_docker.sh --no-build -- \
+  "cd /workspace && go test . -tags gts_parsercorephase0 -run '^TestG18DropPathRejectsForeignInlineRED$' -count=1"
+```
+
+The current characterization commands must pass. The future commands must fail at the RED boundary until production implements the contract.
+
+## Memory gates
+
+Run allocation and storage tests in the focused package gate. Run the resident set size gate after production exists.
+
+Use five isolated runs for each target grammar. Run one grammar at a time.
+
+Measure each run with `/usr/bin/time -v`. Record the maximum resident set size from every run.
+
+Accept a candidate only when its maximum is within this limit:
+
+`baseline maximum + max(1 MiB, 5 percent)`
+
+Use the same Docker image, grammar, command, and limits for both samples. Stop on an out-of-memory result or timeout.
+
+## Artifact binding
+
+The corrected packet binds to Git head:
+
+`f60aee0ae93c3f525d210e18c788560d48aa7aa0`
+
+The Docker image identity is:
+
+`sha256:8988c75c874ba63954c48091176cfa0380ee87f493a5b5d577f368e78921475f`
+
+Create the path digest with this exact serialization:
+
+```sh
+sha256sum \
+  cgo_harness/compact_g18_alternative_set_contract_test.go \
+  docs/compact-g18-alternative-set-design.md \
+  internal/parsercorephase0/g18_alternative_set_contract_test.go \
+  parsercore_phase0_g18_alternative_set_contract_test.go \
+  | LC_ALL=C sort -k2 \
+  | sha256sum
+```
+
+The input has one GNU `sha256sum` line per path. Each line uses two spaces before the ordered relative path.
+
+The external packet manifest records these values:
+
+- The full Git head.
+- The four individual file hashes.
+- The combined path digest.
+- The target manifest digest.
+- The Docker image identity.
+- Every command and artifact directory.
+- The SHA-256 of each artifact `container.log`.
+- The SHA-256 of each artifact `metadata.txt`.
+- The SHA-256 of each artifact `inspect.json`.
+
+## Production gate
+
+Do not implement this design before an independent review accepts it. Keep all profiles unchanged at the RED boundary.
+
+A later implementation must pass these gates:
+
+1. Route every target without its profile grant.
+2. Match locked C for every target.
+3. Reject both Kotlin controls.
+4. Reject all stale, foreign, blended, overflowed, and unproved certificates.
+5. Allocate unique owners for concurrent real `Core` instances.
+6. Preserve exact rollback, reset, reuse, and incremental behavior.
+7. Preserve exact per-store storage and retained-footprint accounting.
+8. Reject every action mutation and each unequal derivation record.
+9. Preserve the scorecard of 198 PASS, 3 FALLBACK, 5 SKIP, and zero defects.
+10. Preserve every parser memory contract.
+
+Retire each profile flag only after its grammar passes every route gate.

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"slices"
 	"sync"
+	"unsafe"
 )
 
 // Symbol and StateID are grammar-table identifiers. They intentionally use
@@ -328,6 +329,15 @@ type Limits struct {
 	MaxCheckpointBytes     uint64
 	MaxSelectedOccurrences uint32
 	MaxSelectedBytes       uint64
+	// MaxDropCohortRefs bounds the shared spill arena for drop-cohort
+	// references. Inline references remain part of their owning records.
+	MaxDropCohortRefs     uint32
+	MaxDropCohortRefBytes uint64
+	// MaxDropCohorts bounds one scheduler session. MaxDropCohortMembers
+	// bounds the stable branch set of one cohort.
+	MaxDropCohorts       uint32
+	MaxDropCohortMembers uint16
+	MaxDropCohortBytes   uint64
 }
 
 func (l Limits) withDefaults() Limits {
@@ -367,6 +377,34 @@ func (l Limits) withDefaults() Limits {
 	if l.MaxSelectedBytes == 0 {
 		l.MaxSelectedBytes = uint64(l.MaxSelectedOccurrences) * 96
 	}
+	if l.MaxDropCohortRefs == 0 {
+		// Keep enough room for the bounded reference history of every node.
+		// The set itself remains capped by dropCohortRefHardCap.
+		maxRefs := uint64(l.MaxNodes) * uint64(dropCohortRefHardCap)
+		if maxRefs > math.MaxUint32 {
+			l.MaxDropCohortRefs = math.MaxUint32
+		} else {
+			l.MaxDropCohortRefs = uint32(maxRefs)
+		}
+		if l.MaxDropCohortRefs == 0 {
+			l.MaxDropCohortRefs = dropCohortRefHardCap
+		}
+	}
+	if l.MaxDropCohortRefBytes == 0 {
+		l.MaxDropCohortRefBytes = uint64(l.MaxDropCohortRefs) * uint64(unsafe.Sizeof(DropCohortRef{}))
+	}
+	if l.MaxDropCohorts == 0 {
+		l.MaxDropCohorts = 4096
+	}
+	if l.MaxDropCohortMembers == 0 {
+		l.MaxDropCohortMembers = dropCohortRefHardCap
+	}
+	if l.MaxDropCohortBytes == 0 {
+		// Keep the certificate arena bounded without coupling its derivation
+		// budget to the reference spill reserve. The latter is sized for node
+		// lineage history and is too small for a complete parser derivation.
+		l.MaxDropCohortBytes = 128 << 20
+	}
 	return l
 }
 
@@ -403,8 +441,9 @@ type nodeRecord struct {
 }
 
 type nodeLineageRecord struct {
-	owner uint32
-	set   AlternativeSet
+	owner          uint32
+	dropCohortRefs DropCohortRefSet
+	set            AlternativeSet
 	// transition only, deleted at stage 3 cleanup (spec.b4b-alternative-set.v1
 	// section 3.2):
 	lineage   uint16
@@ -425,15 +464,16 @@ type nodeLineageRecord struct {
 // nodeLineageJournal append already names every field, so this reorder is
 // layout-only and touches no call site).
 type nodeLineageMutation struct {
-	node        NodeID
-	owner       uint32
-	setSpillRef uint32
-	setCount    uint8
-	setFlags    uint8
-	lineage     uint16
-	rank        CleanPathRankSelection
-	converged   bool
-	blended     bool
+	node           NodeID
+	owner          uint32
+	dropCohortRefs DropCohortRefSet
+	setSpillRef    uint32
+	setCount       uint8
+	setFlags       uint8
+	lineage        uint16
+	rank           CleanPathRankSelection
+	converged      bool
+	blended        bool
 }
 
 // alternativeSetInlineCapacity is the fixed inline member width of
@@ -749,9 +789,10 @@ type Head struct {
 // CondenseCandidate identifies one active scheduler version that a new action
 // output can merge into. The scheduler excludes the source version.
 type CondenseCandidate struct {
-	Head       Head
-	Shifted    bool
-	Checkpoint CheckpointID
+	Head           Head
+	DropCohortRefs DropCohortRefSet
+	Shifted        bool
+	Checkpoint     CheckpointID
 }
 
 // Derivation is one retained exact root-to-head path after local shallow-link
@@ -876,24 +917,49 @@ type Core struct {
 	// resets to length zero (capacity retained) only on Reset, matching
 	// nodeLineageJournal; a rolled-back or superseded segment leaks arena
 	// space until then, bounded by alternativeSetHardCap per record.
-	alternativeSpillArena []uint32
-	condenseCandidates    []CondenseCandidate
-	condenseNewNode       NodeID
-	condenseScopeActive   bool
-	reductionSourceOwner  uint32
-	transactions          []uint64
-	nextTransaction       uint64
-	classificationPhase   uint64
-	work                  Work
-	popScratch            popEnumerationScratch
-	reductionScratch      reductionOutputScratch
-	historicalNodeScratch []NodeID
-	cohortHeadScratch     []Head
-	factorLinkScratch     []linkRecord
-	selectedBuild         selectedStoreBuildScratch
-	selectedPoolMu        sync.Mutex
-	selectedPool          selectedStoreBacking
-	schedulerFrame        schedulerTransactionFrame
+	alternativeSpillArena          []uint32
+	dropCohortRefSpill             []DropCohortRef
+	dropCohortActions              []dropCohortActionIdentity
+	dropCohortRecords              []dropCohortRecord
+	dropCohortMembers              []dropCohortMember
+	dropCohortDerivations          []dropCohortDerivationRecord
+	dropCohortDerivationIntern     []dropCohortDerivationInternEntry
+	dropCohortDerivationBytes      []byte
+	dropCohortCertificateRefs      []DropCohortRef
+	dropCohortMapStore             []dropCohortMapEntry
+	dropCohortJournalStore         []dropCohortJournalStoreEntry
+	dropCohortDerivationScratch    []byte
+	dropCohortPathScratch          []dropCohortPathStep
+	dropCohortEphemeralBytes       uint64
+	dropCohortEphemeralPeak        uint64
+	dropCohortJournal              []dropCohortMutation
+	dropCohortOwner                uint64
+	dropCohortEpoch                uint64
+	dropCohortNextSequence         uint64
+	dropCohortProducerWrites       [dropCohortProducerCount]uint64
+	dropCohortAuthenticatedHistory uint64
+	dropCohortUnprovedHistory      uint64
+	dropCohortOwnerCheckedLookups  uint64
+	dropCohortReservations         []dropCohortReservation
+	dropCohortReserved             [7]uint64
+	dropCohortReservedBytes        uint64
+	condenseCandidates             []CondenseCandidate
+	condenseNewNode                NodeID
+	condenseScopeActive            bool
+	reductionSourceOwner           uint32
+	transactions                   []uint64
+	nextTransaction                uint64
+	classificationPhase            uint64
+	work                           Work
+	popScratch                     popEnumerationScratch
+	reductionScratch               reductionOutputScratch
+	historicalNodeScratch          []NodeID
+	cohortHeadScratch              []Head
+	factorLinkScratch              []linkRecord
+	selectedBuild                  selectedStoreBuildScratch
+	selectedPoolMu                 sync.Mutex
+	selectedPool                   selectedStoreBacking
+	schedulerFrame                 schedulerTransactionFrame
 	// metadataConstructionAuthenticated remains true only while every compact
 	// subtree was published through the authenticated shift/reduction seams.
 	// Diagnostic generic publication clears it monotonically until Reset.
@@ -977,6 +1043,50 @@ type checkpoint struct {
 	boundaryIndex                                                             boundaryIndexSnapshot
 	journal                                                                   int
 	nodeLineageJournal                                                        int
+	dropCohortRefSpill                                                        int
+	dropCohortActions                                                         int
+	dropCohortRecords                                                         int
+	dropCohortMembers                                                         int
+	dropCohortDerivations                                                     int
+	dropCohortDerivationIntern                                                int
+	dropCohortDerivationBytes                                                 int
+	dropCohortCertificateRefs                                                 int
+	dropCohortMapStore                                                        int
+	dropCohortJournalStore                                                    int
+	dropCohortEphemeralBytes                                                  uint64
+	dropCohortJournal                                                         int
+	dropCohortNextSequence                                                    uint64
+	dropCohortProducerWrites                                                  [dropCohortProducerCount]uint64
+	dropCohortAuthenticatedHistory                                            uint64
+	dropCohortUnprovedHistory                                                 uint64
+	dropCohortOwnerCheckedLookups                                             uint64
+	dropCohortReservations                                                    int
+	dropCohortReserved                                                        [7]uint64
+	dropCohortReservedBytes                                                   uint64
+	dropCohortRefSpillCap                                                     int
+	dropCohortActionsCap                                                      int
+	dropCohortRecordsCap                                                      int
+	dropCohortMembersCap                                                      int
+	dropCohortDerivationsCap                                                  int
+	dropCohortDerivationInternCap                                             int
+	dropCohortDerivationBytesCap                                              int
+	dropCohortCertificateRefsCap                                              int
+	dropCohortMapStoreCap                                                     int
+	dropCohortJournalStoreCap                                                 int
+	dropCohortJournalCap                                                      int
+	dropCohortReservationsCap                                                 int
+	dropCohortRefSpillHeader                                                  []DropCohortRef
+	dropCohortActionsHeader                                                   []dropCohortActionIdentity
+	dropCohortRecordsHeader                                                   []dropCohortRecord
+	dropCohortMembersHeader                                                   []dropCohortMember
+	dropCohortDerivationsHeader                                               []dropCohortDerivationRecord
+	dropCohortDerivationInternHeader                                          []dropCohortDerivationInternEntry
+	dropCohortDerivationBytesHeader                                           []byte
+	dropCohortCertificateRefsHeader                                           []DropCohortRef
+	dropCohortMapStoreHeader                                                  []dropCohortMapEntry
+	dropCohortJournalStoreHeader                                              []dropCohortJournalStoreEntry
+	dropCohortJournalHeader                                                   []dropCohortMutation
+	dropCohortReservationsHeader                                              []dropCohortReservation
 	transaction                                                               uint64
 	work                                                                      Work
 }
@@ -1022,11 +1132,55 @@ func (c *Core) markInto(mark *checkpoint) {
 		externalProvenance: len(c.externalProvenance),
 		children:           len(c.children), fields: len(c.fields), aliases: len(c.aliases),
 		frontier: c.frontier, checkpoint: c.checkpoint,
-		boundaryIndex:      c.boundaries.snapshot(),
-		journal:            len(c.boundaryJournal),
-		nodeLineageJournal: len(c.nodeLineageJournal),
-		transaction:        c.nextTransaction,
-		work:               c.work,
+		boundaryIndex:                    c.boundaries.snapshot(),
+		journal:                          len(c.boundaryJournal),
+		nodeLineageJournal:               len(c.nodeLineageJournal),
+		dropCohortRefSpill:               len(c.dropCohortRefSpill),
+		dropCohortActions:                len(c.dropCohortActions),
+		dropCohortRecords:                len(c.dropCohortRecords),
+		dropCohortMembers:                len(c.dropCohortMembers),
+		dropCohortDerivations:            len(c.dropCohortDerivations),
+		dropCohortDerivationIntern:       len(c.dropCohortDerivationIntern),
+		dropCohortDerivationBytes:        len(c.dropCohortDerivationBytes),
+		dropCohortCertificateRefs:        len(c.dropCohortCertificateRefs),
+		dropCohortMapStore:               len(c.dropCohortMapStore),
+		dropCohortJournalStore:           len(c.dropCohortJournalStore),
+		dropCohortEphemeralBytes:         c.dropCohortEphemeralBytes,
+		dropCohortJournal:                len(c.dropCohortJournal),
+		dropCohortNextSequence:           c.dropCohortNextSequence,
+		dropCohortProducerWrites:         c.dropCohortProducerWrites,
+		dropCohortAuthenticatedHistory:   c.dropCohortAuthenticatedHistory,
+		dropCohortUnprovedHistory:        c.dropCohortUnprovedHistory,
+		dropCohortOwnerCheckedLookups:    c.dropCohortOwnerCheckedLookups,
+		dropCohortReservations:           len(c.dropCohortReservations),
+		dropCohortReserved:               c.dropCohortReserved,
+		dropCohortReservedBytes:          c.dropCohortReservedBytes,
+		dropCohortRefSpillCap:            cap(c.dropCohortRefSpill),
+		dropCohortActionsCap:             cap(c.dropCohortActions),
+		dropCohortRecordsCap:             cap(c.dropCohortRecords),
+		dropCohortMembersCap:             cap(c.dropCohortMembers),
+		dropCohortDerivationsCap:         cap(c.dropCohortDerivations),
+		dropCohortDerivationInternCap:    cap(c.dropCohortDerivationIntern),
+		dropCohortDerivationBytesCap:     cap(c.dropCohortDerivationBytes),
+		dropCohortCertificateRefsCap:     cap(c.dropCohortCertificateRefs),
+		dropCohortMapStoreCap:            cap(c.dropCohortMapStore),
+		dropCohortJournalStoreCap:        cap(c.dropCohortJournalStore),
+		dropCohortJournalCap:             cap(c.dropCohortJournal),
+		dropCohortReservationsCap:        cap(c.dropCohortReservations),
+		dropCohortRefSpillHeader:         c.dropCohortRefSpill,
+		dropCohortActionsHeader:          c.dropCohortActions,
+		dropCohortRecordsHeader:          c.dropCohortRecords,
+		dropCohortMembersHeader:          c.dropCohortMembers,
+		dropCohortDerivationsHeader:      c.dropCohortDerivations,
+		dropCohortDerivationInternHeader: c.dropCohortDerivationIntern,
+		dropCohortDerivationBytesHeader:  c.dropCohortDerivationBytes,
+		dropCohortCertificateRefsHeader:  c.dropCohortCertificateRefs,
+		dropCohortMapStoreHeader:         c.dropCohortMapStore,
+		dropCohortJournalStoreHeader:     c.dropCohortJournalStore,
+		dropCohortJournalHeader:          c.dropCohortJournal,
+		dropCohortReservationsHeader:     c.dropCohortReservations,
+		transaction:                      c.nextTransaction,
+		work:                             c.work,
 	}
 	c.transactions = append(c.transactions, mark.transaction)
 	parent := uint64(0)
@@ -1075,6 +1229,7 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 			continue
 		}
 		c.nodeLineages[nodeIndex].owner = mutation.owner
+		c.nodeLineages[nodeIndex].dropCohortRefs = mutation.dropCohortRefs
 		c.nodeLineages[nodeIndex].set.count = mutation.setCount
 		c.nodeLineages[nodeIndex].set.flags = mutation.setFlags
 		c.nodeLineages[nodeIndex].set.spillRef = mutation.setSpillRef
@@ -1084,6 +1239,34 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 		c.nodeLineages[nodeIndex].blended = mutation.blended
 	}
 	c.boundaries.restore(mark.boundaryIndex)
+	c.dropCohortRefSpill = mark.dropCohortRefSpillHeader
+	for index := len(c.dropCohortJournal) - 1; index >= mark.dropCohortJournal; index-- {
+		mutation := c.dropCohortJournal[index]
+		if mutation.index >= 0 && mutation.index < len(c.dropCohortRecords) {
+			c.dropCohortRecords[mutation.index] = mutation.before
+		}
+	}
+	c.dropCohortActions = mark.dropCohortActionsHeader
+	c.dropCohortRecords = mark.dropCohortRecordsHeader
+	c.dropCohortMembers = mark.dropCohortMembersHeader
+	c.dropCohortDerivations = mark.dropCohortDerivationsHeader
+	c.dropCohortDerivationIntern = mark.dropCohortDerivationInternHeader
+	c.dropCohortDerivationBytes = mark.dropCohortDerivationBytesHeader
+	c.dropCohortCertificateRefs = mark.dropCohortCertificateRefsHeader
+	c.dropCohortMapStore = mark.dropCohortMapStoreHeader
+	c.dropCohortJournalStore = mark.dropCohortJournalStoreHeader
+	c.dropCohortDerivationScratch = c.dropCohortDerivationScratch[:0]
+	c.dropCohortPathScratch = c.dropCohortPathScratch[:0]
+	c.dropCohortEphemeralBytes = mark.dropCohortEphemeralBytes
+	c.dropCohortJournal = mark.dropCohortJournalHeader
+	c.dropCohortNextSequence = mark.dropCohortNextSequence
+	c.dropCohortProducerWrites = mark.dropCohortProducerWrites
+	c.dropCohortAuthenticatedHistory = mark.dropCohortAuthenticatedHistory
+	c.dropCohortUnprovedHistory = mark.dropCohortUnprovedHistory
+	c.dropCohortOwnerCheckedLookups = mark.dropCohortOwnerCheckedLookups
+	c.dropCohortReservations = mark.dropCohortReservationsHeader
+	c.dropCohortReserved = mark.dropCohortReserved
+	c.dropCohortReservedBytes = mark.dropCohortReservedBytes
 	clear(c.boundaryJournal[mark.journal:])
 	c.boundaryJournal = c.boundaryJournal[:mark.journal]
 	clear(c.nodeLineageJournal[mark.nodeLineageJournal:])
@@ -1179,6 +1362,11 @@ func (c *Core) RunFreshSchedulerSession(fn func(SchedulerTransactionToken) error
 	}
 	if frame.epoch == math.MaxUint64 || c.nextTransaction == math.MaxUint64 {
 		return errors.New("parser-core phase zero: fresh scheduler session identity overflow")
+	}
+	// A fresh scheduler session receives a new certificate epoch, even when
+	// the session later commits without calling Reset.
+	if err := c.advanceDropCohortEpoch(); err != nil {
+		return err
 	}
 	frame.clearInactive()
 	frame.epoch++
@@ -1364,6 +1552,10 @@ func New(tables TableView, limits Limits) (*Core, error) {
 	if tables == nil {
 		return nil, errors.New("parser-core phase zero: nil table view")
 	}
+	owner, err := allocateDropCohortOwner()
+	if err != nil {
+		return nil, err
+	}
 	limits = limits.withDefaults()
 	boundaries, err := newBoundaryIndex(limits.MaxNodes)
 	if err != nil {
@@ -1373,6 +1565,8 @@ func New(tables TableView, limits Limits) (*Core, error) {
 		tables: tables, limits: limits, frontier: 1, boundaries: boundaries,
 		checkpoints:                       newCheckpointInterner(limits.MaxCheckpoints, limits.MaxCheckpointBytes),
 		classificationPhase:               1,
+		dropCohortOwner:                   owner,
+		dropCohortEpoch:                   1,
 		diagnostics:                       diagnosticOptions{foldSamePredecessorShallowPayloads: true},
 		metadataConstructionAuthenticated: true,
 	}
@@ -1407,10 +1601,16 @@ func (c *Core) Reset() error {
 	if c.classificationPhase == math.MaxUint64 {
 		return errors.New("parser-core phase zero: classification phase overflow")
 	}
+	if c.dropCohortEpoch == math.MaxUint64 {
+		return errors.New("parser-core phase zero: drop-cohort epoch overflow")
+	}
 	if err := phase0AInvalidateCore(c); err != nil {
 		return err
 	}
 	c.classificationPhase++
+	if err := c.advanceDropCohortEpoch(); err != nil {
+		return err
+	}
 	c.nodes = c.nodes[:0]
 	c.nodeLineages = c.nodeLineages[:0]
 	c.nodeCheckpoints = c.nodeCheckpoints[:0]
@@ -1429,6 +1629,29 @@ func (c *Core) Reset() error {
 	clear(c.nodeLineageJournal)
 	c.nodeLineageJournal = c.nodeLineageJournal[:0]
 	c.alternativeSpillArena = c.alternativeSpillArena[:0]
+	c.dropCohortRefSpill = c.dropCohortRefSpill[:0]
+	c.dropCohortActions = c.dropCohortActions[:0]
+	c.dropCohortRecords = c.dropCohortRecords[:0]
+	c.dropCohortMembers = c.dropCohortMembers[:0]
+	c.dropCohortDerivations = c.dropCohortDerivations[:0]
+	c.dropCohortDerivationIntern = c.dropCohortDerivationIntern[:0]
+	c.dropCohortDerivationBytes = c.dropCohortDerivationBytes[:0]
+	c.dropCohortCertificateRefs = c.dropCohortCertificateRefs[:0]
+	c.dropCohortMapStore = c.dropCohortMapStore[:0]
+	c.dropCohortJournalStore = c.dropCohortJournalStore[:0]
+	c.dropCohortDerivationScratch = c.dropCohortDerivationScratch[:0]
+	c.dropCohortPathScratch = c.dropCohortPathScratch[:0]
+	c.dropCohortEphemeralBytes = 0
+	c.dropCohortEphemeralPeak = 0
+	c.dropCohortJournal = c.dropCohortJournal[:0]
+	c.dropCohortNextSequence = 0
+	clear(c.dropCohortProducerWrites[:])
+	c.dropCohortAuthenticatedHistory = 0
+	c.dropCohortUnprovedHistory = 0
+	c.dropCohortOwnerCheckedLookups = 0
+	c.dropCohortReservations = nil
+	clear(c.dropCohortReserved[:])
+	c.dropCohortReservedBytes = 0
 	c.clearLiveCondenseCandidates()
 	c.reductionSourceOwner = 0
 	c.transactions = c.transactions[:0]
@@ -1991,7 +2214,8 @@ const (
 // (reduceOutputsClassifiedIntoActive, scheduler_owned.go), so this reorder
 // is layout-only (b4b-width-repair audit, 2026-08).
 type ReductionOutput struct {
-	Head Head
+	Head           Head
+	DropCohortRefs DropCohortRefSet
 	// HistoricalAlternativeSet is the union of every dead predecessor's
 	// recorded alternative set discovered while producing this boundary
 	// (spec.b4b-alternative-set.v1 section 4, "Dead-node historical
@@ -2022,6 +2246,7 @@ const inlineReductionBoundaryOutputs = 2
 type reductionBoundaryOutput struct {
 	key                           boundaryKey
 	head                          Head
+	dropCohortRefs                DropCohortRefSet
 	historicalSet                 AlternativeSet
 	historicalLineage             uint16
 	freshness                     ReductionFreshness
@@ -2477,6 +2702,7 @@ const (
 type condenseOutcome struct {
 	head                          Head
 	change                        condenseChange
+	historicalDropCohortRefs      DropCohortRefSet
 	historicalBoundarySplit       bool
 	historicalConvergedSplit      bool
 	historicalForestDeterministic bool
@@ -2547,6 +2773,7 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 	var historicalCleanPathRank CleanPathRankSelection
 	var historicalLineage uint16
 	var historicalNode NodeID
+	var historicalDropCohortRefs DropCohortRefSet
 	historicalConvergedSplit := false
 	historicalForestDeterministic := false
 	if probe.found && !c.condenseNodeIsLive(oldID) {
@@ -2568,6 +2795,7 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 			historicalLineage = old.lineage
 			historicalConvergedSplit = old.converged
 		}
+		historicalDropCohortRefs = old.dropCohortRefs
 		oldID = 0
 	}
 	// buildOutcome stamps a returned condenseOutcome with the historical
@@ -2580,6 +2808,7 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 	buildOutcome := func(head Head, change condenseChange) condenseOutcome {
 		return condenseOutcome{
 			head: head, change: change,
+			historicalDropCohortRefs:      historicalDropCohortRefs,
 			historicalBoundarySplit:       historicalBoundarySplit,
 			historicalConvergedSplit:      historicalConvergedSplit,
 			historicalForestDeterministic: historicalForestDeterministic,

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -2658,11 +2658,16 @@ func TestCompactArenaRecordsRemainPointerFree(t *testing.T) {
 		t.Fatalf("ClassifiedBoundary size = %d, want <= 56", got)
 	}
 	for name, typ := range map[string]reflect.Type{
-		"node":                reflect.TypeFor[nodeRecord](),
-		"node-lineage":        reflect.TypeFor[nodeLineageRecord](),
-		"link":                reflect.TypeFor[linkRecord](),
-		"subtree":             reflect.TypeFor[subtreeRecord](),
-		"external-provenance": reflect.TypeFor[externalPayloadProvenance](),
+		"node":                   reflect.TypeFor[nodeRecord](),
+		"node-lineage":           reflect.TypeFor[nodeLineageRecord](),
+		"link":                   reflect.TypeFor[linkRecord](),
+		"subtree":                reflect.TypeFor[subtreeRecord](),
+		"external-provenance":    reflect.TypeFor[externalPayloadProvenance](),
+		"drop-cohort-action":     reflect.TypeFor[dropCohortActionIdentity](),
+		"drop-cohort-record":     reflect.TypeFor[dropCohortRecord](),
+		"drop-cohort-member":     reflect.TypeFor[dropCohortMember](),
+		"drop-cohort-derivation": reflect.TypeFor[dropCohortDerivationRecord](),
+		"drop-cohort-mutation":   reflect.TypeFor[dropCohortMutation](),
 	} {
 		for i := 0; i < typ.NumField(); i++ {
 			kind := typ.Field(i).Type.Kind()
@@ -2674,37 +2679,18 @@ func TestCompactArenaRecordsRemainPointerFree(t *testing.T) {
 	if got := unsafe.Sizeof(nodeRecord{}); got != 24 {
 		t.Fatalf("nodeRecord size = %d, want 24", got)
 	}
-	// spec.b4b-alternative-set.v1 section 3.2: nodeLineageRecord grew from 8
-	// bytes to the transition size of 24 (owner uint32 + AlternativeSet's 16
-	// bytes + the still-present transition scalars lineage/rank/converged).
-	// spec.b4b-alternative-set.v2 section 3.2 widened AlternativeSet's inline
-	// members to uint32 (16 -> 24 bytes padded, +8) and added the blended
-	// bool (+1, padded): 24 -> 36. The b4b-width-repair audit (2026-08) then
-	// lowered AlternativeSet's inline capacity from 4 to 2 members (still
-	// uint32-packed (event, branch); the canonical-fixture census shows
-	// 99.8% of elections already spill past 4 members by election time, so
-	// the threshold was not load-bearing) to restore the 16-byte set: 36 ->
-	// 28, 4 bytes over the pre-v2 24 for the still-present blended bool.
-	// Stage 3 deletes the transition scalars for a smaller final record. The
-	// grown field (AlternativeSet) stays pointer-free, checked above.
-	if got := unsafe.Sizeof(nodeLineageRecord{}); got != 28 {
-		t.Fatalf("nodeLineageRecord size = %d, want 28", got)
+	// G18 adds the value-owned drop-cohort reference set to this lineage
+	// record. Keep the 104-byte width explicit because every node pays it.
+	if got := unsafe.Sizeof(nodeLineageRecord{}); got != 104 {
+		t.Fatalf("nodeLineageRecord size = %d, want 104", got)
 	}
 	if got := unsafe.Sizeof(linkRecord{}); got != 32 {
 		t.Fatalf("linkRecord size = %d, want 32", got)
 	}
-	// spec.b4b-alternative-set.v1 section 4: ReductionOutput grew from 12
-	// bytes to 28 with the added HistoricalAlternativeSet field (dead-node
-	// historical import). spec.b4b-alternative-set.v2 section 3.2 widened
-	// AlternativeSet's inline members to uint32 (+8) and added
-	// HistoricalBlended (+1, padded): 28 -> 40. The b4b-width-repair audit
-	// (2026-08) lowered AlternativeSet's inline capacity to 2 (see
-	// nodeLineageRecord's comment above) and reordered fields (Head and
-	// HistoricalAlternativeSet first, both 4-byte aligned) to fold
-	// HistoricalBlended into existing padding: 40 -> 28, exactly the pre-v2
-	// size despite the extra field. Stays pointer-free, checked above.
-	if got := unsafe.Sizeof(ReductionOutput{}); got != 28 {
-		t.Fatalf("ReductionOutput size = %d, want 28", got)
+	// G18 adds one value-owned reference set beside the historical set. Keep
+	// the 104-byte output width explicit for scheduler copies.
+	if got := unsafe.Sizeof(ReductionOutput{}); got != 104 {
+		t.Fatalf("ReductionOutput size = %d, want 104", got)
 	}
 	if got := unsafe.Sizeof(popPath{}); got != 88 {
 		t.Fatalf("popPath size = %d, want 88", got)

--- a/internal/parsercorephase0/drop_cohort_arena.go
+++ b/internal/parsercorephase0/drop_cohort_arena.go
@@ -1,0 +1,2410 @@
+package parsercorephase0
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"sync/atomic"
+)
+
+// DropCohortSelectionClass identifies the scheduler policy that selected an
+// action. The value is part of the action identity.
+type DropCohortSelectionClass uint8
+
+const (
+	DropCohortSelectionNone DropCohortSelectionClass = iota
+	DropCohortSelectionConflictPolicy
+	DropCohortSelectionRepetitionFold
+	DropCohortSelectionRepetitionFork
+)
+
+// DropCohortActionIdentity is the exact dispatch action that created a
+// producer cohort. Keep the decoded action beside the dispatch coordinates.
+type DropCohortActionIdentity struct {
+	BoundaryState StateID
+	Lookahead     Symbol
+	ActionOrdinal int32
+	Action        Action
+	NoLookahead   bool
+	Selection     DropCohortSelectionClass
+}
+
+// DropCohortSourceCheckpoint records both byte and point coordinates for the
+// lookahead that created a cohort. Scanner identities stay core-local.
+type DropCohortSourceCheckpoint struct {
+	StartByte    uint32
+	EndByte      uint32
+	StartRow     uint32
+	StartColumn  uint32
+	EndRow       uint32
+	EndColumn    uint32
+	ScannerStart CheckpointID
+	ScannerEnd   CheckpointID
+}
+
+// DropCohortHandle is an arena-local cohort identity. Owner and epoch are
+// checked before the sequence is looked up.
+type DropCohortHandle struct {
+	Owner    uint64
+	Epoch    uint64
+	Sequence uint64
+}
+
+// DropCohortDerivationHandle identifies one complete derivation record in the
+// current arena epoch.
+type DropCohortDerivationHandle struct {
+	Owner uint64
+	Epoch uint64
+	Index uint32
+}
+
+// DropCohortState describes the producer lifecycle. Only Complete can be
+// attached to scheduler output headers.
+type DropCohortState uint8
+
+const (
+	DropCohortBuilding DropCohortState = iota + 1
+	DropCohortComplete
+	DropCohortOverflowed
+	DropCohortBlended
+	DropCohortUnproved
+)
+
+const (
+	dropCohortProducerReductionEstablishment = iota
+	dropCohortProducerLinearCanonicalizer
+	dropCohortProducerMappedCanonicalizer
+	dropCohortProducerSiblingAdoption
+	dropCohortProducerConflictReconciliation
+	dropCohortProducerDeadHistoryImport
+	dropCohortProducerCount
+)
+
+// DropCohortProducerMutation identifies one authentic producer transition.
+// These values are production counters, not diagnostic events.
+type DropCohortProducerMutation uint8
+
+const (
+	DropCohortProducerLinearCanonicalization DropCohortProducerMutation = iota + 1
+	DropCohortProducerMappedCanonicalization
+	DropCohortProducerSiblingAdoption
+	DropCohortProducerConflictReconciliation
+	DropCohortProducerDeadHistoryImport
+)
+
+// DropCohortProducerCounters contains counters for real producer mutations.
+// The producer path does not publish these counters as diagnostic telemetry.
+type DropCohortProducerCounters struct {
+	ReductionEstablishment uint64
+	LinearCanonicalizer    uint64
+	MappedCanonicalizer    uint64
+	SiblingAdoption        uint64
+	ConflictReconciliation uint64
+	DeadHistoryImport      uint64
+}
+
+type dropCohortActionIdentity = DropCohortActionIdentity
+
+type dropCohortRecord struct {
+	handle      DropCohortHandle
+	state       DropCohortState
+	expected    uint16
+	written     uint16
+	actionIndex uint32
+	memberStart uint32
+}
+
+type dropCohortMember struct {
+	cohort     DropCohortHandle
+	head       Head
+	branch     uint16
+	action     DropCohortActionIdentity
+	derivation DropCohortDerivationHandle
+}
+
+type dropCohortDerivationRecord struct {
+	handle     DropCohortDerivationHandle
+	head       Head
+	digest     [32]byte
+	byteOffset uint32
+	byteLength uint32
+	rootSymbol Symbol
+	stackDepth uint32
+	checkpoint DropCohortSourceCheckpoint
+}
+
+type dropCohortDerivationInternEntry struct {
+	digest     [32]byte
+	byteOffset uint32
+	byteLength uint32
+}
+
+type dropCohortMapEntry struct {
+	hash  uint64
+	index uint32
+	used  bool
+}
+
+type dropCohortJournalStoreEntry struct {
+	store uint8
+	index uint32
+	value uint64
+}
+
+type dropCohortReservation struct {
+	handle              DropCohortHandle
+	previousNext        uint64
+	actions             int
+	records             int
+	members             int
+	derivations         int
+	derivationBytes     int
+	interner            int
+	certificateRefs     int
+	mapEntries          int
+	journalEntries      int
+	derivationBytesEach uint32
+	actionsCap          int
+	recordsCap          int
+	membersCap          int
+	derivationsCap      int
+	derivationBytesCap  int
+	internerCap         int
+	certificateRefsCap  int
+	mapEntriesCap       int
+	journalEntriesCap   int
+	reservationsCap     int
+	journalMutations    int
+	ownerChecks         uint64
+	reserved            [7]uint64
+	reservationBytes    uint64
+	journalStart        int
+	journalCount        int
+	journalUsed         int
+	actionsHeader       []dropCohortActionIdentity
+	recordsHeader       []dropCohortRecord
+	membersHeader       []dropCohortMember
+	derivationsHeader   []dropCohortDerivationRecord
+	derivationBytesHead []byte
+	internerHeader      []dropCohortDerivationInternEntry
+	certificateRefsHead []DropCohortRef
+	mapEntriesHeader    []dropCohortMapEntry
+	journalStoreHeader  []dropCohortJournalStoreEntry
+	journalHeader       []dropCohortMutation
+	reservationsHeader  []dropCohortReservation
+	reservationsMoved   bool
+}
+
+type dropCohortMutation struct {
+	index  int
+	before dropCohortRecord
+}
+
+var dropCohortOwnerCounter atomic.Uint64
+
+func allocateDropCohortOwner() (uint64, error) {
+	return allocateDropCohortOwnerFrom(&dropCohortOwnerCounter)
+}
+
+func allocateDropCohortOwnerFrom(counter *atomic.Uint64) (uint64, error) {
+	if counter == nil {
+		return 0, errors.New("parser-core phase zero: nil drop-cohort owner allocator")
+	}
+	for {
+		current := counter.Load()
+		if current == math.MaxUint64 {
+			return 0, errors.New("parser-core phase zero: drop-cohort owner overflow")
+		}
+		next := current + 1
+		if next == 0 {
+			return 0, errors.New("parser-core phase zero: drop-cohort owner wrapped")
+		}
+		if counter.CompareAndSwap(current, next) {
+			return next, nil
+		}
+	}
+}
+
+func (c *Core) advanceDropCohortEpoch() error {
+	if c == nil || c.dropCohortEpoch == math.MaxUint64 {
+		return errors.New("parser-core phase zero: drop-cohort epoch overflow")
+	}
+	c.dropCohortEpoch++
+	if c.dropCohortEpoch == 0 {
+		return errors.New("parser-core phase zero: drop-cohort epoch wrapped")
+	}
+	return nil
+}
+
+func (c *Core) dropCohortHandle(sequence uint64) DropCohortHandle {
+	return DropCohortHandle{Owner: c.dropCohortOwner, Epoch: c.dropCohortEpoch, Sequence: sequence}
+}
+
+func (c *Core) validateDropCohortIdentity(handle DropCohortHandle) (int, error) {
+	if c == nil || c.dropCohortOwner == 0 || c.dropCohortEpoch == 0 {
+		return -1, errors.New("parser-core phase zero: drop-cohort arena identity is unavailable")
+	}
+	// Count every attempted lookup before comparing identity. This counter is
+	// diagnostic-only and does not authorize a certificate read.
+	c.dropCohortOwnerCheckedLookups++
+	// Check the owner and epoch before touching the cohort records. This order
+	// keeps stale references from reading any producer state.
+	if handle.Owner != c.dropCohortOwner {
+		return -1, errors.New("parser-core phase zero: drop-cohort owner mismatch")
+	}
+	if handle.Epoch != c.dropCohortEpoch {
+		return -1, errors.New("parser-core phase zero: drop-cohort epoch mismatch")
+	}
+	if handle.Sequence == 0 {
+		return -1, errors.New("parser-core phase zero: zero drop-cohort sequence")
+	}
+	for index := range c.dropCohortRecords {
+		if c.dropCohortRecords[index].handle.Sequence == handle.Sequence {
+			return index, nil
+		}
+	}
+	return -1, errors.New("parser-core phase zero: unknown drop-cohort sequence")
+}
+
+// DropCohortArenaIdentity returns the stable producer owner and current
+// arena epoch. It is an ordinary production read, not diagnostic telemetry.
+func (c *Core) DropCohortArenaIdentity() (uint64, uint64) {
+	if c == nil {
+		return 0, 0
+	}
+	return c.dropCohortOwner, c.dropCohortEpoch
+}
+
+// DropCohortProducerCounts returns authentic producer mutation counts.
+func (c *Core) DropCohortProducerCounts() DropCohortProducerCounters {
+	if c == nil {
+		return DropCohortProducerCounters{}
+	}
+	return DropCohortProducerCounters{
+		ReductionEstablishment: c.dropCohortProducerWrites[dropCohortProducerReductionEstablishment],
+		LinearCanonicalizer:    c.dropCohortProducerWrites[dropCohortProducerLinearCanonicalizer],
+		MappedCanonicalizer:    c.dropCohortProducerWrites[dropCohortProducerMappedCanonicalizer],
+		SiblingAdoption:        c.dropCohortProducerWrites[dropCohortProducerSiblingAdoption],
+		ConflictReconciliation: c.dropCohortProducerWrites[dropCohortProducerConflictReconciliation],
+		DeadHistoryImport:      c.dropCohortProducerWrites[dropCohortProducerDeadHistoryImport],
+	}
+}
+
+func (c *Core) addDropCohortProducerWrite(kind int) {
+	if kind < 0 || kind >= len(c.dropCohortProducerWrites) {
+		return
+	}
+	if c.dropCohortProducerWrites[kind] != math.MaxUint64 {
+		c.dropCohortProducerWrites[kind]++
+	}
+}
+
+func (c *Core) recordDropCohortProducerMutation(kind DropCohortProducerMutation) error {
+	var index int
+	switch kind {
+	case DropCohortProducerLinearCanonicalization:
+		index = dropCohortProducerLinearCanonicalizer
+	case DropCohortProducerMappedCanonicalization:
+		index = dropCohortProducerMappedCanonicalizer
+	case DropCohortProducerSiblingAdoption:
+		index = dropCohortProducerSiblingAdoption
+	case DropCohortProducerConflictReconciliation:
+		index = dropCohortProducerConflictReconciliation
+	case DropCohortProducerDeadHistoryImport:
+		index = dropCohortProducerDeadHistoryImport
+	default:
+		return errors.New("parser-core phase zero: unknown drop-cohort producer mutation")
+	}
+	c.addDropCohortProducerWrite(index)
+	return nil
+}
+
+// RecordDropCohortProducerMutation records one completed producer mutation.
+// The token authenticates both the Core owner and the active scheduler frame.
+func (c *Core) RecordDropCohortProducerMutation(owner SchedulerTransactionToken, kind DropCohortProducerMutation) (err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	err = c.recordDropCohortProducerMutation(kind)
+	return c.finishSchedulerOwned(owner, err)
+}
+
+func (c *Core) dropCohortStoreBytes() uint64 {
+	if c == nil {
+		return 0
+	}
+	return uint64(len(c.dropCohortActions))*coreDropCohortActionBytes +
+		uint64(len(c.dropCohortRecords))*coreDropCohortRecordBytes +
+		uint64(len(c.dropCohortMembers))*uint64(coreDropCohortMemberBytes) +
+		uint64(len(c.dropCohortDerivations))*coreDropCohortDerivationRecordBytes +
+		uint64(len(c.dropCohortDerivationIntern))*uint64(coreDropCohortDerivationInternBytes) +
+		uint64(len(c.dropCohortDerivationBytes)) +
+		uint64(len(c.dropCohortCertificateRefs))*uint64(coreDropCohortRefBytes) +
+		uint64(len(c.dropCohortMapStore))*uint64(coreDropCohortMapEntryBytes) +
+		uint64(len(c.dropCohortJournalStore))*uint64(coreDropCohortJournalStoreBytes) +
+		uint64(len(c.dropCohortReservations))*uint64(coreDropCohortReservationBytes) +
+		uint64(len(c.dropCohortJournal))*uint64(coreDropCohortMutationBytes)
+}
+
+func dropCohortStoreElementBytes(index int) uint64 {
+	switch index {
+	case 0:
+		return coreDropCohortActionBytes
+	case 1:
+		return coreDropCohortDerivationRecordBytes
+	case 2:
+		return coreDropCohortRefBytes
+	case 3:
+		return coreDropCohortMapEntryBytes
+	case 4:
+		return coreDropCohortDerivationInternBytes
+	case 5:
+		return coreDropCohortJournalStoreBytes
+	case 6:
+		return coreDropCohortRecordBytes
+	default:
+		return 0
+	}
+}
+
+func (c *Core) dropCohortPhysicalStoreBytes() [7]uint64 {
+	return [7]uint64{
+		uint64(len(c.dropCohortActions)) * coreDropCohortActionBytes,
+		uint64(len(c.dropCohortDerivations))*coreDropCohortDerivationRecordBytes + uint64(len(c.dropCohortDerivationBytes)),
+		uint64(len(c.dropCohortCertificateRefs)) * coreDropCohortRefBytes,
+		uint64(len(c.dropCohortMapStore)) * coreDropCohortMapEntryBytes,
+		uint64(len(c.dropCohortDerivationIntern)) * coreDropCohortDerivationInternBytes,
+		uint64(len(c.dropCohortJournalStore)) * coreDropCohortJournalStoreBytes,
+		uint64(len(c.dropCohortRecords)) * coreDropCohortRecordBytes,
+	}
+}
+
+func (c *Core) dropCohortRetainedStoreBytes() [7]uint64 {
+	return [7]uint64{
+		uint64(cap(c.dropCohortActions)) * coreDropCohortActionBytes,
+		uint64(cap(c.dropCohortDerivations))*coreDropCohortDerivationRecordBytes + uint64(cap(c.dropCohortDerivationBytes)),
+		uint64(cap(c.dropCohortCertificateRefs)) * coreDropCohortRefBytes,
+		uint64(cap(c.dropCohortMapStore)) * coreDropCohortMapEntryBytes,
+		uint64(cap(c.dropCohortDerivationIntern)) * coreDropCohortDerivationInternBytes,
+		uint64(cap(c.dropCohortJournalStore)) * coreDropCohortJournalStoreBytes,
+		uint64(cap(c.dropCohortRecords)) * coreDropCohortRecordBytes,
+	}
+}
+
+func (c *Core) dropCohortRetainedOtherBytes() (uint64, error) {
+	journal, err := dropCohortMulChecked(uint64(cap(c.dropCohortJournal)), coreDropCohortMutationBytes)
+	if err != nil {
+		return 0, err
+	}
+	reservations, err := dropCohortMulChecked(uint64(cap(c.dropCohortReservations)), coreDropCohortReservationBytes)
+	if err != nil {
+		return 0, err
+	}
+	return dropCohortAddChecked(journal, reservations)
+}
+
+func (c *Core) dropCohortStoreGrowthBytes(index int, demand, derivationBytes uint64) (uint64, error) {
+	var live, capacity uint64
+	switch index {
+	case 0:
+		live, capacity = uint64(len(c.dropCohortActions)), uint64(cap(c.dropCohortActions))
+	case 1:
+		var err error
+		live, err = dropCohortMulChecked(uint64(len(c.dropCohortDerivations)), coreDropCohortDerivationRecordBytes)
+		if err != nil {
+			return 0, err
+		}
+		live, err = dropCohortAddChecked(live, uint64(len(c.dropCohortDerivationBytes)))
+		if err != nil {
+			return 0, err
+		}
+		capacity, err = dropCohortMulChecked(uint64(cap(c.dropCohortDerivations)), coreDropCohortDerivationRecordBytes)
+		if err != nil {
+			return 0, err
+		}
+		capacity, err = dropCohortAddChecked(capacity, uint64(cap(c.dropCohortDerivationBytes)))
+		if err != nil {
+			return 0, err
+		}
+	case 2:
+		live, capacity = uint64(len(c.dropCohortCertificateRefs)), uint64(cap(c.dropCohortCertificateRefs))
+	case 3:
+		live, capacity = uint64(len(c.dropCohortMapStore)), uint64(cap(c.dropCohortMapStore))
+	case 4:
+		live, capacity = uint64(len(c.dropCohortDerivationIntern)), uint64(cap(c.dropCohortDerivationIntern))
+	case 5:
+		live, capacity = uint64(len(c.dropCohortJournalStore)), uint64(cap(c.dropCohortJournalStore))
+	case 6:
+		live, capacity = uint64(len(c.dropCohortRecords)), uint64(cap(c.dropCohortRecords))
+	default:
+		return 0, errors.New("parser-core phase zero: invalid drop-cohort store")
+	}
+	if index != 1 {
+		var err error
+		live, err = dropCohortMulChecked(live, dropCohortStoreElementBytes(index))
+		if err != nil {
+			return 0, err
+		}
+		capacity, err = dropCohortMulChecked(capacity, dropCohortStoreElementBytes(index))
+		if err != nil {
+			return 0, err
+		}
+	}
+	requested, err := dropCohortMulChecked(demand, dropCohortStoreElementBytes(index))
+	if err != nil {
+		return 0, err
+	}
+	if index == 1 {
+		requested, err = dropCohortAddChecked(requested, derivationBytes)
+		if err != nil {
+			return 0, err
+		}
+	}
+	required, err := dropCohortAddChecked(live, requested)
+	if err != nil {
+		return 0, err
+	}
+	if required <= capacity {
+		return 0, nil
+	}
+	return required - capacity, nil
+}
+
+func dropCohortAddChecked(left, right uint64) (uint64, error) {
+	if right > math.MaxUint64-left {
+		return 0, errors.New("parser-core phase zero: drop-cohort byte accounting overflow")
+	}
+	return left + right, nil
+}
+
+func dropCohortMulChecked(left, right uint64) (uint64, error) {
+	if left != 0 && right > math.MaxUint64/left {
+		return 0, errors.New("parser-core phase zero: drop-cohort store demand overflow")
+	}
+	return left * right, nil
+}
+
+func (c *Core) dropCohortPreflightDemand(demand [7]uint64, derivationBytes, extraBytes uint64) error {
+	used := c.dropCohortPhysicalStoreBytes()
+	var totalUsed uint64
+	for _, value := range used {
+		var addErr error
+		totalUsed, addErr = dropCohortAddChecked(totalUsed, value)
+		if addErr != nil {
+			return addErr
+		}
+	}
+	other := c.dropCohortStoreBytes()
+	if other >= totalUsed {
+		other -= totalUsed
+	} else {
+		other = 0
+	}
+	total, err := dropCohortAddChecked(other, extraBytes)
+	if err != nil {
+		return err
+	}
+	for index := range demand {
+		reserved, err := dropCohortMulChecked(c.dropCohortReserved[index], dropCohortStoreElementBytes(index))
+		if err != nil {
+			return err
+		}
+		requested, err := c.dropCohortStoreGrowthBytes(index, demand[index], derivationBytes)
+		if err != nil {
+			return err
+		}
+		perStore, err := dropCohortAddChecked(used[index], reserved)
+		if err != nil {
+			return err
+		}
+		if perStore > c.limits.MaxDropCohortBytes || requested > c.limits.MaxDropCohortBytes-perStore {
+			return fmt.Errorf("parser-core phase zero: drop-cohort store %d byte cap", index)
+		}
+		var err2 error
+		total, err2 = dropCohortAddChecked(total, used[index])
+		if err2 != nil {
+			return err2
+		}
+		total, err2 = dropCohortAddChecked(total, reserved)
+		if err2 != nil {
+			return err2
+		}
+		total, err2 = dropCohortAddChecked(total, requested)
+		if err2 != nil {
+			return err2
+		}
+	}
+	var fixedReserved uint64
+	for index, count := range c.dropCohortReserved {
+		value, err := dropCohortMulChecked(count, dropCohortStoreElementBytes(index))
+		if err != nil {
+			return err
+		}
+		fixedReserved, err = dropCohortAddChecked(fixedReserved, value)
+		if err != nil {
+			return err
+		}
+	}
+	if c.dropCohortReservedBytes < fixedReserved {
+		return errors.New("parser-core phase zero: drop-cohort reservation accounting underflow")
+	}
+	total, err = dropCohortAddChecked(total, c.dropCohortReservedBytes-fixedReserved)
+	if err != nil {
+		return err
+	}
+	if total > c.limits.MaxDropCohortBytes {
+		return fmt.Errorf("parser-core phase zero: drop-cohort aggregate byte cap (total=%d max=%d)", total, c.limits.MaxDropCohortBytes)
+	}
+	return nil
+}
+
+func (c *Core) dropCohortReserveDemandWithExtra(demand [7]uint64, derivationBytes, extraBytes uint64) (uint64, error) {
+	if err := c.dropCohortPreflightDemand(demand, derivationBytes, extraBytes); err != nil {
+		return 0, err
+	}
+	var bytes uint64
+	var err error
+	var nextReserved [7]uint64
+	for index, count := range demand {
+		value, err := dropCohortMulChecked(count, dropCohortStoreElementBytes(index))
+		if err != nil {
+			return 0, err
+		}
+		if index == 1 {
+			value, err = dropCohortAddChecked(value, derivationBytes)
+			if err != nil {
+				return 0, err
+			}
+		}
+		if count > math.MaxUint64-c.dropCohortReserved[index] {
+			return 0, errors.New("parser-core phase zero: drop-cohort reservation count overflow")
+		}
+		nextReserved[index] = c.dropCohortReserved[index] + count
+		bytes, err = dropCohortAddChecked(bytes, value)
+		if err != nil {
+			return 0, err
+		}
+	}
+	bytes, err = dropCohortAddChecked(bytes, extraBytes)
+	if err != nil {
+		return 0, err
+	}
+	nextBytes, err := dropCohortAddChecked(c.dropCohortReservedBytes, bytes)
+	if err != nil {
+		return 0, err
+	}
+	c.dropCohortReserved = nextReserved
+	c.dropCohortReservedBytes = nextBytes
+	return bytes, nil
+}
+
+func (c *Core) dropCohortReserveDemand(demand [7]uint64, derivationBytes uint64) (uint64, error) {
+	return c.dropCohortReserveDemandWithExtra(demand, derivationBytes, 0)
+}
+
+func (c *Core) dropCohortReleaseDemand(reserved [7]uint64, bytes uint64) {
+	for index, count := range reserved {
+		if count >= c.dropCohortReserved[index] {
+			c.dropCohortReserved[index] = 0
+		} else {
+			c.dropCohortReserved[index] -= count
+		}
+	}
+	if bytes >= c.dropCohortReservedBytes {
+		c.dropCohortReservedBytes = 0
+	} else {
+		c.dropCohortReservedBytes -= bytes
+	}
+}
+
+func (c *Core) dropCohortConsumeReservation(cohort DropCohortHandle, consumed [7]uint64, bytes uint64) {
+	c.dropCohortReleaseDemand(consumed, bytes)
+	for index := range c.dropCohortReservations {
+		reservation := &c.dropCohortReservations[index]
+		if reservation.handle != cohort {
+			continue
+		}
+		for store, count := range consumed {
+			if count >= reservation.reserved[store] {
+				reservation.reserved[store] = 0
+			} else {
+				reservation.reserved[store] -= count
+			}
+		}
+		if bytes >= reservation.reservationBytes {
+			reservation.reservationBytes = 0
+		} else {
+			reservation.reservationBytes -= bytes
+		}
+		return
+	}
+}
+
+func (c *Core) dropCohortReleaseReservationRemainder(cohort DropCohortHandle) {
+	for index := range c.dropCohortReservations {
+		reservation := &c.dropCohortReservations[index]
+		if reservation.handle != cohort {
+			continue
+		}
+		remaining := reservation.reserved
+		bytes := reservation.reservationBytes
+		c.dropCohortReleaseDemand(remaining, bytes)
+		clear(reservation.reserved[:])
+		reservation.reservationBytes = 0
+		return
+	}
+}
+
+func (c *Core) dropCohortCurrentReservation() *dropCohortReservation {
+	for index := len(c.dropCohortReservations) - 1; index >= 0; index-- {
+		reservation := &c.dropCohortReservations[index]
+		for _, record := range c.dropCohortRecords {
+			if record.handle == reservation.handle && record.state == DropCohortBuilding {
+				return reservation
+			}
+		}
+	}
+	return nil
+}
+
+func dropCohortDemandBytes(demand [7]uint64, derivationBytes uint64) (uint64, error) {
+	var total uint64
+	for index, count := range demand {
+		value, err := dropCohortMulChecked(count, dropCohortStoreElementBytes(index))
+		if err != nil {
+			return 0, err
+		}
+		if index == 1 {
+			value, err = dropCohortAddChecked(value, derivationBytes)
+			if err != nil {
+				return 0, err
+			}
+		}
+		total, err = dropCohortAddChecked(total, value)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return total, nil
+}
+
+func (c *Core) dropCohortAppendJournalSlots(count int) error {
+	if count < 0 || count > int(^uint(0)>>1)-len(c.dropCohortJournalStore) {
+		return errors.New("parser-core phase zero: drop-cohort journal slot overflow")
+	}
+	needed := len(c.dropCohortJournalStore) + count
+	if needed <= cap(c.dropCohortJournalStore) {
+		c.dropCohortJournalStore = c.dropCohortJournalStore[:needed]
+		return nil
+	}
+	grown := make([]dropCohortJournalStoreEntry, needed, needed)
+	copy(grown, c.dropCohortJournalStore)
+	c.dropCohortJournalStore = grown
+	return nil
+}
+
+func (c *Core) dropCohortAppendJournalMutationSlots(count int) error {
+	if count < 0 || count > int(^uint(0)>>1)-len(c.dropCohortJournal) {
+		return errors.New("parser-core phase zero: drop-cohort journal mutation overflow")
+	}
+	needed := len(c.dropCohortJournal) + count
+	if needed <= cap(c.dropCohortJournal) {
+		return nil
+	}
+	grown := make([]dropCohortMutation, len(c.dropCohortJournal), needed)
+	copy(grown, c.dropCohortJournal)
+	c.dropCohortJournal = grown
+	return nil
+}
+
+func (c *Core) dropCohortJournalGrowthBytes(count int) (uint64, error) {
+	if count < 0 || count > int(^uint(0)>>1)-len(c.dropCohortJournal) {
+		return 0, errors.New("parser-core phase zero: drop-cohort journal mutation overflow")
+	}
+	needed := len(c.dropCohortJournal) + count
+	if needed <= cap(c.dropCohortJournal) {
+		return 0, nil
+	}
+	return dropCohortMulChecked(uint64(needed-cap(c.dropCohortJournal)), coreDropCohortMutationBytes)
+}
+
+func (c *Core) dropCohortPreflight(expected int) error {
+	if c == nil {
+		return errors.New("parser-core phase zero: nil drop-cohort core")
+	}
+	if expected <= 0 {
+		return errors.New("parser-core phase zero: empty drop-cohort output set")
+	}
+	if uint64(expected) > uint64(c.limits.MaxDropCohortMembers) {
+		return errors.New("parser-core phase zero: drop-cohort member cap")
+	}
+	if expected > dropCohortRefHardCap {
+		return errors.New("parser-core phase zero: drop-cohort reference hard cap")
+	}
+	if uint64(len(c.dropCohortRecords))+1 > uint64(c.limits.MaxDropCohorts) {
+		return errors.New("parser-core phase zero: drop-cohort count cap")
+	}
+	if uint64(len(c.dropCohortMembers))+uint64(expected) > uint64(c.limits.MaxDropCohortRefs) {
+		return errors.New("parser-core phase zero: drop-cohort member store cap")
+	}
+	if c.dropCohortNextSequence == math.MaxUint64 {
+		return errors.New("parser-core phase zero: drop-cohort sequence overflow")
+	}
+	var demand [7]uint64
+	demand[0], demand[1], demand[2], demand[3], demand[4] = 1, uint64(expected), uint64(expected), uint64(expected), uint64(expected)
+	demand[5], demand[6] = uint64(expected+2), 1
+	journalBytes, err := c.dropCohortJournalGrowthBytes(expected + 2)
+	if err != nil {
+		return err
+	}
+	return c.dropCohortPreflightDemand(demand, 0, journalBytes)
+}
+
+func (c *Core) beginDropCohortOwned(identity DropCohortActionIdentity, expected int) (DropCohortHandle, error) {
+	if err := c.dropCohortPreflight(expected); err != nil {
+		return DropCohortHandle{}, err
+	}
+	sequence := c.dropCohortNextSequence + 1
+	if sequence == 0 {
+		return DropCohortHandle{}, errors.New("parser-core phase zero: drop-cohort sequence wrapped")
+	}
+	handle := c.dropCohortHandle(sequence)
+	var demand [7]uint64
+	demand[0], demand[1], demand[2], demand[3], demand[4] = 1, uint64(expected), uint64(expected), uint64(expected), uint64(expected)
+	demand[5], demand[6] = uint64(expected+2), 1
+	journalBytes, err := c.dropCohortJournalGrowthBytes(expected + 2)
+	if err != nil {
+		return DropCohortHandle{}, err
+	}
+	reservationBytes, err := c.dropCohortReserveDemandWithExtra(demand, 0, journalBytes)
+	if err != nil {
+		return DropCohortHandle{}, err
+	}
+	actionIndex := uint32(len(c.dropCohortActions))
+	oldActionsCap, oldRecordsCap := cap(c.dropCohortActions), cap(c.dropCohortRecords)
+	oldMembersCap, oldDerivationsCap := cap(c.dropCohortMembers), cap(c.dropCohortDerivations)
+	oldDerivationBytesCap, oldInternerCap := cap(c.dropCohortDerivationBytes), cap(c.dropCohortDerivationIntern)
+	oldCertificateRefsCap, oldMapEntriesCap := cap(c.dropCohortCertificateRefs), cap(c.dropCohortMapStore)
+	oldJournalEntriesCap := cap(c.dropCohortJournalStore)
+	oldReservationsCap := cap(c.dropCohortReservations)
+	oldActions, oldRecords := len(c.dropCohortActions), len(c.dropCohortRecords)
+	oldMembers, oldDerivations := len(c.dropCohortMembers), len(c.dropCohortDerivations)
+	oldDerivationBytes, oldInterner := len(c.dropCohortDerivationBytes), len(c.dropCohortDerivationIntern)
+	oldCertificateRefs, oldMapEntries := len(c.dropCohortCertificateRefs), len(c.dropCohortMapStore)
+	oldJournalEntries := len(c.dropCohortJournalStore)
+	oldReservationsHeader := c.dropCohortReservations
+	reservationsMoved := len(c.dropCohortReservations) == cap(c.dropCohortReservations)
+	oldActionsHeader, oldRecordsHeader := c.dropCohortActions, c.dropCohortRecords
+	oldMembersHeader, oldDerivationsHeader := c.dropCohortMembers, c.dropCohortDerivations
+	oldDerivationBytesHeader, oldInternerHeader := c.dropCohortDerivationBytes, c.dropCohortDerivationIntern
+	oldCertificateRefsHeader, oldMapEntriesHeader := c.dropCohortCertificateRefs, c.dropCohortMapStore
+	oldJournalStoreHeader, oldJournalHeader := c.dropCohortJournalStore, c.dropCohortJournal
+	c.dropCohortActions = append(c.dropCohortActions, identity)
+	c.dropCohortRecords = append(c.dropCohortRecords, dropCohortRecord{
+		handle: handle, state: DropCohortBuilding, expected: uint16(expected),
+		actionIndex: actionIndex, memberStart: uint32(len(c.dropCohortMembers)),
+	})
+	journalStart := len(c.dropCohortJournalStore)
+	if err := c.dropCohortAppendJournalSlots(int(expected) + 2); err != nil {
+		c.dropCohortActions = oldActionsHeader
+		c.dropCohortRecords = oldRecordsHeader
+		c.dropCohortReleaseDemand(demand, reservationBytes)
+		return DropCohortHandle{}, err
+	}
+	if err := c.dropCohortAppendJournalMutationSlots(expected + 2); err != nil {
+		c.dropCohortActions = oldActionsHeader
+		c.dropCohortRecords = oldRecordsHeader
+		c.dropCohortJournalStore = oldJournalStoreHeader
+		c.dropCohortJournal = oldJournalHeader
+		c.dropCohortReleaseDemand(demand, reservationBytes)
+		return DropCohortHandle{}, err
+	}
+	c.dropCohortNextSequence = sequence
+	var consumed [7]uint64
+	consumed[0], consumed[5], consumed[6] = 1, uint64(expected+2), 1
+	consumedBytes, _ := dropCohortDemandBytes(consumed, 0)
+	consumedBytes, _ = dropCohortAddChecked(consumedBytes, journalBytes)
+	c.dropCohortReservations = append(c.dropCohortReservations, dropCohortReservation{
+		handle: handle, previousNext: sequence - 1,
+		actions: oldActions, records: oldRecords, members: oldMembers, derivations: oldDerivations,
+		derivationBytes: oldDerivationBytes, interner: oldInterner,
+		certificateRefs: oldCertificateRefs, mapEntries: oldMapEntries,
+		journalEntries: oldJournalEntries, journalMutations: len(c.dropCohortJournal),
+		ownerChecks: c.dropCohortOwnerCheckedLookups,
+		actionsCap:  oldActionsCap, recordsCap: oldRecordsCap, membersCap: oldMembersCap,
+		derivationsCap: oldDerivationsCap, derivationBytesCap: oldDerivationBytesCap,
+		internerCap: oldInternerCap, certificateRefsCap: oldCertificateRefsCap,
+		mapEntriesCap: oldMapEntriesCap, journalEntriesCap: oldJournalEntriesCap,
+		reservationsCap: oldReservationsCap,
+		reserved:        demand, reservationBytes: reservationBytes,
+		journalStart: journalStart, journalCount: expected + 2,
+		actionsHeader: oldActionsHeader, recordsHeader: oldRecordsHeader,
+		membersHeader: oldMembersHeader, derivationsHeader: oldDerivationsHeader,
+		derivationBytesHead: oldDerivationBytesHeader, internerHeader: oldInternerHeader,
+		certificateRefsHead: oldCertificateRefsHeader, mapEntriesHeader: oldMapEntriesHeader,
+		journalStoreHeader: oldJournalStoreHeader, journalHeader: oldJournalHeader,
+		reservationsHeader: func() []dropCohortReservation {
+			if reservationsMoved {
+				return oldReservationsHeader
+			}
+			return nil
+		}(),
+		reservationsMoved: reservationsMoved,
+	})
+	c.dropCohortConsumeReservation(handle, consumed, consumedBytes)
+	return handle, nil
+}
+
+// BeginDropCohortOwned reserves one atomic cohort for a stable output set.
+func (c *Core) BeginDropCohortOwned(owner SchedulerTransactionToken, identity DropCohortActionIdentity, expected int) (handle DropCohortHandle, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return DropCohortHandle{}, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	handle, err = c.beginDropCohortOwned(identity, expected)
+	err = c.finishSchedulerOwned(owner, err)
+	return handle, err
+}
+
+// AbandonDropCohortOwned removes the latest incomplete cohort after an
+// optional derivation producer reaches a bounded-store limit. The operation
+// keeps the authenticated scheduler frame usable for the ordinary fallback.
+func (c *Core) AbandonDropCohortOwned(owner SchedulerTransactionToken, cohort DropCohortHandle) (err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if len(c.dropCohortReservations) == 0 {
+		return c.finishSchedulerOwned(owner, errors.New("parser-core phase zero: drop-cohort reservation is unavailable"))
+	}
+	reservation := c.dropCohortReservations[len(c.dropCohortReservations)-1]
+	if reservation.handle != cohort {
+		return c.finishSchedulerOwned(owner, errors.New("parser-core phase zero: drop-cohort abandonment is not the latest reservation"))
+	}
+	if index, identityErr := c.validateDropCohortIdentity(cohort); identityErr != nil {
+		return c.finishSchedulerOwned(owner, identityErr)
+	} else if c.dropCohortRecords[index].state != DropCohortBuilding {
+		return c.finishSchedulerOwned(owner, errors.New("parser-core phase zero: drop-cohort is not building"))
+	}
+	c.dropCohortActions = reservation.actionsHeader
+	c.dropCohortRecords = reservation.recordsHeader
+	c.dropCohortMembers = reservation.membersHeader
+	c.dropCohortDerivations = reservation.derivationsHeader
+	c.dropCohortDerivationBytes = reservation.derivationBytesHead
+	c.dropCohortDerivationIntern = reservation.internerHeader
+	c.dropCohortCertificateRefs = reservation.certificateRefsHead
+	c.dropCohortMapStore = reservation.mapEntriesHeader
+	c.dropCohortJournalStore = reservation.journalStoreHeader
+	c.dropCohortJournal = reservation.journalHeader
+	c.dropCohortOwnerCheckedLookups = reservation.ownerChecks
+	c.dropCohortNextSequence = reservation.previousNext
+	c.dropCohortReleaseReservationRemainder(cohort)
+	if reservation.reservationsMoved {
+		c.dropCohortReservations = reservation.reservationsHeader
+	} else {
+		c.dropCohortReservations = c.dropCohortReservations[: len(c.dropCohortReservations)-1 : reservation.reservationsCap]
+	}
+	return nil
+}
+
+const (
+	dropCohortDerivationFormatVersion uint32 = 2
+	dropCohortTagRecordBegin                 = 0xD2
+	dropCohortTagRecordEnd                   = 0xD3
+	dropCohortTagPathBegin                   = 0xB0
+	dropCohortTagPathEnd                     = 0xB1
+	dropCohortTagBoundary                    = 0xA0
+	dropCohortTagEdge                        = 0xA1
+	dropCohortTagSubtreeBegin                = 0xC0
+	dropCohortTagSubtreeEnd                  = 0xC1
+)
+
+// dropCohortPathStep keeps arena identities only while traversing one graph.
+// The step is never copied into derivation bytes.
+type dropCohortPathStep struct {
+	node       NodeID
+	payload    SubtreeID
+	scoreDelta int64
+	order      ForkOrder
+}
+
+type dropCohortEncoder struct {
+	core  *Core
+	dst   []byte
+	limit uint64
+}
+
+func (c *Core) dropCohortEphemeralReserve(bytes uint64) error {
+	if c == nil {
+		return errors.New("parser-core phase zero: nil drop-cohort scratch owner")
+	}
+	if c.dropCohortEphemeralBytes > c.limits.MaxDropCohortBytes ||
+		bytes > c.limits.MaxDropCohortBytes-c.dropCohortEphemeralBytes {
+		return errors.New("parser-core phase zero: drop-cohort ephemeral scratch byte cap")
+	}
+	c.dropCohortEphemeralBytes += bytes
+	if c.dropCohortEphemeralBytes > c.dropCohortEphemeralPeak {
+		c.dropCohortEphemeralPeak = c.dropCohortEphemeralBytes
+	}
+	return nil
+}
+
+func (c *Core) dropCohortEphemeralRelease(bytes uint64) {
+	if c == nil || bytes == 0 {
+		return
+	}
+	if bytes >= c.dropCohortEphemeralBytes {
+		c.dropCohortEphemeralBytes = 0
+		return
+	}
+	c.dropCohortEphemeralBytes -= bytes
+}
+
+func dropCohortScratchBytes(capacity uint64, elementBytes uint64) (uint64, error) {
+	if elementBytes != 0 && capacity > math.MaxUint64/elementBytes {
+		return 0, errors.New("parser-core phase zero: drop-cohort scratch byte overflow")
+	}
+	return capacity * elementBytes, nil
+}
+
+func (e *dropCohortEncoder) reserve(count int) error {
+	if count < 0 {
+		return errors.New("parser-core phase zero: negative drop-cohort encoding size")
+	}
+	if uint64(len(e.dst)) > e.limit || uint64(count) > e.limit-uint64(len(e.dst)) {
+		return errors.New("parser-core phase zero: drop-cohort derivation byte cap")
+	}
+	needed := len(e.dst) + count
+	if needed <= cap(e.dst) {
+		return nil
+	}
+	maxInt := int(^uint(0) >> 1)
+	if needed > maxInt {
+		return errors.New("parser-core phase zero: drop-cohort derivation length overflow")
+	}
+	newCap := cap(e.dst)
+	if newCap < 64 {
+		newCap = 64
+	}
+	for newCap < needed {
+		if newCap > maxInt/2 {
+			newCap = needed
+			break
+		}
+		newCap *= 2
+	}
+	if uint64(newCap) > e.limit {
+		newCap = int(e.limit)
+	}
+	if newCap < needed {
+		return errors.New("parser-core phase zero: drop-cohort derivation byte cap")
+	}
+	if e.core == nil {
+		return errors.New("parser-core phase zero: drop-cohort encoder has no scratch owner")
+	}
+	oldBytes := uint64(cap(e.dst))
+	if err := e.core.dropCohortEphemeralReserve(uint64(newCap)); err != nil {
+		return err
+	}
+	grown := make([]byte, len(e.dst), newCap)
+	copy(grown, e.dst)
+	e.core.dropCohortEphemeralRelease(oldBytes)
+	e.dst = grown
+	return nil
+}
+
+func (e *dropCohortEncoder) bytes(value []byte) error {
+	if err := e.reserve(len(value)); err != nil {
+		return err
+	}
+	start := len(e.dst)
+	e.dst = e.dst[:start+len(value)]
+	copy(e.dst[start:], value)
+	return nil
+}
+
+func (e *dropCohortEncoder) u8(value byte) error {
+	return e.bytes([]byte{value})
+}
+
+func (e *dropCohortEncoder) bool(value bool) error {
+	if value {
+		return e.u8(1)
+	}
+	return e.u8(0)
+}
+
+func (e *dropCohortEncoder) u16(value uint16) error {
+	var encoded [2]byte
+	binary.LittleEndian.PutUint16(encoded[:], value)
+	return e.bytes(encoded[:])
+}
+
+func (e *dropCohortEncoder) u32(value uint32) error {
+	var encoded [4]byte
+	binary.LittleEndian.PutUint32(encoded[:], value)
+	return e.bytes(encoded[:])
+}
+
+func (e *dropCohortEncoder) u64(value uint64) error {
+	var encoded [8]byte
+	binary.LittleEndian.PutUint64(encoded[:], value)
+	return e.bytes(encoded[:])
+}
+
+func (e *dropCohortEncoder) i16(value int16) error { return e.u16(uint16(value)) }
+func (e *dropCohortEncoder) i64(value int64) error { return e.u64(uint64(value)) }
+
+func (e *dropCohortEncoder) patchU32(offset int, value uint32) error {
+	if offset < 0 || offset+4 > len(e.dst) {
+		return errors.New("parser-core phase zero: drop-cohort count patch is out of range")
+	}
+	binary.LittleEndian.PutUint32(e.dst[offset:offset+4], value)
+	return nil
+}
+
+func (c *Core) dropCohortCheckpointDigest(id CheckpointID) (digest [32]byte, exact bool) {
+	_, digest, exact = c.checkpoints.receipt(id)
+	return digest, exact
+}
+
+func (c *Core) dropCohortEncodeCheckpoint(e *dropCohortEncoder, checkpoint DropCohortSourceCheckpoint) error {
+	for _, value := range [...]uint32{
+		checkpoint.StartByte, checkpoint.EndByte, checkpoint.StartRow, checkpoint.StartColumn,
+		checkpoint.EndRow, checkpoint.EndColumn,
+	} {
+		if err := e.u32(value); err != nil {
+			return err
+		}
+	}
+	for _, id := range [...]CheckpointID{checkpoint.ScannerStart, checkpoint.ScannerEnd} {
+		digest, exact := c.dropCohortCheckpointDigest(id)
+		if err := e.bool(exact); err != nil {
+			return err
+		}
+		if err := e.bytes(digest[:]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Core) dropCohortEncodeBoundary(e *dropCohortEncoder, id NodeID) error {
+	node, err := c.node(id)
+	if err != nil {
+		return err
+	}
+	checkpoint, exact := c.nodeScannerCheckpoint(id)
+	if err := e.u8(dropCohortTagBoundary); err != nil {
+		return err
+	}
+	if err := e.u32(uint32(node.state)); err != nil {
+		return err
+	}
+	if err := e.u32(node.byteOffset); err != nil {
+		return err
+	}
+	if err := e.bool(exact); err != nil {
+		return err
+	}
+	digest, digestExact := c.dropCohortCheckpointDigest(checkpoint)
+	if exact && !digestExact {
+		return errors.New("parser-core phase zero: drop-cohort boundary checkpoint is unavailable")
+	}
+	if err := e.bool(digestExact); err != nil {
+		return err
+	}
+	return e.bytes(digest[:])
+}
+
+func dropCohortSliceBounds(first, count uint32, length int) (int, int, error) {
+	if uint64(first)+uint64(count) > uint64(length) {
+		return 0, 0, errors.New("parser-core phase zero: drop-cohort subtree metadata range is invalid")
+	}
+	return int(first), int(first + count), nil
+}
+
+func (c *Core) dropCohortEncodeSubtree(e *dropCohortEncoder, payload SubtreeID, depth uint64) (Symbol, error) {
+	if depth >= uint64(c.limits.MaxSubtrees) {
+		return 0, errors.New("parser-core phase zero: drop-cohort subtree depth cap")
+	}
+	record, err := c.subtree(payload)
+	if err != nil {
+		return 0, err
+	}
+	childStart, childEnd, err := dropCohortSliceBounds(record.firstChild, record.childCount, len(c.children))
+	if err != nil {
+		return 0, err
+	}
+	fieldStart, fieldEnd, err := dropCohortSliceBounds(record.firstField, record.fieldCount, len(c.fields))
+	if err != nil {
+		return 0, err
+	}
+	aliasStart, aliasEnd, err := dropCohortSliceBounds(record.firstAlias, record.aliasCount, len(c.aliases))
+	if err != nil {
+		return 0, err
+	}
+	if err := e.u8(dropCohortTagSubtreeBegin); err != nil {
+		return 0, err
+	}
+	for _, value := range []uint16{uint16(record.symbol), record.productionID} {
+		if err := e.u16(value); err != nil {
+			return 0, err
+		}
+	}
+	if err := e.i16(record.dynamicPrecedence); err != nil {
+		return 0, err
+	}
+	for _, value := range []uint32{record.startByte, record.endByte} {
+		if err := e.u32(value); err != nil {
+			return 0, err
+		}
+	}
+	for _, value := range []bool{record.extra, record.external, record.terminal, record.fragile} {
+		if err := e.bool(value); err != nil {
+			return 0, err
+		}
+	}
+	if record.external {
+		provenance, exact := c.externalPayloadScannerProvenance(payload)
+		if err := e.bool(exact); err != nil {
+			return 0, err
+		}
+		for _, id := range [...]CheckpointID{provenance.start, provenance.end} {
+			digest, digestExact := c.dropCohortCheckpointDigest(id)
+			if exact && !digestExact {
+				return 0, errors.New("parser-core phase zero: external subtree checkpoint is unavailable")
+			}
+			if err := e.bool(digestExact); err != nil {
+				return 0, err
+			}
+			if err := e.bytes(digest[:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if err := e.u32(record.childCount); err != nil {
+		return 0, err
+	}
+	for _, child := range c.children[childStart:childEnd] {
+		if child == 0 || child >= payload {
+			return 0, errors.New("parser-core phase zero: drop-cohort subtree child order is invalid")
+		}
+		if _, err := c.dropCohortEncodeSubtree(e, child, depth+1); err != nil {
+			return 0, err
+		}
+	}
+	if err := e.u32(record.fieldCount); err != nil {
+		return 0, err
+	}
+	for _, field := range c.fields[fieldStart:fieldEnd] {
+		if err := e.u16(uint16(field.FieldID)); err != nil {
+			return 0, err
+		}
+		if err := e.u8(field.ChildIndex); err != nil {
+			return 0, err
+		}
+		if err := e.bool(field.Inherited); err != nil {
+			return 0, err
+		}
+	}
+	if err := e.u32(record.aliasCount); err != nil {
+		return 0, err
+	}
+	for _, alias := range c.aliases[aliasStart:aliasEnd] {
+		if err := e.u16(uint16(alias)); err != nil {
+			return 0, err
+		}
+	}
+	if err := e.u8(dropCohortTagSubtreeEnd); err != nil {
+		return 0, err
+	}
+	return record.symbol, nil
+}
+
+func (c *Core) dropCohortCompareCheckpoint(left, right CheckpointID) (int, error) {
+	leftDigest, leftExact := c.dropCohortCheckpointDigest(left)
+	rightDigest, rightExact := c.dropCohortCheckpointDigest(right)
+	if leftExact != rightExact {
+		if !leftExact {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	return bytesCompare(leftDigest[:], rightDigest[:]), nil
+}
+
+func (c *Core) dropCohortCompareSubtree(left, right SubtreeID) (int, error) {
+	if left == right {
+		return 0, nil
+	}
+	l, err := c.subtree(left)
+	if err != nil {
+		return 0, err
+	}
+	r, err := c.subtree(right)
+	if err != nil {
+		return 0, err
+	}
+	compare := func(a, b int64) int {
+		if a < b {
+			return -1
+		}
+		if a > b {
+			return 1
+		}
+		return 0
+	}
+	for _, pair := range [][2]int64{
+		{int64(l.symbol), int64(r.symbol)}, {int64(l.productionID), int64(r.productionID)},
+		{int64(l.dynamicPrecedence), int64(r.dynamicPrecedence)}, {int64(l.startByte), int64(r.startByte)},
+		{int64(l.endByte), int64(r.endByte)}, {int64(l.childCount), int64(r.childCount)},
+		{int64(l.fieldCount), int64(r.fieldCount)}, {int64(l.aliasCount), int64(r.aliasCount)},
+	} {
+		if result := compare(pair[0], pair[1]); result != 0 {
+			return result, nil
+		}
+	}
+	for _, pair := range [][2]bool{{l.extra, r.extra}, {l.external, r.external}, {l.terminal, r.terminal}, {l.fragile, r.fragile}} {
+		if pair[0] != pair[1] {
+			if !pair[0] {
+				return -1, nil
+			}
+			return 1, nil
+		}
+	}
+	if l.external {
+		lp, lok := c.externalPayloadScannerProvenance(left)
+		rp, rok := c.externalPayloadScannerProvenance(right)
+		if lok != rok {
+			if !lok {
+				return -1, nil
+			}
+			return 1, nil
+		}
+		if lok {
+			for _, pair := range [...]struct{ left, right CheckpointID }{{lp.start, rp.start}, {lp.end, rp.end}} {
+				result, err := c.dropCohortCompareCheckpoint(pair.left, pair.right)
+				if err != nil || result != 0 {
+					return result, err
+				}
+			}
+		}
+	}
+	leftChildStart, leftChildEnd, err := dropCohortSliceBounds(l.firstChild, l.childCount, len(c.children))
+	if err != nil {
+		return 0, err
+	}
+	rightChildStart, rightChildEnd, err := dropCohortSliceBounds(r.firstChild, r.childCount, len(c.children))
+	if err != nil {
+		return 0, err
+	}
+	leftChildren := c.children[leftChildStart:leftChildEnd]
+	rightChildren := c.children[rightChildStart:rightChildEnd]
+	for index := range leftChildren {
+		if leftChildren[index] == 0 || leftChildren[index] >= left || rightChildren[index] == 0 || rightChildren[index] >= right {
+			return 0, errors.New("parser-core phase zero: drop-cohort subtree child order is invalid")
+		}
+		result, err := c.dropCohortCompareSubtree(leftChildren[index], rightChildren[index])
+		if err != nil || result != 0 {
+			return result, err
+		}
+	}
+	leftFieldStart, leftFieldEnd, err := dropCohortSliceBounds(l.firstField, l.fieldCount, len(c.fields))
+	if err != nil {
+		return 0, err
+	}
+	rightFieldStart, _, err := dropCohortSliceBounds(r.firstField, r.fieldCount, len(c.fields))
+	if err != nil {
+		return 0, err
+	}
+	for index, field := range c.fields[leftFieldStart:leftFieldEnd] {
+		other := c.fields[rightFieldStart+index]
+		if field.FieldID != other.FieldID || field.ChildIndex != other.ChildIndex || field.Inherited != other.Inherited {
+			if field.FieldID != other.FieldID {
+				if field.FieldID < other.FieldID {
+					return -1, nil
+				}
+				return 1, nil
+			}
+			if field.ChildIndex < other.ChildIndex {
+				return -1, nil
+			}
+			if field.ChildIndex > other.ChildIndex {
+				return 1, nil
+			}
+			if !field.Inherited {
+				return -1, nil
+			}
+			return 1, nil
+		}
+	}
+	leftAliasStart, leftAliasEnd, err := dropCohortSliceBounds(l.firstAlias, l.aliasCount, len(c.aliases))
+	if err != nil {
+		return 0, err
+	}
+	rightAliasStart, _, err := dropCohortSliceBounds(r.firstAlias, r.aliasCount, len(c.aliases))
+	if err != nil {
+		return 0, err
+	}
+	for index, alias := range c.aliases[leftAliasStart:leftAliasEnd] {
+		other := c.aliases[rightAliasStart+index]
+		if alias != other {
+			if alias < other {
+				return -1, nil
+			}
+			return 1, nil
+		}
+	}
+	return 0, nil
+}
+
+func (c *Core) dropCohortCompareBoundary(left, right NodeID) (int, error) {
+	if left == right {
+		return 0, nil
+	}
+	l, err := c.node(left)
+	if err != nil {
+		return 0, err
+	}
+	r, err := c.node(right)
+	if err != nil {
+		return 0, err
+	}
+	if l.state != r.state {
+		if l.state < r.state {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	if l.byteOffset != r.byteOffset {
+		if l.byteOffset < r.byteOffset {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	leftCheckpoint, leftExact := c.nodeScannerCheckpoint(left)
+	rightCheckpoint, rightExact := c.nodeScannerCheckpoint(right)
+	if leftExact != rightExact {
+		if !leftExact {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	if result, err := c.dropCohortCompareCheckpoint(leftCheckpoint, rightCheckpoint); err != nil || result != 0 {
+		return result, err
+	}
+	leftLinks, err := c.dropCohortSortedLinks(left)
+	if err != nil {
+		return 0, err
+	}
+	defer c.dropCohortReleaseSortedLinks(leftLinks)
+	rightLinks, err := c.dropCohortSortedLinks(right)
+	if err != nil {
+		return 0, err
+	}
+	defer c.dropCohortReleaseSortedLinks(rightLinks)
+	if len(leftLinks.links) != len(rightLinks.links) {
+		if len(leftLinks.links) < len(rightLinks.links) {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	for index := range leftLinks.links {
+		result, err := c.dropCohortCompareLinks(leftLinks.links[index], rightLinks.links[index])
+		if err != nil || result != 0 {
+			return result, err
+		}
+	}
+	return 0, nil
+}
+
+func (c *Core) dropCohortCompareLinks(left, right linkRecord) (int, error) {
+	if left.scoreDelta != right.scoreDelta {
+		if left.scoreDelta < right.scoreDelta {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	if left.hasOrder() != right.hasOrder() {
+		if !left.hasOrder() {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	if left.order != right.order {
+		if left.order < right.order {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	if result, err := c.dropCohortCompareSubtree(left.payload, right.payload); err != nil || result != 0 {
+		return result, err
+	}
+	return c.dropCohortCompareBoundary(left.prev, right.prev)
+}
+
+type dropCohortSortedLinksResult struct {
+	links     []linkRecord
+	byteCount uint64
+}
+
+func (c *Core) dropCohortGrowLinkScratch(links []linkRecord, needed int) ([]linkRecord, error) {
+	if needed <= cap(links) {
+		return links[:needed], nil
+	}
+	maxInt := int(^uint(0) >> 1)
+	newCap := cap(links)
+	if newCap < 1 {
+		newCap = 1
+	}
+	for newCap < needed {
+		if newCap > maxInt/2 {
+			newCap = needed
+			break
+		}
+		newCap *= 2
+	}
+	oldBytes, err := dropCohortScratchBytes(uint64(cap(links)), coreLinkRecordBytes)
+	if err != nil {
+		return nil, err
+	}
+	newBytes, err := dropCohortScratchBytes(uint64(newCap), coreLinkRecordBytes)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.dropCohortEphemeralReserve(newBytes); err != nil {
+		return nil, err
+	}
+	grown := make([]linkRecord, len(links), newCap)
+	copy(grown, links)
+	c.dropCohortEphemeralRelease(oldBytes)
+	return grown[:needed], nil
+}
+
+func (c *Core) dropCohortGrowSeenScratch(seen []LinkID, needed int) ([]LinkID, error) {
+	if needed <= cap(seen) {
+		return seen[:needed], nil
+	}
+	maxInt := int(^uint(0) >> 1)
+	newCap := cap(seen)
+	if newCap < 1 {
+		newCap = 1
+	}
+	for newCap < needed {
+		if newCap > maxInt/2 {
+			newCap = needed
+			break
+		}
+		newCap *= 2
+	}
+	oldBytes, err := dropCohortScratchBytes(uint64(cap(seen)), coreUint32Bytes)
+	if err != nil {
+		return nil, err
+	}
+	newBytes, err := dropCohortScratchBytes(uint64(newCap), coreUint32Bytes)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.dropCohortEphemeralReserve(newBytes); err != nil {
+		return nil, err
+	}
+	grown := make([]LinkID, len(seen), newCap)
+	copy(grown, seen)
+	c.dropCohortEphemeralRelease(oldBytes)
+	return grown[:needed], nil
+}
+
+func (c *Core) dropCohortReleaseSortedLinks(result dropCohortSortedLinksResult) {
+	c.dropCohortEphemeralRelease(result.byteCount)
+}
+
+func (c *Core) dropCohortSortedLinks(id NodeID) (result dropCohortSortedLinksResult, err error) {
+	node, err := c.node(id)
+	if err != nil {
+		return result, err
+	}
+	var links []linkRecord
+	var seen []LinkID
+	releaseAll := func() {
+		linkBytes, linkErr := dropCohortScratchBytes(uint64(cap(links)), coreLinkRecordBytes)
+		if linkErr == nil {
+			c.dropCohortEphemeralRelease(linkBytes)
+		}
+		seenBytes, seenErr := dropCohortScratchBytes(uint64(cap(seen)), coreUint32Bytes)
+		if seenErr == nil {
+			c.dropCohortEphemeralRelease(seenBytes)
+		}
+	}
+	defer func() {
+		if err != nil {
+			releaseAll()
+		}
+	}()
+	linkID := LinkID(node.firstLink)
+	for linkID != 0 {
+		if uint64(linkID) > uint64(len(c.links)) {
+			return result, errors.New("parser-core phase zero: drop-cohort derivation adjacency out of range")
+		}
+		for _, prior := range seen {
+			if prior == linkID {
+				return result, errors.New("parser-core phase zero: drop-cohort derivation adjacency cycle")
+			}
+		}
+		if uint64(len(seen))+1 > uint64(c.limits.MaxLinksPerBoundary) {
+			return result, errors.New("parser-core phase zero: drop-cohort derivation link cap")
+		}
+		seen, err = c.dropCohortGrowSeenScratch(seen, len(seen)+1)
+		if err != nil {
+			return result, err
+		}
+		seen[len(seen)-1] = linkID
+		link := c.links[linkID-1]
+		if link.prev == 0 || link.prev >= id || uint64(link.next) > uint64(len(c.links)) {
+			return result, errors.New("parser-core phase zero: drop-cohort derivation graph is invalid")
+		}
+		links, err = c.dropCohortGrowLinkScratch(links, len(links)+1)
+		if err != nil {
+			return result, err
+		}
+		links[len(links)-1] = link
+		linkID = link.next
+	}
+	for index := 1; index < len(links); index++ {
+		current := links[index]
+		position := index
+		for position > 0 {
+			compareResult, compareErr := c.dropCohortCompareLinks(current, links[position-1])
+			if compareErr != nil {
+				err = compareErr
+				return result, err
+			}
+			if compareResult >= 0 {
+				break
+			}
+			links[position] = links[position-1]
+			position--
+		}
+		links[position] = current
+	}
+	seenBytes, seenErr := dropCohortScratchBytes(uint64(cap(seen)), coreUint32Bytes)
+	if seenErr != nil {
+		err = seenErr
+		return result, err
+	}
+	c.dropCohortEphemeralRelease(seenBytes)
+	seen = nil
+	result = dropCohortSortedLinksResult{links: links}
+	result.byteCount, err = dropCohortScratchBytes(uint64(cap(links)), coreLinkRecordBytes)
+	if err != nil {
+		c.dropCohortEphemeralRelease(result.byteCount)
+		return dropCohortSortedLinksResult{}, err
+	}
+	return result, nil
+}
+
+func (c *Core) dropCohortAppendPathStep(path []dropCohortPathStep, step dropCohortPathStep) ([]dropCohortPathStep, error) {
+	stepBytes := coreDropCohortPathStepBytes
+	if stepBytes == 0 || uint64(len(path)) >= uint64(c.limits.MaxSubtrees) ||
+		uint64(len(path))+1 > c.limits.MaxDropCohortBytes/stepBytes {
+		return path, errors.New("parser-core phase zero: drop-cohort path scratch byte cap")
+	}
+	needed := len(path) + 1
+	if needed > cap(path) {
+		maxInt := int(^uint(0) >> 1)
+		newCap := cap(path)
+		if newCap < 1 {
+			newCap = 1
+		}
+		for newCap < needed {
+			if newCap > maxInt/2 {
+				newCap = needed
+				break
+			}
+			newCap *= 2
+		}
+		maxSteps := c.limits.MaxDropCohortBytes / stepBytes
+		if uint64(newCap) > maxSteps {
+			newCap = int(maxSteps)
+		}
+		if newCap < needed {
+			return path, errors.New("parser-core phase zero: drop-cohort path scratch byte cap")
+		}
+		oldBytes, err := dropCohortScratchBytes(uint64(cap(path)), stepBytes)
+		if err != nil {
+			return path, err
+		}
+		newBytes, err := dropCohortScratchBytes(uint64(newCap), stepBytes)
+		if err != nil {
+			return path, err
+		}
+		if err := c.dropCohortEphemeralReserve(newBytes); err != nil {
+			return path, err
+		}
+		grown := make([]dropCohortPathStep, len(path), newCap)
+		copy(grown, path)
+		c.dropCohortEphemeralRelease(oldBytes)
+		c.dropCohortPathScratch = grown
+		path = grown
+	}
+	return append(path, step), nil
+}
+
+// dropCohortEncodeAllPaths returns the authoritative path slice after every
+// recursive call, so a deeper capacity growth remains owned by all ancestors.
+func (c *Core) dropCohortEncodeAllPaths(e *dropCohortEncoder, id NodeID, path []dropCohortPathStep, score int64, order ForkOrder, count *uint32, maxDepth *uint32, root *Symbol, rootSet *bool) ([]dropCohortPathStep, error) {
+	links, err := c.dropCohortSortedLinks(id)
+	if err != nil {
+		return path, err
+	}
+	defer c.dropCohortReleaseSortedLinks(links)
+	if len(links.links) == 0 {
+		if uint64(*count) >= c.limits.MaxDerivations || *count == math.MaxUint32 {
+			return path, ErrDerivationEnumerationCap
+		}
+		if err := e.u8(dropCohortTagPathBegin); err != nil {
+			return path, err
+		}
+		if err := e.i64(score); err != nil {
+			return path, err
+		}
+		if err := e.u64(order.Value); err != nil {
+			return path, err
+		}
+		if err := e.bool(order.Present); err != nil {
+			return path, err
+		}
+		if uint64(len(path)) > uint64(math.MaxUint32) {
+			return path, errors.New("parser-core phase zero: drop-cohort path length overflow")
+		}
+		if err := e.u32(uint32(len(path))); err != nil {
+			return path, err
+		}
+		if err := c.dropCohortEncodeBoundary(e, id); err != nil {
+			return path, err
+		}
+		for index := len(path) - 1; index >= 0; index-- {
+			step := path[index]
+			if err := e.u8(dropCohortTagEdge); err != nil {
+				return path, err
+			}
+			if err := e.i64(step.scoreDelta); err != nil {
+				return path, err
+			}
+			if err := e.u64(step.order.Value); err != nil {
+				return path, err
+			}
+			if err := e.bool(step.order.Present); err != nil {
+				return path, err
+			}
+			encodedRoot, encodeErr := c.dropCohortEncodeSubtree(e, step.payload, 0)
+			if encodeErr != nil {
+				return path, encodeErr
+			}
+			if !*rootSet {
+				*root = encodedRoot
+				*rootSet = true
+			}
+			if err := c.dropCohortEncodeBoundary(e, step.node); err != nil {
+				return path, err
+			}
+		}
+		if err := e.u8(dropCohortTagPathEnd); err != nil {
+			return path, err
+		}
+		(*count)++
+		if uint32(len(path)) > *maxDepth {
+			*maxDepth = uint32(len(path))
+		}
+		return path, nil
+	}
+	for _, link := range links.links {
+		childOrder := order
+		if link.hasOrder() {
+			childOrder = ForkOrder{Value: link.order, Present: true}
+		}
+		childScore, scoreErr := checkedAddScore(score, link.scoreDelta)
+		if scoreErr != nil {
+			return path, scoreErr
+		}
+		var appendErr error
+		path, appendErr = c.dropCohortAppendPathStep(path, dropCohortPathStep{
+			node: id, payload: link.payload, scoreDelta: link.scoreDelta, order: childOrder,
+		})
+		if appendErr != nil {
+			return path, appendErr
+		}
+		path, err = c.dropCohortEncodeAllPaths(e, link.prev, path, childScore, childOrder, count, maxDepth, root, rootSet)
+		if err != nil {
+			return path, err
+		}
+		path = path[:len(path)-1]
+	}
+	return path, nil
+}
+
+func (c *Core) buildDropCohortDerivationOwned(head Head, checkpoint DropCohortSourceCheckpoint) (DropCohortDerivationHandle, error) {
+	if c == nil {
+		return DropCohortDerivationHandle{}, errors.New("parser-core phase zero: nil drop-cohort core")
+	}
+	c.dropCohortEphemeralBytes = 0
+	c.dropCohortEphemeralPeak = 0
+	defer func() { c.dropCohortEphemeralBytes = 0 }()
+	if uint64(cap(c.dropCohortDerivationScratch)) > c.limits.MaxDropCohortBytes {
+		c.dropCohortDerivationScratch = nil
+	}
+	if coreDropCohortPathStepBytes == 0 || uint64(cap(c.dropCohortPathScratch)) > c.limits.MaxDropCohortBytes/coreDropCohortPathStepBytes {
+		c.dropCohortPathScratch = nil
+	}
+	derivationBytes, err := dropCohortScratchBytes(uint64(cap(c.dropCohortDerivationScratch)), 1)
+	if err != nil {
+		c.dropCohortDerivationScratch = nil
+		c.dropCohortPathScratch = nil
+		return DropCohortDerivationHandle{}, err
+	}
+	pathBytes, err := dropCohortScratchBytes(uint64(cap(c.dropCohortPathScratch)), coreDropCohortPathStepBytes)
+	if err != nil || derivationBytes > c.limits.MaxDropCohortBytes-pathBytes {
+		c.dropCohortDerivationScratch = nil
+		c.dropCohortPathScratch = nil
+		derivationBytes = 0
+		pathBytes = 0
+	}
+	if err := c.dropCohortEphemeralReserve(derivationBytes + pathBytes); err != nil {
+		c.dropCohortDerivationScratch = nil
+		c.dropCohortPathScratch = nil
+		return DropCohortDerivationHandle{}, err
+	}
+	c.dropCohortDerivationScratch = c.dropCohortDerivationScratch[:0]
+	e := dropCohortEncoder{core: c, dst: c.dropCohortDerivationScratch, limit: c.limits.MaxDropCohortBytes}
+	if err := e.u32(dropCohortDerivationFormatVersion); err != nil {
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, err
+	}
+	if err := e.u8(dropCohortTagRecordBegin); err != nil {
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, err
+	}
+	if err := c.dropCohortEncodeBoundary(&e, head.Node); err != nil {
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, err
+	}
+	if err := c.dropCohortEncodeCheckpoint(&e, checkpoint); err != nil {
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, err
+	}
+	countOffset := len(e.dst)
+	if err := e.u32(0); err != nil {
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, err
+	}
+	var root Symbol
+	var rootSet bool
+	var count, maxDepth uint32
+	path := c.dropCohortPathScratch[:0]
+	path, err = c.dropCohortEncodeAllPaths(&e, head.Node, path, 0, ForkOrder{}, &count, &maxDepth, &root, &rootSet)
+	if err != nil {
+		c.dropCohortPathScratch = nil
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, err
+	}
+	c.dropCohortPathScratch = path[:0]
+	if count == 0 {
+		c.dropCohortPathScratch = nil
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, errors.New("parser-core phase zero: drop-cohort head has no derivation")
+	}
+	if err := e.patchU32(countOffset, count); err != nil {
+		c.dropCohortPathScratch = nil
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, err
+	}
+	if err := e.u8(dropCohortTagRecordEnd); err != nil {
+		c.dropCohortPathScratch = nil
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, err
+	}
+	c.dropCohortDerivationScratch = e.dst
+	encoded := c.dropCohortDerivationScratch
+	if uint64(len(c.dropCohortDerivationBytes)) > uint64(math.MaxUint32)-uint64(len(encoded)) || uint64(len(encoded)) > uint64(math.MaxUint32) {
+		c.dropCohortPathScratch = nil
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, errors.New("parser-core phase zero: drop-cohort derivation offset overflow")
+	}
+	byteOffset := uint32(len(c.dropCohortDerivationBytes))
+	digest := sha256.Sum256(encoded)
+	reused := false
+	for _, entry := range c.dropCohortDerivationIntern {
+		if entry.digest != digest || entry.byteLength != uint32(len(encoded)) {
+			continue
+		}
+		start := int(entry.byteOffset)
+		end := start + int(entry.byteLength)
+		if start >= 0 && end >= start && end <= len(c.dropCohortDerivationBytes) && bytesCompare(c.dropCohortDerivationBytes[start:end], encoded) == 0 {
+			byteOffset = entry.byteOffset
+			reused = true
+			break
+		}
+	}
+	reservation := c.dropCohortCurrentReservation()
+	baseStore, baseErr := dropCohortAddChecked(c.dropCohortStoreBytes(), c.dropCohortReservedBytes)
+	if baseErr != nil {
+		c.dropCohortPathScratch = nil
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, baseErr
+	}
+	additionalStore := uint64(0)
+	if reservation == nil {
+		additionalStore, baseErr = dropCohortAddChecked(uint64(coreDropCohortDerivationRecordBytes), uint64(coreDropCohortMapEntryBytes))
+		if baseErr != nil {
+			c.dropCohortPathScratch = nil
+			c.dropCohortDerivationScratch = nil
+			return DropCohortDerivationHandle{}, baseErr
+		}
+	}
+	if !reused {
+		encodedBytes, addErr := dropCohortAddChecked(uint64(len(encoded)), uint64(coreDropCohortDerivationInternBytes))
+		if addErr != nil {
+			c.dropCohortPathScratch = nil
+			c.dropCohortDerivationScratch = nil
+			return DropCohortDerivationHandle{}, addErr
+		}
+		additionalStore, addErr = dropCohortAddChecked(additionalStore, encodedBytes)
+		if addErr != nil {
+			c.dropCohortPathScratch = nil
+			c.dropCohortDerivationScratch = nil
+			return DropCohortDerivationHandle{}, addErr
+		}
+	}
+	if baseStore > c.limits.MaxDropCohortBytes || additionalStore > c.limits.MaxDropCohortBytes-baseStore {
+		c.dropCohortPathScratch = nil
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, fmt.Errorf("parser-core phase zero: drop-cohort derivation byte cap (existing=%d additional=%d max=%d)", baseStore, additionalStore, c.limits.MaxDropCohortBytes)
+	}
+	var dynamicDemand [7]uint64
+	if reservation == nil {
+		dynamicDemand[1], dynamicDemand[3] = 1, 1
+	}
+	if !reused && (reservation == nil || reservation.reserved[4] == 0) {
+		dynamicDemand[4] = 1
+	}
+	dynamicDerivationBytes := uint64(0)
+	if !reused {
+		dynamicDerivationBytes = uint64(len(encoded))
+	}
+	dynamicReserved, reserveErr := c.dropCohortReserveDemand(dynamicDemand, dynamicDerivationBytes)
+	if reserveErr != nil {
+		c.dropCohortPathScratch = nil
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, reserveErr
+	}
+	if !reused {
+		baseWithoutDerivation, baseErr := c.dropCohortRetainedOtherBytes()
+		if baseErr != nil {
+			c.dropCohortReleaseDemand(dynamicDemand, dynamicReserved)
+			c.dropCohortPathScratch = nil
+			c.dropCohortDerivationScratch = nil
+			return DropCohortDerivationHandle{}, baseErr
+		}
+		retainedStores := c.dropCohortRetainedStoreBytes()
+		for store, value := range retainedStores {
+			if store != 1 {
+				baseWithoutDerivation, baseErr = dropCohortAddChecked(baseWithoutDerivation, value)
+				if baseErr != nil {
+					c.dropCohortReleaseDemand(dynamicDemand, dynamicReserved)
+					c.dropCohortPathScratch = nil
+					c.dropCohortDerivationScratch = nil
+					return DropCohortDerivationHandle{}, baseErr
+				}
+			}
+		}
+		recordCapacity, recordErr := dropCohortMulChecked(uint64(cap(c.dropCohortDerivations)), coreDropCohortDerivationRecordBytes)
+		if recordErr != nil {
+			c.dropCohortReleaseDemand(dynamicDemand, dynamicReserved)
+			c.dropCohortPathScratch = nil
+			c.dropCohortDerivationScratch = nil
+			return DropCohortDerivationHandle{}, recordErr
+		}
+		baseWithoutDerivation, recordErr = dropCohortAddChecked(baseWithoutDerivation, recordCapacity)
+		if recordErr != nil {
+			c.dropCohortReleaseDemand(dynamicDemand, dynamicReserved)
+			c.dropCohortPathScratch = nil
+			c.dropCohortDerivationScratch = nil
+			return DropCohortDerivationHandle{}, recordErr
+		}
+		baseWithoutDerivation, recordErr = dropCohortAddChecked(baseWithoutDerivation, coreDropCohortDerivationRecordBytes)
+		if recordErr != nil {
+			c.dropCohortReleaseDemand(dynamicDemand, dynamicReserved)
+			c.dropCohortPathScratch = nil
+			c.dropCohortDerivationScratch = nil
+			return DropCohortDerivationHandle{}, recordErr
+		}
+		if c.dropCohortReservedBytes >= dynamicDerivationBytes {
+			baseWithoutDerivation, recordErr = dropCohortAddChecked(baseWithoutDerivation, c.dropCohortReservedBytes-dynamicDerivationBytes)
+			if recordErr != nil {
+				c.dropCohortReleaseDemand(dynamicDemand, dynamicReserved)
+				c.dropCohortPathScratch = nil
+				c.dropCohortDerivationScratch = nil
+				return DropCohortDerivationHandle{}, recordErr
+			}
+		}
+		if baseWithoutDerivation >= c.limits.MaxDropCohortBytes {
+			c.dropCohortReleaseDemand(dynamicDemand, dynamicReserved)
+			c.dropCohortPathScratch = nil
+			c.dropCohortDerivationScratch = nil
+			return DropCohortDerivationHandle{}, errors.New("parser-core phase zero: drop-cohort derivation byte cap")
+		}
+		permanentLimit := c.limits.MaxDropCohortBytes - baseWithoutDerivation
+		if err := appendDropCohortPermanent(&c.dropCohortDerivationBytes, encoded, permanentLimit); err != nil {
+			c.dropCohortReleaseDemand(dynamicDemand, dynamicReserved)
+			c.dropCohortPathScratch = nil
+			c.dropCohortDerivationScratch = nil
+			return DropCohortDerivationHandle{}, err
+		}
+		if err := appendDropCohortDerivationIntern(c, dropCohortDerivationInternEntry{digest: digest, byteOffset: byteOffset, byteLength: uint32(len(encoded))}); err != nil {
+			c.dropCohortReleaseDemand(dynamicDemand, dynamicReserved)
+			c.dropCohortPathScratch = nil
+			c.dropCohortDerivationScratch = nil
+			return DropCohortDerivationHandle{}, err
+		}
+	}
+	index := uint32(len(c.dropCohortDerivations))
+	handle := DropCohortDerivationHandle{Owner: c.dropCohortOwner, Epoch: c.dropCohortEpoch, Index: index + 1}
+	derivationRecord := dropCohortDerivationRecord{
+		handle: handle, head: head, digest: digest, byteOffset: byteOffset,
+		byteLength: uint32(len(encoded)), rootSymbol: root, stackDepth: maxDepth, checkpoint: checkpoint,
+	}
+	if err := appendDropCohortDerivationRecord(c, derivationRecord); err != nil {
+		c.dropCohortReleaseDemand(dynamicDemand, dynamicReserved)
+		c.dropCohortPathScratch = nil
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, err
+	}
+	if err := appendDropCohortMapEntry(c, dropCohortMapEntry{
+		hash: binary.LittleEndian.Uint64(digest[:8]), index: index, used: true,
+	}); err != nil {
+		c.dropCohortReleaseDemand(dynamicDemand, dynamicReserved)
+		c.dropCohortPathScratch = nil
+		c.dropCohortDerivationScratch = nil
+		return DropCohortDerivationHandle{}, err
+	}
+	if dynamicReserved != 0 {
+		c.dropCohortReleaseDemand(dynamicDemand, dynamicReserved)
+	}
+	if reservation != nil {
+		var consumed [7]uint64
+		consumed[1], consumed[3] = 1, 1
+		if !reused {
+			consumed[4] = 1
+		}
+		fixedBytes, _ := dropCohortDemandBytes(consumed, 0)
+		c.dropCohortConsumeReservation(reservation.handle, consumed, fixedBytes)
+	}
+	c.dropCohortDerivationScratch = c.dropCohortDerivationScratch[:0]
+	return handle, nil
+}
+
+func appendDropCohortPermanent(dst *[]byte, value []byte, limit uint64) error {
+	if dst == nil {
+		return errors.New("parser-core phase zero: nil drop-cohort derivation store")
+	}
+	if uint64(len(*dst)) > limit || uint64(len(value)) > limit-uint64(len(*dst)) {
+		return errors.New("parser-core phase zero: drop-cohort derivation byte cap")
+	}
+	needed := len(*dst) + len(value)
+	if needed > cap(*dst) {
+		maxInt := int(^uint(0) >> 1)
+		newCap := cap(*dst)
+		if newCap < 64 {
+			newCap = 64
+		}
+		for newCap < needed {
+			if newCap > maxInt/2 {
+				newCap = needed
+				break
+			}
+			newCap *= 2
+		}
+		if uint64(newCap) > limit {
+			newCap = int(limit)
+		}
+		if newCap < needed {
+			return errors.New("parser-core phase zero: drop-cohort derivation byte cap")
+		}
+		grown := make([]byte, len(*dst), newCap)
+		copy(grown, *dst)
+		*dst = grown
+	}
+	start := len(*dst)
+	*dst = (*dst)[:needed]
+	copy((*dst)[start:], value)
+	return nil
+}
+
+func appendDropCohortDerivationRecord(c *Core, value dropCohortDerivationRecord) error {
+	if c == nil || len(c.dropCohortDerivations) == int(^uint(0)>>1) {
+		return errors.New("parser-core phase zero: drop-cohort derivation record overflow")
+	}
+	if len(c.dropCohortDerivations) == cap(c.dropCohortDerivations) {
+		newCap, err := c.dropCohortGrowPermanentStore(uint64(cap(c.dropCohortDerivations)), uint64(len(c.dropCohortDerivations)+1), coreDropCohortDerivationRecordBytes)
+		if err != nil {
+			return err
+		}
+		grown := make([]dropCohortDerivationRecord, len(c.dropCohortDerivations), newCap)
+		copy(grown, c.dropCohortDerivations)
+		c.dropCohortDerivations = grown
+	}
+	c.dropCohortDerivations = append(c.dropCohortDerivations, value)
+	return nil
+}
+
+func appendDropCohortDerivationIntern(c *Core, value dropCohortDerivationInternEntry) error {
+	if c == nil || len(c.dropCohortDerivationIntern) == int(^uint(0)>>1) {
+		return errors.New("parser-core phase zero: drop-cohort interner entry overflow")
+	}
+	if len(c.dropCohortDerivationIntern) == cap(c.dropCohortDerivationIntern) {
+		newCap, err := c.dropCohortGrowPermanentStore(uint64(cap(c.dropCohortDerivationIntern)), uint64(len(c.dropCohortDerivationIntern)+1), coreDropCohortDerivationInternBytes)
+		if err != nil {
+			return err
+		}
+		grown := make([]dropCohortDerivationInternEntry, len(c.dropCohortDerivationIntern), newCap)
+		copy(grown, c.dropCohortDerivationIntern)
+		c.dropCohortDerivationIntern = grown
+	}
+	c.dropCohortDerivationIntern = append(c.dropCohortDerivationIntern, value)
+	return nil
+}
+
+func appendDropCohortMapEntry(c *Core, value dropCohortMapEntry) error {
+	if c == nil || len(c.dropCohortMapStore) == int(^uint(0)>>1) {
+		return errors.New("parser-core phase zero: drop-cohort map entry overflow")
+	}
+	if len(c.dropCohortMapStore) == cap(c.dropCohortMapStore) {
+		newCap, err := c.dropCohortGrowPermanentStore(uint64(cap(c.dropCohortMapStore)), uint64(len(c.dropCohortMapStore)+1), coreDropCohortMapEntryBytes)
+		if err != nil {
+			return err
+		}
+		grown := make([]dropCohortMapEntry, len(c.dropCohortMapStore), newCap)
+		copy(grown, c.dropCohortMapStore)
+		c.dropCohortMapStore = grown
+	}
+	c.dropCohortMapStore = append(c.dropCohortMapStore, value)
+	return nil
+}
+
+func (c *Core) dropCohortGrowPermanentStore(current, needed, elementBytes uint64) (int, error) {
+	if needed > uint64(int(^uint(0)>>1)) || elementBytes == 0 {
+		return 0, errors.New("parser-core phase zero: drop-cohort store capacity overflow")
+	}
+	newCap := current
+	if newCap == 0 {
+		newCap = 1
+	}
+	for newCap < needed {
+		if newCap > math.MaxUint64/2 {
+			newCap = needed
+			break
+		}
+		newCap *= 2
+	}
+	base, err := dropCohortAddChecked(c.dropCohortStoreBytes(), c.dropCohortReservedBytes)
+	if err != nil {
+		return 0, err
+	}
+	if base > c.limits.MaxDropCohortBytes {
+		return 0, errors.New("parser-core phase zero: drop-cohort store byte cap")
+	}
+	available := c.limits.MaxDropCohortBytes - base
+	boundedGrowth, err := dropCohortAddChecked(current, available/elementBytes)
+	if err != nil {
+		return 0, err
+	}
+	if boundedGrowth < newCap {
+		newCap = boundedGrowth
+	}
+	if newCap < needed || newCap > uint64(^uint(0)>>1) {
+		return 0, errors.New("parser-core phase zero: drop-cohort store byte cap")
+	}
+	return int(newCap), nil
+}
+
+func bytesCompare(left, right []byte) int {
+	for index := 0; index < len(left) && index < len(right); index++ {
+		if left[index] < right[index] {
+			return -1
+		}
+		if left[index] > right[index] {
+			return 1
+		}
+	}
+	if len(left) < len(right) {
+		return -1
+	}
+	if len(left) > len(right) {
+		return 1
+	}
+	return 0
+}
+
+// BuildDropCohortDerivationOwned records the complete graph derivation for a
+// real parser head. It includes the supplied byte, point, and scanner checks.
+func (c *Core) BuildDropCohortDerivationOwned(owner SchedulerTransactionToken, head Head, checkpoint DropCohortSourceCheckpoint) (handle DropCohortDerivationHandle, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return DropCohortDerivationHandle{}, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	handle, err = c.buildDropCohortDerivationOwned(head, checkpoint)
+	err = c.finishSchedulerOwned(owner, err)
+	return handle, err
+}
+
+// TryBuildDropCohortDerivationOwned keeps a bounded certificate producer
+// failure non-poisoning so the scheduler can commit its ordinary fallback.
+// Authentication failures and malformed graph errors still poison the frame.
+func (c *Core) TryBuildDropCohortDerivationOwned(owner SchedulerTransactionToken, head Head, checkpoint DropCohortSourceCheckpoint) (handle DropCohortDerivationHandle, skipped bool, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return DropCohortDerivationHandle{}, false, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	handle, err = c.buildDropCohortDerivationOwned(head, checkpoint)
+	if err != nil && strings.Contains(err.Error(), "drop-cohort derivation byte cap") {
+		c.dropCohortDerivationScratch = c.dropCohortDerivationScratch[:0]
+		c.dropCohortPathScratch = c.dropCohortPathScratch[:0]
+		c.dropCohortEphemeralBytes = 0
+		return DropCohortDerivationHandle{}, true, nil
+	}
+	err = c.finishSchedulerOwned(owner, err)
+	return handle, false, err
+}
+
+func (c *Core) recordDropCohortMutation(index int) {
+	if len(c.transactions) == 0 || index < 0 || index >= len(c.dropCohortRecords) {
+		return
+	}
+	c.dropCohortJournal = append(c.dropCohortJournal, dropCohortMutation{index: index, before: c.dropCohortRecords[index]})
+	for reservationIndex := range c.dropCohortReservations {
+		reservation := &c.dropCohortReservations[reservationIndex]
+		if reservation.handle != c.dropCohortRecords[index].handle || reservation.journalUsed >= reservation.journalCount {
+			continue
+		}
+		slot := reservation.journalStart + reservation.journalUsed
+		if slot < 0 || slot >= len(c.dropCohortJournalStore) {
+			continue
+		}
+		c.dropCohortJournalStore[slot] = dropCohortJournalStoreEntry{
+			store: 1, index: uint32(index), value: uint64(c.dropCohortRecords[index].state),
+		}
+		reservation.journalUsed++
+		return
+	}
+}
+
+func (c *Core) findDropCohortMember(record dropCohortRecord, branch uint16) (int, bool) {
+	for index := range c.dropCohortMembers {
+		member := c.dropCohortMembers[index]
+		if member.cohort == record.handle && member.branch == branch {
+			return index, true
+		}
+	}
+	return -1, false
+}
+
+func (c *Core) writeDropCohortMemberOwned(cohort DropCohortHandle, head Head, branch uint16, derivation DropCohortDerivationHandle) error {
+	index, err := c.validateDropCohortIdentity(cohort)
+	if err != nil {
+		return err
+	}
+	record := &c.dropCohortRecords[index]
+	if record.state != DropCohortBuilding {
+		return errors.New("parser-core phase zero: drop-cohort is not building")
+	}
+	if uint64(branch) >= uint64(record.expected) {
+		c.recordDropCohortMutation(index)
+		record.state = DropCohortOverflowed
+		return errors.New("parser-core phase zero: drop-cohort branch exceeds expected members")
+	}
+	if derivation.Owner != c.dropCohortOwner || derivation.Epoch != c.dropCohortEpoch {
+		return errors.New("parser-core phase zero: drop-cohort derivation identity mismatch")
+	}
+	if derivation.Index == 0 || uint64(derivation.Index) > uint64(len(c.dropCohortDerivations)) ||
+		c.dropCohortDerivations[derivation.Index-1].head != head {
+		return errors.New("parser-core phase zero: drop-cohort derivation handle is invalid")
+	}
+	if prior, ok := c.findDropCohortMember(*record, branch); ok {
+		if c.dropCohortMembers[prior].head != head || c.dropCohortMembers[prior].derivation != derivation {
+			c.recordDropCohortMutation(index)
+			record.state = DropCohortBlended
+			return errors.New("parser-core phase zero: drop-cohort branch conflict")
+		}
+		return errors.New("parser-core phase zero: duplicate drop-cohort member")
+	}
+	c.dropCohortMembers = append(c.dropCohortMembers, dropCohortMember{
+		cohort: cohort, head: head, branch: branch, derivation: derivation,
+		action: c.dropCohortActions[record.actionIndex],
+	})
+	c.recordDropCohortMutation(index)
+	record.written++
+	var consumed [7]uint64
+	consumed[2] = 1
+	fixedBytes, _ := dropCohortDemandBytes(consumed, 0)
+	c.dropCohortConsumeReservation(cohort, consumed, fixedBytes)
+	return nil
+}
+
+// WriteDropCohortMemberOwned appends one branch after the complete derivation
+// record has been built. Duplicate and conflicting branches fail closed.
+func (c *Core) WriteDropCohortMemberOwned(owner SchedulerTransactionToken, cohort DropCohortHandle, head Head, branch uint16, derivation DropCohortDerivationHandle) error {
+	if err := c.beginSchedulerOwned(owner); err != nil {
+		return err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	return c.finishSchedulerOwned(owner, c.writeDropCohortMemberOwned(cohort, head, branch, derivation))
+}
+
+func (c *Core) finalizeDropCohortOwned(cohort DropCohortHandle) (DropCohortRefSet, error) {
+	index, err := c.validateDropCohortIdentity(cohort)
+	if err != nil {
+		return DropCohortRefSet{}, err
+	}
+	record := &c.dropCohortRecords[index]
+	if record.state != DropCohortBuilding {
+		return DropCohortRefSet{}, errors.New("parser-core phase zero: drop-cohort is not building")
+	}
+	if record.expected == 0 || record.written != record.expected {
+		return DropCohortRefSet{}, errors.New("parser-core phase zero: drop-cohort finalization is partial")
+	}
+	if record.expected > dropCohortRefInlineCapacity {
+		if err := c.dropCohortRefPreflight(int(record.expected) - dropCohortRefInlineCapacity); err != nil {
+			return DropCohortRefSet{}, err
+		}
+	}
+	var refs DropCohortRefSet
+	for _, member := range c.dropCohortMembers {
+		if member.cohort != record.handle {
+			continue
+		}
+		if !c.AddDropCohortRef(&refs, DropCohortRef{
+			Owner: cohort.Owner, Epoch: cohort.Epoch, Sequence: cohort.Sequence, Branch: member.branch,
+		}) {
+			return DropCohortRefSet{}, errors.New("parser-core phase zero: drop-cohort reference overflow")
+		}
+	}
+	if refs.Len() != int(record.expected) {
+		return DropCohortRefSet{}, errors.New("parser-core phase zero: drop-cohort member set is incomplete")
+	}
+	for reservationIndex := range c.dropCohortReservations {
+		reservation := &c.dropCohortReservations[reservationIndex]
+		if reservation.handle != cohort {
+			continue
+		}
+		neededRefs := reservation.certificateRefs + refs.Len()
+		if neededRefs > len(c.dropCohortCertificateRefs) {
+			additional := uint64(neededRefs-len(c.dropCohortCertificateRefs)) * uint64(coreDropCohortRefBytes)
+			existing := c.dropCohortStoreBytes()
+			if existing > c.limits.MaxDropCohortBytes || additional > c.limits.MaxDropCohortBytes-existing {
+				return DropCohortRefSet{}, errors.New("parser-core phase zero: drop-cohort certificate reference byte cap")
+			}
+			c.dropCohortCertificateRefs = append(c.dropCohortCertificateRefs, make([]DropCohortRef, neededRefs-len(c.dropCohortCertificateRefs))...)
+		}
+		for branch := 0; branch < refs.Len(); branch++ {
+			ref, ok := c.DropCohortRefAt(refs, branch)
+			if !ok || reservation.certificateRefs+branch >= len(c.dropCohortCertificateRefs) {
+				return DropCohortRefSet{}, errors.New("parser-core phase zero: drop-cohort certificate reference store is incomplete")
+			}
+			c.dropCohortCertificateRefs[reservation.certificateRefs+branch] = ref
+		}
+		var consumed [7]uint64
+		consumed[2] = uint64(refs.Len())
+		fixedBytes, _ := dropCohortDemandBytes(consumed, 0)
+		c.dropCohortConsumeReservation(cohort, consumed, fixedBytes)
+		break
+	}
+	c.recordDropCohortMutation(index)
+	record.state = DropCohortComplete
+	c.dropCohortReleaseReservationRemainder(cohort)
+	return refs, nil
+}
+
+// FinalizeDropCohortOwned exposes a cohort only after every branch write.
+func (c *Core) FinalizeDropCohortOwned(owner SchedulerTransactionToken, cohort DropCohortHandle) (refs DropCohortRefSet, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return DropCohortRefSet{}, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	refs, err = c.finalizeDropCohortOwned(cohort)
+	err = c.finishSchedulerOwned(owner, err)
+	return refs, err
+}
+
+// DropCohortRefForBranch returns one finalized reference for a scheduler
+// output header. It performs no arena mutation.
+func (c *Core) DropCohortRefForBranch(cohort DropCohortHandle, branch uint16) (DropCohortRef, error) {
+	index, err := c.validateDropCohortIdentity(cohort)
+	if err != nil {
+		return DropCohortRef{}, err
+	}
+	record := c.dropCohortRecords[index]
+	if record.state != DropCohortComplete {
+		return DropCohortRef{}, errors.New("parser-core phase zero: drop-cohort is not complete")
+	}
+	if _, ok := c.findDropCohortMember(record, branch); !ok {
+		return DropCohortRef{}, fmt.Errorf("parser-core phase zero: drop-cohort branch %d is absent", branch)
+	}
+	return DropCohortRef{Owner: cohort.Owner, Epoch: cohort.Epoch, Sequence: cohort.Sequence, Branch: branch}, nil
+}
+
+// DropCohortState returns one cohort's producer state and counts.
+func (c *Core) DropCohortState(handle DropCohortHandle) (DropCohortState, uint16, uint16, error) {
+	index, err := c.validateDropCohortIdentity(handle)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	record := c.dropCohortRecords[index]
+	return record.state, record.expected, record.written, nil
+}
+
+// DropCohortAction returns the exact dispatch identity retained by a cohort.
+func (c *Core) DropCohortAction(handle DropCohortHandle) (DropCohortActionIdentity, bool) {
+	index, err := c.validateDropCohortIdentity(handle)
+	if err != nil {
+		return DropCohortActionIdentity{}, false
+	}
+	actionIndex := c.dropCohortRecords[index].actionIndex
+	if uint64(actionIndex) >= uint64(len(c.dropCohortActions)) {
+		return DropCohortActionIdentity{}, false
+	}
+	return c.dropCohortActions[actionIndex], true
+}
+
+// DropCohortDerivationRecord returns the immutable record metadata and its
+// canonical bytes. The byte slice aliases the Core and is read-only.
+func (c *Core) DropCohortDerivationRecord(handle DropCohortDerivationHandle) (DropCohortDerivationRecord, bool) {
+	if c == nil || handle.Owner != c.dropCohortOwner || handle.Epoch != c.dropCohortEpoch || handle.Index == 0 || uint64(handle.Index) > uint64(len(c.dropCohortDerivations)) {
+		return DropCohortDerivationRecord{}, false
+	}
+	record := c.dropCohortDerivations[handle.Index-1]
+	start := int(record.byteOffset)
+	end := start + int(record.byteLength)
+	if start < 0 || end < start || end > len(c.dropCohortDerivationBytes) {
+		return DropCohortDerivationRecord{}, false
+	}
+	return DropCohortDerivationRecord{
+		Handle: record.handle, Head: record.head, Digest: record.digest,
+		RootSymbol: record.rootSymbol, StackDepth: record.stackDepth,
+		Checkpoint: record.checkpoint, Bytes: c.dropCohortDerivationBytes[start:end],
+	}, true
+}
+
+// DropCohortDerivationRecord is a read-only view of one graph derivation.
+type DropCohortDerivationRecord struct {
+	Handle     DropCohortDerivationHandle
+	Head       Head
+	Digest     [32]byte
+	RootSymbol Symbol
+	StackDepth uint32
+	Checkpoint DropCohortSourceCheckpoint
+	Bytes      []byte
+}

--- a/internal/parsercorephase0/drop_cohort_arena_test.go
+++ b/internal/parsercorephase0/drop_cohort_arena_test.go
@@ -1,0 +1,905 @@
+package parsercorephase0
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"testing"
+)
+
+func g18ProducerHead(t *testing.T, compact *Core, seed Head, symbol Symbol, endByte uint32) Head {
+	t.Helper()
+	payload, err := compact.appendSubtree(subtreeRecord{
+		symbol: symbol, startByte: endByte - 1, endByte: endByte, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.condense(compact.boundaryKey(2, endByte), linkInput{
+		prev: seed.Node, payload: payload,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return head
+}
+
+func g18ProducerIdentity() DropCohortActionIdentity {
+	return DropCohortActionIdentity{
+		BoundaryState: 2,
+		Lookahead:     7,
+		ActionOrdinal: 3,
+		Action: Action{
+			Type: ActionReduce, State: 19, Symbol: 7, ChildCount: 2,
+			DynamicPrecedence: -2, ProductionID: 41, Extra: true,
+			ExtraChain: true, Repetition: true,
+		},
+		NoLookahead: true,
+		Selection:   DropCohortSelectionConflictPolicy,
+	}
+}
+
+func g18ProducerCheckpoint() DropCohortSourceCheckpoint {
+	return DropCohortSourceCheckpoint{
+		StartByte: 11, EndByte: 17,
+		StartRow: 3, StartColumn: 5, EndRow: 4, EndColumn: 2,
+		ScannerStart: 9, ScannerEnd: 10,
+	}
+}
+
+func TestG18DropCohortActionIdentityAcceptsSignedPrecedenceAndChecksWidths(t *testing.T) {
+	values := [14]int64{2, 7, 3, int64(ActionReduce), 19, 7, 41, 2, -2, 1, 1, 1, 1, int64(DropCohortSelectionConflictPolicy)}
+	identity, err := dropCohortProtocolAction(values)
+	if err != nil || identity.Action.DynamicPrecedence != -2 || !identity.NoLookahead {
+		t.Fatalf("signed action identity rejected: identity=%+v err=%v", identity, err)
+	}
+	values[5] = math.MaxUint16 + 1
+	if _, err := dropCohortProtocolAction(values); err == nil {
+		t.Fatal("out-of-width symbol accepted")
+	}
+}
+
+func TestG18DropCohortNestedBeginOvercommitRollsBackReservation(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDropCohortMembers: 4, MaxDropCohortBytes: 1 << 20})
+	before := compact.StorageBytes()
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if _, err := compact.BeginDropCohortOwned(owner, g18ProducerIdentity(), 2); err != nil {
+			return err
+		}
+		compact.limits.MaxDropCohortBytes = compact.dropCohortStoreBytes() + 1
+		_, err := compact.BeginDropCohortOwned(owner, g18ProducerIdentity(), 2)
+		return err
+	})
+	if err == nil || len(compact.dropCohortRecords) != 0 || len(compact.dropCohortReservations) != 0 || compact.dropCohortReservedBytes != 0 || compact.StorageBytes() != before {
+		t.Fatalf("nested overcommit err=%v records=%d reservations=%d reserved=%d storage=%d/%d", err, len(compact.dropCohortRecords), len(compact.dropCohortReservations), compact.dropCohortReservedBytes, compact.StorageBytes(), before)
+	}
+}
+
+func TestG18DropCohortResidualReservationParticipatesInNestedPreflight(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDropCohortMembers: 4, MaxDropCohortBytes: 1 << 20})
+	reserved, err := compact.dropCohortReserveDemandWithExtra([7]uint64{}, 0, 128)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reserved != 128 || compact.dropCohortReservedBytes != 128 {
+		t.Fatalf("reservation bytes=%d durable=%d, want 128", reserved, compact.dropCohortReservedBytes)
+	}
+	compact.limits.MaxDropCohortBytes = 127
+	if err := compact.dropCohortPreflightDemand([7]uint64{}, 0, 0); err == nil {
+		t.Fatal("nested preflight ignored residual durable reservation bytes")
+	}
+	compact.dropCohortReleaseDemand([7]uint64{}, reserved)
+	if compact.dropCohortReservedBytes != 0 {
+		t.Fatalf("reservation rollback left %d bytes", compact.dropCohortReservedBytes)
+	}
+}
+
+func TestG18DropCohortRetainedOtherUsesCapacity(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDropCohortBytes: 1 << 20})
+	compact.dropCohortJournal = make([]dropCohortMutation, 0, 3)
+	compact.dropCohortReservations = make([]dropCohortReservation, 0, 2)
+	got, err := compact.dropCohortRetainedOtherBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := dropCohortAddChecked(3*coreDropCohortMutationBytes, 2*coreDropCohortReservationBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("retained other bytes=%d, want %d", got, want)
+	}
+}
+
+func TestG18DropCohortCheckedCapacityArithmeticRejectsOverflow(t *testing.T) {
+	if _, err := dropCohortAddChecked(math.MaxUint64, 1); err == nil {
+		t.Fatal("checked addition accepted overflow")
+	}
+	if _, err := dropCohortMulChecked(math.MaxUint64, 2); err == nil {
+		t.Fatal("checked multiplication accepted overflow")
+	}
+	compact := newTinyCoreWithLimits(t, Limits{MaxDropCohortBytes: math.MaxUint64})
+	compact.dropCohortActions = make([]dropCohortActionIdentity, 1)
+	compact.dropCohortReservedBytes = math.MaxUint64
+	if _, err := compact.dropCohortGrowPermanentStore(1, 1, 1); err == nil {
+		t.Fatal("permanent store growth accepted base-byte overflow")
+	}
+	compact = newTinyCoreWithLimits(t, Limits{MaxDropCohortBytes: math.MaxUint64})
+	if _, err := compact.dropCohortGrowPermanentStore(math.MaxUint64, 1, 1); err == nil {
+		t.Fatal("permanent store growth accepted bounded-capacity addition overflow")
+	}
+}
+
+func TestG18DropCohortHugeDerivationBytesRejectsBeforeAllocation(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDropCohortMembers: 2, MaxDropCohortBytes: 1 << 20})
+	caps := [7]uint64{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}
+	before := compact.dropCohortStoreBytes()
+	if _, err := compact.DiagnosticDropCohortBeginForTest(2, math.MaxUint32, caps); err == nil {
+		t.Fatal("huge derivation byte demand was accepted")
+	}
+	if compact.dropCohortStoreBytes() != before || len(compact.dropCohortReservations) != 0 || compact.dropCohortReservedBytes != 0 {
+		t.Fatalf("huge derivation demand changed state: storage=%d/%d reservations=%d reserved=%d", compact.dropCohortStoreBytes(), before, len(compact.dropCohortReservations), compact.dropCohortReservedBytes)
+	}
+}
+
+func TestG18DropCohortJournalSlotsDoNotGrowAfterBegin(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDropCohortMembers: 2, MaxDropCohortBytes: 1 << 20})
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head := g18ProducerHead(t, compact, seed, 21, 1)
+	var cohort DropCohortHandle
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		cohort, err = compact.BeginDropCohortOwned(owner, g18ProducerIdentity(), 1)
+		if err != nil {
+			return err
+		}
+		journalCap := cap(compact.dropCohortJournalStore)
+		derivation, buildErr := compact.BuildDropCohortDerivationOwned(owner, head, g18ProducerCheckpoint())
+		if buildErr != nil {
+			return buildErr
+		}
+		if writeErr := compact.WriteDropCohortMemberOwned(owner, cohort, head, 0, derivation); writeErr != nil {
+			return writeErr
+		}
+		if _, finalErr := compact.FinalizeDropCohortOwned(owner, cohort); finalErr != nil {
+			return finalErr
+		}
+		if cap(compact.dropCohortJournalStore) != journalCap {
+			return fmt.Errorf("journal capacity grew from %d to %d", journalCap, cap(compact.dropCohortJournalStore))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestG18DropCohortConflictPreservesPriorMemberBytes(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDropCohortMembers: 2, MaxDropCohortBytes: 1 << 20})
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head := g18ProducerHead(t, compact, seed, 22, 1)
+	caps := [7]uint64{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}
+	values := [14]int64{3, 9, 3, int64(ActionReduce), 0, 2, 5, 1, -2, 0, 0, 0, 0, 1}
+	digest := sha256.Sum256([]byte("prior"))
+	record := []byte("prior")
+	cohort, err := compact.DiagnosticDropCohortBeginForTest(2, uint32(len(record)), caps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.DiagnosticDropCohortWriteForTest(cohort, head, 0, values, digest, record); err != nil {
+		t.Fatal(err)
+	}
+	before := append([]byte(nil), compact.dropCohortDerivationBytes...)
+	values[2]++
+	conflictErr := compact.DiagnosticDropCohortWriteForTest(cohort, head, 0, values, digest, []byte("other"))
+	if conflictErr == nil {
+		t.Fatal("conflicting branch was accepted")
+	}
+	if !bytes.Equal(before, compact.dropCohortDerivationBytes) {
+		t.Fatal("conflict changed prior derivation bytes")
+	}
+	index, _ := compact.validateDropCohortIdentity(DropCohortHandle{Owner: cohort[0], Epoch: cohort[1], Sequence: cohort[2]})
+	if compact.dropCohortRecords[index].state != DropCohortBlended {
+		t.Fatalf("conflict state=%v, want blended", compact.dropCohortRecords[index].state)
+	}
+}
+
+func TestG18DropCohortPhysicalFootprintSeparatesLogicalSnapshot(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDropCohortMembers: 2, MaxDropCohortBytes: 1 << 20})
+	caps := [7]uint64{math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64, math.MaxUint64}
+	if _, err := compact.DiagnosticDropCohortBeginForTest(1, 8, caps); err != nil {
+		t.Fatal(err)
+	}
+	var logical uint64
+	for _, value := range dropCohortStoreVector(compact, false) {
+		logical += value
+	}
+	if compact.StorageBytes() <= logical || compact.FootprintBytes() < compact.StorageBytes() {
+		t.Fatalf("physical accounting storage=%d logical=%d footprint=%d", compact.StorageBytes(), logical, compact.FootprintBytes())
+	}
+}
+
+func TestG18DropCohortProducerLifecycleAndStableOrdering(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxDropCohortMembers: 4})
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	heads := []Head{
+		g18ProducerHead(t, compact, seed, 21, 1),
+		g18ProducerHead(t, compact, seed, 22, 2),
+		g18ProducerHead(t, compact, seed, 23, 3),
+	}
+	checkpoint := g18ProducerCheckpoint()
+	var cohort DropCohortHandle
+	var refs DropCohortRefSet
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		cohort, err = compact.BeginDropCohortOwned(owner, g18ProducerIdentity(), len(heads))
+		if err != nil {
+			return err
+		}
+		for _, branch := range []int{2, 0, 1} {
+			derivation, buildErr := compact.BuildDropCohortDerivationOwned(owner, heads[branch], checkpoint)
+			if buildErr != nil {
+				return buildErr
+			}
+			if writeErr := compact.WriteDropCohortMemberOwned(owner, cohort, heads[branch], uint16(branch), derivation); writeErr != nil {
+				return writeErr
+			}
+		}
+		refs, err = compact.FinalizeDropCohortOwned(owner, cohort)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, expected, written, err := compact.DropCohortState(cohort)
+	if err != nil || state != DropCohortComplete || expected != 3 || written != 3 {
+		t.Fatalf("cohort state=%v expected=%d written=%d err=%v", state, expected, written, err)
+	}
+	if got := refs.Len(); got != 3 {
+		t.Fatalf("final refs=%d, want 3", got)
+	}
+	for index := 0; index < refs.Len(); index++ {
+		ref, ok := compact.DropCohortRefAt(refs, index)
+		if !ok || ref.Branch != uint16(index) {
+			t.Fatalf("ordered ref %d=%+v ok=%t, want branch %d", index, ref, ok, index)
+		}
+	}
+	if compact.dropCohortActions[0] != g18ProducerIdentity() {
+		t.Fatalf("stored action identity=%+v, want %+v", compact.dropCohortActions[0], g18ProducerIdentity())
+	}
+	counters := compact.DropCohortProducerCounts()
+	if counters.ReductionEstablishment != 0 || counters.LinearCanonicalizer != 0 || counters.MappedCanonicalizer != 0 ||
+		counters.SiblingAdoption != 0 || counters.ConflictReconciliation != 0 || counters.DeadHistoryImport != 0 {
+		t.Fatalf("producer counters=%+v, want no reduction establishment for direct arena lifecycle", counters)
+	}
+}
+
+func TestG18DropCohortDerivationIncludesCheckpointAndStableBytes(t *testing.T) {
+	build := func(t *testing.T) (DropCohortDerivationRecord, DropCohortDerivationRecord) {
+		t.Helper()
+		compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8})
+		seed, err := compact.Seed(1, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		head := g18ProducerHead(t, compact, seed, 31, 4)
+		checkpoint := g18ProducerCheckpoint()
+		var first, second DropCohortDerivationHandle
+		err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+			first, err = compact.BuildDropCohortDerivationOwned(owner, head, checkpoint)
+			if err != nil {
+				return err
+			}
+			second, err = compact.BuildDropCohortDerivationOwned(owner, head, checkpoint)
+			return err
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		firstRecord, ok := compact.DropCohortDerivationRecord(first)
+		if !ok {
+			t.Fatal("first derivation record is unavailable")
+		}
+		secondRecord, ok := compact.DropCohortDerivationRecord(second)
+		if !ok {
+			t.Fatal("second derivation record is unavailable")
+		}
+		return firstRecord, secondRecord
+	}
+	firstA, firstB := build(t)
+	secondA, secondB := build(t)
+	if firstA.Checkpoint != g18ProducerCheckpoint() || secondA.Checkpoint != g18ProducerCheckpoint() {
+		t.Fatalf("checkpoint metadata first=%+v second=%+v", firstA.Checkpoint, secondA.Checkpoint)
+	}
+	if firstA.StackDepth != 1 || secondA.StackDepth != 1 || firstA.RootSymbol != 31 || secondA.RootSymbol != 31 {
+		t.Fatalf("derivation shape first=%+v second=%+v", firstA, secondA)
+	}
+	if !bytes.Equal(firstA.Bytes, secondA.Bytes) || firstA.Digest != secondA.Digest || !bytes.Equal(firstB.Bytes, secondB.Bytes) {
+		t.Fatalf("same graph/checkpoint produced different canonical bytes or digest")
+	}
+	if len(firstA.Bytes) == 0 {
+		t.Fatal("derivation record has no canonical bytes")
+	}
+}
+
+func g18SemanticDerivation(t *testing.T, padded bool, childSymbol Symbol) DropCohortDerivationRecord {
+	t.Helper()
+	compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxDropCohortBytes: 1 << 16})
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if padded {
+		_ = g18ProducerHead(t, compact, seed, 90, 1)
+	}
+	child, err := compact.appendSubtree(subtreeRecord{
+		symbol: childSymbol, startByte: 1, endByte: 2, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent, err := compact.appendSubtree(subtreeRecord{
+		symbol: 91, productionID: 7, dynamicPrecedence: -1,
+		startByte: 1, endByte: 2,
+	}, []SubtreeID{child}, []FieldMapEntry{{FieldID: 3, ChildIndex: 0}}, []Symbol{92})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.condense(compact.boundaryKey(2, 2), linkInput{prev: seed.Node, payload: parent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var derivation DropCohortDerivationHandle
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		derivation, err = compact.BuildDropCohortDerivationOwned(owner, head, DropCohortSourceCheckpoint{
+			StartByte: 1, EndByte: 2, StartRow: 4, StartColumn: 5, EndRow: 4, EndColumn: 6,
+		})
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, ok := compact.DropCohortDerivationRecord(derivation)
+	if !ok {
+		t.Fatal("semantic derivation record is unavailable")
+	}
+	return record
+}
+
+func TestG18DropCohortDerivationIgnoresAllocationIdentity(t *testing.T) {
+	first := g18SemanticDerivation(t, false, 70)
+	second := g18SemanticDerivation(t, true, 70)
+	if !bytes.Equal(first.Bytes, second.Bytes) || first.Digest != second.Digest {
+		t.Fatalf("equal semantic graphs produced different derivation bytes: first=%x second=%x", first.Digest, second.Digest)
+	}
+}
+
+func TestG18DropCohortDerivationIncludesUnequalDescendants(t *testing.T) {
+	first := g18SemanticDerivation(t, false, 70)
+	second := g18SemanticDerivation(t, false, 71)
+	if bytes.Equal(first.Bytes, second.Bytes) || first.Digest == second.Digest {
+		t.Fatal("unequal descendant graphs produced equal derivation bytes")
+	}
+}
+
+func g18SemanticBranchDerivation(t *testing.T, reverse bool) DropCohortDerivationRecord {
+	t.Helper()
+	compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxDropCohortBytes: 1 << 16})
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var first, second SubtreeID
+	if reverse {
+		first, err = compact.appendSubtree(subtreeRecord{symbol: Symbol(82), startByte: 2, endByte: 3, terminal: true}, nil, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		second, err = compact.appendSubtree(subtreeRecord{symbol: Symbol(81), startByte: 1, endByte: 2, terminal: true}, nil, nil, nil)
+	} else {
+		first, err = compact.appendSubtree(subtreeRecord{symbol: Symbol(81), startByte: 1, endByte: 2, terminal: true}, nil, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		second, err = compact.appendSubtree(subtreeRecord{symbol: Symbol(82), startByte: 2, endByte: 3, terminal: true}, nil, nil, nil)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	var firstPayload, secondPayload SubtreeID
+	if reverse {
+		firstPayload, secondPayload = second, first
+	} else {
+		firstPayload, secondPayload = first, second
+	}
+	node, err := compact.appendAdjacencyNodeAt(2, 3, 0, []linkRecord{
+		{prev: seed.Node, payload: firstPayload, scoreDelta: 1},
+		{prev: seed.Node, payload: secondPayload, scoreDelta: 2},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var derivation DropCohortDerivationHandle
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		derivation, err = compact.BuildDropCohortDerivationOwned(owner, Head{Node: node}, DropCohortSourceCheckpoint{StartByte: 1, EndByte: 3})
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, ok := compact.DropCohortDerivationRecord(derivation)
+	if !ok {
+		t.Fatal("semantic branch derivation record is unavailable")
+	}
+	return record
+}
+
+func TestG18DropCohortDerivationStableOrderingAcrossAllocationOrder(t *testing.T) {
+	first := g18SemanticBranchDerivation(t, false)
+	second := g18SemanticBranchDerivation(t, true)
+	if !bytes.Equal(first.Bytes, second.Bytes) || first.Digest != second.Digest {
+		t.Fatalf("equal branch graphs produced different ordering bytes: first=%x second=%x", first.Digest, second.Digest)
+	}
+}
+
+func TestG18DropCohortTinyCapBoundsScratchAndRollsBack(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxDropCohortBytes: 96})
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := compact.appendSubtree(subtreeRecord{symbol: 73, startByte: 1, endByte: 2, terminal: true}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index < 12; index++ {
+		payload, err = compact.appendSubtree(subtreeRecord{symbol: Symbol(74 + index), startByte: 1, endByte: 2}, []SubtreeID{payload}, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	head, err := compact.condense(compact.boundaryKey(2, 2), linkInput{prev: seed.Node, payload: payload})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.ApplySchedulerAtomic(func(SchedulerTransactionToken) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	beforeStorage, beforeFootprint := compact.StorageBytes(), compact.FootprintBytes()
+	beforeDerivations, beforeBytes := len(compact.dropCohortDerivations), len(compact.dropCohortDerivationBytes)
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, buildErr := compact.BuildDropCohortDerivationOwned(owner, head, DropCohortSourceCheckpoint{StartByte: 1, EndByte: 2})
+		if buildErr == nil {
+			return errors.New("tiny drop-cohort cap accepted a large authentic graph")
+		}
+		return buildErr
+	})
+	if err == nil {
+		t.Fatal("tiny-cap derivation unexpectedly succeeded")
+	}
+	if len(compact.dropCohortDerivations) != beforeDerivations || len(compact.dropCohortDerivationBytes) != beforeBytes ||
+		compact.StorageBytes() != beforeStorage || compact.FootprintBytes() != beforeFootprint {
+		t.Fatalf("tiny-cap rollback changed arena: derivations=%d bytes=%d storage=%d footprint=%d", len(compact.dropCohortDerivations), len(compact.dropCohortDerivationBytes), compact.StorageBytes(), compact.FootprintBytes())
+	}
+	if uint64(cap(compact.dropCohortDerivationScratch)) > compact.limits.MaxDropCohortBytes {
+		t.Fatalf("scratch capacity=%d exceeds cap=%d", cap(compact.dropCohortDerivationScratch), compact.limits.MaxDropCohortBytes)
+	}
+}
+
+func TestG18DropCohortWideBoundaryTinyCapBoundsEphemeralScratch(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{
+		MaxDerivations:       8,
+		MaxLinksPerBoundary:  32,
+		MaxDropCohortBytes:   256,
+		MaxDropCohortMembers: 2,
+	})
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	links := make([]linkRecord, 0, 32)
+	for index := 0; index < cap(links); index++ {
+		payload, payloadErr := compact.appendSubtree(subtreeRecord{
+			symbol: Symbol(100 + index), startByte: 1, endByte: 2, terminal: true,
+		}, nil, nil, nil)
+		if payloadErr != nil {
+			t.Fatal(payloadErr)
+		}
+		links = append(links, linkRecord{prev: seed.Node, payload: payload, scoreDelta: int64(index)})
+	}
+	node, err := compact.appendAdjacencyNodeAt(2, 2, 0, links)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head := Head{Node: node}
+	if err := compact.ApplySchedulerAtomic(func(SchedulerTransactionToken) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	beforeStorage, beforeFootprint := compact.StorageBytes(), compact.FootprintBytes()
+	beforeDerivations, beforeBytes := len(compact.dropCohortDerivations), len(compact.dropCohortDerivationBytes)
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, buildErr := compact.BuildDropCohortDerivationOwned(owner, head, DropCohortSourceCheckpoint{StartByte: 1, EndByte: 2})
+		if buildErr == nil {
+			return errors.New("wide tiny-cap derivation unexpectedly succeeded")
+		}
+		return buildErr
+	})
+	if err == nil {
+		t.Fatal("wide tiny-cap derivation did not fail closed")
+	}
+	if compact.dropCohortEphemeralPeak == 0 || compact.dropCohortEphemeralPeak > compact.limits.MaxDropCohortBytes {
+		t.Fatalf("ephemeral peak=%d, want bounded positive peak at cap=%d", compact.dropCohortEphemeralPeak, compact.limits.MaxDropCohortBytes)
+	}
+	if compact.dropCohortEphemeralBytes != 0 || uint64(cap(compact.dropCohortDerivationScratch)) > compact.limits.MaxDropCohortBytes {
+		t.Fatalf("ephemeral scratch after rollback current=%d capacity=%d cap=%d", compact.dropCohortEphemeralBytes, cap(compact.dropCohortDerivationScratch), compact.limits.MaxDropCohortBytes)
+	}
+	if len(compact.dropCohortDerivations) != beforeDerivations || len(compact.dropCohortDerivationBytes) != beforeBytes ||
+		compact.StorageBytes() != beforeStorage || compact.FootprintBytes() != beforeFootprint {
+		t.Fatalf("wide tiny-cap rollback changed arena: derivations=%d bytes=%d storage=%d footprint=%d", len(compact.dropCohortDerivations), len(compact.dropCohortDerivationBytes), compact.StorageBytes(), compact.FootprintBytes())
+	}
+}
+
+func g18DeepBranchedPathCore(t *testing.T, maxBytes uint64) (*Core, Head) {
+	t.Helper()
+	compact := newTinyCoreWithLimits(t, Limits{
+		MaxDerivations:      8,
+		MaxLinksPerBoundary: 8,
+		MaxDropCohortBytes:  maxBytes,
+	})
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := compact.appendSubtree(subtreeRecord{
+		symbol: 77, startByte: 1, endByte: 2, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendSingle := func(byteOffset uint32, prev NodeID) NodeID {
+		node, nodeErr := compact.appendAdjacencyNodeAt(2, byteOffset, 0, []linkRecord{{
+			prev: prev, payload: payload,
+		}})
+		if nodeErr != nil {
+			t.Fatal(nodeErr)
+		}
+		return node
+	}
+	leftDepthTwo := appendSingle(2, seed.Node)
+	rightDepthTwo := appendSingle(2, seed.Node)
+	leftDepthThree := appendSingle(3, leftDepthTwo)
+	rightDepthThree := appendSingle(3, rightDepthTwo)
+	root, err := compact.appendAdjacencyNodeAt(2, 4, 0, []linkRecord{
+		{prev: leftDepthThree, payload: payload},
+		{prev: rightDepthThree, payload: payload},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return compact, Head{Node: root}
+}
+
+func TestG18DropCohortDeepBranchedPathScratchOwnershipAndCapRollback(t *testing.T) {
+	const generousCap = 1 << 16
+	compact, head := g18DeepBranchedPathCore(t, generousCap)
+	if err := compact.ApplySchedulerAtomic(func(SchedulerTransactionToken) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	var derivation DropCohortDerivationHandle
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		var buildErr error
+		derivation, buildErr = compact.BuildDropCohortDerivationOwned(owner, head, DropCohortSourceCheckpoint{StartByte: 1, EndByte: 2})
+		return buildErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if derivation.Index == 0 || cap(compact.dropCohortPathScratch) < 4 {
+		t.Fatalf("deep path scratch cap=%d derivation=%+v, want authoritative grown capacity", cap(compact.dropCohortPathScratch), derivation)
+	}
+	record, ok := compact.DropCohortDerivationRecord(derivation)
+	if !ok || record.StackDepth < 3 {
+		t.Fatalf("deep branched derivation=%+v ok=%t, want at least three path steps", record, ok)
+	}
+	if compact.dropCohortEphemeralPeak == 0 || compact.dropCohortEphemeralPeak > generousCap {
+		t.Fatalf("deep path ephemeral peak=%d, want positive bounded peak at cap=%d", compact.dropCohortEphemeralPeak, generousCap)
+	}
+	highPeak := compact.dropCohortEphemeralPeak
+
+	tinyCap := highPeak - 1
+	if tinyCap == 0 {
+		t.Fatal("deep path generous build did not charge scratch")
+	}
+	tiny, tinyHead := g18DeepBranchedPathCore(t, tinyCap)
+	if err := tiny.ApplySchedulerAtomic(func(SchedulerTransactionToken) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	tinyBeforeStorage, tinyBeforeFootprint := tiny.StorageBytes(), tiny.FootprintBytes()
+	err = tiny.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, buildErr := tiny.BuildDropCohortDerivationOwned(owner, tinyHead, DropCohortSourceCheckpoint{StartByte: 1, EndByte: 2})
+		if buildErr == nil {
+			return errors.New("deep branched tiny cap accepted scratch above the boundary")
+		}
+		return buildErr
+	})
+	if err == nil {
+		t.Fatal("deep branched tiny cap unexpectedly succeeded")
+	}
+	if tiny.dropCohortEphemeralPeak > tinyCap || tiny.dropCohortEphemeralBytes != 0 {
+		t.Fatalf("deep branched tiny-cap scratch peak=%d current=%d cap=%d", tiny.dropCohortEphemeralPeak, tiny.dropCohortEphemeralBytes, tinyCap)
+	}
+	if len(tiny.dropCohortDerivations) != 0 || len(tiny.dropCohortDerivationBytes) != 0 ||
+		tiny.StorageBytes() != tinyBeforeStorage || tiny.FootprintBytes() != tinyBeforeFootprint {
+		t.Fatalf("deep branched rollback changed arena: derivations=%d bytes=%d storage=%d/%d footprint=%d/%d", len(tiny.dropCohortDerivations), len(tiny.dropCohortDerivationBytes), tiny.StorageBytes(), tinyBeforeStorage, tiny.FootprintBytes(), tinyBeforeFootprint)
+	}
+	if err := tiny.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	if len(tiny.nodes) != 0 || len(tiny.links) != 0 || len(tiny.dropCohortDerivations) != 0 ||
+		len(tiny.dropCohortDerivationBytes) != 0 || len(tiny.dropCohortPathScratch) != 0 ||
+		tiny.dropCohortEphemeralBytes != 0 || tiny.dropCohortEphemeralPeak != 0 {
+		t.Fatalf("deep branched reset retained live state: nodes=%d links=%d derivations=%d bytes=%d path=%d current=%d peak=%d", len(tiny.nodes), len(tiny.links), len(tiny.dropCohortDerivations), len(tiny.dropCohortDerivationBytes), len(tiny.dropCohortPathScratch), tiny.dropCohortEphemeralBytes, tiny.dropCohortEphemeralPeak)
+	}
+}
+
+func TestG18DropCohortProducerMutationRequiresAuthenticatedToken(t *testing.T) {
+	newCore := func(t *testing.T) *Core {
+		t.Helper()
+		return newTinyCoreWithLimits(t, Limits{MaxDropCohortBytes: 256})
+	}
+	t.Run("no-token", func(t *testing.T) {
+		compact := newCore(t)
+		if err := compact.RecordDropCohortProducerMutation(SchedulerTransactionToken{}, DropCohortProducerLinearCanonicalization); err == nil {
+			t.Fatal("zero token was accepted")
+		}
+		if compact.DropCohortProducerCounts().LinearCanonicalizer != 0 {
+			t.Fatal("zero-token mutation changed producer counters")
+		}
+	})
+	t.Run("stale-token", func(t *testing.T) {
+		compact := newCore(t)
+		var stale SchedulerTransactionToken
+		if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+			stale = owner
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := compact.ApplySchedulerAtomic(func(SchedulerTransactionToken) error {
+			if callErr := compact.RecordDropCohortProducerMutation(stale, DropCohortProducerLinearCanonicalization); callErr == nil {
+				return errors.New("stale token was accepted")
+			}
+			return nil
+		}); err == nil {
+			t.Fatal("stale token did not poison the scheduler transaction")
+		}
+		if compact.DropCohortProducerCounts().LinearCanonicalizer != 0 {
+			t.Fatal("stale-token mutation changed producer counters")
+		}
+	})
+	t.Run("foreign-token", func(t *testing.T) {
+		compact := newCore(t)
+		foreign := newCore(t)
+		if err := compact.ApplySchedulerAtomic(func(SchedulerTransactionToken) error {
+			return foreign.RunFreshSchedulerSession(func(foreignToken SchedulerTransactionToken) error {
+				if callErr := compact.RecordDropCohortProducerMutation(foreignToken, DropCohortProducerLinearCanonicalization); callErr == nil {
+					return errors.New("foreign token was accepted")
+				}
+				return nil
+			})
+		}); err == nil {
+			t.Fatal("foreign token did not poison the scheduler transaction")
+		}
+		if compact.DropCohortProducerCounts().LinearCanonicalizer != 0 {
+			t.Fatal("foreign-token mutation changed producer counters")
+		}
+	})
+	t.Run("rollback", func(t *testing.T) {
+		compact := newCore(t)
+		sentinel := errors.New("authentic producer rollback")
+		err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+			if callErr := compact.RecordDropCohortProducerMutation(owner, DropCohortProducerLinearCanonicalization); callErr != nil {
+				return callErr
+			}
+			return sentinel
+		})
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("rollback error=%v, want sentinel", err)
+		}
+		if compact.DropCohortProducerCounts().LinearCanonicalizer != 0 {
+			t.Fatal("rolled-back mutation changed producer counters")
+		}
+	})
+	t.Run("commit", func(t *testing.T) {
+		compact := newCore(t)
+		if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+			return compact.RecordDropCohortProducerMutation(owner, DropCohortProducerLinearCanonicalization)
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if compact.DropCohortProducerCounts().LinearCanonicalizer != 1 {
+			t.Fatal("authenticated committed mutation was not counted")
+		}
+	})
+}
+
+func TestG18DropCohortDeadHistoryCounterTracksAuthenticImport(t *testing.T) {
+	table := &fakeTable{
+		actions: map[tableCell][]Action{{state: 1, symbol: 9}: {{Type: ActionReduce, Symbol: 2, ChildCount: 1}}},
+		gotos:   map[tableCell]StateID{{state: 1, symbol: 2}: 2},
+	}
+	compact, err := New(table, Limits{MaxDerivations: 8, MaxPopPaths: 8, MaxDropCohortBytes: 1 << 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	makeSource := func(symbols ...Symbol) Head {
+		t.Helper()
+		links := make([]linkRecord, 0, len(symbols))
+		for index, symbol := range symbols {
+			payload, payloadErr := compact.appendSubtree(subtreeRecord{symbol: symbol, startByte: 0, endByte: 1, terminal: true}, nil, nil, nil)
+			if payloadErr != nil {
+				t.Fatal(payloadErr)
+			}
+			links = append(links, linkRecord{prev: seed.Node, payload: payload, scoreDelta: int64(index)})
+		}
+		node, nodeErr := compact.appendAdjacencyNodeAt(1, 1, 0, links)
+		if nodeErr != nil {
+			t.Fatal(nodeErr)
+		}
+		return Head{Node: node}
+	}
+	firstHead := makeSource(101, 102)
+	secondHead := makeSource(103, 104)
+	firstBoundary, err := compact.ClassifyBoundary(firstHead, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var firstOutputs []ReductionOutput
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		firstOutputs, err = compact.ReduceOutputsClassifiedIntoOwned(owner, nil, firstBoundary, 0, ForkOrder{})
+		if err != nil {
+			return err
+		}
+		if len(firstOutputs) != 1 || !firstOutputs[0].MultiplePopPaths {
+			return fmt.Errorf("first reduction outputs=%+v, want one multi-path output", firstOutputs)
+		}
+		return compact.RecordReductionLineageOwned(owner, firstOutputs, 7)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondBoundary, err := compact.ClassifyBoundary(secondHead, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var secondOutputs []ReductionOutput
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		secondOutputs, err = compact.ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesOwned(owner, nil, nil, secondBoundary, 0, ForkOrder{})
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secondOutputs) != 1 || secondOutputs[0].HistoricalBoundaryProvenance != HistoricalBoundaryConverged || secondOutputs[0].HistoricalAlternativeSet.Len() == 0 {
+		t.Fatalf("second reduction historical output=%+v, want proven import", secondOutputs)
+	}
+	counters := compact.DropCohortProducerCounts()
+	if counters.DeadHistoryImport != 1 {
+		t.Fatalf("authentic dead-history counter=%+v, want one import", counters)
+	}
+}
+
+func TestG18DropCohortPreflightRollbackRestoresProducerArena(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDropCohortMembers: 2})
+	if err := compact.ApplySchedulerAtomic(func(SchedulerTransactionToken) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	before := compact.StorageBytes()
+	beforeFootprint := compact.FootprintBytes()
+	beforeActions := len(compact.dropCohortActions)
+	beforeRecords := len(compact.dropCohortRecords)
+	sentinel := errors.New("g18 producer preflight")
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if _, err := compact.BeginDropCohortOwned(owner, g18ProducerIdentity(), 3); err == nil {
+			return errors.New("drop-cohort preflight accepted three members with a two-member limit")
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("transaction error=%v, want sentinel", err)
+	}
+	if len(compact.dropCohortActions) != beforeActions || len(compact.dropCohortRecords) != beforeRecords ||
+		compact.StorageBytes() != before || compact.FootprintBytes() != beforeFootprint {
+		t.Fatalf("preflight rollback changed producer arena: actions=%d records=%d storage=%d footprint=%d", len(compact.dropCohortActions), len(compact.dropCohortRecords), compact.StorageBytes(), compact.FootprintBytes())
+	}
+}
+
+func TestG18DropCohortNestedAndSequentialIsolation(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxDropCohortMembers: 2})
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head := g18ProducerHead(t, compact, seed, 41, 1)
+	checkpoint := g18ProducerCheckpoint()
+	var outer, inner DropCohortHandle
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		outer, err = compact.BeginDropCohortOwned(owner, g18ProducerIdentity(), 1)
+		if err != nil {
+			return err
+		}
+		inner, err = compact.BeginDropCohortOwned(owner, g18ProducerIdentity(), 1)
+		if err != nil {
+			return err
+		}
+		for _, cohort := range []DropCohortHandle{inner, outer} {
+			derivation, buildErr := compact.BuildDropCohortDerivationOwned(owner, head, checkpoint)
+			if buildErr != nil {
+				return buildErr
+			}
+			if writeErr := compact.WriteDropCohortMemberOwned(owner, cohort, head, 0, derivation); writeErr != nil {
+				return writeErr
+			}
+			if _, finalErr := compact.FinalizeDropCohortOwned(owner, cohort); finalErr != nil {
+				return finalErr
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outer.Sequence == 0 || inner.Sequence != outer.Sequence+1 || outer.Owner != inner.Owner || outer.Epoch != inner.Epoch {
+		t.Fatalf("nested handles outer=%+v inner=%+v", outer, inner)
+	}
+	outerRef, err := compact.DropCohortRefForBranch(outer, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	innerRef, err := compact.DropCohortRefForBranch(inner, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outerRef == innerRef {
+		t.Fatalf("nested refs alias: outer=%+v inner=%+v", outerRef, innerRef)
+	}
+	var sequential DropCohortHandle
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		sequential, err = compact.BeginDropCohortOwned(owner, g18ProducerIdentity(), 1)
+		if err != nil {
+			return err
+		}
+		derivation, buildErr := compact.BuildDropCohortDerivationOwned(owner, head, checkpoint)
+		if buildErr != nil {
+			return buildErr
+		}
+		if err := compact.WriteDropCohortMemberOwned(owner, sequential, head, 0, derivation); err != nil {
+			return err
+		}
+		_, err = compact.FinalizeDropCohortOwned(owner, sequential)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sequential.Sequence != inner.Sequence+1 {
+		t.Fatalf("sequential sequence=%d, want %d", sequential.Sequence, inner.Sequence+1)
+	}
+	if !reflect.DeepEqual(outerRef, DropCohortRef{Owner: outer.Owner, Epoch: outer.Epoch, Sequence: outer.Sequence, Branch: 0}) {
+		t.Fatalf("outer ref=%+v", outerRef)
+	}
+}

--- a/internal/parsercorephase0/drop_cohort_ref.go
+++ b/internal/parsercorephase0/drop_cohort_ref.go
@@ -1,0 +1,350 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"math"
+	"unsafe"
+)
+
+// DropCohortRef identifies one branch of one drop cohort. The owner, epoch,
+// and sequence identify the cohort; the branch identifies one valid member.
+type DropCohortRef struct {
+	Owner    uint64
+	Epoch    uint64
+	Sequence uint64
+	Branch   uint16
+}
+
+const (
+	dropCohortRefInlineCapacity = 2
+	dropCohortRefHardCap        = 32
+
+	dropCohortRefFlagOverflowed uint8 = 1 << iota
+	dropCohortRefFlagSpilled
+	dropCohortRefFlagBlended
+)
+
+// DropCohortRefSet is an ordered, value-owned reference set. It keeps two
+// references inline and stores wider sets in Core.dropCohortRefSpill.
+type DropCohortRefSet struct {
+	Inline [dropCohortRefInlineCapacity]DropCohortRef
+	Count  uint8
+	Flags  uint8
+	Spill  uint32 // one-based start index in Core.dropCohortRefSpill
+}
+
+func (s DropCohortRefSet) Empty() bool { return s.Count == 0 }
+
+// Len reports the number of recorded references. Overflowed sets contain a
+// sound subset of the true references and must not prove a drop.
+func (s DropCohortRefSet) Len() int { return int(s.Count) }
+
+func (s DropCohortRefSet) Overflowed() bool { return s.Flags&dropCohortRefFlagOverflowed != 0 }
+func (s DropCohortRefSet) Spilled() bool    { return s.Flags&dropCohortRefFlagSpilled != 0 }
+func (s DropCohortRefSet) Blended() bool    { return s.Flags&dropCohortRefFlagBlended != 0 }
+
+func dropCohortRefLess(a, b DropCohortRef) bool {
+	if a.Owner != b.Owner {
+		return a.Owner < b.Owner
+	}
+	if a.Epoch != b.Epoch {
+		return a.Epoch < b.Epoch
+	}
+	if a.Sequence != b.Sequence {
+		return a.Sequence < b.Sequence
+	}
+	return a.Branch < b.Branch
+}
+
+// Add inserts an inline reference. Core-owned sets use AddDropCohortRef so
+// they can spill without exposing an arena pointer in this value type.
+func (s *DropCohortRefSet) Add(ref DropCohortRef) bool {
+	if s == nil || ref == (DropCohortRef{}) || s.Overflowed() {
+		return false
+	}
+	for i := 0; i < int(s.Count) && i < len(s.Inline); i++ {
+		if s.Inline[i] == ref {
+			return false
+		}
+	}
+	if s.Count >= uint8(len(s.Inline)) {
+		return false
+	}
+	index := int(s.Count)
+	s.Inline[index] = ref
+	s.Count++
+	for index > 0 && dropCohortRefLess(s.Inline[index], s.Inline[index-1]) {
+		s.Inline[index], s.Inline[index-1] = s.Inline[index-1], s.Inline[index]
+		index--
+	}
+	return true
+}
+
+func (c *Core) dropCohortRefCount(set DropCohortRefSet) (int, bool) {
+	if c == nil || !set.Spilled() {
+		return int(set.Count), int(set.Count) <= len(set.Inline)
+	}
+	if set.Spill == 0 {
+		return int(set.Count), set.Count == 0
+	}
+	start := int(set.Spill) - 1
+	end := start + int(set.Count)
+	if start < 0 || end < start || end > len(c.dropCohortRefSpill) {
+		return 0, false
+	}
+	return int(set.Count), true
+}
+
+// DropCohortRefAt returns one sorted reference without exposing an inline
+// slice. Callers can enumerate into fixed storage without a heap escape.
+func (c *Core) DropCohortRefAt(set DropCohortRefSet, index int) (DropCohortRef, bool) {
+	if index < 0 || index >= int(set.Count) {
+		return DropCohortRef{}, false
+	}
+	if !set.Spilled() {
+		if index >= len(set.Inline) {
+			return DropCohortRef{}, false
+		}
+		return set.Inline[index], true
+	}
+	if c == nil || set.Spill == 0 {
+		return DropCohortRef{}, false
+	}
+	position := int(set.Spill) - 1 + index
+	if position < 0 || position >= len(c.dropCohortRefSpill) {
+		return DropCohortRef{}, false
+	}
+	return c.dropCohortRefSpill[position], true
+}
+
+// dropCohortRefSpillLimit returns the configured reference count ceiling.
+func (c *Core) dropCohortRefSpillLimit() uint64 {
+	if c == nil {
+		return 0
+	}
+	return uint64(c.limits.MaxDropCohortRefs)
+}
+
+func (c *Core) dropCohortRefPreflight(additional int) error {
+	if additional <= 0 {
+		return nil
+	}
+	if uint64(len(c.dropCohortRefSpill))+uint64(additional) > c.dropCohortRefSpillLimit() {
+		return errors.New("parser-core phase zero: drop-cohort reference spill cap")
+	}
+	bytes := uint64(additional) * uint64(unsafe.Sizeof(DropCohortRef{}))
+	if bytes > c.limits.MaxDropCohortRefBytes ||
+		uint64(len(c.dropCohortRefSpill))*uint64(unsafe.Sizeof(DropCohortRef{})) > c.limits.MaxDropCohortRefBytes-bytes {
+		return errors.New("parser-core phase zero: drop-cohort reference byte cap")
+	}
+	if uint64(len(c.dropCohortRefSpill)) > uint64(math.MaxUint32)-uint64(additional) {
+		return errors.New("parser-core phase zero: drop-cohort reference spill index overflow")
+	}
+	return nil
+}
+
+func dropCohortRefAppendUnique(dst *[dropCohortRefHardCap]DropCohortRef, count *int, ref DropCohortRef) (changed, overflowed bool) {
+	for i := 0; i < *count; i++ {
+		if dst[i] == ref {
+			return false, false
+		}
+	}
+	if *count >= len(dst) {
+		return false, true
+	}
+	index := *count
+	for i := 0; i < *count; i++ {
+		if dropCohortRefLess(ref, dst[i]) {
+			index = i
+			break
+		}
+	}
+	copy(dst[index+1:*count+1], dst[index:*count])
+	dst[index] = ref
+	(*count)++
+	return true, false
+}
+
+// dropCohortRefUnion performs a transactional, deterministic union. It
+// preflights the complete spill append before changing either the set or the
+// arena, so a rejected union leaves every byte and flag unchanged.
+func (c *Core) dropCohortRefUnion(dst *DropCohortRefSet, src DropCohortRefSet) (bool, error) {
+	if c == nil || dst == nil {
+		return false, errors.New("parser-core phase zero: nil drop-cohort reference union")
+	}
+	if dst.Overflowed() {
+		return false, nil
+	}
+	srcCount, ok := c.dropCohortRefCount(src)
+	if !ok {
+		return false, errors.New("parser-core phase zero: invalid drop-cohort reference spill")
+	}
+	if src.Overflowed() {
+		before := dst.Flags
+		dst.Flags |= dropCohortRefFlagOverflowed
+		if src.Blended() {
+			dst.Flags |= dropCohortRefFlagBlended
+		}
+		return dst.Flags != before, nil
+	}
+	if srcCount == 0 {
+		if src.Blended() && !dst.Blended() {
+			dst.Flags |= dropCohortRefFlagBlended
+			return true, nil
+		}
+		return false, nil
+	}
+	dstCount, ok := c.dropCohortRefCount(*dst)
+	if !ok {
+		return false, errors.New("parser-core phase zero: invalid destination drop-cohort reference spill")
+	}
+	var merged [dropCohortRefHardCap]DropCohortRef
+	count := 0
+	blended := dst.Blended() || src.Blended()
+	overflowed := false
+	for index := 0; index < dstCount; index++ {
+		ref, valid := c.DropCohortRefAt(*dst, index)
+		if !valid {
+			return false, errors.New("parser-core phase zero: invalid destination drop-cohort reference spill")
+		}
+		changed, overflow := dropCohortRefAppendUnique(&merged, &count, ref)
+		overflowed = overflowed || overflow
+		if !changed {
+			continue
+		}
+	}
+	for index := 0; index < srcCount; index++ {
+		ref, valid := c.DropCohortRefAt(src, index)
+		if !valid {
+			return false, errors.New("parser-core phase zero: invalid source drop-cohort reference spill")
+		}
+		changed, overflow := dropCohortRefAppendUnique(&merged, &count, ref)
+		overflowed = overflowed || overflow
+		if !changed {
+			continue
+		}
+	}
+	if overflowed {
+		before := dst.Flags
+		dst.Flags |= dropCohortRefFlagOverflowed
+		if blended {
+			dst.Flags |= dropCohortRefFlagBlended
+		}
+		return dst.Flags != before, nil
+	}
+
+	oldFlags := dst.Flags
+	oldCount := int(dst.Count)
+	if count == oldCount && oldCount != 0 {
+		same := true
+		for i := 0; i < dstCount; i++ {
+			ref, valid := c.DropCohortRefAt(*dst, i)
+			if !valid || merged[i] != ref {
+				same = false
+				break
+			}
+		}
+		if same {
+			if blended {
+				dst.Flags |= dropCohortRefFlagBlended
+			}
+			return dst.Flags != oldFlags, nil
+		}
+	}
+	newFlags := uint8(0)
+	if blended {
+		newFlags |= dropCohortRefFlagBlended
+	}
+	if count <= dropCohortRefInlineCapacity {
+		*dst = DropCohortRefSet{Count: uint8(count), Flags: newFlags}
+		copy(dst.Inline[:], merged[:count])
+		return true, nil
+	}
+	// A destination that already aliases exactly this sequence needs no new
+	// storage. This check also keeps repeated canonicalization idempotent.
+	if dst.Spilled() && dstCount == count {
+		same := true
+		for i := 0; i < dstCount; i++ {
+			ref, valid := c.DropCohortRefAt(*dst, i)
+			if !valid || merged[i] != ref {
+				same = false
+				break
+			}
+		}
+		if same {
+			dst.Flags = dst.Flags&^dropCohortRefFlagBlended | newFlags
+			return dst.Flags != oldFlags, nil
+		}
+	}
+	// A sorted tail extension keeps the existing segment stable and appends
+	// only the new suffix. Copies of the set still read their old prefix.
+	// This avoids quadratic spill growth during sequential reference inserts.
+	if dst.Spilled() && oldCount != 0 && dstCount == oldCount &&
+		int(dst.Spill)-1+oldCount == len(c.dropCohortRefSpill) {
+		prefixEqual := true
+		for index := 0; index < dstCount; index++ {
+			ref, valid := c.DropCohortRefAt(*dst, index)
+			if !valid || merged[index] != ref {
+				prefixEqual = false
+				break
+			}
+		}
+		if prefixEqual && count > oldCount {
+			additional := count - oldCount
+			if err := c.dropCohortRefPreflight(additional); err != nil {
+				return false, err
+			}
+			c.dropCohortRefSpill = append(c.dropCohortRefSpill, merged[oldCount:count]...)
+			dst.Count = uint8(count)
+			dst.Flags = newFlags | dropCohortRefFlagSpilled
+			return true, nil
+		}
+	}
+	if err := c.dropCohortRefPreflight(count); err != nil {
+		return false, err
+	}
+	start := len(c.dropCohortRefSpill)
+	c.dropCohortRefSpill = append(c.dropCohortRefSpill, merged[:count]...)
+	dst.Spill = uint32(start) + 1
+	dst.Count = uint8(count)
+	dst.Flags = newFlags | dropCohortRefFlagSpilled
+	return true, nil
+}
+
+func (c *Core) addDropCohortRef(set *DropCohortRefSet, ref DropCohortRef) (bool, error) {
+	if ref == (DropCohortRef{}) {
+		return false, nil
+	}
+	var singleton DropCohortRefSet
+	singleton.Inline[0] = ref
+	singleton.Count = 1
+	return c.dropCohortRefUnion(set, singleton)
+}
+
+// AddDropCohortRef inserts one reference and spills when required. It returns
+// false for duplicates, overflow, or a rejected preflight.
+func (c *Core) AddDropCohortRef(set *DropCohortRefSet, ref DropCohortRef) bool {
+	changed, _ := c.addDropCohortRef(set, ref)
+	return changed
+}
+
+// UnionDropCohortRefs unions src into dst. A failed preflight leaves dst
+// unchanged and returns false.
+func (c *Core) UnionDropCohortRefs(dst *DropCohortRefSet, src DropCohortRefSet) bool {
+	changed, _ := c.dropCohortRefUnion(dst, src)
+	return changed
+}
+
+// UnionDropCohortRefsChecked reports a spill preflight or stale-reference
+// error to scheduler callers that must fail the enclosing operation.
+func (c *Core) UnionDropCohortRefsChecked(dst *DropCohortRefSet, src DropCohortRefSet) (bool, error) {
+	return c.dropCohortRefUnion(dst, src)
+}
+
+func (c *Core) NodeLineageDropCohortRefs(id NodeID) (DropCohortRefSet, error) {
+	record, err := c.nodeLineage(id)
+	if err != nil {
+		return DropCohortRefSet{}, err
+	}
+	return record.dropCohortRefs, nil
+}

--- a/internal/parsercorephase0/drop_cohort_test_hooks.go
+++ b/internal/parsercorephase0/drop_cohort_test_hooks.go
@@ -1,0 +1,493 @@
+package parsercorephase0
+
+// This file contains the narrow Core contract used by the tagged G18 tests.
+// It does not provide certificate admission, verification, or parser hooks.
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"sync/atomic"
+)
+
+const (
+	dropCohortProtocolActionBytes    = uint64(14 * 8)
+	dropCohortProtocolDerivationMeta = uint64(32 + 4 + 4)
+	dropCohortProtocolReferenceBytes = uint64(32)
+	dropCohortProtocolMapBytes       = uint64(16)
+	dropCohortProtocolInternerBytes  = uint64(40)
+	dropCohortProtocolJournalBytes   = uint64(16)
+	dropCohortProtocolCohortBytes    = uint64(32)
+	dropCohortLogicalActionBytes     = uint64(14 * 8)
+	dropCohortLogicalDerivationBytes = uint64(32 + 4 + 4)
+	dropCohortLogicalRecordBytes     = uint64(32)
+)
+
+type dropCohortProtocolCohort struct {
+	Handle   [3]uint64 `json:"handle"`
+	State    string    `json:"state"`
+	Expected uint16    `json:"expected"`
+	Written  uint16    `json:"written"`
+	Spilled  bool      `json:"spilled"`
+}
+
+type dropCohortProtocolSnapshot struct {
+	Schema                 string                     `json:"schema"`
+	ArenaOwner             uint64                     `json:"arena_owner"`
+	ArenaEpoch             uint64                     `json:"arena_epoch"`
+	Cohorts                []dropCohortProtocolCohort `json:"cohorts"`
+	Storage                [7]uint64                  `json:"storage"`
+	Footprint              [7]uint64                  `json:"footprint"`
+	StorageBytes           uint64                     `json:"storage_bytes"`
+	FootprintBytes         uint64                     `json:"footprint_bytes"`
+	LogicalStorageBytes    uint64                     `json:"logical_storage_bytes"`
+	LogicalFootprintBytes  uint64                     `json:"logical_footprint_bytes"`
+	PhysicalStorageBytes   uint64                     `json:"physical_storage_bytes"`
+	PhysicalFootprintBytes uint64                     `json:"physical_footprint_bytes"`
+	ProducerWrites         map[string]uint64          `json:"producer_writes"`
+	VerifierElections      uint64                     `json:"verifier_elections"`
+	VerifierProofs         uint64                     `json:"verifier_proofs"`
+	VerifierDeclines       uint64                     `json:"verifier_declines"`
+	ActionDeclines         uint64                     `json:"action_identity_declines"`
+	DerivationDeclines     uint64                     `json:"derivation_identity_declines"`
+	AuthenticatedHistory   uint64                     `json:"authenticated_history_imports"`
+	UnprovedHistory        uint64                     `json:"unproved_history_imports"`
+	DeclineReasons         map[string]uint64          `json:"decline_reasons"`
+	OwnerCheckedLookups    uint64                     `json:"owner_checked_lookups"`
+	InlineReads            uint64                     `json:"inline_reads"`
+	SpillReads             uint64                     `json:"spill_reads"`
+	MapReads               uint64                     `json:"map_reads"`
+	InternerReads          uint64                     `json:"interner_reads"`
+}
+
+func dropCohortProtocolHandle(h DropCohortHandle) [3]uint64 {
+	return [3]uint64{h.Owner, h.Epoch, h.Sequence}
+}
+
+func dropCohortProtocolState(state DropCohortState) string {
+	switch state {
+	case DropCohortBuilding:
+		return "building"
+	case DropCohortComplete:
+		return "complete"
+	case DropCohortOverflowed:
+		return "overflowed"
+	case DropCohortBlended:
+		return "blended"
+	case DropCohortUnproved:
+		return "unproved"
+	default:
+		return "unknown"
+	}
+}
+
+func dropCohortProtocolNextPowerOfTwo(value uint64) uint64 {
+	if value <= 1 {
+		return 1
+	}
+	value--
+	value |= value >> 1
+	value |= value >> 2
+	value |= value >> 4
+	value |= value >> 8
+	value |= value >> 16
+	value |= value >> 32
+	return value + 1
+}
+
+func dropCohortStoreVector(c *Core, footprint bool) [7]uint64 {
+	var vector [7]uint64
+	byteCount := func(length, capacity uint64, element uint64) uint64 {
+		if footprint {
+			return capacity * element
+		}
+		return length * element
+	}
+	vector[0] = byteCount(uint64(len(c.dropCohortActions)), uint64(cap(c.dropCohortActions)), dropCohortLogicalActionBytes)
+	vector[1] = byteCount(uint64(len(c.dropCohortDerivations)), uint64(cap(c.dropCohortDerivations)), dropCohortLogicalDerivationBytes) + byteCount(uint64(len(c.dropCohortDerivationBytes)), uint64(cap(c.dropCohortDerivationBytes)), 1)
+	vector[2] = byteCount(uint64(len(c.dropCohortCertificateRefs)), uint64(cap(c.dropCohortCertificateRefs)), coreDropCohortRefBytes)
+	vector[3] = byteCount(uint64(len(c.dropCohortMapStore)), uint64(cap(c.dropCohortMapStore)), coreDropCohortMapEntryBytes)
+	vector[4] = byteCount(uint64(len(c.dropCohortDerivationIntern)), uint64(cap(c.dropCohortDerivationIntern)), coreDropCohortDerivationInternBytes)
+	vector[5] = byteCount(uint64(len(c.dropCohortJournalStore)), uint64(cap(c.dropCohortJournalStore)), coreDropCohortJournalStoreBytes)
+	vector[6] = byteCount(uint64(len(c.dropCohortRecords)), uint64(cap(c.dropCohortRecords)), dropCohortLogicalRecordBytes)
+	return vector
+}
+
+func (c *Core) DiagnosticDropCohortArenaIdentityForTest() (uint64, uint64) {
+	return c.DropCohortArenaIdentity()
+}
+
+func (c *Core) DiagnosticDropCohortSnapshotForTest() []byte {
+	if c == nil {
+		return []byte(`{"schema":"gts-drop-cohort-certificate-arena/v2"}`)
+	}
+	var snapshot dropCohortProtocolSnapshot
+	snapshot.Schema = "gts-drop-cohort-certificate-arena/v2"
+	snapshot.ArenaOwner, snapshot.ArenaEpoch = c.DropCohortArenaIdentity()
+	snapshot.ProducerWrites = map[string]uint64{
+		"reduction_establishment": c.dropCohortProducerWrites[dropCohortProducerReductionEstablishment],
+		"linear_canonicalizer":    c.dropCohortProducerWrites[dropCohortProducerLinearCanonicalizer],
+		"mapped_canonicalizer":    c.dropCohortProducerWrites[dropCohortProducerMappedCanonicalizer],
+		"sibling_adoption":        c.dropCohortProducerWrites[dropCohortProducerSiblingAdoption],
+		"conflict_reconciliation": c.dropCohortProducerWrites[dropCohortProducerConflictReconciliation],
+		"dead_history_import":     c.dropCohortProducerWrites[dropCohortProducerDeadHistoryImport],
+	}
+	snapshot.AuthenticatedHistory = c.dropCohortAuthenticatedHistory
+	snapshot.UnprovedHistory = c.dropCohortUnprovedHistory
+	snapshot.DeclineReasons = map[string]uint64{}
+	for _, record := range c.dropCohortRecords {
+		snapshot.Cohorts = append(snapshot.Cohorts, dropCohortProtocolCohort{
+			Handle: dropCohortProtocolHandle(record.handle), State: dropCohortProtocolState(record.state),
+			Expected: record.expected, Written: record.written, Spilled: record.expected > dropCohortRefInlineCapacity,
+		})
+	}
+	snapshot.Storage = dropCohortStoreVector(c, false)
+	snapshot.Footprint = dropCohortStoreVector(c, true)
+	for _, value := range snapshot.Storage {
+		snapshot.LogicalStorageBytes += value
+	}
+	for _, value := range snapshot.Footprint {
+		snapshot.LogicalFootprintBytes += value
+	}
+	snapshot.StorageBytes = snapshot.LogicalStorageBytes
+	snapshot.FootprintBytes = snapshot.LogicalFootprintBytes
+	snapshot.PhysicalStorageBytes = c.StorageBytes()
+	snapshot.PhysicalFootprintBytes = c.FootprintBytes()
+	snapshot.OwnerCheckedLookups = c.dropCohortOwnerCheckedLookups
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		return []byte(`{"schema":"gts-drop-cohort-certificate-arena/v2"}`)
+	}
+	return encoded
+}
+
+func (c *Core) DiagnosticDropCohortLimitsForTest() (uint16, uint16) {
+	if c == nil {
+		return 0, 0
+	}
+	return uint16(c.limits.MaxDropCohorts), c.limits.MaxDropCohortMembers
+}
+
+func (c *Core) DiagnosticDropCohortSetLimitsForTest(maxCohorts, maxMembers uint16) error {
+	if c == nil || maxCohorts == 0 || maxMembers == 0 || maxMembers > dropCohortRefHardCap {
+		return errors.New("parser-core phase zero: invalid drop-cohort test limits")
+	}
+	c.limits.MaxDropCohorts = uint32(maxCohorts)
+	c.limits.MaxDropCohortMembers = maxMembers
+	return nil
+}
+
+func dropCohortProtocolAction(values [14]int64) (DropCohortActionIdentity, error) {
+	for _, index := range []int{0, 1, 2, 3, 4, 5, 6, 7, 13} {
+		if values[index] < 0 {
+			return DropCohortActionIdentity{}, errors.New("parser-core phase zero: negative action identity field")
+		}
+	}
+	if values[0] > math.MaxUint32 || values[4] > math.MaxUint32 || values[2] > math.MaxInt32 ||
+		values[1] > math.MaxUint16 || values[5] > math.MaxUint16 || values[3] > math.MaxUint8 ||
+		values[7] > math.MaxUint8 || values[6] > math.MaxUint16 || values[13] > math.MaxUint8 ||
+		values[8] < math.MinInt16 || values[8] > math.MaxInt16 {
+		return DropCohortActionIdentity{}, errors.New("parser-core phase zero: action identity field overflow")
+	}
+	for _, index := range []int{9, 10, 11, 12} {
+		if values[index] != 0 && values[index] != 1 {
+			return DropCohortActionIdentity{}, errors.New("parser-core phase zero: boolean action identity field overflow")
+		}
+	}
+	return DropCohortActionIdentity{
+		BoundaryState: StateID(values[0]), Lookahead: Symbol(values[1]), ActionOrdinal: int32(values[2]),
+		Action: Action{Type: ActionType(values[3]), State: StateID(values[4]), Symbol: Symbol(values[5]),
+			ProductionID: uint16(values[6]), ChildCount: uint8(values[7]), DynamicPrecedence: int16(values[8]),
+			Extra: values[9] != 0, ExtraChain: values[10] != 0, Repetition: values[11] != 0},
+		NoLookahead: values[12] != 0, Selection: DropCohortSelectionClass(values[13]),
+	}, nil
+}
+
+func dropCohortRealStorePlan(expected uint16, derivationBytes uint32) ([7]uint64, [7]uint64) {
+	var storage, footprint [7]uint64
+	members := uint64(expected)
+	storage[0] = members * dropCohortProtocolActionBytes
+	storage[1] = members * (dropCohortProtocolDerivationMeta + uint64(derivationBytes))
+	storage[2] = members * dropCohortProtocolReferenceBytes
+	storage[3] = members * dropCohortProtocolMapBytes
+	storage[4] = members * dropCohortProtocolInternerBytes
+	storage[5] = (members + 2) * dropCohortProtocolJournalBytes
+	storage[6] = dropCohortProtocolCohortBytes
+	footprint = storage
+	mapCapacity := dropCohortProtocolNextPowerOfTwo(members * 2)
+	footprint[3] = mapCapacity * dropCohortProtocolMapBytes
+	footprint[4] = mapCapacity * dropCohortProtocolInternerBytes
+	return storage, footprint
+}
+
+func (c *Core) DiagnosticDropCohortBeginForTest(expected uint16, derivationBytes uint32, caps [7]uint64) ([3]uint64, error) {
+	var zero [3]uint64
+	if c == nil {
+		return zero, errors.New("parser-core phase zero: nil drop-cohort core")
+	}
+	storage, footprint := dropCohortRealStorePlan(expected, derivationBytes)
+	for index := range caps {
+		if footprint[index] > caps[index] {
+			return zero, fmt.Errorf("parser-core phase zero: drop-cohort store %d preflight cap", index)
+		}
+	}
+	var handle DropCohortHandle
+	err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		identity, identityErr := dropCohortProtocolAction([14]int64{3, 9, 3, int64(ActionReduce), 0, 2, 5, 1, 2, 0, 0, 0, 0, 1})
+		if identityErr != nil {
+			return identityErr
+		}
+		var beginErr error
+		handle, beginErr = c.beginDropCohortOwned(identity, int(expected))
+		if beginErr != nil {
+			return beginErr
+		}
+		if len(c.dropCohortReservations) == 0 || c.dropCohortReservations[len(c.dropCohortReservations)-1].handle != handle {
+			return errors.New("parser-core phase zero: drop-cohort reservation is unavailable")
+		}
+		c.dropCohortReservations[len(c.dropCohortReservations)-1].derivationBytesEach = derivationBytes
+		derivationDemand, demandErr := dropCohortMulChecked(uint64(expected), uint64(derivationBytes))
+		if demandErr != nil {
+			return demandErr
+		}
+		if derivationDemand > uint64(^uint(0)>>1) {
+			return errors.New("parser-core phase zero: drop-cohort derivation allocation overflow")
+		}
+		if _, demandErr = c.dropCohortReserveDemand([7]uint64{}, derivationDemand); demandErr != nil {
+			return demandErr
+		}
+		// Reserve every certificate store with real backing slices. The
+		// reservation is part of the active Core transaction and every write
+		// fills one reserved slot instead of growing a hidden protocol vector.
+		if cap(c.dropCohortActions)-len(c.dropCohortActions) < int(expected)-1 {
+			grown := make([]dropCohortActionIdentity, len(c.dropCohortActions), len(c.dropCohortActions)+int(expected)-1)
+			copy(grown, c.dropCohortActions)
+			c.dropCohortActions = grown
+		}
+		for count := 1; count < int(expected); count++ {
+			c.dropCohortActions = append(c.dropCohortActions, identity)
+		}
+		c.dropCohortDerivations = append(c.dropCohortDerivations, make([]dropCohortDerivationRecord, int(expected))...)
+		c.dropCohortDerivationBytes = append(c.dropCohortDerivationBytes, make([]byte, int(expected)*int(derivationBytes))...)
+		internerCapacity := int(dropCohortProtocolNextPowerOfTwo(uint64(expected) * 2))
+		internerStore := make([]dropCohortDerivationInternEntry, len(c.dropCohortDerivationIntern)+int(expected), len(c.dropCohortDerivationIntern)+internerCapacity)
+		copy(internerStore, c.dropCohortDerivationIntern)
+		c.dropCohortDerivationIntern = internerStore
+		c.dropCohortCertificateRefs = append(c.dropCohortCertificateRefs, make([]DropCohortRef, int(expected))...)
+		mapCapacity := int(dropCohortProtocolNextPowerOfTwo(uint64(expected) * 2))
+		mapStore := make([]dropCohortMapEntry, len(c.dropCohortMapStore)+int(expected), len(c.dropCohortMapStore)+mapCapacity)
+		copy(mapStore, c.dropCohortMapStore)
+		c.dropCohortMapStore = mapStore
+		var consumed [7]uint64
+		consumed[1], consumed[2], consumed[3], consumed[4] = uint64(expected), uint64(expected), uint64(expected), uint64(expected)
+		consumedBytes, consumedErr := dropCohortDemandBytes(consumed, derivationDemand)
+		if consumedErr != nil {
+			return consumedErr
+		}
+		c.dropCohortConsumeReservation(handle, consumed, consumedBytes)
+		_ = storage
+		_ = footprint
+		return nil
+	})
+	if err != nil {
+		return zero, err
+	}
+	return [3]uint64{handle.Owner, handle.Epoch, handle.Sequence}, nil
+}
+
+func (c *Core) DiagnosticDropCohortWriteForTest(rawHandle [3]uint64, head Head, branch uint16, values [14]int64, digest [sha256.Size]byte, record []byte) error {
+	if c == nil {
+		return errors.New("parser-core phase zero: nil drop-cohort core")
+	}
+	var operationErr error
+	err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		identity, err := dropCohortProtocolAction(values)
+		if err != nil {
+			return err
+		}
+		cohort := DropCohortHandle{Owner: rawHandle[0], Epoch: rawHandle[1], Sequence: rawHandle[2]}
+		cohortIndex, err := c.validateDropCohortIdentity(cohort)
+		if err != nil {
+			return err
+		}
+		var reservation *dropCohortReservation
+		for index := range c.dropCohortReservations {
+			if c.dropCohortReservations[index].handle == cohort {
+				reservation = &c.dropCohortReservations[index]
+				break
+			}
+		}
+		if reservation == nil {
+			return errors.New("parser-core phase zero: drop-cohort reservation is unavailable")
+		}
+		if uint64(branch) >= uint64(c.dropCohortRecords[cohortIndex].expected) {
+			operationErr = c.writeDropCohortMemberOwned(cohort, head, branch, DropCohortDerivationHandle{Owner: c.dropCohortOwner, Epoch: c.dropCohortEpoch, Index: uint32(reservation.derivations + 1)})
+			if operationErr != nil && strings.Contains(operationErr.Error(), "branch exceeds expected") {
+				return nil
+			}
+			return operationErr
+		}
+		if uint32(len(record)) > reservation.derivationBytesEach {
+			return errors.New("parser-core phase zero: drop-cohort derivation record exceeds reservation")
+		}
+		if prior, found := c.findDropCohortMember(c.dropCohortRecords[cohortIndex], branch); found {
+			priorMember := c.dropCohortMembers[prior]
+			priorDerivationIndex := int(priorMember.derivation.Index) - 1
+			derivationOK := priorMember.derivation.Owner == c.dropCohortOwner && priorMember.derivation.Epoch == c.dropCohortEpoch && priorDerivationIndex >= 0 && priorDerivationIndex < len(c.dropCohortDerivations)
+			priorBytesOK := false
+			if derivationOK && c.dropCohortDerivations[priorDerivationIndex].digest == digest && c.dropCohortDerivations[priorDerivationIndex].byteLength == uint32(len(record)) {
+				priorDerivation := c.dropCohortDerivations[priorDerivationIndex]
+				start := int(priorDerivation.byteOffset)
+				end := start + int(priorDerivation.byteLength)
+				priorBytesOK = start >= 0 && end >= start && end <= len(c.dropCohortDerivationBytes) && bytesCompare(c.dropCohortDerivationBytes[start:end], record) == 0
+			}
+			if priorMember.head != head || priorMember.action != identity || !priorBytesOK {
+				c.recordDropCohortMutation(cohortIndex)
+				c.dropCohortRecords[cohortIndex].state = DropCohortBlended
+				operationErr = errors.New("parser-core phase zero: drop-cohort branch conflict")
+				return nil
+			}
+			operationErr = errors.New("parser-core phase zero: duplicate drop-cohort member")
+			return nil
+		}
+		slot := reservation.derivations + int(branch)
+		byteOffset := reservation.derivationBytes + int(branch)*int(reservation.derivationBytesEach)
+		if byteOffset < 0 || byteOffset+int(reservation.derivationBytesEach) > len(c.dropCohortDerivationBytes) {
+			return errors.New("parser-core phase zero: drop-cohort derivation slot is invalid")
+		}
+		for index := byteOffset; index < byteOffset+int(reservation.derivationBytesEach); index++ {
+			c.dropCohortDerivationBytes[index] = 0
+		}
+		copy(c.dropCohortDerivationBytes[byteOffset:], record)
+		c.dropCohortDerivationIntern[reservation.interner+int(branch)] = dropCohortDerivationInternEntry{digest: digest, byteOffset: uint32(byteOffset), byteLength: uint32(len(record))}
+		c.dropCohortMapStore[reservation.mapEntries+int(branch)] = dropCohortMapEntry{hash: binary.LittleEndian.Uint64(digest[:8]), index: uint32(slot), used: true}
+		derivation := DropCohortDerivationHandle{Owner: c.dropCohortOwner, Epoch: c.dropCohortEpoch, Index: uint32(slot + 1)}
+		c.dropCohortDerivations[slot] = dropCohortDerivationRecord{handle: derivation, head: head, digest: digest, byteOffset: uint32(byteOffset), byteLength: uint32(len(record))}
+		operationErr = c.writeDropCohortMemberOwned(cohort, head, branch, derivation)
+		if operationErr == nil {
+			for memberIndex := len(c.dropCohortMembers) - 1; memberIndex >= 0; memberIndex-- {
+				if c.dropCohortMembers[memberIndex].cohort == cohort && c.dropCohortMembers[memberIndex].branch == branch {
+					c.dropCohortMembers[memberIndex].action = identity
+					break
+				}
+			}
+		}
+		if operationErr != nil && (strings.Contains(operationErr.Error(), "branch exceeds expected") || strings.Contains(operationErr.Error(), "branch conflict")) {
+			for index := byteOffset; index < byteOffset+int(reservation.derivationBytesEach); index++ {
+				c.dropCohortDerivationBytes[index] = 0
+			}
+			c.dropCohortDerivations[slot] = dropCohortDerivationRecord{}
+			c.dropCohortDerivationIntern[reservation.interner+int(branch)] = dropCohortDerivationInternEntry{}
+			c.dropCohortMapStore[reservation.mapEntries+int(branch)] = dropCohortMapEntry{}
+			return nil
+		}
+		return operationErr
+	})
+	if err != nil {
+		return err
+	}
+	return operationErr
+}
+
+func (c *Core) DiagnosticDropCohortFinalizeForTest(rawHandle [3]uint64) error {
+	if c == nil {
+		return errors.New("parser-core phase zero: nil drop-cohort core")
+	}
+	return c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, err := c.finalizeDropCohortOwned(DropCohortHandle{Owner: rawHandle[0], Epoch: rawHandle[1], Sequence: rawHandle[2]})
+		return err
+	})
+}
+
+func (c *Core) DiagnosticDropCohortMarkUnprovedForTest(rawHandle [3]uint64) error {
+	if c == nil {
+		return errors.New("parser-core phase zero: nil drop-cohort core")
+	}
+	return c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		cohort := DropCohortHandle{Owner: rawHandle[0], Epoch: rawHandle[1], Sequence: rawHandle[2]}
+		index, err := c.validateDropCohortIdentity(cohort)
+		if err != nil {
+			return err
+		}
+		if c.dropCohortRecords[index].state != DropCohortComplete {
+			return errors.New("parser-core phase zero: drop-cohort is not complete")
+		}
+		c.recordDropCohortMutation(index)
+		c.dropCohortRecords[index].state = DropCohortUnproved
+		return nil
+	})
+}
+
+func (c *Core) DiagnosticDropCohortRollbackForTest(rawHandle [3]uint64) error {
+	if c == nil {
+		return errors.New("parser-core phase zero: nil drop-cohort core")
+	}
+	cohort := DropCohortHandle{Owner: rawHandle[0], Epoch: rawHandle[1], Sequence: rawHandle[2]}
+	if len(c.dropCohortReservations) == 0 {
+		return errors.New("parser-core phase zero: unknown drop-cohort reservation")
+	}
+	reservation := c.dropCohortReservations[len(c.dropCohortReservations)-1]
+	if reservation.handle != cohort {
+		return errors.New("parser-core phase zero: drop-cohort rollback is not the latest reservation")
+	}
+	if reservation.actions > len(c.dropCohortActions) || reservation.records > len(c.dropCohortRecords) || reservation.members > len(c.dropCohortMembers) || reservation.derivations > len(c.dropCohortDerivations) || reservation.derivationBytes > len(c.dropCohortDerivationBytes) || reservation.interner > len(c.dropCohortDerivationIntern) || reservation.certificateRefs > len(c.dropCohortCertificateRefs) || reservation.mapEntries > len(c.dropCohortMapStore) || reservation.journalEntries > len(c.dropCohortJournalStore) || reservation.journalMutations > len(c.dropCohortJournal) {
+		return errors.New("parser-core phase zero: drop-cohort rollback checkpoint is invalid")
+	}
+	c.dropCohortActions = reservation.actionsHeader
+	c.dropCohortRecords = reservation.recordsHeader
+	c.dropCohortMembers = reservation.membersHeader
+	c.dropCohortDerivations = reservation.derivationsHeader
+	c.dropCohortDerivationBytes = reservation.derivationBytesHead
+	c.dropCohortDerivationIntern = reservation.internerHeader
+	c.dropCohortCertificateRefs = reservation.certificateRefsHead
+	c.dropCohortMapStore = reservation.mapEntriesHeader
+	c.dropCohortJournalStore = reservation.journalStoreHeader
+	c.dropCohortJournal = reservation.journalHeader
+	c.dropCohortOwnerCheckedLookups = reservation.ownerChecks
+	c.dropCohortNextSequence = reservation.previousNext
+	c.dropCohortReleaseReservationRemainder(cohort)
+	if reservation.reservationsMoved {
+		c.dropCohortReservations = reservation.reservationsHeader
+	} else {
+		c.dropCohortReservations = c.dropCohortReservations[: len(c.dropCohortReservations)-1 : reservation.reservationsCap]
+	}
+	return nil
+}
+
+func (c *Core) DiagnosticDropCohortOwnerWrapProbeForTest() (uint64, uint64, error) {
+	if c == nil {
+		return 0, 0, errors.New("parser-core phase zero: nil drop-cohort core")
+	}
+	// Exercise the same atomic allocator with a private scoped counter. Do not
+	// overwrite the process allocator while another Core can allocate an owner.
+	var probe atomic.Uint64
+	probe.Store(math.MaxUint64)
+	_, err := allocateDropCohortOwnerFrom(&probe)
+	return math.MaxUint64, 0, err
+}
+
+func (c *Core) DiagnosticDropCohortEpochWrapProbeForTest() (uint64, uint64, error) {
+	if c == nil {
+		return 0, 0, errors.New("parser-core phase zero: nil drop-cohort core")
+	}
+	previous := c.dropCohortEpoch
+	c.dropCohortEpoch = math.MaxUint64
+	err := c.advanceDropCohortEpoch()
+	c.dropCohortEpoch = previous
+	return math.MaxUint64, 0, err
+}
+
+func (c *Core) DiagnosticDropCohortSequenceWrapProbeForTest() (uint64, uint64, error) {
+	if c == nil {
+		return 0, 0, errors.New("parser-core phase zero: nil drop-cohort core")
+	}
+	previous := c.dropCohortNextSequence
+	c.dropCohortNextSequence = math.MaxUint64
+	err := c.dropCohortPreflight(1)
+	c.dropCohortNextSequence = previous
+	return math.MaxUint64, 0, err
+}

--- a/internal/parsercorephase0/eof_recovery_shadow.go
+++ b/internal/parsercorephase0/eof_recovery_shadow.go
@@ -299,6 +299,12 @@ func planDiagnosticEOFRecoveryClone(live *Core, payloads []SubtreeID, providerWr
 		{len(live.checkpoints.bytes), 1},
 		{len(live.boundaries.slots), coreBoundarySlotBytes},
 		{len(live.alternativeSpillArena), coreUint32Bytes},
+		{len(live.dropCohortRefSpill), coreDropCohortRefBytes},
+		{len(live.dropCohortActions), coreDropCohortActionBytes},
+		{len(live.dropCohortRecords), coreDropCohortRecordBytes},
+		{len(live.dropCohortMembers), coreDropCohortMemberBytes},
+		{len(live.dropCohortDerivations), coreDropCohortDerivationRecordBytes},
+		{len(live.dropCohortDerivationBytes), 1},
 	} {
 		bytes, ok := diagnosticEOFRecoveryMul(uint64(item.count), item.bytes)
 		if !ok || !diagnosticEOFRecoveryAdd(&plan.copiedArenaBytes, bytes) {
@@ -454,10 +460,19 @@ func cloneDiagnosticEOFRecoveryCore(
 	shadow.checkpoints.buckets = nil
 	shadow.boundaries.slots = cloneDiagnosticSlice(live.boundaries.slots, 0)
 	shadow.alternativeSpillArena = cloneDiagnosticSlice(live.alternativeSpillArena, 0)
+	shadow.dropCohortRefSpill = cloneDiagnosticSlice(live.dropCohortRefSpill, 0)
+	shadow.dropCohortActions = cloneDiagnosticSlice(live.dropCohortActions, 0)
+	shadow.dropCohortRecords = cloneDiagnosticSlice(live.dropCohortRecords, 0)
+	shadow.dropCohortMembers = cloneDiagnosticSlice(live.dropCohortMembers, 0)
+	shadow.dropCohortDerivations = cloneDiagnosticSlice(live.dropCohortDerivations, 0)
+	shadow.dropCohortDerivationBytes = cloneDiagnosticSlice(live.dropCohortDerivationBytes, 0)
 
 	// One append does not use live journals, schedulers, or retained builders.
 	shadow.boundaryJournal = nil
 	shadow.nodeLineageJournal = nil
+	shadow.dropCohortJournal = nil
+	shadow.dropCohortDerivationScratch = nil
+	shadow.dropCohortPathScratch = nil
 	shadow.condenseCandidates = nil
 	shadow.condenseNewNode = 0
 	shadow.condenseScopeActive = false
@@ -518,7 +533,13 @@ func diagnosticEOFRecoveryCopiedArenasEqual(live, shadow *Core) bool {
 		equalDiagnosticSlice(live.checkpoints.records, shadow.checkpoints.records) &&
 		equalDiagnosticSlice(live.checkpoints.bytes, shadow.checkpoints.bytes) &&
 		equalDiagnosticSlice(live.boundaries.slots, shadow.boundaries.slots) &&
-		equalDiagnosticSlice(live.alternativeSpillArena, shadow.alternativeSpillArena)
+		equalDiagnosticSlice(live.alternativeSpillArena, shadow.alternativeSpillArena) &&
+		equalDiagnosticSlice(live.dropCohortRefSpill, shadow.dropCohortRefSpill) &&
+		equalDiagnosticSlice(live.dropCohortActions, shadow.dropCohortActions) &&
+		equalDiagnosticSlice(live.dropCohortRecords, shadow.dropCohortRecords) &&
+		equalDiagnosticSlice(live.dropCohortMembers, shadow.dropCohortMembers) &&
+		equalDiagnosticSlice(live.dropCohortDerivations, shadow.dropCohortDerivations) &&
+		equalDiagnosticSlice(live.dropCohortDerivationBytes, shadow.dropCohortDerivationBytes)
 }
 
 func diagnosticEOFRecoveryCopiedHeadersEqual(live, shadow *Core) bool {
@@ -565,7 +586,13 @@ func diagnosticEOFRecoveryStorageDisjoint(live, shadow *Core) bool {
 		disjointDiagnosticSlice(live.checkpoints.records, shadow.checkpoints.records) &&
 		disjointDiagnosticSlice(live.checkpoints.bytes, shadow.checkpoints.bytes) &&
 		disjointDiagnosticSlice(live.boundaries.slots, shadow.boundaries.slots) &&
-		disjointDiagnosticSlice(live.alternativeSpillArena, shadow.alternativeSpillArena)
+		disjointDiagnosticSlice(live.alternativeSpillArena, shadow.alternativeSpillArena) &&
+		disjointDiagnosticSlice(live.dropCohortRefSpill, shadow.dropCohortRefSpill) &&
+		disjointDiagnosticSlice(live.dropCohortActions, shadow.dropCohortActions) &&
+		disjointDiagnosticSlice(live.dropCohortRecords, shadow.dropCohortRecords) &&
+		disjointDiagnosticSlice(live.dropCohortMembers, shadow.dropCohortMembers) &&
+		disjointDiagnosticSlice(live.dropCohortDerivations, shadow.dropCohortDerivations) &&
+		disjointDiagnosticSlice(live.dropCohortDerivationBytes, shadow.dropCohortDerivationBytes)
 }
 
 func disjointDiagnosticSlice[T any](left, right []T) bool {

--- a/internal/parsercorephase0/g18_alternative_set_contract_test.go
+++ b/internal/parsercorephase0/g18_alternative_set_contract_test.go
@@ -1,0 +1,202 @@
+package parsercorephase0
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type g18FutureHistoricalCertificateTelemetryProvider interface {
+	DiagnosticDropCohortArenaIdentityForTest() (uint64, uint64)
+	DiagnosticDropCohortSnapshotForTest() []byte
+}
+
+type g18FutureHistoricalCertificateTelemetry struct {
+	Schema                      string            `json:"schema"`
+	ArenaOwner                  uint64            `json:"arena_owner"`
+	ArenaEpoch                  uint64            `json:"arena_epoch"`
+	ProducerWrites              map[string]uint64 `json:"producer_writes"`
+	AuthenticatedHistoryImports uint64            `json:"authenticated_history_imports"`
+	UnprovedHistoryImports      uint64            `json:"unproved_history_imports"`
+}
+
+var g18HistoricalProducerNames = []string{
+	"reduction_establishment",
+	"linear_canonicalizer",
+	"mapped_canonicalizer",
+	"sibling_adoption",
+	"conflict_reconciliation",
+	"dead_history_import",
+}
+
+// TestG18HistoricalAlternativeSetProducerPath exercises the real dead-node
+// import. A retired converged boundary must publish its authenticated set on
+// the replacement reduction output.
+func TestG18HistoricalAlternativeSetProducerPath(t *testing.T) {
+	compact, outputs := g18HistoricalAlternativeSetProducerFixture(t, nil, nil)
+	members, ok := compact.AlternativeSetMembers(outputs[0].HistoricalAlternativeSet)
+	if !ok || len(members) != 3 || outputs[0].HistoricalBlended {
+		t.Fatalf(
+			"replacement history members=%v valid=%t blended=%t, want three authenticated members",
+			members,
+			ok,
+			outputs[0].HistoricalBlended,
+		)
+	}
+}
+
+// TestG18HistoricalAlternativeSetCertificateTelemetryRED binds the real
+// dead-node import to the future certificate arena. Current main does not
+// publish this telemetry.
+func TestG18HistoricalAlternativeSetCertificateTelemetryRED(t *testing.T) {
+	var provider g18FutureHistoricalCertificateTelemetryProvider
+	var before g18FutureHistoricalCertificateTelemetry
+	var after g18FutureHistoricalCertificateTelemetry
+	g18HistoricalAlternativeSetProducerFixture(
+		t,
+		func(compact *Core) {
+			var ok bool
+			provider, ok = any(compact).(g18FutureHistoricalCertificateTelemetryProvider)
+			if !ok {
+				t.Fatal("RED: real Core does not implement dead-history behavior telemetry")
+			}
+			before = g18DecodeHistoricalSnapshot(t, provider)
+		},
+		func(_ *Core) {
+			after = g18DecodeHistoricalSnapshot(t, provider)
+		},
+	)
+	for _, name := range g18HistoricalProducerNames {
+		want := uint64(0)
+		if name == "dead_history_import" {
+			want = 1
+		}
+		if after.ProducerWrites[name] < before.ProducerWrites[name] {
+			t.Fatalf("dead-history producer counter %s decreased", name)
+		}
+		if got := after.ProducerWrites[name] - before.ProducerWrites[name]; got != want {
+			t.Fatalf("dead-history producer delta %s=%d, want %d", name, got, want)
+		}
+	}
+	if after.AuthenticatedHistoryImports < before.AuthenticatedHistoryImports ||
+		after.AuthenticatedHistoryImports-before.AuthenticatedHistoryImports != 1 ||
+		after.UnprovedHistoryImports != before.UnprovedHistoryImports {
+		t.Fatalf(
+			"dead-history import counters authenticated=%d/%d unproved=%d/%d, want authenticated +1 and unproved +0",
+			before.AuthenticatedHistoryImports,
+			after.AuthenticatedHistoryImports,
+			before.UnprovedHistoryImports,
+			after.UnprovedHistoryImports,
+		)
+	}
+}
+
+func g18DecodeHistoricalSnapshot(
+	t *testing.T,
+	provider g18FutureHistoricalCertificateTelemetryProvider,
+) g18FutureHistoricalCertificateTelemetry {
+	t.Helper()
+	var telemetry g18FutureHistoricalCertificateTelemetry
+	if err := json.Unmarshal(provider.DiagnosticDropCohortSnapshotForTest(), &telemetry); err != nil {
+		t.Fatalf("decode dead-history certificate snapshot: %v", err)
+	}
+	owner, epoch := provider.DiagnosticDropCohortArenaIdentityForTest()
+	if telemetry.Schema != "gts-drop-cohort-certificate-arena/v2" || owner == 0 || epoch == 0 ||
+		telemetry.ArenaOwner != owner || telemetry.ArenaEpoch != epoch {
+		t.Fatalf("dead-history certificate snapshot=%+v identity=%d/%d", telemetry, owner, epoch)
+	}
+	for _, producer := range g18HistoricalProducerNames {
+		if _, ok := telemetry.ProducerWrites[producer]; !ok {
+			t.Fatalf("dead-history certificate snapshot omits producer counter %q", producer)
+		}
+	}
+	return telemetry
+}
+
+func g18HistoricalAlternativeSetProducerFixture(
+	t *testing.T,
+	beforeReduce func(*Core),
+	afterReduce func(*Core),
+) (*Core, []ReductionOutput) {
+	t.Helper()
+	tables := &fakeTable{
+		actions: map[tableCell][]Action{
+			{state: 3, symbol: 9}: {{Type: ActionReduce, Symbol: 2, ChildCount: 1}},
+		},
+		gotos: map[tableCell]StateID{{state: 1, symbol: 2}: 4},
+	}
+	compact, err := New(tables, Limits{MaxDerivations: 4, MaxPopPaths: 4, MaxLinksPerBoundary: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact.diagnostics.foldSamePredecessorShallowPayloads = false
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := compact.appendSubtree(
+		subtreeRecord{symbol: 1, terminal: true, endByte: 1}, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := compact.boundaryKey(4, 1)
+	retired, err := compact.condense(key, linkInput{prev: seed.Node, payload: payload, scoreDelta: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	retired, err = compact.condense(key, linkInput{prev: seed.Node, payload: payload, scoreDelta: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := compact.appendDiagnosticPayload(
+		seed,
+		3,
+		Token{Symbol: 10, EndByte: 1},
+		pathMeta{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	classified, err := compact.ClassifyBoundary(source, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var outputs []ReductionOutput
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if err := compact.RecordReductionLineageOwned(owner, []ReductionOutput{{
+			Head: retired, CleanPathRank: CleanPathRankSelected, MultiplePopPaths: true,
+		}}, 7); err != nil {
+			return err
+		}
+		set := NewAlternativeSetMember(7, 0)
+		compact.UnionAlternativeSet(&set, NewAlternativeSetMember(7, 1))
+		compact.UnionAlternativeSet(&set, NewAlternativeSetMember(7, 2))
+		if err := compact.RecordHeadLineageSetOwned(owner, retired, set, false); err != nil {
+			return err
+		}
+		if beforeReduce != nil {
+			beforeReduce(compact)
+		}
+		var reduceErr error
+		outputs, reduceErr = compact.ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesOwned(
+			owner,
+			nil,
+			nil,
+			classified,
+			0,
+			ForkOrder{},
+		)
+		if reduceErr == nil && afterReduce != nil {
+			afterReduce(compact)
+		}
+		return reduceErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(outputs) != 1 || outputs[0].HistoricalBoundaryProvenance != HistoricalBoundaryConverged {
+		t.Fatalf("replacement outputs=%+v, want one converged historical boundary", outputs)
+	}
+	return compact, outputs
+}

--- a/internal/parsercorephase0/g18_refset_test.go
+++ b/internal/parsercorephase0/g18_refset_test.go
@@ -1,0 +1,266 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"reflect"
+	"runtime"
+	"slices"
+	"testing"
+	"unsafe"
+)
+
+func g18Ref(owner, epoch, sequence uint64, branch uint16) DropCohortRef {
+	return DropCohortRef{Owner: owner, Epoch: epoch, Sequence: sequence, Branch: branch}
+}
+
+func g18RefSetFrom(t *testing.T, core *Core, refs ...DropCohortRef) DropCohortRefSet {
+	t.Helper()
+	var set DropCohortRefSet
+	for _, ref := range refs {
+		if !core.AddDropCohortRef(&set, ref) && set.Len() == 0 {
+			t.Fatalf("add drop-cohort ref %v failed", ref)
+		}
+	}
+	return set
+}
+
+func g18Members(t *testing.T, core *Core, set DropCohortRefSet) []DropCohortRef {
+	t.Helper()
+	members := make([]DropCohortRef, set.Len())
+	for index := range members {
+		var ok bool
+		members[index], ok = core.DropCohortRefAt(set, index)
+		if !ok {
+			t.Fatalf("reference %d is invalid in %+v", index, set)
+		}
+	}
+	return members
+}
+
+func TestG18RefSetNestedAndSequential(t *testing.T) {
+	core := newTinyCore(t, 8)
+	var set DropCohortRefSet
+	refs := []DropCohortRef{
+		g18Ref(9, 1, 2, 1),
+		g18Ref(9, 1, 1, 1),
+		g18Ref(9, 1, 3, 0),
+		g18Ref(8, 2, 1, 0),
+	}
+	for _, ref := range refs {
+		if !core.AddDropCohortRef(&set, ref) {
+			t.Fatalf("add %v failed", ref)
+		}
+	}
+	members := g18Members(t, core, set)
+	want := slices.Clone(refs)
+	slices.SortFunc(want, func(left, right DropCohortRef) int {
+		if dropCohortRefLess(left, right) {
+			return -1
+		}
+		if dropCohortRefLess(right, left) {
+			return 1
+		}
+		return 0
+	})
+	if !slices.Equal(members, want) {
+		t.Fatalf("ordered refs=%v, want %v", members, want)
+	}
+	if !set.Spilled() || set.Len() != len(want) {
+		t.Fatalf("nested/sequential set=%+v, want spilled count %d", set, len(want))
+	}
+}
+
+func TestG18RefSetOrderDedupeAndMultiBranchValidity(t *testing.T) {
+	core := newTinyCore(t, 8)
+	first := g18Ref(3, 4, 5, 1)
+	set := g18RefSetFrom(t, core, first, first, g18Ref(3, 4, 5, 0))
+	members := g18Members(t, core, set)
+	if set.Blended() || set.Len() != 2 || len(members) != 2 {
+		t.Fatalf("multi-branch set=%+v members=%v", set, members)
+	}
+	if !dropCohortRefLess(members[0], members[1]) {
+		t.Fatalf("multi-branch order=%v", members)
+	}
+	if core.AddDropCohortRef(&set, first) {
+		t.Fatal("exact duplicate insertion reported a change")
+	}
+	if set.Len() != 2 {
+		t.Fatalf("exact duplicate changed count: %+v", set)
+	}
+}
+
+func TestG18RefSetInlineToSpillAndOverflow(t *testing.T) {
+	core := newTinyCore(t, 8)
+	var set DropCohortRefSet
+	for index := 0; index < dropCohortRefHardCap+1; index++ {
+		ref := g18Ref(1, 1, uint64(index+1), 0)
+		if !core.AddDropCohortRef(&set, ref) && index < dropCohortRefHardCap {
+			t.Fatalf("add %d failed before hard cap", index)
+		}
+	}
+	if !set.Spilled() || !set.Overflowed() || set.Len() != dropCohortRefHardCap {
+		t.Fatalf("overflow set=%+v, want spilled count %d and overflow", set, dropCohortRefHardCap)
+	}
+	if got := len(core.dropCohortRefSpill); got != dropCohortRefHardCap {
+		t.Fatalf("sequential spill length=%d, want %d", got, dropCohortRefHardCap)
+	}
+	before := set
+	if core.AddDropCohortRef(&set, g18Ref(1, 1, 1000, 0)) {
+		t.Fatal("overflowed set accepted a new reference")
+	}
+	if !reflect.DeepEqual(set, before) {
+		t.Fatalf("overflowed set changed: before=%+v after=%+v", before, set)
+	}
+}
+
+func TestG18RefSetRollbackRestoresNodeAndSpillExactly(t *testing.T) {
+	core := newTinyCore(t, 8)
+	head, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeSpill := slices.Clone(core.dropCohortRefSpill)
+	sentinel := errors.New("g18 reference rollback")
+	err = core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		refs := g18RefSetFrom(t, core,
+			g18Ref(1, 1, 1, 0), g18Ref(1, 1, 2, 0), g18Ref(1, 1, 3, 0),
+		)
+		if err := core.RecordHeadLineageRefsOwned(owner, head, refs); err != nil {
+			return err
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("rollback error=%v, want %v", err, sentinel)
+	}
+	got, err := core.NodeLineageDropCohortRefs(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Empty() || !slices.Equal(core.dropCohortRefSpill, beforeSpill) {
+		t.Fatalf("rollback refs=%+v spill=%v, want empty and %v", got, core.dropCohortRefSpill, beforeSpill)
+	}
+}
+
+func TestG18RefSetPreflightLimitsAreAtomic(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxDropCohortRefs: 2, MaxDropCohortRefBytes: 2 * uint64(unsafe.Sizeof(DropCohortRef{}))})
+	var set DropCohortRefSet
+	if !core.AddDropCohortRef(&set, g18Ref(1, 1, 1, 0)) || !core.AddDropCohortRef(&set, g18Ref(1, 1, 2, 0)) {
+		t.Fatal("inline preflight setup failed")
+	}
+	beforeSet := set
+	beforeSpill := slices.Clone(core.dropCohortRefSpill)
+	if core.AddDropCohortRef(&set, g18Ref(1, 1, 3, 0)) {
+		t.Fatal("spill preflight accepted an over-limit reference")
+	}
+	if !reflect.DeepEqual(set, beforeSet) || !slices.Equal(core.dropCohortRefSpill, beforeSpill) {
+		t.Fatalf("failed preflight changed set=%+v spill=%v", set, core.dropCohortRefSpill)
+	}
+}
+
+func TestG18RefSetAccountingResetAndRetentionRelease(t *testing.T) {
+	core := newTinyCore(t, 8)
+	beforeStorage := core.StorageBytes()
+	var set DropCohortRefSet
+	for index := 0; index < 3; index++ {
+		if !core.AddDropCohortRef(&set, g18Ref(1, 1, uint64(index+1), 0)) {
+			t.Fatal("spill setup failed")
+		}
+	}
+	wantDelta := uint64(len(core.dropCohortRefSpill)) * uint64(unsafe.Sizeof(DropCohortRef{}))
+	if got := core.StorageBytes() - beforeStorage; got != wantDelta {
+		t.Fatalf("StorageBytes delta=%d, want %d", got, wantDelta)
+	}
+	if got := core.FootprintBytes(); got < wantDelta {
+		t.Fatalf("FootprintBytes=%d, want at least %d", got, wantDelta)
+	}
+	retained := cap(core.dropCohortRefSpill)
+	if err := core.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	if len(core.dropCohortRefSpill) != 0 || cap(core.dropCohortRefSpill) != retained {
+		t.Fatalf("Reset spill len/cap=%d/%d, want 0/%d", len(core.dropCohortRefSpill), cap(core.dropCohortRefSpill), retained)
+	}
+	core.dropCohortRefSpill = make([]DropCohortRef, coreRetentionCapBytes/uint64(unsafe.Sizeof(DropCohortRef{}))+1)
+	if err := core.ResetReleasingRetention(); err != nil {
+		t.Fatal(err)
+	}
+	if core.dropCohortRefSpill != nil {
+		t.Fatal("retention release kept an oversized drop-cohort spill")
+	}
+}
+
+func TestG18RefSetReductionOutputAndNodePersistence(t *testing.T) {
+	core := newTinyCore(t, 8)
+	head, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := g18RefSetFrom(t, core, g18Ref(1, 2, 3, 0), g18Ref(1, 2, 3, 1), g18Ref(2, 1, 1, 0))
+	if err := core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return core.RecordReductionLineageOwned(owner, []ReductionOutput{{
+			Head: head, DropCohortRefs: refs, CleanPathRank: CleanPathRankSelected, MultiplePopPaths: true,
+		}}, 1)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := core.NodeLineageDropCohortRefs(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	members := g18Members(t, core, got)
+	if len(members) != refs.Len() || got.Blended() {
+		t.Fatalf("persisted refs=%+v members=%v", got, members)
+	}
+}
+
+func TestG18RefSetRecordSizes(t *testing.T) {
+	if got := unsafe.Sizeof(DropCohortRef{}); got != 32 {
+		t.Fatalf("DropCohortRef size=%d, want 32", got)
+	}
+	if got := unsafe.Sizeof(DropCohortRefSet{}); got != 72 {
+		t.Fatalf("DropCohortRefSet size=%d, want 72", got)
+	}
+	if got := unsafe.Sizeof(nodeLineageRecord{}); got != 104 {
+		t.Fatalf("nodeLineageRecord size=%d, want 104", got)
+	}
+	if got := unsafe.Sizeof(nodeLineageMutation{}); got != 96 {
+		t.Fatalf("nodeLineageMutation size=%d, want 96", got)
+	}
+	if got := unsafe.Sizeof(ReductionOutput{}); got != 104 {
+		t.Fatalf("ReductionOutput size=%d, want 104", got)
+	}
+	if got := unsafe.Sizeof(CondenseCandidate{}); got != 88 {
+		t.Fatalf("CondenseCandidate size=%d, want 88", got)
+	}
+}
+
+func TestG18RefSetInlineEnumerationAndUnionAllocations(t *testing.T) {
+	core := newTinyCore(t, 8)
+	left := g18RefSetFrom(t, core, g18Ref(1, 1, 1, 0))
+	right := g18RefSetFrom(t, core, g18Ref(2, 1, 1, 0))
+	var sink DropCohortRef
+	enumerationAllocs := testing.AllocsPerRun(1000, func() {
+		for index := 0; index < left.Len(); index++ {
+			var ok bool
+			sink, ok = core.DropCohortRefAt(left, index)
+			if !ok {
+				t.Fatal("inline reference enumeration failed")
+			}
+		}
+		runtime.KeepAlive(sink)
+	})
+	if enumerationAllocs != 0 {
+		t.Fatalf("inline enumeration allocations=%v, want zero", enumerationAllocs)
+	}
+	unionAllocs := testing.AllocsPerRun(1000, func() {
+		dst := left
+		if !core.UnionDropCohortRefs(&dst, right) {
+			t.Fatal("inline union did not change the destination")
+		}
+		runtime.KeepAlive(dst)
+	})
+	if unionAllocs != 0 {
+		t.Fatalf("inline union allocations=%v, want zero", unionAllocs)
+	}
+}

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -3,6 +3,7 @@ package parsercorephase0
 import (
 	"errors"
 	"fmt"
+	"math"
 )
 
 const inlineSchedulerCohortTargets = 8
@@ -42,10 +43,17 @@ func (c *Core) RecordReductionLineageOwned(owner SchedulerTransactionToken, outp
 			if err := c.recordNodeLineage(output.Head, output.CleanPathRank, lineage); err != nil {
 				return err
 			}
+			if err := c.recordNodeLineageRefs(output.Head, output.DropCohortRefs); err != nil {
+				return err
+			}
 			if err := c.recordNodeLineageMember(output.Head, lineage, uint16(index)); err != nil {
 				return err
 			}
 		}
+		// Count the authentic establishment only after every lineage mutation
+		// succeeds. The surrounding scheduler transaction restores this counter
+		// with the same checkpoint as the lineage journal.
+		c.addDropCohortProducerWrite(dropCohortProducerReductionEstablishment)
 		return nil
 	})
 }
@@ -75,6 +83,7 @@ func (c *Core) RecordHeadLineageOwned(
 	set AlternativeSet,
 	setBlended bool,
 	setDirty bool,
+	dropCohortRefs ...DropCohortRefSet,
 ) error {
 	return c.RunSchedulerOwned(owner, func() error {
 		if rank != CleanPathRankSelected && rank != CleanPathRankUnselected || lineage == 0 {
@@ -84,10 +93,17 @@ func (c *Core) RecordHeadLineageOwned(
 		if err := c.recordNodeLineage(head, rank, lineage); err != nil {
 			return err
 		}
-		if !setDirty {
-			return nil
+		if setDirty {
+			if err := c.recordNodeLineageSet(head, set, setBlended); err != nil {
+				return err
+			}
 		}
-		return c.recordNodeLineageSet(head, set, setBlended)
+		for _, refs := range dropCohortRefs {
+			if err := c.recordNodeLineageRefs(head, refs); err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 }
 
@@ -127,7 +143,7 @@ func (c *Core) recordNodeLineage(head Head, rank CleanPathRankSelection, lineage
 	}
 	if len(c.transactions) != 0 {
 		c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
-			node: head.Node, owner: node.owner,
+			node: head.Node, owner: node.owner, dropCohortRefs: node.dropCohortRefs,
 			setCount: node.set.count, setFlags: node.set.flags, setSpillRef: node.set.spillRef,
 			lineage: node.lineage, rank: node.rank, converged: node.converged, blended: node.blended,
 		})
@@ -156,7 +172,7 @@ func (c *Core) RecordHeadOwnerOwned(owner SchedulerTransactionToken, head Head, 
 		}
 		if len(c.transactions) != 0 {
 			c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
-				node: head.Node, owner: node.owner,
+				node: head.Node, owner: node.owner, dropCohortRefs: node.dropCohortRefs,
 				setCount: node.set.count, setFlags: node.set.flags, setSpillRef: node.set.spillRef,
 				lineage: node.lineage, rank: node.rank, converged: node.converged, blended: node.blended,
 			})
@@ -202,12 +218,47 @@ func (c *Core) recordNodeLineageSet(head Head, set AlternativeSet, setBlended bo
 	nextBlended := beforeBlended || setBlended || incomparable
 	if len(c.transactions) != 0 {
 		c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
-			node: head.Node, owner: node.owner,
+			node: head.Node, owner: node.owner, dropCohortRefs: node.dropCohortRefs,
 			setCount: before.count, setFlags: before.flags, setSpillRef: before.spillRef,
 			lineage: node.lineage, rank: node.rank, converged: node.converged, blended: beforeBlended,
 		})
 	}
 	node.blended = nextBlended
+	return nil
+}
+
+// RecordHeadLineageRefsOwned unions drop-cohort references into one compact
+// head. Keep this separate from the older scalar-and-alternative-set method
+// so callers can migrate without changing the established API shape.
+func (c *Core) RecordHeadLineageRefsOwned(owner SchedulerTransactionToken, head Head, refs DropCohortRefSet) error {
+	return c.RunSchedulerOwned(owner, func() error {
+		return c.recordNodeLineageRefs(head, refs)
+	})
+}
+
+func (c *Core) recordNodeLineageRefs(head Head, refs DropCohortRefSet) error {
+	if refs.Empty() && !refs.Overflowed() && !refs.Blended() {
+		return nil
+	}
+	node, err := c.nodeLineage(head.Node)
+	if err != nil {
+		return err
+	}
+	before := node.dropCohortRefs
+	changed, err := c.dropCohortRefUnion(&node.dropCohortRefs, refs)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	if len(c.transactions) != 0 {
+		c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
+			node: head.Node, owner: node.owner, dropCohortRefs: before,
+			setCount: node.set.count, setFlags: node.set.flags, setSpillRef: node.set.spillRef,
+			lineage: node.lineage, rank: node.rank, converged: node.converged, blended: node.blended,
+		})
+	}
 	return nil
 }
 
@@ -234,7 +285,7 @@ func (c *Core) recordNodeLineageMember(head Head, event, branch uint16) error {
 	}
 	if len(c.transactions) != 0 {
 		c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
-			node: head.Node, owner: node.owner,
+			node: head.Node, owner: node.owner, dropCohortRefs: node.dropCohortRefs,
 			setCount: before.count, setFlags: before.flags, setSpillRef: before.spillRef,
 			lineage: node.lineage, rank: node.rank, converged: node.converged, blended: node.blended,
 		})
@@ -953,6 +1004,14 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 		historicalLineage := previous.historicalLineage
 		historicalSet := previous.historicalSet
 		historicalBlended := previous.historicalBlended
+		dropCohortRefs := previous.dropCohortRefs
+		if source, refsErr := c.nodeLineage(path.prev); refsErr == nil {
+			if _, refsErr = c.dropCohortRefUnion(&dropCohortRefs, source.dropCohortRefs); refsErr != nil {
+				return nil, refsErr
+			}
+		} else {
+			return nil, refsErr
+		}
 		if outcome.historicalBoundarySplit {
 			switch {
 			case !previous.historicalBoundarySplit:
@@ -987,8 +1046,19 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 			// historicalSet blended -- computed before the union mutates it.
 			if outcome.historicalConvergedSplit {
 				if dead, err := c.nodeLineage(outcome.historicalNode); err == nil {
-					historicalBlended = historicalBlended || dead.blended || c.AlternativeSetIncomparable(historicalSet, dead.set)
-					c.alternativeSetUnion(&historicalSet, dead.set)
+					incomparable := c.AlternativeSetIncomparable(historicalSet, dead.set)
+					unionChanged := c.alternativeSetUnion(&historicalSet, dead.set)
+					wasBlended := historicalBlended
+					historicalBlended = historicalBlended || dead.blended || incomparable
+					if unionChanged || historicalBlended != wasBlended {
+						c.addDropCohortProducerWrite(dropCohortProducerDeadHistoryImport)
+						if c.dropCohortAuthenticatedHistory != math.MaxUint64 {
+							c.dropCohortAuthenticatedHistory++
+						}
+					}
+				}
+				if _, refsErr := c.dropCohortRefUnion(&dropCohortRefs, outcome.historicalDropCohortRefs); refsErr != nil {
+					return nil, refsErr
 				}
 			}
 		}
@@ -1006,6 +1076,7 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 		}
 		scratch.store(boundaryIndex, seen, reductionBoundaryOutput{
 			key: key, head: out, freshness: freshness, cleanPathRank: cleanPathRank,
+			dropCohortRefs:                dropCohortRefs,
 			historicalBoundarySplit:       historicalBoundarySplit,
 			historicalConvergedSplit:      historicalConvergedSplit,
 			historicalForestDeterministic: historicalForestDeterministic,
@@ -1027,6 +1098,7 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 		}
 		frontier = append(frontier, ReductionOutput{
 			Head:                         output.head,
+			DropCohortRefs:               output.dropCohortRefs,
 			Freshness:                    output.freshness,
 			CleanPathRank:                output.cleanPathRank,
 			MultiplePopPaths:             multiPop,

--- a/internal/parsercorephase0/storage_bytes.go
+++ b/internal/parsercorephase0/storage_bytes.go
@@ -6,17 +6,26 @@ import "unsafe"
 // once from each record type's real in-memory layout so StorageBytes stays
 // authoritative if a record ever gains or loses a field.
 var (
-	coreNodeRecordBytes    = uint64(unsafe.Sizeof(nodeRecord{}))
-	coreLinkRecordBytes    = uint64(unsafe.Sizeof(linkRecord{}))
-	coreSubtreeRecordBytes = uint64(unsafe.Sizeof(subtreeRecord{}))
-	coreChildRecordBytes   = uint64(unsafe.Sizeof(SubtreeID(0)))
-	coreFieldRecordBytes   = uint64(unsafe.Sizeof(FieldMapEntry{}))
-	coreAliasRecordBytes   = uint64(unsafe.Sizeof(Symbol(0)))
+	coreNodeRecordBytes                 = uint64(unsafe.Sizeof(nodeRecord{}))
+	coreLinkRecordBytes                 = uint64(unsafe.Sizeof(linkRecord{}))
+	coreSubtreeRecordBytes              = uint64(unsafe.Sizeof(subtreeRecord{}))
+	coreChildRecordBytes                = uint64(unsafe.Sizeof(SubtreeID(0)))
+	coreFieldRecordBytes                = uint64(unsafe.Sizeof(FieldMapEntry{}))
+	coreAliasRecordBytes                = uint64(unsafe.Sizeof(Symbol(0)))
+	coreDropCohortActionBytes           = uint64(unsafe.Sizeof(DropCohortActionIdentity{}))
+	coreDropCohortRecordBytes           = uint64(unsafe.Sizeof(dropCohortRecord{}))
+	coreDropCohortMemberBytes           = uint64(unsafe.Sizeof(dropCohortMember{}))
+	coreDropCohortDerivationRecordBytes = uint64(unsafe.Sizeof(dropCohortDerivationRecord{}))
+	coreDropCohortDerivationInternBytes = uint64(unsafe.Sizeof(dropCohortDerivationInternEntry{}))
+	coreDropCohortMutationBytes         = uint64(unsafe.Sizeof(dropCohortMutation{}))
+	coreDropCohortMapEntryBytes         = uint64(unsafe.Sizeof(dropCohortMapEntry{}))
+	coreDropCohortJournalStoreBytes     = uint64(unsafe.Sizeof(dropCohortJournalStoreEntry{}))
+	coreDropCohortReservationBytes      = uint64(unsafe.Sizeof(dropCohortReservation{}))
 )
 
 // StorageBytes returns a cheap, deterministic, O(1) estimate of the compact
 // core's current record storage in bytes: every growable record family's
-// live slice length times that family's real struct size. It costs six
+// live slice length times that family's real struct size. It uses only
 // multiply-adds over already-tracked slice lengths -- no allocation, no
 // traversal, no I/O -- so it is safe to call from a tight scheduler poll
 // (spec.campaign.v7 tranche B8).
@@ -50,13 +59,25 @@ func (c *Core) StorageBytes() uint64 {
 		uint64(len(c.subtrees))*coreSubtreeRecordBytes +
 		uint64(len(c.children))*coreChildRecordBytes +
 		uint64(len(c.fields))*coreFieldRecordBytes +
-		uint64(len(c.aliases))*coreAliasRecordBytes
+		uint64(len(c.aliases))*coreAliasRecordBytes +
+		uint64(len(c.dropCohortRefSpill))*coreDropCohortRefBytes +
+		uint64(len(c.dropCohortActions))*coreDropCohortActionBytes +
+		uint64(len(c.dropCohortRecords))*coreDropCohortRecordBytes +
+		uint64(len(c.dropCohortMembers))*coreDropCohortMemberBytes +
+		uint64(len(c.dropCohortDerivations))*coreDropCohortDerivationRecordBytes +
+		uint64(len(c.dropCohortDerivationIntern))*coreDropCohortDerivationInternBytes +
+		uint64(len(c.dropCohortDerivationBytes)) +
+		uint64(len(c.dropCohortCertificateRefs))*coreDropCohortRefBytes +
+		uint64(len(c.dropCohortMapStore))*coreDropCohortMapEntryBytes +
+		uint64(len(c.dropCohortJournalStore))*coreDropCohortJournalStoreBytes +
+		uint64(len(c.dropCohortReservations))*coreDropCohortReservationBytes +
+		uint64(len(c.dropCohortJournal))*coreDropCohortMutationBytes
 }
 
 // Byte footprints for the additional families FootprintBytes covers that
 // StorageBytes does not: the lineage/checkpoint/provenance side records, the
-// checkpoint interner, the boundary index, and the two dominant per-parse
-// scratch buffers (pop-path enumeration and reduction-output batching).
+// checkpoint interner, the boundary index, producer scratch, and scheduler
+// scratch buffers.
 var (
 	coreNodeLineageRecordBytes    = uint64(unsafe.Sizeof(nodeLineageRecord{}))
 	coreCheckpointIDBytes         = uint64(unsafe.Sizeof(CheckpointID(0)))
@@ -73,6 +94,7 @@ var (
 	coreHeadBytes                 = uint64(unsafe.Sizeof(Head{}))
 	coreLinkRecordSliceBytes      = uint64(unsafe.Sizeof([]linkRecord(nil)))
 	coreSubtreeIDBytes            = uint64(unsafe.Sizeof(SubtreeID(0)))
+	coreDropCohortPathStepBytes   = uint64(unsafe.Sizeof(dropCohortPathStep{}))
 	coreInt64Bytes                = uint64(unsafe.Sizeof(int64(0)))
 	coreForkOrderBytes            = uint64(unsafe.Sizeof(ForkOrder{}))
 	corePathPayloadBytes          = uint64(unsafe.Sizeof(pathPayload{}))
@@ -80,6 +102,7 @@ var (
 	coreReductionBoundaryOutBytes = uint64(unsafe.Sizeof(reductionBoundaryOutput{}))
 	coreBoundaryKeyEntryBytes     = uint64(unsafe.Sizeof(boundaryKey{})) + uint64(unsafe.Sizeof(int(0)))
 	coreUint16Bytes               = uint64(unsafe.Sizeof(uint16(0)))
+	coreDropCohortRefBytes        = uint64(unsafe.Sizeof(DropCohortRef{}))
 )
 
 // FootprintBytes returns a cheap, deterministic, O(1) estimate of the compact
@@ -125,6 +148,24 @@ func (c *Core) FootprintBytes() uint64 {
 	total += uint64(cap(c.boundaryJournal)) * coreBoundaryMutationBytes
 	total += uint64(cap(c.nodeLineageJournal)) * coreNodeLineageMutationBytes
 	total += uint64(cap(c.alternativeSpillArena)) * coreUint32Bytes
+	total += uint64(cap(c.dropCohortRefSpill)) * coreDropCohortRefBytes
+	total += uint64(cap(c.dropCohortActions)) * coreDropCohortActionBytes
+	total += uint64(cap(c.dropCohortRecords)) * coreDropCohortRecordBytes
+	total += uint64(cap(c.dropCohortMembers)) * coreDropCohortMemberBytes
+	total += uint64(cap(c.dropCohortDerivations)) * coreDropCohortDerivationRecordBytes
+	total += uint64(cap(c.dropCohortDerivationIntern)) * coreDropCohortDerivationInternBytes
+	total += uint64(cap(c.dropCohortDerivationBytes))
+	total += uint64(cap(c.dropCohortCertificateRefs)) * coreDropCohortRefBytes
+	total += uint64(cap(c.dropCohortMapStore)) * coreDropCohortMapEntryBytes
+	total += uint64(cap(c.dropCohortJournalStore)) * coreDropCohortJournalStoreBytes
+	total += uint64(cap(c.dropCohortReservations)) * coreDropCohortReservationBytes
+	// A durable reservation is a committed memory budget even before its
+	// backing store is filled. Include it in the containment gauge so nested
+	// sessions cannot hide committed capacity from the scheduler budget.
+	total += c.dropCohortReservedBytes
+	total += uint64(cap(c.dropCohortDerivationScratch))
+	total += uint64(cap(c.dropCohortPathScratch)) * coreDropCohortPathStepBytes
+	total += uint64(cap(c.dropCohortJournal)) * coreDropCohortMutationBytes
 	total += uint64(cap(c.condenseCandidates)) * coreCondenseCandidateBytes
 	total += uint64(cap(c.transactions)) * coreUint64Bytes
 	total += uint64(cap(c.historicalNodeScratch)) * coreNodeIDBytes
@@ -252,6 +293,19 @@ func (c *Core) releaseRecordArenaReserve() {
 	c.links = nil
 	c.subtrees = nil
 	c.children = nil
+	c.dropCohortRefSpill = nil
+	c.dropCohortActions = nil
+	c.dropCohortRecords = nil
+	c.dropCohortMembers = nil
+	c.dropCohortDerivations = nil
+	c.dropCohortDerivationIntern = nil
+	c.dropCohortDerivationBytes = nil
+	c.dropCohortCertificateRefs = nil
+	c.dropCohortMapStore = nil
+	c.dropCohortJournalStore = nil
+	c.dropCohortDerivationScratch = nil
+	c.dropCohortPathScratch = nil
+	c.dropCohortJournal = nil
 }
 
 func (c *Core) releaseOversizedRetention() {
@@ -270,10 +324,26 @@ func (c *Core) releaseOversizedRetention() {
 	c.boundaryJournal = nil
 	c.nodeLineageJournal = nil
 	c.alternativeSpillArena = nil
+	c.dropCohortRefSpill = nil
+	c.dropCohortActions = nil
+	c.dropCohortRecords = nil
+	c.dropCohortMembers = nil
+	c.dropCohortDerivations = nil
+	c.dropCohortDerivationIntern = nil
+	c.dropCohortDerivationBytes = nil
+	c.dropCohortCertificateRefs = nil
+	c.dropCohortMapStore = nil
+	c.dropCohortJournalStore = nil
+	c.dropCohortDerivationScratch = nil
+	c.dropCohortPathScratch = nil
+	c.dropCohortJournal = nil
 	c.transactions = nil
 	c.historicalNodeScratch = nil
 	c.cohortHeadScratch = nil
 	c.factorLinkScratch = nil
+	c.dropCohortReservations = nil
+	clear(c.dropCohortReserved[:])
+	c.dropCohortReservedBytes = 0
 	c.checkpoints.dropOversized()
 	c.boundaries.dropOversized()
 	c.popScratch.dropOversized()

--- a/parsercore_phase0_canonical_scratch_internal_test.go
+++ b/parsercore_phase0_canonical_scratch_internal_test.go
@@ -428,28 +428,11 @@ func TestDiagnosticParserCoreCheckpointCompactLayoutsAMD64(t *testing.T) {
 	if runtime.GOARCH != "amd64" {
 		t.Skip("amd64 layout receipt")
 	}
-	// diagnosticParserCoreHeader grows by 16 bytes for the added altSet
-	// field, then by another 24 bytes (lastPersistedHead core.Head +
-	// lastPersistedAltSet core.AlternativeSet) for the per-dispatch persist
-	// skip: 24 -> 40 -> 64. spec.b4b-alternative-set.v2 section 3.2/3.4
-	// widened altSet and lastPersistedAltSet (uint32 members, +8 bytes each)
-	// and added three bools (blended, resurrectionUnproved,
-	// lastPersistedBlended, +1 each): 64 -> 80 -> 83, padded to 88. The
-	// b4b-width-repair audit (2026-08) lowered AlternativeSet's inline
-	// capacity from 4 to 2 members (core.go; the canonical-fixture census
-	// shows 99.8% of elections already spill past 4 members by election
-	// time, so 4 was not load-bearing), shrinking each embedded set back to
-	// 16 bytes, and reordered this struct's fields (both sets and both Head
-	// copies grouped up front, all 4-byte aligned, ahead of the
-	// byte/uint16-sized fields) so the three added bools fold into what
-	// would otherwise be trailing padding: 88 -> 64, exactly the pre-v2
-	// size despite carrying the full (event, branch) sets and all three
-	// bools. This struct is copied by value on every dispatch (the header
-	// canonicalize double-buffer and the rollback scratch snapshot), so the
-	// 24-byte-per-header reduction applies once per copy, twice per
-	// dispatch.
-	if got := unsafe.Sizeof(diagnosticParserCoreHeader{}); got != 64 {
-		t.Fatalf("scheduler header size=%d, want 64", got)
+	// G18 adds two value-owned DropCohortRefSet fields. Each set is 72 bytes,
+	// so the scheduler header ratchets from 64 to 224 bytes. This header is
+	// copied by the canonicalization and rollback scratch paths.
+	if got := unsafe.Sizeof(diagnosticParserCoreHeader{}); got != 224 {
+		t.Fatalf("scheduler header size=%d, want 224", got)
 	}
 	if got := unsafe.Sizeof(diagnosticParserCorePhaseHead{}); got != 12 {
 		t.Fatalf("canonical phase key size=%d, want 12", got)

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -6351,6 +6351,9 @@ func (s *diagnosticParserCoreGenericScheduler) zeroWidthExtraShiftWithoutProgres
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericAccept(before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) (err error) {
+	if s.freshSessionOwner != nil {
+		return s.applyGenericAcceptOwned(*s.freshSessionOwner, before, cell)
+	}
 	if err := s.headerRollbackScratch.begin(s.headers); err != nil {
 		return err
 	}
@@ -6364,6 +6367,12 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericAccept(before []Diagn
 		s.dispatches, s.work, s.epochProgress = dispatchesBefore, workBefore, epochProgressBefore
 		s.receipt.Rounds = s.receipt.Rounds[:roundsBefore]
 	}()
+	return s.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		return s.applyGenericAcceptOwned(owner, before, cell)
+	})
+}
+
+func (s *diagnosticParserCoreGenericScheduler) applyGenericAcceptOwned(owner core.SchedulerTransactionToken, before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) (err error) {
 	if cell.actions().Len() != 1 || cell.actions().At(0).Type != core.ActionAccept {
 		return errors.New("parser-core phase zero: generic accept requires one accept action")
 	}
@@ -6379,7 +6388,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericAccept(before []Diagn
 	s.epochProgress = true
 	s.work.Accepts++
 	s.work.Dispatches++
-	if err := s.canonicalize(); err != nil {
+	if err := s.canonicalizeOwned(owner); err != nil {
 		return err
 	}
 	if s.fullReceipts() {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -59,9 +59,12 @@ type DiagnosticParserCorePrefixOptions struct {
 	// unbounded. The boundary is checked before another scanner election.
 	GenericStopAtClosedByte *uint32
 	ReceiptMode             DiagnosticParserCoreReceiptMode
-	MaxDispatches           uint64
-	MaxTokens               uint64
-	Limits                  core.Limits
+	// recordDropCohortCertificates keeps the Slice C certificate stores inert
+	// until a focused authentic producer test enables the later activation.
+	recordDropCohortCertificates bool
+	MaxDispatches                uint64
+	MaxTokens                    uint64
+	Limits                       core.Limits
 	// freshSchedulerSession is set only by the reusable fresh-full runner,
 	// which resets before every call and never exposes a declined core.
 	freshSchedulerSession bool
@@ -7067,66 +7070,68 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		if err := s.compact.RecordReductionLineageOwned(owner, outputs, reductionLineage); err != nil {
 			return err
 		}
-		identity := core.DropCohortActionIdentity{
-			BoundaryState: core.StateID(cell.boundary.State()),
-			Lookahead:     core.Symbol(token.Symbol),
-			ActionOrdinal: int32(ordinal),
-			Action:        cell.actions().At(ordinal),
-			NoLookahead:   token.NoLookahead,
-			Selection:     dropCohortSelectionClass(cell.selectedBy),
-		}
-		cohort, err := s.compact.BeginDropCohortOwned(owner, identity, len(outputs))
-		if err != nil {
-			return err
-		}
-		checkpoint := core.DropCohortSourceCheckpoint{
-			StartByte:    token.StartByte,
-			EndByte:      token.EndByte,
-			StartRow:     token.StartPoint.Row,
-			StartColumn:  token.StartPoint.Column,
-			EndRow:       token.EndPoint.Row,
-			EndColumn:    token.EndPoint.Column,
-			ScannerStart: s.checkpointBeforeID,
-			ScannerEnd:   s.checkpointID,
-		}
-		certificateSkipped := false
-		for outputIndex := range outputs {
-			derivation, skipped, buildErr := s.compact.TryBuildDropCohortDerivationOwned(owner, outputs[outputIndex].Head, checkpoint)
-			if buildErr != nil {
-				return buildErr
+		if s.options.recordDropCohortCertificates {
+			identity := core.DropCohortActionIdentity{
+				BoundaryState: core.StateID(cell.boundary.State()),
+				Lookahead:     core.Symbol(token.Symbol),
+				ActionOrdinal: int32(ordinal),
+				Action:        cell.actions().At(ordinal),
+				NoLookahead:   token.NoLookahead,
+				Selection:     dropCohortSelectionClass(cell.selectedBy),
 			}
-			if skipped {
-				certificateSkipped = true
-				break
-			}
-			if writeErr := s.compact.WriteDropCohortMemberOwned(
-				owner, cohort, outputs[outputIndex].Head, uint16(outputIndex), derivation,
-			); writeErr != nil {
-				return writeErr
-			}
-		}
-		if certificateSkipped {
-			if abandonErr := s.compact.AbandonDropCohortOwned(owner, cohort); abandonErr != nil {
-				return abandonErr
-			}
-		} else {
-			if _, err := s.compact.FinalizeDropCohortOwned(owner, cohort); err != nil {
+			cohort, err := s.compact.BeginDropCohortOwned(owner, identity, len(outputs))
+			if err != nil {
 				return err
 			}
+			checkpoint := core.DropCohortSourceCheckpoint{
+				StartByte:    token.StartByte,
+				EndByte:      token.EndByte,
+				StartRow:     token.StartPoint.Row,
+				StartColumn:  token.StartPoint.Column,
+				EndRow:       token.EndPoint.Row,
+				EndColumn:    token.EndPoint.Column,
+				ScannerStart: s.checkpointBeforeID,
+				ScannerEnd:   s.checkpointID,
+			}
+			certificateSkipped := false
 			for outputIndex := range outputs {
-				ref, refErr := s.compact.DropCohortRefForBranch(cohort, uint16(outputIndex))
-				if refErr != nil {
-					return refErr
+				derivation, skipped, buildErr := s.compact.TryBuildDropCohortDerivationOwned(owner, outputs[outputIndex].Head, checkpoint)
+				if buildErr != nil {
+					return buildErr
 				}
-				refs := outputs[outputIndex].DropCohortRefs
-				if !s.compact.AddDropCohortRef(&refs, ref) {
-					// A bounded reference set can reject publication after the
-					// producer cohort is complete. Keep the ordinary reduction
-					// output and let the current fallback route continue. The
-					// verifier is fail-closed when no complete reference is present.
-					continue
+				if skipped {
+					certificateSkipped = true
+					break
 				}
-				outputs[outputIndex].DropCohortRefs = refs
+				if writeErr := s.compact.WriteDropCohortMemberOwned(
+					owner, cohort, outputs[outputIndex].Head, uint16(outputIndex), derivation,
+				); writeErr != nil {
+					return writeErr
+				}
+			}
+			if certificateSkipped {
+				if abandonErr := s.compact.AbandonDropCohortOwned(owner, cohort); abandonErr != nil {
+					return abandonErr
+				}
+			} else {
+				if _, err := s.compact.FinalizeDropCohortOwned(owner, cohort); err != nil {
+					return err
+				}
+				for outputIndex := range outputs {
+					ref, refErr := s.compact.DropCohortRefForBranch(cohort, uint16(outputIndex))
+					if refErr != nil {
+						return refErr
+					}
+					refs := outputs[outputIndex].DropCohortRefs
+					if !s.compact.AddDropCohortRef(&refs, ref) {
+						// A bounded reference set can reject publication after the
+						// producer cohort is complete. Keep the ordinary reduction
+						// output and let the current fallback route continue. The
+						// verifier is fail-closed when no complete reference is present.
+						continue
+					}
+					outputs[outputIndex].DropCohortRefs = refs
+				}
 			}
 		}
 	}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+	"unsafe"
 
 	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
 )
@@ -1050,7 +1051,8 @@ func diagnosticParserCoreSelectedNodeCensus(root *Node) diagnosticParserCoreSele
 }
 
 // Field order groups creationSeq (8-byte aligned), then every 4-byte-aligned
-// field (head, checkpoint, altSet, lastPersistedHead, lastPersistedAltSet),
+// field (head, drop-cohort refs, checkpoint, altSet, lastPersistedHead,
+// lastPersistedAltSet, lastPersistedDropCohortRefs),
 // then cleanPathLineage (2-byte aligned), then every remaining byte-sized
 // field. This is layout-only: every construction site across the package
 // and its tests uses keyed fields (grep-verified), so declaration order
@@ -1063,9 +1065,10 @@ func diagnosticParserCoreSelectedNodeCensus(root *Node) diagnosticParserCoreSele
 // padding a naive append-at-the-end declaration order would otherwise pay
 // for separately.
 type diagnosticParserCoreHeader struct {
-	creationSeq uint64
-	head        core.Head
-	checkpoint  core.CheckpointID
+	creationSeq    uint64
+	head           core.Head
+	dropCohortRefs core.DropCohortRefSet
+	checkpoint     core.CheckpointID
 	// altSet mirrors cleanPathRank/cleanPathLineage but by union rather than
 	// overwrite: it accumulates every converged-split (event, branch) member
 	// this derivation thread has passed through and is never invalidated
@@ -1086,14 +1089,15 @@ type diagnosticParserCoreHeader struct {
 	// that Core itself undid. lastPersistedBlended extends the same no-op
 	// detection to blended: persistHeaderLineageOwned must also re-persist
 	// when only blended changed (spec.b4b-alternative-set.v2 section 10).
-	lastPersistedHead       core.Head
-	lastPersistedAltSet     core.AlternativeSet
-	cleanPathLineage        uint16
-	freshness               core.ReductionFreshness
-	shifted                 bool
-	accepted                bool
-	paused                  bool
-	convergedReductionSplit bool
+	lastPersistedHead           core.Head
+	lastPersistedAltSet         core.AlternativeSet
+	lastPersistedDropCohortRefs core.DropCohortRefSet
+	cleanPathLineage            uint16
+	freshness                   core.ReductionFreshness
+	shifted                     bool
+	accepted                    bool
+	paused                      bool
+	convergedReductionSplit     bool
 	// resurrectionUnproved marks a header descended from a
 	// HistoricalBoundaryUnproved dead-node import: a non-deterministic,
 	// non-converged historical boundary with no recorded provenance to prove
@@ -1217,7 +1221,8 @@ func (s *diagnosticParserCoreGenericScheduler) persistHeaderLineageOwned(
 		); err != nil {
 			return err
 		}
-		if !header.convergedReductionSplit {
+		if !header.convergedReductionSplit && header.dropCohortRefs.Empty() &&
+			!header.dropCohortRefs.Overflowed() && !header.dropCohortRefs.Blended() {
 			continue
 		}
 		// The scalar pair is re-merged unconditionally: recordNodeLineage
@@ -1233,7 +1238,8 @@ func (s *diagnosticParserCoreGenericScheduler) persistHeaderLineageOwned(
 		// also compare blended, or conservatively persist when it changes).
 		setDirty := header.head != header.lastPersistedHead ||
 			header.altSet != header.lastPersistedAltSet ||
-			header.blended != header.lastPersistedBlended
+			header.blended != header.lastPersistedBlended ||
+			header.dropCohortRefs != header.lastPersistedDropCohortRefs
 		if err := s.compact.RecordHeadLineageOwned(
 			owner,
 			header.head,
@@ -1242,11 +1248,13 @@ func (s *diagnosticParserCoreGenericScheduler) persistHeaderLineageOwned(
 			header.altSet,
 			header.blended,
 			setDirty,
+			header.dropCohortRefs,
 		); err != nil {
 			return err
 		}
 		header.lastPersistedHead = header.head
 		header.lastPersistedAltSet = header.altSet
+		header.lastPersistedDropCohortRefs = header.dropCohortRefs
 		header.lastPersistedBlended = header.blended
 	}
 	return nil
@@ -1444,6 +1452,7 @@ type diagnosticParserCoreActionOutput struct {
 	cleanPathLineage uint16
 	cleanPathSet     core.AlternativeSet
 	cleanPathBlended bool
+	dropCohortRefs   core.DropCohortRefSet
 }
 
 func executeDiagnosticParserCoreGenericConflictDetailed(
@@ -1522,6 +1531,11 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 					compact.UnionAlternativeSet(&secondary.altSet, output.cleanPathSet)
 					secondary.blended = secondary.blended || output.cleanPathBlended || incomparable
 				}
+				if !output.dropCohortRefs.Empty() || output.dropCohortRefs.Overflowed() || output.dropCohortRefs.Blended() {
+					if _, err := compact.UnionDropCohortRefsChecked(&secondary.dropCohortRefs, output.dropCohortRefs); err != nil {
+						return err
+					}
+				}
 				if action.Type == core.ActionShift {
 					markDiagnosticParserCoreExternalLineage(&secondary, token)
 				}
@@ -1557,6 +1571,11 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 				incomparable := compact.AlternativeSetIncomparable(primary.altSet, output.cleanPathSet)
 				compact.UnionAlternativeSet(&primary.altSet, output.cleanPathSet)
 				primary.blended = primary.blended || output.cleanPathBlended || incomparable
+			}
+			if !output.dropCohortRefs.Empty() || output.dropCohortRefs.Overflowed() || output.dropCohortRefs.Blended() {
+				if _, err := compact.UnionDropCohortRefsChecked(&primary.dropCohortRefs, output.dropCohortRefs); err != nil {
+					return err
+				}
 			}
 			if primaryAction.Type == core.ActionShift {
 				markDiagnosticParserCoreExternalLineage(&primary, token)
@@ -1594,12 +1613,67 @@ type diagnosticParserCorePhaseHead struct {
 }
 
 type diagnosticParserCoreCanonicalScratch struct {
-	headerBuffers [2][]diagnosticParserCoreHeader
-	inlineHeaders [2][diagnosticParserCoreLinearCanonicalLimit]diagnosticParserCoreHeader
-	nextBuffer    uint8
-	keys          []diagnosticParserCorePhaseHead
-	inlineKeys    [diagnosticParserCoreLinearCanonicalLimit]diagnosticParserCorePhaseHead
-	groups        map[diagnosticParserCorePhaseHead]diagnosticParserCoreCanonicalGroup
+	headerBuffers       [2][]diagnosticParserCoreHeader
+	inlineHeaders       [2][diagnosticParserCoreLinearCanonicalLimit]diagnosticParserCoreHeader
+	nextBuffer          uint8
+	keys                []diagnosticParserCorePhaseHead
+	inlineKeys          [diagnosticParserCoreLinearCanonicalLimit]diagnosticParserCorePhaseHead
+	groups              map[diagnosticParserCorePhaseHead]diagnosticParserCoreCanonicalGroup
+	groupsBucketCount   uint64
+	groupsBucketBytes   uint64
+	groupsRetainedBytes uint64
+}
+
+const (
+	diagnosticParserCoreMapBucketCount = 8
+	diagnosticParserCoreMapLoadNum     = 13
+	diagnosticParserCoreMapLoadDen     = 2
+)
+
+func diagnosticParserCoreCanonicalGroupsBucketBytes(entries int) (uint64, uint64) {
+	if entries <= 0 {
+		return 0, 0
+	}
+	buckets := uint64(1)
+	for buckets*diagnosticParserCoreMapLoadNum < uint64(entries)*diagnosticParserCoreMapLoadDen {
+		buckets <<= 1
+	}
+	keyBytes := uint64(unsafe.Sizeof(diagnosticParserCorePhaseHead{})) * diagnosticParserCoreMapBucketCount
+	valueBytes := uint64(unsafe.Sizeof(diagnosticParserCoreCanonicalGroup{})) * diagnosticParserCoreMapBucketCount
+	metadataBytes := uint64(diagnosticParserCoreMapBucketCount) // tophash
+	overflowPointerBytes := uint64(unsafe.Sizeof(uintptr(0)))
+	base := metadataBytes + keyBytes + valueBytes + overflowPointerBytes
+	alignment := uint64(unsafe.Alignof(uintptr(0)))
+	base = (base + alignment - 1) / alignment * alignment
+	// Estimate each bucket as eight tophash bytes, eight keys, eight values,
+	// one overflow pointer, and alignment padding. Round capacity by the
+	// documented load-factor target, then reserve one overflow bucket for each
+	// two primary buckets. This conservative overcount avoids runtime map
+	// internals and covers overflow chains and metadata retained during growth.
+	overflowBuckets := (buckets + 1) / 2
+	bucketBytes := base * (buckets + overflowBuckets)
+	return buckets, bucketBytes
+}
+
+func (s *diagnosticParserCoreCanonicalScratch) observeGroupsInsertion(entries int) {
+	if s == nil || entries <= 0 {
+		return
+	}
+	buckets, estimate := diagnosticParserCoreCanonicalGroupsBucketBytes(entries)
+	if estimate == 0 {
+		return
+	}
+	if buckets > s.groupsBucketCount {
+		// A grow retains the old bucket array while the new array is live.
+		retained := estimate + s.groupsBucketBytes
+		if retained > s.groupsRetainedBytes {
+			s.groupsRetainedBytes = retained
+		}
+		s.groupsBucketCount = buckets
+		s.groupsBucketBytes = estimate
+	} else if estimate > s.groupsRetainedBytes {
+		s.groupsRetainedBytes = estimate
+	}
 }
 
 // Field order groups winner (8-byte aligned int) and altSet (4-byte
@@ -1608,6 +1682,7 @@ type diagnosticParserCoreCanonicalScratch struct {
 // fields, so this reorder is layout-only (b4b-width-repair audit, 2026-08).
 type diagnosticParserCoreCanonicalGroup struct {
 	winner                  int
+	dropCohortRefs          core.DropCohortRefSet
 	altSet                  core.AlternativeSet
 	cleanPathLineage        uint16
 	runnable                bool
@@ -1620,8 +1695,15 @@ type diagnosticParserCoreCanonicalGroup struct {
 const diagnosticParserCoreLinearCanonicalLimit = 8
 
 func (s *diagnosticParserCoreCanonicalScratch) canonicalize(compact *core.Core, headers []diagnosticParserCoreHeader) ([]diagnosticParserCoreHeader, error) {
+	out, _, err := s.canonicalizeWithMutation(compact, headers)
+	return out, err
+}
+
+func (s *diagnosticParserCoreCanonicalScratch) canonicalizeWithMutation(
+	compact *core.Core, headers []diagnosticParserCoreHeader,
+) ([]diagnosticParserCoreHeader, core.DropCohortProducerMutation, error) {
 	if s == nil {
-		return nil, errors.New("parser-core phase zero: nil canonicalization scratch")
+		return nil, 0, errors.New("parser-core phase zero: nil canonicalization scratch")
 	}
 	target := int(s.nextBuffer & 1)
 	if len(headers) != 0 && cap(s.headerBuffers[target]) != 0 && &headers[0] == &s.headerBuffers[target][:1][0] {
@@ -1650,7 +1732,7 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalize(compact *core.Core, 
 		header := normalized[0]
 		state, byteOffset, err := compact.Boundary(header.head)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if canonical, ok := compact.CanonicalBoundary(state, byteOffset, header.shifted, header.checkpoint); ok {
 			header.head = canonical
@@ -1658,7 +1740,7 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalize(compact *core.Core, 
 		header.freshness = 0
 		normalized[0] = header
 		s.nextBuffer = uint8(target ^ 1)
-		return normalized, nil
+		return normalized, 0, nil
 	}
 	if cap(s.keys) < len(headers) {
 		if len(headers) <= len(s.inlineKeys) {
@@ -1672,7 +1754,7 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalize(compact *core.Core, 
 	for index, header := range normalized {
 		state, byteOffset, err := compact.Boundary(header.head)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if canonical, ok := compact.CanonicalBoundary(state, byteOffset, header.shifted, header.checkpoint); ok {
 			header.head = canonical
@@ -1682,26 +1764,42 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalize(compact *core.Core, 
 		s.keys[index] = key
 	}
 	var out []diagnosticParserCoreHeader
+	var err error
+	var mutation core.DropCohortProducerMutation
 	switch {
 	case len(normalized) == 0:
 		out = normalized
 	case len(normalized) <= diagnosticParserCoreLinearCanonicalLimit:
-		out = s.canonicalizeLinear(compact, normalized)
+		out, mutation, err = s.canonicalizeLinearCheckedWithMutation(compact, normalized)
 	default:
-		out = s.canonicalizeMapped(compact, normalized)
+		out, mutation, err = s.canonicalizeMappedCheckedWithMutation(compact, normalized)
+	}
+	if err != nil {
+		return nil, 0, err
 	}
 	s.headerBuffers[target] = out
 	s.nextBuffer = uint8(target ^ 1)
-	return out, nil
+	return out, mutation, nil
 }
 
 func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinear(compact *core.Core, normalized []diagnosticParserCoreHeader) []diagnosticParserCoreHeader {
+	out, _ := s.canonicalizeLinearChecked(compact, normalized)
+	return out
+}
+
+func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinearChecked(compact *core.Core, normalized []diagnosticParserCoreHeader) ([]diagnosticParserCoreHeader, error) {
+	out, _, err := s.canonicalizeLinearCheckedWithMutation(compact, normalized)
+	return out, err
+}
+
+func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinearCheckedWithMutation(compact *core.Core, normalized []diagnosticParserCoreHeader) ([]diagnosticParserCoreHeader, core.DropCohortProducerMutation, error) {
 	type linearGroup struct {
 		keyIndex int
 		diagnosticParserCoreCanonicalGroup
 	}
 	var groups [diagnosticParserCoreLinearCanonicalLimit]linearGroup
 	groupCount := 0
+	merged := false
 	for index, header := range normalized {
 		groupIndex := -1
 		for candidate := 0; candidate < groupCount; candidate++ {
@@ -1719,11 +1817,13 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinear(compact *core.
 					resurrectionUnproved:    header.resurrectionUnproved,
 					cleanPathRank:           header.cleanPathRank, cleanPathLineage: header.cleanPathLineage,
 					altSet: header.altSet, blended: header.blended,
+					dropCohortRefs: header.dropCohortRefs,
 				},
 			}
 			groupCount++
 			continue
 		}
+		merged = true
 		group := &groups[groupIndex].diagnosticParserCoreCanonicalGroup
 		group.runnable = group.runnable || !header.paused
 		group.convergedReductionSplit = group.convergedReductionSplit || header.convergedReductionSplit
@@ -1747,6 +1847,11 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinear(compact *core.
 			compact.UnionAlternativeSet(&group.altSet, header.altSet)
 			group.blended = group.blended || header.blended || incomparable
 		}
+		if !header.dropCohortRefs.Empty() || header.dropCohortRefs.Overflowed() || header.dropCohortRefs.Blended() {
+			if _, err := compact.UnionDropCohortRefsChecked(&group.dropCohortRefs, header.dropCohortRefs); err != nil {
+				return nil, 0, err
+			}
+		}
 		if diagnosticParserCoreCanonicalCandidateWins(normalized[group.winner], header) {
 			group.winner = index
 		}
@@ -1765,28 +1870,50 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinear(compact *core.
 			header.cleanPathRank = group.cleanPathRank
 			header.cleanPathLineage = group.cleanPathLineage
 			header.altSet = group.altSet
+			header.dropCohortRefs = group.dropCohortRefs
 			header.blended = group.blended
 			normalized[write] = header
 			write++
 			break
 		}
 	}
-	return normalized[:write]
+	var mutation core.DropCohortProducerMutation
+	if merged {
+		mutation = core.DropCohortProducerLinearCanonicalization
+	}
+	return normalized[:write], mutation, nil
 }
 
 func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMapped(compact *core.Core, normalized []diagnosticParserCoreHeader) []diagnosticParserCoreHeader {
+	out, _ := s.canonicalizeMappedChecked(compact, normalized)
+	return out
+}
+
+func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMappedChecked(compact *core.Core, normalized []diagnosticParserCoreHeader) ([]diagnosticParserCoreHeader, error) {
+	out, _, err := s.canonicalizeMappedCheckedWithMutation(compact, normalized)
+	return out, err
+}
+
+func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMappedCheckedWithMutation(compact *core.Core, normalized []diagnosticParserCoreHeader) ([]diagnosticParserCoreHeader, core.DropCohortProducerMutation, error) {
+	// The capacity hint can reserve buckets before unique insertions occur.
+	s.observeGroupsInsertion(len(normalized))
 	if s.groups == nil {
 		s.groups = make(map[diagnosticParserCorePhaseHead]diagnosticParserCoreCanonicalGroup, len(normalized))
 	} else {
 		clear(s.groups)
 	}
+	merged := false
 	for index, header := range normalized {
 		key := s.keys[index]
 		group, duplicate := s.groups[key]
 		if !duplicate {
 			group.winner = index
-		} else if diagnosticParserCoreCanonicalCandidateWins(normalized[group.winner], header) {
-			group.winner = index
+			s.observeGroupsInsertion(len(s.groups) + 1)
+		} else {
+			merged = true
+			if diagnosticParserCoreCanonicalCandidateWins(normalized[group.winner], header) {
+				group.winner = index
+			}
 		}
 		group.runnable = group.runnable || !header.paused
 		group.convergedReductionSplit = group.convergedReductionSplit || header.convergedReductionSplit
@@ -1803,6 +1930,11 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMapped(compact *core.
 			compact.UnionAlternativeSet(&group.altSet, header.altSet)
 			group.blended = group.blended || header.blended || incomparable
 		}
+		if !header.dropCohortRefs.Empty() || header.dropCohortRefs.Overflowed() || header.dropCohortRefs.Blended() {
+			if _, err := compact.UnionDropCohortRefsChecked(&group.dropCohortRefs, header.dropCohortRefs); err != nil {
+				return nil, 0, err
+			}
+		}
 		s.groups[key] = group
 	}
 	write := 0
@@ -1818,11 +1950,16 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMapped(compact *core.
 		header.cleanPathRank = group.cleanPathRank
 		header.cleanPathLineage = group.cleanPathLineage
 		header.altSet = group.altSet
+		header.dropCohortRefs = group.dropCohortRefs
 		header.blended = group.blended
 		normalized[write] = header
 		write++
 	}
-	return normalized[:write]
+	var mutation core.DropCohortProducerMutation
+	if merged {
+		mutation = core.DropCohortProducerMappedCanonicalization
+	}
+	return normalized[:write], mutation, nil
 }
 
 func diagnosticParserCoreCanonicalCandidateWins(incumbent, candidate diagnosticParserCoreHeader) bool {
@@ -1904,6 +2041,7 @@ type diagnosticParserCoreGenericScheduler struct {
 	headers                       []diagnosticParserCoreHeader
 	token                         Token
 	checkpoint                    DiagnosticParserCoreScannerCheckpoint
+	checkpointBeforeID            core.CheckpointID
 	checkpointID                  core.CheckpointID
 	currentElection               DiagnosticParserCoreElection
 	electionIndex                 int
@@ -3439,6 +3577,7 @@ func initializeDiagnosticParserCoreGenericScheduler(
 	scheduler.tokenSource = tokenSource
 	scheduler.scannerScratch = scannerScratch
 	scheduler.checkpoint = checkpoint
+	scheduler.checkpointBeforeID = checkpointID
 	scheduler.checkpointID = checkpointID
 	scheduler.electionIndex = -1
 	scheduler.nextSeq = 1
@@ -3541,6 +3680,19 @@ func (cell *diagnosticParserCoreGenericCell) selectsConflictReduction() bool {
 	return cell.selectedBy != diagnosticParserCoreCellSelectionNone &&
 		cell.selectedBy != diagnosticParserCoreCellSelectionRepetitionFork &&
 		cell.actions().At(cell.selectedActionOrdinal()).Type == core.ActionReduce
+}
+
+func dropCohortSelectionClass(selected diagnosticParserCoreCellSelection) core.DropCohortSelectionClass {
+	switch selected {
+	case diagnosticParserCoreCellSelectionConflictPolicy:
+		return core.DropCohortSelectionConflictPolicy
+	case diagnosticParserCoreCellSelectionRepetitionFold:
+		return core.DropCohortSelectionRepetitionFold
+	case diagnosticParserCoreCellSelectionRepetitionFork:
+		return core.DropCohortSelectionRepetitionFork
+	default:
+		return core.DropCohortSelectionNone
+	}
 }
 
 func diagnosticParserCoreRelexedSymbol(shared, relexed Token) (Symbol, bool) {
@@ -4980,7 +5132,85 @@ func diagnosticParserCoreStopControlTripped(reason ParseStopReason) error {
 // this tranche's scope). See the tranche's PR for the full witness table.
 const stopControlFootprintChurnRatio = 1
 
-// stopControlMemoryBudgetReason compares the compact core's own real
+func diagnosticParserCoreSliceAliases[T any](items []T, inline []T) bool {
+	if cap(items) == 0 || len(inline) == 0 {
+		return false
+	}
+	return unsafe.Pointer(&items[:cap(items)][0]) == unsafe.Pointer(&inline[0])
+}
+
+func diagnosticParserCoreSchedulerFootprintBytes(s *diagnosticParserCoreGenericScheduler) uint64 {
+	if s == nil {
+		return 0
+	}
+	total := uint64(0)
+	add := func(count int, size uintptr) {
+		if count <= 0 {
+			return
+		}
+		bytes := uint64(count) * uint64(size)
+		if math.MaxUint64-total < bytes {
+			total = math.MaxUint64
+			return
+		}
+		total += bytes
+	}
+	add(cap(s.headers), unsafe.Sizeof(diagnosticParserCoreHeader{}))
+	add(cap(s.summaryHeaderScratch), unsafe.Sizeof(DiagnosticParserCoreHeaderReceipt{}))
+	add(len(s.headerRollbackScratch.inline), unsafe.Sizeof(diagnosticParserCoreHeader{}))
+	if !diagnosticParserCoreSliceAliases(s.headerRollbackScratch.headers, s.headerRollbackScratch.inline[:]) {
+		add(cap(s.headerRollbackScratch.headers), unsafe.Sizeof(diagnosticParserCoreHeader{}))
+	}
+	add(len(s.canonicalScratch.inlineHeaders[0]), unsafe.Sizeof(diagnosticParserCoreHeader{}))
+	add(len(s.canonicalScratch.inlineHeaders[1]), unsafe.Sizeof(diagnosticParserCoreHeader{}))
+	for index := range s.canonicalScratch.headerBuffers {
+		aliasesInline := diagnosticParserCoreSliceAliases(s.canonicalScratch.headerBuffers[index], s.canonicalScratch.inlineHeaders[0][:]) ||
+			diagnosticParserCoreSliceAliases(s.canonicalScratch.headerBuffers[index], s.canonicalScratch.inlineHeaders[1][:])
+		if !aliasesInline {
+			add(cap(s.canonicalScratch.headerBuffers[index]), unsafe.Sizeof(diagnosticParserCoreHeader{}))
+		}
+	}
+	if !diagnosticParserCoreSliceAliases(s.canonicalScratch.keys, s.canonicalScratch.inlineKeys[:]) {
+		add(cap(s.canonicalScratch.keys), unsafe.Sizeof(diagnosticParserCorePhaseHead{}))
+	}
+	add(len(s.canonicalScratch.inlineKeys), unsafe.Sizeof(diagnosticParserCorePhaseHead{}))
+	addBytes := func(bytes uint64) {
+		if math.MaxUint64-total < bytes {
+			total = math.MaxUint64
+			return
+		}
+		total += bytes
+	}
+	addBytes(s.canonicalScratch.groupsRetainedBytes)
+	add(cap(s.dispatchScratch.cells), unsafe.Sizeof(diagnosticParserCoreGenericCell{}))
+	add(cap(s.dispatchScratch.noActionIndices), unsafe.Sizeof(int(0)))
+	add(cap(s.conflictScratch.actionOutputs), unsafe.Sizeof(diagnosticParserCoreActionOutput{}))
+	add(cap(s.conflictScratch.reductionOutputs), unsafe.Sizeof(core.ReductionOutput{}))
+	add(cap(s.conflictScratch.outputs), unsafe.Sizeof(diagnosticParserCoreHeader{}))
+	add(cap(s.conflictScratch.armRanges), unsafe.Sizeof(diagnosticParserCoreConflictArmRange{}))
+	add(cap(s.conflictScratch.adopted), unsafe.Sizeof(int(0)))
+	add(cap(s.conflictScratch.headerAssembly), unsafe.Sizeof(diagnosticParserCoreHeader{}))
+	add(cap(s.reductionOutputs), unsafe.Sizeof(core.ReductionOutput{}))
+	add(cap(s.reductionReplacements), unsafe.Sizeof(diagnosticParserCoreHeader{}))
+	add(cap(s.classifiedBoundaries), unsafe.Sizeof(core.ClassifiedBoundary{}))
+	add(cap(s.condenseCandidates), unsafe.Sizeof(core.CondenseCandidate{}))
+	add(cap(s.electStates), unsafe.Sizeof(StateID(0)))
+	add(cap(s.electGLRStates), unsafe.Sizeof(StateID(0)))
+	add(cap(s.acceptedPayloads), unsafe.Sizeof(core.SubtreeID(0)))
+	add(len(s.seedHeaders), unsafe.Sizeof(diagnosticParserCoreHeader{}))
+	add(len(s.corridorCells), unsafe.Sizeof(diagnosticParserCoreGenericCell{}))
+	if s.compact != nil {
+		coreBytes := s.compact.FootprintBytes()
+		if math.MaxUint64-total < coreBytes {
+			total = math.MaxUint64
+		} else {
+			total += coreBytes
+		}
+	}
+	return total
+}
+
+// stopControlMemoryBudgetReason compares the compact core's and scheduler's real
 // retained-memory footprint against the production engine's soft per-parse
 // byte budget (stopControlMemoryBudgetBytes, sourced from
 // parseMemoryBudgetForParser so the same GOT_PARSE_MEMORY_BUDGET_MB
@@ -4992,7 +5222,9 @@ const stopControlFootprintChurnRatio = 1
 // deterministic integer arithmetic -- no wall clock, no GC-timing
 // dependence, and (same input, same budget) the same trip point on every
 // run, unlike the runtime heap/sys signal production's own hard ceiling
-// poll uses (parser_memory_budget_runtime.go). FootprintBytes, not
+// poll uses (parser_memory_budget_runtime.go). The scheduler contribution
+// counts retained and ephemeral slice capacities, while Core.FootprintBytes
+// counts Core-owned spill only once. FootprintBytes, not
 // StorageBytes, is deliberate here: StorageBytes counts live length only,
 // so it reads near zero for a core whose arenas hold retained capacity from
 // an earlier declined attempt on the same cached runner, and it never
@@ -5013,7 +5245,7 @@ func (s *diagnosticParserCoreGenericScheduler) stopControlMemoryBudgetReason() P
 			return false
 		}
 		if !haveFootprint {
-			footprint = s.compact.FootprintBytes()
+			footprint = diagnosticParserCoreSchedulerFootprintBytes(s)
 			haveFootprint = true
 		}
 		return footprint*stopControlFootprintChurnRatio >= uint64(bytes)
@@ -6826,6 +7058,68 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		if err := s.compact.RecordReductionLineageOwned(owner, outputs, reductionLineage); err != nil {
 			return err
 		}
+		identity := core.DropCohortActionIdentity{
+			BoundaryState: core.StateID(cell.boundary.State()),
+			Lookahead:     core.Symbol(token.Symbol),
+			ActionOrdinal: int32(ordinal),
+			Action:        cell.actions().At(ordinal),
+			NoLookahead:   token.NoLookahead,
+			Selection:     dropCohortSelectionClass(cell.selectedBy),
+		}
+		cohort, err := s.compact.BeginDropCohortOwned(owner, identity, len(outputs))
+		if err != nil {
+			return err
+		}
+		checkpoint := core.DropCohortSourceCheckpoint{
+			StartByte:    token.StartByte,
+			EndByte:      token.EndByte,
+			StartRow:     token.StartPoint.Row,
+			StartColumn:  token.StartPoint.Column,
+			EndRow:       token.EndPoint.Row,
+			EndColumn:    token.EndPoint.Column,
+			ScannerStart: s.checkpointBeforeID,
+			ScannerEnd:   s.checkpointID,
+		}
+		certificateSkipped := false
+		for outputIndex := range outputs {
+			derivation, skipped, buildErr := s.compact.TryBuildDropCohortDerivationOwned(owner, outputs[outputIndex].Head, checkpoint)
+			if buildErr != nil {
+				return buildErr
+			}
+			if skipped {
+				certificateSkipped = true
+				break
+			}
+			if writeErr := s.compact.WriteDropCohortMemberOwned(
+				owner, cohort, outputs[outputIndex].Head, uint16(outputIndex), derivation,
+			); writeErr != nil {
+				return writeErr
+			}
+		}
+		if certificateSkipped {
+			if abandonErr := s.compact.AbandonDropCohortOwned(owner, cohort); abandonErr != nil {
+				return abandonErr
+			}
+		} else {
+			if _, err := s.compact.FinalizeDropCohortOwned(owner, cohort); err != nil {
+				return err
+			}
+			for outputIndex := range outputs {
+				ref, refErr := s.compact.DropCohortRefForBranch(cohort, uint16(outputIndex))
+				if refErr != nil {
+					return refErr
+				}
+				refs := outputs[outputIndex].DropCohortRefs
+				if !s.compact.AddDropCohortRef(&refs, ref) {
+					// A bounded reference set can reject publication after the
+					// producer cohort is complete. Keep the ordinary reduction
+					// output and let the current fallback route continue. The
+					// verifier is fail-closed when no complete reference is present.
+					continue
+				}
+				outputs[outputIndex].DropCohortRefs = refs
+			}
+		}
 	}
 	s.reductionOutputs = outputs
 	s.reductionReplacements = s.reductionReplacements[:0]
@@ -6871,18 +7165,22 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 			s.compact.UnionAlternativeSet(&outputSet, output.HistoricalAlternativeSet)
 			outputSetBlended = outputSetBlended || output.HistoricalBlended || incomparable
 		}
+		outputDropCohortRefs := output.DropCohortRefs
 		switch output.Freshness {
 		case core.ReductionUnchanged:
 			if convergedHistory || resurrectionUnproved {
-				if _, err := s.adoptUpdatedReductionSibling(
+				if _, err := s.adoptUpdatedReductionSiblingOwned(
+					owner,
 					cell.headerIndex,
 					output.Head,
 					rank,
 					lineage,
 					outputSet,
 					outputSetBlended,
+					outputDropCohortRefs,
 					convergedHistory,
 					resurrectionUnproved,
+					core.DropCohortProducerSiblingAdoption,
 				); err != nil {
 					return err
 				}
@@ -6894,15 +7192,18 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		}
 		madeFreshProgress = true
 		if output.Freshness == core.ReductionUpdated {
-			adopted, err := s.adoptUpdatedReductionSibling(
+			adopted, err := s.adoptUpdatedReductionSiblingOwned(
+				owner,
 				cell.headerIndex,
 				output.Head,
 				rank,
 				lineage,
 				outputSet,
 				outputSetBlended,
+				outputDropCohortRefs,
 				convergedHistory,
 				resurrectionUnproved,
+				core.DropCohortProducerSiblingAdoption,
 			)
 			if err != nil {
 				return err
@@ -6926,6 +7227,11 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 			// incomparability; it only propagates outputSetBlended.
 			s.compact.UnionAlternativeSet(&replacement.altSet, outputSet)
 			replacement.blended = replacement.blended || outputSetBlended
+		}
+		if !outputDropCohortRefs.Empty() || outputDropCohortRefs.Overflowed() || outputDropCohortRefs.Blended() {
+			if _, err := s.compact.UnionDropCohortRefsChecked(&replacement.dropCohortRefs, outputDropCohortRefs); err != nil {
+				return err
+			}
 		}
 		if len(replacements) > 0 {
 			if s.nextSeq == math.MaxUint64 {
@@ -6956,7 +7262,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 	}
 	s.work.Reductions++
 	s.work.Dispatches++
-	if err := s.canonicalize(); err != nil {
+	if err := s.canonicalizeOwned(owner); err != nil {
 		return err
 	}
 	if err := s.persistHeaderLineageOwned(owner); err != nil {
@@ -6996,7 +7302,8 @@ func (s *diagnosticParserCoreGenericScheduler) collectCondenseCandidates(source 
 			continue
 		}
 		candidates = append(candidates, core.CondenseCandidate{
-			Head: header.head, Shifted: header.shifted, Checkpoint: header.checkpoint,
+			Head: header.head, DropCohortRefs: header.dropCohortRefs,
+			Shifted: header.shifted, Checkpoint: header.checkpoint,
 		})
 	}
 	s.condenseCandidates = candidates
@@ -7013,9 +7320,38 @@ func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(
 	lineage uint16,
 	set core.AlternativeSet,
 	setBlended bool,
-	convergedReductionSplit bool,
-	resurrectionUnproved bool,
+	compat ...interface{},
 ) (bool, error) {
+	var dropCohortRefs core.DropCohortRefSet
+	var convergedReductionSplit, resurrectionUnproved bool
+	switch len(compat) {
+	case 2:
+		var ok bool
+		convergedReductionSplit, ok = compat[0].(bool)
+		if !ok {
+			return false, errors.New("parser-core phase zero: invalid sibling compatibility arguments")
+		}
+		resurrectionUnproved, ok = compat[1].(bool)
+		if !ok {
+			return false, errors.New("parser-core phase zero: invalid sibling compatibility arguments")
+		}
+	case 3:
+		var ok bool
+		dropCohortRefs, ok = compat[0].(core.DropCohortRefSet)
+		if !ok {
+			return false, errors.New("parser-core phase zero: invalid sibling reference set")
+		}
+		convergedReductionSplit, ok = compat[1].(bool)
+		if !ok {
+			return false, errors.New("parser-core phase zero: invalid sibling compatibility arguments")
+		}
+		resurrectionUnproved, ok = compat[2].(bool)
+		if !ok {
+			return false, errors.New("parser-core phase zero: invalid sibling compatibility arguments")
+		}
+	default:
+		return false, errors.New("parser-core phase zero: invalid sibling compatibility arity")
+	}
 	for index := range s.headers {
 		if index == source {
 			continue
@@ -7036,22 +7372,94 @@ func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(
 		s.headers[index].resurrectionUnproved =
 			s.headers[index].resurrectionUnproved || resurrectionUnproved
 		applyDiagnosticParserCoreCleanPathOutput(&s.headers[index], rank, lineage)
+		dst := &s.headers[index]
 		if set.Len() != 0 {
 			// Fold-class union (spec.b4b-alternative-set.v2 section 3.4):
 			// index is a genuinely different, independently tracked header
 			// from source -- this is a joint-resolution merge, not a single
 			// thread's own uniform extension.
-			dst := &s.headers[index]
 			incomparable := s.compact.AlternativeSetIncomparable(dst.altSet, set)
 			s.compact.UnionAlternativeSet(&dst.altSet, set)
 			dst.blended = dst.blended || setBlended || incomparable
+		}
+		if !dropCohortRefs.Empty() || dropCohortRefs.Overflowed() || dropCohortRefs.Blended() {
+			if _, err := s.compact.UnionDropCohortRefsChecked(&dst.dropCohortRefs, dropCohortRefs); err != nil {
+				return false, err
+			}
 		}
 		return true, nil
 	}
 	return false, nil
 }
 
-func (s *diagnosticParserCoreGenericScheduler) reconcileGenericConflictOutputs(source int, outputs []diagnosticParserCoreHeader) ([]diagnosticParserCoreHeader, int, error) {
+func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSiblingOwned(
+	owner core.SchedulerTransactionToken,
+	source int,
+	head core.Head,
+	rank core.CleanPathRankSelection,
+	lineage uint16,
+	set core.AlternativeSet,
+	setBlended bool,
+	dropCohortRefs core.DropCohortRefSet,
+	convergedReductionSplit bool,
+	resurrectionUnproved bool,
+	mutation core.DropCohortProducerMutation,
+) (bool, error) {
+	adopted, err := s.adoptUpdatedReductionSibling(
+		source, head, rank, lineage, set, setBlended, dropCohortRefs,
+		convergedReductionSplit, resurrectionUnproved,
+	)
+	if err != nil || !adopted {
+		return adopted, err
+	}
+	if err := s.compact.RecordDropCohortProducerMutation(owner, mutation); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) reconcileGenericConflictOutputs(first interface{}, compat ...interface{}) ([]diagnosticParserCoreHeader, int, error) {
+	var owner core.SchedulerTransactionToken
+	var source int
+	var outputs []diagnosticParserCoreHeader
+	switch value := first.(type) {
+	case core.SchedulerTransactionToken:
+		if len(compat) != 2 {
+			return nil, 0, errors.New("parser-core phase zero: invalid conflict compatibility arity")
+		}
+		var ok bool
+		source, ok = compat[0].(int)
+		if !ok {
+			return nil, 0, errors.New("parser-core phase zero: invalid conflict source")
+		}
+		outputs, ok = compat[1].([]diagnosticParserCoreHeader)
+		if !ok {
+			return nil, 0, errors.New("parser-core phase zero: invalid conflict outputs")
+		}
+		owner = value
+	case int:
+		if len(compat) != 1 {
+			return nil, 0, errors.New("parser-core phase zero: invalid legacy conflict compatibility arity")
+		}
+		var ok bool
+		outputs, ok = compat[0].([]diagnosticParserCoreHeader)
+		if !ok {
+			return nil, 0, errors.New("parser-core phase zero: invalid legacy conflict outputs")
+		}
+		source = value
+	default:
+		return nil, 0, errors.New("parser-core phase zero: invalid conflict owner")
+	}
+	if owner == (core.SchedulerTransactionToken{}) {
+		var kept []diagnosticParserCoreHeader
+		var adopted int
+		err := s.compact.ApplySchedulerAtomic(func(token core.SchedulerTransactionToken) error {
+			var innerErr error
+			kept, adopted, innerErr = s.reconcileGenericConflictOutputs(token, source, outputs)
+			return innerErr
+		})
+		return kept, adopted, err
+	}
 	kept := outputs[:0]
 	adopted := 0
 	for _, output := range outputs {
@@ -7062,15 +7470,18 @@ func (s *diagnosticParserCoreGenericScheduler) reconcileGenericConflictOutputs(s
 			// alone, pre-dating and orthogonal to the F4 resurrection
 			// signal), so there is no resurrectionUnproved bit to thread
 			// here.
-			ok, err := s.adoptUpdatedReductionSibling(
+			ok, err := s.adoptUpdatedReductionSiblingOwned(
+				owner,
 				source,
 				output.head,
 				output.cleanPathRank,
 				output.cleanPathLineage,
 				output.altSet,
 				output.blended,
+				output.dropCohortRefs,
 				output.cleanPathLineage != 0,
 				false,
+				core.DropCohortProducerConflictReconciliation,
 			)
 			if err != nil {
 				return nil, 0, err
@@ -7080,12 +7491,27 @@ func (s *diagnosticParserCoreGenericScheduler) reconcileGenericConflictOutputs(s
 				continue
 			}
 			if output.freshness == core.ReductionUnchanged {
+				if err := s.compact.RecordDropCohortProducerMutation(owner, core.DropCohortProducerConflictReconciliation); err != nil {
+					return nil, 0, err
+				}
 				continue
 			}
 		}
 		kept = append(kept, output)
 	}
 	return kept, adopted, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) reconcileGenericConflictOutputsOwnedWithMutation(
+	owner core.SchedulerTransactionToken,
+	source int,
+	outputs []diagnosticParserCoreHeader,
+	mutation core.DropCohortProducerMutation,
+) ([]diagnosticParserCoreHeader, int, error) {
+	if mutation != core.DropCohortProducerConflictReconciliation {
+		return nil, 0, errors.New("parser-core phase zero: invalid conflict-reconciliation mutation class")
+	}
+	return s.reconcileGenericConflictOutputs(owner, source, outputs)
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericConflict(before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) (err error) {
@@ -7150,7 +7576,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	}
 	for ordinal := range execution.armRanges {
 		arm := execution.arm(ordinal)
-		kept, adopted, reconcileErr := s.reconcileGenericConflictOutputs(cell.headerIndex, arm)
+		kept, adopted, reconcileErr := s.reconcileGenericConflictOutputs(owner, cell.headerIndex, arm)
 		if reconcileErr != nil {
 			return reconcileErr
 		}
@@ -7231,7 +7657,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	s.work.add(&s.work.CausalConflictForks, uint64(actions.Len()-1))
 	s.work.ConflictHeads += uint64(outputCount)
 	s.work.Dispatches++
-	if err := s.canonicalize(); err != nil {
+	if err := s.canonicalizeOwned(owner); err != nil {
 		return err
 	}
 	if err := s.persistHeaderLineageOwned(owner); err != nil {
@@ -7378,7 +7804,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 	s.epochProgress = true
 	s.work.OrdinaryShifts += uint64(len(cells))
 	s.work.Dispatches += uint64(len(cells))
-	if err := s.canonicalize(); err != nil {
+	if err := s.canonicalizeOwned(owner); err != nil {
 		return err
 	}
 	if err := s.persistHeaderLineageOwned(owner); err != nil {
@@ -7470,7 +7896,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 			s.work.ExtraCohorts++
 		}
 		s.work.Dispatches += uint64(len(cells))
-		if err := s.canonicalize(); err != nil {
+		if err := s.canonicalizeOwned(owner); err != nil {
 			return err
 		}
 		if err := s.persistHeaderLineageOwned(owner); err != nil {
@@ -7672,9 +8098,28 @@ func replaceDiagnosticParserCoreHeader(headers []diagnosticParserCoreHeader, ind
 }
 
 func (s *diagnosticParserCoreGenericScheduler) canonicalize() error {
-	headers, err := s.canonicalScratch.canonicalize(s.compact, s.headers)
+	if s.freshSessionOwner == nil {
+		return errors.New("parser-core phase zero: canonicalization requires an authenticated scheduler token")
+	}
+	return s.canonicalizeOwned(*s.freshSessionOwner)
+}
+
+func (s *diagnosticParserCoreGenericScheduler) canonicalizeOwned(owner core.SchedulerTransactionToken) error {
+	return s.canonicalizeOwnedWithMutation(owner, 0)
+}
+
+func (s *diagnosticParserCoreGenericScheduler) canonicalizeOwnedWithMutation(owner core.SchedulerTransactionToken, expected core.DropCohortProducerMutation) error {
+	headers, mutation, err := s.canonicalScratch.canonicalizeWithMutation(s.compact, s.headers)
 	if err != nil {
 		return err
+	}
+	if expected != 0 && mutation != expected {
+		return fmt.Errorf("parser-core phase zero: canonicalizer mutation class mismatch: got %d want %d", mutation, expected)
+	}
+	if mutation != 0 {
+		if err := s.compact.RecordDropCohortProducerMutation(owner, mutation); err != nil {
+			return err
+		}
 	}
 	s.headers = headers
 	s.work.Canonicalizations++
@@ -7760,6 +8205,7 @@ func (s *diagnosticParserCoreGenericScheduler) elect(first bool) error {
 	if beforeID != s.checkpointID {
 		return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreIdentity, detail: "generic scheduler scanner checkpoint continuity failed"}
 	}
+	s.checkpointBeforeID = beforeID
 	workCountRecordFrontierLexerElection()
 	token := s.tokenSource.Next()
 	afterBytes := s.tokenSource.captureExternalScannerStateInto(s.scannerScratch)
@@ -8017,13 +8463,13 @@ func applyParserCoreConflictActionInto(
 			dst = append(dst, diagnosticParserCoreActionOutput{
 				head: output.Head, freshness: output.Freshness,
 				cleanPathRank: output.CleanPathRank, cleanPathLineage: lineage, cleanPathSet: set,
-				cleanPathBlended: setBlended,
+				cleanPathBlended: setBlended, dropCohortRefs: output.DropCohortRefs,
 			})
 		case core.ReductionNew, core.ReductionUpdated:
 			dst = append(dst, diagnosticParserCoreActionOutput{
 				head: output.Head, freshness: output.Freshness,
 				cleanPathRank: output.CleanPathRank, cleanPathLineage: lineage, cleanPathSet: set,
-				cleanPathBlended: setBlended,
+				cleanPathBlended: setBlended, dropCohortRefs: output.DropCohortRefs,
 			})
 		default:
 			return nil, outputs, errors.New("parser-core phase zero: reduction returned invalid freshness")

--- a/parsercore_phase0_g18_alternative_set_contract_test.go
+++ b/parsercore_phase0_g18_alternative_set_contract_test.go
@@ -1,0 +1,2816 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"unsafe"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+const (
+	g18ReferenceMaxCohorts  = 8
+	g18ReferenceMaxMembers  = 8
+	g18ReferenceInlineLimit = 2
+)
+
+type g18ReferenceCohortID struct {
+	ArenaOwner     uint64
+	ArenaEpoch     uint64
+	CohortSequence uint64
+}
+
+type g18ReferenceCertificateState uint8
+
+const (
+	g18ReferenceCertificateBuilding g18ReferenceCertificateState = iota + 1
+	g18ReferenceCertificateComplete
+	g18ReferenceCertificateOverflowed
+	g18ReferenceCertificateBlended
+	g18ReferenceCertificateUnproved
+)
+
+type g18ReferenceActionIdentity struct {
+	State             core.StateID
+	Lookahead         core.Symbol
+	Ordinal           uint16
+	Type              core.ActionType
+	TargetState       core.StateID
+	Symbol            core.Symbol
+	ProductionID      uint16
+	ChildCount        uint8
+	DynamicPrecedence int16
+	Extra             bool
+	ExtraChain        bool
+	Repetition        bool
+	NoLookahead       bool
+	SelectionClass    uint8
+}
+
+type g18ReferenceDerivationIdentity struct {
+	InternedRecord uint32
+	RootSymbol     core.Symbol
+	StackDepth     uint32
+	Digest         [sha256.Size]byte
+	Record         [64]byte
+	RecordLength   uint8
+}
+
+type g18ReferenceCohortMember struct {
+	Branch     uint16
+	Action     g18ReferenceActionIdentity
+	Derivation g18ReferenceDerivationIdentity
+}
+
+type g18ReferenceCertificate struct {
+	ID              g18ReferenceCohortID
+	State           g18ReferenceCertificateState
+	ExpectedMembers uint8
+	WrittenMembers  uint8
+	Spilled         bool
+	Members         [g18ReferenceMaxMembers]g18ReferenceCohortMember
+}
+
+type g18ReferenceAccounting struct {
+	ActionRecords         uint16
+	DerivationRecords     uint16
+	CertificateReferences uint16
+	MapEntries            uint16
+	InternerEntries       uint16
+	JournalEntries        uint16
+	StorageBytes          uint64
+}
+
+type g18ReferenceLimits struct {
+	MaxActionRecords         uint16
+	MaxDerivationRecords     uint16
+	MaxCertificateReferences uint16
+	MaxMapEntries            uint16
+	MaxInternerEntries       uint16
+	MaxJournalEntries        uint16
+	MaxStorageBytes          uint64
+}
+
+type g18ReferenceCertificateHandle struct {
+	ID    g18ReferenceCohortID
+	Index uint8
+}
+
+type g18ReferenceHeadProof struct {
+	Head        core.Head
+	Certificate g18ReferenceCertificateHandle
+	Member      g18ReferenceCohortMember
+}
+
+type g18ReferenceCertificateArena struct {
+	Owner        uint64
+	Epoch        uint64
+	NextSequence uint64
+	Count        uint8
+	// OwnerCheckedLookups counts every owner-check attempt, including a
+	// rejected foreign or stale handle. It is not a storage-read counter.
+	OwnerCheckedLookups uint64
+	Used                g18ReferenceAccounting
+	Limits              g18ReferenceLimits
+	Certificates        [g18ReferenceMaxCohorts]g18ReferenceCertificate
+}
+
+func g18ReferenceDefaultLimits() g18ReferenceLimits {
+	return g18ReferenceLimits{
+		MaxActionRecords: 64, MaxDerivationRecords: 64, MaxCertificateReferences: 64,
+		MaxMapEntries: 64, MaxInternerEntries: 64, MaxJournalEntries: 96,
+		MaxStorageBytes: 1 << 20,
+	}
+}
+
+func g18ReferencePlan(expected uint8) g18ReferenceAccounting {
+	return g18ReferenceAccounting{
+		ActionRecords: uint16(expected), DerivationRecords: uint16(expected),
+		CertificateReferences: uint16(expected) + 1, MapEntries: uint16(expected),
+		InternerEntries: uint16(expected), JournalEntries: uint16(expected) + 2,
+		StorageBytes: uint64(unsafe.Sizeof(g18ReferenceCertificate{})) +
+			uint64(expected)*uint64(unsafe.Sizeof(g18ReferenceCohortMember{})),
+	}
+}
+
+func g18ReferenceNewArena(owner uint64) g18ReferenceCertificateArena {
+	return g18ReferenceCertificateArena{Owner: owner, Limits: g18ReferenceDefaultLimits()}
+}
+
+func g18ReferenceAllocateOwner(counter *uint64) (uint64, error) {
+	if counter == nil || *counter == math.MaxUint64 {
+		return 0, errors.New("arena owner overflow")
+	}
+	*counter = *counter + 1
+	if *counter == 0 {
+		return 0, errors.New("arena owner is zero")
+	}
+	return *counter, nil
+}
+
+func (arena *g18ReferenceCertificateArena) beginSession() error {
+	if arena.Owner == 0 {
+		return errors.New("arena owner is zero")
+	}
+	if arena.Epoch == math.MaxUint64 {
+		return errors.New("arena epoch overflow")
+	}
+	arena.Epoch++
+	if arena.Epoch == 0 {
+		return errors.New("arena epoch is zero")
+	}
+	arena.NextSequence = 0
+	arena.Count = 0
+	arena.Used = g18ReferenceAccounting{}
+	return nil
+}
+
+func (arena *g18ReferenceCertificateArena) newCertificate(
+	expected uint8,
+	plan g18ReferenceAccounting,
+) (g18ReferenceCertificateHandle, error) {
+	var zero g18ReferenceCertificateHandle
+	if arena.Epoch == 0 {
+		return zero, errors.New("certificate arena is inactive")
+	}
+	if arena.NextSequence == math.MaxUint64 {
+		return zero, errors.New("cohort sequence overflow")
+	}
+	if int(arena.Count) == len(arena.Certificates) {
+		return zero, errors.New("certificate cohort cap")
+	}
+	if expected == 0 || int(expected) > g18ReferenceMaxMembers {
+		return zero, errors.New("certificate member cap")
+	}
+	if plan.ActionRecords < uint16(expected) || plan.DerivationRecords < uint16(expected) ||
+		plan.CertificateReferences < uint16(expected)+1 || plan.MapEntries < uint16(expected) ||
+		plan.InternerEntries < uint16(expected) || plan.JournalEntries < uint16(expected)+2 ||
+		plan.StorageBytes < g18ReferencePlan(expected).StorageBytes {
+		return zero, errors.New("certificate preflight is incomplete")
+	}
+	if !arena.fits(plan) {
+		return zero, errors.New("certificate preflight exceeds a limit")
+	}
+	arena.NextSequence++
+	index := arena.Count
+	certificate := &arena.Certificates[index]
+	*certificate = g18ReferenceCertificate{
+		ID: g18ReferenceCohortID{
+			ArenaOwner: arena.Owner, ArenaEpoch: arena.Epoch, CohortSequence: arena.NextSequence,
+		},
+		State: g18ReferenceCertificateBuilding, ExpectedMembers: expected,
+		Spilled: expected > g18ReferenceInlineLimit,
+	}
+	arena.Count++
+	arena.Used = arena.Used.plus(plan)
+	return g18ReferenceCertificateHandle{ID: certificate.ID, Index: index}, nil
+}
+
+func (arena *g18ReferenceCertificateArena) storageBytes() uint64 {
+	return arena.Used.StorageBytes
+}
+
+func (arena *g18ReferenceCertificateArena) footprintBytes() uint64 {
+	if arena == nil {
+		return 0
+	}
+	return uint64(unsafe.Sizeof(*arena))
+}
+
+func (value g18ReferenceAccounting) plus(other g18ReferenceAccounting) g18ReferenceAccounting {
+	return g18ReferenceAccounting{
+		ActionRecords:         value.ActionRecords + other.ActionRecords,
+		DerivationRecords:     value.DerivationRecords + other.DerivationRecords,
+		CertificateReferences: value.CertificateReferences + other.CertificateReferences,
+		MapEntries:            value.MapEntries + other.MapEntries,
+		InternerEntries:       value.InternerEntries + other.InternerEntries,
+		JournalEntries:        value.JournalEntries + other.JournalEntries,
+		StorageBytes:          value.StorageBytes + other.StorageBytes,
+	}
+}
+
+func (arena *g18ReferenceCertificateArena) fits(plan g18ReferenceAccounting) bool {
+	next := arena.Used.plus(plan)
+	return next.ActionRecords >= arena.Used.ActionRecords && next.ActionRecords <= arena.Limits.MaxActionRecords &&
+		next.DerivationRecords >= arena.Used.DerivationRecords && next.DerivationRecords <= arena.Limits.MaxDerivationRecords &&
+		next.CertificateReferences >= arena.Used.CertificateReferences && next.CertificateReferences <= arena.Limits.MaxCertificateReferences &&
+		next.MapEntries >= arena.Used.MapEntries && next.MapEntries <= arena.Limits.MaxMapEntries &&
+		next.InternerEntries >= arena.Used.InternerEntries && next.InternerEntries <= arena.Limits.MaxInternerEntries &&
+		next.JournalEntries >= arena.Used.JournalEntries && next.JournalEntries <= arena.Limits.MaxJournalEntries &&
+		next.StorageBytes >= arena.Used.StorageBytes && next.StorageBytes <= arena.Limits.MaxStorageBytes
+}
+
+func (arena *g18ReferenceCertificateArena) lookup(
+	handle g18ReferenceCertificateHandle,
+	expose bool,
+) (*g18ReferenceCertificate, error) {
+	// Count every owner-check attempt before comparing the owner.
+	arena.OwnerCheckedLookups++
+	// The owner check must occur before an index, epoch, or sequence lookup.
+	if handle.ID.ArenaOwner == 0 || handle.ID.ArenaOwner != arena.Owner {
+		return nil, errors.New("foreign arena owner")
+	}
+	if handle.ID.ArenaEpoch == 0 || handle.ID.ArenaEpoch != arena.Epoch {
+		return nil, errors.New("stale arena epoch")
+	}
+	if handle.ID.CohortSequence == 0 || int(handle.Index) >= int(arena.Count) {
+		return nil, errors.New("invalid cohort reference")
+	}
+	certificate := &arena.Certificates[handle.Index]
+	if certificate.ID != handle.ID {
+		return nil, errors.New("cohort identity mismatch")
+	}
+	if expose && certificate.State != g18ReferenceCertificateComplete {
+		return nil, errors.New("certificate is not complete")
+	}
+	return certificate, nil
+}
+
+func (arena *g18ReferenceCertificateArena) write(
+	handle g18ReferenceCertificateHandle,
+	member g18ReferenceCohortMember,
+) error {
+	certificate, err := arena.lookup(handle, false)
+	if err != nil {
+		return err
+	}
+	if certificate.State != g18ReferenceCertificateBuilding {
+		return errors.New("certificate is not building")
+	}
+	for index := 0; index < int(certificate.WrittenMembers); index++ {
+		current := certificate.Members[index]
+		if current == member {
+			return errors.New("duplicate certificate member")
+		}
+		if current.Branch == member.Branch {
+			certificate.State = g18ReferenceCertificateBlended
+			return errors.New("conflicting certificate branch")
+		}
+	}
+	if certificate.WrittenMembers >= certificate.ExpectedMembers || int(certificate.WrittenMembers) == len(certificate.Members) {
+		certificate.State = g18ReferenceCertificateOverflowed
+		return errors.New("certificate member overflow")
+	}
+	certificate.Members[certificate.WrittenMembers] = member
+	certificate.WrittenMembers++
+	return nil
+}
+
+func (arena *g18ReferenceCertificateArena) finalize(handle g18ReferenceCertificateHandle) error {
+	certificate, err := arena.lookup(handle, false)
+	if err != nil {
+		return err
+	}
+	if certificate.State != g18ReferenceCertificateBuilding ||
+		certificate.WrittenMembers != certificate.ExpectedMembers {
+		return errors.New("certificate is partial or terminal")
+	}
+	certificate.State = g18ReferenceCertificateComplete
+	return nil
+}
+
+func (arena *g18ReferenceCertificateArena) markUnproved(handle g18ReferenceCertificateHandle) error {
+	certificate, err := arena.lookup(handle, false)
+	if err != nil {
+		return err
+	}
+	certificate.State = g18ReferenceCertificateUnproved
+	return nil
+}
+
+func (certificate *g18ReferenceCertificate) compatibleMerge(source g18ReferenceCertificate) bool {
+	if certificate.ID != source.ID || certificate.State != g18ReferenceCertificateBuilding ||
+		source.State != g18ReferenceCertificateBuilding || source.WrittenMembers == 0 ||
+		source.WrittenMembers != source.ExpectedMembers {
+		certificate.State = g18ReferenceCertificateBlended
+		return false
+	}
+	before := *certificate
+	for index := 0; index < int(source.WrittenMembers); index++ {
+		member := source.Members[index]
+		for existing := 0; existing < int(certificate.WrittenMembers); existing++ {
+			if certificate.Members[existing] == member || certificate.Members[existing].Branch == member.Branch {
+				*certificate = before
+				certificate.State = g18ReferenceCertificateBlended
+				return false
+			}
+		}
+		if certificate.WrittenMembers >= certificate.ExpectedMembers {
+			*certificate = before
+			certificate.State = g18ReferenceCertificateOverflowed
+			return false
+		}
+		certificate.Members[certificate.WrittenMembers] = member
+		certificate.WrittenMembers++
+	}
+	return true
+}
+
+func (certificate *g18ReferenceCertificate) contains(member g18ReferenceCohortMember) bool {
+	for index := 0; index < int(certificate.WrittenMembers); index++ {
+		if certificate.Members[index] == member {
+			return true
+		}
+	}
+	return false
+}
+
+func g18ReferenceVerifyDrop(
+	arena *g18ReferenceCertificateArena,
+	survivor g18ReferenceHeadProof,
+	dropped ...g18ReferenceHeadProof,
+) bool {
+	if arena == nil || len(dropped) == 0 {
+		return false
+	}
+	if survivor.Head.Node == 0 {
+		return false
+	}
+	survivorCertificate, err := arena.lookup(survivor.Certificate, true)
+	if err != nil || !survivorCertificate.contains(survivor.Member) {
+		return false
+	}
+	for candidateIndex, candidate := range dropped {
+		if candidate.Head.Node == 0 || candidate.Head == survivor.Head {
+			return false
+		}
+		for prior := 0; prior < candidateIndex; prior++ {
+			if dropped[prior].Head == candidate.Head {
+				return false
+			}
+		}
+		candidateCertificate, candidateErr := arena.lookup(candidate.Certificate, true)
+		if candidateErr != nil || candidate.Certificate.ID != survivor.Certificate.ID ||
+			!candidateCertificate.contains(candidate.Member) ||
+			candidate.Member.Action != survivor.Member.Action ||
+			candidate.Member.Derivation != survivor.Member.Derivation {
+			return false
+		}
+	}
+	return true
+}
+
+func g18ReferenceMember(branch, actionOrdinal uint16, derivation uint32) g18ReferenceCohortMember {
+	record := [64]byte{
+		byte(derivation), byte(derivation >> 8), byte(derivation >> 16), byte(derivation >> 24),
+		byte(actionOrdinal), 2, 4, 1,
+	}
+	return g18ReferenceCohortMember{
+		Branch: branch,
+		Action: g18ReferenceActionIdentity{
+			State: 3, Lookahead: 9, Ordinal: actionOrdinal, Type: core.ActionReduce,
+			Symbol: 2, ProductionID: 5, ChildCount: 1, DynamicPrecedence: 2,
+		},
+		Derivation: g18ReferenceDerivationIdentity{
+			InternedRecord: derivation, RootSymbol: 2, StackDepth: 4,
+			Digest: sha256.Sum256(record[:8]), Record: record, RecordLength: 8,
+		},
+	}
+}
+
+func g18ValidDropScheduler(t *testing.T) (*diagnosticParserCoreGenericScheduler, core.Head, core.Head) {
+	t.Helper()
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		options: DiagnosticParserCorePrefixOptions{ReceiptMode: DiagnosticParserCoreReceiptSummary},
+		receipt: &DiagnosticParserCoreGenericScheduler{ReceiptMode: DiagnosticParserCoreReceiptSummary},
+	}
+	return scheduler, first, second
+}
+
+func g18RequireValidSummaryHeads(t *testing.T, scheduler *diagnosticParserCoreGenericScheduler) {
+	t.Helper()
+	for index, header := range scheduler.headers {
+		if _, err := scheduler.headerReceipt(header); err != nil {
+			t.Fatalf("header %d summary receipt: %v", index, err)
+		}
+	}
+}
+
+func TestG18DropPathRejectsBlendedSurvivor(t *testing.T) {
+	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
+	scheduler, first, second := g18ValidDropScheduler(t)
+	member := alternativeSetPinBranchMember(t, scheduler.compact, [2]uint16{7, 0})
+	scheduler.headers = []diagnosticParserCoreHeader{
+		{head: first, convergedReductionSplit: true, altSet: member, blended: true},
+		{head: second, convergedReductionSplit: true, altSet: member},
+	}
+	g18RequireValidSummaryHeads(t, scheduler)
+	if err := scheduler.dropGenericNoActionHeads([]int{1}); err == nil ||
+		!strings.Contains(err.Error(), "lacks alternative-set coverage by one non-blended survivor") {
+		t.Fatalf("blended-survivor drop error = %v", err)
+	}
+}
+
+func TestG18DropPathRejectsUnprovedHistoricalImport(t *testing.T) {
+	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
+	scheduler, first, second := g18ValidDropScheduler(t)
+	member := alternativeSetPinBranchMember(t, scheduler.compact, [2]uint16{11, 0})
+	scheduler.headers = []diagnosticParserCoreHeader{
+		{head: first, convergedReductionSplit: true, altSet: member},
+		{head: second, convergedReductionSplit: true, altSet: member, resurrectionUnproved: true},
+	}
+	g18RequireValidSummaryHeads(t, scheduler)
+	if err := scheduler.dropGenericNoActionHeads([]int{1}); err == nil ||
+		!strings.Contains(err.Error(), "unproved historical boundary resurrection") {
+		t.Fatalf("unproved-history drop error = %v", err)
+	}
+}
+
+func TestG18DropPathRejectsForeignSpill(t *testing.T) {
+	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
+	scheduler, first, second := g18ValidDropScheduler(t)
+	foreign := newAlternativeSetPinScheduler(t)
+	foreignSpill := alternativeSetPinBranchMember(
+		t, foreign.compact, [2]uint16{17, 0}, [2]uint16{19, 0}, [2]uint16{23, 0},
+	)
+	if members, ok := foreign.compact.AlternativeSetMembers(foreignSpill); !ok || len(members) != 3 {
+		t.Fatalf("foreign spill setup = %d/%t, want 3/true", len(members), ok)
+	}
+	localInline := alternativeSetPinBranchMember(t, scheduler.compact, [2]uint16{17, 0})
+	scheduler.headers = []diagnosticParserCoreHeader{
+		{head: first, convergedReductionSplit: true, altSet: localInline},
+		{head: second, convergedReductionSplit: true, altSet: foreignSpill},
+	}
+	g18RequireValidSummaryHeads(t, scheduler)
+	if err := scheduler.dropGenericNoActionHeads([]int{1}); err == nil ||
+		!strings.Contains(err.Error(), "lacks alternative-set coverage") {
+		t.Fatalf("foreign-spill drop error = %v", err)
+	}
+}
+
+func TestG18DropPathRejectsResetStaleSpill(t *testing.T) {
+	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
+	scheduler, _, _ := g18ValidDropScheduler(t)
+	stale := alternativeSetPinBranchMember(
+		t, scheduler.compact, [2]uint16{29, 0}, [2]uint16{31, 0}, [2]uint16{37, 0},
+	)
+	if err := scheduler.compact.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	first, err := scheduler.compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := scheduler.compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	local := alternativeSetPinBranchMember(t, scheduler.compact, [2]uint16{29, 0})
+	scheduler.headers = []diagnosticParserCoreHeader{
+		{head: first, convergedReductionSplit: true, altSet: local},
+		{head: second, convergedReductionSplit: true, altSet: stale},
+	}
+	g18RequireValidSummaryHeads(t, scheduler)
+	if err := scheduler.dropGenericNoActionHeads([]int{1}); err == nil ||
+		!strings.Contains(err.Error(), "lacks alternative-set coverage") {
+		t.Fatalf("reset-stale spill drop error = %v", err)
+	}
+}
+
+// TestG18DropPathRejectsForeignInlineRED is intentional RED. The current
+// inline set has no arena identity, so a foreign inline value can authorize
+// a current-arena drop. The future certificate must reject this drop.
+func TestG18DropPathRejectsForeignInlineRED(t *testing.T) {
+	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
+	scheduler, first, second := g18ValidDropScheduler(t)
+	foreign := newAlternativeSetPinScheduler(t)
+	foreignInline := alternativeSetPinBranchMember(t, foreign.compact, [2]uint16{41, 0})
+	localInline := alternativeSetPinBranchMember(t, scheduler.compact, [2]uint16{41, 0})
+	scheduler.headers = []diagnosticParserCoreHeader{
+		{head: first, convergedReductionSplit: true, altSet: localInline},
+		{head: second, convergedReductionSplit: true, altSet: foreignInline},
+	}
+	g18RequireValidSummaryHeads(t, scheduler)
+	if err := scheduler.dropGenericNoActionHeads([]int{1}); err != nil {
+		t.Fatalf("current foreign-inline characterization changed: %v", err)
+	}
+	t.Fatal("RED: foreign inline lineage certified a current-arena drop")
+}
+
+func TestG18CurrentCanonicalizerProducerPaths(t *testing.T) {
+	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left := alternativeSetPinBranchMember(t, compact, [2]uint16{47, 0})
+	right := alternativeSetPinBranchMember(t, compact, [2]uint16{47, 1})
+
+	linear := diagnosticParserCoreCanonicalScratch{}
+	linearOut, err := linear.canonicalize(compact, []diagnosticParserCoreHeader{
+		{head: head, altSet: left},
+		{head: head, altSet: right},
+	})
+	if err != nil || len(linearOut) != 1 || !linearOut[0].blended || linearOut[0].altSet.Len() != 2 {
+		t.Fatalf("linear canonicalizer output=%+v err=%v", linearOut, err)
+	}
+
+	mappedHeaders := make([]diagnosticParserCoreHeader, diagnosticParserCoreLinearCanonicalLimit+1)
+	for index := range mappedHeaders {
+		mappedHeaders[index] = diagnosticParserCoreHeader{head: head, altSet: left}
+	}
+	mappedHeaders[1].altSet = right
+	mapped := diagnosticParserCoreCanonicalScratch{}
+	mappedOut, err := mapped.canonicalize(compact, mappedHeaders)
+	if err != nil || len(mappedOut) != 1 || !mappedOut[0].blended || mappedOut[0].altSet.Len() != 2 {
+		t.Fatalf("mapped canonicalizer output=%+v err=%v", mappedOut, err)
+	}
+}
+
+func g18AdoptionFixture(t *testing.T) (*core.Core, core.Head, core.Head) {
+	t.Helper()
+	table := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 7}: {{Type: core.ActionShift, State: 5}},
+			{state: 1, symbol: 8}: {{Type: core.ActionShift, State: 3}},
+			{state: 5, symbol: 9}: {{Type: core.ActionReduce, Symbol: 2, ChildCount: 1, DynamicPrecedence: 1}},
+			{state: 3, symbol: 9}: {{Type: core.ActionReduce, Symbol: 2, ChildCount: 1, DynamicPrecedence: 2}},
+		},
+		gotos: map[genericConflictCell]core.StateID{{state: 1, symbol: 2}: 4},
+	}
+	compact, err := core.New(table, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	low, err := compact.Shift(seed, 7, 0, core.Token{Symbol: 7, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	high, err := compact.Shift(seed, 8, 0, core.Token{Symbol: 8, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputs, err := compact.ReduceOutputs(low, 9, 0, core.ForkOrder{})
+	if err != nil || len(outputs) != 1 {
+		t.Fatalf("low reduction output=%+v err=%v", outputs, err)
+	}
+	return compact, high, outputs[0].Head
+}
+
+func TestG18CurrentAdoptionAndConflictProducerPaths(t *testing.T) {
+	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
+	for _, test := range []struct {
+		name      string
+		reconcile bool
+	}{
+		{name: "sibling_adoption"},
+		{name: "conflict_reconciliation", reconcile: true},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			compact, high, active := g18AdoptionFixture(t)
+			left := alternativeSetPinBranchMember(t, compact, [2]uint16{53, 0})
+			right := alternativeSetPinBranchMember(t, compact, [2]uint16{53, 1})
+			scheduler := &diagnosticParserCoreGenericScheduler{
+				compact: compact,
+				headers: []diagnosticParserCoreHeader{
+					{head: high, creationSeq: 3, altSet: left},
+					{head: active, creationSeq: 11, altSet: left},
+				},
+			}
+			if !test.reconcile {
+				adopted, err := scheduler.adoptUpdatedReductionSibling(
+					0, active, core.CleanPathRankUnknown, 0, right, false, true, false,
+				)
+				if err != nil || !adopted {
+					t.Fatalf("sibling adoption=%t err=%v", adopted, err)
+				}
+			} else {
+				outputs := []diagnosticParserCoreHeader{{
+					head: active, freshness: core.ReductionUpdated, altSet: right, cleanPathLineage: 53,
+				}}
+				kept, adopted, err := scheduler.reconcileGenericConflictOutputs(0, outputs)
+				if err != nil || len(kept) != 0 || adopted != 1 {
+					t.Fatalf("conflict reconciliation kept=%+v adopted=%d err=%v", kept, adopted, err)
+				}
+			}
+			got := scheduler.headers[1]
+			if got.altSet.Len() != 2 || !got.blended || !got.convergedReductionSplit {
+				t.Fatalf("adopted producer state=%+v", got)
+			}
+		})
+	}
+}
+
+const (
+	g18FutureStoreActionRecords = iota
+	g18FutureStoreDerivationRecords
+	g18FutureStoreCertificateReferences
+	g18FutureStoreMapEntries
+	g18FutureStoreInternerEntries
+	g18FutureStoreJournalEntries
+	g18FutureStoreCohortRecords
+	g18FutureStoreCount
+
+	g18FutureActionFieldCount = 14
+)
+
+var g18FutureProducerNames = []string{
+	"reduction_establishment",
+	"linear_canonicalizer",
+	"mapped_canonicalizer",
+	"sibling_adoption",
+	"conflict_reconciliation",
+	"dead_history_import",
+}
+
+// These aliases are fixed-width protocol primitives. They keep the future
+// API independent of root-package test types, so internal Core can implement
+// the methods without importing this package.
+type g18FutureStoreVector = [g18FutureStoreCount]uint64
+type g18FutureCohortHandle = [3]uint64
+type g18FutureActionVector = [g18FutureActionFieldCount]int64
+
+type g18FutureActionRecordLayout struct {
+	Fields g18FutureActionVector
+}
+
+type g18FutureDerivationRecordLayout struct {
+	Digest [sha256.Size]byte
+	Offset uint32
+	Length uint32
+}
+
+type g18FutureCertificateReferenceLayout struct {
+	Handle g18FutureCohortHandle
+	Head   core.Head
+	Branch uint16
+}
+
+type g18FutureMapEntryLayout struct {
+	Hash  uint64
+	Index uint32
+	Used  bool
+}
+
+type g18FutureInternerEntryLayout struct {
+	Digest [sha256.Size]byte
+	Index  uint32
+	Used   bool
+}
+
+type g18FutureJournalEntryLayout struct {
+	Store uint8
+	Index uint32
+	Value uint64
+}
+
+type g18FutureCohortRecordLayout struct {
+	Handle   g18FutureCohortHandle
+	State    uint8
+	Expected uint16
+	Written  uint16
+	Spilled  bool
+}
+
+type g18FutureCoreCertificateBehavior interface {
+	DiagnosticDropCohortArenaIdentityForTest() (uint64, uint64)
+	DiagnosticDropCohortSnapshotForTest() []byte
+	// The wrap probes use the production atomic counters with a scoped test
+	// value. They return the last accepted value and the rejected wrapped value.
+	DiagnosticDropCohortOwnerWrapProbeForTest() (uint64, uint64, error)
+	DiagnosticDropCohortEpochWrapProbeForTest() (uint64, uint64, error)
+	DiagnosticDropCohortSequenceWrapProbeForTest() (uint64, uint64, error)
+	DiagnosticDropCohortLimitsForTest() (uint16, uint16)
+	DiagnosticDropCohortSetLimitsForTest(uint16, uint16) error
+	DiagnosticDropCohortBeginForTest(uint16, uint32, [g18FutureStoreCount]uint64) ([3]uint64, error)
+	DiagnosticDropCohortWriteForTest(
+		[3]uint64,
+		core.Head,
+		uint16,
+		[g18FutureActionFieldCount]int64,
+		[sha256.Size]byte,
+		[]byte,
+	) error
+	DiagnosticDropCohortFinalizeForTest([3]uint64) error
+	DiagnosticDropCohortMarkUnprovedForTest([3]uint64) error
+	DiagnosticDropCohortRollbackForTest([3]uint64) error
+}
+
+// g18FutureCompileContractProvider proves that an internal-owned provider can
+// satisfy the root adapter with only fixed-width primitives and core.Head.
+type g18FutureCompileContractProvider struct{}
+
+var _ g18FutureCoreCertificateBehavior = (*g18FutureCompileContractProvider)(nil)
+
+func TestG18FutureInternalAPICompileContract(t *testing.T) {
+	var provider g18FutureCoreCertificateBehavior = &g18FutureCompileContractProvider{}
+	if provider == nil {
+		t.Fatal("internal API compile contract provider is nil")
+	}
+}
+
+func (*g18FutureCompileContractProvider) DiagnosticDropCohortArenaIdentityForTest() (uint64, uint64) {
+	return 0, 0
+}
+
+func (*g18FutureCompileContractProvider) DiagnosticDropCohortSnapshotForTest() []byte {
+	return nil
+}
+
+func (*g18FutureCompileContractProvider) DiagnosticDropCohortOwnerWrapProbeForTest() (uint64, uint64, error) {
+	return 0, 0, nil
+}
+
+func (*g18FutureCompileContractProvider) DiagnosticDropCohortEpochWrapProbeForTest() (uint64, uint64, error) {
+	return 0, 0, nil
+}
+
+func (*g18FutureCompileContractProvider) DiagnosticDropCohortSequenceWrapProbeForTest() (uint64, uint64, error) {
+	return 0, 0, nil
+}
+
+func (*g18FutureCompileContractProvider) DiagnosticDropCohortLimitsForTest() (uint16, uint16) {
+	return 0, 0
+}
+
+func (*g18FutureCompileContractProvider) DiagnosticDropCohortSetLimitsForTest(uint16, uint16) error {
+	return nil
+}
+
+func (*g18FutureCompileContractProvider) DiagnosticDropCohortBeginForTest(uint16, uint32, [g18FutureStoreCount]uint64) ([3]uint64, error) {
+	return [3]uint64{}, nil
+}
+
+func (*g18FutureCompileContractProvider) DiagnosticDropCohortWriteForTest([3]uint64, core.Head, uint16, [g18FutureActionFieldCount]int64, [sha256.Size]byte, []byte) error {
+	return nil
+}
+
+func (*g18FutureCompileContractProvider) DiagnosticDropCohortFinalizeForTest([3]uint64) error {
+	return nil
+}
+
+func (*g18FutureCompileContractProvider) DiagnosticDropCohortMarkUnprovedForTest([3]uint64) error {
+	return nil
+}
+
+func (*g18FutureCompileContractProvider) DiagnosticDropCohortRollbackForTest([3]uint64) error {
+	return nil
+}
+
+type g18FutureSchedulerDropBehavior interface {
+	DiagnosticBindDropCohortReferencesForTest([]g18FutureCohortHandle, []uint16) error
+	DiagnosticDropGenericNoActionHeadsForTest([]int) (string, error)
+	DiagnosticDropGenericNoActionHeadsNonDestructiveForTest([]int) (string, uint64, [sha256.Size]byte, error)
+	DiagnosticDropGenericNoActionHeadsVerifierStateDigestForTest() [sha256.Size]byte
+}
+
+// G18DropCohortProducerMutationClass identifies one authenticated producer
+// transition in the test-only Slice C compatibility surface.
+type G18DropCohortProducerMutationClass uint8
+
+const (
+	g18FutureProducerLinearCanonicalization G18DropCohortProducerMutationClass = iota + 1
+	g18FutureProducerMappedCanonicalization
+	g18FutureProducerSiblingAdoption
+	g18FutureProducerConflictReconciliation
+)
+
+// These exported, test-only interfaces are the exact Slice C compatibility
+// contract. Their unique names prevent accidental satisfaction by legacy APIs.
+type g18FutureSiblingAdoptionCompatibility interface {
+	G18AdoptUpdatedReductionSiblingOwned(
+		core.SchedulerTransactionToken,
+		int,
+		core.Head,
+		core.CleanPathRankSelection,
+		uint16,
+		core.AlternativeSet,
+		bool,
+		bool,
+		bool,
+		G18DropCohortProducerMutationClass,
+	) (bool, error)
+}
+
+type g18FutureConflictReconciliationCompatibility interface {
+	G18ReconcileGenericConflictOutputsOwned(
+		core.SchedulerTransactionToken,
+		int,
+		[]diagnosticParserCoreHeader,
+		G18DropCohortProducerMutationClass,
+	) ([]diagnosticParserCoreHeader, int, error)
+}
+
+type g18FutureCanonicalizerCompatibility interface {
+	G18CanonicalizeOwned(core.SchedulerTransactionToken, G18DropCohortProducerMutationClass) error
+}
+
+type g18FutureOwnedSchedulerAdapter struct {
+	scheduler *diagnosticParserCoreGenericScheduler
+}
+
+func (adapter g18FutureOwnedSchedulerAdapter) g18AdoptUpdatedReductionSiblingOwned(
+	owner core.SchedulerTransactionToken,
+	source int,
+	head core.Head,
+	rank core.CleanPathRankSelection,
+	lineage uint16,
+	set core.AlternativeSet,
+	setBlended bool,
+	converged bool,
+	resurrection bool,
+	mutation G18DropCohortProducerMutationClass,
+) (bool, error) {
+	if mutation != g18FutureProducerSiblingAdoption {
+		return false, errors.New("RED: invalid authenticated sibling-adoption mutation class")
+	}
+	wrapper, ok := any(adapter.scheduler).(g18FutureSiblingAdoptionCompatibility)
+	if !ok {
+		return false, errors.New("RED: missing exported Slice C sibling-adoption compatibility method")
+	}
+	return wrapper.G18AdoptUpdatedReductionSiblingOwned(
+		owner, source, head, rank, lineage, set, setBlended, converged, resurrection, mutation,
+	)
+}
+
+func (adapter g18FutureOwnedSchedulerAdapter) g18ReconcileGenericConflictOutputsOwned(
+	owner core.SchedulerTransactionToken,
+	source int,
+	outputs []diagnosticParserCoreHeader,
+	mutation G18DropCohortProducerMutationClass,
+) ([]diagnosticParserCoreHeader, int, error) {
+	if mutation != g18FutureProducerConflictReconciliation {
+		return nil, 0, errors.New("RED: invalid authenticated conflict-reconciliation mutation class")
+	}
+	wrapper, ok := any(adapter.scheduler).(g18FutureConflictReconciliationCompatibility)
+	if !ok {
+		return nil, 0, errors.New("RED: missing exported Slice C conflict-reconciliation compatibility method")
+	}
+	return wrapper.G18ReconcileGenericConflictOutputsOwned(owner, source, outputs, mutation)
+}
+
+func g18FutureAdoptUpdatedReductionSiblingRED(
+	t *testing.T,
+	scheduler *diagnosticParserCoreGenericScheduler,
+	source int,
+	head core.Head,
+	rank core.CleanPathRankSelection,
+	lineage uint16,
+	set core.AlternativeSet,
+	setBlended bool,
+	converged bool,
+	resurrection bool,
+	mutation G18DropCohortProducerMutationClass,
+) (adopted bool, err error) {
+	t.Helper()
+	adapter := g18FutureOwnedSchedulerAdapter{scheduler: scheduler}
+	err = scheduler.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		adopted, err = adapter.g18AdoptUpdatedReductionSiblingOwned(
+			owner, source, head, rank, lineage, set, setBlended, converged, resurrection, mutation,
+		)
+		return err
+	})
+	return adopted, err
+}
+
+func g18FutureReconcileGenericConflictOutputsRED(
+	t *testing.T,
+	scheduler *diagnosticParserCoreGenericScheduler,
+	source int,
+	outputs []diagnosticParserCoreHeader,
+	mutation G18DropCohortProducerMutationClass,
+) (kept []diagnosticParserCoreHeader, adopted int, err error) {
+	t.Helper()
+	adapter := g18FutureOwnedSchedulerAdapter{scheduler: scheduler}
+	err = scheduler.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		kept, adopted, err = adapter.g18ReconcileGenericConflictOutputsOwned(owner, source, outputs, mutation)
+		return err
+	})
+	return kept, adopted, err
+}
+
+func (adapter g18FutureOwnedSchedulerAdapter) g18CanonicalizeOwned(
+	owner core.SchedulerTransactionToken,
+	mutation G18DropCohortProducerMutationClass,
+) error {
+	if mutation != g18FutureProducerLinearCanonicalization && mutation != g18FutureProducerMappedCanonicalization {
+		return errors.New("RED: invalid authenticated canonicalizer mutation class")
+	}
+	wrapper, ok := any(adapter.scheduler).(g18FutureCanonicalizerCompatibility)
+	if !ok {
+		return errors.New("RED: missing exported Slice C canonicalizer compatibility method")
+	}
+	return wrapper.G18CanonicalizeOwned(owner, mutation)
+}
+
+// g18CertificateAdmissionOptionAdapter is a private, test-only seam. It
+// keeps certificate admission outside runtime profile flags and returns an
+// exact restore function for cached parser reuse.
+type g18CertificateAdmissionOptionAdapter interface {
+	DiagnosticEnableDropCohortCertificateAdmissionForTest() func()
+}
+
+func TestG18CertificateAdmissionOptionAdapterCompileContract(t *testing.T) {
+	var parser *Parser
+	if parser != nil {
+		_, _ = any(parser).(g18CertificateAdmissionOptionAdapter)
+	}
+}
+
+type g18FutureCohortSnapshot struct {
+	Handle   g18FutureCohortHandle `json:"handle"`
+	State    string                `json:"state"`
+	Expected uint16                `json:"expected"`
+	Written  uint16                `json:"written"`
+	Spilled  bool                  `json:"spilled"`
+}
+
+type g18FutureCoreSnapshot struct {
+	Schema               string                    `json:"schema"`
+	ArenaOwner           uint64                    `json:"arena_owner"`
+	ArenaEpoch           uint64                    `json:"arena_epoch"`
+	Cohorts              []g18FutureCohortSnapshot `json:"cohorts"`
+	Storage              g18FutureStoreVector      `json:"storage"`
+	Footprint            g18FutureStoreVector      `json:"footprint"`
+	StorageBytes         uint64                    `json:"storage_bytes"`
+	FootprintBytes       uint64                    `json:"footprint_bytes"`
+	ProducerWrites       map[string]uint64         `json:"producer_writes"`
+	VerifierElections    uint64                    `json:"verifier_elections"`
+	VerifierProofs       uint64                    `json:"verifier_proofs"`
+	VerifierDeclines     uint64                    `json:"verifier_declines"`
+	ActionDeclines       uint64                    `json:"action_identity_declines"`
+	DerivationDeclines   uint64                    `json:"derivation_identity_declines"`
+	AuthenticatedHistory uint64                    `json:"authenticated_history_imports"`
+	UnprovedHistory      uint64                    `json:"unproved_history_imports"`
+	DeclineReasons       map[string]uint64         `json:"decline_reasons"`
+	// OwnerCheckedLookups counts every owner-check attempt, including a
+	// rejected foreign or stale handle. It does not count certificate reads.
+	OwnerCheckedLookups uint64 `json:"owner_checked_lookups"`
+	InlineReads         uint64 `json:"inline_reads"`
+	SpillReads          uint64 `json:"spill_reads"`
+	MapReads            uint64 `json:"map_reads"`
+	InternerReads       uint64 `json:"interner_reads"`
+}
+
+func g18RequireFutureCoreBehaviorRED(
+	t *testing.T,
+	compact *core.Core,
+) g18FutureCoreCertificateBehavior {
+	t.Helper()
+	provider, ok := any(compact).(g18FutureCoreCertificateBehavior)
+	if !ok {
+		t.Fatal("RED: real Core does not implement the drop-cohort behavior API")
+	}
+	return provider
+}
+
+func g18FutureDecodeCoreSnapshot(
+	t *testing.T,
+	provider g18FutureCoreCertificateBehavior,
+) g18FutureCoreSnapshot {
+	t.Helper()
+	var snapshot g18FutureCoreSnapshot
+	if err := json.Unmarshal(provider.DiagnosticDropCohortSnapshotForTest(), &snapshot); err != nil {
+		t.Fatalf("decode certificate arena snapshot: %v", err)
+	}
+	owner, epoch := provider.DiagnosticDropCohortArenaIdentityForTest()
+	if snapshot.Schema != "gts-drop-cohort-certificate-arena/v2" || owner == 0 || epoch == 0 ||
+		snapshot.ArenaOwner != owner || snapshot.ArenaEpoch != epoch {
+		t.Fatalf("certificate arena identity = %d/%d snapshot=%+v", owner, epoch, snapshot)
+	}
+	for _, producer := range g18FutureProducerNames {
+		if _, ok := snapshot.ProducerWrites[producer]; !ok {
+			t.Fatalf("certificate arena snapshot omits producer counter %q", producer)
+		}
+	}
+	if snapshot.StorageBytes != g18FutureSumStores(snapshot.Storage) ||
+		snapshot.FootprintBytes != g18FutureSumStores(snapshot.Footprint) {
+		t.Fatalf("certificate arena byte totals = %+v", snapshot)
+	}
+	return snapshot
+}
+
+func g18FutureSumStores(stores g18FutureStoreVector) uint64 {
+	var total uint64
+	for _, value := range stores {
+		total += value
+	}
+	return total
+}
+
+func g18FutureNextPowerOfTwo(value uint64) uint64 {
+	if value <= 1 {
+		return 1
+	}
+	value--
+	value |= value >> 1
+	value |= value >> 2
+	value |= value >> 4
+	value |= value >> 8
+	value |= value >> 16
+	value |= value >> 32
+	return value + 1
+}
+
+func g18FutureAccountingPlan(expected uint16, derivationBytes uint32) (
+	g18FutureStoreVector,
+	g18FutureStoreVector,
+) {
+	members := uint64(expected)
+	mapCapacity := g18FutureNextPowerOfTwo(members * 2)
+	storage := g18FutureStoreVector{
+		g18FutureStoreActionRecords:         members * uint64(unsafe.Sizeof(g18FutureActionRecordLayout{})),
+		g18FutureStoreDerivationRecords:     members * (uint64(unsafe.Sizeof(g18FutureDerivationRecordLayout{})) + uint64(derivationBytes)),
+		g18FutureStoreCertificateReferences: members * uint64(unsafe.Sizeof(g18FutureCertificateReferenceLayout{})),
+		g18FutureStoreMapEntries:            members * uint64(unsafe.Sizeof(g18FutureMapEntryLayout{})),
+		g18FutureStoreInternerEntries:       members * uint64(unsafe.Sizeof(g18FutureInternerEntryLayout{})),
+		g18FutureStoreJournalEntries:        (members + 2) * uint64(unsafe.Sizeof(g18FutureJournalEntryLayout{})),
+		g18FutureStoreCohortRecords:         uint64(unsafe.Sizeof(g18FutureCohortRecordLayout{})),
+	}
+	footprint := storage
+	footprint[g18FutureStoreMapEntries] = mapCapacity * uint64(unsafe.Sizeof(g18FutureMapEntryLayout{}))
+	footprint[g18FutureStoreInternerEntries] = mapCapacity * uint64(unsafe.Sizeof(g18FutureInternerEntryLayout{}))
+	return storage, footprint
+}
+
+func g18RequireOnlyProducerDelta(
+	t *testing.T,
+	before g18FutureCoreSnapshot,
+	after g18FutureCoreSnapshot,
+	producer string,
+) {
+	t.Helper()
+	known := make(map[string]bool, len(g18FutureProducerNames))
+	for _, name := range g18FutureProducerNames {
+		known[name] = true
+	}
+	for name, count := range after.ProducerWrites {
+		if !known[name] && count != before.ProducerWrites[name] {
+			t.Fatalf("unknown producer counter %s changed from %d to %d", name, before.ProducerWrites[name], count)
+		}
+	}
+	for _, name := range g18FutureProducerNames {
+		want := uint64(0)
+		if name == producer {
+			want = 1
+		}
+		if after.ProducerWrites[name] < before.ProducerWrites[name] {
+			t.Fatalf("producer counter %s decreased", name)
+		}
+		if got := after.ProducerWrites[name] - before.ProducerWrites[name]; got != want {
+			t.Fatalf("producer delta %s=%d, want %d; before=%+v after=%+v", name, got, want, before.ProducerWrites, after.ProducerWrites)
+		}
+	}
+}
+
+// TestG18FutureCanonicalizerCertificateTelemetryRED binds both real
+// canonicalizers to the future arena. Current main does not publish it.
+func TestG18FutureCanonicalizerCertificateTelemetryRED(t *testing.T) {
+	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
+	for _, mapped := range []bool{false, true} {
+		mapped := mapped
+		name := "linear_canonicalizer"
+		if mapped {
+			name = "mapped_canonicalizer"
+		}
+		t.Run(name, func(t *testing.T) {
+			compact, err := core.New(&genericConflictTable{}, core.Limits{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			head, err := compact.Seed(1, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			left := alternativeSetPinBranchMember(t, compact, [2]uint16{61, 0})
+			right := alternativeSetPinBranchMember(t, compact, [2]uint16{61, 1})
+			headers := []diagnosticParserCoreHeader{{head: head, altSet: left}, {head: head, altSet: right}}
+			if mapped {
+				headers = make([]diagnosticParserCoreHeader, diagnosticParserCoreLinearCanonicalLimit+1)
+				for index := range headers {
+					headers[index] = diagnosticParserCoreHeader{head: head, altSet: left}
+				}
+				headers[1].altSet = right
+			}
+			provider := g18RequireFutureCoreBehaviorRED(t, compact)
+			before := g18FutureDecodeCoreSnapshot(t, provider)
+			scheduler := &diagnosticParserCoreGenericScheduler{
+				compact: compact,
+				headers: headers,
+			}
+			mutation := g18FutureProducerLinearCanonicalization
+			if mapped {
+				mutation = g18FutureProducerMappedCanonicalization
+			}
+			adapter := g18FutureOwnedSchedulerAdapter{scheduler: scheduler}
+			err = compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+				return adapter.g18CanonicalizeOwned(owner, mutation)
+			})
+			if err != nil || len(scheduler.headers) != 1 {
+				t.Fatalf("canonicalizer outputs=%+v err=%v", scheduler.headers, err)
+			}
+			after := g18FutureDecodeCoreSnapshot(t, provider)
+			g18RequireOnlyProducerDelta(t, before, after, name)
+		})
+	}
+}
+
+// TestG18FutureAdoptionCertificateTelemetryRED binds both real adoption
+// producers to the future arena. Current main does not publish it.
+func TestG18FutureAdoptionCertificateTelemetryRED(t *testing.T) {
+	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
+	for _, test := range []struct {
+		name      string
+		reconcile bool
+	}{
+		{name: "sibling_adoption"},
+		{name: "conflict_reconciliation", reconcile: true},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			compact, high, active := g18AdoptionFixture(t)
+			left := alternativeSetPinBranchMember(t, compact, [2]uint16{67, 0})
+			right := alternativeSetPinBranchMember(t, compact, [2]uint16{67, 1})
+			scheduler := &diagnosticParserCoreGenericScheduler{
+				compact: compact,
+				headers: []diagnosticParserCoreHeader{
+					{head: high, creationSeq: 3, altSet: left},
+					{head: active, creationSeq: 11, altSet: left},
+				},
+			}
+			provider := g18RequireFutureCoreBehaviorRED(t, compact)
+			before := g18FutureDecodeCoreSnapshot(t, provider)
+			if test.reconcile {
+				outputs := []diagnosticParserCoreHeader{{
+					head: active, freshness: core.ReductionUpdated, altSet: right, cleanPathLineage: 67,
+				}}
+				if _, adopted, err := g18FutureReconcileGenericConflictOutputsRED(t, scheduler, 0, outputs, g18FutureProducerConflictReconciliation); err != nil || adopted != 1 {
+					t.Fatalf("conflict reconciliation adopted=%d err=%v", adopted, err)
+				}
+			} else if adopted, err := g18FutureAdoptUpdatedReductionSiblingRED(
+				t, scheduler, 0, active, core.CleanPathRankUnknown, 0, right, false, true, false,
+				g18FutureProducerSiblingAdoption,
+			); err != nil || !adopted {
+				t.Fatalf("sibling adoption=%t err=%v", adopted, err)
+			}
+			after := g18FutureDecodeCoreSnapshot(t, provider)
+			g18RequireOnlyProducerDelta(t, before, after, test.name)
+		})
+	}
+}
+
+func TestG18FutureReductionEstablishmentTelemetryRED(t *testing.T) {
+	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := g18RequireFutureCoreBehaviorRED(t, compact)
+	before := g18FutureDecodeCoreSnapshot(t, provider)
+	err = compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		return compact.RecordReductionLineageOwned(owner, []core.ReductionOutput{{
+			Head: head, CleanPathRank: core.CleanPathRankSelected, MultiplePopPaths: true,
+		}}, 71)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	after := g18FutureDecodeCoreSnapshot(t, provider)
+	g18RequireOnlyProducerDelta(t, before, after, "reduction_establishment")
+}
+
+func g18FutureBehaviorFixture(
+	t *testing.T,
+) (*diagnosticParserCoreGenericScheduler, g18FutureCoreCertificateBehavior, [3]core.Head) {
+	t.Helper()
+	scheduler, first, second := g18ValidDropScheduler(t)
+	compact := scheduler.compact
+	third, err := compact.Seed(3, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := g18RequireFutureCoreBehaviorRED(t, compact)
+	return scheduler, provider, [3]core.Head{first, second, third}
+}
+
+func g18FutureUnlimitedCaps() g18FutureStoreVector {
+	var caps g18FutureStoreVector
+	for index := range caps {
+		caps[index] = math.MaxUint64
+	}
+	return caps
+}
+
+func g18FutureActionIdentity() g18FutureActionVector {
+	return g18FutureActionVector{
+		3, 9, 3, int64(core.ActionReduce), 0, 2, 5, 1, 2, 0, 0, 0, 0, 1,
+	}
+}
+
+func g18FutureDerivationRecord() ([]byte, [sha256.Size]byte) {
+	record := []byte{2, 4, 5, 1, 0, 8, 13, 21}
+	return record, sha256.Sum256(record)
+}
+
+func g18FutureBeginCohort(
+	t *testing.T,
+	provider g18FutureCoreCertificateBehavior,
+	expected uint16,
+	recordBytes uint32,
+) g18FutureCohortHandle {
+	t.Helper()
+	handle, err := provider.DiagnosticDropCohortBeginForTest(
+		expected,
+		recordBytes,
+		g18FutureUnlimitedCaps(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner, epoch := provider.DiagnosticDropCohortArenaIdentityForTest()
+	if handle[0] != owner || handle[1] != epoch || handle[2] == 0 {
+		t.Fatalf("new cohort handle=%v arena=%d/%d", handle, owner, epoch)
+	}
+	return handle
+}
+
+func g18FutureWriteMember(
+	t *testing.T,
+	provider g18FutureCoreCertificateBehavior,
+	handle g18FutureCohortHandle,
+	head core.Head,
+	branch uint16,
+	action g18FutureActionVector,
+	digest [sha256.Size]byte,
+	record []byte,
+) {
+	t.Helper()
+	if err := provider.DiagnosticDropCohortWriteForTest(
+		handle,
+		head,
+		branch,
+		action,
+		digest,
+		record,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func g18FutureFindCohort(
+	t *testing.T,
+	snapshot g18FutureCoreSnapshot,
+	handle g18FutureCohortHandle,
+) g18FutureCohortSnapshot {
+	t.Helper()
+	for _, cohort := range snapshot.Cohorts {
+		if cohort.Handle == handle {
+			return cohort
+		}
+	}
+	t.Fatalf("cohort %v is absent from snapshot %+v", handle, snapshot.Cohorts)
+	return g18FutureCohortSnapshot{}
+}
+
+func g18FutureRequireCohortState(
+	t *testing.T,
+	provider g18FutureCoreCertificateBehavior,
+	handle g18FutureCohortHandle,
+	state string,
+	expected uint16,
+	written uint16,
+) g18FutureCoreSnapshot {
+	t.Helper()
+	snapshot := g18FutureDecodeCoreSnapshot(t, provider)
+	cohort := g18FutureFindCohort(t, snapshot, handle)
+	if cohort.State != state || cohort.Expected != expected || cohort.Written != written {
+		t.Fatalf("cohort state=%+v, want %s %d/%d", cohort, state, expected, written)
+	}
+	return snapshot
+}
+
+func g18FutureSchedulerVerify(
+	t *testing.T,
+	scheduler *diagnosticParserCoreGenericScheduler,
+	provider g18FutureCoreCertificateBehavior,
+	heads []core.Head,
+	handles []g18FutureCohortHandle,
+	branches []uint16,
+	drops ...int,
+) (bool, string) {
+	t.Helper()
+	dropper, ok := any(scheduler).(g18FutureSchedulerDropBehavior)
+	if !ok {
+		return false, "RED: scheduler does not implement the real drop-path behavior API"
+	}
+	scheduler.headers = make([]diagnosticParserCoreHeader, len(heads))
+	for index, head := range heads {
+		scheduler.headers[index] = diagnosticParserCoreHeader{head: head}
+	}
+	g18RequireValidSummaryHeads(t, scheduler)
+	if err := dropper.DiagnosticBindDropCohortReferencesForTest(handles, branches); err != nil {
+		return false, "bind_drop_cohort_references"
+	}
+	var before g18FutureCoreSnapshot
+	if err := json.Unmarshal(provider.DiagnosticDropCohortSnapshotForTest(), &before); err != nil {
+		return false, "telemetry_decode_before"
+	}
+	reason, err := dropper.DiagnosticDropGenericNoActionHeadsForTest(drops)
+	admitted := err == nil
+	var after g18FutureCoreSnapshot
+	if decodeErr := json.Unmarshal(provider.DiagnosticDropCohortSnapshotForTest(), &after); decodeErr != nil {
+		return false, "telemetry_decode_after"
+	}
+	if after.VerifierElections != before.VerifierElections+1 {
+		return false, "telemetry_election_delta"
+	}
+	if admitted {
+		if reason != "proved" || after.VerifierProofs != before.VerifierProofs+1 ||
+			after.VerifierDeclines != before.VerifierDeclines ||
+			g18FutureReasonDelta(t, before.DeclineReasons, after.DeclineReasons) != 0 {
+			return false, "telemetry_proof_delta"
+		}
+		return true, reason
+	}
+	if g18FutureReasonDelta(t, before.DeclineReasons, after.DeclineReasons) != 1 {
+		return false, "telemetry_reason_delta"
+	}
+	if after.VerifierProofs != before.VerifierProofs ||
+		after.VerifierDeclines != before.VerifierDeclines+1 ||
+		after.DeclineReasons[reason] != before.DeclineReasons[reason]+1 {
+		return false, "telemetry_decline_delta"
+	}
+	wantAction := before.ActionDeclines
+	wantDerivation := before.DerivationDeclines
+	if reason == "action_identity_mismatch" {
+		wantAction++
+	}
+	if reason == "derivation_identity_mismatch" {
+		wantDerivation++
+	}
+	if after.ActionDeclines != wantAction || after.DerivationDeclines != wantDerivation {
+		return false, "telemetry_identity_delta"
+	}
+	return false, reason
+}
+
+func g18FutureReasonDelta(
+	t *testing.T,
+	before, after map[string]uint64,
+) uint64 {
+	t.Helper()
+	var delta uint64
+	for reason, count := range after {
+		if count < before[reason] {
+			t.Fatalf("decline reason %s decreased from %d to %d", reason, before[reason], count)
+		}
+		delta += count - before[reason]
+	}
+	for reason, count := range before {
+		if _, ok := after[reason]; !ok && count != 0 {
+			t.Fatalf("decline reason %s disappeared from %d", reason, count)
+		}
+	}
+	return delta
+}
+
+func g18FutureRequireNoCertificateReads(
+	t *testing.T,
+	before, after g18FutureCoreSnapshot,
+) {
+	t.Helper()
+	if after.InlineReads != before.InlineReads ||
+		after.SpillReads != before.SpillReads ||
+		after.MapReads != before.MapReads ||
+		after.InternerReads != before.InternerReads {
+		t.Fatalf(
+			"foreign or stale handle reached certificate storage: before inline/spill/map/interner=%d/%d/%d/%d after=%d/%d/%d/%d",
+			before.InlineReads,
+			before.SpillReads,
+			before.MapReads,
+			before.InternerReads,
+			after.InlineReads,
+			after.SpillReads,
+			after.MapReads,
+			after.InternerReads,
+		)
+	}
+}
+
+func g18FutureSubtractStores(
+	t *testing.T,
+	after g18FutureStoreVector,
+	before g18FutureStoreVector,
+) g18FutureStoreVector {
+	t.Helper()
+	var difference g18FutureStoreVector
+	for index := range difference {
+		if after[index] < before[index] {
+			t.Fatalf("store %d decreased from %d to %d", index, before[index], after[index])
+		}
+		difference[index] = after[index] - before[index]
+	}
+	return difference
+}
+
+func TestG18FutureConcurrentArenaOwnerAllocationRED(t *testing.T) {
+	const instances = 32
+	start := make(chan struct{})
+	results := make(chan struct {
+		owner uint64
+		epoch uint64
+		err   error
+	}, instances)
+	var wait sync.WaitGroup
+	wait.Add(instances)
+	for index := 0; index < instances; index++ {
+		go func() {
+			defer wait.Done()
+			<-start
+			compact, err := core.New(&genericConflictTable{}, core.Limits{})
+			if err != nil {
+				results <- struct {
+					owner uint64
+					epoch uint64
+					err   error
+				}{err: err}
+				return
+			}
+			provider, ok := any(compact).(g18FutureCoreCertificateBehavior)
+			if !ok {
+				results <- struct {
+					owner uint64
+					epoch uint64
+					err   error
+				}{err: errors.New("RED: real Core does not implement the behavior API")}
+				return
+			}
+			owner, epoch := provider.DiagnosticDropCohortArenaIdentityForTest()
+			results <- struct {
+				owner uint64
+				epoch uint64
+				err   error
+			}{owner: owner, epoch: epoch}
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	owners := make(map[uint64]bool, instances)
+	var firstErr error
+	failed := 0
+	for result := range results {
+		if result.err != nil {
+			failed++
+			if firstErr == nil {
+				firstErr = result.err
+			}
+			continue
+		}
+		if result.owner == 0 || result.epoch == 0 || owners[result.owner] {
+			t.Errorf("concurrent arena identity owner=%d epoch=%d duplicate=%t", result.owner, result.epoch, owners[result.owner])
+		}
+		owners[result.owner] = true
+	}
+	if failed != 0 {
+		t.Fatalf("%d concurrent real Core instances failed: %v", failed, firstErr)
+	}
+	if len(owners) != instances {
+		t.Fatalf("concurrent unique owners=%d, want %d", len(owners), instances)
+	}
+}
+
+func TestG18FutureRealVerifierArenaIdentityRED(t *testing.T) {
+	schedulerA, firstA, secondA := g18ValidDropScheduler(t)
+	compactA := schedulerA.compact
+	providerA := g18RequireFutureCoreBehaviorRED(t, compactA)
+	thirdA, err := compactA.Seed(3, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	headsA := [3]core.Head{firstA, secondA, thirdA}
+	schedulerB, firstB, secondB := g18ValidDropScheduler(t)
+	providerB := g18RequireFutureCoreBehaviorRED(t, schedulerB.compact)
+	thirdB, err := schedulerB.compact.Seed(3, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	headsB := [3]core.Head{firstB, secondB, thirdB}
+	ownerA, epochA := providerA.DiagnosticDropCohortArenaIdentityForTest()
+	ownerB, epochB := providerB.DiagnosticDropCohortArenaIdentityForTest()
+	if ownerA == ownerB || epochA != epochB {
+		t.Fatalf("arena identities A=%d/%d B=%d/%d", ownerA, epochA, ownerB, epochB)
+	}
+	action := g18FutureActionIdentity()
+	record, digest := g18FutureDerivationRecord()
+
+	inlineA := g18FutureBeginCohort(t, providerA, 2, uint32(len(record)))
+	inlineB := g18FutureBeginCohort(t, providerB, 2, uint32(len(record)))
+	for index := 0; index < 2; index++ {
+		g18FutureWriteMember(t, providerA, inlineA, headsA[index], uint16(index), action, digest, record)
+		g18FutureWriteMember(t, providerB, inlineB, headsB[index], uint16(index), action, digest, record)
+	}
+	if inlineA[1] != inlineB[1] || inlineA[2] != inlineB[2] {
+		t.Fatalf("inline equal-session handles A=%v B=%v", inlineA, inlineB)
+	}
+	if err := providerA.DiagnosticDropCohortFinalizeForTest(inlineA); err != nil {
+		t.Fatal(err)
+	}
+	if err := providerB.DiagnosticDropCohortFinalizeForTest(inlineB); err != nil {
+		t.Fatal(err)
+	}
+	beforeLocalInline := g18FutureDecodeCoreSnapshot(t, providerA)
+	if admitted, reason := g18FutureSchedulerVerify(
+		t,
+		schedulerA,
+		providerA,
+		headsA[:2],
+		[]g18FutureCohortHandle{inlineA, inlineA},
+		[]uint16{0, 1},
+		1,
+	); !admitted || reason != "proved" {
+		t.Fatalf("arena A inline verification=%t reason=%q", admitted, reason)
+	}
+	afterLocalInline := g18FutureDecodeCoreSnapshot(t, providerA)
+	if afterLocalInline.OwnerCheckedLookups != beforeLocalInline.OwnerCheckedLookups+2 {
+		t.Fatalf("local inline owner-check attempts: before=%d after=%d, want two attempts", beforeLocalInline.OwnerCheckedLookups, afterLocalInline.OwnerCheckedLookups)
+	}
+	// Snapshot after the valid local proof. The owner counter measures attempts.
+	beforeForeignInline := afterLocalInline
+	if admitted, reason := g18FutureSchedulerVerify(
+		t,
+		schedulerA,
+		providerA,
+		headsA[:2],
+		[]g18FutureCohortHandle{inlineB, inlineA},
+		[]uint16{1, 0},
+		1,
+	); admitted || reason != "foreign_arena_owner" {
+		t.Fatalf("foreign inline verification=%t reason=%q", admitted, reason)
+	}
+	afterForeignInline := g18FutureDecodeCoreSnapshot(t, providerA)
+	if afterForeignInline.OwnerCheckedLookups != beforeForeignInline.OwnerCheckedLookups+1 {
+		t.Fatalf("foreign inline owner-check attempts: before=%d after=%d, want one rejected attempt", beforeForeignInline.OwnerCheckedLookups, afterForeignInline.OwnerCheckedLookups)
+	}
+	g18FutureRequireNoCertificateReads(t, beforeForeignInline, afterForeignInline)
+
+	spillA := g18FutureBeginCohort(t, providerA, 3, uint32(len(record)))
+	spillB := g18FutureBeginCohort(t, providerB, 3, uint32(len(record)))
+	for index := 0; index < 3; index++ {
+		g18FutureWriteMember(t, providerA, spillA, headsA[index], uint16(index), action, digest, record)
+		g18FutureWriteMember(t, providerB, spillB, headsB[index], uint16(index), action, digest, record)
+	}
+	if spillA[1] != spillB[1] || spillA[2] != spillB[2] {
+		t.Fatalf("spill equal-session handles A=%v B=%v", spillA, spillB)
+	}
+	if err := providerA.DiagnosticDropCohortFinalizeForTest(spillA); err != nil {
+		t.Fatal(err)
+	}
+	if err := providerB.DiagnosticDropCohortFinalizeForTest(spillB); err != nil {
+		t.Fatal(err)
+	}
+	if cohort := g18FutureFindCohort(t, g18FutureDecodeCoreSnapshot(t, providerA), spillA); !cohort.Spilled {
+		t.Fatalf("arena A spill cohort=%+v", cohort)
+	}
+	beforeLocalSpill := g18FutureDecodeCoreSnapshot(t, providerA)
+	if admitted, reason := g18FutureSchedulerVerify(
+		t,
+		schedulerA,
+		providerA,
+		headsA[:],
+		[]g18FutureCohortHandle{spillA, spillA, spillA},
+		[]uint16{0, 1, 2},
+		1,
+		2,
+	); !admitted || reason != "proved" {
+		t.Fatalf("arena A spill verification=%t reason=%q", admitted, reason)
+	}
+	afterLocalSpill := g18FutureDecodeCoreSnapshot(t, providerA)
+	if afterLocalSpill.OwnerCheckedLookups != beforeLocalSpill.OwnerCheckedLookups+3 {
+		t.Fatalf("local spill owner-check attempts: before=%d after=%d, want three attempts", beforeLocalSpill.OwnerCheckedLookups, afterLocalSpill.OwnerCheckedLookups)
+	}
+	beforeForeignSpill := afterLocalSpill
+	if admitted, reason := g18FutureSchedulerVerify(
+		t,
+		schedulerA,
+		providerA,
+		headsA[:],
+		[]g18FutureCohortHandle{spillB, spillA, spillA},
+		[]uint16{1, 0, 0},
+		1,
+		2,
+	); admitted || reason != "foreign_arena_owner" {
+		t.Fatalf("foreign spill verification=%t reason=%q", admitted, reason)
+	}
+	afterForeignSpill := g18FutureDecodeCoreSnapshot(t, providerA)
+	if afterForeignSpill.OwnerCheckedLookups != beforeForeignSpill.OwnerCheckedLookups+1 {
+		t.Fatalf("foreign spill owner-check attempts: before=%d after=%d, want one rejected attempt", beforeForeignSpill.OwnerCheckedLookups, afterForeignSpill.OwnerCheckedLookups)
+	}
+	g18FutureRequireNoCertificateReads(t, beforeForeignSpill, afterForeignSpill)
+
+	stale := spillA
+	if err := compactA.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	resetOwner, resetEpoch := providerA.DiagnosticDropCohortArenaIdentityForTest()
+	if resetOwner != ownerA {
+		t.Fatalf("reset owner=%d, old=%d", resetOwner, ownerA)
+	}
+	if resetEpoch == epochA {
+		t.Fatalf("reset epoch=%d, old=%d", resetEpoch, epochA)
+	}
+	for index := range headsA {
+		head, err := compactA.Seed(core.StateID(index+1), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		headsA[index] = head
+	}
+	fresh := g18FutureBeginCohort(t, providerA, 2, uint32(len(record)))
+	for index := 0; index < 2; index++ {
+		g18FutureWriteMember(t, providerA, fresh, headsA[index], uint16(index), action, digest, record)
+	}
+	if err := providerA.DiagnosticDropCohortFinalizeForTest(fresh); err != nil {
+		t.Fatal(err)
+	}
+	beforeFreshProof := g18FutureDecodeCoreSnapshot(t, providerA)
+	if admitted, reason := g18FutureSchedulerVerify(
+		t,
+		schedulerA,
+		providerA,
+		headsA[:2],
+		[]g18FutureCohortHandle{fresh, fresh},
+		[]uint16{0, 1},
+		1,
+	); !admitted || reason != "proved" {
+		t.Fatalf("fresh post-reset verification=%t reason=%q", admitted, reason)
+	}
+	afterFreshProof := g18FutureDecodeCoreSnapshot(t, providerA)
+	if afterFreshProof.OwnerCheckedLookups != beforeFreshProof.OwnerCheckedLookups+2 {
+		t.Fatalf("fresh post-reset owner-check attempts: before=%d after=%d, want two attempts", beforeFreshProof.OwnerCheckedLookups, afterFreshProof.OwnerCheckedLookups)
+	}
+	// Snapshot after the valid local proof before testing the stale foreign epoch.
+	beforeResetStale := afterFreshProof
+	if admitted, reason := g18FutureSchedulerVerify(
+		t,
+		schedulerA,
+		providerA,
+		headsA[:2],
+		[]g18FutureCohortHandle{stale, fresh},
+		[]uint16{1, 0},
+		1,
+	); admitted || reason != "stale_arena_epoch" {
+		t.Fatalf("reset-stale verification=%t reason=%q", admitted, reason)
+	}
+	resetAfter := g18FutureDecodeCoreSnapshot(t, providerA)
+	if resetAfter.OwnerCheckedLookups != beforeResetStale.OwnerCheckedLookups+1 {
+		t.Fatalf("reset-stale owner-check attempts=%d, want %d", resetAfter.OwnerCheckedLookups, beforeResetStale.OwnerCheckedLookups+1)
+	}
+	g18FutureRequireNoCertificateReads(t, beforeResetStale, resetAfter)
+}
+
+func TestG18FutureRealVerifierAllocationsRED(t *testing.T) {
+	scheduler, provider, heads := g18FutureBehaviorFixture(t)
+	action := g18FutureActionIdentity()
+	record, digest := g18FutureDerivationRecord()
+	handle := g18FutureBeginCohort(t, provider, 2, uint32(len(record)))
+	g18FutureWriteMember(t, provider, handle, heads[0], 0, action, digest, record)
+	g18FutureWriteMember(t, provider, handle, heads[1], 1, action, digest, record)
+	if err := provider.DiagnosticDropCohortFinalizeForTest(handle); err != nil {
+		t.Fatal(err)
+	}
+	scheduler.headers = []diagnosticParserCoreHeader{
+		{head: heads[0]},
+		{head: heads[1]},
+	}
+	g18RequireValidSummaryHeads(t, scheduler)
+	dropper, ok := any(scheduler).(g18FutureSchedulerDropBehavior)
+	if !ok {
+		t.Fatal("RED: scheduler does not implement the real verifier API")
+	}
+	if err := dropper.DiagnosticBindDropCohortReferencesForTest(
+		[]g18FutureCohortHandle{handle, handle}, []uint16{0, 1},
+	); err != nil {
+		t.Fatal(err)
+	}
+	boundHeaders := append([]diagnosticParserCoreHeader(nil), scheduler.headers...)
+	if len(boundHeaders) != 2 {
+		t.Fatalf("bound verifier headers=%d, want exactly two", len(boundHeaders))
+	}
+	beforeSnapshot := g18FutureDecodeCoreSnapshot(t, provider)
+	beforeStateDigest := dropper.DiagnosticDropGenericNoActionHeadsVerifierStateDigestForTest()
+	drops := [...]int{1}
+	warmReason, warmInvocation, warmStateDigest, warmErr := dropper.DiagnosticDropGenericNoActionHeadsNonDestructiveForTest(drops[:])
+	if warmErr != nil || warmReason != "proved" || warmStateDigest != beforeStateDigest {
+		t.Fatalf("real verifier warm-up reason=%q invocation=%d state=%x err=%v", warmReason, warmInvocation, warmStateDigest, warmErr)
+	}
+	if !reflect.DeepEqual(scheduler.headers, boundHeaders) {
+		t.Fatal("non-destructive warm-up changed the bound headers")
+	}
+	if afterWarmup := g18FutureDecodeCoreSnapshot(t, provider); !reflect.DeepEqual(afterWarmup, beforeSnapshot) {
+		t.Fatalf("non-destructive warm-up changed certificate state: before=%+v after=%+v", beforeSnapshot, afterWarmup)
+	}
+	var reason string
+	var invocation uint64
+	var stateDigest [sha256.Size]byte
+	var err error
+	var invalidCalls uint64
+	nextInvocation := warmInvocation + 1
+	if got := testing.AllocsPerRun(1000, func() {
+		reason, invocation, stateDigest, err = dropper.DiagnosticDropGenericNoActionHeadsNonDestructiveForTest(drops[:])
+		if err != nil || reason != "proved" || invocation != nextInvocation || stateDigest != beforeStateDigest {
+			invalidCalls++
+		}
+		nextInvocation++
+	}); got != 0 {
+		t.Fatalf("real future verifier allocations=%v, want 0 (last reason=%q invocation=%d state=%x err=%v)", got, reason, invocation, stateDigest, err)
+	}
+	if invalidCalls != 0 || invocation != warmInvocation+1001 || nextInvocation != warmInvocation+1002 {
+		t.Fatalf("real future verifier calls=%d invocation=%d next=%d, want 1001 valid calls after warm-up invocation %d", invalidCalls, invocation, nextInvocation, warmInvocation)
+	}
+	if !reflect.DeepEqual(scheduler.headers, boundHeaders) {
+		t.Fatal("measured non-destructive verifier calls changed the bound headers")
+	}
+	if afterMeasured := g18FutureDecodeCoreSnapshot(t, provider); !reflect.DeepEqual(afterMeasured, beforeSnapshot) {
+		t.Fatalf("measured non-destructive verifier calls changed certificate state: before=%+v after=%+v", beforeSnapshot, afterMeasured)
+	}
+	if afterStateDigest := dropper.DiagnosticDropGenericNoActionHeadsVerifierStateDigestForTest(); afterStateDigest != beforeStateDigest {
+		t.Fatalf("measured non-destructive verifier calls changed state digest: before=%x after=%x", beforeStateDigest, afterStateDigest)
+	}
+}
+
+func g18FutureRequireCounterWrapRED(
+	t *testing.T,
+	name string,
+	probe func(g18FutureCoreCertificateBehavior) (uint64, uint64, error),
+) {
+	t.Helper()
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := g18RequireFutureCoreBehaviorRED(t, compact)
+	before := g18FutureDecodeCoreSnapshot(t, provider)
+	lastAccepted, rejected, probeErr := probe(provider)
+	if probeErr == nil || !strings.Contains(probeErr.Error(), "overflow") {
+		t.Fatalf("%s wrap error=%v, want overflow", name, probeErr)
+	}
+	if lastAccepted != math.MaxUint64 || rejected != 0 {
+		t.Fatalf("%s wrap values accepted=%d rejected=%d, want max/zero", name, lastAccepted, rejected)
+	}
+	after := g18FutureDecodeCoreSnapshot(t, provider)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("%s wrap probe changed the real arena: before=%+v after=%+v", name, before, after)
+	}
+}
+
+func TestG18FutureRealAtomicOwnerWrapRED(t *testing.T) {
+	g18FutureRequireCounterWrapRED(t, "owner", func(provider g18FutureCoreCertificateBehavior) (uint64, uint64, error) {
+		return provider.DiagnosticDropCohortOwnerWrapProbeForTest()
+	})
+}
+
+func TestG18FutureRealAtomicEpochWrapRED(t *testing.T) {
+	g18FutureRequireCounterWrapRED(t, "epoch", func(provider g18FutureCoreCertificateBehavior) (uint64, uint64, error) {
+		return provider.DiagnosticDropCohortEpochWrapProbeForTest()
+	})
+}
+
+func TestG18FutureRealAtomicSequenceWrapRED(t *testing.T) {
+	g18FutureRequireCounterWrapRED(t, "sequence", func(provider g18FutureCoreCertificateBehavior) (uint64, uint64, error) {
+		return provider.DiagnosticDropCohortSequenceWrapProbeForTest()
+	})
+}
+
+func TestG18FutureRealDefaultDropCohortMembersRED(t *testing.T) {
+	_, provider, heads := g18FutureBehaviorFixture(t)
+	maxCohorts, maxMembers := provider.DiagnosticDropCohortLimitsForTest()
+	if maxCohorts != 4096 || maxMembers != 32 {
+		t.Fatalf("real drop-cohort defaults=%d/%d, want MaxDropCohorts=4096 MaxDropCohortMembers=32", maxCohorts, maxMembers)
+	}
+	action := g18FutureActionIdentity()
+	record, digest := g18FutureDerivationRecord()
+	handle := g18FutureBeginCohort(t, provider, 32, uint32(len(record)))
+	for index := 0; index < int(maxMembers); index++ {
+		g18FutureWriteMember(t, provider, handle, heads[index%len(heads)], uint16(index), action, digest, record)
+	}
+	if err := provider.DiagnosticDropCohortFinalizeForTest(handle); err != nil {
+		t.Fatal(err)
+	}
+	g18FutureRequireCohortState(t, provider, handle, "complete", 32, 32)
+}
+
+func TestG18FutureRealMaxDropCohortsCapOverflowRED(t *testing.T) {
+	_, provider, _ := g18FutureBehaviorFixture(t)
+	if err := provider.DiagnosticDropCohortSetLimitsForTest(2, 32); err != nil {
+		t.Fatal(err)
+	}
+	if maxCohorts, maxMembers := provider.DiagnosticDropCohortLimitsForTest(); maxCohorts != 2 || maxMembers != 32 {
+		t.Fatalf("real cohort limits after setter=%d/%d, want 2/32", maxCohorts, maxMembers)
+	}
+	record, _ := g18FutureDerivationRecord()
+	for index := 0; index < 2; index++ {
+		g18FutureBeginCohort(t, provider, 1, uint32(len(record)))
+	}
+	beforeOverflow := g18FutureDecodeCoreSnapshot(t, provider)
+	if _, err := provider.DiagnosticDropCohortBeginForTest(1, uint32(len(record)), g18FutureUnlimitedCaps()); err == nil {
+		t.Fatal("MaxDropCohorts overflow was accepted")
+	}
+	afterOverflow := g18FutureDecodeCoreSnapshot(t, provider)
+	if !reflect.DeepEqual(afterOverflow, beforeOverflow) {
+		t.Fatalf("cohort-cap preflight changed real arena: before=%+v after=%+v", beforeOverflow, afterOverflow)
+	}
+}
+
+func TestG18FutureRealMaxDropCohortMembersCapOverflowRED(t *testing.T) {
+	_, provider, heads := g18FutureBehaviorFixture(t)
+	if err := provider.DiagnosticDropCohortSetLimitsForTest(4, 2); err != nil {
+		t.Fatal(err)
+	}
+	if maxCohorts, maxMembers := provider.DiagnosticDropCohortLimitsForTest(); maxCohorts != 4 || maxMembers != 2 {
+		t.Fatalf("real cohort limits after setter=%d/%d, want 4/2", maxCohorts, maxMembers)
+	}
+	record, digest := g18FutureDerivationRecord()
+	before := g18FutureDecodeCoreSnapshot(t, provider)
+	if _, err := provider.DiagnosticDropCohortBeginForTest(3, uint32(len(record)), g18FutureUnlimitedCaps()); err == nil {
+		t.Fatal("MaxDropCohortMembers overflow was accepted")
+	}
+	afterRejected := g18FutureDecodeCoreSnapshot(t, provider)
+	if !reflect.DeepEqual(afterRejected, before) {
+		t.Fatalf("member-cap preflight changed real arena: before=%+v after=%+v", before, afterRejected)
+	}
+	handle := g18FutureBeginCohort(t, provider, 2, uint32(len(record)))
+	g18FutureWriteMember(t, provider, handle, heads[0], 0, g18FutureActionIdentity(), digest, record)
+	if err := provider.DiagnosticDropCohortWriteForTest(handle, heads[1], 1, g18FutureActionIdentity(), digest, record); err != nil {
+		t.Fatal(err)
+	}
+	if err := provider.DiagnosticDropCohortWriteForTest(handle, heads[2], 2, g18FutureActionIdentity(), digest, record); err == nil {
+		t.Fatal("member-cap overflow after reservation was accepted")
+	}
+	g18FutureRequireCohortState(t, provider, handle, "overflowed", 2, 2)
+}
+
+func TestG18FutureRealCertificateLifecycleRED(t *testing.T) {
+	scheduler, provider, heads := g18FutureBehaviorFixture(t)
+	action := g18FutureActionIdentity()
+	record, digest := g18FutureDerivationRecord()
+	before := g18FutureDecodeCoreSnapshot(t, provider)
+	building := g18FutureBeginCohort(t, provider, 2, uint32(len(record)))
+	afterBegin := g18FutureRequireCohortState(t, provider, building, "building", 2, 0)
+	wantStorage, wantFootprint := g18FutureAccountingPlan(2, uint32(len(record)))
+	if got := g18FutureSubtractStores(t, afterBegin.Storage, before.Storage); got != wantStorage {
+		t.Fatalf("reserved storage=%v, want %v", got, wantStorage)
+	}
+	if got := g18FutureSubtractStores(t, afterBegin.Footprint, before.Footprint); got != wantFootprint {
+		t.Fatalf("reserved footprint=%v, want %v", got, wantFootprint)
+	}
+	g18FutureWriteMember(t, provider, building, heads[0], 0, action, digest, record)
+	g18FutureRequireCohortState(t, provider, building, "building", 2, 1)
+	if admitted, reason := g18FutureSchedulerVerify(
+		t,
+		scheduler,
+		provider,
+		heads[:2],
+		[]g18FutureCohortHandle{building, building},
+		[]uint16{0, 1},
+		1,
+	); admitted || reason != "certificate_building" {
+		t.Fatalf("partial exposure verification=%t reason=%q", admitted, reason)
+	}
+	if err := provider.DiagnosticDropCohortFinalizeForTest(building); err == nil {
+		t.Fatal("partial certificate finalized")
+	}
+	if err := provider.DiagnosticDropCohortWriteForTest(building, heads[0], 0, action, digest, record); err == nil {
+		t.Fatal("duplicate certificate member was accepted")
+	}
+	g18FutureRequireCohortState(t, provider, building, "building", 2, 1)
+	g18FutureWriteMember(t, provider, building, heads[1], 1, action, digest, record)
+	if err := provider.DiagnosticDropCohortFinalizeForTest(building); err != nil {
+		t.Fatal(err)
+	}
+	complete := g18FutureRequireCohortState(t, provider, building, "complete", 2, 2)
+	if complete.Storage != afterBegin.Storage || complete.Footprint != afterBegin.Footprint {
+		t.Fatalf("producer writes changed reserved bytes: begin=%+v complete=%+v", afterBegin, complete)
+	}
+	if admitted, reason := g18FutureSchedulerVerify(
+		t,
+		scheduler,
+		provider,
+		heads[:2],
+		[]g18FutureCohortHandle{building, building},
+		[]uint16{0, 1},
+		1,
+	); !admitted || reason != "proved" {
+		t.Fatalf("complete verification=%t reason=%q", admitted, reason)
+	}
+
+	overflowed := g18FutureBeginCohort(t, provider, 1, uint32(len(record)))
+	g18FutureWriteMember(t, provider, overflowed, heads[0], 0, action, digest, record)
+	if err := provider.DiagnosticDropCohortWriteForTest(overflowed, heads[1], 1, action, digest, record); err == nil {
+		t.Fatal("certificate overflow was accepted")
+	}
+	g18FutureRequireCohortState(t, provider, overflowed, "overflowed", 1, 1)
+	if err := provider.DiagnosticDropCohortFinalizeForTest(overflowed); err == nil {
+		t.Fatal("overflowed certificate finalized")
+	}
+
+	blended := g18FutureBeginCohort(t, provider, 2, uint32(len(record)))
+	g18FutureWriteMember(t, provider, blended, heads[0], 0, action, digest, record)
+	conflict := action
+	conflict[2]++
+	if err := provider.DiagnosticDropCohortWriteForTest(blended, heads[1], 0, conflict, digest, record); err == nil {
+		t.Fatal("conflicting branch was accepted")
+	}
+	g18FutureRequireCohortState(t, provider, blended, "blended", 2, 1)
+	if err := provider.DiagnosticDropCohortFinalizeForTest(blended); err == nil {
+		t.Fatal("blended certificate finalized")
+	}
+
+	unproved := g18FutureBeginCohort(t, provider, 2, uint32(len(record)))
+	for index := 0; index < 2; index++ {
+		g18FutureWriteMember(t, provider, unproved, heads[index], uint16(index), action, digest, record)
+	}
+	if err := provider.DiagnosticDropCohortMarkUnprovedForTest(unproved); err != nil {
+		t.Fatal(err)
+	}
+	g18FutureRequireCohortState(t, provider, unproved, "unproved", 2, 2)
+	if err := provider.DiagnosticDropCohortWriteForTest(unproved, heads[0], 0, action, digest, record); err == nil {
+		t.Fatal("unproved certificate accepted a later write")
+	}
+	if admitted, reason := g18FutureSchedulerVerify(
+		t,
+		scheduler,
+		provider,
+		heads[:2],
+		[]g18FutureCohortHandle{unproved, unproved},
+		[]uint16{0, 1},
+		1,
+	); admitted || reason != "certificate_unproved" {
+		t.Fatalf("unproved verification=%t reason=%q", admitted, reason)
+	}
+
+	rollbackBefore := g18FutureDecodeCoreSnapshot(t, provider)
+	rolledBack := g18FutureBeginCohort(t, provider, 1, uint32(len(record)))
+	g18FutureWriteMember(t, provider, rolledBack, heads[0], 0, action, digest, record)
+	if err := provider.DiagnosticDropCohortRollbackForTest(rolledBack); err != nil {
+		t.Fatal(err)
+	}
+	rollbackAfter := g18FutureDecodeCoreSnapshot(t, provider)
+	if !reflect.DeepEqual(rollbackAfter, rollbackBefore) {
+		t.Fatalf("rollback snapshot differs: before=%+v after=%+v", rollbackBefore, rollbackAfter)
+	}
+	if admitted, reason := g18FutureSchedulerVerify(
+		t,
+		scheduler,
+		provider,
+		heads[:2],
+		[]g18FutureCohortHandle{rolledBack, rolledBack},
+		[]uint16{0, 0},
+		1,
+	); admitted || reason != "unknown_cohort" {
+		t.Fatalf("rolled-back verification=%t reason=%q", admitted, reason)
+	}
+}
+
+func TestG18FutureSequentialAndNestedCohortsRED(t *testing.T) {
+	scheduler, provider, heads := g18FutureBehaviorFixture(t)
+	action := g18FutureActionIdentity()
+	record, digest := g18FutureDerivationRecord()
+	complete := func(handle g18FutureCohortHandle, first, second int) {
+		g18FutureWriteMember(t, provider, handle, heads[first], 0, action, digest, record)
+		g18FutureWriteMember(t, provider, handle, heads[second], 1, action, digest, record)
+		if err := provider.DiagnosticDropCohortFinalizeForTest(handle); err != nil {
+			t.Fatal(err)
+		}
+	}
+	first := g18FutureBeginCohort(t, provider, 2, uint32(len(record)))
+	complete(first, 0, 1)
+	second := g18FutureBeginCohort(t, provider, 2, uint32(len(record)))
+	complete(second, 0, 1)
+	if second[2] != first[2]+1 {
+		t.Fatalf("sequential handles first=%v second=%v", first, second)
+	}
+	if admitted, reason := g18FutureSchedulerVerify(
+		t,
+		scheduler,
+		provider,
+		heads[:2],
+		[]g18FutureCohortHandle{first, second},
+		[]uint16{0, 1},
+		1,
+	); admitted || reason != "foreign_cohort_sequence" {
+		t.Fatalf("sequential blend verification=%t reason=%q", admitted, reason)
+	}
+
+	outer := g18FutureBeginCohort(t, provider, 2, uint32(len(record)))
+	g18FutureWriteMember(t, provider, outer, heads[0], 0, action, digest, record)
+	inner := g18FutureBeginCohort(t, provider, 2, uint32(len(record)))
+	complete(inner, 0, 1)
+	g18FutureWriteMember(t, provider, outer, heads[1], 1, action, digest, record)
+	if err := provider.DiagnosticDropCohortFinalizeForTest(outer); err != nil {
+		t.Fatal(err)
+	}
+	if inner[2] != outer[2]+1 {
+		t.Fatalf("nested handles outer=%v inner=%v", outer, inner)
+	}
+	for name, handle := range map[string]g18FutureCohortHandle{"outer": outer, "inner": inner} {
+		if admitted, reason := g18FutureSchedulerVerify(
+			t,
+			scheduler,
+			provider,
+			heads[:2],
+			[]g18FutureCohortHandle{handle, handle},
+			[]uint16{0, 1},
+			1,
+		); !admitted || reason != "proved" {
+			t.Fatalf("%s nested verification=%t reason=%q", name, admitted, reason)
+		}
+	}
+}
+
+func TestG18FutureAtomicPreflightForEveryStoreRED(t *testing.T) {
+	storeNames := []string{
+		"action_records",
+		"derivation_records",
+		"certificate_references",
+		"map_entries",
+		"interner_entries",
+		"journal_entries",
+		"cohort_records",
+	}
+	record, _ := g18FutureDerivationRecord()
+	_, footprint := g18FutureAccountingPlan(2, uint32(len(record)))
+	for store, name := range storeNames {
+		store := store
+		name := name
+		t.Run(name, func(t *testing.T) {
+			_, provider, _ := g18FutureBehaviorFixture(t)
+			before := g18FutureDecodeCoreSnapshot(t, provider)
+			caps := g18FutureUnlimitedCaps()
+			caps[store] = footprint[store] - 1
+			if _, err := provider.DiagnosticDropCohortBeginForTest(2, uint32(len(record)), caps); err == nil {
+				t.Fatal("over-limit preflight was accepted")
+			}
+			after := g18FutureDecodeCoreSnapshot(t, provider)
+			if !reflect.DeepEqual(after, before) {
+				t.Fatalf("failed preflight changed state: before=%+v after=%+v", before, after)
+			}
+		})
+	}
+}
+
+func TestG18FutureExactStorageAndFootprintRED(t *testing.T) {
+	record, _ := g18FutureDerivationRecord()
+	for _, expected := range []uint16{1, 2, 3} {
+		expected := expected
+		t.Run(fmt.Sprintf("members_%d", expected), func(t *testing.T) {
+			_, provider, _ := g18FutureBehaviorFixture(t)
+			before := g18FutureDecodeCoreSnapshot(t, provider)
+			handle := g18FutureBeginCohort(t, provider, expected, uint32(len(record)))
+			after := g18FutureRequireCohortState(t, provider, handle, "building", expected, 0)
+			wantStorage, wantFootprint := g18FutureAccountingPlan(expected, uint32(len(record)))
+			if got := g18FutureSubtractStores(t, after.Storage, before.Storage); got != wantStorage {
+				t.Fatalf("storage delta=%v, want %v", got, wantStorage)
+			}
+			if got := g18FutureSubtractStores(t, after.Footprint, before.Footprint); got != wantFootprint {
+				t.Fatalf("footprint delta=%v, want %v", got, wantFootprint)
+			}
+			if after.StorageBytes-before.StorageBytes != g18FutureSumStores(wantStorage) ||
+				after.FootprintBytes-before.FootprintBytes != g18FutureSumStores(wantFootprint) {
+				t.Fatalf("byte totals before=%+v after=%+v", before, after)
+			}
+		})
+	}
+}
+
+func TestG18FutureEveryActionIdentityFieldRED(t *testing.T) {
+	fieldNames := []string{
+		"state",
+		"lookahead",
+		"ordinal",
+		"type",
+		"target_state",
+		"symbol",
+		"production_id",
+		"child_count",
+		"dynamic_precedence",
+		"extra",
+		"extra_chain",
+		"repetition",
+		"no_lookahead",
+		"selection_class",
+	}
+	record, digest := g18FutureDerivationRecord()
+	for field, name := range fieldNames {
+		field := field
+		name := name
+		t.Run(name, func(t *testing.T) {
+			scheduler, provider, heads := g18FutureBehaviorFixture(t)
+			handle := g18FutureBeginCohort(t, provider, 2, uint32(len(record)))
+			base := g18FutureActionIdentity()
+			candidate := base
+			if field >= 9 && field <= 12 {
+				candidate[field] = 1 - candidate[field]
+			} else {
+				candidate[field]++
+			}
+			g18FutureWriteMember(t, provider, handle, heads[0], 0, base, digest, record)
+			g18FutureWriteMember(t, provider, handle, heads[1], 1, candidate, digest, record)
+			if err := provider.DiagnosticDropCohortFinalizeForTest(handle); err != nil {
+				t.Fatal(err)
+			}
+			if admitted, reason := g18FutureSchedulerVerify(
+				t,
+				scheduler,
+				provider,
+				heads[:2],
+				[]g18FutureCohortHandle{handle, handle},
+				[]uint16{0, 1},
+				1,
+			); admitted || reason != "action_identity_mismatch" {
+				t.Fatalf("field %s verification=%t reason=%q", name, admitted, reason)
+			}
+		})
+	}
+}
+
+func TestG18FutureDerivationFullRecordEqualityRED(t *testing.T) {
+	scheduler, provider, heads := g18FutureBehaviorFixture(t)
+	action := g18FutureActionIdentity()
+	digest := sha256.Sum256([]byte("forced equal digest"))
+	recordA := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	recordB := []byte{1, 2, 3, 4, 5, 6, 7, 9}
+	collision := g18FutureBeginCohort(t, provider, 2, uint32(len(recordA)))
+	g18FutureWriteMember(t, provider, collision, heads[0], 0, action, digest, recordA)
+	g18FutureWriteMember(t, provider, collision, heads[1], 1, action, digest, recordB)
+	if err := provider.DiagnosticDropCohortFinalizeForTest(collision); err != nil {
+		t.Fatal(err)
+	}
+	if admitted, reason := g18FutureSchedulerVerify(
+		t,
+		scheduler,
+		provider,
+		heads[:2],
+		[]g18FutureCohortHandle{collision, collision},
+		[]uint16{0, 1},
+		1,
+	); admitted || reason != "derivation_identity_mismatch" {
+		t.Fatalf("equal-digest unequal-record verification=%t reason=%q", admitted, reason)
+	}
+
+	equal := g18FutureBeginCohort(t, provider, 2, uint32(len(recordA)))
+	g18FutureWriteMember(t, provider, equal, heads[0], 0, action, digest, recordA)
+	g18FutureWriteMember(t, provider, equal, heads[1], 1, action, digest, recordA)
+	if err := provider.DiagnosticDropCohortFinalizeForTest(equal); err != nil {
+		t.Fatal(err)
+	}
+	if admitted, reason := g18FutureSchedulerVerify(
+		t,
+		scheduler,
+		provider,
+		heads[:2],
+		[]g18FutureCohortHandle{equal, equal},
+		[]uint16{0, 1},
+		1,
+	); !admitted || reason != "proved" {
+		t.Fatalf("full-record equality verification=%t reason=%q", admitted, reason)
+	}
+}
+
+// The reference oracle below checks the predicate shape only. The RED tests
+// above bind every future behavior to a real Core instance.
+func g18ReferenceBuildCertificate(
+	t *testing.T,
+	arena *g18ReferenceCertificateArena,
+	members ...g18ReferenceCohortMember,
+) g18ReferenceCertificateHandle {
+	t.Helper()
+	handle, err := arena.newCertificate(uint8(len(members)), g18ReferencePlan(uint8(len(members))))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, member := range members {
+		if err := arena.write(handle, member); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := arena.finalize(handle); err != nil {
+		t.Fatal(err)
+	}
+	return handle
+}
+
+func g18ReferenceRequireValidHeads(t *testing.T) (core.Head, core.Head) {
+	t.Helper()
+	scheduler, first, second := g18ValidDropScheduler(t)
+	scheduler.headers = []diagnosticParserCoreHeader{{head: first}, {head: second}}
+	g18RequireValidSummaryHeads(t, scheduler)
+	return first, second
+}
+
+func g18ReferenceProof(
+	head core.Head,
+	handle g18ReferenceCertificateHandle,
+	member g18ReferenceCohortMember,
+) g18ReferenceHeadProof {
+	return g18ReferenceHeadProof{Head: head, Certificate: handle, Member: member}
+}
+
+func g18ReferenceSamePayload(left, right g18ReferenceCertificate) bool {
+	left.ID = g18ReferenceCohortID{}
+	right.ID = g18ReferenceCohortID{}
+	return left == right
+}
+
+func TestG18ReferenceArenaOwnerIdentityInlineAndSpill(t *testing.T) {
+	firstHead, secondHead := g18ReferenceRequireValidHeads(t)
+	arenaA := g18ReferenceNewArena(101)
+	arenaB := g18ReferenceNewArena(202)
+	if err := arenaA.beginSession(); err != nil {
+		t.Fatal(err)
+	}
+	if err := arenaB.beginSession(); err != nil {
+		t.Fatal(err)
+	}
+	inline := []g18ReferenceCohortMember{
+		g18ReferenceMember(0, 3, 71), g18ReferenceMember(1, 3, 71),
+	}
+	inlineA := g18ReferenceBuildCertificate(t, &arenaA, inline...)
+	inlineB := g18ReferenceBuildCertificate(t, &arenaB, inline...)
+	if inlineA.ID.ArenaEpoch != inlineB.ID.ArenaEpoch ||
+		inlineA.ID.CohortSequence != inlineB.ID.CohortSequence {
+		t.Fatalf("equal-session identities differ: A=%+v B=%+v", inlineA.ID, inlineB.ID)
+	}
+	if !g18ReferenceSamePayload(
+		arenaA.Certificates[inlineA.Index], arenaB.Certificates[inlineB.Index],
+	) {
+		t.Fatal("equal-session inline certificate payloads differ")
+	}
+	lookupsBefore := arenaA.OwnerCheckedLookups
+	if !g18ReferenceVerifyDrop(
+		&arenaA,
+		g18ReferenceProof(firstHead, inlineA, inline[0]),
+		g18ReferenceProof(secondHead, inlineA, inline[1]),
+	) {
+		t.Fatal("arena A rejected its valid inline certificate")
+	}
+	if got := arenaA.OwnerCheckedLookups - lookupsBefore; got != 2 {
+		t.Fatalf("local inline owner-check attempts=%d, want 2", got)
+	}
+	lookupsBefore = arenaA.OwnerCheckedLookups
+	if g18ReferenceVerifyDrop(
+		&arenaA,
+		g18ReferenceProof(firstHead, inlineB, inline[0]),
+		g18ReferenceProof(secondHead, inlineA, inline[1]),
+	) {
+		t.Fatal("arena A accepted arena B inline identity")
+	}
+	if got := arenaA.OwnerCheckedLookups - lookupsBefore; got != 1 {
+		t.Fatalf("foreign owner reached lookup: checked lookups=%d, want 1 survivor lookup", got)
+	}
+
+	spill := []g18ReferenceCohortMember{
+		g18ReferenceMember(0, 5, 73), g18ReferenceMember(1, 5, 73),
+		g18ReferenceMember(2, 5, 73),
+	}
+	spillA := g18ReferenceBuildCertificate(t, &arenaA, spill...)
+	spillB := g18ReferenceBuildCertificate(t, &arenaB, spill...)
+	if !arenaA.Certificates[spillA.Index].Spilled || !arenaB.Certificates[spillB.Index].Spilled {
+		t.Fatal("three-member certificates did not use spill storage")
+	}
+	if spillA.ID.ArenaEpoch != spillB.ID.ArenaEpoch ||
+		spillA.ID.CohortSequence != spillB.ID.CohortSequence ||
+		!g18ReferenceSamePayload(
+			arenaA.Certificates[spillA.Index], arenaB.Certificates[spillB.Index],
+		) {
+		t.Fatalf("equal-session spill identities or payloads differ: A=%+v B=%+v", spillA.ID, spillB.ID)
+	}
+	lookupsBefore = arenaA.OwnerCheckedLookups
+	if !g18ReferenceVerifyDrop(
+		&arenaA,
+		g18ReferenceProof(firstHead, spillA, spill[0]),
+		g18ReferenceProof(secondHead, spillA, spill[1]),
+	) {
+		t.Fatal("arena A rejected its valid spilled certificate")
+	}
+	if got := arenaA.OwnerCheckedLookups - lookupsBefore; got != 2 {
+		t.Fatalf("local spill owner-check attempts=%d, want 2", got)
+	}
+	lookupsBefore = arenaA.OwnerCheckedLookups
+	if g18ReferenceVerifyDrop(
+		&arenaA,
+		g18ReferenceProof(firstHead, spillB, spill[0]),
+		g18ReferenceProof(secondHead, spillA, spill[1]),
+	) {
+		t.Fatal("arena A accepted arena B spilled identity")
+	}
+	if got := arenaA.OwnerCheckedLookups - lookupsBefore; got != 1 {
+		t.Fatalf("foreign spilled owner reached lookup: checked lookups=%d, want 1", got)
+	}
+
+	staleA := spillA
+	if err := arenaA.beginSession(); err != nil {
+		t.Fatal(err)
+	}
+	fresh := g18ReferenceBuildCertificate(t, &arenaA, spill...)
+	lookupsBefore = arenaA.OwnerCheckedLookups
+	if g18ReferenceVerifyDrop(
+		&arenaA,
+		g18ReferenceProof(firstHead, staleA, spill[0]),
+		g18ReferenceProof(secondHead, fresh, spill[1]),
+	) {
+		t.Fatal("reset arena A accepted its stale certificate")
+	}
+	if got := arenaA.OwnerCheckedLookups - lookupsBefore; got != 1 {
+		t.Fatalf("reset-stale owner-check attempts=%d, want 1", got)
+	}
+}
+
+func TestG18ReferenceFinalizationAndTerminalStates(t *testing.T) {
+	arena := g18ReferenceNewArena(303)
+	if err := arena.beginSession(); err != nil {
+		t.Fatal(err)
+	}
+	partial, err := arena.newCertificate(2, g18ReferencePlan(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := g18ReferenceMember(0, 3, 71)
+	if err := arena.write(partial, first); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := arena.lookup(partial, true); err == nil {
+		t.Fatal("building certificate was exposed")
+	}
+	if err := arena.finalize(partial); err == nil {
+		t.Fatal("partial certificate finalized")
+	}
+	if err := arena.write(partial, first); err == nil ||
+		arena.Certificates[partial.Index].WrittenMembers != 1 {
+		t.Fatalf("duplicate write error=%v certificate=%+v", err, arena.Certificates[partial.Index])
+	}
+	if err := arena.write(partial, g18ReferenceMember(1, 3, 71)); err != nil {
+		t.Fatal(err)
+	}
+	if err := arena.finalize(partial); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := arena.lookup(partial, true); err != nil {
+		t.Fatalf("complete certificate was not exposed: %v", err)
+	}
+
+	blended, err := arena.newCertificate(2, g18ReferencePlan(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := arena.write(blended, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := arena.write(blended, g18ReferenceMember(0, 4, 72)); err == nil ||
+		arena.Certificates[blended.Index].State != g18ReferenceCertificateBlended {
+		t.Fatalf("blended write error=%v certificate=%+v", err, arena.Certificates[blended.Index])
+	}
+
+	overflowed, err := arena.newCertificate(1, g18ReferencePlan(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := arena.write(overflowed, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := arena.write(overflowed, g18ReferenceMember(1, 3, 71)); err == nil ||
+		arena.Certificates[overflowed.Index].State != g18ReferenceCertificateOverflowed {
+		t.Fatalf("overflow write error=%v certificate=%+v", err, arena.Certificates[overflowed.Index])
+	}
+
+	unproved, err := arena.newCertificate(1, g18ReferencePlan(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := arena.write(unproved, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := arena.markUnproved(unproved); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := arena.lookup(unproved, true); err == nil ||
+		arena.Certificates[unproved.Index].State != g18ReferenceCertificateUnproved {
+		t.Fatalf("unproved exposure error=%v certificate=%+v", err, arena.Certificates[unproved.Index])
+	}
+}
+
+func TestG18ReferenceVerifierIdentityAndImportRules(t *testing.T) {
+	firstHead, secondHead := g18ReferenceRequireValidHeads(t)
+	arena := g18ReferenceNewArena(404)
+	if err := arena.beginSession(); err != nil {
+		t.Fatal(err)
+	}
+	members := []g18ReferenceCohortMember{
+		g18ReferenceMember(0, 3, 71), g18ReferenceMember(1, 3, 71),
+	}
+	handle := g18ReferenceBuildCertificate(t, &arena, members...)
+	survivor := g18ReferenceProof(firstHead, handle, members[0])
+	dropped := g18ReferenceProof(secondHead, handle, members[1])
+	if !g18ReferenceVerifyDrop(&arena, survivor, dropped) {
+		t.Fatal("authenticated Ada import did not prove the exact derivation")
+	}
+	if g18ReferenceVerifyDrop(&arena, survivor) {
+		t.Fatal("empty drop request was accepted")
+	}
+	zeroHead := dropped
+	zeroHead.Head = core.Head{}
+	if g18ReferenceVerifyDrop(&arena, survivor, zeroHead) {
+		t.Fatal("zero drop head was accepted")
+	}
+	if g18ReferenceVerifyDrop(&arena, survivor, dropped, dropped) {
+		t.Fatal("duplicate drop head was accepted")
+	}
+
+	actionMutations := []struct {
+		name   string
+		mutate func(*g18ReferenceActionIdentity)
+	}{
+		{name: "state", mutate: func(value *g18ReferenceActionIdentity) { value.State++ }},
+		{name: "lookahead", mutate: func(value *g18ReferenceActionIdentity) { value.Lookahead++ }},
+		{name: "ordinal", mutate: func(value *g18ReferenceActionIdentity) { value.Ordinal++ }},
+		{name: "type", mutate: func(value *g18ReferenceActionIdentity) { value.Type++ }},
+		{name: "target_state", mutate: func(value *g18ReferenceActionIdentity) { value.TargetState++ }},
+		{name: "symbol", mutate: func(value *g18ReferenceActionIdentity) { value.Symbol++ }},
+		{name: "production_id", mutate: func(value *g18ReferenceActionIdentity) { value.ProductionID++ }},
+		{name: "child_count", mutate: func(value *g18ReferenceActionIdentity) { value.ChildCount++ }},
+		{name: "dynamic_precedence", mutate: func(value *g18ReferenceActionIdentity) { value.DynamicPrecedence++ }},
+		{name: "extra", mutate: func(value *g18ReferenceActionIdentity) { value.Extra = !value.Extra }},
+		{name: "extra_chain", mutate: func(value *g18ReferenceActionIdentity) { value.ExtraChain = !value.ExtraChain }},
+		{name: "repetition", mutate: func(value *g18ReferenceActionIdentity) { value.Repetition = !value.Repetition }},
+		{name: "no_lookahead", mutate: func(value *g18ReferenceActionIdentity) { value.NoLookahead = !value.NoLookahead }},
+		{name: "selection_class", mutate: func(value *g18ReferenceActionIdentity) { value.SelectionClass++ }},
+	}
+	for _, mutation := range actionMutations {
+		mutation := mutation
+		t.Run("action_"+mutation.name, func(t *testing.T) {
+			actionMismatch := dropped
+			mutation.mutate(&actionMismatch.Member.Action)
+			if g18ReferenceVerifyDrop(&arena, survivor, actionMismatch) {
+				t.Fatal("action identity mismatch was accepted")
+			}
+		})
+	}
+	derivationMismatch := dropped
+	derivationMismatch.Member.Derivation.InternedRecord++
+	if g18ReferenceVerifyDrop(&arena, survivor, derivationMismatch) {
+		t.Fatal("Kotlin derivation mismatch was accepted")
+	}
+	digestCollision := dropped
+	digestCollision.Member.Derivation.Record[0]++
+	if digestCollision.Member.Derivation.Digest != dropped.Member.Derivation.Digest {
+		t.Fatal("equal-digest collision setup changed the digest")
+	}
+	if g18ReferenceVerifyDrop(&arena, survivor, digestCollision) {
+		t.Fatal("equal-digest unequal derivation record was accepted")
+	}
+	for _, mutate := range []func(*g18ReferenceCertificateHandle){
+		func(value *g18ReferenceCertificateHandle) { value.ID.ArenaOwner++ },
+		func(value *g18ReferenceCertificateHandle) { value.ID.ArenaEpoch++ },
+		func(value *g18ReferenceCertificateHandle) { value.ID.ArenaEpoch = 0 },
+		func(value *g18ReferenceCertificateHandle) { value.ID.CohortSequence++ },
+	} {
+		invalid := dropped
+		mutate(&invalid.Certificate)
+		if g18ReferenceVerifyDrop(&arena, survivor, invalid) {
+			t.Fatal("reference verifier accepted an invalid identity")
+		}
+	}
+	for _, state := range []g18ReferenceCertificateState{
+		g18ReferenceCertificateBuilding,
+		g18ReferenceCertificateOverflowed,
+		g18ReferenceCertificateBlended,
+		g18ReferenceCertificateUnproved,
+	} {
+		copyArena := arena
+		copyArena.Certificates[handle.Index].State = state
+		if g18ReferenceVerifyDrop(&copyArena, survivor, dropped) {
+			t.Fatalf("reference verifier accepted state %d", state)
+		}
+	}
+}
+
+func TestG18ReferenceCompatibleCohortMerge(t *testing.T) {
+	id := g18ReferenceCohortID{ArenaOwner: 505, ArenaEpoch: 1, CohortSequence: 1}
+	left := g18ReferenceCertificate{
+		ID: id, State: g18ReferenceCertificateBuilding, ExpectedMembers: 2, WrittenMembers: 1,
+		Members: [g18ReferenceMaxMembers]g18ReferenceCohortMember{g18ReferenceMember(0, 3, 71)},
+	}
+	right := g18ReferenceCertificate{
+		ID: id, State: g18ReferenceCertificateBuilding, ExpectedMembers: 1, WrittenMembers: 1,
+		Members: [g18ReferenceMaxMembers]g18ReferenceCohortMember{g18ReferenceMember(1, 4, 73)},
+	}
+	if !left.compatibleMerge(right) || left.WrittenMembers != 2 ||
+		left.State != g18ReferenceCertificateBuilding {
+		t.Fatalf("compatible cohort merge=%+v", left)
+	}
+
+	conflictTarget := g18ReferenceCertificate{
+		ID: id, State: g18ReferenceCertificateBuilding, ExpectedMembers: 2, WrittenMembers: 1,
+		Members: [g18ReferenceMaxMembers]g18ReferenceCohortMember{g18ReferenceMember(0, 3, 71)},
+	}
+	conflict := g18ReferenceCertificate{
+		ID: id, State: g18ReferenceCertificateBuilding, ExpectedMembers: 1, WrittenMembers: 1,
+		Members: [g18ReferenceMaxMembers]g18ReferenceCohortMember{g18ReferenceMember(0, 5, 79)},
+	}
+	if conflictTarget.compatibleMerge(conflict) ||
+		conflictTarget.State != g18ReferenceCertificateBlended || conflictTarget.WrittenMembers != 1 {
+		t.Fatalf("conflicting cohort merge=%+v", conflictTarget)
+	}
+
+	partialTarget := g18ReferenceCertificate{
+		ID: id, State: g18ReferenceCertificateBuilding, ExpectedMembers: 2, WrittenMembers: 1,
+		Members: [g18ReferenceMaxMembers]g18ReferenceCohortMember{g18ReferenceMember(0, 3, 71)},
+	}
+	partialSource := g18ReferenceCertificate{
+		ID: id, State: g18ReferenceCertificateBuilding, ExpectedMembers: 2, WrittenMembers: 1,
+		Members: [g18ReferenceMaxMembers]g18ReferenceCohortMember{g18ReferenceMember(1, 4, 73)},
+	}
+	if partialTarget.compatibleMerge(partialSource) ||
+		partialTarget.State != g18ReferenceCertificateBlended || partialTarget.WrittenMembers != 1 {
+		t.Fatalf("partial cohort merge=%+v", partialTarget)
+	}
+}
+
+func TestG18ReferenceSequentialAndNestedCohorts(t *testing.T) {
+	firstHead, secondHead := g18ReferenceRequireValidHeads(t)
+	arena := g18ReferenceNewArena(606)
+	if err := arena.beginSession(); err != nil {
+		t.Fatal(err)
+	}
+	firstMembers := []g18ReferenceCohortMember{
+		g18ReferenceMember(0, 3, 71), g18ReferenceMember(1, 3, 71),
+	}
+	first := g18ReferenceBuildCertificate(t, &arena, firstMembers...)
+	secondMembers := []g18ReferenceCohortMember{
+		g18ReferenceMember(0, 4, 73), g18ReferenceMember(1, 4, 73),
+	}
+	second := g18ReferenceBuildCertificate(t, &arena, secondMembers...)
+	if second.ID.CohortSequence != first.ID.CohortSequence+1 {
+		t.Fatalf("sequential cohort identities: first=%+v second=%+v", first.ID, second.ID)
+	}
+	if g18ReferenceVerifyDrop(
+		&arena,
+		g18ReferenceProof(firstHead, first, firstMembers[0]),
+		g18ReferenceProof(secondHead, second, secondMembers[1]),
+	) {
+		t.Fatal("sequential cohorts blended")
+	}
+
+	outer, err := arena.newCertificate(2, g18ReferencePlan(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	outerMembers := []g18ReferenceCohortMember{
+		g18ReferenceMember(0, 5, 79), g18ReferenceMember(1, 5, 79),
+	}
+	if err := arena.write(outer, outerMembers[0]); err != nil {
+		t.Fatal(err)
+	}
+	innerMembers := []g18ReferenceCohortMember{
+		g18ReferenceMember(0, 6, 83), g18ReferenceMember(1, 6, 83),
+	}
+	inner := g18ReferenceBuildCertificate(t, &arena, innerMembers...)
+	if err := arena.write(outer, outerMembers[1]); err != nil {
+		t.Fatal(err)
+	}
+	if err := arena.finalize(outer); err != nil {
+		t.Fatal(err)
+	}
+	if inner.ID.CohortSequence != outer.ID.CohortSequence+1 ||
+		!g18ReferenceVerifyDrop(
+			&arena,
+			g18ReferenceProof(firstHead, outer, outerMembers[0]),
+			g18ReferenceProof(secondHead, outer, outerMembers[1]),
+		) ||
+		!g18ReferenceVerifyDrop(
+			&arena,
+			g18ReferenceProof(firstHead, inner, innerMembers[0]),
+			g18ReferenceProof(secondHead, inner, innerMembers[1]),
+		) {
+		t.Fatalf("nested cohort identities: outer=%+v inner=%+v", outer.ID, inner.ID)
+	}
+}
+
+func TestG18ReferenceArenaLifecycleAndAccounting(t *testing.T) {
+	firstHead, secondHead := g18ReferenceRequireValidHeads(t)
+	var ownerCounter uint64
+	owner, err := g18ReferenceAllocateOwner(&ownerCounter)
+	if err != nil || owner == 0 {
+		t.Fatalf("allocate arena owner=%d err=%v", owner, err)
+	}
+	ownerOverflow := uint64(math.MaxUint64)
+	if _, err := g18ReferenceAllocateOwner(&ownerOverflow); err == nil ||
+		!strings.Contains(err.Error(), "overflow") {
+		t.Fatalf("owner wrap error=%v", err)
+	}
+	zeroOwner := g18ReferenceNewArena(0)
+	if err := zeroOwner.beginSession(); err == nil || !strings.Contains(err.Error(), "owner") {
+		t.Fatalf("zero-owner session error=%v", err)
+	}
+
+	arena := g18ReferenceNewArena(707)
+	if err := arena.beginSession(); err != nil {
+		t.Fatal(err)
+	}
+	plan := g18ReferencePlan(2)
+	old := g18ReferenceBuildCertificate(
+		t, &arena, g18ReferenceMember(0, 3, 71), g18ReferenceMember(1, 3, 71),
+	)
+	if got := arena.storageBytes(); got != plan.StorageBytes {
+		t.Fatalf("storage bytes=%d, want %d", got, plan.StorageBytes)
+	}
+	wantFootprint := uint64(unsafe.Sizeof(arena))
+	if got := arena.footprintBytes(); got != wantFootprint {
+		t.Fatalf("footprint bytes=%d, want %d", got, wantFootprint)
+	}
+
+	transactionBefore := arena
+	temporary, err := arena.newCertificate(1, g18ReferencePlan(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := arena.write(temporary, g18ReferenceMember(0, 4, 73)); err != nil {
+		t.Fatal(err)
+	}
+	arena = transactionBefore
+	if arena != transactionBefore {
+		t.Fatal("rollback did not restore all arena values")
+	}
+	if _, err := arena.lookup(temporary, true); err == nil {
+		t.Fatal("rollback left a certificate reference visible")
+	}
+
+	if err := arena.beginSession(); err != nil {
+		t.Fatal(err)
+	}
+	if got := arena.footprintBytes(); got != wantFootprint {
+		t.Fatalf("reset footprint bytes=%d, want retained %d", got, wantFootprint)
+	}
+	freshMembers := []g18ReferenceCohortMember{
+		g18ReferenceMember(0, 3, 71), g18ReferenceMember(1, 3, 71),
+	}
+	fresh := g18ReferenceBuildCertificate(t, &arena, freshMembers...)
+	if g18ReferenceVerifyDrop(
+		&arena,
+		g18ReferenceProof(firstHead, fresh, freshMembers[0]),
+		g18ReferenceProof(secondHead, old, freshMembers[1]),
+	) {
+		t.Fatal("reset and reuse accepted a stale certificate")
+	}
+
+	for int(arena.Count) < len(arena.Certificates) {
+		if _, err := arena.newCertificate(1, g18ReferencePlan(1)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := arena.newCertificate(1, g18ReferencePlan(1)); err == nil || !strings.Contains(err.Error(), "cap") {
+		t.Fatalf("cohort cap error=%v", err)
+	}
+
+	epochOverflow := g18ReferenceNewArena(808)
+	epochOverflow.Epoch = math.MaxUint64
+	if err := epochOverflow.beginSession(); err == nil || !strings.Contains(err.Error(), "overflow") {
+		t.Fatalf("epoch wrap error=%v", err)
+	}
+	sequenceOverflow := g18ReferenceNewArena(909)
+	sequenceOverflow.Epoch = 1
+	sequenceOverflow.NextSequence = math.MaxUint64
+	if _, err := sequenceOverflow.newCertificate(1, g18ReferencePlan(1)); err == nil || !strings.Contains(err.Error(), "overflow") {
+		t.Fatalf("sequence wrap error=%v", err)
+	}
+}
+
+func TestG18ReferencePreflightIsAtomicForEveryStore(t *testing.T) {
+	base := g18ReferenceNewArena(1001)
+	if err := base.beginSession(); err != nil {
+		t.Fatal(err)
+	}
+	plan := g18ReferencePlan(2)
+	tests := []struct {
+		name  string
+		limit func(*g18ReferenceLimits)
+	}{
+		{name: "action_records", limit: func(value *g18ReferenceLimits) { value.MaxActionRecords = plan.ActionRecords - 1 }},
+		{name: "derivation_records", limit: func(value *g18ReferenceLimits) { value.MaxDerivationRecords = plan.DerivationRecords - 1 }},
+		{name: "certificate_references", limit: func(value *g18ReferenceLimits) { value.MaxCertificateReferences = plan.CertificateReferences - 1 }},
+		{name: "map_entries", limit: func(value *g18ReferenceLimits) { value.MaxMapEntries = plan.MapEntries - 1 }},
+		{name: "interner_entries", limit: func(value *g18ReferenceLimits) { value.MaxInternerEntries = plan.InternerEntries - 1 }},
+		{name: "journal_entries", limit: func(value *g18ReferenceLimits) { value.MaxJournalEntries = plan.JournalEntries - 1 }},
+		{name: "storage_bytes", limit: func(value *g18ReferenceLimits) { value.MaxStorageBytes = plan.StorageBytes - 1 }},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			arena := base
+			test.limit(&arena.Limits)
+			before := arena
+			if _, err := arena.newCertificate(2, plan); err == nil {
+				t.Fatal("preflight accepted an over-limit reservation")
+			}
+			if arena != before {
+				t.Fatalf("failed preflight wrote arena state: before=%+v after=%+v", before, arena)
+			}
+		})
+	}
+
+	incomplete := plan
+	incomplete.JournalEntries = 0
+	before := base
+	if _, err := base.newCertificate(2, incomplete); err == nil || !strings.Contains(err.Error(), "incomplete") {
+		t.Fatalf("incomplete preflight error=%v", err)
+	}
+	if base != before {
+		t.Fatal("incomplete preflight wrote arena state")
+	}
+}
+
+func TestG18ReferenceVerifierAllocations(t *testing.T) {
+	firstHead, secondHead := g18ReferenceRequireValidHeads(t)
+	arena := g18ReferenceNewArena(1111)
+	if err := arena.beginSession(); err != nil {
+		t.Fatal(err)
+	}
+	members := []g18ReferenceCohortMember{
+		g18ReferenceMember(0, 3, 71), g18ReferenceMember(1, 3, 71),
+	}
+	handle := g18ReferenceBuildCertificate(t, &arena, members...)
+	survivor := g18ReferenceProof(firstHead, handle, members[0])
+	dropped := g18ReferenceProof(secondHead, handle, members[1])
+	if got := testing.AllocsPerRun(1000, func() {
+		if !g18ReferenceVerifyDrop(&arena, survivor, dropped) {
+			panic("reference verifier declined")
+		}
+	}); got != 0 {
+		t.Fatalf("reference verifier allocations=%v, want 0", got)
+	}
+}

--- a/parsercore_phase0_g18_refset_internal_test.go
+++ b/parsercore_phase0_g18_refset_internal_test.go
@@ -1,0 +1,468 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+	"unsafe"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func g18RootRefs(t *testing.T, compact *core.Core) core.DropCohortRefSet {
+	t.Helper()
+	var refs core.DropCohortRefSet
+	for _, ref := range []core.DropCohortRef{
+		{Owner: 7, Epoch: 2, Sequence: 3, Branch: 1},
+		{Owner: 7, Epoch: 2, Sequence: 3, Branch: 0},
+		{Owner: 8, Epoch: 1, Sequence: 1, Branch: 0},
+	} {
+		if !compact.AddDropCohortRef(&refs, ref) {
+			t.Fatalf("add drop-cohort reference %+v failed", ref)
+		}
+	}
+	return refs
+}
+
+func g18RootMembers(t *testing.T, compact *core.Core, refs core.DropCohortRefSet) []core.DropCohortRef {
+	t.Helper()
+	members := make([]core.DropCohortRef, refs.Len())
+	for index := range members {
+		var ok bool
+		members[index], ok = compact.DropCohortRefAt(refs, index)
+		if !ok {
+			t.Fatalf("drop-cohort reference %d is invalid: %+v", index, refs)
+		}
+	}
+	return members
+}
+
+func TestG18RefSetHeaderAndCanonicalPropagation(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	refs := g18RootRefs(t, compact)
+	var scratch diagnosticParserCoreCanonicalScratch
+	out, err := scratch.canonicalize(compact, []diagnosticParserCoreHeader{
+		{head: head, dropCohortRefs: refs, creationSeq: 1},
+		{head: head, dropCohortRefs: refs, creationSeq: 2},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || !slices.Equal(g18RootMembers(t, compact, out[0].dropCohortRefs), g18RootMembers(t, compact, refs)) {
+		t.Fatalf("linear canonical refs=%+v output=%+v", refs, out)
+	}
+
+	// Force the mapped path and fold a distinct reference into its winner.
+	heads := make([]core.Head, 9)
+	for index := range heads {
+		heads[index], err = compact.Seed(core.StateID(index+10), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	other := core.DropCohortRefSet{}
+	if !compact.AddDropCohortRef(&other, core.DropCohortRef{Owner: 9, Epoch: 1, Sequence: 1, Branch: 0}) {
+		t.Fatal("add mapped reference failed")
+	}
+	headers := make([]diagnosticParserCoreHeader, 0, 10)
+	for index, seeded := range heads {
+		set := refs
+		if index == 0 {
+			set = other
+		}
+		headers = append(headers, diagnosticParserCoreHeader{head: seeded, dropCohortRefs: set, creationSeq: uint64(index + 1)})
+	}
+	headers = append(headers, diagnosticParserCoreHeader{head: heads[0], dropCohortRefs: refs, creationSeq: 99})
+	out, err = scratch.canonicalize(compact, headers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 9 || scratch.groups == nil {
+		t.Fatalf("mapped canonical output len=%d groups=%v", len(out), scratch.groups != nil)
+	}
+	var winner diagnosticParserCoreHeader
+	for _, header := range out {
+		if header.head == heads[0] {
+			winner = header
+			break
+		}
+	}
+	if winner.head != heads[0] {
+		t.Fatalf("mapped canonical output omitted the duplicate winner: %+v", out)
+	}
+	members := g18RootMembers(t, compact, winner.dropCohortRefs)
+	want := append(g18RootMembers(t, compact, refs), g18RootMembers(t, compact, other)...)
+	slices.SortFunc(want, func(left, right core.DropCohortRef) int {
+		if left.Owner != right.Owner {
+			if left.Owner < right.Owner {
+				return -1
+			}
+			return 1
+		}
+		if left.Epoch != right.Epoch {
+			if left.Epoch < right.Epoch {
+				return -1
+			}
+			return 1
+		}
+		if left.Sequence != right.Sequence {
+			if left.Sequence < right.Sequence {
+				return -1
+			}
+			return 1
+		}
+		if left.Branch < right.Branch {
+			return -1
+		}
+		if left.Branch > right.Branch {
+			return 1
+		}
+		return 0
+	})
+	if !slices.Equal(members, want) {
+		t.Fatalf("mapped canonical refs=%v, want %v", members, want)
+	}
+	if scratch.groupsRetainedBytes == 0 || scratch.groupsBucketCount == 0 {
+		t.Fatalf("mapped canonical groups were not accounted: %+v", scratch)
+	}
+	peak := scratch.groupsRetainedBytes
+	_, err = scratch.canonicalize(compact, headers[:1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scratch.groupsRetainedBytes != peak {
+		t.Fatalf("canonical group clear dropped retained peak: got %d want %d", scratch.groupsRetainedBytes, peak)
+	}
+
+	scheduler := &diagnosticParserCoreGenericScheduler{compact: compact, headers: []diagnosticParserCoreHeader{{head: head, dropCohortRefs: refs}}}
+	candidates := scheduler.collectCondenseCandidates(-1)
+	if len(candidates) != 1 || !slices.Equal(g18RootMembers(t, compact, candidates[0].DropCohortRefs), g18RootMembers(t, compact, refs)) {
+		t.Fatalf("condense candidates=%+v", candidates)
+	}
+}
+
+func TestG18AuthenticGenericReductionEstablishesProducerCohort(t *testing.T) {
+	table := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 8}: {{Type: core.ActionShift, State: 3}},
+			{state: 2, symbol: 8}: {{Type: core.ActionShift, State: 3}},
+			{state: 3, symbol: 9}: {{Type: core.ActionReduce, Symbol: 2, ChildCount: 1}},
+		},
+		gotos: map[genericConflictCell]core.StateID{
+			{state: 1, symbol: 2}: 4,
+			{state: 2, symbol: 2}: 4,
+		},
+	}
+	compact, err := core.New(table, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondSeed, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := core.Token{Symbol: 8, StartByte: 0, EndByte: 1}
+	_, err = compact.Shift(seed, 8, 0, token, core.ForkOrder{Present: true, Value: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := compact.Shift(secondSeed, 8, 0, token, core.ForkOrder{Present: true, Value: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := compact.Derivations(second)
+	if err != nil || len(paths) != 2 {
+		t.Fatalf("multi-path setup derivations=%d err=%v", len(paths), err)
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		headers: []diagnosticParserCoreHeader{{head: second, creationSeq: 1}},
+		token: Token{
+			Symbol: 9, StartByte: 1, EndByte: 2,
+			StartPoint: Point{Row: 4, Column: 6}, EndPoint: Point{Row: 4, Column: 7},
+		},
+		nextCleanPathLineage: 1,
+		options:              DiagnosticParserCorePrefixOptions{MaxDispatches: 20}, receipt: &DiagnosticParserCoreGenericScheduler{},
+	}
+	before, err := diagnosticParserCoreHeaderReceipts(compact, scheduler.headers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cell := mustDiagnosticParserCoreGenericCell(t, compact, 0, scheduler.headers[0], 9)
+	if err := scheduler.applyGenericReduction(before, cell); err != nil {
+		t.Fatal(err)
+	}
+	if len(scheduler.headers) != 1 || scheduler.headers[0].dropCohortRefs.Len() != 1 {
+		t.Fatalf("producer header=%+v, want one branch reference", scheduler.headers)
+	}
+	ref, ok := compact.DropCohortRefAt(scheduler.headers[0].dropCohortRefs, 0)
+	if !ok {
+		t.Fatal("producer header reference is unreadable")
+	}
+	state, expected, written, err := compact.DropCohortState(core.DropCohortHandle{Owner: ref.Owner, Epoch: ref.Epoch, Sequence: ref.Sequence})
+	if err != nil || state != core.DropCohortComplete || expected != 1 || written != 1 {
+		t.Fatalf("producer state=%v expected=%d written=%d err=%v", state, expected, written, err)
+	}
+	storedAction, ok := compact.DropCohortAction(core.DropCohortHandle{Owner: ref.Owner, Epoch: ref.Epoch, Sequence: ref.Sequence})
+	if !ok || storedAction.BoundaryState != 3 || storedAction.Lookahead != 9 || storedAction.ActionOrdinal != 0 ||
+		storedAction.Action.Type != core.ActionReduce || storedAction.Action.Symbol != 2 || storedAction.NoLookahead ||
+		storedAction.Selection != core.DropCohortSelectionNone {
+		t.Fatalf("producer action identity=%+v, want state=3 lookahead=9 ordinal=0 reduce selection=none", storedAction)
+	}
+	counters := compact.DropCohortProducerCounts()
+	if counters.ReductionEstablishment != 1 {
+		t.Fatalf("authentic producer counters=%+v, want one establishment", counters)
+	}
+}
+
+func TestG18RefSetCanonicalGroupsBucketGrowthBoundaries(t *testing.T) {
+	previous := uint64(0)
+	for _, entries := range []int{1, 6, 7, 13, 14, 26, 27} {
+		buckets, bytes := diagnosticParserCoreCanonicalGroupsBucketBytes(entries)
+		if buckets == 0 || bytes < previous {
+			t.Fatalf("entries=%d buckets=%d bytes=%d previous=%d", entries, buckets, bytes, previous)
+		}
+		previous = bytes
+	}
+}
+
+func TestG18RefSetCanonicalGroupsDuplicateHintRetention(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	refs := g18RootRefs(t, compact)
+	normalized := make([]diagnosticParserCoreHeader, 0, 33)
+	for index := 0; index < cap(normalized); index++ {
+		normalized = append(normalized, diagnosticParserCoreHeader{head: head, creationSeq: uint64(index + 1), dropCohortRefs: refs})
+	}
+	var scratch diagnosticParserCoreCanonicalScratch
+	if _, err := scratch.canonicalize(compact, normalized); err != nil {
+		t.Fatal(err)
+	}
+	_, hinted := diagnosticParserCoreCanonicalGroupsBucketBytes(len(normalized))
+	if scratch.groupsRetainedBytes < hinted {
+		t.Fatalf("duplicate-heavy map hint under-accounted: got %d want at least %d", scratch.groupsRetainedBytes, hinted)
+	}
+	peak := scratch.groupsRetainedBytes
+	if _, err := scratch.canonicalize(compact, normalized[:1]); err != nil {
+		t.Fatal(err)
+	}
+	if scratch.groupsRetainedBytes != peak {
+		t.Fatalf("clear/reuse dropped hinted peak: got %d want %d", scratch.groupsRetainedBytes, peak)
+	}
+	scheduler := diagnosticParserCoreGenericScheduler{compact: compact, canonicalScratch: scratch}
+	if err := resetDiagnosticParserCoreGenericScheduler(&scheduler); err != nil {
+		t.Fatal(err)
+	}
+	if scheduler.canonicalScratch.groupsRetainedBytes != 0 || scheduler.canonicalScratch.groups != nil {
+		t.Fatalf("reset retained canonical map estimate: %+v", scheduler.canonicalScratch)
+	}
+}
+
+func TestG18AuthenticProducerCanonicalizationCounters(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	scheduler := diagnosticParserCoreGenericScheduler{compact: compact}
+	if err := compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		scheduler.headers = []diagnosticParserCoreHeader{
+			{head: head, creationSeq: 1}, {head: head, creationSeq: 2},
+		}
+		if err := scheduler.canonicalizeOwned(owner); err != nil {
+			return err
+		}
+		scheduler.headers = make([]diagnosticParserCoreHeader, 9)
+		for index := range scheduler.headers {
+			scheduler.headers[index] = diagnosticParserCoreHeader{head: head, creationSeq: uint64(index + 1)}
+		}
+		return scheduler.canonicalizeOwned(owner)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	counters := compact.DropCohortProducerCounts()
+	if counters.LinearCanonicalizer != 1 || counters.MappedCanonicalizer != 1 {
+		t.Fatalf("authentic canonicalizer counters=%+v, want linear=1 mapped=1", counters)
+	}
+}
+
+func TestG18RefSetHeaderPersistenceSiblingAdoptionAndConflictReconciliation(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	refs := g18RootRefs(t, compact)
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		headers: []diagnosticParserCoreHeader{{head: head, creationSeq: 1, dropCohortRefs: refs, convergedReductionSplit: true}},
+	}
+	if err := compact.RunFreshSchedulerSession(func(owner core.SchedulerTransactionToken) error {
+		return scheduler.persistHeaderLineageOwned(owner)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	persisted, err := compact.NodeLineageDropCohortRefs(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(g18RootMembers(t, compact, persisted), g18RootMembers(t, compact, refs)) {
+		t.Fatalf("persisted refs=%v, want %v", persisted, refs)
+	}
+
+	secondary := diagnosticParserCoreHeader{head: head, creationSeq: 2}
+	scheduler.headers = []diagnosticParserCoreHeader{scheduler.headers[0], secondary}
+	if err := compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		adopted, err := scheduler.adoptUpdatedReductionSiblingOwned(owner, 0, head, core.CleanPathRankUnknown, 0, core.AlternativeSet{}, false, refs, false, false, core.DropCohortProducerSiblingAdoption)
+		if err != nil || !adopted {
+			return fmt.Errorf("sibling adoption adopted=%t err=%v", adopted, err)
+		}
+		if !slices.Equal(g18RootMembers(t, compact, scheduler.headers[1].dropCohortRefs), g18RootMembers(t, compact, refs)) {
+			return fmt.Errorf("adopted sibling refs=%+v", scheduler.headers[1].dropCohortRefs)
+		}
+
+		scheduler.headers = []diagnosticParserCoreHeader{{head: head, creationSeq: 1}, {head: head, creationSeq: 2}}
+		outputs, conflictAdopted, err := scheduler.reconcileGenericConflictOutputs(owner, 0, []diagnosticParserCoreHeader{{
+			head: head, freshness: core.ReductionUpdated, dropCohortRefs: refs,
+		}})
+		if err != nil || conflictAdopted != 1 || len(outputs) != 0 {
+			return fmt.Errorf("conflict reconciliation outputs=%+v adopted=%d err=%v", outputs, conflictAdopted, err)
+		}
+		if !slices.Equal(g18RootMembers(t, compact, scheduler.headers[1].dropCohortRefs), g18RootMembers(t, compact, refs)) {
+			return fmt.Errorf("reconciled sibling refs=%+v", scheduler.headers[1].dropCohortRefs)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	counters := compact.DropCohortProducerCounts()
+	if counters.SiblingAdoption != 1 || counters.ConflictReconciliation != 1 {
+		t.Fatalf("authentic sibling/conflict counters=%+v, want sibling=1 conflict=1", counters)
+	}
+}
+
+func TestG18RefSetPoolClearing(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	refs := g18RootRefs(t, compact)
+
+	headerScratch := make([]diagnosticParserCoreHeader, 1, 1)
+	headerScratch[0].dropCohortRefs = refs
+	reductionScratch := make([]core.ReductionOutput, 1, 1)
+	reductionScratch[0].DropCohortRefs = refs
+	candidateScratch := make([]core.CondenseCandidate, 1, 1)
+	candidateScratch[0] = core.CondenseCandidate{Head: head, DropCohortRefs: refs}
+	canonicalHeaders := make([]diagnosticParserCoreHeader, 1, 1)
+	canonicalHeaders[0].dropCohortRefs = refs
+	canonical := diagnosticParserCoreCanonicalScratch{
+		headerBuffers: [2][]diagnosticParserCoreHeader{canonicalHeaders, canonicalHeaders},
+		keys:          make([]diagnosticParserCorePhaseHead, 1, 1),
+		groups:        map[diagnosticParserCorePhaseHead]diagnosticParserCoreCanonicalGroup{{}: {dropCohortRefs: refs}},
+	}
+	canonical.inlineHeaders[0][0].dropCohortRefs = refs
+
+	scheduler := diagnosticParserCoreGenericScheduler{
+		canonicalScratch:      canonical,
+		reductionReplacements: headerScratch,
+		reductionOutputs:      reductionScratch,
+		condenseCandidates:    candidateScratch,
+	}
+	if err := resetDiagnosticParserCoreGenericScheduler(&scheduler); err != nil {
+		t.Fatal(err)
+	}
+	if got := scheduler.reductionReplacements[:cap(scheduler.reductionReplacements)][0].dropCohortRefs; got != (core.DropCohortRefSet{}) {
+		t.Fatalf("header scratch retained refs=%+v", got)
+	}
+	if got := scheduler.reductionOutputs[:cap(scheduler.reductionOutputs)][0].DropCohortRefs; got != (core.DropCohortRefSet{}) {
+		t.Fatalf("reduction scratch retained refs=%+v", got)
+	}
+	if got := scheduler.condenseCandidates[:cap(scheduler.condenseCandidates)][0].DropCohortRefs; got != (core.DropCohortRefSet{}) {
+		t.Fatalf("candidate scratch retained refs=%+v", got)
+	}
+	for index, buffer := range scheduler.canonicalScratch.headerBuffers {
+		if buffer != nil {
+			t.Fatalf("canonical header buffer %d retained backing storage", index)
+		}
+	}
+	if got := scheduler.canonicalScratch.inlineHeaders[0][0].dropCohortRefs; got != (core.DropCohortRefSet{}) {
+		t.Fatalf("inline canonical headers retained refs=%+v", got)
+	}
+	if scheduler.canonicalScratch.groups != nil {
+		t.Fatalf("canonical groups retained backing storage")
+	}
+}
+
+func TestG18RefSetSchedulerMemoryBudgetAccounting(t *testing.T) {
+	compact, _, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	scheduler := diagnosticParserCoreGenericScheduler{compact: compact}
+	base := diagnosticParserCoreSchedulerFootprintBytes(&scheduler)
+	scheduler.headers = make([]diagnosticParserCoreHeader, 0, 2)
+	scheduler.summaryHeaderScratch = make([]DiagnosticParserCoreHeaderReceipt, 0, 21)
+	scheduler.headerRollbackScratch.headers = make([]diagnosticParserCoreHeader, 0, 3)
+	scheduler.canonicalScratch.headerBuffers[0] = make([]diagnosticParserCoreHeader, 0, 4)
+	scheduler.canonicalScratch.keys = make([]diagnosticParserCorePhaseHead, 0, 5)
+	scheduler.canonicalScratch.groups = make(map[diagnosticParserCorePhaseHead]diagnosticParserCoreCanonicalGroup)
+	for index := 0; index < 6; index++ {
+		scheduler.canonicalScratch.groups[diagnosticParserCorePhaseHead{head: core.Head{Node: core.NodeID(index + 1)}}] = diagnosticParserCoreCanonicalGroup{}
+	}
+	scheduler.canonicalScratch.observeGroupsInsertion(6)
+	scheduler.dispatchScratch.cells = make([]diagnosticParserCoreGenericCell, 0, 6)
+	scheduler.dispatchScratch.noActionIndices = make([]int, 0, 7)
+	scheduler.conflictScratch.actionOutputs = make([]diagnosticParserCoreActionOutput, 0, 8)
+	scheduler.conflictScratch.reductionOutputs = make([]core.ReductionOutput, 0, 9)
+	scheduler.conflictScratch.outputs = make([]diagnosticParserCoreHeader, 0, 10)
+	scheduler.conflictScratch.armRanges = make([]diagnosticParserCoreConflictArmRange, 0, 11)
+	scheduler.conflictScratch.adopted = make([]int, 0, 12)
+	scheduler.conflictScratch.headerAssembly = make([]diagnosticParserCoreHeader, 0, 13)
+	scheduler.reductionOutputs = make([]core.ReductionOutput, 0, 14)
+	scheduler.reductionReplacements = make([]diagnosticParserCoreHeader, 0, 15)
+	scheduler.classifiedBoundaries = make([]core.ClassifiedBoundary, 0, 16)
+	scheduler.condenseCandidates = make([]core.CondenseCandidate, 0, 17)
+	scheduler.electStates = make([]StateID, 0, 18)
+	scheduler.electGLRStates = make([]StateID, 0, 19)
+	scheduler.acceptedPayloads = make([]core.SubtreeID, 0, 20)
+	got := diagnosticParserCoreSchedulerFootprintBytes(&scheduler) - base
+	want := uint64(2)*uint64(unsafe.Sizeof(diagnosticParserCoreHeader{})) +
+		uint64(21)*uint64(unsafe.Sizeof(DiagnosticParserCoreHeaderReceipt{})) +
+		uint64(3)*uint64(unsafe.Sizeof(diagnosticParserCoreHeader{})) +
+		uint64(4)*uint64(unsafe.Sizeof(diagnosticParserCoreHeader{})) +
+		uint64(5)*uint64(unsafe.Sizeof(diagnosticParserCorePhaseHead{})) +
+		scheduler.canonicalScratch.groupsRetainedBytes +
+		uint64(6)*uint64(unsafe.Sizeof(diagnosticParserCoreGenericCell{})) +
+		uint64(7)*uint64(unsafe.Sizeof(int(0))) +
+		uint64(8)*uint64(unsafe.Sizeof(diagnosticParserCoreActionOutput{})) +
+		uint64(9)*uint64(unsafe.Sizeof(core.ReductionOutput{})) +
+		uint64(10)*uint64(unsafe.Sizeof(diagnosticParserCoreHeader{})) +
+		uint64(11)*uint64(unsafe.Sizeof(diagnosticParserCoreConflictArmRange{})) +
+		uint64(12)*uint64(unsafe.Sizeof(int(0))) +
+		uint64(13)*uint64(unsafe.Sizeof(diagnosticParserCoreHeader{})) +
+		uint64(14)*uint64(unsafe.Sizeof(core.ReductionOutput{})) +
+		uint64(15)*uint64(unsafe.Sizeof(diagnosticParserCoreHeader{})) +
+		uint64(16)*uint64(unsafe.Sizeof(core.ClassifiedBoundary{})) +
+		uint64(17)*uint64(unsafe.Sizeof(core.CondenseCandidate{})) +
+		uint64(18)*uint64(unsafe.Sizeof(StateID(0))) +
+		uint64(19)*uint64(unsafe.Sizeof(StateID(0))) +
+		uint64(20)*uint64(unsafe.Sizeof(core.SubtreeID(0)))
+	if got != want {
+		t.Fatalf("scheduler footprint delta=%d, want %d", got, want)
+	}
+	scheduler.options.stopControlMemoryBudgetBytes = int64(diagnosticParserCoreSchedulerFootprintBytes(&scheduler))
+	if reason := scheduler.stopControlMemoryBudgetReason(); reason != ParseStopMemoryBudget {
+		t.Fatalf("budget stop reason=%v, want memory budget", reason)
+	}
+	scheduler.options.stopControlMemoryBudgetBytes++
+	if reason := scheduler.stopControlMemoryBudgetReason(); reason != ParseStopNone {
+		t.Fatalf("budget-plus-one reason=%v, want none", reason)
+	}
+}
+
+func TestG18RefSetSchedulerRecordSizeRatchets(t *testing.T) {
+	if got := unsafe.Sizeof(diagnosticParserCoreHeader{}); got != 224 {
+		t.Fatalf("scheduler header size=%d, want 224", got)
+	}
+	if got := unsafe.Sizeof(diagnosticParserCoreCanonicalGroup{}); got != 104 {
+		t.Fatalf("canonical group size=%d, want 104", got)
+	}
+	if got := unsafe.Sizeof(diagnosticParserCoreActionOutput{}); got != 104 {
+		t.Fatalf("action output size=%d, want 104", got)
+	}
+	if got := unsafe.Sizeof(core.CondenseCandidate{}); got != 88 {
+		t.Fatalf("condense candidate size=%d, want 88", got)
+	}
+}

--- a/parsercore_phase0_g18_refset_internal_test.go
+++ b/parsercore_phase0_g18_refset_internal_test.go
@@ -188,7 +188,7 @@ func TestG18AuthenticGenericReductionEstablishesProducerCohort(t *testing.T) {
 			StartPoint: Point{Row: 4, Column: 6}, EndPoint: Point{Row: 4, Column: 7},
 		},
 		nextCleanPathLineage: 1,
-		options:              DiagnosticParserCorePrefixOptions{MaxDispatches: 20}, receipt: &DiagnosticParserCoreGenericScheduler{},
+		options:              DiagnosticParserCorePrefixOptions{MaxDispatches: 20, recordDropCohortCertificates: true}, receipt: &DiagnosticParserCoreGenericScheduler{},
 	}
 	before, err := diagnosticParserCoreHeaderReceipts(compact, scheduler.headers)
 	if err != nil {
@@ -218,6 +218,75 @@ func TestG18AuthenticGenericReductionEstablishesProducerCohort(t *testing.T) {
 	counters := compact.DropCohortProducerCounts()
 	if counters.ReductionEstablishment != 1 {
 		t.Fatalf("authentic producer counters=%+v, want one establishment", counters)
+	}
+}
+
+func TestG18GenericReductionLeavesDropCohortsInertByDefault(t *testing.T) {
+	table := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 8}: {{Type: core.ActionShift, State: 3}},
+			{state: 2, symbol: 8}: {{Type: core.ActionShift, State: 3}},
+			{state: 3, symbol: 9}: {{Type: core.ActionReduce, Symbol: 2, ChildCount: 1}},
+		},
+		gotos: map[genericConflictCell]core.StateID{
+			{state: 1, symbol: 2}: 4,
+			{state: 2, symbol: 2}: 4,
+		},
+	}
+	compact, err := core.New(table, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondSeed, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := core.Token{Symbol: 8, StartByte: 0, EndByte: 1}
+	if _, err = compact.Shift(seed, 8, 0, token, core.ForkOrder{Present: true, Value: 1}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := compact.Shift(secondSeed, 8, 0, token, core.ForkOrder{Present: true, Value: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := compact.Derivations(second)
+	if err != nil || len(paths) != 2 {
+		t.Fatalf("multi-path setup derivations=%d err=%v", len(paths), err)
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		headers: []diagnosticParserCoreHeader{{head: second, creationSeq: 1}},
+		token: Token{
+			Symbol: 9, StartByte: 1, EndByte: 2,
+			StartPoint: Point{Row: 4, Column: 6}, EndPoint: Point{Row: 4, Column: 7},
+		},
+		nextCleanPathLineage: 1,
+		options:              DiagnosticParserCorePrefixOptions{MaxDispatches: 20},
+		receipt:              &DiagnosticParserCoreGenericScheduler{},
+	}
+	before, err := diagnosticParserCoreHeaderReceipts(compact, scheduler.headers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cell := mustDiagnosticParserCoreGenericCell(t, compact, 0, scheduler.headers[0], 9)
+	if err := scheduler.applyGenericReduction(before, cell); err != nil {
+		t.Fatal(err)
+	}
+	if len(scheduler.headers) != 1 || scheduler.headers[0].dropCohortRefs.Len() != 0 {
+		t.Fatalf("default-off producer header=%+v, want one branch without cohort refs", scheduler.headers)
+	}
+	if scheduler.headers[0].cleanPathLineage == 0 || scheduler.headers[0].altSet.Len() == 0 || !scheduler.headers[0].convergedReductionSplit {
+		t.Fatalf("default-off lineage state=%+v, want retained lineage and alternative set", scheduler.headers[0])
+	}
+	counters := compact.DropCohortProducerCounts()
+	// RecordReductionLineageOwned remains unconditional. Its one authentic
+	// lineage establishment is distinct from the gated cohort construction.
+	if counters.ReductionEstablishment != 1 {
+		t.Fatalf("default-off producer counters=%+v, want one lineage establishment", counters)
 	}
 }
 

--- a/parsercore_phase0_g18_slice_c_compat_test.go
+++ b/parsercore_phase0_g18_slice_c_compat_test.go
@@ -1,0 +1,57 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// These methods are test-only adapters for the frozen v20 contract. Their
+// names do not overlap legacy scheduler helpers.
+func (s *diagnosticParserCoreGenericScheduler) G18AdoptUpdatedReductionSiblingOwned(
+	owner core.SchedulerTransactionToken,
+	source int,
+	head core.Head,
+	rank core.CleanPathRankSelection,
+	lineage uint16,
+	set core.AlternativeSet,
+	setBlended bool,
+	converged bool,
+	resurrection bool,
+	mutation G18DropCohortProducerMutationClass,
+) (bool, error) {
+	if mutation != g18FutureProducerSiblingAdoption {
+		return false, errors.New("invalid sibling-adoption mutation class")
+	}
+	return s.adoptUpdatedReductionSiblingOwned(owner, source, head, rank, lineage, set, setBlended, core.DropCohortRefSet{}, converged, resurrection, core.DropCohortProducerSiblingAdoption)
+}
+
+func (s *diagnosticParserCoreGenericScheduler) G18ReconcileGenericConflictOutputsOwned(
+	owner core.SchedulerTransactionToken,
+	source int,
+	outputs []diagnosticParserCoreHeader,
+	mutation G18DropCohortProducerMutationClass,
+) ([]diagnosticParserCoreHeader, int, error) {
+	if mutation != g18FutureProducerConflictReconciliation {
+		return nil, 0, errors.New("invalid conflict-reconciliation mutation class")
+	}
+	return s.reconcileGenericConflictOutputsOwnedWithMutation(owner, source, outputs, core.DropCohortProducerConflictReconciliation)
+}
+
+func (s *diagnosticParserCoreGenericScheduler) G18CanonicalizeOwned(
+	owner core.SchedulerTransactionToken,
+	mutation G18DropCohortProducerMutationClass,
+) error {
+	var expected core.DropCohortProducerMutation
+	switch mutation {
+	case g18FutureProducerLinearCanonicalization:
+		expected = core.DropCohortProducerLinearCanonicalization
+	case g18FutureProducerMappedCanonicalization:
+		expected = core.DropCohortProducerMappedCanonicalization
+	default:
+		return errors.New("invalid canonicalizer mutation class")
+	}
+	return s.canonicalizeOwnedWithMutation(owner, expected)
+}


### PR DESCRIPTION
## Summary

Add bounded compact alternative-set storage and authenticated producer contracts for G18 Slice C.

## Verification

- Full internal parser-core tests pass.
- Current and reference Docker gates pass.
- Cgo current fallback and cgo compile gates pass.
- Concurrent owner race, no-parser-core compile, root compile, and future compile gates pass.
- Docker runs report no out-of-memory failures.

## Expected Slice D RED seams

- Future full contract tests remain RED at `scheduler does not implement the real drop-path behavior API`.
- Future verifier allocation tests remain RED at `scheduler does not implement the real verifier API`.

The branch is rebased onto current `origin/main`. Do not merge this draft until Slice D supplies the missing verifier and admission seams.