### PR TITLE
fix(grep): preserve quoted where-clause separators

### DIFF
--- a/grep/where.go
+++ b/grep/where.go
@@ -31,7 +31,10 @@ func CompileWhere(where string) (WhereFilter, error) {
 	}
 
 	// Split on semicolons and newlines to support multiple constraints.
-	clauses := splitClauses(where)
+	clauses, err := splitClauses(where)
+	if err != nil {
+		return nil, fmt.Errorf("split where clauses: %w", err)
+	}
 
 	var filters []WhereFilter
 	for _, clause := range clauses {
@@ -62,10 +65,10 @@ func CompileWhere(where string) (WhereFilter, error) {
 }
 
 // splitClauses splits a where string on semicolons and newlines that occur
-// outside of single- or double-quoted arguments. A quote preceded by an odd
-// run of backslashes is escaped and does not terminate the argument; an even
-// run does not escape it.
-func splitClauses(s string) []string {
+// outside of single- or double-quoted arguments. A quote opens a quoted region
+// only at an argument boundary, so apostrophes in unquoted words remain data.
+// A quote preceded by an odd run of backslashes is escaped; an even run is not.
+func splitClauses(s string) ([]string, error) {
 	var clauses []string
 	var cur strings.Builder
 	var quote byte
@@ -84,6 +87,10 @@ func splitClauses(s string) []string {
 			}
 			bs = 0
 		case c == '"' || c == '\'':
+			if !atWhereArgumentStart(cur.String()) {
+				cur.WriteByte(c)
+				continue
+			}
 			quote = c
 			bs = 0
 			cur.WriteByte(c)
@@ -94,8 +101,19 @@ func splitClauses(s string) []string {
 			cur.WriteByte(c)
 		}
 	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated %c quote in where clause", quote)
+	}
 	clauses = append(clauses, cur.String())
-	return clauses
+	return clauses, nil
+}
+
+func atWhereArgumentStart(s string) bool {
+	i := len(s) - 1
+	for i >= 0 && (s[i] == ' ' || s[i] == '\t' || s[i] == '\r' || s[i] == '\n') {
+		i--
+	}
+	return i < 0 || s[i] == '(' || s[i] == ','
 }
 
 // compileClause compiles a single where constraint.

--- a/grep/where.go
+++ b/grep/where.go
@@ -61,11 +61,41 @@ func CompileWhere(where string) (WhereFilter, error) {
 	}, nil
 }
 
-// splitClauses splits a where string on semicolons and newlines.
+// splitClauses splits a where string on semicolons and newlines that occur
+// outside of single- or double-quoted arguments. A quote preceded by an odd
+// run of backslashes is escaped and does not terminate the argument; an even
+// run does not escape it.
 func splitClauses(s string) []string {
-	// Replace newlines with semicolons, then split.
-	s = strings.ReplaceAll(s, "\n", ";")
-	return strings.Split(s, ";")
+	var clauses []string
+	var cur strings.Builder
+	var quote byte
+	var bs int
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case quote != 0:
+			cur.WriteByte(c)
+			if c == '\\' {
+				bs++
+				continue
+			}
+			if c == quote && bs%2 == 0 {
+				quote = 0
+			}
+			bs = 0
+		case c == '"' || c == '\'':
+			quote = c
+			bs = 0
+			cur.WriteByte(c)
+		case c == ';' || c == '\n':
+			clauses = append(clauses, cur.String())
+			cur.Reset()
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	clauses = append(clauses, cur.String())
+	return clauses
 }
 
 // compileClause compiles a single where constraint.
