### PR TITLE
Keep TypeScript dispatcher live pending parity proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,20 @@ for tags and release notes while still in `0.x`.
   `docs/compact-route-real-corpus-matrix.md` for the control, traces, and
   reopening condition.
 
+- Record the N31b TypeScript dispatcher blocker at main commit
+  `731f8a9d9440a006b2cc6b56ef5b31c0ff3b5ce7`. The tracked fixture has source
+  SHA-256 `40b4a7a06fde353d8c2b726acb16f59aab44d49d1b6257c37345c2a1f56b9fb7`.
+  It records 1,462 visited nodes and 15 rewritten nodes. The available
+  positive, typed-arrow, generic-call, and issue-544 controls match locked C
+  on the checked routes. Compact fallback remains fail closed. Incremental
+  scanner reuse remains enabled. The cap-one diagnostic exposes a typed-arrow
+  root-error divergence. The A0 manifest and authenticated corpus do not
+  include TypeScript. The generic-call selection test remains skipped. The
+  held-out webworker receipt was not rerun because its source is unavailable.
+  Keep `dispatch.typescript` live. No production code changed. See
+  `docs/root-normalization-retirement.md` for the receipt, artifacts, and
+  reopening condition.
+
 - Record the C26b Swift issue #576 conformance-list recovery blocker at main
   commit `838aba943038248529429a572c4d6d98359bd87e`. The 66-byte
   `associatedtype` witness still differs from locked C. Go emits

