### PR TITLE
archive: preserve local Swift 559 worktree state

### DIFF
--- a/grammars/swift_parse_regression_test.go
+++ b/grammars/swift_parse_regression_test.go
@@ -135,62 +135,6 @@ func TestSwiftRightShiftOperatorUnaffected(t *testing.T) {
 	}
 }
 
-// TestSwiftCustomOperatorCloseAngleRunsUnaffected is the regression test for
-// the review finding on PR #567: splitSwiftWideCloseAngleToken used to split
-// any external close-angle run made only of '>' characters as soon as any
-// active parser state accepted a lone '>' (true in every comparison
-// context), destroying Swift custom operators built from '>' runs (`>>>`,
-// `>>>>`, ...) even when no generic argument list was open. Each case here
-// has no unclosed '<' in scope, so the run must stay one custom_operator
-// token: no ERROR node, and exactly the statement count the source implies.
-func TestSwiftCustomOperatorCloseAngleRunsUnaffected(t *testing.T) {
-	lang := SwiftLanguage()
-	cases := []struct {
-		name           string
-		src            string
-		wantStatements int
-	}{
-		{name: "triple_infix", src: "let v = x >>> y\n", wantStatements: 1},
-		{name: "infix_declaration", src: "infix operator >>> : MultiplicationPrecedence\n", wantStatements: 1},
-		{name: "chained_triple_infix", src: "let v = a >>> b >>> c\n", wantStatements: 1},
-		{name: "quadruple_infix", src: "let v = x >>>> y\n", wantStatements: 1},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			for _, route := range []struct {
-				name    string
-				compact bool
-			}{
-				{name: "production"},
-				{name: "compact", compact: true},
-			} {
-				t.Run(route.name, func(t *testing.T) {
-					parser := gotreesitter.NewParser(lang)
-					parser.SetAdmissionCandidateRoute(route.compact)
-					src := []byte(tc.src)
-					tree, err := parser.Parse(src)
-					if err != nil {
-						t.Fatalf("parse %q: %v", tc.src, err)
-					}
-					defer tree.Release()
-
-					root := tree.RootNode()
-					if root.HasError() {
-						t.Fatalf("%q has parse errors: %s", tc.src, root.SExpr(lang))
-					}
-					sexpr := root.SExpr(lang)
-					if !strings.Contains(sexpr, "(custom_operator)") {
-						t.Fatalf("%q did not keep a custom_operator token: %s", tc.src, sexpr)
-					}
-					if got, want := root.NamedChildCount(), tc.wantStatements; got != want {
-						t.Fatalf("%q statement count = %d, want %d; tree: %s", tc.src, got, want, sexpr)
-					}
-				})
-			}
-		})
-	}
-}
-
 // TestSwiftStringLiteralEndingInDotDoesNotCorruptFollowingToken guards against
 // a regression in shouldDemoteSwiftMemberKeyword/isAfterSwiftMemberDot: a
 // string literal whose last content character is '.' immediately before the
