### PR TITLE
[archive] Preserve latest C26ag table identity state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,8 +79,8 @@ for tags and release notes while still in `0.x`.
   13/4/4 values. Correct production routes record 14/5/5. Compact admission
   records zero sidecars and zero incremental reuse. Reject the compact
   candidate.
-  Keep issue #576 open until compact sidecars and safe nonzero reuse have a
-  generic proof.
+  Keep SQL compact admission gated until compact sidecars and safe nonzero
+  reuse have a generic proof.
 
 - Screened generic compact-admission sidecars for checkpointed scanners in
   C26z. The diagnostic SQL route recorded 14 records, 5 leaves, and 5
@@ -91,7 +91,7 @@ for tags and release notes while still in `0.x`.
   parse-state replay. Generated content replay state `180` made checkpoint
   scanning return error span `9-14`. Locked production state `16613` returned
   expected span `9-12`. A stale grammar identity reused zero subtrees and zero
-  bytes. Keep issue #576 open.
+  bytes. Keep SQL compact admission gated.
 
 - Recorded the C26ad SQL compact replay state-provenance blocker at publication
   base `515df769b9b4e2f8e3ea715e78b75a44faa3b6d6`. The evidence base was
@@ -106,8 +106,20 @@ for tags and release notes while still in `0.x`.
   transitions across tables. The clean Docker route still fails generated
   dollar-quoted parity with the generated scanner's reference symbol mapping;
   temporary target-symbol binding repaired that route but did not establish a
-  generic replay contract. No parser, scanner, or test change ships. Keep issue
-  #576 open. See `docs/compact-route-real-corpus-matrix.md`.
+  generic replay contract. No parser, scanner, or test change ships. Keep SQL
+  compact replay gated. See `docs/compact-route-real-corpus-matrix.md`.
+
+- Added the C26ag generic table-identity guard at base
+  `af9ded2b77b7828b12b1d2da7c9fff8dd5ca053b`. The compact core captures the
+  producer identity at construction. Loaded languages use the exact grammar
+  blob SHA-256. In-memory languages use one process-local producer token.
+  Replay now declines before state reconstruction when the producer identity
+  changes or is absent. The guard preserves same-language replay and does not
+  translate numeric parser states. Focused identity tests passed in Docker.
+  SQL scanner unit tests passed. The generated SQL route still has the known
+  dollar-quoted locked-C divergence. Keep SQL compact admission gated until
+  that parity gap and the complete replay contract are resolved. See
+  `docs/compact-route-real-corpus-matrix.md`.
 
 - Added authenticated generated-SQL scanner identity to the grammargen C
   parity route. The route now reloads the generated blob through `LoadLanguage`
@@ -116,8 +128,8 @@ for tags and release notes while still in `0.x`.
   checkpoint records, 4 checkpoint leaves, and 4 snapshots. Fresh and
   incremental trees match. A stale
   reference grammar identity reuses zero subtrees and zero bytes. The four
-  generated SQL locked-C divergences remain. Keep issue #576 open until
-  generated and locked-C trees match.
+  generated SQL locked-C divergences remain. Keep generated SQL compact parity
+  gated until generated and locked-C trees match.
 
 - Recorded the `dispatch.solidity` blocker at publication base
   `e24ccf5a87bbd7febc21f67f014c2d5301d229d0`. Keep the arm live. The A0
@@ -149,7 +161,7 @@ for tags and release notes while still in `0.x`.
   use exact allocation deltas. Reset clears the identity. Native SQL passed
   the route and real-corpus gates. Generated SQL still has four locked-C
   divergences. A one-shot accounting screen is diagnostic only. It does not
-  provide release performance evidence. Keep issue #576 open.
+  provide release performance evidence. Keep the SQL identity gate scoped.
 
 - Recorded the C26i, C26j, and C26k Swift issue #576 scanner checkpoint
   blocker. C26i and C26j use evidence base

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -1221,7 +1221,7 @@ capability proves all of the following:
 
 Publication base: `a62b9db306bcb983852cbf0043852546e864e856`.
 
-Status: **GO FOR THE BOUNDED IDENTITY GATE. KEEP ISSUE #576 OPEN.**
+Status: **GO FOR THE BOUNDED IDENTITY GATE.**
 
 C26q binds an external scanner checkpoint to its scanner and grammar identity.
 The gate runs at incremental checkpoint reuse. It does not change GLR
