### PR TITLE
test: Record Doxygen blocker receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,22 @@ for tags and release notes while still in `0.x`.
 - Record a durable DTD locked-C blocker receipt. Keep the DTD compatibility
   entry live until both recorded error-flag divergences close.
 
+- Record a durable Doxygen locked-C blocker receipt. Keep `dispatch.doxygen`
+  live. The three A0 witnesses report zero raw and production rewrites. The
+  historical childless and recovered routes report 3 and 14 named rewrites
+  across production, compact, forest, and incremental routes. The real corpus
+  has no Doxygen directory, so its census remains uncovered. The current
+  denominator is 31 dispatcher arms, 33 dispatcher languages, 32 live entries,
+  and 56 retired entries. The focused artifacts are
+  `harness_out/docker/20260822T202538Z-doxygen-blocker-routes-final` and
+  `harness_out/docker/20260822T202308Z-doxygen-blocker-locked-c`, with the
+  registry and census gates at
+  `harness_out/docker/20260822T202324Z-doxygen-blocker-registry-a0` and
+  `harness_out/docker/20260822T202335Z-doxygen-blocker-census`. Locked C
+  differs at `/document` for CMakeLists and example, and at `/ERROR` with
+  `children=0` versus `children=279` for metrics. Status: `NO-GO`;
+  `KEEP LIVE`.
+
 - Make the explicit forest route fail closed on an `ERROR` root. Reuse the
   existing forest decline decision. Keep Ledger recovery triggers on the
   production fallback until their forest trees match the locked C tree.