@@ -647,9 +591,6 @@ func TestSwiftTripleNestedGenericTypeAnnotationParses(t *testing.T) {
 		"struct S { let value: A<B<C<Int>>> }",
 		"func f(value: A<B<C<Int>>>) {}",
 		"let value: A<B<C<Int>>> = make()",
-		// Depth-4: locks in that the fix generalizes over the run length
-		// instead of only handling the depth-3 shape from issue #559.
-		"let value: A<B<C<D<Int>>>> = make()",
 	} {
 		t.Run(src, func(t *testing.T) {
 			parser := gotreesitter.NewParser(lang)
@@ -660,61 +601,6 @@ func TestSwiftTripleNestedGenericTypeAnnotationParses(t *testing.T) {
 			defer tree.Release()
 			if root := tree.RootNode(); root.HasError() {
 				t.Fatalf("triple nested generic type has parse errors: %s", root.SExpr(lang))
-			}
-		})
-	}
-}
-
-// swiftTreeHasMissingNode walks the parse tree looking for a MISSING node,
-// the exact presentation issue #559 named: a wide close-angle run that a
-// parser cannot split leaves a generic argument list open, and recovery
-// inserts a MISSING closer instead of surfacing a plain ERROR.
-func swiftTreeHasMissingNode(n *gotreesitter.Node) bool {
-	if n == nil {
-		return false
-	}
-	if n.IsMissing() {
-		return true
-	}
-	for i := 0; i < n.ChildCount(); i++ {
-		if swiftTreeHasMissingNode(n.Child(i)) {
-			return true
-		}
-	}
-	return false
-}
-
-// TestSwiftTripleNestedGenericCallParses is the direct regression test for
-// issue #559: `A<B<C<Int>>>()` construction calls, not just type
-// annotations, used to fail with a MISSING close-angle node inserted by
-// error recovery even though HasError() could still report false.
-func TestSwiftTripleNestedGenericCallParses(t *testing.T) {
-	lang := SwiftLanguage()
-	for _, src := range []string{
-		"func f() { let v = A<B<C<Int>>>() }",
-		"func f() { let v = IndexValidator<ChunksOfCountCollection<ClosedRange<Int>>>() }",
-		// Depth-5: one level deeper than the issue's own repro, guarding
-		// against a fix that only special-cases depth 3 or 4.
-		"func f() { let v = A<B<C<D<E<Int>>>>>() }",
-	} {
-		t.Run(src, func(t *testing.T) {
-			parser := gotreesitter.NewParser(lang)
-			tree, err := parser.Parse([]byte(src))
-			if err != nil {
-				t.Fatalf("parse triple nested generic call: %v", err)
-			}
-			defer tree.Release()
-
-			root := tree.RootNode()
-			if root.HasError() {
-				t.Fatalf("triple nested generic call has parse errors: %s", root.SExpr(lang))
-			}
-			if swiftTreeHasMissingNode(root) {
-				t.Fatalf("triple nested generic call has a MISSING node: %s", root.SExpr(lang))
-			}
-			sexpr := root.SExpr(lang)
-			if !strings.Contains(sexpr, "(constructor_expression") {
-				t.Fatalf("triple nested generic call is not a constructor_expression: %s", sexpr)
 			}
 		})
 	}

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -3165,25 +3165,6 @@ func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
 	return tok, true
 }
 
