### PR TITLE
Keep AWK dispatcher live pending corpus parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Correctness
+
+- Recorded the AWK dispatcher blocker at main commit
+  `5648911ecf509df8ec870a1214917d9e95cf54f1`. Keep `dispatch.awk` live.
+  The focused receipt proves clean raw, production, compact, forest, and
+  incremental parity. The tracked `T.gawk` fixture uses provenance commit
+  `61a7c75e225e3035390be32d635545e40d8c5faf`. The authenticated corpus lock
+  uses AWK revision `5739fd79bcfc75ba7526773d0cf634521f8aca3c`.
+  The recovery witness still differs from locked C. Ship no parser or
+  registry change. See `docs/root-normalization-retirement.md` for the
+  route receipt, failed attempts, and reopening condition.
+
 ### Performance
 
 - Recorded the P25e issue #454 fresh-profile investigation collected at

--- a/cgo_harness/awk_dispatch_blocker_receipt_test.go
+++ b/cgo_harness/awk_dispatch_blocker_receipt_test.go
@@ -1,0 +1,278 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const (
+	awkRecoveredSourceSHA = "f3dd8c811b2ad06c865fb1ad59ac0098fef57bdbb89377ac96ddb4e845f6bfba"
+	awkRecoveredRawDigest = "6d53efe8af8b1e47aaf1defa8d2a727a6bcd43c7a9fc37516c6bb2b45ad0db56"
+	awkRecoveredGoDigest  = "cead9d68f270583fa37ed19b470ca4482ce315b41a30528b7432e95a07fefee8"
+	awkRecoveredCDigest   = "bb33c51db03cf6f16c5b206ce6d47d8369e4904f86466fecd9440311e5995925"
+	awkCleanSourceSHA     = "99d1043aabedfc2a53a4d50d35fd0e5f257beb49612617c0855c37ab4baa6ec1"
+	awkCleanDigest        = "6cd4e8645947bff0604ea5131f9b2188322a021b84db5f3f7c729a76b330d5d2"
+)
+
+type awkDispatchRouteWitness struct {
+	name       string
+	source     []byte
+	sourceSHA  string
+	rawDigest  string
+	goDigest   string
+	cDigest    string
+	goChildren int
+	cChildren  int
+}
+
+// TestAWKDispatchBlockerRoutes records the live AWK arm on focused routes.
+func TestAWKDispatchBlockerRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	recovered := awkRecoveredFixture(t)
+	witnesses := []awkDispatchRouteWitness{
+		{
+			name: "clean", source: []byte("BEGIN { print 1 }\n"),
+			sourceSHA: awkCleanSourceSHA, rawDigest: awkCleanDigest, goDigest: awkCleanDigest, cDigest: awkCleanDigest,
+		},
+		{
+			name: "recovery", source: recovered,
+			sourceSHA: awkRecoveredSourceSHA, rawDigest: awkRecoveredRawDigest, goDigest: awkRecoveredGoDigest, cDigest: awkRecoveredCDigest,
+			goChildren: 408, cChildren: 338,
+		},
+	}
+
+	language := grammars.AwkLanguage()
+	if language.ExternalScanner == nil {
+		t.Fatal("AWK language has no registered external scanner")
+	}
+	scanner, ok := language.ExternalScanner.(gotreesitter.IncrementalReuseExternalScanner)
+	if !ok || !scanner.SupportsIncrementalReuse() {
+		t.Fatal("AWK scanner does not support incremental reuse")
+	}
+	stateless, ok := language.ExternalScanner.(gotreesitter.StatelessExternalScanner)
+	preserving, preservingOK := language.ExternalScanner.(gotreesitter.FailurePreservingExternalScanner)
+	if !ok || !stateless.ExternalScannerIsStateless() || !preservingOK || !preserving.PreservesStateOnScanFailure() {
+		t.Fatal("AWK scanner lost stateless or failure-preserving proof")
+	}
+	cLanguage, err := COracleLanguage("awk")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, witness := range witnesses {
+		witness := witness
+		t.Run(witness.name, func(t *testing.T) {
+			cTree := awkCTree(t, cLanguage, witness.source)
+			defer cTree.Close()
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := fmt.Sprintf("%x", sha256.Sum256(witness.source)); got != witness.sourceSHA {
+				t.Fatalf("source SHA-256=%s, want %s", got, witness.sourceSHA)
+			}
+			if cDigest != witness.cDigest {
+				t.Fatalf("locked-C digest=%s, want %s", cDigest, witness.cDigest)
+			}
+
+			rawParser := gotreesitter.NewParser(language)
+			rawParser.SetAdmissionCandidateRoute(false)
+			raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(witness.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer raw.Release()
+			awkCheckRoute(t, "raw", raw, language, cTree, cDigest, witness.rawDigest)
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(witness.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer production.Release()
+			awkCheckRoute(t, "production", production, language, cTree, cDigest, witness.goDigest)
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactParser := gotreesitter.NewParser(language)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.Parse(witness.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer compact.Release()
+			awkCheckRoute(t, "compact", compact, language, cTree, cDigest, witness.goDigest)
+			if witness.name == "recovery" {
+				routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+				if routedAfter-routedBefore != 0 || fallbackAfter-fallbackBefore != 1 {
+					t.Fatalf("recovery compact counter delta=%d/%d, want routed=0 fallback=1", routedAfter-routedBefore, fallbackAfter-fallbackBefore)
+				}
+			}
+
+			forestParser := gotreesitter.NewParser(language)
+			forest, forestOK := forestParser.ParseForestExperimental(witness.source)
+			if witness.name == "clean" {
+				if !forestOK || forest == nil {
+					t.Fatal("clean forest route declined")
+				}
+				defer forest.Release()
+				awkCheckRoute(t, "forest", forest, language, cTree, cDigest, witness.goDigest)
+			} else if forestOK || forest != nil {
+				if forest != nil {
+					forest.Release()
+				}
+				t.Fatal("recovery forest route accepted")
+			}
+
+			if witness.name == "clean" {
+				awkCheckCleanIncremental(t, language, witness.source, cLanguage)
+			}
+			if witness.goChildren > 0 {
+				if got := int(production.RootNode().ChildCount()); got != witness.goChildren {
+					t.Fatalf("production root children=%d, want %d", got, witness.goChildren)
+				}
+				if got := int(cTree.RootNode().ChildCount()); got != witness.cChildren {
+					t.Fatalf("locked-C root children=%d, want %d", got, witness.cChildren)
+				}
+				if child := production.RootNode().Child(0); child == nil || child.StartByte() != 0 || child.EndByte() != 11 {
+					t.Fatalf("production first rule span changed")
+				}
+				if child := cTree.RootNode().Child(0); child == nil || child.StartByte() != 0 || child.EndByte() != 47 {
+					t.Fatalf("locked-C first rule span changed")
+				}
+			}
+		})
+	}
+}
+
+func TestAWKDispatchBlockerReceiptDocument(t *testing.T) {
+	doc, err := os.ReadFile("../docs/root-normalization-retirement.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	changelog, err := os.ReadFile("../CHANGELOG.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, marker := range []string{
+		"## 2026-08-24 AWK dispatcher blocker receipt",
+		"Status: `KEEP LIVE / NO-GO`. Keep `dispatch.awk` live.",
+		"61a7c75e225e3035390be32d635545e40d8c5faf",
+		"5739fd79bcfc75ba7526773d0cf634521f8aca3c",
+		"f3dd8c811b2ad06c865fb1ad59ac0098fef57bdbb89377ac96ddb4e845f6bfba",
+		"6d53efe8af8b1e47aaf1defa8d2a727a6bcd43c7a9fc37516c6bb2b45ad0db56",
+		"cead9d68f270583fa37ed19b470ca4482ce315b41a30528b7432e95a07fefee8",
+		"bb33c51db03cf6f16c5b206ce6d47d8369e4904f86466fecd9440311e5995925",
+		"Both witnesses cover raw,",
+		"Only the clean witness has an incremental receipt.",
+		"Recovery incremental telemetry remains absent.",
+		"recovery incremental telemetry is recorded",
+		"The original",
+		"generated probe sources are absent",
+		"20260823T061200Z",
+		"20260823T054932Z-awk-c-routes",
+		"20260823T055314Z-awk-normalizer-order",
+	} {
+		if !strings.Contains(string(doc), marker) {
+			t.Fatalf("retirement document lacks marker %q", marker)
+		}
+	}
+	for _, marker := range []string{
+		"Recorded the AWK dispatcher blocker",
+		"Keep `dispatch.awk` live",
+		"Ship no parser or",
+		"registry change.",
+	} {
+		if !strings.Contains(string(changelog), marker) {
+			t.Fatalf("changelog lacks marker %q", marker)
+		}
+	}
+}
+
+func awkRecoveredFixture(t *testing.T) []byte {
+	t.Helper()
+	encoded, err := os.ReadFile("../testdata/awk_recovered_rule_split/T.gawk.b64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := base64.StdEncoding.DecodeString(strings.Join(strings.Fields(string(encoded)), ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(source) != 7392 || fmt.Sprintf("%x", sha256.Sum256(source)) != awkRecoveredSourceSHA {
+		t.Fatal("tracked T.gawk fixture identity changed")
+	}
+	return source
+}
+
+func awkCTree(t *testing.T, language *sitter.Language, source []byte) *sitter.Tree {
+	t.Helper()
+	parser := sitter.NewParser()
+	t.Cleanup(parser.Close)
+	if err := parser.SetLanguage(language); err != nil {
+		t.Fatal(err)
+	}
+	tree := parser.Parse(source, nil)
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("C parser returned no root")
+	}
+	return tree
+}
+
+func awkCheckRoute(t *testing.T, route string, tree *gotreesitter.Tree, language *gotreesitter.Language, cTree *sitter.Tree, cDigest, wantDigest string) {
+	t.Helper()
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.SHA256 != wantDigest {
+		t.Fatalf("%s digest=%s, want %s", route, inspection.SHA256, wantDigest)
+	}
+	diff := FirstDivergenceDumpV1(tree.RootNode(), language, cTree.RootNode())
+	exact := diff == nil && inspection.SHA256 == cDigest
+	t.Logf("route=%s bytes=%d digest=%s c_digest=%s exact=%t error_root=%t rewrites=%d divergence=%+v", route, len(tree.Source()), inspection.SHA256, cDigest, exact, tree.RootNode().HasError(), tree.ParseRuntime().NormalizationNodesRewritten, diff)
+}
+
+func awkCheckCleanIncremental(t *testing.T, language *gotreesitter.Language, source []byte, cLanguage *sitter.Language) {
+	t.Helper()
+	edited := bytes.Replace(source, []byte("print 1"), []byte("print 2"), 1)
+	if len(edited) != len(source) {
+		t.Fatal("clean edit changed source length")
+	}
+	parser := gotreesitter.NewParser(language)
+	oldTree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oldTree.Release()
+	offset := bytes.Index(source, []byte("1"))
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte: uint32(offset), OldEndByte: uint32(offset + 1), NewEndByte: uint32(offset + 1),
+		StartPoint:  gotreesitter.Point{Row: 0, Column: uint32(offset)},
+		OldEndPoint: gotreesitter.Point{Row: 0, Column: uint32(offset + 1)},
+		NewEndPoint: gotreesitter.Point{Row: 0, Column: uint32(offset + 1)},
+	})
+	incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer incremental.Release()
+	if profile.ReuseUnsupported || profile.ReusedSubtrees != 1 || profile.ReusedBytes != 18 || profile.ReparseNanos != 0 {
+		t.Fatalf("clean incremental profile=%+v", profile)
+	}
+	cTree := awkCTree(t, cLanguage, edited)
+	defer cTree.Close()
+	awkCheckRoute(t, "incremental", incremental, language, cTree, awkCleanDigest, awkCleanDigest)
+}

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -11,6 +11,91 @@ The mechanically checked compatibility inventory remains
 [`testdata/result_compat_ownership_v1.json`](../testdata/result_compat_ownership_v1.json).
 This document defines the retirement program around that inventory.
 
