### PR TITLE
feat(scanner): add default-off checkpoint identity foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,31 @@ for tags and release notes while still in `0.x`.
   `docs/compact-route-real-corpus-matrix.md` for identities, traces, routes,
   and reopening conditions.
 
+- Accepted the C26l default-off external-scanner checkpoint foundation at
+  evidence and publication base
+  `929609ccde78b0c9f4e57cf2225e0ae1204149cb`. The opt-in API
+  requires stable, non-empty scanner and grammar identities. It accepts only
+  identities of at most 256 bytes and complete, non-empty serialized state.
+  It owns source position, lexer state, token span, identity, and serialized
+  bytes. It deep-copies state and fails closed on missing capability,
+  incomplete state, inverted spans, or identity mismatch. The API has zero
+  production call sites. It does not change parser, grammar,
+  Swift, generalized LR (GLR), recovery, merge, or incremental behavior.
+  Restore verifies the serialized payload after `Deserialize` and fails closed
+  on any length or byte mismatch. Callers must discard a payload after failed
+  verification.
+  Synthetic lifecycle tests cover capture, fork, merge, recovery transfer,
+  failed-scan restore, overlong-record rejection, restore verification
+  mismatch, external-scanner use, and scanner-free off mode. The
+  focused Docker run used
+  one central processing unit (CPU), 4 GiB, `GOMEMLIMIT=3GiB`, `GOFLAGS=-p=1`,
+  and `-parallel=1`.
+  Metadata does not set `GOMAXPROCS`. The run passed without an out-of-memory
+  kill or wall timeout. Its artifact is
+  `/tmp/gts-c26l-checkpoint-foundation-rebase/harness_out/docker/20260823T102036Z-c26l-checkpoint-foundation-rebase`.
+  Keep issue #576 open until a real scanner and parser lifecycle use this
+  capability with locked-C parity.
+
 - Recorded the N31e C and C++ dispatcher blocker at main commit
   `ab2010d74da5330d64dbddb0d9c58969da766d6d`. Keep `dispatch.c_cpp` live.
   The initial dispatcher census (A0) excludes both languages, and the

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -1122,6 +1122,86 @@ control, and a scanner-free control. Keep the capability default off and fail
 closed when identity or completeness is unavailable. No code or test change
 was made.
 
+## C26l Swift issue #576 checkpoint foundation
+
+Evidence and publication base:
+`929609ccde78b0c9f4e57cf2225e0ae1204149cb`.
+
+Status: **ACCEPTED DEFAULT-OFF FOUNDATION**. Keep issue #576 open.
+
+C26l adds an opt-in identity-bearing checkpoint capability. It does not add a
+parser production call site. It does not change Swift, grammar, generalized
+LR (GLR), recovery, merge, or incremental paths. It does not change behavior
+when the capability is absent.
+
+### API and safety boundary
+
+`ExternalScannerCheckpointIdentityProvider` embeds the existing
+`CheckpointedExternalScanner` contract. It adds `CheckpointIdentity`, which
+must return stable, non-empty scanner and grammar identifiers. Each identifier
+must be at most 256 bytes. The existing contract requires complete
+serialization. C26l also requires non-empty serialized bytes from `Serialize`.
+
+The internal owned record stores:
+
+- scanner and grammar identifiers;
+- source byte and source point;
+- external lexer state;
+- token start and end bytes;
+- serialized scanner bytes.
+
+Capture fails closed when the capability is absent, disabled, or incomplete.
+It also fails closed when identity is missing or too large, serialization is
+empty or too large, or the token span is inverted. Capture deep-copies identity
+and serialized bytes. Fork cloning makes independent copies. Share and merge
+require exact identity, source position, lexer state, token span, and
+serialized bytes. Restore checks exact identity before it calls `Deserialize`.
+It serializes the restored payload into the bounded buffer and requires exact
+length and byte equality. It returns false on any mismatch. Callers must
+discard a payload after failed verification. Restore passes a copied byte
+slice and rejects an inverted token span.
+
+The synthetic lifecycle tests cover:
+
+- absent capability, incomplete identity, oversized identity, or invalid
+  serialization;
+- owned identity and serialized state bytes;
+- independent fork copies;
+- exact merge equality and mismatch;
+- elected recovery-state transfer;
+- restore after a failed scan;
+- an internally overlong record and restore verification mismatch;
+- identity-mismatch restore failure;
+- an external-scanner control;
+- scanner-free off mode.
+
+### Structural proof and focused validation
+
+The new files are
+`external_scanner_checkpoint_capability.go` and
+`external_scanner_checkpoint_capability_test.go`. Scoped Canopy searches found
+the new definitions and test references. Direct no-cache Canopy impact for
+`captureExternalScannerCheckpointRecord` returned only 14 affected test
+functions in `external_scanner_checkpoint_capability_test.go`. It returned no
+affected production file. A literal search found no production caller outside
+the new API file. This proves zero production call sites. Therefore the
+absent-capability path has no parser runtime or allocation change. This is a
+structural proof, not a performance benchmark.
+
+The focused Docker artifact is
+`/tmp/gts-c26l-checkpoint-foundation-rebase/harness_out/docker/20260823T102036Z-c26l-checkpoint-foundation-rebase`.
+The run executed the C26l tests in the root package. It used one central
+processing unit (CPU), 4 GiB, `GOMEMLIMIT=3GiB`, `GOFLAGS=-p=1`, and
+`-parallel=1`. The metadata does not set `GOMAXPROCS`. The run passed with
+exit code zero. It had no out-of-memory kill and no wall timeout. This focused
+validation did not collect maximum resident set size (RSS).
+
+This foundation does not prove scanner ownership across real parser versions.
+It does not prove GLR scheduling, recovery, merge, or edit-reuse parity. The
+next proof must connect the capability to those paths without enabling it for
+Swift or any grammar. Keep issue #576 open until that proof passes against
+locked C.
+
 ### C26i decision and reopening condition
 
 Keep issue #576 open.

