### PR TITLE
NO-GO: Record SQL compact replay blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,31 @@ for tags and release notes while still in `0.x`.
   absent. Keep the arm live.
   No registry or production code changes are included. See
   `docs/root-normalization-retirement.md`.
+- Recorded the C26y SQL compact checkpoint trace on base
+  `e24ccf5a87bbd7febc21f67f014c2d5301d229d0`. The pinned source uses commit
+  `587f30d184b058450be2a2330878210c5f33b3f9`. The grammar and scanner source
+  hashes are `42f011860137175a5a0cb820d1a694e5ccca1d17f226729ff6a4e886910cde1c`
+  and `d437ad9f517d7a1f4248ccd05abe58370b5040c0037c877dab1f0aefeaa04af6`.
+  The semantically correct locked-blob and target-symbol routes share four
+  scanner transitions. At `7-9`, the state changes from `00` to `242400`.
+  At `9-12`, it remains `242400`. At `12-14`, it changes to `00`. At `14-15`,
+  it remains `00`. The direct generated route emits an error tree with
+  13/4/4 values. Correct production routes record 14/5/5. Compact admission
+  records zero sidecars and zero incremental reuse. Reject the compact
+  candidate.
+  Keep issue #576 open until compact sidecars and safe nonzero reuse have a
+  generic proof.
+
+- Screened generic compact-admission sidecars for checkpointed scanners in
+  C26z. The diagnostic SQL route recorded 14 records, 5 leaves, and 5
+  snapshots with the correct `7-9`, `9-12`, `12-14`, and `14-15` scanner
+  transitions. Generated, locked-blob, and locked-C trees matched. Compact
+  reuse was 1 subtree and 6 bytes. Production reuse was 1 subtree and 16
+  bytes. The candidate was reverted after C26aa traced the gap to compact
+  parse-state replay. Generated content replay state `180` made checkpoint
+  scanning return error span `9-14`. Locked production state `16613` returned
+  expected span `9-12`. A stale grammar identity reused zero subtrees and zero
+  bytes. Keep issue #576 open.
 
 - Added authenticated generated-SQL scanner identity to the grammargen C
   parity route. The route now reloads the generated blob through `LoadLanguage`

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -2078,6 +2078,134 @@ The boundary originally moved four files to FALLBACK:
 Focused field-aware C-oracle receipts now certify Bash, Erlang, and JavaScript.
 Those files route directly again. Kotlin remains fail-closed.
 
