### PR TITLE
test(cooklang): add dispatcher retirement ratchet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,21 @@ for tags and release notes while still in `0.x`.
   registry change. See `docs/root-normalization-retirement.md` for the
   route receipt, failed attempts, and reopening condition.
 
+- Recorded the N31i Cooklang dispatcher blocker at evidence base
+  `7498a678c52029a82f312e9637ecb66b15defa0b` and publication base
+  `675697a1144fad306489c5142aedaae0825545d9`. Keep `dispatch.cooklang` live.
+  A0 lists three Cooklang files, three checked files, three run files, and
+  1,021 rewrites. The focused probe covers nine witnesses and six routes.
+  Seven non-control witnesses differ from locked C on at least one route.
+  Four witnesses differ from locked C on the production route.
+  Compact fallback and forest decline remain active for those witnesses.
+  Incremental parsing reports external-scanner fallback with zero reuse.
+  The authenticated corpus and source lock are unavailable. The focused guard
+  pins source, grammar, C, route, pass, forest, and counter identities. Ship no
+  parser, registry, or production change. See
+  `docs/root-normalization-retirement.md` for the receipt and reopening
+  conditions.
+
 ### Performance
 
 - Recorded the P25k-P25w performance blocker at publication base

--- a/cgo_harness/cooklang_next_live_probe_test.go
+++ b/cgo_harness/cooklang_next_live_probe_test.go
@@ -1,0 +1,466 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+type cooklangNextDivergence struct {
+	path     string
+	category string
+	goValue  string
+	cValue   string
+}
+
+type cooklangNextPass struct {
+	checked   uint64
+	run       uint64
+	visited   uint64
+	rewritten uint64
+}
+
+type cooklangNextRoute struct {
+	digest     string
+	errorRoot  bool
+	divergence *cooklangNextDivergence
+	pass       *cooklangNextPass
+}
+
+type cooklangNextWitness struct {
+	name         string
+	source       []byte
+	sourceSHA    string
+	cDigest      string
+	routes       map[string]cooklangNextRoute
+	cExpectation string
+	forest       string
+}
+
+const (
+	cooklangNextGrammarRepo       = "https://github.com/addcninblue/tree-sitter-cooklang"
+	cooklangNextGrammarCommit     = "4ebe237c1cf64cf3826fc249e9ec0988fe07e58e"
+	cooklangNextGrammarBlobSHA256 = "2fd57f20461bcc0830fd14420cd06ad08750dd3cbbc440670e63056d59b3692a"
+	cooklangNextGrammarLockSHA256 = "9ddb6324afd014f6ecdd1cae3dd1ba238f1e62ce03d126e6d8b267ce34d72ecb"
+	cooklangNextCArtifactSHA256   = "009b897908abbc248d72855a7926b70715ac7955fed1f44c8fb2e8148f7ee83c"
+)
+
+// TestCooklangNextLiveArmLockedCRoutes records all five routes for Cooklang.
+// It keeps the producer, recovery, scanner, and forest gaps visible.
+func TestCooklangNextLiveArmLockedCRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	t.Setenv("GOT_PARSE_PHASE_TIMING", "1")
+	language := grammars.CooklangLanguage()
+	if language == nil || language.Name != "cooklang" {
+		t.Fatalf("Cooklang language=%v, want cooklang", language)
+	}
+	if language.ExternalScanner == nil {
+		t.Fatal("Cooklang language has no external scanner")
+	}
+	if got := cooklangNextFileSHA(t, "../grammars/languages.lock"); got != cooklangNextGrammarLockSHA256 {
+		t.Fatalf("grammar lock SHA-256=%s, want %s", got, cooklangNextGrammarLockSHA256)
+	}
+	if got := cooklangNextFileSHA(t, "../grammars/grammar_blobs/cooklang.bin"); got != cooklangNextGrammarBlobSHA256 {
+		t.Fatalf("Cooklang grammar blob SHA-256=%s, want %s", got, cooklangNextGrammarBlobSHA256)
+	}
+	cLanguage, err := COracleLanguage("cooklang")
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := COracleIdentity("cooklang")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.GrammarRepo != cooklangNextGrammarRepo || identity.GrammarCommit != cooklangNextGrammarCommit {
+		t.Fatalf("C grammar identity=%s@%s, want %s@%s", identity.GrammarRepo, identity.GrammarCommit, cooklangNextGrammarRepo, cooklangNextGrammarCommit)
+	}
+	if identity.GrammarArtifactSHA256 != cooklangNextCArtifactSHA256 {
+		t.Fatalf("C grammar artifact SHA-256=%s, want %s", identity.GrammarArtifactSHA256, cooklangNextCArtifactSHA256)
+	}
+	t.Logf("grammar=cooklang external_scanner=true grammar_lock_sha256=%s grammar_blob_sha256=%s c_runtime=%s@%s c_grammar=%s@%s c_artifact=%s c_artifact_sha256=%s", cooklangNextGrammarLockSHA256, cooklangNextGrammarBlobSHA256, identity.RuntimeVersion, identity.RuntimeCommit, identity.GrammarRepo, identity.GrammarCommit, identity.GrammarArtifactPath, identity.GrammarArtifactSHA256)
+
+	witnesses := cooklangNextWitnesses(t)
+	for _, witness := range witnesses {
+		witness := witness
+		t.Run(witness.name, func(t *testing.T) {
+			if got := fmt.Sprintf("%x", sha256.Sum256(witness.source)); got != witness.sourceSHA {
+				t.Fatalf("source SHA-256=%s, want %s", got, witness.sourceSHA)
+			}
+			cTree := cooklangNextLockedCTree(t, cLanguage, witness.source)
+			t.Cleanup(cTree.Close)
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cDigest != witness.cDigest {
+				t.Fatalf("locked C digest=%s, want %s", cDigest, witness.cDigest)
+			}
+
+			raw := cooklangNextParseRoute(t, language, witness.source, false, func(p *gotreesitter.Parser, source []byte) (*gotreesitter.Tree, error) {
+				return p.ParseNoResultCompatibilityBenchmarkOnly(source)
+			})
+			cooklangNextAssertRoute(t, "raw", raw, language, cTree, cDigest, witness.routes["raw"])
+
+			production := cooklangNextParseRoute(t, language, witness.source, false, func(p *gotreesitter.Parser, source []byte) (*gotreesitter.Tree, error) {
+				return p.Parse(source)
+			})
+			cooklangNextAssertRoute(t, "production", production, language, cTree, cDigest, witness.routes["production"])
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactParser := gotreesitter.NewParser(language)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.Parse(witness.source)
+			if err != nil {
+				t.Fatalf("compact parse: %v", err)
+			}
+			t.Cleanup(compact.Release)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			compactRoute := witness.cExpectation
+			switch witness.cExpectation {
+			case "fallback":
+				if routedAfter != routedBefore || fallbackAfter != fallbackBefore+1 {
+					t.Fatalf("compact fallback counters before=(%d,%d) after=(%d,%d), want routed unchanged and fallback +1", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+				}
+				if !strings.Contains(gotreesitter.AdmissionCandidateLastFallbackReason(), "did not accept EOF") {
+					t.Fatalf("compact fallback reason=%q", gotreesitter.AdmissionCandidateLastFallbackReason())
+				}
+			case "accepted":
+				if routedAfter != routedBefore+1 || fallbackAfter != fallbackBefore {
+					t.Fatalf("compact accepted counters before=(%d,%d) after=(%d,%d), want routed +1 and fallback unchanged", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+				}
+			default:
+				t.Fatalf("unknown compact expectation %q", witness.cExpectation)
+			}
+			cooklangNextAssertRoute(t, "compact", compact, language, cTree, cDigest, witness.routes["compact"])
+
+			forestParser := gotreesitter.NewParser(language)
+			forest, forestOK := forestParser.ParseForestExperimental(witness.source)
+			forestRoute := "declined"
+			if forestOK {
+				if forest == nil {
+					t.Fatal("forest route reported accepted with nil tree")
+				}
+				forestRoute = "accepted"
+				if witness.forest != "accepted" {
+					forest.Release()
+					t.Fatalf("forest route accepted, want %s", witness.forest)
+				}
+				t.Cleanup(forest.Release)
+				cooklangNextAssertRoute(t, "forest", forest, language, cTree, cDigest, witness.routes["forest"])
+			} else {
+				if forest != nil {
+					forest.Release()
+					t.Fatal("forest route declined with a non-nil tree")
+				}
+				if witness.forest != "declined" {
+					t.Fatalf("forest route declined, want %s", witness.forest)
+				}
+			}
+
+			incrementalParser := gotreesitter.NewParser(language)
+			incrementalParser.SetAdmissionCandidateRoute(false)
+			base := bytes.TrimSuffix(witness.source, []byte{'\n'})
+			oldTree, err := incrementalParser.Parse(base)
+			if err != nil {
+				t.Fatalf("incremental base parse: %v", err)
+			}
+			t.Cleanup(oldTree.Release)
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(len(base)),
+				OldEndByte:  uint32(len(base)),
+				NewEndByte:  uint32(len(witness.source)),
+				StartPoint:  cooklangNextPointAtByte(base),
+				OldEndPoint: cooklangNextPointAtByte(base),
+				NewEndPoint: cooklangNextPointAtByte(witness.source),
+			})
+			incremental, profile, err := incrementalParser.ParseIncrementalProfiled(witness.source, oldTree)
+			if err != nil {
+				t.Fatalf("incremental parse: %v", err)
+			}
+			t.Cleanup(incremental.Release)
+			if profile.OldTreeReuseRoute || !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+				t.Fatalf("incremental profile=%+v, want external-scanner fallback with zero reuse", profile)
+			}
+			cooklangNextAssertRoute(t, "incremental", incremental, language, cTree, cDigest, witness.routes["incremental"])
+			t.Logf("witness=%s bytes=%d source_sha256=%s c_digest=%s compact=%s forest=%s incremental_reuse=%t unsupported=%t reason=%q", witness.name, len(witness.source), witness.sourceSHA, cDigest, compactRoute, forestRoute, profile.OldTreeReuseRoute, profile.ReuseUnsupported, profile.ReuseUnsupportedReason)
+		})
+	}
+}
+
+// TestCooklangNextLiveArmReceiptDocument guards the blocker receipt markers.
+func TestCooklangNextLiveArmReceiptDocument(t *testing.T) {
+	raw, err := os.ReadFile("../docs/root-normalization-retirement.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	document := strings.Join(strings.Fields(string(raw)), " ")
+	for _, marker := range []string{
+		"The Cooklang dispatcher arm remains live.",
+		"Evidence base: `7498a678c52029a82f312e9637ecb66b15defa0b`. Publication base: `675697a1144fad306489c5142aedaae0825545d9`.",
+		"The grammar lock SHA-256 is `9ddb6324afd014f6ecdd1cae3dd1ba238f1e62ce03d126e6d8b267ce34d72ecb`.",
+		"The embedded Go grammar blob SHA-256 is `2fd57f20461bcc0830fd14420cd06ad08750dd3cbbc440670e63056d59b3692a`.",
+		"The A0 (authenticated dispatcher census) manifest has 14 languages, 42 files, and 14 receipts. Cooklang has three files, three checked, three run, 1037 nodes visited, 1021 rewrites, two error roots, and zero parse errors.",
+		"The tracked census has seven fixtures across six languages. It omits Cooklang. Its aggregate has nine checked, nine run, 26022 nodes visited, 2107 rewrites, and zero error roots. The authenticated real-corpus census is unavailable.",
+		"The worktree lacks `cgo_harness/corpus_real`, `corpus_sources.lock`, and `cgo_harness/perf_scan/corpus_sources.lock`.",
+		"The three raw-digest controls from rejected pull request (PR) #793 are retained.",
+		"The focused receipt covers nine witnesses. It covers raw, production, compact, forest, incremental, and locked-C routes.",
+		"Every Go tree reports `NativeRecoveredStructureAuthoritative=false`.",
+		"Forest declines seven witnesses and accepts two controls.",
+		"Compact falls back for seven witnesses. It accepts the clean and no-op controls.",
+		"A fallback keeps the routed counter unchanged and increments the fallback counter by one.",
+		"Incremental parsing reports `external_scanner_unsupported` for every witness. It reuses zero subtrees and zero bytes.",
+		"Forest returns nil when it declines and returns a non-nil tree when it accepts.",
+		"The successful focused Docker route receipt is under `/tmp/gts-n31i-cooklang-rebased-artifacts/20260823T105932Z-final-rebased-routes`.",
+		"The successful document guard receipt is under `/tmp/gts-n31i-cooklang-rebased-artifacts/20260823T105956Z-final-rebased-document`.",
+		"Keep dispatch.cooklang live until scheduler_action_semantics emits the locked-C tree on every route.",
+	} {
+		marker = strings.Join(strings.Fields(marker), " ")
+		if !strings.Contains(document, marker) {
+			t.Fatalf("Cooklang blocker receipt lacks marker %q", marker)
+		}
+	}
+}
+
+func cooklangNextWitnesses(t *testing.T) []cooklangNextWitness {
+	t.Helper()
+	pass := func(rewritten uint64) *cooklangNextPass {
+		return &cooklangNextPass{checked: 1, run: 1, rewritten: rewritten}
+	}
+	div := func(path, category, goValue, cValue string) *cooklangNextDivergence {
+		return &cooklangNextDivergence{path: path, category: category, goValue: goValue, cValue: cValue}
+	}
+	allRoutes := func(raw, normalized cooklangNextRoute) map[string]cooklangNextRoute {
+		return map[string]cooklangNextRoute{
+			"raw": raw, "production": normalized, "compact": normalized,
+			"forest": normalized, "incremental": normalized,
+		}
+	}
+	exact := func(digest string, p *cooklangNextPass) cooklangNextRoute {
+		return cooklangNextRoute{digest: digest, pass: p}
+	}
+	divergent := func(digest string, rootError bool, d *cooklangNextDivergence, p *cooklangNextPass) cooklangNextRoute {
+		return cooklangNextRoute{digest: digest, errorRoot: rootError, divergence: d, pass: p}
+	}
+	witnesses := []cooklangNextWitness{
+		{
+			name: "a0-medium-complex", source: mustCooklangFile(t, "../testdata/dispatcher_census_a0/cooklang/medium__complex_test_recipe.cook"),
+			sourceSHA: "6120e9cafce48a745c0f5dade752499883bc2b07230cae93d6a452a788c7ba74", cDigest: "17c3be167109ab72b919cfc700715330f5b0c33e3fdea559ef25f01ae8ad7a1f",
+			routes: allRoutes(
+				divergent("edc7662c358880c8fd35c182092aa7a15547f9d624bdcb7f31ed30fee1248e36", true, div("/recipe", "shape", "children=22", "children=42"), nil),
+				divergent("585034f453f485b2c3ccc7cf20e204d0dd210465e871d3e449fe1547e5684d87", true, div("/recipe", "shape", "children=23", "children=42"), pass(442)),
+			), cExpectation: "fallback", forest: "declined",
+		},
+		{
+			name: "a0-medium-frontmatter", source: mustCooklangFile(t, "../testdata/dispatcher_census_a0/cooklang/medium__frontmatter_test_recipe.cook"),
+			sourceSHA: "956fcaf1c14e0e915efded324450789cb5d9a896cf60e4feafb71b918c8e621a", cDigest: "cc2dc5fd1f73c2def6c0f7370a431c795a229506d9ad7e762243382f95cf8327",
+			routes: allRoutes(
+				divergent("76560c38e365ea67b8f84f4f2c5b36b760df71daa880803c4a1f610ce797d7fc", true, div("/recipe", "shape", "children=36", "children=47"), nil),
+				divergent("3f433923a14de13456e84914cab679db1e59bc5c7e6cb6e13e2ec9168b4f5eaf", true, div("/recipe", "shape", "children=35", "children=47"), pass(287)),
+			), cExpectation: "fallback", forest: "declined",
+		},
+		{
+			name: "a0-medium-recipe", source: mustCooklangFile(t, "../testdata/dispatcher_census_a0/cooklang/medium__test_recipe.cook"),
+			sourceSHA: "1acb11626700218ebc8ff8b7d445e1a257b12af35dea7dbc0fcef0587a79468f", cDigest: "ff61d92143c45498b4db19a499414be137894e6c3d5b71c6917140edc8eb3b0b",
+			routes: allRoutes(
+				divergent("f2992b217d2bef245959891d67abbca56b91252f683f3f64170eecda9e85ee94", true, div("/recipe", "shape", "children=34", "children=43"), nil),
+				divergent("83a5757e3dc00f198115e21f8a34b368a3f4da118764ba899300fe47bce23189", false, div("/recipe", "error", "false", "true"), pass(292)),
+			), cExpectation: "fallback", forest: "declined",
+		},
+		{
+			name: "pr793-punctuation", source: []byte("Add @salt{1%tsp}.\n"),
+			sourceSHA: "8dd8b584db0c0ef919fdcc229645c2cb5d7697c7f555624b3c075e7f1a4eb53a", cDigest: "c6e4535b725516550ca7a0ee4c69974799c2d2d10fed4e5f1ba6b71e43c5ba8a",
+			routes: allRoutes(
+				divergent("0e6880ec4902576c2a6de014424c3cba7eef99cdc5fd8fded8ceb6382a6df9cd", true, div("/recipe", "error", "true", "false"), nil),
+				exact("c6e4535b725516550ca7a0ee4c69974799c2d2d10fed4e5f1ba6b71e43c5ba8a", pass(4)),
+			), cExpectation: "fallback", forest: "declined",
+		},
+		{
+			name: "pr793-recovered", source: []byte("---\nservings: 4\nemoji: 🥟\ntags: warm, fried, starter\n---\n\nServe hot.\n"),
+			sourceSHA: "8fefd1eb97742b1ef8349e9e51b5260c28295ed0d583d12eb5fbc04db579ce8a", cDigest: "3ae5ffba70cd0922976d24ed3e4d254cbb9d356639e8485b8b4b3abdc2667133",
+			routes: allRoutes(
+				divergent("896d9f79d941c3869dca7b855bae45738392d02519f0fbe3ac45cc2623fcfa2f", true, div("/recipe", "shape", "children=6", "children=7"), nil),
+				divergent("814240a8aff9c3e253b37ce1ff535ff2cd96510c6afea40680a270405699967f", true, div("/recipe", "shape", "children=5", "children=7"), pass(18)),
+			), cExpectation: "fallback", forest: "declined",
+		},
+		{
+			name: "pr793-without-newline", source: []byte("Add @salt{1%tsp}."),
+			sourceSHA: "6d60ac3d4e9155e84ead7b1f9e751728dcebafe03d6561d913f3f18f58a14297", cDigest: "dd3692a1a0e9145af9f2d082126a1e798d60cbe74942427746d3f0e83bd31e1c",
+			routes: allRoutes(
+				divergent("f49ca1a85a0b2ee7ed7f07993d6bc8b103d66311f83d4a026e085cf2013a69ec", true, div("/recipe", "error", "true", "false"), nil),
+				exact("dd3692a1a0e9145af9f2d082126a1e798d60cbe74942427746d3f0e83bd31e1c", pass(4)),
+			), cExpectation: "fallback", forest: "declined",
+		},
+		{
+			name: "clean-control", source: []byte("Add @salt{1%tsp}\n"),
+			sourceSHA: "c31fe39c742b150ec7daec33319e21b39511207fa10fe97d04deac94a31db43e", cDigest: "5bbe67b1d36f2d57144a29d329e44cd39b5a90f6191ed0fc05f307ce983e67c2",
+			routes:       cooklangNextControlRoutes("5bbe67b1d36f2d57144a29d329e44cd39b5a90f6191ed0fc05f307ce983e67c2", 1),
+			cExpectation: "accepted", forest: "accepted",
+		},
+		{
+			name: "no-op-ingredient-control", source: []byte("Add @salt{}\n"),
+			sourceSHA: "e28998769b7ac8e1f8f615bd7ee4e8f1dff629890201c96abba1b2a60d70362b", cDigest: "ed03c94ecef09c4724f5a4931b33d9d0b476c85a49b5121ad3dc0f39cc944461",
+			routes:       cooklangNextControlRoutes("ed03c94ecef09c4724f5a4931b33d9d0b476c85a49b5121ad3dc0f39cc944461", 1),
+			cExpectation: "accepted", forest: "accepted",
+		},
+		{
+			name: "malformed-frontmatter", source: []byte("---\nservings:\n---\nServe hot.\n"),
+			sourceSHA: "f2c2b1b02d9b3497d42c1cc53b94373974bd7b525af438d7dcf73391725f3615", cDigest: "b7b9d810d3d03756017e082edb333785c5fa196fe46a2f69d34191eeec6b9cf0",
+			routes: allRoutes(
+				divergent("21557aa2d5b8757be18c010fb673b8611171dcd7232784565b11113c741e3092", true, div("/recipe", "error", "true", "false"), nil),
+				exact("b7b9d810d3d03756017e082edb333785c5fa196fe46a2f69d34191eeec6b9cf0", pass(11)),
+			), cExpectation: "fallback", forest: "declined",
+		},
+	}
+	return witnesses
+}
+
+func cooklangNextControlRoutes(digest string, rewritten uint64) map[string]cooklangNextRoute {
+	pass := &cooklangNextPass{checked: 1, run: 1, rewritten: rewritten}
+	return map[string]cooklangNextRoute{
+		"raw":         {digest: digest},
+		"production":  {digest: digest, pass: pass},
+		"compact":     {digest: digest},
+		"forest":      {digest: digest, pass: pass},
+		"incremental": {digest: digest, pass: pass},
+	}
+}
+
+func cooklangNextLockedCTree(t *testing.T, language *sitter.Language, source []byte) *sitter.Tree {
+	t.Helper()
+	parser := sitter.NewParser()
+	t.Cleanup(parser.Close)
+	if err := parser.SetLanguage(language); err != nil {
+		t.Fatal(err)
+	}
+	tree := parser.Parse(source, nil)
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("locked C parser returned no root")
+	}
+	return tree
+}
+
+func cooklangNextParseRoute(t *testing.T, language *gotreesitter.Language, source []byte, admission bool, parse func(*gotreesitter.Parser, []byte) (*gotreesitter.Tree, error)) *gotreesitter.Tree {
+	t.Helper()
+	parser := gotreesitter.NewParser(language)
+	parser.SetAdmissionCandidateRoute(admission)
+	tree, err := parse(parser, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(tree.Release)
+	return tree
+}
+
+func cooklangNextAssertRoute(t *testing.T, route string, tree *gotreesitter.Tree, language *gotreesitter.Language, cTree *sitter.Tree, cDigest string, want cooklangNextRoute) {
+	t.Helper()
+	if tree == nil {
+		t.Fatalf("%s returned no tree", route)
+	}
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatalf("%s returned a tree with no root", route)
+	}
+	if tree.ParseRuntime().NativeRecoveredStructureAuthoritative {
+		t.Fatalf("%s native recovered structure authoritative=true, want false", route)
+	}
+	if root == nil || root.HasError() != want.errorRoot {
+		t.Fatalf("%s root error=%t, want %t", route, root != nil && root.HasError(), want.errorRoot)
+	}
+	inspection, err := benchfixtures.InspectGoTree(root, language)
+	if err != nil {
+		t.Fatalf("%s inspect: %v", route, err)
+	}
+	if inspection.SHA256 != want.digest {
+		t.Fatalf("%s digest=%s, want %s", route, inspection.SHA256, want.digest)
+	}
+	diff := FirstDivergenceDumpV1(root, language, cTree.RootNode())
+	if want.divergence == nil {
+		if diff != nil || inspection.SHA256 != cDigest {
+			t.Fatalf("%s locked-C divergence=%+v digest=%s C=%s", route, diff, inspection.SHA256, cDigest)
+		}
+	} else if diff == nil || diff.Path != want.divergence.path || diff.Category != want.divergence.category || diff.GoValue != want.divergence.goValue || diff.CValue != want.divergence.cValue {
+		t.Fatalf("%s divergence=%+v, want %+v", route, diff, want.divergence)
+	}
+	got := cooklangNextPassReceipt(t, tree, "dispatch.cooklang")
+	recovered := cooklangNextPassReceipt(t, tree, "dispatch.cooklang.recovered-recipe")
+	if want.pass == nil {
+		if got != nil {
+			t.Fatalf("%s unexpected dispatch receipt=%+v", route, got)
+		}
+		if recovered != nil {
+			t.Fatalf("%s unexpected recovered-recipe receipt=%+v", route, recovered)
+		}
+	} else {
+		if got == nil {
+			t.Fatalf("%s missing dispatch.cooklang receipt", route)
+		}
+		if got.checked != want.pass.checked || got.run != want.pass.run || got.rewritten != want.pass.rewritten {
+			t.Fatalf("%s dispatch.cooklang checked/run/visited/rewritten=%d/%d/%d/%d, want 1/1/diagnostic/%d", route, got.checked, got.run, got.visited, got.rewritten, want.pass.rewritten)
+		}
+		if recovered == nil {
+			t.Fatalf("%s missing dispatch.cooklang.recovered-recipe receipt", route)
+		}
+		if recovered.checked != want.pass.checked || recovered.run != want.pass.run || recovered.rewritten != want.pass.rewritten {
+			t.Fatalf("%s recovered-recipe checked/run/visited/rewritten=%d/%d/%d/%d, want 1/1/diagnostic/%d", route, recovered.checked, recovered.run, recovered.visited, recovered.rewritten, want.pass.rewritten)
+		}
+	}
+	t.Logf("route=%s error=%t digest=%s c_digest=%s divergence=%+v dispatch=%+v recovered_recipe=%+v", route, root.HasError(), inspection.SHA256, cDigest, diff, got, recovered)
+}
+
+func cooklangNextPassReceipt(t *testing.T, tree *gotreesitter.Tree, name string) *cooklangNextPass {
+	t.Helper()
+	if tree == nil || tree.ParseRuntime().NormalizationPasses == nil {
+		return nil
+	}
+	var found *cooklangNextPass
+	for _, pass := range *tree.ParseRuntime().NormalizationPasses {
+		if pass.Name == name {
+			if found != nil {
+				t.Fatalf("tree recorded duplicate %s passes", name)
+			}
+			found = &cooklangNextPass{checked: pass.Checked, run: pass.Run, visited: pass.NodesVisited, rewritten: pass.NodesRewritten}
+		}
+	}
+	return found
+}
+
+func cooklangNextPointAtByte(source []byte) gotreesitter.Point {
+	var point gotreesitter.Point
+	for _, value := range source {
+		if value == '\n' {
+			point.Row++
+			point.Column = 0
+		} else {
+			point.Column++
+		}
+	}
+	return point
+}
+
+func mustCooklangFile(t *testing.T, path string) []byte {
+	t.Helper()
+	source, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return source
+}
+
+func cooklangNextFileSHA(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(data))
+}

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -2177,6 +2177,160 @@ Each run used one grammar, one CPU, 4 GiB memory, 512 process IDs,
 The route run used a 20-minute timeout. Every successful run exited zero.
 No run timed out or exhausted memory.
 
