### PR TITLE
[archive] Preserve C26ag table identity worktree state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,18 @@ for tags and release notes while still in `0.x`.
   generic replay contract. No parser, scanner, or test change ships. Keep issue
   #576 open. See `docs/compact-route-real-corpus-matrix.md`.
 
+- Added the C26ag generic table-identity guard at base
+  `d134ed5f963c7ed1d27fa1247aeb2a16746ab585`. The compact core captures the
+  producer identity at construction. Loaded languages use the exact grammar
+  blob SHA-256. In-memory languages use one process-local producer token.
+  Replay now declines before state reconstruction when the producer identity
+  changes or is absent. The guard preserves same-language replay and does not
+  translate numeric parser states. Focused identity tests passed in Docker.
+  SQL scanner unit tests passed. The generated SQL route still has the known
+  dollar-quoted locked-C divergence. Keep issue #576 open until that parity gap
+  and the complete replay contract are resolved. See
+  `docs/compact-route-real-corpus-matrix.md`.
+
 - Added authenticated generated-SQL scanner identity to the grammargen C
   parity route. The route now reloads the generated blob through `LoadLanguage`
   before scanner adaptation. The scanner binds checkpoints to exact generated

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -2374,6 +2374,159 @@ identity:
 The contract must reject a missing or changed identity before it attempts
 scanner replay. A numeric state translation alone is not sufficient.
 
