### PR TITLE
Integrate default-off D6b driver verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ for tags and release notes while still in `0.x`.
   and full derivation. Roll back consumed-state journals. Leave driver and
   admission paths inactive.
 
+- Add default-off D6b driver verification before no-action drops. Keep route
+  admission and production drops disabled.
+
 ### Removed
 
 - Swift ternary expressions now come directly from the regenerated grammar

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -1,8 +1,8 @@
 # Compact route real-corpus matrix
 
 Current evidence date: 2026-08-22.
-Current base commit: `9ff47f2c` from `main`.
-Current candidate base commit: `9ff47f2c`.
+Current base commit: `f298328a` from `main`.
+Current candidate base commit: `f298328a`.
 
 ## Current bounded result
 
@@ -74,6 +74,12 @@ This receipt does not graduate the route and does not verify D6b.
 D6b adds a default-off authenticated internal consumer for complete frontiers.
 It does not activate the route driver, admission, or production drop wiring.
 
+The driver verifier collects exact current heads and references. It requires
+one common nonzero frontier sequence, rebuilds the frontier token, and consumes
+the authenticated frontier immediately before each of the three drop sites.
+Zero or mixed sequences fail closed. The verifier remains default-off, and the
+route remains ungraduated.
+
 The consumer enforces these contracts:
 
 - Authenticate the owner, epoch, election, token, frontier seal, and ordered records.
@@ -82,12 +88,21 @@ The consumer enforces these contracts:
 - Match the exact survivor reference and compare action and full derivation identity, metadata, and bytes.
 - Journal the consumed state only after proof succeeds, then restore it through checkpoint rollback.
 
-The focused Docker gates passed:
+The focused Docker gate results are:
 
 | Target | Result | Artifact |
 |---|---|---|
 | `TestG18D6b` | PASS, exit 0 | `harness_out/docker/20260822T101332Z-d6b-proof-tests-v4` |
 | `TestG18DropCohortFrontier` plus `TestG18D6b` | PASS, exit 0 | `harness_out/docker/20260822T101347Z-d6b-frontier-regression-v4` |
+| `TestG18D6bDriver` | PASS, exit 0, no out-of-memory (OOM), no timeout | `harness_out/docker/20260822T123532Z-d6b-driver-refresh-v19` |
+| `TestG18D6aProducerTelemetry/go/language` | PASS, exit 0, no OOM, no timeout | `harness_out/docker/20260822T123627Z-d6a-go-language-refresh-v21` |
+| `TestG18D6aProducerTelemetry/erlang/macro_expanded_top_level_function` | PASS, exit 0, no OOM, no timeout | `harness_out/docker/20260822T123634Z-d6a-erlang-refresh-v22` |
+| Default no-tag compile | PASS, exit 0, no OOM, no timeout | `harness_out/docker/20260822T123642Z-d6b-no-tag-refresh-v23` |
+| Combined D6a/D6b gate | FAIL, exit 1, no OOM, no timeout | `harness_out/docker/20260822T123547Z-d6b-d6a-combined-refresh-v20` |
+| Combined D6a/D6b gate | FAIL, exit 1, no OOM, no timeout | `harness_out/docker/20260822T123655Z-d6b-d6a-combined-refresh-v24` |
+
+Both combined gates failed only in the documented process-global pool telemetry comparison.
+The affected subtests changed between runs. The isolated targets passed. No OOM or timeout occurred.
 
 The matrix counts and performance counts remain unchanged.
 This evidence does not graduate the route or wire production drops.

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -65,6 +65,9 @@ type DiagnosticParserCorePrefixOptions struct {
 	// recordDropCohortFrontiers enables only the D6a frontier producer. It does
 	// not enable historical certificate authentication or admission behavior.
 	recordDropCohortFrontiers bool
+	// verifyDropCohortFrontiers enables the D6b consumer only for a private
+	// focused verifier run. The default remains false.
+	verifyDropCohortFrontiers bool
 	MaxDispatches             uint64
 	MaxTokens                 uint64
 	Limits                    core.Limits
@@ -3288,6 +3291,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyCompactEOFRecoveryAdmission(
 			return rollback(publishErr)
 		}
 	}
+	if consumeErr := s.consumeDropCohortFrontierOwned(indices); consumeErr != nil {
+		return rollback(consumeErr)
+	}
 	if dropErr := s.dropGenericNoActionHeads(indices); dropErr != nil {
 		return rollback(dropErr)
 	}
