### PR TITLE
Add authenticated compact drop frontiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Added
+
+- Add the default-off authenticated D6a drop-cohort frontier producer. It
+  binds the scheduler owner and epoch, the election token and scanner
+  checkpoints, the ordered participants, the action identity, the derivation
+  bytes, digest, and checkpoint, and a seal. D6a does not enable admission,
+  history, or verification.
+
 ### Removed
 
 - Swift ternary expressions now come directly from the regenerated grammar

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -129,6 +129,8 @@ func (p *Parser) DiagnosticEnableDropCohortCertificateAdmissionForTest() func() 
 		return func() {}
 	}
 	token := &dropCohortActivationToken{marker: 1}
+	runner.frontierRecordingEnabled = false
+	runner.options.recordDropCohortFrontiers = false
 	runner.certificateAdmissionToken = token
 	runner.certificateAdmissionEnabled = true
 	restored := false
@@ -142,8 +144,10 @@ func (p *Parser) DiagnosticEnableDropCohortCertificateAdmissionForTest() func() 
 			return
 		}
 		cached.certificateAdmissionEnabled = false
+		cached.frontierRecordingEnabled = false
 		cached.certificateAdmissionToken = nil
 		cached.options.recordDropCohortCertificates = false
+		cached.options.recordDropCohortFrontiers = false
 	}
 }
 

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -1,8 +1,8 @@
 # Compact route real-corpus matrix
 
-Current evidence date: 2026-07-30.
-Current base commit: `83548f55` from `main`.
-Current candidate base commit: `44e0a0fc`.
+Current evidence date: 2026-08-22.
+Current base commit: `69d5ccaf` from `main`.
+Current candidate base commit: `69d5ccaf`.
 
 ## Current bounded result
 
@@ -23,6 +23,51 @@ The AWK medium file needs a separate slow-path budget.
 
 The direct route served 64 percent of the selected files.
 Production served every fallback and every ineligible file.