--- a/external_scanner_checkpoint_capability.go
+++ b/external_scanner_checkpoint_capability.go
@@ -1,0 +1,135 @@
+package gotreesitter
+
+import "bytes"
+
+const externalScannerCheckpointIdentityMaxBytes = 256
+
+// ExternalScannerCheckpointIdentity identifies the scanner and grammar that
+// produced an external-scanner checkpoint. Both identifiers must be stable,
+// non-empty, and at most 256 bytes for the scanner capability to be accepted.
+type ExternalScannerCheckpointIdentity struct {
+	Scanner []byte
+	Grammar []byte
+}
+
+// ExternalScannerCheckpointIdentityProvider is an opt-in extension for a
+// checkpointed scanner. CheckpointIdentity must return stable identifiers for
+// the scanner implementation and the exact grammar blob.
+//
+// This capability is not consumed by parser production, GLR scheduling,
+// recovery, merge, or incremental-reuse paths yet.
+type ExternalScannerCheckpointIdentityProvider interface {
+	CheckpointedExternalScanner
+	CheckpointIdentity() (ExternalScannerCheckpointIdentity, bool)
+}
+
+type externalScannerCheckpointRecord struct {
+	identity         ExternalScannerCheckpointIdentity
+	sourceByte       uint32
+	sourcePoint      Point
+	externalLexState uint16
+	tokenStartByte   uint32
+	tokenEndByte     uint32
+	serialized       []byte
+}
+
+func (id ExternalScannerCheckpointIdentity) complete() bool {
+	return len(id.Scanner) > 0 && len(id.Scanner) <= externalScannerCheckpointIdentityMaxBytes &&
+		len(id.Grammar) > 0 && len(id.Grammar) <= externalScannerCheckpointIdentityMaxBytes
+}
+
+func (id ExternalScannerCheckpointIdentity) clone() ExternalScannerCheckpointIdentity {
+	return ExternalScannerCheckpointIdentity{
+		Scanner: append([]byte(nil), id.Scanner...),
+		Grammar: append([]byte(nil), id.Grammar...),
+	}
+}
+
+func (id ExternalScannerCheckpointIdentity) equal(other ExternalScannerCheckpointIdentity) bool {
+	return bytes.Equal(id.Scanner, other.Scanner) && bytes.Equal(id.Grammar, other.Grammar)
+}
+
+func (r externalScannerCheckpointRecord) complete() bool {
+	return r.identity.complete() && len(r.serialized) != 0 &&
+		len(r.serialized) <= externalScannerSerializationBufferSize &&
+		r.tokenStartByte <= r.tokenEndByte
+}
+
+func (r externalScannerCheckpointRecord) clone() externalScannerCheckpointRecord {
+	r.identity = r.identity.clone()
+	r.serialized = append([]byte(nil), r.serialized...)
+	return r
+}
+
+func (r externalScannerCheckpointRecord) equal(other externalScannerCheckpointRecord) bool {
+	return r.complete() && other.complete() &&
+		r.identity.equal(other.identity) &&
+		r.sourceByte == other.sourceByte &&
+		r.sourcePoint == other.sourcePoint &&
+		r.externalLexState == other.externalLexState &&
+		r.tokenStartByte == other.tokenStartByte &&
+		r.tokenEndByte == other.tokenEndByte &&
+		bytes.Equal(r.serialized, other.serialized)
+}
+
+// captureExternalScannerCheckpointRecord captures a complete checkpoint
+// without changing any parser or token-source state.
+func captureExternalScannerCheckpointRecord(
+	scanner ExternalScanner,
+	payload any,
+	sourceByte uint32,
+	sourcePoint Point,
+	externalLexState uint16,
+	tokenStartByte uint32,
+	tokenEndByte uint32,
+) (externalScannerCheckpointRecord, bool) {
+	if scanner == nil || tokenStartByte > tokenEndByte {
+		return externalScannerCheckpointRecord{}, false
+	}
+	provider, ok := scanner.(ExternalScannerCheckpointIdentityProvider)
+	if !ok || !provider.UsesExternalScannerCheckpoints() {
+		return externalScannerCheckpointRecord{}, false
+	}
+	identity, ok := provider.CheckpointIdentity()
+	if !ok || !identity.complete() {
+		return externalScannerCheckpointRecord{}, false
+	}
+
+	buf := make([]byte, externalScannerSerializationBufferSize)
+	n := scanner.Serialize(payload, buf)
+	if n <= 0 || n > len(buf) {
+		return externalScannerCheckpointRecord{}, false
+	}
+	return externalScannerCheckpointRecord{
+		identity:         identity.clone(),
+		sourceByte:       sourceByte,
+		sourcePoint:      sourcePoint,
+		externalLexState: externalLexState,
+		tokenStartByte:   tokenStartByte,
+		tokenEndByte:     tokenEndByte,
+		serialized:       append([]byte(nil), buf[:n]...),
+	}, true
+}
+
+func canShareExternalScannerCheckpoint(a, b externalScannerCheckpointRecord) bool {
+	return a.equal(b)
+}
+
+func (r externalScannerCheckpointRecord) restore(scanner ExternalScanner, payload any) bool {
+	// Callers must discard payload when restore fails because Deserialize may mutate it.
+	if scanner == nil || !r.complete() {
+		return false
+	}
+	provider, ok := scanner.(ExternalScannerCheckpointIdentityProvider)
+	if !ok || !provider.UsesExternalScannerCheckpoints() {
+		return false
+	}
+	identity, ok := provider.CheckpointIdentity()
+	if !ok || !identity.complete() || !r.identity.equal(identity) {
+		return false
+	}
+	scanner.Deserialize(payload, append([]byte(nil), r.serialized...))
+	buf := make([]byte, externalScannerSerializationBufferSize)
+	n := scanner.Serialize(payload, buf)
+	return n == len(r.serialized) && n <= len(buf) && bytes.Equal(buf[:n], r.serialized)
+}