--- a/cgo_harness/doxygen_retirement_parity_test.go
+++ b/cgo_harness/doxygen_retirement_parity_test.go
@@ -1,0 +1,184 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// TestDoxygenDispatchRetirementLockedCParity keeps the three A0 divergence
+// classes exact. The registered smoke witness remains an exact C control.
+func TestDoxygenDispatchRetirementLockedCParity(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+
+	entry, ok := parityEntriesByName["doxygen"]
+	if !ok {
+		t.Fatal("missing Doxygen grammar entry")
+	}
+	goLanguage := entry.Language()
+	cLanguage, err := COracleLanguage("doxygen")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	witnesses := []struct {
+		name           string
+		path           string
+		source         string
+		sourceSHA256   string
+		goDigest       string
+		cDigest        string
+		wantDivergence *normalizationKnownDivergence
+	}{
+		{
+			name:         "a0_CMakeLists",
+			path:         filepath.Join("..", "testdata", "dispatcher_census_a0", "doxygen", "medium__CMakeLists.txt"),
+			sourceSHA256: "66408d6539b27d7c49b1e51777605c38c91b6d924267db5109ee00e2a1cfcf41",
+			goDigest:     "01d09d1ffd9d09af0333bcd887c35e68bcb4a96d15ff0d96c29a1780971b7e04",
+			cDigest:      "d6f623d2b87344001e98de5528b44e38b102e564491871a9ffb64c1b73d193c5",
+			wantDivergence: &normalizationKnownDivergence{
+				Path:     "/document",
+				Category: "type",
+				GoValue:  "document",
+				CValue:   "ERROR",
+				Reason:   "the C oracle keeps the whole A0 source under an ERROR root",
+			},
+		},
+		{
+			name:         "a0_metrics",
+			path:         filepath.Join("..", "testdata", "dispatcher_census_a0", "doxygen", "medium__metrics.py"),
+			sourceSHA256: "31622a6c075ffa6f78a16af6e379f517213d42ff67729bbd0d10551c5fca9702",
+			goDigest:     "5adbacb1ec949237a802a56a5c95c3c7a1ce17fe9c8db5423b63f083da62d5d1",
+			cDigest:      "6660931c2bf1bf1e0f909a1cac1e4cd8446853ae4466781c943e28fbcc61e860",
+			wantDivergence: &normalizationKnownDivergence{
+				Path:     "/ERROR",
+				Category: "shape",
+				GoValue:  "children=0",
+				CValue:   "children=279",
+				Reason:   "the C oracle retains the recovered ERROR children that Go currently drops",
+			},
+		},
+		{
+			name:         "a0_example_cfg",
+			path:         filepath.Join("..", "testdata", "dispatcher_census_a0", "doxygen", "small__example.cfg"),
+			sourceSHA256: "86998161914382f8152e4984db091e7bf486799c1091fc6c57db4e704eee4a3b",
+			goDigest:     "3b803e3d4b9ffcf99c771c352118f3f7026420ea5f26c8d934349ac848789b23",
+			cDigest:      "f1938d5c7bc544856a5df6c204af75af10a5395bd1f89f560c74caef5acf191f",
+			wantDivergence: &normalizationKnownDivergence{
+				Path:     "/document",
+				Category: "type",
+				GoValue:  "document",
+				CValue:   "ERROR",
+				Reason:   "the C oracle keeps the whole A0 source under an ERROR root",
+			},
+		},
+		{
+			name:         "registered_smoke",
+			source:       grammars.ParseSmokeSample("doxygen"),
+			sourceSHA256: "e2d564b999c40b0a53450771ffa82adf7880375449e8628fefd118aae21056d7",
+			goDigest:     "1ae089a98760be594f06d0820951e01714097e99621cc2cd4428ce09ba867083",
+			cDigest:      "1ae089a98760be594f06d0820951e01714097e99621cc2cd4428ce09ba867083",
+		},
+	}
+
+	for _, witness := range witnesses {
+		witness := witness
+		t.Run(witness.name, func(t *testing.T) {
+			source := []byte(witness.source)
+			if witness.path != "" {
+				var err error
+				source, err = os.ReadFile(witness.path)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != witness.sourceSHA256 {
+				t.Fatalf("source SHA-256 = %s, want %s", got, witness.sourceSHA256)
+			}
+
+			rawParser := gotreesitter.NewParser(goLanguage)
+			rawParser.SetAdmissionCandidateRoute(false)
+			rawTree, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(source)
+			if err != nil {
+				t.Fatalf("raw parse: %v", err)
+			}
+			t.Cleanup(rawTree.Release)
+
+			productionParser := gotreesitter.NewParser(goLanguage)
+			productionParser.SetAdmissionCandidateRoute(false)
+			productionTree, err := productionParser.Parse(source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			t.Cleanup(productionTree.Release)
+
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C oracle returned a nil tree")
+			}
+			t.Cleanup(cTree.Close)
+
+			rawInspection, err := benchfixtures.InspectGoTree(rawTree.RootNode(), goLanguage)
+			if err != nil {
+				t.Fatalf("inspect raw Go tree: %v", err)
+			}
+			productionInspection, err := benchfixtures.InspectGoTree(productionTree.RootNode(), goLanguage)
+			if err != nil {
+				t.Fatalf("inspect production Go tree: %v", err)
+			}
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatalf("inspect C tree: %v", err)
+			}
+			if rawInspection.SHA256 != witness.goDigest || productionInspection.SHA256 != witness.goDigest {
+				t.Fatalf("Go digest changed: raw=%s production=%s want=%s", rawInspection.SHA256, productionInspection.SHA256, witness.goDigest)
+			}
+			if cDigest != witness.cDigest {
+				t.Fatalf("C digest changed: got=%s want=%s", cDigest, witness.cDigest)
+			}
+			if rawTree.ParseRuntime().NormalizationNodesRewritten != 0 {
+				t.Fatalf("raw route rewrote %d nodes", rawTree.ParseRuntime().NormalizationNodesRewritten)
+			}
+			if productionTree.ParseRuntime().NormalizationNodesRewritten != 0 {
+				t.Fatalf("production route rewrote %d nodes", productionTree.ParseRuntime().NormalizationNodesRewritten)
+			}
+			t.Logf(
+				"source_sha256=%s raw_digest=%s production_digest=%s c_digest=%s raw_rewrites=%d production_rewrites=%d",
+				witness.sourceSHA256,
+				rawInspection.SHA256,
+				productionInspection.SHA256,
+				cDigest,
+				rawTree.ParseRuntime().NormalizationNodesRewritten,
+				productionTree.ParseRuntime().NormalizationNodesRewritten,
+			)
+
+			diff := FirstDivergenceDumpV1(productionTree.RootNode(), goLanguage, cTree.RootNode())
+			if !normalizationAssertKnownDivergence(t, witness.name, diff, witness.wantDivergence) {
+				return
+			}
+			if diff := firstLockedCTreeFlagDivergence(productionTree.RootNode(), goLanguage, cTree.RootNode(), "/"+productionTree.RootNode().Type(goLanguage)); diff != nil {
+				t.Fatalf("production flags diverge from locked C: %v", diff)
+			}
+			if productionInspection.SHA256 != cDigest {
+				t.Fatalf("production deep digest=%s, want C=%s", productionInspection.SHA256, cDigest)
+			}
+			if rawInspection.SHA256 != productionInspection.SHA256 {
+				t.Fatalf("raw and production deep digests differ: raw=%s production=%s", rawInspection.SHA256, productionInspection.SHA256)
+			}
+		})
+	}
+}

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -216,6 +216,65 @@ The focused gates pass. The provenance gate accepts retirement commit
 `dispatch.jsdoc` deletion evidence. Reopen this retirement if a future JSDoc
 witness rewrites a node or diverges from locked C on any covered route.
 
