### PR TITLE
Improve GSS entry hash dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,11 @@ for tags and release notes while still in `0.x`.
 - Removed duplicate dynamic-precedence dispatch in `gssEntryHash` while
   preserving semantics. The primary trio changed by `+0.16%` for full parsing,
   `+0.21%` for single-byte edits, and `-3.86%` for no-edit parsing. Its
-  geomean changed by `-1.18%`. Bytes per operation and allocations per
-  operation stayed unchanged. The real `grammargen_lr` run improved by
-  `-3.13%` (`p=0.004`, `n=20`). The three-sample RSS medians were `615840`
-  and `593760 KiB` (`-3.59%`). The candidate has two `157 allocs/op`
+  geometric mean (geomean) changed by `-1.18%`. Bytes per operation and
+  allocations per operation stayed unchanged. The real `grammargen_lr` run
+  improved by `-3.13%` (`p=0.004`, `n=20`). The three-sample maximum resident
+  set size (RSS) medians were `615840 KiB` and `593760 KiB` (`-3.59%`). The
+  candidate has two `157 allocs/op`
   outliers; other samples report `156 allocs/op`. Focused Go, locked-C, hash,
   merge, forest, raw-shape, and incremental gates passed. The P25e profile
   supplies attribution. Its SHA-256 is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- Removed duplicate dynamic-precedence dispatch in `gssEntryHash` while
+  preserving semantics. The primary trio changed by `+0.16%` for full parsing,
+  `+0.21%` for single-byte edits, and `-3.86%` for no-edit parsing. Its
+  geomean changed by `-1.18%`. Bytes per operation and allocations per
+  operation stayed unchanged. The real `grammargen_lr` run improved by
+  `-3.13%` (`p=0.004`, `n=20`). The three-sample RSS medians were `615840`
+  and `593760 KiB` (`-3.59%`). The candidate has two `157 allocs/op`
+  outliers; other samples report `156 allocs/op`. Focused Go, locked-C, hash,
+  merge, forest, raw-shape, and incremental gates passed. The P25e profile
+  supplies attribution. Its SHA-256 is
+  `96bead7a8c448a597e4986839b000b602a08bf72b5ffaa5685fa72dcc432715c`.
+  Exclude the failed `20260823T061724Z` runtime probe. No accepted run timed
+  out or exhausted memory. Keep issue #454 open. See
+  `docs/perf-attribution.md` for the evidence base and validation artifacts.
+
 - Recorded the P25e issue #454 fresh-profile investigation collected at
   evidence base `14f6692fac65eab817f65af8cc6072e423ca6563` and published
   from main commit `2b755f744aef8dd253a4415ca4a5816fa85b0dbb`. The workload

--- a/docs/perf-attribution.md
+++ b/docs/perf-attribution.md
@@ -10,6 +10,91 @@ published receipt.
 This is measurement infrastructure only. It changes no parser code, no
 routing, and no shipped behavior.
 