--- a/cgo_harness/typescript_dispatch_blocker_receipt_test.go
+++ b/cgo_harness/typescript_dispatch_blocker_receipt_test.go
@@ -1,0 +1,422 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+type typescriptDispatchWitness struct {
+	name                     string
+	source                   func(*testing.T) []byte
+	wantSourceSHA            string
+	wantDigest               string
+	wantProductionVisited    uint64
+	wantProductionRewritten  uint64
+	wantIncrementalVisited   uint64
+	wantIncrementalRewritten uint64
+	wantCompactMode          string
+	wantReusedSubtrees       uint64
+	wantReusedBytes          uint64
+}
+
+// TestTypeScriptDispatchBlockerRoutes records all required routes for the
+// live TypeScript dispatcher arm and its focused selection witnesses.
+func TestTypeScriptDispatchBlockerRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	language := grammars.TypescriptLanguage()
+	if language.ExternalScanner == nil {
+		t.Fatal("TypeScript language has no registered external scanner")
+	}
+	reusable, ok := language.ExternalScanner.(gotreesitter.IncrementalReuseExternalScanner)
+	if !ok || !reusable.SupportsIncrementalReuse() {
+		t.Fatalf("TypeScript external scanner does not support incremental reuse: %T", language.ExternalScanner)
+	}
+	t.Logf("scanner=present type=%T supports_incremental_reuse=true", language.ExternalScanner)
+
+	cLanguage, err := COracleLanguage("typescript")
+	if err != nil {
+		t.Fatal(err)
+	}
+	witnesses := []typescriptDispatchWitness{
+		{
+			name: "tracked-1462-15", source: func(t *testing.T) []byte {
+				source, err := os.ReadFile(filepath.Join("..", "cgo_harness", "corpus_structural", "typescript_sample.ts"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				return source
+			},
+			wantSourceSHA:            "40b4a7a06fde353d8c2b726acb16f59aab44d49d1b6257c37345c2a1f56b9fb7",
+			wantDigest:               "0c29d566e57e5bdee435a7c8f17578bc2b0e5ff53c8dfea720655fec2b9f7f39",
+			wantProductionVisited:    1462,
+			wantProductionRewritten:  15,
+			wantIncrementalVisited:   1462,
+			wantIncrementalRewritten: 10,
+			wantCompactMode:          "fallback",
+			wantReusedSubtrees:       406,
+			wantReusedBytes:          2289,
+		},
+		{
+			name: "positive-simple", source: func(*testing.T) []byte {
+				return []byte("const value: number = 1;\n")
+			},
+			wantSourceSHA:          "5967d633a6670814c4b5e0a8c889eb5c0e51155258d35d68a476eb1717e6e2ee",
+			wantDigest:             "1e38064181b465fdf83382149c49a085ccad8cc2a7fcefad67b187c6d87ee619",
+			wantProductionVisited:  12,
+			wantIncrementalVisited: 12,
+			wantCompactMode:        "accepted",
+			wantReusedSubtrees:     5,
+			wantReusedBytes:        18,
+		},
+		{
+			name: "typed-arrow-return", source: func(*testing.T) []byte {
+				return []byte("const f = (a: A): B => a;\n")
+			},
+			wantSourceSHA:          "8ede7d478c3201e1cbd1ba129ec7b844e71f174094be19ecaf27a2344a6d67f2",
+			wantDigest:             "6c5d7858e8ca512ff1f3082e2f4be701ce95c4741ea01ddb41e1f2d681e83d00",
+			wantProductionVisited:  21,
+			wantIncrementalVisited: 21,
+			wantCompactMode:        "fallback",
+			wantReusedSubtrees:     6,
+			wantReusedBytes:        10,
+		},
+		{
+			name: "generic-arrow-comma", source: func(*testing.T) []byte {
+				return []byte("const f = <T,>(a: T): T => a;\n")
+			},
+			wantSourceSHA:          "b0e90a18d9bdf1da875885b3ac4c0d80b0214b316f2d5ff2170023f91e62d849",
+			wantDigest:             "61aa2071bbcdba4a421c3ebff9a2fdfa3bb282c799c85deab98c26b7a2a6adc0",
+			wantProductionVisited:  27,
+			wantIncrementalVisited: 27,
+			wantCompactMode:        "fallback",
+			wantReusedSubtrees:     4,
+			wantReusedBytes:        8,
+		},
+		{
+			name: "generic-call-simple", source: func(*testing.T) []byte {
+				return []byte("foo<number>(1);\n")
+			},
+			wantSourceSHA:          "399364dd8ba692c16b2387a2954c653a75b2e52f0af88e5810bdc4d9555f1fb5",
+			wantDigest:             "5fd25b615488dd97468bc371bfb05af01b4fa13d17559c52c35246d27174739b",
+			wantProductionVisited:  14,
+			wantIncrementalVisited: 14,
+			wantCompactMode:        "fallback",
+			wantReusedSubtrees:     2,
+			wantReusedBytes:        9,
+		},
+		{
+			name: "generic-call-selection-gap", source: func(*testing.T) []byte {
+				return []byte("token() === SyntaxKind.TrueKeyword || token() === SyntaxKind.FalseKeyword ? parseTokenNode<BooleanLiteral>() : parseLiteralLikeNode(token()) as LiteralExpression\n")
+			},
+			wantSourceSHA:          "7ffd2531b611cb09cd9d47e2be4b024d8b4c5f7b98a14e9a9fa73ed882f246bb",
+			wantDigest:             "d0ba1c98d9058b3aff2795d1cf5b019a57306a6b247724f92dc961a62b802f02",
+			wantProductionVisited:  51,
+			wantIncrementalVisited: 51,
+			wantCompactMode:        "accepted",
+			wantReusedSubtrees:     9,
+			wantReusedBytes:        52,
+		},
+		{
+			name: "issue-544-structural-control", source: func(t *testing.T) []byte {
+				source, err := os.ReadFile(filepath.Join("..", "grammars", "testdata", "typescript_issue_544.ts"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				return source
+			},
+			wantSourceSHA:            "fe0ffa1df2c94d1f0ccde7d1aad3a50b90469fcfe1e98ad5812eba13c22809a4",
+			wantDigest:               "6049f72952e720eb432bad16a60ca80f541f16785f17d2ea143b5e4ac3422103",
+			wantProductionVisited:    832,
+			wantProductionRewritten:  2,
+			wantIncrementalVisited:   832,
+			wantIncrementalRewritten: 2,
+			wantCompactMode:          "fallback",
+			wantReusedSubtrees:       11,
+			wantReusedBytes:          64,
+		},
+	}
+
+	for _, witness := range witnesses {
+		witness := witness
+		t.Run(witness.name, func(t *testing.T) {
+			source := witness.source(t)
+			sourceSHA := fmt.Sprintf("%x", sha256.Sum256(source))
+			if sourceSHA != witness.wantSourceSHA {
+				t.Fatalf("source SHA-256=%s, want %s", sourceSHA, witness.wantSourceSHA)
+			}
+
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("locked-C parser returned no root")
+			}
+			t.Cleanup(cTree.Close)
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cDigest != witness.wantDigest {
+				t.Fatalf("locked-C digest=%s, want %s", cDigest, witness.wantDigest)
+			}
+
+			goLang := language
+			rawParser := gotreesitter.NewParser(goLang)
+			rawParser.SetAdmissionCandidateRoute(false)
+			raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(raw.Release)
+			typescriptDispatchAssertExact(t, "raw", raw, goLang, cTree, witness.wantDigest)
+
+			productionParser := gotreesitter.NewParser(goLang)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(production.Release)
+			typescriptDispatchAssertExact(t, "production", production, goLang, cTree, witness.wantDigest)
+			typescriptDispatchCheckPass(t, "production", production, witness.wantProductionVisited, witness.wantProductionRewritten)
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactParser := gotreesitter.NewParser(goLang)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(compact.Release)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			compactMode := typescriptDispatchCompactMode(routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+			if compactMode != witness.wantCompactMode {
+				t.Fatalf("compact mode=%s, want %s", compactMode, witness.wantCompactMode)
+			}
+			if compactMode == "fallback" && !strings.Contains(gotreesitter.AdmissionCandidateLastFallbackReason(), "scheduler-frontier-shape") {
+				t.Fatalf("compact fallback reason=%q, want scheduler-frontier-shape", gotreesitter.AdmissionCandidateLastFallbackReason())
+			}
+			typescriptDispatchAssertExact(t, "compact", compact, goLang, cTree, witness.wantDigest)
+			typescriptDispatchCheckPass(t, "compact", compact, witness.wantProductionVisited, witness.wantProductionRewritten)
+
+			forestParser := gotreesitter.NewParser(goLang)
+			forest, forestOK := forestParser.ParseForestExperimental(source)
+			if !forestOK || forest == nil {
+				t.Fatal("forest route declined for an accessible TypeScript witness")
+			}
+			t.Cleanup(forest.Release)
+			typescriptDispatchAssertExact(t, "forest", forest, goLang, cTree, witness.wantDigest)
+
+			incrementalParser := gotreesitter.NewParser(goLang)
+			incrementalParser.SetAdmissionCandidateRoute(false)
+			base := bytes.TrimSuffix(source, []byte{'\n'})
+			oldTree, err := incrementalParser.Parse(base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(oldTree.Release)
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(len(base)),
+				OldEndByte:  uint32(len(base)),
+				NewEndByte:  uint32(len(source)),
+				StartPoint:  typescriptDispatchPoint(base),
+				OldEndPoint: typescriptDispatchPoint(base),
+				NewEndPoint: typescriptDispatchPoint(source),
+			})
+			incremental, profile, err := incrementalParser.ParseIncrementalProfiled(source, oldTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(incremental.Release)
+			typescriptDispatchAssertExact(t, "incremental", incremental, goLang, cTree, witness.wantDigest)
+			typescriptDispatchCheckPass(t, "incremental", incremental, witness.wantIncrementalVisited, witness.wantIncrementalRewritten)
+			if !profile.OldTreeReuseRoute || profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" {
+				t.Fatalf("incremental reuse route changed: old_tree=%t unsupported=%t reason=%q", profile.OldTreeReuseRoute, profile.ReuseUnsupported, profile.ReuseUnsupportedReason)
+			}
+			if profile.ReusedSubtrees != witness.wantReusedSubtrees || profile.ReusedBytes != witness.wantReusedBytes {
+				t.Fatalf("incremental reuse=%d subtrees/%d bytes, want %d/%d", profile.ReusedSubtrees, profile.ReusedBytes, witness.wantReusedSubtrees, witness.wantReusedBytes)
+			}
+			t.Logf("witness=%s bytes=%d source_sha256=%s digest=%s compact=%s incremental_reuse=true reused_subtrees=%d reused_bytes=%d", witness.name, len(source), sourceSHA, witness.wantDigest, compactMode, profile.ReusedSubtrees, profile.ReusedBytes)
+		})
+	}
+}
+
+// TestTypeScriptMergeCapOneTypedArrowReceipt preserves the controlled
+// diagnostic that exposes the unresolved parser selection boundary.
+func TestTypeScriptMergeCapOneTypedArrowReceipt(t *testing.T) {
+	const source = "const f = (a: A): B => a;\n"
+	wantGoDigest := "43ea0e22e93ca342e3180c8675e86c043674bec8d056d775cffeb30f2e017a42"
+	wantCDigest := "6c5d7858e8ca512ff1f3082e2f4be701ce95c4741ea01ddb41e1f2d681e83d00"
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "1")
+	gotreesitter.ResetParseEnvConfigCacheForTests()
+	t.Cleanup(gotreesitter.ResetParseEnvConfigCacheForTests)
+
+	goLang := grammars.TypescriptLanguage()
+	cLanguage, err := COracleLanguage("typescript")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse([]byte(source), nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("locked-C parser returned no root")
+	}
+	t.Cleanup(cTree.Close)
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cDigest != wantCDigest {
+		t.Fatalf("locked-C digest=%s, want %s", cDigest, wantCDigest)
+	}
+
+	parser := gotreesitter.NewParser(goLang)
+	parser.SetAdmissionCandidateRoute(false)
+	tree, err := parser.ParseNoResultCompatibilityBenchmarkOnly([]byte(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(tree.Release)
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), goLang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.SHA256 != wantGoDigest {
+		t.Fatalf("cap-one Go digest=%s, want %s", inspection.SHA256, wantGoDigest)
+	}
+	if !tree.RootNode().HasError() {
+		t.Fatal("cap-one typed-arrow tree has no root error")
+	}
+	diff := FirstDivergenceDumpV1(tree.RootNode(), goLang, cTree.RootNode())
+	wantDiff := &DumpV1Divergence{Path: "/program", Category: "error", GoValue: "true", CValue: "false"}
+	if diff == nil || *diff != *wantDiff {
+		t.Fatalf("cap-one first divergence=%+v, want %+v", diff, wantDiff)
+	}
+	t.Logf("cap=1 source_sha256=%x go_digest=%s c_digest=%s first_divergence=%+v", sha256.Sum256([]byte(source)), inspection.SHA256, cDigest, diff)
+}
+
+// TestTypeScriptDispatchBlockerReceiptDocument guards the durable receipt.
+func TestTypeScriptDispatchBlockerReceiptDocument(t *testing.T) {
+	doc, err := os.ReadFile("../docs/root-normalization-retirement.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	changelog, err := os.ReadFile("../CHANGELOG.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	document := strings.Join(strings.Fields(string(doc)), " ")
+	for _, marker := range []string{
+		"## 2026-08-24 TypeScript dispatcher blocker receipt",
+		"Status: `KEEP LIVE / NO-GO`. Keep `dispatch.typescript` live.",
+		"Base commit: `731f8a9d9440a006b2cc6b56ef5b31c0ff3b5ce7`.",
+		"cgo_harness/typescript_dispatch_blocker_receipt_test.go",
+		"40b4a7a06fde353d8c2b726acb16f59aab44d49d1b6257c37345c2a1f56b9fb7",
+		"1,462 visited nodes, 15 rewritten nodes",
+		"The A0 (initial dispatcher census) manifest has 14 languages and 42 files.",
+		"It excludes TypeScript and TSX.",
+		"The full authenticated TypeScript and TSX corpus is unavailable.",
+		"supports_incremental_reuse=true",
+		"0c29d566e57e5bdee435a7c8f17578bc2b0e5ff53c8dfea720655fec2b9f7f39",
+		"GOT_GLR_MAX_MERGE_PER_KEY=1",
+		"The existing ternary generic-call selection test remains skipped.",
+		"webworker.generated.d.ts",
+		"was not rerun locally",
+		"Keep `dispatch.typescript` live until",
+	} {
+		marker = strings.Join(strings.Fields(marker), " ")
+		if !strings.Contains(document, marker) {
+			t.Fatalf("retirement document lacks marker %q", marker)
+		}
+	}
+	for _, marker := range []string{
+		"Record the N31b TypeScript dispatcher blocker",
+		"731f8a9d9440a006b2cc6b56ef5b31c0ff3b5ce7",
+		"Keep `dispatch.typescript` live.",
+		"No production code changed.",
+	} {
+		if !strings.Contains(string(changelog), marker) {
+			t.Fatalf("changelog lacks marker %q", marker)
+		}
+	}
+}
+
+func typescriptDispatchAssertExact(t *testing.T, route string, tree *gotreesitter.Tree, language *gotreesitter.Language, cTree *sitter.Tree, wantDigest string) {
+	t.Helper()
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatalf("%s returned no tree", route)
+	}
+	if tree.RootNode().HasError() {
+		t.Fatalf("%s returned a root error: %s", route, tree.RootNode().SExpr(language))
+	}
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatalf("%s inspect: %v", route, err)
+	}
+	if inspection.SHA256 != wantDigest {
+		t.Fatalf("%s digest=%s, want %s", route, inspection.SHA256, wantDigest)
+	}
+	if diff := FirstDivergenceDumpV1(tree.RootNode(), language, cTree.RootNode()); diff != nil {
+		t.Fatalf("%s first locked-C divergence=%+v", route, diff)
+	}
+}
+
+func typescriptDispatchCheckPass(t *testing.T, route string, tree *gotreesitter.Tree, wantVisited, wantRewritten uint64) {
+	t.Helper()
+	runtime := tree.ParseRuntime()
+	if runtime.NormalizationPasses == nil {
+		t.Fatalf("%s did not record normalization passes", route)
+	}
+	for _, pass := range *runtime.NormalizationPasses {
+		if pass.Name != "dispatch.typescript" {
+			continue
+		}
+		if pass.NodesVisited != wantVisited || pass.NodesRewritten != wantRewritten {
+			t.Fatalf("%s dispatch pass=%d/%d, want %d/%d", route, pass.NodesVisited, pass.NodesRewritten, wantVisited, wantRewritten)
+		}
+		return
+	}
+	t.Fatalf("%s did not record dispatch.typescript", route)
+}
+
+func typescriptDispatchCompactMode(routedBefore, fallbackBefore, routedAfter, fallbackAfter uint64) string {
+	if routedAfter == routedBefore+1 && fallbackAfter == fallbackBefore {
+		return "accepted"
+	}
+	if routedAfter == routedBefore && fallbackAfter == fallbackBefore+1 {
+		return "fallback"
+	}
+	return fmt.Sprintf("counters=%d/%d->%d/%d", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+}
+
+func typescriptDispatchPoint(source []byte) gotreesitter.Point {
+	var point gotreesitter.Point
+	for _, value := range source {
+		if value == '\n' {
+			point.Row++
+			point.Column = 0
+		} else {
+			point.Column++
+		}
+	}
+	return point
+}

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -173,6 +173,140 @@ and every registered recovery witness matches locked C on raw, production,
 compact, forest, incremental, and C-oracle routes. Require zero dispatcher
 rewrites on the matching witnesses. Keep the registry unchanged.
 
+## 2026-08-24 TypeScript dispatcher blocker receipt
+
+Status: `KEEP LIVE / NO-GO`. Keep `dispatch.typescript` live.
+
+Base commit: `731f8a9d9440a006b2cc6b56ef5b31c0ff3b5ce7`.
+This receipt adds one focused route test. It changes no parser or registry
+behavior.
+
+The registry entry is `dispatch.typescript`. It calls
+`normalizeTypeScriptTreeCompatibilityWithParser` in
+`parser_result_javascript_typescript.go`. Its authoritative owner is
+`derivation_election_selection`. Retirement requires exact production,
+compact, forest, incremental, and locked-C output for every registered
+witness.
+
+The grammar lock pins TypeScript and TypeScript JSX (TSX) to commit
+`75b3874edb2dc714fb1fd77a32013d0f8699989f` in
+`grammars/languages.lock`. The A0 (initial dispatcher census) manifest has 14
+languages and 42 files. It excludes TypeScript and TSX. Its parser revision is
+`3c55dca287c9dd6ed987c764b9aafd90b22281a2`. Its grammar lock digest is
+`9ddb6324afd014f6ecdd1cae3dd1ba238f1e62ce03d126e6d8b267ce34d72ecb`.
+The manifest names `corpus_sources.lock`, but that file is absent.
+
+The tracked census has seven fixtures. Its TypeScript receipt is
+`cgo_harness/corpus_structural/typescript_sample.ts`. The source SHA-256 is
+`40b4a7a06fde353d8c2b726acb16f59aab44d49d1b6257c37345c2a1f56b9fb7`.
+The receipt records one check, one run, 1,462 visited nodes, 15 rewritten
+nodes, and no error root. The 15 rewrites remain active evidence. They do not
+support retirement.
+
+The full authenticated TypeScript and TSX corpus is unavailable. Neither
+`cgo_harness/corpus_real/typescript` nor `cgo_harness/corpus_real/tsx` exists.
+The checked-in `grammars/testdata/typescript_issue_544.ts` file is a structural
+control, not an authenticated corpus receipt. The corpus manifests reference
+TypeScript paths that are not present in this worktree.
+
+The focused probe is
+`cgo_harness/typescript_dispatch_blocker_receipt_test.go`. It records raw,
+production, compact, forest, incremental, and locked-C routes. It also checks
+the TypeScript external scanner. The scanner reports
+`supports_incremental_reuse=true`.
+
+The tracked witness matches locked C on every available route. Its deep digest
+is `0c29d566e57e5bdee435a7c8f17578bc2b0e5ff53c8dfea720655fec2b9f7f39`.
+Production records `dispatch.typescript` as 1,462 visited and 15 rewritten.
+Compact declines with this fail-closed reason:
+`converged-path reduction split no-action drop lacks alternative-set coverage
+by one non-blended survivor`. Forest accepts. Incremental reuse records 406
+subtrees and 2,289 bytes. Its pass records 1,462 visited and 10 rewritten.
+
+The positive control `const value: number = 1;` matches locked C at digest
+`1e38064181b465fdf83382149c49a085ccad8cc2a7fcefad67b187c6d87ee619`.
+Production records 12 visited and zero rewritten. Compact accepts, forest
+accepts, and incremental reuse records 5 subtrees and 18 bytes.
+
+The typed-arrow control `const f = (a: A): B => a;` matches locked C at digest
+`6c5d7858e8ca512ff1f3082e2f4be701ce95c4741ea01ddb41e1f2d681e83d00` under the
+default cap. Production records 21 visited and zero rewritten. Compact falls
+back, forest accepts, and incremental reuse records 6 subtrees and 10 bytes.
+The generic-arrow comma control also matches locked C. Its production pass is
+27 visited and zero rewritten. Compact falls back and incremental reuse records
+4 subtrees and 8 bytes.
+
+The simple generic-call control matches locked C at digest
+`5fd25b615488dd97468bc371bfb05af01b4fa13d17559c52c35246d27174739b`.
+Production records 14 visited and zero rewritten. Compact falls back, forest
+accepts, and incremental reuse records 2 subtrees and 9 bytes.
+
+The existing ternary generic-call selection test remains skipped. Its direct
+route witness currently matches locked C at digest
+`d0ba1c98d9058b3aff2795d1cf5b019a57306a6b247724f92dc961a62b802f02`.
+The production pass records 51 visited and zero rewritten. Compact accepts and
+incremental reuse records 9 subtrees and 52 bytes. The skipped test still
+marks the unresolved PrecDynamic tie-break boundary.
+
+The checked-in issue-544 structural control matches locked C at digest
+`6049f72952e720eb432bad16a60ca80f541f16785f17d2ea143b5e4ac3422103`.
+Production records 832 visited and two rewritten. Compact falls back, forest
+accepts, and incremental reuse records 11 subtrees and 64 bytes.
+
+The controlled diagnostic forces `GOT_GLR_MAX_MERGE_PER_KEY=1`. It is not the
+shipping profile. The typed-arrow raw Go digest becomes
+`43ea0e22e93ca342e3180c8675e86c043674bec8d056d775cffeb30f2e017a42`.
+Locked C remains
+`6c5d7858e8ca512ff1f3082e2f4be701ce95c4741ea01ddb41e1f2d681e83d00`.
+The first divergence is `/program`, where Go has an error and C does not.
+Production records 20 visited and zero rewritten at cap one. Forest still
+returns the exact C tree. The generic-arrow comma form shows the same
+cap-one selection family. This diagnostic identifies a parser-core boundary.
+It does not prove a safe grammar-agnostic correction.
+
+The held-out `typescript/src/lib/webworker.generated.d.ts` receipt remains
+open. The 786,262-byte source fails the default 512 MiB budget with Go root
+`ERROR`, C root `program`, and child counts 330 versus 1,484. The source is
+absent from this worktree. This receipt was not rerun locally. The
+recorded threshold remains above 576 MiB and at or below 640 MiB.
+
+Canopy traces the first producer path from
+`runLanguageResultCompatibility` to `dispatcherArmCensus`, then to
+`normalizeTypeScriptTreeCompatibilityWithParser`, the fused JavaScript and
+TypeScript walk, and the TypeScript candidate collector. The route evidence
+does not show that the producer emits the C tree for the authenticated corpus.
+No safe producer or parser-core fix is proven.
+
+The focused artifacts are:
+
+- `/tmp/gts-n31b-artifacts/20260823T035236Z-n31b-registry-tracked`;
+- `/tmp/gts-n31b-artifacts/20260823T035715Z-n31b-typescript-core`;
+- `/tmp/gts-n31b-artifacts/20260823T035737Z-n31b-typescript-parser-result`;
+- `/tmp/gts-n31b-artifacts/20260823T040002Z-n31b-typescript-routes-v4`;
+- `/tmp/gts-n31b-artifacts/20260823T040319Z-n31b-typescript-cap1-gap`;
+- `/tmp/gts-n31b-artifacts/20260823T040340Z-n31b-typescript-lineage-parity`;
+- `/tmp/gts-n31b-artifacts/20260823T040347Z-n31b-typescript-grammar-gaps`;
+- `/tmp/gts-n31b-artifacts/20260823T040450Z-n31b-typescript-import-types`;
+- `/tmp/gts-n31b-artifacts/20260823T040459Z-n31b-typescript-grammar-regressions`.
+- `/tmp/gts-n31b-artifacts/20260823T041728Z-n31b-typescript-blocker-receipt-routes-v2`;
+- `/tmp/gts-n31b-artifacts/20260823T041826Z-n31b-typescript-blocker-receipt-cap1`;
+- `/tmp/gts-n31b-artifacts/20260823T041925Z-n31b-typescript-blocker-receipt-docs-v3`.
+
+Retire `dispatch.typescript` only after all of these conditions hold:
+
+1. Add `corpus_sources.lock` and authenticated TypeScript and TSX A0 receipts.
+2. Rerun every registered witness at the locked grammar revision.
+3. Prove exact raw, production, compact, forest, incremental, and locked-C
+   output for every witness and control.
+4. Preserve exact scanner reuse receipts on all incremental routes.
+5. Resolve and unskip the generic-call selection test with a
+   grammar-agnostic PrecDynamic tie-break proof.
+6. Prove typed-arrow selection without a source-specific exception.
+7. Close the default-budget webworker divergence with a safe condense design.
+
+Keep `dispatch.typescript` live until each condition passes.
+Keep the registry entry unchanged until each condition passes.
+
 ## 2026-08-22 normalization checkpoint
 
 Status: NO-GO. Do not retire an entry from this checkpoint.


### PR DESCRIPTION
## Summary

Decision: KEEP LIVE / NO-GO.

Keep `dispatch.typescript` live.

Record the N31b TypeScript normalization blocker.

Add one focused parity guard.

No parser, registry, or production code changes ship.

## Evidence

- Base commit: `731f8a9d9440a006b2cc6b56ef5b31c0ff3b5ce7`.
- The tracked fixture has SHA-256 `40b4a7a06fde353d8c2b726acb16f59aab44d49d1b6257c37345c2a1f56b9fb7`.
- The tracked census records 1,462 visited nodes and 15 rewritten nodes.
- Seven route witnesses cover raw, production, compact, forest, incremental, and locked-C output.
- The external scanner reports incremental reuse support.
- The A0 manifest has 14 languages and 42 files. It excludes TypeScript and TSX.
- The authenticated TypeScript corpus is unavailable.
- The cap-one diagnostic retains the typed-arrow root-error divergence.
- The held-out webworker source is unavailable and was not rerun.

## Validation

- Route Docker test passed.
- Cap-one Docker test passed.
- Document Docker test passed.
- `gofmt` passed.
- Markdown parsing passed.
- `git diff --check` passed.

Artifacts:

- `/tmp/gts-n31b-publish-artifacts/20260823T043231Z-n31b-publish-routes`
- `/tmp/gts-n31b-publish-artifacts/20260823T043235Z-n31b-publish-cap1`
- `/tmp/gts-n31b-publish-artifacts/20260823T043236Z-n31b-publish-docs`

The receipt records the reopening conditions.