+## 2026-08-24 AWK dispatcher blocker receipt
+
+Status: `KEEP LIVE / NO-GO`. Keep `dispatch.awk` live.
+
+Base commit: `5648911ecf509df8ec870a1214917d9e95cf54f1`.
+This receipt adds one focused test. It changes no parser or registry behavior.
+
+The registry entry is `dispatch.awk`. It calls
+`normalizeAwkCompatibility` in `parser_result_awk.go`. Its authoritative owner
+is `scheduler_action_semantics`. Canopy confirms the dispatcher call at
+`parser_result_compat.go:125`. Retirement requires exact production, compact,
+forest, incremental, and locked-C output for every registered witness.
+
+The grammar lock pins AWK to Beaglefoot commit
+`34bbdc7cce8e803096f47b625979e34c1be38127`. The generated AWK blob SHA-256 is
+`925312ca0bc6e279602402c64700b8198c55ed949ac967ce92bae40f7f21cedf`.
+The A0 (initial dispatcher census) manifest has 14 languages and 42 files.
+It excludes AWK. Its parser revision is
+`3c55dca287c9dd6ed987c764b9aafd90b22281a2`. Its grammar-lock digest is
+`9ddb6324afd014f6ecdd1cae3dd1ba238f1e62ce03d126e6d8b267ce34d72ecb`.
+The manifest names `corpus_sources.lock`, but that file is absent from this
+worktree. The sidecar records the expected SHA-256
+`41c744279c8b1d7c9fe7b1b8e26fba733423e77cd48efea46927309c22d163ea`.
+
+The tracked census has seven fixtures. It has no AWK fixture. The outline
+baseline has 206 languages. AWK is T4, with no tags query, smoke capture, or
+recorded real corpus. The external AWK checkout has 454 files, including 316
+files under `testdir`. It is pinned by the authenticated lock at
+`5739fd79bcfc75ba7526773d0cf634521f8aca3c`.
+
+The tracked fixture is
+`testdata/awk_recovered_rule_split/T.gawk.b64`. Its decoded source is 7,392
+bytes with SHA-256
+`f3dd8c811b2ad06c865fb1ad59ac0098fef57bdbb89377ac96ddb4e845f6bfba`.
+The fixture comment and the top-50 manifest cite provenance commit
+`61a7c75e225e3035390be32d635545e40d8c5faf`. That commit is distinct from the
+authenticated corpus-lock revision. The current external `testdir/T.gawk`
+has the same bytes and SHA-256.
+
+The focused test is
+`cgo_harness/awk_dispatch_blocker_receipt_test.go`. Both witnesses cover raw,
+production, compact, forest, and locked-C routes.
+Only the clean witness has an incremental receipt. Recovery incremental telemetry remains absent. The clean source is 18 bytes with SHA-256
+`99d1043aabedfc2a53a4d50d35fd0e5f257beb49612617c0855c37ab4baa6ec1`.
+Every clean route has digest
+`6cd4e8645947bff0604ea5131f9b2188322a021b84db5f3f7c729a76b330d5d2`.
+The clean incremental route reuses one subtree and 18 bytes with zero
+reported reparse time. The AWK external scanner is stateless, preserves state
+on scan failure, and supports incremental reuse.
+
+The recovery raw Go digest is
+`6d53efe8af8b1e47aaf1defa8d2a727a6bcd43c7a9fc37516c6bb2b45ad0db56`.
+Production and compact digest to
+`cead9d68f270583fa37ed19b470ca4482ce315b41a30528b7432e95a07fefee8`.
+Locked C digests to
+`bb33c51db03cf6f16c5b206ce6d47d8369e4904f86466fecd9440311e5995925`.
+The first divergence is at `/program`, where raw Go has 454 children and
+locked C has 338. Production and compact have 408 children. The first deep
+span differs at `rule[0:11]` in Go and `rule[0:47]` in C. Compact falls back
+to production because the fresh full runner does not accept end of file.
+The forest route declines. The raw-to-production digest change records live
+compatibility work; route telemetry `rewrites=0` does not mean zero
+normalizer rewrites.
+
+Docker used image `gotreesitter/cgo-harness:go1.25-local`, 4 GiB memory, one
+CPU, 4,096 PIDs, `GOMAXPROCS=1`, `GOFLAGS=-p=1`, and `GOMEMLIMIT=3GiB`.
+The successful artifacts are:
+
+- `/tmp/gts-n31d-awk-receipt-draft/harness_out/docker/20260823T061200Z`
+- `/tmp/gts-n31d-awk-receipt-draft/harness_out/docker/20260823T061046Z`
+- `/tmp/gts-n31d-awk-receipt-draft/harness_out/docker/20260823T061107Z`
+
+These artifacts completed without timeout or out-of-memory failure. The original
+generated probe sources are absent. The following failed attempts remain
+excluded from the successful receipt:
+
+- `/tmp/gts-n31d-artifacts/20260823T054932Z-awk-c-routes` failed at probe compilation.
+- `/tmp/gts-n31d-artifacts/20260823T055314Z-awk-normalizer-order` failed at test setup.
+
+No safe grammar-agnostic correction follows from one recovery mismatch. Keep
+the arm live until the authenticated AWK corpus enters the A0 and tracked
+coverage, recovery incremental telemetry is recorded, and every registered
+witness matches locked C on all required routes. Then trace the correction to
+scheduler action semantics. Ship no parser or registry change.
+
 ## End state
 
 The root is clean when all of the following are true:


### PR DESCRIPTION
## Summary

Keep `dispatch.awk` live. Record the N31d AWK blocker receipt.

The receipt adds one focused parity and document guard test. It records clean and recovery witnesses against locked C. Both witnesses cover raw, production, compact, forest, and locked-C routes. Only the clean witness has an incremental receipt. Recovery incremental telemetry remains absent.

The result is `KEEP LIVE / NO-GO`. No parser or registry change ships.

## Validation

- Run `gofmt` on the focused test.
- Pass the Docker Markdown parser check.
- Pass the Docker document guard.
- Pass `git diff --check`.

The exact scope is `CHANGELOG.md`, `docs/root-normalization-retirement.md`, and `cgo_harness/awk_dispatch_blocker_receipt_test.go`. Do not merge this receipt until the authenticated corpus and recovery incremental proof satisfy the reopening condition.