@@ -169,9 +199,19 @@ func parseTwoArgFunc(clause, funcName string) (capName, arg string, err error) {
 // stripQuotes removes surrounding double quotes or single quotes from s.
 func stripQuotes(s string) string {
 	if len(s) >= 2 {
-		if (s[0] == '"' && s[len(s)-1] == '"') ||
-			(s[0] == '\'' && s[len(s)-1] == '\'') {
-			return s[1 : len(s)-1]
+		q := s[0]
+		if (q == '"' || q == '\'') && s[len(s)-1] == q {
+			s = s[1 : len(s)-1]
+			var out strings.Builder
+			for i := 0; i < len(s); i++ {
+				if s[i] == '\\' && i+1 < len(s) && s[i+1] == q {
+					out.WriteByte(q)
+					i++
+					continue
+				}
+				out.WriteByte(s[i])
+			}
+			return out.String()
 		}
 	}
 	return s

--- a/grep/where_test.go
+++ b/grep/where_test.go
@@ -183,6 +183,60 @@ func TestCompileWhere_MultipleClauses(t *testing.T) {
 	}
 }
 
+func TestCompileWhere_QuotedSeparators(t *testing.T) {
+	match := func(where, text string) bool {
+		filter, err := CompileWhere(where)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", where, err)
+		}
+		r := &Result{Captures: map[string]Capture{
+			"NAME": {Name: "NAME", Text: []byte(text)},
+		}}
+		return filter(r, nil, nil)
+	}
+
+	// Quoted separators stay within one clause.
+	if !match(`contains($NAME, "a;b")`, "a;b") {
+		t.Error("double-quoted semicolon should stay in one clause")
+	}
+	if !match(`contains($NAME, 'a;b')`, "a;b") {
+		t.Error("single-quoted semicolon should stay in one clause")
+	}
+	if !match("contains($NAME, \"a\nb\")", "a\nb") {
+		t.Error("double-quoted newline should stay in one clause")
+	}
+	if !match("contains($NAME, 'a\nb')", "a\nb") {
+		t.Error("single-quoted newline should stay in one clause")
+	}
+
+	// Backslash-escaped matching quote, separator later in same argument.
+	if !match(`contains($NAME, "a\";b")`, `a";b`) {
+		t.Error("escaped double quote should not close the argument")
+	}
+	if !match(`contains($NAME, 'a\';b')`, `a';b`) {
+		t.Error("escaped single quote should not close the argument")
+	}
+	if !match(`contains($NAME, "\d+")`, `\d+`) {
+		t.Error("unrelated regex-style backslashes should be preserved")
+	}
+
+	// An even run of backslashes does not escape the following quote.
+	if !match(`contains($NAME, "a\\b"); contains($NAME, "c")`, `a\\bc`) {
+		t.Error("even backslash run should not falsely escape the quote")
+	}
+
+	// Ordinary separators still split into ANDed clauses.
+	if !match(`contains($NAME, "f"); not contains($NAME, "t")`, "foo") {
+		t.Error("semicolon should split clauses")
+	}
+	if !match("contains($NAME, \"f\")\nnot contains($NAME, \"t\")", "foo") {
+		t.Error("newline should split clauses")
+	}
+	if match(`contains($NAME, "f"); not contains($NAME, "t")`, "tofu") {
+		t.Error("clauses should be ANDed")
+	}
+}
+
 func TestCompileWhere_MissingCapture(t *testing.T) {
 	filter, err := CompileWhere(`contains($MISSING, "hello")`)
 	if err != nil {

--- a/grep/where_test.go
+++ b/grep/where_test.go
@@ -220,8 +220,8 @@ func TestCompileWhere_QuotedSeparators(t *testing.T) {
 		t.Error("unrelated regex-style backslashes should be preserved")
 	}
 
-	// An even run of backslashes does not escape the following quote.
-	if !match(`contains($NAME, "a\\b"); contains($NAME, "c")`, `a\\bc`) {
+	// An even run of backslashes does not escape the closing quote.
+	if !match(`contains($NAME, "a\\"); contains($NAME, "b")`, `a\\b`) {
 		t.Error("even backslash run should not falsely escape the quote")
 	}
 
@@ -234,6 +234,31 @@ func TestCompileWhere_QuotedSeparators(t *testing.T) {
 	}
 	if match(`contains($NAME, "f"); not contains($NAME, "t")`, "tofu") {
 		t.Error("clauses should be ANDed")
+	}
+}
+
+func TestCompileWhere_UnquotedApostropheStillSplitsClauses(t *testing.T) {
+	filter, err := CompileWhere(`contains($NAME, don't); contains($NAME, stop)`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	matching := &Result{Captures: map[string]Capture{
+		"NAME": {Name: "NAME", Text: []byte("don't stop")},
+	}}
+	if !filter(matching, nil, nil) {
+		t.Error("expected both unquoted clauses to match")
+	}
+	notMatching := &Result{Captures: map[string]Capture{
+		"NAME": {Name: "NAME", Text: []byte("don't go")},
+	}}
+	if filter(notMatching, nil, nil) {
+		t.Error("expected second unquoted clause to reject the capture")
+	}
+}
+
+func TestCompileWhere_RejectsUnterminatedQuotedArgument(t *testing.T) {
+	if _, err := CompileWhere(`contains($NAME, "a;b)`); err == nil {
+		t.Fatal("expected an unterminated quoted argument error")
 	}
 }
 


### PR DESCRIPTION
Ox Alpha supplemental slice, isolated from the ongoing parser/performance campaign. The initial WIP checkpoint exposed review regressions; commit fe22d763 repairs them. Independent review is GO. Focused and full grep package tests pass. Draft remains open for CI and final merge review.