+## 2026-08-24 Cooklang dispatcher blocker receipt
+
+Status: `KEEP LIVE / NO-GO`. Keep `dispatch.cooklang` live.
+The Cooklang dispatcher arm remains live.
+
+Evidence base: `7498a678c52029a82f312e9637ecb66b15defa0b`.
+Publication base: `675697a1144fad306489c5142aedaae0825545d9`.
+This receipt changes only the receipt document, CHANGELOG.md, and focused test.
+It changes no parser, registry, or production code.
+
+The registry contains 88 entries. It contains 78 dispatcher arms, three
+dispatcher subpasses, one dispatcher predicate, three generic passes, and
+three fixpoint passes. The live denominator contains 31 dispatcher arms, 33
+dispatcher-arm language labels, one predicate, 32 live entries, and 56
+retired entries. It contains zero live generic or fixpoint passes.
+
+The registry names `normalizeCooklangCompatibilityWithCensus` in
+`parser_result_cooklang.go`. Its owner is `scheduler_action_semantics`.
+The registered subpass is `dispatch.cooklang.recovered-recipe`. It names
+`normalizeCooklangRecoveredRecipe` in the same file. Its witness is
+`parser_result_test/materialization_subpass_census_test.go`. Its purpose is to
+construct recovered steps, metadata, punctuation errors, and fence comments.
+The arm witness is `cgo_harness/parity_cgo_test.go`.
+
+The locked grammar is `tree-sitter-cooklang` at commit
+`4ebe237c1cf64cf3826fc249e9ec0988fe07e58e`.
+The grammar lock SHA-256 is
+`9ddb6324afd014f6ecdd1cae3dd1ba238f1e62ce03d126e6d8b267ce34d72ecb`.
+The embedded Go grammar blob SHA-256 is
+`2fd57f20461bcc0830fd14420cd06ad08750dd3cbbc440670e63056d59b3692a`.
+The Cooklang language has an external scanner.
+
+The A0 (authenticated dispatcher census) manifest has 14 languages, 42 files,
+and 14 receipts. Cooklang has three files, three checked, three run, 1037
+nodes visited, 1021 rewrites, two error roots, and zero parse errors.
+The A0 aggregate has 44 checked, 44 run, 313572 nodes visited, 3267 rewrites,
+20 error roots, and zero parse errors.
+
+The Cooklang A0 files are:
+
+- `testdata/dispatcher_census_a0/cooklang/medium__complex_test_recipe.cook` — source SHA-256 `6120e9cafce48a745c0f5dade752499883bc2b07230cae93d6a452a788c7ba74`;
+- `testdata/dispatcher_census_a0/cooklang/medium__frontmatter_test_recipe.cook` — source SHA-256 `956fcaf1c14e0e915efded324450789cb5d9a896cf60e4feafb71b918c8e621a`;
+- `testdata/dispatcher_census_a0/cooklang/medium__test_recipe.cook` — source SHA-256 `1acb11626700218ebc8ff8b7d445e1a257b12af35dea7dbc0fcef0587a79468f`.
+
+The tracked census has seven fixtures across six languages. It omits Cooklang.
+Its aggregate has nine checked, nine run, 26022 nodes visited, 2107 rewrites,
+and zero error roots.
+The authenticated real-corpus census is unavailable. The worktree lacks
+`cgo_harness/corpus_real`, `corpus_sources.lock`, and
+`cgo_harness/perf_scan/corpus_sources.lock`. The A0 sidecar records only the
+expected corpus lock SHA-256
+`41c744279c8b1d7c9fe7b1b8e26fba733423e77cd48efea46927309c22d163ea`.
+
+The focused receipt covers nine witnesses. It covers raw, production, compact,
+forest, incremental, and locked-C routes. The test pins each source and C
+digest. It records both Cooklang pass identities on every route that runs a
+pass. Every Go tree reports
+`NativeRecoveredStructureAuthoritative=false`. Forest declines seven witnesses
+and accepts two controls.
+
+The three A0 witnesses diverge from locked C on raw, production, compact, and
+incremental routes. Forest declines all three witnesses. The first differences
+are:
+
+- `medium__complex_test_recipe.cook`: raw first differs at `/recipe`, shape.
+  Go has `children=22`. C has `children=42`. Recovery has `children=23`.
+- `medium__frontmatter_test_recipe.cook`: raw first differs at `/recipe`, shape.
+  Go has `children=36`. C has `children=47`. Recovery has `children=35`.
+- `medium__test_recipe.cook`: raw first differs at `/recipe`, shape.
+  Go has `children=34`. C has `children=43`. Recovery changes the first
+  difference to error, `false` versus `true`.
+
+The A0 rewrite receipts are `1/1/450/442`, `1/1/289/287`, and `1/1/298/292`.
+The values are checked, run, visited, and rewritten. Both registered Cooklang
+pass identities report each value. The focused guard ratchets checked, run,
+and rewritten values. It treats visited values as diagnostic.
+
+The three raw-digest controls from rejected pull request (PR) #793 are
+retained.
+
+- `Add @salt{1%tsp}.\n` uses source SHA-256
+  `8dd8b584db0c0ef919fdcc229645c2cb5d7697c7f555624b3c075e7f1a4eb53a`.
+  Raw digest is
+  `0e6880ec4902576c2a6de014424c3cba7eef99cdc5fd8fded8ceb6382a6df9cd`.
+  Locked C and result digest are
+  `c6e4535b725516550ca7a0ee4c69974799c2d2d10fed4e5f1ba6b71e43c5ba8a`.
+  Production, compact, and incremental report `1/1/13/4`. Forest declines.
+- The recovered recipe uses source SHA-256
+  `8fefd1eb97742b1ef8349e9e51b5260c28295ed0d583d12eb5fbc04db579ce8a`.
+  Raw digest is
+  `896d9f79d941c3869dca7b855bae45738392d02519f0fbe3ac45cc2623fcfa2f`.
+  Locked C digest is
+  `3ae5ffba70cd0922976d24ed3e4d254cbb9d356639e8485b8b4b3abdc2667133`.
+  Production, compact, and incremental report digest
+  `814240a8aff9c3e253b37ce1ff535ff2cd96510c6afea40680a270405699967f`.
+  They report `1/1/20/18`. Forest declines.
+- `Add @salt{1%tsp}.` uses source SHA-256
+  `6d60ac3d4e9155e84ead7b1f9e751728dcebafe03d6561d913f3f18f58a14297`.
+  Raw digest is
+  `f49ca1a85a0b2ee7ed7f07993d6bc8b103d66311f83d4a026e085cf2013a69ec`.
+  Locked C and result digest are
+  `dd3692a1a0e9145af9f2d082126a1e798d60cbe74942427746d3f0e83bd31e1c`.
+  Production, compact, and incremental report `1/1/13/4`. Forest declines.
+
+The recovered recipe still differs after 18 rewrites. The mismatch is
+`/recipe`, shape, `children=5` versus `children=7`.
+
+The malformed frontmatter witness has source SHA-256
+`f2c2b1b02d9b3497d42c1cc53b94373974bd7b525af438d7dcf73391725f3615`.
+Raw differs from locked C at `/recipe`, error, `true` versus `false`.
+Production, compact, and incremental match locked C. They report
+`1/1/13/11`. Forest declines.
+
+The clean control and the no-op ingredient control match locked C on every
+route. Forest accepts both controls. The clean control reports `1/1/11/1` on
+production, forest, and incremental routes. The no-op control reports
+`1/1/7/1` on those routes. Compact records no Cooklang pass for either control.
+
+Compact falls back for seven witnesses. It accepts the clean and no-op
+controls. A fallback keeps the routed counter unchanged and increments the
+fallback counter by one. An accepted route increments the routed counter by one
+and keeps the fallback counter unchanged. The fallback says that the generic
+scheduler has no table action for the elected token. The guard checks each
+transition exactly.
+
+Incremental parsing reports `external_scanner_unsupported` for every witness.
+It reuses zero subtrees and zero bytes. These scanner fallbacks are route
+results, not retirement proof. Forest returns nil when it declines and returns a
+non-nil tree when it accepts. The guard releases any unexpected tree before it
+fails.
+
+The locked C oracle uses runtime `0.25.1` at commit
+`f5afe475deb7c0bae6407fb776c76824f717bb61`. The successful route run used C
+artifact SHA-256
+`009b897908abbc248d72855a7926b70715ac7955fed1f44c8fb2e8148f7ee83c`.
+
+The successful focused Docker route receipt is under
+`/tmp/gts-n31i-cooklang-rebased-artifacts/20260823T105932Z-final-rebased-routes`.
+Its `container.log` SHA-256 is
+`c83f451f157271c078abd286af1355a9687b37d864f39315d58e45079c9c3502`.
+
+The successful document guard receipt is under
+`/tmp/gts-n31i-cooklang-rebased-artifacts/20260823T105956Z-final-rebased-document`.
+Its `container.log` SHA-256 is
+`b14a8c8a5f18610c20657cff0868bd3832f888cb11c319c946c4585d5b5ae78e`.
+
+Keep `dispatch.cooklang` live. Require a producer fix for the A0 and recovered
+recipe differences. Require the authenticated Cooklang corpus and source lock.
+Move scanner and recovery controls to their owning subsystems before retirement.
+Keep dispatch.cooklang live until scheduler_action_semantics emits the locked-C
+tree on every route. Require zero required dispatcher rewrites and exact
+production, compact, forest, incremental, and locked-C parity. Do not change
+the registry or production state before every condition passes.
+
 ### R3 — move materialization invariants upstream
 
 Status: in progress.


