### PR TITLE
update(apex-parity): record Apex blocker receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,11 @@ for tags and release notes while still in `0.x`.
   witnesses. The full authenticated Rust census is unavailable. The Rust
   real-corpus run still reports two structural mismatches in `weird-exprs.rs`.
   Keep the registry unchanged. See `docs/root-normalization-retirement.md`.
+- Record the `dispatch.apex` blocker receipt at base
+  `f42b88ac9014537d20d3edd76e2c9caa4330a579`. Keep the arm live. The receipt
+  covers four registered witness families, five clean route witnesses, and
+  three malformed recovery witnesses. The forest route still diverges from
+  locked C. See `docs/root-normalization-retirement.md`.
 
 - Record a durable DTD locked-C blocker receipt. Keep the DTD compatibility
   entry live until both recorded error-flag divergences close.

--- a/cgo_harness/apex_dispatch_blocker_receipt_test.go
+++ b/cgo_harness/apex_dispatch_blocker_receipt_test.go
@@ -1,0 +1,359 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+type apexExpectedDivergence struct {
+	path     string
+	category string
+	goValue  string
+	cValue   string
+}
+
+// TestApexDispatchBlockerLockedCRoutes records all five routes for Apex
+// witnesses. It requires zero rewrites only on raw, production, compact, and incremental routes.
+func TestApexDispatchBlockerLockedCRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	language := grammars.ApexLanguage()
+	cLanguage, err := COracleLanguage("apex")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	witnesses := []struct {
+		name               string
+		source             []byte
+		wantForestRewrite  bool
+		wantForestRewrites uint64
+		wantError          bool
+		expected           map[string]apexExpectedDivergence
+	}{
+		{
+			name: "registered-class-literal-alias",
+			source: []byte("public class C {\n" +
+				"  void m() {\n" +
+				"    Object t = RecordPage.class;\n" +
+				"  }\n" +
+				"}"),
+			wantForestRewrite:  true,
+			wantForestRewrites: 3,
+			expected: apexExpectedRoutes(apexExpectedDivergence{
+				path:     "/parser_output/class_declaration[0]/class_body[3]/method_declaration[1]/block[3]/local_variable_declaration[1]/variable_declarator[1]/field_access[2]/identifier[0]",
+				category: "field",
+				goValue:  "",
+				cValue:   "object",
+			}, "forest"),
+		},
+		{
+			name: "registered-qualified-class-literal-alias",
+			source: []byte("public class C {\n" +
+				"  void m() {\n" +
+				"    Object t = Outer.Inner.class;\n" +
+				"  }\n" +
+				"}"),
+			expected: apexExpectedRoutes(apexExpectedDivergence{
+				path:     "/parser_output/class_declaration[0]/class_body[3]/method_declaration[1]/block[3]/local_variable_declaration[1]/variable_declarator[1]/class_literal[2]",
+				category: "type",
+				goValue:  "class_literal",
+				cValue:   "field_access",
+			}, "forest"),
+		},
+		{
+			name: "registered-nested-generic-local",
+			source: []byte("public class C {\n" +
+				"  void m() {\n" +
+				"    List<List<SObject>> searchResults = [FIND :keyword IN ALL FIELDS];\n" +
+				"  }\n" +
+				"}"),
+		},
+		{
+			name: "registered-right-shift",
+			source: []byte("public class C {\n" +
+				"  Integer m(Integer value) {\n" +
+				"    return value >> 1;\n" +
+				"  }\n" +
+				"}"),
+		},
+		{
+			name: "positive-plain-field-access",
+			source: []byte("public class C {\n" +
+				"  void m() {\n" +
+				"    Object t = RecordPage.someField;\n" +
+				"  }\n" +
+				"}"),
+		},
+		{
+			name:      "malformed-missing-class-body",
+			source:    []byte("public class C { void m() { Object t = RecordPage.class;"),
+			wantError: true,
+			expected: apexExpectedRoutes(apexExpectedDivergence{
+				path:     "/parser_output/ERROR[0]/void_type[4]",
+				category: "field",
+				goValue:  "",
+				cValue:   "type",
+			}, "raw", "production", "compact", "incremental"),
+		},
+		{
+			name:      "malformed-class-literal-dot",
+			source:    []byte("public class C { void m() { Object t = RecordPage.; } }"),
+			wantError: true,
+			expected: apexExpectedRoutes(apexExpectedDivergence{
+				path:     "/parser_output/class_declaration[0]/class_body[3]/method_declaration[1]/block[3]/local_variable_declaration[1]",
+				category: "shape",
+				goValue:  "children=3",
+				cValue:   "children=4",
+			}, "raw", "production", "compact", "incremental"),
+		},
+		{
+			name:      "malformed-class-literal-close",
+			source:    []byte("public class C { void m() { Object t = RecordPage.class"),
+			wantError: true,
+			expected: apexExpectedRoutes(apexExpectedDivergence{
+				path:     "/parser_output/ERROR[0]",
+				category: "shape",
+				goValue:  "children=10",
+				cValue:   "children=12",
+			}, "raw", "production", "compact", "incremental"),
+		},
+	}
+
+	for _, witness := range witnesses {
+		witness := witness
+		t.Run(witness.name, func(t *testing.T) {
+			target := append([]byte(nil), witness.source...)
+			if len(target) == 0 || target[len(target)-1] != '\n' {
+				target = append(target, '\n')
+			}
+			if got := fmt.Sprintf("%x", sha256.Sum256(target)); got == "" {
+				t.Fatal("source SHA-256 is empty")
+			}
+			cTree := apexLockedCTree(t, cLanguage, target)
+			t.Cleanup(cTree.Close)
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatalf("inspect locked C tree: %v", err)
+			}
+			if got := cTree.RootNode().HasError(); got != witness.wantError {
+				t.Fatalf("locked C root error=%t, want %t", got, witness.wantError)
+			}
+
+			rawParser := gotreesitter.NewParser(language)
+			rawParser.SetAdmissionCandidateRoute(false)
+			raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(target)
+			if err != nil {
+				t.Fatalf("raw parse: %v", err)
+			}
+			t.Cleanup(raw.Release)
+			assertApexBlockerRouteExact(t, "raw", raw, language, cTree, cDigest, witness.wantError, apexExpectedRoute(witness.expected, "raw"))
+			if got := apexDispatchRewriteCount(raw); got != 0 {
+				t.Fatalf("raw dispatch.apex rewrites=%d, want 0", got)
+			}
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(target)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			t.Cleanup(production.Release)
+			assertApexBlockerRouteExact(t, "production", production, language, cTree, cDigest, witness.wantError, apexExpectedRoute(witness.expected, "production"))
+			if got := apexDispatchRewriteCount(production); got != 0 {
+				t.Fatalf("production dispatch.apex rewrites=%d, want 0", got)
+			}
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactParser := gotreesitter.NewParser(language)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.Parse(target)
+			if err != nil {
+				t.Fatalf("compact parse: %v", err)
+			}
+			t.Cleanup(compact.Release)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			compactRoute := "accepted"
+			if routedAfter == routedBefore && fallbackAfter == fallbackBefore+1 {
+				compactRoute = "fallback:" + gotreesitter.AdmissionCandidateLastFallbackReason()
+			} else if routedAfter != routedBefore+1 || fallbackAfter != fallbackBefore {
+				t.Fatalf("compact counters before=(%d,%d) after=(%d,%d)", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+			}
+			assertApexBlockerRouteExact(t, "compact", compact, language, cTree, cDigest, witness.wantError, apexExpectedRoute(witness.expected, "compact"))
+			if got := apexDispatchRewriteCount(compact); got != 0 {
+				t.Fatalf("compact dispatch.apex rewrites=%d, want 0", got)
+			}
+
+			forestParser := gotreesitter.NewParser(language)
+			forest, forestOK := forestParser.ParseForestExperimental(target)
+			forestRoute := "declined"
+			forestRewrite := uint64(0)
+			if forestOK && forest != nil {
+				t.Cleanup(forest.Release)
+				forestRoute = "accepted"
+				assertApexBlockerRouteExact(t, "forest", forest, language, cTree, cDigest, witness.wantError, apexExpectedRoute(witness.expected, "forest"))
+				forestRewrite = apexDispatchRewriteCount(forest)
+				if forestRewrite != witness.wantForestRewrites {
+					t.Fatalf("forest dispatch.apex rewrites=%d, want %d", forestRewrite, witness.wantForestRewrites)
+				}
+			} else if witness.wantForestRewrite {
+				t.Fatalf("forest route declined for the live positive control")
+			}
+
+			incrementalParser := gotreesitter.NewParser(language)
+			incrementalParser.SetAdmissionCandidateRoute(false)
+			base := bytes.TrimSuffix(target, []byte{'\n'})
+			oldTree, err := incrementalParser.Parse(base)
+			if err != nil {
+				t.Fatalf("incremental base parse: %v", err)
+			}
+			t.Cleanup(oldTree.Release)
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(len(base)),
+				OldEndByte:  uint32(len(base)),
+				NewEndByte:  uint32(len(target)),
+				StartPoint:  apexPointAtByte(base, len(base)),
+				OldEndPoint: apexPointAtByte(base, len(base)),
+				NewEndPoint: apexPointAtByte(target, len(target)),
+			})
+			incremental, profile, err := incrementalParser.ParseIncrementalProfiled(target, oldTree)
+			if err != nil {
+				t.Fatalf("incremental parse: %v", err)
+			}
+			t.Cleanup(incremental.Release)
+			assertApexBlockerRouteExact(t, "incremental", incremental, language, cTree, cDigest, witness.wantError, apexExpectedRoute(witness.expected, "incremental"))
+			if got := apexDispatchRewriteCount(incremental); got != 0 {
+				t.Fatalf("incremental dispatch.apex rewrites=%d, want 0", got)
+			}
+
+			t.Logf("witness=%s bytes=%d source_sha256=%x c_digest=%s compact=%s forest=%s forest_rewrites=%d incremental_reuse=%t reuse_unsupported=%t reuse_reason=%s reused_subtrees=%d reused_bytes=%d raw_rewrites=%d production_rewrites=%d compact_rewrites=%d incremental_rewrites=%d error_root=%t", witness.name, len(target), sha256.Sum256(target), cDigest, compactRoute, forestRoute, forestRewrite, profile.OldTreeReuseRoute, profile.ReuseUnsupported, profile.ReuseUnsupportedReason, profile.ReusedSubtrees, profile.ReusedBytes, raw.ParseRuntime().NormalizationNodesRewritten, production.ParseRuntime().NormalizationNodesRewritten, compact.ParseRuntime().NormalizationNodesRewritten, incremental.ParseRuntime().NormalizationNodesRewritten, witness.wantError)
+		})
+	}
+}
+
+// TestApexDispatchBlockerReceiptDocument guards the A0 and route scope markers.
+func TestApexDispatchBlockerReceiptDocument(t *testing.T) {
+	raw, err := os.ReadFile("../docs/root-normalization-retirement.md")
+	if err != nil {
+		t.Fatalf("read Apex blocker receipt: %v", err)
+	}
+	document := strings.Join(strings.Fields(string(raw)), " ")
+	for _, marker := range []string{
+		"The A0 manifest has 14 languages and 14 receipts. It includes Apex with three files, three checked, three run, and zero rewrites. Only the seven-fixture tracked census excludes Apex.",
+		"The raw, production, compact, and incremental routes report zero `dispatch.apex` rewrites for every clean witness.",
+		"`registered-class-literal-alias`: `dispatch.apex` rewrites 3 nodes.",
+	} {
+		marker = strings.Join(strings.Fields(marker), " ")
+		if !strings.Contains(document, marker) {
+			t.Fatalf("Apex blocker receipt lacks marker %q", marker)
+		}
+	}
+	for _, marker := range []string{
+		"The A0 manifest has 14 languages and 14 receipts. It excludes Apex.",
+		"Each clean route reports zero `dispatch.apex` rewrites.",
+	} {
+		if strings.Contains(document, marker) {
+			t.Fatalf("Apex blocker receipt retains stale marker %q", marker)
+		}
+	}
+}
+
+func apexLockedCTree(t *testing.T, language *sitter.Language, source []byte) *sitter.Tree {
+	t.Helper()
+	parser := sitter.NewParser()
+	t.Cleanup(parser.Close)
+	if err := parser.SetLanguage(language); err != nil {
+		t.Fatal(err)
+	}
+	tree := parser.Parse(source, nil)
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("locked C parse returned no root")
+	}
+	return tree
+}
+
+func assertApexBlockerRouteExact(t *testing.T, route string, tree *gotreesitter.Tree, language *gotreesitter.Language, cTree *sitter.Tree, cDigest string, wantError bool, expected *apexExpectedDivergence) {
+	t.Helper()
+	root := tree.RootNode()
+	if root == nil || root.HasError() != wantError {
+		t.Fatalf("%s root error=%t, want %t", route, root != nil && root.HasError(), wantError)
+	}
+	if diff := FirstDivergenceDumpV1(root, language, cTree.RootNode()); diff != nil {
+		if expected == nil {
+			t.Fatalf("%s differs from locked C: %+v", route, diff)
+		}
+		if diff.Path != expected.path || diff.Category != expected.category || diff.GoValue != expected.goValue || diff.CValue != expected.cValue {
+			t.Fatalf("%s divergence changed: got=%+v want=%+v", route, diff, expected)
+		}
+		inspection, err := benchfixtures.InspectGoTree(root, language)
+		if err != nil {
+			t.Fatalf("%s inspect divergent Go tree: %v", route, err)
+		}
+		t.Logf("%s locked-C divergence=%+v go_digest=%s c_digest=%s", route, diff, inspection.SHA256, cDigest)
+		return
+	}
+	if expected != nil {
+		t.Fatalf("%s no longer reports the recorded locked-C divergence: want=%+v", route, expected)
+	}
+	inspection, err := benchfixtures.InspectGoTree(root, language)
+	if err != nil {
+		t.Fatalf("%s inspect Go tree: %v", route, err)
+	}
+	if inspection.SHA256 != cDigest {
+		t.Fatalf("%s deep digest=%s, locked C=%s", route, inspection.SHA256, cDigest)
+	}
+}
+
+func apexExpectedRoutes(divergence apexExpectedDivergence, routes ...string) map[string]apexExpectedDivergence {
+	expected := make(map[string]apexExpectedDivergence, len(routes))
+	for _, route := range routes {
+		expected[route] = divergence
+	}
+	return expected
+}
+
+func apexExpectedRoute(expected map[string]apexExpectedDivergence, route string) *apexExpectedDivergence {
+	divergence, ok := expected[route]
+	if !ok {
+		return nil
+	}
+	return &divergence
+}
+
+func apexDispatchRewriteCount(tree *gotreesitter.Tree) uint64 {
+	if tree == nil || tree.ParseRuntime().NormalizationPasses == nil {
+		return 0
+	}
+	for _, pass := range *tree.ParseRuntime().NormalizationPasses {
+		if pass.Name == "dispatch.apex.class-literal-alias" {
+			return pass.NodesRewritten
+		}
+	}
+	return 0
+}
+
+func apexPointAtByte(source []byte, offset int) gotreesitter.Point {
+	var point gotreesitter.Point
+	for index, value := range source {
+		if index >= offset {
+			break
+		}
+		if value == '\n' {
+			point.Row++
+			point.Column = 0
+		} else {
+			point.Column++
+		}
+	}
+	return point
+}

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -275,6 +275,109 @@ The focused Docker artifacts are:
 - `harness_out/docker/20260822T202324Z-doxygen-blocker-registry-a0`;
 - `harness_out/docker/20260822T202335Z-doxygen-blocker-census`.
 
