### PR TITLE
Bind SQL checkpoints to scanner identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ for tags and release notes while still in `0.x`.
 
 ### Correctness
 
+- Added the C26q SQL scanner identity gate on publication base
+  `a62b9db306bcb983852cbf0043852546e864e856`. Native SQL binds each
+  checkpoint to its scanner and exact grammar blob. Generated overrides hash
+  their exact bytes before scanner adaptation. Equal identities permit reuse;
+  missing or changed identities fail closed. The scanner identity is
+  `7e493677411a501e6d8592c6b9cc158e21a1bfed44c72ca914e2d81e4e34861d`.
+  It includes local port hash
+  `588328cd27eea49e88b704b9bd8e46958046564187a5db1a70f6622308a7fff8`.
+  A test hashes the marked local source region. Production code does not read
+  source files. The exact-byte loader owns grammar identity. The public
+  language API cannot relabel a loaded language. Equal raw bytes with a
+  changed scanner identity fail closed. Arena identity set and inherit paths
+  use exact allocation deltas. Reset clears the identity. Native SQL passed
+  the route and real-corpus gates. Generated SQL still has four locked-C
+  divergences. A one-shot accounting screen is diagnostic only. It does not
+  provide release performance evidence. Keep issue #576 open.
+
 - Recorded the C26i, C26j, and C26k Swift issue #576 scanner checkpoint
   blocker. C26i and C26j use evidence base
   `137860ebd80921094e5a8069007d49188dcb5e50`. C26k uses evidence base

