### PR TITLE
archive: preserve local Swift 558 worktree state

### DIFF
--- a/grammars/swift_parse_regression_test.go
+++ b/grammars/swift_parse_regression_test.go
@@ -584,3 +584,31 @@ func TestSwiftTernaryFieldsAndShape(t *testing.T) {
 		t.Fatalf("ternary end = %d, want %d", got, want)
 	}
 }
+
+func TestSwiftNestedIfLetParses(t *testing.T) {
+	lang := SwiftLanguage()
+	src := []byte("func f() {\n  if let a = a {\n    if let b = b {\n      print(a, b)\n    }\n  }\n}\n")
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse nested if-let: %v", err)
+	}
+	defer tree.Release()
+	if root := tree.RootNode(); root.HasError() {
+		t.Fatalf("nested if-let has parse errors: %s", root.SExpr(lang))
+	}
+}
+
+func TestSwiftNestedIfLetComparisonParses(t *testing.T) {
+	lang := SwiftLanguage()
+	src := []byte("func f() {\n  if let limit = limit {\n    if baseIdx == nil {\n      if baseDistance > 0 && limit == endIndex {\n        if self.distance(from: i, to: limit) < distance {\n          return\n        }\n      }\n    }\n  }\n}\n")
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse nested if-let comparison: %v", err)
+	}
+	defer tree.Release()
+	if root := tree.RootNode(); root.HasError() {
+		t.Fatalf("nested if-let comparison has parse errors: %s", root.SExpr(lang))
+	}
+}


### PR DESCRIPTION
Archival checkpoint of the exact local dirty state from gotreesitter-campaign-swift558 on 2026-08-23. This PR is intentionally based on the dedicated archived HEAD ref, is not an acceptance or merge recommendation, and has not been rebased onto the active campaign. The staged diff passed gitleaks and its binary patch digest was verified before and after materialization: 577fdd469a5bc2d9d2357224494e5e3f0dbbf3e046f77d5599e80c273ac15120.