### PR TITLE
document: Keep HLSL normalization live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,15 @@ for tags and release notes while still in `0.x`.
   three malformed recovery witnesses. The forest route still diverges from
   locked C. See `docs/root-normalization-retirement.md`.
 
+- Record the `dispatch.hlsl` blocker receipt at base
+  `0b4470b0156afb1e3492f7f5f6a618c9e50f7c33`. Keep the arm live. The A0
+  manifest records three HLSL files, three checks, three runs, and zero
+  rewrites. The clean negative-number cast rewrites on production, compact,
+  forest, and incremental routes, but normalized output misses the C `left`
+  field. The malformed cast and unorm witnesses still diverge from locked C.
+  The authenticated HLSL corpus is unavailable. No registry or production
+  code changes are included. See `docs/root-normalization-retirement.md`.
+
 - Reconfirm the DTD locked-C blocker at base
   `30f470f5c2bf18540f7a18b2b22a7e33b88d4e10`. Keep `dispatch.dtd` live. The
   raw route matches the production route by deep digest for all four

--- a/cgo_harness/hlsl_next_live_probe_test.go
+++ b/cgo_harness/hlsl_next_live_probe_test.go
@@ -1,0 +1,326 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+type hlslNextWitness struct {
+	name                 string
+	source               []byte
+	wantError            bool
+	wantForest           bool
+	wantRewrite          bool
+	wantRawDigest        string
+	wantNormalizedDigest string
+	wantDivergence       *DumpV1Divergence
+	wantNormalizedDiff   *DumpV1Divergence
+}
+
+// TestHLSLNextLiveArmLockedCRoutes records the HLSL arm on all five routes.
+// It keeps the producer gap and malformed recovery gap visible.
+func TestHLSLNextLiveArmLockedCRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	t.Setenv("GOT_PARSE_PHASE_TIMING", "1")
+	goLanguage := grammars.HlslLanguage()
+	cLanguage, err := COracleLanguage("hlsl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	witnesses := []hlslNextWitness{
+		{
+			name:                 "cast-negative-number",
+			source:               []byte("float4 main() : SV_Target { return (float4)-1; }\n"),
+			wantForest:           true,
+			wantRewrite:          true,
+			wantRawDigest:        "e5d64d87ea862f2e28d3f53dd6bf53dd21936ee79496c9137d2fa944171eb1ca",
+			wantNormalizedDigest: "c6895007d3b8523d87aa77eadf1123f1e96c60def279c9ce77f506609f74334f",
+			wantDivergence: &DumpV1Divergence{
+				Path:     "/translation_unit/function_definition[0]/compound_statement[2]/return_statement[1]/cast_expression[1]",
+				Category: "type",
+				GoValue:  "cast_expression",
+				CValue:   "binary_expression",
+			},
+			wantNormalizedDiff: &DumpV1Divergence{
+				Path:     "/translation_unit/function_definition[0]/compound_statement[2]/return_statement[1]/binary_expression[1]/parenthesized_expression[0]",
+				Category: "field",
+				GoValue:  "",
+				CValue:   "left",
+			},
+		},
+		{
+			name:                 "cast-negative-number-malformed",
+			source:               []byte("float4 main() : SV_Target { return (float4)-; }\n"),
+			wantError:            true,
+			wantRawDigest:        "1313f71496a9b8c1f981085f87c1b1bc3eb484815c640554e63697d301414f02",
+			wantNormalizedDigest: "1313f71496a9b8c1f981085f87c1b1bc3eb484815c640554e63697d301414f02",
+			wantDivergence: &DumpV1Divergence{
+				Path:     "/translation_unit/function_definition[0]/compound_statement[2]/return_statement[1]/cast_expression[1]",
+				Category: "type",
+				GoValue:  "cast_expression",
+				CValue:   "binary_expression",
+			},
+			wantNormalizedDiff: &DumpV1Divergence{
+				Path:     "/translation_unit/function_definition[0]/compound_statement[2]/return_statement[1]/cast_expression[1]",
+				Category: "type",
+				GoValue:  "cast_expression",
+				CValue:   "binary_expression",
+			},
+		},
+		{
+			name:                 "unorm-buffer-control",
+			source:               []byte("buffer<unorm::float4> value...;\n"),
+			wantRawDigest:        "8cbb8f76171423dfab0b254e1602c4619a85b1f0ab7184edfadbad3b886ad647",
+			wantNormalizedDigest: "8cbb8f76171423dfab0b254e1602c4619a85b1f0ab7184edfadbad3b886ad647",
+		},
+		{
+			name:                 "unorm-buffer-malformed",
+			source:               []byte("buffer<unorm float4> value...;\n"),
+			wantError:            true,
+			wantRawDigest:        "05b2bf7a42e5c0ebbcf90d1ed35fddff902e995f97ce767404941a6299d337d9",
+			wantNormalizedDigest: "05b2bf7a42e5c0ebbcf90d1ed35fddff902e995f97ce767404941a6299d337d9",
+			wantDivergence: &DumpV1Divergence{
+				Path:     "/translation_unit/expression_statement[0]",
+				Category: "type",
+				GoValue:  "expression_statement",
+				CValue:   "declaration",
+			},
+			wantNormalizedDiff: &DumpV1Divergence{
+				Path:     "/translation_unit/expression_statement[0]",
+				Category: "type",
+				GoValue:  "expression_statement",
+				CValue:   "declaration",
+			},
+		},
+		{
+			name:                 "subscript-assignment-control",
+			source:               []byte("void f() { Foo[bar] = value; }\n"),
+			wantForest:           true,
+			wantRawDigest:        "688445ba93476a6948684073b044cc8cf3dd13cbf4fbe889681221e12b774737",
+			wantNormalizedDigest: "688445ba93476a6948684073b044cc8cf3dd13cbf4fbe889681221e12b774737",
+		},
+		{
+			name:                 "subscript-assignment-top-level-control",
+			source:               []byte("Foo[bar] = value;\n"),
+			wantRawDigest:        "55f06b3603d46533fa00b5bdb6b586df5f6999aad99829764c05140bb1335266",
+			wantNormalizedDigest: "55f06b3603d46533fa00b5bdb6b586df5f6999aad99829764c05140bb1335266",
+		},
+	}
+
+	for _, witness := range witnesses {
+		witness := witness
+		t.Run(witness.name, func(t *testing.T) {
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(witness.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("locked C parser returned no tree")
+			}
+			t.Cleanup(cTree.Close)
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			raw := hlslParseRoute(t, goLanguage, witness.source, "raw", func(p *gotreesitter.Parser, source []byte) (*gotreesitter.Tree, error) {
+				return p.ParseNoResultCompatibilityBenchmarkOnly(source)
+			})
+			production := hlslParseRoute(t, goLanguage, witness.source, "production", func(p *gotreesitter.Parser, source []byte) (*gotreesitter.Tree, error) {
+				return p.Parse(source)
+			})
+
+			assertHLSLNextRoute(t, "raw", raw, goLanguage, cTree, cDigest, witness.wantError, witness.wantRawDigest, witness.wantDivergence, witness.wantRewrite, false)
+			assertHLSLNextRoute(t, "production", production, goLanguage, cTree, cDigest, witness.wantError, witness.wantNormalizedDigest, witness.wantNormalizedDiff, witness.wantRewrite, true)
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactParser := gotreesitter.NewParser(goLanguage)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.Parse(witness.source)
+			if err != nil {
+				t.Fatalf("compact parse: %v", err)
+			}
+			t.Cleanup(compact.Release)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			compactRoute := "accepted"
+			if fallbackAfter > fallbackBefore {
+				compactRoute = "fallback:" + gotreesitter.AdmissionCandidateLastFallbackReason()
+			}
+			assertHLSLNextRoute(t, "compact", compact, goLanguage, cTree, cDigest, witness.wantError, witness.wantNormalizedDigest, witness.wantNormalizedDiff, witness.wantRewrite, true)
+
+			forestParser := gotreesitter.NewParser(goLanguage)
+			forest, forestOK := forestParser.ParseForestExperimental(witness.source)
+			forestRoute := "declined"
+			if forestOK && forest != nil {
+				forestRoute = "accepted"
+				t.Cleanup(forest.Release)
+				assertHLSLNextRoute(t, "forest", forest, goLanguage, cTree, cDigest, witness.wantError, witness.wantNormalizedDigest, witness.wantNormalizedDiff, witness.wantRewrite, true)
+			} else if witness.wantForest {
+				t.Fatal("forest route declined for a required witness")
+			}
+
+			base := bytes.TrimSuffix(witness.source, []byte{'\n'})
+			incrementalParser := gotreesitter.NewParser(goLanguage)
+			oldTree, err := incrementalParser.Parse(base)
+			if err != nil {
+				t.Fatalf("incremental base parse: %v", err)
+			}
+			t.Cleanup(oldTree.Release)
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(len(base)),
+				OldEndByte:  uint32(len(base)),
+				NewEndByte:  uint32(len(witness.source)),
+				StartPoint:  hlslPointAtByte(base),
+				OldEndPoint: hlslPointAtByte(base),
+				NewEndPoint: hlslPointAtByte(witness.source),
+			})
+			incremental, profile, err := incrementalParser.ParseIncrementalProfiled(witness.source, oldTree)
+			if err != nil {
+				t.Fatalf("incremental parse: %v", err)
+			}
+			t.Cleanup(incremental.Release)
+			assertHLSLNextRoute(t, "incremental", incremental, goLanguage, cTree, cDigest, witness.wantError, witness.wantNormalizedDigest, witness.wantNormalizedDiff, witness.wantRewrite, true)
+
+			t.Logf("witness=%s bytes=%d source_sha256=%x c_digest=%s compact=%s counters=%d/%d->%d/%d forest=%s incremental_reuse=%t incremental_fallback=%t reason=%q raw_rewrite=%t production_rewrite=%t compact_rewrite=%t forest_rewrite=%t incremental_rewrite=%t", witness.name, len(witness.source), sha256.Sum256(witness.source), cDigest, compactRoute, routedBefore, fallbackBefore, routedAfter, fallbackAfter, forestRoute, profile.OldTreeReuseRoute, profile.ReuseUnsupported, profile.ReuseUnsupportedReason, witness.wantRewrite && hasHLSLCastRewrite(raw.RootNode(), goLanguage), witness.wantRewrite && hasHLSLCastRewrite(production.RootNode(), goLanguage), witness.wantRewrite && hasHLSLCastRewrite(compact.RootNode(), goLanguage), witness.wantRewrite && forest != nil && hasHLSLCastRewrite(forest.RootNode(), goLanguage), witness.wantRewrite && hasHLSLCastRewrite(incremental.RootNode(), goLanguage))
+		})
+	}
+}
+
+// TestHLSLNextLiveArmReceiptDocument guards the blocker receipt markers.
+func TestHLSLNextLiveArmReceiptDocument(t *testing.T) {
+	raw, err := os.ReadFile("../docs/root-normalization-retirement.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	document := strings.Join(strings.Fields(string(raw)), " ")
+	for _, marker := range []string{
+		"The HLSL arm remains live.",
+		"A0 has three HLSL files, three checked, three run, and zero rewrites.",
+		"The clean cast witness rewrites one cast_expression node on production, compact, forest, and incremental routes.",
+		"The normalized routes diverge from locked C at the missing left field.",
+		"Keep dispatch.hlsl live until scheduler_action_semantics emits the C field.",
+	} {
+		marker = strings.Join(strings.Fields(marker), " ")
+		if !strings.Contains(document, marker) {
+			t.Fatalf("HLSL blocker receipt lacks marker %q", marker)
+		}
+	}
+}
+
+func hlslParseRoute(t *testing.T, language *gotreesitter.Language, source []byte, route string, parse func(*gotreesitter.Parser, []byte) (*gotreesitter.Tree, error)) *gotreesitter.Tree {
+	t.Helper()
+	parser := gotreesitter.NewParser(language)
+	tree, err := parse(parser, source)
+	if err != nil {
+		t.Fatalf("%s parse: %v", route, err)
+	}
+	t.Cleanup(tree.Release)
+	return tree
+}
+
+func assertHLSLNextRoute(t *testing.T, route string, tree *gotreesitter.Tree, language *gotreesitter.Language, cTree *sitter.Tree, cDigest string, wantError bool, wantDigest string, wantDiff *DumpV1Divergence, wantRewrite bool, normalized bool) {
+	t.Helper()
+	root := tree.RootNode()
+	if root == nil || root.HasError() != wantError {
+		t.Fatalf("%s root error=%t, want %t", route, root != nil && root.HasError(), wantError)
+	}
+	inspection, err := benchfixtures.InspectGoTree(root, language)
+	if err != nil {
+		t.Fatalf("%s inspect Go tree: %v", route, err)
+	}
+	if inspection.SHA256 != wantDigest {
+		t.Fatalf("%s Go digest=%s, want %s", route, inspection.SHA256, wantDigest)
+	}
+	diff := FirstDivergenceDumpV1(root, language, cTree.RootNode())
+	if wantDiff == nil {
+		if diff != nil {
+			t.Fatalf("%s unexpected locked-C divergence: %+v", route, diff)
+		}
+		if inspection.SHA256 != cDigest {
+			t.Fatalf("%s exact tree digest=%s, C=%s", route, inspection.SHA256, cDigest)
+		}
+	} else if diff == nil || *diff != *wantDiff {
+		t.Fatalf("%s divergence=%+v, want %+v", route, diff, wantDiff)
+	}
+	castCount := countHLSLNodes(root, language, "cast_expression")
+	binaryCount := countHLSLNodes(root, language, "binary_expression")
+	if wantRewrite {
+		if normalized && castCount != 0 {
+			t.Fatalf("%s retained %d cast_expression nodes after the live rewrite", route, castCount)
+		}
+		if !normalized && castCount == 0 {
+			t.Fatalf("%s lost the raw cast_expression before the live rewrite", route)
+		}
+		if normalized && binaryCount == 0 {
+			t.Fatalf("%s lacks the normalized binary_expression", route)
+		}
+	}
+	t.Logf("route=%s error=%t digest=%s c_digest=%s divergence=%v cast_nodes=%d binary_nodes=%d dispatch=%s", route, root.HasError(), inspection.SHA256, cDigest, diff, castCount, binaryCount, hlslDispatchReceipt(tree))
+}
+
+func countHLSLNodes(root *gotreesitter.Node, language *gotreesitter.Language, typ string) int {
+	if root == nil {
+		return 0
+	}
+	count := 0
+	var walk func(*gotreesitter.Node)
+	walk = func(node *gotreesitter.Node) {
+		if node == nil {
+			return
+		}
+		if node.Type(language) == typ {
+			count++
+		}
+		for i := 0; i < node.ChildCount(); i++ {
+			walk(node.Child(i))
+		}
+	}
+	walk(root)
+	return count
+}
+
+func hasHLSLCastRewrite(root *gotreesitter.Node, language *gotreesitter.Language) bool {
+	return countHLSLNodes(root, language, "cast_expression") == 0 && countHLSLNodes(root, language, "binary_expression") > 0
+}
+
+func hlslDispatchReceipt(tree *gotreesitter.Tree) string {
+	if tree == nil {
+		return "none"
+	}
+	runtime := tree.ParseRuntime()
+	if runtime.NormalizationPasses == nil {
+		return "none"
+	}
+	for _, pass := range *runtime.NormalizationPasses {
+		if pass.Name == "dispatch.hlsl" {
+			return fmt.Sprintf("%d/%d/%d/%d", pass.Checked, pass.Run, pass.NodesVisited, pass.NodesRewritten)
+		}
+	}
+	return "none"
+}
+
+func hlslPointAtByte(source []byte) gotreesitter.Point {
+	var point gotreesitter.Point
+	for _, value := range source {
+		if value == '\n' {
+			point.Row++
+			point.Column = 0
+		} else {
+			point.Column++
+		}
+	}
+	return point
+}

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -742,6 +742,133 @@ Keep this entry live until a producer fix closes both structural mismatches.
 Require the authenticated Rust corpus.
 Move the recovery controls to their owning subsystem.
 
+## 2026-08-22 HLSL blocker receipt
+
+Status: NO-GO. KEEP LIVE: `dispatch.hlsl`. The HLSL arm remains live.
+
+Base commit: `0b4470b0156afb1e3492f7f5f6a618c9e50f7c33`.
+
+The registry contains 88 entries. It contains 78 dispatcher arms, three
+dispatcher subpasses, one dispatcher predicate, three generic passes, and
+three fixpoint passes. The live denominator contains 31 dispatcher arms, 33
+dispatcher-arm language labels, one predicate, 32 live entries, and 56 retired
+entries. It contains zero generic passes and zero post-finalization arms.
+It contains zero post-finalization language labels.
+
+The registry keeps `dispatch.hlsl` live. It names
+`normalizeHLSLCompatibility` in `parser_result_hlsl.go`. Its remaining
+members repair negative-number casts and unorm buffer template arguments.
+Its three registered witnesses are:
+
+- `cgo_harness/parity_cgo_test.go`;
+- `grammars/hlsl_subscript_assignment_native_regression_test.go`;
+- `cgo_harness/hlsl_subscript_assignment_parity_cgo_test.go`.
+
+The A0 (authenticated dispatcher census) manifest has 14 languages, 42 files,
+and 14 receipts. A0 has three HLSL files, three checked, three run, and zero
+rewrites.
+It records 100,424 visited nodes, one error root, and zero parse errors.
+The HLSL files are:
+
+- `large__scalar-operators-assign-exact-precision.hlsl`;
+- `medium__SubD11_SmoothPS.hlsl`;
+- `small__atomic_cast1.hlsl`.
+
+The tracked census has seven fixtures in six languages. It excludes HLSL.
+The authenticated real-corpus census is unavailable because
+`cgo_harness/corpus_real` is not mounted. No HLSL A3 receipt is registered.
+
+The focused route receipt uses six witnesses. It covers raw, production,
+compact, forest, incremental, and locked-C routes. It also includes two
+malformed recovery witnesses and two native subscript controls.
+
+The clean cast witness uses source SHA-256
+`495d7be10c3780d26df6dc12d4190d6621a5fc51543a041374e65166ca572132`.
+Its raw Go digest is
+`e5d64d87ea862f2e28d3f53dd6bf53dd21936ee79496c9137d2fa944171eb1ca`.
+Locked C digest is
+`87800a73e5ce82b935120f2a14ae20ea6cc61023a631333cc7986a52f78a6ead`.
+Raw and C differ at
+`/translation_unit/function_definition[0]/compound_statement[2]/return_statement[1]/cast_expression[1]`.
+Go has `cast_expression`. C has `binary_expression`.
+
+Production, compact, forest, and incremental routes produce digest
+`c6895007d3b8523d87aa77eadf1123f1e96c60def279c9ce77f506609f74334f`.
+The clean cast witness rewrites one cast_expression node on production,
+compact, forest, and incremental routes. The normalized routes diverge from
+locked C at the missing left field.
+The first normalized difference is
+`/translation_unit/function_definition[0]/compound_statement[2]/return_statement[1]/binary_expression[1]/parenthesized_expression[0]`, with Go field empty and C field `left`.
+Forest and incremental receipts report
+`dispatch.hlsl` as `1/1/23/8`. Incremental reuse is unsupported because the
+HLSL external scanner requires a fresh fallback.
+The four values are checked, run, visited, and rewritten. The final `8` is the
+dispatcher node-rewrite count. The source-level rewrite is one
+cast_expression-to-binary replacement.
+
+The malformed cast witness uses source SHA-256
+`5626b370caee23a1da24c0c428ef6acece8539f59c9af40de0e1a62e8c4703d8`.
+It keeps Go digest
+`1313f71496a9b8c1f981085f87c1b1bc3eb484815c640554e63697d301414f02` on raw,
+production, compact, and incremental routes. Locked C digest is
+`ff8d5517a3727d8cc08631b3e71fc4efb99818cf800fb2db0b96206dee969b6b`.
+The first difference remains the cast-versus-binary node type at
+`/translation_unit/function_definition[0]/compound_statement[2]/return_statement[1]/cast_expression[1]`.
+The forest route declines. Compact recovery falls back because the scheduler
+has no table action for the elected token. Incremental reuse is unsupported.
+
+The valid unorm buffer control uses source SHA-256
+`23d5e4a473c6518140c0f63fd9c58d91b79d792562a616e9c56a2adb28dd127c`.
+It matches locked C on raw, production, compact,
+and incremental routes. Its Go and C digest is
+`8cbb8f76171423dfab0b254e1602c4619a85b1f0ab7184edfadbad3b886ad647`.
+Production, compact, and incremental report `dispatch.hlsl` as `1/1/15/0`.
+The forest route declines. The malformed unorm witness uses source SHA-256
+`95326c7ce08df600cc54d8e785a6794a51099f51968e697b2e6e3903c9c62dcd`.
+It keeps Go digest
+`05b2bf7a42e5c0ebbcf90d1ed35fddff902e995f97ce767404941a6299d337d9`.
+Locked C digest is
+`d3aa05dea7693d685f06f9dd32b9f2b155c92dac3bc5715b4195a4e7857de668`.
+Production, compact, and incremental report `dispatch.hlsl` as `1/1/14/0`.
+The first difference is `/translation_unit/expression_statement[0]`.
+Go has `expression_statement`. C has `declaration`. The malformed forest
+route declines. Compact recovery falls back because the scheduler has no
+table action for the elected token. Incremental reuse is unsupported.
+The two unorm witnesses produce no unorm rewrite. The authenticated corpus is
+required before classifying that member as unreachable.
+
+The valid unorm compact route also falls back. Its scheduler frontier lacks
+alternative-set coverage by one non-blended survivor. The function subscript
+compact route falls back for the same scheduler-frontier reason. The top-level
+subscript compact route falls back because it lacks a sole homogeneous accept
+frontier. Forest accepts both subscript controls.
+
+The function subscript control uses source SHA-256
+`d288bf6a5b940b282cb1285d60209e4690589374d2ed76e214fc572d993e42f6`.
+It matches locked C on every route with digest
+`688445ba93476a6948684073b044cc8cf3dd13cbf4fbe889681221e12b774737`.
+The top-level control uses source SHA-256
+`fb0d81ee0973f6d1611b7cccea93cfccb267087fb65002d5d6d8a1fe541f639f`.
+It matches locked C on every route with digest
+`55f06b3603d46533fa00b5bdb6b586df5f6999aad99829764c05140bb1335266`.
+Both controls report zero rewrites. They preserve the retired subscript
+member's native election. Compact may decline at a scheduler frontier.
+
+The successful focused Docker artifacts are:
+
+- `/tmp/hlsl-next-artifacts/20260822T235342Z-hlsl-next-blocker-final3` — route and document guard;
+- `/tmp/hlsl-next-artifacts/20260822T235504Z-hlsl-next-document-guard-final2` — final document guard;
+- `/tmp/hlsl-next-artifacts/20260822T234934Z-hlsl-next-registry` — registry receipt;
+- `/tmp/hlsl-next-artifacts/20260822T234940Z-hlsl-next-a0` — A0 manifest receipt;
+- `/tmp/hlsl-next-artifacts/20260822T234948Z-hlsl-next-tracked` — tracked census receipt;
+- `/tmp/hlsl-next-artifacts/20260822T234955Z-hlsl-next-real-corpus` — unavailable corpus receipt.
+
+The receipt remains NO-GO. Keep `dispatch.hlsl` live. Require the native
+producer to emit the locked-C cast and unorm shapes before compatibility.
+Require exact production, compact, forest, incremental, and locked-C parity.
+Keep dispatch.hlsl live until scheduler_action_semantics emits the C field.
+Require the authenticated HLSL corpus before retirement.
+
 The mandatory shape is census before migration. Historical audits already
 found that table or engine fixes can leave old normalizers behind.
 


### PR DESCRIPTION
## Summary

Status: KEEP LIVE / NO-GO.
Keep `dispatch.hlsl` live.
No production or registry code changes ship.
This PR changes only `CHANGELOG.md`, `docs/root-normalization-retirement.md`, and `cgo_harness/hlsl_next_live_probe_test.go`.

## Census

The registry has 88 entries, 78 dispatcher arms, three subpasses, one predicate, three generic passes, and three fixpoint passes.
The live denominator has 31 arms, 33 language labels, one predicate, 32 live entries, and 56 retired entries.
The A0 manifest has 14 languages, 42 files, and 14 receipts.
HLSL has three files, three checks, three runs, zero rewrites, 100,424 visited nodes, one error root, and zero parse errors.
The authenticated HLSL corpus is unavailable.

## Witness evidence

The probe covers raw, production, compact, forest, incremental, and locked-C routes.
It covers six witnesses, two malformed recovery cases, and two native subscript controls.
The clean cast witness differs from locked C at the cast-versus-binary node.
Production, compact, forest, and incremental routes rewrite one cast node.
The normalized routes still miss the C `left` field.
The malformed cast and malformed unorm witnesses still differ from locked C.
The two controls match locked C.
The incremental route reports `external_scanner_unsupported` and uses a fresh fallback.

The clean cast source hash is `495d7be10c3780d26df6dc12d4190d6621a5fc51543a041374e65166ca572132`.
The clean raw digest is `e5d64d87ea862f2e28d3f53dd6bf53dd21936ee79496c9137d2fa944171eb1ca`.
The clean normalized digest is `c6895007d3b8523d87aa77eadf1123f1e96c60def279c9ce77f506609f74334f`.
The locked-C digest is `87800a73e5ce82b935120f2a14ae20ea6cc61023a631333cc7986a52f78a6ead`.
The first normalized difference is the missing `left` field under `parenthesized_expression`.

## Validation

The focused Docker guard passed all six witnesses and the receipt document guard.
Fresh artifact: `/tmp/hlsl-next-pr-artifacts/20260823T003037Z-hlsl-next-pr`.
The audited artifacts are:
- `/tmp/hlsl-next-artifacts/20260822T235342Z-hlsl-next-blocker-final3`
- `/tmp/hlsl-next-artifacts/20260822T235504Z-hlsl-next-document-guard-final2`
- `/tmp/hlsl-next-artifacts/20260822T234934Z-hlsl-next-registry`
- `/tmp/hlsl-next-artifacts/20260822T234940Z-hlsl-next-a0`
- `/tmp/hlsl-next-artifacts/20260822T234948Z-hlsl-next-tracked`
- `/tmp/hlsl-next-artifacts/20260822T234955Z-hlsl-next-real-corpus`
Direct no-cache Canopy found the changed test symbols.
Gofmt, Markdown lint, Markdown parse, and diff checks passed.

## Reopening

Reopen retirement only after the native producer emits the locked-C cast and unorm shapes.
Require exact production, compact, forest, incremental, and locked-C parity.
Keep `dispatch.hlsl` live until `scheduler_action_semantics` emits the C field.
Require the authenticated HLSL corpus before retirement.

No production or registry code changes ship.