### PR TITLE
test(scanner): add checkpoint lifecycle proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,26 @@ for tags and release notes while still in `0.x`.
   Keep issue #576 open until a real scanner and parser lifecycle use this
   capability with locked-C parity.
 
+- Audited the C26n synthetic external-scanner checkpoint lifecycle at evidence
+  base `2c533f5c19f5f7ab9b586cd8454f0cdc4ece014b`. The exact code scope is
+  `external_scanner_checkpoint_lifecycle.go` and
+  `external_scanner_checkpoint_lifecycle_test.go`. The lifecycle is explicit
+  opt-in and test-only. It has no production caller and does not reference
+  `glrStack` or `gssNode`. Failed restore verification now destroys and removes
+  the payload. Merge and condense reserialize each payload before they share a
+  checkpoint. Condense deletes listed dead siblings and rejects unknown or
+  incomplete live siblings. The focused Docker run used one central
+  processing unit (CPU),
+  4 GiB, `GOMAXPROCS=1`, `GOMEMLIMIT=3GiB`, and `GOFLAGS=-p=1`. It passed with
+  no out-of-memory kill or wall timeout. The artifact is
+  `/tmp/gts-c26n-rebased-20260824/harness_out/docker/20260823T112731Z-c26n-hardened-1cpu-4g`.
+  Eight C26n test functions cover these lifecycle rules.
+  The code file hashes are
+  `961bad1b3872b35253f02aeb1ea1f2427bc2807a3719b78cf723a610b967e412` and
+  `a039dd39f9cb0196bcc798b5e05d1607c0ca10b9339da59bfaa0613c1483bcad`.
+  Keep issue #576 open. Do not connect this lifecycle to real GLR, recovery,
+  condense, or incremental parser paths without locked-C proof.
+
 - Recorded the N31e C and C++ dispatcher blocker at main commit
   `ab2010d74da5330d64dbddb0d9c58969da766d6d`. Keep `dispatch.c_cpp` live.
   The initial dispatcher census (A0) excludes both languages, and the

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -1216,6 +1216,81 @@ capability proves all of the following:
 - Pass the full witness on raw, production, compact, forest, and incremental routes.
 - Use an authenticated source lock and corpus evidence.
 
+## C26n Swift issue #576 synthetic checkpoint lifecycle
+
+Evidence and publication base: `2c533f5c19f5f7ab9b586cd8454f0cdc4ece014b`.
+
+Status: **KEEP ISSUE #576 OPEN / NO-GO FOR REAL PARSER INTEGRATION**.
+
+C26n adds a bounded synthetic lifecycle for an external scanner checkpoint.
+It remains explicit opt-in and test-only. It does not add a production caller.
+It does not enter `glrStack` or `gssNode`. It does not change parser, grammar,
+Swift, generalized LR (GLR), recovery, condense, merge, or incremental paths.
+
+### Lifecycle safety result
+
+The exact code files are:
+
+- `external_scanner_checkpoint_lifecycle.go`;
+- `external_scanner_checkpoint_lifecycle_test.go`.
+
+The lifecycle records a stable epoch and monotonic version key. It owns each
+scanner payload until merge, deletion, or close. It destroys a payload when
+restore verification fails. It also removes that version from the ledger.
+Failed election and recovery restore paths use this fail-closed rule.
+
+Before merge or condense sharing, the lifecycle serializes the current payload
+and compares it with the complete checkpoint record. A stale payload cannot
+share a checkpoint. Normal active-version lookup rejects incomplete records.
+Cleanup inspects owned entries so dead or incomplete records cannot remain
+hidden.
+
+The tests cover:
+
+- explicit opt-in and disabled mode;
+- capture and stable version ownership;
+- failed-scan rollback and failed restore destruction;
+- independent forks and exact checkpoint sharing;
+- stale and mismatched checkpoint rejection;
+- condense selection, dead-sibling cleanup, and unknown-sibling rejection;
+- incomplete live-sibling rejection and destruction;
+- incomplete merge rejection and dead-version cleanup;
+- recovery resume and dead-version deletion.
+
+Eight C26n test functions cover these lifecycle rules.
+
+### Structural proof and focused validation
+
+Canopy version `v0.18.0-19-g01a5f95-dirty` traced the constructor. Its reverse
+caller result contains only `external_scanner_checkpoint_lifecycle_test.go`.
+Literal search found no production caller. Literal search found no
+`glrStack` or `gssNode` reference in either C26n file.
+
+The focused Docker artifact is
+`/tmp/gts-c26n-rebased-20260824/harness_out/docker/20260823T112731Z-c26n-hardened-1cpu-4g`.
+The command ran the C26l and C26n checkpoint tests with one CPU and 4 GiB.
+It set `GOMAXPROCS=1`, `GOMEMLIMIT=3GiB`, `GOFLAGS=-p=1`, and `-parallel=1`.
+The run passed with exit code zero. It had no out-of-memory kill or wall
+timeout. The container log hash is
+`dc46c5647db98f5e40b4372e52343f124dc986156aff2da7345e0c9a7d381e49`.
+The metadata hash is
+`9b614b771f6ca077439e2b532b2753e7410c57dba40ee23235f529d9532d069b`.
+The inspect hash is
+`fad5bb486e85d1e13014a0da084402f806a6b6efeb45a01c8bd593251bb92296`.
+
+The corrected code file hashes are:
+
+- `external_scanner_checkpoint_lifecycle.go`:
+  `961bad1b3872b35253f02aeb1ea1f2427bc2807a3719b78cf723a610b967e412`;
+- `external_scanner_checkpoint_lifecycle_test.go`:
+  `a039dd39f9cb0196bcc798b5e05d1607c0ca10b9339da59bfaa0613c1483bcad`.
+
+The four-file documentation and code receipt passes `go doc`, `gofmt`, Canopy,
+Markdown++, and `git diff --check`. It proves only a synthetic lifecycle.
+It does not prove real scanner ownership across GLR versions, recovery,
+condense, or incremental reuse. Keep issue #576 open until a real parser
+integration passes locked-C parity on the full route set.
+
 
 ## Current bounded result
 

