### PR TITLE
Add authenticated D6b frontier consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ for tags and release notes while still in `0.x`.
   bytes, digest, and checkpoint, and a seal. D6a does not enable admission,
   history, or verification.
 
+- Add default-off authenticated D6b consumption. Prove common survivor action
+  and full derivation. Roll back consumed-state journals. Leave driver and
+  admission paths inactive.
+
 ### Removed
 
 - Swift ternary expressions now come directly from the regenerated grammar

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -1,8 +1,8 @@
 # Compact route real-corpus matrix
 
 Current evidence date: 2026-08-22.
-Current base commit: `69d5ccaf` from `main`.
-Current candidate base commit: `69d5ccaf`.
+Current base commit: `9ff47f2c` from `main`.
+Current candidate base commit: `9ff47f2c`.
 
 ## Current bounded result
 
@@ -68,6 +68,29 @@ Discard the earlier sequential full-set comparison because unrelated host
 tests overlapped the candidate run.
 
 This receipt does not graduate the route and does not verify D6b.
+
+## D6b internal-consumer evidence
+
+D6b adds a default-off authenticated internal consumer for complete frontiers.
+It does not activate the route driver, admission, or production drop wiring.
+
+The consumer enforces these contracts:
+
+- Authenticate the owner, epoch, election, token, frontier seal, and ordered records.
+- Reject producer-cap violations, blended references, malformed offsets, and mismatched reference sets.
+- Require one survivor member to match every dropped participant within one common cohort.
+- Match the exact survivor reference and compare action and full derivation identity, metadata, and bytes.
+- Journal the consumed state only after proof succeeds, then restore it through checkpoint rollback.
+
+The focused Docker gates passed:
+
+| Target | Result | Artifact |
+|---|---|---|
+| `TestG18D6b` | PASS, exit 0 | `harness_out/docker/20260822T101332Z-d6b-proof-tests-v4` |
+| `TestG18DropCohortFrontier` plus `TestG18D6b` | PASS, exit 0 | `harness_out/docker/20260822T101347Z-d6b-frontier-regression-v4` |
+
+The matrix counts and performance counts remain unchanged.
+This evidence does not graduate the route or wire production drops.
 
 ## Current fallback taxonomy
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -931,6 +931,7 @@ type Core struct {
 	dropCohortFrontiers            []dropCohortFrontierRecord
 	dropCohortFrontierParticipants []dropCohortFrontierParticipant
 	dropCohortFrontierMembers      []dropCohortFrontierMember
+	dropCohortFrontierJournal      []dropCohortFrontierMutation
 	dropCohortDerivationScratch    []byte
 	dropCohortPathScratch          []dropCohortPathStep
 	dropCohortEphemeralBytes       uint64
@@ -1089,6 +1090,7 @@ type checkpoint struct {
 	dropCohortFrontiers                                                       int
 	dropCohortFrontierParticipants                                            int
 	dropCohortFrontierMembers                                                 int
+	dropCohortFrontierJournal                                                 int
 	dropCohortEphemeralBytes                                                  uint64
 	dropCohortJournal                                                         int
 	dropCohortNextSequence                                                    uint64
@@ -1121,6 +1123,7 @@ type checkpoint struct {
 	dropCohortMapStoreCap                                                     int
 	dropCohortJournalStoreCap                                                 int
 	dropCohortJournalCap                                                      int
+	dropCohortFrontierJournalCap                                              int
 	dropCohortReservationsCap                                                 int
 	dropCohortRefSpillHeader                                                  []DropCohortRef
 	dropCohortActionsHeader                                                   []dropCohortActionIdentity
@@ -1135,6 +1138,7 @@ type checkpoint struct {
 	dropCohortFrontiersHeader                                                 []dropCohortFrontierRecord
 	dropCohortFrontierParticipantsHeader                                      []dropCohortFrontierParticipant
 	dropCohortFrontierMembersHeader                                           []dropCohortFrontierMember
+	dropCohortFrontierJournalHeader                                           []dropCohortFrontierMutation
 	dropCohortJournalHeader                                                   []dropCohortMutation
 	dropCohortReservationsHeader                                              []dropCohortReservation
 	transaction                                                               uint64
@@ -1198,6 +1202,7 @@ func (c *Core) markInto(mark *checkpoint) {
 		dropCohortFrontiers:                  len(c.dropCohortFrontiers),
 		dropCohortFrontierParticipants:       len(c.dropCohortFrontierParticipants),
 		dropCohortFrontierMembers:            len(c.dropCohortFrontierMembers),
+		dropCohortFrontierJournal:            len(c.dropCohortFrontierJournal),
 		dropCohortEphemeralBytes:             c.dropCohortEphemeralBytes,
 		dropCohortJournal:                    len(c.dropCohortJournal),
 		dropCohortNextSequence:               c.dropCohortNextSequence,
@@ -1230,6 +1235,7 @@ func (c *Core) markInto(mark *checkpoint) {
 		dropCohortMapStoreCap:                cap(c.dropCohortMapStore),
 		dropCohortJournalStoreCap:            cap(c.dropCohortJournalStore),
 		dropCohortJournalCap:                 cap(c.dropCohortJournal),
+		dropCohortFrontierJournalCap:         cap(c.dropCohortFrontierJournal),
 		dropCohortReservationsCap:            cap(c.dropCohortReservations),
 		dropCohortRefSpillHeader:             c.dropCohortRefSpill,
 		dropCohortActionsHeader:              c.dropCohortActions,
@@ -1244,6 +1250,7 @@ func (c *Core) markInto(mark *checkpoint) {
 		dropCohortFrontiersHeader:            c.dropCohortFrontiers,
 		dropCohortFrontierParticipantsHeader: c.dropCohortFrontierParticipants,
 		dropCohortFrontierMembersHeader:      c.dropCohortFrontierMembers,
+		dropCohortFrontierJournalHeader:      c.dropCohortFrontierJournal,
 		dropCohortJournalHeader:              c.dropCohortJournal,
 		dropCohortReservationsHeader:         c.dropCohortReservations,
 		transaction:                          c.nextTransaction,
@@ -1313,6 +1320,12 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 			c.dropCohortRecords[mutation.index] = mutation.before
 		}
 	}
+	for index := len(c.dropCohortFrontierJournal) - 1; index >= mark.dropCohortFrontierJournal; index-- {
+		mutation := c.dropCohortFrontierJournal[index]
+		if uint64(mutation.index) < uint64(len(c.dropCohortFrontiers)) {
+			c.dropCohortFrontiers[mutation.index].state = mutation.before
+		}
+	}
 	c.dropCohortActions = mark.dropCohortActionsHeader
 	c.dropCohortRecords = mark.dropCohortRecordsHeader
 	c.dropCohortMembers = mark.dropCohortMembersHeader
@@ -1325,6 +1338,7 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 	c.dropCohortFrontiers = mark.dropCohortFrontiersHeader
 	c.dropCohortFrontierParticipants = mark.dropCohortFrontierParticipantsHeader
 	c.dropCohortFrontierMembers = mark.dropCohortFrontierMembersHeader
+	c.dropCohortFrontierJournal = mark.dropCohortFrontierJournalHeader
 	c.dropCohortDerivationScratch = c.dropCohortDerivationScratch[:0]
 	c.dropCohortPathScratch = c.dropCohortPathScratch[:0]
 	c.dropCohortEphemeralBytes = mark.dropCohortEphemeralBytes
@@ -1739,6 +1753,7 @@ func (c *Core) Reset() error {
 	c.dropCohortFrontiers = c.dropCohortFrontiers[:0]
 	c.dropCohortFrontierParticipants = c.dropCohortFrontierParticipants[:0]
 	c.dropCohortFrontierMembers = c.dropCohortFrontierMembers[:0]
+	c.dropCohortFrontierJournal = c.dropCohortFrontierJournal[:0]
 	c.dropCohortDerivationScratch = c.dropCohortDerivationScratch[:0]
 	c.dropCohortPathScratch = c.dropCohortPathScratch[:0]
 	c.dropCohortEphemeralBytes = 0

--- a/internal/parsercorephase0/drop_cohort_arena.go
+++ b/internal/parsercorephase0/drop_cohort_arena.go
@@ -349,6 +349,7 @@ func (c *Core) dropCohortStoreBytes() uint64 {
 		uint64(len(c.dropCohortFrontiers))*coreDropCohortFrontierRecordBytes +
 		uint64(len(c.dropCohortFrontierParticipants))*coreDropCohortFrontierParticipantBytes +
 		uint64(len(c.dropCohortFrontierMembers))*coreDropCohortFrontierMemberBytes +
+		uint64(len(c.dropCohortFrontierJournal))*coreDropCohortFrontierMutationBytes +
 		uint64(len(c.dropCohortReservations))*uint64(coreDropCohortReservationBytes) +
 		uint64(len(c.dropCohortJournal))*uint64(coreDropCohortMutationBytes)
 }
@@ -419,6 +420,10 @@ func (c *Core) dropCohortRetainedOtherBytes() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
+	frontierJournal, err := dropCohortMulChecked(uint64(cap(c.dropCohortFrontierJournal)), coreDropCohortFrontierMutationBytes)
+	if err != nil {
+		return 0, err
+	}
 	retained, err := dropCohortAddChecked(journal, reservations)
 	if err != nil {
 		return 0, err
@@ -431,7 +436,11 @@ func (c *Core) dropCohortRetainedOtherBytes() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return dropCohortAddChecked(retained, members)
+	retained, err = dropCohortAddChecked(retained, members)
+	if err != nil {
+		return 0, err
+	}
+	return dropCohortAddChecked(retained, frontierJournal)
 }
 
 func (c *Core) dropCohortStoreGrowthBytes(index int, demand, derivationBytes uint64) (uint64, error) {

--- a/internal/parsercorephase0/drop_cohort_frontier.go
+++ b/internal/parsercorephase0/drop_cohort_frontier.go
@@ -42,6 +42,7 @@ const (
 	DropCohortFrontierComplete
 	DropCohortFrontierOverflowed
 	DropCohortFrontierIncomplete
+	DropCohortFrontierConsumed
 )
 
 const (
@@ -86,6 +87,11 @@ type dropCohortFrontierRecord struct {
 	seal                 [32]byte
 }
 
+type dropCohortFrontierMutation struct {
+	index  uint32
+	before DropCohortFrontierState
+}
+
 func dropCohortFrontierProtocolHandle(handle DropCohortFrontierHandle) [3]uint64 {
 	return [3]uint64{handle.Owner, handle.Epoch, handle.Sequence}
 }
@@ -100,6 +106,8 @@ func dropCohortFrontierProtocolState(state DropCohortFrontierState) string {
 		return "overflowed"
 	case DropCohortFrontierIncomplete:
 		return "incomplete"
+	case DropCohortFrontierConsumed:
+		return "consumed"
 	default:
 		return "unknown"
 	}
@@ -230,6 +238,52 @@ func (c *Core) dropCohortFrontierReserveCapacity(additionalRecords, additionalPa
 		grown := make([]dropCohortFrontierMember, len(c.dropCohortFrontierMembers), int(members))
 		copy(grown, c.dropCohortFrontierMembers)
 		c.dropCohortFrontierMembers = grown
+	}
+	return nil
+}
+
+func (c *Core) dropCohortFrontierReserveJournalCapacity(additional int) error {
+	if c == nil || additional < 0 {
+		return errors.New("parser-core phase zero: frontier journal capacity demand is invalid")
+	}
+	maxInt := uint64(^uint(0) >> 1)
+	if uint64(additional) > maxInt-uint64(len(c.dropCohortFrontierJournal)) {
+		return errors.New("parser-core phase zero: frontier journal capacity overflow")
+	}
+	needed := uint64(len(c.dropCohortFrontierJournal)) + uint64(additional)
+
+	retained, err := c.dropCohortRetainedOtherBytes()
+	if err != nil {
+		return err
+	}
+	for _, value := range c.dropCohortRetainedStoreBytes() {
+		retained, err = dropCohortAddChecked(retained, value)
+		if err != nil {
+			return err
+		}
+	}
+	retained, err = dropCohortAddChecked(retained, c.dropCohortReservedBytes)
+	if err != nil {
+		return err
+	}
+	if needed > uint64(cap(c.dropCohortFrontierJournal)) {
+		additionalCapacity := needed - uint64(cap(c.dropCohortFrontierJournal))
+		additionalBytes, mulErr := dropCohortMulChecked(additionalCapacity, coreDropCohortFrontierMutationBytes)
+		if mulErr != nil {
+			return mulErr
+		}
+		retained, err = dropCohortAddChecked(retained, additionalBytes)
+		if err != nil {
+			return err
+		}
+	}
+	if retained > c.limits.MaxDropCohortBytes {
+		return errors.New("parser-core phase zero: frontier journal byte cap")
+	}
+	if needed > uint64(cap(c.dropCohortFrontierJournal)) {
+		grown := make([]dropCohortFrontierMutation, len(c.dropCohortFrontierJournal), int(needed))
+		copy(grown, c.dropCohortFrontierJournal)
+		c.dropCohortFrontierJournal = grown
 	}
 	return nil
 }
@@ -753,6 +807,343 @@ func (c *Core) ValidateDropCohortFrontierSequenceOwned(owner SchedulerTransactio
 			Owner: c.dropCohortOwner, Epoch: c.dropCohortEpoch, Sequence: sequence,
 		}, heads)
 	}
+	return c.finishSchedulerOwned(owner, err)
+}
+
+func (c *Core) validateDropCohortFrontierStoredCounts(record dropCohortFrontierRecord) error {
+	if uint64(record.expectedParticipants) == 0 ||
+		uint64(record.expectedParticipants) > uint64(dropCohortFrontierParticipantHardCap) {
+		return errors.New("parser-core phase zero: stored frontier participant cap")
+	}
+	if uint64(record.expectedMembers) == 0 ||
+		uint64(record.expectedMembers) > uint64(dropCohortFrontierMemberHardCap) {
+		return errors.New("parser-core phase zero: stored frontier member cap")
+	}
+	if uint64(record.writtenParticipants) > uint64(dropCohortFrontierParticipantHardCap) ||
+		uint64(record.writtenMembers) > uint64(dropCohortFrontierMemberHardCap) {
+		return errors.New("parser-core phase zero: stored frontier written count cap")
+	}
+	return nil
+}
+
+func dropCohortFrontierSameCohort(left, right DropCohortRef) bool {
+	return left.Owner != 0 && left.Owner == right.Owner &&
+		left.Epoch != 0 && left.Epoch == right.Epoch &&
+		left.Sequence != 0 && left.Sequence == right.Sequence
+}
+
+func (c *Core) dropCohortFrontierMemberForRefOwned(
+	owner SchedulerTransactionToken,
+	participantIndex int,
+	refs DropCohortRefSet,
+	target DropCohortRef,
+) (dropCohortFrontierMember, bool, error) {
+	if err := c.validateSchedulerTransaction(owner); err != nil {
+		return dropCohortFrontierMember{}, false, err
+	}
+	count, valid := c.dropCohortRefCount(refs)
+	if !valid || count <= 0 || count > dropCohortRefHardCap {
+		return dropCohortFrontierMember{}, false, errors.New("parser-core phase zero: frontier candidate reference set is invalid")
+	}
+	if participantIndex < 0 || participantIndex >= len(c.dropCohortFrontierParticipants) {
+		return dropCohortFrontierMember{}, false, errors.New("parser-core phase zero: frontier candidate participant is absent")
+	}
+	participant := c.dropCohortFrontierParticipants[participantIndex]
+	start := uint64(participant.memberStart)
+	end := start + uint64(count)
+	if end < start || end > uint64(len(c.dropCohortFrontierMembers)) {
+		return dropCohortFrontierMember{}, false, errors.New("parser-core phase zero: frontier candidate member bounds are invalid")
+	}
+	for refIndex := 0; refIndex < count; refIndex++ {
+		if err := c.validateSchedulerTransaction(owner); err != nil {
+			return dropCohortFrontierMember{}, false, err
+		}
+		ref, ok := c.DropCohortRefAtOwned(owner, refs, refIndex)
+		if !ok {
+			return dropCohortFrontierMember{}, false, errors.New("parser-core phase zero: frontier candidate reference accessor failed")
+		}
+		if ref == target {
+			return c.dropCohortFrontierMembers[int(start)+refIndex], true, nil
+		}
+	}
+	return dropCohortFrontierMember{}, false, nil
+}
+
+func (c *Core) dropCohortFrontierHasMatchingMemberForCohortOwned(
+	owner SchedulerTransactionToken,
+	participantIndex int,
+	refs DropCohortRefSet,
+	target DropCohortRef,
+	want dropCohortFrontierMember,
+) (bool, error) {
+	if err := c.validateSchedulerTransaction(owner); err != nil {
+		return false, err
+	}
+	count, valid := c.dropCohortRefCount(refs)
+	if !valid || count <= 0 || count > dropCohortRefHardCap {
+		return false, errors.New("parser-core phase zero: frontier candidate reference set is invalid")
+	}
+	if participantIndex < 0 || participantIndex >= len(c.dropCohortFrontierParticipants) {
+		return false, errors.New("parser-core phase zero: frontier candidate participant is absent")
+	}
+	participant := c.dropCohortFrontierParticipants[participantIndex]
+	start := uint64(participant.memberStart)
+	end := start + uint64(count)
+	if end < start || end > uint64(len(c.dropCohortFrontierMembers)) {
+		return false, errors.New("parser-core phase zero: frontier candidate member bounds are invalid")
+	}
+	for refIndex := 0; refIndex < count; refIndex++ {
+		if err := c.validateSchedulerTransaction(owner); err != nil {
+			return false, err
+		}
+		ref, ok := c.DropCohortRefAtOwned(owner, refs, refIndex)
+		if !ok {
+			return false, errors.New("parser-core phase zero: frontier candidate reference accessor failed")
+		}
+		if !dropCohortFrontierSameCohort(ref, target) {
+			continue
+		}
+		member := c.dropCohortFrontierMembers[int(start)+refIndex]
+		if member.action == want.action &&
+			c.dropCohortVerifierDerivationEqual(member.derivation, want.derivation, false) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (c *Core) consumeDropCohortFrontierSequenceOwned(
+	owner SchedulerTransactionToken,
+	sequence uint64,
+	electionSequence uint64,
+	token DropCohortFrontierToken,
+	heads []Head,
+	refs []DropCohortRefSet,
+	drops []int,
+) error {
+	if err := c.validateSchedulerTransaction(owner); err != nil {
+		return err
+	}
+	if sequence == 0 {
+		return errors.New("parser-core phase zero: zero frontier sequence")
+	}
+	if electionSequence == 0 {
+		return errors.New("parser-core phase zero: zero frontier election sequence")
+	}
+	if len(heads) < 2 {
+		return errors.New("parser-core phase zero: frontier requires multiple participants")
+	}
+	if len(heads) != len(refs) {
+		return errors.New("parser-core phase zero: frontier header and reference count mismatch")
+	}
+	handle := DropCohortFrontierHandle{Owner: c.dropCohortOwner, Epoch: c.dropCohortEpoch, Sequence: sequence}
+	index, err := c.validateDropCohortFrontierIdentity(handle)
+	if err != nil {
+		return err
+	}
+	record := c.dropCohortFrontiers[index]
+	if record.handle.Owner != c.dropCohortOwner || record.handle.Epoch != c.dropCohortEpoch || record.handle.Sequence != sequence {
+		return errors.New("parser-core phase zero: frontier owner or epoch identity mismatch")
+	}
+	if record.state == DropCohortFrontierConsumed {
+		return errors.New("parser-core phase zero: frontier has already been consumed")
+	}
+	if record.state != DropCohortFrontierComplete {
+		return errors.New("parser-core phase zero: frontier is not complete")
+	}
+	if record.electionSequence != electionSequence {
+		return errors.New("parser-core phase zero: frontier election sequence mismatch")
+	}
+	if record.token != token {
+		return errors.New("parser-core phase zero: frontier token mismatch")
+	}
+	if !c.dropCohortFrontierTokenValid(owner, token) {
+		return errors.New("parser-core phase zero: frontier token receipt is invalid")
+	}
+	if err := c.validateDropCohortFrontierStoredCounts(record); err != nil {
+		return err
+	}
+	if record.writtenParticipants != record.expectedParticipants || int(record.expectedParticipants) != len(heads) {
+		return errors.New("parser-core phase zero: frontier participant count mismatch")
+	}
+	if record.expectedMembers == 0 || record.expectedMembers != record.writtenMembers {
+		return errors.New("parser-core phase zero: frontier member count mismatch")
+	}
+	participantStart := uint64(record.participantStart)
+	participantEnd := participantStart + uint64(record.expectedParticipants)
+	if participantEnd < participantStart || participantEnd > uint64(len(c.dropCohortFrontierParticipants)) {
+		return errors.New("parser-core phase zero: frontier participant store is incomplete")
+	}
+	memberStart := uint64(record.memberStart)
+	memberEnd := memberStart + uint64(record.writtenMembers)
+	if memberEnd < memberStart || memberEnd > uint64(len(c.dropCohortFrontierMembers)) {
+		return errors.New("parser-core phase zero: frontier member store is incomplete")
+	}
+	nextMember := memberStart
+	for participantIndex, head := range heads {
+		participant := c.dropCohortFrontierParticipants[int(participantStart)+participantIndex]
+		if participant.head != head {
+			return errors.New("parser-core phase zero: frontier header identity mismatch")
+		}
+		if participant.branchOrder != uint64(participantIndex) {
+			return errors.New("parser-core phase zero: frontier branch order mismatch")
+		}
+		if uint64(participant.memberCount) == 0 || uint64(participant.memberCount) > uint64(dropCohortRefHardCap) {
+			return errors.New("parser-core phase zero: stored frontier reference count cap")
+		}
+		participantMemberStart := uint64(participant.memberStart)
+		participantMemberEnd := participantMemberStart + uint64(participant.memberCount)
+		if participantMemberEnd < participantMemberStart || participantMemberStart != nextMember ||
+			participantMemberStart < memberStart || participantMemberEnd > memberEnd ||
+			participantMemberEnd > uint64(len(c.dropCohortFrontierMembers)) {
+			return errors.New("parser-core phase zero: frontier participant member bounds are invalid")
+		}
+		count, valid := c.dropCohortRefCount(refs[participantIndex])
+		if !valid || refs[participantIndex].Overflowed() || refs[participantIndex].Blended() ||
+			participant.referenceFlags&dropCohortRefFlagBlended != 0 || count <= 0 || count > dropCohortRefHardCap ||
+			uint16(count) != participant.memberCount || refs[participantIndex].Flags != participant.referenceFlags {
+			return errors.New("parser-core phase zero: frontier reference set is blended or mismatched")
+		}
+		for memberIndex := 0; memberIndex < count; memberIndex++ {
+			if err := c.validateSchedulerTransaction(owner); err != nil {
+				return err
+			}
+			ref, ok := c.DropCohortRefAtOwned(owner, refs[participantIndex], memberIndex)
+			if !ok {
+				return errors.New("parser-core phase zero: frontier reference accessor failed")
+			}
+			member := c.dropCohortFrontierMembers[int(participantMemberStart)+memberIndex]
+			if ref != member.ref {
+				return errors.New("parser-core phase zero: frontier reference order mismatch")
+			}
+			if member.participant != uint16(participantIndex) || member.participantHead != participant.head ||
+				member.branchOrder != participant.branchOrder {
+				return errors.New("parser-core phase zero: frontier member identity mismatch")
+			}
+			if !c.dropCohortFrontierMemberValid(owner, member) {
+				return errors.New("parser-core phase zero: frontier member is invalid")
+			}
+		}
+		nextMember = participantMemberEnd
+	}
+	if nextMember != memberEnd {
+		return errors.New("parser-core phase zero: frontier member count is incomplete")
+	}
+	if seal, ok := c.dropCohortFrontierSealOwned(owner, index); !ok || seal != record.seal {
+		return errors.New("parser-core phase zero: frontier seal mismatch")
+	}
+	if len(drops) == 0 || len(drops) >= len(heads) {
+		return errors.New("parser-core phase zero: frontier drop set is invalid")
+	}
+	previousDrop := -1
+	for _, drop := range drops {
+		if drop < 0 || drop >= len(heads) || drop <= previousDrop {
+			return errors.New("parser-core phase zero: frontier drop order is invalid")
+		}
+		previousDrop = drop
+	}
+	survivorIndex := -1
+	for participantIndex := range heads {
+		isDropped := false
+		for _, drop := range drops {
+			if participantIndex == drop {
+				isDropped = true
+				break
+			}
+		}
+		if !isDropped {
+			survivorIndex = participantIndex
+			break
+		}
+	}
+	if survivorIndex < 0 {
+		return errors.New("parser-core phase zero: frontier has no surviving participant")
+	}
+	survivorRefs := refs[survivorIndex]
+	survivorCount, survivorValid := c.dropCohortRefCount(survivorRefs)
+	if !survivorValid || survivorRefs.Overflowed() || survivorCount <= 0 || survivorCount > dropCohortRefHardCap {
+		return errors.New("parser-core phase zero: frontier survivor reference set is invalid")
+	}
+	proof := false
+	for candidateIndex := 0; candidateIndex < survivorCount; candidateIndex++ {
+		if err := c.validateSchedulerTransaction(owner); err != nil {
+			return err
+		}
+		candidate, ok := c.DropCohortRefAtOwned(owner, survivorRefs, candidateIndex)
+		if !ok {
+			continue
+		}
+		if err := c.validateSchedulerTransaction(owner); err != nil {
+			return err
+		}
+		candidateRecordIndex, _, reason := c.dropCohortVerifierLookup(candidate, false)
+		if reason != dropCohortVerifierProved {
+			continue
+		} else if reason = dropCohortVerifierClassifyRecord(c.dropCohortRecords[candidateRecordIndex]); reason != dropCohortVerifierProved {
+			continue
+		}
+		survivorMember, found, memberErr := c.dropCohortFrontierMemberForRefOwned(
+			owner, int(participantStart)+survivorIndex, survivorRefs, candidate,
+		)
+		if memberErr != nil {
+			return memberErr
+		}
+		if !found {
+			continue
+		}
+		candidateProof := true
+		for _, drop := range drops {
+			matched, memberErr := c.dropCohortFrontierHasMatchingMemberForCohortOwned(
+				owner, int(participantStart)+drop, refs[drop], candidate, survivorMember,
+			)
+			if memberErr != nil {
+				return memberErr
+			}
+			if err := c.validateSchedulerTransaction(owner); err != nil {
+				return err
+			}
+			if !matched {
+				candidateProof = false
+				break
+			}
+		}
+		if candidateProof {
+			proof = true
+			break
+		}
+	}
+	if !proof {
+		return errors.New("parser-core phase zero: frontier dropped members lack a common action and derivation")
+	}
+	if uint64(index) > uint64(^uint32(0)) {
+		return errors.New("parser-core phase zero: frontier index overflow")
+	}
+	if err := c.dropCohortFrontierReserveJournalCapacity(1); err != nil {
+		return err
+	}
+	c.dropCohortFrontierJournal = append(c.dropCohortFrontierJournal, dropCohortFrontierMutation{
+		index: uint32(index), before: record.state,
+	})
+	c.dropCohortFrontiers[index].state = DropCohortFrontierConsumed
+	return nil
+}
+
+// ConsumeDropCohortFrontierSequenceOwned authenticates and consumes one
+// complete scheduler frontier by sequence.
+func (c *Core) ConsumeDropCohortFrontierSequenceOwned(
+	owner SchedulerTransactionToken,
+	sequence uint64,
+	electionSequence uint64,
+	token DropCohortFrontierToken,
+	heads []Head,
+	refs []DropCohortRefSet,
+	drops []int,
+) (err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	err = c.consumeDropCohortFrontierSequenceOwned(owner, sequence, electionSequence, token, heads, refs, drops)
 	return c.finishSchedulerOwned(owner, err)
 }
 

--- a/internal/parsercorephase0/drop_cohort_frontier_test.go
+++ b/internal/parsercorephase0/drop_cohort_frontier_test.go
@@ -1,6 +1,7 @@
 package parsercorephase0
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -101,6 +102,61 @@ func publishDropCohortFrontierFixture(t *testing.T, fixture *dropCohortFrontierF
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func buildDropCohortFrontierTestCohort(
+	t *testing.T,
+	core *Core,
+	identity DropCohortActionIdentity,
+	state StateID,
+	byteOffset uint32,
+) DropCohortRefSet {
+	t.Helper()
+	seed, err := core.Seed(state, byteOffset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head := g18ProducerHead(t, core, seed, Symbol(120+state), byteOffset+1)
+	var refs DropCohortRefSet
+	if err := core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		cohort, beginErr := core.BeginDropCohortOwned(owner, identity, 1)
+		if beginErr != nil {
+			return beginErr
+		}
+		derivation, buildErr := core.BuildDropCohortDerivationOwned(owner, head, DropCohortSourceCheckpoint{
+			StartByte: byteOffset, EndByte: byteOffset + 1,
+		})
+		if buildErr != nil {
+			return buildErr
+		}
+		if writeErr := core.WriteDropCohortMemberOwned(owner, cohort, head, 0, derivation); writeErr != nil {
+			return writeErr
+		}
+		refs, err = core.FinalizeDropCohortOwned(owner, cohort)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return refs
+}
+
+func newDropCohortFrontierTwoCohortFixture(t *testing.T, shared bool) dropCohortFrontierFixture {
+	t.Helper()
+	fixture := newDropCohortFrontierFixture(t, 2, 1)
+	first := fixture.refs[0]
+	secondIdentity := g18ProducerIdentity()
+	secondIdentity.ActionOrdinal++
+	second := buildDropCohortFrontierTestCohort(t, fixture.core, secondIdentity, 3, 10)
+	if shared {
+		combined := first
+		if !fixture.core.UnionDropCohortRefs(&combined, second) {
+			t.Fatal("multi-cohort reference union did not change the set")
+		}
+		fixture.refs[0], fixture.refs[1] = combined, combined
+	} else {
+		fixture.refs[0], fixture.refs[1] = first, second
+	}
+	return fixture
 }
 
 func TestG18DropCohortFrontierPublishesOrderedOwnedRecord(t *testing.T) {
@@ -393,5 +449,722 @@ func TestG18DropCohortFrontierStaleTokenPoisonsAndRollsBackOuterMutation(t *test
 		len(fixture.core.dropCohortFrontierMembers) != beforeMembers ||
 		fixture.core.dropCohortFrontierNextSequence != beforeSequence {
 		t.Fatalf("stale-token rollback retained state: writes=%v/%v records=%d/%d participants=%d/%d members=%d/%d sequence=%d/%d", fixture.core.dropCohortProducerWrites, beforeWrites, len(fixture.core.dropCohortFrontiers), beforeRecords, len(fixture.core.dropCohortFrontierParticipants), beforeParticipants, len(fixture.core.dropCohortFrontierMembers), beforeMembers, fixture.core.dropCohortFrontierNextSequence, beforeSequence)
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedSucceedsAndRejectsReplay(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 1)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	if err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierConsumed {
+		t.Fatalf("frontier state=%v, want consumed", got)
+	}
+	if len(fixture.core.dropCohortFrontierJournal) != 1 {
+		t.Fatalf("frontier journal length=%d, want 1", len(fixture.core.dropCohortFrontierJournal))
+	}
+	mutation := fixture.core.dropCohortFrontierJournal[0]
+	if mutation.index != uint32(fixture.frontier.Sequence-1) || mutation.before != DropCohortFrontierComplete {
+		t.Fatalf("frontier mutation=%+v, want prior complete state for sequence %d", mutation, fixture.frontier.Sequence)
+	}
+	replayErr := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		)
+	})
+	if replayErr == nil {
+		t.Fatal("replayed frontier consumption succeeded")
+	}
+	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierConsumed {
+		t.Fatalf("frontier state after replay=%v, want consumed", got)
+	}
+	if len(fixture.core.dropCohortFrontierJournal) != 1 {
+		t.Fatalf("frontier journal length after replay=%d, want 1", len(fixture.core.dropCohortFrontierJournal))
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedRollsBackOuterError(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 1)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	beforeJournal := len(fixture.core.dropCohortFrontierJournal)
+	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if consumeErr := fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		); consumeErr != nil {
+			return consumeErr
+		}
+		return errors.New("forced outer rollback")
+	})
+	if err == nil {
+		t.Fatal("forced outer error did not roll back")
+	}
+	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
+		t.Fatalf("frontier state after rollback=%v, want complete", got)
+	}
+	if len(fixture.core.dropCohortFrontierJournal) != beforeJournal {
+		t.Fatalf("frontier journal length after rollback=%d, want %d", len(fixture.core.dropCohortFrontierJournal), beforeJournal)
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedJournalByteCapDeclines(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 1)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	retained, err := fixture.core.dropCohortRetainedOtherBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, value := range fixture.core.dropCohortRetainedStoreBytes() {
+		retained, err = dropCohortAddChecked(retained, value)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	retained, err = dropCohortAddChecked(retained, fixture.core.dropCohortReservedBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.core.limits.MaxDropCohortBytes = retained
+	beforeJournalLen := len(fixture.core.dropCohortFrontierJournal)
+	beforeJournalCap := cap(fixture.core.dropCohortFrontierJournal)
+	err = fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		)
+	})
+	if err == nil {
+		t.Fatal("journal byte-cap decline was accepted")
+	}
+	if len(fixture.core.dropCohortFrontierJournal) != beforeJournalLen || cap(fixture.core.dropCohortFrontierJournal) != beforeJournalCap {
+		t.Fatalf("frontier journal changed after byte-cap decline: len=%d/%d cap=%d/%d", len(fixture.core.dropCohortFrontierJournal), beforeJournalLen, cap(fixture.core.dropCohortFrontierJournal), beforeJournalCap)
+	}
+	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
+		t.Fatalf("frontier state after byte-cap decline=%v, want complete", got)
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedResetClearsConsumedState(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 1)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	if err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.core.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	if len(fixture.core.dropCohortFrontiers) != 0 || len(fixture.core.dropCohortFrontierParticipants) != 0 ||
+		len(fixture.core.dropCohortFrontierMembers) != 0 || len(fixture.core.dropCohortFrontierJournal) != 0 {
+		t.Fatalf("reset retained consumed frontier stores: frontiers=%d participants=%d members=%d journal=%d", len(fixture.core.dropCohortFrontiers), len(fixture.core.dropCohortFrontierParticipants), len(fixture.core.dropCohortFrontierMembers), len(fixture.core.dropCohortFrontierJournal))
+	}
+}
+
+func TestG18D6bResetReleasingRetentionDropsConsumedFrontierJournal(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 1)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	if err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if cap(fixture.core.dropCohortFrontierJournal) == 0 {
+		t.Fatal("consumed frontier did not retain journal capacity")
+	}
+	if err := fixture.core.ResetReleasingRetention(); err != nil {
+		t.Fatal(err)
+	}
+	if len(fixture.core.dropCohortFrontierJournal) != 0 || cap(fixture.core.dropCohortFrontierJournal) != 0 {
+		t.Fatalf("retention reset kept frontier journal len=%d cap=%d", len(fixture.core.dropCohortFrontierJournal), cap(fixture.core.dropCohortFrontierJournal))
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedRejectsMalformedStoredOffsets(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Core)
+	}{
+		{name: "participant_start", mutate: func(core *Core) {
+			core.dropCohortFrontiers[0].participantStart = ^uint32(0)
+		}},
+		{name: "member_start", mutate: func(core *Core) {
+			core.dropCohortFrontiers[0].memberStart = ^uint32(0)
+		}},
+		{name: "participant_member_start", mutate: func(core *Core) {
+			core.dropCohortFrontierParticipants[0].memberStart = ^uint32(0)
+		}},
+	}
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newDropCohortFrontierFixture(t, 2, 2)
+			publishDropCohortFrontierFixture(t, &fixture)
+			if !fixture.frontierOK {
+				t.Fatal("frontier did not publish")
+			}
+			testCase.mutate(fixture.core)
+			var consumeErr error
+			outerErr := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				consumeErr = fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+					owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{0},
+				)
+				return consumeErr
+			})
+			if consumeErr == nil || outerErr == nil {
+				t.Fatalf("malformed offset accepted: consume=%v outer=%v", consumeErr, outerErr)
+			}
+			if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
+				t.Fatalf("frontier state after malformed offset=%v, want complete", got)
+			}
+			if len(fixture.core.dropCohortFrontierJournal) != 0 {
+				t.Fatalf("frontier journal after malformed offset=%d, want 0", len(fixture.core.dropCohortFrontierJournal))
+			}
+		})
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedRejectsStoredCountCaps(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Core)
+	}{
+		{name: "expected_participants", mutate: func(core *Core) {
+			core.dropCohortFrontiers[0].expectedParticipants = dropCohortFrontierParticipantHardCap + 1
+		}},
+		{name: "expected_members", mutate: func(core *Core) {
+			core.dropCohortFrontiers[0].expectedMembers = dropCohortFrontierMemberHardCap + 1
+		}},
+		{name: "stored_per_head_references", mutate: func(core *Core) {
+			core.dropCohortFrontierParticipants[0].memberCount = dropCohortRefHardCap + 1
+		}},
+	}
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newDropCohortFrontierFixture(t, 2, 2)
+			publishDropCohortFrontierFixture(t, &fixture)
+			if !fixture.frontierOK {
+				t.Fatal("frontier did not publish")
+			}
+			testCase.mutate(fixture.core)
+			var consumeErr error
+			outerErr := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				consumeErr = fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+					owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{0},
+				)
+				return consumeErr
+			})
+			if consumeErr == nil || outerErr == nil {
+				t.Fatalf("stored count cap accepted: consume=%v outer=%v", consumeErr, outerErr)
+			}
+			if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
+				t.Fatalf("frontier state after stored count cap=%v, want complete", got)
+			}
+			if len(fixture.core.dropCohortFrontierJournal) != 0 {
+				t.Fatalf("frontier journal after stored count cap=%d, want 0", len(fixture.core.dropCohortFrontierJournal))
+			}
+		})
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedRejectsMismatchedAction(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 1)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	fixture.core.dropCohortFrontierMembers[1].action.ActionOrdinal++
+	if err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		seal, ok := fixture.core.dropCohortFrontierSealOwned(owner, 0)
+		if !ok {
+			return errors.New("frontier seal could not be rebuilt")
+		}
+		fixture.core.dropCohortFrontiers[0].seal = seal
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		)
+	})
+	if err == nil {
+		t.Fatal("mismatched action was accepted")
+	}
+	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
+		t.Fatalf("frontier state after action mismatch=%v, want complete", got)
+	}
+	if len(fixture.core.dropCohortFrontierJournal) != 0 {
+		t.Fatalf("frontier journal after action mismatch=%d, want 0", len(fixture.core.dropCohortFrontierJournal))
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedRejectsMismatchedDerivation(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 1)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	fixture.core.dropCohortFrontierMembers[1].derivationLength++
+	if err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		seal, ok := fixture.core.dropCohortFrontierSealOwned(owner, 0)
+		if !ok {
+			return errors.New("frontier seal could not be rebuilt")
+		}
+		fixture.core.dropCohortFrontiers[0].seal = seal
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		)
+	})
+	if err == nil {
+		t.Fatal("mismatched derivation was accepted")
+	}
+	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
+		t.Fatalf("frontier state after derivation mismatch=%v, want complete", got)
+	}
+	if len(fixture.core.dropCohortFrontierJournal) != 0 {
+		t.Fatalf("frontier journal after derivation mismatch=%d, want 0", len(fixture.core.dropCohortFrontierJournal))
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedRejectsResealedBlendedRefs(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 1)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	fixture.refs[0].Flags |= dropCohortRefFlagBlended
+	fixture.core.dropCohortFrontierParticipants[0].referenceFlags |= dropCohortRefFlagBlended
+	if err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		seal, ok := fixture.core.dropCohortFrontierSealOwned(owner, 0)
+		if !ok {
+			return errors.New("frontier seal could not be rebuilt")
+		}
+		fixture.core.dropCohortFrontiers[0].seal = seal
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		)
+	})
+	if err == nil {
+		t.Fatal("resealed blended references were accepted")
+	}
+	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
+		t.Fatalf("frontier state after blended rejection=%v, want complete", got)
+	}
+	if len(fixture.core.dropCohortFrontierJournal) != 0 {
+		t.Fatalf("frontier journal after blended rejection=%d, want 0", len(fixture.core.dropCohortFrontierJournal))
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedRejectsValidBranchDerivationMismatch(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 2)
+	branchZero, ok := fixture.core.DropCohortRefAt(fixture.refs[0], 0)
+	if !ok {
+		t.Fatal("source branch zero reference is unavailable")
+	}
+	branchOne, ok := fixture.core.DropCohortRefAt(fixture.refs[0], 1)
+	if !ok {
+		t.Fatal("source branch one reference is unavailable")
+	}
+	var survivorRefs, droppedRefs DropCohortRefSet
+	if !fixture.core.AddDropCohortRef(&survivorRefs, branchZero) ||
+		!fixture.core.AddDropCohortRef(&droppedRefs, branchOne) {
+		t.Fatal("source branch reference subset construction failed")
+	}
+	fixture.refs[0], fixture.refs[1] = survivorRefs, droppedRefs
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		)
+	})
+	if err == nil {
+		t.Fatal("valid branch derivation mismatch was accepted")
+	}
+	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
+		t.Fatalf("frontier state after valid branch mismatch=%v, want complete", got)
+	}
+	if len(fixture.core.dropCohortFrontierJournal) != 0 {
+		t.Fatalf("frontier journal after valid branch mismatch=%d, want 0", len(fixture.core.dropCohortFrontierJournal))
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedSelectsMatchingLaterBranch(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 2)
+	branchZero, ok := fixture.core.DropCohortRefAt(fixture.refs[0], 0)
+	if !ok {
+		t.Fatal("source branch zero reference is unavailable")
+	}
+	branchOne, ok := fixture.core.DropCohortRefAt(fixture.refs[0], 1)
+	if !ok {
+		t.Fatal("source branch one reference is unavailable")
+	}
+	var survivorRefs, droppedRefs DropCohortRefSet
+	if !fixture.core.AddDropCohortRef(&survivorRefs, branchZero) ||
+		!fixture.core.AddDropCohortRef(&survivorRefs, branchOne) ||
+		!fixture.core.AddDropCohortRef(&droppedRefs, branchOne) {
+		t.Fatal("same-cohort branch reference subset construction failed")
+	}
+	fixture.refs[0], fixture.refs[1] = survivorRefs, droppedRefs
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	if err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierConsumed {
+		t.Fatalf("frontier state after same-cohort branch fallback=%v, want consumed", got)
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedRejectsNoCommonCohort(t *testing.T) {
+	fixture := newDropCohortFrontierTwoCohortFixture(t, false)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		)
+	})
+	if err == nil {
+		t.Fatal("frontier with no common cohort was accepted")
+	}
+	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
+		t.Fatalf("frontier state after no-common decline=%v, want complete", got)
+	}
+	if len(fixture.core.dropCohortFrontierJournal) != 0 {
+		t.Fatalf("frontier journal after no-common decline=%d, want 0", len(fixture.core.dropCohortFrontierJournal))
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedSelectsMultiRefCandidate(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 2)
+	branchZero, ok := fixture.core.DropCohortRefAt(fixture.refs[0], 0)
+	if !ok {
+		t.Fatal("first source branch zero reference is unavailable")
+	}
+	branchOne, ok := fixture.core.DropCohortRefAt(fixture.refs[0], 1)
+	if !ok {
+		t.Fatal("first source branch one reference is unavailable")
+	}
+	second := buildDropCohortFrontierTestCohort(t, fixture.core, func() DropCohortActionIdentity {
+		identity := g18ProducerIdentity()
+		identity.ActionOrdinal++
+		return identity
+	}(), 3, 10)
+	secondRef, ok := fixture.core.DropCohortRefAt(second, 0)
+	if !ok {
+		t.Fatal("second source reference is unavailable")
+	}
+	var survivorRefs, droppedRefs DropCohortRefSet
+	for _, ref := range []DropCohortRef{branchZero, secondRef} {
+		if !fixture.core.AddDropCohortRef(&survivorRefs, ref) {
+			t.Fatal("survivor multi-ref construction failed")
+		}
+	}
+	for _, ref := range []DropCohortRef{branchOne, secondRef} {
+		if !fixture.core.AddDropCohortRef(&droppedRefs, ref) {
+			t.Fatal("dropped multi-ref construction failed")
+		}
+	}
+	fixture.refs[0], fixture.refs[1] = survivorRefs, droppedRefs
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	if fixture.refs[0].Len() != 2 {
+		t.Fatalf("multi-ref fixture count=%d, want 2", fixture.refs[0].Len())
+	}
+	if err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierConsumed {
+		t.Fatalf("frontier state after multi-ref proof=%v, want consumed", got)
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedJournalRollbackRestoresCheckpointHeader(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 1)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	if err := fixture.core.dropCohortFrontierReserveJournalCapacity(1); err != nil {
+		t.Fatal(err)
+	}
+	beforeJournalLen := len(fixture.core.dropCohortFrontierJournal)
+	beforeJournalCap := cap(fixture.core.dropCohortFrontierJournal)
+	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if consumeErr := fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		); consumeErr != nil {
+			return consumeErr
+		}
+		return errors.New("forced outer rollback")
+	})
+	if err == nil {
+		t.Fatal("forced outer error did not roll back")
+	}
+	if len(fixture.core.dropCohortFrontierJournal) != beforeJournalLen ||
+		cap(fixture.core.dropCohortFrontierJournal) != beforeJournalCap {
+		t.Fatalf("frontier journal checkpoint changed: len=%d/%d cap=%d/%d", len(fixture.core.dropCohortFrontierJournal), beforeJournalLen, cap(fixture.core.dropCohortFrontierJournal), beforeJournalCap)
+	}
+	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
+		t.Fatalf("frontier state after journal rollback=%v, want complete", got)
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedRejectsCurrentInputMutations(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*uint64, *DropCohortFrontierToken, []Head, []DropCohortRefSet, *[]int)
+	}{
+		{name: "wrong_election", mutate: func(election *uint64, _ *DropCohortFrontierToken, _ []Head, _ []DropCohortRefSet, _ *[]int) {
+			*election = 12
+		}},
+		{name: "token_symbol", mutate: func(_ *uint64, token *DropCohortFrontierToken, _ []Head, _ []DropCohortRefSet, _ *[]int) {
+			token.Symbol++
+		}},
+		{name: "scanner_digest", mutate: func(_ *uint64, token *DropCohortFrontierToken, _ []Head, _ []DropCohortRefSet, _ *[]int) {
+			token.ScannerBeforeDigest[0] ^= 0xff
+		}},
+		{name: "swapped_heads", mutate: func(_ *uint64, _ *DropCohortFrontierToken, heads []Head, _ []DropCohortRefSet, _ *[]int) {
+			heads[0], heads[1] = heads[1], heads[0]
+		}},
+		{name: "reference_flags", mutate: func(_ *uint64, _ *DropCohortFrontierToken, _ []Head, refs []DropCohortRefSet, _ *[]int) {
+			refs[0].Flags ^= dropCohortRefFlagBlended
+		}},
+		{name: "reference_count", mutate: func(_ *uint64, _ *DropCohortFrontierToken, _ []Head, refs []DropCohortRefSet, _ *[]int) {
+			refs[0].Count--
+		}},
+		{name: "ordered_reference", mutate: func(_ *uint64, _ *DropCohortFrontierToken, _ []Head, refs []DropCohortRefSet, _ *[]int) {
+			refs[0].Inline[0], refs[0].Inline[1] = refs[0].Inline[1], refs[0].Inline[0]
+		}},
+		{name: "empty_drops", mutate: func(_ *uint64, _ *DropCohortFrontierToken, _ []Head, _ []DropCohortRefSet, drops *[]int) {
+			*drops = []int{}
+		}},
+		{name: "duplicate_drops", mutate: func(_ *uint64, _ *DropCohortFrontierToken, _ []Head, _ []DropCohortRefSet, drops *[]int) {
+			*drops = []int{0, 0}
+		}},
+		{name: "descending_drops", mutate: func(_ *uint64, _ *DropCohortFrontierToken, _ []Head, _ []DropCohortRefSet, drops *[]int) {
+			*drops = []int{1, 0}
+		}},
+		{name: "negative_drop", mutate: func(_ *uint64, _ *DropCohortFrontierToken, _ []Head, _ []DropCohortRefSet, drops *[]int) {
+			*drops = []int{-1}
+		}},
+		{name: "out_of_range_drop", mutate: func(_ *uint64, _ *DropCohortFrontierToken, _ []Head, _ []DropCohortRefSet, drops *[]int) {
+			*drops = []int{2}
+		}},
+		{name: "all_header_drops", mutate: func(_ *uint64, _ *DropCohortFrontierToken, _ []Head, _ []DropCohortRefSet, drops *[]int) {
+			*drops = []int{0, 1}
+		}},
+	}
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newDropCohortFrontierFixture(t, 2, 2)
+			publishDropCohortFrontierFixture(t, &fixture)
+			if !fixture.frontierOK {
+				t.Fatal("frontier did not publish")
+			}
+			election := uint64(11)
+			token := fixture.token
+			heads := append([]Head(nil), fixture.heads...)
+			refs := append([]DropCohortRefSet(nil), fixture.refs...)
+			drops := []int{1}
+			testCase.mutate(&election, &token, heads, refs, &drops)
+			var ownedErr error
+			outerErr := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				ownedErr = fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+					owner, fixture.frontier.Sequence, election, token, heads, refs, drops,
+				)
+				return ownedErr
+			})
+			if ownedErr == nil || outerErr == nil {
+				t.Fatalf("mutated input accepted: owned=%v outer=%v", ownedErr, outerErr)
+			}
+			if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
+				t.Fatalf("frontier state after rollback=%v, want complete", got)
+			}
+			if len(fixture.core.dropCohortFrontierJournal) != 0 {
+				t.Fatalf("frontier journal length after rollback=%d, want 0", len(fixture.core.dropCohortFrontierJournal))
+			}
+		})
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedRejectsStoredAuthenticationMutations(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Core)
+	}{
+		{name: "record_seal", mutate: func(core *Core) {
+			core.dropCohortFrontiers[0].seal[0] ^= 0xff
+		}},
+		{name: "participant_head", mutate: func(core *Core) {
+			core.dropCohortFrontierParticipants[0].head.Node++
+		}},
+		{name: "participant_branch_order", mutate: func(core *Core) {
+			core.dropCohortFrontierParticipants[0].branchOrder++
+		}},
+		{name: "participant_reference_flags", mutate: func(core *Core) {
+			core.dropCohortFrontierParticipants[0].referenceFlags ^= dropCohortRefFlagBlended
+		}},
+		{name: "participant_member_count", mutate: func(core *Core) {
+			core.dropCohortFrontierParticipants[0].memberCount++
+		}},
+		{name: "member_participant", mutate: func(core *Core) {
+			core.dropCohortFrontierMembers[0].participant++
+		}},
+		{name: "member_ref_branch", mutate: func(core *Core) {
+			core.dropCohortFrontierMembers[0].ref.Branch++
+		}},
+		{name: "member_participant_head", mutate: func(core *Core) {
+			core.dropCohortFrontierMembers[0].participantHead.Node++
+		}},
+		{name: "member_branch_order", mutate: func(core *Core) {
+			core.dropCohortFrontierMembers[0].branchOrder++
+		}},
+		{name: "member_derivation_digest", mutate: func(core *Core) {
+			core.dropCohortFrontierMembers[0].derivationDigest[0] ^= 0xff
+		}},
+	}
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newDropCohortFrontierFixture(t, 2, 2)
+			publishDropCohortFrontierFixture(t, &fixture)
+			if !fixture.frontierOK {
+				t.Fatal("frontier did not publish")
+			}
+			testCase.mutate(fixture.core)
+			var ownedErr error
+			outerErr := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				ownedErr = fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+					owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{0},
+				)
+				return ownedErr
+			})
+			if ownedErr == nil || outerErr == nil {
+				t.Fatalf("stored mutation accepted: owned=%v outer=%v", ownedErr, outerErr)
+			}
+			if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
+				t.Fatalf("frontier state after rollback=%v, want complete", got)
+			}
+			if len(fixture.core.dropCohortFrontierJournal) != 0 {
+				t.Fatalf("frontier journal length after rollback=%d, want 0", len(fixture.core.dropCohortFrontierJournal))
+			}
+		})
+	}
+}
+
+func TestG18D6bConsumeDropCohortFrontierSequenceOwnedRejectsStaleAndForeignOwners(t *testing.T) {
+	fixture := newDropCohortFrontierFixture(t, 2, 2)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	var stale SchedulerTransactionToken
+	if err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		stale = owner
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	beforeChecks := fixture.core.dropCohortOwnerCheckedLookups
+	var staleOwnedErr error
+	staleOuterErr := fixture.core.ApplySchedulerAtomic(func(_ SchedulerTransactionToken) error {
+		staleOwnedErr = fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			stale, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{0},
+		)
+		return nil
+	})
+	if staleOwnedErr == nil || staleOuterErr == nil {
+		t.Fatalf("stale owner accepted: owned=%v outer=%v", staleOwnedErr, staleOuterErr)
+	}
+	if fixture.core.dropCohortOwnerCheckedLookups != beforeChecks {
+		t.Fatalf("stale owner changed frontier lookup count: got=%d want=%d", fixture.core.dropCohortOwnerCheckedLookups, beforeChecks)
+	}
+	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
+		t.Fatalf("frontier state after stale owner=%v, want complete", got)
+	}
+	if len(fixture.core.dropCohortFrontierJournal) != 0 {
+		t.Fatalf("frontier journal after stale owner=%d, want 0", len(fixture.core.dropCohortFrontierJournal))
+	}
+
+	foreignCore := newTinyCoreWithLimits(t, Limits{})
+	beforeChecks = fixture.core.dropCohortOwnerCheckedLookups
+	var foreignOwnedErr, fixtureOuterErr error
+	foreignOuterErr := foreignCore.ApplySchedulerAtomic(func(foreign SchedulerTransactionToken) error {
+		fixtureOuterErr = fixture.core.ApplySchedulerAtomic(func(_ SchedulerTransactionToken) error {
+			foreignOwnedErr = fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+				foreign, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{0},
+			)
+			return nil
+		})
+		return nil
+	})
+	if foreignOuterErr != nil {
+		t.Fatalf("foreign core transaction failed: %v", foreignOuterErr)
+	}
+	if foreignOwnedErr == nil || fixtureOuterErr == nil {
+		t.Fatalf("foreign owner accepted: owned=%v outer=%v", foreignOwnedErr, fixtureOuterErr)
+	}
+	if fixture.core.dropCohortOwnerCheckedLookups != beforeChecks {
+		t.Fatalf("foreign owner changed frontier lookup count: got=%d want=%d", fixture.core.dropCohortOwnerCheckedLookups, beforeChecks)
+	}
+	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
+		t.Fatalf("frontier state after foreign owner=%v, want complete", got)
+	}
+	if len(fixture.core.dropCohortFrontierJournal) != 0 {
+		t.Fatalf("frontier journal after foreign owner=%d, want 0", len(fixture.core.dropCohortFrontierJournal))
 	}
 }