+## 2026-08-22 Doxygen blocker receipt
+
+Status: `NO-GO`. `KEEP LIVE`: `dispatch.doxygen`.
+
+Base commit: `97a7bde26bac9b1a110bbf9216cc681ca59cc5aa`.
+The accepted receipt was first recorded on `ed0568d9a822b1c83e7bb7e69b0e0f4b8ad529cf`.
+The initial probe used `0c34a681db29a3e8d27e488c5f26d6d7a5f02592`.
+
+The current registry denominator is 31 dispatcher arms and 33 dispatcher
+languages. It has one predicate, zero generic passes, zero post-finalization
+arms, zero post-finalization languages, 32 live entries, and 56 retired
+entries.
+The registry has 35 live language labels, or 34 after case folding.
+
+The real-corpus census covered 20 languages. It found 5 inert arms, 15 active
+arms, 14 uncovered registered arms, and 31 languages without a dispatcher arm.
+Doxygen remains uncovered because the mounted corpus has no Doxygen directory.
+The three dedicated A0 fixtures provide its current census evidence.
+
+The A0 manifest remains authenticated with 14 languages and 14 receipts. Its
+Doxygen receipt records 3 files, 2 checks, 2 runs, 4 visited nodes, zero
+rewrites, 3 error roots, and zero parse errors.
+
+The focused route receipt covers raw, production, compact, forest, and
+incremental routes for all three A0 files. Raw and production report zero
+rewrites for every file. The CMakeLists and example files record
+`dispatch.doxygen` with zero rewrites. The metrics file has no Doxygen pass
+record because its root is a whole-input `ERROR` node. Compact parsing falls
+back at the parser-core end-of-file check. Forest parsing falls back at
+`dead_end`. Incremental parsing falls back for the external scanner.
+
+The same receipt covers the historical childless and recovered witnesses. The
+named Doxygen pass rewrites 3 nodes for the childless witness and 14 nodes for
+the recovered witness. Each count remains exact on production, compact,
+forest-fallback, and incremental-fallback routes.
+
+The locked-C receipt keeps three A0 divergence classes exact:
+
+- `medium__CMakeLists.txt`: `/document`, category `type`, Go `document`, C
+  `ERROR`.
+- `medium__metrics.py`: `/ERROR`, category `shape`, Go `children=0`, C
+  `children=279`.
+- `small__example.cfg`: `/document`, category `type`, Go `document`, C
+  `ERROR`.
+
+The registered Doxygen smoke witness matches locked C exactly. Its raw and
+production digest is
+`1ae089a98760be594f06d0820951e01714097e99621cc2cd4428ce09ba867083`.
+
+Do not retire `dispatch.doxygen` until each known divergence closes, the
+historical rewrite counts reach zero, and every route matches locked C.
+
+The focused Docker artifacts are:
+
+- `harness_out/docker/20260822T202538Z-doxygen-blocker-routes-final`;
+- `harness_out/docker/20260822T202308Z-doxygen-blocker-locked-c`;
+- `harness_out/docker/20260822T202324Z-doxygen-blocker-registry-a0`;
+- `harness_out/docker/20260822T202335Z-doxygen-blocker-census`.
+
 ## Ordered program
 
 ### R0 — inventory and containment

