### PR TITLE
archive: preserve local Swift 556 worktree state

### DIFF
--- a/grammars/swift_parse_regression_test.go
+++ b/grammars/swift_parse_regression_test.go
@@ -101,147 +101,23 @@ func TestSwiftNestedGenericCallAdjacentClosers(t *testing.T) {
 	}
 }
 
-// TestSwiftOptionalGenericTypeParses checks issue #556: a generic type
-// annotated optional (`Range<Int>?`) must parse error-free, and the
-// reconstructed tree must be optional_type wrapping a user_type with a
-// type_arguments list, not just an error-free tree of any shape.
 func TestSwiftOptionalGenericTypeParses(t *testing.T) {
 	lang := SwiftLanguage()
-	for _, tc := range []struct {
-		src          string
-		typeArgCount int
-	}{
-		{src: "struct S { internal let kRange: Range<Int>? }", typeArgCount: 1},
-		{src: "struct S { let value: Dictionary<String, Int>? }", typeArgCount: 2},
+	for _, src := range []string{
+		"struct S { internal let kRange: Range<Int>? }",
+		"struct S { let value: Dictionary<String, Int>? }",
 	} {
-		t.Run(tc.src, func(t *testing.T) {
+		t.Run(src, func(t *testing.T) {
 			parser := gotreesitter.NewParser(lang)
-			tree, err := parser.Parse([]byte(tc.src))
+			tree, err := parser.Parse([]byte(src))
 			if err != nil {
 				t.Fatalf("parse optional generic type: %v", err)
 			}
 			defer tree.Release()
-			root := tree.RootNode()
-			if root.HasError() {
+			if root := tree.RootNode(); root.HasError() {
 				t.Fatalf("optional generic type has parse errors: %s", root.SExpr(lang))
 			}
-			var optType *gotreesitter.Node
-			var find func(n *gotreesitter.Node)
-			find = func(n *gotreesitter.Node) {
-				if n == nil || optType != nil {
-					return
-				}
-				if n.Type(lang) == "optional_type" {
-					optType = n
-					return
-				}
-				for i := 0; i < n.ChildCount(); i++ {
-					find(n.Child(i))
-				}
-			}
-			find(root)
-			if optType == nil {
-				t.Fatalf("no optional_type node: %s", root.SExpr(lang))
-			}
-			userType := optType.NamedChild(0)
-			if userType == nil || userType.Type(lang) != "user_type" {
-				t.Fatalf("optional_type does not wrap a user_type: %s", root.SExpr(lang))
-			}
-			var typeArgs *gotreesitter.Node
-			for i := 0; i < userType.NamedChildCount(); i++ {
-				if c := userType.NamedChild(i); c.Type(lang) == "type_arguments" {
-					typeArgs = c
-				}
-			}
-			if typeArgs == nil {
-				t.Fatalf("user_type is missing type_arguments: %s", root.SExpr(lang))
-			}
-			if got, want := typeArgs.NamedChildCount(), tc.typeArgCount; got != want {
-				t.Fatalf("type_arguments count = %d, want %d: %s", got, want, root.SExpr(lang))
-			}
 		})
-	}
-}
-
-// TestSwiftOptionalGenericCloseDoesNotStarveCustomOperator guards the fix for
-// issue #556 against a regression the fix itself introduced: deferring the
-// `>?` close-angle split to the DFA must fire only when a `>` genuinely
-// closes an open generic argument list. A standalone trailing `>?` (no open
-// generic in scope) must still reach the external scanner as one
-// `_custom_operator` token and parse exactly as it does without the #556
-// fix in place: as its own custom_operator node, never a full parse
-// failure and never a bare anonymous `>` / `?` pair with no error reported.
-func TestSwiftOptionalGenericCloseDoesNotStarveCustomOperator(t *testing.T) {
-	lang := SwiftLanguage()
-	for _, tc := range []struct {
-		name string
-		src  string
-		want string
-	}{
-		{
-			name: "trailing after property",
-			src:  "let a = 1\n>?",
-			want: "(source_file (property_declaration (value_binding_pattern) (pattern (simple_identifier)) (integer_literal)) (custom_operator))",
-		},
-		{
-			name: "trailing after import",
-			src:  "import Foundation\n>?",
-			want: "(source_file (import_declaration (identifier (simple_identifier))) (custom_operator))",
-		},
-		{
-			name: "trailing after function",
-			src:  "func f() {}\n>?",
-			want: "(source_file (function_declaration (simple_identifier) (function_body)) (custom_operator))",
-		},
-		{
-			name: "trailing after bare identifier",
-			src:  "let a = 1\nb >?",
-			want: "(source_file (property_declaration (value_binding_pattern) (pattern (simple_identifier)) (integer_literal)) (simple_identifier) (custom_operator))",
-		},
-		{
-			name: "trailing after class",
-			src:  "class C {}\n>?",
-			want: "(source_file (class_declaration (type_identifier) (class_body)) (custom_operator))",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			parser := gotreesitter.NewParser(lang)
-			tree, err := parser.Parse([]byte(tc.src))
-			if err != nil {
-				t.Fatalf("parse: %v", err)
-			}
-			defer tree.Release()
-			root := tree.RootNode()
-			if root.HasError() {
-				t.Fatalf("trailing >? fixture has parse errors: %s", root.SExpr(lang))
-			}
-			if got := root.SExpr(lang); got != tc.want {
-				t.Fatalf("s-expr = %s, want %s", got, tc.want)
-			}
-		})
-	}
-}
-
-// TestSwiftOptionalGenericCloseKeepsCustomOperatorDeclarations guards that
-// the #556 fix does not disturb genuine custom operators: an `infix operator
-// >?` declaration and its use must keep the `>?` spelling intact as a single
-// custom_operator node, both in the declaration and at each use site.
-func TestSwiftOptionalGenericCloseKeepsCustomOperatorDeclarations(t *testing.T) {
-	lang := SwiftLanguage()
-	src := "infix operator >?\nlet q = a >? b\n"
-	parser := gotreesitter.NewParser(lang)
-	tree, err := parser.Parse([]byte(src))
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	defer tree.Release()
-	root := tree.RootNode()
-	if root.HasError() {
-		t.Fatalf("custom operator declaration has parse errors: %s", root.SExpr(lang))
-	}
-	want := "(source_file (operator_declaration (custom_operator)) (property_declaration (value_binding_pattern) (pattern (simple_identifier)) (infix_expression (simple_identifier) (custom_operator) (simple_identifier))))"
-	if got := root.SExpr(lang); got != want {
-		t.Fatalf("s-expr = %s, want %s", got, want)
 	}
 }
 

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -1838,6 +1838,9 @@ func (d *dfaTokenSource) normalizeDFAToken(tok Token, endPos int, endRow, endCol
 	if splitTok, splitEndPos, splitEndRow, splitEndCol, ok := d.splitCompactCloseAngleToken(tok); ok {
 		return splitTok, splitEndPos, splitEndRow, splitEndCol
 	}
+	if splitTok, splitEndPos, splitEndRow, splitEndCol, ok := d.splitSwiftOptionalGenericCloseToken(tok); ok {
+		return splitTok, splitEndPos, splitEndRow, splitEndCol
+	}
 	if d.isBashGenerated {
 		if splitTok, splitEndPos, splitEndRow, splitEndCol, ok := d.splitBashGeneratedDoubleCloseParenToken(tok); ok {
 			return splitTok, splitEndPos, splitEndRow, splitEndCol
@@ -2190,6 +2193,30 @@ func (d *dfaTokenSource) splitCompactCloseAngleToken(tok Token) (Token, int, uin
 		tok.Text = tok.Text[:1]
 	}
 	return tok, int(tok.EndByte), tok.EndPoint.Row, tok.EndPoint.Column, true
+}
+
+// splitSwiftOptionalGenericCloseToken keeps the generic close and optional
+// marker separate when Swift's external scanner reports `>?` as one operator.
+func (d *dfaTokenSource) splitSwiftOptionalGenericCloseToken(tok Token) (Token, int, uint32, uint32, bool) {
+	if d == nil || d.language == nil || d.lexer == nil || d.language.Name != "swift" ||
+		d.symbolName(tok.Symbol) != "_custom_operator" || tok.EndByte != tok.StartByte+2 ||
+		tok.EndPoint.Row != tok.StartPoint.Row {
+		return tok, 0, 0, 0, false
+	}
+	start := int(tok.StartByte)
+	if start < 0 || start+1 >= len(d.lexer.source) ||
+		d.lexer.source[start] != '>' || d.lexer.source[start+1] != '?' {
+		return tok, 0, 0, 0, false
+	}
+	gtSym, ok := d.bestActiveSymbolByName(">")
+	if !ok || gtSym == 0 {
+		return tok, 0, 0, 0, false
+	}
+	tok.Symbol = gtSym
+	tok.EndByte = tok.StartByte + 1
+	tok.EndPoint = Point{Row: tok.StartPoint.Row, Column: tok.StartPoint.Column + 1}
+	tok.Text = ">"
+	return tok, start + 1, tok.EndPoint.Row, tok.EndPoint.Column, true
 }
 
 func supportsCompactCloseAngleSplit(languageName string) bool {
@@ -3162,22 +3189,6 @@ func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
 	return tok, true
 }
 
-// shouldDeferSwiftOptionalGenericCloseToDFA reports that the byte pair at the
-// lexer position is `>?` and that at least one active state resolves the DFA's
-// plain `>` candidate by reducing a production (closing an open generic
-// argument list), not merely shifting it. A shift-only match means some other
-// live GLR stack reads `>` as the start of an unrelated construct (for
-// example a comparison operator continuing across a line break); deferring
-// there would starve every stack of the external `_custom_operator` token
-// and turn a harmless trailing `>?` into a full parse failure. Requiring a
-// reduce restricts deferral to states where `>` genuinely closes a
-// `type_arguments` list, matching the C tree-sitter behavior of splitting the
-// generic close from the following `?` only in that context.
-//
-// Known limitation: this only recognizes the exact `>?` byte pair. A run of
-// closing angle brackets before the `?` (for example `A<B<Int>>?`) still
-// combines into one external `_custom_operator` token and is out of scope for
-// this fix; see the follow-up issue for the `>`-run-then-`?` family.
 func (d *dfaTokenSource) shouldDeferSwiftOptionalGenericCloseToDFA(valid []bool, states []StateID) bool {
 	if d == nil || d.language == nil || d.lexer == nil || d.lookupActionIndex == nil || d.language.Name != "swift" {
 		return false
@@ -3200,33 +3211,14 @@ func (d *dfaTokenSource) shouldDeferSwiftOptionalGenericCloseToDFA(valid []bool,
 		return false
 	}
 	if len(states) == 0 {
-		var single [1]StateID
-		single[0] = d.state
-		states = single[:]
+		states = []StateID{d.state}
 	}
 	for _, state := range states {
-		cand, endPos, _, _ := d.scanPreferredTokenForState(state)
-		if cand.Symbol == 0 || cand.StartByte != uint32(pos) || endPos <= pos || d.symbolName(cand.Symbol) != ">" {
+		cand, _, _, _ := d.scanPreferredTokenForState(state)
+		if cand.StartByte != uint32(pos) || d.symbolName(cand.Symbol) != ">" {
 			continue
 		}
-		actionIdx := d.lookupActionIndex(state, cand.Symbol)
-		if actionIdx == 0 || int(actionIdx) >= len(d.language.ParseActions) {
-			continue
-		}
-		if d.swiftCloseAngleActionReduces(actionIdx) {
-			return true
-		}
-	}
-	return false
-}
-
-// swiftCloseAngleActionReduces reports that the parse action entry contains a
-// reduce action. A reduce here means the `>` candidate closes an open
-// production (a generic argument list) rather than merely shifting into a
-// state that expects further tokens.
-func (d *dfaTokenSource) swiftCloseAngleActionReduces(actionIdx uint16) bool {
-	for _, a := range d.language.ParseActions[actionIdx].Actions {
-		if a.Type == ParseActionReduce {
+		if d.lookupActionIndex(state, cand.Symbol) != 0 {
 			return true
 		}
 	}


### PR DESCRIPTION
Archival checkpoint of the exact local dirty state from gotreesitter-campaign-swift on 2026-08-23. This PR is intentionally based on the dedicated archived HEAD ref, is not an acceptance or merge recommendation, and has not been rebased onto the active campaign. The staged diff passed gitleaks and its binary patch digest was verified before and after materialization: f1532080e3b171e342874765638a926b121b1920c3902ac94b015351e6c7a1c6.