--- a/internal/parsercorephase0/storage_bytes.go
+++ b/internal/parsercorephase0/storage_bytes.go
@@ -24,6 +24,7 @@ var (
 	coreDropCohortFrontierRecordBytes      = uint64(unsafe.Sizeof(dropCohortFrontierRecord{}))
 	coreDropCohortFrontierParticipantBytes = uint64(unsafe.Sizeof(dropCohortFrontierParticipant{}))
 	coreDropCohortFrontierMemberBytes      = uint64(unsafe.Sizeof(dropCohortFrontierMember{}))
+	coreDropCohortFrontierMutationBytes    = uint64(unsafe.Sizeof(dropCohortFrontierMutation{}))
 )
 
 // StorageBytes returns a cheap, deterministic, O(1) estimate of the compact
@@ -76,6 +77,7 @@ func (c *Core) StorageBytes() uint64 {
 		uint64(len(c.dropCohortFrontiers))*coreDropCohortFrontierRecordBytes +
 		uint64(len(c.dropCohortFrontierParticipants))*coreDropCohortFrontierParticipantBytes +
 		uint64(len(c.dropCohortFrontierMembers))*coreDropCohortFrontierMemberBytes +
+		uint64(len(c.dropCohortFrontierJournal))*coreDropCohortFrontierMutationBytes +
 		uint64(len(c.dropCohortReservations))*coreDropCohortReservationBytes +
 		uint64(len(c.dropCohortJournal))*coreDropCohortMutationBytes
 }