--- a/grammars/doxygen_retirement_route_receipt_test.go
+++ b/grammars/doxygen_retirement_route_receipt_test.go
@@ -1,0 +1,188 @@
+//go:build !grammar_subset
+
+package grammars
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+// TestDoxygenDispatchBlockerRoutes records the exact Doxygen witnesses that
+// keep dispatch.doxygen live. The A0 files stay rewrite-free. The historical
+// triggers retain their observed rewrite counts on every covered route.
+func TestDoxygenDispatchBlockerRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+
+	witnesses := []struct {
+		name             string
+		path             string
+		source           string
+		sourceSHA256     string
+		rawDigest        string
+		productionDigest string
+		routeRewrites    uint64
+		wantArmPass      bool
+	}{
+		{
+			name:             "a0_CMakeLists",
+			path:             filepath.Join("..", "testdata", "dispatcher_census_a0", "doxygen", "medium__CMakeLists.txt"),
+			sourceSHA256:     "66408d6539b27d7c49b1e51777605c38c91b6d924267db5109ee00e2a1cfcf41",
+			rawDigest:        "01d09d1ffd9d09af0333bcd887c35e68bcb4a96d15ff0d96c29a1780971b7e04",
+			productionDigest: "01d09d1ffd9d09af0333bcd887c35e68bcb4a96d15ff0d96c29a1780971b7e04",
+			routeRewrites:    0,
+			wantArmPass:      true,
+		},
+		{
+			name:             "a0_metrics",
+			path:             filepath.Join("..", "testdata", "dispatcher_census_a0", "doxygen", "medium__metrics.py"),
+			sourceSHA256:     "31622a6c075ffa6f78a16af6e379f517213d42ff67729bbd0d10551c5fca9702",
+			rawDigest:        "5adbacb1ec949237a802a56a5c95c3c7a1ce17fe9c8db5423b63f083da62d5d1",
+			productionDigest: "5adbacb1ec949237a802a56a5c95c3c7a1ce17fe9c8db5423b63f083da62d5d1",
+			routeRewrites:    0,
+			wantArmPass:      false,
+		},
+		{
+			name:             "a0_example_cfg",
+			path:             filepath.Join("..", "testdata", "dispatcher_census_a0", "doxygen", "small__example.cfg"),
+			sourceSHA256:     "86998161914382f8152e4984db091e7bf486799c1091fc6c57db4e704eee4a3b",
+			rawDigest:        "3b803e3d4b9ffcf99c771c352118f3f7026420ea5f26c8d934349ac848789b23",
+			productionDigest: "3b803e3d4b9ffcf99c771c352118f3f7026420ea5f26c8d934349ac848789b23",
+			routeRewrites:    0,
+			wantArmPass:      true,
+		},
+		{
+			name:             "historical_childless_error",
+			source:           "/** Adds all words in \\a s to document \\a doc with weight \\a wfd */",
+			sourceSHA256:     "ff90d209911d0d32bf44ebff0742e6f42ff40a6f4978860a00ec3f7228b2af24",
+			rawDigest:        "6c16ff1b99a3b116d575f90aa0fe5456381b442a58af021dac36e6954345ce4c",
+			productionDigest: "0e1129b2130636e62dd05b2494c22a9a2b5b6ec044aea2eeb4dc836380e38b38",
+			routeRewrites:    3,
+			wantArmPass:      true,
+		},
+		{
+			name:             "historical_recovered_document",
+			source:           "/**\n * @param {int} value\n * @brief Example\n */",
+			sourceSHA256:     "f6deae068bcf0fe684f8623d671ee5dfbfab47c93d7827ec03c3b4b5330f8309",
+			rawDigest:        "c5869cce363642fbe2dc1350d194685f5ff81fe14ef6f45f4f4044f4304d204a",
+			productionDigest: "21374502deb13653ec081dd59a4e21311f501aa9adfd34ea1fe3a2f09bc5f8d5",
+			routeRewrites:    14,
+			wantArmPass:      true,
+		},
+	}
+
+	language := DoxygenLanguage()
+	for _, witness := range witnesses {
+		witness := witness
+		t.Run(witness.name, func(t *testing.T) {
+			source := []byte(witness.source)
+			if witness.path != "" {
+				var err error
+				source, err = os.ReadFile(witness.path)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != witness.sourceSHA256 {
+				t.Fatalf("source SHA-256 = %s, want %s", got, witness.sourceSHA256)
+			}
+
+			rawParser := gotreesitter.NewParser(language)
+			rawParser.SetAdmissionCandidateRoute(false)
+			raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(source)
+			if err != nil {
+				t.Fatalf("raw parse: %v", err)
+			}
+			t.Cleanup(raw.Release)
+			assertDoxygenRouteReceipt(t, "raw", raw, language, witness.rawDigest, 0, false, 0)
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			t.Cleanup(production.Release)
+			assertDoxygenRouteReceipt(t, "production", production, language, witness.productionDigest, 0, witness.wantArmPass, witness.routeRewrites)
+
+			routeReceipts := retiredDispatchRouteReceiptsAllowCompactAndForestFallbackExactSource(t, language, source)
+			for _, receipt := range routeReceipts {
+				assertDoxygenRouteReceipt(t, receipt.name, receipt.tree, language, witness.productionDigest, 0, witness.wantArmPass, witness.routeRewrites)
+				if receipt.name == "incremental" {
+					profile := receipt.incrementalProfile
+					if !profile.ReuseUnsupported && (!profile.OldTreeReuseRoute || profile.ReusedSubtrees == 0) {
+						t.Fatalf("incremental route has neither reuse nor documented fallback: %+v", profile)
+					}
+					t.Logf(
+						"incremental reuse=%t reused_subtrees=%d reused_bytes=%d fallback=%t reason=%q",
+						profile.OldTreeReuseRoute,
+						profile.ReusedSubtrees,
+						profile.ReusedBytes,
+						profile.ReuseUnsupported,
+						profile.ReuseUnsupportedReason,
+					)
+				}
+			}
+		})
+	}
+}
+
+func assertDoxygenRouteReceipt(
+	t *testing.T,
+	route string,
+	tree *gotreesitter.Tree,
+	language *gotreesitter.Language,
+	wantDigest string,
+	wantTotalRewrites uint64,
+	wantArmPass bool,
+	wantArmRewrites uint64,
+) {
+	t.Helper()
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatalf("inspect %s route: %v", route, err)
+	}
+	runtime := tree.ParseRuntime()
+	if inspection.SHA256 != wantDigest {
+		t.Fatalf("%s digest = %s, want %s", route, inspection.SHA256, wantDigest)
+	}
+	if runtime.NormalizationNodesRewritten != wantTotalRewrites {
+		t.Fatalf("%s total rewrites = %d, want %d", route, runtime.NormalizationNodesRewritten, wantTotalRewrites)
+	}
+
+	var pass *gotreesitter.NormalizationPassRuntime
+	if runtime.NormalizationPasses != nil {
+		for index := range *runtime.NormalizationPasses {
+			candidate := &(*runtime.NormalizationPasses)[index]
+			if candidate.Name == "dispatch.doxygen" {
+				pass = candidate
+				break
+			}
+		}
+	}
+	if wantArmPass && pass == nil {
+		t.Fatalf("%s route did not record dispatch.doxygen", route)
+	}
+	if !wantArmPass && pass != nil {
+		t.Fatalf("%s route unexpectedly recorded dispatch.doxygen: %+v", route, *pass)
+	}
+	if pass != nil && pass.NodesRewritten != wantArmRewrites {
+		t.Fatalf("%s dispatch.doxygen rewrites = %d, want %d", route, pass.NodesRewritten, wantArmRewrites)
+	}
+	t.Logf(
+		"route=%s source_digest=%s root=%s[%d,%d) error=%t total_rewrites=%d dispatch_doxygen=%+v",
+		route,
+		inspection.SHA256,
+		tree.RootNode().Type(language),
+		tree.RootNode().StartByte(),
+		tree.RootNode().EndByte(),
+		tree.RootNode().HasError(),
+		runtime.NormalizationNodesRewritten,
+		pass,
+	)
+}


