### PR TITLE
Authenticate dead history imports

### DIFF
--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -991,6 +991,12 @@ type Core struct {
 	// synthetic EOF token. A transparent goto completes an extra in place.
 	// The scheduler sets this only around one authenticated reduction.
 	reduceNoLookaheadContext bool
+	// dropCohortSelectionContext carries the authenticated scheduler selection
+	// class into reduction-owned historical certificate checks.
+	dropCohortSelectionContext DropCohortSelectionClass
+	// historicalCertificateAuthentication keeps D2 certificate checks inert
+	// until an explicit producer fixture enables them.
+	historicalCertificateAuthentication bool
 	// externalPayloadsQuiescent is a one-way language capability. The caller
 	// certifies that external payload identity does not depend on scanner state.
 	// Reset retains it because the property is stable for this core's tables.
@@ -1021,6 +1027,19 @@ func (c *Core) SetReduceNoLookaheadContext(v bool) {
 		return
 	}
 	c.reduceNoLookaheadContext = v
+}
+
+// SetDropCohortSelectionContextOwned sets the transient selection class under
+// the active scheduler owner used by exact certificate authentication.
+func (c *Core) SetDropCohortSelectionContextOwned(owner SchedulerTransactionToken, v DropCohortSelectionClass) error {
+	if c == nil {
+		return errors.New("parser-core phase zero: nil core selection context")
+	}
+	if err := c.validateSchedulerTransaction(owner); err != nil {
+		return err
+	}
+	c.dropCohortSelectionContext = v
+	return nil
 }
 
 // CertifyExternalPayloadsQuiescent permits recursive insertion to compare and
