### PR TITLE
Align recovery error flags with C parity

### DIFF
--- a/cgo_harness/c_error_flag_parity_test.go
+++ b/cgo_harness/c_error_flag_parity_test.go
@@ -1,0 +1,204 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestIssue454CErrorFlagFreshAndIncrementalDeepParity(t *testing.T) {
+	source := []byte("int f0(void) { int x0 = 0; return x0; }\n")
+	if len(source) != 40 {
+		t.Fatalf("minimized C witness length = %d, want 40", len(source))
+	}
+	site := bytes.Index(source, []byte("x0"))
+	if site < 0 {
+		t.Fatal("C edit marker is absent")
+	}
+	edited := append(append([]byte(nil), source[:site]...), source[site+1:]...)
+	point := issue454CErrorFlagPointAt(source, site)
+	lang := grammars.CLanguage()
+	oldTree, err := gts.NewParser(lang).Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oldTree.Release()
+	oldTree.Edit(gts.InputEdit{
+		StartByte: uint32(site), OldEndByte: uint32(site + 1), NewEndByte: uint32(site),
+		StartPoint: point, OldEndPoint: gts.Point{Row: point.Row, Column: point.Column + 1}, NewEndPoint: point,
+	})
+	incremental, _, err := gts.NewParser(lang).ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer incremental.Release()
+	fresh, err := gts.NewParser(lang).Parse(edited)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fresh.Release()
+	goFresh, err := benchfixtures.InspectGoTree(fresh.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	goIncremental, err := benchfixtures.InspectGoTree(incremental.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cLang, err := COracleLanguage("c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse(edited, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("C oracle returned no tree")
+	}
+	defer cTree.Close()
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if goFresh.SHA256 != cDigest || goIncremental.SHA256 != cDigest {
+		t.Fatalf("deep digest mismatch: fresh=%s incremental=%s C=%s", goFresh.SHA256, goIncremental.SHA256, cDigest)
+	}
+	assertIssue454ErrorChild(t, fresh.RootNode(), lang, cTree.RootNode())
+	assertIssue454ErrorChild(t, incremental.RootNode(), lang, cTree.RootNode())
+}
+
+func TestIssue454CErrorFlagNonCControls(t *testing.T) {
+	cases := []struct {
+		name   string
+		lang   *gts.Language
+		source []byte
+	}{
+		{name: "go", lang: grammars.GoLanguage(), source: []byte("package p\nfunc f() { f(1 2) }\n")},
+		{name: "javascript", lang: grammars.JavascriptLanguage(), source: []byte("function f(){return 1;}@\n")},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			tree, err := gts.NewParser(test.lang).Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tree.Release()
+			if !tree.RootNode().HasErrorOrMissing() {
+				t.Fatalf("root HasErrorOrMissing = false, want true: %s", tree.RootNode().SExpr(test.lang))
+			}
+			goDigest, err := benchfixtures.InspectGoTree(tree.RootNode(), test.lang)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cLang, err := COracleLanguage(test.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(test.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C oracle returned no tree")
+			}
+			defer cTree.Close()
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if goDigest.SHA256 != cDigest {
+				t.Fatalf("deep digest mismatch: Go=%s C=%s", goDigest.SHA256, cDigest)
+			}
+			assertIssue454ErrorChild(t, tree.RootNode(), test.lang, cTree.RootNode())
+		})
+	}
+}
+
+func assertIssue454ErrorChild(t *testing.T, goRoot *gts.Node, lang *gts.Language, cRoot *sitter.Node) {
+	t.Helper()
+	goError, goChild := issue454GoErrorWithOrdinaryChild(goRoot)
+	if goError == nil || goChild == nil {
+		t.Fatalf("no ERROR node with an ordinary child: %s", goRoot.SExpr(nil))
+	}
+	if !goError.HasError() {
+		t.Fatal("ERROR parent HasError = false, want true")
+	}
+	if goChild.HasError() {
+		t.Fatalf("ordinary ERROR child %q HasError = true, want false", goChild.Type(lang))
+	}
+	cError, cChild := issue454CErrorWithOrdinaryChild(cRoot)
+	if cError == nil || cChild == nil {
+		t.Fatal("C oracle has no matching ERROR node with an ordinary child")
+	}
+	if cError.Kind() != goError.Type(lang) || cChild.Kind() != goChild.Type(lang) ||
+		cError.StartByte() != uint(goError.StartByte()) || cError.EndByte() != uint(goError.EndByte()) ||
+		cChild.StartByte() != uint(goChild.StartByte()) || cChild.EndByte() != uint(goChild.EndByte()) {
+		t.Fatalf("ERROR child shape differs: Go=%s/%s [%d:%d]/[%d:%d] C=%s/%s [%d:%d]/[%d:%d]",
+			goError.Type(lang), goChild.Type(lang), goError.StartByte(), goError.EndByte(), goChild.StartByte(), goChild.EndByte(),
+			cError.Kind(), cChild.Kind(), cError.StartByte(), cError.EndByte(), cChild.StartByte(), cChild.EndByte())
+	}
+}
+
+func issue454GoErrorWithOrdinaryChild(root *gts.Node) (*gts.Node, *gts.Node) {
+	if root == nil {
+		return nil, nil
+	}
+	if root.IsError() {
+		for i := 0; i < root.ChildCount(); i++ {
+			child := root.Child(i)
+			if child != nil && !child.IsError() && !child.IsMissing() {
+				return root, child
+			}
+		}
+	}
+	for i := 0; i < root.ChildCount(); i++ {
+		if parent, child := issue454GoErrorWithOrdinaryChild(root.Child(i)); parent != nil {
+			return parent, child
+		}
+	}
+	return nil, nil
+}
+
+func issue454CErrorWithOrdinaryChild(root *sitter.Node) (*sitter.Node, *sitter.Node) {
+	if root == nil {
+		return nil, nil
+	}
+	if root.IsError() {
+		for i := uint(0); i < root.ChildCount(); i++ {
+			child := root.Child(i)
+			if child != nil && !child.IsError() && !child.IsMissing() {
+				return root, child
+			}
+		}
+	}
+	for i := uint(0); i < root.ChildCount(); i++ {
+		if parent, child := issue454CErrorWithOrdinaryChild(root.Child(i)); parent != nil {
+			return parent, child
+		}
+	}
+	return nil, nil
+}
+
+func issue454CErrorFlagPointAt(source []byte, offset int) gts.Point {
+	var row, column uint32
+	for _, b := range source[:offset] {
+		if b == '\n' {
+			row++
+			column = 0
+		} else {
+			column++
+		}
+	}
+	return gts.Point{Row: row, Column: column}
+}

--- a/internal/parsercorephase0/error_region.go
+++ b/internal/parsercorephase0/error_region.go
@@ -12,10 +12,8 @@ import "errors"
 // (:3948,:3596), themselves faithful ports of tree-sitter C's
 // ts_parser__recover's strategy-2 tail and ts_parser__recover_to_state. The
 // pinned C oracle is the parity arbiter (decision 0007): where the production
-// Go port's own construction diverges from the C oracle, this port follows
-// the oracle, not the Go port's literal bit -- see ErrorRegionLeaf's doc
-// comment for the one confirmed instance (finding
-// production-recovery-structural-divergence).
+// Go port's own construction differs from the C oracle, this port follows the
+// oracle's node flags. ErrorRegionLeaf documents the ordinary-token rule.
 //
 // The open error region itself is NOT a record in this file: it lives on the
 // driver's header (parsercore_phase0_driver.go), a plain Go slice of already-
@@ -36,26 +34,9 @@ import "errors"
 const ErrorRegionSymbol Symbol = 65535
 
 // ErrorRegionLeaf publishes one absorbed terminal into the compact subtree
-// arena for a driver-owned open error region.
-//
-// HasError is deliberately never stored or forced true here, even when
-// symbol is itself ErrorRegionSymbol (an unlexable byte the token source
-// could not classify as any grammar terminal). This mirrors the pinned C
-// oracle exactly, and deliberately does NOT mirror production Go's
-// cAbsorbTokenIntoError, which calls leaf.setHasError(true) unconditionally
-// on every absorbed leaf (parser_recover_c.go:3766) -- a confirmed,
-// receipted production/C divergence (finding
-// production-recovery-structural-divergence; verified byte-for-byte against
-// the locked C oracle in Docker for all ten html_erroneous_end_tag
-// witnesses: every remaining structural gap after this port's mechanism ran
-// was exactly one absorbed leaf's own HasError flag reading true in Go
-// where the C oracle reads false). The wrapping ERROR container (see
-// ErrorRegionNode) is materialization's sole per-node HasError trigger for
-// this region; ordinary ancestor propagation (populateParentNode, tree.go)
-// already ORs a true child flag up through every enclosing reduce with zero
-// additional code, so leaving every leaf false here is what makes that
-// propagation land in exactly the right place -- on the container, and only
-// the container, exactly like the C oracle.
+// arena for a driver-owned open error region. The leaf does not carry the
+// HasError flag. The enclosing ERROR node carries that recovery error, which
+// matches the pinned C oracle for ordinary absorbed terminals.
 func (c *Core) ErrorRegionLeaf(symbol Symbol, startByte, endByte uint32, extra bool) (id SubtreeID, err error) {
 	mark := c.mark()
 	defer c.completeTransaction(mark, &err)

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -4277,7 +4277,9 @@ func (p *Parser) cAbsorbTokenIntoError(v *glrStack, tok Token, nodeCount *int, a
 	if leafVisible {
 		leaf = newLeafNodeInArena(arena, tok.Symbol, tok.Symbol == errorSymbol || p.isNamedSymbol(tok.Symbol),
 			tok.StartByte, tok.EndByte, tok.StartPoint, tok.EndPoint)
-		leaf.setHasError(true)
+		// The enclosing ERROR node carries the recovery error. C does not mark
+		// an ordinary token child as erroneous merely because recovery absorbs it.
+		// Keep HasError derived from the node's own error state and descendants.
 		// C: if the token shifts as extra in state 1, mark it extra so it is
 		// not counted in error cost calculations.
 		if idx := p.lookupActionIndex(1, tok.Symbol); idx != 0 && int(idx) < len(p.language.ParseActions) {


### PR DESCRIPTION
## Summary

Align absorbed recovery leaves with the locked C error-flag rule.

- Keep ordinary absorbed token children free of `HasError`.
- Keep the enclosing `ERROR` node marked.
- Preserve fresh and incremental parser behavior.
- Keep the umbrella issue open.

## Witness

Use the exact 40-byte C witness:

```text
int f0(void) { int x0 = 0; return x0; }\n
```

The fresh and incremental Go trees match the locked C deep digest.
The test also checks the parent flag and the ordinary child flag.

Go and JavaScript controls match the locked C deep digest.

## Tests

- Focused C witness Docker test: PASS, `oom_killed=false`.
- Go control Docker test: PASS, `oom_killed=false`.
- JavaScript control Docker test: PASS, `oom_killed=false`.
- Existing Go issue 454 regression: PASS.
- WGSL atomic recovery leaf test: PASS, `oom_killed=false`.
- Single `c_lang` grammar parity: PASS, deep parity `1/1`.
- Direct changed-file Canopy analysis: PASS.
- No ratchet rows changed.

Artifacts:

- `/tmp/gts454-fix-artifacts/20260822T034445Z-issue454-all-focused-final`
- `/tmp/gts454-fix-artifacts/20260822T034339Z-issue454-go-regression-final`
- `/tmp/gts454-fix-artifacts/20260822T034726Z-issue454-wgsl-atomic-final`
- `/tmp/gts454-single-grammar-evidence/docker/20260822T034642Z-diag-c_lang`

Do not merge this pull request until the required checks pass.
