### PR TITLE
Add durable DTD normalization blocker receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- Record a durable DTD locked-C blocker receipt. Keep the DTD compatibility
+  entry live until both recorded error-flag divergences close.
+
 - Make the explicit forest route fail closed on an `ERROR` root. Reuse the
   existing forest decline decision. Keep Ledger recovery triggers on the
   production fallback until their forest trees match the locked C tree.

--- a/cgo_harness/dtd_retirement_parity_test.go
+++ b/cgo_harness/dtd_retirement_parity_test.go
@@ -1,0 +1,217 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestDTDDispatchRetirementLockedCParity(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+
+	entry, ok := parityEntriesByName["dtd"]
+	if !ok {
+		t.Fatal("missing DTD grammar entry")
+	}
+	language := entry.Language()
+	cLanguage, err := COracleLanguage("dtd")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	witnesses := []struct {
+		name           string
+		source         []byte
+		path           string
+		sha256         string
+		goDigest       string
+		cDigest        string
+		wantDivergence *normalizationKnownDivergence
+	}{
+		{
+			name:     "parser-produced-pe-reference-trigger",
+			source:   []byte("<!ELEMENT colspec %ho; EMPTY >"),
+			sha256:   "f6903445e1a330ae0fd42b19c43538ea30b0da6261c1fe5ae452fc713597f0c7",
+			goDigest: "3e32d101e13010d7e964bcd68524291d3439309022f5aeff218d1e1c20478f0c",
+			cDigest:  "5c2393834cf7a941dfc5e0c86dacb344cb122822631b379e21f9bf607544c860",
+			wantDivergence: &normalizationKnownDivergence{
+				Path:     "/extSubset/elementdecl[0]/ERROR[4]/Name[0]",
+				Category: "error",
+				GoValue:  "true",
+				CValue:   "false",
+				Reason:   "the parser-produced PE-reference witness still marks the Name subtree as an error",
+			},
+		},
+		{
+			name:     "historical-medium-calstblx",
+			path:     filepath.Join("..", "testdata", "dispatcher_census_a0", "dtd", "medium__calstblx.dtd"),
+			sha256:   "54c96c2aa55e2a95b4d0f9ac30df90cfdd717fa1c52f6d3547f1cbd3c8ad4b85",
+			goDigest: "6aafeee4581dbcbea8dc807d04a56339d500c18fd7a9f034f885439fadaf2311",
+			cDigest:  "6316281505e3891906174c07c691814c0b187d3619aa455fc01174efd2736a3e",
+			wantDivergence: &normalizationKnownDivergence{
+				Path:     "/extSubset/AttlistDecl[31]/AttDef[3]/ERROR[3]/)[0]",
+				Category: "error",
+				GoValue:  "true",
+				CValue:   "false",
+				Reason:   "the historical Calstblx witness still marks the recovered closing token as an error",
+			},
+		},
+		{
+			name:   "historical-large-dbits",
+			path:   filepath.Join("..", "testdata", "dispatcher_census_a0", "dtd", "large__dbits.dtd"),
+			sha256: "923e8f6ea911bd940ea95d957028fa3155a11b54a756bbe291d3710e110172d9",
+		},
+		{
+			name:   "historical-large-docbook",
+			path:   filepath.Join("..", "testdata", "dispatcher_census_a0", "dtd", "large__docbook.dtd"),
+			sha256: "4f54c108abea1e4ae8e13e98d79bc0534d442012ed7ab40fcb4052dc843f65dd",
+		},
+	}
+
+	for _, witness := range witnesses {
+		witness := witness
+		t.Run(witness.name, func(t *testing.T) {
+			source := witness.source
+			if witness.path != "" {
+				var err error
+				source, err = os.ReadFile(witness.path)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != witness.sha256 {
+				t.Fatalf("source SHA-256 = %s, want %s", got, witness.sha256)
+			}
+
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C oracle returned a nil tree")
+			}
+			t.Cleanup(cTree.Close)
+
+			rawParser := gotreesitter.NewParser(language)
+			rawParser.SetAdmissionCandidateRoute(false)
+			rawTree, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(source)
+			if err != nil {
+				t.Fatalf("raw parse: %v", err)
+			}
+			t.Cleanup(rawTree.Release)
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			productionTree, err := productionParser.Parse(source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			t.Cleanup(productionTree.Release)
+
+			if witness.wantDivergence != nil {
+				assertDTDKnownDeepDigests(t, witness.name, rawTree, productionTree, language, cTree, witness.goDigest, witness.cDigest)
+			}
+
+			rawDiff := FirstDivergenceDumpV1(rawTree.RootNode(), language, cTree.RootNode())
+			if !normalizationAssertKnownDivergence(t, witness.name, rawDiff, witness.wantDivergence) {
+				return
+			}
+			rawDigest := assertDTDLockedCTreeExact(t, "raw", rawTree, language, cTree)
+			productionDigest := assertDTDLockedCTreeExact(t, "production", productionTree, language, cTree)
+			if rawDigest != productionDigest {
+				t.Fatalf("raw and production deep digests differ: raw=%s production=%s", rawDigest, productionDigest)
+			}
+			if rawTree.ParseRuntime().NormalizationNodesRewritten != 0 {
+				t.Fatalf("raw route rewrote %d nodes", rawTree.ParseRuntime().NormalizationNodesRewritten)
+			}
+			if productionTree.ParseRuntime().NormalizationNodesRewritten != 0 {
+				t.Fatalf("production route rewrote %d nodes", productionTree.ParseRuntime().NormalizationNodesRewritten)
+			}
+			t.Logf(
+				"source_sha256=%x bytes=%d raw_digest=%s production_digest=%s rewrites=0",
+				sha256.Sum256(source),
+				len(source),
+				rawDigest,
+				productionDigest,
+			)
+		})
+	}
+}
+
+func assertDTDKnownDeepDigests(
+	t *testing.T,
+	witness string,
+	rawTree *gotreesitter.Tree,
+	productionTree *gotreesitter.Tree,
+	language *gotreesitter.Language,
+	cTree *sitter.Tree,
+	wantGoDigest string,
+	wantCDigest string,
+) {
+	t.Helper()
+	rawInspection, err := benchfixtures.InspectGoTree(rawTree.RootNode(), language)
+	if err != nil {
+		t.Fatalf("inspect raw %s tree: %v", witness, err)
+	}
+	productionInspection, err := benchfixtures.InspectGoTree(productionTree.RootNode(), language)
+	if err != nil {
+		t.Fatalf("inspect production %s tree: %v", witness, err)
+	}
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatalf("inspect C %s tree: %v", witness, err)
+	}
+	if rawInspection.SHA256 != wantGoDigest || productionInspection.SHA256 != wantGoDigest || cDigest != wantCDigest {
+		t.Fatalf(
+			"pinned %s tree digest changed: raw Go=%s production Go=%s C=%s; want Go=%s C=%s",
+			witness,
+			rawInspection.SHA256,
+			productionInspection.SHA256,
+			cDigest,
+			wantGoDigest,
+			wantCDigest,
+		)
+	}
+	t.Logf("pinned %s tree digests: raw Go=%s production Go=%s C=%s", witness, rawInspection.SHA256, productionInspection.SHA256, cDigest)
+}
+
+func assertDTDLockedCTreeExact(
+	t *testing.T,
+	label string,
+	goTree *gotreesitter.Tree,
+	goLang *gotreesitter.Language,
+	cTree *sitter.Tree,
+) string {
+	t.Helper()
+	goRoot := goTree.RootNode()
+	cRoot := cTree.RootNode()
+	if diff := FirstDivergenceDumpV1(goRoot, goLang, cRoot); diff != nil {
+		t.Fatalf("%s node or field divergence: %+v", label, diff)
+	}
+	if diff := firstLockedCTreeFlagDivergence(goRoot, goLang, cRoot, "/"+goRoot.Type(goLang)); diff != nil {
+		t.Fatal(diff)
+	}
+	goInspection, err := benchfixtures.InspectGoTree(goRoot, goLang)
+	if err != nil {
+		t.Fatalf("inspect Go deep tree: %v", err)
+	}
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatalf("inspect C deep tree: %v", err)
+	}
+	if goInspection.SHA256 != cDigest {
+		t.Fatalf("%s deep digest Go=%s C=%s", label, goInspection.SHA256, cDigest)
+	}
+	t.Logf("%s exact symbols, fields, spans, points, extras, missing/error flags, and deep digest=%s", label, cDigest)
+	return goInspection.SHA256
+}