+## 2026-08-24 P25f GSS entry hash candidate
+
+Status: **CANDIDATE ACCEPTED FOR REVIEW**. Keep issue #454 open.
+
+The publication base is main commit
+`5e307cb2509fa5b4c6b0e50aba7454f5ec6748a3`.
+The performance evidence uses base commit
+`f0904533b6398775d5df5e01bc34d32feee34900`.
+
+The candidate changes only `glr_gss.go`. It removes duplicate dynamic-
+precedence dispatch in `gssEntryHash`. The switch reads the same field for
+`Node`, `noTreeNode`, `compactFullLeaf`, and `pendingParent` entries. Nil and
+unknown entries keep the existing sentinel path. The raw diff SHA-256 is
+`7ba71f7d82f3273e7c1028ea23034bfffb18ba1fb2e42714713e8e1566edb5c3`.
+
+### Performance receipt
+
+The primary trio used one Go grammar and 20 sequential seeds. Each seed used
+one process, `GOMAXPROCS=1`, `GOFLAGS=-p=1`, `-count=1`, `-benchtime=750ms`,
+`-benchmem`, and its own shuffle seed. Docker used one CPU, four GiB of
+memory, and `GOMEMLIMIT=3GiB`.
+
+| Benchmark | Candidate change | Result |
+|---|---:|---|
+| Full parse | `+0.16%` | neutral (`p=0.718`, `n=20`) |
+| Incremental single-byte edit | `+0.21%` | neutral (`p=0.473`, `n=20`) |
+| Incremental no-edit | `-3.86%` | significant (`p=0.000`, `n=20`) |
+| Trio geomean | `-1.18%` | — |
+
+Bytes per operation and allocations per operation stayed unchanged. Full
+parses used `53.67 KiB/op` and four allocations. Both incremental lanes used
+zero bytes and zero allocations. The primary raw outputs are:
+
+- `/tmp/gts-p25f-baseline/p25f-primary-baseline-final.txt`
+- `/tmp/gts-p25f-candidate/p25f-primary-candidate-final.txt`
+
+The real `grammargen_lr` run improved by `-3.13%` (`p=0.004`, `n=20`).
+Bytes per operation were effectively neutral. The candidate reported `157`
+allocations in two samples. Its other samples reported `156` allocations.
+
+The three-sample RSS medians were `615840 KiB` for the baseline and `593760
+KiB` for the candidate. The median change was `-3.59%`.
+
+- Baseline RSS: `/tmp/gts-p25f-baseline/harness_out/docker/20260823T063727Z-p25f-rss-baseline-repeat`
+- Candidate RSS: `/tmp/gts-p25f-candidate/harness_out/docker/20260823T063750Z-p25f-rss-candidate-repeat`
+
+The one-sample P25f values were `602720 KiB` for the baseline and `595040 KiB`
+for the candidate. No accepted run timed out or exhausted memory.
+
+### Attribution and correctness
+
+The P25e CPU profile supplies the candidate attribution. It was collected at
+base commit `14f6692fac65eab817f65af8cc6072e423ca6563`. Its SHA-256 is
+`96bead7a8c448a597e4986839b000b602a08bf72b5ffaa5685fa72dcc432715c`.
+The profile path is
+`/tmp/gts-p25e-investigation/harness_out/p25e-real-go-grammargen.pprof`.
+The profile reports `gssEntryHash` at `3.67%` flat CPU and `7.35%` cumulative
+CPU. P25f did not create a new CPU profile. Keep this provenance explicit.
+
+The accepted correctness artifacts are:
+
+- `/tmp/gts-p25f-artifacts/20260823T061027Z-p25f-candidate-correctness`
+- `/tmp/gts-p25f-artifacts/20260823T061054Z-p25f-candidate-locked-c`
+- `/tmp/gts-p25f-artifacts/20260823T061605Z-p25f-candidate-path-tests`
+
+The current-main reruns passed at:
+
+- `/tmp/gts-p25f-publication-20260824/harness_out/docker/20260823T064341Z-p25f-publication-go-correctness`
+- `/tmp/gts-p25f-publication-20260824/harness_out/docker/20260823T064348Z-p25f-publication-go-locked-c`
+- `/tmp/gts-p25f-publication-20260824/harness_out/docker/20260823T064403Z-p25f-publication-path-tests`
+
+The focused path tests cover hash semantics, dynamic precedence, linear and
+forked GSS paths, materialization, raw-shape handling, forest parsing, and
+incremental parsing. The candidate and baseline runtime probes report the
+same accepted parse, budget, retry, recovery, stack, node, arena, scratch,
+and GSS telemetry.
+
+The initial candidate runtime probe failed because it referenced unavailable
+`ParseRuntime` fields. Exclude its artifact:
+`/tmp/gts-p25f-artifacts/20260823T061724Z-p25f-candidate-runtime`.
+The corrected candidate probe passed at
+`/tmp/gts-p25f-artifacts/20260823T061757Z-p25f-candidate-runtime`.
+
+Keep issue #454 open. Review the candidate on current main before merge.
+
 ## 2026-08-23 P25e one-Go-grammar fresh-profile evidence receipt
 
 Status: **KEEP ISSUE #454 LIVE / NO-GO**. Ship no candidate code.

--- a/docs/perf-attribution.md
+++ b/docs/perf-attribution.md
@@ -10,7 +10,7 @@ published receipt.
 This is measurement infrastructure only. It changes no parser code, no
 routing, and no shipped behavior.
 
-## 2026-08-24 P25f GSS entry hash candidate
+## 2026-08-24 P25f graph-structured stack (GSS) entry hash candidate
 
 Status: **CANDIDATE ACCEPTED FOR REVIEW**. Keep issue #454 open.
 
@@ -37,7 +37,7 @@ memory, and `GOMEMLIMIT=3GiB`.
 | Full parse | `+0.16%` | neutral (`p=0.718`, `n=20`) |
 | Incremental single-byte edit | `+0.21%` | neutral (`p=0.473`, `n=20`) |
 | Incremental no-edit | `-3.86%` | significant (`p=0.000`, `n=20`) |
-| Trio geomean | `-1.18%` | — |
+| Trio geometric mean (geomean) | `-1.18%` | — |
 
 Bytes per operation and allocations per operation stayed unchanged. Full
 parses used `53.67 KiB/op` and four allocations. Both incremental lanes used