@@ -1363,7 +1363,7 @@ Its `metadata.txt` SHA-256 is
 `ccede21b768050fcd6b08cfe8b4e735c3e584da63a85e7ff0bc1d818f773507e`.
 
 The route remains blocked by four generated SQL locked-C divergences. Keep
-issue #576 open until those trees match node for node.
+generated SQL compact parity gated until those trees match node for node.
 
 ### Generated SQL override proof
 
@@ -1526,7 +1526,7 @@ evidence. The final direct runner commands above are the evidence.
 
 GO applies only to the bounded native SQL identity gate and generated override
 fail-closed behavior. This gate does not prove generated SQL parity with C.
-Keep issue #576 open.
+Keep generated SQL compact parity gated.
 
 Reopen the generated SQL path only after all of the following conditions hold:
 
@@ -1538,8 +1538,7 @@ Reopen the generated SQL path only after all of the following conditions hold:
 - Avoid source-hash, blob-exception, witness-repair, and language-specific
   policy.
 
-Keep issue #576 open until the generated route
-passes the full locked-C proof.
+Keep the generated SQL route gated until it passes the full locked-C proof.
 
 ## Current bounded result
 
@@ -2143,8 +2142,8 @@ route's failed external-token mapping and error recovery. The invariant for a
 correct SQL route is the four byte-span and serialized-state pairs above,
 plus a complete tree with no error. A future candidate must materialize these
 sidecars, preserve scanner and grammar identity, and prove nonzero reuse.
-Keep issue #576 open. Do not require the path-specific 13/4/4 receipt for a
-semantically correct route.
+Keep SQL compact admission gated. Do not require the path-specific 13/4/4
+receipt for a semantically correct route.
 
 ## C26z SQL compact checkpoint sidecars
 
@@ -2203,8 +2202,9 @@ selection. The generated compact content leaf covered bytes `9-12` with
 replay state `180`; checkpoint scanning then returned an error span `9-14`.
 The locked production leaf used state `16613` and returned the expected
 `9-12` span. No generic state remap passed the equality and stale-identity
-guards. The production and test changes were reverted. Keep issue #576 open
-until a generic replay contract proves production-equivalent reuse.
+guards. The production and test changes were reverted. Keep SQL compact
+admission gated until a generic replay contract proves production-equivalent
+reuse.
 
 ## C26ad SQL compact replay state provenance
 
@@ -2213,7 +2213,7 @@ C26ad used evidence base
 This receipt is rebased onto publication base
 `515df769b9b4e2f8e3ea715e78b75a44faa3b6d6` after PR #868 merged.
 
-Status: NO-GO. Keep issue #576 open.
+Status: NO-GO. Keep SQL compact replay gated.
 
 The pinned SQL source remains commit
 `587f30d184b058450be2a2330878210c5f33b3f9`.
