### PR TITLE
docs: keep C# normalization arm live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,16 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- Record the `dispatch.c_sharp` blocker at main commit
+  `ef57c9d1b73bac046ef40f2a111bb76db643ebfd`. The A0 manifest excludes C#;
+  the tracked census records one C# fixture with 2,085 rewrites. The focused
+  probe keeps one exact positive control, but the A0 and recovery witnesses
+  still differ from locked C. Forest declines the recovery witnesses, and
+  incremental reuse remains unsupported because the grammar has an external
+  scanner. Keep the arm live. No parser or registry code changes ship. See
+  `docs/root-normalization-retirement.md` for the digests, artifacts, and
+  reopening condition.
+
 - Reject the issue #454 generic recovery candidate from PR #793. The candidate
   code and test hash is
   `71fdb2ab00f8f31e74b7e165f381c0856bd3720abdeb4d1556454d0cc75c50fa`.

--- a/cgo_harness/csharp_dispatch_blocker_receipt_test.go
+++ b/cgo_harness/csharp_dispatch_blocker_receipt_test.go
@@ -1,0 +1,448 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+type csharpDispatchWitness struct {
+	name              string
+	src               func(*testing.T) []byte
+	wantSourceSHA     string
+	wantRawDigest     string
+	wantGoDigest      string
+	wantCDigest       string
+	wantRawDiff       *DumpV1Divergence
+	wantRouteDiff     *DumpV1Divergence
+	wantCompactMode   string
+	wantForest        bool
+	wantCompactPass   bool
+	wantForestPass    bool
+	wantIncremental   bool
+	wantPassVisited   uint64
+	wantPassRewritten uint64
+	wantNative        bool
+}
+
+// TestCSharpDispatchBlockerRoutes records the live C# arm on raw, production,
+// compact, forest, incremental, and locked-C routes.
+func TestCSharpDispatchBlockerRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	witnesses := []csharpDispatchWitness{
+		{
+			name: "a0-jsontextreader", src: func(t *testing.T) []byte {
+				source, err := os.ReadFile("../testdata/parser_result/csharp/jsontextreader_excerpt.cs")
+				if err != nil {
+					t.Fatal(err)
+				}
+				return source
+			},
+			wantSourceSHA:     "d76fd62cfc90076c11d86cb7d7a0058df181231aa3b34f30e549f650b5294d4a",
+			wantRawDigest:     "b68127ae4dc6e4f18ac52af73e4c12ca97d7e4ae23166a7fc9d449cb227508dc",
+			wantGoDigest:      "6e5eb91f5577569ca2adebf26056095af492a5921ed09c72b05cba045dca57dc",
+			wantCDigest:       "17a882ecc47150a396236512827eb2dd077ff2d65d9923d79d4ba98cb0b66abf",
+			wantRawDiff:       csharpExpectedDivergence("/compilation_unit", "shape", "children=5", "children=6"),
+			wantRouteDiff:     csharpExpectedDivergence("/compilation_unit", "error", "false", "true"),
+			wantCompactMode:   "fallback",
+			wantCompactPass:   true,
+			wantIncremental:   true,
+			wantPassVisited:   2093,
+			wantPassRewritten: 2085,
+		},
+		{
+			name: "positive-simple", src: func(*testing.T) []byte {
+				return []byte("class C { public int M() { return 1; } }\n")
+			},
+			wantSourceSHA:   "a6946abc5b7086a1ba0d6cd585882b3b8a20d96b6e578351cf07ecf993964362",
+			wantRawDigest:   "58cdc6772314e0e82478a1d5811db6c8c09d939b5ac690ced9fb9695e0946ae7",
+			wantGoDigest:    "58cdc6772314e0e82478a1d5811db6c8c09d939b5ac690ced9fb9695e0946ae7",
+			wantCDigest:     "58cdc6772314e0e82478a1d5811db6c8c09d939b5ac690ced9fb9695e0946ae7",
+			wantCompactMode: "accepted",
+			wantForest:      true,
+			wantForestPass:  true,
+			wantIncremental: true,
+			wantPassVisited: 22,
+		},
+		{
+			name: "historical-issue454", src: csharpDispatchIssue454Source,
+			wantSourceSHA:   "a0de6cfb0e98995f41f1bac3931a4d0300ab8d34f68dd30843afecd9ee984711",
+			wantRawDigest:   "4e6e7e9f33ca204763aff7a4d3e8ab4aee089ad057a9515cbc37a7c9a35f49aa",
+			wantGoDigest:    "4e6e7e9f33ca204763aff7a4d3e8ab4aee089ad057a9515cbc37a7c9a35f49aa",
+			wantCDigest:     "d9ca44d4b6d5d7d555e5066a2c45fa329afb0fa237791746abe855fd31494ae4",
+			wantRawDiff:     csharpExpectedDivergence("/compilation_unit/namespace_declaration[0]/declaration_list[2]/class_declaration[1]/declaration_list[4]/method_declaration[1]/block[5]/expression_statement[1]/assignment_expression[0]/ERROR[1]/integer_literal[0]", "error", "true", "false"),
+			wantRouteDiff:   csharpExpectedDivergence("/compilation_unit/namespace_declaration[0]/declaration_list[2]/class_declaration[1]/declaration_list[4]/method_declaration[1]/block[5]/expression_statement[1]/assignment_expression[0]/ERROR[1]/integer_literal[0]", "error", "true", "false"),
+			wantCompactMode: "fallback",
+			wantCompactPass: true,
+			wantIncremental: true,
+			wantPassVisited: 57067,
+			wantNative:      true,
+		},
+		{
+			name: "malformed-missing-body", src: func(*testing.T) []byte {
+				return []byte("class C { void M() { int x = ;\n")
+			},
+			wantSourceSHA:   "86a8c9f0a2ea38797add255cbbffcbe748af3c6f465d3db989b9dffd182d4ce8",
+			wantRawDigest:   "5140aac5a98ce1a8fa774400df978fa57b87ffcbe1d66fb159a82fe0de6553e2",
+			wantGoDigest:    "5140aac5a98ce1a8fa774400df978fa57b87ffcbe1d66fb159a82fe0de6553e2",
+			wantCDigest:     "b252b21dc16f944cda8457956f65879a0222792efd936673448083a3b678aabc",
+			wantRawDiff:     csharpExpectedDivergence("/compilation_unit/ERROR[0]", "extra", "false", "true"),
+			wantRouteDiff:   csharpExpectedDivergence("/compilation_unit/ERROR[0]", "extra", "false", "true"),
+			wantCompactMode: "fallback",
+			wantCompactPass: true,
+			wantIncremental: true,
+			wantPassVisited: 19,
+		},
+	}
+
+	language := grammars.CSharpLanguage()
+	if language.ExternalScanner == nil {
+		t.Fatal("C# language has no registered external scanner")
+	}
+	if reusable, ok := language.ExternalScanner.(gotreesitter.IncrementalReuseExternalScanner); ok && reusable.SupportsIncrementalReuse() {
+		t.Fatal("C# external scanner unexpectedly supports incremental reuse")
+	}
+	cLanguage, err := COracleLanguage("c_sharp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, witness := range witnesses {
+		witness := witness
+		t.Run(witness.name, func(t *testing.T) {
+			source := witness.src(t)
+			if len(source) == 0 || source[len(source)-1] != '\n' {
+				source = append(source, '\n')
+			}
+			cTree := csharpDispatchCTree(t, cLanguage, source)
+			defer cTree.Close()
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sourceSHA := fmt.Sprintf("%x", sha256.Sum256(source))
+			if sourceSHA != witness.wantSourceSHA {
+				t.Fatalf("source SHA-256=%s, want %s", sourceSHA, witness.wantSourceSHA)
+			}
+			if cDigest != witness.wantCDigest {
+				t.Fatalf("locked-C digest=%s, want %s", cDigest, witness.wantCDigest)
+			}
+			t.Logf("witness=%s bytes=%d source_sha256=%s c_digest=%s c_error=%t", witness.name, len(source), sourceSHA, cDigest, cTree.RootNode().HasError())
+
+			rawParser := gotreesitter.NewParser(language)
+			rawParser.SetAdmissionCandidateRoute(false)
+			raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer raw.Release()
+			rawDiff := csharpDispatchAssertReceipt(t, "raw", raw, language, cTree, cDigest)
+			csharpDispatchCheckDigest(t, "raw", raw, language, witness.wantRawDigest)
+			csharpDispatchCheckDivergence(t, "raw", rawDiff, witness.wantRawDiff)
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer production.Release()
+			productionDiff := csharpDispatchAssertReceipt(t, "production", production, language, cTree, cDigest)
+			productionPass := csharpDispatchPass(production)
+			if productionPass == nil {
+				t.Fatalf("production did not record dispatch.c_sharp")
+			}
+			csharpDispatchCheckDigest(t, "production", production, language, witness.wantGoDigest)
+			csharpDispatchCheckDivergence(t, "production", productionDiff, witness.wantRouteDiff)
+			csharpDispatchCheckPass(t, "production", productionPass, true, witness.wantPassVisited, witness.wantPassRewritten)
+			if production.ParseRuntime().NativeRecoveredStructureAuthoritative != witness.wantNative {
+				t.Fatalf("production native authority=%t, want %t", production.ParseRuntime().NativeRecoveredStructureAuthoritative, witness.wantNative)
+			}
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactParser := gotreesitter.NewParser(language)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer compact.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			compactMode := csharpDispatchCompactMode(routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+			compactDiff := csharpDispatchAssertReceipt(t, "compact", compact, language, cTree, cDigest)
+			compactPass := csharpDispatchPass(compact)
+			if compactMode != witness.wantCompactMode {
+				t.Fatalf("compact mode=%s, want %s", compactMode, witness.wantCompactMode)
+			}
+			csharpDispatchCheckDigest(t, "compact", compact, language, witness.wantGoDigest)
+			csharpDispatchCheckDivergence(t, "compact", compactDiff, witness.wantRouteDiff)
+			csharpDispatchCheckPass(t, "compact", compactPass, witness.wantCompactPass, witness.wantPassVisited, witness.wantPassRewritten)
+
+			forestParser := gotreesitter.NewParser(language)
+			forest, forestOK := forestParser.ParseForestExperimental(source)
+			forestMode := "declined"
+			var forestDiff *DumpV1Divergence
+			var forestPass *gotreesitter.NormalizationPassRuntime
+			if forestOK && forest != nil {
+				defer forest.Release()
+				forestMode = "accepted"
+				forestDiff = csharpDispatchAssertReceipt(t, "forest", forest, language, cTree, cDigest)
+				forestPass = csharpDispatchPass(forest)
+				csharpDispatchCheckDigest(t, "forest", forest, language, witness.wantGoDigest)
+				csharpDispatchCheckDivergence(t, "forest", forestDiff, witness.wantRouteDiff)
+				csharpDispatchCheckPass(t, "forest", forestPass, witness.wantForestPass, witness.wantPassVisited, witness.wantPassRewritten)
+			} else if witness.wantForest {
+				t.Fatal("forest route declined")
+			}
+
+			incrementalParser := gotreesitter.NewParser(language)
+			incrementalParser.SetAdmissionCandidateRoute(false)
+			base := bytes.TrimSuffix(source, []byte{'\n'})
+			oldTree, err := incrementalParser.Parse(base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer oldTree.Release()
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(len(base)),
+				OldEndByte:  uint32(len(base)),
+				NewEndByte:  uint32(len(source)),
+				StartPoint:  csharpDispatchPoint(base),
+				OldEndPoint: csharpDispatchPoint(base),
+				NewEndPoint: csharpDispatchPoint(source),
+			})
+			incremental, profile, err := incrementalParser.ParseIncrementalProfiled(source, oldTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer incremental.Release()
+			incrementalDiff := csharpDispatchAssertReceipt(t, "incremental", incremental, language, cTree, cDigest)
+			incrementalPass := csharpDispatchPass(incremental)
+			csharpDispatchCheckDigest(t, "incremental", incremental, language, witness.wantGoDigest)
+			csharpDispatchCheckDivergence(t, "incremental", incrementalDiff, witness.wantRouteDiff)
+			csharpDispatchCheckPass(t, "incremental", incrementalPass, witness.wantIncremental, witness.wantPassVisited, witness.wantPassRewritten)
+			if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+				t.Fatalf("incremental reuse changed: unsupported=%t reason=%q old_tree=%t subtrees=%d bytes=%d", profile.ReuseUnsupported, profile.ReuseUnsupportedReason, profile.OldTreeReuseRoute, profile.ReusedSubtrees, profile.ReusedBytes)
+			}
+
+			switch witness.name {
+			case "a0-jsontextreader":
+				if productionPass.NodesRewritten != 2085 || productionPass.NodesVisited != 2093 {
+					t.Fatalf("A0 dispatch pass = visited:%d rewritten:%d, want 2093/2085", productionPass.NodesVisited, productionPass.NodesRewritten)
+				}
+				if rawDiff == nil || rawDiff.Category != "shape" || productionDiff == nil || productionDiff.Category != "error" || compactMode != "fallback" || forestOK || compactPass == nil || incrementalPass == nil || compactPass.NodesVisited != 2093 || compactPass.NodesRewritten != 2085 || incrementalPass.NodesVisited != 2093 || incrementalPass.NodesRewritten != 2085 {
+					t.Fatalf("A0 evidence changed: raw=%+v production=%+v compact=%s forest=%t", rawDiff, productionDiff, compactMode, forestOK)
+				}
+			case "positive-simple":
+				if productionPass.NodesRewritten != 0 || productionPass.NodesVisited != 22 {
+					t.Fatalf("positive dispatch pass = visited:%d rewritten:%d, want 22/0", productionPass.NodesVisited, productionPass.NodesRewritten)
+				}
+				if rawDiff != nil || productionDiff != nil || compactDiff != nil || forestDiff != nil || incrementalDiff != nil || !forestOK || compactMode != "accepted" || (compactPass != nil && compactPass.NodesRewritten != 0) || (incrementalPass != nil && incrementalPass.NodesRewritten != 0) {
+					t.Fatalf("positive control lost exact route parity: raw=%+v production=%+v compact=%+v forest=%+v incremental=%+v compact_mode=%s", rawDiff, productionDiff, compactDiff, forestDiff, incrementalDiff, compactMode)
+				}
+			case "historical-issue454":
+				if productionPass.NodesRewritten != 0 || productionPass.NodesVisited != 57067 {
+					t.Fatalf("issue-454 dispatch pass = visited:%d rewritten:%d, want 57067/0", productionPass.NodesVisited, productionPass.NodesRewritten)
+				}
+				if production.ParseRuntime().NativeRecoveredStructureAuthoritative != true || productionDiff == nil || productionDiff.Category != "error" || compactMode != "fallback" || forestOK {
+					t.Fatalf("issue-454 evidence changed: native=%t production=%+v compact=%s forest=%t", production.ParseRuntime().NativeRecoveredStructureAuthoritative, productionDiff, compactMode, forestOK)
+				}
+			case "malformed-missing-body":
+				if productionPass.NodesRewritten != 0 || productionPass.NodesVisited != 19 {
+					t.Fatalf("malformed dispatch pass = visited:%d rewritten:%d, want 19/0", productionPass.NodesVisited, productionPass.NodesRewritten)
+				}
+				if productionDiff == nil || productionDiff.Category != "extra" || compactMode != "fallback" || forestOK {
+					t.Fatalf("malformed evidence changed: production=%+v compact=%s forest=%t", productionDiff, compactMode, forestOK)
+				}
+			}
+			forestDispatch := csharpDispatchPassSummary(forestPass)
+			t.Logf("route-summary compact=%s forest=%s incremental_reuse=%t raw=%+v production=%+v compact_diff=%+v forest_diff=%+v incremental_diff=%+v production_dispatch=%s compact_dispatch=%s forest_dispatch=%s incremental_dispatch=%s", compactMode, forestMode, profile.OldTreeReuseRoute, rawDiff, productionDiff, compactDiff, forestDiff, incrementalDiff, csharpDispatchPassSummary(productionPass), csharpDispatchPassSummary(compactPass), forestDispatch, csharpDispatchPassSummary(incrementalPass))
+		})
+	}
+}
+
+func TestCSharpDispatchBlockerReceiptDocument(t *testing.T) {
+	doc, err := os.ReadFile("../docs/root-normalization-retirement.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	changelog, err := os.ReadFile("../CHANGELOG.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	docMarkers := []string{
+		"## 2026-08-24 C# dispatcher blocker receipt",
+		"Status: `NO-GO`. Keep `dispatch.c_sharp` live.",
+		"Base commit: `ef57c9d1b73bac046ef40f2a111bb76db643ebfd`.",
+		"88366631d598ce6595ec655ce1591b315cffb14c",
+		"The A0 (initial dispatcher census) manifest has 14",
+		"d76fd62cfc90076c11d86cb7d7a0058df181231aa3b34f30e549f650b5294d4a",
+		"6e5eb91f5577569ca2adebf26056095af492a5921ed09c72b05cba045dca57dc",
+		"17a882ecc47150a396236512827eb2dd077ff2d65d9923d79d4ba98cb0b66abf",
+		"a6946abc5b7086a1ba0d6cd585882b3b8a20d96b6e578351cf07ecf993964362",
+		"58cdc6772314e0e82478a1d5811db6c8c09d939b5ac690ced9fb9695e0946ae7",
+		"a0de6cfb0e98995f41f1bac3931a4d0300ab8d34f68dd30843afecd9ee984711",
+		"4e6e7e9f33ca204763aff7a4d3e8ab4aee089ad057a9515cbc37a7c9a35f49aa",
+		"d9ca44d4b6d5d7d555e5066a2c45fa329afb0fa237791746abe855fd31494ae4",
+		"86a8c9f0a2ea38797add255cbbffcbe748af3c6f465d3db989b9dffd182d4ce8",
+		"5140aac5a98ce1a8fa774400df978fa57b87ffcbe1d66fb159a82fe0de6553e2",
+		"b252b21dc16f944cda8457956f65879a0222792efd936673448083a3b678aabc",
+		"external_scanner_unsupported",
+		"2,085 dispatcher rewrites.",
+		"full authenticated corpus is unavailable",
+		"20260823T030038Z-csharp-audit-route-final-v2",
+	}
+	for _, marker := range docMarkers {
+		if !strings.Contains(string(doc), marker) {
+			t.Fatalf("retirement document lacks marker %q", marker)
+		}
+	}
+	for _, marker := range []string{
+		"Record the `dispatch.c_sharp` blocker at main commit",
+		"ef57c9d1b73bac046ef40f2a111bb76db643ebfd",
+		"Keep the arm live.",
+	} {
+		if !strings.Contains(string(changelog), marker) {
+			t.Fatalf("changelog lacks marker %q", marker)
+		}
+	}
+}
+
+func csharpExpectedDivergence(path, category, goValue, cValue string) *DumpV1Divergence {
+	return &DumpV1Divergence{Path: path, Category: category, GoValue: goValue, CValue: cValue}
+}
+
+func csharpDispatchCTree(t *testing.T, language *sitter.Language, source []byte) *sitter.Tree {
+	t.Helper()
+	parser := sitter.NewParser()
+	t.Cleanup(parser.Close)
+	if err := parser.SetLanguage(language); err != nil {
+		t.Fatal(err)
+	}
+	tree := parser.Parse(source, nil)
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("C parser returned no root")
+	}
+	return tree
+}
+
+func csharpDispatchAssertReceipt(t *testing.T, route string, tree *gotreesitter.Tree, language *gotreesitter.Language, cTree *sitter.Tree, cDigest string) *DumpV1Divergence {
+	t.Helper()
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	diff := FirstDivergenceDumpV1(tree.RootNode(), language, cTree.RootNode())
+	t.Logf("route=%s error_root=%t digest=%s c_digest=%s exact=%t rewrites=%d native_authoritative=%t divergence=%+v", route, tree.RootNode().HasError(), inspection.SHA256, cDigest, diff == nil && inspection.SHA256 == cDigest, tree.ParseRuntime().NormalizationNodesRewritten, tree.ParseRuntime().NativeRecoveredStructureAuthoritative, diff)
+	return diff
+}
+
+func csharpDispatchPass(tree *gotreesitter.Tree) *gotreesitter.NormalizationPassRuntime {
+	runtime := tree.ParseRuntime()
+	if runtime.NormalizationPasses == nil {
+		return nil
+	}
+	for i := range *runtime.NormalizationPasses {
+		pass := &(*runtime.NormalizationPasses)[i]
+		if pass.Name == "dispatch.c_sharp" {
+			return pass
+		}
+	}
+	return nil
+}
+
+func csharpDispatchPassSummary(pass *gotreesitter.NormalizationPassRuntime) string {
+	if pass == nil {
+		return "not-recorded"
+	}
+	return fmt.Sprintf("%d/%d", pass.NodesVisited, pass.NodesRewritten)
+}
+
+func csharpDispatchCheckDigest(t *testing.T, route string, tree *gotreesitter.Tree, language *gotreesitter.Language, want string) {
+	t.Helper()
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatalf("%s inspect: %v", route, err)
+	}
+	if inspection.SHA256 != want {
+		t.Fatalf("%s digest=%s, want %s", route, inspection.SHA256, want)
+	}
+}
+
+func csharpDispatchCheckDivergence(t *testing.T, route string, got, want *DumpV1Divergence) {
+	t.Helper()
+	if got == nil || want == nil {
+		if got != want {
+			t.Fatalf("%s divergence=%+v, want %+v", route, got, want)
+		}
+		return
+	}
+	if *got != *want {
+		t.Fatalf("%s divergence=%+v, want %+v", route, got, want)
+	}
+}
+
+func csharpDispatchCheckPass(t *testing.T, route string, got *gotreesitter.NormalizationPassRuntime, recorded bool, wantVisited, wantRewritten uint64) {
+	t.Helper()
+	if !recorded {
+		if got != nil {
+			t.Fatalf("%s recorded dispatch pass=%+v, want none", route, got)
+		}
+		return
+	}
+	if got == nil {
+		t.Fatalf("%s did not record dispatch.c_sharp", route)
+	}
+	if got.NodesVisited != wantVisited || got.NodesRewritten != wantRewritten {
+		t.Fatalf("%s dispatch pass=%d/%d, want %d/%d", route, got.NodesVisited, got.NodesRewritten, wantVisited, wantRewritten)
+	}
+}
+
+func csharpDispatchCompactMode(routedBefore, fallbackBefore, routedAfter, fallbackAfter uint64) string {
+	if routedAfter == routedBefore+1 && fallbackAfter == fallbackBefore {
+		return "accepted"
+	}
+	if routedAfter == routedBefore && fallbackAfter == fallbackBefore+1 {
+		return "fallback"
+	}
+	return fmt.Sprintf("counters=%d/%d->%d/%d", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+}
+
+func csharpDispatchPoint(source []byte) gotreesitter.Point {
+	var point gotreesitter.Point
+	for _, value := range source {
+		if value == '\n' {
+			point.Row++
+			point.Column = 0
+		} else {
+			point.Column++
+		}
+	}
+	return point
+}
+
+func csharpDispatchIssue454Source(t *testing.T) []byte {
+	t.Helper()
+	var source strings.Builder
+	source.Grow(137*1024 + 256)
+	source.WriteString("namespace Bench {\n")
+	for i := 0; source.Len() < 137*1024; i++ {
+		fmt.Fprintf(&source, "public static class C%d { public static int F%d() { var x%d = %d; return x%d; } }\n", i, i, i, i, i)
+	}
+	source.WriteString("}\n")
+	result := []byte(source.String())
+	site := bytes.Index(result, []byte("x0"))
+	if site < 0 {
+		t.Fatal("C# edit marker is absent")
+	}
+	return append(append([]byte(nil), result[:site]...), result[site+1:]...)
+}

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -69,6 +69,110 @@ year-directive recovery use the production fallback after that decline. The
 Ledger receipt records both forest routes and locked-C parity. Reopen Ledger
 retirement if a future witness differs on any covered route.
 
+## 2026-08-24 C# dispatcher blocker receipt
+
+Status: `NO-GO`. Keep `dispatch.c_sharp` live.
+
+Base commit: `ef57c9d1b73bac046ef40f2a111bb76db643ebfd`.
+This receipt adds one focused probe test. It changes no parser or registry
+behavior.
+
+The registry contains 88 entries. It has 31 live dispatcher arms, one live
+dispatcher predicate, and 35 live dispatcher labels. The C# entry is
+`dispatch.c_sharp`. Its function is `normalizeCSharpCompatibility` in
+`parser_result_csharp.go`. Its authoritative owner is
+`scheduler_action_semantics`. Retirement requires exact production, compact,
+forest, incremental, and locked-C output for every registered witness.
+
+The grammar lock pins C# to commit
+`88366631d598ce6595ec655ce1591b315cffb14c` in
+`grammars/languages.lock`. The A0 (initial dispatcher census) manifest has 14
+languages, 42 files, and 14 receipts. It excludes C#. The seven-fixture
+tracked census includes one C# fixture:
+`testdata/parser_result/csharp/jsontextreader_excerpt.cs`. It records one
+check, one run, 2,093 visited nodes, and 2,085 rewritten nodes.
+
+The full authenticated corpus is unavailable to the committed census.
+`cgo_harness/corpus_real` does not exist, so
+`TestDispatcherArmCensusOverRealCorpus` skips. An external C# source checkout
+exists, but it is not the committed corpus gate.
+
+The focused probe is
+`cgo_harness/csharp_dispatch_blocker_receipt_test.go`. It runs one C# grammar
+workload and records raw, production, compact, forest, incremental, and
+locked-C routes. The fresh route receipt is
+`/tmp/gts-n31a-csharp-audit/harness_out/docker/20260823T030038Z-csharp-audit-route-final-v2`.
+
+The A0 witness is `jsontextreader_excerpt.cs`. Its source SHA-256 is
+`d76fd62cfc90076c11d86cb7d7a0058df181231aa3b34f30e549f650b5294d4a`.
+The Go deep digest is
+`6e5eb91f5577569ca2adebf26056095af492a5921ed09c72b05cba045dca57dc`.
+The locked-C deep digest is
+`17a882ecc47150a396236512827eb2dd077ff2d65d9923d79d4ba98cb0b66abf`.
+The raw first divergence is at `/compilation_unit`, with five Go children and
+six C children. Production, compact, and incremental report a root error flag
+of `false` in Go and `true` in C. Production, compact, and incremental record
+2,085 dispatcher rewrites. Forest declines.
+
+The positive producer control is `class C { public int M() { return 1; } }`.
+Its source SHA-256 is
+`a6946abc5b7086a1ba0d6cd585882b3b8a20d96b6e578351cf07ecf993964362`.
+Every route matches locked C at digest
+`58cdc6772314e0e82478a1d5811db6c8c09d939b5ac690ced9fb9695e0946ae7`.
+The production, forest, and incremental dispatch passes visit 22 nodes and
+rewrite zero nodes. Compact records no compatibility pass because it accepts
+the native tree. Compact and forest accept the control.
+
+The historical issue #454 witness is 140,289 bytes. Its source SHA-256 is
+`a0de6cfb0e98995f41f1bac3931a4d0300ab8d34f68dd30843afecd9ee984711`.
+The Go digest is
+`4e6e7e9f33ca204763aff7a4d3e8ab4aee089ad057a9515cbc37a7c9a35f49aa`.
+The locked-C digest is
+`d9ca44d4b6d5d7d555e5066a2c45fa329afb0fa237791746abe855fd31494ae4`.
+The first divergence is
+`/compilation_unit/namespace_declaration[0]/declaration_list[2]/class_declaration[1]/declaration_list[4]/method_declaration[1]/block[5]/expression_statement[1]/assignment_expression[0]/ERROR[1]/integer_literal[0]`.
+Go marks the node as an error. C does not. Production marks the native
+recovered structure authoritative, but the digest still differs. The
+production, compact, and incremental dispatch passes visit 57,067 nodes
+and rewrite zero nodes. Compact and forest decline during recovery.
+
+The malformed witness is `class C { void M() { int x = ;`. Its source
+SHA-256 is
+`86a8c9f0a2ea38797add255cbbffcbe748af3c6f465d3db989b9dffd182d4ce8`.
+The Go digest is
+`5140aac5a98ce1a8fa774400df978fa57b87ffcbe1d66fb159a82fe0de6553e2`.
+The locked-C digest is
+`b252b21dc16f944cda8457956f65879a0222792efd936673448083a3b678aabc`.
+The first divergence is `/compilation_unit/ERROR[0]`; C has an extra child.
+The production, compact, and incremental dispatch passes visit 19 nodes and
+rewrite zero nodes. Compact and forest decline during recovery.
+
+Every incremental receipt reports `external_scanner_unsupported`. Each run
+uses a fresh parse, with zero reused subtrees and zero reused bytes. The C#
+external-lex-state regression passes. The `DeclaredTypeManager.cs` first-pass
+guard also passes when the external source checkout is mounted. The fresh
+isolated audit artifacts are:
+
+- `/tmp/gts-n31a-csharp-audit/harness_out/docker/20260823T030038Z-csharp-audit-route-final-v2` — route receipt;
+- `/tmp/gts-n31a-csharp-audit/harness_out/docker/20260823T030139Z-csharp-audit-document-guard` — document guard;
+- `/tmp/gts-n31a-csharp-audit/harness_out/docker/20260823T025339Z-csharp-audit-scanner` — scanner regression;
+- `/tmp/gts-n31a-csharp-audit/harness_out/docker/20260823T025346Z-csharp-audit-scanner-corpus` — mounted scanner corpus;
+- `/tmp/gts-n31a-csharp-audit/harness_out/docker/20260823T025357Z-csharp-audit-registry` — registry receipt;
+- `/tmp/gts-n31a-csharp-audit/harness_out/docker/20260823T025404Z-csharp-audit-a0` — A0 receipt;
+- `/tmp/gts-n31a-csharp-audit/harness_out/docker/20260823T025410Z-csharp-audit-tracked` — tracked receipt;
+- `/tmp/gts-n31a-csharp-audit/harness_out/docker/20260823T025418Z-csharp-audit-census` — real-corpus skip receipt.
+
+Canopy confirms the dispatcher call from
+`runLanguageResultCompatibility` to `dispatcherArmCensus`, and the C# call to
+`normalizeCSharpCompatibility`. Its recovery helpers own top-level chunks,
+namespaces, and type declarations. The probe does not prove that the generic
+scheduler emits the C tree. It therefore does not support retirement.
+
+Reopen C# retirement only after the authenticated corpus becomes available
+and every registered recovery witness matches locked C on raw, production,
+compact, forest, incremental, and C-oracle routes. Require zero dispatcher
+rewrites on the matching witnesses. Keep the registry unchanged.
+
 ## 2026-08-22 normalization checkpoint
 
 Status: NO-GO. Do not retire an entry from this checkpoint.


### PR DESCRIPTION
## Decision

Keep `dispatch.c_sharp` live. Record a NO-GO for retirement.
Ship no parser or registry change.

## Evidence

- Use the C# grammar lock at `88366631d598ce6595ec655ce1591b315cffb14c`.
- Record the A0, tracked-census, route, and locked-C results.
- Cover raw, production, compact, forest, incremental, and C-oracle routes.
- Keep the positive control exact on every accepted route.
- Record the C# recovery witnesses that diverge from locked C.
- Record external-scanner limits and zero incremental reuse.
- Record that the authenticated corpus is unavailable.

The focused Docker route guard passed at:
`/tmp/gts-n31a-csharp-audit/harness_out/docker/20260823T033033Z-csharp-live-route-rebase`.

The focused Docker document guard passed at:
`/tmp/gts-n31a-csharp-audit/harness_out/docker/20260823T033051Z-csharp-live-document-rebase`.

Both runs used one C# workload, one CPU, and `GOMAXPROCS=1`.
Both runs exited zero without an out-of-memory failure or timeout.

## Checks

- Gofmt passed for the focused probe.
- Markdown parsing passed for the two documents.
- `git diff --check` passed.
- The patch changes only the three intended files.