--- a/cgo_harness/normalization_known_divergence_test.go
+++ b/cgo_harness/normalization_known_divergence_test.go
@@ -1,0 +1,68 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import "testing"
+
+type normalizationKnownDivergence struct {
+	Path     string
+	Category string
+	GoValue  string
+	CValue   string
+	Reason   string
+}
+
+func normalizationAssertKnownDivergence(
+	t *testing.T,
+	witness string,
+	got *DumpV1Divergence,
+	want *normalizationKnownDivergence,
+) bool {
+	t.Helper()
+	if want == nil {
+		if got != nil {
+			t.Fatalf(
+				"%s has an unexpected locked-C divergence: path=%q category=%q Go=%q C=%q",
+				witness,
+				got.Path,
+				got.Category,
+				got.GoValue,
+				got.CValue,
+			)
+		}
+		return true
+	}
+	if got == nil {
+		t.Fatalf(
+			"known divergence %q now matches locked C; remove the ratchet after route verification",
+			witness,
+		)
+	}
+	if got.Path != want.Path ||
+		got.Category != want.Category ||
+		got.GoValue != want.GoValue ||
+		got.CValue != want.CValue {
+		t.Fatalf(
+			"known divergence changed for %q: got path=%q category=%q Go=%q C=%q; want path=%q category=%q Go=%q C=%q",
+			witness,
+			got.Path,
+			got.Category,
+			got.GoValue,
+			got.CValue,
+			want.Path,
+			want.Category,
+			want.GoValue,
+			want.CValue,
+		)
+	}
+	t.Skipf(
+		"known locked-C divergence for %q: %s; path=%s category=%s Go=%s C=%s",
+		witness,
+		want.Reason,
+		want.Path,
+		want.Category,
+		want.GoValue,
+		want.CValue,
+	)
+	return false
+}

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -13,18 +13,23 @@ without updating that registry.
 
 ## Current denominator
 