-// splitSwiftWideCloseAngleToken narrows a run of external `_custom_operator`
-// close-angle characters (">>", ">>>", ">>>>", ...) down to a single `>` when
-// the run is really N adjacent generic closers, e.g. the trailing `>>>` in
-// `A<B<C<Int>>>`. Swift's external scanner has no notion of generic nesting:
-// it greedily lexes any maximal run of `>` bytes as one custom-operator
-// token, so only the parser's own angle-bracket bookkeeping can tell that
-// run apart from a genuine multi-character user operator (Swift lets you
-// declare `infix operator >>> : ...` and use it standalone, e.g. `x >>> y`).
-//
-// hasSwiftUnclosedAngleBefore is the load-bearing guard: it requires at
-// least one unclosed '<' before this run. Without an open generic to close,
-// `x >>> y` must be refused here and left as one _custom_operator token.
-// This function only ever runs for language "swift" (guard below), so Java
-// and JavaScript/TypeScript `>>>`/`>>>=` shift operators never reach it.
-//
-// Known limitation, tracked separately and not fixed here: a run like
-// `>>>?` (close-angle run immediately followed by optional-chaining `?`)
-// isn't handled by this split — the all-'>' check below refuses it as soon
-// as it sees the `?`, so `A<B<C<Int>>>?` still needs its own follow-up fix.
 func (d *dfaTokenSource) splitSwiftWideCloseAngleToken(tok Token, states []StateID) (Token, int, uint32, uint32, bool) {
 	if d == nil || d.language == nil || d.language.Name != "swift" || d.lexer == nil ||
 		tok.EndPoint.Row != tok.StartPoint.Row || tok.EndByte <= tok.StartByte+1 {
@@ -3196,68 +3177,25 @@ func (d *dfaTokenSource) splitSwiftWideCloseAngleToken(tok Token, states []State
 		}
 		tok.Text = bytesToStringNoCopy(d.lexer.source[start:end])
 	}
-	for i := 0; i < len(tok.Text); i++ {
-		if tok.Text[i] != '>' {
+	for _, ch := range tok.Text {
+		if ch != '>' {
 			return tok, 0, 0, 0, false
 		}
-	}
-	if !d.hasSwiftUnclosedAngleBefore(int(tok.StartByte)) {
-		return tok, 0, 0, 0, false
 	}
 	gtSym, ok := d.bestActiveSymbolByName(">")
 	if !ok || gtSym == 0 {
 		return tok, 0, 0, 0, false
 	}
-	// Secondary safety net alongside the angle-depth gate above: if the
-	// parser's own action tables treat the run as a more specific match kept
-	// whole (as the custom operator) than as a lone '>', defer to that
-	// reading. Mirrors the gtSym/shiftSym specificity comparison in
-	// shouldSplitCompactCloseAngleToken.
-	if d.activeActionSpecificity(gtSym) < d.activeActionSpecificity(tok.Symbol) {
-		return tok, 0, 0, 0, false
-	}
 	for _, state := range states {
 		if d.lookupActionIndex(state, gtSym) != 0 {
 			tok.Symbol = gtSym
-			tok.Text = tok.Text[:1]
+			tok.Text = ">"
 			tok.EndByte = tok.StartByte + 1
 			tok.EndPoint = Point{Row: tok.StartPoint.Row, Column: tok.StartPoint.Column + 1}
-			// tok.ExternalScannerToken stays true (it was set by the caller
-			// before this function ran): realTokenAttachmentGapIsParserPadding
-			// (parser.go) relies on that flag to treat the gap between the
-			// previous real token and this narrowed token as scanner padding
-			// rather than a parse error.
 			return tok, int(tok.EndByte), tok.EndPoint.Row, tok.EndPoint.Column, true
 		}
 	}
 	return tok, 0, 0, 0, false
-}
-
-// hasSwiftUnclosedAngleBefore reports whether an unclosed '<' opens before
-// byte pos in the current statement/scope. This is the same "are we inside a
-// generic argument list" heuristic hasJavaUnclosedAngleBefore uses for Java.
-// The scan stops at a statement/scope boundary (; { } ( )) so an operator in
-// one statement is never mistaken for a generic closer left open by an
-// unrelated, already-closed earlier statement.
-func (d *dfaTokenSource) hasSwiftUnclosedAngleBefore(pos int) bool {
-	if d == nil || d.lexer == nil || pos <= 0 {
-		return false
-	}
-	depth := 0
-	for i := pos - 1; i >= 0; i-- {
-		switch d.lexer.source[i] {
-		case ';', '{', '}', '(', ')':
-			return depth > 0
-		case '>':
-			depth--
-		case '<':
-			depth++
-			if depth > 0 {
-				return true
-			}
-		}
-	}
-	return depth > 0
 }
 
 func (d *dfaTokenSource) bashGeneratedSyntheticExternalLiteral(valid []bool) (Token, bool) {


### PR DESCRIPTION
Archival checkpoint of the exact local dirty state from gotreesitter-campaign-swift559 on 2026-08-23. This PR is intentionally based on the dedicated archived HEAD ref, is not an acceptance or merge recommendation, and has not been rebased onto the active campaign. The staged diff passed gitleaks and its binary patch digest was verified before and after materialization: f80f46cf070663aeedf7baeea3b0d289af1f1f4e6578abaad951a364b707fda4. The first Buckley commit-message request timed out before commit; a bounded retry succeeded.