### PR TITLE
improve(glr): Improve gssEntryHash parity tests and attribution metadata

### DIFF
--- a/docs/perf-attribution.md
+++ b/docs/perf-attribution.md
@@ -118,7 +118,7 @@ incremental behavior, and locked-C parity before another benchmark campaign.
 
 The receipt records no accepted candidate. It records no production code.
 
-## 2026-08-24 P25f graph-structured stack (GSS) entry hash candidate
+## 2026-08-23 P25f graph-structured stack (GSS) entry hash candidate
 
 Status: **CANDIDATE ACCEPTED FOR REVIEW**. Keep issue #454 open.
 
@@ -132,6 +132,14 @@ precedence dispatch in `gssEntryHash`. The switch reads the same field for
 `Node`, `noTreeNode`, `compactFullLeaf`, and `pendingParent` entries. Nil and
 unknown entries keep the existing sentinel path. The raw diff SHA-256 is
 `7ba71f7d82f3273e7c1028ea23034bfffb18ba1fb2e42714713e8e1566edb5c3`.
+Use this command to reproduce the digest:
+
+```sh
+git -c core.abbrev=8 diff --no-ext-diff --no-color --binary 5133fcd1^ 5133fcd1 -- glr_gss.go | sha256sum
+```
+
+This command produces the recorded
+`7ba71f7d82f3273e7c1028ea23034bfffb18ba1fb2e42714713e8e1566edb5c3` digest.
 
 ### Performance receipt
 

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -397,18 +397,61 @@ func TestGSSEntryHashMatchesAccessorSemantics(t *testing.T) {
 		childRange: newPendingChildRange(0, 0, 3),
 	}
 
-	entries := []stackEntry{
-		{state: 1},
-		newStackEntryNode(2, node),
-		newStackEntryNoTreeNode(3, noTree),
-		newStackEntryCompactFullLeaf(4, compactLeaf),
-		newStackEntryPendingParent(5, pending),
+	builders := []struct {
+		kind  string
+		build func(dynamicPrecedence int32) stackEntry
+	}{
+		{"Node", func(p int32) stackEntry {
+			n := *node
+			n.dynamicPrecedence = p
+			return newStackEntryNode(2, &n)
+		}},
+		{"noTreeNode", func(p int32) stackEntry {
+			n := *noTree
+			n.dynamicPrecedence = p
+			return newStackEntryNoTreeNode(3, &n)
+		}},
+		{"compactFullLeaf", func(p int32) stackEntry {
+			n := *compactLeaf
+			n.dynamicPrecedence = p
+			return newStackEntryCompactFullLeaf(4, &n)
+		}},
+		{"pendingParent", func(p int32) stackEntry {
+			n := *pending
+			n.dynamicPrecedence = p
+			return newStackEntryPendingParent(5, &n)
+		}},
 	}
-	for _, entry := range entries {
-		got := gssEntryHash(gssHashSeed, entry)
-		want := gssEntryHashViaAccessors(gssHashSeed, entry)
-		if got != want {
-			t.Fatalf("gssEntryHash(%+v) = %d, want %d", entry, got, want)
+
+	cases := []struct {
+		name       string
+		precedence int32
+	}{
+		{"zero", 0},
+		{"positive-9", 9},
+		{"negative-9", -9},
+	}
+
+	nilEntry := stackEntry{state: 1}
+	got := gssEntryHash(gssHashSeed, nilEntry)
+	want := gssEntryHashViaAccessors(gssHashSeed, nilEntry)
+	if got != want {
+		t.Fatalf("nil entry: direct hash = %d, want accessor hash = %d", got, want)
+	}
+
+	for _, b := range builders {
+		zeroEntry := b.build(0)
+		zeroHash := gssEntryHash(gssHashSeed, zeroEntry)
+		for _, tc := range cases {
+			entry := b.build(tc.precedence)
+			got := gssEntryHash(gssHashSeed, entry)
+			want := gssEntryHashViaAccessors(gssHashSeed, entry)
+			if got != want {
+				t.Fatalf("%s %s: direct hash = %d, want accessor hash = %d", b.kind, tc.name, got, want)
+			}
+			if tc.precedence != 0 && got == zeroHash {
+				t.Fatalf("%s %s: hash = %d equals %s zero-precedence hash = %d", b.kind, tc.name, got, b.kind, zeroHash)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Strengthen the P25f graph-structured stack hash proof. Keep issue #454 open.

## Changes

- Check accessor equivalence for all four stack payload kinds.
- Cover zero, positive, and negative dynamic precedence values.
- Prove that nonzero precedence changes each payload hash.
- Correct the P25f evidence date.
- Record the exact raw-diff digest command.

## Validation

- The two focused GSS hash tests passed in the repository Docker wrapper.
- The rebased run exited zero. It did not exhaust memory or reach the wall timeout.
- The documented command reproduces SHA-256 7ba71f7d82f3273e7c1028ea23034bfffb18ba1fb2e42714713e8e1566edb5c3.
- git diff --check passed.
- Narrow Canopy analysis reports no new complexity hotspot.

This pull request changes tests and evidence only. It does not close the issue #454 correctness gate.