@@ -1714,6 +1733,8 @@ func (c *Core) Reset() error {
 	c.metadataConstructionAuthenticated = true
 	c.reduceConflictContext = false
 	c.reduceNoLookaheadContext = false
+	c.dropCohortSelectionContext = DropCohortSelectionNone
+	c.historicalCertificateAuthentication = false
 	c.externalTokenScannerStart = 0
 	c.externalTokenScannerEnd = 0
 	c.externalTokenScannerExact = false
@@ -2429,7 +2450,7 @@ func (c *Core) ReduceOutputsInto(dst []ReductionOutput, head Head, lookahead Sym
 func (c *Core) ReduceOutputsClassifiedInto(dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder) (frontier []ReductionOutput, err error) {
 	mark := c.mark()
 	defer c.completeTransaction(mark, &err)
-	return c.reduceOutputsClassifiedIntoUncheckpointed(dst, boundary, actionOrdinal, fork)
+	return c.reduceOutputsClassifiedIntoUncheckpointed(SchedulerTransactionToken{}, dst, boundary, actionOrdinal, fork)
 }
 
 func (c *Core) reductionParentForPath(

--- a/internal/parsercorephase0/drop_cohort_arena_test.go
+++ b/internal/parsercorephase0/drop_cohort_arena_test.go
@@ -742,6 +742,7 @@ func TestG18DropCohortDeadHistoryCounterTracksAuthenticImport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	compact.historicalCertificateAuthentication = true
 	seed, err := compact.Seed(1, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -777,7 +778,30 @@ func TestG18DropCohortDeadHistoryCounterTracksAuthenticImport(t *testing.T) {
 		if len(firstOutputs) != 1 || !firstOutputs[0].MultiplePopPaths {
 			return fmt.Errorf("first reduction outputs=%+v, want one multi-path output", firstOutputs)
 		}
-		return compact.RecordReductionLineageOwned(owner, firstOutputs, 7)
+		if err := compact.RecordReductionLineageOwned(owner, firstOutputs, 7); err != nil {
+			return err
+		}
+		cohort, err := compact.BeginDropCohortOwned(owner, DropCohortActionIdentity{
+			BoundaryState: 1,
+			Lookahead:     9,
+			ActionOrdinal: 0,
+			Action:        Action{Type: ActionReduce, Symbol: 2, ChildCount: 1},
+		}, 1)
+		if err != nil {
+			return err
+		}
+		derivation, err := compact.BuildDropCohortDerivationOwned(owner, firstOutputs[0].Head, DropCohortSourceCheckpoint{})
+		if err != nil {
+			return err
+		}
+		if err := compact.WriteDropCohortMemberOwned(owner, cohort, firstOutputs[0].Head, 0, derivation); err != nil {
+			return err
+		}
+		refs, err := compact.FinalizeDropCohortOwned(owner, cohort)
+		if err != nil {
+			return err
+		}
+		return compact.RecordHeadLineageRefsOwned(owner, firstOutputs[0].Head, refs)
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/parsercorephase0/g18_alternative_set_contract_test.go
+++ b/internal/parsercorephase0/g18_alternative_set_contract_test.go
@@ -44,6 +44,25 @@ func TestG18HistoricalAlternativeSetProducerPath(t *testing.T) {
 	}
 }
 
+func TestG18HistoricalAlternativeSetDefaultOffCompatibility(t *testing.T) {
+	compact, outputs := g18HistoricalAlternativeSetProducerFixture(t, nil, nil)
+	if len(compact.dropCohortRecords) != 0 {
+		t.Fatalf("default-off fixture created %d certificates", len(compact.dropCohortRecords))
+	}
+	if len(outputs) != 1 || outputs[0].HistoricalBoundaryProvenance != HistoricalBoundaryConverged ||
+		outputs[0].HistoricalAlternativeSet.Len() != 3 || !outputs[0].DropCohortRefs.Empty() {
+		t.Fatalf("default-off output=%+v, want pre-D2 converged union without refs", outputs)
+	}
+	if compact.dropCohortAuthenticatedHistory != 1 || compact.dropCohortUnprovedHistory != 0 ||
+		compact.dropCohortProducerWrites[dropCohortProducerDeadHistoryImport] != 1 {
+		t.Fatalf("default-off telemetry authenticated=%d unproved=%d dead=%d, want 1/0/1",
+			compact.dropCohortAuthenticatedHistory,
+			compact.dropCohortUnprovedHistory,
+			compact.dropCohortProducerWrites[dropCohortProducerDeadHistoryImport],
+		)
+	}
+}
+
 // TestG18HistoricalAlternativeSetCertificateTelemetryRED binds the real
 // dead-node import to the future certificate arena. Current main does not
 // publish this telemetry.
@@ -51,7 +70,7 @@ func TestG18HistoricalAlternativeSetCertificateTelemetryRED(t *testing.T) {
 	var provider g18FutureHistoricalCertificateTelemetryProvider
 	var before g18FutureHistoricalCertificateTelemetry
 	var after g18FutureHistoricalCertificateTelemetry
-	g18HistoricalAlternativeSetProducerFixture(
+	g18HistoricalAlternativeSetProducerFixtureAuthenticated(
 		t,
 		func(compact *Core) {
 			var ok bool
@@ -90,6 +109,102 @@ func TestG18HistoricalAlternativeSetCertificateTelemetryRED(t *testing.T) {
 	}
 }
 
+func TestG18HistoricalAlternativeSetImportRejectsMissingCertificate(t *testing.T) {
+	compact, outputs := g18HistoricalAlternativeSetProducerFixtureWithCertificate(t, nil, nil, false)
+	if len(outputs) != 1 || outputs[0].HistoricalBoundaryProvenance != HistoricalBoundaryUnproved ||
+		outputs[0].HistoricalAlternativeSet.Len() != 0 || !outputs[0].DropCohortRefs.Empty() {
+		t.Fatalf("missing-certificate output=%+v, want unproved history without imported state", outputs)
+	}
+	if compact.dropCohortAuthenticatedHistory != 0 || compact.dropCohortUnprovedHistory != 1 ||
+		compact.dropCohortProducerWrites[dropCohortProducerDeadHistoryImport] != 0 {
+		t.Fatalf("missing-certificate telemetry authenticated=%d unproved=%d writes=%d",
+			compact.dropCohortAuthenticatedHistory,
+			compact.dropCohortUnprovedHistory,
+			compact.dropCohortProducerWrites[dropCohortProducerDeadHistoryImport],
+		)
+	}
+}
+
+func TestG18HistoricalAlternativeSetImportRejectsIdentityCorruption(t *testing.T) {
+	mutateRef := func(mutate func(*DropCohortRef)) func(*Core) {
+		return func(compact *Core) {
+			for index := range compact.nodeLineages {
+				refs := &compact.nodeLineages[index].dropCohortRefs
+				if refs.Empty() || refs.Spilled() {
+					continue
+				}
+				mutate(&refs.Inline[0])
+				return
+			}
+			t.Fatal("certificate fixture has no inline historical reference")
+		}
+	}
+	tests := []struct {
+		name   string
+		mutate func(*Core)
+	}{
+		{
+			name: "foreign-reference",
+			mutate: mutateRef(func(ref *DropCohortRef) {
+				ref.Owner ^= 1
+			}),
+		},
+		{
+			name: "stale-reference",
+			mutate: mutateRef(func(ref *DropCohortRef) {
+				ref.Epoch++
+			}),
+		},
+		{
+			name: "building",
+			mutate: func(compact *Core) {
+				compact.dropCohortRecords[0].state = DropCohortBuilding
+			},
+		},
+		{
+			name: "terminal",
+			mutate: func(compact *Core) {
+				compact.dropCohortRecords[0].state = DropCohortOverflowed
+			},
+		},
+		{
+			name: "action",
+			mutate: func(compact *Core) {
+				compact.dropCohortMembers[0].action.Action.Symbol++
+			},
+		},
+		{
+			name: "derivation",
+			mutate: func(compact *Core) {
+				compact.dropCohortDerivationBytes[0] ^= 0xff
+			},
+		},
+		{
+			name: "over-budget",
+			mutate: func(compact *Core) {
+				compact.limits.MaxDropCohortBytes = 1
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			compact, outputs := g18HistoricalAlternativeSetProducerFixtureWithCertificate(t, test.mutate, nil, true)
+			if len(outputs) != 1 || outputs[0].HistoricalBoundaryProvenance != HistoricalBoundaryUnproved ||
+				outputs[0].HistoricalAlternativeSet.Len() != 0 || !outputs[0].DropCohortRefs.Empty() {
+				t.Fatalf("corrupt %s output=%+v, want unproved history without imported set", test.name, outputs)
+			}
+			if compact.dropCohortAuthenticatedHistory != 0 || compact.dropCohortUnprovedHistory != 1 ||
+				compact.dropCohortProducerWrites[dropCohortProducerDeadHistoryImport] != 0 {
+				t.Fatalf("corrupt %s telemetry authenticated=%d unproved=%d writes=%d", test.name,
+					compact.dropCohortAuthenticatedHistory,
+					compact.dropCohortUnprovedHistory,
+					compact.dropCohortProducerWrites[dropCohortProducerDeadHistoryImport],
+				)
+			}
+		})
+	}
+}
+
 func g18DecodeHistoricalSnapshot(
 	t *testing.T,
 	provider g18FutureHistoricalCertificateTelemetryProvider,
@@ -117,6 +232,33 @@ func g18HistoricalAlternativeSetProducerFixture(
 	beforeReduce func(*Core),
 	afterReduce func(*Core),
 ) (*Core, []ReductionOutput) {
+	return g18HistoricalAlternativeSetProducerFixtureWithCertificateAndAuth(t, beforeReduce, afterReduce, false, false)
+}
+
+func g18HistoricalAlternativeSetProducerFixtureAuthenticated(
+	t *testing.T,
+	beforeReduce func(*Core),
+	afterReduce func(*Core),
+) (*Core, []ReductionOutput) {
+	return g18HistoricalAlternativeSetProducerFixtureWithCertificateAndAuth(t, beforeReduce, afterReduce, true, true)
+}
+
+func g18HistoricalAlternativeSetProducerFixtureWithCertificate(
+	t *testing.T,
+	beforeReduce func(*Core),
+	afterReduce func(*Core),
+	withCertificate bool,
+) (*Core, []ReductionOutput) {
+	return g18HistoricalAlternativeSetProducerFixtureWithCertificateAndAuth(t, beforeReduce, afterReduce, withCertificate, true)
+}
+
+func g18HistoricalAlternativeSetProducerFixtureWithCertificateAndAuth(
+	t *testing.T,
+	beforeReduce func(*Core),
+	afterReduce func(*Core),
+	withCertificate bool,
+	authenticate bool,
+) (*Core, []ReductionOutput) {
 	t.Helper()
 	tables := &fakeTable{
 		actions: map[tableCell][]Action{
@@ -128,6 +270,7 @@ func g18HistoricalAlternativeSetProducerFixture(
 	if err != nil {
 		t.Fatal(err)
 	}
+	compact.historicalCertificateAuthentication = authenticate
 	compact.diagnostics.foldSamePredecessorShallowPayloads = false
 	seed, err := compact.Seed(1, 0)
 	if err != nil {
@@ -169,6 +312,31 @@ func g18HistoricalAlternativeSetProducerFixture(
 		}}, 7); err != nil {
 			return err
 		}
+		if withCertificate {
+			cohort, beginErr := compact.BeginDropCohortOwned(owner, DropCohortActionIdentity{
+				BoundaryState: 3,
+				Lookahead:     9,
+				ActionOrdinal: 0,
+				Action:        Action{Type: ActionReduce, Symbol: 2, ChildCount: 1},
+			}, 1)
+			if beginErr != nil {
+				return beginErr
+			}
+			derivation, derivationErr := compact.BuildDropCohortDerivationOwned(owner, retired, DropCohortSourceCheckpoint{})
+			if derivationErr != nil {
+				return derivationErr
+			}
+			if writeErr := compact.WriteDropCohortMemberOwned(owner, cohort, retired, 0, derivation); writeErr != nil {
+				return writeErr
+			}
+			refs, finalizeErr := compact.FinalizeDropCohortOwned(owner, cohort)
+			if finalizeErr != nil {
+				return finalizeErr
+			}
+			if err := compact.RecordHeadLineageRefsOwned(owner, retired, refs); err != nil {
+				return err
+			}
+		}
 		set := NewAlternativeSetMember(7, 0)
 		compact.UnionAlternativeSet(&set, NewAlternativeSetMember(7, 1))
 		compact.UnionAlternativeSet(&set, NewAlternativeSetMember(7, 2))
@@ -195,8 +363,8 @@ func g18HistoricalAlternativeSetProducerFixture(
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(outputs) != 1 || outputs[0].HistoricalBoundaryProvenance != HistoricalBoundaryConverged {
-		t.Fatalf("replacement outputs=%+v, want one converged historical boundary", outputs)
+	if len(outputs) != 1 {
+		t.Fatalf("replacement outputs=%+v, want one historical boundary", outputs)
 	}
 	return compact, outputs
 }

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -1,6 +1,7 @@
 package parsercorephase0
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"math"
@@ -806,12 +807,12 @@ func (c *Core) ReduceOutputsCorridorClassifiedIntoWithLiveCondenseCandidatesOwne
 		return frontier, c.finishSchedulerOwned(owner, err)
 	}
 	if c.schedulerFrame.fresh {
-		frontier, err = c.reduceOutputsCorridorClassifiedIntoUncheckpointed(dst, boundary, fork)
+		frontier, err = c.reduceOutputsCorridorClassifiedIntoUncheckpointed(owner, dst, boundary, fork)
 		c.clearLiveCondenseCandidates()
 		return frontier, c.finishSchedulerOwned(owner, err)
 	}
 	defer c.clearLiveCondenseCandidates()
-	frontier, err = c.reduceOutputsCorridorClassifiedIntoUncheckpointed(dst, boundary, fork)
+	frontier, err = c.reduceOutputsCorridorClassifiedIntoUncheckpointed(owner, dst, boundary, fork)
 	return frontier, c.finishSchedulerOwned(owner, err)
 }
 
@@ -825,23 +826,23 @@ func (c *Core) reduceOutputsClassifiedIntoMaybeLiveScopedOwned(owner SchedulerTr
 	}
 	defer c.recoverSchedulerOwnedPanic(owner)
 	if !liveScoped {
-		frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(dst, boundary, actionOrdinal, fork)
+		frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(owner, dst, boundary, actionOrdinal, fork)
 		return frontier, c.finishSchedulerOwned(owner, err)
 	}
 	if err = c.enterLiveCondenseCandidates(candidates); err != nil {
 		return frontier, c.finishSchedulerOwned(owner, err)
 	}
 	if c.schedulerFrame.fresh {
-		frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(dst, boundary, actionOrdinal, fork)
+		frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(owner, dst, boundary, actionOrdinal, fork)
 		c.clearLiveCondenseCandidates()
 		return frontier, c.finishSchedulerOwned(owner, err)
 	}
 	defer c.clearLiveCondenseCandidates()
-	frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(dst, boundary, actionOrdinal, fork)
+	frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(owner, dst, boundary, actionOrdinal, fork)
 	return frontier, c.finishSchedulerOwned(owner, err)
 }
 
-func (c *Core) reduceOutputsClassifiedIntoUncheckpointed(dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder) ([]ReductionOutput, error) {
+func (c *Core) reduceOutputsClassifiedIntoUncheckpointed(owner SchedulerTransactionToken, dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder) ([]ReductionOutput, error) {
 	frontier := dst[:0]
 	if c.popScratch.busy {
 		return nil, errors.New("parser-core phase zero: reentrant reduction while pop scratch is active")
@@ -853,10 +854,99 @@ func (c *Core) reduceOutputsClassifiedIntoUncheckpointed(dst []ReductionOutput, 
 	defer c.popScratch.resetLogical()
 	c.reductionScratch.begin()
 	defer c.reductionScratch.finish()
-	return c.reduceOutputsClassifiedIntoActive(frontier, boundary, actionOrdinal, fork, false)
+	return c.reduceOutputsClassifiedIntoActive(owner, frontier, boundary, actionOrdinal, fork, false)
 }
 
-func (c *Core) reduceOutputsCorridorClassifiedIntoUncheckpointed(dst []ReductionOutput, boundary ClassifiedBoundary, fork ForkOrder) ([]ReductionOutput, error) {
+func (c *Core) historicalImportEnvelope(owner SchedulerTransactionToken, refs DropCohortRefSet, historicalNode NodeID) (int, bool) {
+	if c == nil || historicalNode == 0 || c.validateSchedulerTransaction(owner) != nil || refs.Empty() || refs.Overflowed() || refs.Blended() {
+		return 0, false
+	}
+	if _, err := c.nodeLineage(historicalNode); err != nil {
+		return 0, false
+	}
+	count, valid := c.dropCohortRefCount(refs)
+	if !valid || count == 0 {
+		return 0, false
+	}
+	storeBytes, addErr := dropCohortAddChecked(c.dropCohortStoreBytes(), c.dropCohortReservedBytes)
+	if addErr != nil || storeBytes > c.limits.MaxDropCohortBytes {
+		return 0, false
+	}
+	return count, true
+}
+
+func (c *Core) historicalImportRef(ref DropCohortRef, historicalNode NodeID, expected DropCohortActionIdentity) bool {
+	if ref.Owner != c.dropCohortOwner || ref.Epoch != c.dropCohortEpoch || ref.Sequence == 0 {
+		return false
+	}
+	recordIndex, handle, reason := c.dropCohortVerifierLookup(ref, false)
+	if reason != dropCohortVerifierProved || recordIndex < 0 || recordIndex >= len(c.dropCohortRecords) {
+		return false
+	}
+	record := c.dropCohortRecords[recordIndex]
+	if record.handle != handle || dropCohortVerifierClassifyRecord(record) != dropCohortVerifierProved {
+		return false
+	}
+	member, memberReason := c.dropCohortVerifierMember(record, Head{Node: historicalNode}, ref.Branch)
+	if memberReason != dropCohortVerifierProved || member.action != expected {
+		return false
+	}
+	return c.historicalImportDerivation(member.derivation, member.head, historicalNode)
+}
+
+func (c *Core) historicalImportDerivation(derivation DropCohortDerivationHandle, memberHead Head, historicalNode NodeID) bool {
+	if derivation.Owner != c.dropCohortOwner || derivation.Epoch != c.dropCohortEpoch || derivation.Index == 0 ||
+		uint64(derivation.Index) > uint64(len(c.dropCohortDerivations)) {
+		return false
+	}
+	record := c.dropCohortDerivations[derivation.Index-1]
+	if record.handle != derivation || record.head != memberHead || record.head.Node != historicalNode ||
+		uint64(record.byteLength) > c.limits.MaxDropCohortBytes {
+		return false
+	}
+	start := uint64(record.byteOffset)
+	length := uint64(record.byteLength)
+	if start > uint64(len(c.dropCohortDerivationBytes)) || length > uint64(len(c.dropCohortDerivationBytes))-start {
+		return false
+	}
+	end := int(start + length)
+	bytes := c.dropCohortDerivationBytes[int(start):end]
+	return sha256.Sum256(bytes) == record.digest && c.historicalImportDerivationInterned(record)
+}
+
+func (c *Core) historicalImportDerivationInterned(record dropCohortDerivationRecord) bool {
+	for _, entry := range c.dropCohortDerivationIntern {
+		if entry.digest == record.digest && entry.byteOffset == record.byteOffset && entry.byteLength == record.byteLength {
+			return true
+		}
+	}
+	return false
+}
+
+// authenticateHistoricalDropCohortImport validates one dead-node reference
+// set under the active scheduler owner before historical state can be reused.
+// It reads only immutable certificate records and never publishes verifier
+// diagnostics or changes the production drop route.
+func (c *Core) authenticateHistoricalDropCohortImport(
+	owner SchedulerTransactionToken,
+	refs DropCohortRefSet,
+	historicalNode NodeID,
+	expected DropCohortActionIdentity,
+) bool {
+	count, ok := c.historicalImportEnvelope(owner, refs, historicalNode)
+	if !ok {
+		return false
+	}
+	for index := 0; index < count; index++ {
+		ref, ok := c.DropCohortRefAt(refs, index)
+		if !ok || !c.historicalImportRef(ref, historicalNode, expected) {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *Core) reduceOutputsCorridorClassifiedIntoUncheckpointed(owner SchedulerTransactionToken, dst []ReductionOutput, boundary ClassifiedBoundary, fork ForkOrder) ([]ReductionOutput, error) {
 	frontier := dst[:0]
 	if c.popScratch.busy {
 		return nil, errors.New("parser-core phase zero: reentrant reduction while pop scratch is active")
@@ -865,10 +955,10 @@ func (c *Core) reduceOutputsCorridorClassifiedIntoUncheckpointed(dst []Reduction
 	defer c.popScratch.resetLogical()
 	c.reductionScratch.begin()
 	defer c.reductionScratch.finish()
-	return c.reduceOutputsClassifiedIntoActive(frontier, boundary, 0, fork, true)
+	return c.reduceOutputsClassifiedIntoActive(owner, frontier, boundary, 0, fork, true)
 }
 
-func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder, corridorTrusted bool) ([]ReductionOutput, error) {
+func (c *Core) reduceOutputsClassifiedIntoActive(owner SchedulerTransactionToken, frontier []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder, corridorTrusted bool) ([]ReductionOutput, error) {
 	var act *Action
 	var err error
 	if corridorTrusted {
@@ -884,6 +974,14 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 	}
 	if act.Type != ActionReduce {
 		return nil, fmt.Errorf("parser-core phase zero: action %d is %v, not reduce", actionOrdinal, act.Type)
+	}
+	expectedHistoricalAction := DropCohortActionIdentity{
+		BoundaryState: boundary.state,
+		Lookahead:     boundary.lookahead,
+		ActionOrdinal: int32(actionOrdinal),
+		Action:        *act,
+		NoLookahead:   c.reduceNoLookaheadContext,
+		Selection:     c.dropCohortSelectionContext,
 	}
 	source, err := c.nodeLineage(boundary.head.Node)
 	if err != nil {
@@ -1045,20 +1143,56 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 			// record that was itself blended, mark this boundary's accumulated
 			// historicalSet blended -- computed before the union mutates it.
 			if outcome.historicalConvergedSplit {
-				if dead, err := c.nodeLineage(outcome.historicalNode); err == nil {
-					incomparable := c.AlternativeSetIncomparable(historicalSet, dead.set)
-					unionChanged := c.alternativeSetUnion(&historicalSet, dead.set)
-					wasBlended := historicalBlended
-					historicalBlended = historicalBlended || dead.blended || incomparable
-					if unionChanged || historicalBlended != wasBlended {
+				if !c.historicalCertificateAuthentication {
+					// Preserve the pre-D2 historical union and counter behavior.
+					if dead, err := c.nodeLineage(outcome.historicalNode); err == nil {
+						incomparable := c.AlternativeSetIncomparable(historicalSet, dead.set)
+						unionChanged := c.alternativeSetUnion(&historicalSet, dead.set)
+						wasBlended := historicalBlended
+						historicalBlended = historicalBlended || dead.blended || incomparable
+						if unionChanged || historicalBlended != wasBlended {
+							c.addDropCohortProducerWrite(dropCohortProducerDeadHistoryImport)
+							if c.dropCohortAuthenticatedHistory != math.MaxUint64 {
+								c.dropCohortAuthenticatedHistory++
+							}
+						}
+					}
+					if _, refsErr := c.dropCohortRefUnion(&dropCohortRefs, outcome.historicalDropCohortRefs); refsErr != nil {
+						return nil, refsErr
+					}
+				} else {
+					markUnproved := func() {
+						historicalConvergedSplit = false
+						historicalForestDeterministic = false
+						historicalCleanPathRank = CleanPathRankUnknown
+						historicalLineage = 0
+						historicalSet = AlternativeSet{}
+						historicalBlended = false
+						// Do not retain source or historical certificate refs on an
+						// unproved result.
+						dropCohortRefs = DropCohortRefSet{}
+						if c.dropCohortUnprovedHistory != math.MaxUint64 {
+							c.dropCohortUnprovedHistory++
+						}
+					}
+					if !c.authenticateHistoricalDropCohortImport(
+						owner, outcome.historicalDropCohortRefs, outcome.historicalNode, expectedHistoricalAction,
+					) {
+						markUnproved()
+					} else if dead, err := c.nodeLineage(outcome.historicalNode); err != nil {
+						markUnproved()
+					} else {
 						c.addDropCohortProducerWrite(dropCohortProducerDeadHistoryImport)
 						if c.dropCohortAuthenticatedHistory != math.MaxUint64 {
 							c.dropCohortAuthenticatedHistory++
 						}
+						incomparable := c.AlternativeSetIncomparable(historicalSet, dead.set)
+						historicalBlended = historicalBlended || dead.blended || incomparable
+						c.alternativeSetUnion(&historicalSet, dead.set)
+						if _, refsErr := c.dropCohortRefUnion(&dropCohortRefs, outcome.historicalDropCohortRefs); refsErr != nil {
+							return nil, refsErr
+						}
 					}
-				}
-				if _, refsErr := c.dropCohortRefUnion(&dropCohortRefs, outcome.historicalDropCohortRefs); refsErr != nil {
-					return nil, refsErr
 				}
 			}
 		}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1496,6 +1496,16 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 	// on every exit path, including error returns from RunSchedulerOwned.
 	compact.SetReduceConflictContext(true)
 	defer compact.SetReduceConflictContext(false)
+	if err := compact.SetDropCohortSelectionContextOwned(owner, core.DropCohortSelectionConflictPolicy); err != nil {
+		return diagnosticParserCoreConflictExecution{}, err
+	}
+	defer func() {
+		_ = compact.SetDropCohortSelectionContextOwned(owner, core.DropCohortSelectionNone)
+	}()
+	if token.NoLookahead {
+		compact.SetReduceNoLookaheadContext(true)
+		defer compact.SetReduceNoLookaheadContext(false)
+	}
 	secondaryCount := uint64(actions.Len() - 1)
 	if secondaryCount > math.MaxUint64-branchOrder {
 		return diagnosticParserCoreConflictExecution{}, errors.New("parser-core phase zero: conflict branch order overflow")
@@ -7138,6 +7148,12 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		s.compact.SetReduceNoLookaheadContext(true)
 		defer s.compact.SetReduceNoLookaheadContext(false)
 	}
+	if err := s.compact.SetDropCohortSelectionContextOwned(owner, dropCohortSelectionClass(cell.selectedBy)); err != nil {
+		return err
+	}
+	defer func() {
+		_ = s.compact.SetDropCohortSelectionContextOwned(owner, core.DropCohortSelectionNone)
+	}()
 	var outputs []core.ReductionOutput
 	var err error
 	if cell.corridorTrustedReduction {


### PR DESCRIPTION
## Summary

Authenticate dead-history imports with owner-scoped drop-cohort certificates.

Keep authentication default-off. Preserve the legacy union path when disabled.

Clear imported history and certificate references after every failed authenticated import.

Keep production certificate admission, allowlists, profile grants, C routes, and fallback proof logic unchanged.

## Tests

- `go test ./internal/parsercorephase0 -run "^(TestG18|TestHistorical)" -count=1`
- `go test . -run "^$" -count=1`
- Docker historical artifact: `harness_out/docker/20260822T004727Z-g18-d2-rebased-historical`
- Docker owner and rollback artifact: `harness_out/docker/20260822T004735Z-g18-d2-rebased-owner-rollback`
- Both Docker runs exited with code zero and reported no out-of-memory kill.

## Complexity

- Authentication coordinator cyclomatic complexity: 5.
- New validator complexity range: 5 to 12.

## Review scope

Review the five changed files in this branch. Do not activate production certificate admission.