### PR TITLE
[archive] Preserve Python dispatcher blocker receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,18 @@ for tags and release notes while still in `0.x`.
   `docs/root-normalization-retirement.md` for the receipt, artifacts, and
   reopening condition.
 
+- Record the N31c Python dispatcher blocker at main commit
+  `11d9aec70eaef0c0d65c3cd14b8f594d64869c7b`. The A0 manifest excludes
+  Python, and the authenticated Python corpus and lock are unavailable. The
+  tracked Python fixture records zero rewrites. The positive witness differs
+  from locked C only before normalization; production, compact, forest, and
+  incremental routes match. Two f-string witnesses differ from locked C on
+  every route. Incremental parsing reports
+  `external_scanner_unsupported` with zero reuse. Keep `dispatch.python` live.
+  No production or registry change survives. See
+  `docs/root-normalization-retirement.md` for the receipt, artifacts, and
+  reopening condition.
+
 - Record the C26b Swift issue #576 conformance-list recovery blocker at main
   commit `838aba943038248529429a572c4d6d98359bd87e`. The 66-byte
   `associatedtype` witness still differs from locked C. Go emits

--- a/cgo_harness/python_dispatch_blocker_receipt_test.go
+++ b/cgo_harness/python_dispatch_blocker_receipt_test.go
@@ -1,0 +1,419 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+type pythonDispatchPassExpectation struct {
+	recorded  bool
+	checked   uint64
+	run       uint64
+	visited   uint64
+	rewritten uint64
+}
+
+type pythonDispatchBlockerWitness struct {
+	name               string
+	source             []byte
+	wantSourceSHA      string
+	wantRawDigest      string
+	wantGoDigest       string
+	wantCDigest        string
+	wantRawDiff        *DumpV1Divergence
+	wantRouteDiff      *DumpV1Divergence
+	wantCompactMode    string
+	wantRoutedBefore   uint64
+	wantFallbackBefore uint64
+	wantRoutedAfter    uint64
+	wantFallbackAfter  uint64
+	wantProduction     pythonDispatchPassExpectation
+	wantCompact        pythonDispatchPassExpectation
+	wantForest         pythonDispatchPassExpectation
+	wantIncremental    pythonDispatchPassExpectation
+}
+
+// TestPythonDispatchBlockerReceiptRoutes records the live Python arm on all
+// required routes before a possible retirement.
+func TestPythonDispatchBlockerReceiptRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	language := grammars.PythonLanguage()
+	if language.ExternalScanner == nil {
+		t.Fatal("Python language has no registered external scanner")
+	}
+	if reusable, ok := language.ExternalScanner.(gotreesitter.IncrementalReuseExternalScanner); ok && reusable.SupportsIncrementalReuse() {
+		t.Fatal("Python external scanner unexpectedly supports incremental reuse")
+	}
+	cLanguage, err := COracleLanguage("python")
+	if err != nil {
+		t.Fatal(err)
+	}
+	startRouted, startFallback := gotreesitter.AdmissionCandidateCounters()
+
+	witnesses := []pythonDispatchBlockerWitness{
+		{
+			name:          "assignment_bare_tuple_positive",
+			source:        []byte("x, y, z = 1, 2, 3\nxyz = x, y, z\n"),
+			wantSourceSHA: "6a1661337725eea3d5f3e26c38c3c3536f2c9fbfb66e04ae73f2dcc1a1afdd03",
+			wantRawDigest: "1ee859d4c1d2489f24dd57e0671a1832480b1c43afb960c10f798ce9f71f9759",
+			wantGoDigest:  "577a8b7b9281fa12c48dfa239a977c82f3a94e3d248253663c4a6fafc9121622",
+			wantCDigest:   "577a8b7b9281fa12c48dfa239a977c82f3a94e3d248253663c4a6fafc9121622",
+			wantRawDiff: pythonDispatchExpectedDivergence(
+				"/module/assignment[1]/pattern_list[2]", "type", "pattern_list", "expression_list",
+			),
+			wantCompactMode:    "accepted",
+			wantRoutedBefore:   0,
+			wantFallbackBefore: 0,
+			wantRoutedAfter:    1,
+			wantFallbackAfter:  0,
+			wantProduction:     pythonDispatchPassExpectation{recorded: true, checked: 1, run: 1, visited: 24, rewritten: 1},
+			wantCompact:        pythonDispatchPassExpectation{},
+			wantForest:         pythonDispatchPassExpectation{recorded: true, checked: 1, run: 1, visited: 24},
+			wantIncremental:    pythonDispatchPassExpectation{recorded: true, checked: 1, run: 1, visited: 24, rewritten: 1},
+		},
+		{
+			name:          "fstring_interpolation_bare_tuple_recovery_gap",
+			source:        []byte("x = 1\ny = 2\nz = f\"{x, y}\"\n"),
+			wantSourceSHA: "7d0029944fcffb700144302da9b1b80b03da8f89d716772b3a207dca9ba543a7",
+			wantRawDigest: "89ca835ae4fb5cf19d38e40b6ae4f09c99c66987ca77d8b4921aa9f593aaa641",
+			wantGoDigest:  "89ca835ae4fb5cf19d38e40b6ae4f09c99c66987ca77d8b4921aa9f593aaa641",
+			wantCDigest:   "84c987ddc73cc06bcc63e0cc860ecaa58560a46db882c775815ecb8867f95c07",
+			wantRawDiff: pythonDispatchExpectedDivergence(
+				"/module/assignment[2]/string[2]/interpolation[1]/pattern_list[1]", "type", "pattern_list", "expression_list",
+			),
+			wantRouteDiff: pythonDispatchExpectedDivergence(
+				"/module/assignment[2]/string[2]/interpolation[1]/pattern_list[1]", "type", "pattern_list", "expression_list",
+			),
+			wantCompactMode:    "accepted",
+			wantRoutedBefore:   1,
+			wantFallbackBefore: 0,
+			wantRoutedAfter:    2,
+			wantFallbackAfter:  0,
+			wantProduction:     pythonDispatchPassExpectation{recorded: true, checked: 1, run: 1, visited: 22},
+			wantCompact:        pythonDispatchPassExpectation{},
+			wantForest:         pythonDispatchPassExpectation{recorded: true, checked: 1, run: 1, visited: 22, rewritten: 1},
+			wantIncremental:    pythonDispatchPassExpectation{recorded: true, checked: 1, run: 1, visited: 22},
+		},
+		{
+			name:          "fstring_interpolation_splat_recovery_gap",
+			source:        []byte("xs = [1, 2]\nz = f\"{*xs,}\"\n"),
+			wantSourceSHA: "660a9ed55b63e6b98cfc70db1776895ec9046a16c906c33b3d273bee496a121d",
+			wantRawDigest: "102ebedd10a3864a2640cb293f541e42f63b4f1ce3d60c9f219d7088b4f484c6",
+			wantGoDigest:  "102ebedd10a3864a2640cb293f541e42f63b4f1ce3d60c9f219d7088b4f484c6",
+			wantCDigest:   "e646688923780dab15e472c1754d89e87ebfdb669fafeda109d4a2d630b4a4c9",
+			wantRawDiff: pythonDispatchExpectedDivergence(
+				"/module/assignment[1]/string[2]/interpolation[1]/pattern_list[1]", "type", "pattern_list", "expression_list",
+			),
+			wantRouteDiff: pythonDispatchExpectedDivergence(
+				"/module/assignment[1]/string[2]/interpolation[1]/pattern_list[1]", "type", "pattern_list", "expression_list",
+			),
+			wantCompactMode:    "accepted",
+			wantRoutedBefore:   2,
+			wantFallbackBefore: 0,
+			wantRoutedAfter:    3,
+			wantFallbackAfter:  0,
+			wantProduction:     pythonDispatchPassExpectation{recorded: true, checked: 1, run: 1, visited: 24},
+			wantCompact:        pythonDispatchPassExpectation{},
+			wantForest:         pythonDispatchPassExpectation{recorded: true, checked: 1, run: 1, visited: 24},
+			wantIncremental:    pythonDispatchPassExpectation{recorded: true, checked: 1, run: 1, visited: 24},
+		},
+	}
+
+	for _, witness := range witnesses {
+		witness := witness
+		t.Run(witness.name, func(t *testing.T) {
+			source := append([]byte(nil), witness.source...)
+			sourceSHA := fmt.Sprintf("%x", sha256.Sum256(source))
+			if sourceSHA != witness.wantSourceSHA {
+				t.Fatalf("source SHA-256=%s, want %s", sourceSHA, witness.wantSourceSHA)
+			}
+
+			cTree := pythonDispatchCTree(t, cLanguage, source)
+			defer cTree.Close()
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cDigest != witness.wantCDigest {
+				t.Fatalf("locked-C digest=%s, want %s", cDigest, witness.wantCDigest)
+			}
+			if cTree.RootNode().HasError() {
+				t.Fatal("locked-C witness unexpectedly has an error root")
+			}
+
+			rawParser := gotreesitter.NewParser(language)
+			rawParser.SetAdmissionCandidateRoute(false)
+			raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer raw.Release()
+			rawDiff := pythonDispatchAssertReceipt(t, "raw", raw, language, cTree, cDigest)
+			pythonDispatchCheckDigest(t, "raw", raw, language, witness.wantRawDigest)
+			pythonDispatchCheckDivergence(t, "raw", rawDiff, witness.wantRawDiff)
+			pythonDispatchCheckPass(t, "raw", raw, pythonDispatchPassExpectation{})
+			pythonDispatchCheckNativeAuthority(t, "raw", raw)
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer production.Release()
+			productionDiff := pythonDispatchAssertReceipt(t, "production", production, language, cTree, cDigest)
+			pythonDispatchCheckDigest(t, "production", production, language, witness.wantGoDigest)
+			pythonDispatchCheckDivergence(t, "production", productionDiff, witness.wantRouteDiff)
+			pythonDispatchCheckPass(t, "production", production, witness.wantProduction)
+			pythonDispatchCheckNativeAuthority(t, "production", production)
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			wantRoutedBefore := startRouted + witness.wantRoutedBefore
+			wantFallbackBefore := startFallback + witness.wantFallbackBefore
+			wantRoutedAfter := startRouted + witness.wantRoutedAfter
+			wantFallbackAfter := startFallback + witness.wantFallbackAfter
+			if routedBefore != wantRoutedBefore || fallbackBefore != wantFallbackBefore {
+				t.Fatalf("compact counters before=%d/%d, want %d/%d", routedBefore, fallbackBefore, wantRoutedBefore, wantFallbackBefore)
+			}
+			compactParser := gotreesitter.NewParser(language)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer compact.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			compactMode := pythonDispatchCompactMode(routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+			if compactMode != witness.wantCompactMode || routedAfter != wantRoutedAfter || fallbackAfter != wantFallbackAfter {
+				t.Fatalf("compact mode=%s counters=%d/%d->%d/%d, want %s %d/%d->%d/%d", compactMode, routedBefore, fallbackBefore, routedAfter, fallbackAfter, witness.wantCompactMode, wantRoutedBefore, wantFallbackBefore, wantRoutedAfter, wantFallbackAfter)
+			}
+			compactDiff := pythonDispatchAssertReceipt(t, "compact", compact, language, cTree, cDigest)
+			pythonDispatchCheckDigest(t, "compact", compact, language, witness.wantGoDigest)
+			pythonDispatchCheckDivergence(t, "compact", compactDiff, witness.wantRouteDiff)
+			pythonDispatchCheckPass(t, "compact", compact, witness.wantCompact)
+			pythonDispatchCheckNativeAuthority(t, "compact", compact)
+
+			forestParser := gotreesitter.NewParser(language)
+			forest, forestOK := forestParser.ParseForestExperimental(source)
+			if !forestOK || forest == nil {
+				t.Fatal("forest route declined")
+			}
+			defer forest.Release()
+			forestDiff := pythonDispatchAssertReceipt(t, "forest", forest, language, cTree, cDigest)
+			pythonDispatchCheckDigest(t, "forest", forest, language, witness.wantGoDigest)
+			pythonDispatchCheckDivergence(t, "forest", forestDiff, witness.wantRouteDiff)
+			pythonDispatchCheckPass(t, "forest", forest, witness.wantForest)
+			pythonDispatchCheckNativeAuthority(t, "forest", forest)
+
+			incrementalParser := gotreesitter.NewParser(language)
+			incrementalParser.SetAdmissionCandidateRoute(false)
+			base := bytes.TrimSuffix(source, []byte{'\n'})
+			oldTree, err := incrementalParser.Parse(base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer oldTree.Release()
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(len(base)),
+				OldEndByte:  uint32(len(base)),
+				NewEndByte:  uint32(len(source)),
+				StartPoint:  pythonDispatchPoint(base),
+				OldEndPoint: pythonDispatchPoint(base),
+				NewEndPoint: pythonDispatchPoint(source),
+			})
+			incremental, profile, err := incrementalParser.ParseIncrementalProfiled(source, oldTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer incremental.Release()
+			incrementalDiff := pythonDispatchAssertReceipt(t, "incremental", incremental, language, cTree, cDigest)
+			pythonDispatchCheckDigest(t, "incremental", incremental, language, witness.wantGoDigest)
+			pythonDispatchCheckDivergence(t, "incremental", incrementalDiff, witness.wantRouteDiff)
+			pythonDispatchCheckPass(t, "incremental", incremental, witness.wantIncremental)
+			pythonDispatchCheckNativeAuthority(t, "incremental", incremental)
+			if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+				t.Fatalf("incremental reuse changed: unsupported=%t reason=%q old_tree=%t subtrees=%d bytes=%d", profile.ReuseUnsupported, profile.ReuseUnsupportedReason, profile.OldTreeReuseRoute, profile.ReusedSubtrees, profile.ReusedBytes)
+			}
+
+			t.Logf("route-summary compact=%s raw=%s production=%s forest=%s incremental=%s reuse=%t unsupported=%t reason=%q", compactMode, pythonDispatchPassSummary(raw), pythonDispatchPassSummary(production), pythonDispatchPassSummary(forest), pythonDispatchPassSummary(incremental), profile.OldTreeReuseRoute, profile.ReuseUnsupported, profile.ReuseUnsupportedReason)
+		})
+	}
+}
+
+// TestPythonDispatchBlockerReceiptDocument guards the durable receipt markers.
+func TestPythonDispatchBlockerReceiptDocument(t *testing.T) {
+	doc, err := os.ReadFile("../docs/root-normalization-retirement.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	changelog, err := os.ReadFile("../CHANGELOG.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	document := strings.Join(strings.Fields(string(doc)), " ")
+	for _, marker := range []string{
+		"## 2026-08-24 Python dispatcher blocker receipt",
+		"Status: `NO-GO`. Keep `dispatch.python` live.",
+		"Base commit: `11d9aec70eaef0c0d65c3cd14b8f594d64869c7b`.",
+		"The raw positive witness differs from locked C, but production, compact, forest, and incremental routes match locked C.",
+		"The two f-string witnesses differ from locked C on every route.",
+		"external_scanner_unsupported",
+		"native_authoritative=false",
+		"The authenticated Python corpus and corpus lock are unavailable.",
+		"The sidecar records the expected corpus lock SHA, but it does not provide the corpus.",
+		"The A0 (initial dispatcher census) manifest has 14 languages, 42 files, and 14 receipts. It excludes Python.",
+		"The tracked census has seven fixtures. Its Python fixture is",
+		"20260823T052051Z-n31c-python-blocker-final5",
+		"20260823T051420Z-n31c-python-receipts-final",
+		"20260823T051431Z-n31c-python-census-final",
+		"20260823T051442Z-n31c-python-a3-corpus-absence",
+		"Canopy traces `runLanguageResultCompatibility` to `dispatcherArmCensus` and then to `normalizePythonCompatibilityWithParser`.",
+		"Keep dispatch.python live until scheduler_action_semantics emits the locked-C tree for every witness and route.",
+	} {
+		marker = strings.Join(strings.Fields(marker), " ")
+		if !strings.Contains(document, marker) {
+			t.Fatalf("retirement document lacks marker %q", marker)
+		}
+	}
+	for _, marker := range []string{
+		"Record the N31c Python dispatcher blocker at main commit",
+		"11d9aec70eaef0c0d65c3cd14b8f594d64869c7b",
+		"Keep `dispatch.python` live.",
+	} {
+		if !strings.Contains(string(changelog), marker) {
+			t.Fatalf("changelog lacks marker %q", marker)
+		}
+	}
+}
+
+func pythonDispatchExpectedDivergence(path, category, goValue, cValue string) *DumpV1Divergence {
+	return &DumpV1Divergence{Path: path, Category: category, GoValue: goValue, CValue: cValue}
+}
+
+func pythonDispatchCTree(t *testing.T, language *sitter.Language, source []byte) *sitter.Tree {
+	t.Helper()
+	parser := sitter.NewParser()
+	t.Cleanup(parser.Close)
+	if err := parser.SetLanguage(language); err != nil {
+		t.Fatal(err)
+	}
+	tree := parser.Parse(source, nil)
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("C parser returned no root")
+	}
+	return tree
+}
+
+func pythonDispatchAssertReceipt(t *testing.T, route string, tree *gotreesitter.Tree, language *gotreesitter.Language, cTree *sitter.Tree, cDigest string) *DumpV1Divergence {
+	t.Helper()
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	diff := FirstDivergenceDumpV1(tree.RootNode(), language, cTree.RootNode())
+	t.Logf("route=%s bytes=%d error_root=%t digest=%s c_digest=%s exact=%t rewrites=%d native_authoritative=%t divergence=%+v", route, len(tree.Source()), tree.RootNode().HasError(), inspection.SHA256, cDigest, diff == nil && inspection.SHA256 == cDigest, tree.ParseRuntime().NormalizationNodesRewritten, tree.ParseRuntime().NativeRecoveredStructureAuthoritative, diff)
+	return diff
+}
+
+func pythonDispatchCheckDigest(t *testing.T, route string, tree *gotreesitter.Tree, language *gotreesitter.Language, want string) {
+	t.Helper()
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatalf("%s inspect: %v", route, err)
+	}
+	if inspection.SHA256 != want {
+		t.Fatalf("%s digest=%s, want %s", route, inspection.SHA256, want)
+	}
+}
+
+func pythonDispatchCheckDivergence(t *testing.T, route string, got, want *DumpV1Divergence) {
+	t.Helper()
+	if got == nil || want == nil {
+		if got != want {
+			t.Fatalf("%s divergence=%+v, want %+v", route, got, want)
+		}
+		return
+	}
+	if *got != *want {
+		t.Fatalf("%s divergence=%+v, want %+v", route, got, want)
+	}
+}
+
+func pythonDispatchCheckPass(t *testing.T, route string, tree *gotreesitter.Tree, want pythonDispatchPassExpectation) {
+	t.Helper()
+	pass := pythonDispatchPass(tree)
+	if !want.recorded {
+		if pass != nil {
+			t.Fatalf("%s recorded dispatch.python pass=%+v, want none", route, pass)
+		}
+		return
+	}
+	if pass == nil {
+		t.Fatalf("%s did not record dispatch.python", route)
+	}
+	if pass.Checked != want.checked || pass.Run != want.run || pass.NodesVisited != want.visited || pass.NodesRewritten != want.rewritten {
+		t.Fatalf("%s dispatch.python pass=%d/%d/%d/%d, want %d/%d/%d/%d", route, pass.Checked, pass.Run, pass.NodesVisited, pass.NodesRewritten, want.checked, want.run, want.visited, want.rewritten)
+	}
+}
+
+func pythonDispatchCheckNativeAuthority(t *testing.T, route string, tree *gotreesitter.Tree) {
+	t.Helper()
+	if tree.ParseRuntime().NativeRecoveredStructureAuthoritative {
+		t.Fatalf("%s native_authoritative=true, want false", route)
+	}
+}
+
+func pythonDispatchPass(tree *gotreesitter.Tree) *gotreesitter.NormalizationPassRuntime {
+	if tree == nil || tree.ParseRuntime().NormalizationPasses == nil {
+		return nil
+	}
+	for i := range *tree.ParseRuntime().NormalizationPasses {
+		pass := &(*tree.ParseRuntime().NormalizationPasses)[i]
+		if pass.Name == "dispatch.python" {
+			return pass
+		}
+	}
+	return nil
+}
+
+func pythonDispatchPassSummary(tree *gotreesitter.Tree) string {
+	pass := pythonDispatchPass(tree)
+	if pass == nil {
+		return "none"
+	}
+	return fmt.Sprintf("%d/%d/%d/%d", pass.Checked, pass.Run, pass.NodesVisited, pass.NodesRewritten)
+}
+
+func pythonDispatchCompactMode(routedBefore, fallbackBefore, routedAfter, fallbackAfter uint64) string {
+	if routedAfter == routedBefore+1 && fallbackAfter == fallbackBefore {
+		return "accepted"
+	}
+	if routedAfter == routedBefore && fallbackAfter == fallbackBefore+1 {
+		return "fallback"
+	}
+	return fmt.Sprintf("counters=%d/%d->%d/%d", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+}
+
+func pythonDispatchPoint(source []byte) gotreesitter.Point {
+	var point gotreesitter.Point
+	for _, value := range source {
+		if value == '\n' {
+			point.Row++
+			point.Column = 0
+		} else {
+			point.Column++
+		}
+	}
+	return point
+}

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -307,6 +307,131 @@ Retire `dispatch.typescript` only after all of these conditions hold:
 Keep `dispatch.typescript` live until each condition passes.
 Keep the registry entry unchanged until each condition passes.
 
+## 2026-08-24 Python dispatcher blocker receipt
+
+Status: `NO-GO`. Keep `dispatch.python` live.
+
+Base commit: `11d9aec70eaef0c0d65c3cd14b8f594d64869c7b`.
+This receipt adds one focused route and document guard test. It changes no
+parser or registry behavior.
+
+The registry arm is `dispatch.python`. Its function is
+`normalizePythonCompatibilityWithParser` in `parser_result_python.go`. Its
+authoritative owner is `scheduler_action_semantics`. Its route coverage is
+production, compact, forest, incremental, and locked-C. The registry status
+is `live`. Retirement requires exact native output for every registered
+witness on every covered route.
+
+The A0 (initial dispatcher census) manifest has 14 languages, 42 files, and
+14 receipts. It excludes Python. Its parser revision is
+`3c55dca287c9dd6ed987c764b9aafd90b22281a2`. Its grammar lock SHA-256 is
+`9ddb6324afd014f6ecdd1cae3dd1ba238f1e62ce03d126e6d8b267ce34d72ecb`.
+Its totals are `checked=44`, `run=44`, `nodes_visited=313572`,
+`nodes_rewritten=3267`, `error_roots=20`, and `parse_errors=0`.
+
+The tracked census has seven fixtures. Its Python fixture is
+`cgo_harness/corpus_structural/python_sample.py`. Its source SHA-256 is
+`3de858b73ba43ad3c2d43b9cfc08426f62dd4ae7bcf1358e3989ed311b435157`.
+It records one check, one run, 1,547 visited nodes, zero rewritten nodes, and
+no error root. The tracked totals are `checked=9`, `run=9`,
+`nodes_visited=26022`, and `nodes_rewritten=2107`.
+
+The authenticated Python corpus and corpus lock are unavailable. The
+`cgo_harness/corpus_real` directory does not exist. The manifests reference
+that directory, but they cannot provide its files. The sidecar
+`cgo_harness/perf_scan/corpus_sources.lock.sha256` records
+`41c744279c8b1d7c9fe7b1b8e26fba733423e77cd48efea46927309c22d163ea`.
+The sidecar records the expected corpus lock SHA, but it does not provide the
+corpus. The full Python A3 corpus sweep therefore skips.
+
+The focused test is
+`cgo_harness/python_dispatch_blocker_receipt_test.go`. It pins three
+witnesses, their source bytes, source SHA-256 values, locked-C digests, Go
+digests, first divergences, route results, and dispatcher pass counts.
+Pass counts use the format `checked/run/visited/rewritten`.
+
+The positive witness is 32 bytes. Its source SHA-256 is
+`6a1661337725eea3d5f3e26c38c3c3536f2c9fbfb66e04ae73f2dcc1a1afdd03`.
+Its raw Go digest is
+`1ee859d4c1d2489f24dd57e0671a1832480b1c43afb960c10f798ce9f71f9759`.
+Locked C and normalized Go use digest
+`577a8b7b9281fa12c48dfa239a977c82f3a94e3d248253663c4a6fafc9121622`.
+The raw first divergence is
+`/module/assignment[1]/pattern_list[2]`, where Go uses `pattern_list` and C
+uses `expression_list`.
+
+The raw positive witness differs from locked C, but production, compact,
+forest, and incremental routes match locked C. Production records
+`1/1/24/1`. Compact accepts the candidate route and records no dispatcher
+pass, with counters `0/0->1/0`. Forest records `1/1/24/0`. Incremental
+records `1/1/24/1`.
+Raw records no dispatcher pass.
+
+The bare-tuple f-string witness is 26 bytes. Its source SHA-256 is
+`7d0029944fcffb700144302da9b1b80b03da8f89d716772b3a207dca9ba543a7`.
+Its Go digest is
+`89ca835ae4fb5cf19d38e40b6ae4f09c99c66987ca77d8b4921aa9f593aaa641`.
+Locked C uses digest
+`84c987ddc73cc06bcc63e0cc860ecaa58560a46db882c775815ecb8867f95c07`.
+The first divergence is
+`/module/assignment[2]/string[2]/interpolation[1]/pattern_list[1]`, where Go
+uses `pattern_list` and C uses `expression_list`.
+
+The splat f-string witness is 26 bytes. Its source SHA-256 is
+`660a9ed55b63e6b98cfc70db1776895ec9046a16c906c33b3d273bee496a121d`.
+Its Go digest is
+`102ebedd10a3864a2640cb293f541e42f63b4f1ce3d60c9f219d7088b4f484c6`.
+Locked C uses digest
+`e646688923780dab15e472c1754d89e87ebfdb669fafeda109d4a2d630b4a4c9`.
+The first divergence is
+`/module/assignment[1]/string[2]/interpolation[1]/pattern_list[1]`, where Go
+uses `pattern_list` and C uses `expression_list`.
+
+The two f-string witnesses differ from locked C on every route. Production,
+compact, forest, and incremental retain the Go digest. Their dispatcher
+counts are listed below. Raw records no dispatcher pass for both witnesses.
+
+- Bare tuple: production `1/1/22/0`, compact accepted with counters
+  `1/0->2/0`, forest `1/1/22/1`, and incremental `1/1/22/0`.
+- Splat: production `1/1/24/0`, compact accepted with counters `2/0->3/0`,
+  forest `1/1/24/0`, and incremental `1/1/24/0`.
+
+All route receipts set `native_authoritative=false`. Every incremental route
+reports `external_scanner_unsupported`, with zero reused subtrees and zero
+reused bytes. Incremental equality is therefore a fresh-parse result, not a
+reuse proof.
+
+The existing load-bearing C-oracle test passes its three assignment witnesses.
+The root-error and byte-drop tests pass. The existing known-gap test skips both
+f-string witnesses. The skipped cases remain explicit blockers.
+
+Canopy traces `runLanguageResultCompatibility` to `dispatcherArmCensus` and
+then to `normalizePythonCompatibilityWithParser`. It also traces the generic
+selection paths `reduceForkWindowPreference` and
+`stackCompareForResultSelectionWithRawShape`. The f-string tie affects
+`for`, `except`, `with`, `del`, and `match` target shapes. A generic scheduler
+change could affect every grammar. No safe generic correction is proven.
+
+The Docker controls use one Python workload, one CPU, 4 GiB memory,
+`GOMAXPROCS=1`, `-p=1`, and test parallelism one. The successful final
+artifacts are:
+
+- `/tmp/gts-n31c-python-blocker-20260824/harness_out/docker/20260823T052051Z-n31c-python-blocker-final5` — route and document guard;
+- `/tmp/gts-n31c-python-blocker-20260824/harness_out/docker/20260823T051420Z-n31c-python-receipts-final` — canonical Python receipts;
+- `/tmp/gts-n31c-python-blocker-20260824/harness_out/docker/20260823T051431Z-n31c-python-census-final` — tracked census;
+- `/tmp/gts-n31c-python-blocker-20260824/harness_out/docker/20260823T051442Z-n31c-python-a3-corpus-absence` — authenticated corpus skip.
+
+Each run completed without timeout or out-of-memory failure. Maximum resident
+set size was 303,840 KB for the route guard, 231,200 KB for the canonical
+receipts, 609,280 KB for the tracked census, and 230,560 KB for the corpus
+skip.
+
+Keep dispatch.python live until scheduler_action_semantics emits the locked-C
+tree for every witness and route. Reopen retirement only after the
+authenticated corpus and lock become available, the A0 denominator includes
+Python, both f-string gaps close, the skipped tests run, and all route digests
+match. Preserve the scanner limitation as a separate incremental receipt.
+
 ## 2026-08-22 normalization checkpoint
 
 Status: NO-GO. Do not retire an entry from this checkpoint.


### PR DESCRIPTION
Remote durability checkpoint only — this draft PR is durable storage, not acceptance or a merge recommendation.

Preserves the exact authored working-tree blobs for entry #34, based on exact source HEAD `11d9aec70eaef0c0d65c3cd14b8f594d64869c7b`.

Validation performed before and after checkpoint:
- root `LICENSE` is tracked, non-empty, and MIT
- focused staged-patch gitleaks scan passed
- staged blob hashes matched the source worktree immediately before commit
- carrier commit parent equals the source HEAD
- local HEAD, upstream tracking ref, and live `git ls-remote` SHA are identical
- every remote tree blob matches the post-push source worktree byte-for-byte
- carrier is clean and the original worktree was not edited

This branch is immutable archival evidence. Tests and review determine acceptance separately.