### PR TITLE
Correct Markdown incremental status documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- Correct the Markdown scanner documentation for [issue #454](https://github.com/odvcencio/gotreesitter/issues/454).
+  Mark Markdown as `certified reuse`. Changed-token and shape-changing edits
+  can still use the production full-parse fallback when reuse gates reject the
+  edit. Keep Markdown Inline as `fallback (uncertified)`.
+
 - End recovery convergence after a clean condense. Pending forks no longer
   keep clean C initializer suffixes on the recovery merge path.
 

--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -365,9 +365,10 @@ not certify a scanner by themselves: CMake, SQL, and HTML opt in, while Python,
 Mojo, Starlark, and Svelte explicitly opt out. Custom
 `TokenSource` implementations have their own
 `IncrementalReuseTokenSource` contract and are outside this registry matrix.
-The registered Markdown and Markdown Inline scanners remain uncertified, so
-changed-token or shape-changing edits take the production full-parse fallback
-rather than scanner-dependent reuse.
+The Markdown scanner is certified for incremental reuse. The Markdown Inline
+scanner remains uncertified. Changed-token or shape-changing edits can still
+take the production full-parse fallback when dirty-span, fragility,
+byte-equality, scanner-boundary, or error-tree gates reject reuse.
 
 PowerShell's scanner is stateless: it recognizes one zero-width statement
 terminator from the current lookahead and valid-symbol set, carries no payload,


### PR DESCRIPTION
## Summary

- Update the Markdown scanner matrix and the Unreleased changelog.
- Mark Markdown as certified reuse.
- Keep Markdown Inline as fallback (uncertified).
- Document that changed-token and shape-changing edits can use the production full-parse fallback when dirty-span, fragility, byte-equality, scanner-boundary, or error-tree gates reject reuse.
- Keep runtime behavior unchanged.

## Evidence

- The runtime source is the source of truth. Markdown enables SupportsIncrementalReuse. Markdown Inline does not implement that interface.
- The focused Docker documentation contract test passed at exact main 9abfd8816bd92ac275c9c82527b536d87c897899.
- Artifact: /tmp/gts-docs-markdown-status/harness_out/docker/20260822T140152Z-docs-markdown-status-v2/metadata.txt
- The diff changes only CHANGELOG.md and docs/external-scanners.md.