+## C26ag generic compact table identity guard
+
+C26ag used base
+`d134ed5f963c7ed1d27fa1247aeb2a16746ab585`.
+The isolated worktree was `/tmp/gts-c26ag-table-identity-20260824`.
+
+Status: ACCEPTED guard. Keep issue #576 open for the remaining SQL parity gap.
+
+The guard adds a dependency-neutral `TableIdentityProvider` contract at
+`internal/parsercorephase0/core.go:277-282`.
+`Core` stores the producer identity at construction and compares it before
+parser-state replay (`internal/parsercorephase0/core.go:898-900,1690-1708`).
+The root adapter supplies the identity from its current `Language`
+(`parsercore_phase0_driver.go:552-562`).
+Replay returns an identity decline before it allocates or walks replay states
+when the identity differs (`parsestate_replay_compact.go:145-155`).
+
+Loaded languages use their exact compressed grammar blob SHA-256.
+In-memory generated languages use one process-local producer token.
+The contract does not translate numeric parser states.
+
+The existing reuse cursor requires the same `*Language` pointer
+(`parser.go:3450-3452`). Scanner checkpoint reuse requires scanner and grammar
+identity (`external_scanner_checkpoint_capability.go:153-159`). These gates
+remain unchanged. The new core guard covers the earlier replay boundary.
+
+### Identity evidence
+
+The focused tests cover matching identity, producer drift, and missing identity.
+The blob test proves that two loaded copies use the same exact blob SHA-256.
+The language-swap test proves that replay returns
+`DiagnosticParserCoreIdentity` before state reconstruction.
+
+The test files are:
+
+- `internal/parsercorephase0/core_test.go`
+- `parsercore_phase0_action_test.go`
+- `parsercore_phase0_language_tables_internal_test.go`
+
+### Docker validation
+
+Run the SQL scanner unit gate:
+
+```sh
+bash cgo_harness/docker/run_parity_in_docker.sh \
+  --repo-root /tmp/gts-c26ag-table-identity-20260824 \
+  --out-root /tmp/gts-c26ag-artifacts \
+  --label c26ag-sql-unit --no-build --memory 4g --cpus 1 \
+  --goflags -p=1 --test-parallel 1 --timeout 10m \
+  --mount /tmp/gts-c26ad-grammar_parity:/tmp/grammar_parity:ro -- \
+  'export PATH=/usr/local/go/bin:$PATH; cd /workspace && \
+   go test ./grammars -run "^TestSQLScanner" -count=1 -v'
+```
+
+Artifact:
+`/tmp/gts-c26ag-artifacts/20260823T210107Z-c26ag-sql-unit`.
+
+- `container.log`: `a78c2bedc254da214328c2882471946d22bb92f95d2cb77edeec9b257a0fcfc5`
+- `metadata.txt`: `4c97fb3e942ff14b56ea4f29a168cb3c51028af9497c6ae5e083de609860b772`
+- `inspect.json`: `d3a5f75fb417f633964c50ebbb56f257d13d291218e47cc0ee2996e1e8697c80`
+
+The unit gate passed all SQL scanner tests.
+
+Run the generated SQL, locked-C, fresh-tree, incremental-reuse, and
+stale-identity gate:
+
+```sh
+bash cgo_harness/docker/run_parity_in_docker.sh \
+  --repo-root /tmp/gts-c26ag-table-identity-20260824 \
+  --out-root /tmp/gts-c26ag-artifacts \
+  --label c26ag-sql-generated-locked-c --no-build --memory 4g --cpus 1 \
+  --goflags -p=1 --test-parallel 1 --timeout 10m \
+  --mount /tmp/gts-c26ad-grammar_parity:/tmp/grammar_parity:ro -- \
+  'export PATH=/usr/local/go/bin:$PATH; cd /workspace/cgo_harness && \
+   go test -tags "cgo treesitter_c_parity" . \
+   -run "^TestSQLGrammargenCGORegressionCases$" -count=1 -v'
+```
+
+Artifact:
+`/tmp/gts-c26ag-artifacts/20260823T210145Z-c26ag-sql-generated-locked-c`.
+
+- `container.log`: `736e2f2eaf768a36a66eb502e20bb1e087de33deee27fb3927cba06dbf55c62a`
+- `metadata.txt`: `6c34e0c42da9ec862263e90709c16d9de7c1afcdf580c4a2832e5520cf0e604c`
+- `inspect.json`: `76d02ec4b1fb55a7003c057181431404ca6e6579d75e2e695a037c3886b8861d`
+
+The generated identity matched the generated blob:
+`4ffb2a6d09e2000126f10101db9028d28e0752ac3e4f83e401f045c3b028ca7c`.
+The route reused one subtree and 16 bytes.
+The stale identity route reused zero subtrees and zero bytes.
+The identifier and parenthesized Boolean cases passed.
+The dollar-quoted case failed with the known generated-vs-locked-C error
+tree difference. The guard did not change that result.
+
+Run the focused identity tests:
+
+```sh
+bash cgo_harness/docker/run_parity_in_docker.sh \
+  --repo-root /tmp/gts-c26ag-table-identity-20260824 \
+  --out-root /tmp/gts-c26ag-artifacts \
+  --label c26ag-table-identity-tests --no-build --memory 4g --cpus 1 \
+  --goflags -p=1 --test-parallel 1 --timeout 10m -- \
+  'export PATH=/usr/local/go/bin:$PATH; cd /workspace && \
+   go test ./internal/parsercorephase0 \
+   -run "^TestCoreTableIdentityCapturesAndRejectsProducerDrift$" -count=1 && \
+   go test -tags gts_parsercorephase0 . \
+   -run "^TestParserCoreReplayRejectsLanguageTableSwap$" -count=1'
+```
+
+Artifact:
+`/tmp/gts-c26ag-artifacts/20260823T210252Z-c26ag-table-identity-tests`.
+
+- `container.log`: `f9e9347197bd61ec6cccab08cfe9ffdfd592a77c8b03fef9996cbe4d7ff0d7b3`
+- `metadata.txt`: `586ee50d8776c8acdb86852efdd72d36b7d673831858f8bac42d288528c7aa2e`
+- `inspect.json`: `e13703264e21a47ab1b4b0265150f39471df1bd934796b22c08e89baea8184a9`
+
+The focused core and root tests passed.
+
+Run the loaded-blob identity test:
+
+```sh
+bash cgo_harness/docker/run_parity_in_docker.sh \
+  --repo-root /tmp/gts-c26ag-table-identity-20260824 \
+  --out-root /tmp/gts-c26ag-artifacts \
+  --label c26ag-identity-blob-test --no-build --memory 4g --cpus 1 \
+  --goflags -p=1 --test-parallel 1 --timeout 10m -- \
+  'export PATH=/usr/local/go/bin:$PATH; cd /workspace && \
+   go test -tags gts_parsercorephase0 . \
+   -run "^TestParserCoreRootTablesIdentityUsesLanguageBlobHash$" -count=1'
+```
+
+Artifact:
+`/tmp/gts-c26ag-artifacts/20260823T210428Z-c26ag-identity-blob-test`.
+
+- `container.log`: `ff89dcb7bfb870183e0871a08aa11a9aabe11a46967ab8b294db15f662815e0c`
+- `metadata.txt`: `34ab6bf29fa3b2ebadb28e303b6afa5c4ccb57e7c3a5a76dc8190d6f5b251aa1`
+- `inspect.json`: `1db29621cf1c5c1a2d8245f869a4d477683a6ebbed6a5b92813aa74358af5d25`
+
+The blob identity test passed.
+
+### Decision and reopening condition
+
+Accept the generic table-identity guard. Do not add SQL-specific symbol maps.
+Keep the SQL compact route gated until generated SQL matches locked C on the
+dollar-quoted witness and the replay contract covers all derivation metadata.
+
+Reopen the SQL route only after a Docker gate proves all of these conditions:
+
+- equal table identity permits replay;
+- changed or missing identity declines before replay;
+- scanner identity and checkpoint bytes remain exact;
+- fresh, compact, incremental, and locked-C trees match; and
+- the generated SQL dollar-quoted witness passes without a state remap.
+
 ## Corpus state
 
 The current manifest has these properties:

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -271,6 +271,13 @@ type TableView interface {
 	ProductionAliases(uint16, int) ([]Symbol, error)
 }
 