@@ -167,6 +169,7 @@ func (c *Core) FootprintBytes() uint64 {
 	total += uint64(cap(c.dropCohortFrontiers)) * coreDropCohortFrontierRecordBytes
 	total += uint64(cap(c.dropCohortFrontierParticipants)) * coreDropCohortFrontierParticipantBytes
 	total += uint64(cap(c.dropCohortFrontierMembers)) * coreDropCohortFrontierMemberBytes
+	total += uint64(cap(c.dropCohortFrontierJournal)) * coreDropCohortFrontierMutationBytes
 	total += uint64(cap(c.dropCohortReservations)) * coreDropCohortReservationBytes
 	// A durable reservation is a committed memory budget even before its
 	// backing store is filled. Include it in the containment gauge so nested
@@ -315,6 +318,7 @@ func (c *Core) releaseRecordArenaReserve() {
 	c.dropCohortFrontiers = nil
 	c.dropCohortFrontierParticipants = nil
 	c.dropCohortFrontierMembers = nil
+	c.dropCohortFrontierJournal = nil
 	c.dropCohortDerivationScratch = nil
 	c.dropCohortPathScratch = nil
 	c.dropCohortJournal = nil
@@ -349,6 +353,7 @@ func (c *Core) releaseOversizedRetention() {
 	c.dropCohortFrontiers = nil
 	c.dropCohortFrontierParticipants = nil
 	c.dropCohortFrontierMembers = nil
+	c.dropCohortFrontierJournal = nil
 	c.dropCohortDerivationScratch = nil
 	c.dropCohortPathScratch = nil
 	c.dropCohortJournal = nil


### PR DESCRIPTION
## Summary

- Add a default-off internal D6b foundation for authenticated frontier consumption.
- Prove one full common-survivor action and derivation identity before mutation.
- Journal consumed-state changes, support checkpoint rollback, and account for retained memory.
- Keep driver and admission activation disabled.
- Update `CHANGELOG.md` and `docs/compact-route-real-corpus-matrix.md`.

## Verification

Focused Docker gates passed:

- `harness_out/docker/20260822T101332Z-d6b-proof-tests-v4`
- `harness_out/docker/20260822T101347Z-d6b-frontier-regression-v4`
- `harness_out/docker/20260822T102426Z-d6b-default-build-v6`
- `harness_out/docker/20260822T102441Z-d6b-default-off-v6`
- `harness_out/docker/20260822T102447Z-d6b-d6a-go-language-v6`
- `harness_out/docker/20260822T102454Z-d6b-d6a-go-grammargen-lr-v6`

The original combined v5 gate reported a D6a runtime mismatch:
`harness_out/docker/20260822T101753Z-d6b-root-contract-v5`.
The mismatch came from pooled parser-state allocation telemetry.
Clean and isolated reruns passed, including `harness_out/docker/20260822T102211Z-d6b-root-contract-diagnostic-v2` and the v6 gates above.

Production route integration remains follow-up work.