@@ -5838,6 +5844,9 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 					return nil, err
 				}
 			}
+			if err := s.consumeDropCohortFrontierOwned(noActionIndices); err != nil {
+				return nil, err
+			}
 			return nil, s.dropGenericNoActionHeads(noActionIndices)
 		}
 		if len(noActionIndices) != 0 {
@@ -5954,6 +5963,9 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			if err := s.publishDropCohortFrontierOwned(noActionIndices); err != nil {
 				return nil, err
 			}
+		}
+		if err := s.consumeDropCohortFrontierOwned(noActionIndices); err != nil {
+			return nil, err
 		}
 		return nil, s.dropGenericNoActionHeads(noActionIndices)
 	}
@@ -7065,11 +7077,10 @@ func (s *diagnosticParserCoreGenericScheduler) publishDropCohortFrontierOwned(dr
 	if err != nil {
 		return err
 	}
-	// Keep the authenticated handle on every current header. The no-action
-	// consumer can then carry the producer result into D6b without enabling
-	// admission or verifier work in D6a.
+	// Replace every current header sequence with this publication result. A
+	// zero result must clear stale reduction state before the no-action drop.
 	for index := range s.headers {
-		s.headers[index].frontierSequence = mergeDiagnosticParserCoreFrontier(s.headers[index].frontierSequence, sequence)
+		s.headers[index].frontierSequence = sequence
 	}
 	return nil
 }
@@ -7110,6 +7121,53 @@ func (s *diagnosticParserCoreGenericScheduler) attachDiagnosticParserCoreFrontie
 			s.headers[index].frontierSequence = mergeDiagnosticParserCoreFrontier(s.headers[index].frontierSequence, sequence)
 		}
 	}
