### PR TITLE
archive: preserve local compact evidence state

### DIFF
--- a/admission_switch_converged_path_test.go
+++ b/admission_switch_converged_path_test.go
@@ -22,12 +22,12 @@ func TestAdmissionCandidateCertifiedConvergedPathSplitsMatchProduction(t *testin
 	}{
 		{
 			name:       "bash",
-			corpusPath: filepath.Join("cgo_harness", "corpus_real", "bash", "medium__clean-old.sh"),
+			corpusPath: filepath.Join("testdata", "compact_converged_split", "bash.sh"),
 			load:       grammars.BashLanguage,
 		},
 		{
 			name:       "erlang",
-			corpusPath: filepath.Join("cgo_harness", "corpus_real", "erlang", "medium__attributes.erl"),
+			corpusPath: filepath.Join("testdata", "compact_converged_split", "erlang.erl"),
 			load:       grammars.ErlangLanguage,
 		},
 		{
@@ -37,7 +37,7 @@ func TestAdmissionCandidateCertifiedConvergedPathSplitsMatchProduction(t *testin
 		},
 		{
 			name:       "javascript",
-			corpusPath: filepath.Join("cgo_harness", "corpus_real", "javascript", "small__functions.js"),
+			corpusPath: filepath.Join("testdata", "compact_converged_split", "javascript.js"),
 			load:       grammars.JavascriptLanguage,
 		},
 		{
@@ -53,11 +53,8 @@ func TestAdmissionCandidateCertifiedConvergedPathSplitsMatchProduction(t *testin
 			if test.corpusPath != "" {
 				var err error
 				source, err = os.ReadFile(test.corpusPath)
-				if os.IsNotExist(err) {
-					t.Skipf("real-corpus witness is unavailable: %s", test.corpusPath)
-				}
 				if err != nil {
-					t.Fatalf("read real-corpus witness: %v", err)
+					t.Fatalf("read compact certification witness: %v", err)
 				}
 			}
 

--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -830,10 +830,10 @@ func TestParityCompactConvergedSplitCorpus(t *testing.T) {
 		corpusPath string
 		source     string
 	}{
-		{name: "bash", corpusPath: "corpus_real/bash/medium__clean-old.sh"},
-		{name: "erlang", corpusPath: "corpus_real/erlang/medium__attributes.erl"},
+		{name: "bash", corpusPath: "../testdata/compact_converged_split/bash.sh"},
+		{name: "erlang", corpusPath: "../testdata/compact_converged_split/erlang.erl"},
 		{name: "haskell", source: grammars.ParseSmokeSample("haskell")},
-		{name: "javascript", corpusPath: "corpus_real/javascript/small__functions.js"},
+		{name: "javascript", corpusPath: "../testdata/compact_converged_split/javascript.js"},
 		{name: "python", source: "def greet(name):\n    return f\"hello {name}\"\n\nprint(greet(\"world\"))\n"},
 	}
 
@@ -843,11 +843,8 @@ func TestParityCompactConvergedSplitCorpus(t *testing.T) {
 			if test.corpusPath != "" {
 				var err error
 				source, err = os.ReadFile(test.corpusPath)
-				if os.IsNotExist(err) {
-					t.Skipf("real-corpus witness is unavailable: %s", test.corpusPath)
-				}
 				if err != nil {
-					t.Fatalf("read real-corpus witness: %v", err)
+					t.Fatalf("read compact certification witness: %v", err)
 				}
 			}
 


### PR DESCRIPTION
Archival checkpoint of the exact local dirty state from gotreesitter-compact-evidence on 2026-08-23. This PR is intentionally based on the dedicated archived HEAD ref and is not an acceptance or merge recommendation. The staged diff passed gitleaks and its binary patch digest was verified before and after materialization: 94d45289532a4a5773718ce4853156d123a20bcbc0319708669f709167003f8d.