### PR TITLE
fix(parser): Restore generic recovery field parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,17 +192,27 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
-- Record the issue #454 compact-parser correctness blocker. A 1 KiB fresh Go
-  tree differs from locked C at
-  `/translation_unit/function_definition[0]/compound_statement[2]/ERROR[2]/number_literal[0]`.
-  Issue #454 reports C latency with correctness marked OK. This repository uses
-  an internal deterministic C witness. Go marks the `number_literal` as an
-  error, and C does not. The original source has 140,288 bytes. The edited
-  source has 140,287 bytes. The same difference persists at 4, 16, 64, and
-  137 KiB. Incremental Go equals fresh Go at 137 KiB, and the memory-budget fallback reports
-  `incremental_parse_memory_budget_full_retry`. The fresh-parse mismatch makes
-  retry selection unable to fix C parity. Status: NO-GO. Keep issue #454 open.
-  See [the issue #454 compact-parser correctness blocker receipt](docs/issue-454-compact-correctness-blocker.md).
+- Record the audited generic recovery fix for issue #454. The candidate diff
+  SHA-256 is
+  `71fdb2ab00f8f31e74b7e165f381c0856bd3720abdeb4d1556454d0cc75c50fa`.
+  `cAbsorbTokenIntoError` leaves visible absorbed leaves clean.
+  `cRecoverToState` preserves field metadata when it flattens hidden nodes.
+  The five-size Docker guard matches locked C at 1, 4, 16, 64, and 137 KiB.
+  The replace, insert, and delete guards match fresh parses. Direct
+  grammargen-to-C parity passes 20 of 20 cases. The C real-corpus result
+  matches the base result: 23 of 25 no-error cases and 20 of 25 deep-parity
+  cases. A controlled three-pair Docker RSS audit measured a base mean of
+  596,448 KiB and a candidate mean of 612,329 KiB. The candidate mean was
+  2.66% higher. The earlier 1,089,364 KiB candidate result did not reproduce.
+  The focused C recovery workload measured 857,624 KiB for base and 842,900
+  KiB for candidate. Allocation profiles measured 1,180.79 MB versus 1,167.62
+  MB allocated, and 129.30 MB versus 128.66 MB retained. Arena field storage
+  and element counts were equal. No release-blocking memory regression
+  reproduced. The standard 20-seed primary Go trio was not run because only C
+  recovery paths changed. The focused C workload is the relevant gate. No
+  out-of-memory failure or timeout occurred. Keep issue #454 open until this
+  change merges and main CI passes. See [the issue #454 compact-parser
+  correctness receipt](docs/issue-454-compact-correctness-blocker.md).
 
 - Record the `dispatch.rust` blocker receipt at base
   `97a7bde26bac9b1a110bbf9216cc681ca59cc5aa`. Keep the arm live. The receipt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,9 +210,9 @@ for tags and release notes while still in `0.x`.
   and element counts were equal. No release-blocking memory regression
   reproduced. The standard 20-seed primary Go trio was not run because only C
   recovery paths changed. The focused C workload is the relevant gate. No
-  out-of-memory failure or timeout occurred. Keep issue #454 open until this
-  change merges and main CI passes. See [the issue #454 compact-parser
-  correctness receipt](docs/issue-454-compact-correctness-blocker.md).
+  out-of-memory failure or timeout occurred. Keep issue #454 open for the
+  remaining field-report performance and recovery work. See [the issue #454
+  compact-parser correctness receipt](docs/issue-454-compact-correctness-blocker.md).
 
 - Record the `dispatch.rust` blocker receipt at base
   `97a7bde26bac9b1a110bbf9216cc681ca59cc5aa`. Keep the arm live. The receipt

--- a/cgo_harness/issue454_c_compact_blocker_parity_test.go
+++ b/cgo_harness/issue454_c_compact_blocker_parity_test.go
@@ -10,11 +10,9 @@ import (
 	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
-// TestIssue454COneKiBLockedCDivergence keeps the smallest issue #454 witness
-// visible while recovery materialization remains under investigation. The
-// test passes only when the known-divergence ratchet remains exact. Remove
-// this ratchet after a generic recovery fix restores locked-C parity.
-func TestIssue454COneKiBLockedCDivergence(t *testing.T) {
+// TestIssue454COneKiBLockedCParity keeps the smallest issue #454 witness
+// visible after the generic recovery fix restores locked-C parity.
+func TestIssue454COneKiBLockedCParity(t *testing.T) {
 	source := append([]byte(nil), benchfixtures.Issue454CSource()[:1024]...)
 	site := bytes.Index(source, []byte("x0"))
 	if site < 0 {
@@ -51,17 +49,8 @@ func TestIssue454COneKiBLockedCDivergence(t *testing.T) {
 	}
 
 	diff := FirstDivergenceDumpV1(goTree.RootNode(), goLang, cTree.RootNode())
-	if diff == nil {
-		t.Fatal("known issue #454 divergence now matches locked C; remove this ratchet after route verification")
+	if diff != nil {
+		t.Fatalf("issue #454 locked-C parity diverged: %+v", *diff)
 	}
-	want := DumpV1Divergence{
-		Path:     "/translation_unit/function_definition[0]/compound_statement[2]/ERROR[2]/number_literal[0]",
-		Category: "error",
-		GoValue:  "true",
-		CValue:   "false",
-	}
-	if *diff != want {
-		t.Fatalf("issue #454 divergence changed: got %+v, want %+v", *diff, want)
-	}
-	t.Logf("known locked-C divergence: path=%s category=%s Go=%s C=%s", diff.Path, diff.Category, diff.GoValue, diff.CValue)
+	t.Log("issue #454 1 KiB witness matches locked C")
 }

--- a/docs/issue-454-compact-correctness-blocker.md
+++ b/docs/issue-454-compact-correctness-blocker.md
@@ -140,13 +140,15 @@ The focused run artifacts are:
 - `/tmp/gts-issue454-rss-audit/20260823T005555Z-issue454-arena-breakdown-baseline`
 - `/tmp/gts-issue454-rss-audit/20260823T005611Z-issue454-arena-breakdown-candidate`
 
-## Issue-closing condition
+## Issue status
 
-Keep issue #454 open during publication. Close it only after all conditions
-pass:
+This patch closes only the recorded C locked-tree parity subproblem.
+Keep issue #454 open for the remaining field-report performance and recovery
+work.
 
-1. Merge this candidate.
-2. Pass main CI.
-3. Keep the five-size locked-C guard green.
-4. Keep the replace, insert, and delete guards green.
-5. Preserve the memory-budget fallback as a separate performance concern.
+Remaining work includes performance, memory-budget retry, scanner, flat-root,
+JavaScript, and other recovery findings.
+
+The five-size locked-C guard and the replace, insert, and delete guards remain
+focused regression guards. Preserve the memory-budget fallback as a separate
+performance concern.

--- a/docs/issue-454-compact-correctness-blocker.md
+++ b/docs/issue-454-compact-correctness-blocker.md
@@ -1,80 +1,152 @@
-# Issue #454 compact-parser correctness blocker
+# Issue #454 compact-parser correctness fix
 
-Status: **NO-GO**. Ship no parser change from this investigation. Keep issue
-[#454](https://github.com/odvcencio/gotreesitter/issues/454) open.
+Status: **GO for publication**. The candidate fixes the recorded locked-C
+difference. Do not close issue
+[#454](https://github.com/odvcencio/gotreesitter/issues/454) until this change
+merges and main CI passes.
 
 ## Scope
 
-This receipt uses base commit
-`30f470f5c2bf18540f7a18b2b22a7e33b88d4e10`.
+The audit uses base commit
+`60b7b41c06443627ad063497f974ef50aca2fa85`.
 
-The issue #454 report describes C latency and marks correctness as OK. This
-repository uses an internal deterministic C witness. The witness uses a
-repeated source near 137 kibibytes (KiB). The edit removes the first `x` from
-`x0`. The transient malformed text becomes `0`. The original source has
-140,288 bytes. The edited source has 140,287 bytes.
+The candidate diff SHA-256 is
+`71fdb2ab00f8f31e74b7e165f381c0856bd3720abdeb4d1556454d0cc75c50fa`.
+The candidate changes exactly these files:
 
-The smallest locked-C witness uses the same source prefix at 1,024 bytes. The
-known-divergence ratchet is
-`cgo_harness/issue454_c_compact_blocker_parity_test.go`.
+- `parser_recover_c.go`
+- `cgo_harness/issue454_c_compact_blocker_parity_test.go`
+
+The receipt patch changes four files. It updates this document and the changelog.
+
+The patch changes no grammar registry or grammar blob. The deterministic C
+witness uses a repeated source with 140,288 bytes. The edit removes the first
+`x` from `x0`. The edited source has 140,287 bytes.
+
+## Producer proof
+
+The first difference came from generic recovery materialization.
+
+1. `cRecoverDispatchInError` calls `cAbsorbTokenIntoError`.
+   The absorbed visible leaf now remains clean. The enclosing `ERROR` node
+   still reports an error.
+2. `cRecoverStrategy1Election` calls `cRecoverToState`.
+   Hidden nodes with field metadata now use the field-preserving flatten path.
+   The materializer copies field identifiers and field sources into the new
+   recovery node.
+
+Direct no-cache Canopy queries confirmed both call paths. Other recovery
+entry points remain unchanged.
 
 ## Locked-C evidence
 
-The guard compares a fresh Go tree with the pinned C parser. Both roots report
-an error. The first deep-tree difference is:
+Before the fix, the first difference was:
 
 ```text
 /translation_unit/function_definition[0]/compound_statement[2]/ERROR[2]/number_literal[0]
 category=error Go=true C=false
 ```
 
-The fresh Go tree differs from locked C at every tested size:
+After the fix, the fresh Go tree matches locked C at every tested size:
 
 | Source size | Result |
 | --- | --- |
-| 1 KiB (1,024 bytes) | The first difference is the recorded `number_literal` error flag. |
-| 4 KiB (4,096 bytes) | The same first difference remains. |
-| 16 KiB (16,384 bytes) | The same first difference remains. |
-| 64 KiB (65,536 bytes) | The same first difference remains. |
-| 137 KiB (140,288 bytes) | The same first difference remains. |
+| 1 KiB (1,024 bytes) | Exact tree parity |
+| 4 KiB (4,096 bytes) | Exact tree parity |
+| 16 KiB (16,384 bytes) | Exact tree parity |
+| 64 KiB (65,536 bytes) | Exact tree parity |
+| 137 KiB (140,288 bytes) | Exact tree parity |
 
-The structure probe records all digest pairs in
-`/tmp/gts-issue454-artifacts/20260822T221718Z-issue454-c-structure/container.log`.
+The audit-only five-size guard passed in Docker. Its artifact is
+`/tmp/gts-issue454-independent-artifacts/20260823T003842Z-five-sizes`.
+
+The committed 1 KiB guard is
+`TestIssue454COneKiBLockedCParity`.
+Its artifact is
+`/tmp/gts-issue454-independent-artifacts/20260823T004435Z-committed-1k`.
 
 ## Incremental evidence
 
-The 137 KiB incremental Go tree equals the fresh Go tree. Both have digest
-`9c979bb436f92e7f96885454de81d9d95d2befff242145b1026addf5d9395c4d`.
+`TestIssue454CIncrementalDeleteMatchesFresh` passed its replace, insert, and
+delete subtests. Each incremental tree matched its fresh tree.
 
-The locked-C digest is
-`8fe04819317a4f225b5c298a71acdceb5aa965abb3a397e35eb48c5849888d5c`.
+The replace and insert cases retained old-tree reuse. The delete case retained
+the fail-closed reason
+`incremental_parse_memory_budget_full_retry`.
 
-The incremental profile reports
-`ReuseUnsupportedReason=incremental_parse_memory_budget_full_retry`.
-The parser completes the edit after the memory-budget fallback. The existing
-replace, insert, and delete regression passes in
-`/tmp/gts-issue454-artifacts/20260822T221438Z-issue454-c-current`.
+The artifact is
+`/tmp/gts-issue454-independent-artifacts/20260823T003852Z-incremental-edit-classes`.
 
-The fresh Go mismatch proves that retry selection cannot repair the C parity
-difference. The fallback fixes the incremental failure mode only.
+The focused recovery and field tests passed in
+`/tmp/gts-issue454-independent-artifacts/20260823T003826Z-parser-core-unit`.
 
-## Ownership and decision
+The direct grammargen-to-C preset passed 20 of 20 cases. Its artifact is
+`/tmp/gts-issue454-field-followup-audit-20260823/harness_out/grammargen_cparity/20260822_174020-focus-c`.
 
-The first difference is a child error flag inside a recovered declaration. It
-appears during fresh parsing, before incremental retry selection. The likely
-owner is generic recovery or error-node materialization. A bounded generic fix
-is not safe without wider recovery validation.
+The C real-corpus preset reported 23 of 25 no-error cases and 20 of 25 deep
+parity cases. The unmodified base reported the same counts and three type
+divergences. This is a known baseline result, not a regression from this fix.
 
-The 1 KiB known-divergence ratchet passes in
-`/tmp/gts-issue454-artifacts-rebase/20260822T230037Z-issue454-c-1k-ratchet-20260822`.
+## Controlled memory audit
 
-## Reopening conditions
+The audit used three alternating base and candidate order pairs. Each pair ran
+one C language in one Docker container. The container used 8 GiB memory, one
+CPU, 512 process IDs, and one Go test worker. The command used 25 cases and a
+15-minute timeout.
 
-Reopen this work only when all conditions pass:
+| Pair | Base RSS | Candidate RSS | Candidate minus base |
+| --- | ---: | ---: | ---: |
+| 1 | 566,680 KiB | 609,464 KiB | +42,784 KiB |
+| 2 | 628,852 KiB | 606,980 KiB | -21,872 KiB |
+| 3 | 593,812 KiB | 620,544 KiB | +26,732 KiB |
 
-1. Keep the 1 KiB known-divergence ratchet as the only CI guard.
-2. Trace the producer that sets the `number_literal` error flag.
-3. Repair generic recovery materialization without changing unrelated routes.
-4. Require fresh and incremental trees to match locked C at 1, 4, 16, 64, and 137 KiB.
-5. Re-run the existing replace, insert, delete, and C recovery gates.
-6. Preserve the memory-budget fallback as a separate correctness concern.
+The base mean was 596,448 KiB. The candidate mean was 612,329 KiB. The
+candidate mean was 2.66% higher. The pair results include one lower candidate
+run. The earlier 1,089,364 KiB candidate result did not reproduce.
+
+The focused workload used `TestIssue454CIncrementalDeleteMatchesFresh`. It
+passed the replace, insert, and delete cases. Without heap profiling, RSS was
+857,624 KiB for base and 842,900 KiB for candidate. A paired heap-profile run
+measured 858,400 KiB for base and 863,336 KiB for candidate.
+
+The base `alloc_space` profile measured 1,180.79 MB. The candidate measured
+1,167.62 MB. The base `inuse_space` profile measured 129.30 MB. The candidate
+measured 128.66 MB. The arena breakdown was equal for both trees:
+
+- Fresh field storage: 196,608 bytes, with 41,745 field identifiers and 41,745 field sources.
+- Incremental-delete field storage: 393,216 bytes, with 83,472 field identifiers and 83,472 field sources.
+
+The standard 20-seed primary Go trio was not run. The candidate changes only C
+recovery paths. The focused C workload is the relevant performance gate.
+
+No release-blocking memory regression reproduced. All Docker runs completed
+without an out-of-memory failure or timeout.
+
+The real-corpus logs are:
+
+- `/tmp/gts-issue454-rss-audit/rep1-base/20260823T004613Z/real_corpus/diag_c_lang.log`
+- `/tmp/gts-issue454-rss-audit/rep1-candidate/20260823T004629Z/real_corpus/diag_c_lang.log`
+- `/tmp/gts-issue454-rss-audit/rep2-candidate/20260823T004646Z/real_corpus/diag_c_lang.log`
+- `/tmp/gts-issue454-rss-audit/rep2-base/20260823T004702Z/real_corpus/diag_c_lang.log`
+- `/tmp/gts-issue454-rss-audit/rep3-base/20260823T004719Z/real_corpus/diag_c_lang.log`
+- `/tmp/gts-issue454-rss-audit/rep3-candidate/20260823T004917Z/real_corpus/diag_c_lang.log`
+
+The focused run artifacts are:
+
+- `/tmp/gts-issue454-rss-audit/20260823T005027Z-issue454-focused-baseline-timed`
+- `/tmp/gts-issue454-rss-audit/20260823T005043Z-issue454-focused-candidate-timed`
+- `/tmp/gts-issue454-heap-audit/base/issue454.pprof`
+- `/tmp/gts-issue454-heap-audit/candidate/issue454.pprof`
+- `/tmp/gts-issue454-rss-audit/20260823T005555Z-issue454-arena-breakdown-baseline`
+- `/tmp/gts-issue454-rss-audit/20260823T005611Z-issue454-arena-breakdown-candidate`
+
+## Issue-closing condition
+
+Keep issue #454 open during publication. Close it only after all conditions
+pass:
+
+1. Merge this candidate.
+2. Pass main CI.
+3. Keep the five-size locked-C guard green.
+4. Keep the replace, insert, and delete guards green.
+5. Preserve the memory-budget fallback as a separate performance concern.

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -4074,6 +4074,21 @@ func (p *Parser) cAppendVisibleSplice(dst []*Node, n *Node) []*Node {
 	return dst
 }
 
+func (p *Parser) cAppendVisibleSpliceWithFields(scratch *reduceBuildScratch, n *Node) {
+	if p == nil || scratch == nil || n == nil {
+		return
+	}
+	if n.symbol == errorSymbol || n.isMissing() || p.cSymbolVisible(n.symbol) {
+		scratch.appendNode(n)
+		return
+	}
+	if hiddenTreeHasFieldIDs(n) {
+		appendFlattenedHiddenChildrenWithFieldScratch(scratch, n, p.language.SymbolMetadata, nil)
+		return
+	}
+	appendFlattenedHiddenChildrenToScratch(scratch, n, p.language.SymbolMetadata, nil)
+}
+
 func (p *Parser) cAppendVisibleSpliceUntil(dst []*Node, n *Node, limit int) ([]*Node, bool) {
 	if n == nil {
 		return dst, true
@@ -4162,7 +4177,8 @@ func (p *Parser) cRecoverToState(v *glrStack, depth int, goal StateID, arena *no
 	// open ERROR node's children) and splice invisible nodes the way the
 	// engine's reduce does. The raw popped extent pins the ERROR span (C
 	// error regions cover invisible subtrees too).
-	children := make([]*Node, 0, len(wrapped)+2)
+	splice := reduceBuildScratch{}
+	splice.nodes = make([]*Node, 0, len(wrapped)+2)
 	openErr := (*cRecoverState)(nil)
 	if v.cRec != nil {
 		openErr = v.cRec
@@ -4175,14 +4191,17 @@ func (p *Parser) cRecoverToState(v *glrStack, depth int, goal StateID, arena *no
 		rawLast = n
 		if openErr != nil && n == openErr.openErr {
 			// Open-region children were visible-spliced at absorb time.
-			children = append(children, n.children...)
+			for _, child := range n.children {
+				splice.appendNode(child)
+			}
 			continue
 		}
 		// C parity: popped closed subtrees (ERROR carriers included) keep
 		// their identity inside the new ERROR; only invisible subtrees
 		// flatten.
-		children = p.cAppendVisibleSplice(children, n)
+		p.cAppendVisibleSpliceWithFields(&splice, n)
 	}
+	children, fieldIDs, fieldSources := materializeReduceChildrenFromScratch(&splice, arena)
 
 	fork := v.cloneWithScratch(gssScratch)
 	fork.cRec = nil
@@ -4215,6 +4234,7 @@ func (p *Parser) cRecoverToState(v *glrStack, depth int, goal StateID, arena *no
 
 	if rawFirst != nil {
 		errNode := p.newRecoveryParentNodeInArena(arena, errorSymbol, true, children, 0)
+		errNode.setFieldMetadata(fieldIDs, fieldSources)
 		cSetNodeSpan(errNode, rawFirst.startByte, rawLast.endByte, rawFirst.startPoint, rawLast.endPoint)
 		errNode.setHasError(true)
 		errNode.setExtra(true)
@@ -4277,7 +4297,6 @@ func (p *Parser) cAbsorbTokenIntoError(v *glrStack, tok Token, nodeCount *int, a
 	if leafVisible {
 		leaf = newLeafNodeInArena(arena, tok.Symbol, tok.Symbol == errorSymbol || p.isNamedSymbol(tok.Symbol),
 			tok.StartByte, tok.EndByte, tok.StartPoint, tok.EndPoint)
-		leaf.setHasError(true)
 		// C: if the token shifts as extra in state 1, mark it extra so it is
 		// not counted in error cost calculations.
 		if idx := p.lookupActionIndex(1, tok.Symbol); idx != 0 && int(idx) < len(p.language.ParseActions) {


### PR DESCRIPTION
## Decision

GO for publication. This patch closes only the recorded C locked-tree parity subproblem. Keep issue #454 open for the remaining field-report performance and recovery work.

## Semantic fix

- Keep absorbed visible leaves clean while the enclosing `ERROR` node still reports an error.
- Preserve field identifiers and field sources when hidden recovery nodes flatten.
- Route recovery splices through scratch buffers and apply recovered fields.
- Change only generic C recovery materialization and its focused parity test.
- Change no grammar registry or grammar blob.

## Correctness evidence

- The first old mismatch was `number_literal[0]` under `ERROR[2]` in the 140,288-byte witness.
- The five-size locked-C guard passed at 1, 4, 16, 64, and 137 KiB.
- Direct grammargen-to-C parity passed 20 of 20 cases.
- Incremental replace, insert, and delete trees matched fresh trees.
- The delete case retained `incremental_parse_memory_budget_full_retry`.
- The C real-corpus preset matched the base: 23 of 25 no-error cases and 20 of 25 deep-parity cases.
- The three known type divergences remained unchanged from the base.

## Memory evidence

The audit used three alternating base and candidate pairs in one-language Docker runs.

| Pair | Base RSS | Candidate RSS | Difference |
| --- | ---: | ---: | ---: |
| 1 | 566,680 KiB | 609,464 KiB | +42,784 KiB |
| 2 | 628,852 KiB | 606,980 KiB | -21,872 KiB |
| 3 | 593,812 KiB | 620,544 KiB | +26,732 KiB |

The base mean was 596,448 KiB. The candidate mean was 612,329 KiB, or 2.66% higher.
The earlier 1,089,364 KiB candidate result did not reproduce.

- Focused workload RSS was 857,624 KiB for base and 842,900 KiB for candidate without heap profiling.
- Paired heap-profile RSS was 858,400 KiB for base and 863,336 KiB for candidate.
- `alloc_space` was 1,180.79 MB for base and 1,167.62 MB for candidate.
- `inuse_space` was 129.30 MB for base and 128.66 MB for candidate.
- Arena field storage and field counts were equal in fresh and incremental-delete trees.
- No release-blocking memory regression reproduced. No Docker run hit an out-of-memory failure or timeout.

The standard 20-seed primary Go trio was not run because the candidate changes only C recovery paths.
The focused C workload is the relevant performance gate.

## Scope and validation

The patch changes exactly four files: `parser_recover_c.go`, `cgo_harness/issue454_c_compact_blocker_parity_test.go`, `docs/issue-454-compact-correctness-blocker.md`, and `CHANGELOG.md`.
The audited code and test patch SHA-256 is `71fdb2ab00f8f31e74b7e165f381c0856bd3720abdeb4d1556454d0cc75c50fa`.
The corrected four-file patch SHA-256 is `8b3e84d911ceaed861fc95d0a9ce466d5798bc69a5a5a2a972afda2939bfde65`.
Gofmt, direct no-cache Canopy, Markdown lint and parse, focused parser tests, the 1 KiB locked-C guard, and incremental edit guards passed in Docker.
The changelog and the blocker document record the proof and the memory tradeoff.

## Issue status

This patch closes only the recorded C locked-tree parity subproblem. Keep issue #454 open for the remaining field-report performance and recovery work.
Remaining work includes performance, memory-budget retry, scanner, flat-root, JavaScript, and other recovery findings.
The five-size locked-C guard and the replace, insert, and delete guards remain focused regression guards. Preserve the memory-budget fallback as a separate performance concern.
