### PR TITLE
archive: preserve local materialization cycle probe

### DIFF
--- a/parser_go_materialization_cycle_regression_test.go
+++ b/parser_go_materialization_cycle_regression_test.go
@@ -1,0 +1,79 @@
+package gotreesitter_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestGoRepeatedNestedSubtestsReturnedTreeAcyclic(t *testing.T) {
+	fixture, err := os.ReadFile("internal/parsercorephase0/core_test.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const start, end = 60255, 68583
+	if len(fixture) < end {
+		t.Fatalf("fixture size = %d, want at least %d", len(fixture), end)
+	}
+	source := append([]byte("package p\n"), fixture[start:end]...)
+	function := append([]byte(nil), source[len("package p\n"):]...)
+	for range 7 {
+		source = append(source, function...)
+	}
+
+	type parseResult struct {
+		tree *gotreesitter.Tree
+		err  error
+	}
+	done := make(chan parseResult, 1)
+	go func() {
+		tree, err := gotreesitter.NewParser(grammars.GoLanguage()).Parse(source)
+		done <- parseResult{tree: tree, err: err}
+	}()
+
+	var tree *gotreesitter.Tree
+	select {
+	case result := <-done:
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+		tree = result.tree
+	case <-time.After(30 * time.Second):
+		t.Fatal("parse did not return")
+	}
+	defer tree.Release()
+
+	root := tree.RootNode()
+	type frame struct {
+		node  *gotreesitter.Node
+		child int
+	}
+	active := map[*gotreesitter.Node]struct{}{root: {}}
+	stack := []frame{{node: root}}
+	for len(stack) > 0 {
+		top := &stack[len(stack)-1]
+		if top.child >= top.node.ChildCount() {
+			delete(active, top.node)
+			stack = stack[:len(stack)-1]
+			continue
+		}
+		child := top.node.Child(top.child)
+		top.child++
+		if child == nil {
+			continue
+		}
+		if _, ok := active[child]; ok {
+			t.Fatalf(
+				"returned tree contains a back-edge to %s [%d,%d)",
+				child.Type(grammars.GoLanguage()),
+				child.StartByte(),
+				child.EndByte(),
+			)
+		}
+		active[child] = struct{}{}
+		stack = append(stack, frame{node: child})
+	}
+}

--- a/parser_result.go
+++ b/parser_result.go
@@ -322,12 +322,18 @@ func (p *Parser) buildResultFromGLR(stacks []glrStack, source []byte, arena *nod
 	if resultMaterializationShouldStop(reason) {
 		return errorTreeWithStopReason(reason)
 	}
+	if !recoveredResultNodesAcyclic(nodes) {
+		panic("result cycle before transient parent materialization")
+	}
 	materializeStart := time.Time{}
 	if materializationTiming != nil {
 		materializeStart = time.Now()
 	}
 	if reason := materializeTransientParentNodes(nodes, arena, transientParents, transientChildren, p); resultMaterializationShouldStop(reason) {
 		return errorTreeWithStopReason(reason)
+	}
+	if !recoveredResultNodesAcyclic(nodes) {
+		panic("result cycle after transient parent materialization")
 	}
 	if materializationTiming != nil {
 		materializationTiming.transientParentMaterializeNanos += time.Since(materializeStart).Nanoseconds()

--- a/transient_parents.go
+++ b/transient_parents.go
@@ -276,10 +276,16 @@ func (s *transientParentScratch) materializeVisitedNodeUntil(n *Node, arena *nod
 				}
 			}
 			if replacement := s.transientReplacement(child); replacement != nil {
+				if replacement == n {
+					panic("transient replacement linked node to itself")
+				}
 				out[i] = replacement
 				continue
 			}
 			if replacement, ok := s.seen[child]; ok {
+				if replacement == n {
+					panic("seen replacement linked node to itself")
+				}
 				out[i] = replacement
 			}
 		}

--- a/tree.go
+++ b/tree.go
@@ -339,6 +339,20 @@ func setNodeParentLink(child, parent *Node, index int) {
 	if child == nil {
 		return
 	}
+	if child.ownerArena == nil && parent != nil {
+		panic(fmt.Sprintf(
+			"linked ownerless child symbol=%d span=%d:%d to parent symbol=%d span=%d:%d child=%p parent=%p index=%d",
+			child.symbol,
+			child.startByte,
+			child.endByte,
+			parent.symbol,
+			parent.startByte,
+			parent.endByte,
+			child,
+			parent,
+			index,
+		))
+	}
 	child.parent = parent
 	if sidecar, ok := child.ownerArena.finalChildSidecarForNode(child); ok {
 		sidecar.parent = parent


### PR DESCRIPTION
Archival checkpoint of the exact local dirty state from gotreesitter-cycle-fix-agent on 2026-08-23. This PR is intentionally based on the dedicated archived HEAD ref and is not an acceptance or merge recommendation. All four path blobs were verified byte-identical to the untouched source worktree after commit; the staged state passed gitleaks. Tracked patch digest: 148216e3f6bbef77363487c4a4dc1bbec70036400317c611badb81b9d7455cbc. New test blob digest: f3c2deb74195f8749fa76dbc55c07cbdc4c9735e8f427ff8bdda137bfaf0fd9a.