### PR TITLE
document: Keep Ada normalization live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,15 @@ for tags and release notes while still in `0.x`.
   exact error flags. The full authenticated corpus remains unavailable. See
   `docs/root-normalization-retirement.md`.
 
+- Record the `dispatch.ada` blocker receipt at base
+  `30f470f5c2bf18540f7a18b2b22a7e33b88d4e10`. Keep the arm live. The receipt
+  covers nine clean and two malformed witnesses across raw, production,
+  compact, forest, and incremental routes. The raw route elects the wrong
+  derivation for seven clean witnesses. The production pass rewrites seven
+  witnesses and still differs on two. Both malformed witnesses differ from
+  locked C. The full real-corpus census is unavailable. See
+  `docs/root-normalization-retirement.md`.
+
 - Record a durable Doxygen locked-C blocker receipt. Keep `dispatch.doxygen`
   live. The three A0 witnesses report zero raw and production rewrites. The
   historical childless and recovered routes report 3 and 14 named rewrites

--- a/cgo_harness/ada_next_live_probe_test.go
+++ b/cgo_harness/ada_next_live_probe_test.go
@@ -1,0 +1,250 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// TestAdaNextLiveArmProbe records every route before a possible retirement.
+// It does not assert parity. The receipt exposes each real rewrite and
+// divergence, including malformed recovery and forest behavior.
+func TestAdaNextLiveArmProbe(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	language := grammars.AdaLanguage()
+	cLanguage, err := COracleLanguage("ada")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	witnesses := []struct {
+		name      string
+		source    []byte
+		malformed bool
+	}{
+		{
+			name: "positional-object-decl-access",
+			source: []byte("procedure P is\n" +
+				"   X : Rec (Pkg.Obj'Access);\n" +
+				"begin\n" +
+				"   null;\n" +
+				"end P;\n"),
+		},
+		{
+			name: "positional-subtype-decl-access",
+			source: []byte("procedure P is\n" +
+				"   subtype S is Rec (Pkg.Obj'Access);\n" +
+				"begin\n" +
+				"   null;\n" +
+				"end P;\n"),
+		},
+		{
+			name: "positional-record-component-access",
+			source: []byte("procedure P is\n" +
+				"   type Holder is record\n" +
+				"      Field : Rec (Pkg.Obj'Access);\n" +
+				"   end record;\n" +
+				"begin\n" +
+				"   null;\n" +
+				"end P;\n"),
+		},
+		{
+			name: "positional-nested-selector-access",
+			source: []byte("procedure P is\n" +
+				"   X : Rec (Pkg.Sub.Obj'Access);\n" +
+				"begin\n" +
+				"   null;\n" +
+				"end P;\n"),
+		},
+		{
+			name: "positional-allocator-access",
+			source: []byte("procedure P is\n" +
+				"begin\n" +
+				"   A := new T (Pkg.Obj'Access);\n" +
+				"end P;\n"),
+		},
+		{
+			name: "positional-object-decl-size",
+			source: []byte("procedure P is\n" +
+				"   X : Rec (Obj'Size);\n" +
+				"begin\n" +
+				"   null;\n" +
+				"end P;\n"),
+		},
+		{
+			name: "positional-array-aggregate",
+			source: []byte("package P is\n" +
+				"   type A is array (1 .. 3) of Boolean;\n" +
+				"   V : constant A := (1, 2, 3);\n" +
+				"end P;\n"),
+		},
+		{
+			name: "named-association-control",
+			source: []byte("procedure P is\n" +
+				"begin\n" +
+				"   A := new T (F => Pkg.Obj'Access);\n" +
+				"end P;\n"),
+		},
+		{
+			name: "array-others-control",
+			source: []byte("procedure P is\n" +
+				"begin\n" +
+				"   A := (others => 0);\n" +
+				"end P;\n"),
+		},
+		{
+			name: "malformed-truncated-association",
+			source: []byte("procedure P is\n" +
+				"begin\n" +
+				"   A := (Pkg.Obj'Access;\n"),
+			malformed: true,
+		},
+		{
+			name: "malformed-truncated-array-aggregate",
+			source: []byte("package P is\n" +
+				"   type A is array (1 .. 3) of Boolean;\n" +
+				"   V : constant A := (1, 2,\n"),
+			malformed: true,
+		},
+	}
+
+	for _, witness := range witnesses {
+		witness := witness
+		t.Run(witness.name, func(t *testing.T) {
+			target := append([]byte(nil), witness.source...)
+			if len(target) == 0 || target[len(target)-1] != '\n' {
+				target = append(target, '\n')
+			}
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(target, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parse returned no root")
+			}
+			t.Cleanup(cTree.Close)
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rawParser := gotreesitter.NewParser(language)
+			rawParser.SetAdmissionCandidateRoute(false)
+			raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(raw.Release)
+			t.Logf("route=raw %s", adaProbeReceipt(raw, language, cTree, cDigest))
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(production.Release)
+			t.Logf("route=production %s", adaProbeReceipt(production, language, cTree, cDigest))
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactParser := gotreesitter.NewParser(language)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.Parse(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(compact.Release)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			compactRoute := "accepted"
+			if routedAfter == routedBefore && fallbackAfter == fallbackBefore+1 {
+				compactRoute = "fallback:" + gotreesitter.AdmissionCandidateLastFallbackReason()
+			} else if routedAfter != routedBefore+1 || fallbackAfter != fallbackBefore {
+				t.Fatalf("compact counters before=(%d,%d) after=(%d,%d)", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+			}
+			t.Logf("route=compact mode=%s %s", compactRoute, adaProbeReceipt(compact, language, cTree, cDigest))
+
+			forestParser := gotreesitter.NewParser(language)
+			forest, forestOK := forestParser.ParseForestExperimental(target)
+			if forestOK && forest != nil {
+				t.Cleanup(forest.Release)
+				t.Logf("route=forest mode=accepted %s", adaProbeReceipt(forest, language, cTree, cDigest))
+			} else {
+				t.Logf("route=forest mode=declined")
+			}
+
+			incrementalParser := gotreesitter.NewParser(language)
+			incrementalParser.SetAdmissionCandidateRoute(false)
+			base := bytes.TrimSuffix(target, []byte{'\n'})
+			oldTree, err := incrementalParser.Parse(base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(oldTree.Release)
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(len(base)),
+				OldEndByte:  uint32(len(base)),
+				NewEndByte:  uint32(len(target)),
+				StartPoint:  adaProbePointAtByte(base, len(base)),
+				OldEndPoint: adaProbePointAtByte(base, len(base)),
+				NewEndPoint: adaProbePointAtByte(target, len(target)),
+			})
+			incremental, profile, err := incrementalParser.ParseIncrementalProfiled(target, oldTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(incremental.Release)
+			t.Logf("route=incremental reuse=%t unsupported=%t reason=%s reused_subtrees=%d reused_bytes=%d %s", profile.OldTreeReuseRoute, profile.ReuseUnsupported, profile.ReuseUnsupportedReason, profile.ReusedSubtrees, profile.ReusedBytes, adaProbeReceipt(incremental, language, cTree, cDigest))
+			t.Logf("witness=%s malformed=%t bytes=%d source_sha256=%x c_digest=%s", witness.name, witness.malformed, len(target), sha256.Sum256(target), cDigest)
+		})
+	}
+}
+
+func adaProbeReceipt(tree *gotreesitter.Tree, language *gotreesitter.Language, cTree *sitter.Tree, cDigest string) string {
+	if tree == nil || tree.RootNode() == nil {
+		return "tree=nil"
+	}
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		return fmt.Sprintf("inspect_error=%v", err)
+	}
+	diff := FirstDivergenceDumpV1(tree.RootNode(), language, cTree.RootNode())
+	return fmt.Sprintf("error_root=%t digest=%s rewrites=%d passes=%s c_digest=%s exact=%t divergence=%+v", tree.RootNode().HasError(), inspection.SHA256, tree.ParseRuntime().NormalizationNodesRewritten, adaProbePasses(tree), cDigest, diff == nil && inspection.SHA256 == cDigest, diff)
+}
+
+func adaProbePasses(tree *gotreesitter.Tree) string {
+	runtime := tree.ParseRuntime()
+	if runtime.NormalizationPasses == nil {
+		return "none"
+	}
+	parts := make([]string, 0, len(*runtime.NormalizationPasses))
+	for _, pass := range *runtime.NormalizationPasses {
+		parts = append(parts, fmt.Sprintf("%s:%d", pass.Name, pass.NodesRewritten))
+	}
+	return fmt.Sprintf("%v", parts)
+}
+
+func adaProbePointAtByte(source []byte, offset int) gotreesitter.Point {
+	var point gotreesitter.Point
+	for index, value := range source {
+		if index >= offset {
+			break
+		}
+		if value == '\n' {
+			point.Row++
+			point.Column = 0
+		} else {
+			point.Column++
+		}
+	}
+	return point
+}

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -482,6 +482,133 @@ The focused Docker artifacts are:
 - `/tmp/dtd-post-apex-artifacts/20260822T230229Z-dtd-real-corpus-census`;
 - `/tmp/dtd-post-apex-artifacts/20260822T230234Z-dtd-unit-recovery`.
 
+## 2026-08-22 Ada blocker receipt
+
+Status: `NO-GO`. `KEEP LIVE`: `dispatch.ada`.
+
+Base commit: `30f470f5c2bf18540f7a18b2b22a7e33b88d4e10`.
+
+Select Ada after the Apex, Rust, Doxygen, and DTD investigations. Ada has the
+strongest remaining focused evidence among the zero-rewrite A0 arms. Existing
+Ada tests cover raw parity, derivation elections, and the A3 compact
+certification sweep.
+
+The remaining zero-rewrite A0 arms are Ada, Corn, HLSL, and Wolfram. Corn and
+Wolfram lack an equivalent focused locked-C route receipt. HLSL has two known
+live members. Ada has the broadest focused evidence among these candidates.
+
+The ownership registry records 78 dispatcher arms. It records 31 live arms,
+47 retired arms, one live predicate, 32 live entries, and 56 retired entries.
+The live dispatcher arms cover 33 language labels.
+
+The registry records `dispatch.ada` with these subpasses:
+
+- `dispatch.ada.constraint-kind-election`;
+- `dispatch.ada.aggregate-kind-election`.
+
+Both subpasses call `normalizeAdaCompatibilityWithCensus` in
+`parser_result_ada.go`. The registry assigns derivation election selection as
+the authoritative owner.
+
+The A0 (initial dispatcher census) manifest has 14 languages and 14 receipts.
+Ada reports three files, three checked, three runs, 17861 nodes visited, zero
+rewritten nodes, zero error roots, and zero parse errors.
+
+The tracked census has seven fixtures across six languages. It excludes Ada.
+The full real-corpus census is unavailable because
+`cgo_harness/corpus_real` is absent. The focused census test skips this lane.
+
+The A3 (compact certification sweep) has 23 constructed sources and no real
+corpus sources. It reports 20 accepted routes, three declined routes, and zero
+unadjudicated divergences. The decline classes are two
+`material-acceptance-election` cases and one `no-eof-accept` case.
+
+The isolated receipt covers nine clean witnesses and two malformed witnesses.
+It runs raw, production, compact, forest, and incremental routes. Every
+incremental run reuses the old tree and reports `reuse_unsupported=false`.
+
+| Witness | Source SHA-256 | Locked C digest | Route result |
+| --- | --- | --- | --- |
+| `positional-object-decl-access` | `438601cf3ab4e8530a28ef369308d32f33c9ba93cb2af7f1ddba990be33f4710` | `4802317080861161572ad64b8186f0cc207df05eb4c348c2ac00ba95f937f02a` | Raw differs. Production rewrites 21 nodes and matches. Compact falls back and matches. Forest and incremental match. |
+| `positional-subtype-decl-access` | `75297a2141a0752b6f85b0e6603dd1629ed8f8d742c1494d453b3ca1e6d8be5d` | `6364a3353a36a4fe9d23fab0a1479425b4dc35e9ae89c5194ebb5f44496762be` | Raw differs. Production rewrites 21 nodes and matches. Compact falls back and matches. Forest and incremental match. |
+| `positional-record-component-access` | `115014deda4ea4f6ea5c955d123f39e879c82be371446cd0a34b7d81a7f35bea` | `725d1f35f72151989492731f321816097e74ec2303811998987008ac115084d0` | Raw differs. Production rewrites 24 nodes and matches. Compact falls back and matches. Forest and incremental match. |
+| `positional-nested-selector-access` | `26f9e5730eff55859815ac7d7f7d1eb2d9703fd756acfd730ae4e7f891456be8` | `a98a7102a5379b460c251254e52d86cd51f41accedefdbdefde3bfd137a25902` | Raw differs. Production rewrites 24 nodes and matches. Compact falls back and matches. Forest and incremental match. |
+| `positional-allocator-access` | `0e692276407f81c0335054ddb2ba0f87823aabeb6fcc0d272ea485c6cc60244c` | `39c57a7494b06c554088cfbf481565214f82957011f2f116d00bcd19fe470100` | Raw differs. Production rewrites 16 nodes and still differs. Compact, forest, and incremental retain the same divergence. |
+| `positional-object-decl-size` | `b18f3836c72f58b167394a08dc857059f2c38b5f4af7e1f89f7edfcc7ca3be07` | `736482700417ccad93eb25b2baff8cadfab5502608899c1a2dc270276c47a473` | Raw differs. Production rewrites 18 nodes and still differs. Compact, forest, and incremental retain the same divergence. |
+| `positional-array-aggregate` | `f507e195d424e0deea4651429140847a5ec7aef3cbddcbb3d9f55290b22aaba6` | `d58ee0a74c0cda930f06996759bf776efd2aaa263e43906347c38f993cf7d6a6` | Raw differs. Production and forest rewrite 18 nodes and match. Compact accepts directly and matches. Incremental matches. |
+| `named-association-control` | `4e53062ce52bee02944da551d4202771624fec474001c7b588934d946eecd0b5` | `1ff63805d27116ae37f295a738ea5edbdf8e67d4b35a6ce12252221b5450216a` | All five routes match. All `dispatch.ada` pass counts are zero. |
+| `array-others-control` | `234c680409f4a7c7719cdf3e30db7ac46b15ba6470b072dcdcba6dcf93b0cff1` | `792acfe40259059b0cc90820e27afdea91d5a057d8aeb895d2d4c85ac81a5c6e` | All five routes match. The `dispatch.ada` pass count is zero. |
+| `malformed-truncated-association` | `1045848382c3e5ffd917d614196ba9fde076a561529b21b9e26c6c966f62a044` | `4f4c3a61c7bb09d5aabf794d4b1c7af48b53c1d7238925a9663aafb73fa8ff26` | Raw, production, compact, and incremental differ under an `ERROR` root. Forest declines. No rewrite occurs. |
+| `malformed-truncated-array-aggregate` | `deac6f71adfa4f875839eb6e2fd0f7cb7b4793123a8d9e486ef2fbba47028dab` | `a5fe2f991a85e4f5009a4b5f3831dcbc9d85658f04dac5db49868465cc071298` | Raw, production, compact, and incremental differ under an `ERROR` root. Forest declines. No rewrite occurs. |
+
+The compact route falls back for every positional attribute witness. It accepts
+the array aggregate and both controls directly. Malformed compact parses fall
+back during recovery.
+
+The forest route accepts all nine clean witnesses. It declines both malformed
+witnesses. The incremental route reuses old trees for all eleven witnesses.
+
+The raw route differs from locked C at these clean witnesses:
+
+- `positional-object-decl-access`: `discriminant_constraint` versus
+  `index_constraint` at
+  `/compilation/compilation_unit[0]/subprogram_body[0]/non_empty_declarative_part[2]/object_declaration[0]/discriminant_constraint[3]`;
+- `positional-subtype-decl-access`: `discriminant_constraint` versus
+  `index_constraint` at
+  `/compilation/compilation_unit[0]/subprogram_body[0]/non_empty_declarative_part[2]/subtype_declaration[0]/discriminant_constraint[4]`;
+- `positional-record-component-access`: `discriminant_constraint` versus
+  `index_constraint` at
+  `/compilation/compilation_unit[0]/subprogram_body[0]/non_empty_declarative_part[2]/full_type_declaration[0]/record_type_definition[3]/record_definition[0]/component_list[1]/component_declaration[0]/component_definition[2]/discriminant_constraint[1]`;
+- `positional-nested-selector-access`: `discriminant_constraint` versus
+  `index_constraint` at
+  `/compilation/compilation_unit[0]/subprogram_body[0]/non_empty_declarative_part[2]/object_declaration[0]/discriminant_constraint[3]`;
+- `positional-allocator-access`: `discriminant_association` versus
+  `expression` at
+  `/compilation/compilation_unit[0]/subprogram_body[0]/handled_sequence_of_statements[3]/assignment_statement[0]/expression[2]/term[0]/allocator[0]/discriminant_constraint[2]/discriminant_association[1]`;
+- `positional-object-decl-size`: `discriminant_constraint` versus
+  `index_constraint` at
+  `/compilation/compilation_unit[0]/subprogram_body[0]/non_empty_declarative_part[2]/object_declaration[0]/discriminant_constraint[3]`;
+- `positional-array-aggregate`: `record_aggregate` versus
+  `positional_array_aggregate` at
+  `/compilation/compilation_unit[0]/package_declaration[0]/object_declaration[4]/expression[5]/term[0]/record_aggregate[0]`.
+
+The production route still differs after the native dispatch pass for these
+witnesses:
+
+- `positional-allocator-access`: `index_constraint` versus
+  `discriminant_constraint` at
+  `/compilation/compilation_unit[0]/subprogram_body[0]/handled_sequence_of_statements[3]/assignment_statement[0]/expression[2]/term[0]/allocator[0]/index_constraint[2]`;
+- `positional-object-decl-size`: `access` versus `identifier` in the
+  attribute designator at
+  `/compilation/compilation_unit[0]/subprogram_body[0]/non_empty_declarative_part[2]/object_declaration[0]/index_constraint[3]/attribute_designator[3]/access[0]`.
+
+The malformed association witness differs at `/compilation/ERROR[0]`:
+Go emits `ERROR`, while locked C emits `compilation_unit`.
+
+The malformed aggregate witness differs at
+`/compilation/ERROR[0]/identifier[7]`: Go has an empty field, while locked C
+has the `subtype_mark` field.
+
+The live controls are `named-association-control` and
+`array-others-control`. Existing controls also pass in
+`TestAdaConstraintKindElectionCParity`.
+
+Keep `dispatch.ada` live. The raw route still elects the wrong derivation for
+seven clean witnesses. The production pass still rewrites seven witnesses and
+fails exact parity on two of them. Two malformed witnesses fail exact parity.
+
+Do not change registry or production state.
+Reopen retirement only after the derivation election owner emits exact trees.
+Require zero `dispatch.ada` rewrites on all five routes.
+Require both malformed witnesses to match locked C.
+
+The focused Docker artifacts are:
+
+- `/tmp/ada-next-live-rebased-artifacts/20260822T232057Z-ada-route-probe`;
+- `/tmp/ada-next-live-rebased-artifacts/20260822T232109Z-ada-existing-guards`;
+- `/tmp/ada-next-live-rebased-artifacts/20260822T232118Z-ada-census-registry`;
+- `/tmp/ada-next-live-rebased-artifacts/20260822T232128Z-ada-real-census`.
+
 ## Ordered program
 
 ### R0 — inventory and containment


### PR DESCRIPTION
## Summary

Status: KEEP LIVE / NO-GO.

Keep `dispatch.ada` live.
Do not change production or registry code.
Record the Ada blocker after the prior normalization receipts.
Update `CHANGELOG.md` and `docs/root-normalization-retirement.md`.
Add the focused probe `cgo_harness/ada_next_live_probe_test.go`.

## Evidence

The registry has 78 dispatcher arms, 31 live arms, 47 retired arms, 32 live entries, and 56 retired entries.
Ada has three files, three checks, three runs, 17,861 nodes, zero rewrites, zero error roots, and zero parse errors.
The A3 sweep has 23 constructed sources, 20 accepted routes, three declined routes, and zero unadjudicated divergences.
The receipt covers nine clean and two malformed witnesses.
It covers raw, production, compact, forest, and incremental routes.
The raw route elects the wrong derivation for seven clean witnesses.
The production route rewrites seven witnesses and still differs on two.
Both malformed witnesses differ from locked C.
The real corpus is unavailable.

## Validation

The focused Docker probe passed all 11 witnesses.
Docker artifact: `/tmp/ada-next-live-pr-docker-artifacts/20260822T235551Z-ada-next-live-pr`.
The receipt artifacts are:
- `/tmp/ada-next-live-rebased-artifacts/20260822T232057Z-ada-route-probe`
- `/tmp/ada-next-live-rebased-artifacts/20260822T232109Z-ada-existing-guards`
- `/tmp/ada-next-live-rebased-artifacts/20260822T232118Z-ada-census-registry`
- `/tmp/ada-next-live-rebased-artifacts/20260822T232128Z-ada-real-census`
Canopy found four functions with a direct no-cache search.
Markdown diff, parse, and error-level lint checks passed.
`gofmt -d` produced no output.

## Reopening

Reopen retirement only after the derivation election owner emits exact trees.
Require zero `dispatch.ada` rewrites on all five routes.
Require both malformed witnesses to match locked C.

No production or registry change ships.