+
+## D6a producer evidence
+
+D6a publishes an authenticated drop-cohort frontier with the feature disabled
+by default. It does not enable route admission, frontier history, or frontier
+verification. The bounded matrix counts above remain unchanged because D6a is
+producer-only.
+
+The isolated Docker targets accepted these published and member counts:
+
+| Grammar | Target | Published/member | Route | Natural fallback |
+|---|---|---:|---:|---|
+| Go | `query_compile` | 2/6 | 0/1 | Unchanged |
+| Go | `rewrite` | 2/6 | 0/1 | Unchanged |
+| Go | `language` | 2/2 | 0/1 | Unchanged |
+| Go | `grammargen_lr` | 2/2 | 0/1 | Unchanged |
+| Erlang | `macro_function_clauses` | 8/26 | 0/1 | Unchanged |
+| Erlang | `macro_expanded_top_level_function` | 3/6 | 0/1 | Unchanged |
+| Haskell | `smoke` | 2/2 | 0/1 | Unchanged |
+| JavaScript | `functions` | 2/8 | 0/1 | Unchanged |
+| Bash | `converged_split` | 4/24 | 0/1 | Unchanged |
+
+The gate fixed complete frontier byte accounting and stale-token transaction
+poisoning.
+It ran 10 internal tests. The root and no-core gates passed.
+The final Docker artifacts span `20260822T065000Z` through
+`20260822T065433Z`.
+
+### Interleaved performance receipt
+
+The accepted receipt uses 20 interleaved seeds and the primary benchmark trio.
+
+| Benchmark | Candidate versus base | Probability |
+|---|---:|---:|
+| Full parse | -3.01% | `p=0.678` |
+| Incremental single-byte edit | -1.09% | `p=0.758` |
+| Incremental no-edit | +7.34% | `p=0.910` |
+| Geomean | +0.97% | — |
+
+Full-parse bytes per operation changed by -3.10 percent.
+Allocation counts remained unchanged.
+Discard the earlier sequential full-set comparison because unrelated host
+tests overlapped the candidate run.
+
+This receipt does not graduate the route and does not verify D6b.
 
 ## Current fallback taxonomy
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -928,6 +928,9 @@ type Core struct {
 	dropCohortCertificateRefs      []DropCohortRef
 	dropCohortMapStore             []dropCohortMapEntry
 	dropCohortJournalStore         []dropCohortJournalStoreEntry
+	dropCohortFrontiers            []dropCohortFrontierRecord
+	dropCohortFrontierParticipants []dropCohortFrontierParticipant
+	dropCohortFrontierMembers      []dropCohortFrontierMember
 	dropCohortDerivationScratch    []byte
 	dropCohortPathScratch          []dropCohortPathStep
 	dropCohortEphemeralBytes       uint64
@@ -936,6 +939,7 @@ type Core struct {
 	dropCohortOwner                uint64
 	dropCohortEpoch                uint64
 	dropCohortNextSequence         uint64
+	dropCohortFrontierNextSequence uint64
 	dropCohortProducerWrites       [dropCohortProducerCount]uint64
 	dropCohortAuthenticatedHistory uint64
 	dropCohortUnprovedHistory      uint64
@@ -1082,9 +1086,13 @@ type checkpoint struct {
 	dropCohortCertificateRefs                                                 int
 	dropCohortMapStore                                                        int
 	dropCohortJournalStore                                                    int
+	dropCohortFrontiers                                                       int
+	dropCohortFrontierParticipants                                            int
+	dropCohortFrontierMembers                                                 int
 	dropCohortEphemeralBytes                                                  uint64
 	dropCohortJournal                                                         int
 	dropCohortNextSequence                                                    uint64
+	dropCohortFrontierNextSequence                                            uint64
 	dropCohortProducerWrites                                                  [dropCohortProducerCount]uint64
 	dropCohortAuthenticatedHistory                                            uint64
 	dropCohortUnprovedHistory                                                 uint64
@@ -1124,6 +1132,9 @@ type checkpoint struct {
 	dropCohortCertificateRefsHeader                                           []DropCohortRef
 	dropCohortMapStoreHeader                                                  []dropCohortMapEntry
 	dropCohortJournalStoreHeader                                              []dropCohortJournalStoreEntry
+	dropCohortFrontiersHeader                                                 []dropCohortFrontierRecord
+	dropCohortFrontierParticipantsHeader                                      []dropCohortFrontierParticipant
+	dropCohortFrontierMembersHeader                                           []dropCohortFrontierMember
 	dropCohortJournalHeader                                                   []dropCohortMutation
 	dropCohortReservationsHeader                                              []dropCohortReservation
 	transaction                                                               uint64
@@ -1171,65 +1182,72 @@ func (c *Core) markInto(mark *checkpoint) {
 		externalProvenance: len(c.externalProvenance),
 		children:           len(c.children), fields: len(c.fields), aliases: len(c.aliases),
 		frontier: c.frontier, checkpoint: c.checkpoint,
-		boundaryIndex:                    c.boundaries.snapshot(),
-		journal:                          len(c.boundaryJournal),
-		nodeLineageJournal:               len(c.nodeLineageJournal),
-		dropCohortRefSpill:               len(c.dropCohortRefSpill),
-		dropCohortActions:                len(c.dropCohortActions),
-		dropCohortRecords:                len(c.dropCohortRecords),
-		dropCohortMembers:                len(c.dropCohortMembers),
-		dropCohortDerivations:            len(c.dropCohortDerivations),
-		dropCohortDerivationIntern:       len(c.dropCohortDerivationIntern),
-		dropCohortDerivationBytes:        len(c.dropCohortDerivationBytes),
-		dropCohortCertificateRefs:        len(c.dropCohortCertificateRefs),
-		dropCohortMapStore:               len(c.dropCohortMapStore),
-		dropCohortJournalStore:           len(c.dropCohortJournalStore),
-		dropCohortEphemeralBytes:         c.dropCohortEphemeralBytes,
-		dropCohortJournal:                len(c.dropCohortJournal),
-		dropCohortNextSequence:           c.dropCohortNextSequence,
-		dropCohortProducerWrites:         c.dropCohortProducerWrites,
-		dropCohortAuthenticatedHistory:   c.dropCohortAuthenticatedHistory,
-		dropCohortUnprovedHistory:        c.dropCohortUnprovedHistory,
-		dropCohortOwnerCheckedLookups:    c.dropCohortOwnerCheckedLookups,
-		dropCohortVerifierElections:      c.dropCohortVerifierElections,
-		dropCohortVerifierProofs:         c.dropCohortVerifierProofs,
-		dropCohortVerifierDeclines:       c.dropCohortVerifierDeclines,
-		dropCohortActionDeclines:         c.dropCohortActionDeclines,
-		dropCohortDerivationDeclines:     c.dropCohortDerivationDeclines,
-		dropCohortDeclineReasons:         c.dropCohortDeclineReasons,
-		dropCohortInlineReads:            c.dropCohortInlineReads,
-		dropCohortSpillReads:             c.dropCohortSpillReads,
-		dropCohortMapReads:               c.dropCohortMapReads,
-		dropCohortInternerReads:          c.dropCohortInternerReads,
-		dropCohortReservations:           len(c.dropCohortReservations),
-		dropCohortReserved:               c.dropCohortReserved,
-		dropCohortReservedBytes:          c.dropCohortReservedBytes,
-		dropCohortRefSpillCap:            cap(c.dropCohortRefSpill),
-		dropCohortActionsCap:             cap(c.dropCohortActions),
-		dropCohortRecordsCap:             cap(c.dropCohortRecords),
-		dropCohortMembersCap:             cap(c.dropCohortMembers),
-		dropCohortDerivationsCap:         cap(c.dropCohortDerivations),
-		dropCohortDerivationInternCap:    cap(c.dropCohortDerivationIntern),
-		dropCohortDerivationBytesCap:     cap(c.dropCohortDerivationBytes),
-		dropCohortCertificateRefsCap:     cap(c.dropCohortCertificateRefs),
-		dropCohortMapStoreCap:            cap(c.dropCohortMapStore),
-		dropCohortJournalStoreCap:        cap(c.dropCohortJournalStore),
-		dropCohortJournalCap:             cap(c.dropCohortJournal),
-		dropCohortReservationsCap:        cap(c.dropCohortReservations),
-		dropCohortRefSpillHeader:         c.dropCohortRefSpill,
-		dropCohortActionsHeader:          c.dropCohortActions,
-		dropCohortRecordsHeader:          c.dropCohortRecords,
-		dropCohortMembersHeader:          c.dropCohortMembers,
-		dropCohortDerivationsHeader:      c.dropCohortDerivations,
-		dropCohortDerivationInternHeader: c.dropCohortDerivationIntern,
-		dropCohortDerivationBytesHeader:  c.dropCohortDerivationBytes,
-		dropCohortCertificateRefsHeader:  c.dropCohortCertificateRefs,
-		dropCohortMapStoreHeader:         c.dropCohortMapStore,
-		dropCohortJournalStoreHeader:     c.dropCohortJournalStore,
-		dropCohortJournalHeader:          c.dropCohortJournal,
-		dropCohortReservationsHeader:     c.dropCohortReservations,
-		transaction:                      c.nextTransaction,
-		work:                             c.work,
+		boundaryIndex:                        c.boundaries.snapshot(),
+		journal:                              len(c.boundaryJournal),
+		nodeLineageJournal:                   len(c.nodeLineageJournal),
+		dropCohortRefSpill:                   len(c.dropCohortRefSpill),
+		dropCohortActions:                    len(c.dropCohortActions),
+		dropCohortRecords:                    len(c.dropCohortRecords),
+		dropCohortMembers:                    len(c.dropCohortMembers),
+		dropCohortDerivations:                len(c.dropCohortDerivations),
+		dropCohortDerivationIntern:           len(c.dropCohortDerivationIntern),
+		dropCohortDerivationBytes:            len(c.dropCohortDerivationBytes),
+		dropCohortCertificateRefs:            len(c.dropCohortCertificateRefs),
+		dropCohortMapStore:                   len(c.dropCohortMapStore),
+		dropCohortJournalStore:               len(c.dropCohortJournalStore),
+		dropCohortFrontiers:                  len(c.dropCohortFrontiers),
+		dropCohortFrontierParticipants:       len(c.dropCohortFrontierParticipants),
+		dropCohortFrontierMembers:            len(c.dropCohortFrontierMembers),
+		dropCohortEphemeralBytes:             c.dropCohortEphemeralBytes,
+		dropCohortJournal:                    len(c.dropCohortJournal),
+		dropCohortNextSequence:               c.dropCohortNextSequence,
+		dropCohortFrontierNextSequence:       c.dropCohortFrontierNextSequence,
+		dropCohortProducerWrites:             c.dropCohortProducerWrites,
+		dropCohortAuthenticatedHistory:       c.dropCohortAuthenticatedHistory,
+		dropCohortUnprovedHistory:            c.dropCohortUnprovedHistory,
+		dropCohortOwnerCheckedLookups:        c.dropCohortOwnerCheckedLookups,
+		dropCohortVerifierElections:          c.dropCohortVerifierElections,
+		dropCohortVerifierProofs:             c.dropCohortVerifierProofs,
+		dropCohortVerifierDeclines:           c.dropCohortVerifierDeclines,
+		dropCohortActionDeclines:             c.dropCohortActionDeclines,
+		dropCohortDerivationDeclines:         c.dropCohortDerivationDeclines,
+		dropCohortDeclineReasons:             c.dropCohortDeclineReasons,
+		dropCohortInlineReads:                c.dropCohortInlineReads,
+		dropCohortSpillReads:                 c.dropCohortSpillReads,
+		dropCohortMapReads:                   c.dropCohortMapReads,
+		dropCohortInternerReads:              c.dropCohortInternerReads,
+		dropCohortReservations:               len(c.dropCohortReservations),
+		dropCohortReserved:                   c.dropCohortReserved,
+		dropCohortReservedBytes:              c.dropCohortReservedBytes,
+		dropCohortRefSpillCap:                cap(c.dropCohortRefSpill),
+		dropCohortActionsCap:                 cap(c.dropCohortActions),
+		dropCohortRecordsCap:                 cap(c.dropCohortRecords),
+		dropCohortMembersCap:                 cap(c.dropCohortMembers),
+		dropCohortDerivationsCap:             cap(c.dropCohortDerivations),
+		dropCohortDerivationInternCap:        cap(c.dropCohortDerivationIntern),
+		dropCohortDerivationBytesCap:         cap(c.dropCohortDerivationBytes),
+		dropCohortCertificateRefsCap:         cap(c.dropCohortCertificateRefs),
+		dropCohortMapStoreCap:                cap(c.dropCohortMapStore),
+		dropCohortJournalStoreCap:            cap(c.dropCohortJournalStore),
+		dropCohortJournalCap:                 cap(c.dropCohortJournal),
+		dropCohortReservationsCap:            cap(c.dropCohortReservations),
+		dropCohortRefSpillHeader:             c.dropCohortRefSpill,
+		dropCohortActionsHeader:              c.dropCohortActions,
+		dropCohortRecordsHeader:              c.dropCohortRecords,
+		dropCohortMembersHeader:              c.dropCohortMembers,
+		dropCohortDerivationsHeader:          c.dropCohortDerivations,
+		dropCohortDerivationInternHeader:     c.dropCohortDerivationIntern,
+		dropCohortDerivationBytesHeader:      c.dropCohortDerivationBytes,
+		dropCohortCertificateRefsHeader:      c.dropCohortCertificateRefs,
+		dropCohortMapStoreHeader:             c.dropCohortMapStore,
+		dropCohortJournalStoreHeader:         c.dropCohortJournalStore,
+		dropCohortFrontiersHeader:            c.dropCohortFrontiers,
+		dropCohortFrontierParticipantsHeader: c.dropCohortFrontierParticipants,
+		dropCohortFrontierMembersHeader:      c.dropCohortFrontierMembers,
+		dropCohortJournalHeader:              c.dropCohortJournal,
+		dropCohortReservationsHeader:         c.dropCohortReservations,
+		transaction:                          c.nextTransaction,
+		work:                                 c.work,
 	}
 	c.transactions = append(c.transactions, mark.transaction)
 	parent := uint64(0)
@@ -1304,11 +1322,15 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 	c.dropCohortCertificateRefs = mark.dropCohortCertificateRefsHeader
 	c.dropCohortMapStore = mark.dropCohortMapStoreHeader
 	c.dropCohortJournalStore = mark.dropCohortJournalStoreHeader
+	c.dropCohortFrontiers = mark.dropCohortFrontiersHeader
+	c.dropCohortFrontierParticipants = mark.dropCohortFrontierParticipantsHeader
+	c.dropCohortFrontierMembers = mark.dropCohortFrontierMembersHeader
 	c.dropCohortDerivationScratch = c.dropCohortDerivationScratch[:0]
 	c.dropCohortPathScratch = c.dropCohortPathScratch[:0]
 	c.dropCohortEphemeralBytes = mark.dropCohortEphemeralBytes
 	c.dropCohortJournal = mark.dropCohortJournalHeader
 	c.dropCohortNextSequence = mark.dropCohortNextSequence
+	c.dropCohortFrontierNextSequence = mark.dropCohortFrontierNextSequence
 	c.dropCohortProducerWrites = mark.dropCohortProducerWrites
 	c.dropCohortAuthenticatedHistory = mark.dropCohortAuthenticatedHistory
 	c.dropCohortUnprovedHistory = mark.dropCohortUnprovedHistory
@@ -1714,12 +1736,16 @@ func (c *Core) Reset() error {
 	c.dropCohortCertificateRefs = c.dropCohortCertificateRefs[:0]
 	c.dropCohortMapStore = c.dropCohortMapStore[:0]
 	c.dropCohortJournalStore = c.dropCohortJournalStore[:0]
+	c.dropCohortFrontiers = c.dropCohortFrontiers[:0]
+	c.dropCohortFrontierParticipants = c.dropCohortFrontierParticipants[:0]
+	c.dropCohortFrontierMembers = c.dropCohortFrontierMembers[:0]
 	c.dropCohortDerivationScratch = c.dropCohortDerivationScratch[:0]
 	c.dropCohortPathScratch = c.dropCohortPathScratch[:0]
 	c.dropCohortEphemeralBytes = 0
 	c.dropCohortEphemeralPeak = 0
 	c.dropCohortJournal = c.dropCohortJournal[:0]
 	c.dropCohortNextSequence = 0
+	c.dropCohortFrontierNextSequence = 0
 	clear(c.dropCohortProducerWrites[:])
 	c.dropCohortAuthenticatedHistory = 0
 	c.dropCohortUnprovedHistory = 0
@@ -2022,6 +2048,15 @@ func (c *Core) InternCheckpoint(serialized []byte) (CheckpointID, error) {
 // serialized storage.
 func (c *Core) CheckpointReceipt(id CheckpointID) (uint32, [32]byte, bool) {
 	if c == nil {
+		return 0, [32]byte{}, false
+	}
+	return c.checkpoints.receipt(id)
+}
+
+// CheckpointReceiptOwned resolves one checkpoint only under the active
+// scheduler token. Callers use it before reading checkpoint interner state.
+func (c *Core) CheckpointReceiptOwned(owner SchedulerTransactionToken, id CheckpointID) (uint32, [32]byte, bool) {
+	if c == nil || c.validateSchedulerTransaction(owner) != nil {
 		return 0, [32]byte{}, false
 	}
 	return c.checkpoints.receipt(id)

--- a/internal/parsercorephase0/drop_cohort_arena.go
+++ b/internal/parsercorephase0/drop_cohort_arena.go
@@ -346,6 +346,9 @@ func (c *Core) dropCohortStoreBytes() uint64 {
 		uint64(len(c.dropCohortCertificateRefs))*uint64(coreDropCohortRefBytes) +
 		uint64(len(c.dropCohortMapStore))*uint64(coreDropCohortMapEntryBytes) +
 		uint64(len(c.dropCohortJournalStore))*uint64(coreDropCohortJournalStoreBytes) +
+		uint64(len(c.dropCohortFrontiers))*coreDropCohortFrontierRecordBytes +
+		uint64(len(c.dropCohortFrontierParticipants))*coreDropCohortFrontierParticipantBytes +
+		uint64(len(c.dropCohortFrontierMembers))*coreDropCohortFrontierMemberBytes +
 		uint64(len(c.dropCohortReservations))*uint64(coreDropCohortReservationBytes) +
 		uint64(len(c.dropCohortJournal))*uint64(coreDropCohortMutationBytes)
 }
@@ -404,7 +407,31 @@ func (c *Core) dropCohortRetainedOtherBytes() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return dropCohortAddChecked(journal, reservations)
+	frontiers, err := dropCohortMulChecked(uint64(cap(c.dropCohortFrontiers)), coreDropCohortFrontierRecordBytes)
+	if err != nil {
+		return 0, err
+	}
+	participants, err := dropCohortMulChecked(uint64(cap(c.dropCohortFrontierParticipants)), coreDropCohortFrontierParticipantBytes)
+	if err != nil {
+		return 0, err
+	}
+	members, err := dropCohortMulChecked(uint64(cap(c.dropCohortFrontierMembers)), coreDropCohortFrontierMemberBytes)
+	if err != nil {
+		return 0, err
+	}
+	retained, err := dropCohortAddChecked(journal, reservations)
+	if err != nil {
+		return 0, err
+	}
+	retained, err = dropCohortAddChecked(retained, frontiers)
+	if err != nil {
+		return 0, err
+	}
+	retained, err = dropCohortAddChecked(retained, participants)
+	if err != nil {
+		return 0, err
+	}
+	return dropCohortAddChecked(retained, members)
 }
 
 func (c *Core) dropCohortStoreGrowthBytes(index int, demand, derivationBytes uint64) (uint64, error) {
@@ -2339,9 +2366,7 @@ func (c *Core) FinalizeDropCohortOwned(owner SchedulerTransactionToken, cohort D
 	return refs, err
 }
 
-// DropCohortRefForBranch returns one finalized reference for a scheduler
-// output header. It performs no arena mutation.
-func (c *Core) DropCohortRefForBranch(cohort DropCohortHandle, branch uint16) (DropCohortRef, error) {
+func (c *Core) dropCohortRefForBranch(cohort DropCohortHandle, branch uint16) (DropCohortRef, error) {
 	index, err := c.validateDropCohortIdentity(cohort)
 	if err != nil {
 		return DropCohortRef{}, err
@@ -2354,6 +2379,21 @@ func (c *Core) DropCohortRefForBranch(cohort DropCohortHandle, branch uint16) (D
 		return DropCohortRef{}, fmt.Errorf("parser-core phase zero: drop-cohort branch %d is absent", branch)
 	}
 	return DropCohortRef{Owner: cohort.Owner, Epoch: cohort.Epoch, Sequence: cohort.Sequence, Branch: branch}, nil
+}
+
+// DropCohortRefForBranch returns one finalized reference for a scheduler
+// output header. It performs no arena mutation.
+func (c *Core) DropCohortRefForBranch(cohort DropCohortHandle, branch uint16) (DropCohortRef, error) {
+	return c.dropCohortRefForBranch(cohort, branch)
+}
+
+// DropCohortRefForBranchOwned reads one finalized branch only under the
+// active scheduler token. It validates ownership before the cohort store read.
+func (c *Core) DropCohortRefForBranchOwned(owner SchedulerTransactionToken, cohort DropCohortHandle, branch uint16) (DropCohortRef, error) {
+	if c == nil || c.validateSchedulerTransaction(owner) != nil {
+		return DropCohortRef{}, errors.New("parser-core phase zero: drop-cohort branch owner mismatch")
+	}
+	return c.dropCohortRefForBranch(cohort, branch)
 }
 
 // DropCohortState returns one cohort's producer state and counts.
@@ -2379,9 +2419,7 @@ func (c *Core) DropCohortAction(handle DropCohortHandle) (DropCohortActionIdenti
 	return c.dropCohortActions[actionIndex], true
 }
 
-// DropCohortDerivationRecord returns the immutable record metadata and its
-// canonical bytes. The byte slice aliases the Core and is read-only.
-func (c *Core) DropCohortDerivationRecord(handle DropCohortDerivationHandle) (DropCohortDerivationRecord, bool) {
+func (c *Core) dropCohortDerivationRecord(handle DropCohortDerivationHandle) (DropCohortDerivationRecord, bool) {
 	if c == nil || handle.Owner != c.dropCohortOwner || handle.Epoch != c.dropCohortEpoch || handle.Index == 0 || uint64(handle.Index) > uint64(len(c.dropCohortDerivations)) {
 		return DropCohortDerivationRecord{}, false
 	}
@@ -2396,6 +2434,21 @@ func (c *Core) DropCohortDerivationRecord(handle DropCohortDerivationHandle) (Dr
 		RootSymbol: record.rootSymbol, StackDepth: record.stackDepth,
 		Checkpoint: record.checkpoint, Bytes: c.dropCohortDerivationBytes[start:end],
 	}, true
+}
+
+// DropCohortDerivationRecord returns the immutable record metadata and its
+// canonical bytes. The byte slice aliases the Core and is read-only.
+func (c *Core) DropCohortDerivationRecord(handle DropCohortDerivationHandle) (DropCohortDerivationRecord, bool) {
+	return c.dropCohortDerivationRecord(handle)
+}
+
+// dropCohortDerivationRecordOwned reads derivation storage only under the
+// active scheduler token. Frontier verification uses this private adapter.
+func (c *Core) dropCohortDerivationRecordOwned(owner SchedulerTransactionToken, handle DropCohortDerivationHandle) (DropCohortDerivationRecord, bool) {
+	if c == nil || c.validateSchedulerTransaction(owner) != nil {
+		return DropCohortDerivationRecord{}, false
+	}
+	return c.dropCohortDerivationRecord(handle)
 }
 
 // DropCohortDerivationRecord is a read-only view of one graph derivation.

--- a/internal/parsercorephase0/drop_cohort_frontier.go
+++ b/internal/parsercorephase0/drop_cohort_frontier.go
@@ -1,0 +1,952 @@
+package parsercorephase0
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+)
+
+// DropCohortFrontierHandle identifies one authenticated scheduler frontier.
+// The owner and epoch are checked before the sequence is read.
+type DropCohortFrontierHandle struct {
+	Owner    uint64
+	Epoch    uint64
+	Sequence uint64
+}
+
+// DropCohortFrontierToken is the immutable token receipt bound to one
+// frontier. Checkpoint digests are checked against the Core interner.
+type DropCohortFrontierToken struct {
+	Symbol               Symbol
+	StartByte            uint32
+	EndByte              uint32
+	StartRow             uint32
+	StartColumn          uint32
+	EndRow               uint32
+	EndColumn            uint32
+	NoLookahead          bool
+	Missing              bool
+	ExternalScannerToken bool
+	ScannerBefore        CheckpointID
+	ScannerAfter         CheckpointID
+	ScannerBeforeDigest  [32]byte
+	ScannerAfterDigest   [32]byte
+}
+
+// DropCohortFrontierState describes one frontier producer lifecycle.
+type DropCohortFrontierState uint8
+
+const (
+	DropCohortFrontierBuilding DropCohortFrontierState = iota + 1
+	DropCohortFrontierComplete
+	DropCohortFrontierOverflowed
+	DropCohortFrontierIncomplete
+)
+
+const (
+	dropCohortFrontierParticipantHardCap = dropCohortRefHardCap
+	dropCohortFrontierMemberHardCap      = dropCohortRefHardCap * dropCohortRefHardCap
+)
+
+type dropCohortFrontierParticipant struct {
+	head           Head
+	branchOrder    uint64
+	memberStart    uint32
+	memberCount    uint16
+	referenceFlags uint8
+}
+
+type dropCohortFrontierMember struct {
+	participant          uint16
+	ref                  DropCohortRef
+	participantHead      Head
+	sourceHead           Head
+	branchOrder          uint64
+	action               DropCohortActionIdentity
+	derivation           DropCohortDerivationHandle
+	derivationDigest     [32]byte
+	derivationLength     uint32
+	derivationRootSymbol Symbol
+	derivationStackDepth uint32
+	derivationCheckpoint DropCohortSourceCheckpoint
+}
+
+type dropCohortFrontierRecord struct {
+	handle               DropCohortFrontierHandle
+	electionSequence     uint64
+	token                DropCohortFrontierToken
+	state                DropCohortFrontierState
+	expectedParticipants uint16
+	writtenParticipants  uint16
+	expectedMembers      uint32
+	writtenMembers       uint32
+	participantStart     uint32
+	memberStart          uint32
+	seal                 [32]byte
+}
+
+func dropCohortFrontierProtocolHandle(handle DropCohortFrontierHandle) [3]uint64 {
+	return [3]uint64{handle.Owner, handle.Epoch, handle.Sequence}
+}
+
+func dropCohortFrontierProtocolState(state DropCohortFrontierState) string {
+	switch state {
+	case DropCohortFrontierBuilding:
+		return "building"
+	case DropCohortFrontierComplete:
+		return "complete"
+	case DropCohortFrontierOverflowed:
+		return "overflowed"
+	case DropCohortFrontierIncomplete:
+		return "incomplete"
+	default:
+		return "unknown"
+	}
+}
+
+func (c *Core) validateDropCohortFrontierIdentity(handle DropCohortFrontierHandle) (int, error) {
+	if c == nil || c.dropCohortOwner == 0 || c.dropCohortEpoch == 0 {
+		return -1, errors.New("parser-core phase zero: frontier arena identity is unavailable")
+	}
+	// Count the attempted identity check before comparing it. Do not read the
+	// frontier record until owner and epoch checks have passed.
+	c.dropCohortOwnerCheckedLookups++
+	if handle.Owner != c.dropCohortOwner {
+		return -1, errors.New("parser-core phase zero: frontier owner mismatch")
+	}
+	if handle.Epoch != c.dropCohortEpoch {
+		return -1, errors.New("parser-core phase zero: frontier epoch mismatch")
+	}
+	if handle.Sequence == 0 {
+		return -1, errors.New("parser-core phase zero: zero frontier sequence")
+	}
+	index := handle.Sequence - 1
+	if index < uint64(len(c.dropCohortFrontiers)) && c.dropCohortFrontiers[index].handle.Sequence == handle.Sequence {
+		return int(index), nil
+	}
+	return -1, errors.New("parser-core phase zero: unknown frontier sequence")
+}
+
+func (c *Core) dropCohortFrontierTokenValid(owner SchedulerTransactionToken, token DropCohortFrontierToken) bool {
+	if c == nil || c.validateSchedulerTransaction(owner) != nil {
+		return false
+	}
+	_, before, beforeOK := c.CheckpointReceiptOwned(owner, token.ScannerBefore)
+	_, after, afterOK := c.CheckpointReceiptOwned(owner, token.ScannerAfter)
+	return beforeOK && afterOK && before == token.ScannerBeforeDigest && after == token.ScannerAfterDigest
+}
+
+func (c *Core) dropCohortFrontierWithinByteLimit(additionalRecords, additionalParticipants, additionalMembers int) bool {
+	if c == nil || additionalRecords < 0 || additionalParticipants < 0 || additionalMembers < 0 {
+		return false
+	}
+	recordBytes, err := dropCohortMulChecked(uint64(additionalRecords), coreDropCohortFrontierRecordBytes)
+	if err != nil {
+		return false
+	}
+	participantBytes, err := dropCohortMulChecked(uint64(additionalParticipants), coreDropCohortFrontierParticipantBytes)
+	if err != nil {
+		return false
+	}
+	memberBytes, err := dropCohortMulChecked(uint64(additionalMembers), coreDropCohortFrontierMemberBytes)
+	if err != nil {
+		return false
+	}
+	additional, err := dropCohortAddChecked(recordBytes, participantBytes)
+	if err != nil {
+		return false
+	}
+	additional, err = dropCohortAddChecked(additional, memberBytes)
+	if err != nil {
+		return false
+	}
+	current := c.dropCohortStoreBytes()
+	return current <= c.limits.MaxDropCohortBytes && additional <= c.limits.MaxDropCohortBytes-current
+}
+
+// dropCohortFrontierReserveCapacity reserves the exact capacities needed by
+// one frontier append sequence. It checks all retained drop-cohort storage
+// before replacing any backing array, so a cap failure cannot grow a store.
+func (c *Core) dropCohortFrontierReserveCapacity(additionalRecords, additionalParticipants, additionalMembers int) error {
+	if c == nil || additionalRecords < 0 || additionalParticipants < 0 || additionalMembers < 0 {
+		return errors.New("parser-core phase zero: frontier capacity demand is invalid")
+	}
+	maxInt := uint64(^uint(0) >> 1)
+	records := uint64(len(c.dropCohortFrontiers)) + uint64(additionalRecords)
+	participants := uint64(len(c.dropCohortFrontierParticipants)) + uint64(additionalParticipants)
+	members := uint64(len(c.dropCohortFrontierMembers)) + uint64(additionalMembers)
+	if records > maxInt || participants > maxInt || members > maxInt {
+		return errors.New("parser-core phase zero: frontier capacity overflow")
+	}
+
+	retained, err := c.dropCohortRetainedOtherBytes()
+	if err != nil {
+		return err
+	}
+	for _, value := range c.dropCohortRetainedStoreBytes() {
+		retained, err = dropCohortAddChecked(retained, value)
+		if err != nil {
+			return err
+		}
+	}
+	retained, err = dropCohortAddChecked(retained, c.dropCohortReservedBytes)
+	if err != nil {
+		return err
+	}
+
+	targets := [...]uint64{records, participants, members}
+	caps := [...]int{cap(c.dropCohortFrontiers), cap(c.dropCohortFrontierParticipants), cap(c.dropCohortFrontierMembers)}
+	elements := [...]uint64{coreDropCohortFrontierRecordBytes, coreDropCohortFrontierParticipantBytes, coreDropCohortFrontierMemberBytes}
+	for index, target := range targets {
+		if target <= uint64(caps[index]) {
+			continue
+		}
+		additionalCapacity := target - uint64(caps[index])
+		additionalBytes, mulErr := dropCohortMulChecked(additionalCapacity, elements[index])
+		if mulErr != nil {
+			return mulErr
+		}
+		retained, err = dropCohortAddChecked(retained, additionalBytes)
+		if err != nil {
+			return err
+		}
+	}
+	if retained > c.limits.MaxDropCohortBytes {
+		return errors.New("parser-core phase zero: frontier byte cap")
+	}
+
+	if uint64(cap(c.dropCohortFrontiers)) < records {
+		grown := make([]dropCohortFrontierRecord, len(c.dropCohortFrontiers), int(records))
+		copy(grown, c.dropCohortFrontiers)
+		c.dropCohortFrontiers = grown
+	}
+	if uint64(cap(c.dropCohortFrontierParticipants)) < participants {
+		grown := make([]dropCohortFrontierParticipant, len(c.dropCohortFrontierParticipants), int(participants))
+		copy(grown, c.dropCohortFrontierParticipants)
+		c.dropCohortFrontierParticipants = grown
+	}
+	if uint64(cap(c.dropCohortFrontierMembers)) < members {
+		grown := make([]dropCohortFrontierMember, len(c.dropCohortFrontierMembers), int(members))
+		copy(grown, c.dropCohortFrontierMembers)
+		c.dropCohortFrontierMembers = grown
+	}
+	return nil
+}
+
+func (c *Core) beginDropCohortFrontierOwned(
+	owner SchedulerTransactionToken,
+	electionSequence uint64,
+	token DropCohortFrontierToken,
+	expectedParticipants, expectedMembers int,
+) (DropCohortFrontierHandle, error) {
+	if electionSequence == 0 {
+		return DropCohortFrontierHandle{}, errors.New("parser-core phase zero: zero frontier election sequence")
+	}
+	if expectedParticipants <= 0 || expectedParticipants > dropCohortFrontierParticipantHardCap {
+		return DropCohortFrontierHandle{}, errors.New("parser-core phase zero: frontier participant cap")
+	}
+	if expectedMembers < 0 || expectedMembers > dropCohortFrontierMemberHardCap {
+		return DropCohortFrontierHandle{}, errors.New("parser-core phase zero: frontier member cap")
+	}
+	if !c.dropCohortFrontierTokenValid(owner, token) {
+		return DropCohortFrontierHandle{}, errors.New("parser-core phase zero: frontier token receipt is invalid")
+	}
+	if uint64(len(c.dropCohortFrontiers))+1 > uint64(c.limits.MaxDropCohorts) {
+		return DropCohortFrontierHandle{}, errors.New("parser-core phase zero: frontier record cap")
+	}
+	if c.dropCohortFrontierNextSequence == ^uint64(0) {
+		return DropCohortFrontierHandle{}, errors.New("parser-core phase zero: frontier sequence overflow")
+	}
+	sequence := c.dropCohortFrontierNextSequence + 1
+	handle := DropCohortFrontierHandle{Owner: c.dropCohortOwner, Epoch: c.dropCohortEpoch, Sequence: sequence}
+	participantStart := len(c.dropCohortFrontierParticipants)
+	memberStart := len(c.dropCohortFrontierMembers)
+	if uint64(participantStart)+uint64(expectedParticipants) > uint64(^uint32(0)) ||
+		uint64(memberStart)+uint64(expectedMembers) > uint64(^uint32(0)) {
+		return DropCohortFrontierHandle{}, errors.New("parser-core phase zero: frontier arena index overflow")
+	}
+	if err := c.dropCohortFrontierReserveCapacity(1, expectedParticipants, expectedMembers); err != nil {
+		return DropCohortFrontierHandle{}, err
+	}
+	c.dropCohortFrontiers = append(c.dropCohortFrontiers, dropCohortFrontierRecord{
+		handle: handle, electionSequence: electionSequence, token: token,
+		state: DropCohortFrontierBuilding, expectedParticipants: uint16(expectedParticipants),
+		expectedMembers: uint32(expectedMembers), participantStart: uint32(participantStart),
+		memberStart: uint32(memberStart),
+	})
+	c.dropCohortFrontierNextSequence = sequence
+	return handle, nil
+}
+
+// BeginDropCohortFrontierOwned starts one bounded, owner-authenticated
+// frontier record. It does not publish a header reference.
+func (c *Core) BeginDropCohortFrontierOwned(
+	owner SchedulerTransactionToken,
+	electionSequence uint64,
+	token DropCohortFrontierToken,
+	expectedParticipants, expectedMembers int,
+) (handle DropCohortFrontierHandle, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return DropCohortFrontierHandle{}, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	handle, err = c.beginDropCohortFrontierOwned(owner, electionSequence, token, expectedParticipants, expectedMembers)
+	return handle, c.finishSchedulerOwned(owner, err)
+}
+
+func (c *Core) dropCohortFrontierMarkIncomplete(index int, overflow bool) {
+	if index < 0 || index >= len(c.dropCohortFrontiers) {
+		return
+	}
+	if overflow {
+		c.dropCohortFrontiers[index].state = DropCohortFrontierOverflowed
+	} else {
+		c.dropCohortFrontiers[index].state = DropCohortFrontierIncomplete
+	}
+}
+
+func (c *Core) dropCohortFrontierRef(ref DropCohortRef) (dropCohortRecord, dropCohortMember, error) {
+	// The caller must perform the scheduler-token check before this helper.
+	if ref.Owner == 0 || ref.Owner != c.dropCohortOwner {
+		return dropCohortRecord{}, dropCohortMember{}, errors.New("parser-core phase zero: frontier reference owner mismatch")
+	}
+	if ref.Epoch == 0 || ref.Epoch != c.dropCohortEpoch {
+		return dropCohortRecord{}, dropCohortMember{}, errors.New("parser-core phase zero: frontier reference epoch mismatch")
+	}
+	if ref.Sequence == 0 {
+		return dropCohortRecord{}, dropCohortMember{}, errors.New("parser-core phase zero: frontier reference sequence is zero")
+	}
+	index, _, reason := c.dropCohortVerifierLookup(ref, false)
+	if reason != dropCohortVerifierProved {
+		return dropCohortRecord{}, dropCohortMember{}, dropCohortVerifierError(reason)
+	}
+	record := c.dropCohortRecords[index]
+	if dropCohortVerifierClassifyRecord(record) != dropCohortVerifierProved {
+		return dropCohortRecord{}, dropCohortMember{}, errors.New("parser-core phase zero: frontier reference cohort is not complete")
+	}
+	memberIndex, ok := c.findDropCohortMember(record, ref.Branch)
+	if !ok {
+		return dropCohortRecord{}, dropCohortMember{}, errors.New("parser-core phase zero: frontier reference branch is absent")
+	}
+	return record, c.dropCohortMembers[memberIndex], nil
+}
+
+func (c *Core) dropCohortFrontierMemberFromRef(
+	owner SchedulerTransactionToken,
+	frontier DropCohortFrontierHandle,
+	participant uint16,
+	participantHead Head,
+	branchOrder uint64,
+	ref DropCohortRef,
+) (dropCohortFrontierMember, error) {
+	if err := c.validateSchedulerTransaction(owner); err != nil {
+		return dropCohortFrontierMember{}, err
+	}
+	if _, err := c.validateDropCohortFrontierIdentity(frontier); err != nil {
+		return dropCohortFrontierMember{}, errors.New("parser-core phase zero: frontier member identity mismatch")
+	}
+	record, source, err := c.dropCohortFrontierRef(ref)
+	if err != nil {
+		return dropCohortFrontierMember{}, err
+	}
+	if record.handle.Owner != frontier.Owner || record.handle.Epoch != frontier.Epoch {
+		return dropCohortFrontierMember{}, errors.New("parser-core phase zero: frontier member cohort identity mismatch")
+	}
+	actionIndex := record.actionIndex
+	if uint64(actionIndex) >= uint64(len(c.dropCohortActions)) {
+		return dropCohortFrontierMember{}, errors.New("parser-core phase zero: frontier action record is absent")
+	}
+	derivation, ok := c.dropCohortDerivationRecordOwned(owner, source.derivation)
+	if !ok || derivation.Head != source.head {
+		return dropCohortFrontierMember{}, errors.New("parser-core phase zero: frontier derivation record is absent")
+	}
+	return dropCohortFrontierMember{
+		participant: participant, ref: ref, participantHead: participantHead,
+		sourceHead: source.head, branchOrder: branchOrder,
+		action: c.dropCohortActions[actionIndex], derivation: source.derivation,
+		derivationDigest: derivation.Digest, derivationLength: uint32(len(derivation.Bytes)),
+		derivationRootSymbol: derivation.RootSymbol, derivationStackDepth: derivation.StackDepth,
+		derivationCheckpoint: derivation.Checkpoint,
+	}, nil
+}
+
+func (c *Core) writeDropCohortFrontierParticipantOwned(
+	owner SchedulerTransactionToken,
+	frontier DropCohortFrontierHandle,
+	participant uint16,
+	head Head,
+	branchOrder uint64,
+	refs DropCohortRefSet,
+) error {
+	if err := c.validateSchedulerTransaction(owner); err != nil {
+		return err
+	}
+	index, err := c.validateDropCohortFrontierIdentity(frontier)
+	if err != nil {
+		return err
+	}
+	record := &c.dropCohortFrontiers[index]
+	if record.state != DropCohortFrontierBuilding {
+		return errors.New("parser-core phase zero: frontier is not building")
+	}
+	if participant != record.writtenParticipants || participant >= record.expectedParticipants {
+		c.dropCohortFrontierMarkIncomplete(index, false)
+		return errors.New("parser-core phase zero: frontier participant order is incomplete")
+	}
+	if head.Node == 0 {
+		c.dropCohortFrontierMarkIncomplete(index, false)
+		return errors.New("parser-core phase zero: frontier participant identity is incomplete")
+	}
+	for prior := uint16(0); prior < participant; prior++ {
+		previous := c.dropCohortFrontierParticipants[int(record.participantStart)+int(prior)]
+		if previous.head == head {
+			c.dropCohortFrontierMarkIncomplete(index, false)
+			return errors.New("parser-core phase zero: frontier participant heads are duplicated")
+		}
+	}
+	count, valid := c.dropCohortRefCount(refs)
+	if !valid || refs.Overflowed() || count == 0 || count > dropCohortRefHardCap {
+		c.dropCohortFrontierMarkIncomplete(index, refs.Overflowed())
+		return errors.New("parser-core phase zero: frontier reference set is incomplete")
+	}
+	var members [dropCohortRefHardCap]dropCohortFrontierMember
+	for refIndex := 0; refIndex < count; refIndex++ {
+		if err := c.validateSchedulerTransaction(owner); err != nil {
+			return err
+		}
+		// DropCohortRefAt may read the spill arena. Keep this owner check
+		// immediately before the accessor.
+		ref, ok := c.DropCohortRefAtOwned(owner, refs, refIndex)
+		if !ok {
+			c.dropCohortFrontierMarkIncomplete(index, false)
+			return errors.New("parser-core phase zero: frontier reference accessor failed")
+		}
+		for prior := 0; prior < refIndex; prior++ {
+			if members[prior].ref == ref {
+				c.dropCohortFrontierMarkIncomplete(index, false)
+				return errors.New("parser-core phase zero: frontier reference set contains a duplicate")
+			}
+		}
+		member, memberErr := c.dropCohortFrontierMemberFromRef(owner, frontier, participant, head, branchOrder, ref)
+		if memberErr != nil {
+			c.dropCohortFrontierMarkIncomplete(index, false)
+			return memberErr
+		}
+		members[refIndex] = member
+	}
+	if uint64(len(c.dropCohortFrontierParticipants))+1 > uint64(^uint32(0)) ||
+		uint64(len(c.dropCohortFrontierMembers))+uint64(count) > uint64(^uint32(0)) {
+		c.dropCohortFrontierMarkIncomplete(index, true)
+		return errors.New("parser-core phase zero: frontier arena index overflow")
+	}
+	if reserveErr := c.dropCohortFrontierReserveCapacity(0, 1, count); reserveErr != nil {
+		c.dropCohortFrontierMarkIncomplete(index, true)
+		return reserveErr
+	}
+	participantRecord := dropCohortFrontierParticipant{
+		head: head, branchOrder: branchOrder, referenceFlags: refs.Flags,
+		memberStart: uint32(len(c.dropCohortFrontierMembers)), memberCount: uint16(count),
+	}
+	c.dropCohortFrontierParticipants = append(c.dropCohortFrontierParticipants, participantRecord)
+	c.dropCohortFrontierMembers = append(c.dropCohortFrontierMembers, members[:count]...)
+	record.writtenParticipants++
+	record.writtenMembers += uint32(count)
+	return nil
+}
+
+// WriteDropCohortFrontierParticipantOwned appends one ordered participant.
+// It publishes no scheduler header reference.
+func (c *Core) WriteDropCohortFrontierParticipantOwned(
+	owner SchedulerTransactionToken,
+	frontier DropCohortFrontierHandle,
+	participant uint16,
+	head Head,
+	branchOrder uint64,
+	refs DropCohortRefSet,
+) (err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	err = c.writeDropCohortFrontierParticipantOwned(owner, frontier, participant, head, branchOrder, refs)
+	return c.finishSchedulerOwned(owner, err)
+}
+
+func (c *Core) dropCohortFrontierMemberValid(owner SchedulerTransactionToken, member dropCohortFrontierMember) bool {
+	if c.validateSchedulerTransaction(owner) != nil {
+		return false
+	}
+	if member.ref.Owner != c.dropCohortOwner || member.ref.Epoch != c.dropCohortEpoch || member.ref.Sequence == 0 {
+		return false
+	}
+	index, _, reason := c.dropCohortVerifierLookup(member.ref, false)
+	if reason != dropCohortVerifierProved {
+		return false
+	}
+	record := c.dropCohortRecords[index]
+	if dropCohortVerifierClassifyRecord(record) != dropCohortVerifierProved {
+		return false
+	}
+	memberIndex, ok := c.findDropCohortMember(record, member.ref.Branch)
+	if !ok {
+		return false
+	}
+	source := c.dropCohortMembers[memberIndex]
+	if source.head != member.sourceHead || source.derivation != member.derivation || source.action != member.action {
+		return false
+	}
+	if uint64(record.actionIndex) >= uint64(len(c.dropCohortActions)) || c.dropCohortActions[record.actionIndex] != member.action {
+		return false
+	}
+	derivation, ok := c.dropCohortDerivationRecordOwned(owner, member.derivation)
+	if !ok || derivation.Head != member.sourceHead || derivation.Digest != member.derivationDigest ||
+		uint32(len(derivation.Bytes)) != member.derivationLength || derivation.RootSymbol != member.derivationRootSymbol ||
+		derivation.StackDepth != member.derivationStackDepth || derivation.Checkpoint != member.derivationCheckpoint {
+		return false
+	}
+	return sha256.Sum256(derivation.Bytes) == member.derivationDigest
+}
+
+func (c *Core) dropCohortFrontierSealOwned(owner SchedulerTransactionToken, index int) ([32]byte, bool) {
+	if c == nil || c.validateSchedulerTransaction(owner) != nil {
+		return [32]byte{}, false
+	}
+	if index < 0 || index >= len(c.dropCohortFrontiers) {
+		return [32]byte{}, false
+	}
+	record := c.dropCohortFrontiers[index]
+	start := int(record.participantStart)
+	end := start + int(record.expectedParticipants)
+	memberStart := int(record.memberStart)
+	memberEnd := memberStart + int(record.writtenMembers)
+	if start < 0 || end < start || end > len(c.dropCohortFrontierParticipants) ||
+		memberStart < 0 || memberEnd < memberStart || memberEnd > len(c.dropCohortFrontierMembers) {
+		return [32]byte{}, false
+	}
+	h := sha256.New()
+	writeU64 := func(value uint64) {
+		var buf [8]byte
+		binary.LittleEndian.PutUint64(buf[:], value)
+		_, _ = h.Write(buf[:])
+	}
+	writeU32 := func(value uint32) {
+		var buf [4]byte
+		binary.LittleEndian.PutUint32(buf[:], value)
+		_, _ = h.Write(buf[:])
+	}
+	writeBool := func(value bool) {
+		if value {
+			writeU64(1)
+		} else {
+			writeU64(0)
+		}
+	}
+	writeU64(record.handle.Owner)
+	writeU64(record.handle.Epoch)
+	writeU64(record.handle.Sequence)
+	writeU64(record.electionSequence)
+	writeU64(uint64(record.token.Symbol))
+	for _, value := range [...]uint32{record.token.StartByte, record.token.EndByte, record.token.StartRow, record.token.StartColumn, record.token.EndRow, record.token.EndColumn} {
+		writeU32(value)
+	}
+	writeBool(record.token.NoLookahead)
+	writeBool(record.token.Missing)
+	writeBool(record.token.ExternalScannerToken)
+	writeU64(uint64(record.token.ScannerBefore))
+	writeU64(uint64(record.token.ScannerAfter))
+	_, _ = h.Write(record.token.ScannerBeforeDigest[:])
+	_, _ = h.Write(record.token.ScannerAfterDigest[:])
+	writeU64(uint64(record.expectedParticipants))
+	writeU64(uint64(record.writtenParticipants))
+	writeU64(uint64(record.writtenMembers))
+	for participantIndex := start; participantIndex < end; participantIndex++ {
+		participant := c.dropCohortFrontierParticipants[participantIndex]
+		writeU64(uint64(participant.head.Node))
+		writeU64(participant.branchOrder)
+		writeU64(uint64(participant.referenceFlags))
+		writeU64(uint64(participant.memberStart))
+		writeU64(uint64(participant.memberCount))
+		for memberIndex := int(participant.memberStart); memberIndex < int(participant.memberStart)+int(participant.memberCount); memberIndex++ {
+			if memberIndex < memberStart || memberIndex >= memberEnd {
+				return [32]byte{}, false
+			}
+			member := c.dropCohortFrontierMembers[memberIndex]
+			writeU64(uint64(member.participant))
+			writeU64(member.ref.Owner)
+			writeU64(member.ref.Epoch)
+			writeU64(member.ref.Sequence)
+			writeU64(uint64(member.ref.Branch))
+			writeU64(uint64(member.participantHead.Node))
+			writeU64(uint64(member.sourceHead.Node))
+			writeU64(member.branchOrder)
+			writeU64(uint64(member.action.BoundaryState))
+			writeU64(uint64(member.action.Lookahead))
+			writeU64(uint64(member.action.ActionOrdinal))
+			writeU64(uint64(member.action.Action.Type))
+			writeU64(uint64(member.action.Action.State))
+			writeU64(uint64(member.action.Action.Symbol))
+			writeU64(uint64(member.action.Action.ChildCount))
+			writeU64(uint64(uint16(member.action.Action.DynamicPrecedence)))
+			writeU64(uint64(member.action.Action.ProductionID))
+			writeBool(member.action.Action.Extra)
+			writeBool(member.action.Action.ExtraChain)
+			writeBool(member.action.Action.Repetition)
+			writeBool(member.action.NoLookahead)
+			writeU64(uint64(member.action.Selection))
+			writeU64(member.derivation.Owner)
+			writeU64(member.derivation.Epoch)
+			writeU64(uint64(member.derivation.Index))
+			writeU64(uint64(member.derivationLength))
+			writeU64(uint64(member.derivationRootSymbol))
+			writeU64(uint64(member.derivationStackDepth))
+			for _, value := range [...]uint32{member.derivationCheckpoint.StartByte, member.derivationCheckpoint.EndByte, member.derivationCheckpoint.StartRow, member.derivationCheckpoint.StartColumn, member.derivationCheckpoint.EndRow, member.derivationCheckpoint.EndColumn} {
+				writeU32(value)
+			}
+			writeU64(uint64(member.derivationCheckpoint.ScannerStart))
+			writeU64(uint64(member.derivationCheckpoint.ScannerEnd))
+			_, _ = h.Write(member.derivationDigest[:])
+		}
+	}
+	var seal [32]byte
+	copy(seal[:], h.Sum(nil))
+	return seal, true
+}
+
+func (c *Core) finalizeDropCohortFrontierOwned(owner SchedulerTransactionToken, frontier DropCohortFrontierHandle) error {
+	if err := c.validateSchedulerTransaction(owner); err != nil {
+		return err
+	}
+	index, err := c.validateDropCohortFrontierIdentity(frontier)
+	if err != nil {
+		return err
+	}
+	record := &c.dropCohortFrontiers[index]
+	if record.state != DropCohortFrontierBuilding {
+		return errors.New("parser-core phase zero: frontier is not building")
+	}
+	if record.writtenParticipants != record.expectedParticipants || record.writtenMembers == 0 ||
+		(record.expectedMembers != 0 && record.writtenMembers != record.expectedMembers) {
+		c.dropCohortFrontierMarkIncomplete(index, false)
+		return errors.New("parser-core phase zero: frontier membership is incomplete")
+	}
+	start := int(record.participantStart)
+	end := start + int(record.expectedParticipants)
+	if start < 0 || end < start || end > len(c.dropCohortFrontierParticipants) {
+		c.dropCohortFrontierMarkIncomplete(index, false)
+		return errors.New("parser-core phase zero: frontier participant store is incomplete")
+	}
+	memberCount := 0
+	for participantIndex := start; participantIndex < end; participantIndex++ {
+		participant := c.dropCohortFrontierParticipants[participantIndex]
+		if participant.head.Node == 0 || participant.memberCount == 0 ||
+			int(participant.memberStart) < 0 || int(participant.memberStart)+int(participant.memberCount) > len(c.dropCohortFrontierMembers) {
+			c.dropCohortFrontierMarkIncomplete(index, false)
+			return errors.New("parser-core phase zero: frontier participant record is incomplete")
+		}
+		memberCount += int(participant.memberCount)
+		for memberIndex := int(participant.memberStart); memberIndex < int(participant.memberStart)+int(participant.memberCount); memberIndex++ {
+			if !c.dropCohortFrontierMemberValid(owner, c.dropCohortFrontierMembers[memberIndex]) {
+				c.dropCohortFrontierMarkIncomplete(index, false)
+				return errors.New("parser-core phase zero: frontier member identity is invalid")
+			}
+		}
+	}
+	if memberCount != int(record.writtenMembers) {
+		c.dropCohortFrontierMarkIncomplete(index, false)
+		return errors.New("parser-core phase zero: frontier member count is incomplete")
+	}
+	seal, ok := c.dropCohortFrontierSealOwned(owner, index)
+	if !ok {
+		c.dropCohortFrontierMarkIncomplete(index, false)
+		return errors.New("parser-core phase zero: frontier seal could not be built")
+	}
+	record.seal = seal
+	record.state = DropCohortFrontierComplete
+	return nil
+}
+
+// FinalizeDropCohortFrontierOwned seals one complete frontier. No header
+// reference is published by this method.
+func (c *Core) FinalizeDropCohortFrontierOwned(owner SchedulerTransactionToken, frontier DropCohortFrontierHandle) (err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	err = c.finalizeDropCohortFrontierOwned(owner, frontier)
+	return c.finishSchedulerOwned(owner, err)
+}
+
+// validateDropCohortFrontierOwned rechecks every source record and member
+// header while the caller owns the active scheduler transaction. It fails
+// closed when a source action or derivation byte changes.
+func (c *Core) validateDropCohortFrontierOwned(owner SchedulerTransactionToken, frontier DropCohortFrontierHandle, heads []Head) error {
+	index, lookupErr := c.validateDropCohortFrontierIdentity(frontier)
+	if lookupErr != nil {
+		return lookupErr
+	}
+	record := c.dropCohortFrontiers[index]
+	if record.state != DropCohortFrontierComplete {
+		return errors.New("parser-core phase zero: frontier is not complete")
+	}
+	if len(heads) != int(record.expectedParticipants) {
+		return errors.New("parser-core phase zero: frontier header count mismatch")
+	}
+	start := int(record.participantStart)
+	end := start + int(record.expectedParticipants)
+	if start < 0 || end < start || end > len(c.dropCohortFrontierParticipants) {
+		return errors.New("parser-core phase zero: frontier participant store is incomplete")
+	}
+	for participantIndex, head := range heads {
+		participant := c.dropCohortFrontierParticipants[start+participantIndex]
+		if participant.head != head {
+			return errors.New("parser-core phase zero: frontier header identity mismatch")
+		}
+		memberStart := int(participant.memberStart)
+		memberEnd := memberStart + int(participant.memberCount)
+		if memberStart < 0 || memberEnd < memberStart || memberEnd > len(c.dropCohortFrontierMembers) {
+			return errors.New("parser-core phase zero: frontier member store is incomplete")
+		}
+		for memberIndex := memberStart; memberIndex < memberEnd; memberIndex++ {
+			if !c.dropCohortFrontierMemberValid(owner, c.dropCohortFrontierMembers[memberIndex]) {
+				return errors.New("parser-core phase zero: frontier member identity is invalid")
+			}
+		}
+	}
+	if seal, ok := c.dropCohortFrontierSealOwned(owner, index); !ok || seal != record.seal {
+		return errors.New("parser-core phase zero: frontier seal mismatch")
+	}
+	return nil
+}
+
+// ValidateDropCohortFrontierOwned rechecks every source record and member
+// header. It fails closed when a source action or derivation byte changes.
+func (c *Core) ValidateDropCohortFrontierOwned(owner SchedulerTransactionToken, frontier DropCohortFrontierHandle, heads []Head) (err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if err = c.validateSchedulerTransaction(owner); err != nil {
+		return c.finishSchedulerOwned(owner, err)
+	}
+	err = c.validateDropCohortFrontierOwned(owner, frontier, heads)
+	return c.finishSchedulerOwned(owner, err)
+}
+
+// ValidateDropCohortFrontierSequenceOwned validates a scheduler frontier by
+// its header sequence. The core supplies owner and epoch only after checking
+// the opaque scheduler token, so the caller cannot forge either identity.
+func (c *Core) ValidateDropCohortFrontierSequenceOwned(owner SchedulerTransactionToken, sequence uint64, heads []Head) (err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if err = c.validateSchedulerTransaction(owner); err != nil {
+		return c.finishSchedulerOwned(owner, err)
+	}
+	if sequence == 0 {
+		err = errors.New("parser-core phase zero: zero frontier sequence")
+	} else if len(heads) < 2 {
+		err = errors.New("parser-core phase zero: frontier requires multiple participants")
+	} else {
+		err = c.validateDropCohortFrontierOwned(owner, DropCohortFrontierHandle{
+			Owner: c.dropCohortOwner, Epoch: c.dropCohortEpoch, Sequence: sequence,
+		}, heads)
+	}
+	return c.finishSchedulerOwned(owner, err)
+}
+
+func (c *Core) rollbackDropCohortFrontierPublication(frontierCount, participantCount, memberCount int, nextSequence uint64) {
+	if c == nil {
+		return
+	}
+	if frontierCount >= 0 && frontierCount <= len(c.dropCohortFrontiers) {
+		clear(c.dropCohortFrontiers[frontierCount:])
+		c.dropCohortFrontiers = c.dropCohortFrontiers[:frontierCount]
+	}
+	if participantCount >= 0 && participantCount <= len(c.dropCohortFrontierParticipants) {
+		clear(c.dropCohortFrontierParticipants[participantCount:])
+		c.dropCohortFrontierParticipants = c.dropCohortFrontierParticipants[:participantCount]
+	}
+	if memberCount >= 0 && memberCount <= len(c.dropCohortFrontierMembers) {
+		clear(c.dropCohortFrontierMembers[memberCount:])
+		c.dropCohortFrontierMembers = c.dropCohortFrontierMembers[:memberCount]
+	}
+	c.dropCohortFrontierNextSequence = nextSequence
+}
+
+func (c *Core) publishDropCohortFrontierOwned(
+	owner SchedulerTransactionToken,
+	electionSequence uint64,
+	token DropCohortFrontierToken,
+	heads []Head,
+	branchOrders []uint64,
+	refs []DropCohortRefSet,
+) (handle DropCohortFrontierHandle, complete bool, err error) {
+	if len(heads) == 0 || len(heads) != len(branchOrders) || len(heads) != len(refs) {
+		return DropCohortFrontierHandle{}, false, nil
+	}
+	frontierCount := len(c.dropCohortFrontiers)
+	participantCount := len(c.dropCohortFrontierParticipants)
+	memberCount := len(c.dropCohortFrontierMembers)
+	previousSequence := c.dropCohortFrontierNextSequence
+	var expectedMembers int
+	for index := range refs {
+		count, valid := c.dropCohortRefCount(refs[index])
+		if !valid || count <= 0 || count > dropCohortRefHardCap {
+			return DropCohortFrontierHandle{}, false, nil
+		}
+		expectedMembers += count
+		if expectedMembers > dropCohortFrontierMemberHardCap {
+			return DropCohortFrontierHandle{}, false, nil
+		}
+	}
+	handle, err = c.beginDropCohortFrontierOwned(owner, electionSequence, token, len(heads), expectedMembers)
+	if err != nil {
+		return DropCohortFrontierHandle{}, false, nil
+	}
+	for index := range heads {
+		if writeErr := c.writeDropCohortFrontierParticipantOwned(owner, handle, uint16(index), heads[index], branchOrders[index], refs[index]); writeErr != nil {
+			c.rollbackDropCohortFrontierPublication(frontierCount, participantCount, memberCount, previousSequence)
+			return DropCohortFrontierHandle{}, false, nil
+		}
+	}
+	if finalizeErr := c.finalizeDropCohortFrontierOwned(owner, handle); finalizeErr != nil {
+		c.rollbackDropCohortFrontierPublication(frontierCount, participantCount, memberCount, previousSequence)
+		return DropCohortFrontierHandle{}, false, nil
+	}
+	return handle, true, nil
+}
+
+// PublishDropCohortFrontierOwned records one complete scheduler frontier.
+// Incomplete source facts return complete=false without poisoning the owner;
+// real scheduler errors poison the enclosing transaction.
+func (c *Core) PublishDropCohortFrontierOwned(
+	owner SchedulerTransactionToken,
+	electionSequence uint64,
+	token DropCohortFrontierToken,
+	heads []Head,
+	branchOrders []uint64,
+	refs []DropCohortRefSet,
+) (handle DropCohortFrontierHandle, complete bool, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return DropCohortFrontierHandle{}, false, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	handle, complete, err = c.publishDropCohortFrontierOwned(owner, electionSequence, token, heads, branchOrders, refs)
+	err = c.finishSchedulerOwned(owner, err)
+	return handle, complete, err
+}
+
+// DropCohortFrontierStateOwned returns a bounded lifecycle view for focused
+// tests. The owner token is checked before the frontier store is read.
+func (c *Core) DropCohortFrontierStateOwned(owner SchedulerTransactionToken, handle DropCohortFrontierHandle) (state DropCohortFrontierState, expected, written uint16, members uint32, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return 0, 0, 0, 0, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if err = c.validateSchedulerTransaction(owner); err != nil {
+		return 0, 0, 0, 0, c.finishSchedulerOwned(owner, err)
+	}
+	index, err := c.validateDropCohortFrontierIdentity(handle)
+	if err != nil {
+		return 0, 0, 0, 0, c.finishSchedulerOwned(owner, err)
+	}
+	record := c.dropCohortFrontiers[index]
+	return record.state, record.expectedParticipants, record.writtenParticipants, record.writtenMembers, nil
+}
+
+type dropCohortFrontierProtocolRecord struct {
+	Handle               [3]uint64                               `json:"handle"`
+	ElectionSequence     uint64                                  `json:"election_sequence"`
+	State                string                                  `json:"state"`
+	ExpectedParticipants uint16                                  `json:"expected_participants"`
+	WrittenParticipants  uint16                                  `json:"written_participants"`
+	WrittenMembers       uint32                                  `json:"written_members"`
+	Seal                 [32]byte                                `json:"seal"`
+	Token                DropCohortFrontierToken                 `json:"token"`
+	Participants         []dropCohortFrontierProtocolParticipant `json:"participants"`
+}
+
+type dropCohortFrontierProtocolParticipant struct {
+	Head           Head                               `json:"head"`
+	BranchOrder    uint64                             `json:"branch_order"`
+	ReferenceFlags uint8                              `json:"reference_flags"`
+	MemberCount    uint16                             `json:"member_count"`
+	Members        []dropCohortFrontierProtocolMember `json:"members"`
+}
+
+type dropCohortFrontierProtocolMember struct {
+	Participant          uint16                     `json:"participant"`
+	Ref                  DropCohortRef              `json:"ref"`
+	ParticipantHead      Head                       `json:"participant_head"`
+	SourceHead           Head                       `json:"source_head"`
+	BranchOrder          uint64                     `json:"branch_order"`
+	Action               DropCohortActionIdentity   `json:"action"`
+	Derivation           DropCohortDerivationHandle `json:"derivation"`
+	DerivationDigest     [32]byte                   `json:"derivation_digest"`
+	DerivationLength     uint32                     `json:"derivation_length"`
+	DerivationRootSymbol Symbol                     `json:"derivation_root_symbol"`
+	DerivationStackDepth uint32                     `json:"derivation_stack_depth"`
+	DerivationCheckpoint DropCohortSourceCheckpoint `json:"derivation_checkpoint"`
+}
+
+type dropCohortFrontierProtocolSnapshot struct {
+	Schema    string                             `json:"schema"`
+	Frontiers []dropCohortFrontierProtocolRecord `json:"frontiers"`
+}
+
+// DiagnosticDropCohortFrontierSnapshotOwnedForTest exposes the latest
+// immutable frontier metadata after validating the scheduler token.
+func (c *Core) DiagnosticDropCohortFrontierSnapshotOwnedForTest(owner SchedulerTransactionToken) []byte {
+	if c == nil || c.validateSchedulerTransaction(owner) != nil {
+		return []byte(`{"schema":"gts-drop-cohort-frontier/v1"}`)
+	}
+	snapshot := dropCohortFrontierProtocolSnapshot{Schema: "gts-drop-cohort-frontier/v1"}
+	if len(c.dropCohortFrontiers) != 0 {
+		record := c.dropCohortFrontiers[len(c.dropCohortFrontiers)-1]
+		protocol := dropCohortFrontierProtocolRecord{
+			Handle: dropCohortFrontierProtocolHandle(record.handle), ElectionSequence: record.electionSequence,
+			State: dropCohortFrontierProtocolState(record.state), ExpectedParticipants: record.expectedParticipants,
+			WrittenParticipants: record.writtenParticipants, WrittenMembers: record.writtenMembers, Seal: record.seal,
+			Token: record.token,
+		}
+		participantStart := int(record.participantStart)
+		participantEnd := participantStart + int(record.writtenParticipants)
+		memberStart := int(record.memberStart)
+		memberEnd := memberStart + int(record.writtenMembers)
+		if participantStart < 0 || participantEnd < participantStart || participantEnd > len(c.dropCohortFrontierParticipants) ||
+			memberStart < 0 || memberEnd < memberStart || memberEnd > len(c.dropCohortFrontierMembers) {
+			return []byte(`{"schema":"gts-drop-cohort-frontier/v1"}`)
+		}
+		for participantIndex := participantStart; participantIndex < participantEnd; participantIndex++ {
+			participant := c.dropCohortFrontierParticipants[participantIndex]
+			start := int(participant.memberStart)
+			end := start + int(participant.memberCount)
+			if start < memberStart || end < start || end > memberEnd {
+				return []byte(`{"schema":"gts-drop-cohort-frontier/v1"}`)
+			}
+			protocolParticipant := dropCohortFrontierProtocolParticipant{
+				Head: participant.head, BranchOrder: participant.branchOrder,
+				ReferenceFlags: participant.referenceFlags, MemberCount: participant.memberCount,
+			}
+			for memberIndex := start; memberIndex < end; memberIndex++ {
+				member := c.dropCohortFrontierMembers[memberIndex]
+				protocolParticipant.Members = append(protocolParticipant.Members, dropCohortFrontierProtocolMember{
+					Participant: member.participant, Ref: member.ref, ParticipantHead: member.participantHead,
+					SourceHead: member.sourceHead, BranchOrder: member.branchOrder, Action: member.action,
+					Derivation: member.derivation, DerivationDigest: member.derivationDigest,
+					DerivationLength: member.derivationLength, DerivationRootSymbol: member.derivationRootSymbol,
+					DerivationStackDepth: member.derivationStackDepth, DerivationCheckpoint: member.derivationCheckpoint,
+				})
+			}
+			protocol.Participants = append(protocol.Participants, protocolParticipant)
+		}
+		snapshot.Frontiers = append(snapshot.Frontiers, protocol)
+	}
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		return []byte(`{"schema":"gts-drop-cohort-frontier/v1"}`)
+	}
+	return encoded
+}

--- a/internal/parsercorephase0/drop_cohort_frontier_test.go
+++ b/internal/parsercorephase0/drop_cohort_frontier_test.go
@@ -1,0 +1,397 @@
+package parsercorephase0
+
+import (
+	"testing"
+)
+
+type dropCohortFrontierFixture struct {
+	core       *Core
+	token      DropCohortFrontierToken
+	heads      []Head
+	refs       []DropCohortRefSet
+	branch     []uint64
+	frontier   DropCohortFrontierHandle
+	frontierOK bool
+}
+
+func newDropCohortFrontierFixture(t *testing.T, participants, refsPerParticipant int) dropCohortFrontierFixture {
+	t.Helper()
+	if participants <= 0 || refsPerParticipant <= 0 {
+		t.Fatalf("invalid frontier fixture shape %d/%d", participants, refsPerParticipant)
+	}
+	core := newTinyCoreWithLimits(t, Limits{
+		MaxDropCohortMembers: uint16(max(participants, refsPerParticipant)),
+		MaxDropCohortBytes:   1 << 20,
+	})
+	start := mustInternCheckpoint(t, core, []byte{1, 2, 3})
+	end := mustInternCheckpoint(t, core, []byte{4, 5, 6})
+	if err := core.SetPhaseExternalTokenScannerCheckpoints(start, end); err != nil {
+		t.Fatal(err)
+	}
+	_, beforeDigest, beforeOK := core.CheckpointReceipt(start)
+	_, afterDigest, afterOK := core.CheckpointReceipt(end)
+	if !beforeOK || !afterOK {
+		t.Fatal("frontier fixture checkpoint receipt is unavailable")
+	}
+	seed, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	heads := make([]Head, participants)
+	for index := range heads {
+		heads[index] = g18ProducerHead(t, core, seed, Symbol(30+index), uint32(index+1))
+	}
+	cohortHeads := make([]Head, refsPerParticipant)
+	for index := range cohortHeads {
+		cohortHeads[index] = g18ProducerHead(t, core, seed, Symbol(90+index), uint32(index+1))
+	}
+	var refs DropCohortRefSet
+	err = core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		cohort, beginErr := core.BeginDropCohortOwned(owner, g18ProducerIdentity(), refsPerParticipant)
+		if beginErr != nil {
+			return beginErr
+		}
+		for branch, head := range cohortHeads {
+			derivation, buildErr := core.BuildDropCohortDerivationOwned(owner, head, DropCohortSourceCheckpoint{
+				StartByte: uint32(branch), EndByte: uint32(branch + 1),
+			})
+			if buildErr != nil {
+				return buildErr
+			}
+			if writeErr := core.WriteDropCohortMemberOwned(owner, cohort, head, uint16(branch), derivation); writeErr != nil {
+				return writeErr
+			}
+		}
+		refs, err = core.FinalizeDropCohortOwned(owner, cohort)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refs.Len() != refsPerParticipant {
+		t.Fatalf("fixture refs=%d, want %d", refs.Len(), refsPerParticipant)
+	}
+	sets := make([]DropCohortRefSet, participants)
+	for index := range sets {
+		sets[index] = refs
+	}
+	branch := make([]uint64, participants)
+	for index := range branch {
+		branch[index] = uint64(index)
+	}
+	return dropCohortFrontierFixture{
+		core: core, token: DropCohortFrontierToken{
+			Symbol: 9, StartByte: 0, EndByte: 1,
+			ScannerBefore: start, ScannerAfter: end,
+			ScannerBeforeDigest: beforeDigest, ScannerAfterDigest: afterDigest,
+		},
+		heads: heads, refs: sets, branch: branch,
+	}
+}
+
+func publishDropCohortFrontierFixture(t *testing.T, fixture *dropCohortFrontierFixture) {
+	t.Helper()
+	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		var err error
+		fixture.frontier, fixture.frontierOK, err = fixture.core.PublishDropCohortFrontierOwned(
+			owner, 11, fixture.token, fixture.heads, fixture.branch, fixture.refs,
+		)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestG18DropCohortFrontierPublishesOrderedOwnedRecord(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 1)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK || fixture.frontier.Sequence == 0 {
+		t.Fatalf("frontier=%+v complete=%t", fixture.frontier, fixture.frontierOK)
+	}
+	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		state, expected, written, members, stateErr := fixture.core.DropCohortFrontierStateOwned(owner, fixture.frontier)
+		if stateErr != nil || state != DropCohortFrontierComplete || expected != 2 || written != 2 || members != 2 {
+			t.Fatalf("frontier state=%v expected=%d written=%d members=%d err=%v", state, expected, written, members, stateErr)
+		}
+		return fixture.core.ValidateDropCohortFrontierOwned(owner, fixture.frontier, fixture.heads)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fixture.core.dropCohortFrontierParticipants) != 2 || fixture.core.dropCohortFrontierParticipants[0].head != fixture.heads[0] || fixture.core.dropCohortFrontierParticipants[1].head != fixture.heads[1] {
+		t.Fatalf("participant order=%+v", fixture.core.dropCohortFrontierParticipants)
+	}
+	if fixture.core.dropCohortFrontierParticipants[0].branchOrder != 0 {
+		t.Fatalf("zero branch order was rejected or changed: %+v", fixture.core.dropCohortFrontierParticipants[0])
+	}
+}
+
+func TestG18DropCohortFrontierRejectsForeignAndStaleOwnerBeforeStoreReads(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 1, 3)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("spill frontier did not publish")
+	}
+	beforeRecords := len(fixture.core.dropCohortFrontiers)
+	beforeParticipants := len(fixture.core.dropCohortFrontierParticipants)
+	beforeMembers := len(fixture.core.dropCohortFrontierMembers)
+	beforeChecks := fixture.core.dropCohortOwnerCheckedLookups
+	other := newTinyCoreWithLimits(t, Limits{})
+	err := other.ApplySchedulerAtomic(func(foreign SchedulerTransactionToken) error {
+		state, expected, written, members, stateErr := fixture.core.DropCohortFrontierStateOwned(foreign, fixture.frontier)
+		if state != 0 || expected != 0 || written != 0 || members != 0 || stateErr == nil {
+			t.Fatalf("foreign token read state=%v expected=%d written=%d members=%d err=%v", state, expected, written, members, stateErr)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fixture.core.dropCohortOwnerCheckedLookups != beforeChecks || len(fixture.core.dropCohortFrontiers) != beforeRecords || len(fixture.core.dropCohortFrontierParticipants) != beforeParticipants || len(fixture.core.dropCohortFrontierMembers) != beforeMembers {
+		t.Fatalf("foreign token changed stores/checks: checks=%d/%d frontiers=%d/%d participants=%d/%d members=%d/%d", fixture.core.dropCohortOwnerCheckedLookups, beforeChecks, len(fixture.core.dropCohortFrontiers), beforeRecords, len(fixture.core.dropCohortFrontierParticipants), beforeParticipants, len(fixture.core.dropCohortFrontierMembers), beforeMembers)
+	}
+	old := fixture.frontier
+	err = fixture.core.Reset()
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleErr := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, _, _, _, stateErr := fixture.core.DropCohortFrontierStateOwned(owner, old)
+		if stateErr == nil {
+			t.Fatal("stale frontier handle was accepted after reset")
+		}
+		return nil
+	})
+	if staleErr == nil {
+		t.Fatal("stale frontier transaction was not poisoned")
+	}
+}
+
+func TestG18DropCohortFrontierPublicationRollsBackIncompleteRecords(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 1)
+	fixture.heads[1] = fixture.heads[0]
+	before := fixture.core.StorageBytes()
+	publishDropCohortFrontierFixture(t, &fixture)
+	if fixture.frontierOK || fixture.frontier != (DropCohortFrontierHandle{}) {
+		t.Fatalf("incomplete publication returned frontier=%+v complete=%t", fixture.frontier, fixture.frontierOK)
+	}
+	if len(fixture.core.dropCohortFrontiers) != 0 || len(fixture.core.dropCohortFrontierParticipants) != 0 || len(fixture.core.dropCohortFrontierMembers) != 0 || fixture.core.dropCohortFrontierNextSequence != 0 {
+		t.Fatalf("incomplete publication retained frontier stores: records=%d participants=%d members=%d next=%d", len(fixture.core.dropCohortFrontiers), len(fixture.core.dropCohortFrontierParticipants), len(fixture.core.dropCohortFrontierMembers), fixture.core.dropCohortFrontierNextSequence)
+	}
+	if fixture.core.StorageBytes() != before {
+		t.Fatalf("incomplete publication changed storage bytes: got=%d want=%d", fixture.core.StorageBytes(), before)
+	}
+}
+
+func TestG18DropCohortFrontierAcceptsBlendedAndRejectsOverflowedRefs(t *testing.T) {
+	blended := newDropCohortFrontierFixture(t, 1, 1)
+	blended.refs[0].Flags |= dropCohortRefFlagBlended
+	publishDropCohortFrontierFixture(t, &blended)
+	if !blended.frontierOK {
+		t.Fatal("blended frontier was rejected")
+	}
+	overflowed := newDropCohortFrontierFixture(t, 1, 1)
+	overflowed.refs[0].Flags |= dropCohortRefFlagOverflowed
+	publishDropCohortFrontierFixture(t, &overflowed)
+	if overflowed.frontierOK || len(overflowed.core.dropCohortFrontiers) != 0 {
+		t.Fatalf("overflowed frontier published: complete=%t records=%d", overflowed.frontierOK, len(overflowed.core.dropCohortFrontiers))
+	}
+}
+
+func TestG18DropCohortFrontierSealRejectsEveryActionFieldMutation(t *testing.T) {
+	mutations := []struct {
+		name string
+		edit func(*DropCohortActionIdentity)
+	}{
+		{"boundary", func(identity *DropCohortActionIdentity) { identity.BoundaryState++ }},
+		{"lookahead", func(identity *DropCohortActionIdentity) { identity.Lookahead++ }},
+		{"ordinal", func(identity *DropCohortActionIdentity) { identity.ActionOrdinal++ }},
+		{"type", func(identity *DropCohortActionIdentity) { identity.Action.Type = ActionShift }},
+		{"state", func(identity *DropCohortActionIdentity) { identity.Action.State++ }},
+		{"symbol", func(identity *DropCohortActionIdentity) { identity.Action.Symbol++ }},
+		{"child_count", func(identity *DropCohortActionIdentity) { identity.Action.ChildCount++ }},
+		{"dynamic_precedence", func(identity *DropCohortActionIdentity) { identity.Action.DynamicPrecedence++ }},
+		{"production", func(identity *DropCohortActionIdentity) { identity.Action.ProductionID++ }},
+		{"extra", func(identity *DropCohortActionIdentity) { identity.Action.Extra = !identity.Action.Extra }},
+		{"extra_chain", func(identity *DropCohortActionIdentity) { identity.Action.ExtraChain = !identity.Action.ExtraChain }},
+		{"repetition", func(identity *DropCohortActionIdentity) { identity.Action.Repetition = !identity.Action.Repetition }},
+		{"no_lookahead", func(identity *DropCohortActionIdentity) { identity.NoLookahead = !identity.NoLookahead }},
+		{"selection", func(identity *DropCohortActionIdentity) { identity.Selection++ }},
+	}
+	for _, mutation := range mutations {
+		mutation := mutation
+		t.Run(mutation.name, func(t *testing.T) {
+			fixture := newDropCohortFrontierFixture(t, 1, 1)
+			publishDropCohortFrontierFixture(t, &fixture)
+			if !fixture.frontierOK {
+				t.Fatal("frontier did not publish")
+			}
+			mutation.edit(&fixture.core.dropCohortActions[0])
+			var validateErr error
+			err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				validateErr = fixture.core.ValidateDropCohortFrontierOwned(owner, fixture.frontier, fixture.heads)
+				return nil
+			})
+			if validateErr == nil || err == nil {
+				t.Fatalf("action mutation %s validation=%v transaction=%v", mutation.name, validateErr, err)
+			}
+		})
+	}
+}
+
+func TestG18DropCohortFrontierSealRejectsDerivationByteMutationWithStoredDigest(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 1, 1)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK || len(fixture.core.dropCohortDerivationBytes) == 0 {
+		t.Fatal("frontier fixture has no derivation bytes")
+	}
+	beforeDigest := fixture.core.dropCohortDerivations[0].digest
+	fixture.core.dropCohortDerivationBytes[0] ^= 0xff
+	if fixture.core.dropCohortDerivations[0].digest != beforeDigest {
+		t.Fatal("test changed the stored derivation digest")
+	}
+	var validateErr error
+	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		validateErr = fixture.core.ValidateDropCohortFrontierOwned(owner, fixture.frontier, fixture.heads)
+		return nil
+	})
+	if validateErr == nil || err == nil {
+		t.Fatalf("derivation byte mutation validation=%v transaction=%v", validateErr, err)
+	}
+}
+
+func TestG18DropCohortFrontierResetAndOwnedReadsStayBounded(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 1, 3)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK || !fixture.refs[0].Spilled() {
+		t.Fatal("frontier fixture did not exercise spill storage")
+	}
+	before := fixture.core.StorageBytes()
+	if before == 0 || before > fixture.core.limits.MaxDropCohortBytes {
+		t.Fatalf("frontier storage=%d max=%d", before, fixture.core.limits.MaxDropCohortBytes)
+	}
+	if err := fixture.core.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	if len(fixture.core.dropCohortFrontiers) != 0 || len(fixture.core.dropCohortFrontierParticipants) != 0 || len(fixture.core.dropCohortFrontierMembers) != 0 {
+		t.Fatal("reset retained logical frontier records")
+	}
+	if fixture.core.dropCohortFrontierNextSequence != 0 {
+		t.Fatalf("reset frontier sequence=%d, want 0", fixture.core.dropCohortFrontierNextSequence)
+	}
+}
+
+func TestG18DropCohortFrontierByteCapDeclinesBeforePublication(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 1, 1)
+	fixture.core.limits.MaxDropCohortBytes = fixture.core.dropCohortStoreBytes()
+	publishDropCohortFrontierFixture(t, &fixture)
+	if fixture.frontierOK || len(fixture.core.dropCohortFrontiers) != 0 {
+		t.Fatalf("frontier exceeded byte cap: complete=%t records=%d", fixture.frontierOK, len(fixture.core.dropCohortFrontiers))
+	}
+}
+
+func TestG18DropCohortFrontierCumulativeBudgetDeclinesWithoutGrowth(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 1)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("first frontier did not publish")
+	}
+	live := fixture.core.dropCohortStoreBytes()
+	budget, err := fixture.core.dropCohortRetainedOtherBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, value := range fixture.core.dropCohortRetainedStoreBytes() {
+		budget, err = dropCohortAddChecked(budget, value)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	budget, err = dropCohortAddChecked(budget, fixture.core.dropCohortReservedBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if budget < live {
+		t.Fatalf("retained budget=%d is below live storage=%d", budget, live)
+	}
+	fixture.core.limits.MaxDropCohortBytes = budget
+
+	beforeRecords := len(fixture.core.dropCohortFrontiers)
+	beforeParticipants := len(fixture.core.dropCohortFrontierParticipants)
+	beforeMembers := len(fixture.core.dropCohortFrontierMembers)
+	beforeSequence := fixture.core.dropCohortFrontierNextSequence
+	beforeStore := fixture.core.dropCohortStoreBytes()
+	var second DropCohortFrontierHandle
+	var complete bool
+	err = fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		var publishErr error
+		second, complete, publishErr = fixture.core.PublishDropCohortFrontierOwned(
+			owner, 12, fixture.token, fixture.heads, fixture.branch, fixture.refs,
+		)
+		return publishErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if complete || second != (DropCohortFrontierHandle{}) {
+		t.Fatalf("second frontier published: handle=%+v complete=%t", second, complete)
+	}
+	if len(fixture.core.dropCohortFrontiers) != beforeRecords ||
+		len(fixture.core.dropCohortFrontierParticipants) != beforeParticipants ||
+		len(fixture.core.dropCohortFrontierMembers) != beforeMembers ||
+		fixture.core.dropCohortFrontierNextSequence != beforeSequence ||
+		fixture.core.dropCohortStoreBytes() != beforeStore {
+		t.Fatalf("declined frontier changed logical store: records=%d/%d participants=%d/%d members=%d/%d sequence=%d/%d store=%d/%d", len(fixture.core.dropCohortFrontiers), beforeRecords, len(fixture.core.dropCohortFrontierParticipants), beforeParticipants, len(fixture.core.dropCohortFrontierMembers), beforeMembers, fixture.core.dropCohortFrontierNextSequence, beforeSequence, fixture.core.dropCohortStoreBytes(), beforeStore)
+	}
+	frontierBytes, err := dropCohortMulChecked(uint64(cap(fixture.core.dropCohortFrontiers)), coreDropCohortFrontierRecordBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frontierBytes, err = dropCohortAddChecked(frontierBytes, uint64(cap(fixture.core.dropCohortFrontierParticipants))*coreDropCohortFrontierParticipantBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frontierBytes, err = dropCohortAddChecked(frontierBytes, uint64(cap(fixture.core.dropCohortFrontierMembers))*coreDropCohortFrontierMemberBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if frontierBytes > fixture.core.limits.MaxDropCohortBytes {
+		t.Fatalf("retained frontier capacity=%d exceeds cap=%d", frontierBytes, fixture.core.limits.MaxDropCohortBytes)
+	}
+}
+
+func TestG18DropCohortFrontierStaleTokenPoisonsAndRollsBackOuterMutation(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 1)
+	var stale SchedulerTransactionToken
+	if err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		stale = owner
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	beforeWrites := fixture.core.dropCohortProducerWrites
+	beforeRecords := len(fixture.core.dropCohortFrontiers)
+	beforeParticipants := len(fixture.core.dropCohortFrontierParticipants)
+	beforeMembers := len(fixture.core.dropCohortFrontierMembers)
+	beforeSequence := fixture.core.dropCohortFrontierNextSequence
+	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if mutationErr := fixture.core.RecordDropCohortProducerMutation(owner, DropCohortProducerLinearCanonicalization); mutationErr != nil {
+			return mutationErr
+		}
+		_, _, _ = fixture.core.PublishDropCohortFrontierOwned(
+			stale, 13, fixture.token, fixture.heads, fixture.branch, fixture.refs,
+		)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("outer scheduler transaction committed after ignored stale-token error")
+	}
+	if fixture.core.dropCohortProducerWrites != beforeWrites ||
+		len(fixture.core.dropCohortFrontiers) != beforeRecords ||
+		len(fixture.core.dropCohortFrontierParticipants) != beforeParticipants ||
+		len(fixture.core.dropCohortFrontierMembers) != beforeMembers ||
+		fixture.core.dropCohortFrontierNextSequence != beforeSequence {
+		t.Fatalf("stale-token rollback retained state: writes=%v/%v records=%d/%d participants=%d/%d members=%d/%d sequence=%d/%d", fixture.core.dropCohortProducerWrites, beforeWrites, len(fixture.core.dropCohortFrontiers), beforeRecords, len(fixture.core.dropCohortFrontierParticipants), beforeParticipants, len(fixture.core.dropCohortFrontierMembers), beforeMembers, fixture.core.dropCohortFrontierNextSequence, beforeSequence)
+	}
+}

--- a/internal/parsercorephase0/drop_cohort_ref.go
+++ b/internal/parsercorephase0/drop_cohort_ref.go
@@ -95,9 +95,7 @@ func (c *Core) dropCohortRefCount(set DropCohortRefSet) (int, bool) {
 	return int(set.Count), true
 }
 
-// DropCohortRefAt returns one sorted reference without exposing an inline
-// slice. Callers can enumerate into fixed storage without a heap escape.
-func (c *Core) DropCohortRefAt(set DropCohortRefSet, index int) (DropCohortRef, bool) {
+func (c *Core) dropCohortRefAt(set DropCohortRefSet, index int) (DropCohortRef, bool) {
 	if index < 0 || index >= int(set.Count) {
 		return DropCohortRef{}, false
 	}
@@ -115,6 +113,21 @@ func (c *Core) DropCohortRefAt(set DropCohortRefSet, index int) (DropCohortRef, 
 		return DropCohortRef{}, false
 	}
 	return c.dropCohortRefSpill[position], true
+}
+
+// DropCohortRefAt returns one sorted reference without exposing an inline
+// slice. Callers can enumerate into fixed storage without a heap escape.
+func (c *Core) DropCohortRefAt(set DropCohortRefSet, index int) (DropCohortRef, bool) {
+	return c.dropCohortRefAt(set, index)
+}
+
+// DropCohortRefAtOwned reads one reference only under the active scheduler
+// token. It permits bounded spill access without an unowned store read.
+func (c *Core) DropCohortRefAtOwned(owner SchedulerTransactionToken, set DropCohortRefSet, index int) (DropCohortRef, bool) {
+	if c == nil || c.validateSchedulerTransaction(owner) != nil {
+		return DropCohortRef{}, false
+	}
+	return c.dropCohortRefAt(set, index)
 }
 
 // dropCohortRefSpillLimit returns the configured reference count ceiling.

--- a/internal/parsercorephase0/storage_bytes.go
+++ b/internal/parsercorephase0/storage_bytes.go
@@ -6,21 +6,24 @@ import "unsafe"
 // once from each record type's real in-memory layout so StorageBytes stays
 // authoritative if a record ever gains or loses a field.
 var (
-	coreNodeRecordBytes                 = uint64(unsafe.Sizeof(nodeRecord{}))
-	coreLinkRecordBytes                 = uint64(unsafe.Sizeof(linkRecord{}))
-	coreSubtreeRecordBytes              = uint64(unsafe.Sizeof(subtreeRecord{}))
-	coreChildRecordBytes                = uint64(unsafe.Sizeof(SubtreeID(0)))
-	coreFieldRecordBytes                = uint64(unsafe.Sizeof(FieldMapEntry{}))
-	coreAliasRecordBytes                = uint64(unsafe.Sizeof(Symbol(0)))
-	coreDropCohortActionBytes           = uint64(unsafe.Sizeof(DropCohortActionIdentity{}))
-	coreDropCohortRecordBytes           = uint64(unsafe.Sizeof(dropCohortRecord{}))
-	coreDropCohortMemberBytes           = uint64(unsafe.Sizeof(dropCohortMember{}))
-	coreDropCohortDerivationRecordBytes = uint64(unsafe.Sizeof(dropCohortDerivationRecord{}))
-	coreDropCohortDerivationInternBytes = uint64(unsafe.Sizeof(dropCohortDerivationInternEntry{}))
-	coreDropCohortMutationBytes         = uint64(unsafe.Sizeof(dropCohortMutation{}))
-	coreDropCohortMapEntryBytes         = uint64(unsafe.Sizeof(dropCohortMapEntry{}))
-	coreDropCohortJournalStoreBytes     = uint64(unsafe.Sizeof(dropCohortJournalStoreEntry{}))
-	coreDropCohortReservationBytes      = uint64(unsafe.Sizeof(dropCohortReservation{}))
+	coreNodeRecordBytes                    = uint64(unsafe.Sizeof(nodeRecord{}))
+	coreLinkRecordBytes                    = uint64(unsafe.Sizeof(linkRecord{}))
+	coreSubtreeRecordBytes                 = uint64(unsafe.Sizeof(subtreeRecord{}))
+	coreChildRecordBytes                   = uint64(unsafe.Sizeof(SubtreeID(0)))
+	coreFieldRecordBytes                   = uint64(unsafe.Sizeof(FieldMapEntry{}))
+	coreAliasRecordBytes                   = uint64(unsafe.Sizeof(Symbol(0)))
+	coreDropCohortActionBytes              = uint64(unsafe.Sizeof(DropCohortActionIdentity{}))
+	coreDropCohortRecordBytes              = uint64(unsafe.Sizeof(dropCohortRecord{}))
+	coreDropCohortMemberBytes              = uint64(unsafe.Sizeof(dropCohortMember{}))
+	coreDropCohortDerivationRecordBytes    = uint64(unsafe.Sizeof(dropCohortDerivationRecord{}))
+	coreDropCohortDerivationInternBytes    = uint64(unsafe.Sizeof(dropCohortDerivationInternEntry{}))
+	coreDropCohortMutationBytes            = uint64(unsafe.Sizeof(dropCohortMutation{}))
+	coreDropCohortMapEntryBytes            = uint64(unsafe.Sizeof(dropCohortMapEntry{}))
+	coreDropCohortJournalStoreBytes        = uint64(unsafe.Sizeof(dropCohortJournalStoreEntry{}))
+	coreDropCohortReservationBytes         = uint64(unsafe.Sizeof(dropCohortReservation{}))
+	coreDropCohortFrontierRecordBytes      = uint64(unsafe.Sizeof(dropCohortFrontierRecord{}))
+	coreDropCohortFrontierParticipantBytes = uint64(unsafe.Sizeof(dropCohortFrontierParticipant{}))
+	coreDropCohortFrontierMemberBytes      = uint64(unsafe.Sizeof(dropCohortFrontierMember{}))
 )
 
 // StorageBytes returns a cheap, deterministic, O(1) estimate of the compact
@@ -70,6 +73,9 @@ func (c *Core) StorageBytes() uint64 {
 		uint64(len(c.dropCohortCertificateRefs))*coreDropCohortRefBytes +
 		uint64(len(c.dropCohortMapStore))*coreDropCohortMapEntryBytes +
 		uint64(len(c.dropCohortJournalStore))*coreDropCohortJournalStoreBytes +
+		uint64(len(c.dropCohortFrontiers))*coreDropCohortFrontierRecordBytes +
+		uint64(len(c.dropCohortFrontierParticipants))*coreDropCohortFrontierParticipantBytes +
+		uint64(len(c.dropCohortFrontierMembers))*coreDropCohortFrontierMemberBytes +
 		uint64(len(c.dropCohortReservations))*coreDropCohortReservationBytes +
 		uint64(len(c.dropCohortJournal))*coreDropCohortMutationBytes
 }
@@ -158,6 +164,9 @@ func (c *Core) FootprintBytes() uint64 {
 	total += uint64(cap(c.dropCohortCertificateRefs)) * coreDropCohortRefBytes
 	total += uint64(cap(c.dropCohortMapStore)) * coreDropCohortMapEntryBytes
 	total += uint64(cap(c.dropCohortJournalStore)) * coreDropCohortJournalStoreBytes
+	total += uint64(cap(c.dropCohortFrontiers)) * coreDropCohortFrontierRecordBytes
+	total += uint64(cap(c.dropCohortFrontierParticipants)) * coreDropCohortFrontierParticipantBytes
+	total += uint64(cap(c.dropCohortFrontierMembers)) * coreDropCohortFrontierMemberBytes
 	total += uint64(cap(c.dropCohortReservations)) * coreDropCohortReservationBytes
 	// A durable reservation is a committed memory budget even before its
 	// backing store is filled. Include it in the containment gauge so nested
@@ -303,6 +312,9 @@ func (c *Core) releaseRecordArenaReserve() {
 	c.dropCohortCertificateRefs = nil
 	c.dropCohortMapStore = nil
 	c.dropCohortJournalStore = nil
+	c.dropCohortFrontiers = nil
+	c.dropCohortFrontierParticipants = nil
+	c.dropCohortFrontierMembers = nil
 	c.dropCohortDerivationScratch = nil
 	c.dropCohortPathScratch = nil
 	c.dropCohortJournal = nil
@@ -334,6 +346,9 @@ func (c *Core) releaseOversizedRetention() {
 	c.dropCohortCertificateRefs = nil
 	c.dropCohortMapStore = nil
 	c.dropCohortJournalStore = nil
+	c.dropCohortFrontiers = nil
+	c.dropCohortFrontierParticipants = nil
+	c.dropCohortFrontierMembers = nil
 	c.dropCohortDerivationScratch = nil
 	c.dropCohortPathScratch = nil
 	c.dropCohortJournal = nil

--- a/parsercore_phase0_canonical_scratch_internal_test.go
+++ b/parsercore_phase0_canonical_scratch_internal_test.go
@@ -428,9 +428,9 @@ func TestDiagnosticParserCoreCheckpointCompactLayoutsAMD64(t *testing.T) {
 	if runtime.GOARCH != "amd64" {
 		t.Skip("amd64 layout receipt")
 	}
-	// G18 adds two value-owned DropCohortRefSet fields. Each set is 72 bytes,
-	// so the scheduler header ratchets from 64 to 224 bytes. This header is
-	// copied by the canonicalization and rollback scratch paths.
+	// G18 adds two value-owned DropCohortRefSet fields. Each set is 72 bytes.
+	// The exact scheduler header size is 224 bytes. Canonicalization and
+	// rollback copy this header.
 	if got := unsafe.Sizeof(diagnosticParserCoreHeader{}); got != 224 {
 		t.Fatalf("scheduler header size=%d, want 224", got)
 	}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -62,9 +62,12 @@ type DiagnosticParserCorePrefixOptions struct {
 	// recordDropCohortCertificates keeps the Slice C certificate stores inert
 	// until a focused authentic producer test enables the later activation.
 	recordDropCohortCertificates bool
-	MaxDispatches                uint64
-	MaxTokens                    uint64
-	Limits                       core.Limits
+	// recordDropCohortFrontiers enables only the D6a frontier producer. It does
+	// not enable historical certificate authentication or admission behavior.
+	recordDropCohortFrontiers bool
+	MaxDispatches             uint64
+	MaxTokens                 uint64
+	Limits                    core.Limits
 	// freshSchedulerSession is set only by the reusable fresh-full runner,
 	// which resets before every call and never exposes a declined core.
 	freshSchedulerSession bool
@@ -1059,8 +1062,8 @@ func diagnosticParserCoreSelectedNodeCensus(root *Node) diagnosticParserCoreSele
 // then cleanPathLineage (2-byte aligned), then every remaining byte-sized
 // field. This is layout-only: every construction site across the package
 // and its tests uses keyed fields (grep-verified), so declaration order
-// changes memory footprint, never behavior. It restores this struct to its
-// pre-b4b-v2 64 bytes (unsafe.Sizeof-verified, parsercore_phase0_canonical_scratch_internal_test.go)
+// changes memory footprint, never behavior. The exact current size is 224
+// bytes (unsafe.Sizeof-verified, parsercore_phase0_canonical_scratch_internal_test.go).
 // despite carrying two full (event, branch) alternative sets plus three
 // bools v1 never had (b4b-width-repair audit, 2026-08): the widened
 // AlternativeSet's own inline-capacity reduction (core.go) supplies most of
@@ -1095,6 +1098,7 @@ type diagnosticParserCoreHeader struct {
 	lastPersistedHead           core.Head
 	lastPersistedAltSet         core.AlternativeSet
 	lastPersistedDropCohortRefs core.DropCohortRefSet
+	frontierSequence            uint32
 	cleanPathLineage            uint16
 	freshness                   core.ReductionFreshness
 	shifted                     bool
@@ -1207,6 +1211,19 @@ func markDiagnosticParserCoreExternalLineage(
 	}
 	header.cleanPathRank = core.CleanPathRankUnknown
 	header.cleanPathLineage = 0
+}
+
+func mergeDiagnosticParserCoreFrontier(left, right uint32) uint32 {
+	if left == 0 {
+		return right
+	}
+	if right == 0 || left == right {
+		return left
+	}
+	// A canonical group must not claim two different producer frontiers.
+	// Clear the compact sequence and let the authenticated producer state fail
+	// closed if a later consumer requests a frontier from this group.
+	return 0
 }
 
 func (s *diagnosticParserCoreGenericScheduler) persistHeaderLineageOwned(
@@ -1694,15 +1711,49 @@ func (s *diagnosticParserCoreCanonicalScratch) observeGroupsInsertion(entries in
 // construction site (canonicalizeLinear/canonicalizeMapped) uses keyed
 // fields, so this reorder is layout-only (b4b-width-repair audit, 2026-08).
 type diagnosticParserCoreCanonicalGroup struct {
-	winner                  int
-	dropCohortRefs          core.DropCohortRefSet
-	altSet                  core.AlternativeSet
-	cleanPathLineage        uint16
-	runnable                bool
-	convergedReductionSplit bool
-	resurrectionUnproved    bool
-	cleanPathRank           core.CleanPathRankSelection
-	blended                 bool
+	winner           int
+	dropCohortRefs   core.DropCohortRefSet
+	altSet           core.AlternativeSet
+	frontierSequence uint32
+	cleanPathLineage uint16
+	cleanPathRank    core.CleanPathRankSelection
+	flags            uint8
+}
+
+const (
+	diagnosticParserCoreCanonicalGroupRunnable uint8 = 1 << iota
+	diagnosticParserCoreCanonicalGroupConvergedReductionSplit
+	diagnosticParserCoreCanonicalGroupResurrectionUnproved
+	diagnosticParserCoreCanonicalGroupBlended
+)
+
+func (group *diagnosticParserCoreCanonicalGroup) setFlag(flag uint8, value bool) {
+	if value {
+		group.flags |= flag
+	} else {
+		group.flags &^= flag
+	}
+}
+
+func (group diagnosticParserCoreCanonicalGroup) hasFlag(flag uint8) bool {
+	return group.flags&flag != 0
+}
+
+func diagnosticParserCoreCanonicalGroupFlags(header diagnosticParserCoreHeader) uint8 {
+	var flags uint8
+	if !header.paused {
+		flags |= diagnosticParserCoreCanonicalGroupRunnable
+	}
+	if header.convergedReductionSplit {
+		flags |= diagnosticParserCoreCanonicalGroupConvergedReductionSplit
+	}
+	if header.resurrectionUnproved {
+		flags |= diagnosticParserCoreCanonicalGroupResurrectionUnproved
+	}
+	if header.blended {
+		flags |= diagnosticParserCoreCanonicalGroupBlended
+	}
+	return flags
 }
 
 const diagnosticParserCoreLinearCanonicalLimit = 8
@@ -1825,12 +1876,11 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinearCheckedWithMuta
 			groups[groupCount] = linearGroup{
 				keyIndex: index,
 				diagnosticParserCoreCanonicalGroup: diagnosticParserCoreCanonicalGroup{
-					winner: index, runnable: !header.paused,
-					convergedReductionSplit: header.convergedReductionSplit,
-					resurrectionUnproved:    header.resurrectionUnproved,
-					cleanPathRank:           header.cleanPathRank, cleanPathLineage: header.cleanPathLineage,
-					altSet: header.altSet, blended: header.blended,
+					winner: index, frontierSequence: header.frontierSequence,
+					cleanPathRank: header.cleanPathRank, cleanPathLineage: header.cleanPathLineage,
+					altSet:         header.altSet,
 					dropCohortRefs: header.dropCohortRefs,
+					flags:          diagnosticParserCoreCanonicalGroupFlags(header),
 				},
 			}
 			groupCount++
@@ -1838,9 +1888,9 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinearCheckedWithMuta
 		}
 		merged = true
 		group := &groups[groupIndex].diagnosticParserCoreCanonicalGroup
-		group.runnable = group.runnable || !header.paused
-		group.convergedReductionSplit = group.convergedReductionSplit || header.convergedReductionSplit
-		group.resurrectionUnproved = group.resurrectionUnproved || header.resurrectionUnproved
+		group.setFlag(diagnosticParserCoreCanonicalGroupRunnable, group.hasFlag(diagnosticParserCoreCanonicalGroupRunnable) || !header.paused)
+		group.setFlag(diagnosticParserCoreCanonicalGroupConvergedReductionSplit, group.hasFlag(diagnosticParserCoreCanonicalGroupConvergedReductionSplit) || header.convergedReductionSplit)
+		group.setFlag(diagnosticParserCoreCanonicalGroupResurrectionUnproved, group.hasFlag(diagnosticParserCoreCanonicalGroupResurrectionUnproved) || header.resurrectionUnproved)
 		group.cleanPathRank, group.cleanPathLineage = mergeDiagnosticParserCoreCleanPathLineage(
 			group.cleanPathRank,
 			group.cleanPathLineage,
@@ -1858,13 +1908,14 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinearCheckedWithMuta
 		if header.altSet.Len() != 0 {
 			incomparable := compact.AlternativeSetIncomparable(group.altSet, header.altSet)
 			compact.UnionAlternativeSet(&group.altSet, header.altSet)
-			group.blended = group.blended || header.blended || incomparable
+			group.setFlag(diagnosticParserCoreCanonicalGroupBlended, group.hasFlag(diagnosticParserCoreCanonicalGroupBlended) || header.blended || incomparable)
 		}
 		if !header.dropCohortRefs.Empty() || header.dropCohortRefs.Overflowed() || header.dropCohortRefs.Blended() {
 			if _, err := compact.UnionDropCohortRefsChecked(&group.dropCohortRefs, header.dropCohortRefs); err != nil {
 				return nil, 0, err
 			}
 		}
+		group.frontierSequence = mergeDiagnosticParserCoreFrontier(group.frontierSequence, header.frontierSequence)
 		if diagnosticParserCoreCanonicalCandidateWins(normalized[group.winner], header) {
 			group.winner = index
 		}
@@ -1876,15 +1927,16 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinearCheckedWithMuta
 			if group.winner != index {
 				continue
 			}
-			header.paused = !group.runnable
+			header.paused = !group.hasFlag(diagnosticParserCoreCanonicalGroupRunnable)
 			header.freshness = 0
-			header.convergedReductionSplit = group.convergedReductionSplit
-			header.resurrectionUnproved = group.resurrectionUnproved
+			header.convergedReductionSplit = group.hasFlag(diagnosticParserCoreCanonicalGroupConvergedReductionSplit)
+			header.resurrectionUnproved = group.hasFlag(diagnosticParserCoreCanonicalGroupResurrectionUnproved)
 			header.cleanPathRank = group.cleanPathRank
 			header.cleanPathLineage = group.cleanPathLineage
 			header.altSet = group.altSet
 			header.dropCohortRefs = group.dropCohortRefs
-			header.blended = group.blended
+			header.frontierSequence = group.frontierSequence
+			header.blended = group.hasFlag(diagnosticParserCoreCanonicalGroupBlended)
 			normalized[write] = header
 			write++
 			break
@@ -1921,16 +1973,16 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMappedCheckedWithMuta
 		group, duplicate := s.groups[key]
 		if !duplicate {
 			group.winner = index
+			group.frontierSequence = header.frontierSequence
+			group.flags = diagnosticParserCoreCanonicalGroupFlags(header)
 			s.observeGroupsInsertion(len(s.groups) + 1)
 		} else {
 			merged = true
-			if diagnosticParserCoreCanonicalCandidateWins(normalized[group.winner], header) {
-				group.winner = index
-			}
+			group.frontierSequence = mergeDiagnosticParserCoreFrontier(group.frontierSequence, header.frontierSequence)
 		}
-		group.runnable = group.runnable || !header.paused
-		group.convergedReductionSplit = group.convergedReductionSplit || header.convergedReductionSplit
-		group.resurrectionUnproved = group.resurrectionUnproved || header.resurrectionUnproved
+		group.setFlag(diagnosticParserCoreCanonicalGroupRunnable, group.hasFlag(diagnosticParserCoreCanonicalGroupRunnable) || !header.paused)
+		group.setFlag(diagnosticParserCoreCanonicalGroupConvergedReductionSplit, group.hasFlag(diagnosticParserCoreCanonicalGroupConvergedReductionSplit) || header.convergedReductionSplit)
+		group.setFlag(diagnosticParserCoreCanonicalGroupResurrectionUnproved, group.hasFlag(diagnosticParserCoreCanonicalGroupResurrectionUnproved) || header.resurrectionUnproved)
 		group.cleanPathRank, group.cleanPathLineage = mergeDiagnosticParserCoreCleanPathLineage(
 			group.cleanPathRank,
 			group.cleanPathLineage,
@@ -1941,12 +1993,15 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMappedCheckedWithMuta
 		if header.altSet.Len() != 0 {
 			incomparable := compact.AlternativeSetIncomparable(group.altSet, header.altSet)
 			compact.UnionAlternativeSet(&group.altSet, header.altSet)
-			group.blended = group.blended || header.blended || incomparable
+			group.setFlag(diagnosticParserCoreCanonicalGroupBlended, group.hasFlag(diagnosticParserCoreCanonicalGroupBlended) || header.blended || incomparable)
 		}
 		if !header.dropCohortRefs.Empty() || header.dropCohortRefs.Overflowed() || header.dropCohortRefs.Blended() {
 			if _, err := compact.UnionDropCohortRefsChecked(&group.dropCohortRefs, header.dropCohortRefs); err != nil {
 				return nil, 0, err
 			}
+		}
+		if diagnosticParserCoreCanonicalCandidateWins(normalized[group.winner], header) {
+			group.winner = index
 		}
 		s.groups[key] = group
 	}
@@ -1956,15 +2011,16 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMappedCheckedWithMuta
 		if group.winner != index {
 			continue
 		}
-		header.paused = !group.runnable
+		header.paused = !group.hasFlag(diagnosticParserCoreCanonicalGroupRunnable)
 		header.freshness = 0
-		header.convergedReductionSplit = group.convergedReductionSplit
-		header.resurrectionUnproved = group.resurrectionUnproved
+		header.convergedReductionSplit = group.hasFlag(diagnosticParserCoreCanonicalGroupConvergedReductionSplit)
+		header.resurrectionUnproved = group.hasFlag(diagnosticParserCoreCanonicalGroupResurrectionUnproved)
 		header.cleanPathRank = group.cleanPathRank
 		header.cleanPathLineage = group.cleanPathLineage
 		header.altSet = group.altSet
 		header.dropCohortRefs = group.dropCohortRefs
-		header.blended = group.blended
+		header.frontierSequence = group.frontierSequence
+		header.blended = group.hasFlag(diagnosticParserCoreCanonicalGroupBlended)
 		normalized[write] = header
 		write++
 	}
@@ -3227,6 +3283,11 @@ func (s *diagnosticParserCoreGenericScheduler) applyCompactEOFRecoveryAdmission(
 	if accepted != 1 || len(indices) != 1 {
 		return rollback(errors.New("parser-core phase zero: EOF recovery admission did not preserve one accepting head"))
 	}
+	if s.options.recordDropCohortFrontiers {
+		if publishErr := s.publishDropCohortFrontierOwned(indices); publishErr != nil {
+			return rollback(publishErr)
+		}
+	}
 	if dropErr := s.dropGenericNoActionHeads(indices); dropErr != nil {
 		return rollback(dropErr)
 	}
@@ -3526,11 +3587,12 @@ func (s *diagnosticParserCoreGenericScheduler) headerReceipts(headers []diagnost
 }
 
 // diagnosticParserCoreSeedObserver is a tagged, diagnostic-only probe seam.
-// It can inspect closed frontiers immediately before an election and stop a
-// seed-owned run immediately after an election, before any action dispatch.
+// It can inspect closed frontiers before an election, after an election, or
+// after a complete owned frontier seal and before header publication.
 type diagnosticParserCoreSeedObserver struct {
-	beforeElection func(*diagnosticParserCoreGenericScheduler) error
-	afterElection  func(*diagnosticParserCoreGenericScheduler) (bool, error)
+	beforeElection    func(*diagnosticParserCoreGenericScheduler) error
+	afterElection     func(*diagnosticParserCoreGenericScheduler) (bool, error)
+	frontierPublished func(*diagnosticParserCoreGenericScheduler, core.SchedulerTransactionToken, []int) error
 }
 
 func newDiagnosticParserCoreGenericScheduler(
@@ -5771,6 +5833,11 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 	}
 	if len(cells) == 0 {
 		if diagnosticParserCoreGenericNoActionDropEligible(s.headers, noActionIndices, s.epochProgress) {
+			if s.options.recordDropCohortFrontiers {
+				if err := s.publishDropCohortFrontierOwned(noActionIndices); err != nil {
+					return nil, err
+				}
+			}
 			return nil, s.dropGenericNoActionHeads(noActionIndices)
 		}
 		if len(noActionIndices) != 0 {
@@ -5882,6 +5949,11 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 		}
 		if accepted != 1 || len(noActionIndices)+1 != len(s.headers) {
 			return nil, errors.New("parser-core phase zero: certified EOF accept did not preserve one accepted head")
+		}
+		if s.options.recordDropCohortFrontiers {
+			if err := s.publishDropCohortFrontierOwned(noActionIndices); err != nil {
+				return nil, err
+			}
 		}
 		return nil, s.dropGenericNoActionHeads(noActionIndices)
 	}
@@ -6912,6 +6984,134 @@ func diagnosticParserCoreSelectedLineageDrops(
 	return proved, true
 }
 
+// publishDropCohortFrontierOwned records the complete current election before
+// the no-action consumer sees its headers. Incomplete producer facts keep the
+// existing v2 fallback unchanged.
+const diagnosticParserCoreFrontierParticipantCap = 32
+
+func (s *diagnosticParserCoreGenericScheduler) dropCohortFrontierTokenOwned(owner core.SchedulerTransactionToken) (core.DropCohortFrontierToken, bool) {
+	if s == nil || s.compact == nil {
+		return core.DropCohortFrontierToken{}, false
+	}
+	beforeLength, beforeDigest, beforeOK := s.compact.CheckpointReceiptOwned(owner, s.checkpointBeforeID)
+	afterLength, afterDigest, afterOK := s.compact.CheckpointReceiptOwned(owner, s.checkpointID)
+	if !beforeOK || !afterOK || beforeLength != uint32(s.currentElection.ScannerBefore.Length) || afterLength != uint32(s.currentElection.ScannerAfter.Length) {
+		return core.DropCohortFrontierToken{}, false
+	}
+	return core.DropCohortFrontierToken{
+		Symbol: core.Symbol(s.token.Symbol), StartByte: s.token.StartByte, EndByte: s.token.EndByte,
+		StartRow: s.token.StartPoint.Row, StartColumn: s.token.StartPoint.Column,
+		EndRow: s.token.EndPoint.Row, EndColumn: s.token.EndPoint.Column,
+		NoLookahead: s.token.NoLookahead, Missing: s.token.Missing,
+		ExternalScannerToken: s.token.ExternalScannerToken,
+		ScannerBefore:        s.checkpointBeforeID, ScannerAfter: s.checkpointID,
+		ScannerBeforeDigest: beforeDigest, ScannerAfterDigest: afterDigest,
+	}, true
+}
+
+func (s *diagnosticParserCoreGenericScheduler) publishDropCohortFrontierMembersOwned(
+	owner core.SchedulerTransactionToken,
+	electionSequence uint64,
+	heads []core.Head,
+	refs []core.DropCohortRefSet,
+	dropIndices []int,
+) (uint32, bool, error) {
+	if s == nil || !s.options.recordDropCohortFrontiers || electionSequence == 0 ||
+		len(heads) == 0 || len(heads) > diagnosticParserCoreFrontierParticipantCap || len(heads) != len(refs) {
+		return 0, false, nil
+	}
+	token, ok := s.dropCohortFrontierTokenOwned(owner)
+	if !ok {
+		return 0, false, nil
+	}
+	var branchOrders [diagnosticParserCoreFrontierParticipantCap]uint64
+	for index := range heads {
+		branchOrders[index] = uint64(index)
+	}
+	handle, complete, err := s.compact.PublishDropCohortFrontierOwned(
+		owner, electionSequence, token, heads, branchOrders[:len(heads)], refs,
+	)
+	if err != nil || !complete {
+		return 0, complete, err
+	}
+	if handle.Sequence > math.MaxUint32 {
+		return 0, false, errors.New("parser-core phase zero: frontier sequence does not fit the header")
+	}
+	if s.observer.frontierPublished != nil {
+		if err := s.observer.frontierPublished(s, owner, dropIndices); err != nil {
+			return 0, false, err
+		}
+	}
+	return uint32(handle.Sequence), true, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) publishDropCohortFrontierOwned(dropContext ...[]int) error {
+	if s == nil || !s.options.recordDropCohortFrontiers || s.freshSessionOwner == nil ||
+		len(s.headers) == 0 || len(s.headers) > diagnosticParserCoreFrontierParticipantCap {
+		return nil
+	}
+	var heads [diagnosticParserCoreFrontierParticipantCap]core.Head
+	var refs [diagnosticParserCoreFrontierParticipantCap]core.DropCohortRefSet
+	for index, header := range s.headers {
+		heads[index], refs[index] = header.head, header.dropCohortRefs
+	}
+	var dropIndices []int
+	if len(dropContext) != 0 {
+		dropIndices = dropContext[0]
+	}
+	sequence, _, err := s.publishDropCohortFrontierMembersOwned(
+		*s.freshSessionOwner, uint64(s.electionIndex+1), heads[:len(s.headers)], refs[:len(s.headers)], dropIndices,
+	)
+	if err != nil {
+		return err
+	}
+	// Keep the authenticated handle on every current header. The no-action
+	// consumer can then carry the producer result into D6b without enabling
+	// admission or verifier work in D6a.
+	for index := range s.headers {
+		s.headers[index].frontierSequence = mergeDiagnosticParserCoreFrontier(s.headers[index].frontierSequence, sequence)
+	}
+	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) publishDropCohortFrontierForReductionOwned(
+	owner core.SchedulerTransactionToken,
+	cohort core.DropCohortHandle,
+	outputs []core.ReductionOutput,
+) (uint32, error) {
+	if len(outputs) < 2 || len(outputs) > diagnosticParserCoreFrontierParticipantCap {
+		return 0, nil
+	}
+	var heads [diagnosticParserCoreFrontierParticipantCap]core.Head
+	var refs [diagnosticParserCoreFrontierParticipantCap]core.DropCohortRefSet
+	for index, output := range outputs {
+		ref, err := s.compact.DropCohortRefForBranchOwned(owner, cohort, uint16(index))
+		if err != nil {
+			return 0, nil
+		}
+		heads[index] = output.Head
+		refs[index] = core.DropCohortRefSet{Inline: [2]core.DropCohortRef{ref}, Count: 1}
+	}
+	sequence, complete, err := s.publishDropCohortFrontierMembersOwned(
+		owner, uint64(s.electionIndex+1), heads[:len(outputs)], refs[:len(outputs)], nil,
+	)
+	if err != nil || !complete {
+		return 0, err
+	}
+	return sequence, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) attachDiagnosticParserCoreFrontierToHead(head core.Head, sequence uint32) {
+	if s == nil || !s.options.recordDropCohortFrontiers || sequence == 0 {
+		return
+	}
+	for index := range s.headers {
+		if s.headers[index].head == head {
+			s.headers[index].frontierSequence = mergeDiagnosticParserCoreFrontier(s.headers[index].frontierSequence, sequence)
+		}
+	}
+}
+
 // dropGenericNoActionHeads removes the paused/no-action heads named by indices.
 // indices is produced in ascending, unique header order by the dispatch pass,
 // so the surviving frontier is compacted in place with no allocation. The drop
@@ -7181,6 +7381,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		}
 	}
 	var reductionLineage uint16
+	var reductionFrontierSequence uint32
 	if hasMultiplePopPaths {
 		reductionLineage, err = nextDiagnosticParserCoreCleanPathLineage(&s.nextCleanPathLineage)
 		if err != nil {
@@ -7236,8 +7437,15 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 				if _, err := s.compact.FinalizeDropCohortOwned(owner, cohort); err != nil {
 					return err
 				}
+				if s.options.recordDropCohortFrontiers {
+					if sequence, publishErr := s.publishDropCohortFrontierForReductionOwned(owner, cohort, outputs); publishErr != nil {
+						return publishErr
+					} else {
+						reductionFrontierSequence = sequence
+					}
+				}
 				for outputIndex := range outputs {
-					ref, refErr := s.compact.DropCohortRefForBranch(cohort, uint16(outputIndex))
+					ref, refErr := s.compact.DropCohortRefForBranchOwned(owner, cohort, uint16(outputIndex))
 					if refErr != nil {
 						return refErr
 					}
@@ -7317,6 +7525,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 				); err != nil {
 					return err
 				}
+				if reductionFrontierSequence != 0 {
+					s.attachDiagnosticParserCoreFrontierToHead(output.Head, reductionFrontierSequence)
+				}
 			}
 			continue
 		case core.ReductionNew, core.ReductionUpdated:
@@ -7342,11 +7553,15 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 				return err
 			}
 			if adopted {
+				if reductionFrontierSequence != 0 {
+					s.attachDiagnosticParserCoreFrontierToHead(output.Head, reductionFrontierSequence)
+				}
 				continue
 			}
 		}
 		replacement := s.headers[cell.headerIndex]
 		replacement.head = output.Head
+		replacement.frontierSequence = mergeDiagnosticParserCoreFrontier(replacement.frontierSequence, reductionFrontierSequence)
 		replacement.paused = false
 		replacement.shifted = token.NoLookahead
 		replacement.convergedReductionSplit = replacement.convergedReductionSplit || convergedHistory
@@ -7455,6 +7670,10 @@ func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(
 	setBlended bool,
 	compat ...interface{},
 ) (bool, error) {
+	if source < 0 || source >= len(s.headers) {
+		return false, errors.New("parser-core phase zero: sibling adoption source is out of range")
+	}
+	sourceFrontier := s.headers[source].frontierSequence
 	var dropCohortRefs core.DropCohortRefSet
 	var convergedReductionSplit, resurrectionUnproved bool
 	switch len(compat) {
@@ -7504,6 +7723,10 @@ func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(
 			s.headers[index].convergedReductionSplit || convergedReductionSplit
 		s.headers[index].resurrectionUnproved =
 			s.headers[index].resurrectionUnproved || resurrectionUnproved
+		s.headers[index].frontierSequence = mergeDiagnosticParserCoreFrontier(
+			s.headers[index].frontierSequence,
+			sourceFrontier,
+		)
 		applyDiagnosticParserCoreCleanPathOutput(&s.headers[index], rank, lineage)
 		dst := &s.headers[index]
 		if set.Len() != 0 {
@@ -8377,6 +8600,7 @@ func (s *diagnosticParserCoreGenericScheduler) elect(first bool) error {
 	for index := range s.headers {
 		s.headers[index].shifted = false
 		s.headers[index].paused = false
+		s.headers[index].frontierSequence = 0
 		s.headers[index].checkpoint = afterID
 	}
 	s.electionIndex++

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -31,11 +31,14 @@ type parserCoreFreshFullRunner struct {
 	options                           DiagnosticParserCorePrefixOptions
 	replayParseStates                 bool
 	allowConvergedReductionSplitDrops bool
-	// certificateAdmissionEnabled is armed only by the private test seam.
+	// certificateAdmissionEnabled is armed only by the private D3 test seam.
 	// It is copied into options for each cached parse after Core.Reset.
 	certificateAdmissionEnabled bool
-	certificateAdmissionToken   *dropCohortActivationToken
-	scannerScratch              []byte
+	// frontierRecordingEnabled is armed only by the private D6a test seam.
+	// It never enables historical certificate authentication or admission.
+	frontierRecordingEnabled  bool
+	certificateAdmissionToken *dropCohortActivationToken
+	scannerScratch            []byte
 	// scratch retains the reusable per-parse materialization buffers. The runner
 	// is per-Parser and single-goroutine, so reusing these buffers across parses
 	// mirrors production's parser-held arena reuse and keeps the warm steady
@@ -96,6 +99,15 @@ func newParserCoreFreshFullRunner(scanner ExternalScanner, options DiagnosticPar
 }
 
 func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact *core.Core, reset bool) (*diagnosticParserCoreGenericScheduler, *dfaTokenSource, error) {
+	return r.executeSchedulerOpenWithObserver(source, compact, reset, diagnosticParserCoreSeedObserver{})
+}
+
+func (r *parserCoreFreshFullRunner) executeSchedulerOpenWithObserver(
+	source []byte,
+	compact *core.Core,
+	reset bool,
+	observer diagnosticParserCoreSeedObserver,
+) (*diagnosticParserCoreGenericScheduler, *dfaTokenSource, error) {
 	if r == nil || r.parser == nil || r.lang == nil || r.tables == nil || compact == nil {
 		return nil, nil, errors.New("parser-core fresh-full runner is incomplete")
 	}
@@ -108,6 +120,7 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 	// option on every cached parse so the owner callback can re-arm it only for
 	// this fresh session. The default path remains false and allocation-free.
 	r.options.recordDropCohortCertificates = r.certificateAdmissionEnabled
+	r.options.recordDropCohortFrontiers = r.frontierRecordingEnabled
 	// B3 stage S3: force the shared token source's error-run lexing on when
 	// native compact recovery is admitted, so a genuinely unlexable byte run
 	// surfaces as its own errorSymbol token (parser_api.go's
@@ -162,7 +175,7 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 	}()
 	scheduler, err := executeDiagnosticParserCoreGenericSchedulerFromSeedInto(
 		&r.scheduler, compact, tokenSource, &r.scannerScratch, r.lang.InitialState,
-		r.options, diagnosticParserCoreSeedObserver{},
+		r.options, observer,
 	)
 	if err != nil {
 		tokenSource.Close()
@@ -339,6 +352,13 @@ func (r *parserCoreFreshFullRunner) materializeSelectedStoreSelection(
 // redundancy costs one extra FootprintBytes comparison on the decline path,
 // never on the accepted-and-returned path.
 func (r *parserCoreFreshFullRunner) parse(source []byte) (tree *Tree, err error) {
+	return r.parseWithObserver(source, diagnosticParserCoreSeedObserver{})
+}
+
+func (r *parserCoreFreshFullRunner) parseWithObserver(
+	source []byte,
+	observer diagnosticParserCoreSeedObserver,
+) (tree *Tree, err error) {
 	if r == nil || r.compact == nil {
 		return nil, errors.New("parser-core fresh-full runner is incomplete")
 	}
@@ -350,7 +370,7 @@ func (r *parserCoreFreshFullRunner) parse(source []byte) (tree *Tree, err error)
 			err = errors.Join(err, fmt.Errorf("parser-core fresh-full runner: reset after decline: %w", resetErr))
 		}
 	}()
-	scheduler, tokenSource, err2 := r.executeSchedulerOpen(source, r.compact, true)
+	scheduler, tokenSource, err2 := r.executeSchedulerOpenWithObserver(source, r.compact, true, observer)
 	if err2 != nil {
 		return nil, err2
 	}

--- a/parsercore_phase0_g18_d6a_acceptance_external_test.go
+++ b/parsercore_phase0_g18_d6a_acceptance_external_test.go
@@ -1,0 +1,396 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+type g18D6aTarget struct {
+	Grammar string
+	Name    string
+	Source  []byte
+	Load    func() *gts.Language
+}
+
+type g18D6aSnapshot struct {
+	Schema    string                 `json:"schema"`
+	Frontiers []g18D6aFrontierRecord `json:"frontiers"`
+}
+
+type g18D6aObserverPayload struct {
+	Frontier      g18D6aSnapshot         `json:"frontier"`
+	HeaderHeads   []core.Head            `json:"header_heads"`
+	HeaderRefs    [][]core.DropCohortRef `json:"header_refs"`
+	DropIndices   []int                  `json:"drop_indices"`
+	ElectionIndex int                    `json:"election_index"`
+}
+
+type g18D6aFrontierRecord struct {
+	Handle               [3]uint64                    `json:"handle"`
+	ElectionSequence     uint64                       `json:"election_sequence"`
+	State                string                       `json:"state"`
+	ExpectedParticipants uint16                       `json:"expected_participants"`
+	WrittenParticipants  uint16                       `json:"written_participants"`
+	WrittenMembers       uint32                       `json:"written_members"`
+	Seal                 [32]byte                     `json:"seal"`
+	Token                core.DropCohortFrontierToken `json:"token"`
+	Participants         []g18D6aParticipant          `json:"participants"`
+}
+
+type g18D6aParticipant struct {
+	Head           core.Head      `json:"head"`
+	BranchOrder    uint64         `json:"branch_order"`
+	ReferenceFlags uint8          `json:"reference_flags"`
+	MemberCount    uint16         `json:"member_count"`
+	Members        []g18D6aMember `json:"members"`
+}
+
+type g18D6aMember struct {
+	Participant          uint16                          `json:"participant"`
+	Ref                  core.DropCohortRef              `json:"ref"`
+	ParticipantHead      core.Head                       `json:"participant_head"`
+	SourceHead           core.Head                       `json:"source_head"`
+	BranchOrder          uint64                          `json:"branch_order"`
+	Action               core.DropCohortActionIdentity   `json:"action"`
+	Derivation           core.DropCohortDerivationHandle `json:"derivation"`
+	DerivationDigest     [32]byte                        `json:"derivation_digest"`
+	DerivationLength     uint32                          `json:"derivation_length"`
+	DerivationRootSymbol core.Symbol                     `json:"derivation_root_symbol"`
+	DerivationStackDepth uint32                          `json:"derivation_stack_depth"`
+	DerivationCheckpoint core.DropCohortSourceCheckpoint `json:"derivation_checkpoint"`
+}
+
+type g18D6aRouteResult struct {
+	Routed, Fallback uint64
+	FallbackReason   string
+	RawDigest        string
+	ResultDigest     string
+	RuntimeDigest    string
+	Runtime          gts.ParseRuntime
+}
+
+// g18D6aCandidateOutcome records the candidate's exact success or decline
+// boundary. The producer test compares this value with recording disabled and
+// enabled, so certificate recording cannot move or reword a candidate gate.
+type g18D6aCandidateOutcome struct {
+	Success   bool
+	Boundary  string
+	Detail    string
+	ErrorType string
+}
+
+func g18D6aCloneLanguage(language *gts.Language) *gts.Language {
+	value := reflect.ValueOf(language).Elem()
+	clone := reflect.New(value.Type()).Elem()
+	for index := 0; index < value.NumField(); index++ {
+		if value.Type().Field(index).IsExported() {
+			clone.Field(index).Set(value.Field(index))
+		}
+	}
+	return clone.Addr().Interface().(*gts.Language)
+}
+
+func g18D6aTargets(t *testing.T) []g18D6aTarget {
+	t.Helper()
+	fixtures, err := benchfixtures.LoadGoFullParseFixtures()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fixtures) != 4 {
+		t.Fatalf("Go fixtures=%d, want 4", len(fixtures))
+	}
+	targets := make([]g18D6aTarget, 0, 9)
+	for _, fixture := range fixtures {
+		targets = append(targets, g18D6aTarget{"go", fixture.Fixture.ID, fixture.Source, grammars.GoLanguage})
+	}
+	targets = append(targets,
+		g18D6aTarget{"erlang", "macro_function_clauses", []byte("-module(m).\n-define(FN, foo(0) -> zero; foo(N) when N > 0 -> pos; foo(_) -> neg).\n?FN.\n"), grammars.ErlangLanguage},
+		g18D6aTarget{"erlang", "macro_expanded_top_level_function", []byte("-module(m).\n-define(FN1, bar(1) -> one).\n?FN1.\n"), grammars.ErlangLanguage},
+		g18D6aTarget{"haskell", "smoke", []byte(grammars.ParseSmokeSample("haskell")), grammars.HaskellLanguage},
+	)
+	for _, row := range []struct {
+		grammar, name, file string
+		load                func() *gts.Language
+	}{
+		{"javascript", "functions", "javascript.js", grammars.JavascriptLanguage},
+		{"bash", "converged_split", "bash.sh", grammars.BashLanguage},
+	} {
+		source, err := os.ReadFile(filepath.Join("testdata", "compact_converged_split", row.file))
+		if err != nil {
+			t.Fatal(err)
+		}
+		targets = append(targets, g18D6aTarget{row.grammar, row.name, source, row.load})
+	}
+	return targets
+}
+
+func g18D6aDigest(bytes []byte) string {
+	digest := sha256.Sum256(bytes)
+	return hex.EncodeToString(digest[:])
+}
+
+func g18D6aResultDigest(tree *gts.Tree, language *gts.Language) string {
+	return g18D6aDigest([]byte(tree.RootNode().SExpr(language)))
+}
+
+func g18D6aRuntimeDigest(runtime gts.ParseRuntime) string {
+	encoded, _ := json.Marshal(runtime)
+	return g18D6aDigest(encoded)
+}
+
+func g18D6aRuntimeEqualExceptPoolBaselines(left, right gts.ParseRuntime) bool {
+	left.ArenaBaselineBytes = 0
+	left.ScratchBaselineBytes = 0
+	left.GSSBaselineBytes = 0
+	right.ArenaBaselineBytes = 0
+	right.ScratchBaselineBytes = 0
+	right.GSSBaselineBytes = 0
+	return reflect.DeepEqual(left, right)
+}
+
+func g18D6aPoolBaselines(runtime gts.ParseRuntime) string {
+	return fmt.Sprintf("ArenaBaselineBytes=%d ScratchBaselineBytes=%d GSSBaselineBytes=%d",
+		runtime.ArenaBaselineBytes, runtime.ScratchBaselineBytes, runtime.GSSBaselineBytes)
+}
+
+func g18D6aCandidateOutcomeForError(err error) g18D6aCandidateOutcome {
+	if err == nil {
+		return g18D6aCandidateOutcome{Success: true}
+	}
+	const separator = ": "
+	message := err.Error()
+	boundary, detail := message, ""
+	for index := 0; index+len(separator) <= len(message); index++ {
+		if message[index:index+len(separator)] == separator {
+			boundary, detail = message[:index], message[index+len(separator):]
+			break
+		}
+	}
+	return g18D6aCandidateOutcome{
+		Boundary:  boundary,
+		Detail:    detail,
+		ErrorType: fmt.Sprintf("%T", err),
+	}
+}
+
+func g18D6aParseRoute(t *testing.T, target g18D6aTarget) g18D6aRouteResult {
+	t.Helper()
+	language := g18D6aCloneLanguage(target.Load())
+	language.CompactConvergedReductionSplitDropsCertified = false
+	gts.ResetAdmissionCandidateCountersForTest()
+	parser := gts.NewParser(language)
+	parser.SetAdmissionCandidateRoute(true)
+	restore := parser.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+	tree, err := parser.Parse(target.Source)
+	restore()
+	if err != nil {
+		t.Fatalf("%s/%s parse: %v", target.Grammar, target.Name, err)
+	}
+	t.Cleanup(tree.Release)
+	routed, fallback := gts.AdmissionCandidateCounters()
+	runtime := tree.ParseRuntime()
+	return g18D6aRouteResult{
+		Routed: routed, Fallback: fallback, FallbackReason: gts.AdmissionCandidateLastFallbackReason(),
+		RawDigest: g18D6aDigest(target.Source), ResultDigest: g18D6aResultDigest(tree, language),
+		RuntimeDigest: g18D6aRuntimeDigest(runtime), Runtime: runtime,
+	}
+}
+
+func g18D6aCandidateOutcomeForTarget(t *testing.T, target g18D6aTarget, record bool) g18D6aCandidateOutcome {
+	t.Helper()
+	language := g18D6aCloneLanguage(target.Load())
+	language.CompactConvergedReductionSplitDropsCertified = false
+	parser := gts.NewParser(language)
+	parser.SetAdmissionCandidateRoute(true)
+	tree, _, candidateErr, productionErr := gts.DiagnosticParseCandidateWithDropCohortFrontierModeForTest(parser, target.Source, record, nil)
+	if tree != nil {
+		tree.Release()
+	}
+	if productionErr != nil {
+		t.Fatalf("record=%t production parse: %v", record, productionErr)
+	}
+	return g18D6aCandidateOutcomeForError(candidateErr)
+}
+
+func g18D6aSnapshotDecode(t *testing.T, bytes []byte) g18D6aObserverPayload {
+	t.Helper()
+	var snapshot g18D6aObserverPayload
+	if err := json.Unmarshal(bytes, &snapshot); err != nil {
+		t.Fatalf("decode frontier snapshot: %v; bytes=%s", err, bytes)
+	}
+	return snapshot
+}
+
+func g18D6aRequireCompleteFrontier(t *testing.T, payload g18D6aObserverPayload) {
+	t.Helper()
+	snapshot := payload.Frontier
+	if snapshot.Schema != "gts-drop-cohort-frontier/v1" || len(snapshot.Frontiers) != 1 {
+		t.Fatalf("snapshot schema/frontier count=%q/%d", snapshot.Schema, len(snapshot.Frontiers))
+	}
+	record := snapshot.Frontiers[0]
+	if record.State != "complete" || record.Handle[0] == 0 || record.Handle[1] == 0 || record.Handle[2] == 0 ||
+		record.ElectionSequence == 0 || record.ExpectedParticipants == 0 ||
+		record.ExpectedParticipants != record.WrittenParticipants || record.WrittenMembers == 0 ||
+		len(record.Participants) != int(record.WrittenParticipants) || record.Seal == [32]byte{} {
+		t.Fatalf("frontier is incomplete: %+v", record)
+	}
+	if record.Token.ScannerBeforeDigest == [32]byte{} || record.Token.ScannerAfterDigest == [32]byte{} {
+		t.Fatalf("frontier checkpoint identity is incomplete: %+v", record.Token)
+	}
+	for index, participant := range record.Participants {
+		if participant.Head.Node == 0 || participant.MemberCount == 0 || len(participant.Members) != int(participant.MemberCount) {
+			t.Fatalf("participant %d is incomplete: %+v", index, participant)
+		}
+		for memberIndex, member := range participant.Members {
+			if member.Participant != uint16(index) || member.Ref.Owner != record.Handle[0] || member.Ref.Epoch != record.Handle[1] ||
+				member.Ref.Sequence == 0 || member.ParticipantHead != participant.Head || member.SourceHead.Node == 0 ||
+				member.Derivation.Owner != record.Handle[0] || member.Derivation.Epoch != record.Handle[1] ||
+				member.DerivationDigest == [32]byte{} || member.DerivationLength == 0 {
+				t.Fatalf("participant %d member %d is not authenticated: %+v", index, memberIndex, member)
+			}
+		}
+	}
+}
+
+func g18D6aIsTargetDropFrontier(payload g18D6aObserverPayload) bool {
+	if len(payload.DropIndices) == 0 || len(payload.Frontier.Frontiers) != 1 || len(payload.Frontier.Frontiers[0].Participants) < 2 ||
+		len(payload.HeaderHeads) != len(payload.HeaderRefs) || len(payload.HeaderHeads) != len(payload.Frontier.Frontiers[0].Participants) {
+		return false
+	}
+	frontier := payload.Frontier.Frontiers[0]
+	for index, participant := range frontier.Participants {
+		if participant.Head != payload.HeaderHeads[index] || len(participant.Members) != len(payload.HeaderRefs[index]) {
+			return false
+		}
+		for memberIndex, member := range participant.Members {
+			if member.Ref != payload.HeaderRefs[index][memberIndex] || member.ParticipantHead != payload.HeaderHeads[index] {
+				return false
+			}
+		}
+	}
+	for _, dropIndex := range payload.DropIndices {
+		if dropIndex < 0 || dropIndex >= len(payload.HeaderHeads) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestG18D6aProducerTelemetry(t *testing.T) {
+	for _, target := range g18D6aTargets(t) {
+		target := target
+		t.Run(target.Grammar+"/"+target.Name, func(t *testing.T) {
+			baseline := g18D6aParseRoute(t, target)
+			offCandidate := g18D6aCandidateOutcomeForTarget(t, target, false)
+			onCandidate := g18D6aCandidateOutcomeForTarget(t, target, true)
+			if offCandidate != onCandidate {
+				t.Fatalf("recording changed candidate outcome: off=%+v on=%+v", offCandidate, onCandidate)
+			}
+			language := g18D6aCloneLanguage(target.Load())
+			language.CompactConvergedReductionSplitDropsCertified = false
+			parser := gts.NewParser(language)
+			parser.SetAdmissionCandidateRoute(true)
+			gts.ResetAdmissionCandidateCountersForTest()
+			var snapshots []g18D6aObserverPayload
+			tree, published, observerCandidateErr, err := gts.DiagnosticParseWithDropCohortFrontierObserverForTest(parser, target.Source, func(bytes []byte) {
+				snapshots = append(snapshots, g18D6aSnapshotDecode(t, bytes))
+			})
+			if err != nil || tree == nil {
+				t.Fatalf("producer parse err=%v tree_nil=%t published=%d snapshots=%d", err, tree == nil, published, len(snapshots))
+			}
+			if published == 0 || len(snapshots) == 0 {
+				t.Fatalf("producer parse=%v published=%d snapshots=%d, want one complete frontier", err, published, len(snapshots))
+			}
+			if observerCandidate := g18D6aCandidateOutcomeForError(observerCandidateErr); observerCandidate != onCandidate {
+				t.Fatalf("observer probe changed candidate outcome: observer=%+v direct=%+v", observerCandidate, onCandidate)
+			}
+			targetDrop := false
+			for _, snapshot := range snapshots {
+				g18D6aRequireCompleteFrontier(t, snapshot)
+				targetDrop = targetDrop || g18D6aIsTargetDropFrontier(snapshot)
+			}
+			if !targetDrop {
+				t.Fatalf("producer telemetry did not capture an authenticated multi-participant frontier immediately before a target drop")
+			}
+			if tree != nil {
+				t.Cleanup(tree.Release)
+			}
+			routed, fallback := gts.AdmissionCandidateCounters()
+			if routed != baseline.Routed || fallback != baseline.Fallback || gts.AdmissionCandidateLastFallbackReason() != baseline.FallbackReason {
+				t.Fatalf("producer observer changed admission decision: observed=%d/%d/%q baseline=%d/%d/%q", routed, fallback, gts.AdmissionCandidateLastFallbackReason(), baseline.Routed, baseline.Fallback, baseline.FallbackReason)
+			}
+			if tree != nil {
+				observedRuntime := tree.ParseRuntime()
+				if g18D6aDigest(target.Source) != baseline.RawDigest || g18D6aResultDigest(tree, language) != baseline.ResultDigest || !g18D6aRuntimeEqualExceptPoolBaselines(observedRuntime, baseline.Runtime) {
+					t.Fatalf("D6a producer changed D3 runtime outside pool baselines: observed=(%s) baseline=(%s)", g18D6aPoolBaselines(observedRuntime), g18D6aPoolBaselines(baseline.Runtime))
+				}
+			}
+			t.Logf("parse_err=%v published=%d members=%d route=%d/%d reason=%q raw=%s result=%s runtime=%s", err, published,
+				snapshots[len(snapshots)-1].Frontier.Frontiers[0].WrittenMembers, baseline.Routed, baseline.Fallback,
+				baseline.FallbackReason, baseline.RawDigest, baseline.ResultDigest, baseline.RuntimeDigest)
+		})
+	}
+}
+
+func TestG18D6aIncompletePublicationPreservesNaturalNoActionDecline(t *testing.T) {
+	var target g18D6aTarget
+	for _, candidate := range g18D6aTargets(t) {
+		if candidate.Grammar == "go" && candidate.Name == "rewrite" {
+			target = candidate
+			break
+		}
+	}
+	if target.Source == nil {
+		t.Fatal("Go rewrite target is unavailable")
+	}
+	off := g18D6aCandidateOutcomeForTarget(t, target, false)
+	on := g18D6aCandidateOutcomeForTarget(t, target, true)
+	if off.Success || on.Success || off != on {
+		t.Fatalf("incomplete frontier publication changed natural no-action decline: off=%+v on=%+v", off, on)
+	}
+	if off.Boundary != "no_action" || off.Detail != "converged-path reduction split no-action drop lacks alternative-set coverage by one non-blended survivor" {
+		t.Fatalf("rewrite natural decline=%+v", off)
+	}
+}
+
+func TestG18D6aKotlinControlsRemainNonCandidate(t *testing.T) {
+	for _, row := range []struct {
+		name, source string
+	}{
+		{"line", "@Deprecated(\"old\")\nval Int.double: Int\n    get() = this * 2\n// trailing\n"},
+		{"block", "@Deprecated(\"old\")\nval Int.double: Int\n    get() = this * 2\n/* trailing */\n"},
+	} {
+		row := row
+		t.Run(row.name, func(t *testing.T) {
+			language := g18D6aCloneLanguage(grammars.KotlinLanguage())
+			language.CompactConvergedReductionSplitDropsCertified = false
+			parser := gts.NewParser(language)
+			parser.SetAdmissionCandidateRoute(false)
+			gts.ResetAdmissionCandidateCountersForTest()
+			restore := parser.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+			tree, err := parser.Parse([]byte(row.source))
+			restore()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(tree.Release)
+			routed, fallback := gts.AdmissionCandidateCounters()
+			if routed != 0 || fallback != 0 {
+				t.Fatalf("Kotlin non-candidate parser consumed admission: %d/%d", routed, fallback)
+			}
+		})
+	}
+}

--- a/parsercore_phase0_g18_d6a_test_hooks_test.go
+++ b/parsercore_phase0_g18_d6a_test_hooks_test.go
@@ -1,0 +1,154 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"encoding/json"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+type diagnosticParserCoreFrontierObserverPayloadForTest struct {
+	Frontier      json.RawMessage        `json:"frontier"`
+	HeaderHeads   []core.Head            `json:"header_heads"`
+	HeaderRefs    [][]core.DropCohortRef `json:"header_refs"`
+	DropIndices   []int                  `json:"drop_indices"`
+	ElectionIndex int                    `json:"election_index"`
+}
+
+func diagnosticParserCoreFrontierObserverPayload(
+	scheduler *diagnosticParserCoreGenericScheduler,
+	owner core.SchedulerTransactionToken,
+	dropIndices []int,
+) []byte {
+	if scheduler == nil || scheduler.compact == nil {
+		return []byte(`{"frontier":{"schema":"gts-drop-cohort-frontier/v1"}}`)
+	}
+	heads := make([]core.Head, len(scheduler.headers))
+	refs := make([][]core.DropCohortRef, len(scheduler.headers))
+	for index, header := range scheduler.headers {
+		heads[index] = header.head
+		refs[index] = make([]core.DropCohortRef, 0, header.dropCohortRefs.Len())
+		for refIndex := 0; refIndex < header.dropCohortRefs.Len(); refIndex++ {
+			ref, ok := scheduler.compact.DropCohortRefAtOwned(owner, header.dropCohortRefs, refIndex)
+			if !ok {
+				return []byte(`{"frontier":{"schema":"gts-drop-cohort-frontier/v1"}}`)
+			}
+			refs[index] = append(refs[index], ref)
+		}
+	}
+	frontier := scheduler.compact.DiagnosticDropCohortFrontierSnapshotOwnedForTest(owner)
+	payload, err := json.Marshal(diagnosticParserCoreFrontierObserverPayloadForTest{
+		Frontier:      frontier,
+		HeaderHeads:   heads,
+		HeaderRefs:    refs,
+		DropIndices:   append([]int(nil), dropIndices...),
+		ElectionIndex: scheduler.electionIndex,
+	})
+	if err != nil {
+		return []byte(`{"frontier":{"schema":"gts-drop-cohort-frontier/v1"}}`)
+	}
+	return payload
+}
+
+// DiagnosticParserCoreFrontierObserverForTest receives one latest frontier
+// snapshot after the producer seals it and before it publishes header state.
+// The hook exists only in the focused parser-core test build.
+type DiagnosticParserCoreFrontierObserverForTest func([]byte)
+
+// DiagnosticParseWithDropCohortFrontierObserverForTest runs a separate probe
+// parser with D3 certificates and D6a frontier recording enabled. It then
+// returns the caller parser's public Parse result through the D3 seam.
+// The probe cannot change the caller tree, runtime, or route counters.
+func DiagnosticParseWithDropCohortFrontierObserverForTest(
+	parser *Parser,
+	source []byte,
+	observer DiagnosticParserCoreFrontierObserverForTest,
+) (tree *Tree, published int, candidateErr, err error) {
+	if parser == nil || parser.language == nil {
+		return nil, 0, &diagnosticParserCoreDecline{
+				boundary: DiagnosticParserCoreRoute,
+				detail:   "frontier observer requires a parser language",
+			}, &diagnosticParserCoreDecline{
+				boundary: DiagnosticParserCoreRoute,
+				detail:   "frontier observer requires a parser language",
+			}
+	}
+	parser.SetAdmissionCandidateRoute(true)
+	probeParser := NewParser(parser.language)
+	probeParser.SetAdmissionCandidateRoute(true)
+	runner, err := newAdmissionCandidateRunner(probeParser)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	runner.certificateAdmissionEnabled = true
+	runner.frontierRecordingEnabled = true
+	seedObserver := diagnosticParserCoreSeedObserver{
+		frontierPublished: func(scheduler *diagnosticParserCoreGenericScheduler, owner core.SchedulerTransactionToken, dropIndices []int) error {
+			published++
+			if observer != nil {
+				observer(diagnosticParserCoreFrontierObserverPayload(scheduler, owner, dropIndices))
+			}
+			return nil
+		},
+	}
+	candidateTree, candidateErr := runner.parseWithObserver(source, seedObserver)
+	if candidateTree != nil {
+		candidateTree.Release()
+	}
+	runner.certificateAdmissionEnabled = false
+	runner.frontierRecordingEnabled = false
+	runner.options.recordDropCohortCertificates = false
+	runner.options.recordDropCohortFrontiers = false
+	restore := parser.DiagnosticEnableDropCohortCertificateAdmissionForTest()
+	tree, err = parser.Parse(source)
+	restore()
+	return tree, published, candidateErr, err
+}
+
+// DiagnosticParseCandidateWithDropCohortFrontierModeForTest runs one direct
+// candidate probe, then one production fallback with candidate routing held.
+// The returned candidate error identifies the exact candidate boundary and
+// detail. The recording flag affects only the D6a frontier producer.
+func DiagnosticParseCandidateWithDropCohortFrontierModeForTest(
+	parser *Parser,
+	source []byte,
+	record bool,
+	observer DiagnosticParserCoreFrontierObserverForTest,
+) (tree *Tree, published int, candidateErr, err error) {
+	if parser == nil || parser.language == nil {
+		return nil, 0, nil, &diagnosticParserCoreDecline{
+			boundary: DiagnosticParserCoreRoute,
+			detail:   "frontier mode probe requires a parser language",
+		}
+	}
+	runner, err := parser.acquireAdmissionCandidateRunner()
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	runner.certificateAdmissionEnabled = true
+	runner.frontierRecordingEnabled = record
+	seedObserver := diagnosticParserCoreSeedObserver{}
+	if record {
+		seedObserver.frontierPublished = func(scheduler *diagnosticParserCoreGenericScheduler, owner core.SchedulerTransactionToken, dropIndices []int) error {
+			published++
+			if observer != nil {
+				observer(diagnosticParserCoreFrontierObserverPayload(scheduler, owner, dropIndices))
+			}
+			return nil
+		}
+	}
+	var candidateTree *Tree
+	candidateTree, candidateErr = runner.parseWithObserver(source, seedObserver)
+	if candidateTree != nil {
+		candidateTree.Release()
+	}
+	parser.admissionRouteSuppressed++
+	tree, err = parser.Parse(source)
+	parser.admissionRouteSuppressed--
+	runner.options.recordDropCohortCertificates = false
+	runner.options.recordDropCohortFrontiers = false
+	runner.certificateAdmissionEnabled = false
+	runner.frontierRecordingEnabled = false
+	return tree, published, candidateErr, err
+}

--- a/parsercore_phase0_g18_refset_internal_test.go
+++ b/parsercore_phase0_g18_refset_internal_test.go
@@ -44,14 +44,17 @@ func TestG18RefSetHeaderAndCanonicalPropagation(t *testing.T) {
 	refs := g18RootRefs(t, compact)
 	var scratch diagnosticParserCoreCanonicalScratch
 	out, err := scratch.canonicalize(compact, []diagnosticParserCoreHeader{
-		{head: head, dropCohortRefs: refs, creationSeq: 1},
-		{head: head, dropCohortRefs: refs, creationSeq: 2},
+		{head: head, dropCohortRefs: refs, creationSeq: 1, frontierSequence: 17},
+		{head: head, dropCohortRefs: refs, creationSeq: 2, frontierSequence: 17},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(out) != 1 || !slices.Equal(g18RootMembers(t, compact, out[0].dropCohortRefs), g18RootMembers(t, compact, refs)) {
 		t.Fatalf("linear canonical refs=%+v output=%+v", refs, out)
+	}
+	if out[0].frontierSequence != 17 {
+		t.Fatalf("linear canonical frontier=%d, want 17", out[0].frontierSequence)
 	}
 
 	// Force the mapped path and fold a distinct reference into its winner.
@@ -72,9 +75,9 @@ func TestG18RefSetHeaderAndCanonicalPropagation(t *testing.T) {
 		if index == 0 {
 			set = other
 		}
-		headers = append(headers, diagnosticParserCoreHeader{head: seeded, dropCohortRefs: set, creationSeq: uint64(index + 1)})
+		headers = append(headers, diagnosticParserCoreHeader{head: seeded, dropCohortRefs: set, creationSeq: uint64(index + 1), frontierSequence: 23})
 	}
-	headers = append(headers, diagnosticParserCoreHeader{head: heads[0], dropCohortRefs: refs, creationSeq: 99})
+	headers = append(headers, diagnosticParserCoreHeader{head: heads[0], dropCohortRefs: refs, creationSeq: 99, frontierSequence: 23})
 	out, err = scratch.canonicalize(compact, headers)
 	if err != nil {
 		t.Fatal(err)
@@ -91,6 +94,9 @@ func TestG18RefSetHeaderAndCanonicalPropagation(t *testing.T) {
 	}
 	if winner.head != heads[0] {
 		t.Fatalf("mapped canonical output omitted the duplicate winner: %+v", out)
+	}
+	if winner.frontierSequence != 23 {
+		t.Fatalf("mapped canonical frontier=%d, want 23", winner.frontierSequence)
 	}
 	members := g18RootMembers(t, compact, winner.dropCohortRefs)
 	want := append(g18RootMembers(t, compact, refs), g18RootMembers(t, compact, other)...)
@@ -126,6 +132,13 @@ func TestG18RefSetHeaderAndCanonicalPropagation(t *testing.T) {
 	}
 	if scratch.groupsRetainedBytes == 0 || scratch.groupsBucketCount == 0 {
 		t.Fatalf("mapped canonical groups were not accounted: %+v", scratch)
+	}
+	mismatched := []diagnosticParserCoreHeader{
+		{head: heads[0], frontierSequence: 31},
+		{head: heads[0], frontierSequence: 32},
+	}
+	if out, err := scratch.canonicalize(compact, mismatched); err != nil || len(out) != 1 || out[0].frontierSequence != 0 {
+		t.Fatalf("mismatched mapped frontier=%+v err=%v, want one cleared sequence", out, err)
 	}
 	peak := scratch.groupsRetainedBytes
 	_, err = scratch.canonicalize(compact, headers[:1])
@@ -361,7 +374,7 @@ func TestG18RefSetHeaderPersistenceSiblingAdoptionAndConflictReconciliation(t *t
 	refs := g18RootRefs(t, compact)
 	scheduler := &diagnosticParserCoreGenericScheduler{
 		compact: compact,
-		headers: []diagnosticParserCoreHeader{{head: head, creationSeq: 1, dropCohortRefs: refs, convergedReductionSplit: true}},
+		headers: []diagnosticParserCoreHeader{{head: head, creationSeq: 1, dropCohortRefs: refs, convergedReductionSplit: true, frontierSequence: 41}},
 	}
 	if err := compact.RunFreshSchedulerSession(func(owner core.SchedulerTransactionToken) error {
 		return scheduler.persistHeaderLineageOwned(owner)
@@ -386,8 +399,11 @@ func TestG18RefSetHeaderPersistenceSiblingAdoptionAndConflictReconciliation(t *t
 		if !slices.Equal(g18RootMembers(t, compact, scheduler.headers[1].dropCohortRefs), g18RootMembers(t, compact, refs)) {
 			return fmt.Errorf("adopted sibling refs=%+v", scheduler.headers[1].dropCohortRefs)
 		}
+		if scheduler.headers[1].frontierSequence != 41 {
+			return fmt.Errorf("adopted sibling frontier=%d, want 41", scheduler.headers[1].frontierSequence)
+		}
 
-		scheduler.headers = []diagnosticParserCoreHeader{{head: head, creationSeq: 1}, {head: head, creationSeq: 2}}
+		scheduler.headers = []diagnosticParserCoreHeader{{head: head, creationSeq: 1, frontierSequence: 43}, {head: head, creationSeq: 2}}
 		outputs, conflictAdopted, err := scheduler.reconcileGenericConflictOutputs(owner, 0, []diagnosticParserCoreHeader{{
 			head: head, freshness: core.ReductionUpdated, dropCohortRefs: refs,
 		}})
@@ -396,6 +412,9 @@ func TestG18RefSetHeaderPersistenceSiblingAdoptionAndConflictReconciliation(t *t
 		}
 		if !slices.Equal(g18RootMembers(t, compact, scheduler.headers[1].dropCohortRefs), g18RootMembers(t, compact, refs)) {
 			return fmt.Errorf("reconciled sibling refs=%+v", scheduler.headers[1].dropCohortRefs)
+		}
+		if scheduler.headers[1].frontierSequence != 43 {
+			return fmt.Errorf("reconciled sibling frontier=%d, want 43", scheduler.headers[1].frontierSequence)
 		}
 		return nil
 	}); err != nil {
@@ -533,5 +552,48 @@ func TestG18RefSetSchedulerRecordSizeRatchets(t *testing.T) {
 	}
 	if got := unsafe.Sizeof(core.CondenseCandidate{}); got != 88 {
 		t.Fatalf("condense candidate size=%d, want 88", got)
+	}
+}
+
+func TestG18DropCohortFrontierDefaultOffHasNoAllocationOrStorage(t *testing.T) {
+	compact, _, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	scheduler := &diagnosticParserCoreGenericScheduler{compact: compact}
+	baseSchedulerFootprint := diagnosticParserCoreSchedulerFootprintBytes(scheduler)
+	baseStorage := compact.StorageBytes()
+	allocs := testing.AllocsPerRun(100, func() {
+		if err := scheduler.publishDropCohortFrontierOwned(); err != nil {
+			t.Fatalf("default-off producer returned error: %v", err)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("default-off frontier producer allocations=%f, want 0", allocs)
+	}
+	if got := diagnosticParserCoreSchedulerFootprintBytes(scheduler); got != baseSchedulerFootprint {
+		t.Fatalf("default-off scheduler footprint=%d, want unchanged %d", got, baseSchedulerFootprint)
+	}
+	if got := compact.StorageBytes(); got != baseStorage {
+		t.Fatalf("default-off compact storage=%d, want unchanged %d", got, baseStorage)
+	}
+	if scheduler.options.recordDropCohortCertificates || scheduler.canonicalScratch.groups != nil {
+		t.Fatalf("default-off scheduler state expanded: options=%+v canonical=%+v", scheduler.options, scheduler.canonicalScratch)
+	}
+	t.Logf("default-off scheduler=%d bytes, header=%d bytes, compact storage=%d bytes", unsafe.Sizeof(*scheduler), unsafe.Sizeof(diagnosticParserCoreHeader{}), baseStorage)
+}
+
+func TestG18FrontierHeaderReplacementAndRollbackPropagation(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	headers := []diagnosticParserCoreHeader{{head: head, frontierSequence: 51}}
+	replaced := replaceDiagnosticParserCoreHeader(headers, 0, []diagnosticParserCoreHeader{{head: head, frontierSequence: 52}})
+	if len(replaced) != 1 || replaced[0].frontierSequence != 52 {
+		t.Fatalf("replacement frontier=%+v, want 52", replaced)
+	}
+	scheduler := diagnosticParserCoreGenericScheduler{compact: compact, headers: replaced}
+	if err := scheduler.headerRollbackScratch.begin(scheduler.headers); err != nil {
+		t.Fatal(err)
+	}
+	scheduler.headers[0].frontierSequence = 99
+	scheduler.headerRollbackScratch.finish(&scheduler.headers, true)
+	if scheduler.headers[0].frontierSequence != 52 {
+		t.Fatalf("rollback frontier=%d, want 52", scheduler.headers[0].frontierSequence)
 	}
 }


### PR DESCRIPTION
## Outcome

- Record authenticated frontiers for complete compact drop-cohort elections.
- Keep the producer disabled by default.
- Do not activate admission, history, verification, or route graduation.
- Update the changelog and compact route evidence matrix.

## Correctness

- Fix complete frontier byte accounting.
- Poison the scheduler transaction after a stale publication token.
- Pass the focused Docker gates and nine isolated telemetry targets.

## Performance

- Compare the primary benchmark trio with 20 interleaved seeds.
- Record a 0.97 percent time geomean increase.
- Record a 3.10 percent full-parse byte reduction.
- Keep allocation counts unchanged.
- Benchstat found no significant result.
- Discard the sequential comparison because an unrelated host test overlapped it.

## Risk and follow-up

- Keep the compact route unchanged.
- Require D6b to authenticate and consume frontier sequences before graduation.