@@ -50,8 +50,9 @@ The real `grammargen_lr` run improved by `-3.13%` (`p=0.004`, `n=20`).
 Bytes per operation were effectively neutral. The candidate reported `157`
 allocations in two samples. Its other samples reported `156` allocations.
 
-The three-sample RSS medians were `615840 KiB` for the baseline and `593760
-KiB` for the candidate. The median change was `-3.59%`.
+The three-sample maximum resident set size (RSS) medians were `615840 KiB` for
+the baseline and `593760 KiB` for the candidate. The median change was
+`-3.59%`.
 
 - Baseline RSS: `/tmp/gts-p25f-baseline/harness_out/docker/20260823T063727Z-p25f-rss-baseline-repeat`
 - Candidate RSS: `/tmp/gts-p25f-candidate/harness_out/docker/20260823T063750Z-p25f-rss-candidate-repeat`

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -580,6 +580,7 @@ func gssEntryHash(prev uint64, entry stackEntry) uint64 {
 	var productionID uint16
 	var childCount int
 	var flags nodeFlags
+	var dynamicPrecedence int32
 
 	switch entry.kind {
 	case stackEntryKindNode:
@@ -592,6 +593,7 @@ func gssEntryHash(prev uint64, entry stackEntry) uint64 {
 		productionID = n.productionID
 		childCount = nodeChildCountNoMaterialize(n)
 		flags = n.flags
+		dynamicPrecedence = n.dynamicPrecedence
 	case stackEntryKindNoTreeNode:
 		n := (*noTreeNode)(entry.node)
 		symbol = n.symbol
@@ -601,6 +603,7 @@ func gssEntryHash(prev uint64, entry stackEntry) uint64 {
 		preGotoState = n.preGotoState
 		productionID = n.productionID
 		flags = n.flags
+		dynamicPrecedence = n.dynamicPrecedence
 	case stackEntryKindCompactFullLeaf:
 		n := (*compactFullLeaf)(entry.node)
 		symbol = n.symbol
@@ -610,6 +613,7 @@ func gssEntryHash(prev uint64, entry stackEntry) uint64 {
 		preGotoState = n.preGotoState
 		productionID = n.productionID
 		flags = n.flags
+		dynamicPrecedence = n.dynamicPrecedence
 	case stackEntryKindPendingParent:
 		n := (*pendingParent)(entry.node)
 		symbol = n.symbol
@@ -620,6 +624,7 @@ func gssEntryHash(prev uint64, entry stackEntry) uint64 {
 		productionID = n.productionID
 		childCount = n.childEntryCount()
 		flags = n.flags
+		dynamicPrecedence = n.dynamicPrecedence
 	default:
 		h ^= gssNilNodeSentinel
 		h *= gssHashPrime
@@ -638,7 +643,7 @@ func gssEntryHash(prev uint64, entry stackEntry) uint64 {
 	h *= gssHashPrime
 	h ^= uint64(childCount)
 	h *= gssHashPrime
-	h ^= uint64(uint32(stackEntryDynamicPrecedence(entry)))
+	h ^= uint64(uint32(dynamicPrecedence))
 	h *= gssHashPrime
 	h ^= gssEntryFlagHash(flags)
 	h *= gssHashPrime


### PR DESCRIPTION
## Summary

- Remove duplicate dynamic-precedence dispatch in `gssEntryHash` while preserving semantics.
- Keep issue #454 open for the remaining correctness proof.

## Performance evidence

- The 20-seed primary trio changed by +0.16% for full parsing, +0.21% for single-byte edits, and -3.86% for no-edit parsing. The geometric mean (geomean) changed by -1.18%.
- Bytes per operation and allocations per operation stayed unchanged.
- The real `grammargen_lr` run improved by -3.13% (`p=0.004`, `n=20`). Two samples reported 157 allocations per operation. Other samples reported 156.
- Three-sample maximum resident set size (RSS) medians changed from 615840 KiB to 593760 KiB (-3.59%). No accepted run timed out or exhausted memory.

## Validation

- Current-main Docker gates passed for focused Go correctness, locked-C Go parity, and hash, merge, forest, raw-shape, and incremental paths.
- Markdown parsing, `gofmt`, and `git diff --check` passed.
- The P25e profile supplies attribution. Its SHA-256 is `96bead7a8c448a597e4986839b000b602a08bf72b5ffaa5685fa72dcc432715c`. P25f did not create a new CPU profile.
- The failed runtime probe `20260823T061724Z` is excluded. The corrected runtime probe passed.

## Scope

This PR changes exactly `glr_gss.go`, `CHANGELOG.md`, and `docs/perf-attribution.md`. It adds no grammar change. The P25f candidate is ready for review. Do not merge until the remaining issue #454 correctness proof is accepted.