### PR TITLE
docs: Keep the BitBake normalization arm live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,15 @@ for tags and release notes while still in `0.x`.
   locked C. The full real-corpus census is unavailable. See
   `docs/root-normalization-retirement.md`.
 
+- Record the `dispatch.bitbake` blocker receipt at base
+  `9f6380a8a0795b631a0b5e3a573253977f673bf4`. Keep the arm live. A0 covers
+  three files, 40358 visited nodes, two error roots, and zero rewrites. The
+  focused receipt covers eight witnesses across raw, production, compact,
+  forest, incremental, and locked-C routes. The medium and large A0 witnesses
+  differ at `/recipe`. Three constructed producer witnesses also differ. The
+  full authenticated corpus is unavailable. Do not change registry or
+  production state. See `docs/root-normalization-retirement.md`.
+
 - Record a durable Doxygen locked-C blocker receipt. Keep `dispatch.doxygen`
   live. The three A0 witnesses report zero raw and production rewrites. The
   historical childless and recovered routes report 3 and 14 named rewrites

--- a/cgo_harness/bitbake_next_live_probe_test.go
+++ b/cgo_harness/bitbake_next_live_probe_test.go
@@ -1,0 +1,260 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const bitbakeNextAddtaskSource = `SUMMARY = "Test recipe for fetching git submodules"
+HOMEPAGE = "http://git.yoctoproject.org/cgit/cgit.cgi/git-submodule-test/"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+# Note: this is intentionally not the latest version in the original .bb
+SRCREV = "f280847494763cdcf71197557a81ba7d8a6bce42"
+PV = "0.1+git"
+PR = "r2"
+
+SRC_URI = "gitsm://git.yoctoproject.org/git-submodule-test;branch=master;protocol=https"
+UPSTREAM_CHECK_COMMITS = "1"
+RECIPE_NO_UPDATE_REASON = "This recipe is used to test devtool upgrade feature"
+
+EXCLUDE_FROM_WORLD = "1"
+
+do_test_git_as_user() {
+    cd ${S}
+    git status
+    git submodule status
+}
+addtask test_git_as_user after do_unpack
+
+fakeroot do_test_git_as_root() {
+    cd ${S}
+    git status
+    git submodule status
+}
+do_test_git_as_root[depends] += "virtual/fakeroot-native:do_populate_sysroot"
+addtask test_git_as_root after do_unpack`
+
+const bitbakeNextFunctionFlagSource = `do_run_tests () {
+    meson test -C "${B}" --no-rebuild
+}
+do_run_tests[doc] = "Run meson test using qemu-user"
+addtask do_run_tests after do_compile`
+
+const bitbakeNextOverrideSource = `do_install:append() {
+    ln -sf am335x-bonegreen-ext.dtb "${D}/boot/devicetree/am335x-bonegreen-ext-alias.dtb"
+}
+
+do_deploy:append() {
+    ln -sf am335x-bonegreen-ext.dtb "${DEPLOYDIR}/devicetree/am335x-bonegreen-ext-alias.dtb"
+}`
+
+const bitbakeNextMalformedSource = `do_install() {
+    echo "missing close"
+`
+
+// TestBitbakeNextLiveArmProbe records every route before a possible retirement.
+// It keeps recovery, shell-function, and flag-assignment behavior visible.
+func TestBitbakeNextLiveArmProbe(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	language := grammars.BitbakeLanguage()
+	if language.ExternalScanner == nil {
+		t.Fatal("BitBake language has no registered external scanner")
+	}
+	if reusable, ok := language.ExternalScanner.(gotreesitter.IncrementalReuseExternalScanner); ok && reusable.SupportsIncrementalReuse() {
+		t.Fatal("BitBake external scanner unexpectedly supports incremental reuse")
+	}
+	cLanguage, err := COracleLanguage("bitbake")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	witnesses := []struct {
+		name      string
+		file      string
+		source    []byte
+		malformed bool
+	}{
+		{name: "a0-small-error", file: "small__error.bb"},
+		{name: "a0-medium-clang-git", file: "medium__clang_git.bb"},
+		{name: "a0-large-linux-firmware", file: "large__linux-firmware_20260519.bb"},
+		{name: "addtask-error-wrapper", source: []byte(bitbakeNextAddtaskSource)},
+		{name: "function-flag-assignment", source: []byte(bitbakeNextFunctionFlagSource)},
+		{name: "adjacent-override-functions", source: []byte(bitbakeNextOverrideSource)},
+		{name: "plain-assignment-control", source: []byte("SUMMARY = \"hello\"\n")},
+		{name: "malformed-shell-function", source: []byte(bitbakeNextMalformedSource), malformed: true},
+	}
+
+	for _, witness := range witnesses {
+		witness := witness
+		t.Run(witness.name, func(t *testing.T) {
+			source := witness.source
+			if source == nil {
+				var err error
+				source, err = os.ReadFile(filepath.Join(
+					"..", "testdata", "dispatcher_census_a0", "bitbake", witness.file,
+				))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			t.Logf("witness=%s malformed=%t bytes=%d source_sha256=%x", witness.name, witness.malformed, len(source), sha256.Sum256(source))
+
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parser returned no root")
+			}
+			t.Cleanup(cTree.Close)
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rawParser := gotreesitter.NewParser(language)
+			rawParser.SetAdmissionCandidateRoute(false)
+			raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(raw.Release)
+			t.Logf("route=raw %s", bitbakeNextReceipt(raw, language, cTree, cDigest))
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(production.Release)
+			t.Logf("route=production %s", bitbakeNextReceipt(production, language, cTree, cDigest))
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactParser := gotreesitter.NewParser(language)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(compact.Release)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			compactMode := fmt.Sprintf("counters=%d/%d->%d/%d", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+			if routedAfter == routedBefore && fallbackAfter == fallbackBefore+1 {
+				compactMode += " fallback:" + gotreesitter.AdmissionCandidateLastFallbackReason()
+			} else if routedAfter == routedBefore+1 && fallbackAfter == fallbackBefore {
+				compactMode += " accepted"
+			}
+			t.Logf("route=compact mode=%s %s", compactMode, bitbakeNextReceipt(compact, language, cTree, cDigest))
+
+			forestParser := gotreesitter.NewParser(language)
+			forest, forestOK := forestParser.ParseForestExperimental(source)
+			if forestOK && forest != nil {
+				t.Cleanup(forest.Release)
+				t.Logf("route=forest mode=accepted %s", bitbakeNextReceipt(forest, language, cTree, cDigest))
+			} else {
+				t.Log("route=forest mode=declined")
+			}
+
+			incrementalParser := gotreesitter.NewParser(language)
+			incrementalParser.SetAdmissionCandidateRoute(false)
+			base := bytes.TrimSuffix(source, []byte{'\n'})
+			oldTree, err := incrementalParser.Parse(base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(oldTree.Release)
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(len(base)),
+				OldEndByte:  uint32(len(base)),
+				NewEndByte:  uint32(len(source)),
+				StartPoint:  bitbakeNextPointAtByte(base),
+				OldEndPoint: bitbakeNextPointAtByte(base),
+				NewEndPoint: bitbakeNextPointAtByte(source),
+			})
+			incremental, profile, err := incrementalParser.ParseIncrementalProfiled(source, oldTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(incremental.Release)
+			t.Logf("route=incremental reuse=%t unsupported=%t reason=%q reused_subtrees=%d reused_bytes=%d %s", profile.OldTreeReuseRoute, profile.ReuseUnsupported, profile.ReuseUnsupportedReason, profile.ReusedSubtrees, profile.ReusedBytes, bitbakeNextReceipt(incremental, language, cTree, cDigest))
+		})
+	}
+}
+
+// TestBitbakeNextLiveArmReceiptDocument guards the blocker receipt markers.
+func TestBitbakeNextLiveArmReceiptDocument(t *testing.T) {
+	raw, err := os.ReadFile("../docs/root-normalization-retirement.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	document := strings.Join(strings.Fields(string(raw)), " ")
+	for _, marker := range []string{
+		"The BitBake arm remains live.",
+		"A0 has three BitBake files, three checked, three run, and zero rewrites.",
+		"The medium A0 witness differs from locked C at the recipe shape.",
+		"The malformed shell-function witness remains a recovery blocker.",
+		"BitBake has a registered external scanner. It does not implement incremental reuse support.",
+		"Keep dispatch.bitbake live until scheduler_action_semantics emits the locked-C shell-function tree.",
+	} {
+		marker = strings.Join(strings.Fields(marker), " ")
+		if !strings.Contains(document, marker) {
+			t.Fatalf("BitBake blocker receipt lacks marker %q", marker)
+		}
+	}
+}
+
+func bitbakeNextReceipt(tree *gotreesitter.Tree, language *gotreesitter.Language, cTree *sitter.Tree, cDigest string) string {
+	if tree == nil || tree.RootNode() == nil {
+		return "tree=nil"
+	}
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		return fmt.Sprintf("inspect_error=%v", err)
+	}
+	diff := FirstDivergenceDumpV1(tree.RootNode(), language, cTree.RootNode())
+	return fmt.Sprintf("error_root=%t digest=%s c_digest=%s exact=%t rewrites=%d passes=%s divergence=%+v", tree.RootNode().HasError(), inspection.SHA256, cDigest, diff == nil && inspection.SHA256 == cDigest, tree.ParseRuntime().NormalizationNodesRewritten, bitbakeNextPasses(tree), diff)
+}
+
+func bitbakeNextPasses(tree *gotreesitter.Tree) string {
+	runtime := tree.ParseRuntime()
+	if runtime.NormalizationPasses == nil {
+		return "none"
+	}
+	parts := make([]string, 0, len(*runtime.NormalizationPasses))
+	for _, pass := range *runtime.NormalizationPasses {
+		parts = append(parts, fmt.Sprintf("%s:%d/%d/%d/%d", pass.Name, pass.Checked, pass.Run, pass.NodesVisited, pass.NodesRewritten))
+	}
+	return fmt.Sprintf("%v", parts)
+}
+
+func bitbakeNextPointAtByte(source []byte) gotreesitter.Point {
+	var point gotreesitter.Point
+	for _, value := range source {
+		if value == '\n' {
+			point.Row++
+			point.Column = 0
+		} else {
+			point.Column++
+		}
+	}
+	return point
+}

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -719,6 +719,106 @@ The successful focused Docker artifacts are:
 - `/tmp/corn-next-artifacts/20260823T002440Z-corn-next-a0` — A0 receipt;
 - `/tmp/corn-next-artifacts/20260823T002449Z-corn-next-tracked` — tracked census receipt;
 - `/tmp/corn-next-artifacts/20260823T002457Z-corn-next-real-corpus` — controlled corpus skip.
+## 2026-08-24 BitBake blocker receipt
+
+Status: `NO-GO`. `KEEP LIVE`: `dispatch.bitbake`.
+The BitBake arm remains live.
+
+Base commit: `9f6380a8a0795b631a0b5e3a573253977f673bf4`.
+
+Select BitBake after excluding the Apex, Rust, Doxygen, DTD, Ada, HLSL, and
+Corn arms. BitBake has 40358 A0 visited nodes and zero rewrites. Wolfram has
+77 A0 visited nodes, three error roots, and zero rewrites. BitBake has the
+stronger remaining evidence.
+
+The ownership registry contains 88 entries. It contains 78 dispatcher arms,
+one dispatcher predicate, three dispatcher subpasses, three generic passes,
+and three second-pass fixpoints. It contains 31 live dispatcher arms, one
+live predicate, 32 live entries, and 56 retired entries. The live dispatcher
+arms cover 33 language labels.
+
+The registry records `dispatch.bitbake` as a `dispatcher_arm`. Its function is
+`normalizeBitbakeCompatibility` in `parser_result_bitbake.go`. Its
+authoritative owner is `scheduler_action_semantics`. Its registered witness is
+`cgo_harness/parity_cgo_test.go`.
+
+The production, compact, forest, and incremental routes use the shared
+compatibility tail. The C oracle route uses the curated single-grammar parity
+path.
+
+The A0 (initial dispatcher census) manifest contains 14 languages and 42
+files. A0 has three BitBake files, three checked, three run, and zero rewrites.
+It records 40358 visited nodes, two error roots, and zero parse errors.
+
+The tracked census contains seven fixtures across six languages. It excludes
+BitBake and Wolfram. The authenticated real-corpus census is unavailable
+because `cgo_harness/corpus_real` is absent. The focused census test skips
+this lane.
+
+The focused receipt covers eight witnesses:
+
+| Witness | Bytes | Source SHA-256 | Go digest | Locked-C digest | Result |
+| --- | ---: | --- | --- | --- | --- |
+| `a0-small-error` | 259 | `fbdb85e443edd378e944e5a1416c0c4a1e485f0cd38f70a5ac75748073a15d12` | `6154c15dcc0a1f365b7cfb0bf0cc120f3e365b55a491ca793a0cf170bc5cfe92` | `6154c15dcc0a1f365b7cfb0bf0cc120f3e365b55a491ca793a0cf170bc5cfe92` | Exact. |
+| `a0-medium-clang-git` | 9229 | `7deb41efd839d8b5b8b2c98589614377d12fd81fa6033824330084e07c5eaf9f` | `f9d3bffb1d39a952d36d56b4ac15e2fe69e020d2cebabc359c8e897ab4ba2c2c` | `7eb2e581801fd0dbf1ed79a9eaf2ad357062725d6b26a238a168b3e14473d064` | Diverges at `/recipe`: shape, children 72 versus 71. |
+| `a0-large-linux-firmware` | 168224 | `eaa9e3f2354345d558717c4791a67144d8b27767674bf5468e157a0e0a332ff6` | `d3c65cb639ef93ddbc96a03b39abbd184ac28ee8261cd894aab3bc6cc63e048d` | `9627acb8fdaf0b4cb9adaf5c23dc0229ea5cfcdeca63e8b8856645654ff33734` | Diverges at `/recipe`: shape, children 2056 versus 2054. |
+| `addtask-error-wrapper` | 964 | `35ccf9d007ef76548258088b18adb39d7c0509452b4fb62bd7dfdc94cdcdf780` | `54ff030bff3669038144d08a72aa778c6e7d5f44de6682ce0fbc78c31fc9620c` | `464f3db4c1ad8be4dabc16c9631524f4cee1d99c9c1c6f4abfad6d6bfe8cabed` | Diverges at `/recipe`: Go error false, C error true. |
+| `function-flag-assignment` | 148 | `8655832f5acd3b4ada197881f41b0110657572aa0c791ecf4524fbc10603a1eb` | `6fda1b4df6c27597c4b6218dd30b0b6c55a51f4d7e7adfff8756fe05f5adef7e` | `dd7147f575544eadae2a0c5aa1ecd571495d66f40da096cba1fd9b309635bd61` | Diverges at `/recipe/function_definition[0]/ERROR[4]`: shape, children 10 versus 9. |
+| `adjacent-override-functions` | 230 | `068037e13b101cf01d0a36da586f798972fa39b99ba0c2a86dc17996bc34d185` | `e939ebdd239811c6154def7a5e4c3faa1a4024f8540ece27d4e3d78bb92c7eed` | `f972c3f88404f41643400bfa2c200c72f2ddbcb93295a258c8b1f404e2cb7d9b` | Diverges at `/recipe`: shape, children 2 versus 3. |
+| `plain-assignment-control` | 18 | `b6a30f2e69cfe6ad0a3ca514e855b86b3c7e9403c5106d7d2239c3f42abea292` | `99187413f4fea3d1d6a10fb61768341c4188db1bd8582cdb041837d8ff49306b` | `99187413f4fea3d1d6a10fb61768341c4188db1bd8582cdb041837d8ff49306b` | Exact no-op control. |
+| `malformed-shell-function` | 40 | `248dddc07429da83d3f05a14da1137270b7715dca43aa41abf58a51109b14477` | `f3ad263fcb44ab306ad7b1cc6a510840ce86c2683c7c94df7333fdec57edeae0` | `f3ad263fcb44ab306ad7b1cc6a510840ce86c2683c7c94df7333fdec57edeae0` | Exact error tree. |
+
+The raw and production routes emit the same digest for every witness. The
+production pass checks, runs, visits, and rewrites these counts:
+
+| Witness | `dispatch.bitbake` checked/run/visited/rewritten |
+| --- | ---: |
+| `a0-small-error` | `1/1/48/0` |
+| `a0-medium-clang-git` | `1/1/1486/0` |
+| `a0-large-linux-firmware` | `1/1/38824/0` |
+| `addtask-error-wrapper` | `1/1/144/0` |
+| `function-flag-assignment` | `1/1/35/0` |
+| `adjacent-override-functions` | `1/1/37/0` |
+| `plain-assignment-control` | `1/1/9/0` |
+| `malformed-shell-function` | `1/1/7/0` |
+
+Every raw, production, compact, and incremental tree reports zero normalization
+nodes rewritten. Each accepted forest tree also reports zero rewrites.
+
+The medium A0 witness differs from locked C at the recipe shape. The large
+A0 witness has the same divergence category. The three constructed producer
+witnesses also differ from locked C. The malformed shell-function witness
+remains a recovery blocker.
+
+The compact route accepts `a0-small-error` and
+`plain-assignment-control`. It falls back for the other six witnesses with
+reason `compact route declined at recovery [mechanism=recovery-entered]: did
+not accept EOF: generic scheduler has no table action for the elected token`.
+
+The forest route accepts `a0-small-error` and
+`plain-assignment-control`. It declines the other six witnesses.
+
+BitBake has a registered external scanner. It does not implement incremental
+reuse support. Every incremental route therefore reports `reuse=false`,
+`unsupported=true`, reason `external_scanner_unsupported`, zero reused
+subtrees, and zero reused bytes.
+The incremental digest equals the raw digest for every witness. It therefore
+matches C for three witnesses and preserves the five locked-C divergences.
+
+The raw, production, compact, forest, incremental, and C-oracle receipts do
+not prove native ownership. Keep dispatch.bitbake live until scheduler_action_semantics emits the locked-C shell-function tree.
+Require `scheduler_action_semantics` to emit that tree for every
+registered witness. Require exact route parity and an authenticated corpus
+before retirement. Do not change the registry or production state.
+
+The current-main Docker artifacts are:
+
+- `/tmp/gts-bitbake-audit-20260824/harness_out/docker/20260823T024229Z-bitbake-current-route-final` — route probe;
+- `/tmp/gts-bitbake-audit-20260824/harness_out/docker/20260823T024239Z-bitbake-current-document-final` — document guard;
+- `/tmp/gts-bitbake-audit-20260824/harness_out/docker/20260823T023912Z-bitbake-current-registry` — registry receipt;
+- `/tmp/gts-bitbake-audit-20260824/harness_out/docker/20260823T023919Z-bitbake-current-a0` — A0 receipt;
+- `/tmp/gts-bitbake-audit-20260824/harness_out/docker/20260823T023927Z-bitbake-current-tracked` — tracked census receipt;
+- `/tmp/gts-bitbake-audit-20260824/harness_out/docker/20260823T023935Z-bitbake-current-real-corpus` — real-corpus availability receipt.
 
 ## Ordered program
 


### PR DESCRIPTION
## Summary

- Keep `dispatch.bitbake` live.
- Record the BitBake normalization blocker and its eight route witnesses.
- Add a focused parity probe for future retirement work.
- Make no registry or production parser change.

## Decision

Status: `KEEP LIVE` / `NO-GO`.

The medium and large A0 witnesses diverge from locked C at `/recipe`. Three
constructed producer witnesses also diverge. The malformed shell-function
witness remains a recovery blocker. The authenticated real corpus is not
available.

## Validation

- Base: `9f6380a8a0795b631a0b5e3a573253977f673bf4`
- Focused Docker probe passed for all eight witnesses.
- Artifact: `/tmp/gts-bitbake-publication-20260824/harness_out/docker/20260823T025359Z-bitbake-publication-focused`
- Markdown checks passed.
- `gofmt` passed.
- `git diff --check` passed.
- Buckley change hash: `c2dc79826ec4fbaf5bf9b82719ce3e324cec6af198004de86c43fba757eb831b`

Keep issue evidence and the dispatcher arm live until the scheduler emits
the locked-C shell-function tree for every registered witness.
