### PR TITLE
optimize(parser): reuse scratch map for recovery version ranks

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -461,6 +461,14 @@ type Parser struct {
 	// Parsers that use none of these features pay no sidecar allocation.
 	// Explicit ParseForestExperimental calls intentionally ignore this memo.
 	forestDeclineMemo *parserColdState
+	// cCondenseVersionKeyRanks is parser-owned scratch for the capped recovery
+	// version window. Parser is not safe for concurrent use, so this map needs no
+	// lock. cCondenseAndResume clears it before each qualifying pass and stores
+	// only the first cRecoverMaxVersionCount keys. The bounded map remains
+	// allocated after the first qualifying pass, but its key values are cleared
+	// at parse and snippet-parser reset boundaries to avoid retaining recovery
+	// groups from an earlier parse.
+	cCondenseVersionKeyRanks map[cCondenseVersionKey]uint8
 }
 
 var snippetParserPools sync.Map
@@ -1747,6 +1755,9 @@ func resetSnippetParser(parser *Parser) {
 	parser.cNodeMemoOperationDepth = 0
 	parser.cNodeMemoPeakTier = RecoveryNodeMemoTierNone
 	parser.cNodeMemoOperationPeakTier = RecoveryNodeMemoTierNone
+	if parser.cCondenseVersionKeyRanks != nil {
+		clear(parser.cCondenseVersionKeyRanks)
+	}
 	if cold := parser.forestDeclineMemo; cold != nil {
 		cold.cNodeMemoRetainedCache = nil
 		cold.cNodeMemoCollisions = 0
@@ -4566,6 +4577,9 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		p.mergeScratch = nil
 		p.budgetScratch = prevBudgetScratch
 		p.goCompatFrames = nil
+		if p.cCondenseVersionKeyRanks != nil {
+			clear(p.cCondenseVersionKeyRanks)
+		}
 		if p.cNodeMemoOperationDepth == 0 {
 			p.finishCNodeMemoParse()
 		}

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -4597,18 +4597,19 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token,
 		// least-promising excess keys), and leave same-key duplicates — C's
 		// merged links — to the engine's own boundary merge/cull population
 		// discipline.
-		keyRanks := make(map[cCondenseVersionKey]int, len(stacks))
+		keyRanks := p.cCondenseVersionKeyRanks
+		if keyRanks == nil {
+			keyRanks = make(map[cCondenseVersionKey]uint8, cRecoverMaxVersionCount)
+			p.cCondenseVersionKeyRanks = keyRanks
+		} else {
+			clear(keyRanks)
+		}
 		for i := 0; i < len(stacks); i++ {
 			if reason := checkStop(); reason != ParseStopNone {
 				return stacks, false, tok, reason
 			}
 			key := p.cCondenseVersionKeyFor(&stacks[i])
-			rank, seen := keyRanks[key]
-			if !seen {
-				rank = len(keyRanks)
-				keyRanks[key] = rank
-			}
-			if rank < cRecoverMaxVersionCount {
+			if cCondenseVersionRankFor(keyRanks, key) < cRecoverMaxVersionCount {
 				continue
 			}
 			if p.glrTrace {
@@ -4766,6 +4767,21 @@ type cCondenseVersionKey struct {
 	paused       bool
 	recGroup     *cRecGroup
 	missingGroup *cRecGroup
+}
+
+// cCondenseVersionRankFor returns the same cap decision as the legacy rank
+// map. It stores only ranks below the cap, because every excess rank is
+// dropped and every later copy of an excess key is dropped too.
+func cCondenseVersionRankFor(ranks map[cCondenseVersionKey]uint8, key cCondenseVersionKey) int {
+	rank, seen := ranks[key]
+	if seen {
+		return int(rank)
+	}
+	rank = uint8(len(ranks))
+	if rank < cRecoverMaxVersionCount {
+		ranks[key] = rank
+	}
+	return int(rank)
 }
 
 func (p *Parser) cCondenseVersionKeyFor(s *glrStack) cCondenseVersionKey {

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -2245,7 +2245,7 @@ func TestRecoveryMemoTelemetryPreservesAMD64HotLayouts(t *testing.T) {
 	if unsafe.Sizeof(uintptr(0)) != 8 {
 		t.Skip("amd64 layout ratchet")
 	}
-	if got, want := unsafe.Sizeof(Parser{}), uintptr(2176); got != want {
+	if got, want := unsafe.Sizeof(Parser{}), uintptr(2184); got != want {
 		t.Fatalf("Parser size = %d, want %d", got, want)
 	}
 	if got, want := unsafe.Sizeof(ParseRuntime{}), uintptr(3040); got != want {

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -2013,6 +2013,101 @@ func TestCCondenseAndResumeComparesMissingGroupStacks(t *testing.T) {
 	}
 }
 
+func TestCCondenseVersionRankScratchMatchesLegacyMap(t *testing.T) {
+	key := func(state StateID) cCondenseVersionKey {
+		return cCondenseVersionKey{state: state}
+	}
+	cases := []struct {
+		name string
+		keys []cCondenseVersionKey
+	}{
+		{
+			name: "accepted",
+			keys: []cCondenseVersionKey{key(0), key(1), key(2), key(3), key(4), key(5)},
+		},
+		{
+			name: "repeated",
+			keys: []cCondenseVersionKey{key(0), key(1), key(2), key(3), key(4), key(5), key(0), key(5), key(1)},
+		},
+		{
+			name: "excess",
+			keys: []cCondenseVersionKey{key(0), key(1), key(2), key(3), key(4), key(5), key(6), key(7)},
+		},
+		{
+			name: "repeated-excess",
+			keys: []cCondenseVersionKey{key(0), key(1), key(2), key(3), key(4), key(5), key(6), key(6), key(7), key(6), key(1), key(7)},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			legacy := make(map[cCondenseVersionKey]int, len(tc.keys))
+			scratch := make(map[cCondenseVersionKey]uint8, cRecoverMaxVersionCount)
+			for i, key := range tc.keys {
+				wantRank, seen := legacy[key]
+				if !seen {
+					wantRank = len(legacy)
+					legacy[key] = wantRank
+				}
+				gotRank := cCondenseVersionRankFor(scratch, key)
+				if (gotRank < cRecoverMaxVersionCount) != (wantRank < cRecoverMaxVersionCount) {
+					t.Fatalf("key %d rank decision = %d, want legacy rank %d", i, gotRank, wantRank)
+				}
+			}
+			if got := len(scratch); got > cRecoverMaxVersionCount {
+				t.Fatalf("scratch stored %d keys, want at most %d", got, cRecoverMaxVersionCount)
+			}
+			for i := 0; i < cRecoverMaxVersionCount; i++ {
+				if _, ok := scratch[key(StateID(i))]; !ok {
+					t.Fatalf("scratch lost accepted key %d", i)
+				}
+			}
+			for i := cRecoverMaxVersionCount; i < 8; i++ {
+				if _, ok := scratch[key(StateID(i))]; ok {
+					t.Fatalf("scratch retained excess key %d", i)
+				}
+			}
+		})
+	}
+}
+
+func TestCCondenseVersionRankScratchResetClearsKeys(t *testing.T) {
+	parser := &Parser{cCondenseVersionKeyRanks: make(map[cCondenseVersionKey]uint8, cRecoverMaxVersionCount)}
+	parser.cCondenseVersionKeyRanks[cCondenseVersionKey{state: 1}] = 0
+	resetSnippetParser(parser)
+	if got := len(parser.cCondenseVersionKeyRanks); got != 0 {
+		t.Fatalf("reset retained %d condense keys, want 0", got)
+	}
+}
+
+func TestCCondenseVersionRankScratchParseExitClearsKeys(t *testing.T) {
+	parser := NewParser(buildArithmeticLanguage())
+	parser.SetAdmissionCandidateRoute(false)
+	parser.cCondenseVersionKeyRanks = make(map[cCondenseVersionKey]uint8, cRecoverMaxVersionCount)
+	parser.cCondenseVersionKeyRanks[cCondenseVersionKey{state: 1}] = 0
+	tree, err := parser.Parse([]byte("1 + 2"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if tree == nil {
+		t.Fatal("parse returned nil tree")
+	}
+	tree.Release()
+	if got := len(parser.cCondenseVersionKeyRanks); got != 0 {
+		t.Fatalf("parse exit retained %d condense keys, want 0", got)
+	}
+}
+
+func TestCCondenseVersionRankScratchLayout(t *testing.T) {
+	var parser Parser
+	parserSize := unsafe.Sizeof(parser)
+	scratchOffset := unsafe.Offsetof(parser.cCondenseVersionKeyRanks)
+	scratchSize := unsafe.Sizeof(parser.cCondenseVersionKeyRanks)
+	if scratchOffset+scratchSize != parserSize {
+		t.Fatalf("condense rank scratch is not at Parser tail: offset=%d size=%d parser_size=%d", scratchOffset, scratchSize, parserSize)
+	}
+	t.Logf("P23_LAYOUT parser_size=%d scratch_offset=%d scratch_size=%d key_size=%d rank_size=%d", parserSize, scratchOffset, scratchSize, unsafe.Sizeof(cCondenseVersionKey{}), unsafe.Sizeof(uint8(0)))
+}
+
 func collidingCNodeMemoNodes(t *testing.T, setCount int) (*Node, *Node, *Node) {
 	t.Helper()
 	nodes := make([]Node, setCount*2+1)


### PR DESCRIPTION
## Summary

- Reuse a parser-owned map for the capped recovery version ranks.
- Store at most six distinct keys and drop excess keys without insertion.
- Clear the map at condense, parse-exit, and snippet-parser reset boundaries.
- Keep the scratch map at the Parser tail.

## Layout cost

- The tail map adds 8 bytes to `Parser` on amd64.
- `Parser` grows from 2176 to 2184 bytes.
- Existing hot field offsets remain unchanged.
- `TestRecoveryMemoTelemetryPreservesAMD64HotLayouts` now ratchets 2184 bytes.
- `TestCCondenseVersionRankScratchLayout` asserts the map remains at the Parser tail without architecture-specific offsets.

## Verification

- Focused host and Docker tests passed.
- C# switch-tuple parity passed.
- Swift witness #586 locked-C parity passed.
- Primary 20-seed time geomean improved 3.67%.
- Full-parse B/op improved 10.88%.
- Early and recovery allocation counts improved 4.28% and 47.90%.
- Matched early and recovery RSS fell 12.87%.
- All final Docker receipts exited zero with `oom_killed=false`.

## Attribution

Separate allocation profiles show the flat `cCondenseAndResume` allocation falling from 53,736 KiB to 54 KiB. Other recovery allocation variance masks part of the total saving. Swift #586 wall time is neutral and noisy. This PR advances P23 but does not close #586.

The signed evidence packet is recorded at `/tmp/gts-p23-evidence/p23-final-packet.txt` with its detached signature and public key. Do not merge this pull request without root review.