+## 2026-08-22 Apex blocker receipt
+
+Status: `NO-GO`. `KEEP LIVE`: `dispatch.apex`.
+
+Base commit: `f42b88ac9014537d20d3edd76e2c9caa4330a579`.
+
+Select Apex next because its registry entry has four witnesses and the
+strongest remaining focused route evidence. The existing classic-route tests
+and the A3 sweep report no clean-route divergence.
+
+The registry denominator has 31 dispatcher arms, 33 dispatcher languages, and
+one predicate. It has zero generic passes, zero post-finalization arms, zero
+post-finalization languages, 32 live entries, and 56 retired entries.
+
+The A0 manifest has 14 languages and 14 receipts. It includes Apex with three
+files, three checked, three run, and zero rewrites. Only the seven-fixture
+tracked census excludes Apex. The full real-corpus census is unavailable
+because `cgo_harness/corpus_real` is absent.
+
+The Apex A3 sweep covers 25 constructed sources. It accepts 21 compact routes
+and declines four routes. It reports zero unadjudicated divergences. The real
+source count is zero because Apex has no `corpus_real` directory.
+
+The registry names these four Apex witness families:
+
+- `cgo_harness/parity_cgo_test.go`;
+- `cgo_harness/apex_generic_local_parity_test.go`;
+- `cgo_harness/apex_a3_certification_sweep_test.go`;
+- `grammars/apex_class_literal_election_native_regression_test.go`.
+
+The isolated route receipt adds five clean witnesses and three malformed
+witnesses. Every clean raw, production, compact, and incremental tree matches
+locked C. The raw, production, compact, and incremental routes report zero
+`dispatch.apex` rewrites for every clean witness.
+
+| Witness | Bytes | Source SHA-256 | Clean Go and locked C deep digest |
+| --- | ---: | --- | --- |
+| `registered-class-literal-alias` | 69 | `67d9865508abbd1a9640cbc87d8cbddf72a4b183b745682fe34f503153abad00` | `35a8cb0bdcf84a752c313b3c9cf296d4bf2acaac240646e0b32578c858832096` |
+| `registered-qualified-class-literal-alias` | 70 | `6e38260d6936f22392a03eb1a8c15ac18e7d2998cc7b9ea6364093f146077601` | `74c5a760a71ec70ba65163ce52911f205bb92225f64c6948b34f997a78626069` |
+| `registered-nested-generic-local` | 107 | `9de68692750cafd3be200abcb067c465922abf43a11b440c6718252ebc4f3bd3` | `7d39cbbd2e1ae5eb23bfd005f4a893688c380f3366cc0c2894d66d752e93f0a3` |
+| `registered-right-shift` | 75 | `f4c26cdc96c489b569b5ed006a98f67e80218924e7d420a6417f19e44df30259` | `968e0352600624b2111c45a75dfc8d280da6b81d56d7c7bf3baf40ec91cf7dde` |
+| `positive-plain-field-access` | 73 | `1e1e8663abedb7b72258789988e431d5fe4381022fb8898694f5ea83c53e77eb` | `571dfece7252cfa94c445516451636440e1a85e7638c9974dee7d278b8c66ac8` |
+
+The compact route accepts the generic, shift, and plain-field witnesses. It
+declines both class-literal witnesses for material-acceptance-election.
+
+The forest route exposes two blockers:
+
+- `registered-class-literal-alias`: `dispatch.apex` rewrites 3 nodes. The Go
+  digest is `691872382855aafce9519a115ca30ac191c4a118d4ab7170e88e0193fd2f5bb6`.
+  Locked C is `35a8cb0bdcf84a752c313b3c9cf296d4bf2acaac240646e0b32578c858832096`.
+  The first difference is the empty Go field versus C field `object` at
+  `/parser_output/class_declaration[0]/class_body[3]/method_declaration[1]/block[3]/local_variable_declaration[1]/variable_declarator[1]/field_access[2]/identifier[0]`.
+- `registered-qualified-class-literal-alias`: the forest route rewrites 0
+  nodes. The Go digest is `d07fbabd2be95f7f44171295d492ca520128437dcc5dcd503ef4fa007f69edd3`.
+  Locked C is `74c5a760a71ec70ba65163ce52911f205bb92225f64c6948b34f997a78626069`.
+  The first difference is `class_literal` versus `field_access` at
+  `/parser_output/class_declaration[0]/class_body[3]/method_declaration[1]/block[3]/local_variable_declaration[1]/variable_declarator[1]/class_literal[2]`.
+
+The three malformed witnesses produce error roots. Their raw, production,
+compact, and incremental trees share one Go digest, but differ from C:
+
+- `malformed-missing-class-body`: source SHA-256
+  `a3bd159e3c54195698c93db0910da07c022a13b6f398abb5845bb88d6f5c7f86`;
+  Go `471d9b5ccdc6ec2d3edb1db54108f4c4c29bacbadabf1cb453b990b403c3dea9`;
+  C `5b51972dce75e001300bfe94099d660c769c2a81106f9b2334f09ba467b2efe0`;
+  first difference `/parser_output/ERROR[0]/void_type[4]`, empty Go field versus
+  C field `type`.
+- `malformed-class-literal-dot`: source SHA-256
+  `d2683c1e724221f18ea27687120a863e8aa80ce0af745a61f03934e2f4a405f6`;
+  Go `ed9ef8a595f589c87334ea8abfc5e41aba6664656ae1e58114fc16a6fed39bbd`;
+  C `a6bcbd2878b4529fc71604aa42cd1c21e07aa24e50cc57dc049b80dbd4b177d4`;
+  first difference at `/parser_output/class_declaration[0]/class_body[3]/method_declaration[1]/block[3]/local_variable_declaration[1]`, with 3 Go children and 4 C children.
+- `malformed-class-literal-close`: source SHA-256
+  `d876a4c358f1841cbe7e29994c96da39de55ecb79ff6f5c5cd5ecdc3e0fd3ad5`;
+  Go `27f56a9b801f65fade3be3ce9732f04ede66962a49a9bce3ec22395b0cc5cdfb`;
+  C `a64f5e5f4d06be1d29fc1805ca14ad59247904b1b43b45769dabe69c9f2f27db`;
+  first difference at `/parser_output/ERROR[0]`, with 10 Go children and 12 C children.
+
+The malformed compact route declines during recovery. The malformed forest
+route declines. Every incremental run uses old-tree reuse without unsupported
+fallback.
+
+The live positive controls are:
+
+- `TestApexClassLiteralElectionNeedsNoResultCompatibility`;
+- `TestApexClassLiteralElectionRoutesMatch`;
+- `TestApexClassLiteralForestStillNeedsResultCompatibility`;
+- `TestApexPlainFieldAccessUnaffected`.
+
+Do not retire `dispatch.apex`. The forest route still rewrites the unqualified
+class-literal witness and fails exact locked-C parity on both class-literal
+witnesses. The malformed recovery witnesses also fail exact parity.
+
+The focused Docker artifacts are:
+
+- `harness_out/docker/20260822T212753Z-apex-native`;
+- `harness_out/docker/20260822T212848Z-apex-a3`;
+- `harness_out/docker/20260822T213413Z-apex-registry-census`;
+- `harness_out/docker/20260822T213506Z-apex-blocker-routes-edited`;
+- `harness_out/docker/20260822T220318Z-apex-blocker-final`;
+- `harness_out/docker/20260822T220051Z-apex-census-corrected`.
+
 ## Ordered program
 
 ### R0 — inventory and containment


### PR DESCRIPTION
Status: NO-GO. Keep dispatch.apex live.

Summary:

- Record five clean and three malformed Apex witnesses against locked C.
- A0 includes Apex with three files, three checked, three run, and zero rewrites.
- The seven-fixture tracked census excludes Apex. The full authenticated real-corpus census is unavailable.
- Raw, production, compact, and incremental routes report zero dispatch.apex rewrites for every clean witness.
- The forest route exposes two blockers. The unqualified class-literal witness rewrites exactly three nodes.
- The qualified class-literal witness rewrites zero nodes but differs from locked C.
- The malformed witnesses differ from locked C. Compact and forest routes decline during recovery.
- Make no registry or production change.

Validation:

- Docker route guard passed for all five routes and eight witnesses.
- Docker document guard passed.
- Docker A3 sweep passed: 25 sources, 21 accepted, and four declined.
- Docker A0 and tracked census checks passed.
- Docker registry and Apex positive-control checks passed.
- git diff --check and gofmt checks passed.

Keep the arm live until a producer fix closes both forest blockers and the malformed parity differences. Reopen retirement after route-complete locked-C parity passes.

See docs/root-normalization-retirement.md for witness digests, divergence paths, and artifact paths.