### PR DESCRIPTION
## Decision

Keep `dispatch.cooklang` live. Mark this receipt `KEEP LIVE / NO-GO`.

This PR adds no parser, production, or registry change.

## Evidence

- Evidence base: `7498a678c52029a82f312e9637ecb66b15defa0b`.
- Publication base: `675697a1144fad306489c5142aedaae0825545d9`.
- Nine witnesses cover raw, production, compact, forest, incremental, and locked-C routes.
- Seven non-control witnesses differ from locked C on at least one route.
- Four witnesses differ from locked C on the production route.
- Cooklang has an external scanner.
- The authenticated Cooklang corpus and source lock are unavailable.

## Validation

- Route artifact: `/tmp/gts-n31i-cooklang-rebased-artifacts/20260823T105932Z-final-rebased-routes`.
- Route log SHA-256: `c83f451f157271c078abd286af1355a9687b37d864f39315d58e45079c9c3502`.
- Document artifact: `/tmp/gts-n31i-cooklang-rebased-artifacts/20260823T105956Z-final-rebased-document`.
- Document log SHA-256: `b14a8c8a5f18610c20657cff0868bd3832f888cb11c319c946c4585d5b5ae78e`.
- Use one Cooklang grammar, one CPU, 4 GiB, GOMEMLIMIT=3GiB, GOMAXPROCS=1, GOFLAGS=-p=1, and -parallel=1.
- The route and document guards pass without timeout or out-of-memory failure.
- Canopy, gofmt, Markdown parsing, and diff checks pass.
- The changelog retains baseline duplicate-heading lint warnings.

## Reopening

Require an authenticated Cooklang corpus and source lock.
Require zero required dispatcher rewrites.
Require exact production, compact, forest, incremental, and locked-C parity.
Move scanner and recovery controls to their owning subsystems before retirement.