--- a/arena.go
+++ b/arena.go
@@ -132,6 +132,7 @@ type nodeArena struct {
 	fieldSourceSlabs                   []fieldSourceSliceSlab
 	externalScannerNodeCheckpoints     externalScannerCheckpointSet
 	externalScannerNodeCheckpointSlabs []externalScannerCheckpointSlab
+	externalScannerCheckpointIdentity  externalScannerCheckpointIdentityState
 	hiddenFieldRepeatScratch           hiddenFieldRepeatScratch
 	childSlabCursor                    int
 	fieldSlabCursor                    int
@@ -561,6 +562,7 @@ func (a *nodeArena) reset() {
 	a.resetCounters()
 	a.resetFieldSlabs()
 	a.resetFieldSourceSlabs()
+	a.externalScannerCheckpointIdentity.clear()
 	a.childSlabCursor = 0
 	a.fieldSlabCursor = 0
 	a.fieldSourceSlabCursor = 0
@@ -1886,6 +1888,7 @@ func (a *nodeArena) recomputeAllocatedBytes() {
 	for i := range a.externalScannerNodeCheckpointSlabs {
 		total += a.externalScannerNodeCheckpointSlabs[i].checkpoints.bytesAllocated()
 	}
+	total += a.externalScannerCheckpointIdentity.bytesAllocated()
 	a.allocatedBytes = total
 }
 

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -1217,6 +1217,290 @@ capability proves all of the following:
 - Use an authenticated source lock and corpus evidence.
 
 
+## C26q SQL scanner identity gate
+
+Publication base: `a62b9db306bcb983852cbf0043852546e864e856`.
+
+Status: **GO FOR THE BOUNDED IDENTITY GATE. KEEP ISSUE #576 OPEN.**
+
+C26q binds an external scanner checkpoint to its scanner and grammar identity.
+The gate runs at incremental checkpoint reuse. It does not change GLR
+scheduling, recovery election, condense, merge, or forest ownership.
+
+### Identity inputs
+
+The native SQL scanner uses these authenticated inputs:
+
+- Upstream repository: [tree-sitter-sql](https://github.com/m-novikov/tree-sitter-sql).
+- Upstream commit: `587f30d184b058450be2a2330878210c5f33b3f9`.
+- `src/grammar.json`: 319,142 bytes,
+  SHA-256 `42f011860137175a5a0cb820d1a694e5ccca1d17f226729ff6a4e886910cde1c`.
+- `src/scanner.cc`: 4,333 bytes,
+  SHA-256 `d437ad9f517d7a1f4248ccd05abe58370b5040c0037c877dab1f0aefeaa04af6`.
+- External names: `_dollar_quoted_string_tag`,
+  `_dollar_quoted_string_content`, and `_dollar_quoted_string_end_tag`.
+- Scanner semantics: tagged state, zero-length empty state, bounded tags,
+  content-end scanning, state preservation on failure, and a 4,095-byte tag
+  limit.
+
+The scanner identity is the raw SHA-256 value
+`7e493677411a501e6d8592c6b9cc158e21a1bfed44c72ca914e2d81e4e34861d`.
+It includes the local Go port hash
+`588328cd27eea49e88b704b9bd8e46958046564187a5db1a70f6622308a7fff8`.
+The focused test hashes the marked local source region. A semantics change
+fails the test until the scanner identity is updated with review.
+
+The checked-in SQL blob is `grammars/grammar_blobs/sql.bin`. It has 581,443
+bytes and SHA-256
+`e21421cbab52b54cf5ba15c8f78a2bb4729bf4e8c0da14368069e897de451268`.
+The trusted exact-byte loader records this hash before it adapts the SQL
+scanner. The public `Language` API has no grammar identity setter. Callers
+cannot relabel a loaded language after adaptation.
+
+`gotreesitter.LoadLanguage` is the trusted construction path for this identity.
+It hashes the exact input bytes after envelope validation. A manually created
+`Language` has no trusted grammar identity and fails closed at reuse. The
+focused tests reject scanner and grammar drift when raw checkpoint bytes remain
+equal. The SQL source guard uses test-only file reads. Production code does not
+read its source file. Identity set and inherit paths charge only the exact
+state delta. Conflict state removes the charge, and reset clears it.
+
+The override loader reads the exact override bytes and hashes them before
+scanner adaptation. It never copies the checked-in grammar identity.
+Each SQL identity contains two raw 32-byte SHA-256 values. The arena accounts
+for 64 identity bytes in the parser memory budget. Arena reset clears them.
+Tree copies and checkpoint copies preserve them. Legacy scanners without the
+capability keep their previous reuse behavior.
+
+### Native SQL certification
+
+The native SQL language loaded the checked-in blob identity above. The focused
+tests passed for identity stability, local-port source binding, checkpoint
+round trips, scanner failure restore, native blob identity, cross-scanner
+rejection, exact arena accounting, and SQL incremental certification.
+
+The route probe reported this digest for every accepted route:
+`2c78089192b45b7aa6f2870fa8d2e492f00ce403c6b4b26fd59d6dfa28572982`.
+Production, compact, included-ranges, and incremental routes matched.
+Forest admission was true. The route artifact used one CPU, 4 GiB,
+`GOMEMLIMIT=3GiB`, and `GOFLAGS=-p=1`.
+
+`/tmp/gts-c26q-hardening-artifacts/20260823T141907Z-c26q-hardening-sql-route`
+
+Its `container.log` SHA-256 is
+`269d63d598e8ffbcf9590412af73e2f18469846dc9108e29d11e8eb15b662ce4`.
+Its `metadata.txt` SHA-256 is
+`d40840ee4aa12992707fd8344e73ab2b540e6abb10e17b21fcf2beb6293d5cb4`.
+
+The SQL incremental certification artifact is:
+
+`/tmp/gts-c26q-hardening-artifacts/20260823T141430Z-c26q-hardening-sql-incremental`
+
+Its `container.log` SHA-256 is
+`a9c95e8b30bea5437c8f0e39116a08b70565b5ccada0280ec97073546261156f`.
+Its `metadata.txt` SHA-256 is
+`a607c51e6cceef40f86a9a8ecb5ea6666b504c00b64d518840b05b8675d68c79`.
+
+The post-hardening raw and range gate covered SQL scanner recovery, the
+no-tree retry, SQL incremental certification, and the included-range parser
+probe. Its artifact is:
+
+`/tmp/gts-c26q-hardening-artifacts/20260823T143124Z-c26q-hardening-sql-raw-ranges`
+
+Its `container.log` SHA-256 is
+`8d475defa727ff4e5c07647a2aadf68520c9e4892e8ab6efd024b76ced7042f2`.
+Its `metadata.txt` SHA-256 is
+`2b4fadadb9726a4d00d6cb32039daaebff9fd322e9151045c41fb5226a2677ac`.
+
+The SQL real-corpus probe passed 25 of 25 no-error cases, 25 of 25
+S-expression comparisons, and 25 of 25 deep comparisons. It saw 28 of 186
+available samples. Maximum resident set size was 1,087,976 KiB. The run used
+one CPU, 4 GiB, `GOMAXPROCS=1`, and `GOFLAGS=-p=1`.
+The Docker artifact is:
+
+`/tmp/gts-c26q-production-proof-20260823/harness_out/docker/20260823T142119Z-diag-sql`
+
+Its `container.log` SHA-256 is
+`c397c45908dfbe46bc8375d9f1e33fe44056d7b7ee9da70b78f1eb008e15acff`.
+Its `metadata.txt` SHA-256 is
+`995ff318234b4e2325904a24339b677ef9825787f8fd6eacacf5268654afc10a`.
+
+### Generated SQL override proof
+
+The generated override tests use the checked-in SQL blob as input. They
+change only the language name before gzip and gob encoding. The positive
+override is 582,159 bytes with SHA-256
+`2e484c002ffc7773fe02944901c5b2e87194932ca32025c0e3d9dac597540149`.
+Its scanner receives that override hash, not the checked-in hash. Equal
+override identities preserve incremental reuse and fresh-tree equality.
+
+The drift test uses these two generated blobs:
+
+- First: 582,165 bytes,
+  SHA-256 `ec701f2ea2286db40bb0b6fa09957aab6f901962bfa5f7c103db6a0459ae2fb6`.
+- Second: 582,165 bytes,
+  SHA-256 `493e63f1a5645be6c6948244abb0be5654b624e98f9aed97fcff848e0fa4fe3f`.
+
+The new language rejects the old tree after this drift. It reuses zero
+subtrees and zero bytes. The fresh and incremental trees remain equal.
+Adaptation without a target grammar identity keeps the scanner usable but
+returns no checkpoint identity. The identity gate then fails closed.
+
+The post-hardening SQL and override gate artifact is:
+
+`/tmp/gts-c26q-hardening-artifacts/20260823T141319Z-c26q-hardening-sql`
+
+Its `container.log` SHA-256 is
+`2e125602ce5fb7ff33d8b9464b8edd37784ab46459cdebcd55485b72ec182cd5`.
+Its `metadata.txt` SHA-256 is
+`1d461d8740c49d8d18a79b5ef9ff5e922ca6891d1b7b9530ba56be652c29d241`.
+
+The post-hardening race artifact covers the native scanner and generated
+override tests. It used one CPU, 4 GiB, `GOMAXPROCS=1`, and `GOFLAGS=-p=1`.
+Its artifact is:
+
+`/tmp/gts-c26q-hardening-artifacts/20260823T141349Z-c26q-hardening-sql-race`
+
+Its `container.log` SHA-256 is
+`bd6d48591e98924cd49ba82725b5b864a98076d9553b69f2b808646f49adbed3`.
+Its `metadata.txt` SHA-256 is
+`915f4559d2a01d13a6fd99bd99187a7a764ff062281d0aee340ba31a5e35e847`.
+
+### Generated SQL locked-C boundary
+
+The generated SQL route is not the checked-in native SQL blob route. The
+locked-C probe used 25 eligible samples. It reported 23 of 25 no-error
+results, 21 of 25 tree matches, and four divergences.
+
+The four known divergences are:
+
+- `SELECT $$hey$$;`: generated SQL adds an `ERROR` at bytes 12 to 14.
+- `SELECT $$(a + b)$$;`: generated SQL adds an `ERROR` at bytes 16 to 18.
+- `CREATE DOMAIN test;`: generated `CREATE_DOMAIN` has one child; C has zero.
+- `CREATE DOMAIN test AS text;`: generated `CREATE_DOMAIN` has one child; C has zero.
+
+The checked-in SQL blob matches C for these witnesses. These four generated
+grammar divergences remain outside the bounded native identity gate.
+
+The post-hardening primary locked-C artifact is:
+
+`/tmp/gts-c26q-production-proof-20260823/harness_out/grammargen_cparity/20260823_071725-c26q-hardening-sql-locked-c`
+
+Its `container.log` SHA-256 is
+`3da06f65285aa598d7b2f931a1b7e519314dcf7be9ac833e5b2977ae6d21e2c8`.
+Its `metadata.txt` SHA-256 is
+`7e28e8013623b9f3664621b1d34739f27393f14615af1eaf50db18118c947bad`.
+
+### Post-hardening validation
+
+The final hardening reran the root, SQL, race, incremental, route,
+real-corpus, and locked-C gates. Each run used one container and one CPU.
+No run reported an out-of-memory kill or a wall timeout.
+
+The final root gate artifact is:
+
+`/tmp/gts-c26q-hardening-artifacts/20260823T143340Z-c26q-hardening-root-final`
+
+Its `container.log` SHA-256 is
+`9cf08c045266c069239c06b10a6e134fe7e6eb7c797d9804aa35ec5bd5aa77f9`.
+Its `metadata.txt` SHA-256 is
+`1ce71c4845672333cf1fdcf2b2291d3ed0e4a8c703ac27a227ecf395d6dd9ddf`.
+
+The root race artifact is:
+
+`/tmp/gts-c26q-hardening-artifacts/20260823T141242Z-c26q-hardening-root-race`
+
+Its `container.log` SHA-256 is
+`cb69e6ec92349fa703a93e0fa45dccdfe087b7b838412cc23eed17b8f3daca6a`.
+Its `metadata.txt` SHA-256 is
+`8fcf380350708abaf4337d3d5b9e952da3128c67a807351e88dd9d4bb5e86d39`.
+
+The SQL race, incremental, route, and diagnostic screen artifacts are:
+
+- SQL race: `/tmp/gts-c26q-hardening-artifacts/20260823T141349Z-c26q-hardening-sql-race`.
+- Incremental: `/tmp/gts-c26q-hardening-artifacts/20260823T141430Z-c26q-hardening-sql-incremental`.
+- Routes: `/tmp/gts-c26q-hardening-artifacts/20260823T141907Z-c26q-hardening-sql-route`.
+- Diagnostic screen, candidate: `/tmp/gts-c26q-hardening-artifacts/20260823T142008Z-c26q-hardening-sql-perf-candidate`.
+- Diagnostic screen, base: `/tmp/gts-c26q-hardening-artifacts/20260823T142021Z-c26q-hardening-sql-perf-base`.
+
+The diagnostic screen is not performance evidence. It used a temporary
+benchmark and one sample. Treat the accounting change as correctness-only.
+
+The real-corpus artifact is:
+
+`/tmp/gts-c26q-production-proof-20260823/harness_out/docker/20260823T142119Z-diag-sql`
+
+The locked-C artifact is:
+
+`/tmp/gts-c26q-production-proof-20260823/harness_out/grammargen_cparity/20260823_071725-c26q-hardening-sql-locked-c`
+
+The SQL race metadata records `GOMAXPROCS=1` and `GOFLAGS=-p=1`.
+The route metadata records `GOMEMLIMIT=3GiB` and `GOFLAGS=-p=1`.
+The real-corpus metadata records `GOMAXPROCS=1` and `GOFLAGS=-p=1`.
+
+### Focused Docker gates and scope
+
+The root identity tests passed. The root race tests passed. SQL scanner,
+override, incremental, raw, included-ranges, real-corpus, and locked-C gates
+also passed their process exit checks. No run reported an out-of-memory kill
+or wall timeout. The focused runs used one CPU and 4 GiB. SQL race and
+locked-C runs set `GOMAXPROCS=1` and `GOFLAGS=-p=1`. The real-corpus metadata
+records `GOMAXPROCS=1` and `GOFLAGS=-p=1`.
+
+The proof excludes Swift, other grammar changes, GLR scheduler changes,
+recovery election changes, condense or merge changes, forest ownership
+changes, and performance claims. It does not close the generated SQL parity
+gap.
+
+The code and test patch SHA-256 against the publication base is
+`cdc8d0d83204a7ea613442cafa461d961f27b81d3ad7fd3e3e85aebe3906ee48`.
+The patch contains these files:
+
+- `arena.go`
+- `external_scanner_checkpoint_capability.go`
+- `external_scanner_checkpoint_identity_test.go`
+- `external_scanner_checkpoints.go`
+- `grammars/embedded_loader.go`
+- `grammars/grammargen_blob_override.go`
+- `grammars/grammargen_blob_override_test.go`
+- `grammars/sql_scanner.go`
+- `grammars/sql_scanner_test.go`
+- `language.go`
+- `load_language.go`
+- `parser.go`
+- `tree.go`
+
+The receipt adds only `CHANGELOG.md` and this document. No C26q document
+guard test exists. Therefore, no two-stage document-guard chain is needed.
+The diagnostic C parity log change was restored before this receipt.
+
+Several commands were quarantined. The root command `go test ./cgo_harness ...`
+was invalid because `cgo_harness` is a separate module. A later command used
+`cd /workspace/cgo_harness && go test . ...`. A trial passed the unsupported
+`--gomaxprocs` option to `run_parity_in_docker.sh`; the wrapper printed usage.
+Later probes passed unsupported `--out-root` and `--src-dir` options, and one
+sent SQL to a wrapper that excludes SQL. Those probes produced no test
+evidence. The final direct runner commands above are the evidence.
+
+### C26q decision and reopening condition
+
+GO applies only to the bounded native SQL identity gate and generated override
+fail-closed behavior. This gate does not prove generated SQL parity with C.
+Keep issue #576 open.
+
+Reopen the generated SQL path only after all of the following conditions hold:
+
+- Explain and fix the four generated SQL locked-C divergences.
+- Prove generated source and grammar identities from an authenticated lock.
+- Pass equal-identity reuse and changed-identity rejection on generated SQL.
+- Pass raw, production, compact, forest, included-ranges, and incremental
+  parity for native and generated SQL.
+- Avoid source-hash, blob-exception, witness-repair, and language-specific
+  policy.
+
+Keep issue #576 open until the generated route
+passes the full locked-C proof.
+
 ## Current bounded result
 
 The bounded matrix completed with no silent divergence.

--- a/external_scanner_checkpoint_capability.go
+++ b/external_scanner_checkpoint_capability.go
@@ -16,11 +16,146 @@ type ExternalScannerCheckpointIdentity struct {
 // checkpointed scanner. CheckpointIdentity must return stable identifiers for
 // the scanner implementation and the exact grammar blob.
 //
-// This capability is not consumed by parser production, GLR scheduling,
-// recovery, merge, or incremental-reuse paths yet.
+// The production parser consumes this capability only at the checkpoint-aware
+// incremental reuse boundary. It does not alter GLR scheduling or recovery.
 type ExternalScannerCheckpointIdentityProvider interface {
 	CheckpointedExternalScanner
 	CheckpointIdentity() (ExternalScannerCheckpointIdentity, bool)
+}
+
+// externalScannerCheckpointIdentityState stores one immutable identity for an
+// arena. Fixed storage keeps checkpoint identity outside parser hot structures.
+type externalScannerCheckpointIdentityState struct {
+	scanner    [externalScannerCheckpointIdentityMaxBytes]byte
+	grammar    [externalScannerCheckpointIdentityMaxBytes]byte
+	scannerLen uint16
+	grammarLen uint16
+	valid      bool
+	conflict   bool
+}
+
+func (s *externalScannerCheckpointIdentityState) set(id ExternalScannerCheckpointIdentity) bool {
+	if s == nil || s.conflict || !id.complete() {
+		return false
+	}
+	if s.valid {
+		if s.matches(id) {
+			return true
+		}
+		s.conflict = true
+		return false
+	}
+	copy(s.scanner[:], id.Scanner)
+	copy(s.grammar[:], id.Grammar)
+	s.scannerLen = uint16(len(id.Scanner))
+	s.grammarLen = uint16(len(id.Grammar))
+	s.valid = true
+	return true
+}
+
+func (s *externalScannerCheckpointIdentityState) inherit(source *externalScannerCheckpointIdentityState) bool {
+	if s == nil {
+		return false
+	}
+	if source == nil {
+		return true
+	}
+	if s.conflict {
+		return false
+	}
+	if source.conflict {
+		s.conflict = true
+		return false
+	}
+	if !source.valid {
+		return true
+	}
+	if !s.valid {
+		copy(s.scanner[:], source.scanner[:source.scannerLen])
+		copy(s.grammar[:], source.grammar[:source.grammarLen])
+		s.scannerLen = source.scannerLen
+		s.grammarLen = source.grammarLen
+		s.valid = true
+		return true
+	}
+	if s.scannerLen == source.scannerLen && s.grammarLen == source.grammarLen &&
+		bytes.Equal(s.scanner[:s.scannerLen], source.scanner[:source.scannerLen]) &&
+		bytes.Equal(s.grammar[:s.grammarLen], source.grammar[:source.grammarLen]) {
+		return true
+	}
+	s.conflict = true
+	return false
+}
+
+func (s *externalScannerCheckpointIdentityState) matches(id ExternalScannerCheckpointIdentity) bool {
+	return s != nil && s.valid && !s.conflict && id.complete() &&
+		s.scannerLen == uint16(len(id.Scanner)) && s.grammarLen == uint16(len(id.Grammar)) &&
+		bytes.Equal(s.scanner[:s.scannerLen], id.Scanner) &&
+		bytes.Equal(s.grammar[:s.grammarLen], id.Grammar)
+}
+
+func (s *externalScannerCheckpointIdentityState) clear() {
+	if s == nil {
+		return
+	}
+	*s = externalScannerCheckpointIdentityState{}
+}
+
+func (s *externalScannerCheckpointIdentityState) bytesAllocated() int64 {
+	if s == nil || !s.valid || s.conflict {
+		return 0
+	}
+	return int64(s.scannerLen) + int64(s.grammarLen)
+}
+
+// externalScannerCheckpointIdentityStatus reports whether a language requires
+// identity-aware checkpoint reuse and whether its current identity is valid.
+// A scanner without this provider keeps the legacy reuse behavior.
+func externalScannerCheckpointIdentityStatus(lang *Language) (ExternalScannerCheckpointIdentity, bool, bool) {
+	if lang == nil || lang.ExternalScanner == nil {
+		return ExternalScannerCheckpointIdentity{}, false, true
+	}
+	provider, ok := lang.ExternalScanner.(ExternalScannerCheckpointIdentityProvider)
+	if !ok || !provider.UsesExternalScannerCheckpoints() {
+		return ExternalScannerCheckpointIdentity{}, false, true
+	}
+	identity, ok := provider.CheckpointIdentity()
+	return identity, true, ok && identity.complete()
+}
+
+func (a *nodeArena) setExternalScannerCheckpointIdentityForLanguage(lang *Language) bool {
+	if a == nil {
+		return false
+	}
+	identity, required, valid := externalScannerCheckpointIdentityStatus(lang)
+	if !required || !valid {
+		return false
+	}
+	before := a.externalScannerCheckpointIdentity.bytesAllocated()
+	if !a.externalScannerCheckpointIdentity.set(identity) {
+		a.allocatedBytes += a.externalScannerCheckpointIdentity.bytesAllocated() - before
+		return false
+	}
+	a.allocatedBytes += a.externalScannerCheckpointIdentity.bytesAllocated() - before
+	return true
+}
+
+func (a *nodeArena) inheritExternalScannerCheckpointIdentity(source *nodeArena) bool {
+	if a == nil || source == nil {
+		return false
+	}
+	before := a.externalScannerCheckpointIdentity.bytesAllocated()
+	ok := a.externalScannerCheckpointIdentity.inherit(&source.externalScannerCheckpointIdentity)
+	a.allocatedBytes += a.externalScannerCheckpointIdentity.bytesAllocated() - before
+	return ok
+}
+
+func (a *nodeArena) externalScannerCheckpointIdentityMatches(lang *Language) bool {
+	identity, required, valid := externalScannerCheckpointIdentityStatus(lang)
+	if !required {
+		return true
+	}
+	return valid && a != nil && a.externalScannerCheckpointIdentity.matches(identity)
 }
 
 type externalScannerCheckpointRecord struct {

--- a/external_scanner_checkpoint_identity_test.go
+++ b/external_scanner_checkpoint_identity_test.go
@@ -1,0 +1,236 @@
+package gotreesitter
+
+import (
+	"crypto/sha256"
+	"testing"
+)
+
+type c26qLegacyCheckpointPayload struct{}
+
+type c26qLegacyCheckpointScanner struct{}
+
+func (c26qLegacyCheckpointScanner) Create() any { return &c26qLegacyCheckpointPayload{} }
+func (c26qLegacyCheckpointScanner) Destroy(any) {}
+func (c26qLegacyCheckpointScanner) Serialize(payload any, buf []byte) int {
+	_ = payload
+	return copy(buf, []byte{1, 2, 3})
+}
+func (c26qLegacyCheckpointScanner) Deserialize(any, []byte) {}
+func (c26qLegacyCheckpointScanner) Scan(any, *ExternalLexer, []bool) bool {
+	return false
+}
+func (c26qLegacyCheckpointScanner) UsesExternalScannerCheckpoints() bool { return true }
+
+func TestC26qLoadLanguageRecordsExactBlobIdentity(t *testing.T) {
+	encoded, err := EncodeLanguageBlob(&Language{Name: "c26q-blob-identity"})
+	if err != nil {
+		t.Fatalf("EncodeLanguageBlob: %v", err)
+	}
+	loaded, err := LoadLanguage(encoded)
+	if err != nil {
+		t.Fatalf("LoadLanguage: %v", err)
+	}
+	want := sha256.Sum256(encoded)
+	got, ok := loaded.GrammarBlobSHA256()
+	if !ok || got != want {
+		t.Fatalf("loaded grammar identity = (%x, %t), want (%x, true)", got, ok, want)
+	}
+}
+
+func TestC26qArenaIdentityAccountingResetAndPoolReuse(t *testing.T) {
+	scanner := newC26lCheckpointScanner()
+	lang := &Language{ExternalScanner: scanner}
+	arena := newNodeArena(arenaClassFull)
+	arena.setBudget(1)
+	before := arena.allocatedBytes
+	if !arena.setExternalScannerCheckpointIdentityForLanguage(lang) {
+		t.Fatal("arena rejected a complete identity")
+	}
+	wantBytes := int64(len(scanner.scannerID) + len(scanner.grammarID))
+	if got := arena.allocatedBytes - before; got != wantBytes {
+		t.Fatalf("identity allocation = %d, want %d", got, wantBytes)
+	}
+	if !arena.budgetExhausted() {
+		t.Fatal("identity allocation did not count against the arena budget")
+	}
+
+	node := newLeafNodeInArena(arena, 1, true, 0, 3, Point{}, Point{Column: 3})
+	node.preGotoState = 7
+	if !arena.recordExternalScannerLeafCheckpoint(node, []byte{1, 2, 3}, []byte{1, 2, 3}) {
+		t.Fatal("source checkpoint was not recorded")
+	}
+	cloneArena := newNodeArena(arenaClassIncremental)
+	clone := cloneNodeInArena(cloneArena, node)
+	if clone == nil || !cloneArena.externalScannerCheckpointIdentity.matches(
+		ExternalScannerCheckpointIdentity{Scanner: scanner.scannerID, Grammar: scanner.grammarID},
+	) {
+		t.Fatal("node clone did not preserve checkpoint identity")
+	}
+	cloneArena.Release()
+
+	arena.reset()
+	if arena.externalScannerCheckpointIdentity.valid || arena.externalScannerCheckpointIdentity.bytesAllocated() != 0 {
+		t.Fatal("arena reset retained checkpoint identity")
+	}
+	arena.Release()
+
+	pooled := acquireNodeArena(arenaClassFull)
+	defer pooled.Release()
+	if pooled.externalScannerCheckpointIdentity.valid || pooled.externalScannerCheckpointIdentity.bytesAllocated() != 0 {
+		t.Fatal("pooled arena exposed a stale checkpoint identity")
+	}
+}
+
+func TestC26qArenaIdentityAccountingConflictDelta(t *testing.T) {
+	first := newC26lCheckpointScanner()
+	second := newC26lCheckpointScanner()
+	second.scannerID = []byte("scanner-drift")
+	firstLanguage := &Language{ExternalScanner: first}
+	secondLanguage := &Language{ExternalScanner: second}
+	arena := newNodeArena(arenaClassIncremental)
+	defer arena.Release()
+	baseline := arena.allocatedBytes
+	if !arena.setExternalScannerCheckpointIdentityForLanguage(firstLanguage) {
+		t.Fatal("first identity was rejected")
+	}
+	wantBytes := int64(len(first.scannerID) + len(first.grammarID))
+	if got := arena.allocatedBytes - baseline; got != wantBytes {
+		t.Fatalf("first identity allocation = %d, want %d", got, wantBytes)
+	}
+	if arena.setExternalScannerCheckpointIdentityForLanguage(secondLanguage) {
+		t.Fatal("conflicting identity was accepted")
+	}
+	if got := arena.allocatedBytes - baseline; got != 0 {
+		t.Fatalf("conflicting identity allocation = %d, want 0", got)
+	}
+	if !arena.externalScannerCheckpointIdentity.conflict {
+		t.Fatal("conflicting identity did not mark the arena")
+	}
+}
+
+func TestC26qArenaIdentityAccountingInheritedConflictDelta(t *testing.T) {
+	first := newC26lCheckpointScanner()
+	second := newC26lCheckpointScanner()
+	second.scannerID = []byte("scanner-inherited-drift")
+	firstLanguage := &Language{ExternalScanner: first}
+	secondLanguage := &Language{ExternalScanner: second}
+
+	source := newNodeArena(arenaClassFull)
+	defer source.Release()
+	if !source.setExternalScannerCheckpointIdentityForLanguage(firstLanguage) {
+		t.Fatal("source identity was rejected")
+	}
+
+	inherited := newNodeArena(arenaClassIncremental)
+	defer inherited.Release()
+	baseline := inherited.allocatedBytes
+	if !inherited.inheritExternalScannerCheckpointIdentity(source) {
+		t.Fatal("matching inherited identity was rejected")
+	}
+	wantBytes := int64(len(first.scannerID) + len(first.grammarID))
+	if got := inherited.allocatedBytes - baseline; got != wantBytes {
+		t.Fatalf("inherited identity allocation = %d, want %d", got, wantBytes)
+	}
+
+	driftSource := newNodeArena(arenaClassFull)
+	defer driftSource.Release()
+	if !driftSource.setExternalScannerCheckpointIdentityForLanguage(secondLanguage) {
+		t.Fatal("drift source identity was rejected")
+	}
+	if inherited.inheritExternalScannerCheckpointIdentity(driftSource) {
+		t.Fatal("inherited identity drift was accepted")
+	}
+	if got := inherited.allocatedBytes - baseline; got != 0 {
+		t.Fatalf("inherited conflict allocation = %d, want 0", got)
+	}
+	if !inherited.externalScannerCheckpointIdentity.conflict {
+		t.Fatal("inherited identity drift did not mark the arena")
+	}
+}
+
+func TestC26qTreeCopyPreservesArenaCheckpointIdentity(t *testing.T) {
+	scanner := newC26lCheckpointScanner()
+	lang := &Language{ExternalScanner: scanner}
+	arena := newNodeArena(arenaClassIncremental)
+	if !arena.setExternalScannerCheckpointIdentityForLanguage(lang) {
+		t.Fatal("arena rejected a complete identity")
+	}
+	root := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
+	tree := newTreeWithArenas(root, []byte("x"), lang, arena, nil)
+	copyTree := tree.Copy()
+	if copyTree == nil || copyTree.arena == nil || !copyTree.arena.externalScannerCheckpointIdentity.matches(
+		ExternalScannerCheckpointIdentity{Scanner: scanner.scannerID, Grammar: scanner.grammarID},
+	) {
+		t.Fatal("Tree.Copy did not preserve checkpoint identity")
+	}
+	copyTree.Release()
+	tree.Release()
+}
+
+func TestC26qReuseRejectsMissingAndMismatchedIdentity(t *testing.T) {
+	oldScanner := newC26lCheckpointScanner()
+	oldLanguage := &Language{ExternalScanner: oldScanner}
+	oldArena := newNodeArena(arenaClassFull)
+	defer oldArena.Release()
+	if !oldArena.setExternalScannerCheckpointIdentityForLanguage(oldLanguage) {
+		t.Fatal("old arena rejected a complete identity")
+	}
+	node := newLeafNodeInArena(oldArena, 1, true, 0, 3, Point{}, Point{Column: 3})
+	node.preGotoState = 9
+	if !oldArena.recordExternalScannerLeafCheckpoint(node, []byte{1, 2, 3}, []byte{1, 2, 3}) {
+		t.Fatal("old checkpoint was not recorded")
+	}
+
+	matching := &dfaTokenSource{
+		language:        oldLanguage,
+		externalPayload: oldScanner.Create(),
+	}
+	if _, ok := canReuseNodeWithExternalScannerCheckpoint(matching, 9, node); !ok {
+		t.Fatal("matching scanner and grammar identity was rejected")
+	}
+
+	drifted := newC26lCheckpointScanner()
+	drifted.grammarID = []byte("grammar-drift")
+	driftedLanguage := &Language{ExternalScanner: drifted}
+	driftedSource := &dfaTokenSource{
+		language:        driftedLanguage,
+		externalPayload: drifted.Create(),
+	}
+	if _, ok := canReuseNodeWithExternalScannerCheckpoint(driftedSource, 9, node); ok {
+		t.Fatal("grammar identity drift was admitted with equal raw bytes")
+	}
+
+	scannerDrift := newC26lCheckpointScanner()
+	scannerDrift.scannerID = []byte("scanner-drift")
+	scannerDriftLanguage := &Language{ExternalScanner: scannerDrift}
+	scannerDriftSource := &dfaTokenSource{
+		language:        scannerDriftLanguage,
+		externalPayload: scannerDrift.Create(),
+	}
+	if _, ok := canReuseNodeWithExternalScannerCheckpoint(scannerDriftSource, 9, node); ok {
+		t.Fatal("scanner identity drift was admitted with equal raw bytes")
+	}
+
+	missingArena := newNodeArena(arenaClassFull)
+	defer missingArena.Release()
+	missingNode := newLeafNodeInArena(missingArena, 1, true, 0, 3, Point{}, Point{Column: 3})
+	missingNode.preGotoState = 9
+	if !missingArena.recordExternalScannerLeafCheckpoint(missingNode, []byte{1, 2, 3}, []byte{1, 2, 3}) {
+		t.Fatal("missing-identity checkpoint was not recorded")
+	}
+	missingSource := &dfaTokenSource{
+		language:        oldLanguage,
+		externalPayload: oldScanner.Create(),
+	}
+	if _, ok := canReuseNodeWithExternalScannerCheckpoint(missingSource, 9, missingNode); ok {
+		t.Fatal("identity-bearing scanner reused an old arena without identity")
+	}
+
+	legacySource := &dfaTokenSource{
+		language:        &Language{ExternalScanner: c26qLegacyCheckpointScanner{}},
+		externalPayload: (&c26qLegacyCheckpointScanner{}).Create(),
+	}
+	if _, ok := canReuseNodeWithExternalScannerCheckpoint(legacySource, 9, node); !ok {
+		t.Fatal("legacy scanner lost raw checkpoint reuse behavior")
+	}
+}

--- a/external_scanner_checkpoints.go
+++ b/external_scanner_checkpoints.go
@@ -150,6 +150,9 @@ func copyExternalScannerCheckpointToNode(dst, src *Node) bool {
 	if dst == nil || src == nil || dst.ownerArena == nil || src.ownerArena == nil {
 		return false
 	}
+	if !dst.ownerArena.inheritExternalScannerCheckpointIdentity(src.ownerArena) {
+		return false
+	}
 	cp, ok := externalScannerCheckpointRefForNode(src)
 	if !ok {
 		return false
@@ -372,6 +375,12 @@ func canReuseNodeWithExternalScannerCheckpointAtLookahead(ts TokenSource, startS
 		return externalScannerCheckpointRef{}, externalScannerBoundaryQuiescentWithoutCheckpoint(dts.language)
 	}
 	if node == nil || startState != node.PreGotoState() {
+		return externalScannerCheckpointRef{}, false
+	}
+	// An identity-bearing scanner may not reuse a raw checkpoint from an arena
+	// that lacks the same grammar and scanner identity. This check runs before
+	// checkpointless admission, so equal raw bytes cannot bypass the proof.
+	if !node.ownerArena.externalScannerCheckpointIdentityMatches(dts.language) {
 		return externalScannerCheckpointRef{}, false
 	}
 	cp, ok := externalScannerCheckpointRefForNode(node)

--- a/grammars/embedded_loader.go
+++ b/grammars/embedded_loader.go
@@ -1,11 +1,8 @@
 package grammars
 
 import (
-	"bytes"
-	"compress/gzip"
 	"container/list"
 	"crypto/sha256"
-	"encoding/gob"
 	"fmt"
 	"os"
 	"strconv"
@@ -526,63 +523,18 @@ func decodeEmbeddedLanguage(blobName string) (*gotreesitter.Language, [32]byte, 
 }
 
 func decodeLanguageBlobData(blobName string, data []byte) (*gotreesitter.Language, error) {
-	compressed, expectsTrailer, err := gotreesitter.UnwrapLanguageBlobEnvelope(data)
+	lang, err := gotreesitter.LoadLanguage(data)
 	if err != nil {
 		return nil, fmt.Errorf("decode grammar blob %q: %w", blobName, err)
 	}
-	gzr, err := gzip.NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		return nil, fmt.Errorf("open gzip grammar blob %q: %w", blobName, err)
-	}
-	defer gzr.Close()
+	compactDecodedLanguage(lang)
+	repairNoLookaheadLexModes(lang)
+	repairJavaScriptTypeScriptOptionalChainTokenSymbol(blobName, lang)
+	repairDartCollapsedLeafTokenSymbols(blobName, lang)
+	repairDhallUnicodeAnonymousSymbolNames(blobName, lang)
+	attachReduceChainHints(blobName, lang)
 
-	// Decode from a fully-buffered *bytes.Reader, not gzr directly: gob's
-	// Decoder can read ahead past its own message boundary on a streaming
-	// reader, which would silently swallow the optional LargeStateGotos
-	// trailer (see gotreesitter.DecodeLargeStateGotosTrailer) before we get a
-	// chance to read it.
-	//
-	// Pre-size that buffer from the gzip ISIZE trailer instead of a plain
-	// io.ReadAll: for the largest shipped grammars (Swift's ~308 MB
-	// decompressed table is the extreme case) io.ReadAll's repeated buffer
-	// doublings roughly double peak transient allocation on every
-	// Language() call, which is what actually trips container memory
-	// limits. See ReadAllGzipWithSizeHint's doc comment for the full
-	// rationale; this is the same helper gotreesitter.LoadLanguage uses.
-	raw, err := gotreesitter.ReadAllGzipWithSizeHint(gzr, compressed)
-	if err != nil {
-		return nil, fmt.Errorf("read gzip grammar blob %q: %w", blobName, err)
-	}
-
-	br := bytes.NewReader(raw)
-	dec := gob.NewDecoder(br)
-	var lang gotreesitter.Language
-	if err := dec.Decode(&lang); err != nil {
-		return nil, fmt.Errorf("decode grammar blob %q: %w", blobName, err)
-	}
-	trailer, err := gotreesitter.DecodeLargeStateGotosTrailer(br)
-	if err != nil {
-		return nil, fmt.Errorf("decode grammar blob %q: %w", blobName, err)
-	}
-	if expectsTrailer && len(trailer) == 0 {
-		return nil, fmt.Errorf("decode grammar blob %q: envelope requires a non-empty large-state-gotos trailer", blobName)
-	}
-	if !expectsTrailer && len(trailer) != 0 {
-		return nil, fmt.Errorf("decode grammar blob %q: large-state-gotos trailer requires a versioned envelope", blobName)
-	}
-	if trailer != nil {
-		lang.LargeStateGotos = trailer
-	}
-
-	gotreesitter.InferGeneratedRepeatAuxMetadata(&lang)
-	compactDecodedLanguage(&lang)
-	repairNoLookaheadLexModes(&lang)
-	repairJavaScriptTypeScriptOptionalChainTokenSymbol(blobName, &lang)
-	repairDartCollapsedLeafTokenSymbols(blobName, &lang)
-	repairDhallUnicodeAnonymousSymbolNames(blobName, &lang)
-	attachReduceChainHints(blobName, &lang)
-
-	return &lang, nil
+	return lang, nil
 }
 
 func repairDhallUnicodeAnonymousSymbolNames(blobName string, lang *gotreesitter.Language) {

--- a/grammars/grammargen_blob_override.go
+++ b/grammars/grammargen_blob_override.go
@@ -40,7 +40,12 @@ func loadPreferredLanguageOverride(name string) *gotreesitter.Language {
 
 	entry := getPreferredLanguageOverrideCacheEntry(path)
 	entry.once.Do(func() {
-		entry.lang, entry.err = decodeLanguageBlobFromPath(path)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			entry.err = fmt.Errorf("read grammar blob %q: %w", path, err)
+			return
+		}
+		entry.lang, entry.err = decodeLanguageBlobData(path, data)
 		if entry.err != nil {
 			return
 		}

--- a/grammars/grammargen_blob_override_test.go
+++ b/grammars/grammargen_blob_override_test.go
@@ -3,11 +3,172 @@ package grammars
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
 	"encoding/gob"
 	"os"
 	"path/filepath"
 	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
 )
+
+func TestSQLLanguageOverridePropagatesIdentityAndReusesEqualBlob(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	purgePreferredLanguageOverrideCache()
+	t.Cleanup(func() {
+		PurgeEmbeddedLanguageCache()
+		purgePreferredLanguageOverrideCache()
+	})
+
+	overrideDir := t.TempDir()
+	override, original := writeSQLOverrideBlob(t, overrideDir, "sql-override")
+	t.Setenv(grammargenBlobDirEnv, overrideDir)
+
+	loaded := SqlLanguage()
+	got, ok := loaded.GrammarBlobSHA256()
+	if !ok || got != sha256.Sum256(override) {
+		t.Fatalf("SQL override grammar identity = (%x, %t), want override bytes %x", got, ok, sha256.Sum256(override))
+	}
+	if got == sha256.Sum256(original) {
+		t.Fatal("SQL override inherited the checked-in source grammar identity")
+	}
+	provider, ok := loaded.ExternalScanner.(gotreesitter.ExternalScannerCheckpointIdentityProvider)
+	if !ok {
+		t.Fatal("SQL override scanner is not identity-bearing")
+	}
+	identity, ok := provider.CheckpointIdentity()
+	if !ok || string(identity.Grammar) != string(got[:]) {
+		t.Fatal("SQL override scanner did not receive the override grammar identity")
+	}
+
+	source := []byte("SELECT $$x$$;\n")
+	parser := gotreesitter.NewParser(loaded)
+	parser.SetAdmissionCandidateRoute(false)
+	oldTree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("SQL override base parse: %v", err)
+	}
+	defer oldTree.Release()
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte:   9,
+		OldEndByte:  10,
+		NewEndByte:  10,
+		StartPoint:  gotreesitter.Point{Column: 9},
+		OldEndPoint: gotreesitter.Point{Column: 10},
+		NewEndPoint: gotreesitter.Point{Column: 10},
+	})
+	updated, profile, err := parser.ParseIncrementalProfiled([]byte("SELECT $$y$$;\n"), oldTree)
+	if err != nil {
+		t.Fatalf("SQL override incremental parse: %v", err)
+	}
+	defer updated.Release()
+	if profile.ReuseUnsupported || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("equal SQL override identity did not preserve reuse: %+v", profile)
+	}
+	fresh, err := gotreesitter.NewParser(loaded).Parse([]byte("SELECT $$y$$;\n"))
+	if err != nil {
+		t.Fatalf("SQL override fresh parse: %v", err)
+	}
+	defer fresh.Release()
+	if got, want := updated.RootNode().SExpr(loaded), fresh.RootNode().SExpr(loaded); got != want {
+		t.Fatalf("SQL override incremental tree differs from fresh parse:\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestSQLLanguageOverrideRejectsOldTreeAfterBlobDrift(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	purgePreferredLanguageOverrideCache()
+	t.Cleanup(func() {
+		PurgeEmbeddedLanguageCache()
+		purgePreferredLanguageOverrideCache()
+	})
+
+	overrideDir := t.TempDir()
+	first, _ := writeSQLOverrideBlob(t, overrideDir, "sql-override-first")
+	t.Setenv(grammargenBlobDirEnv, overrideDir)
+	oldLanguage := SqlLanguage()
+	oldHash, ok := oldLanguage.GrammarBlobSHA256()
+	if !ok || oldHash != sha256.Sum256(first) {
+		t.Fatal("first SQL override did not record its own blob identity")
+	}
+	oldParser := gotreesitter.NewParser(oldLanguage)
+	oldParser.SetAdmissionCandidateRoute(false)
+	oldTree, err := oldParser.Parse([]byte("SELECT $$x$$;\n"))
+	if err != nil {
+		t.Fatalf("first SQL override parse: %v", err)
+	}
+	defer oldTree.Release()
+
+	second, _ := writeSQLOverrideBlob(t, overrideDir, "sql-override-second")
+	if sha256.Sum256(first) == sha256.Sum256(second) {
+		t.Fatal("SQL override drift fixture did not change blob bytes")
+	}
+	PurgeEmbeddedLanguageCache()
+	newLanguage := SqlLanguage()
+	newHash, ok := newLanguage.GrammarBlobSHA256()
+	if !ok || newHash != sha256.Sum256(second) || newHash == oldHash {
+		t.Fatalf("SQL override drift identities = old %x, new (%x, %t)", oldHash, newHash, ok)
+	}
+
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte:   9,
+		OldEndByte:  10,
+		NewEndByte:  10,
+		StartPoint:  gotreesitter.Point{Column: 9},
+		OldEndPoint: gotreesitter.Point{Column: 10},
+		NewEndPoint: gotreesitter.Point{Column: 10},
+	})
+	parser := gotreesitter.NewParser(newLanguage)
+	parser.SetAdmissionCandidateRoute(false)
+	updated, profile, err := parser.ParseIncrementalProfiled([]byte("SELECT $$y$$;\n"), oldTree)
+	if err != nil {
+		t.Fatalf("drifted SQL override incremental parse: %v", err)
+	}
+	defer updated.Release()
+	if profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+		t.Fatalf("drifted SQL override reused old checkpoints: %+v", profile)
+	}
+	fresh, err := gotreesitter.NewParser(newLanguage).Parse([]byte("SELECT $$y$$;\n"))
+	if err != nil {
+		t.Fatalf("drifted SQL override fresh parse: %v", err)
+	}
+	defer fresh.Release()
+	if got, want := updated.RootNode().SExpr(newLanguage), fresh.RootNode().SExpr(newLanguage); got != want {
+		t.Fatalf("drifted SQL override tree differs from fresh parse:\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestSQLAdaptedScannerFailsClosedWithoutGrammarIdentity(t *testing.T) {
+	lang := &gotreesitter.Language{ExternalSymbols: append([]gotreesitter.Symbol(nil), SqlLanguage().ExternalSymbols...)}
+	if !AdaptScannerForLanguage("sql", lang) {
+		t.Fatal("SQL scanner adaptation failed for a structurally valid target")
+	}
+	provider, ok := lang.ExternalScanner.(gotreesitter.ExternalScannerCheckpointIdentityProvider)
+	if !ok {
+		t.Fatal("adapted SQL scanner does not expose checkpoint identity")
+	}
+	if _, ok := provider.CheckpointIdentity(); ok {
+		t.Fatal("adapted SQL scanner exposed identity without a target grammar blob")
+	}
+}
+
+func writeSQLOverrideBlob(t *testing.T, dir, name string) ([]byte, []byte) {
+	t.Helper()
+	original, err := os.ReadFile(filepath.Join("grammar_blobs", "sql.bin"))
+	if err != nil {
+		t.Fatalf("read checked-in SQL blob: %v", err)
+	}
+	lang, err := decodeLanguageBlobData("grammar_blobs/sql.bin", original)
+	if err != nil {
+		t.Fatalf("decode checked-in SQL blob: %v", err)
+	}
+	lang.Name = name
+	override := encodeLanguageBlobForTest(t, lang)
+	if err := os.WriteFile(filepath.Join(dir, "sql.bin"), override, 0o644); err != nil {
+		t.Fatalf("write SQL override blob: %v", err)
+	}
+	return override, original
+}
 
 func TestFortranLanguageUsesPreferredGrammargenBlobOverride(t *testing.T) {
 	PurgeEmbeddedLanguageCache()

--- a/grammars/sql_scanner.go
+++ b/grammars/sql_scanner.go
@@ -2,7 +2,17 @@
 
 package grammars
 
-import gotreesitter "github.com/odvcencio/gotreesitter"
+import (
+	"crypto/sha256"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// sqlExternalScannerLocalPortSHA256 identifies the marked local scanner port.
+// A focused test checks this value against the source region below.
+const sqlExternalScannerLocalPortSHA256 = "588328cd27eea49e88b704b9bd8e46958046564187a5db1a70f6622308a7fff8"
+
+// C26Q_SQL_SCANNER_LOCAL_PORT_BEGIN
 
 // External token indexes for the SQL grammar (DerekStride/tree-sitter-sql).
 const (
@@ -18,6 +28,34 @@ const (
 // closed at the affected boundary without changing full-parse semantics.
 const sqlMaxDollarTagBytes = 4095
 
+const (
+	sqlExternalScannerUpstreamRepo    = "https://github.com/m-novikov/tree-sitter-sql"
+	sqlExternalScannerUpstreamCommit  = "587f30d184b058450be2a2330878210c5f33b3f9"
+	sqlExternalScannerGrammarSHA256   = "42f011860137175a5a0cb820d1a694e5ccca1d17f226729ff6a4e886910cde1c"
+	sqlExternalScannerSourceSHA256    = "d437ad9f517d7a1f4248ccd05abe58370b5040c0037c877dab1f0aefeaa04af6"
+	sqlExternalScannerIdentityVersion = "gotreesitter/sql-external-scanner/v1"
+	sqlExternalScannerSemantics       = "state=tag;empty=0;nonempty=tag-nul;scan=tag-content-end;failure=preserve;max-tag=4095"
+)
+
+var sqlExternalScannerSpec = ExternalScannerSpec{
+	Language:       "sql",
+	UpstreamRepo:   sqlExternalScannerUpstreamRepo,
+	UpstreamCommit: sqlExternalScannerUpstreamCommit,
+	SourceFiles: []ExternalScannerSourceFile{
+		{Path: "src/grammar.json", SHA256: sqlExternalScannerGrammarSHA256},
+		{Path: "src/scanner.cc", SHA256: sqlExternalScannerSourceSHA256},
+	},
+	Externals: []string{
+		"_dollar_quoted_string_tag",
+		"_dollar_quoted_string_content",
+		"_dollar_quoted_string_end_tag",
+	},
+}
+
+func init() {
+	RegisterExternalScannerSpec(sqlExternalScannerSpec)
+}
+
 // sqlScannerState stores the dollar-quote tag for matching the closing delimiter.
 type sqlScannerState struct {
 	tag string // empty when not inside a dollar-quoted string
@@ -28,7 +66,36 @@ type sqlScannerState struct {
 // This is a Go port of the C external scanner from DerekStride/tree-sitter-sql.
 // The scanner handles PostgreSQL dollar-quoted strings: $tag$..content..$tag$.
 // It uses state to remember the opening tag so the closing tag can be matched.
-type SqlExternalScanner struct{}
+type SqlExternalScanner struct {
+	grammarBlobSHA256      [32]byte
+	grammarIdentityPresent bool
+}
+
+// ExternalScannerForLanguage binds SQL identity to the exact compressed blob.
+// A language without that identity keeps the scanner functional but fails
+// closed at the identity-aware incremental reuse boundary.
+func (SqlExternalScanner) ExternalScannerForLanguage(lang *gotreesitter.Language) gotreesitter.ExternalScanner {
+	scanner := SqlExternalScanner{}
+	if lang != nil {
+		if sum, ok := lang.GrammarBlobSHA256(); ok {
+			scanner.grammarBlobSHA256 = sum
+			scanner.grammarIdentityPresent = true
+		}
+	}
+	return scanner
+}
+
+// CheckpointIdentity returns the stable SQL scanner identity and its bound
+// grammar blob identity. Both values are raw 32-byte SHA-256 values.
+func (s SqlExternalScanner) CheckpointIdentity() (gotreesitter.ExternalScannerCheckpointIdentity, bool) {
+	if !s.grammarIdentityPresent {
+		return gotreesitter.ExternalScannerCheckpointIdentity{}, false
+	}
+	return gotreesitter.ExternalScannerCheckpointIdentity{
+		Scanner: append([]byte(nil), sqlExternalScannerIdentity[:]...),
+		Grammar: append([]byte(nil), s.grammarBlobSHA256[:]...),
+	}, true
+}
 
 func (SqlExternalScanner) Create() any {
 	return &sqlScannerState{}
@@ -218,3 +285,16 @@ func sqlIsScannerWhitespace(ch rune) bool {
 func sqlValid(validSymbols []bool, idx int) bool {
 	return idx >= 0 && idx < len(validSymbols) && validSymbols[idx]
 }
+
+// C26Q_SQL_SCANNER_LOCAL_PORT_END
+
+var sqlExternalScannerIdentity = sha256.Sum256([]byte(
+	sqlExternalScannerIdentityVersion + "\x00" +
+		"local-port=" + sqlExternalScannerLocalPortSHA256 + "\x00" +
+		sqlExternalScannerUpstreamRepo + "\x00" +
+		sqlExternalScannerUpstreamCommit + "\x00" +
+		"src/grammar.json=" + sqlExternalScannerGrammarSHA256 + "\x00" +
+		"src/scanner.cc=" + sqlExternalScannerSourceSHA256 + "\x00" +
+		"externals=_dollar_quoted_string_tag,_dollar_quoted_string_content,_dollar_quoted_string_end_tag\x00" +
+		sqlExternalScannerSemantics,
+))

--- a/grammars/sql_scanner_test.go
+++ b/grammars/sql_scanner_test.go
@@ -3,6 +3,12 @@
 package grammars
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	_ "unsafe"
@@ -11,7 +17,7 @@ import (
 )
 
 func TestSQLScannerCheckpointRoundTrip(t *testing.T) {
-	scanner := SqlExternalScanner{}
+	scanner := SqlExternalScanner{}.ExternalScannerForLanguage(SqlLanguage()).(SqlExternalScanner)
 	buf := make([]byte, 4096)
 
 	for _, tag := range []string{"", "$$", "$named_42$", "$" + strings.Repeat("x", sqlMaxDollarTagBytes-2) + "$"} {
@@ -56,6 +62,102 @@ func TestSQLScannerFailedClosePreservesCheckpointState(t *testing.T) {
 	}
 	if state.tag != "$wanted$" {
 		t.Fatalf("failed scan mutated tag to %q", state.tag)
+	}
+}
+
+func TestSQLScannerCheckpointIdentityBindsExactGrammarBlob(t *testing.T) {
+	lang := SqlLanguage()
+	grammar, ok := lang.GrammarBlobSHA256()
+	if !ok {
+		t.Fatal("native SQL language has no grammar identity")
+	}
+	bound, ok := SqlExternalScanner{}.ExternalScannerForLanguage(lang).(gotreesitter.ExternalScannerCheckpointIdentityProvider)
+	if !ok {
+		t.Fatal("bound SQL scanner does not expose checkpoint identity")
+	}
+	first, ok := bound.CheckpointIdentity()
+	if !ok || len(first.Scanner) != sha256.Size || len(first.Grammar) != sha256.Size {
+		t.Fatalf("SQL checkpoint identity = (%d, %d, %t), want two 32-byte values", len(first.Scanner), len(first.Grammar), ok)
+	}
+	if string(first.Grammar) != string(grammar[:]) {
+		t.Fatalf("SQL grammar identity = %x, want %x", first.Grammar, grammar)
+	}
+	if got, want := hex.EncodeToString(first.Scanner), "7e493677411a501e6d8592c6b9cc158e21a1bfed44c72ca914e2d81e4e34861d"; got != want {
+		t.Fatalf("SQL scanner identity = %s, want %s", got, want)
+	}
+	second, ok := bound.CheckpointIdentity()
+	if !ok || string(first.Scanner) != string(second.Scanner) || string(first.Grammar) != string(second.Grammar) {
+		t.Fatal("SQL checkpoint identity was not stable")
+	}
+	first.Scanner[0]++
+	first.Grammar[0]++
+	third, ok := bound.CheckpointIdentity()
+	if !ok || third.Scanner[0] == first.Scanner[0] || third.Grammar[0] == first.Grammar[0] {
+		t.Fatal("SQL checkpoint identity returned aliased mutable bytes")
+	}
+
+	identityScanner := SqlExternalScanner{}.ExternalScannerForLanguage(&gotreesitter.Language{}).(gotreesitter.ExternalScannerCheckpointIdentityProvider)
+	if _, ok := identityScanner.CheckpointIdentity(); ok {
+		t.Fatal("SQL scanner exposed identity without a bound grammar blob")
+	}
+}
+
+func TestSQLScannerIdentityBindsLocalPortSource(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	source, err := os.ReadFile(filepath.Join(filepath.Dir(testFile), "sql_scanner.go"))
+	if err != nil {
+		t.Fatalf("read SQL scanner source: %v", err)
+	}
+	begin := []byte("// C26Q_SQL_SCANNER_LOCAL_PORT_BEGIN\n")
+	end := []byte("// C26Q_SQL_SCANNER_LOCAL_PORT_END\n")
+	start := bytes.Index(source, begin)
+	if start < 0 {
+		t.Fatal("SQL scanner local-port begin marker is missing")
+	}
+	start += len(begin)
+	finish := bytes.Index(source[start:], end)
+	if finish < 0 {
+		t.Fatal("SQL scanner local-port end marker is missing")
+	}
+	got := sha256.Sum256(source[start : start+finish])
+	if gotHex := hex.EncodeToString(got[:]); gotHex != sqlExternalScannerLocalPortSHA256 {
+		t.Fatalf("SQL local scanner port hash = %s, want %s; update the identity when the marked port changes", gotHex, sqlExternalScannerLocalPortSHA256)
+	}
+}
+
+func TestSQLScannerSpecAndNativeBlobIdentity(t *testing.T) {
+	spec, ok := LookupExternalScannerSpec("sql")
+	if !ok {
+		t.Fatal("missing SQL external scanner spec")
+	}
+	if got, want := spec.UpstreamCommit, sqlExternalScannerUpstreamCommit; got != want {
+		t.Fatalf("SQL scanner commit = %q, want %q", got, want)
+	}
+	if got, want := len(spec.SourceFiles), 2; got != want {
+		t.Fatalf("SQL scanner source count = %d, want %d", got, want)
+	}
+	lang := SqlLanguage()
+	grammarSum, ok := lang.GrammarBlobSHA256()
+	if !ok {
+		t.Fatal("native SQL language has no compressed blob identity")
+	}
+	wantBytes, err := hex.DecodeString("e21421cbab52b54cf5ba15c8f78a2bb4729bf4e8c0da14368069e897de451268")
+	if err != nil {
+		t.Fatalf("decode SQL blob digest: %v", err)
+	}
+	if string(grammarSum[:]) != string(wantBytes) {
+		t.Fatalf("native SQL grammar identity = %x, want %x", grammarSum, wantBytes)
+	}
+	provider, ok := lang.ExternalScanner.(gotreesitter.ExternalScannerCheckpointIdentityProvider)
+	if !ok {
+		t.Fatal("native SQL scanner is not identity-bearing")
+	}
+	identity, ok := provider.CheckpointIdentity()
+	if !ok || string(identity.Grammar) != string(grammarSum[:]) {
+		t.Fatal("native SQL scanner did not bind the native grammar identity")
 	}
 }
 

--- a/language.go
+++ b/language.go
@@ -560,6 +560,10 @@ type Language struct {
 	// External scanner (nil if not needed)
 	ExternalScanner ExternalScanner
 	ExternalSymbols []Symbol // external token index -> symbol
+	// grammarBlobSHA256 identifies the exact compressed grammar bytes that
+	// produced this Language. Keep it private so blob encoding stays stable.
+	grammarBlobSHA256      [32]byte
+	grammarBlobSHA256Valid bool
 	// ImmediateTokens is a bitmask of symbol IDs that are token.immediate() tokens.
 	// When the lexer matches one of these after consuming whitespace, the match
 	// should be rejected — immediate tokens must match at the original position.
@@ -990,6 +994,14 @@ func (l *Language) Version() uint32 {
 		return 0
 	}
 	return l.LanguageVersion
+}
+
+// GrammarBlobSHA256 returns the exact compressed grammar blob identity.
+func (l *Language) GrammarBlobSHA256() ([32]byte, bool) {
+	if l == nil || !l.grammarBlobSHA256Valid {
+		return [32]byte{}, false
+	}
+	return l.grammarBlobSHA256, true
 }
 
 // CompatibleWithRuntime reports whether this language can be parsed by the

--- a/load_language.go
+++ b/load_language.go
@@ -3,6 +3,7 @@ package gotreesitter
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
 	"encoding/binary"
 	"encoding/gob"
 	"fmt"
@@ -53,7 +54,8 @@ func LoadLanguage(data []byte) (*Language, error) {
 	if trailer != nil {
 		lang.LargeStateGotos = trailer
 	}
-
+	lang.grammarBlobSHA256 = sha256.Sum256(data)
+	lang.grammarBlobSHA256Valid = true
 	InferGeneratedRepeatAuxMetadata(&lang)
 
 	return &lang, nil

--- a/parser.go
+++ b/parser.go
@@ -4729,6 +4729,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	p.ensureParseInitialCapacity(source, arenaClass, arena, scratch)
 	memoryBudget := parseMemoryBudgetForParser(p, len(source))
 	arena.setBudget(memoryBudget)
+	arena.setExternalScannerCheckpointIdentityForLanguage(p.language)
 	scratch.setBudget(memoryBudget)
 	restoreRuntimeMemoryBudget := p.enterRuntimeMemoryBudget(memoryBudget, len(source))
 	if restoreRuntimeMemoryBudget.parser != nil {

--- a/tree.go
+++ b/tree.go
@@ -3455,6 +3455,7 @@ func (t *Tree) Copy() *Tree {
 		class = t.arena.class
 	}
 	arena := acquireNodeArena(class)
+	arena.inheritExternalScannerCheckpointIdentity(t.arena)
 	out.root = cloneTreeNodesIntoArena(t.root, arena)
 	out.arena = arena
 	return out
@@ -3604,6 +3605,9 @@ func cloneNodeHeaderInto(dst, src *Node, arena *nodeArena, offset *cloneOffset) 
 	dst.parent = nil
 	dst.childIndex = -1
 	dst.ownerArena = arena
+	if arena != nil && src.ownerArena != nil {
+		arena.inheritExternalScannerCheckpointIdentity(src.ownerArena)
+	}
 	if src.ownerArena == nil || src.ownerArena.externalScannerCheckpointRecords == 0 {
 		return
 	}
@@ -3725,6 +3729,9 @@ func cloneFinalChildRefsIntoArenaWithMetrics(src, dst *Node, arena *nodeArena, o
 }
 
 func cloneStackEntryIntoArena(srcArena, dstArena *nodeArena, entry stackEntry, offset *cloneOffset, metrics cloneMetricScope) stackEntry {
+	if dstArena != nil && srcArena != nil {
+		dstArena.inheritExternalScannerCheckpointIdentity(srcArena)
+	}
 	if node := stackEntryNode(entry); node != nil {
 		cloned := cloneTreeNodesIntoArenaWithOffset(node, dstArena, offset)
 		return newStackEntryNode(cloned.parseState, cloned)


### PR DESCRIPTION
## Summary

This PR adds a bounded native SQL checkpoint identity gate. It keeps issue #576 open.

- LoadLanguage records the exact grammar blob SHA-256. Generated overrides hash exact bytes before SQL scanner adaptation.
- Native SQL binds checkpoints to the scanner identity and grammar identity. Missing, changed, or mismatched identities fail closed.
- The loader owns grammar identity. Arena copies and resets preserve or clear checkpoint identity and its memory charge.
- Post-hardening Docker root, race, SQL, route, incremental, raw, included-range, and real-corpus gates passed.
- Generated SQL still has four locked-C divergences. This PR does not claim generated SQL parity.

No unrelated parser route changes are included. No merge is requested here.

Related to #576. Keep issue #576 open.