+## C26y SQL compact checkpoint trace
+
+C26y used base
+`e24ccf5a87bbd7febc21f67f014c2d5301d229d0`.
+
+Status: NO-GO.
+
+Restore the pinned source with:
+
+```sh
+bash scripts/seed_real_corpus_from_lock.sh /tmp/gts-c26y-pinned-grammar-20260824 sql
+```
+
+The source used commit
+`587f30d184b058450be2a2330878210c5f33b3f9`.
+
+- `src/grammar.json`: `42f011860137175a5a0cb820d1a694e5ccca1d17f226729ff6a4e886910cde1c`
+- `src/scanner.cc`: `d437ad9f517d7a1f4248ccd05abe58370b5040c0037c877dab1f0aefeaa04af6`
+
+The direct production and locked-C parity artifact is
+`/tmp/gts-c26y-artifacts-prod2/20260823T174027Z-c26y-production-direct-trace`.
+Its log SHA-256 is
+`9db58d347835f6c2fede671ebce47c89c840f8651bed93fb109c6be24ea3cbc5`.
+Its metadata SHA-256 is
+`17b8ca563d6e41000490371aff422500fea4857d9551e9bdffc458e0b9e2b012`.
+
+The direct generated route recorded 13 records, 4 leaves, and 4 snapshots,
+but it returned an error tree. The locked blob returned the correct tree and
+recorded 14 records, 5 leaves, and 5 snapshots. The locked C comparison in
+the same parity suite matched the locked blob tree. The C binding does not
+expose scanner serialization bytes.
+
+The target-symbol wrapper production artifact is
+`/tmp/gts-c26y-artifacts-wrapperprod2/20260823T174239Z-c26y-wrapper-production-trace2`.
+Its log SHA-256 is
+`87658133020bc5232ce5e2b67b12fb61b6d253a39f3af56137894ef937b575a0`.
+Its metadata SHA-256 is
+`5fe266fdab999e4c2b825ff6ed81e54c4503c487a4779595cc567f95b36e0207`.
+The wrapper returned the correct tree. It recorded 14 records, 5 leaves, and
+5 snapshots. Its target symbols differed, but its scanner bytes matched the
+locked blob at every checkpoint boundary.
+
+The successful compact-admission artifact is
+`/tmp/gts-c26y-artifacts-compact2/20260823T174539Z-c26y-compact-wrapper-trace2`.
+Its log SHA-256 is
+`81ff5dee3f401dd15e11b0bc3a6bee5f15e86aed18c8e177c015af5228a7ba09`.
+Its metadata SHA-256 is
+`4a6329873e021ad0db5a4d28c968971e629669a58fee81baccf8d5e0e1314563`.
+The compact scheduler captured the same four current checkpoint pairs:
+
+- `7-9`: `00` to `242400`
+- `9-12`: `242400` to `242400`
+- `12-14`: `242400` to `00`
+- `14-15`: `00` to `00`
+
+The compact tree returned zero records, zero leaves, and zero snapshots. Its
+incremental probe reused zero subtrees and zero bytes. The route therefore
+has a semantic scanner trace but no tree-owned sidecar proof. Do not enable
+checkpointed compact reuse from this trace alone.
+
+The 13/4/4 values are path-specific. They come from the direct generated
+route's failed external-token mapping and error recovery. The invariant for a
+correct SQL route is the four byte-span and serialized-state pairs above,
+plus a complete tree with no error. A future candidate must materialize these
+sidecars, preserve scanner and grammar identity, and prove nonzero reuse.
+Keep issue #576 open. Do not require the path-specific 13/4/4 receipt for a
+semantically correct route.
+
+## C26z SQL compact checkpoint sidecars
+
+C26z used base
+`f8b9d718ee19f65598e274035f5481a899ab2b72`.
+
+Status: NO-GO.
+
+The diagnostic candidate attached the scheduler's authenticated checkpoint
+pairs to compact terminal nodes before parent construction. It also bound
+adapted scanners to the target grammar blob identity. Duplicate spans with
+different states failed closed. The candidate was reverted after the C26aa
+screen because compact replay did not prove production-equivalent reuse.
+
+The pinned SQL source remains commit
+`587f30d184b058450be2a2330878210c5f33b3f9` with grammar hash
+`42f011860137175a5a0cb820d1a694e5ccca1d17f226729ff6a4e886910cde1c` and
+scanner hash
+`d437ad9f517d7a1f4248ccd05abe58370b5040c0037c877dab1f0aefeaa04af6`.
+
+The generated SQL witness records 14 checkpoint records, 5 leaf nodes, and
+5 snapshot payloads. It uses these scanner transitions:
+
+- `7-9`: `00` to `242400`
+- `9-12`: `242400` to `242400`
+- `12-14`: `242400` to `00`
+- `14-15`: `00` to `00`
+
+The generated tree matches the locked blob and locked C trees for all three
+focused inputs. Incremental parsing reuses 1 subtree and 6 bytes. A stale
+grammar identity reuses 0 subtrees and 0 bytes. The focused Docker run passed:
+
+```text
+/tmp/gts-c26z-artifacts/20260823T181038Z-c26z-final-gate
+```
+
+The container log SHA-256 is
+`1bb984c67b55adaaf6ded853f31473c0eeb38bc844c9c046af6ba2b9b2c99c4c`.
+The metadata SHA-256 is
+`d866055e83db3d9e17b45c5007b6acc2d46cca28bed28363d7951ce18a159e8d`.
+
+The unit gate passed in
+`/tmp/gts-c26z-artifacts/20260823T181230Z-c26z-unit-final`, and the grammar
+binding gate passed in
+`/tmp/gts-c26z-artifacts/20260823T181309Z-c26z-grammars-final`.
+Their container log and metadata hashes are
+`2bea71d9e86e304da3da8c7e4b04c16549c0d867408423bd79ca4f0e75d8fda6` and
+`a89df6d2adb725d9cfefb55b04dc6d8b6f338155c142fa8d7d51f8bf05829215`, and
+`e24f45dcc56d9960e364a9288f64731806b5a9156da9ad6196c30fe0f6589424` and
+`8acd3e1d407a44fea29389ba25097d2a14191edd5fe494dfc482e93e549884ae`.
+
+The diagnostic compact route had tree-owned sidecars and safe nonzero reuse.
+The observed 6-byte reuse was lower than the earlier 16-byte production
+receipt. C26aa traced the difference to parse-state replay, not span
+selection. The generated compact content leaf covered bytes `9-12` with
+replay state `180`; checkpoint scanning then returned an error span `9-14`.
+The locked production leaf used state `16613` and returned the expected
+`9-12` span. No generic state remap passed the equality and stale-identity
+guards. The production and test changes were reverted. Keep issue #576 open
+until a generic replay contract proves production-equivalent reuse.
+
 ## Corpus state
 
 The current manifest has these properties:


### PR DESCRIPTION
Status: NO-GO.

Summary:

- C26y recorded the correct SQL route with 14 checkpoint records, 5 leaves, and 5 snapshots. Compact admission recorded zero sidecars and zero reuse.
- C26z attached diagnostic compact sidecars. The route recorded 14/5/5 and matched the generated, locked-blob, and locked-C trees.
- The diagnostic route reused 1 subtree and 6 bytes. Production reused 1 subtree and 16 bytes.
- C26aa found the blocker in parse-state replay. Generated compact state 180 produced error span 9-14. Locked production state 16613 produced the expected span 9-12.
- The stale identity route reused 0 subtrees and 0 bytes. Fresh-tree equality passed.
- All candidate code and tests were reverted. Keep issue #576 open: https://github.com/odvcencio/gotreesitter/issues/576

Checks:

- Markdown parsing passed for both documents.
- Changelog lint matched the baseline at 248 findings. Matrix lint matched the baseline at zero findings.
- Git diff checks passed.

The receipt changes only CHANGELOG.md and docs/compact-route-real-corpus-matrix.md.