--- a/external_scanner_checkpoint_lifecycle.go
+++ b/external_scanner_checkpoint_lifecycle.go
@@ -1,0 +1,482 @@
+package gotreesitter
+
+// externalScannerCheckpointVersionKey identifies one parser version inside a
+// single checkpoint lifecycle. It is not a parser stack field.
+type externalScannerCheckpointVersionKey struct {
+	parseEpoch uint64
+	versionID  uint64
+}
+
+// externalScannerCheckpointVersion keeps scanner ownership beside, rather
+// than inside, a parser stack. The lifecycle is opt-in and has no production
+// parser caller yet.
+type externalScannerCheckpointVersion struct {
+	key        externalScannerCheckpointVersionKey
+	payload    any
+	checkpoint externalScannerCheckpointRecord
+	alive      bool
+}
+
+// externalScannerCheckpointLifecycle is a bounded ownership ledger for the
+// synthetic parser lifecycle proof. It does not wire scanner state into GLR.
+type externalScannerCheckpointLifecycle struct {
+	scanner  ExternalScanner
+	epoch    uint64
+	nextID   uint64
+	versions map[externalScannerCheckpointVersionKey]*externalScannerCheckpointVersion
+}
+
+// newExternalScannerCheckpointLifecycle requires an explicit opt-in. A
+// missing or disabled capability returns no lifecycle and no ledger.
+func newExternalScannerCheckpointLifecycle(scanner ExternalScanner, enabled bool) (*externalScannerCheckpointLifecycle, bool) {
+	if !enabled || scanner == nil {
+		return nil, false
+	}
+	provider, ok := scanner.(ExternalScannerCheckpointIdentityProvider)
+	if !ok || !provider.UsesExternalScannerCheckpoints() {
+		return nil, false
+	}
+	return &externalScannerCheckpointLifecycle{
+		scanner:  scanner,
+		epoch:    1,
+		nextID:   1,
+		versions: make(map[externalScannerCheckpointVersionKey]*externalScannerCheckpointVersion),
+	}, true
+}
+
+func (l *externalScannerCheckpointLifecycle) nextVersionKey() (externalScannerCheckpointVersionKey, bool) {
+	if l == nil || l.epoch == 0 || l.nextID == 0 {
+		return externalScannerCheckpointVersionKey{}, false
+	}
+	key := externalScannerCheckpointVersionKey{
+		parseEpoch: l.epoch,
+		versionID:  l.nextID,
+	}
+	if _, exists := l.versions[key]; exists {
+		return externalScannerCheckpointVersionKey{}, false
+	}
+	if l.nextID == ^uint64(0) {
+		l.nextID = 0
+	} else {
+		l.nextID++
+	}
+	return key, true
+}
+
+func (l *externalScannerCheckpointLifecycle) close() {
+	if l == nil {
+		return
+	}
+	for _, version := range l.versions {
+		if version != nil && version.payload != nil {
+			l.scanner.Destroy(version.payload)
+			version.payload = nil
+		}
+		if version != nil {
+			version.alive = false
+		}
+	}
+	clear(l.versions)
+}
+
+func (l *externalScannerCheckpointLifecycle) ownedVersion(key externalScannerCheckpointVersionKey) (*externalScannerCheckpointVersion, bool) {
+	if l == nil || l.versions == nil {
+		return nil, false
+	}
+	version, ok := l.versions[key]
+	return version, ok && version != nil
+}
+
+func (l *externalScannerCheckpointLifecycle) version(key externalScannerCheckpointVersionKey) (*externalScannerCheckpointVersion, bool) {
+	version, ok := l.ownedVersion(key)
+	if !ok || !version.alive || !version.checkpoint.complete() {
+		return nil, false
+	}
+	return version, true
+}
+
+func (l *externalScannerCheckpointLifecycle) addRoot(
+	payload any,
+	sourceByte uint32,
+	sourcePoint Point,
+	externalLexState uint16,
+	tokenStartByte uint32,
+	tokenEndByte uint32,
+) (externalScannerCheckpointVersionKey, bool) {
+	if l == nil {
+		return externalScannerCheckpointVersionKey{}, false
+	}
+	record, ok := captureExternalScannerCheckpointRecord(
+		l.scanner,
+		payload,
+		sourceByte,
+		sourcePoint,
+		externalLexState,
+		tokenStartByte,
+		tokenEndByte,
+	)
+	if !ok {
+		return externalScannerCheckpointVersionKey{}, false
+	}
+	key, ok := l.nextVersionKey()
+	if !ok {
+		if payload != nil {
+			l.scanner.Destroy(payload)
+		}
+		return externalScannerCheckpointVersionKey{}, false
+	}
+	l.versions[key] = &externalScannerCheckpointVersion{
+		key:        key,
+		payload:    payload,
+		checkpoint: record,
+		alive:      true,
+	}
+	return key, true
+}
+
+// restoreAndVerify restores the owned bytes, then captures them again. The
+// second capture proves that Deserialize accepted the complete checkpoint.
+func (l *externalScannerCheckpointLifecycle) restoreAndVerify(version *externalScannerCheckpointVersion) bool {
+	if l == nil || version == nil || !version.alive || !version.checkpoint.complete() {
+		return false
+	}
+	if !version.checkpoint.restore(l.scanner, version.payload) {
+		return false
+	}
+	restored, ok := captureExternalScannerCheckpointRecord(
+		l.scanner,
+		version.payload,
+		version.checkpoint.sourceByte,
+		version.checkpoint.sourcePoint,
+		version.checkpoint.externalLexState,
+		version.checkpoint.tokenStartByte,
+		version.checkpoint.tokenEndByte,
+	)
+	return ok && restored.equal(version.checkpoint)
+}
+
+// discardVersion destroys a payload after failed restore verification. It
+// also removes an owned version from the lifecycle ledger.
+func (l *externalScannerCheckpointLifecycle) discardVersion(version *externalScannerCheckpointVersion) {
+	if version == nil {
+		return
+	}
+	if l != nil && l.versions != nil {
+		if current, ok := l.versions[version.key]; ok && current == version {
+			version.alive = false
+			_ = l.deleteDead(version.key)
+			return
+		}
+	}
+	if version.payload != nil {
+		if l != nil && l.scanner != nil {
+			l.scanner.Destroy(version.payload)
+		}
+		version.payload = nil
+	}
+	version.alive = false
+}
+
+// elect runs one synthetic token election. A failed scan restores the prior
+// checkpoint and keeps the version only after verified restoration.
+func (l *externalScannerCheckpointLifecycle) elect(
+	key externalScannerCheckpointVersionKey,
+	sourceByte uint32,
+	sourcePoint Point,
+	externalLexState uint16,
+	scan func(any) (Token, bool),
+) (Token, bool) {
+	version, ok := l.version(key)
+	if !ok || scan == nil {
+		return Token{}, false
+	}
+	before, ok := captureExternalScannerCheckpointRecord(
+		l.scanner,
+		version.payload,
+		sourceByte,
+		sourcePoint,
+		externalLexState,
+		sourceByte,
+		sourceByte,
+	)
+	if !ok {
+		return Token{}, false
+	}
+	tok, ok := scan(version.payload)
+	if !ok {
+		if !before.restore(l.scanner, version.payload) {
+			l.discardVersion(version)
+			return Token{}, false
+		}
+		if restored, restoreOK := captureExternalScannerCheckpointRecord(
+			l.scanner,
+			version.payload,
+			before.sourceByte,
+			before.sourcePoint,
+			before.externalLexState,
+			before.tokenStartByte,
+			before.tokenEndByte,
+		); !restoreOK || !restored.equal(before) {
+			l.discardVersion(version)
+			return Token{}, false
+		}
+		return Token{}, false
+	}
+	after, ok := captureExternalScannerCheckpointRecord(
+		l.scanner,
+		version.payload,
+		sourceByte,
+		sourcePoint,
+		externalLexState,
+		tok.StartByte,
+		tok.EndByte,
+	)
+	if !ok {
+		if !before.restore(l.scanner, version.payload) {
+			l.discardVersion(version)
+			return Token{}, false
+		}
+		restored, restoreOK := captureExternalScannerCheckpointRecord(
+			l.scanner,
+			version.payload,
+			before.sourceByte,
+			before.sourcePoint,
+			before.externalLexState,
+			before.tokenStartByte,
+			before.tokenEndByte,
+		)
+		if !restoreOK || !restored.equal(before) {
+			l.discardVersion(version)
+		}
+		return Token{}, false
+	}
+	version.checkpoint = after
+	return tok, true
+}
+
+func (l *externalScannerCheckpointLifecycle) fork(parentKey externalScannerCheckpointVersionKey) (externalScannerCheckpointVersionKey, bool) {
+	parent, ok := l.version(parentKey)
+	if !ok {
+		return externalScannerCheckpointVersionKey{}, false
+	}
+	childPayload := l.scanner.Create()
+	child := &externalScannerCheckpointVersion{
+		payload:    childPayload,
+		checkpoint: parent.checkpoint.clone(),
+		alive:      true,
+	}
+	if !l.restoreAndVerify(child) {
+		l.discardVersion(child)
+		return externalScannerCheckpointVersionKey{}, false
+	}
+	key, ok := l.nextVersionKey()
+	if !ok {
+		l.discardVersion(child)
+		return externalScannerCheckpointVersionKey{}, false
+	}
+	child.key = key
+	l.versions[key] = child
+	return key, true
+}
+
+func (l *externalScannerCheckpointLifecycle) canShare(aKey, bKey externalScannerCheckpointVersionKey) bool {
+	a, aOK := l.ownedVersion(aKey)
+	b, bOK := l.ownedVersion(bKey)
+	if !aOK || !bOK {
+		return false
+	}
+	if !a.alive {
+		_ = l.deleteDead(aKey)
+		return false
+	}
+	if !b.alive {
+		_ = l.deleteDead(bKey)
+		return false
+	}
+	if !a.checkpoint.complete() {
+		l.discardVersion(a)
+		return false
+	}
+	if !b.checkpoint.complete() {
+		l.discardVersion(b)
+		return false
+	}
+	if !l.currentStateMatches(a) {
+		l.discardVersion(a)
+		return false
+	}
+	if !l.currentStateMatches(b) {
+		l.discardVersion(b)
+		return false
+	}
+	return canShareExternalScannerCheckpoint(a.checkpoint, b.checkpoint)
+}
+
+func (l *externalScannerCheckpointLifecycle) currentStateMatches(version *externalScannerCheckpointVersion) bool {
+	if l == nil || version == nil || !version.alive || !version.checkpoint.complete() {
+		return false
+	}
+	record, ok := captureExternalScannerCheckpointRecord(
+		l.scanner,
+		version.payload,
+		version.checkpoint.sourceByte,
+		version.checkpoint.sourcePoint,
+		version.checkpoint.externalLexState,
+		version.checkpoint.tokenStartByte,
+		version.checkpoint.tokenEndByte,
+	)
+	return ok && record.equal(version.checkpoint)
+}
+
+// merge removes the candidate only when its complete record equals the keep
+// record. A mismatch leaves both versions alive for a safe fallback.
+func (l *externalScannerCheckpointLifecycle) merge(keepKey, candidateKey externalScannerCheckpointVersionKey) bool {
+	if keepKey == candidateKey || !l.canShare(keepKey, candidateKey) {
+		return false
+	}
+	return l.markDeadAndDelete(candidateKey)
+}
+
+// condense selects one version and deletes dead or exact-record siblings.
+// It rejects unknown, incomplete, or mismatched live siblings.
+func (l *externalScannerCheckpointLifecycle) condense(selectedKey externalScannerCheckpointVersionKey, siblingKeys []externalScannerCheckpointVersionKey) (any, bool) {
+	selected, ok := l.ownedVersion(selectedKey)
+	if !ok || !selected.alive || !selected.checkpoint.complete() {
+		if ok && selected.alive {
+			l.discardVersion(selected)
+		}
+		return nil, false
+	}
+	if !l.restoreAndVerify(selected) {
+		l.discardVersion(selected)
+		return nil, false
+	}
+	seen := make(map[externalScannerCheckpointVersionKey]struct{}, len(siblingKeys))
+	for _, siblingKey := range siblingKeys {
+		if siblingKey == selectedKey {
+			continue
+		}
+		if _, duplicate := seen[siblingKey]; duplicate {
+			continue
+		}
+		seen[siblingKey] = struct{}{}
+		sibling, siblingOK := l.ownedVersion(siblingKey)
+		if !siblingOK {
+			return nil, false
+		}
+		if !sibling.alive {
+			_ = l.deleteDead(siblingKey)
+			continue
+		}
+		if !sibling.checkpoint.complete() {
+			l.discardVersion(sibling)
+			return nil, false
+		}
+		if !l.canShare(selectedKey, siblingKey) {
+			return nil, false
+		}
+	}
+	for siblingKey := range seen {
+		if sibling, siblingOK := l.ownedVersion(siblingKey); siblingOK && sibling.alive {
+			sibling.alive = false
+			_ = l.deleteDead(siblingKey)
+		}
+	}
+	return selected.payload, true
+}
+
+// resume restores the selected version before the recovery callback. A failed
+// callback keeps the version only after verified restoration.
+func (l *externalScannerCheckpointLifecycle) resume(
+	key externalScannerCheckpointVersionKey,
+	sourceByte uint32,
+	sourcePoint Point,
+	externalLexState uint16,
+	recover func(any) (Token, bool),
+) (Token, bool) {
+	version, ok := l.version(key)
+	if !ok || recover == nil {
+		return Token{}, false
+	}
+	if !l.restoreAndVerify(version) {
+		l.discardVersion(version)
+		return Token{}, false
+	}
+	before := version.checkpoint.clone()
+	tok, ok := recover(version.payload)
+	if !ok {
+		if !before.restore(l.scanner, version.payload) {
+			l.discardVersion(version)
+			return Token{}, false
+		}
+		if !l.restoreAndVerify(version) {
+			l.discardVersion(version)
+		}
+		return Token{}, false
+	}
+	after, ok := captureExternalScannerCheckpointRecord(
+		l.scanner,
+		version.payload,
+		sourceByte,
+		sourcePoint,
+		externalLexState,
+		tok.StartByte,
+		tok.EndByte,
+	)
+	if !ok {
+		if !before.restore(l.scanner, version.payload) {
+			l.discardVersion(version)
+			return Token{}, false
+		}
+		restored, restoreOK := captureExternalScannerCheckpointRecord(
+			l.scanner,
+			version.payload,
+			before.sourceByte,
+			before.sourcePoint,
+			before.externalLexState,
+			before.tokenStartByte,
+			before.tokenEndByte,
+		)
+		if !restoreOK || !restored.equal(before) {
+			l.discardVersion(version)
+		}
+		return Token{}, false
+	}
+	version.checkpoint = after
+	return tok, true
+}
+
+func (l *externalScannerCheckpointLifecycle) markDead(key externalScannerCheckpointVersionKey) bool {
+	version, ok := l.ownedVersion(key)
+	if !ok || !version.alive {
+		return false
+	}
+	version.alive = false
+	return true
+}
+
+func (l *externalScannerCheckpointLifecycle) deleteDead(key externalScannerCheckpointVersionKey) bool {
+	if l == nil {
+		return false
+	}
+	version, ok := l.versions[key]
+	if !ok || version == nil || version.alive {
+		return false
+	}
+	if version.payload != nil {
+		payload := version.payload
+		version.payload = nil
+		l.scanner.Destroy(payload)
+	}
+	delete(l.versions, key)
+	return true
+}
+
+func (l *externalScannerCheckpointLifecycle) markDeadAndDelete(key externalScannerCheckpointVersionKey) bool {
+	version, ok := l.versions[key]
+	if !ok || version == nil || !version.alive {
+		return false
+	}
+	version.alive = false
+	return l.deleteDead(key)
+}

