### PR TITLE
Fallback experimental forest error roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- Make the explicit forest route fail closed on an `ERROR` root. Reuse the
+  existing forest decline decision. Keep Ledger recovery triggers on the
+  production fallback until their forest trees match the locked C tree.
+
 - Correct the Markdown scanner documentation for [issue #454](https://github.com/odvcencio/gotreesitter/issues/454).
   Mark Markdown as `certified reuse`. Changed-token and shape-changing edits
   can still use the production full-parse fallback when reuse gates reject the

--- a/cgo_harness/ledger_forest_error_root_fallback_parity_test.go
+++ b/cgo_harness/ledger_forest_error_root_fallback_parity_test.go
@@ -1,0 +1,161 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// TestLedgerForestExperimentalErrorRootFallbackLockedC proves that both
+// Ledger forest declines use production trees that match locked C exactly.
+func TestLedgerForestExperimentalErrorRootFallbackLockedC(t *testing.T) {
+	entry, ok := parityEntriesByName["ledger"]
+	if !ok {
+		t.Fatal("missing Ledger grammar entry")
+	}
+	language := entry.Language()
+	cLanguage, err := COracleLanguage("ledger")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name   string
+		source []byte
+	}{
+		{
+			name:   "recovered-date-suffix",
+			source: []byte("\n15.03.2006 Exxon\n    Expenses:Auto:Gas          10,00 EUR\n    Liabilities:MasterCard    -10,00 EUR\n"),
+		},
+		{
+			name: "year-directive",
+			source: []byte(`
+--input-date-format %d.%m
+
+Y2010
+03.01 * Foo
+    A                 10.00 EUR
+    B
+
+05.02 * Bar
+    A                 20.00 EUR
+    B
+
+test reg A
+10-Jan-03 Foo                   A                         10.00 EUR    10.00 EUR
+10-Feb-05 Bar                   A                         20.00 EUR    30.00 EUR
+end test
+
+`),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(test.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("locked C parser returned no tree")
+			}
+			t.Cleanup(cTree.Close)
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			forestParser := gts.NewParser(language)
+			forest, ok := forestParser.ParseForestExperimental(test.source)
+			if ok || forest != nil {
+				if forest != nil {
+					forest.Release()
+				}
+				t.Fatalf("forest result ok=%t tree_nil=%t, want error_root decline", ok, forest == nil)
+			}
+			_, _, reason, _ := forestParser.ForestDeclineInfo()
+			if reason != "error_root" {
+				t.Fatalf("forest decline reason=%q, want error_root", reason)
+			}
+
+			fallback, err := forestParser.Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(fallback.Release)
+			if fallback.ParseRuntime().ForestFastPath {
+				t.Fatal("fallback used the forest route")
+			}
+			assertForestFallbackLockedC(t, fallback, language, cTree, cDigest)
+		})
+	}
+}
+
+// TestForestExperimentalCleanControlLockedC proves that a clean forest result
+// remains direct and matches locked C after the error-root guard.
+func TestForestExperimentalCleanControlLockedC(t *testing.T) {
+	entry, ok := parityEntriesByName["bash"]
+	if !ok {
+		t.Fatal("missing Bash grammar entry")
+	}
+	language := entry.Language()
+	cLanguage, err := COracleLanguage("bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := []byte("x=1\n")
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("locked C parser returned no tree")
+	}
+	t.Cleanup(cTree.Close)
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	forest, ok := gts.NewParser(language).ParseForestExperimental(source)
+	if !ok || forest == nil {
+		t.Fatalf("clean forest result ok=%t tree_nil=%t", ok, forest == nil)
+	}
+	t.Cleanup(forest.Release)
+	if !forest.ParseRuntime().ForestFastPath || forest.RootNode().IsError() || forest.RootNode().HasErrorOrMissing() {
+		t.Fatalf("clean forest runtime/root invalid: %s", forest.ParseRuntime().Summary())
+	}
+	assertForestFallbackLockedC(t, forest, language, cTree, cDigest)
+}
+
+func assertForestFallbackLockedC(
+	t *testing.T,
+	goTree *gts.Tree,
+	goLanguage *gts.Language,
+	cTree *sitter.Tree,
+	wantDigest string,
+) {
+	t.Helper()
+	if diff := FirstDivergenceDumpV1(goTree.RootNode(), goLanguage, cTree.RootNode()); diff != nil {
+		t.Fatalf("tree diverges from locked C: %+v", diff)
+	}
+	if diff := firstLockedCTreeFlagDivergence(goTree.RootNode(), goLanguage, cTree.RootNode(), "/"+goTree.RootNode().Type(goLanguage)); diff != nil {
+		t.Fatalf("tree flags diverge from locked C: %v", diff)
+	}
+	inspection, err := benchfixtures.InspectGoTree(goTree.RootNode(), goLanguage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.SHA256 != wantDigest {
+		t.Fatalf("Go digest=%s, locked C digest=%s", inspection.SHA256, wantDigest)
+	}
+	t.Logf("locked C parity digest=%s", inspection.SHA256)
+}

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -212,6 +212,11 @@ tree. The receipts are in these Docker artifacts:
 Reopen the entry if a future Ninja witness rewrites a node or differs on any
 production, compact, forest, incremental, or locked C route.
 
+The explicit forest route now fails closed on a synthetic `ERROR` root.
+It records `error_root` and leaves production fallback to the caller.
+Ledger remains live while its recovery triggers use that fallback. Reopen
+Ledger retirement only after both triggers return locked-C forest receipts.
+
 The live probes parse each source without result compatibility.
 They also compare census-enabled output with normal production output.
 Each digest matches base commit

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -63,6 +63,11 @@ Each PR retires one ownership mechanism or one proven-inert family:
 Correctness is the merge gate. Performance measurements may select the next
 candidate, but a performance result cannot substitute for route parity.
 
+The explicit forest route now shares the automatic route's `ERROR`-root
+decline. It records `error_root` and returns no tree. Ledger date-suffix and
+year-directive recovery remain on the production fallback until both forest
+routes match locked C. Reopen Ledger retirement after that proof.
+
 ## Ordered program
 
 ### R0 — inventory and containment

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -391,6 +391,11 @@ func (p *Parser) parseForestExperimental(source []byte) (*Tree, bool) {
 		arena.Release()
 		return nil, false
 	}
+	if forestRootMustDecline(root) {
+		p.recordForestDecline(forestDeclineErrorRoot, Token{StartByte: root.EndByte()}, nil)
+		arena.Release()
+		return nil, false
+	}
 	p.finalizeForestRoot(root, source)
 	tree := newTreeWithArenas(root, source, p.language, arena, nil)
 	tree.setParseRuntime(forestAcceptedRuntime(root, source))

--- a/grammars/ledger_forest_error_root_fallback_test.go
+++ b/grammars/ledger_forest_error_root_fallback_test.go
@@ -1,0 +1,153 @@
+//go:build !grammar_subset
+
+package grammars
+
+import (
+	"os"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+const (
+	ledgerRecoveredDateSuffixLockedCDigest = "d89a89fd6a1397d5ccb1c9f38271dcef632e7bd4a8d307146483f180af66e173"
+	ledgerYearDirectiveLockedCDigest       = "1d4aa453808e5f85eba81c33fff5bc91c217c9ec2cf66264bff2f8e4092a563b"
+)
+
+// TestLedgerForestExperimentalErrorRootFallback proves that the explicit
+// forest route declines both Ledger recovery roots before compatibility runs.
+// The production fallback must retain the locked C digest.
+func TestLedgerForestExperimentalErrorRootFallback(t *testing.T) {
+	tests := []struct {
+		name          string
+		source        []byte
+		lockedCDigest string
+	}{
+		{
+			name:          "recovered-date-suffix",
+			source:        []byte("\n15.03.2006 Exxon\n    Expenses:Auto:Gas          10,00 EUR\n    Liabilities:MasterCard    -10,00 EUR\n"),
+			lockedCDigest: ledgerRecoveredDateSuffixLockedCDigest,
+		},
+		{
+			name: "year-directive",
+			source: []byte(`
+--input-date-format %d.%m
+
+Y2010
+03.01 * Foo
+    A                 10.00 EUR
+    B
+
+05.02 * Bar
+    A                 20.00 EUR
+    B
+
+test reg A
+10-Jan-03 Foo                   A                         10.00 EUR    10.00 EUR
+10-Feb-05 Bar                   A                         20.00 EUR    30.00 EUR
+end test
+
+`),
+			lockedCDigest: ledgerYearDirectiveLockedCDigest,
+		},
+	}
+
+	language := LedgerLanguage()
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(production.Release)
+			if production.ParseRuntime().ForestFastPath {
+				t.Fatal("production parse used the forest route")
+			}
+			assertLedgerLockedCDigest(t, "production", production, language, test.lockedCDigest)
+
+			forestParser := gotreesitter.NewParser(language)
+			forest, ok := forestParser.ParseForestExperimental(test.source)
+			if ok || forest != nil {
+				if forest != nil {
+					forest.Release()
+				}
+				t.Fatalf("forest result ok=%t tree_nil=%t, want error_root decline", ok, forest == nil)
+			}
+			_, _, reason, _ := forestParser.ForestDeclineInfo()
+			if reason != "error_root" {
+				t.Fatalf("forest decline reason=%q, want error_root", reason)
+			}
+
+			fallback, err := forestParser.Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(fallback.Release)
+			if fallback.ParseRuntime().ForestFastPath {
+				t.Fatal("forest fallback used the forest route")
+			}
+			assertLedgerLockedCDigest(t, "forest-fallback", fallback, language, test.lockedCDigest)
+		})
+	}
+}
+
+func assertLedgerLockedCDigest(
+	t *testing.T,
+	route string,
+	tree *gotreesitter.Tree,
+	language *gotreesitter.Language,
+	want string,
+) {
+	t.Helper()
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatalf("inspect %s route: %v", route, err)
+	}
+	if inspection.SHA256 != want {
+		t.Fatalf("%s digest=%s, want locked C digest %s", route, inspection.SHA256, want)
+	}
+	t.Logf("%s digest=%s locked C digest", route, inspection.SHA256)
+}
+
+// TestForestExperimentalCleanRootControl proves clean forest trees remain
+// direct results after the error-root guard rejects recovery-only roots.
+func TestForestExperimentalCleanRootControl(t *testing.T) {
+	previousForest := os.Getenv("GOT_GLR_FOREST") != "0"
+	gotreesitter.SetGLRForestEnabled(false)
+	t.Cleanup(func() { gotreesitter.SetGLRForestEnabled(previousForest) })
+
+	language := BashLanguage()
+	source := []byte("x=1\n")
+	production, err := gotreesitter.NewParser(language).Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(production.Release)
+
+	forest, ok := gotreesitter.NewParser(language).ParseForestExperimental(source)
+	if !ok || forest == nil {
+		t.Fatalf("clean forest result ok=%t tree_nil=%t", ok, forest == nil)
+	}
+	t.Cleanup(forest.Release)
+	if !forest.ParseRuntime().ForestFastPath {
+		t.Fatal("clean result did not report the forest route")
+	}
+	if forest.RootNode().IsError() || forest.RootNode().HasErrorOrMissing() {
+		t.Fatalf("clean forest root has recovery flags: %s", forest.RootNode().SExpr(language))
+	}
+	productionDigest, err := benchfixtures.InspectGoTree(production.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	forestDigest, err := benchfixtures.InspectGoTree(forest.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if forestDigest.SHA256 != productionDigest.SHA256 {
+		t.Fatalf("clean forest digest=%s, production=%s", forestDigest.SHA256, productionDigest.SHA256)
+	}
+}


### PR DESCRIPTION
## Summary

- Reuse the shared `forestRootMustDecline` policy in `parseForestExperimental`.
- Record `error_root`, release arena state, and return `(nil, false)`.
- Keep the normal `Parse` policy unchanged.

## Evidence

- Ledger recovered-date trigger digest: `d89a89fd6a1397d5ccb1c9f38271dcef632e7bd4a8d307146483f180af66e173`.
- Ledger year-directive trigger digest: `1d4aa453808e5f85eba81c33fff5bc91c217c9ec2cf66264bff2f8e4092a563b`.
- Bash clean forest control digest: `2656fba839391821266a464b9993f94a61b77c24106f61556c290adf9011dfb9`.
- Locked-C tests compare node types, fields, spans, points, flags, and deep digests.

## Tests

- Grammar gate artifact: `/tmp/gts-forest-experimental-error-root-fallback-20260822/harness_out/docker/20260822T150935Z-forest-error-root-fallback-refresh-grammars`.
- Core predicate gate artifact: `/tmp/gts-forest-experimental-error-root-fallback-20260822/harness_out/docker/20260822T150941Z-forest-error-root-fallback-refresh-core`.
- Locked-C gate artifact: `/tmp/gts-forest-experimental-error-root-fallback-20260822/harness_out/docker/20260822T150948Z-forest-error-root-fallback-refresh-c`.
- Each gate exited with code 0.
- Each gate reported no out-of-memory event and no timeout.

## Documentation

- Update `CHANGELOG.md`, `docs/compat-tier.md`, and `docs/root-normalization-retirement.md`.
- Keep Ledger retirement as a follow-up after its candidate reruns retirement gates.

The refreshed branch uses main commit `9f86b488df80f5b9fb4f917728a3c78aec3fa3e9`.