-The v1 registry freezes the current source and registry:
+At exact main commit `d530d969429550555a384525352120138ef6f05d`, the v1
+registry freezes the current source and registry:
 
 - 32 explicit `runLanguageResultCompatibility` switch arms;
+- 34 dispatcher languages across those arms;
 - one predicate-dispatched COBOL entry matching exactly `cobol` or `COBOL`;
 - zero generic passes after language dispatch;
-- zero post-finalization second-pass fixpoint arms.
+- zero post-finalization second-pass fixpoint arms;
+- zero post-finalization languages.
 
 The registry contains 33 live entries and 55 retired entries. The live entries
 name 36 language labels. Shared switch arms account for the label difference.
 The retired count includes the Swift ternary, JavaScript dynamic-import, Kotlin
 interpolated-call, Bash generated-command assignment, Ninja recovery, and
 Ledger recovery arms.
+The 2026-08-22 normalization checkpoint keeps the DTD entry live. See the
+[checkpoint receipt](root-normalization-retirement.md#2026-08-22-normalization-checkpoint).
 The registry covers
 only this documented internal result-compatibility tier. Scheduler experiments
 and other engine research belong in their owning subsystem's durable traces.

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -69,6 +69,43 @@ year-directive recovery use the production fallback after that decline. The
 Ledger receipt records both forest routes and locked-C parity. Reopen Ledger
 retirement if a future witness differs on any covered route.
 
+## 2026-08-22 normalization checkpoint
+
+Status: NO-GO. Do not retire an entry from this checkpoint.
+
+Base commit: `d530d969429550555a384525352120138ef6f05d`.
+The current registry denominator is 32 dispatcher arms, 34 dispatcher
+languages, one predicate, zero generic passes, zero post-finalization arms,
+zero post-finalization languages, 33 live entries, 55 retired entries, and 36
+live language labels.
+
+The focused evidence keeps the DTD entry live.
+
+| Candidate | Exact passing subset | Current divergence | Evidence |
+| --- | --- | --- | --- |
+| DTD | `historical-large-dbits` raw and production digest `a1655ece34d0000ed54e2954faaf93c315fc86e9cea65430022fda9b33677e1d`; `historical-large-docbook` raw and production digest `5f61a372e602e6e0f772ad1a053e5cc42492add24bb045eef10370096d8cd04f` | `parser-produced-pe-reference-trigger`: `/extSubset/elementdecl[0]/ERROR[4]/Name[0]`, Go `error=true`, C `error=false`; `historical-medium-calstblx`: `/extSubset/AttlistDecl[31]/AttDef[3]/ERROR[3]/)[0]`, Go `error=true`, C `error=false` | `TestDTDDispatchRouteReceipts`; `TestDTDDispatchRetirementLockedCParity`; `harness_out/docker/20260822T164115Z`; `harness_out/docker/20260822T164122Z` |
+
+The DTD route receipt covers raw, production, compact, forest or forest-fallback,
+and incremental parses for all four sources. It requires equal production digests
+and zero dispatcher rewrites on every route.
+The known blocker tree digests are:
+
+- `parser-produced-pe-reference-trigger`: Go `3e32d101e13010d7e964bcd68524291d3439309022f5aeff218d1e1c20478f0c`; C `5c2393834cf7a941dfc5e0c86dacb344cb122822631b379e21f9bf607544c860`.
+- `historical-medium-calstblx`: Go `6aafeee4581dbcbea8dc807d04a56339d500c18fd7a9f034f885439fadaf2311`; C `6316281505e3891906174c07c691814c0b187d3619aa455fc01174efd2736a3e`.
+
+The route digests are:
+
+- `parser-produced-pe-reference-trigger`: `3e32d101e13010d7e964bcd68524291d3439309022f5aeff218d1e1c20478f0c`.
+- `historical-medium-calstblx`: `6aafeee4581dbcbea8dc807d04a56339d500c18fd7a9f034f885439fadaf2311`.
+- `historical-large-dbits`: `a1655ece34d0000ed54e2954faaf93c315fc86e9cea65430022fda9b33677e1d`.
+- `historical-large-docbook`: `5f61a372e602e6e0f772ad1a053e5cc42492add24bb045eef10370096d8cd04f`.
+
+Reopen DTD only after both known divergences close. Then retain exact raw,
+production, compact, forest, incremental, and locked-C receipts for all four
+sources.
+
+Do not change the registry until the matching candidate condition is complete.
+
 ## Ordered program
 
 ### R0 — inventory and containment

--- a/grammars/dtd_retirement_route_receipt_test.go
+++ b/grammars/dtd_retirement_route_receipt_test.go
@@ -1,0 +1,134 @@
+//go:build !grammar_subset
+
+package grammars
+
+import (
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+func TestDTDDispatchRouteReceipts(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+
+	witnesses := []struct {
+		name   string
+		source []byte
+		path   string
+	}{
+		{
+			name:   "parser-produced-pe-reference-trigger",
+			source: []byte("<!ELEMENT colspec %ho; EMPTY >"),
+		},
+		{
+			name: "historical-medium-calstblx",
+			path: filepath.Join("..", "testdata", "dispatcher_census_a0", "dtd", "medium__calstblx.dtd"),
+		},
+		{
+			name: "historical-large-dbits",
+			path: filepath.Join("..", "testdata", "dispatcher_census_a0", "dtd", "large__dbits.dtd"),
+		},
+		{
+			name: "historical-large-docbook",
+			path: filepath.Join("..", "testdata", "dispatcher_census_a0", "dtd", "large__docbook.dtd"),
+		},
+	}
+
+	for _, witness := range witnesses {
+		witness := witness
+		t.Run(witness.name, func(t *testing.T) {
+			source := witness.source
+			if witness.path != "" {
+				var err error
+				source, err = os.ReadFile(witness.path)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			language := DtdLanguage()
+			raw, err := gotreesitter.NewParser(language).
+				ParseNoResultCompatibilityBenchmarkOnly(source)
+			if err != nil {
+				t.Fatalf("raw parse failed: %v", err)
+			}
+			t.Cleanup(raw.Release)
+			rawInspection, err := benchfixtures.InspectGoTree(raw.RootNode(), language)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			receipts := retiredDispatchRouteReceiptsAllowCompactAndForestFallbackExactSource(t, language, source)
+
+			var productionDigest string
+			for _, receipt := range receipts {
+				inspection, inspectErr := benchfixtures.InspectGoTree(receipt.tree.RootNode(), language)
+				if inspectErr != nil {
+					t.Fatal(inspectErr)
+				}
+				if receipt.name == "production" {
+					productionDigest = inspection.SHA256
+				}
+				runtime := receipt.tree.ParseRuntime()
+				foundDispatchMetric := false
+				if runtime.NormalizationPasses != nil {
+					for _, pass := range *runtime.NormalizationPasses {
+						if pass.Name != "dispatch.dtd" {
+							continue
+						}
+						foundDispatchMetric = true
+						t.Logf(
+							"source_sha256=%x route=%s digest=%s dispatch.dtd checked=%d run=%d visited=%d rewritten=%d",
+							sha256.Sum256(source),
+							receipt.name,
+							inspection.SHA256,
+							pass.Checked,
+							pass.Run,
+							pass.NodesVisited,
+							pass.NodesRewritten,
+						)
+						if pass.NodesRewritten != 0 {
+							t.Fatalf("route %s rewrote %d nodes", receipt.name, pass.NodesRewritten)
+						}
+						if pass.Checked == 0 || pass.Run == 0 {
+							t.Fatalf("route %s did not run dispatch.dtd: checked=%d run=%d", receipt.name, pass.Checked, pass.Run)
+						}
+					}
+				}
+				if !foundDispatchMetric {
+					t.Fatalf("route %s did not record dispatch.dtd metrics", receipt.name)
+				}
+				if receipt.name == "incremental" {
+					profile := receipt.incrementalProfile
+					t.Logf(
+						"source_sha256=%x route=incremental digest=%s reuse=%t reused_subtrees=%d reused_bytes=%d fresh_fallback=%t reason=%q",
+						sha256.Sum256(source),
+						inspection.SHA256,
+						profile.OldTreeReuseRoute,
+						profile.ReusedSubtrees,
+						profile.ReusedBytes,
+						profile.ReuseUnsupported,
+						profile.ReuseUnsupportedReason,
+					)
+					if !profile.ReuseUnsupported && (!profile.OldTreeReuseRoute || profile.ReusedSubtrees == 0) {
+						t.Fatalf("incremental route has neither reuse nor documented fallback: %+v", profile)
+					}
+				}
+				if receipt.name != "production" && productionDigest != "" && inspection.SHA256 != productionDigest {
+					t.Fatalf("route %s digest=%s, want production %s", receipt.name, inspection.SHA256, productionDigest)
+				}
+			}
+			if productionDigest == "" {
+				t.Fatal("production receipt missing")
+			}
+			if rawInspection.SHA256 != productionDigest {
+				t.Fatalf("raw digest=%s production=%s", rawInspection.SHA256, productionDigest)
+			}
+			t.Logf("source_bytes=%d raw_digest=%s production_digest=%s", len(source), rawInspection.SHA256, productionDigest)
+		})
+	}
+}

--- a/grammars/retired_dispatch_route_receipt_test.go
+++ b/grammars/retired_dispatch_route_receipt_test.go
@@ -34,7 +34,29 @@ func retiredDispatchRouteReceiptsAllowCompactFallbackExactSource(
 	lang *gotreesitter.Language,
 	source []byte,
 ) []retiredDispatchRouteReceipt {
-	return retiredDispatchRouteReceiptsWithCompactPolicyAndNewline(t, lang, source, false, false)
+	return retiredDispatchRouteReceiptsWithCompactPolicyAndRoutes(
+		t,
+		lang,
+		source,
+		false,
+		false,
+		false,
+	)
+}
+
+func retiredDispatchRouteReceiptsAllowCompactAndForestFallbackExactSource(
+	t *testing.T,
+	lang *gotreesitter.Language,
+	source []byte,
+) []retiredDispatchRouteReceipt {
+	return retiredDispatchRouteReceiptsWithCompactPolicyAndRoutes(
+		t,
+		lang,
+		source,
+		false,
+		false,
+		true,
+	)
 }
 
 func retiredDispatchRouteReceiptsWithCompactPolicy(
@@ -43,15 +65,23 @@ func retiredDispatchRouteReceiptsWithCompactPolicy(
 	baseSource []byte,
 	requireDirectCompact bool,
 ) []retiredDispatchRouteReceipt {
-	return retiredDispatchRouteReceiptsWithCompactPolicyAndNewline(t, lang, baseSource, requireDirectCompact, true)
+	return retiredDispatchRouteReceiptsWithCompactPolicyAndRoutes(
+		t,
+		lang,
+		baseSource,
+		requireDirectCompact,
+		true,
+		false,
+	)
 }
 
-func retiredDispatchRouteReceiptsWithCompactPolicyAndNewline(
+func retiredDispatchRouteReceiptsWithCompactPolicyAndRoutes(
 	t *testing.T,
 	lang *gotreesitter.Language,
 	baseSource []byte,
 	requireDirectCompact bool,
 	appendTrailingNewline bool,
+	allowForestFallback bool,
 ) []retiredDispatchRouteReceipt {
 	t.Helper()
 
@@ -92,15 +122,30 @@ func retiredDispatchRouteReceiptsWithCompactPolicyAndNewline(
 			gotreesitter.AdmissionCandidateLastFallbackReason(),
 		)
 	}
+	if direct {
+		t.Logf("compact route=direct")
+	} else {
+		t.Logf("compact route=fallback reason=%q", gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
 
 	forestParser := gotreesitter.NewParser(lang)
 	forest, ok := forestParser.ParseForestExperimental(source)
+	forestName := "forest"
 	if !ok || forest == nil {
 		offset, symbol, reason, _ := forestParser.ForestDeclineInfo()
-		t.Fatalf("forest route declined at %d symbol=%d reason=%s", offset, symbol, reason)
+		if !allowForestFallback {
+			t.Fatalf("forest route declined at %d symbol=%d reason=%s", offset, symbol, reason)
+		}
+		t.Logf("forest route=fallback offset=%d symbol=%d reason=%q", offset, symbol, reason)
+		var fallbackErr error
+		forest, fallbackErr = forestParser.Parse(source)
+		if fallbackErr != nil {
+			t.Fatalf("forest fallback parse failed: %v", fallbackErr)
+		}
+		forestName = "forest-fallback"
 	}
 	t.Cleanup(forest.Release)
-	if !forest.ParseRuntime().ForestFastPath {
+	if forestName == "forest" && !forest.ParseRuntime().ForestFastPath {
 		t.Fatal("forest parse did not report the forest route")
 	}
 
@@ -134,7 +179,7 @@ func retiredDispatchRouteReceiptsWithCompactPolicyAndNewline(
 	receipts := []retiredDispatchRouteReceipt{
 		{name: "production", tree: production},
 		{name: "compact", tree: compact},
-		{name: "forest", tree: forest},
+		{name: forestName, tree: forest},
 		{name: "incremental", tree: incremental, incrementalProfile: incrementalProfile},
 	}
 	want, err := benchfixtures.InspectGoTree(production.RootNode(), lang)


### PR DESCRIPTION
## Summary

- Keep the DTD compatibility entry live.
- Pin two known error-flag divergences with raw Go, production Go, and locked C digests.
- Verify two exact locked-C passes.
- Cover raw, production, compact, forest fallback, and incremental routes.
- Require zero dispatcher rewrites.
- Update the changelog and compatibility documents.

## Evidence

- `harness_out/docker/20260822T164115Z`: route receipts, exit 0.
- `harness_out/docker/20260822T164122Z`: locked-C parity, exit 0.
- Both artifacts report no out-of-memory kill and no timeout.