@@ -2357,10 +2357,10 @@ The focused scanner unit gate passed:
 go test ./grammars -run '^TestSQLScanner' -count=1
 ```
 
-### Decision and reopening condition
+### C26ad decision and reopening condition
 
 Reject the generic state-remap fix. Keep compact replay disabled for this
-scanner route and keep issue #576 open.
+scanner route.
 
 Reopen only after a replay contract binds all of these values to one language
 identity:
@@ -2373,6 +2373,145 @@ identity:
 
 The contract must reject a missing or changed identity before it attempts
 scanner replay. A numeric state translation alone is not sufficient.
+
+## C26ag generic compact table identity guard
+
+C26ag used base
+`af9ded2b77b7828b12b1d2da7c9fff8dd5ca053b`.
+The isolated worktree was `/tmp/gts-c26ag-table-identity-20260824`.
+
+Status: ACCEPTED guard. Keep the SQL compact route gated for the remaining
+parity gap.
+
+The guard adds a dependency-neutral `TableIdentityProvider` contract at
+`internal/parsercorephase0/core.go:277-282`.
+`Core` stores the producer identity at construction and compares it before
+parser-state replay (`internal/parsercorephase0/core.go:898-900,1690-1708`).
+The root adapter supplies the identity from its current `Language`
+(`parsercore_phase0_driver.go:552-562`).
+Replay returns an identity decline before it allocates or walks replay states
+when the identity differs (`parsestate_replay_compact.go:145-155`).
+
+Loaded languages use their exact compressed grammar blob SHA-256.
+In-memory generated languages use one process-local producer token.
+The contract does not translate numeric parser states.
+
+The existing reuse cursor requires the same `*Language` pointer
+(`parser.go:3450-3452`). Scanner checkpoint reuse requires scanner and grammar
+identity (`external_scanner_checkpoint_capability.go:153-159`). These gates
+remain unchanged. The new core guard covers the earlier replay boundary.
+
+### Identity evidence
+
+The focused tests cover matching identity, producer drift, and missing identity.
+The blob test proves that two loaded copies use the same exact blob SHA-256.
+The language-swap test proves that replay returns
+`DiagnosticParserCoreIdentity` before state reconstruction.
+
+The test files are:
+
+- `internal/parsercorephase0/core_test.go`
+- `parsercore_phase0_action_test.go`
+- `parsercore_phase0_language_tables_internal_test.go`
+
+### Docker validation
+
+Run the SQL scanner unit gate:
+
+```sh
+bash cgo_harness/docker/run_parity_in_docker.sh \
+  --repo-root /tmp/gts-c26ag-table-identity-20260824 \
+  --out-root /tmp/gts-c26ag-rebase-artifacts \
+  --label c26ag-sql-unit --no-build --memory 4g --cpus 1 \
+  --goflags -p=1 --test-parallel 1 --timeout 10m \
+  --mount /tmp/gts-c26ad-grammar_parity:/tmp/grammar_parity:ro -- \
+  'export PATH=/usr/local/go/bin:$PATH; cd /workspace && \
+   go test ./grammars -run "^TestSQLScanner" -count=1 -v'
+```
+
+Artifact:
+`/tmp/gts-c26ag-rebase-artifacts/20260823T212531Z-c26ag-rebase-sql-unit`.
+
+- `container.log`: `1a28ef0f1efe4bebc927e9862aea837eee92ca0c2e62ed23adf708d801f495fe`
+- `metadata.txt`: `c2384dead613fb5dc42f50acf30514aaa5cb102de47a10f032e8ca8f625144d4`
+- `inspect.json`: `513471da41ef3940206edb341aaeeedc508685beae79985016bcd3581ef5216f`
+
+The unit gate passed all SQL scanner tests.
+
+Run the generated SQL, locked-C, fresh-tree, incremental-reuse, and
+stale-identity gate:
+
+```sh
+bash cgo_harness/docker/run_parity_in_docker.sh \
+  --repo-root /tmp/gts-c26ag-table-identity-20260824 \
+  --out-root /tmp/gts-c26ag-rebase-artifacts \
+  --label c26ag-sql-generated-locked-c --no-build --memory 4g --cpus 1 \
+  --goflags -p=1 --test-parallel 1 --timeout 10m \
+  --mount /tmp/gts-c26ad-grammar_parity:/tmp/grammar_parity:ro -- \
+  'export PATH=/usr/local/go/bin:$PATH; cd /workspace/cgo_harness && \
+   go test -tags "cgo treesitter_c_parity" . \
+   -run "^TestSQLGrammargenCGORegressionCases$" -count=1 -v'
+```
+
+Artifact:
+`/tmp/gts-c26ag-rebase-artifacts/20260823T212540Z-c26ag-rebase-sql-generated-locked-c`.
+
+- `container.log`: `0dbd795350eed2d2377a2faaad7a2cb5881c173c968d7b01340c7f2afeebc735`
+- `metadata.txt`: `7ee590184625734bf48088652ecf39e48329a7390179b161c578bc855d2c71fa`
+- `inspect.json`: `50dfd29cdacca84b10c98495ad2277f5c83824fec1eb21127618e8dfc1ba4f25`
+
+The generated identity matched the generated blob:
+`4ffb2a6d09e2000126f10101db9028d28e0752ac3e4f83e401f045c3b028ca7c`.
+The route reused one subtree and 16 bytes.
+The stale identity route reused zero subtrees and zero bytes.
+The identifier and parenthesized Boolean cases passed.
+The dollar-quoted case failed with the known generated-vs-locked-C error
+tree difference. The guard did not change that result.
+
+Run the focused identity tests:
+
+```sh
+bash cgo_harness/docker/run_parity_in_docker.sh \
+  --repo-root /tmp/gts-c26ag-table-identity-20260824 \
+  --out-root /tmp/gts-c26ag-rebase-artifacts \
+  --label c26ag-table-identity-tests --no-build --memory 4g --cpus 1 \
+  --goflags -p=1 --test-parallel 1 --timeout 10m -- \
+  'export PATH=/usr/local/go/bin:$PATH; cd /workspace && \
+   go test ./internal/parsercorephase0 \
+   -run "^TestCoreTableIdentityCapturesAndRejectsProducerDrift$" -count=1 && \
+   go test -tags gts_parsercorephase0 . \
+   -run "^TestParserCore(ReplayRejectsLanguageTableSwap|RootTablesIdentityUsesLanguageBlobHash)$" -count=1 && \
+   go test -race -tags gts_parsercorephase0 . \
+   -run "^TestParserCoreReplayRejectsLanguageTableSwap$" -count=1 && \
+   go test -tags gts_no_parsercorephase0 . -run "^$" -count=1'
+```
+
+Artifact:
+`/tmp/gts-c26ag-rebase-artifacts/20260823T212504Z-c26ag-rebase-focused`.
+
+- `container.log`: `978d7ed3cd5f8d5456f275c7eb84ac39a3a312a9c84b0232cfa3d41e2e452f5c`
+- `metadata.txt`: `743799aa73c12ac6d10e75fb4394fc16afe5aa3a1033194e2d94945276d1ad06`
+- `inspect.json`: `f51a3b6421499a9eeb0fdfa6043d03a2513c8f964c7f50cc7abba93551afabe0`
+
+The focused core and root tests passed.
+
+The loaded-blob identity, race, and compile-out tests ran in the combined
+focused command above. They passed in this artifact:
+`/tmp/gts-c26ag-rebase-artifacts/20260823T212504Z-c26ag-rebase-focused`.
+
+### C26ag decision and reopening condition
+
+Accept the generic table-identity guard. Do not add SQL-specific symbol maps.
+Keep the SQL compact route gated until generated SQL matches locked C on the
+dollar-quoted witness and the replay contract covers all derivation metadata.
+
+Reopen the SQL route only after a Docker gate proves all of these conditions:
+
+- equal table identity permits replay;
+- changed or missing identity declines before replay;
+- scanner identity and checkpoint bytes remain exact;
+- fresh, compact, incremental, and locked-C trees match; and
+- the generated SQL dollar-quoted witness passes without a state remap.
 
 ## Corpus state
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -271,6 +271,13 @@ type TableView interface {
 	ProductionAliases(uint16, int) ([]Symbol, error)
 }
 
+// TableIdentityProvider supplies the immutable identity of the table producer.
+// A compact core must not replay parser states after its producer changes.
+// Adapters that do not provide an identity cannot prove replay compatibility.
+type TableIdentityProvider interface {
+	TableIdentity() ([32]byte, bool)
+}
+
 // Decline identifies a feature that phase zero cannot execute faithfully.
 type Decline string
 
@@ -891,6 +898,8 @@ type RawSelectedCensus struct {
 // into pointer-free slices; the production parser is unaffected.
 type Core struct {
 	tables             TableView
+	tableIdentity      [32]byte
+	tableIdentityValid bool
 	plans              ReductionPlanProvider
 	selectedProvider   SelectedStorePolicyProvider
 	selectedPolicy     *SelectedStorePolicy
@@ -1681,9 +1690,27 @@ func New(tables TableView, limits Limits) (*Core, error) {
 		diagnostics:                       diagnosticOptions{foldSamePredecessorShallowPayloads: true},
 		metadataConstructionAuthenticated: true,
 	}
+	if provider, ok := tables.(TableIdentityProvider); ok {
+		core.tableIdentity, core.tableIdentityValid = provider.TableIdentity()
+	}
 	core.plans, _ = tables.(ReductionPlanProvider)
 	core.selectedProvider, _ = tables.(SelectedStorePolicyProvider)
 	return core, nil
+}
+
+// TableIdentityMatches reports whether the table producer still matches the
+// identity captured when the compact core was created. Missing identity fails
+// closed because parser-state replay needs exact table provenance.
+func (c *Core) TableIdentityMatches() bool {
+	if c == nil || !c.tableIdentityValid {
+		return false
+	}
+	provider, ok := c.tables.(TableIdentityProvider)
+	if !ok {
+		return false
+	}
+	identity, valid := provider.TableIdentity()
+	return valid && identity == c.tableIdentity
 }
 
 // AuthenticationGeneration identifies the current Core capability phase.

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -11,6 +11,41 @@ import (
 	"unsafe"
 )
 
+type identityTestTable struct {
+	fakeTable
+	identity [32]byte
+	valid    bool
+}
+
+func (t *identityTestTable) TableIdentity() ([32]byte, bool) {
+	if t == nil {
+		return [32]byte{}, false
+	}
+	return t.identity, t.valid
+}
+
+func TestCoreTableIdentityCapturesAndRejectsProducerDrift(t *testing.T) {
+	tables := &identityTestTable{identity: [32]byte{1}, valid: true}
+	compact, err := New(tables, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compact.TableIdentityMatches() {
+		t.Fatal("matching table identity was rejected")
+	}
+	tables.identity[0] = 2
+	if compact.TableIdentityMatches() {
+		t.Fatal("changed table identity was accepted")
+	}
+	legacy, err := New(&fakeTable{}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.TableIdentityMatches() {
+		t.Fatal("table without identity was accepted for replay")
+	}
+}
+
 func TestPinnedGoConflictAndReductionMetadata(t *testing.T) {
 	wantConflict := []Action{
 		{Type: ActionReduce, Symbol: 171, ChildCount: 1},

--- a/language.go
+++ b/language.go
@@ -648,6 +648,12 @@ type Language struct {
 	compactTables     any   // *parserCoreLanguageTables under the default build
 	compactTablesErr  error // the build error, memoized alongside compactTables
 
+	// compactTableIdentityOnce assigns one immutable identity to the parser
+	// table producer. Loaded blobs use their exact blob hash. In-memory
+	// generated languages use a process-local token until they are encoded.
+	compactTableIdentityOnce sync.Once
+	compactTableIdentity     [32]byte
+
 	// corridorProgram memoizes the compiled C4 bytecode corridor program for
 	// this Language (spec.c4-bytecode-isa.v1 section 3.6: the stream is
 	// memoized per *Language beside compactTables and dies with the Language).
@@ -1002,6 +1008,25 @@ func (l *Language) GrammarBlobSHA256() ([32]byte, bool) {
 		return [32]byte{}, false
 	}
 	return l.grammarBlobSHA256, true
+}
+
+var nextCompactTableIdentity atomic.Uint64
+
+func (l *Language) parserCoreTableIdentity() ([32]byte, bool) {
+	if l == nil {
+		return [32]byte{}, false
+	}
+	l.compactTableIdentityOnce.Do(func() {
+		if blob, ok := l.GrammarBlobSHA256(); ok {
+			l.compactTableIdentity = blob
+			return
+		}
+		id := nextCompactTableIdentity.Add(1)
+		for i := 0; i < 8; i++ {
+			l.compactTableIdentity[i] = byte(id >> (8 * i))
+		}
+	})
+	return l.compactTableIdentity, true
 }
 
 // CompatibleWithRuntime reports whether this language can be parsed by the

--- a/parsercore_phase0_action_test.go
+++ b/parsercore_phase0_action_test.go
@@ -103,6 +103,39 @@ func TestParserCoreRootTablesRejectInvalidActionWhileCaching(t *testing.T) {
 	}
 }
 
+func TestParserCoreReplayRejectsLanguageTableSwap(t *testing.T) {
+	firstLanguage := &Language{
+		LargeStateCount: 1,
+		ParseTable:      [][]uint16{{0}},
+		ParseActions:    []ParseActionEntry{{}},
+	}
+	parser := NewParser(firstLanguage)
+	tables, err := newParserCoreRootTables(parser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact, err := core.New(tables, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compact.TableIdentityMatches() {
+		t.Fatal("initial table identity did not match")
+	}
+	parser.language = &Language{
+		LargeStateCount: 1,
+		ParseTable:      [][]uint16{{0}},
+		ParseActions:    []ParseActionEntry{{}},
+	}
+	if compact.TableIdentityMatches() {
+		t.Fatal("language table swap retained the old identity")
+	}
+	_, err = parser.replayCompactDerivation(compact, nil)
+	var decline *diagnosticParserCoreDecline
+	if !errors.As(err, &decline) || decline.boundary != DiagnosticParserCoreIdentity {
+		t.Fatalf("replay error=%v, want identity decline", err)
+	}
+}
+
 func TestParserCoreRootlessTablesRemainUsableWithoutSelectedStorePolicy(t *testing.T) {
 	lang := &Language{
 		LargeStateCount: 1,

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -554,6 +554,16 @@ type parserCoreRootTables struct {
 	*parserCoreLanguageTables
 }
 
+// TableIdentity binds compact replay to the immutable Language that produced
+// the cached action and reduction tables. The parser back-reference is read at
+// validation time, so a language change cannot reuse stale state numbers.
+func (a *parserCoreRootTables) TableIdentity() ([32]byte, bool) {
+	if a == nil || a.parser == nil {
+		return [32]byte{}, false
+	}
+	return a.parser.language.parserCoreTableIdentity()
+}
+
 // acquireParserCoreLanguageTables returns the converted tables for the parser's
 // language, building them once and caching them on the Language itself.
 //

--- a/parsercore_phase0_language_tables_internal_test.go
+++ b/parsercore_phase0_language_tables_internal_test.go
@@ -121,3 +121,28 @@ func TestParserCoreLanguageTablesCacheSharesAcrossParsers(t *testing.T) {
 		}
 	}
 }
+
+func TestParserCoreRootTablesIdentityUsesLanguageBlobHash(t *testing.T) {
+	firstLanguage := loadCertifiedGoLanguageForTest(t)
+	secondLanguage := loadCertifiedGoLanguageForTest(t)
+	first, err := newParserCoreRootTables(NewParser(firstLanguage))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := newParserCoreRootTables(NewParser(secondLanguage))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, ok := firstLanguage.GrammarBlobSHA256()
+	if !ok {
+		t.Fatal("certified language has no blob identity")
+	}
+	got, ok := first.TableIdentity()
+	if !ok || got != want {
+		t.Fatalf("first table identity=%x/%t, want blob=%x", got, ok, want)
+	}
+	other, ok := second.TableIdentity()
+	if !ok || other != want {
+		t.Fatalf("second table identity=%x/%t, want blob=%x", other, ok, want)
+	}
+}

--- a/parsestate_replay_compact.go
+++ b/parsestate_replay_compact.go
@@ -146,6 +146,12 @@ func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.Subtre
 	if p == nil || p.language == nil || compact == nil {
 		return nil, errors.New("parser-core phase zero: replay requires parser and core")
 	}
+	if !compact.TableIdentityMatches() {
+		return nil, &diagnosticParserCoreDecline{
+			boundary: DiagnosticParserCoreIdentity,
+			detail:   "compact parser table identity does not match the materialization parser",
+		}
+	}
 	n := compact.SubtreeArenaLen() + 1
 	states := acquireCompactReplayStates(n)
 	seed := p.replayRootPreGotoState()


### PR DESCRIPTION
Remote durability checkpoint only — this draft PR is durable storage, not acceptance or a merge recommendation.

Preserves the exact current nine-file C26ag working-tree state after the source advanced to exact HEAD `af9ded2b77b7828b12b1d2da7c9fff8dd5ca053b`. Seven code/test blobs were already durable through the earlier archive; this immutable branch additionally preserves the two newly authored receipt blobs in their coherent full snapshot. No earlier branch was rewritten.

Validation performed before and after checkpoint:
- root `LICENSE` is tracked, non-empty, and MIT
- focused staged-patch gitleaks scan passed
- staged blob hashes matched the source worktree immediately before commit
- carrier commit parent equals the source HEAD
- local HEAD, upstream tracking ref, and live `git ls-remote` SHA are identical
- all nine remote tree blobs match the post-push source worktree byte-for-byte
- carrier is clean and the original worktree was not edited

This archival PR is not a merge recommendation. Tests and review determine acceptance separately. Refs #576.