### PR TITLE
docs/test: Keep dispatch.corn live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,14 @@ for tags and release notes while still in `0.x`.
   exact error flags. The full authenticated corpus remains unavailable. See
   `docs/root-normalization-retirement.md`.
 
+- Record the `dispatch.corn` blocker receipt at base
+  `613a0775a329998a0af0c6f24251c8008c6783aa`. Keep the arm live. The A0
+  manifest records three Corn files, three checks, three runs, and zero
+  rewrites. The quoted-path trigger rewrites four nodes and still differs from
+  locked C. The malformed quoted-path witness differs in one error flag. The
+  full Corn corpus is unavailable. No registry or production code changes are
+  included. See `docs/root-normalization-retirement.md`.
+
 - Record the `dispatch.ada` blocker receipt at base
   `30f470f5c2bf18540f7a18b2b22a7e33b88d4e10`. Keep the arm live. The receipt
   covers nine clean and two malformed witnesses across raw, production,

--- a/cgo_harness/corn_next_live_probe_test.go
+++ b/cgo_harness/corn_next_live_probe_test.go
@@ -1,0 +1,216 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// TestCornNextLiveArmProbe records every route before a possible retirement.
+// It keeps the quoted-path rewrite and malformed recovery visible.
+func TestCornNextLiveArmProbe(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	language := grammars.CornLanguage()
+	cLanguage, err := COracleLanguage("corn")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	witnesses := []struct {
+		name      string
+		file      string
+		source    []byte
+		malformed bool
+	}{
+		{name: "a0-compact", file: "small__compact.corn"},
+		{name: "a0-complex", file: "small__complex.corn"},
+		{name: "a0-readme-example", file: "small__readme_example.corn"},
+		{
+			name: "quoted-keys-trigger",
+			source: []byte("{\n" +
+				"    'foo.bar' = 42\n" +
+				"    'green.eggs'.and.ham = \"hello world\"\n" +
+				"    'with spaces' = true\n" +
+				"    'escaped\\'quote' = false\n" +
+				"    'escaped=equals' = -3\n" +
+				"}\n"),
+		},
+		{
+			name:   "plain-path-control",
+			source: []byte("{\n    foo.bar = 42\n}\n"),
+		},
+		{
+			name:      "malformed-quoted-path",
+			source:    []byte("{\n    'foo.bar' = 42\n"),
+			malformed: true,
+		},
+	}
+
+	for _, witness := range witnesses {
+		witness := witness
+		t.Run(witness.name, func(t *testing.T) {
+			source := witness.source
+			if source == nil {
+				var err error
+				source, err = os.ReadFile(filepath.Join(
+					"..", "testdata", "dispatcher_census_a0", "corn", witness.file,
+				))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			t.Logf("witness=%s malformed=%t bytes=%d source_sha256=%x", witness.name, witness.malformed, len(source), sha256.Sum256(source))
+
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parser returned no root")
+			}
+			t.Cleanup(cTree.Close)
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rawParser := gotreesitter.NewParser(language)
+			rawParser.SetAdmissionCandidateRoute(false)
+			raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(raw.Release)
+			t.Logf("route=raw %s", cornNextReceipt(raw, language, cTree, cDigest))
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(production.Release)
+			t.Logf("route=production %s", cornNextReceipt(production, language, cTree, cDigest))
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactParser := gotreesitter.NewParser(language)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(compact.Release)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			compactMode := fmt.Sprintf("counters=%d/%d->%d/%d", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+			if routedAfter == routedBefore && fallbackAfter == fallbackBefore+1 {
+				compactMode += " fallback:" + gotreesitter.AdmissionCandidateLastFallbackReason()
+			} else if routedAfter == routedBefore+1 && fallbackAfter == fallbackBefore {
+				compactMode += " accepted"
+			}
+			t.Logf("route=compact mode=%s %s", compactMode, cornNextReceipt(compact, language, cTree, cDigest))
+
+			forestParser := gotreesitter.NewParser(language)
+			forest, forestOK := forestParser.ParseForestExperimental(source)
+			if forestOK && forest != nil {
+				t.Cleanup(forest.Release)
+				t.Logf("route=forest mode=accepted %s", cornNextReceipt(forest, language, cTree, cDigest))
+			} else {
+				t.Log("route=forest mode=declined")
+			}
+
+			incrementalParser := gotreesitter.NewParser(language)
+			incrementalParser.SetAdmissionCandidateRoute(false)
+			base := bytes.TrimSuffix(source, []byte{'\n'})
+			oldTree, err := incrementalParser.Parse(base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(oldTree.Release)
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(len(base)),
+				OldEndByte:  uint32(len(base)),
+				NewEndByte:  uint32(len(source)),
+				StartPoint:  cornNextPointAtByte(base),
+				OldEndPoint: cornNextPointAtByte(base),
+				NewEndPoint: cornNextPointAtByte(source),
+			})
+			incremental, profile, err := incrementalParser.ParseIncrementalProfiled(source, oldTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(incremental.Release)
+			t.Logf("route=incremental reuse=%t unsupported=%t reason=%q reused_subtrees=%d reused_bytes=%d %s", profile.OldTreeReuseRoute, profile.ReuseUnsupported, profile.ReuseUnsupportedReason, profile.ReusedSubtrees, profile.ReusedBytes, cornNextReceipt(incremental, language, cTree, cDigest))
+		})
+	}
+}
+
+// TestCornNextLiveArmReceiptDocument guards the blocker receipt markers.
+func TestCornNextLiveArmReceiptDocument(t *testing.T) {
+	raw, err := os.ReadFile("../docs/root-normalization-retirement.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	document := strings.Join(strings.Fields(string(raw)), " ")
+	for _, marker := range []string{
+		"The Corn arm remains live.",
+		"A0 has three Corn files, three checked, three run, and zero rewrites.",
+		"The quoted-path trigger rewrites four nodes and still differs from locked C.",
+		"The malformed quoted-path witness differs from locked C at the error flag.",
+		"Keep dispatch.corn live until scheduler_action_semantics emits the locked-C quoted-path tree.",
+	} {
+		marker = strings.Join(strings.Fields(marker), " ")
+		if !strings.Contains(document, marker) {
+			t.Fatalf("Corn blocker receipt lacks marker %q", marker)
+		}
+	}
+}
+
+func cornNextReceipt(tree *gotreesitter.Tree, language *gotreesitter.Language, cTree *sitter.Tree, cDigest string) string {
+	if tree == nil || tree.RootNode() == nil {
+		return "tree=nil"
+	}
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		return fmt.Sprintf("inspect_error=%v", err)
+	}
+	diff := FirstDivergenceDumpV1(tree.RootNode(), language, cTree.RootNode())
+	return fmt.Sprintf("error_root=%t digest=%s c_digest=%s exact=%t rewrites=%d passes=%s divergence=%+v", tree.RootNode().HasError(), inspection.SHA256, cDigest, diff == nil && inspection.SHA256 == cDigest, tree.ParseRuntime().NormalizationNodesRewritten, cornNextPasses(tree), diff)
+}
+
+func cornNextPasses(tree *gotreesitter.Tree) string {
+	runtime := tree.ParseRuntime()
+	if runtime.NormalizationPasses == nil {
+		return "none"
+	}
+	parts := make([]string, 0, len(*runtime.NormalizationPasses))
+	for _, pass := range *runtime.NormalizationPasses {
+		parts = append(parts, fmt.Sprintf("%s:%d/%d/%d/%d", pass.Name, pass.Checked, pass.Run, pass.NodesVisited, pass.NodesRewritten))
+	}
+	return fmt.Sprintf("%v", parts)
+}
+
+func cornNextPointAtByte(source []byte) gotreesitter.Point {
+	var point gotreesitter.Point
+	for _, value := range source {
+		if value == '\n' {
+			point.Row++
+			point.Column = 0
+		} else {
+			point.Column++
+		}
+	}
+	return point
+}

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -609,6 +609,117 @@ The focused Docker artifacts are:
 - `/tmp/ada-next-live-rebased-artifacts/20260822T232118Z-ada-census-registry`;
 - `/tmp/ada-next-live-rebased-artifacts/20260822T232128Z-ada-real-census`.
 
+## 2026-08-23 Corn blocker receipt
+
+Status: NO-GO. KEEP LIVE: `dispatch.corn`. The Corn arm remains live.
+
+Base commit: `613a0775a329998a0af0c6f24251c8008c6783aa`.
+
+Select Corn after the Apex, Rust, Doxygen, DTD, Ada, and HLSL investigations.
+Corn has the strongest remaining clean zero-rewrite A0 evidence. BitBake has
+40,358 visited nodes but two error roots. Wolfram has 77 visited nodes and
+three error roots. Corn has 792 visited nodes and zero error roots.
+
+The ownership registry contains 88 entries. It contains 78 dispatcher arms,
+three dispatcher subpasses, one dispatcher predicate, three generic passes,
+and three fixpoint passes. It contains 31 live dispatcher arms, 33
+dispatcher-arm language labels, one live predicate, 32 live entries, and 56
+retired entries. It contains zero live generic passes and zero live
+post-finalization arms.
+
+The registry keeps `dispatch.corn` live. It names
+`normalizeCornCompatibility` in `parser_result_corn.go`. The authoritative
+owner is `scheduler_action_semantics`. The registered witness is
+`cgo_harness/parity_cgo_test.go`. The registry covers production, compact,
+forest, incremental, and locked-C routes.
+
+The A0 (authenticated dispatcher census) manifest has 14 languages, 42 files,
+and 14 receipts. A0 has three Corn files, three checked, three run, and zero
+rewrites. It records 792 visited nodes, zero error roots, and zero parse
+errors. The files are:
+
+- `small__compact.corn`;
+- `small__complex.corn`;
+- `small__readme_example.corn`.
+
+The tracked census has seven fixtures in six languages. It excludes Corn. The
+authenticated real-corpus census is unavailable because
+`cgo_harness/corpus_real` is not mounted. No Corn A3 receipt is registered.
+
+The focused receipt covers six witnesses. It runs raw, production, compact,
+forest, incremental, and locked-C routes. It includes three A0 files, one
+quoted-path trigger, one plain-path control, and one malformed witness. Corn
+has no external scanner. Every incremental route reuses the old tree and
+reports `reuse_unsupported=false`.
+
+The three A0 witnesses match locked C on every accepted route. They report
+zero `dispatch.corn` rewrites:
+
+| Witness | Source SHA-256 | Locked C and Go digest | Production pass |
+| --- | --- | --- | --- |
+| `a0-compact` | `e9793277f21b19593024cf7f670934333deefb54eae122caaa1f66cf41c7606a` | `6925a38d869d585460c85ab53d4d3486e675f6e6ed8e97f92e6c5702bcf951ad` | `1/1/246/0` |
+| `a0-complex` | `98aaba0d478418a7855fa538cb9cd52ab81b2d2e581402d212bc3951a6a5db02` | `2e25bed381c2d79a7ba0bdd909dfbd30e738b3c8be29a7fc7352ea1fd975969a` | `1/1/287/0` |
+| `a0-readme-example` | `7d412d6e3c5e396818885601df14ad092b8cbe4aac690a45d7a4c29e0410da94` | `8d705f274c5421a5a60b9ef31013e8768f0c12dbd737bedca57ce3730a644a50` | `1/1/259/0` |
+
+The four values are checked, run, visited, and rewritten. Compact accepts all
+three files. Forest accepts all three files. Incremental reuse reports 57,
+97, and 138 reused subtrees for the three files.
+
+The quoted-path trigger uses source SHA-256
+`7bcdf348ffbe92ef87dcb79b45ebae007811fe7af717c2d2cdea09f8c61872c8`.
+Raw Go digest is
+`2e3f95ebc022876fe74c65948a03d6725855723e24592f6a56851b474b175ff8`.
+Locked C digest is
+`92b1b5257e650d85af9692640cf30b287453eb7ec15af25f1c1560899d3b7615`.
+Raw Go differs at `/source_file/object[0]`: Go has seven children and C has
+eight. The raw tree has an error root. Production, compact, and incremental
+routes produce digest
+`714e0b57f2920716ba5ac832d2284ac17db8189e7e12c21f4f6978e3d3936e2e`.
+They still differ from locked C at that path. Production and compact routes
+rewrite four nodes. Forest declines. Incremental reuse reports three reused
+subtrees. The production pass reports `1/1/71/4`.
+The quoted-path trigger rewrites four nodes and still differs from locked C.
+
+The plain-path control uses source SHA-256
+`40dc0c83705af7393578499a43eab93269e4b91b99f3c1ec901dad1fd76f4bd0`.
+All routes match locked C with digest
+`1c9dd43135dfa64e87c1af706f3fa9d66c420ec4003d54dd0e37e5d2f9896a08`.
+All routes report zero rewrites. Compact accepts the control. Forest accepts
+the control. Incremental reuse reports two reused subtrees.
+
+The malformed quoted-path witness uses source SHA-256
+`b86b200a916bc043d21c2b9b45f35968db1b88733c789984ae070cde7d56d324`.
+Raw Go digest is
+`39af32691e83a255b944db485ae4b05a164ab696da70860215805d75c7b7a73c`.
+Locked C, production, compact, and incremental digest is
+`e55d7e35692aa8895adedf98d61b37f5b4d6fbdbc78f5a4106ae2cac94badbdf`.
+The malformed quoted-path witness differs from locked C at the error flag.
+Raw differs at
+`/source_file/object[0]/pair[1]/path[0]/path_seg[0]/ERROR[1]/.[0]`.
+Go marks the dot error. C does not. Production performs one rewrite and
+matches C. Compact falls back because the scheduler has no table action for
+the elected token. Forest declines. Incremental reuse reports two reused
+subtrees.
+
+The receipt remains NO-GO. Keep `dispatch.corn` live. The quoted-path trigger
+still differs from locked C after four rewrites. The malformed witness still
+requires one recovery rewrite.
+
+Keep dispatch.corn live until scheduler_action_semantics emits the locked-C
+quoted-path tree. Require malformed recovery to match locked C. Require exact
+production, compact, forest, incremental, and locked-C receipts. Require the
+authenticated Corn corpus before retirement. Do not change the registry or
+production code.
+
+The successful focused Docker artifacts are:
+
+- `/tmp/corn-next-artifacts/20260823T002827Z-corn-next-final` — route and document guard;
+- `/tmp/corn-next-artifacts/20260823T002844Z-corn-next-document-guard-final` — final document guard;
+- `/tmp/corn-next-artifacts/20260823T002433Z-corn-next-registry` — registry receipt;
+- `/tmp/corn-next-artifacts/20260823T002440Z-corn-next-a0` — A0 receipt;
+- `/tmp/corn-next-artifacts/20260823T002449Z-corn-next-tracked` — tracked census receipt;
+- `/tmp/corn-next-artifacts/20260823T002457Z-corn-next-real-corpus` — controlled corpus skip.
+
 ## Ordered program
 
 ### R0 — inventory and containment


### PR DESCRIPTION
## Decision

KEEP LIVE. NO-GO for retirement. Keep `dispatch.corn` active.
No production parser or registry change ships in this PR.

## Scope

This PR changes exactly these files:

- `CHANGELOG.md`
- `docs/root-normalization-retirement.md`
- `cgo_harness/corn_next_live_probe_test.go`

The receipt preserves evidence from base commit
`613a0775a329998a0af0c6f24251c8008c6783aa`.
The PR parent is `0448715e9a80305556b687b6ecaf041da42e9d9d`.

## Census

The authenticated dispatcher census has 14 languages, 42 files, and 14 receipts.
Corn has three files, three checked, three run, and zero rewrites.
Corn has 792 visited nodes, zero error roots, and zero parse errors.
The tracked census has seven fixtures in six languages and excludes Corn.

The probe covers six routes:

- raw
- production
- compact
- forest
- incremental
- locked C

The three A0 witnesses match locked C on every accepted route.
Their incremental routes reuse 57, 97, and 138 subtrees.

## Quoted-path blocker

The quoted-path trigger has four production rewrites.
Its raw Go tree has seven children. Locked C has eight children at
`/source_file/object[0]`.
Production, compact, and incremental routes retain this divergence.
Forest declines.
Incremental reuse reports three reused subtrees.

The production pass reports `1/1/71/4`.
The raw Go digest is `2e3f95eb...`.
The locked-C digest is `92b1b525...`.
The production digest is `714e0b57...`.

## Malformed blocker

The malformed quoted-path witness has a raw error-flag divergence.
The path is
`/source_file/object[0]/pair[1]/path[0]/path_seg[0]/ERROR[1]/.[0]`.
Go marks the dot as an error. Locked C does not.
Production performs one rewrite and matches locked C.
Compact falls back because the scheduler has no table action for the elected token.
Forest declines. Incremental reuse reports two reused subtrees.

## Corpus and artifacts

The authenticated real-corpus census is unavailable.
The `cgo_harness/corpus_real` directory is not mounted.
No Corn A3 receipt is registered.

Focused artifacts are available at:

- `/tmp/corn-next-artifacts/20260823T002827Z-corn-next-final`
- `/tmp/corn-next-artifacts/20260823T002844Z-corn-next-document-guard-final`
- `/tmp/corn-next-artifacts/20260823T002433Z-corn-next-registry`
- `/tmp/corn-next-artifacts/20260823T002440Z-corn-next-a0`
- `/tmp/corn-next-artifacts/20260823T002449Z-corn-next-tracked`
- `/tmp/corn-next-artifacts/20260823T002457Z-corn-next-real-corpus`
- `/tmp/corn-next-rebase-artifacts/20260823T020300Z-corn-next-rebase-final`

## Reopening condition

Retire `dispatch.corn` only when `scheduler_action_semantics` emits the
locked-C quoted-path tree.
Require malformed recovery to match locked C.
Require exact raw, production, compact, forest, incremental, and locked-C receipts.
Require the authenticated Corn corpus before retirement.
Do not change the registry or production code in this blocker receipt.

## Validation

- Focused Docker guard: pass.
- Direct no-cache Canopy symbols and call graph: pass.
- `gofmt -d`: pass.
- `git diff --check`: pass.
- Markdown warning-level lint and parse: pass.
