### PR TITLE
docs: record issue #454 compact-parser blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,18 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- Record the issue #454 compact-parser correctness blocker. A 1 KiB fresh Go
+  tree differs from locked C at
+  `/translation_unit/function_definition[0]/compound_statement[2]/ERROR[2]/number_literal[0]`.
+  Issue #454 reports C latency with correctness marked OK. This repository uses
+  an internal deterministic C witness. Go marks the `number_literal` as an
+  error, and C does not. The original source has 140,288 bytes. The edited
+  source has 140,287 bytes. The same difference persists at 4, 16, 64, and
+  137 KiB. Incremental Go equals fresh Go at 137 KiB, and the memory-budget fallback reports
+  `incremental_parse_memory_budget_full_retry`. The fresh-parse mismatch makes
+  retry selection unable to fix C parity. Status: NO-GO. Keep issue #454 open.
+  See [the issue #454 compact-parser correctness blocker receipt](docs/issue-454-compact-correctness-blocker.md).
+
 - Record the `dispatch.rust` blocker receipt at base
   `97a7bde26bac9b1a110bbf9216cc681ca59cc5aa`. Keep the arm live. The receipt
   covers 23 zero-rewrite Rust witnesses and exact locked-C production, compact,

--- a/cgo_harness/issue454_c_compact_blocker_parity_test.go
+++ b/cgo_harness/issue454_c_compact_blocker_parity_test.go
@@ -1,0 +1,67 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// TestIssue454COneKiBLockedCDivergence keeps the smallest issue #454 witness
+// visible while recovery materialization remains under investigation. The
+// test passes only when the known-divergence ratchet remains exact. Remove
+// this ratchet after a generic recovery fix restores locked-C parity.
+func TestIssue454COneKiBLockedCDivergence(t *testing.T) {
+	source := append([]byte(nil), benchfixtures.Issue454CSource()[:1024]...)
+	site := bytes.Index(source, []byte("x0"))
+	if site < 0 {
+		t.Fatal("C edit marker is absent")
+	}
+	edited := append(append([]byte(nil), source[:site]...), source[site+1:]...)
+
+	goTree, goLang, err := parseWithGo(parityCase{name: "c"}, edited, nil)
+	if err != nil {
+		t.Fatalf("parse edited C witness with Go: %v", err)
+	}
+	defer releaseGoTree(goTree)
+
+	cLang, err := ParityCLanguage("c")
+	if err != nil {
+		t.Fatalf("load locked C grammar: %v", err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatalf("set locked C grammar: %v", err)
+	}
+	cTree := cParser.Parse(edited, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("locked C parser returned no tree")
+	}
+	defer cTree.Close()
+
+	if got, want := goTree.RootNode().HasError(), true; got != want {
+		t.Fatalf("Go root HasError() = %v, want %v", got, want)
+	}
+	if got, want := cTree.RootNode().HasError(), true; got != want {
+		t.Fatalf("locked C root HasError() = %v, want %v", got, want)
+	}
+
+	diff := FirstDivergenceDumpV1(goTree.RootNode(), goLang, cTree.RootNode())
+	if diff == nil {
+		t.Fatal("known issue #454 divergence now matches locked C; remove this ratchet after route verification")
+	}
+	want := DumpV1Divergence{
+		Path:     "/translation_unit/function_definition[0]/compound_statement[2]/ERROR[2]/number_literal[0]",
+		Category: "error",
+		GoValue:  "true",
+		CValue:   "false",
+	}
+	if *diff != want {
+		t.Fatalf("issue #454 divergence changed: got %+v, want %+v", *diff, want)
+	}
+	t.Logf("known locked-C divergence: path=%s category=%s Go=%s C=%s", diff.Path, diff.Category, diff.GoValue, diff.CValue)
+}

--- a/docs/issue-454-compact-correctness-blocker.md
+++ b/docs/issue-454-compact-correctness-blocker.md
@@ -1,0 +1,80 @@
+# Issue #454 compact-parser correctness blocker
+
+Status: **NO-GO**. Ship no parser change from this investigation. Keep issue
+[#454](https://github.com/odvcencio/gotreesitter/issues/454) open.
+
+## Scope
+
+This receipt uses base commit
+`30f470f5c2bf18540f7a18b2b22a7e33b88d4e10`.
+
+The issue #454 report describes C latency and marks correctness as OK. This
+repository uses an internal deterministic C witness. The witness uses a
+repeated source near 137 kibibytes (KiB). The edit removes the first `x` from
+`x0`. The transient malformed text becomes `0`. The original source has
+140,288 bytes. The edited source has 140,287 bytes.
+
+The smallest locked-C witness uses the same source prefix at 1,024 bytes. The
+known-divergence ratchet is
+`cgo_harness/issue454_c_compact_blocker_parity_test.go`.
+
+## Locked-C evidence
+
+The guard compares a fresh Go tree with the pinned C parser. Both roots report
+an error. The first deep-tree difference is:
+
+```text
+/translation_unit/function_definition[0]/compound_statement[2]/ERROR[2]/number_literal[0]
+category=error Go=true C=false
+```
+
+The fresh Go tree differs from locked C at every tested size:
+
+| Source size | Result |
+| --- | --- |
+| 1 KiB (1,024 bytes) | The first difference is the recorded `number_literal` error flag. |
+| 4 KiB (4,096 bytes) | The same first difference remains. |
+| 16 KiB (16,384 bytes) | The same first difference remains. |
+| 64 KiB (65,536 bytes) | The same first difference remains. |
+| 137 KiB (140,288 bytes) | The same first difference remains. |
+
+The structure probe records all digest pairs in
+`/tmp/gts-issue454-artifacts/20260822T221718Z-issue454-c-structure/container.log`.
+
+## Incremental evidence
+
+The 137 KiB incremental Go tree equals the fresh Go tree. Both have digest
+`9c979bb436f92e7f96885454de81d9d95d2befff242145b1026addf5d9395c4d`.
+
+The locked-C digest is
+`8fe04819317a4f225b5c298a71acdceb5aa965abb3a397e35eb48c5849888d5c`.
+
+The incremental profile reports
+`ReuseUnsupportedReason=incremental_parse_memory_budget_full_retry`.
+The parser completes the edit after the memory-budget fallback. The existing
+replace, insert, and delete regression passes in
+`/tmp/gts-issue454-artifacts/20260822T221438Z-issue454-c-current`.
+
+The fresh Go mismatch proves that retry selection cannot repair the C parity
+difference. The fallback fixes the incremental failure mode only.
+
+## Ownership and decision
+
+The first difference is a child error flag inside a recovered declaration. It
+appears during fresh parsing, before incremental retry selection. The likely
+owner is generic recovery or error-node materialization. A bounded generic fix
+is not safe without wider recovery validation.
+
+The 1 KiB known-divergence ratchet passes in
+`/tmp/gts-issue454-artifacts-rebase/20260822T230037Z-issue454-c-1k-ratchet-20260822`.
+
+## Reopening conditions
+
+Reopen this work only when all conditions pass:
+
+1. Keep the 1 KiB known-divergence ratchet as the only CI guard.
+2. Trace the producer that sets the `number_literal` error flag.
+3. Repair generic recovery materialization without changing unrelated routes.
+4. Require fresh and incremental trees to match locked C at 1, 4, 16, 64, and 137 KiB.
+5. Re-run the existing replace, insert, delete, and C recovery gates.
+6. Preserve the memory-budget fallback as a separate correctness concern.


### PR DESCRIPTION
## Decision

Status: `NO-GO`. Keep issue [#454](https://github.com/odvcencio/gotreesitter/issues/454) open. Ship no parser change.

## Evidence

- Keep the 1 KiB known-divergence ratchet as the CI guard.
- The locked-C divergence persists at 1, 4, 16, 64, and 137 KiB.
- The 137 KiB incremental Go tree equals the fresh Go tree.
- The incremental run completes after the memory-budget fallback.
- The fresh-parse mismatch occurs before retry selection. Retry selection cannot repair C parity.
- Require fresh and incremental trees to match locked C before reopening the issue.
- Preserve the replace, insert, delete, and C recovery gates.

## Validation

- Focused Docker validation passed for the 1 KiB locked-C ratchet and the existing issue #454 regression lanes.
- The patch changes only `CHANGELOG.md`, the blocker document, and one focused guard test.
- The patch changes no production parser or registry code.