--- a/external_scanner_checkpoint_lifecycle_test.go
+++ b/external_scanner_checkpoint_lifecycle_test.go
@@ -1,0 +1,372 @@
+package gotreesitter
+
+import (
+	"bytes"
+	"testing"
+)
+
+type c26nCheckpointPayload struct {
+	state []byte
+}
+
+type c26nCheckpointScanner struct {
+	scannerID           []byte
+	grammarID           []byte
+	destroyed           int
+	deserializeMismatch bool
+}
+
+func (s *c26nCheckpointScanner) Create() any {
+	return &c26nCheckpointPayload{state: []byte{1, 2, 3}}
+}
+
+func (s *c26nCheckpointScanner) Destroy(any) { s.destroyed++ }
+
+func (s *c26nCheckpointScanner) Serialize(payload any, buf []byte) int {
+	p, ok := payload.(*c26nCheckpointPayload)
+	if !ok || len(p.state) == 0 || len(p.state) > len(buf) {
+		return 0
+	}
+	return copy(buf, p.state)
+}
+
+func (s *c26nCheckpointScanner) Deserialize(payload any, buf []byte) {
+	p, ok := payload.(*c26nCheckpointPayload)
+	if !ok {
+		return
+	}
+	if s.deserializeMismatch {
+		p.state = []byte{9, 9, 9}
+		return
+	}
+	p.state = append(p.state[:0], buf...)
+}
+
+func (*c26nCheckpointScanner) Scan(any, *ExternalLexer, []bool) bool {
+	return false
+}
+
+func (*c26nCheckpointScanner) UsesExternalScannerCheckpoints() bool {
+	return true
+}
+
+func (s *c26nCheckpointScanner) CheckpointIdentity() (ExternalScannerCheckpointIdentity, bool) {
+	return ExternalScannerCheckpointIdentity{
+		Scanner: s.scannerID,
+		Grammar: s.grammarID,
+	}, true
+}
+
+func newC26nCheckpointScanner() *c26nCheckpointScanner {
+	return &c26nCheckpointScanner{
+		scannerID: []byte("scanner-c26n"),
+		grammarID: []byte("grammar-c26n"),
+	}
+}
+
+func c26nPayloadState(t *testing.T, payload any) []byte {
+	t.Helper()
+	p, ok := payload.(*c26nCheckpointPayload)
+	if !ok {
+		t.Fatalf("payload type = %T, want *c26nCheckpointPayload", payload)
+	}
+	return append([]byte(nil), p.state...)
+}
+
+func TestC26nCheckpointLifecycleRequiresExplicitOptIn(t *testing.T) {
+	scanner := newC26nCheckpointScanner()
+	if lifecycle, ok := newExternalScannerCheckpointLifecycle(scanner, false); ok || lifecycle != nil {
+		t.Fatal("disabled lifecycle allocated an ownership ledger")
+	}
+	if lifecycle, ok := newExternalScannerCheckpointLifecycle(nil, true); ok || lifecycle != nil {
+		t.Fatal("nil scanner enabled a lifecycle")
+	}
+}
+
+func TestC26nCheckpointLifecycleDiscardsFailedRestore(t *testing.T) {
+	scanner := newC26nCheckpointScanner()
+	lifecycle, ok := newExternalScannerCheckpointLifecycle(scanner, true)
+	if !ok {
+		t.Fatal("explicit lifecycle opt-in was rejected")
+	}
+
+	rootPayload := scanner.Create()
+	rootKey, ok := lifecycle.addRoot(rootPayload, 10, Point{Row: 1}, 7, 10, 10)
+	if !ok {
+		t.Fatal("root checkpoint was rejected")
+	}
+	scanner.deserializeMismatch = true
+	if _, ok := lifecycle.elect(rootKey, 10, Point{Row: 1}, 7, func(payload any) (Token, bool) {
+		payload.(*c26nCheckpointPayload).state = []byte{9, 9, 9}
+		return Token{}, false
+	}); ok {
+		t.Fatal("failed election unexpectedly succeeded")
+	}
+	if _, exists := lifecycle.versions[rootKey]; exists {
+		t.Fatal("failed election retained an unverified payload")
+	}
+	if scanner.destroyed != 1 {
+		t.Fatalf("destroy count after failed election = %d, want 1", scanner.destroyed)
+	}
+
+	scanner.deserializeMismatch = false
+	resumePayload := scanner.Create()
+	resumeKey, ok := lifecycle.addRoot(resumePayload, 11, Point{Row: 1}, 7, 11, 11)
+	if !ok {
+		t.Fatal("resume checkpoint was rejected")
+	}
+	scanner.deserializeMismatch = true
+	if _, ok := lifecycle.resume(resumeKey, 11, Point{Row: 1}, 7, func(any) (Token, bool) {
+		return Token{}, false
+	}); ok {
+		t.Fatal("failed resume unexpectedly succeeded")
+	}
+	if _, exists := lifecycle.versions[resumeKey]; exists {
+		t.Fatal("failed resume retained an unverified payload")
+	}
+	if scanner.destroyed != 2 {
+		t.Fatalf("destroy count after failed resume = %d, want 2", scanner.destroyed)
+	}
+	lifecycle.close()
+	if scanner.destroyed != 2 {
+		t.Fatalf("close destroyed discarded payloads again: count = %d", scanner.destroyed)
+	}
+}
+
+func newC26nLifecycleRoot(t *testing.T) (*c26nCheckpointScanner, *externalScannerCheckpointLifecycle, externalScannerCheckpointVersionKey) {
+	t.Helper()
+	scanner := newC26nCheckpointScanner()
+	lifecycle, ok := newExternalScannerCheckpointLifecycle(scanner, true)
+	if !ok {
+		t.Fatal("explicit lifecycle opt-in was rejected")
+	}
+	t.Cleanup(lifecycle.close)
+	key, ok := lifecycle.addRoot(scanner.Create(), 10, Point{Row: 1}, 7, 10, 10)
+	if !ok {
+		t.Fatal("root checkpoint was rejected")
+	}
+	return scanner, lifecycle, key
+}
+
+func TestC26nCondenseDeletesDeadSibling(t *testing.T) {
+	scanner, lifecycle, rootKey := newC26nLifecycleRoot(t)
+	siblingKey, ok := lifecycle.fork(rootKey)
+	if !ok {
+		t.Fatal("sibling fork was rejected")
+	}
+	if !lifecycle.markDead(siblingKey) {
+		t.Fatal("sibling was not marked dead")
+	}
+	if _, ok := lifecycle.condense(rootKey, []externalScannerCheckpointVersionKey{siblingKey}); !ok {
+		t.Fatal("condense rejected a dead sibling")
+	}
+	if _, exists := lifecycle.versions[siblingKey]; exists {
+		t.Fatal("condense retained a dead sibling")
+	}
+	if scanner.destroyed != 1 {
+		t.Fatalf("destroy count after dead sibling cleanup = %d, want 1", scanner.destroyed)
+	}
+}
+
+func TestC26nCondenseRejectsAndDestroysIncompleteSibling(t *testing.T) {
+	scanner, lifecycle, rootKey := newC26nLifecycleRoot(t)
+	siblingKey, ok := lifecycle.fork(rootKey)
+	if !ok {
+		t.Fatal("sibling fork was rejected")
+	}
+	lifecycle.versions[siblingKey].checkpoint.serialized = nil
+	if _, ok := lifecycle.condense(rootKey, []externalScannerCheckpointVersionKey{siblingKey}); ok {
+		t.Fatal("condense accepted an incomplete sibling")
+	}
+	if _, exists := lifecycle.versions[siblingKey]; exists {
+		t.Fatal("incomplete sibling remained in the ledger")
+	}
+	if scanner.destroyed != 1 {
+		t.Fatalf("destroy count after incomplete sibling rejection = %d, want 1", scanner.destroyed)
+	}
+}
+
+func TestC26nMergeDiscardsIncompleteVersion(t *testing.T) {
+	scanner, lifecycle, rootKey := newC26nLifecycleRoot(t)
+	candidateKey, ok := lifecycle.fork(rootKey)
+	if !ok {
+		t.Fatal("candidate fork was rejected")
+	}
+	lifecycle.versions[candidateKey].checkpoint.serialized = nil
+	if lifecycle.merge(rootKey, candidateKey) {
+		t.Fatal("merge accepted an incomplete candidate")
+	}
+	if _, exists := lifecycle.versions[candidateKey]; exists {
+		t.Fatal("incomplete candidate remained in the ledger")
+	}
+	if scanner.destroyed != 1 {
+		t.Fatalf("destroy count after incomplete merge rejection = %d, want 1", scanner.destroyed)
+	}
+}
+
+func TestC26nCondenseRejectsUnknownSibling(t *testing.T) {
+	_, lifecycle, rootKey := newC26nLifecycleRoot(t)
+	unknownKey := externalScannerCheckpointVersionKey{parseEpoch: 1, versionID: 999}
+	if _, ok := lifecycle.condense(rootKey, []externalScannerCheckpointVersionKey{unknownKey}); ok {
+		t.Fatal("condense accepted an unknown sibling")
+	}
+	if _, exists := lifecycle.versions[rootKey]; !exists {
+		t.Fatal("condense removed the selected version after unknown sibling")
+	}
+}
+
+func TestC26nMarkDeadCleansUpIncompleteVersion(t *testing.T) {
+	scanner, lifecycle, rootKey := newC26nLifecycleRoot(t)
+	lifecycle.versions[rootKey].checkpoint.serialized = nil
+	if !lifecycle.markDead(rootKey) {
+		t.Fatal("markDead rejected an incomplete live version")
+	}
+	if !lifecycle.deleteDead(rootKey) {
+		t.Fatal("deleteDead rejected an incomplete dead version")
+	}
+	if _, exists := lifecycle.versions[rootKey]; exists {
+		t.Fatal("incomplete version remained after deletion")
+	}
+	if scanner.destroyed != 1 {
+		t.Fatalf("destroy count after incomplete cleanup = %d, want 1", scanner.destroyed)
+	}
+}
+
+func TestC26nCheckpointLifecycle(t *testing.T) {
+	scanner := newC26nCheckpointScanner()
+	lifecycle, ok := newExternalScannerCheckpointLifecycle(scanner, true)
+	if !ok {
+		t.Fatal("explicit lifecycle opt-in was rejected")
+	}
+	defer lifecycle.close()
+
+	rootPayload := scanner.Create()
+	rootKey, ok := lifecycle.addRoot(rootPayload, 10, Point{Row: 1, Column: 2}, 7, 10, 10)
+	if !ok {
+		t.Fatal("root checkpoint was rejected")
+	}
+
+	selectedToken, ok := lifecycle.elect(rootKey, 10, Point{Row: 1, Column: 2}, 7, func(payload any) (Token, bool) {
+		p := payload.(*c26nCheckpointPayload)
+		p.state = []byte{4, 5, 6}
+		return Token{Symbol: 11, StartByte: 10, EndByte: 12}, true
+	})
+	if !ok || selectedToken.Symbol != 11 || selectedToken.EndByte != 12 {
+		t.Fatalf("election = (%+v, %t), want symbol 11 and success", selectedToken, ok)
+	}
+	if got := c26nPayloadState(t, rootPayload); !bytes.Equal(got, []byte{4, 5, 6}) {
+		t.Fatalf("elected payload = %v, want [4 5 6]", got)
+	}
+	rootRecord := lifecycle.versions[rootKey].checkpoint.clone()
+
+	failedToken, ok := lifecycle.elect(rootKey, 12, Point{Row: 1, Column: 4}, 7, func(payload any) (Token, bool) {
+		p := payload.(*c26nCheckpointPayload)
+		p.state = []byte{9, 9, 9}
+		return Token{}, false
+	})
+	if ok || failedToken != (Token{}) {
+		t.Fatalf("failed election = (%+v, %t), want zero token and failure", failedToken, ok)
+	}
+	if got := c26nPayloadState(t, rootPayload); !bytes.Equal(got, []byte{4, 5, 6}) {
+		t.Fatalf("failed-election payload = %v, want [4 5 6]", got)
+	}
+	if !lifecycle.versions[rootKey].checkpoint.equal(rootRecord) {
+		t.Fatal("failed election changed the owned checkpoint")
+	}
+
+	exactFork, ok := lifecycle.fork(rootKey)
+	if !ok {
+		t.Fatal("exact fork was rejected")
+	}
+	if !lifecycle.canShare(rootKey, exactFork) {
+		t.Fatal("exact fork did not share its copied checkpoint")
+	}
+	childPayload := lifecycle.versions[exactFork].payload
+	if got := c26nPayloadState(t, childPayload); !bytes.Equal(got, []byte{4, 5, 6}) {
+		t.Fatalf("fork payload = %v, want [4 5 6]", got)
+	}
+	childPayload.(*c26nCheckpointPayload).state[0] = 99
+	if got := c26nPayloadState(t, rootPayload); !bytes.Equal(got, []byte{4, 5, 6}) {
+		t.Fatalf("fork mutation changed root payload = %v, want [4 5 6]", got)
+	}
+	if !lifecycle.restoreAndVerify(lifecycle.versions[exactFork]) {
+		t.Fatal("exact fork did not restore after an independent payload mutation")
+	}
+	staleFork, ok := lifecycle.fork(rootKey)
+	if !ok {
+		t.Fatal("stale fork was rejected")
+	}
+	lifecycle.versions[staleFork].payload.(*c26nCheckpointPayload).state[0] = 77
+	if lifecycle.merge(rootKey, staleFork) {
+		t.Fatal("stale checkpoint merge was accepted")
+	}
+	if _, exists := lifecycle.versions[staleFork]; exists {
+		t.Fatal("stale checkpoint remained shareable")
+	}
+	if !lifecycle.merge(rootKey, exactFork) {
+		t.Fatal("exact checkpoint merge was rejected")
+	}
+	if _, exists := lifecycle.versions[exactFork]; exists {
+		t.Fatal("merged fork was not deleted")
+	}
+	if got := c26nPayloadState(t, rootPayload); !bytes.Equal(got, []byte{4, 5, 6}) {
+		t.Fatalf("root payload after merge = %v, want [4 5 6]", got)
+	}
+
+	mismatchedFork, ok := lifecycle.fork(rootKey)
+	if !ok {
+		t.Fatal("mismatched fork was rejected")
+	}
+	if _, ok := lifecycle.elect(mismatchedFork, 12, Point{Row: 1, Column: 4}, 7, func(payload any) (Token, bool) {
+		p := payload.(*c26nCheckpointPayload)
+		p.state = []byte{8, 8, 8}
+		return Token{Symbol: 12, StartByte: 12, EndByte: 13}, true
+	}); !ok {
+		t.Fatal("mismatched election was rejected")
+	}
+	if lifecycle.merge(rootKey, mismatchedFork) {
+		t.Fatal("mismatched checkpoint merge was accepted")
+	}
+	if _, exists := lifecycle.versions[mismatchedFork]; !exists {
+		t.Fatal("mismatched version was dropped after merge rejection")
+	}
+
+	if _, ok := lifecycle.condense(rootKey, []externalScannerCheckpointVersionKey{mismatchedFork}); ok {
+		t.Fatal("condense dropped a live mismatched version")
+	}
+	if !lifecycle.markDead(mismatchedFork) {
+		t.Fatal("mismatched version was not marked dead")
+	}
+	if !lifecycle.deleteDead(mismatchedFork) {
+		t.Fatal("dead version was not deleted")
+	}
+	if _, exists := lifecycle.versions[mismatchedFork]; exists {
+		t.Fatal("dead version remains in the ledger")
+	}
+
+	condenseFork, ok := lifecycle.fork(rootKey)
+	if !ok {
+		t.Fatal("condense fork was rejected")
+	}
+	if _, ok := lifecycle.condense(rootKey, []externalScannerCheckpointVersionKey{condenseFork}); !ok {
+		t.Fatal("exact condense selection was rejected")
+	}
+	if _, exists := lifecycle.versions[condenseFork]; exists {
+		t.Fatal("exact condense sibling was not deleted")
+	}
+
+	resumedToken, ok := lifecycle.resume(rootKey, 13, Point{Row: 1, Column: 5}, 7, func(payload any) (Token, bool) {
+		p := payload.(*c26nCheckpointPayload)
+		if !bytes.Equal(p.state, []byte{4, 5, 6}) {
+			return Token{}, false
+		}
+		p.state = []byte{7, 7, 7}
+		return Token{Symbol: 13, StartByte: 13, EndByte: 14}, true
+	})
+	if !ok || resumedToken.Symbol != 13 {
+		t.Fatalf("recovery resume = (%+v, %t), want symbol 13 and success", resumedToken, ok)
+	}
+	if got := c26nPayloadState(t, rootPayload); !bytes.Equal(got, []byte{7, 7, 7}) {
+		t.Fatalf("resumed payload = %v, want [7 7 7]", got)
+	}
+}


### PR DESCRIPTION
## Decision

Keep issue #576 open. This PR adds a synthetic, default-off, test-only
checkpoint lifecycle proof.

- Ship no real parser integration.
- Destroy payloads after failed restore verification.
- Reject stale, incomplete, mismatched, and unknown lifecycle entries.
- Keep complete mismatches alive for safe fallback.
- Keep `glrStack`, `gssNode`, and production callers unchanged.

## Validation

- Focused Docker C26l and C26n tests pass with one CPU and 4 GiB.
- The run uses `GOMAXPROCS=1`, `GOMEMLIMIT=3GiB`, and `GOFLAGS=-p=1`.
- Markdown++, `go doc`, `gofmt`, Canopy, and diff checks pass.
- The real GLR, recovery, condense, and incremental integration remains NO-GO.