+}
+
+// consumeDropCohortFrontierOwned authenticates the current frontier before a
+// no-action drop mutates the scheduler headers. The private option stays off.
+func (s *diagnosticParserCoreGenericScheduler) consumeDropCohortFrontierOwned(indices []int) error {
+	if s == nil || !s.options.verifyDropCohortFrontiers {
+		return nil
+	}
+	if s.compact == nil || s.freshSessionOwner == nil {
+		return errors.New("parser-core phase zero: D6b frontier consumer requires an owned fresh session")
+	}
+	if len(s.headers) < 2 || len(s.headers) > diagnosticParserCoreFrontierParticipantCap {
+		return errors.New("parser-core phase zero: D6b frontier consumer requires a bounded multi-participant frontier")
+	}
+	sequence := uint32(0)
+	var heads [diagnosticParserCoreFrontierParticipantCap]core.Head
+	var refs [diagnosticParserCoreFrontierParticipantCap]core.DropCohortRefSet
+	for index, header := range s.headers {
+		if header.frontierSequence == 0 {
+			return errors.New("parser-core phase zero: D6b frontier consumer requires a nonzero frontier sequence")
+		}
+		if sequence == 0 {
+			sequence = header.frontierSequence
+		} else if header.frontierSequence != sequence {
+			return errors.New("parser-core phase zero: D6b frontier consumer requires one common frontier sequence")
+		}
+		heads[index] = header.head
+		refs[index] = header.dropCohortRefs
+	}
+	electionSequence := s.electionIndex + 1
+	if electionSequence <= 0 {
+		return errors.New("parser-core phase zero: D6b frontier consumer has no election sequence")
+	}
+	owner := *s.freshSessionOwner
+	token, ok := s.dropCohortFrontierTokenOwned(owner)
+	if !ok {
+		return errors.New("parser-core phase zero: D6b frontier consumer could not rebuild the frontier token")
+	}
+	return s.compact.ConsumeDropCohortFrontierSequenceOwned(
+		owner,
+		uint64(sequence),
+		uint64(electionSequence),
+		token,
+		heads[:len(s.headers)],
+		refs[:len(s.headers)],
+		indices,
+	)
 }
 
 // dropGenericNoActionHeads removes the paused/no-action heads named by indices.

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -36,9 +36,12 @@ type parserCoreFreshFullRunner struct {
 	certificateAdmissionEnabled bool
 	// frontierRecordingEnabled is armed only by the private D6a test seam.
 	// It never enables historical certificate authentication or admission.
-	frontierRecordingEnabled  bool
-	certificateAdmissionToken *dropCohortActivationToken
-	scannerScratch            []byte
+	frontierRecordingEnabled bool
+	// frontierVerificationEnabled is armed only by the private D6b test seam.
+	// It never enables the production admission route.
+	frontierVerificationEnabled bool
+	certificateAdmissionToken   *dropCohortActivationToken
+	scannerScratch              []byte
 	// scratch retains the reusable per-parse materialization buffers. The runner
 	// is per-Parser and single-goroutine, so reusing these buffers across parses
 	// mirrors production's parser-held arena reuse and keeps the warm steady
@@ -121,6 +124,7 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpenWithObserver(
 	// this fresh session. The default path remains false and allocation-free.
 	r.options.recordDropCohortCertificates = r.certificateAdmissionEnabled
 	r.options.recordDropCohortFrontiers = r.frontierRecordingEnabled
+	r.options.verifyDropCohortFrontiers = r.frontierVerificationEnabled
 	// B3 stage S3: force the shared token source's error-run lexing on when
 	// native compact recovery is admitted, so a genuinely unlexable byte run
 	// surfaces as its own errorSymbol token (parser_api.go's

--- a/parsercore_phase0_g18_d6b_driver_internal_test.go
+++ b/parsercore_phase0_g18_d6b_driver_internal_test.go
@@ -1,0 +1,264 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func cleanupG18D6bDriverTestRunner(t *testing.T, runner *parserCoreFreshFullRunner) {
+	t.Helper()
+	t.Cleanup(func() {
+		runner.certificateAdmissionEnabled = false
+		runner.frontierRecordingEnabled = false
+		runner.frontierVerificationEnabled = false
+		runner.options.recordDropCohortCertificates = false
+		runner.options.recordDropCohortFrontiers = false
+		runner.options.verifyDropCohortFrontiers = false
+		if runner.compact != nil {
+			if err := runner.compact.ResetReleasingRetention(); err != nil {
+				t.Errorf("reset D6b test runner: %v", err)
+			}
+		}
+	})
+}
+
+func newG18D6bDriverTestRunner(t *testing.T) *parserCoreFreshFullRunner {
+	t.Helper()
+	lang, err := authenticatedParserCoreGoLanguage(parserCoreWarmGoScanner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lang.CompactConvergedReductionSplitDropsCertified = false
+	parser := NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	runner, err := newAdmissionCandidateRunner(parser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupG18D6bDriverTestRunner(t, runner)
+	return runner
+}
+
+func TestG18D6bDriverVerificationIsDefaultOff(t *testing.T) {
+	runner := newG18D6bDriverTestRunner(t)
+	if runner.frontierVerificationEnabled || runner.options.verifyDropCohortFrontiers {
+		t.Fatal("D6b driver verification is enabled by default")
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		options: DiagnosticParserCorePrefixOptions{},
+		headers: []diagnosticParserCoreHeader{
+			{frontierSequence: 0},
+			{frontierSequence: 9},
+		},
+	}
+	if err := scheduler.consumeDropCohortFrontierOwned([]int{0}); err != nil {
+		t.Fatalf("default-off verifier changed the drop path: %v", err)
+	}
+}
+
+func withG18D6bDriverSyntheticFrontier(
+	t *testing.T,
+	consume func(core.SchedulerTransactionToken, *diagnosticParserCoreGenericScheduler, core.DropCohortFrontierHandle) error,
+) error {
+	t.Helper()
+	runner := newG18D6bDriverTestRunner(t)
+	compact := runner.compact
+	start, err := compact.InternCheckpoint([]byte{1, 2, 3})
+	if err != nil {
+		return err
+	}
+	end, err := compact.InternCheckpoint([]byte{4, 5, 6})
+	if err != nil {
+		return err
+	}
+	if err := compact.SetPhaseExternalTokenScannerCheckpoints(start, end); err != nil {
+		return err
+	}
+	_, beforeDigest, beforeOK := compact.CheckpointReceipt(start)
+	_, afterDigest, afterOK := compact.CheckpointReceipt(end)
+	if !beforeOK || !afterOK {
+		return fmt.Errorf("synthetic frontier checkpoint receipt is unavailable")
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		return err
+	}
+	droppedSeed, err := compact.Seed(2, 0)
+	if err != nil {
+		return err
+	}
+	return compact.RunFreshSchedulerSession(func(owner core.SchedulerTransactionToken) error {
+		identity := core.DropCohortActionIdentity{
+			BoundaryState: 2,
+			Lookahead:     7,
+			ActionOrdinal: 3,
+			Action: core.Action{
+				Type: core.ActionReduce, State: 19, Symbol: 7, ChildCount: 2,
+				DynamicPrecedence: -2, ProductionID: 41, Extra: true,
+				ExtraChain: true, Repetition: true,
+			},
+			NoLookahead: true,
+			Selection:   core.DropCohortSelectionConflictPolicy,
+		}
+		cohort, err := compact.BeginDropCohortOwned(owner, identity, 2)
+		if err != nil {
+			return err
+		}
+		checkpoint := core.DropCohortSourceCheckpoint{
+			StartByte: 0, EndByte: 1, ScannerStart: start, ScannerEnd: end,
+		}
+		for branch := uint16(0); branch < 2; branch++ {
+			derivation, buildErr := compact.BuildDropCohortDerivationOwned(owner, seed, checkpoint)
+			if buildErr != nil {
+				return buildErr
+			}
+			if writeErr := compact.WriteDropCohortMemberOwned(owner, cohort, seed, branch, derivation); writeErr != nil {
+				return writeErr
+			}
+		}
+		refs, err := compact.FinalizeDropCohortOwned(owner, cohort)
+		if err != nil {
+			return err
+		}
+		token := core.DropCohortFrontierToken{
+			Symbol: 9, StartByte: 0, EndByte: 1,
+			ScannerBefore: start, ScannerAfter: end,
+			ScannerBeforeDigest: beforeDigest, ScannerAfterDigest: afterDigest,
+		}
+		handle, complete, err := compact.PublishDropCohortFrontierOwned(
+			owner, 11, token, []core.Head{seed, droppedSeed}, []uint64{0, 1},
+			[]core.DropCohortRefSet{refs, refs},
+		)
+		if err != nil {
+			return err
+		}
+		if !complete {
+			return fmt.Errorf("synthetic frontier did not complete")
+		}
+		scheduler := &diagnosticParserCoreGenericScheduler{
+			compact:            compact,
+			freshSessionOwner:  &owner,
+			checkpointBeforeID: start,
+			checkpointID:       end,
+			token:              Token{Symbol: 9, StartByte: 0, EndByte: 1},
+			currentElection: DiagnosticParserCoreElection{
+				ScannerBefore: DiagnosticParserCoreScannerCheckpoint{Length: 3},
+				ScannerAfter:  DiagnosticParserCoreScannerCheckpoint{Length: 3},
+			},
+			electionIndex: 10,
+			options:       DiagnosticParserCorePrefixOptions{verifyDropCohortFrontiers: true},
+			headers: []diagnosticParserCoreHeader{
+				{head: seed, frontierSequence: uint32(handle.Sequence), dropCohortRefs: refs},
+				{head: droppedSeed, frontierSequence: uint32(handle.Sequence), dropCohortRefs: refs},
+			},
+		}
+		return consume(owner, scheduler, handle)
+	})
+}
+
+func TestG18D6bDriverConsumesSyntheticValidFrontier(t *testing.T) {
+	err := withG18D6bDriverSyntheticFrontier(t, func(owner core.SchedulerTransactionToken, scheduler *diagnosticParserCoreGenericScheduler, handle core.DropCohortFrontierHandle) error {
+		if err := scheduler.consumeDropCohortFrontierOwned([]int{1}); err != nil {
+			return err
+		}
+		state, _, _, _, err := scheduler.compact.DropCohortFrontierStateOwned(owner, handle)
+		if err != nil {
+			return err
+		}
+		if state != core.DropCohortFrontierConsumed {
+			return fmt.Errorf("synthetic frontier state=%v, want consumed", state)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestG18D6bDriverRejectsQueryCompileIncompleteFrontier(t *testing.T) {
+	fixture := loadDiagnosticParserCoreCanonicalFixture(t, "query_compile")
+	runner := newG18D6bDriverTestRunner(t)
+	runner.certificateAdmissionEnabled = true
+	runner.frontierRecordingEnabled = true
+	runner.frontierVerificationEnabled = true
+	dropCallbacks := 0
+	tree, err := runner.parseWithObserver(fixture.Source, diagnosticParserCoreSeedObserver{
+		frontierPublished: func(_ *diagnosticParserCoreGenericScheduler, _ core.SchedulerTransactionToken, dropIndices []int) error {
+			if len(dropIndices) != 0 {
+				dropCallbacks++
+			}
+			return nil
+		},
+	})
+	if tree != nil {
+		tree.Release()
+		t.Fatal("query_compile incomplete frontier was accepted")
+	}
+	if dropCallbacks != 0 {
+		t.Fatalf("query_compile published %d complete drop frontiers", dropCallbacks)
+	}
+	if err == nil || !strings.Contains(err.Error(), "requires a nonzero frontier sequence") {
+		t.Fatalf("query_compile error=%v, want zero-sequence rejection", err)
+	}
+}
+
+func TestG18D6bDriverRejectsMutatedPublishedToken(t *testing.T) {
+	var consumeErr error
+	runErr := withG18D6bDriverSyntheticFrontier(t, func(owner core.SchedulerTransactionToken, scheduler *diagnosticParserCoreGenericScheduler, handle core.DropCohortFrontierHandle) error {
+		token, ok := scheduler.dropCohortFrontierTokenOwned(owner)
+		if !ok {
+			return fmt.Errorf("synthetic frontier token rebuild failed")
+		}
+		token.Symbol++
+		consumeErr = scheduler.compact.ConsumeDropCohortFrontierSequenceOwned(
+			owner, handle.Sequence, uint64(scheduler.electionIndex+1), token,
+			[]core.Head{scheduler.headers[0].head, scheduler.headers[1].head},
+			[]core.DropCohortRefSet{scheduler.headers[0].dropCohortRefs, scheduler.headers[1].dropCohortRefs},
+			[]int{1},
+		)
+		return nil
+	})
+	if consumeErr == nil || !strings.Contains(consumeErr.Error(), "frontier token mismatch") {
+		t.Fatalf("mutated frontier token error=%v, want token mismatch", consumeErr)
+	}
+	if runErr != nil && !strings.Contains(runErr.Error(), "frontier token mismatch") {
+		t.Fatalf("mutated frontier session error=%v, want token mismatch", runErr)
+	}
+}
+
+func TestG18D6bDriverRejectsZeroAndMixedSequences(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		sequences  []uint32
+		wantDetail string
+	}{
+		{name: "zero", sequences: []uint32{0, 0}, wantDetail: "nonzero frontier sequence"},
+		{name: "mixed", sequences: []uint32{7, 8}, wantDetail: "one common frontier sequence"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			headers := make([]diagnosticParserCoreHeader, len(test.sequences))
+			for index, sequence := range test.sequences {
+				headers[index] = diagnosticParserCoreHeader{
+					head:             core.Head{Node: core.NodeID(index + 1)},
+					frontierSequence: sequence,
+				}
+			}
+			scheduler := &diagnosticParserCoreGenericScheduler{
+				compact:           &core.Core{},
+				freshSessionOwner: &core.SchedulerTransactionToken{},
+				options: DiagnosticParserCorePrefixOptions{
+					verifyDropCohortFrontiers: true,
+				},
+				headers: headers,
+			}
+			if err := scheduler.consumeDropCohortFrontierOwned([]int{1}); err == nil || !strings.Contains(err.Error(), test.wantDetail) {
+				t.Fatalf("sequence rejection=%v, want %q", err, test.wantDetail)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add private default-off D6b verification before each of the three `dropGenericNoActionHeads` sites.
- Replace each current header sequence with the latest published sequence, including zero.
- Authenticate current heads, references, the rebuilt token, owner, epoch, election, frontier seal, and records.
- Keep route admission, production drops, and route graduation inactive.

## Tests

- Prove synthetic complete-frontier consumption and consumed state.
- Reject incomplete frontiers, mutated tokens, and zero or mixed sequences before drops.
- Update CHANGELOG.md and docs/compact-route-real-corpus-matrix.md.

Focused Docker evidence:

- v19 PASS: `20260822T123532Z-d6b-driver-refresh-v19` (exit 0; no OOM; no timeout).
- v20 FAIL: `20260822T123547Z-d6b-d6a-combined-refresh-v20` (exit 1; no OOM; no timeout).
- v21 PASS: `20260822T123627Z-d6a-go-language-refresh-v21` (exit 0; no OOM; no timeout).
- v22 PASS: `20260822T123634Z-d6a-erlang-refresh-v22` (exit 0; no OOM; no timeout).
- v23 PASS: `20260822T123642Z-d6b-no-tag-refresh-v23` (exit 0; no OOM; no timeout).
- v24 FAIL: `20260822T123655Z-d6b-d6a-combined-refresh-v24` (exit 1; no OOM; no timeout).

Both combined failures only hit the process-global pool telemetry comparison. Affected subtests changed between runs. The isolated targets passed. This flake does not change D6b verification results.

Production integration remains default-off and ungraduated.