### PR TITLE
Preserve safe D6b frontier fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ for tags and release notes while still in `0.x`.
 - Add default-off D6b driver verification before no-action drops. Keep route
   admission and production drops disabled.
 
+- Keep D6b fail-closed for malformed frontier records. Require every dropped
+  participant to share one cohort with the survivor candidate before returning
+  a typed decline for a missing common action or exact derivation. Treat a
+  mixed-cohort frontier as a fatal error. Continue with the existing
+  alternative-set proof. The `grammargen_lr` witness uses production fallback
+  because that proof also declines. Keep direct D6b admission ungraduated.
+
 - Record the Swift #576 unsafe minimal and corpus divergences as open. Keep
   the focused locked-C receipt without changing parser behavior.
 

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -104,6 +104,36 @@ The focused Docker gate results are:
 Both combined gates failed only in the documented process-global pool telemetry comparison.
 The affected subtests changed between runs. The isolated targets passed. No OOM or timeout occurred.
 
+### Safe D6b decline
+
+D6a authenticates each frontier member independently. D6b also requires one common action and exact derivation.
+
+An authenticated frontier can place every dropped participant in one cohort with the survivor candidate.
+If it has no common proof, the consumer returns a typed decline.
+The scheduler then runs the existing alternative-set proof.
+
+A mixed-cohort frontier is not a safe decline. The consumer returns a fatal error and poisons the transaction.
+
+Keep every malformed, stale, foreign, resealed, blended, different-cohort, or otherwise unauthenticated frontier as a fatal error.
+Do not weaken exact derivation comparison.
+
+The `grammargen_lr` witness demonstrates this boundary:
+
+- D6a publishes two complete frontiers.
+- The target frontier has two members with equal actions and different derivation digests.
+- D6b declines the frontier without changing its state or journal.
+- The existing alternative-set proof declines, so production fallback serves the tree.
+- Candidate and production trees have equal locked-C deep digests.
+
+The focused Docker receipts are:
+
+- `harness_out/docker/20260822T184936Z-d6b-core-typed-decline-refresh-review7`
+- `harness_out/docker/20260822T184953Z-d6b-grammargen-lr-safe-decline-refresh-review8`
+- `harness_out/docker/20260822T185008Z-d6b-driver-positive-fatal-refresh-review9`
+- `harness_out/docker/20260822T185021Z-d6b-layout-budgets-refresh-review10`
+
+These receipts do not graduate direct D6b admission.
+
 The matrix counts and performance counts remain unchanged.
 This evidence does not graduate the route or wire production drops.
 

--- a/internal/parsercorephase0/drop_cohort_frontier.go
+++ b/internal/parsercorephase0/drop_cohort_frontier.go
@@ -7,6 +7,11 @@ import (
 	"errors"
 )
 
