### PR TITLE
docs: Record the Swift #576 token-production blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,16 @@ for tags and release notes while still in `0.x`.
   receipt is superseded and excluded: its anchored expression matched no
   combined test. See docs/perf-attribution.md for the full receipt.
 
+### Correctness
+
+- Record the C26a Swift issue #576 token-production blocker at main commit
+  `18d63b6f7802b28a0ddb889327fcd4ebebb99426`. The 20-byte witness still
+  differs from the locked C reference parser at the first error node. The
+  isolated grammar-agnostic predicate did not change the output. No
+  production or test change survives. Keep issue #576 open. See
+  `docs/compact-route-real-corpus-matrix.md` for the digests, trace artifact,
+  and reopening condition.
+
 ### Added
 
 - Add the default-off authenticated D6a drop-cohort frontier producer. It

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -4,6 +4,88 @@ Current evidence date: 2026-08-22.
 Current base commit: `f298328a` from `main`.
 Current candidate base commit: `f298328a`.
 
+## C26a Swift issue #576 token-production blocker
+
+Receipt base: `18d63b6f7802b28a0ddb889327fcd4ebebb99426`.
+
+Status: **NO-GO / KEEP LIVE**. This receipt does not change compact route
+admission, D6 status, or the bounded matrix counts. Keep issue #576 open.
+
+The smallest existing witness is the 20-byte source `let x = unsafe bar()`.
+Its source SHA-256 digest is
+`b511d81ace2a89b05e8e5e0ca6730c10f2ac9295111dae013097c7c6be8861fe`.
+The Go deep-tree digest is
+`860b79483c37e217690deae43036bada15b259bed77713606124fa851702e62f`.
+The locked C deep-tree digest is
+`c64b894edc4a20e15f2b4127bad4223f698c8996dba091c06c34aa89386d3c68`.
+
+The first divergence is
+`/source_file/property_declaration[0]/call_expression[3]/ERROR[1]`, bytes
+15..18. Go emits a childless `ERROR` node. Locked C emits an `ERROR` node with
+the `bar` child. The two existing Swift corpus witnesses share this unsafe
+expression-prefix cause.
+
+The locked C reference parser uses grammar version `0.7.2`, grammar commit
+`41d6e5fe811ec94229ee71771174a8cce558dfee`, runtime `0.25.1`, and runtime
+commit `f5afe475deb7c0bae6407fb776c76824f717bb61`. Its lexer skips `bar`,
+emits an error token of size four, detects the error, and resumes through the
+previous recovery point. Go emits identifier symbol `160`, reaches state 47
+without a parser action, and enters generic recovery. Go therefore does not
+receive the C error token before it materializes the childless `ERROR` node.
+
+The exact minimal-witness C logger trace is at
+`/tmp/gts-c26a-correction-artifacts/20260823T024242Z-swift576-c-trace-exact`.
+It records the skipped characters, the four-byte `ERROR` token, `detect_error`,
+`resume`, and `recover_to_previous state:2543, depth:2`. The trace also records
+the 20-byte C and Go trees. The Go state trace is at
+`/tmp/gts-c26a-artifacts/20260823T022437Z-swift576-predicate-trace-min`.
+
+Canopy attributes the generic C error-mode acquisition to
+`cRecoverAcquireToken` in `parser_recover_c.go`. The
+`cRecoverResumeLookahead` path serves custom source fallback. The
+`pushLexErrorRunLeaf` path owns the C-shaped error wrapper. Those paths cannot
+restore a token that the deterministic finite automaton (DFA) token source did
+not produce. The divergence is therefore in token production and grammar-table
+behavior, before generic error materialization. The direct structural queries
+were:
+
+- `scripts/canopy_query.sh search symbols parser_recover_c.go --limit 120 --no-cache`
+- `canopy graph calls 'pushLexErrorRunLeaf' parser_reduce.go --no-cache --depth 3`
+- `canopy graph calls 'cRecoverAcquireToken' parser_recover_c.go --no-cache --depth 3`
+- `canopy graph calls --reverse 'cRecoverResumeLookahead' parser_recover_c.go --no-cache --depth 2`
+
+The isolated experiment tried a grammar-agnostic predicate. When normal
+lookahead had no parser action, it relexed from broad error mode before
+recovery. The prototype touched only `parser.go` and
+`parser_dfa_token_source.go`. The focused Swift run kept both deep-tree
+digests and the first divergence unchanged. The prototype was removed. No
+production or test change survives.
+
+The focused Docker artifacts are:
+
+- `/tmp/gts-c26a-artifacts/20260823T021728Z-swift576-minimal`
+- `/tmp/gts-c26a-artifacts/20260823T021757Z-swift576-corpus`
+- `/tmp/gts-c26a-artifacts/20260823T022322Z-swift576-predicate2`
+- `/tmp/gts-c26a-correction-artifacts/20260823T024140Z-swift576-minimal-current`
+- `/tmp/gts-c26a-correction-artifacts/20260823T024242Z-swift576-c-trace-exact`
+
+An upstream regeneration also left the witness unchanged. It produced blob
+digest `be5cd0bf8df7077804fe4b54ee47d76005c9a85c7c33b857ef6d2aff34461286`.
+The shipped Go Swift blob is
+`be4575bc0acc3c60324aab635d067f940ac5f0557b80a8e3565d1e7d02d53582`.
+The upstream probe used revision
+`172ada1cc4117d0260d9340680b4134adba2bc2c`, package version `0.7.3`, and
+these artifacts:
+
+- `/tmp/gts-swift-upstream-probe-artifacts/20260823T000638Z-swift-upstream-issue576-range`
+- `/tmp/gts-swift-upstream-probe-artifacts/20260823T000433Z-swift-upstream-issue576-parity`
+
+Reopen implementation work after a grammar or lexer revision changes token
+production for the `unsafe` expression prefix. Reopen it after a generic
+runtime change produces the locked C error token without a Swift-specific
+rule. Then run the 20-byte witness and one corpus witness in separate Docker
+parity runs. Keep issue #576 open until both witnesses pass.
+
 ## Current bounded result
 
 The bounded matrix completed with no silent divergence.


### PR DESCRIPTION
## Summary

- Record the C26a Swift issue #576 token-production blocker.
- Keep issue #576 open and the parser behavior unchanged.
- Record the locked-C trace, digests, ownership findings, and reopening condition.

## Evidence

- The minimal witness is `let x = unsafe bar()`.
- Go emits an `ERROR` node without `bar`.
- Locked C emits an `ERROR` node with `bar`.
- The tested grammar-agnostic predicate did not change the output.
- No production or test code changed.

## Validation

- Markdown checks passed for both changed documents.
- `git diff --check` passed.
- Buckley change hash: `717d1f22b1dfb140bc622ed98550d28f6c658b074cba55b2f9db7de80b82c6f6`.

This is a documentation-only blocker receipt. It ships no parser or grammar fix. Issue #576 remains open.
