### PR TITLE
Add inert drop-cohort verifier diagnostics

### DIFF
--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -940,6 +940,16 @@ type Core struct {
 	dropCohortAuthenticatedHistory uint64
 	dropCohortUnprovedHistory      uint64
 	dropCohortOwnerCheckedLookups  uint64
+	dropCohortVerifierElections    uint64
+	dropCohortVerifierProofs       uint64
+	dropCohortVerifierDeclines     uint64
+	dropCohortActionDeclines       uint64
+	dropCohortDerivationDeclines   uint64
+	dropCohortDeclineReasons       [dropCohortVerifierReasonCount]uint64
+	dropCohortInlineReads          uint64
+	dropCohortSpillReads           uint64
+	dropCohortMapReads             uint64
+	dropCohortInternerReads        uint64
 	dropCohortReservations         []dropCohortReservation
 	dropCohortReserved             [7]uint64
 	dropCohortReservedBytes        uint64
@@ -1060,6 +1070,16 @@ type checkpoint struct {
 	dropCohortAuthenticatedHistory                                            uint64
 	dropCohortUnprovedHistory                                                 uint64
 	dropCohortOwnerCheckedLookups                                             uint64
+	dropCohortVerifierElections                                               uint64
+	dropCohortVerifierProofs                                                  uint64
+	dropCohortVerifierDeclines                                                uint64
+	dropCohortActionDeclines                                                  uint64
+	dropCohortDerivationDeclines                                              uint64
+	dropCohortDeclineReasons                                                  [dropCohortVerifierReasonCount]uint64
+	dropCohortInlineReads                                                     uint64
+	dropCohortSpillReads                                                      uint64
+	dropCohortMapReads                                                        uint64
+	dropCohortInternerReads                                                   uint64
 	dropCohortReservations                                                    int
 	dropCohortReserved                                                        [7]uint64
 	dropCohortReservedBytes                                                   uint64
@@ -1152,6 +1172,16 @@ func (c *Core) markInto(mark *checkpoint) {
 		dropCohortAuthenticatedHistory:   c.dropCohortAuthenticatedHistory,
 		dropCohortUnprovedHistory:        c.dropCohortUnprovedHistory,
 		dropCohortOwnerCheckedLookups:    c.dropCohortOwnerCheckedLookups,
+		dropCohortVerifierElections:      c.dropCohortVerifierElections,
+		dropCohortVerifierProofs:         c.dropCohortVerifierProofs,
+		dropCohortVerifierDeclines:       c.dropCohortVerifierDeclines,
+		dropCohortActionDeclines:         c.dropCohortActionDeclines,
+		dropCohortDerivationDeclines:     c.dropCohortDerivationDeclines,
+		dropCohortDeclineReasons:         c.dropCohortDeclineReasons,
+		dropCohortInlineReads:            c.dropCohortInlineReads,
+		dropCohortSpillReads:             c.dropCohortSpillReads,
+		dropCohortMapReads:               c.dropCohortMapReads,
+		dropCohortInternerReads:          c.dropCohortInternerReads,
 		dropCohortReservations:           len(c.dropCohortReservations),
 		dropCohortReserved:               c.dropCohortReserved,
 		dropCohortReservedBytes:          c.dropCohortReservedBytes,
@@ -1264,6 +1294,16 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 	c.dropCohortAuthenticatedHistory = mark.dropCohortAuthenticatedHistory
 	c.dropCohortUnprovedHistory = mark.dropCohortUnprovedHistory
 	c.dropCohortOwnerCheckedLookups = mark.dropCohortOwnerCheckedLookups
+	c.dropCohortVerifierElections = mark.dropCohortVerifierElections
+	c.dropCohortVerifierProofs = mark.dropCohortVerifierProofs
+	c.dropCohortVerifierDeclines = mark.dropCohortVerifierDeclines
+	c.dropCohortActionDeclines = mark.dropCohortActionDeclines
+	c.dropCohortDerivationDeclines = mark.dropCohortDerivationDeclines
+	c.dropCohortDeclineReasons = mark.dropCohortDeclineReasons
+	c.dropCohortInlineReads = mark.dropCohortInlineReads
+	c.dropCohortSpillReads = mark.dropCohortSpillReads
+	c.dropCohortMapReads = mark.dropCohortMapReads
+	c.dropCohortInternerReads = mark.dropCohortInternerReads
 	c.dropCohortReservations = mark.dropCohortReservationsHeader
 	c.dropCohortReserved = mark.dropCohortReserved
 	c.dropCohortReservedBytes = mark.dropCohortReservedBytes
@@ -1649,6 +1689,16 @@ func (c *Core) Reset() error {
 	c.dropCohortAuthenticatedHistory = 0
 	c.dropCohortUnprovedHistory = 0
 	c.dropCohortOwnerCheckedLookups = 0
+	c.dropCohortVerifierElections = 0
+	c.dropCohortVerifierProofs = 0
+	c.dropCohortVerifierDeclines = 0
+	c.dropCohortActionDeclines = 0
+	c.dropCohortDerivationDeclines = 0
+	clear(c.dropCohortDeclineReasons[:])
+	c.dropCohortInlineReads = 0
+	c.dropCohortSpillReads = 0
+	c.dropCohortMapReads = 0
+	c.dropCohortInternerReads = 0
 	c.dropCohortReservations = nil
 	clear(c.dropCohortReserved[:])
 	c.dropCohortReservedBytes = 0

--- a/internal/parsercorephase0/drop_cohort_test_hooks.go
+++ b/internal/parsercorephase0/drop_cohort_test_hooks.go
@@ -1,7 +1,7 @@
 package parsercorephase0
 
 // This file contains the narrow Core contract used by the tagged G18 tests.
-// It does not provide certificate admission, verification, or parser hooks.
+// It exposes verifier test hooks while production certificate admission remains inactive.
 
 import (
 	"crypto/sha256"
@@ -139,6 +139,16 @@ func (c *Core) DiagnosticDropCohortSnapshotForTest() []byte {
 	snapshot.AuthenticatedHistory = c.dropCohortAuthenticatedHistory
 	snapshot.UnprovedHistory = c.dropCohortUnprovedHistory
 	snapshot.DeclineReasons = map[string]uint64{}
+	snapshot.VerifierElections = c.dropCohortVerifierElections
+	snapshot.VerifierProofs = c.dropCohortVerifierProofs
+	snapshot.VerifierDeclines = c.dropCohortVerifierDeclines
+	snapshot.ActionDeclines = c.dropCohortActionDeclines
+	snapshot.DerivationDeclines = c.dropCohortDerivationDeclines
+	for reason := dropCohortVerifierReason(1); reason < dropCohortVerifierReasonCount; reason++ {
+		if count := c.dropCohortDeclineReasons[reason]; count != 0 {
+			snapshot.DeclineReasons[dropCohortVerifierReasonString(reason)] = count
+		}
+	}
 	for _, record := range c.dropCohortRecords {
 		snapshot.Cohorts = append(snapshot.Cohorts, dropCohortProtocolCohort{
 			Handle: dropCohortProtocolHandle(record.handle), State: dropCohortProtocolState(record.state),
@@ -158,6 +168,10 @@ func (c *Core) DiagnosticDropCohortSnapshotForTest() []byte {
 	snapshot.PhysicalStorageBytes = c.StorageBytes()
 	snapshot.PhysicalFootprintBytes = c.FootprintBytes()
 	snapshot.OwnerCheckedLookups = c.dropCohortOwnerCheckedLookups
+	snapshot.InlineReads = c.dropCohortInlineReads
+	snapshot.SpillReads = c.dropCohortSpillReads
+	snapshot.MapReads = c.dropCohortMapReads
+	snapshot.InternerReads = c.dropCohortInternerReads
 	encoded, err := json.Marshal(snapshot)
 	if err != nil {
 		return []byte(`{"schema":"gts-drop-cohort-certificate-arena/v2"}`)
@@ -413,8 +427,10 @@ func (c *Core) DiagnosticDropCohortMarkUnprovedForTest(rawHandle [3]uint64) erro
 		if err != nil {
 			return err
 		}
-		if c.dropCohortRecords[index].state != DropCohortComplete {
-			return errors.New("parser-core phase zero: drop-cohort is not complete")
+		record := c.dropCohortRecords[index]
+		if (record.state != DropCohortBuilding && record.state != DropCohortComplete) ||
+			record.expected == 0 || record.written != record.expected {
+			return errors.New("parser-core phase zero: drop-cohort is incomplete")
 		}
 		c.recordDropCohortMutation(index)
 		c.dropCohortRecords[index].state = DropCohortUnproved

--- a/internal/parsercorephase0/drop_cohort_verifier.go
+++ b/internal/parsercorephase0/drop_cohort_verifier.go
@@ -1,0 +1,331 @@
+package parsercorephase0
+
+import (
+	"encoding/binary"
+	"errors"
+)
+
+// dropCohortVerifierReason is the stable classification emitted by the inert
+// verifier seam. Keep the values stable because receipts use their strings.
+type dropCohortVerifierReason uint8
+
+const (
+	dropCohortVerifierProved dropCohortVerifierReason = iota
+	dropCohortVerifierForeignOwner
+	dropCohortVerifierStaleEpoch
+	dropCohortVerifierUnknownCohort
+	dropCohortVerifierCertificateBuilding
+	dropCohortVerifierCertificateOverflowed
+	dropCohortVerifierCertificateBlended
+	dropCohortVerifierCertificateUnproved
+	dropCohortVerifierForeignSequence
+	dropCohortVerifierActionMismatch
+	dropCohortVerifierDerivationMismatch
+	dropCohortVerifierHeadMismatch
+	dropCohortVerifierInvalidDrop
+	dropCohortVerifierReasonCount
+)
+
+var dropCohortVerifierErrors = [...]error{
+	nil,
+	errors.New("parser-core phase zero: foreign arena owner"),
+	errors.New("parser-core phase zero: stale arena epoch"),
+	errors.New("parser-core phase zero: unknown cohort"),
+	errors.New("parser-core phase zero: certificate is building"),
+	errors.New("parser-core phase zero: certificate is overflowed"),
+	errors.New("parser-core phase zero: certificate is blended"),
+	errors.New("parser-core phase zero: certificate is unproved"),
+	errors.New("parser-core phase zero: foreign cohort sequence"),
+	errors.New("parser-core phase zero: action identity mismatch"),
+	errors.New("parser-core phase zero: derivation identity mismatch"),
+	errors.New("parser-core phase zero: head identity mismatch"),
+	errors.New("parser-core phase zero: invalid drop"),
+}
+
+func dropCohortVerifierReasonString(reason dropCohortVerifierReason) string {
+	switch reason {
+	case dropCohortVerifierProved:
+		return "proved"
+	case dropCohortVerifierForeignOwner:
+		return "foreign_arena_owner"
+	case dropCohortVerifierStaleEpoch:
+		return "stale_arena_epoch"
+	case dropCohortVerifierUnknownCohort:
+		return "unknown_cohort"
+	case dropCohortVerifierCertificateBuilding:
+		return "certificate_building"
+	case dropCohortVerifierCertificateOverflowed:
+		return "certificate_overflowed"
+	case dropCohortVerifierCertificateBlended:
+		return "certificate_blended"
+	case dropCohortVerifierCertificateUnproved:
+		return "certificate_unproved"
+	case dropCohortVerifierForeignSequence:
+		return "foreign_cohort_sequence"
+	case dropCohortVerifierActionMismatch:
+		return "action_identity_mismatch"
+	case dropCohortVerifierDerivationMismatch:
+		return "derivation_identity_mismatch"
+	case dropCohortVerifierHeadMismatch:
+		return "head_identity_mismatch"
+	case dropCohortVerifierInvalidDrop:
+		return "invalid_drop"
+	default:
+		return "unknown_cohort"
+	}
+}
+
+func dropCohortVerifierError(reason dropCohortVerifierReason) error {
+	if reason >= dropCohortVerifierReasonCount {
+		return dropCohortVerifierErrors[dropCohortVerifierUnknownCohort]
+	}
+	return dropCohortVerifierErrors[reason]
+}
+
+func dropCohortVerifierIncrement(value *uint64) {
+	if value != nil && *value != ^uint64(0) {
+		(*value)++
+	}
+}
+
+func (c *Core) dropCohortVerifierLookup(ref DropCohortRef, count bool) (int, DropCohortHandle, dropCohortVerifierReason) {
+	handle := DropCohortHandle{Owner: ref.Owner, Epoch: ref.Epoch, Sequence: ref.Sequence}
+	if c == nil {
+		return -1, handle, dropCohortVerifierUnknownCohort
+	}
+	if count {
+		dropCohortVerifierIncrement(&c.dropCohortOwnerCheckedLookups)
+	}
+	// Check the arena owner and epoch before reading any certificate store.
+	if ref.Owner == 0 || ref.Owner != c.dropCohortOwner {
+		return -1, handle, dropCohortVerifierForeignOwner
+	}
+	if ref.Epoch == 0 || ref.Epoch != c.dropCohortEpoch {
+		return -1, handle, dropCohortVerifierStaleEpoch
+	}
+	if ref.Sequence == 0 {
+		return -1, handle, dropCohortVerifierUnknownCohort
+	}
+	for index := range c.dropCohortRecords {
+		if c.dropCohortRecords[index].handle != handle {
+			continue
+		}
+		if count {
+			if c.dropCohortRecords[index].expected > dropCohortRefInlineCapacity {
+				dropCohortVerifierIncrement(&c.dropCohortSpillReads)
+			} else {
+				dropCohortVerifierIncrement(&c.dropCohortInlineReads)
+			}
+		}
+		return index, handle, dropCohortVerifierProved
+	}
+	return -1, handle, dropCohortVerifierUnknownCohort
+}
+
+func (c *Core) dropCohortVerifierMember(record dropCohortRecord, head Head, branch uint16) (dropCohortMember, dropCohortVerifierReason) {
+	index, found := c.findDropCohortMember(record, branch)
+	if !found {
+		return dropCohortMember{}, dropCohortVerifierUnknownCohort
+	}
+	member := c.dropCohortMembers[index]
+	if member.head != head {
+		return dropCohortMember{}, dropCohortVerifierHeadMismatch
+	}
+	return member, dropCohortVerifierProved
+}
+
+func (c *Core) dropCohortVerifierDerivationEqual(left, right DropCohortDerivationHandle, count bool) bool {
+	if left.Owner != c.dropCohortOwner || right.Owner != c.dropCohortOwner ||
+		left.Epoch != c.dropCohortEpoch || right.Epoch != c.dropCohortEpoch ||
+		left.Index == 0 || right.Index == 0 ||
+		uint64(left.Index) > uint64(len(c.dropCohortDerivations)) ||
+		uint64(right.Index) > uint64(len(c.dropCohortDerivations)) {
+		return false
+	}
+	if count {
+		dropCohortVerifierIncrement(&c.dropCohortMapReads)
+		dropCohortVerifierIncrement(&c.dropCohortInternerReads)
+	}
+	leftRecord := c.dropCohortDerivations[left.Index-1]
+	rightRecord := c.dropCohortDerivations[right.Index-1]
+	if leftRecord.digest != rightRecord.digest || leftRecord.byteLength != rightRecord.byteLength || leftRecord.rootSymbol != rightRecord.rootSymbol ||
+		leftRecord.stackDepth != rightRecord.stackDepth || leftRecord.checkpoint != rightRecord.checkpoint {
+		return false
+	}
+	leftStart := int(leftRecord.byteOffset)
+	rightStart := int(rightRecord.byteOffset)
+	length := int(leftRecord.byteLength)
+	if leftStart < 0 || rightStart < 0 || length < 0 ||
+		leftStart > len(c.dropCohortDerivationBytes)-length ||
+		rightStart > len(c.dropCohortDerivationBytes)-length {
+		return false
+	}
+	return bytesCompare(
+		c.dropCohortDerivationBytes[leftStart:leftStart+length],
+		c.dropCohortDerivationBytes[rightStart:rightStart+length],
+	) == 0
+}
+
+func (c *Core) dropCohortVerifierPublish(reason dropCohortVerifierReason) {
+	dropCohortVerifierIncrement(&c.dropCohortVerifierElections)
+	if reason == dropCohortVerifierProved {
+		dropCohortVerifierIncrement(&c.dropCohortVerifierProofs)
+		return
+	}
+	dropCohortVerifierIncrement(&c.dropCohortVerifierDeclines)
+	if reason < dropCohortVerifierReasonCount {
+		dropCohortVerifierIncrement(&c.dropCohortDeclineReasons[reason])
+	}
+	if reason == dropCohortVerifierActionMismatch {
+		dropCohortVerifierIncrement(&c.dropCohortActionDeclines)
+	}
+	if reason == dropCohortVerifierDerivationMismatch {
+		dropCohortVerifierIncrement(&c.dropCohortDerivationDeclines)
+	}
+}
+
+func dropCohortVerifierIsDropped(index int, drops []int) bool {
+	for _, drop := range drops {
+		if drop == index {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Core) dropCohortVerifierResult(reason dropCohortVerifierReason, publish bool) dropCohortVerifierReason {
+	if publish {
+		c.dropCohortVerifierPublish(reason)
+	}
+	return reason
+}
+
+func dropCohortVerifierValidateInputs(heads []Head, refs []DropCohortRef, drops []int) (int, dropCohortVerifierReason) {
+	if len(heads) == 0 || len(heads) != len(refs) || len(drops) == 0 || len(drops) >= len(heads) {
+		return -1, dropCohortVerifierInvalidDrop
+	}
+	for index, drop := range drops {
+		if drop < 0 || drop >= len(heads) || heads[drop].Node == 0 || dropCohortVerifierIsDropped(drop, drops[:index]) {
+			return -1, dropCohortVerifierInvalidDrop
+		}
+	}
+	for index := range heads {
+		if !dropCohortVerifierIsDropped(index, drops) {
+			if heads[index].Node == 0 {
+				return -1, dropCohortVerifierInvalidDrop
+			}
+			return index, dropCohortVerifierProved
+		}
+	}
+	return -1, dropCohortVerifierInvalidDrop
+}
+
+func dropCohortVerifierClassifyRecord(record dropCohortRecord) dropCohortVerifierReason {
+	switch record.state {
+	case DropCohortBuilding:
+		return dropCohortVerifierCertificateBuilding
+	case DropCohortOverflowed:
+		return dropCohortVerifierCertificateOverflowed
+	case DropCohortBlended:
+		return dropCohortVerifierCertificateBlended
+	case DropCohortUnproved:
+		return dropCohortVerifierCertificateUnproved
+	case DropCohortComplete:
+		if record.expected == 0 || record.written != record.expected {
+			return dropCohortVerifierCertificateBuilding
+		}
+		return dropCohortVerifierProved
+	default:
+		return dropCohortVerifierUnknownCohort
+	}
+}
+
+func (c *Core) dropCohortVerifierSurvivor(head Head, ref DropCohortRef, count bool) (DropCohortHandle, dropCohortMember, dropCohortVerifierReason) {
+	index, handle, reason := c.dropCohortVerifierLookup(ref, count)
+	if reason != dropCohortVerifierProved {
+		return handle, dropCohortMember{}, reason
+	}
+	record := c.dropCohortRecords[index]
+	if reason = dropCohortVerifierClassifyRecord(record); reason != dropCohortVerifierProved {
+		return handle, dropCohortMember{}, reason
+	}
+	member, reason := c.dropCohortVerifierMember(record, head, ref.Branch)
+	return handle, member, reason
+}
+
+func (c *Core) dropCohortVerifierCandidate(head Head, ref DropCohortRef, survivorHandle DropCohortHandle, survivorMember dropCohortMember, count bool) dropCohortVerifierReason {
+	index, candidateHandle, reason := c.dropCohortVerifierLookup(ref, count)
+	if reason != dropCohortVerifierProved {
+		return reason
+	}
+	candidateRecord := c.dropCohortRecords[index]
+	if reason = dropCohortVerifierClassifyRecord(candidateRecord); reason != dropCohortVerifierProved {
+		return reason
+	}
+	if candidateHandle != survivorHandle {
+		return dropCohortVerifierForeignSequence
+	}
+	candidateMember, reason := c.dropCohortVerifierMember(candidateRecord, head, ref.Branch)
+	if reason != dropCohortVerifierProved {
+		return reason
+	}
+	if candidateMember.action != survivorMember.action {
+		return dropCohortVerifierActionMismatch
+	}
+	if !c.dropCohortVerifierDerivationEqual(survivorMember.derivation, candidateMember.derivation, count) {
+		return dropCohortVerifierDerivationMismatch
+	}
+	return dropCohortVerifierProved
+}
+
+func (c *Core) dropCohortVerifyRefs(heads []Head, refs []DropCohortRef, drops []int, publish bool) dropCohortVerifierReason {
+	if c == nil {
+		return dropCohortVerifierUnknownCohort
+	}
+	survivorIndex, reason := dropCohortVerifierValidateInputs(heads, refs, drops)
+	if reason != dropCohortVerifierProved {
+		return c.dropCohortVerifierResult(reason, publish)
+	}
+	survivorHandle, survivorMember, reason := c.dropCohortVerifierSurvivor(heads[survivorIndex], refs[survivorIndex], publish)
+	if reason != dropCohortVerifierProved {
+		return c.dropCohortVerifierResult(reason, publish)
+	}
+	for _, drop := range drops {
+		if heads[drop] == heads[survivorIndex] {
+			return c.dropCohortVerifierResult(dropCohortVerifierInvalidDrop, publish)
+		}
+		reason = c.dropCohortVerifierCandidate(heads[drop], refs[drop], survivorHandle, survivorMember, publish)
+		if reason != dropCohortVerifierProved {
+			return c.dropCohortVerifierResult(reason, publish)
+		}
+	}
+	return c.dropCohortVerifierResult(dropCohortVerifierProved, publish)
+}
+
+// DiagnosticVerifyDropCohortRefsForTest exposes only the inert verifier
+// foundation. It does not compact headers or authorize a production drop.
+func (c *Core) DiagnosticVerifyDropCohortRefsForTest(heads []Head, refs []DropCohortRef, drops []int) (string, error) {
+	reason := c.dropCohortVerifyRefs(heads, refs, drops, true)
+	return dropCohortVerifierReasonString(reason), dropCohortVerifierError(reason)
+}
+
+// DiagnosticVerifyDropCohortRefsNonDestructiveForTest evaluates the same
+// predicate without counters, storage-read telemetry, or arena mutation.
+func (c *Core) DiagnosticVerifyDropCohortRefsNonDestructiveForTest(heads []Head, refs []DropCohortRef, drops []int) (string, error) {
+	reason := c.dropCohortVerifyRefs(heads, refs, drops, false)
+	return dropCohortVerifierReasonString(reason), dropCohortVerifierError(reason)
+}
+
+// DiagnosticDropCohortVerifierStateDigestForTest returns a fixed-width digest
+// of verifier counters. The non-destructive seam leaves this value unchanged.
+func (c *Core) DiagnosticDropCohortVerifierStateDigestForTest() [32]byte {
+	var digest [32]byte
+	if c == nil {
+		return digest
+	}
+	binary.LittleEndian.PutUint64(digest[0:8], c.dropCohortVerifierElections)
+	binary.LittleEndian.PutUint64(digest[8:16], c.dropCohortVerifierProofs)
+	binary.LittleEndian.PutUint64(digest[16:24], c.dropCohortVerifierDeclines)
+	binary.LittleEndian.PutUint64(digest[24:32], c.dropCohortOwnerCheckedLookups)
+	return digest
+}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2076,6 +2076,11 @@ type diagnosticParserCoreGenericScheduler struct {
 	conflictPostExecutionFault    func() error
 	extraPostExecutionFault       func() error
 	freshSessionOwner             *core.SchedulerTransactionToken
+	verifierHeads                 [32]core.Head
+	verifierRefs                  [32]core.DropCohortRef
+	verifierBound                 int
+	verifierHeaderPtr             *diagnosticParserCoreHeader
+	verifierInvocation            uint64
 	observer                      diagnosticParserCoreSeedObserver
 	stoppedAfterElection          bool
 	requireEOFPostNoLookaheadRoot bool
@@ -6988,6 +6993,99 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 	s.work.add(&s.work.ConvergedReductionSplitDrops, convergedReductionSplitDrops)
 	s.work.add(&s.work.ConvergedCoverageDrops, convergedCoverageDrops)
 	return nil
+}
+
+// DiagnosticBindDropCohortReferencesForTest binds opaque certificate handles
+// to the existing headers. It performs no validation and does not activate the
+// production admission route.
+func (s *diagnosticParserCoreGenericScheduler) DiagnosticBindDropCohortReferencesForTest(handles [][3]uint64, branches []uint16) error {
+	if s == nil || s.compact == nil {
+		return errors.New("parser-core phase zero: nil verifier scheduler")
+	}
+	if len(handles) != len(branches) || len(handles) != len(s.headers) {
+		return errors.New("parser-core phase zero: verifier binding length mismatch")
+	}
+	if len(handles) > len(s.verifierRefs) {
+		return errors.New("parser-core phase zero: verifier header cap")
+	}
+	for index := range s.headers {
+		raw := handles[index]
+		s.verifierRefs[index] = core.DropCohortRef{
+			Owner: raw[0], Epoch: raw[1], Sequence: raw[2], Branch: branches[index],
+		}
+		s.headers[index].dropCohortRefs = core.DropCohortRefSet{
+			Inline: [2]core.DropCohortRef{{
+				Owner: raw[0], Epoch: raw[1], Sequence: raw[2], Branch: branches[index],
+			}},
+			Count: 1,
+		}
+	}
+	s.verifierBound = len(handles)
+	if len(s.headers) == 0 {
+		s.verifierHeaderPtr = nil
+	} else {
+		s.verifierHeaderPtr = &s.headers[0]
+	}
+	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) diagnosticDropCohortVerifierInputs() (int, error) {
+	if s == nil || s.compact == nil {
+		return 0, errors.New("parser-core phase zero: nil verifier scheduler")
+	}
+	if len(s.headers) > len(s.verifierHeads) {
+		return 0, errors.New("parser-core phase zero: verifier header cap")
+	}
+	if s.verifierBound != len(s.headers) {
+		return 0, errors.New("parser-core phase zero: verifier binding is absent")
+	}
+	if len(s.headers) != 0 && s.verifierHeaderPtr != &s.headers[0] {
+		return 0, errors.New("parser-core phase zero: verifier binding is stale")
+	}
+	for index := range s.headers {
+		s.verifierHeads[index] = s.headers[index].head
+		bound := s.headers[index].dropCohortRefs
+		if bound.Count != 1 || bound.Spilled() || bound.Inline[0] != s.verifierRefs[index] {
+			return 0, errors.New("parser-core phase zero: verifier reference binding is stale")
+		}
+	}
+	return len(s.headers), nil
+}
+
+// DiagnosticDropGenericNoActionHeadsForTest runs only the inert certificate
+// verifier. It never compacts headers or changes the production drop route.
+func (s *diagnosticParserCoreGenericScheduler) DiagnosticDropGenericNoActionHeadsForTest(indices []int) (string, error) {
+	count, err := s.diagnosticDropCohortVerifierInputs()
+	if err != nil {
+		return "unknown_cohort", err
+	}
+	return s.compact.DiagnosticVerifyDropCohortRefsForTest(
+		s.verifierHeads[:count], s.verifierRefs[:count], indices,
+	)
+}
+
+// DiagnosticDropGenericNoActionHeadsNonDestructiveForTest evaluates the same
+// certificate without telemetry, header mutation, or arena mutation.
+func (s *diagnosticParserCoreGenericScheduler) DiagnosticDropGenericNoActionHeadsNonDestructiveForTest(indices []int) (string, uint64, [32]byte, error) {
+	var zero [32]byte
+	count, err := s.diagnosticDropCohortVerifierInputs()
+	if err != nil {
+		return "unknown_cohort", s.verifierInvocation, zero, err
+	}
+	if s.verifierInvocation != ^uint64(0) {
+		s.verifierInvocation++
+	}
+	reason, verifyErr := s.compact.DiagnosticVerifyDropCohortRefsNonDestructiveForTest(
+		s.verifierHeads[:count], s.verifierRefs[:count], indices,
+	)
+	return reason, s.verifierInvocation, s.compact.DiagnosticDropCohortVerifierStateDigestForTest(), verifyErr
+}
+
+func (s *diagnosticParserCoreGenericScheduler) DiagnosticDropGenericNoActionHeadsVerifierStateDigestForTest() [32]byte {
+	if s == nil || s.compact == nil {
+		return [32]byte{}
+	}
+	return s.compact.DiagnosticDropCohortVerifierStateDigestForTest()
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericReduction(before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) (err error) {

--- a/parsercore_phase0_g18_alternative_set_contract_test.go
+++ b/parsercore_phase0_g18_alternative_set_contract_test.go
@@ -2037,6 +2037,52 @@ func TestG18FutureRealCertificateLifecycleRED(t *testing.T) {
 	}
 }
 
+func TestG18FutureRealVerifierCertificateStateReasonsRED(t *testing.T) {
+	scheduler, provider, heads := g18FutureBehaviorFixture(t)
+	action := g18FutureActionIdentity()
+	record, digest := g18FutureDerivationRecord()
+	complete := g18FutureBeginCohort(t, provider, 2, uint32(len(record)))
+	g18FutureWriteMember(t, provider, complete, heads[0], 0, action, digest, record)
+	g18FutureWriteMember(t, provider, complete, heads[1], 1, action, digest, record)
+	if err := provider.DiagnosticDropCohortFinalizeForTest(complete); err != nil {
+		t.Fatal(err)
+	}
+	overflowed := g18FutureBeginCohort(t, provider, 1, uint32(len(record)))
+	g18FutureWriteMember(t, provider, overflowed, heads[0], 0, action, digest, record)
+	if err := provider.DiagnosticDropCohortWriteForTest(overflowed, heads[1], 1, action, digest, record); err == nil {
+		t.Fatal("overflowed certificate accepted an extra member")
+	}
+	blended := g18FutureBeginCohort(t, provider, 2, uint32(len(record)))
+	g18FutureWriteMember(t, provider, blended, heads[0], 0, action, digest, record)
+	conflict := action
+	conflict[2]++
+	if err := provider.DiagnosticDropCohortWriteForTest(blended, heads[1], 0, conflict, digest, record); err == nil {
+		t.Fatal("blended certificate accepted a conflicting member")
+	}
+	for _, test := range []struct {
+		name   string
+		handle g18FutureCohortHandle
+		want   string
+	}{
+		{name: "overflowed", handle: overflowed, want: "certificate_overflowed"},
+		{name: "blended", handle: blended, want: "certificate_blended"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if admitted, reason := g18FutureSchedulerVerify(
+				t,
+				scheduler,
+				provider,
+				heads[:2],
+				[]g18FutureCohortHandle{complete, test.handle},
+				[]uint16{0, 1},
+				1,
+			); admitted || reason != test.want {
+				t.Fatalf("state verification=%t reason=%q, want %q", admitted, reason, test.want)
+			}
+		})
+	}
+}
+
 func TestG18FutureSequentialAndNestedCohortsRED(t *testing.T) {
 	scheduler, provider, heads := g18FutureBehaviorFixture(t)
 	action := g18FutureActionIdentity()


### PR DESCRIPTION
## Summary

Add an inert verifier foundation for compact parser graduation.

- Keep production certificate admission disabled.
- Check the arena owner and epoch before certificate storage reads.
- Persist verifier counters through checkpoint and restore. Reset all verifier state with the arena.
- Preserve the existing alternative-set fallback.

## Evidence

- The warm non-destructive verifier path reports zero allocations.
- Direct Canopy analysis reports maximum verifier cyclomatic complexity 20.
- Base commit: `0b9a90d8ad8e93eb02ce4352a1dbb6b3766b3dca`.
- Source change hash: `sha256:a7e594a018aa0db3f7361f665a9bcf3d027f0ea92406a4162cebc4c02533584b`.
- Focused Docker gates passed after the rebase.

```text
TestG18FutureRealVerifierArenaIdentityRED
TestG18FutureRealVerifierAllocationsRED
TestG18FutureRealCertificateLifecycleRED
TestG18FutureRealVerifierCertificateStateReasonsRED
TestG18FutureSequentialAndNestedCohortsRED
TestG18FutureEveryActionIdentityFieldRED
TestG18FutureDerivationFullRecordEqualityRED
TestG18HistoricalAlternativeSetProducerPath
TestG18HistoricalAlternativeSetCertificateTelemetryRED
TestG18ReferenceVerifierIdentityAndImportRules
TestG18ReferenceCompatibleCohortMerge
TestG18ReferenceSequentialAndNestedCohorts
TestG18ReferenceArenaLifecycleAndAccounting
TestG18ReferencePreflightIsAtomicForEveryStore
TestG18ReferenceVerifierAllocations
```

## Remaining intentionally RED contracts

- `TestG18DropPathRejectsForeignInlineRED` remains RED while production admission stays inactive.
- C-route admission and Kotlin decline telemetry RED contracts remain for later slices.
- Historical producer and telemetry contracts pass. This pull request does not change historical import behavior.

Do not merge this draft until root completes the remaining campaign review.