+// ErrDropCohortFrontierNoCommonProof identifies an authenticated frontier that
+// has no common action and exact derivation across its survivor and drops.
+// Callers may decline D6b and continue with the older alternative-set proof.
+var ErrDropCohortFrontierNoCommonProof = errors.New("parser-core phase zero: frontier dropped members lack a common action and derivation")
+
 // DropCohortFrontierHandle identifies one authenticated scheduler frontier.
 // The owner and epoch are checked before the sequence is read.
 type DropCohortFrontierHandle struct {
@@ -875,41 +880,43 @@ func (c *Core) dropCohortFrontierHasMatchingMemberForCohortOwned(
 	refs DropCohortRefSet,
 	target DropCohortRef,
 	want dropCohortFrontierMember,
-) (bool, error) {
+) (bool, bool, error) {
 	if err := c.validateSchedulerTransaction(owner); err != nil {
-		return false, err
+		return false, false, err
 	}
 	count, valid := c.dropCohortRefCount(refs)
 	if !valid || count <= 0 || count > dropCohortRefHardCap {
-		return false, errors.New("parser-core phase zero: frontier candidate reference set is invalid")
+		return false, false, errors.New("parser-core phase zero: frontier candidate reference set is invalid")
 	}
 	if participantIndex < 0 || participantIndex >= len(c.dropCohortFrontierParticipants) {
-		return false, errors.New("parser-core phase zero: frontier candidate participant is absent")
+		return false, false, errors.New("parser-core phase zero: frontier candidate participant is absent")
 	}
 	participant := c.dropCohortFrontierParticipants[participantIndex]
 	start := uint64(participant.memberStart)
 	end := start + uint64(count)
 	if end < start || end > uint64(len(c.dropCohortFrontierMembers)) {
-		return false, errors.New("parser-core phase zero: frontier candidate member bounds are invalid")
+		return false, false, errors.New("parser-core phase zero: frontier candidate member bounds are invalid")
 	}
+	commonCohort := false
 	for refIndex := 0; refIndex < count; refIndex++ {
 		if err := c.validateSchedulerTransaction(owner); err != nil {
-			return false, err
+			return false, false, err
 		}
 		ref, ok := c.DropCohortRefAtOwned(owner, refs, refIndex)
 		if !ok {
-			return false, errors.New("parser-core phase zero: frontier candidate reference accessor failed")
+			return false, false, errors.New("parser-core phase zero: frontier candidate reference accessor failed")
 		}
 		if !dropCohortFrontierSameCohort(ref, target) {
 			continue
 		}
+		commonCohort = true
 		member := c.dropCohortFrontierMembers[int(start)+refIndex]
 		if member.action == want.action &&
 			c.dropCohortVerifierDerivationEqual(member.derivation, want.derivation, false) {
-			return true, nil
+			return true, true, nil
 		}
 	}
-	return false, nil
+	return false, commonCohort, nil
 }
 
 func (c *Core) consumeDropCohortFrontierSequenceOwned(
@@ -1065,6 +1072,7 @@ func (c *Core) consumeDropCohortFrontierSequenceOwned(
 		return errors.New("parser-core phase zero: frontier survivor reference set is invalid")
 	}
 	proof := false
+	noCommonActionOrDerivation := false
 	for candidateIndex := 0; candidateIndex < survivorCount; candidateIndex++ {
 		if err := c.validateSchedulerTransaction(owner); err != nil {
 			return err
@@ -1092,8 +1100,9 @@ func (c *Core) consumeDropCohortFrontierSequenceOwned(
 			continue
 		}
 		candidateProof := true
+		candidateCommonCohort := true
 		for _, drop := range drops {
-			matched, memberErr := c.dropCohortFrontierHasMatchingMemberForCohortOwned(
+			matched, commonCohort, memberErr := c.dropCohortFrontierHasMatchingMemberForCohortOwned(
 				owner, int(participantStart)+drop, refs[drop], candidate, survivorMember,
 			)
 			if memberErr != nil {
@@ -1102,18 +1111,26 @@ func (c *Core) consumeDropCohortFrontierSequenceOwned(
 			if err := c.validateSchedulerTransaction(owner); err != nil {
 				return err
 			}
+			if !commonCohort {
+				candidateCommonCohort = false
+			}
 			if !matched {
 				candidateProof = false
-				break
 			}
 		}
 		if candidateProof {
 			proof = true
 			break
 		}
+		if candidateCommonCohort {
+			noCommonActionOrDerivation = true
+		}
 	}
 	if !proof {
-		return errors.New("parser-core phase zero: frontier dropped members lack a common action and derivation")
+		if noCommonActionOrDerivation {
+			return ErrDropCohortFrontierNoCommonProof
+		}
+		return errors.New("parser-core phase zero: frontier dropped members lack a common cohort")
 	}
 	if uint64(index) > uint64(^uint32(0)) {
 		return errors.New("parser-core phase zero: frontier index overflow")
@@ -1144,6 +1161,12 @@ func (c *Core) ConsumeDropCohortFrontierSequenceOwned(
 	}
 	defer c.recoverSchedulerOwnedPanic(owner)
 	err = c.consumeDropCohortFrontierSequenceOwned(owner, sequence, electionSequence, token, heads, refs, drops)
+	if errors.Is(err, ErrDropCohortFrontierNoCommonProof) {
+		// This result leaves the frontier complete and the journal unchanged. Do
+		// not poison the active scheduler transaction; the caller may continue
+		// with the existing alternative-set proof.
+		return err
+	}
 	return c.finishSchedulerOwned(owner, err)
 }
 

--- a/internal/parsercorephase0/drop_cohort_frontier_test.go
+++ b/internal/parsercorephase0/drop_cohort_frontier_test.go
@@ -159,6 +159,26 @@ func newDropCohortFrontierTwoCohortFixture(t *testing.T, shared bool) dropCohort
 	return fixture
 }
 
+func newDropCohortFrontierSameCohortDifferentDerivationFixture(t *testing.T) dropCohortFrontierFixture {
+	t.Helper()
+	fixture := newDropCohortFrontierFixture(t, 2, 2)
+	branchZero, ok := fixture.core.DropCohortRefAt(fixture.refs[0], 0)
+	if !ok {
+		t.Fatal("source branch zero reference is unavailable")
+	}
+	branchOne, ok := fixture.core.DropCohortRefAt(fixture.refs[0], 1)
+	if !ok {
+		t.Fatal("source branch one reference is unavailable")
+	}
+	var survivorRefs, droppedRefs DropCohortRefSet
+	if !fixture.core.AddDropCohortRef(&survivorRefs, branchZero) ||
+		!fixture.core.AddDropCohortRef(&droppedRefs, branchOne) {
+		t.Fatal("same-cohort branch reference subset construction failed")
+	}
+	fixture.refs[0], fixture.refs[1] = survivorRefs, droppedRefs
+	return fixture
+}
+
 func TestG18DropCohortFrontierPublishesOrderedOwnedRecord(t *testing.T) {
 	fixture := newDropCohortFrontierFixture(t, 2, 1)
 	publishDropCohortFrontierFixture(t, &fixture)
@@ -791,21 +811,7 @@ func TestG18D6bConsumeDropCohortFrontierSequenceOwnedRejectsResealedBlendedRefs(
 }
 
 func TestG18D6bConsumeDropCohortFrontierSequenceOwnedRejectsValidBranchDerivationMismatch(t *testing.T) {
-	fixture := newDropCohortFrontierFixture(t, 2, 2)
-	branchZero, ok := fixture.core.DropCohortRefAt(fixture.refs[0], 0)
-	if !ok {
-		t.Fatal("source branch zero reference is unavailable")
-	}
-	branchOne, ok := fixture.core.DropCohortRefAt(fixture.refs[0], 1)
-	if !ok {
-		t.Fatal("source branch one reference is unavailable")
-	}
-	var survivorRefs, droppedRefs DropCohortRefSet
-	if !fixture.core.AddDropCohortRef(&survivorRefs, branchZero) ||
-		!fixture.core.AddDropCohortRef(&droppedRefs, branchOne) {
-		t.Fatal("source branch reference subset construction failed")
-	}
-	fixture.refs[0], fixture.refs[1] = survivorRefs, droppedRefs
+	fixture := newDropCohortFrontierSameCohortDifferentDerivationFixture(t)
 	publishDropCohortFrontierFixture(t, &fixture)
 	if !fixture.frontierOK {
 		t.Fatal("frontier did not publish")
@@ -866,18 +872,65 @@ func TestG18D6bConsumeDropCohortFrontierSequenceOwnedRejectsNoCommonCohort(t *te
 		t.Fatal("frontier did not publish")
 	}
 	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
-		return fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+		consumeErr := fixture.core.ConsumeDropCohortFrontierSequenceOwned(
 			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
 		)
+		if consumeErr == nil {
+			t.Fatal("no-common cohort was accepted")
+		}
+		if errors.Is(consumeErr, ErrDropCohortFrontierNoCommonProof) {
+			t.Fatalf("different cohort returned typed decline: %v", consumeErr)
+		}
+		if fixture.core.schedulerFrame.poisoned == nil {
+			t.Fatal("different-cohort error did not poison the scheduler transaction")
+		}
+		return consumeErr
 	})
 	if err == nil {
-		t.Fatal("frontier with no common cohort was accepted")
+		t.Fatal("different-cohort frontier did not poison the transaction")
+	}
+	if errors.Is(err, ErrDropCohortFrontierNoCommonProof) {
+		t.Fatalf("different cohort returned typed decline: %v", err)
 	}
 	if got := fixture.core.dropCohortFrontiers[0].state; got != DropCohortFrontierComplete {
 		t.Fatalf("frontier state after no-common decline=%v, want complete", got)
 	}
 	if len(fixture.core.dropCohortFrontierJournal) != 0 {
 		t.Fatalf("frontier journal after no-common decline=%d, want 0", len(fixture.core.dropCohortFrontierJournal))
+	}
+}
+
+func TestG18D6bNoCommonProofLeavesSchedulerOwnerUsable(t *testing.T) {
+	fixture := newDropCohortFrontierSameCohortDifferentDerivationFixture(t)
+	publishDropCohortFrontierFixture(t, &fixture)
+	if !fixture.frontierOK {
+		t.Fatal("frontier did not publish")
+	}
+	var consumeErr error
+	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		consumeErr = fixture.core.ConsumeDropCohortFrontierSequenceOwned(
+			owner, fixture.frontier.Sequence, 11, fixture.token, fixture.heads, fixture.refs, []int{1},
+		)
+		if !errors.Is(consumeErr, ErrDropCohortFrontierNoCommonProof) {
+			return errors.New("no-common frontier did not return its typed outcome")
+		}
+		state, _, _, _, stateErr := fixture.core.DropCohortFrontierStateOwned(owner, fixture.frontier)
+		if stateErr != nil {
+			return stateErr
+		}
+		if state != DropCohortFrontierComplete {
+			return errors.New("no-common frontier changed state before the legacy proof")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !errors.Is(consumeErr, ErrDropCohortFrontierNoCommonProof) {
+		t.Fatalf("consume result=%v, want typed no-common proof", consumeErr)
+	}
+	if len(fixture.core.dropCohortFrontierJournal) != 0 {
+		t.Fatalf("frontier journal after typed decline=%d, want 0", len(fixture.core.dropCohortFrontierJournal))
 	}
 }
 

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2107,49 +2107,55 @@ func diagnosticParserCoreHeaderPathReceipts(compact *core.Core, headers []diagno
 }
 
 type diagnosticParserCoreGenericScheduler struct {
-	compact                       *core.Core
-	tokenSource                   *dfaTokenSource
-	scannerScratch                *[]byte
-	headers                       []diagnosticParserCoreHeader
-	token                         Token
-	checkpoint                    DiagnosticParserCoreScannerCheckpoint
-	checkpointBeforeID            core.CheckpointID
-	checkpointID                  core.CheckpointID
-	currentElection               DiagnosticParserCoreElection
-	electionIndex                 int
-	noLookaheadSteps              uint8
-	tokens                        uint64
-	dispatches                    uint64
-	branchOrder                   uint64
-	nextSeq                       uint64
-	nextCleanPathLineage          uint16
-	options                       DiagnosticParserCorePrefixOptions
-	receiptBacking                DiagnosticParserCoreGenericScheduler
-	receipt                       *DiagnosticParserCoreGenericScheduler
-	summaryHeaderScratch          []DiagnosticParserCoreHeaderReceipt
-	headerRollbackScratch         diagnosticParserCoreHeaderRollbackScratch
-	canonicalScratch              diagnosticParserCoreCanonicalScratch
-	dispatchScratch               diagnosticParserCoreDispatchScratch
-	conflictScratch               diagnosticParserCoreConflictScratch
-	reductionOutputs              []core.ReductionOutput
-	reductionReplacements         []diagnosticParserCoreHeader
-	classifiedBoundaries          []core.ClassifiedBoundary
-	condenseCandidates            []core.CondenseCandidate
-	electStates                   []StateID
-	electGLRStates                []StateID
-	work                          DiagnosticParserCoreGenericWork
-	epochProgress                 bool
-	acceptedHead                  core.Head
-	acceptedPayloads              []core.SubtreeID
-	eofRecoveryAdmission          compactEOFRecoveryAdmissionReceipt
-	conflictPostExecutionFault    func() error
-	extraPostExecutionFault       func() error
-	freshSessionOwner             *core.SchedulerTransactionToken
-	verifierHeads                 [32]core.Head
-	verifierRefs                  [32]core.DropCohortRef
-	verifierBound                 int
-	verifierHeaderPtr             *diagnosticParserCoreHeader
-	verifierInvocation            uint64
+	compact                    *core.Core
+	tokenSource                *dfaTokenSource
+	scannerScratch             *[]byte
+	headers                    []diagnosticParserCoreHeader
+	token                      Token
+	checkpoint                 DiagnosticParserCoreScannerCheckpoint
+	checkpointBeforeID         core.CheckpointID
+	checkpointID               core.CheckpointID
+	currentElection            DiagnosticParserCoreElection
+	electionIndex              int
+	noLookaheadSteps           uint8
+	tokens                     uint64
+	dispatches                 uint64
+	branchOrder                uint64
+	nextSeq                    uint64
+	nextCleanPathLineage       uint16
+	options                    DiagnosticParserCorePrefixOptions
+	receiptBacking             DiagnosticParserCoreGenericScheduler
+	receipt                    *DiagnosticParserCoreGenericScheduler
+	summaryHeaderScratch       []DiagnosticParserCoreHeaderReceipt
+	headerRollbackScratch      diagnosticParserCoreHeaderRollbackScratch
+	canonicalScratch           diagnosticParserCoreCanonicalScratch
+	dispatchScratch            diagnosticParserCoreDispatchScratch
+	conflictScratch            diagnosticParserCoreConflictScratch
+	reductionOutputs           []core.ReductionOutput
+	reductionReplacements      []diagnosticParserCoreHeader
+	classifiedBoundaries       []core.ClassifiedBoundary
+	condenseCandidates         []core.CondenseCandidate
+	electStates                []StateID
+	electGLRStates             []StateID
+	work                       DiagnosticParserCoreGenericWork
+	epochProgress              bool
+	acceptedHead               core.Head
+	acceptedPayloads           []core.SubtreeID
+	eofRecoveryAdmission       compactEOFRecoveryAdmissionReceipt
+	conflictPostExecutionFault func() error
+	extraPostExecutionFault    func() error
+	freshSessionOwner          *core.SchedulerTransactionToken
+	verifierHeads              [32]core.Head
+	verifierRefs               [32]core.DropCohortRef
+	verifierBound              int
+	verifierHeaderPtr          *diagnosticParserCoreHeader
+	verifierInvocation         uint64
+	// frontierProofVerified binds one successful D6b proof to the immediately
+	// following no-action drop. The state is reset with the scheduler and is
+	// consumed by dropGenericNoActionHeads.
+	frontierProofVerified         bool
+	frontierProofDropCount        uint8
+	frontierProofDropIndices      [diagnosticParserCoreFrontierParticipantCap]int
 	observer                      diagnosticParserCoreSeedObserver
 	stoppedAfterElection          bool
 	requireEOFPostNoLookaheadRoot bool
@@ -7126,7 +7132,12 @@ func (s *diagnosticParserCoreGenericScheduler) attachDiagnosticParserCoreFrontie
 // consumeDropCohortFrontierOwned authenticates the current frontier before a
 // no-action drop mutates the scheduler headers. The private option stays off.
 func (s *diagnosticParserCoreGenericScheduler) consumeDropCohortFrontierOwned(indices []int) error {
-	if s == nil || !s.options.verifyDropCohortFrontiers {
+	if s == nil {
+		return nil
+	}
+	s.frontierProofVerified = false
+	s.frontierProofDropCount = 0
+	if !s.options.verifyDropCohortFrontiers {
 		return nil
 	}
 	if s.compact == nil || s.freshSessionOwner == nil {
@@ -7159,7 +7170,10 @@ func (s *diagnosticParserCoreGenericScheduler) consumeDropCohortFrontierOwned(in
 	if !ok {
 		return errors.New("parser-core phase zero: D6b frontier consumer could not rebuild the frontier token")
 	}
-	return s.compact.ConsumeDropCohortFrontierSequenceOwned(
+	if len(indices) > len(s.frontierProofDropIndices) {
+		return errors.New("parser-core phase zero: D6b frontier consumer drop set exceeds its bounded receipt")
+	}
+	if err := s.compact.ConsumeDropCohortFrontierSequenceOwned(
 		owner,
 		uint64(sequence),
 		uint64(electionSequence),
@@ -7167,7 +7181,18 @@ func (s *diagnosticParserCoreGenericScheduler) consumeDropCohortFrontierOwned(in
 		heads[:len(s.headers)],
 		refs[:len(s.headers)],
 		indices,
-	)
+	); err != nil {
+		if errors.Is(err, core.ErrDropCohortFrontierNoCommonProof) {
+			// D6b declines this authenticated but heterogeneous frontier. Keep
+			// the proof flag clear so the existing alternative-set gate runs.
+			return nil
+		}
+		return err
+	}
+	copy(s.frontierProofDropIndices[:], indices)
+	s.frontierProofDropCount = uint8(len(indices))
+	s.frontierProofVerified = true
+	return nil
 }
 
 // dropGenericNoActionHeads removes the paused/no-action heads named by indices.
@@ -7176,6 +7201,11 @@ func (s *diagnosticParserCoreGenericScheduler) consumeDropCohortFrontierOwned(in
 // runs outside any rollback transaction, so mutating the s.headers backing is
 // safe.
 func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices []int) error {
+	frontierProofVerified := s.frontierProofMatchesDrop(indices)
+	defer func() {
+		s.frontierProofVerified = false
+		s.frontierProofDropCount = 0
+	}()
 	if len(indices) == 0 || len(indices) >= len(s.headers) {
 		return errors.New("parser-core phase zero: sibling-backed no-action drop removed the complete frontier")
 	}
@@ -7209,7 +7239,12 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 	// to its stage 3 certificate precondition, not this gate.
 	convergedCoverageDrops, proved := uint64(0), metadataDrop
 	if !metadataDrop {
-		convergedCoverageDrops, proved = s.diagnosticParserCoreConvergedCoverageDropsV2(indices)
+		if frontierProofVerified {
+			convergedCoverageDrops = s.frontierProofConvergedDropCount(indices)
+			proved = true
+		} else {
+			convergedCoverageDrops, proved = s.diagnosticParserCoreConvergedCoverageDropsV2(indices)
+		}
 	}
 	if !metadataDrop && diagnosticParserCoreShadowCensusEnabled() {
 		// The retired scalar proof is evaluated only here, next to the v2
@@ -7266,6 +7301,28 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 	s.work.add(&s.work.ConvergedReductionSplitDrops, convergedReductionSplitDrops)
 	s.work.add(&s.work.ConvergedCoverageDrops, convergedCoverageDrops)
 	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) frontierProofMatchesDrop(indices []int) bool {
+	if s == nil || !s.frontierProofVerified || len(indices) != int(s.frontierProofDropCount) {
+		return false
+	}
+	for index, drop := range indices {
+		if s.frontierProofDropIndices[index] != drop {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *diagnosticParserCoreGenericScheduler) frontierProofConvergedDropCount(indices []int) uint64 {
+	var count uint64
+	for _, index := range indices {
+		if index >= 0 && index < len(s.headers) && s.headers[index].convergedReductionSplit {
+			count++
+		}
+	}
+	return count
 }
 
 // DiagnosticBindDropCohortReferencesForTest binds opaque certificate handles

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -40,6 +40,7 @@ type parserCoreFreshFullRunner struct {
 	// frontierVerificationEnabled is armed only by the private D6b test seam.
 	// It never enables the production admission route.
 	frontierVerificationEnabled bool
+	frontierVerificationToken   *dropCohortActivationToken
 	certificateAdmissionToken   *dropCohortActivationToken
 	scannerScratch              []byte
 	// scratch retains the reusable per-parse materialization buffers. The runner
@@ -48,6 +49,9 @@ type parserCoreFreshFullRunner struct {
 	// state from re-allocating the public-tree scratch on every parse.
 	scratch   parserCoreRunnerScratch
 	scheduler diagnosticParserCoreGenericScheduler
+	// frontierPublishedObserver is populated only by the focused D6 test seam.
+	// The production route leaves it nil and keeps the observer allocation-free.
+	frontierPublishedObserver func(*diagnosticParserCoreGenericScheduler, core.SchedulerTransactionToken, []int) error
 }
 
 func newParserCoreFreshFullRunner(scanner ExternalScanner, options DiagnosticParserCorePrefixOptions) (*parserCoreFreshFullRunner, error) {
@@ -113,6 +117,9 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpenWithObserver(
 ) (*diagnosticParserCoreGenericScheduler, *dfaTokenSource, error) {
 	if r == nil || r.parser == nil || r.lang == nil || r.tables == nil || compact == nil {
 		return nil, nil, errors.New("parser-core fresh-full runner is incomplete")
+	}
+	if observer.frontierPublished == nil {
+		observer.frontierPublished = r.frontierPublishedObserver
 	}
 	if reset {
 		if err := compact.Reset(); err != nil {

--- a/parsercore_phase0_g18_d6a_acceptance_external_test.go
+++ b/parsercore_phase0_g18_d6a_acceptance_external_test.go
@@ -92,6 +92,12 @@ type g18D6aCandidateOutcome struct {
 	ErrorType string
 }
 
+type g18D6bVerifierSnapshot struct {
+	VerifierElections uint64 `json:"verifier_elections"`
+	VerifierProofs    uint64 `json:"verifier_proofs"`
+	VerifierDeclines  uint64 `json:"verifier_declines"`
+}
+
 func g18D6aCloneLanguage(language *gts.Language) *gts.Language {
 	value := reflect.ValueOf(language).Elem()
 	clone := reflect.New(value.Type()).Elem()
@@ -392,5 +398,116 @@ func TestG18D6aKotlinControlsRemainNonCandidate(t *testing.T) {
 				t.Fatalf("Kotlin non-candidate parser consumed admission: %d/%d", routed, fallback)
 			}
 		})
+	}
+}
+
+func TestG18D6bGrammargenLRNoCommonDerivationFallsBack(t *testing.T) {
+	fixtures, err := benchfixtures.LoadGoFullParseFixtures()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture benchfixtures.LoadedFixture
+	for _, candidate := range fixtures {
+		if candidate.Fixture.ID == "grammargen_lr" {
+			fixture = candidate
+			break
+		}
+	}
+	if fixture.Fixture.ID != "grammargen_lr" {
+		t.Fatal("grammargen_lr fixture is unavailable")
+	}
+
+	language := g18D6aCloneLanguage(grammars.GoLanguage())
+	language.CompactConvergedReductionSplitDropsCertified = false
+	parser := gts.NewParser(language)
+	parser.SetAdmissionCandidateRoute(true)
+	gts.ResetAdmissionCandidateCountersForTest()
+	var snapshots []g18D6aObserverPayload
+	restore := parser.DiagnosticEnableDropCohortFrontierVerificationForTest(func(bytes []byte) {
+		snapshots = append(snapshots, g18D6aSnapshotDecode(t, bytes))
+	})
+	candidate, err := parser.Parse(fixture.Source)
+	restore()
+	if err != nil {
+		t.Fatalf("candidate parse: %v", err)
+	}
+	if candidate == nil {
+		t.Fatal("candidate parse returned nil tree")
+	}
+	t.Cleanup(candidate.Release)
+
+	routed, fallback := gts.AdmissionCandidateCounters()
+	wantFallbackReason := "compact route declined at no_action: converged-path reduction split no-action drop lacks alternative-set coverage by one non-blended survivor"
+	if routed != 0 || fallback != 1 || gts.AdmissionCandidateLastFallbackReason() != wantFallbackReason {
+		t.Fatalf("candidate route counters=%d/%d reason=%q, want 0/1 and %q", routed, fallback, gts.AdmissionCandidateLastFallbackReason(), wantFallbackReason)
+	}
+	targetSnapshot := -1
+	for index, snapshot := range snapshots {
+		g18D6aRequireCompleteFrontier(t, snapshot)
+		if g18D6aIsTargetDropFrontier(snapshot) {
+			if targetSnapshot >= 0 {
+				t.Fatalf("target frontier publications=%d, want 1", targetSnapshot+1)
+			}
+			targetSnapshot = index
+		}
+	}
+	if targetSnapshot < 0 {
+		t.Fatalf("frontier publications=%d, none bind the target drop", len(snapshots))
+	}
+
+	candidateInspection, err := benchfixtures.InspectGoTree(candidate.RootNode(), language)
+	if err != nil {
+		t.Fatalf("inspect candidate tree: %v", err)
+	}
+	if err := fixture.Fixture.VerifyDeepTreeDigest(candidateInspection.SHA256); err != nil {
+		t.Fatalf("candidate tree is not exact locked-C parity: %v", err)
+	}
+
+	productionLanguage := g18D6aCloneLanguage(grammars.GoLanguage())
+	productionParser := gts.NewParser(productionLanguage)
+	productionParser.SetAdmissionCandidateRoute(false)
+	production, err := productionParser.Parse(fixture.Source)
+	if err != nil {
+		t.Fatalf("production parse: %v", err)
+	}
+	if production == nil {
+		t.Fatal("production parse returned nil tree")
+	}
+	t.Cleanup(production.Release)
+	productionInspection, err := benchfixtures.InspectGoTree(production.RootNode(), productionLanguage)
+	if err != nil {
+		t.Fatalf("inspect production tree: %v", err)
+	}
+	if err := fixture.Fixture.VerifyDeepTreeDigest(productionInspection.SHA256); err != nil {
+		t.Fatalf("production tree is not exact locked-C parity: %v", err)
+	}
+	if candidateInspection.SHA256 != productionInspection.SHA256 {
+		t.Fatalf("candidate and production digests differ: candidate=%s production=%s", candidateInspection.SHA256, productionInspection.SHA256)
+	}
+
+	var telemetry g18D6bVerifierSnapshot
+	if err := json.Unmarshal(parser.DiagnosticDropCohortSnapshotForTest(), &telemetry); err != nil {
+		t.Fatalf("decode verifier telemetry: %v", err)
+	}
+	if telemetry.VerifierElections != 0 || telemetry.VerifierProofs != 0 || telemetry.VerifierDeclines != 0 {
+		t.Fatalf("verifier telemetry=%+v, want no D6b proof after the typed decline", telemetry)
+	}
+
+	publicationCount := len(snapshots)
+	gts.ResetAdmissionCandidateCountersForTest()
+	repeated, err := parser.Parse(fixture.Source)
+	if err != nil {
+		t.Fatalf("restored candidate parse: %v", err)
+	}
+	if repeated == nil {
+		t.Fatal("restored candidate parse returned nil tree")
+	}
+	t.Cleanup(repeated.Release)
+	routed, fallback = gts.AdmissionCandidateCounters()
+	if routed != 0 || fallback != 1 || gts.AdmissionCandidateLastFallbackReason() != wantFallbackReason {
+		t.Fatalf("restored candidate route counters=%d/%d reason=%q, want 0/1 and %q", routed, fallback, gts.AdmissionCandidateLastFallbackReason(), wantFallbackReason)
+	}
+	if len(snapshots) != publicationCount {
+		t.Fatalf("restored parse published new frontier telemetry: before=%d after=%d", publicationCount, len(snapshots))
 	}
 }

--- a/parsercore_phase0_g18_d6a_test_hooks_test.go
+++ b/parsercore_phase0_g18_d6a_test_hooks_test.go
@@ -152,3 +152,60 @@ func DiagnosticParseCandidateWithDropCohortFrontierModeForTest(
 	runner.frontierRecordingEnabled = false
 	return tree, published, candidateErr, err
 }
+
+// DiagnosticEnableDropCohortFrontierVerificationForTest enables the D6a
+// producer and D6b consumer for one cached candidate parse. The closure is
+// idempotent and restores the runner before cached reuse.
+func (p *Parser) DiagnosticEnableDropCohortFrontierVerificationForTest(observer DiagnosticParserCoreFrontierObserverForTest) func() {
+	if p == nil || !p.admissionCandidateFullParseEligible(nil, true) {
+		return func() {}
+	}
+	runner, err := p.acquireAdmissionCandidateRunner()
+	if err != nil || runner == nil {
+		return func() {}
+	}
+	token := &dropCohortActivationToken{marker: 2}
+	previousObserver := runner.frontierPublishedObserver
+	runner.frontierVerificationToken = token
+	runner.certificateAdmissionEnabled = true
+	runner.frontierRecordingEnabled = true
+	runner.frontierVerificationEnabled = true
+	runner.frontierPublishedObserver = func(scheduler *diagnosticParserCoreGenericScheduler, owner core.SchedulerTransactionToken, dropIndices []int) error {
+		if observer != nil {
+			observer(diagnosticParserCoreFrontierObserverPayload(scheduler, owner, dropIndices))
+		}
+		return nil
+	}
+	restored := false
+	return func() {
+		if restored {
+			return
+		}
+		restored = true
+		cached, ok := p.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+		if !ok || cached == nil || cached.frontierVerificationToken != token {
+			return
+		}
+		cached.certificateAdmissionEnabled = false
+		cached.frontierRecordingEnabled = false
+		cached.frontierVerificationEnabled = false
+		cached.frontierVerificationToken = nil
+		cached.frontierPublishedObserver = previousObserver
+		cached.options.recordDropCohortCertificates = false
+		cached.options.recordDropCohortFrontiers = false
+		cached.options.verifyDropCohortFrontiers = false
+	}
+}
+
+// DiagnosticDropCohortSnapshotForTest returns the cached candidate runner's
+// verifier telemetry. It is available only in the focused parser-core tests.
+func (p *Parser) DiagnosticDropCohortSnapshotForTest() []byte {
+	if p == nil {
+		return nil
+	}
+	runner, ok := p.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+	if !ok || runner == nil || runner.compact == nil {
+		return nil
+	}
+	return runner.compact.DiagnosticDropCohortSnapshotForTest()
+}


### PR DESCRIPTION
## Summary

Keep direct D6b admission ungraduated.

The frontier producer proves the same action with different exact derivations.
Only a fully authenticated same-cohort frontier with no common proof returns the typed non-poisoning decline.
Mixed-cohort frontiers and every invalid or unauthenticated case remain fatal and poison the transaction.
The driver then runs the existing alternative-set proof.
The `grammargen_lr` witness falls back to the exact locked-C production tree.

The candidate uses base `c46c9597005faf57ea810e3268e2cf55239da7e4`.
Independent review returned GO.

## Verification

All fresh Docker gates exited 0, with no out-of-memory event and no timeout:

- `harness_out/docker/20260822T184936Z-d6b-core-typed-decline-refresh-review7`
- `harness_out/docker/20260822T184953Z-d6b-grammargen-lr-safe-decline-refresh-review8`
- `harness_out/docker/20260822T185008Z-d6b-driver-positive-fatal-refresh-review9`
- `harness_out/docker/20260822T185021Z-d6b-layout-budgets-refresh-review10`

The post-merge main run passed: https://github.com/odvcencio/gotreesitter/actions/runs/32591815732

## Scope

The change contains exactly eight files:

- `CHANGELOG.md`
- `docs/compact-route-real-corpus-matrix.md`
- `internal/parsercorephase0/drop_cohort_frontier.go`
- `internal/parsercorephase0/drop_cohort_frontier_test.go`
- `parsercore_phase0_driver.go`
- `parsercore_phase0_fresh_full_runner.go`
- `parsercore_phase0_g18_d6a_acceptance_external_test.go`
- `parsercore_phase0_g18_d6a_test_hooks_test.go`
