### PR TITLE
Preserve lexer skip provenance in JSDoc parser roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,12 @@ for tags and release notes while still in `0.x`.
   Docker receipts record zero `dispatch.jsdoc` rewrites and equal raw and
   production digests on every covered route. Keep the JSDoc compatibility arm
   and registry entry live until one-grammar locked-C parity proves node, field,
-  span, point, extra, missing, and error equality.
+  span, point, extra, missing, and error equality. Preserve the root span for
+  an authenticated leading DFA skip. Keep unproven non-trivia gaps fail-closed.
+
+- Align the Bash skipped-escape and Erlang leading-skip witnesses with locked
+  C. Keep Bash `e \\ cho hi` clean. Keep Erlang `\x010` and `\x100` clean with
+  root span `1..2`.
 
 - Correct the Markdown scanner documentation for [issue #454](https://github.com/odvcencio/gotreesitter/issues/454).
   Mark Markdown as `certified reuse`. Changed-token and shape-changing edits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ for tags and release notes while still in `0.x`.
   existing forest decline decision. Keep Ledger recovery triggers on the
   production fallback until their forest trees match the locked C tree.
 
+- Preserve lexer skip-transition provenance for JSDoc padding. The focused
+  Docker receipts record zero `dispatch.jsdoc` rewrites and equal raw and
+  production digests on every covered route. Keep the JSDoc compatibility arm
+  and registry entry live until one-grammar locked-C parity proves node, field,
+  span, point, extra, missing, and error equality.
+
 - Correct the Markdown scanner documentation for [issue #454](https://github.com/odvcencio/gotreesitter/issues/454).
   Mark Markdown as `certified reuse`. Changed-token and shape-changing edits
   can still use the production full-parse fallback when reuse gates reject the

--- a/admission_route_equality_byte_continuity_gap_test.go
+++ b/admission_route_equality_byte_continuity_gap_test.go
@@ -38,29 +38,9 @@ import (
 //     instances in the record's own sweep) is real and is closed by this
 //     predicate retirement in general; this specific witness just no
 //     longer needs that closure to already be correct.
-//   - bash_stray_backslash_space: NOT a false-clean at all, and NOT a
-//     closure. The C oracle parses `e \ cho hi` CLEAN
-//     (HasError()==false): a backslash-space is a scanner-skipped escape
-//     in bash, and the two skipped bytes are legitimately uncovered by any
-//     leaf in C's OWN tree -- the leaf-tiling invariant this gate enforces
-//     is not a C invariant for scanner-skip escape classes. Before this
-//     fix, compact accepted this input directly and matched the C oracle
-//     byte-exactly. After this fix, the now-narrower
-//     bytesAreSingleByteDecorationTrivia-free auditor cannot tell this
-//     shape apart from a genuine drop, so it declines -- a coverage loss
-//     traded for safety, not a defect closure: the auditor's own decline
-//     contract is "stop rather than guess," and it is honoring that
-//     contract correctly here even though the input was actually fine.
-//     The production tree served after the decline (a flat
-//     ERROR[0:10], HasError()==true) diverges from the C oracle; that
-//     divergence is a pre-existing, unrelated production defect in how
-//     the GLR engine handles a bare backslash-space escape (real shell:
-//     `echo \ leading`, `tar -c \ -f x.tar dir`, `VAR=1 \ cmd`;
-//     backslash-newline line continuation is a different, unaffected
-//     class), not something this PR introduces or fixes. It is exposed
-//     here only because compact no longer masks it by accepting the
-//     input directly. Tracked separately as a production bash repair
-//     lane; out of scope for this PR.
+//   - bash_stray_backslash_space: the C oracle and every Go route report a
+//     clean, byte-exact tree. This witness is a scanner-skipped escape,
+//     not a false-clean closure. Keep the test aligned with locked C.
 func TestCompactRouteLexerSkippedByteGapDeclines(t *testing.T) {
 	// html and javascript are not otherwise loaded by the always-on
 	// (untagged) suite; purge the process-wide embedded cache afterward so
@@ -83,11 +63,8 @@ func TestCompactRouteLexerSkippedByteGapDeclines(t *testing.T) {
 		// makes compact accept this input correctly. See the doc comment
 		// above.
 		{"html_amp_stray", "html", "<html> & <body>Hello</body></html>"},
-		// NOT a false-clean: the C oracle reports this input clean. Pins
-		// the auditor's fail-closed decline contract, not a defect
-		// closure; the production-served tree's own divergence from C is
-		// a separate, pre-existing production defect. See the doc comment
-		// above.
+		// The C oracle reports this input clean. Keep this route regression
+		// guard aligned with the exact production and candidate trees.
 		{"bash_stray_backslash_space", "bash", "e \\ cho hi"},
 	}
 
@@ -108,14 +85,9 @@ func TestCompactRouteLexerSkippedByteGapDeclines(t *testing.T) {
 				t.Fatalf("production parse: %v", err)
 			}
 			defer productionTree.Release()
-			// Production's own verdict is HasError()==true for all four
-			// cases, including bash_stray_backslash_space -- that witness's
-			// production tree diverges from the C oracle (see the doc
-			// comment above), but production still reports it as an error
-			// on its own terms, which is the verdict the route-safety check
-			// below holds compact's served tree to.
-			if !productionTree.RootNode().HasError() {
-				t.Fatalf("production HasError=false, want true for %q", c.source)
+			wantError := c.name != "bash_stray_backslash_space"
+			if got := productionTree.RootNode().HasError(); got != wantError {
+				t.Fatalf("production HasError=%t, want %t for %q", got, wantError, c.source)
 			}
 
 			gts.ResetAdmissionCandidateCountersForTest()

--- a/admission_route_equality_root_leading_gap_test.go
+++ b/admission_route_equality_root_leading_gap_test.go
@@ -20,8 +20,8 @@ import (
 // accepted-root-leading-gap decline, the shared post-materialization
 // normalizeRootSourceStart (parser_result_root_build.go) pulled the public
 // root span back over the dropped byte on the assumption of a legitimately
-// elided leading extra, publishing HasError()==false while production
-// correctly reports an error for the same bytes.
+// elided leading extra. The locked C oracle keeps clean skipped-byte
+// witnesses outside the root span, so the route must preserve that span.
 func TestCompactRouteRootLeadingGapDeclines(t *testing.T) {
 	// html, erlang, and haskell are not otherwise loaded by the always-on
 	// (untagged) suite; purge the process-wide embedded cache afterward so
@@ -30,18 +30,20 @@ func TestCompactRouteRootLeadingGapDeclines(t *testing.T) {
 	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
 
 	cases := []struct {
-		name   string
-		lang   string
-		source string
+		name      string
+		lang      string
+		source    string
+		wantError bool
+		wantStart uint32
 	}{
-		{"html_amp_digit", "html", "&0"},
-		{"html_amp_semicolon", "html", "&;"},
-		{"html_amp_hash", "html", "&#"},
-		{"html_close_angle_digit", "html", ">0"},
-		{"html_amp_zeros", "html", "&000"},
-		{"erlang_soh_digit", "erlang", "\x010"},
-		{"erlang_du_digit", "erlang", "\x100"},
-		{"haskell_unterminated_string", "haskell", "\"\n"},
+		{"html_amp_digit", "html", "&0", true, 0},
+		{"html_amp_semicolon", "html", "&;", true, 0},
+		{"html_amp_hash", "html", "&#", true, 0},
+		{"html_close_angle_digit", "html", ">0", true, 0},
+		{"html_amp_zeros", "html", "&000", true, 0},
+		{"erlang_soh_digit", "erlang", "\x010", false, 1},
+		{"erlang_du_digit", "erlang", "\x100", false, 1},
+		{"haskell_unterminated_string", "haskell", "\"\n", true, 0},
 	}
 
 	for _, c := range cases {
@@ -61,8 +63,11 @@ func TestCompactRouteRootLeadingGapDeclines(t *testing.T) {
 				t.Fatalf("production parse: %v", err)
 			}
 			defer productionTree.Release()
-			if !productionTree.RootNode().HasError() {
-				t.Fatalf("production HasError=false, want true for %q", c.source)
+			if got := productionTree.RootNode().HasError(); got != c.wantError {
+				t.Fatalf("production HasError=%t, want %t for %q", got, c.wantError, c.source)
+			}
+			if got := productionTree.RootNode().StartByte(); got != c.wantStart {
+				t.Fatalf("production root startByte=%d, want %d for %q", got, c.wantStart, c.source)
 			}
 
 			gts.ResetAdmissionCandidateCountersForTest()

--- a/cgo_harness/jsdoc_retirement_parity_test.go
+++ b/cgo_harness/jsdoc_retirement_parity_test.go
@@ -1,0 +1,113 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const (
+	jsdocProducerTrigger       = "/**\n * @param {string} name\n * @returns {number}\n */\n"
+	jsdocProducerControl       = "/**\n * @param {string} name\n */\n"
+	jsdocProducerTriggerSHA256 = "8a1683a43035994f3abf03f2f9556b96514a745018c5373ff77d3127fb27d201"
+	jsdocProducerControlSHA256 = "0f4dbe6ca5d62b8c033c09ac26689c787a66298540c46b3af7a9760a7240b5ce"
+)
+
+func TestJsdocLexerSkipProvenanceLockedCParity(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	entry, ok := parityEntriesByName["jsdoc"]
+	if !ok {
+		t.Fatal("missing JSDoc grammar entry")
+	}
+	language := entry.Language()
+	cLanguage, err := COracleLanguage("jsdoc")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name   string
+		source []byte
+		sha256 string
+	}{
+		{name: "multi_tag_trigger", source: []byte(jsdocProducerTrigger), sha256: jsdocProducerTriggerSHA256},
+		{name: "single_tag_control", source: []byte(jsdocProducerControl), sha256: jsdocProducerControlSHA256},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := fmt.Sprintf("%x", sha256.Sum256(test.source)); got != test.sha256 {
+				t.Fatalf("source SHA-256 = %s, want %s", got, test.sha256)
+			}
+
+			rawParser := gotreesitter.NewParser(language)
+			rawParser.SetAdmissionCandidateRoute(false)
+			raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(test.source)
+			if err != nil {
+				t.Fatalf("raw parse: %v", err)
+			}
+			t.Cleanup(raw.Release)
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(test.source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			t.Cleanup(production.Release)
+
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(test.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C oracle returned a nil tree")
+			}
+			t.Cleanup(cTree.Close)
+
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatalf("inspect C deep tree: %v", err)
+			}
+			rawRuntime := raw.ParseRuntime()
+			productionRuntime := production.ParseRuntime()
+			if rawRuntime.NormalizationNodesRewritten != 0 || productionRuntime.NormalizationNodesRewritten != 0 {
+				t.Fatalf("JSDoc normalization rewrote nodes: raw=%d production=%d", rawRuntime.NormalizationNodesRewritten, productionRuntime.NormalizationNodesRewritten)
+			}
+			t.Logf("witness=%s bytes=%d source_sha256=%s raw_rewrites=%d production_rewrites=%d c_digest=%s", test.name, len(test.source), test.sha256, rawRuntime.NormalizationNodesRewritten, productionRuntime.NormalizationNodesRewritten, cDigest)
+
+			assertJsdocLockedCTreeExact(t, "raw", raw, language, cTree, cDigest)
+			assertJsdocLockedCTreeExact(t, "production", production, language, cTree, cDigest)
+		})
+	}
+}
+
+func assertJsdocLockedCTreeExact(t *testing.T, label string, goTree *gotreesitter.Tree, goLang *gotreesitter.Language, cTree *sitter.Tree, wantDigest string) {
+	t.Helper()
+	goRoot := goTree.RootNode()
+	cRoot := cTree.RootNode()
+	if diff := FirstDivergenceDumpV1(goRoot, goLang, cRoot); diff != nil {
+		t.Errorf("%s tree diverges from the locked C oracle: %+v", label, diff)
+		return
+	}
+	if diff := firstLockedCTreeFlagDivergence(goRoot, goLang, cRoot, "/"+goRoot.Type(goLang)); diff != nil {
+		t.Errorf("%s tree has a missing or error flag divergence: %v", label, diff)
+		return
+	}
+	inspection, err := benchfixtures.InspectGoTree(goRoot, goLang)
+	if err != nil {
+		t.Errorf("inspect %s Go deep tree: %v", label, err)
+		return
+	}
+	if inspection.SHA256 != wantDigest {
+		t.Errorf("%s deep digest Go=%s C=%s", label, inspection.SHA256, wantDigest)
+		return
+	}
+	t.Logf("%s route matches locked C exactly: symbols, fields, spans, points, extras, missing/error flags, deep digest=%s", label, inspection.SHA256)
+}

--- a/cgo_harness/jsdoc_retirement_parity_test.go
+++ b/cgo_harness/jsdoc_retirement_parity_test.go
@@ -88,6 +88,148 @@ func TestJsdocLexerSkipProvenanceLockedCParity(t *testing.T) {
 	}
 }
 
+func TestErlangLeadingSkippedPrefixLockedCParity(t *testing.T) {
+	entry, ok := parityEntriesByName["erlang"]
+	if !ok {
+		t.Fatal("missing Erlang grammar entry")
+	}
+	language := entry.Language()
+	cLanguage, err := COracleLanguage("erlang")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name   string
+		source []byte
+	}{
+		{name: "soh_digit", source: []byte("\x010")},
+		{name: "du_digit", source: []byte("\x100")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(test.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C oracle returned a nil tree")
+			}
+			t.Cleanup(cTree.Close)
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rawParser := gotreesitter.NewParser(language)
+			raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(test.source)
+			if err != nil {
+				t.Fatalf("raw parse: %v", err)
+			}
+			t.Cleanup(raw.Release)
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(test.source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			t.Cleanup(production.Release)
+			candidateParser := gotreesitter.NewParser(language)
+			candidateParser.SetAdmissionCandidateRoute(true)
+			candidate, err := candidateParser.Parse(test.source)
+			if err != nil {
+				t.Fatalf("candidate parse: %v", err)
+			}
+			t.Cleanup(candidate.Release)
+
+			for _, route := range []struct {
+				name string
+				tree *gotreesitter.Tree
+			}{
+				{name: "raw", tree: raw}, {name: "production", tree: production}, {name: "candidate", tree: candidate},
+			} {
+				root := route.tree.RootNode()
+				if root.HasError() {
+					t.Errorf("%s HasError=true, want false", route.name)
+				}
+				if root.StartByte() != 1 || root.EndByte() != 2 {
+					t.Errorf("%s root span=%d..%d, want 1..2", route.name, root.StartByte(), root.EndByte())
+				}
+				assertJsdocLockedCTreeExact(t, "erlang_"+route.name, route.tree, language, cTree, cDigest)
+			}
+			if cRoot := cTree.RootNode(); cRoot.HasError() || cRoot.StartByte() != 1 || cRoot.EndByte() != 2 {
+				t.Fatalf("C root has_error=%t span=%d..%d, want false and 1..2", cRoot.HasError(), cRoot.StartByte(), cRoot.EndByte())
+			}
+		})
+	}
+}
+
+func TestBashSkippedEscapeLockedCParity(t *testing.T) {
+	entry, ok := parityEntriesByName["bash"]
+	if !ok {
+		t.Fatal("missing Bash grammar entry")
+	}
+	language := entry.Language()
+	cLanguage, err := COracleLanguage("bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := []byte("e \\ cho hi")
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("C oracle returned a nil tree")
+	}
+	t.Cleanup(cTree.Close)
+	cRoot := cTree.RootNode()
+	if cRoot.HasError() {
+		t.Fatalf("C root HasError=true, want false")
+	}
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawParser := gotreesitter.NewParser(language)
+	raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(source)
+	if err != nil {
+		t.Fatalf("raw parse: %v", err)
+	}
+	t.Cleanup(raw.Release)
+	productionParser := gotreesitter.NewParser(language)
+	productionParser.SetAdmissionCandidateRoute(false)
+	production, err := productionParser.Parse(source)
+	if err != nil {
+		t.Fatalf("production parse: %v", err)
+	}
+	t.Cleanup(production.Release)
+	candidateParser := gotreesitter.NewParser(language)
+	candidateParser.SetAdmissionCandidateRoute(true)
+	candidate, err := candidateParser.Parse(source)
+	if err != nil {
+		t.Fatalf("candidate parse: %v", err)
+	}
+	t.Cleanup(candidate.Release)
+
+	for _, route := range []struct {
+		name string
+		tree *gotreesitter.Tree
+	}{
+		{name: "raw", tree: raw},
+		{name: "production", tree: production},
+		{name: "candidate", tree: candidate},
+	} {
+		if route.tree.RootNode().HasError() {
+			t.Errorf("%s HasError=true, want false", route.name)
+		}
+		assertJsdocLockedCTreeExact(t, "bash_skipped_escape_"+route.name, route.tree, language, cTree, cDigest)
+	}
+}
+
 func assertJsdocLockedCTreeExact(t *testing.T, label string, goTree *gotreesitter.Tree, goLang *gotreesitter.Language, cTree *sitter.Tree, wantDigest string) {
 	t.Helper()
 	goRoot := goTree.RootNode()

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -111,12 +111,13 @@ Do not change the registry until the matching candidate condition is complete.
 Status: producer fix accepted by the focused gates. Keep `dispatch.jsdoc` and
 `normalizeJsdocCompatibility` live until a separate retirement change.
 
-Base commit: `6c94426b69f5aa106873b0d667dd4112acc138f9`.
+Base commit: `a01f8037319c9f8f0ea12ae3c96523112656ce22`.
 
 The shared lexer now records the start of a skipped prefix on the emitted real
 token. The parser accepts that prefix as padding only when it begins at the
-stack byte offset. This change keeps the JSDoc normalizer and registry entry
-unchanged.
+stack byte offset. Root finalization preserves the span for an authenticated
+leading skip. It does not preserve an unproven non-trivia gap. This change
+keeps the JSDoc normalizer and registry entry unchanged.
 
 The focused Docker receipts pass for both parser-produced sources:
 
@@ -144,13 +145,21 @@ included-range regression, and the existing non-trivia gap rejection tests.
 The locked-C receipt compares symbols, fields, spans, points, extras, missing
 and error flags, and the deep digest for both witnesses.
 
+The Bash witness `e \\ cho hi` remains clean and matches locked C. The Erlang
+witnesses `\x010` and `\x100` remain clean with the exact root span `1..2`.
+
 The exact Docker artifacts are:
 
-- `harness_out/docker/20260822T173522Z-jsdoc-lexer-skip-provenance-routes-final3`
-- `harness_out/docker/20260822T171919Z-jsdoc-lexer-skip-provenance-locked-c`
-- `harness_out/docker/20260822T171937Z-jsdoc-lexer-skip-provenance-javascript`
-- `harness_out/docker/20260822T171958Z-jsdoc-lexer-skip-provenance-included-range`
-- `harness_out/docker/20260822T172019Z-jsdoc-lexer-skip-provenance-gap-boundary`
+- `harness_out/docker/20260822T181926Z-jsdoc-v20-layout-provenance-20260822`
+- `harness_out/docker/20260822T181942Z-jsdoc-v21-included-range-20260822`
+- `harness_out/docker/20260822T181951Z-jsdoc-v22-root-leading-gap-20260822`
+- `harness_out/docker/20260822T182000Z-jsdoc-v23-bash-gap-20260822`
+- `harness_out/docker/20260822T182017Z-jsdoc-v25-a0-manifest-20260822`
+- `harness_out/docker/20260822T182106Z-jsdoc-v26-erlang-locked-c-final-20260822`
+- `harness_out/docker/20260822T182215Z-jsdoc-v27-bash-locked-c-final-20260822`
+- `harness_out/docker/20260822T182230Z-jsdoc-v28-jsdoc-locked-c-final-20260822`
+- `harness_out/docker/20260822T182245Z-jsdoc-v29-js-unicode-final-20260822`
+- `harness_out/docker/20260822T182252Z-jsdoc-v30-gap-boundaries-final-20260822`
 
 Retire the JSDoc compatibility arm only after raw and production trees match
 locked C, both receipts report zero rewrites, and every listed route passes.

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -106,6 +106,56 @@ sources.
 
 Do not change the registry until the matching candidate condition is complete.
 
+## 2026-08-22 JSDoc producer-fix checkpoint
+
+Status: producer fix accepted by the focused gates. Keep `dispatch.jsdoc` and
+`normalizeJsdocCompatibility` live until a separate retirement change.
+
+Base commit: `6c94426b69f5aa106873b0d667dd4112acc138f9`.
+
+The shared lexer now records the start of a skipped prefix on the emitted real
+token. The parser accepts that prefix as padding only when it begins at the
+stack byte offset. This change keeps the JSDoc normalizer and registry entry
+unchanged.
+
+The focused Docker receipts pass for both parser-produced sources:
+
+| Witness | Source SHA-256 | Raw and production digest | Dispatch rewrites |
+| --- | --- | --- | ---: |
+| multi-tag trigger | `8a1683a43035994f3abf03f2f9556b96514a745018c5373ff77d3127fb27d201` | `63238fbed1257ab8d7b198d02beed85a8f4915b5a48149a85bf7b7a993e9388b` | 0 |
+| single-tag control | `0f4dbe6ca5d62b8c033c09ac26689c787a66298540c46b3af7a9760a7240b5ce` | `b8aec819c51b10e62d76937186fc52a8cdf91b66f4d198baa53f4a5860b3b232` | 0 |
+
+The route receipt records these exact routes:
+
+- Trigger: compact fallback for `accepted-leaf-tiling-gap`, forest fallback
+  at `51:22:dead_end`, and incremental fallback for
+  `external_scanner_unsupported`.
+- Control: compact direct, forest fallback at
+  `31:0:nolook_relex_empty`, and incremental fallback for
+  `external_scanner_unsupported`.
+
+The direct-route rule is: the control compact direct route bypasses
+normalization and requires no `dispatch.jsdoc` record. Its forest production
+fallback requires zero JSDoc rewrites and may record `dispatch.jsdoc`. Other
+fallback routes require their own `dispatch.jsdoc` record with zero rewrites.
+
+The focused Docker gates pass for the JavaScript unicode regression, the
+included-range regression, and the existing non-trivia gap rejection tests.
+The locked-C receipt compares symbols, fields, spans, points, extras, missing
+and error flags, and the deep digest for both witnesses.
+
+The exact Docker artifacts are:
+
+- `harness_out/docker/20260822T173522Z-jsdoc-lexer-skip-provenance-routes-final3`
+- `harness_out/docker/20260822T171919Z-jsdoc-lexer-skip-provenance-locked-c`
+- `harness_out/docker/20260822T171937Z-jsdoc-lexer-skip-provenance-javascript`
+- `harness_out/docker/20260822T171958Z-jsdoc-lexer-skip-provenance-included-range`
+- `harness_out/docker/20260822T172019Z-jsdoc-lexer-skip-provenance-gap-boundary`
+
+Retire the JSDoc compatibility arm only after raw and production trees match
+locked C, both receipts report zero rewrites, and every listed route passes.
+Reopen the candidate if any node, flag, digest, or route result diverges.
+
 ## Ordered program
 
 ### R0 — inventory and containment

--- a/grammars/jsdoc_retirement_route_receipt_test.go
+++ b/grammars/jsdoc_retirement_route_receipt_test.go
@@ -1,0 +1,281 @@
+//go:build !grammar_subset
+
+package grammars
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+const (
+	jsdocProducerTrigger       = "/**\n * @param {string} name\n * @returns {number}\n */\n"
+	jsdocProducerControl       = "/**\n * @param {string} name\n */\n"
+	jsdocProducerTriggerSHA256 = "8a1683a43035994f3abf03f2f9556b96514a745018c5373ff77d3127fb27d201"
+	jsdocProducerControlSHA256 = "0f4dbe6ca5d62b8c033c09ac26689c787a66298540c46b3af7a9760a7240b5ce"
+)
+
+func TestJsdocLexerSkipProvenanceRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	language := JsdocLanguage()
+	for _, test := range []struct {
+		name             string
+		source           []byte
+		sha256           string
+		compactRoute     string
+		forestRoute      string
+		incrementalRoute string
+	}{
+		{
+			name:             "multi_tag_trigger",
+			source:           []byte(jsdocProducerTrigger),
+			sha256:           jsdocProducerTriggerSHA256,
+			compactRoute:     "fallback:compact route declined at accept_without_materialization: accepted-leaf-tiling-gap: compact subtree symbol=38 span=7..48 has an unaccounted byte range 27..31 not covered by any child",
+			forestRoute:      "fallback:51:22:dead_end",
+			incrementalRoute: "fallback:external_scanner_unsupported",
+		},
+		{
+			name:             "single_tag_control",
+			source:           []byte(jsdocProducerControl),
+			sha256:           jsdocProducerControlSHA256,
+			compactRoute:     "direct",
+			forestRoute:      "fallback:31:0:nolook_relex_empty",
+			incrementalRoute: "fallback:external_scanner_unsupported",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := fmt.Sprintf("%x", sha256.Sum256(test.source)); got != test.sha256 {
+				t.Fatalf("source SHA-256 = %s, want %s", got, test.sha256)
+			}
+
+			rawParser := gotreesitter.NewParser(language)
+			rawParser.SetAdmissionCandidateRoute(false)
+			raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(test.source)
+			if err != nil {
+				t.Fatalf("raw parse: %v", err)
+			}
+			t.Cleanup(raw.Release)
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(test.source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			t.Cleanup(production.Release)
+
+			rawDigest := jsdocTreeDigest(t, raw, language)
+			productionDigest := jsdocTreeDigest(t, production, language)
+			pass := jsdocDispatchPass(t, production)
+			if pass.NodesRewritten != 0 {
+				t.Fatalf("dispatch.jsdoc rewrote %d nodes after the producer fix: %+v", pass.NodesRewritten, pass)
+			}
+			if rawDigest != productionDigest {
+				t.Fatalf("raw digest=%s production digest=%s", rawDigest, productionDigest)
+			}
+			t.Logf("witness=%s bytes=%d source_sha256=%s raw_digest=%s production_digest=%s dispatch=%+v", test.name, len(test.source), test.sha256, rawDigest, productionDigest, pass)
+
+			compactRoute, compactDigest := jsdocCompactRoute(t, language, test.source, productionDigest)
+			if compactRoute != test.compactRoute {
+				t.Fatalf("compact route=%q, want %q", compactRoute, test.compactRoute)
+			}
+			t.Logf("compact route=%s digest=%s", compactRoute, compactDigest)
+
+			forestRoute, forestDigest := jsdocForestRoute(t, language, test.source, productionDigest)
+			if forestRoute != test.forestRoute {
+				t.Fatalf("forest route=%q, want %q", forestRoute, test.forestRoute)
+			}
+			t.Logf("forest route=%s digest=%s", forestRoute, forestDigest)
+
+			incrementalRoute, incrementalDigest := jsdocIncrementalRoute(t, language, test.source, productionDigest)
+			if incrementalRoute != test.incrementalRoute {
+				t.Fatalf("incremental route=%q, want %q", incrementalRoute, test.incrementalRoute)
+			}
+			t.Logf("incremental route=%s digest=%s", incrementalRoute, incrementalDigest)
+		})
+	}
+}
+
+func jsdocDispatchPass(t *testing.T, tree *gotreesitter.Tree) gotreesitter.NormalizationPassRuntime {
+	t.Helper()
+	if tree.ParseRuntime().NormalizationPasses == nil {
+		t.Fatal("missing normalization pass records")
+	}
+	for _, pass := range *tree.ParseRuntime().NormalizationPasses {
+		if pass.Name == "dispatch.jsdoc" {
+			return pass
+		}
+	}
+	t.Fatal("missing dispatch.jsdoc pass record")
+	return gotreesitter.NormalizationPassRuntime{}
+}
+
+func jsdocTreeDigest(t *testing.T, tree *gotreesitter.Tree, language *gotreesitter.Language) string {
+	t.Helper()
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return inspection.SHA256
+}
+
+func jsdocRequireZeroDispatchRewrites(t *testing.T, tree *gotreesitter.Tree, route string) gotreesitter.NormalizationPassRuntime {
+	t.Helper()
+	pass := jsdocDispatchPass(t, tree)
+	if pass.NodesRewritten != 0 {
+		t.Fatalf("%s route rewrote %d JSDoc nodes: %+v", route, pass.NodesRewritten, pass)
+	}
+	return pass
+}
+
+func jsdocRequireDirectBypass(t *testing.T, tree *gotreesitter.Tree, route string) {
+	t.Helper()
+	runtime := tree.ParseRuntime()
+	if runtime.NormalizationPassesRun != 0 || runtime.NormalizationNodesRewritten != 0 {
+		t.Fatalf("%s route ran normalization: passes=%d rewrites=%d", route, runtime.NormalizationPassesRun, runtime.NormalizationNodesRewritten)
+	}
+	if runtime.NormalizationPasses != nil {
+		for _, pass := range *runtime.NormalizationPasses {
+			if pass.Name == "dispatch.jsdoc" {
+				t.Fatalf("%s route unexpectedly recorded dispatch.jsdoc: %+v", route, pass)
+			}
+		}
+	}
+}
+
+func jsdocRequireZeroDispatchRewritesOrBypass(t *testing.T, tree *gotreesitter.Tree, route string) {
+	t.Helper()
+	if tree.ParseRuntime().NormalizationPasses == nil {
+		jsdocRequireDirectBypass(t, tree, route)
+		return
+	}
+	jsdocRequireZeroDispatchRewrites(t, tree, route)
+}
+
+func jsdocCompactRoute(t *testing.T, language *gotreesitter.Language, source []byte, wantDigest string) (string, string) {
+	t.Helper()
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	parser := gotreesitter.NewParser(language)
+	parser.SetAdmissionCandidateRoute(true)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("compact parse: %v", err)
+	}
+	t.Cleanup(tree.Release)
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	digest := jsdocTreeDigest(t, tree, language)
+	if digest != wantDigest {
+		t.Fatalf("compact digest=%s production digest=%s", digest, wantDigest)
+	}
+	switch {
+	case routedAfter == routedBefore+1 && fallbackAfter == fallbackBefore:
+		jsdocRequireDirectBypass(t, tree, "compact direct")
+		return "direct", digest
+	case routedAfter == routedBefore && fallbackAfter == fallbackBefore+1:
+		reason := gotreesitter.AdmissionCandidateLastFallbackReason()
+		if reason == "" {
+			t.Fatal("compact fallback has no reason")
+		}
+		jsdocRequireZeroDispatchRewrites(t, tree, "compact fallback")
+		return "fallback:" + reason, digest
+	default:
+		t.Fatalf("compact counters routed=%d/%d fallback=%d/%d", routedBefore, routedAfter, fallbackBefore, fallbackAfter)
+		return "", ""
+	}
+}
+
+func jsdocForestRoute(t *testing.T, language *gotreesitter.Language, source []byte, wantDigest string) (string, string) {
+	t.Helper()
+	parser := gotreesitter.NewParser(language)
+	tree, ok := parser.ParseForestExperimental(source)
+	if !ok || tree == nil {
+		offset, symbol, reason, _ := parser.ForestDeclineInfo()
+		if reason == "" {
+			t.Fatalf("forest declined without a reason at %d symbol=%d", offset, symbol)
+		}
+		route := fmt.Sprintf("forest fallback at %d:%d:%s", offset, symbol, reason)
+		fallback, err := parser.Parse(source)
+		if err != nil {
+			t.Fatalf("%s production parse: %v", route, err)
+		}
+		t.Cleanup(fallback.Release)
+		digest := jsdocTreeDigest(t, fallback, language)
+		if digest != wantDigest {
+			t.Fatalf("%s digest=%s production digest=%s", route, digest, wantDigest)
+		}
+		jsdocRequireZeroDispatchRewritesOrBypass(t, fallback, route)
+		return fmt.Sprintf("fallback:%d:%d:%s", offset, symbol, reason), digest
+	}
+	t.Cleanup(tree.Release)
+	if !tree.ParseRuntime().ForestFastPath {
+		t.Fatal("forest parse did not report the forest route")
+	}
+	digest := jsdocTreeDigest(t, tree, language)
+	if digest != wantDigest {
+		t.Fatalf("forest digest=%s production digest=%s", digest, wantDigest)
+	}
+	jsdocRequireDirectBypass(t, tree, "forest direct")
+	return "direct", digest
+}
+
+func jsdocIncrementalRoute(t *testing.T, language *gotreesitter.Language, source []byte, wantDigest string) (string, string) {
+	t.Helper()
+	parser := gotreesitter.NewParser(language)
+	parser.SetAdmissionCandidateRoute(false)
+	variant := append(append([]byte(nil), source...), ' ')
+	oldTree, err := parser.Parse(variant)
+	if err != nil {
+		t.Fatalf("incremental variant base parse: %v", err)
+	}
+	t.Cleanup(oldTree.Release)
+	startPoint := jsdocPointAtByte(source, len(source))
+	oldEndPoint := jsdocPointAtByte(variant, len(variant))
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte:   uint32(len(source)),
+		OldEndByte:  uint32(len(variant)),
+		NewEndByte:  uint32(len(source)),
+		StartPoint:  startPoint,
+		OldEndPoint: oldEndPoint,
+		NewEndPoint: startPoint,
+	})
+	tree, profile, err := parser.ParseIncrementalProfiled(source, oldTree)
+	if err != nil {
+		t.Fatalf("incremental parse: %v", err)
+	}
+	t.Cleanup(tree.Release)
+	digest := jsdocTreeDigest(t, tree, language)
+	if digest != wantDigest {
+		t.Fatalf("incremental digest=%s production digest=%s profile=%+v", digest, wantDigest, profile)
+	}
+	if profile.ReuseUnsupported {
+		if profile.ReuseUnsupportedReason == "" {
+			t.Fatalf("incremental fallback has no reason: %+v", profile)
+		}
+		jsdocRequireZeroDispatchRewrites(t, tree, "incremental fallback")
+		return "fallback:" + profile.ReuseUnsupportedReason, digest
+	}
+	jsdocRequireDirectBypass(t, tree, "incremental reuse")
+	if !profile.OldTreeReuseRoute || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("incremental route did not reuse the old tree: %+v", profile)
+	}
+	return fmt.Sprintf("reuse:%d:%d", profile.ReusedSubtrees, profile.ReusedBytes), digest
+}
+
+func jsdocPointAtByte(source []byte, offset int) gotreesitter.Point {
+	var point gotreesitter.Point
+	for index, value := range source {
+		if index == offset {
+			break
+		}
+		if value == '\n' {
+			point.Row++
+			point.Column = 0
+			continue
+		}
+		point.Column++
+	}
+	return point
+}

--- a/intern.go
+++ b/intern.go
@@ -138,8 +138,8 @@ type InternObservationStats struct {
 //     barrier — normalizers mutate Node.children freely; the intern table
 //     is gone by then.
 
-// internKey is the lookup key for a single node shape. Keep the struct
-// tight: every reduce traverses this struct hot.
+// internKey is the lookup key for one node shape. Keep this struct tight
+// because every reduction traverses it on the hot path.
 type internKey struct {
 	// symbol identifies the node's grammar symbol. uint16 in the runtime;
 	// widened to uint32 here so the struct lays out cleanly without
@@ -148,10 +148,9 @@ type internKey struct {
 	// productionID disambiguates two reductions for the same symbol
 	// that produced different shapes (e.g. different rule alternatives).
 	productionID uint16
-	// flags captures isNamed/isExtra/hasError/isMissing in the same byte
-	// layout as Node.flags. Two nodes with the same shape but different
-	// flags MUST hash to different buckets.
-	flags uint8
+	// flags captures the runtime leaf flags used by the shape. Two nodes with
+	// different shape flags MUST hash to different buckets.
+	flags nodeFlags
 	// childCount is duplicated from len(childrenHash) to allow rejection
 	// without indexing the slice.
 	childCount uint8
@@ -172,6 +171,22 @@ type internKey struct {
 	// values. The pointers themselves live in the table's separate
 	// children-pointer arena; we compare them on hash collision.
 	childrenHash uint64
+}
+
+// internedLeafFlagsMask includes flags that affect a leaf's interned shape.
+// Fragility flags remain path metadata and never enter this key.
+const internedLeafFlagsMask nodeFlags = nodeFlagNamed |
+	nodeFlagExtra |
+	nodeFlagMissing |
+	nodeFlagHasError |
+	nodeFlagDirty |
+	nodeFlagFieldIDCacheComputed |
+	nodeFlagFieldIDCacheHasFieldIDs |
+	nodeFlagExternalScannerToken |
+	nodeFlagLexerSkippedPrefixAtSourceStart
+
+func internedLeafFlags(flags nodeFlags) nodeFlags {
+	return flags & internedLeafFlagsMask
 }
 
 // internEntry holds one intern table entry. The pointer comparison on
@@ -285,7 +300,7 @@ func buildKey(symbol Symbol, productionID uint16, flags nodeFlags, startByte, en
 	return internKey{
 		symbol:       uint32(symbol),
 		productionID: productionID,
-		flags:        uint8(flags),
+		flags:        internedLeafFlags(flags),
 		childCount:   uint8(len(children)),
 		startByte:    startByte,
 		endByte:      endByte,
@@ -302,7 +317,7 @@ func buildKeyFromNode(n *Node) internKey {
 	return internKey{
 		symbol:       uint32(n.symbol),
 		productionID: n.productionID,
-		flags:        uint8(n.flags),
+		flags:        internedLeafFlags(n.flags),
 		childCount:   uint8(len(n.children)),
 		startByte:    n.startByte,
 		endByte:      n.endByte,

--- a/lexer.go
+++ b/lexer.go
@@ -31,6 +31,10 @@ type Token struct {
 	// began, before scanner-side skip advances moved StartByte forward.
 	ExternalScannerToken     bool
 	ExternalScannerStartByte uint32
+	// lexerSkippedPrefix records that the DFA consumed one or more skip
+	// transitions before producing this token.
+	lexerSkippedPrefix      bool
+	lexerSkippedPrefixStart uint32
 }
 
 func bytesToStringNoCopy(b []byte) string {
@@ -109,6 +113,7 @@ func (l *Lexer) next(startState uint32, emitErrorRuns bool) Token {
 	// whitespace the failed attempt skipped) when it switches to error-mode
 	// lexing; capture it for the errorModeRetry branch below.
 	callStartPos, callStartRow, callStartCol := l.pos, l.row, l.col
+	skippedPrefix := false
 	for {
 		// EOF check.
 		if l.pos >= len(l.source) {
@@ -131,12 +136,20 @@ func (l *Lexer) next(startState uint32, emitErrorRuns bool) Token {
 				// advanced past the skipped content to prevent an
 				// infinite loop on zero-width skip matches.
 				if l.pos <= tokenStartPos {
+					skippedPrefix = false
 					l.skipOneRune()
+				} else {
+					skippedPrefix = true
 				}
 				continue
 			}
+			if skippedPrefix {
+				tok.lexerSkippedPrefix = true
+				tok.lexerSkippedPrefixStart = uint32(callStartPos)
+			}
 			return tok
 		}
+		skippedPrefix = false
 
 		if emitErrorRuns && l.hasErrorRunLexState && l.errorModeRetry && startState != l.errorRunLexState {
 			// Faithful C error-recovery port: ts_parser__lex retries a failed
@@ -231,6 +244,7 @@ func (l *Lexer) scan(startState uint32, startPos int, startRow, startCol uint32)
 	tokenStartPos := startPos
 	tokenStartRow := startRow
 	tokenStartCol := startCol
+	skippedPrefix := false
 
 	// Track the last accepting state.
 	acceptPos := -1
@@ -331,6 +345,7 @@ func (l *Lexer) scan(startState uint32, startPos int, startRow, startCol uint32)
 
 		if skipTransition {
 			// tree-sitter SKIP(state) consumes and resets token start.
+			skippedPrefix = true
 			tokenStartPos = scanPos
 			tokenStartRow = scanRow
 			tokenStartCol = scanCol
@@ -382,20 +397,24 @@ func (l *Lexer) scan(startState uint32, startPos int, startRow, startCol uint32)
 	if acceptSkip {
 		// Return a zero-Symbol token to signal "skip".
 		return Token{
-			StartByte:  uint32(acceptStartPos),
-			EndByte:    uint32(acceptPos),
-			StartPoint: Point{Row: acceptStartRow, Column: acceptStartCol},
-			EndPoint:   Point{Row: acceptRow, Column: acceptCol},
+			StartByte:               uint32(acceptStartPos),
+			EndByte:                 uint32(acceptPos),
+			StartPoint:              Point{Row: acceptStartRow, Column: acceptStartCol},
+			EndPoint:                Point{Row: acceptRow, Column: acceptCol},
+			lexerSkippedPrefix:      skippedPrefix,
+			lexerSkippedPrefixStart: uint32(startPos),
 		}, true
 	}
 
 	return Token{
-		Symbol:     acceptSymbol,
-		Text:       bytesToStringNoCopy(l.source[acceptStartPos:acceptPos]),
-		StartByte:  uint32(acceptStartPos),
-		EndByte:    uint32(acceptPos),
-		StartPoint: Point{Row: acceptStartRow, Column: acceptStartCol},
-		EndPoint:   Point{Row: acceptRow, Column: acceptCol},
+		Symbol:                  acceptSymbol,
+		Text:                    bytesToStringNoCopy(l.source[acceptStartPos:acceptPos]),
+		StartByte:               uint32(acceptStartPos),
+		EndByte:                 uint32(acceptPos),
+		StartPoint:              Point{Row: acceptStartRow, Column: acceptStartCol},
+		EndPoint:                Point{Row: acceptRow, Column: acceptCol},
+		lexerSkippedPrefix:      skippedPrefix,
+		lexerSkippedPrefixStart: uint32(startPos),
 	}, true
 }
 

--- a/no_tree_node.go
+++ b/no_tree_node.go
@@ -160,8 +160,11 @@ func (n *noTreeNode) setMissing(v bool)              { n.setFlag(nodeFlagMissing
 func (n *noTreeNode) hasError() bool                 { return n.hasFlag(nodeFlagHasError) }
 func (n *noTreeNode) setHasError(v bool)             { n.setFlag(nodeFlagHasError, v) }
 func (n *noTreeNode) setExternalScannerToken(v bool) { n.setFlag(nodeFlagExternalScannerToken, v) }
-func (n *noTreeNode) dirty() bool                    { return n.hasFlag(nodeFlagDirty) }
-func (n *noTreeNode) setDirty(v bool)                { n.setFlag(nodeFlagDirty, v) }
+func (n *noTreeNode) setLexerSkippedPrefixAtSourceStart(v bool) {
+	n.setFlag(nodeFlagLexerSkippedPrefixAtSourceStart, v)
+}
+func (n *noTreeNode) dirty() bool     { return n.hasFlag(nodeFlagDirty) }
+func (n *noTreeNode) setDirty(v bool) { n.setFlag(nodeFlagDirty, v) }
 
 // setFragileLeft/setFragileRight/isFragileLeft/isFragileRight mirror the
 // Node methods of the same name (tree.go); see markReduceFragility

--- a/parser.go
+++ b/parser.go
@@ -3981,6 +3981,9 @@ func realTokenAttachmentGapIsParserPadding(source []byte, s *glrStack, tok Token
 	if tok.ExternalScannerToken && tok.ExternalScannerStartByte == s.byteOffset {
 		return true
 	}
+	if tok.lexerSkippedPrefix && tok.lexerSkippedPrefixStart == s.byteOffset {
+		return true
+	}
 	if int(s.byteOffset) > len(source) || int(tok.StartByte) > len(source) {
 		return true
 	}

--- a/parser_lexer_skip_provenance_test.go
+++ b/parser_lexer_skip_provenance_test.go
@@ -33,3 +33,55 @@ func TestRealTokenAttachmentGapHonorsLexerSkipProvenanceWithIncludedRange(t *tes
 		t.Fatal("badStack.dead = false, want true for mismatched skip provenance")
 	}
 }
+
+func TestNormalizeRootSourceStartRequiresAcceptedSkipProvenance(t *testing.T) {
+	source := []byte{1, '0'}
+	newTree := func(provenance bool) *Node {
+		arena := newNodeArena(arenaClassFull)
+		child := newLeafNodeInArena(arena, 1, true, 1, 2, Point{Column: 1}, Point{Column: 2})
+		child.setLexerSkippedPrefixAtSourceStart(provenance)
+		root := newParentNodeInArena(arena, 2, true, []*Node{child}, nil, 0)
+		root.startByte = 1
+		root.startPoint = Point{Column: 1}
+		return root
+	}
+
+	accepted := newTree(true)
+	(&Parser{}).normalizeRootSourceStart(accepted, source)
+	if accepted.startByte != 1 || accepted.startPoint != (Point{Column: 1}) {
+		t.Fatalf("accepted root span moved across leading skipped byte: %d at %#v", accepted.startByte, accepted.startPoint)
+	}
+
+	unproven := newTree(false)
+	(&Parser{}).normalizeRootSourceStart(unproven, source)
+	if unproven.startByte != 0 || unproven.startPoint != (Point{}) {
+		t.Fatalf("unproven root span = %d at %#v, want pullback to 0", unproven.startByte, unproven.startPoint)
+	}
+}
+
+func TestLeadingSkipProvenanceSurvivesCompactAndPendingPayloads(t *testing.T) {
+	arena := newNodeArena(arenaClassFull)
+	noTreeLeaf := newNoTreeLeafNodeInArena(arena, 1, true, 1, 2, Point{Column: 1}, Point{Column: 2})
+	noTreeLeaf.setLexerSkippedPrefixAtSourceStart(true)
+	if !stackEntryHasLeadingLexerSkippedPrefixAtSourceStart(newStackEntryNoTreeNode(1, noTreeLeaf), arena) {
+		t.Fatal("no-tree leaf lost leading skip provenance")
+	}
+
+	compactLeaf := newCompactFullLeafInArena(arena, 1, true, 1, 2, Point{Column: 1}, Point{Column: 2})
+	compactLeaf.setLexerSkippedPrefixAtSourceStart(true)
+	inner := newPendingParentInArena(arena, 2, true, 0,
+		[]stackEntry{newStackEntryCompactFullLeaf(1, compactLeaf)},
+		1, 2, Point{Column: 1}, Point{Column: 2}, false)
+	outer := newPendingParentInArena(arena, 3, true, 0,
+		[]stackEntry{newStackEntryPendingParent(1, inner)},
+		1, 2, Point{Column: 1}, Point{Column: 2}, false)
+	root := newParentNodeInArenaWithFinalChildRefs(arena, 4, true, outer.childRange, 0, false)
+	if !root.hasLeadingLexerSkippedPrefixAtSourceStart() {
+		t.Fatal("compact leaf provenance did not survive pending and final-child payloads")
+	}
+
+	compactLeaf.setLexerSkippedPrefixAtSourceStart(false)
+	if root.hasLeadingLexerSkippedPrefixAtSourceStart() {
+		t.Fatal("unproven compact leaf retained leading skip provenance")
+	}
+}

--- a/parser_lexer_skip_provenance_test.go
+++ b/parser_lexer_skip_provenance_test.go
@@ -1,0 +1,35 @@
+package gotreesitter
+
+import "testing"
+
+func TestRealTokenAttachmentGapHonorsLexerSkipProvenanceWithIncludedRange(t *testing.T) {
+	source := []byte("a\n * b")
+	stack := newGLRStack(1)
+	stack.byteOffset = 1
+	tok := Token{
+		Symbol:                  1,
+		StartByte:               5,
+		EndByte:                 6,
+		StartPoint:              Point{Row: 1, Column: 3},
+		EndPoint:                Point{Row: 1, Column: 4},
+		lexerSkippedPrefix:      true,
+		lexerSkippedPrefixStart: 1,
+	}
+	parser := &Parser{included: []Range{{StartByte: 1, EndByte: uint32(len(source))}}}
+	if !parser.guardRealTokenAttachmentGap(source, &stack, tok, "included-range") {
+		t.Fatal("guardRealTokenAttachmentGap = false, want true for lexer skip provenance")
+	}
+	if stack.dead {
+		t.Fatal("stack.dead = true, want false for lexer skip provenance")
+	}
+
+	badStack := newGLRStack(1)
+	badStack.byteOffset = 1
+	tok.lexerSkippedPrefixStart = 0
+	if (&Parser{}).guardRealTokenAttachmentGap(source, &badStack, tok, "included-range") {
+		t.Fatal("guardRealTokenAttachmentGap = true, want false for mismatched skip provenance")
+	}
+	if !badStack.dead {
+		t.Fatal("badStack.dead = false, want true for mismatched skip provenance")
+	}
+}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -2551,6 +2551,7 @@ func (p *Parser) applyShiftAction(s *glrStack, act ParseAction, tok Token, nodeC
 			leaf := newCompactCheckpointLeafInArena(arena, tok.Symbol, named, tok.StartByte, tok.EndByte, cp)
 			leaf.setExtra(extra)
 			leaf.setExternalScannerToken(tok.ExternalScannerToken)
+			leaf.setLexerSkippedPrefixAtSourceStart(tok.lexerSkippedPrefix && tok.lexerSkippedPrefixStart == 0)
 			leaf.preGotoState = currentState
 			leaf.parseState = targetState
 			p.pushStackCompactCheckpointLeaf(s, targetState, leaf, entryScratch, gssScratch)
@@ -2559,6 +2560,7 @@ func (p *Parser) applyShiftAction(s *glrStack, act ParseAction, tok Token, nodeC
 				tok.StartByte, tok.EndByte, tok.StartPoint, tok.EndPoint)
 			leaf.setExtra(extra)
 			leaf.setExternalScannerToken(tok.ExternalScannerToken)
+			leaf.setLexerSkippedPrefixAtSourceStart(tok.lexerSkippedPrefix && tok.lexerSkippedPrefixStart == 0)
 			leaf.preGotoState = currentState
 			leaf.parseState = targetState
 			p.pushStackNoTreeNode(s, targetState, leaf, entryScratch, gssScratch)
@@ -2574,6 +2576,7 @@ func (p *Parser) applyShiftAction(s *glrStack, act ParseAction, tok Token, nodeC
 			leaf.hasCheckpoint = true
 		}
 		leaf.setExternalScannerToken(tok.ExternalScannerToken)
+		leaf.setLexerSkippedPrefixAtSourceStart(tok.lexerSkippedPrefix && tok.lexerSkippedPrefixStart == 0)
 		leaf.preGotoState = currentState
 		leaf.parseState = targetState
 		p.pushStackCompactFullLeaf(s, targetState, leaf, entryScratch, gssScratch)
@@ -2596,11 +2599,14 @@ func (p *Parser) applyShiftAction(s *glrStack, act ParseAction, tok Token, nodeC
 		if tok.ExternalScannerToken {
 			flags |= nodeFlagExternalScannerToken
 		}
+		if tok.lexerSkippedPrefix && tok.lexerSkippedPrefixStart == 0 {
+			flags |= nodeFlagLexerSkippedPrefixAtSourceStart
+		}
 		substituteActive := internLeavesSubstituteEnabled || (p != nil && p.leafInternByLang)
 		if substituteActive {
 			key := internKey{
 				symbol:       uint32(tok.Symbol),
-				flags:        uint8(flags),
+				flags:        internedLeafFlags(flags),
 				startByte:    tok.StartByte,
 				endByte:      tok.EndByte,
 				parseState:   targetState,
@@ -2642,6 +2648,7 @@ func (p *Parser) applyShiftAction(s *glrStack, act ParseAction, tok Token, nodeC
 		}
 		leaf.setExtra(act.Extra)
 		leaf.setExternalScannerToken(tok.ExternalScannerToken)
+		leaf.setLexerSkippedPrefixAtSourceStart(tok.lexerSkippedPrefix && tok.lexerSkippedPrefixStart == 0)
 		if leaf.isExtra() && perfCountersEnabled {
 			perfRecordExtraNode()
 		}

--- a/parser_result_javascript_unicode_trivia_test.go
+++ b/parser_result_javascript_unicode_trivia_test.go
@@ -1,0 +1,41 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestJavaScriptUnicodeLineSeparatorAfterExtraParsesClean(t *testing.T) {
+	source := []byte("let x = { a: //\u2028 3\n}")
+	lang := grammars.JavascriptLanguage()
+	want := "(program (lexical_declaration (variable_declarator (identifier) (object (pair (property_identifier) (comment) (number))))))"
+
+	for _, candidate := range []bool{true, false} {
+		name := "production"
+		if candidate {
+			name = "candidate"
+		}
+		t.Run(name, func(t *testing.T) {
+			parser := gts.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(candidate)
+			tree, err := parser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tree.Release()
+
+			root := tree.RootNode()
+			if root == nil {
+				t.Fatal("parser returned a nil root")
+			}
+			if root.HasError() {
+				t.Fatalf("unicode line separator produced an error tree: %s", root.SExpr(lang))
+			}
+			if got := root.SExpr(lang); got != want {
+				t.Fatalf("tree = %s, want %s", got, want)
+			}
+		})
+	}
+}

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -1518,8 +1518,11 @@ func (p *Parser) normalizeRootSourceStart(root *Node, source []byte) {
 		return
 	}
 	if firstSource < root.startByte {
-		// A root can start after a dropped leading extra. Pull it back to the
-		// first source token so the root still covers the lost token.
+		// Pull the root back unless the retained leftmost leaf proves that a
+		// DFA skip began at source byte zero and owns the prefix boundary.
+		if root.hasLeadingLexerSkippedPrefixAtSourceStart() {
+			return
+		}
 		root.startByte = firstSource
 		root.startPoint = advancePointByBytes(Point{}, source[:firstSource])
 		return

--- a/testdata/dispatcher_census_a0_manifest_v1.json
+++ b/testdata/dispatcher_census_a0_manifest_v1.json
@@ -592,9 +592,9 @@
       "files": 3,
       "checked": 3,
       "run": 3,
-      "nodes_visited": 31,
+      "nodes_visited": 169,
       "nodes_rewritten": 0,
-      "error_roots": 3,
+      "error_roots": 2,
       "parse_errors": 0
     },
     {

--- a/tree.go
+++ b/tree.go
@@ -67,6 +67,9 @@ const (
 	nodeFlagFieldIDCacheComputed
 	nodeFlagFieldIDCacheHasFieldIDs
 	nodeFlagExternalScannerToken
+	// nodeFlagLexerSkippedPrefixAtSourceStart records authenticated DFA skip
+	// provenance on the retained leaf that starts after source byte zero.
+	nodeFlagLexerSkippedPrefixAtSourceStart
 	// nodeFlagFragileLeft / nodeFlagFragileRight mirror C tree-sitter's
 	// Subtree.fragile_left / fragile_right (subtree.h): a subtree is fragile
 	// on a given edge when the reduce that produced it happened under an
@@ -114,6 +117,48 @@ func (n *Node) isExternalScannerToken() bool {
 	return n != nil && n.hasFlag(nodeFlagExternalScannerToken)
 }
 func (n *Node) setExternalScannerToken(v bool) { n.setFlag(nodeFlagExternalScannerToken, v) }
+
+func (n *Node) setLexerSkippedPrefixAtSourceStart(v bool) {
+	n.setFlag(nodeFlagLexerSkippedPrefixAtSourceStart, v)
+}
+
+func (n *Node) hasLeadingLexerSkippedPrefixAtSourceStart() bool {
+	if n == nil {
+		return false
+	}
+	if n.hasFlag(nodeFlagLexerSkippedPrefixAtSourceStart) {
+		return true
+	}
+	for i := 0; i < nodeChildCountNoMaterialize(n); i++ {
+		entry, ok := nodeChildEntryAtNoMaterialize(n, i)
+		if !ok || stackEntryNodeIsExtra(entry) {
+			continue
+		}
+		return stackEntryHasLeadingLexerSkippedPrefixAtSourceStart(entry, n.ownerArena)
+	}
+	return false
+}
+
+func stackEntryHasLeadingLexerSkippedPrefixAtSourceStart(entry stackEntry, arena *nodeArena) bool {
+	if n := stackEntryNode(entry); n != nil {
+		return n.hasLeadingLexerSkippedPrefixAtSourceStart()
+	}
+	if n := stackEntryNoTreeNode(entry); n != nil {
+		return n.hasFlag(nodeFlagLexerSkippedPrefixAtSourceStart)
+	}
+	if n := stackEntryCompactFullLeaf(entry); n != nil {
+		return n.hasFlag(nodeFlagLexerSkippedPrefixAtSourceStart)
+	}
+	if parent := stackEntryPendingParent(entry); parent != nil {
+		for i := 0; i < parent.childEntryCount(); i++ {
+			child := parent.childEntry(arena, i)
+			if !stackEntryNodeIsExtra(child) {
+				return stackEntryHasLeadingLexerSkippedPrefixAtSourceStart(child, arena)
+			}
+		}
+	}
+	return false
+}
 func (n *Node) dirty() bool {
 	return n != nil && n.hasFlag(nodeFlagDirty)
 }


### PR DESCRIPTION
## Summary

Preserve lexer skip provenance for JavaScript documentation (JSDoc) parser roots.

The lexer records a skipped prefix and its exact source offset.
The parser accepts that prefix only when it matches the stack offset.
Root normalization preserves an authenticated leading skip.
It rejects an unproven non-trivia gap.
Keep the JSDoc normalizer and registry entry live.

The Bash witness `e \\ cho hi` stays clean and matches locked C.
The Erlang witnesses `\x010` and `\x100` stay clean with root span `1..2`.
Locked-C parity compares symbols, fields, spans, points, extras, missing/error flags, and deep digests.
Route receipts show zero `dispatch.jsdoc` rewrites.

## Validation

The first implementation commit `2d1ce1a5` triggered [CI run 3214](https://github.com/odvcencio/gotreesitter/actions/runs/32588865828).
That run failed the Erlang and Bash route assertions, two root-race shards, and the JSDoc A0 receipt.
Commit `79fc84ff` corrected these failures.
It preserves authenticated source-start skip provenance, updates route expectations, and refreshes the manifest.
Independent review: GO.

## Combined scope

This PR changes exactly 16 files:

- `CHANGELOG.md`
- `admission_route_equality_byte_continuity_gap_test.go`
- `admission_route_equality_root_leading_gap_test.go`
- `cgo_harness/jsdoc_retirement_parity_test.go`
- `docs/root-normalization-retirement.md`
- `grammars/jsdoc_retirement_route_receipt_test.go`
- `intern.go`
- `lexer.go`
- `no_tree_node.go`
- `parser.go`
- `parser_lexer_skip_provenance_test.go`
- `parser_reduce.go`
- `parser_result_javascript_unicode_trivia_test.go`
- `parser_result_root_build.go`
- `testdata/dispatcher_census_a0_manifest_v1.json`
- `tree.go`

## Docker artifacts

- `harness_out/docker/20260822T181926Z-jsdoc-v20-layout-provenance-20260822`
- `harness_out/docker/20260822T181942Z-jsdoc-v21-included-range-20260822`
- `harness_out/docker/20260822T181951Z-jsdoc-v22-root-leading-gap-20260822`
- `harness_out/docker/20260822T182000Z-jsdoc-v23-bash-gap-20260822`
- `harness_out/docker/20260822T182017Z-jsdoc-v25-a0-manifest-20260822`
- `harness_out/docker/20260822T182106Z-jsdoc-v26-erlang-locked-c-final-20260822`
- `harness_out/docker/20260822T182215Z-jsdoc-v27-bash-locked-c-final-20260822`
- `harness_out/docker/20260822T182230Z-jsdoc-v28-jsdoc-locked-c-final-20260822`
- `harness_out/docker/20260822T182245Z-jsdoc-v29-js-unicode-final-20260822`
- `harness_out/docker/20260822T182252Z-jsdoc-v30-gap-boundaries-final-20260822`

Do not merge this pull request yet.