### PR TITLE
Add parser certificate activation seam

### DIFF
--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -33,6 +33,13 @@ func admissionCandidateLimits() core.Limits {
 	}
 }
 
+// dropCohortActivationToken identifies one private test activation without a
+// counter wrap. The non-zero payload keeps every allocation independently
+// addressable, even when an older runner is discarded.
+type dropCohortActivationToken struct {
+	marker byte
+}
+
 // newAdmissionCandidateRunner builds a fresh-full runner bound to p's own
 // language, external scanner, and DFA tables.
 func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) {
@@ -108,6 +115,36 @@ func (p *Parser) acquireAdmissionCandidateRunner() (*parserCoreFreshFullRunner, 
 	}
 	p.admissionCandidateRunner = runner
 	return runner, nil
+}
+
+// DiagnosticEnableDropCohortCertificateAdmissionForTest enables one cached
+// candidate parse for focused certificate tests. Production code never calls
+// this method, and the returned closure restores the runner before reuse.
+func (p *Parser) DiagnosticEnableDropCohortCertificateAdmissionForTest() func() {
+	if p == nil || !p.admissionCandidateFullParseEligible(nil, true) {
+		return func() {}
+	}
+	runner, err := p.acquireAdmissionCandidateRunner()
+	if err != nil || runner == nil {
+		return func() {}
+	}
+	token := &dropCohortActivationToken{marker: 1}
+	runner.certificateAdmissionToken = token
+	runner.certificateAdmissionEnabled = true
+	restored := false
+	return func() {
+		if restored {
+			return
+		}
+		restored = true
+		cached, ok := p.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+		if !ok || cached == nil || cached.certificateAdmissionToken != token {
+			return
+		}
+		cached.certificateAdmissionEnabled = false
+		cached.certificateAdmissionToken = nil
+		cached.options.recordDropCohortCertificates = false
+	}
 }
 
 // admissionCandidateCompactStorageBytes reports p's cached admission-candidate

--- a/admission_switch_stub.go
+++ b/admission_switch_stub.go
@@ -13,6 +13,12 @@ func (p *Parser) tryCompactFullParseRoute(_ []byte) (*Tree, bool, string) {
 	return nil, false, "compact candidate route compiled out (built with -tags gts_no_parsercorephase0)"
 }
 
+// DiagnosticEnableDropCohortCertificateAdmissionForTest is inert when the
+// compact parser build is disabled.
+func (p *Parser) DiagnosticEnableDropCohortCertificateAdmissionForTest() func() {
+	return func() {}
+}
+
 // admissionCandidateCompactStorageBytes is the emergency-build stub: the
 // compact engine is compiled out, so no cached runner and no compact storage
 // ever exist.

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1395,6 +1395,19 @@ func (c *Core) validateSchedulerTransaction(token SchedulerTransactionToken) err
 	return nil
 }
 
+// SetHistoricalCertificateAuthenticationOwned arms the D2 import checks for
+// the current scheduler session. Require the active owner for every change.
+func (c *Core) SetHistoricalCertificateAuthenticationOwned(token SchedulerTransactionToken, enabled bool) error {
+	if c == nil {
+		return errors.New("parser-core phase zero: historical authentication on nil core")
+	}
+	if err := c.validateSchedulerTransaction(token); err != nil {
+		return err
+	}
+	c.historicalCertificateAuthentication = enabled
+	return nil
+}
+
 // RunFreshSchedulerSession authenticates one scheduler-owned run without
 // taking per-operation arena checkpoints. It is restricted to a core with no
 // active transaction. Successful runs keep their compact graph; any error or
