### PR TITLE
docs(perf): correct P25x-P25ab receipt claims

### DIFF
--- a/docs/perf-attribution.md
+++ b/docs/perf-attribution.md
@@ -42,7 +42,8 @@ C incremental used digest
 `b03cf98e18bdddbd5ee3d2a0bc39410c51e21c41fbde89f7c5f3107c63276502`.
 
 The candidate did not prove a grammar-agnostic skip. P25x therefore stopped
-before publication and removed the candidate.
+before publication. The candidate remains uncommitted in the isolated
+`/tmp/gts-p25x-condense` worktree; no candidate code ships.
 
 P25x artifacts are:
 
@@ -182,8 +183,10 @@ P25ab artifacts are:
 - Performance compile: `/tmp/gts-p25ab-artifacts/20260823T114626Z-p25ab-compile-perf`.
 
 All P25ab Docker metadata used one CPU, four GiB, `GOMEMLIMIT=3GiB`,
-`GOMAXPROCS=1`, `GOFLAGS=-p=1`, and test parallelism one. Every run passed
-without timeout or out-of-memory failure. The telemetry was removed.
+`GOFLAGS=-p=1`, and test parallelism one. Seven of the nine receipts explicitly
+set `GOMAXPROCS=1`; the normal and performance compile receipts do not record
+it. Every run passed without timeout or out-of-memory failure. The telemetry
+was removed.
 
 ### P25x-P25ab decision and reopening condition
 


### PR DESCRIPTION
## Summary

- Correct the merged P25x candidate-state claim. The exact-diff candidate remains uncommitted in its isolated worktree. No candidate code ships.
- Correct the P25ab environment claim. Seven of nine receipts explicitly set `GOMAXPROCS=1`; the two compile receipts omit it.

## Evidence

- Exact base: `891fdefbdec0a48357a05c7bb218c473ad796b2e`
- Exact head: `5b4cdf5ae2a6e06303a3a72cb43a5b3e3468ee2a`
- Only `docs/perf-attribution.md` changes (6 insertions, 3 deletions).
- The P25x live worktree is at `3d6cd2628f7a42c348f51dce0a0ed9b92b183c6a`. It has one uncommitted `parser_recover_c.go` diff. Its SHA-256 is `4ac139b25516f7856bba0ed7967ba4fb777a00bcd60bbfde6802f80257a40c6e`.
- All nine P25ab metadata receipts use the documented CPU, memory, Go memory, Go flags, parallelism, exit, timeout, and out-of-memory settings. Exactly seven record `GOMAXPROCS=1`; the two compile receipts omit it.
- Markdown++ parsing and `git diff --check` pass.
- Independent review: GO.

This PR corrects evidence only. It changes no parser, test, benchmark, or runtime code.