--- a/external_scanner_checkpoint_capability_test.go
+++ b/external_scanner_checkpoint_capability_test.go
@@ -1,0 +1,295 @@
+package gotreesitter
+
+import (
+	"bytes"
+	"testing"
+)
+
+type c26lCheckpointPayload struct {
+	state []byte
+}
+
+type c26lCheckpointScanner struct {
+	scannerID           []byte
+	grammarID           []byte
+	identityOK          bool
+	checkpoint          bool
+	serializeOK         bool
+	serializeTooLong    bool
+	deserializeMismatch bool
+}
+
+func (s *c26lCheckpointScanner) Create() any {
+	return &c26lCheckpointPayload{state: []byte{1, 2, 3}}
+}
+
+func (*c26lCheckpointScanner) Destroy(any) {}
+
+func (s *c26lCheckpointScanner) Serialize(payload any, buf []byte) int {
+	if !s.serializeOK {
+		return 0
+	}
+	if s.serializeTooLong {
+		return len(buf) + 1
+	}
+	p, ok := payload.(*c26lCheckpointPayload)
+	if !ok || len(p.state) == 0 || len(p.state) > len(buf) {
+		return 0
+	}
+	return copy(buf, p.state)
+}
+
+func (s *c26lCheckpointScanner) Deserialize(payload any, buf []byte) {
+	p, ok := payload.(*c26lCheckpointPayload)
+	if !ok {
+		return
+	}
+	if s.deserializeMismatch {
+		p.state = []byte{9, 9, 9}
+		return
+	}
+	p.state = append(p.state[:0], buf...)
+}
+
+func (*c26lCheckpointScanner) Scan(any, *ExternalLexer, []bool) bool {
+	return false
+}
+
+func (s *c26lCheckpointScanner) UsesExternalScannerCheckpoints() bool {
+	return s.checkpoint
+}
+
+func (s *c26lCheckpointScanner) CheckpointIdentity() (ExternalScannerCheckpointIdentity, bool) {
+	return ExternalScannerCheckpointIdentity{
+		Scanner: s.scannerID,
+		Grammar: s.grammarID,
+	}, s.identityOK
+}
+
+type c26lPlainScanner struct{}
+
+func (*c26lPlainScanner) Create() any               { return nil }
+func (*c26lPlainScanner) Destroy(any)               {}
+func (*c26lPlainScanner) Serialize(any, []byte) int { return 0 }
+func (*c26lPlainScanner) Deserialize(any, []byte)   {}
+func (*c26lPlainScanner) Scan(any, *ExternalLexer, []bool) bool {
+	return false
+}
+
+func newC26lCheckpointScanner() *c26lCheckpointScanner {
+	return &c26lCheckpointScanner{
+		scannerID:   []byte("scanner-c26l"),
+		grammarID:   []byte("grammar-c26l"),
+		identityOK:  true,
+		checkpoint:  true,
+		serializeOK: true,
+	}
+}
+
+func captureC26lRecord(t *testing.T, scanner *c26lCheckpointScanner, payload any) externalScannerCheckpointRecord {
+	t.Helper()
+	record, ok := captureExternalScannerCheckpointRecord(scanner, payload, 17, Point{Row: 2, Column: 3}, 9, 17, 21)
+	if !ok {
+		t.Fatal("captureExternalScannerCheckpointRecord rejected a complete checkpoint")
+	}
+	return record
+}
+
+func TestC26lCheckpointRejectsAbsentCapability(t *testing.T) {
+	if _, ok := captureExternalScannerCheckpointRecord(&c26lPlainScanner{}, nil, 0, Point{}, 0, 0, 0); ok {
+		t.Fatal("capture accepted a scanner without the identity capability")
+	}
+}
+
+func TestC26lCheckpointRejectsIncompleteIdentityAndSerialization(t *testing.T) {
+	tests := map[string]func(*c26lCheckpointScanner){
+		"missing identity": func(scanner *c26lCheckpointScanner) {
+			scanner.identityOK = false
+		},
+		"empty scanner identity": func(scanner *c26lCheckpointScanner) {
+			scanner.scannerID = nil
+		},
+		"empty grammar identity": func(scanner *c26lCheckpointScanner) {
+			scanner.grammarID = nil
+		},
+		"oversized scanner identity": func(scanner *c26lCheckpointScanner) {
+			scanner.scannerID = make([]byte, externalScannerCheckpointIdentityMaxBytes+1)
+		},
+		"oversized grammar identity": func(scanner *c26lCheckpointScanner) {
+			scanner.grammarID = make([]byte, externalScannerCheckpointIdentityMaxBytes+1)
+		},
+		"incomplete serialization": func(scanner *c26lCheckpointScanner) {
+			scanner.serializeOK = false
+		},
+		"serialization length exceeds buffer": func(scanner *c26lCheckpointScanner) {
+			scanner.serializeTooLong = true
+		},
+		"checkpoint disabled": func(scanner *c26lCheckpointScanner) {
+			scanner.checkpoint = false
+		},
+	}
+	for name, configure := range tests {
+		t.Run(name, func(t *testing.T) {
+			scanner := newC26lCheckpointScanner()
+			configure(scanner)
+			if _, ok := captureExternalScannerCheckpointRecord(scanner, scanner.Create(), 0, Point{}, 0, 0, 0); ok {
+				t.Fatal("capture accepted an incomplete checkpoint")
+			}
+		})
+	}
+}
+
+func TestC26lCheckpointRejectsInvertedTokenSpan(t *testing.T) {
+	scanner := newC26lCheckpointScanner()
+	if _, ok := captureExternalScannerCheckpointRecord(scanner, scanner.Create(), 0, Point{}, 0, 8, 7); ok {
+		t.Fatal("capture accepted an inverted token span")
+	}
+
+	record := captureC26lRecord(t, scanner, scanner.Create())
+	inverted := record.clone()
+	inverted.tokenStartByte = inverted.tokenEndByte + 1
+	if inverted.complete() {
+		t.Fatal("record completeness accepted an inverted token span")
+	}
+	if canShareExternalScannerCheckpoint(record, inverted) {
+		t.Fatal("share accepted an inverted token span")
+	}
+}
+
+func TestC26lCheckpointRejectsInternallyOverlongRecord(t *testing.T) {
+	scanner := newC26lCheckpointScanner()
+	record := captureC26lRecord(t, scanner, scanner.Create())
+	record.serialized = make([]byte, externalScannerSerializationBufferSize+1)
+	if record.complete() {
+		t.Fatal("record completeness accepted overlong serialized state")
+	}
+	if canShareExternalScannerCheckpoint(record, record) {
+		t.Fatal("share accepted an overlong serialized state")
+	}
+}
+
+func TestC26lCheckpointOwnsIdentityAndStateBytes(t *testing.T) {
+	scanner := newC26lCheckpointScanner()
+	payload := scanner.Create().(*c26lCheckpointPayload)
+	record := captureC26lRecord(t, scanner, payload)
+
+	scanner.scannerID[0] = 'X'
+	scanner.grammarID[0] = 'Y'
+	payload.state[0] = 99
+	if !bytes.Equal(record.identity.Scanner, []byte("scanner-c26l")) {
+		t.Fatalf("record scanner identity changed through alias: %q", record.identity.Scanner)
+	}
+	if !bytes.Equal(record.identity.Grammar, []byte("grammar-c26l")) {
+		t.Fatalf("record grammar identity changed through alias: %q", record.identity.Grammar)
+	}
+	if !bytes.Equal(record.serialized, []byte{1, 2, 3}) {
+		t.Fatalf("record serialized state changed through alias: %v", record.serialized)
+	}
+}
+
+func TestC26lCheckpointForkCopiesIndependently(t *testing.T) {
+	scanner := newC26lCheckpointScanner()
+	record := captureC26lRecord(t, scanner, scanner.Create())
+	fork := record.clone()
+	fork.identity.Scanner[0] = 'F'
+	fork.serialized[0] = 42
+
+	if bytes.Equal(record.identity.Scanner, fork.identity.Scanner) {
+		t.Fatal("fork identity aliases the parent")
+	}
+	if bytes.Equal(record.serialized, fork.serialized) {
+		t.Fatal("fork state aliases the parent")
+	}
+	if canShareExternalScannerCheckpoint(record, fork) {
+		t.Fatal("fork with changed state was shareable")
+	}
+}
+
+func TestC26lCheckpointRequiresExactMergeIdentity(t *testing.T) {
+	scanner := newC26lCheckpointScanner()
+	record := captureC26lRecord(t, scanner, scanner.Create())
+	if !canShareExternalScannerCheckpoint(record, record.clone()) {
+		t.Fatal("equal records were not shareable")
+	}
+
+	stateMismatch := record.clone()
+	stateMismatch.serialized[0]++
+	if canShareExternalScannerCheckpoint(record, stateMismatch) {
+		t.Fatal("records with different serialized state were shareable")
+	}
+	identityMismatch := record.clone()
+	identityMismatch.identity.Grammar[0] = 'X'
+	if canShareExternalScannerCheckpoint(record, identityMismatch) {
+		t.Fatal("records with different grammar identity were shareable")
+	}
+	if canShareExternalScannerCheckpoint(record, externalScannerCheckpointRecord{}) {
+		t.Fatal("complete record shared with an incomplete record")
+	}
+}
+
+func TestC26lCheckpointTransfersElectedRecoveryState(t *testing.T) {
+	scanner := newC26lCheckpointScanner()
+	selectedPayload := scanner.Create()
+	selected := captureC26lRecord(t, scanner, selectedPayload)
+	electedPayload := scanner.Create().(*c26lCheckpointPayload)
+	electedPayload.state = []byte{8, 8, 8}
+
+	if !selected.clone().restore(scanner, electedPayload) {
+		t.Fatal("elected recovery state did not restore")
+	}
+	if !bytes.Equal(electedPayload.state, []byte{1, 2, 3}) {
+		t.Fatalf("elected recovery state = %v, want [1 2 3]", electedPayload.state)
+	}
+}
+
+func TestC26lCheckpointRestoresAfterFailedScan(t *testing.T) {
+	scanner := newC26lCheckpointScanner()
+	payload := scanner.Create().(*c26lCheckpointPayload)
+	selected := captureC26lRecord(t, scanner, payload)
+
+	payload.state = []byte{7, 7, 7}
+	if scanner.Scan(payload, nil, nil) {
+		t.Fatal("synthetic scanner unexpectedly succeeded")
+	}
+	if !selected.restore(scanner, payload) {
+		t.Fatal("failed-scan checkpoint did not restore")
+	}
+	if !bytes.Equal(payload.state, []byte{1, 2, 3}) {
+		t.Fatalf("restored state = %v, want [1 2 3]", payload.state)
+	}
+}
+
+func TestC26lCheckpointRestoreFailsClosedOnIdentityMismatch(t *testing.T) {
+	scanner := newC26lCheckpointScanner()
+	selected := captureC26lRecord(t, scanner, scanner.Create())
+	other := newC26lCheckpointScanner()
+	other.grammarID = []byte("other-grammar")
+	if selected.restore(other, other.Create()) {
+		t.Fatal("restore accepted a different grammar identity")
+	}
+}
+
+func TestC26lCheckpointRestoreFailsClosedWhenDeserializeDoesNotReproduce(t *testing.T) {
+	scanner := newC26lCheckpointScanner()
+	selected := captureC26lRecord(t, scanner, scanner.Create())
+	scanner.deserializeMismatch = true
+	if selected.restore(scanner, scanner.Create()) {
+		t.Fatal("restore accepted a payload that did not reproduce the checkpoint")
+	}
+}
+
+func TestC26lCheckpointExternalScannerControl(t *testing.T) {
+	scanner := newC26lCheckpointScanner()
+	if _, ok := captureExternalScannerCheckpointRecord(scanner, scanner.Create(), 4, Point{Row: 1}, 3, 4, 5); !ok {
+		t.Fatal("external-scanner control did not capture a checkpoint")
+	}
+}
+
+func TestC26lCheckpointScannerFreeOffMode(t *testing.T) {
+	if _, ok := captureExternalScannerCheckpointRecord(nil, nil, 0, Point{}, 0, 0, 0); ok {
+		t.Fatal("scanner-free off mode captured a checkpoint")
+	}
+	if canShareExternalScannerCheckpoint(externalScannerCheckpointRecord{}, externalScannerCheckpointRecord{}) {
+		t.Fatal("scanner-free off mode shared an absent checkpoint")
+	}
+}


### PR DESCRIPTION
## Summary

Add a default-off external-scanner checkpoint identity foundation.

- Require stable scanner and grammar identities.
- Reject incomplete or oversized checkpoint state.
- Verify restored state by exact bounded reserialization.
- Require callers to discard payloads after failed verification.
- Keep the capability outside parser production and real scanner integration.

## Evidence

Focused Docker C26l tests passed with one CPU, 4 GiB, GOMEMLIMIT=3GiB, GOFLAGS=-p=1, and -parallel=1. Go documentation checks passed. Markdown++ parsing, error lint, gofmt, and git diff checks passed.

Issue #576 remains open. This PR adds no parser integration and does not claim locked-C parity.

No merge is requested in this PR.