### PR DESCRIPTION
## Summary

Record the Doxygen normalization blocker.

- Keep `dispatch.doxygen` live.
- Preserve the blocker until producer output matches the locked C oracle.

## Scope

This PR changes exactly four files:

- `CHANGELOG.md`
- `docs/root-normalization-retirement.md`
- `grammars/doxygen_retirement_route_receipt_test.go`
- `cgo_harness/doxygen_retirement_parity_test.go`

It changes no production parser code and no registry data.

## Evidence

- The registry has 31 dispatcher arms, 33 dispatcher languages, 1 predicate, 0 generic passes, 0 post-finalization arms, 0 post-finalization languages, 32 live entries, and 56 retired entries.
- The census covers 20 languages. It reports 5 inert arms, 15 active arms, 14 uncovered registered arms, and 31 languages without a dispatcher arm. Doxygen has no mounted real-corpus directory.
- The A0 (acceptance-zero) manifest has 14 languages and 14 receipts. The three Doxygen files report zero raw and production rewrites.
- Locked C differs for CMakeLists at `/document`, category `type`, Go `document`, C `ERROR`.
- Locked C differs for example at `/document`, category `type`, Go `document`, C `ERROR`.
- Locked C differs for metrics at `/ERROR`, category `shape`, Go `children=0`, C `children=279`.
- Historical childless and recovered witnesses report 3 and 14 named rewrites on production, compact, forest, and incremental routes.

## Verification

Independent review: GO for this blocker receipt.

Retirement decision: NO-GO. KEEP LIVE: `dispatch.doxygen`.

The successful main run is [run 32597329815](https://github.com/odvcencio/gotreesitter/actions/runs/32597329815).

Docker receipts:

- `harness_out/docker/20260822T202538Z-doxygen-blocker-routes-final`
- `harness_out/docker/20260822T202308Z-doxygen-blocker-locked-c`
- `harness_out/docker/20260822T202324Z-doxygen-blocker-registry-a0`
- `harness_out/docker/20260822T202335Z-doxygen-blocker-census`