+// TableIdentityProvider supplies the immutable identity of the table producer.
+// A compact core must not replay parser states after its producer changes.
+// Adapters that do not provide an identity cannot prove replay compatibility.
+type TableIdentityProvider interface {
+	TableIdentity() ([32]byte, bool)
+}
+
 // Decline identifies a feature that phase zero cannot execute faithfully.
 type Decline string
 
@@ -891,6 +898,8 @@ type RawSelectedCensus struct {
 // into pointer-free slices; the production parser is unaffected.
 type Core struct {
 	tables             TableView
+	tableIdentity      [32]byte
+	tableIdentityValid bool
 	plans              ReductionPlanProvider
 	selectedProvider   SelectedStorePolicyProvider
 	selectedPolicy     *SelectedStorePolicy
@@ -1681,9 +1690,27 @@ func New(tables TableView, limits Limits) (*Core, error) {
 		diagnostics:                       diagnosticOptions{foldSamePredecessorShallowPayloads: true},
 		metadataConstructionAuthenticated: true,
 	}
+	if provider, ok := tables.(TableIdentityProvider); ok {
+		core.tableIdentity, core.tableIdentityValid = provider.TableIdentity()
+	}
 	core.plans, _ = tables.(ReductionPlanProvider)
 	core.selectedProvider, _ = tables.(SelectedStorePolicyProvider)
 	return core, nil
+}
+
+// TableIdentityMatches reports whether the table producer still matches the
+// identity captured when the compact core was created. Missing identity fails
+// closed because parser-state replay needs exact table provenance.
+func (c *Core) TableIdentityMatches() bool {
+	if c == nil || !c.tableIdentityValid {
+		return false
+	}
+	provider, ok := c.tables.(TableIdentityProvider)
+	if !ok {
+		return false
+	}
+	identity, valid := provider.TableIdentity()
+	return valid && identity == c.tableIdentity
 }
 
 // AuthenticationGeneration identifies the current Core capability phase.

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -11,6 +11,41 @@ import (
 	"unsafe"
 )
 
+type identityTestTable struct {
+	fakeTable
+	identity [32]byte
+	valid    bool
+}
+
+func (t *identityTestTable) TableIdentity() ([32]byte, bool) {
+	if t == nil {
+		return [32]byte{}, false
+	}
+	return t.identity, t.valid
+}
+
+func TestCoreTableIdentityCapturesAndRejectsProducerDrift(t *testing.T) {
+	tables := &identityTestTable{identity: [32]byte{1}, valid: true}
+	compact, err := New(tables, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compact.TableIdentityMatches() {
+		t.Fatal("matching table identity was rejected")
+	}
+	tables.identity[0] = 2
+	if compact.TableIdentityMatches() {
+		t.Fatal("changed table identity was accepted")
+	}
+	legacy, err := New(&fakeTable{}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.TableIdentityMatches() {
+		t.Fatal("table without identity was accepted for replay")
+	}
+}
+
 func TestPinnedGoConflictAndReductionMetadata(t *testing.T) {
 	wantConflict := []Action{
 		{Type: ActionReduce, Symbol: 171, ChildCount: 1},

--- a/language.go
+++ b/language.go
@@ -648,6 +648,12 @@ type Language struct {
 	compactTables     any   // *parserCoreLanguageTables under the default build
 	compactTablesErr  error // the build error, memoized alongside compactTables
 
+	// compactTableIdentityOnce assigns one immutable identity to the parser
+	// table producer. Loaded blobs use their exact blob hash. In-memory
+	// generated languages use a process-local token until they are encoded.
+	compactTableIdentityOnce sync.Once
+	compactTableIdentity     [32]byte
+
 	// corridorProgram memoizes the compiled C4 bytecode corridor program for
 	// this Language (spec.c4-bytecode-isa.v1 section 3.6: the stream is
 	// memoized per *Language beside compactTables and dies with the Language).
@@ -1002,6 +1008,25 @@ func (l *Language) GrammarBlobSHA256() ([32]byte, bool) {
 		return [32]byte{}, false
 	}
 	return l.grammarBlobSHA256, true
+}
+
+var nextCompactTableIdentity atomic.Uint64
+
+func (l *Language) parserCoreTableIdentity() ([32]byte, bool) {
+	if l == nil {
+		return [32]byte{}, false
+	}
+	l.compactTableIdentityOnce.Do(func() {
+		if blob, ok := l.GrammarBlobSHA256(); ok {
+			l.compactTableIdentity = blob
+			return
+		}
+		id := nextCompactTableIdentity.Add(1)
+		for i := 0; i < 8; i++ {
+			l.compactTableIdentity[i] = byte(id >> (8 * i))
+		}
+	})
+	return l.compactTableIdentity, true
 }
 
 // CompatibleWithRuntime reports whether this language can be parsed by the

--- a/parsercore_phase0_action_test.go
+++ b/parsercore_phase0_action_test.go
@@ -103,6 +103,39 @@ func TestParserCoreRootTablesRejectInvalidActionWhileCaching(t *testing.T) {
 	}
 }
 
+func TestParserCoreReplayRejectsLanguageTableSwap(t *testing.T) {
+	firstLanguage := &Language{
+		LargeStateCount: 1,
+		ParseTable:      [][]uint16{{0}},
+		ParseActions:    []ParseActionEntry{{}},
+	}
+	parser := NewParser(firstLanguage)
+	tables, err := newParserCoreRootTables(parser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact, err := core.New(tables, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compact.TableIdentityMatches() {
+		t.Fatal("initial table identity did not match")
+	}
+	parser.language = &Language{
+		LargeStateCount: 1,
+		ParseTable:      [][]uint16{{0}},
+		ParseActions:    []ParseActionEntry{{}},
+	}
+	if compact.TableIdentityMatches() {
+		t.Fatal("language table swap retained the old identity")
+	}
+	_, err = parser.replayCompactDerivation(compact, nil)
+	var decline *diagnosticParserCoreDecline
+	if !errors.As(err, &decline) || decline.boundary != DiagnosticParserCoreIdentity {
+		t.Fatalf("replay error=%v, want identity decline", err)
+	}
+}
+
 func TestParserCoreRootlessTablesRemainUsableWithoutSelectedStorePolicy(t *testing.T) {
 	lang := &Language{
 		LargeStateCount: 1,

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -554,6 +554,16 @@ type parserCoreRootTables struct {
 	*parserCoreLanguageTables
 }
 
+// TableIdentity binds compact replay to the immutable Language that produced
+// the cached action and reduction tables. The parser back-reference is read at
+// validation time, so a language change cannot reuse stale state numbers.
+func (a *parserCoreRootTables) TableIdentity() ([32]byte, bool) {
+	if a == nil || a.parser == nil {
+		return [32]byte{}, false
+	}
+	return a.parser.language.parserCoreTableIdentity()
+}
+
 // acquireParserCoreLanguageTables returns the converted tables for the parser's
 // language, building them once and caching them on the Language itself.
 //

--- a/parsercore_phase0_language_tables_internal_test.go
+++ b/parsercore_phase0_language_tables_internal_test.go
@@ -121,3 +121,28 @@ func TestParserCoreLanguageTablesCacheSharesAcrossParsers(t *testing.T) {
 		}
 	}
 }
+
+func TestParserCoreRootTablesIdentityUsesLanguageBlobHash(t *testing.T) {
+	firstLanguage := loadCertifiedGoLanguageForTest(t)
+	secondLanguage := loadCertifiedGoLanguageForTest(t)
+	first, err := newParserCoreRootTables(NewParser(firstLanguage))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := newParserCoreRootTables(NewParser(secondLanguage))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, ok := firstLanguage.GrammarBlobSHA256()
+	if !ok {
+		t.Fatal("certified language has no blob identity")
+	}
+	got, ok := first.TableIdentity()
+	if !ok || got != want {
+		t.Fatalf("first table identity=%x/%t, want blob=%x", got, ok, want)
+	}
+	other, ok := second.TableIdentity()
+	if !ok || other != want {
+		t.Fatalf("second table identity=%x/%t, want blob=%x", other, ok, want)
+	}
+}

--- a/parsestate_replay_compact.go
+++ b/parsestate_replay_compact.go
@@ -146,6 +146,12 @@ func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.Subtre
 	if p == nil || p.language == nil || compact == nil {
 		return nil, errors.New("parser-core phase zero: replay requires parser and core")
 	}
+	if !compact.TableIdentityMatches() {
+		return nil, &diagnosticParserCoreDecline{
+			boundary: DiagnosticParserCoreIdentity,
+			detail:   "compact parser table identity does not match the materialization parser",
+		}
+	}
 	n := compact.SubtreeArenaLen() + 1
 	states := acquireCompactReplayStates(n)
 	seed := p.replayRootPreGotoState()


### PR DESCRIPTION
Remote durability checkpoint only — this draft PR is durable storage, not acceptance or a merge recommendation.

Preserves the exact nine authored working-tree blobs observed after the C26ag owner became quiescent, based on exact detached HEAD `d134ed5f963c7ed1d27fa1247aeb2a16746ab585`.

Validation performed before checkpoint:
- root `LICENSE` is tracked, non-empty, and MIT
- focused staged-patch gitleaks scan passed
- staged blob hashes matched the source worktree immediately before commit
- carrier commit parent equals the source HEAD
- local HEAD, upstream tracking ref, and live `git ls-remote` SHA are identical
- every remote tree blob matches the source worktree snapshot byte-for-byte
- original worktree was not edited

The source owner reported focused identity, parsercore/replay, and SQL checks in the worktree; this archival PR intentionally does not claim those results as merge acceptance. Refs #576.