### PR TITLE
test(cgo_harness): execute Dart live-arm ratchet in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -914,11 +914,13 @@ jobs:
       - name: CGo Parity Smoke Gate
         # TestOutlineOracleDifferential (cgo_harness/outline_differential_test.go)
         # joined this regex next to its query/capture-parity sibling
-        # TestParityHighlight. Every cgo parity lane in this file runs a
-        # FIXED --run regex, so a new cgo test runs nowhere unless it is
-        # named here; see docs/ci-gate-coverage.md. Its CoreNine subtest
-        # hard-gates the nine core languages; its FleetCensus subtest only
-        # logs a census row, so naming the whole test is safe.
+        # TestParityHighlight. The Dart live-arm probe and receipt guard are
+        # also named explicitly so their blocker receipt remains executable.
+        # Every cgo parity lane in this file runs a FIXED --run regex, so a
+        # new cgo test runs nowhere unless it is named here; see
+        # docs/ci-gate-coverage.md. Its CoreNine subtest hard-gates the nine
+        # core languages; its FleetCensus subtest only logs a census row, so
+        # naming the whole test is safe.
         run: |
           GTS_PARITY_MODE=smoke \
           bash cgo_harness/docker/run_parity_in_docker.sh \
@@ -930,7 +932,7 @@ jobs:
             --goflags -p=1 \
             --test-parallel 1 \
             --timeout 20m \
-            --run '^TestParityFreshParse$|^TestParityIncrementalParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$|^TestParityGLRCanaryGo$|^TestParityGLRCanarySet$|^TestParityGLRCapPressureTopLanguages$|^TestParityGateCoverageRatchet$|^TestParityHighlight$|^TestOutlineOracleDifferential$|^TestParityJavaScriptAutomaticSemicolonBeforeTrailingComment$|^TestParityJavaScriptAdjacentBlockCommentsDoNotConsumeFollowingToken$|^TestIncludedRangesGoRootParity$|^TestIncludedRangesGoArmGuardsRootSymbol$|^TestIncludedRangesKotlinRootParity$'
+            --run '^TestParityFreshParse$|^TestParityIncrementalParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$|^TestParityGLRCanaryGo$|^TestParityGLRCanarySet$|^TestParityGLRCapPressureTopLanguages$|^TestParityGateCoverageRatchet$|^TestParityHighlight$|^TestOutlineOracleDifferential$|^TestParityJavaScriptAutomaticSemicolonBeforeTrailingComment$|^TestParityJavaScriptAdjacentBlockCommentsDoNotConsumeFollowingToken$|^TestIncludedRangesGoRootParity$|^TestIncludedRangesGoArmGuardsRootSymbol$|^TestIncludedRangesKotlinRootParity$|^TestDartNextLiveArmProbe$|^TestDartNextLiveArmReceiptDocument$'
 
   parity-cgo-exhaustive:
     needs: exhaustive_parity_scope

--- a/cgo_harness/dart_next_live_probe_test.go
+++ b/cgo_harness/dart_next_live_probe_test.go
@@ -332,6 +332,9 @@ func TestDartNextLiveArmProbe(t *testing.T) {
 			if profile.OldTreeReuseRoute != witness.incrementalReuse || profile.ReuseUnsupported != witness.incrementalUnsupported {
 				t.Fatalf("incremental reuse=%t unsupported=%t, want reuse=%t unsupported=%t (reason=%q)", profile.OldTreeReuseRoute, profile.ReuseUnsupported, witness.incrementalReuse, witness.incrementalUnsupported, profile.ReuseUnsupportedReason)
 			}
+			if profile.OldTreeReuseRoute && (profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0) {
+				t.Fatalf("incremental reuse route reported no material reuse: subtrees=%d bytes=%d", profile.ReusedSubtrees, profile.ReusedBytes)
+			}
 			assertDartNextRoute(t, "incremental", incremental, language, cTree, cDigest, witness.incrementalDigest, witness.incrementalRewrites, witness.productionDivergencePath, witness.productionDivergenceCat, true)
 			t.Logf("route=incremental reuse=%t unsupported=%t reason=%q reused_subtrees=%d reused_bytes=%d %s", profile.OldTreeReuseRoute, profile.ReuseUnsupported, profile.ReuseUnsupportedReason, profile.ReusedSubtrees, profile.ReusedBytes, dartNextReceipt(incremental, language, cTree, cDigest))
 		})

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -2001,7 +2001,7 @@ document guard used the same limits and passed with no out-of-memory kill or
 wall timeout. Its maximum resident set size was 231520 KiB.
 
 
-## 2026-08-24 Dart dispatcher blocker receipt
+## 2026-08-23 Dart dispatcher blocker receipt
 
 Status: `KEEP LIVE / NO-GO`. Keep `dispatch.dart` live.
 The Dart arm remains live.


### PR DESCRIPTION
## Why

PR #820 merged after its existing checks passed, but the fixed parity-cgo regex compiled without executing either new Dart ratchet. This follow-up makes that receipt executable and tightens its reuse claim.

## Changes

- Add both Dart live-arm tests to the parity-cgo fixed regex.
- Require a claimed incremental reuse route to report nonzero reused subtrees and bytes.
- Correct the Dart receipt date to the evidence date.

## Validation

- actionlint .github/workflows/ci.yml
- Exact amended parity regex: PASS, 1m57s, 523288 KiB max RSS, no timeout/OOM.
- Amended focused Docker run: PASS, 4.46s, 273440 KiB max RSS, no timeout/OOM.
- No parser, grammar, registry, or production code changes.

Commit created and pushed through Buckley commit runtime using the Codex backend; no OpenRouter call.