@@ -1436,6 +1449,9 @@ func (c *Core) RunFreshSchedulerSession(fn func(SchedulerTransactionToken) error
 	token := SchedulerTransactionToken{owner: c, epoch: frame.epoch, transaction: frame.mark.transaction}
 	defer func() {
 		recovered := recover()
+		// Historical certificate authentication is scoped to this fresh session.
+		// Clear the policy before invalidating the owner frame on every exit.
+		c.historicalCertificateAuthentication = false
 		if recovered != nil {
 			frame.clearInactive()
 			_ = c.ResetReleasingRetention()

--- a/internal/parsercorephase0/historical_authentication_owner_test.go
+++ b/internal/parsercorephase0/historical_authentication_owner_test.go
@@ -1,0 +1,48 @@
+package parsercorephase0
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHistoricalCertificateAuthenticationOwnedValidatesOwner(t *testing.T) {
+	compact, _, _ := newSchedulerTransactionShiftFixture(t)
+	if err := compact.SetHistoricalCertificateAuthenticationOwned(SchedulerTransactionToken{}, true); err == nil {
+		t.Fatal("zero token enabled historical authentication")
+	}
+	var stale SchedulerTransactionToken
+	if err := compact.RunFreshSchedulerSession(func(owner SchedulerTransactionToken) error {
+		stale = owner
+		if err := compact.SetHistoricalCertificateAuthenticationOwned(owner, true); err != nil {
+			return err
+		}
+		if !compact.historicalCertificateAuthentication {
+			t.Fatal("owned setter did not enable historical authentication")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if compact.historicalCertificateAuthentication {
+		t.Fatal("fresh session retained historical authentication after exit")
+	}
+	if err := compact.SetHistoricalCertificateAuthenticationOwned(stale, false); err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("stale token result=%v", err)
+	}
+
+	foreign, _, _ := newSchedulerTransactionShiftFixture(t)
+	if err := foreign.RunFreshSchedulerSession(func(owner SchedulerTransactionToken) error {
+		if err := compact.SetHistoricalCertificateAuthenticationOwned(owner, true); err == nil || !strings.Contains(err.Error(), "different core") {
+			t.Fatalf("foreign token result=%v", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	if compact.historicalCertificateAuthentication {
+		t.Fatal("Reset retained historical authentication")
+	}
+}

--- a/parsercore_phase0_d3_activation_nocore_test.go
+++ b/parsercore_phase0_d3_activation_nocore_test.go
@@ -1,0 +1,11 @@
+//go:build gts_no_parsercorephase0
+
+package gotreesitter
+
+import "testing"
+
+func TestG18CertificateActivationNoParserCoreIsNoOp(t *testing.T) {
+	var p *Parser
+	restore := p.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+	restore()
+}

--- a/parsercore_phase0_d3_activation_test.go
+++ b/parsercore_phase0_d3_activation_test.go
@@ -1,0 +1,197 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import "testing"
+
+func TestG18CertificateActivationRestoresCachedRunner(t *testing.T) {
+	p := newAdmissionCandidateGoParser(t)
+	p.SetAdmissionCandidateRoute(true)
+
+	firstRestore := p.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+	runner, err := p.acquireAdmissionCandidateRunner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !runner.certificateAdmissionEnabled {
+		t.Fatal("certificate activation did not arm the cached runner")
+	}
+
+	secondRestore := p.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+	firstRestore()
+	if !runner.certificateAdmissionEnabled {
+		t.Fatal("an older restore disabled a newer activation")
+	}
+	secondRestore()
+	secondRestore()
+	if runner.certificateAdmissionEnabled || runner.options.recordDropCohortCertificates {
+		t.Fatal("idempotent restore did not clear cached activation")
+	}
+}
+
+func TestG18CertificateActivationIgnoresProductionRoute(t *testing.T) {
+	p := newAdmissionCandidateGoParser(t)
+	p.SetAdmissionCandidateRoute(false)
+	restore := p.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+	restore()
+	if p.admissionCandidateRunner != nil {
+		t.Fatal("production route unexpectedly acquired a candidate runner")
+	}
+}
+
+func TestG18CertificateActivationDefaultOffAndNilSafe(t *testing.T) {
+	var nilParser *Parser
+	nilParser.DiagnosticEnableDropCohortCertificateAdmissionForTest()()
+
+	p := &Parser{}
+	p.SetAdmissionCandidateRoute(true)
+	p.DiagnosticEnableDropCohortCertificateAdmissionForTest()()
+	if p.admissionCandidateRunner != nil {
+		t.Fatal("failed runner acquisition published cached state")
+	}
+
+	runner := newAdmissionCandidateGoParser(t)
+	runner.SetAdmissionCandidateRoute(true)
+	cached, err := runner.acquireAdmissionCandidateRunner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cached.certificateAdmissionEnabled || cached.options.recordDropCohortCertificates {
+		t.Fatal("candidate runner defaulted to certificate admission")
+	}
+}
+
+func TestG18CertificateActivationEligibilityIsolation(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*Parser) func()
+	}{
+		{name: "included-ranges", setup: func(p *Parser) func() {
+			p.SetIncludedRanges([]Range{{StartByte: 0, EndByte: 1}})
+			return p.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+		}},
+		{name: "logger", setup: func(p *Parser) func() {
+			p.SetLogger(func(ParserLogType, string) {})
+			return p.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+		}},
+		{name: "suppressed", setup: func(p *Parser) func() {
+			unsuppress := p.suppressAdmissionCandidateRoute()
+			restore := p.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+			unsuppress()
+			return restore
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := newAdmissionCandidateGoParser(t)
+			p.SetAdmissionCandidateRoute(true)
+			restore := test.setup(p)
+			restore()
+			if p.admissionCandidateRunner != nil {
+				t.Fatal("ineligible activation acquired a runner")
+			}
+		})
+	}
+}
+
+func TestG18CertificateActivationRestoreIsolation(t *testing.T) {
+	p := newAdmissionCandidateGoParser(t)
+	p.SetAdmissionCandidateRoute(true)
+	oldRestore := p.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+	oldRunner, err := p.acquireAdmissionCandidateRunner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.pinToProductionRoute()
+	oldRestore()
+	if p.admissionCandidateRunner != nil {
+		t.Fatal("restore republished a pinned runner")
+	}
+
+	p.SetAdmissionCandidateRoute(true)
+	newRestore := p.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+	newRunner, err := p.acquireAdmissionCandidateRunner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldRunner == newRunner {
+		t.Fatal("runner replacement did not allocate a new runner")
+	}
+	oldRestore()
+	if !newRunner.certificateAdmissionEnabled {
+		t.Fatal("out-of-date restore disabled the replacement runner")
+	}
+	if err := newRunner.compact.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	newRestore()
+	if newRunner.certificateAdmissionEnabled || newRunner.certificateAdmissionToken != nil {
+		t.Fatal("restore after reset did not clear the active runner")
+	}
+}
+
+func TestG18CertificateActivationNestedOutOfOrderRestore(t *testing.T) {
+	p := newAdmissionCandidateGoParser(t)
+	p.SetAdmissionCandidateRoute(true)
+	outer := p.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+	inner := p.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+	outer()
+	runner, err := p.acquireAdmissionCandidateRunner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !runner.certificateAdmissionEnabled {
+		t.Fatal("outer restore disabled the nested activation")
+	}
+	inner()
+	if runner.certificateAdmissionEnabled || runner.certificateAdmissionToken != nil {
+		t.Fatal("nested restore did not clear activation")
+	}
+}
+
+func TestG18CertificateActivationCachedParseBoundary(t *testing.T) {
+	p := newAdmissionCandidateGoParser(t)
+	p.SetAdmissionCandidateRoute(true)
+	resetAdmissionCandidateCounters()
+	source := []byte("package p\n")
+	restore := p.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+	runner, err := p.acquireAdmissionCandidateRunner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := p.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !runner.certificateAdmissionEnabled || !runner.options.recordDropCohortCertificates {
+		t.Fatal("activation did not remain armed until restore")
+	}
+	routed, fallback := AdmissionCandidateCounters()
+	if routed != 1 || fallback != 0 {
+		t.Fatalf("first parse counters=%d/%d, want 1/0", routed, fallback)
+	}
+	first.Release()
+	restore()
+	if runner.certificateAdmissionEnabled || runner.options.recordDropCohortCertificates {
+		t.Fatal("restore left the cached runner armed")
+	}
+	second, err := p.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deferredRunner, err := p.acquireAdmissionCandidateRunner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deferredRunner != runner {
+		t.Fatal("second parse replaced the cached runner")
+	}
+	routed, fallback = AdmissionCandidateCounters()
+	if routed != 2 || fallback != 0 {
+		t.Fatalf("second parse counters=%d/%d, want 2/0", routed, fallback)
+	}
+	if runner.certificateAdmissionEnabled || runner.options.recordDropCohortCertificates {
+		t.Fatal("restored runner re-armed certificate admission")
+	}
+	second.Release()
+}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -4021,6 +4021,11 @@ func executeDiagnosticParserCoreGenericSchedulerFromSeedInto(
 			return compact.RunFreshSchedulerSession(func(owner core.SchedulerTransactionToken) error {
 				scheduler.freshSessionOwner = &owner
 				defer func() { scheduler.freshSessionOwner = nil }()
+				if options.recordDropCohortCertificates {
+					if err := compact.SetHistoricalCertificateAuthenticationOwned(owner, true); err != nil {
+						return err
+					}
+				}
 				if err := scheduler.persistHeaderLineageOwned(owner); err != nil {
 					return err
 				}

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -31,7 +31,11 @@ type parserCoreFreshFullRunner struct {
 	options                           DiagnosticParserCorePrefixOptions
 	replayParseStates                 bool
 	allowConvergedReductionSplitDrops bool
-	scannerScratch                    []byte
+	// certificateAdmissionEnabled is armed only by the private test seam.
+	// It is copied into options for each cached parse after Core.Reset.
+	certificateAdmissionEnabled bool
+	certificateAdmissionToken   *dropCohortActivationToken
+	scannerScratch              []byte
 	// scratch retains the reusable per-parse materialization buffers. The runner
 	// is per-Parser and single-goroutine, so reusing these buffers across parses
 	// mirrors production's parser-held arena reuse and keeps the warm steady
@@ -100,6 +104,10 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 			return nil, nil, err
 		}
 	}
+	// Core.Reset clears the session authentication bit. Refresh the scheduler
+	// option on every cached parse so the owner callback can re-arm it only for
+	// this fresh session. The default path remains false and allocation-free.
+	r.options.recordDropCohortCertificates = r.certificateAdmissionEnabled
 	// B3 stage S3: force the shared token source's error-run lexing on when
 	// native compact recovery is admitted, so a genuinely unlexable byte run
 	// surfaces as its own errorSymbol token (parser_api.go's


### PR DESCRIPTION
Implement the private test activation seam for one compact parser session.

- Keep default and production behavior unchanged.
- Validate the active scheduler owner before historical authentication.
- Clear authentication when the fresh session exits.
- Use a pointer token for safe restore and cached runner reuse.
- Cover cached reuse, pool scrubbing, reset boundaries, and no-parsercore builds.
- Pass focused Docker gates with OOM=false.
- Keep the current fallback characterization green.
- Leave future positive RED contracts at the missing verifier telemetry and unproved historical proof seams.

This change does not add production admission, diagnostic providers, telemetry APIs, profile grants, allowlists, or suppression behavior.