### PR TITLE
[archive] Preserve Perl dispatcher blocker receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ for tags and release notes while still in `0.x`.
   Locked C still differs in shape, type, and error state.
   No parser or registry change is included.
   See `docs/root-normalization-retirement.md`.
+- Recorded the unreceipted `dispatch.perl` blocker at base
+  `af9ded2b77b7828b12b1d2da7c9fff8dd5ca053b`.
+  The focused Docker receipt covers raw, production, compact, forest,
+  incremental, and locked-C routes for two source-hashed Perl witnesses.
+  It pins the grammar lock, blob, scanner, C artifact, runtime, binding,
+  compiler, source digests, route digests, dispatch counts, compact counters,
+  forest results, and incremental reuse status.
+  Raw trees diverge from locked C, while normalized routes match after dispatch.
+  The Perl corpus lock is absent, and the scanner provides no incremental reuse.
+  Keep the arm live. No parser or registry change is included.
+  See `docs/root-normalization-retirement.md`.
 
 - Recorded the unreceipted `dispatch.wolfram` blocker at base
   `f8b9d718ee19f65598e274035f5481a899ab2b72`. The A0 manifest records three

--- a/cgo_harness/perl_n31s_dispatcher_blocker_receipt_test.go
+++ b/cgo_harness/perl_n31s_dispatcher_blocker_receipt_test.go
@@ -1,0 +1,273 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	gots "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const (
+	perlN31sBaseCommit         = "af9ded2b77b7828b12b1d2da7c9fff8dd5ca053b"
+	perlN31sGrammarLockSHA     = "9ddb6324afd014f6ecdd1cae3dd1ba238f1e62ce03d126e6d8b267ce34d72ecb"
+	perlN31sGrammarBlobSHA     = "22388f06c2c54bb4748fd5f5f682ed25eecff8115a7e8e6a98f94f9c94bb9820"
+	perlN31sA0ManifestSHA      = "215df59aa56d28caa403f799733ef915db1c4ac07eb2bc96a9402f80cf67f80a"
+	perlN31sTrackedManifestSHA = "be584a0a4a26f0ca5268a7845cf3f04247e6b57259b9c7057e8eb2c9af26f839"
+	perlN31sCorpusSidecarSHA   = "2b2209597d1701ccc813bd35d1685b5b13730e6ebd285e66485ce812e35877cf"
+	perlN31sCorpusLockSHA      = "41c744279c8b1d7c9fe7b1b8e26fba733423e77cd48efea46927309c22d163ea"
+	perlN31sCArtifactSHA       = "3d8bb427c9043d5e4846f5cd83313afecf6b6e27be8fb82a7cd58f3b8f52ab87"
+	perlN31sGrammarRepo        = "https://github.com/tree-sitter-perl/tree-sitter-perl"
+	perlN31sGrammarCommit      = "ad74e6db234c35d537de9358799a8e0cc4f5dee0"
+)
+
+func TestPerlN31sDispatcherBlockerReceipt(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	sources := []struct {
+		name string
+		src  []byte
+	}{
+		{name: "push_two_args", src: []byte("push @found, $_;\n")},
+		{name: "push_three_args", src: []byte("push @found, $a, $b;\n")},
+	}
+	goLang := grammars.PerlLanguage()
+	if goLang == nil || goLang.Name != "perl" {
+		t.Fatalf("language=%v, want perl", goLang)
+	}
+	if goLang.ExternalScanner == nil || fmt.Sprintf("%T", goLang.ExternalScanner) != "grammars.PerlExternalScanner" {
+		t.Fatalf("scanner=%T, want grammars.PerlExternalScanner", goLang.ExternalScanner)
+	}
+	if _, ok := goLang.ExternalScanner.(gots.IncrementalReuseExternalScanner); ok {
+		t.Fatal("Perl scanner unexpectedly advertises incremental reuse")
+	}
+	for path, want := range map[string]string{
+		"../grammars/languages.lock":                        perlN31sGrammarLockSHA,
+		"../grammars/grammar_blobs/perl.bin":                perlN31sGrammarBlobSHA,
+		"../testdata/dispatcher_census_a0_manifest_v1.json": perlN31sA0ManifestSHA,
+		"../testdata/dispatcher_census_tracked_v1.json":     perlN31sTrackedManifestSHA,
+	} {
+		if got := perlN31sHashFile(t, path); got != want {
+			t.Fatalf("%s SHA-256=%s, want %s", path, got, want)
+		}
+	}
+	if got := perlN31sHashFile(t, "perf_scan/corpus_sources.lock.sha256"); got != perlN31sCorpusSidecarSHA {
+		t.Fatalf("corpus sidecar SHA-256=%s, want %s", got, perlN31sCorpusSidecarSHA)
+	}
+	sidecar, err := os.ReadFile("perf_scan/corpus_sources.lock.sha256")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(sidecar)) != perlN31sCorpusLockSHA+"  corpus_sources.lock" {
+		t.Fatalf("corpus sidecar=%q", string(sidecar))
+	}
+	for _, absent := range []string{"../corpus_sources.lock", "perf_scan/corpus_sources.lock"} {
+		if _, err := os.Stat(absent); !os.IsNotExist(err) {
+			t.Fatalf("unauthenticated corpus lock %s is present or readable: %v", absent, err)
+		}
+	}
+	cLang, err := COracleLanguage("perl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := COracleIdentity("perl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.Contract != COracleContractVersion || identity.Transport != "cgo_parity_binding" || identity.BindingModule != COracleBindingModule || identity.BindingVersion != COracleBindingVersion || identity.BindingCommit != COracleBindingCommit || identity.RuntimeVersion != COracleRuntimeVersion || identity.RuntimeCommit != COracleRuntimeCommit || identity.RuntimeLinkage != "static_cgo_test_binary" || identity.Language != "perl" || identity.GrammarRepo != perlN31sGrammarRepo || identity.GrammarCommit != perlN31sGrammarCommit || identity.GrammarLinkage != "shared_dlopen" || identity.GrammarCompileFlags != COracleGrammarCFlags || identity.CompilerPath != "/usr/bin/cc" || identity.CompilerVersion != "cc (Debian 12.2.0-14+deb12u1) 12.2.0" || identity.GrammarArtifactPath == "" || identity.GrammarArtifactSHA256 != perlN31sCArtifactSHA {
+		t.Fatalf("locked-C identity changed: %+v", identity)
+	}
+	t.Logf("base=%s locked_c_identity=%+v scanner=%T scanner_incremental_reuse=false included_ranges=not_applicable", perlN31sBaseCommit, identity, goLang.ExternalScanner)
+	for _, tc := range sources {
+		t.Run(tc.name, func(t *testing.T) {
+			want := perlN31sExpected(tc.name)
+			if got := fmt.Sprintf("%x", sha256.Sum256(tc.src)); got != want.sourceSHA {
+				t.Fatalf("source SHA-256=%s, want %s", got, want.sourceSHA)
+			}
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(tc.src, nil)
+			defer cTree.Close()
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cDigest != want.cDigest {
+				t.Fatalf("locked-C digest=%s, want %s", cDigest, want.cDigest)
+			}
+			parse := func(route string, candidate bool, fn func(*gots.Parser) (*gots.Tree, error)) {
+				p := gots.NewParser(goLang)
+				p.SetAdmissionCandidateRoute(candidate)
+				tree, err := fn(p)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer tree.Release()
+				inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), goLang)
+				if err != nil {
+					t.Fatal(err)
+				}
+				diff := FirstDivergenceDumpV1(tree.RootNode(), goLang, cTree.RootNode())
+				routeWant := want.routes[route]
+				if inspection.SHA256 != routeWant.digest || tree.RootNode().HasError() != routeWant.error || perlN31sDispatch(tree) != routeWant.dispatch || (diff == nil) != (routeWant.diff == nil) || (diff != nil && *diff != *routeWant.diff) {
+					t.Fatalf("%s result digest=%s error=%t divergence=%+v dispatch=%s, want digest=%s error=%t divergence=%+v dispatch=%s", route, inspection.SHA256, tree.RootNode().HasError(), diff, perlN31sDispatch(tree), routeWant.digest, routeWant.error, routeWant.diff, routeWant.dispatch)
+				}
+				t.Logf("source_sha256=%x route=%s digest=%s c_digest=%s error=%t c_error=%t divergence=%+v dispatch=%s rewrites=%d", sha256.Sum256(tc.src), route, inspection.SHA256, cDigest, tree.RootNode().HasError(), cTree.RootNode().HasError(), diff, perlN31sDispatch(tree), tree.ParseRuntime().NormalizationNodesRewritten)
+			}
+			parse("raw", false, func(p *gots.Parser) (*gots.Tree, error) { return p.ParseNoResultCompatibilityBenchmarkOnly(tc.src) })
+			parse("production", false, func(p *gots.Parser) (*gots.Tree, error) { return p.Parse(tc.src) })
+			beforeRouted, beforeFallback := gots.AdmissionCandidateCounters()
+			parse("compact", true, func(p *gots.Parser) (*gots.Tree, error) { return p.Parse(tc.src) })
+			afterRouted, afterFallback := gots.AdmissionCandidateCounters()
+			if afterRouted-beforeRouted != want.compactRouted || afterFallback-beforeFallback != want.compactFallback || gots.AdmissionCandidateLastFallbackReason() != want.compactReason {
+				t.Fatalf("compact counters=%d/%d reason=%q, want %d/%d reason=%q", afterRouted-beforeRouted, afterFallback-beforeFallback, gots.AdmissionCandidateLastFallbackReason(), want.compactRouted, want.compactFallback, want.compactReason)
+			}
+			t.Logf("compact routed=%d fallback=%d reason=%q", afterRouted-beforeRouted, afterFallback-beforeFallback, gots.AdmissionCandidateLastFallbackReason())
+			forestParser := gots.NewParser(goLang)
+			forest, ok := forestParser.ParseForestExperimental(tc.src)
+			if ok != want.forestOK {
+				t.Fatalf("forest accepted=%t, want %t", ok, want.forestOK)
+			}
+			if ok {
+				defer forest.Release()
+				inspection, err := benchfixtures.InspectGoTree(forest.RootNode(), goLang)
+				if err != nil {
+					t.Fatal(err)
+				}
+				diff := FirstDivergenceDumpV1(forest.RootNode(), goLang, cTree.RootNode())
+				if inspection.SHA256 != want.forestDigest || forest.RootNode().HasError() != want.forestError || perlN31sDispatch(forest) != want.forestDispatch || diff != nil {
+					t.Fatalf("forest digest=%s error=%t divergence=%+v dispatch=%s", inspection.SHA256, forest.RootNode().HasError(), diff, perlN31sDispatch(forest))
+				}
+				t.Logf("forest accepted=true digest=%s error=%t divergence=%+v dispatch=%s rewrites=%d", inspection.SHA256, forest.RootNode().HasError(), FirstDivergenceDumpV1(forest.RootNode(), goLang, cTree.RootNode()), perlN31sDispatch(forest), forest.ParseRuntime().NormalizationNodesRewritten)
+			} else {
+				t.Logf("forest accepted=false")
+			}
+			base := bytes.TrimSuffix(tc.src, []byte{'\n'})
+			incParser := gots.NewParser(goLang)
+			oldTree, err := incParser.Parse(base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer oldTree.Release()
+			oldTree.Edit(gots.InputEdit{StartByte: uint32(len(base)), OldEndByte: uint32(len(base)), NewEndByte: uint32(len(tc.src)), StartPoint: perlN31sPoint(base), OldEndPoint: perlN31sPoint(base), NewEndPoint: perlN31sPoint(tc.src)})
+			inc, profile, err := incParser.ParseIncrementalProfiled(tc.src, oldTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer inc.Release()
+			inspection, err := benchfixtures.InspectGoTree(inc.RootNode(), goLang)
+			if err != nil {
+				t.Fatal(err)
+			}
+			diff := FirstDivergenceDumpV1(inc.RootNode(), goLang, cTree.RootNode())
+			if inspection.SHA256 != want.incrementalDigest || inc.RootNode().HasError() != want.incrementalError || perlN31sDispatch(inc) != want.incrementalDispatch || diff != nil {
+				t.Fatalf("incremental digest=%s error=%t divergence=%+v dispatch=%s", inspection.SHA256, inc.RootNode().HasError(), diff, perlN31sDispatch(inc))
+			}
+			if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+				t.Fatalf("incremental reuse profile=%+v, want unsupported external scanner and zero reuse", profile)
+			}
+			t.Logf("incremental digest=%s error=%t divergence=%+v dispatch=%s rewrites=%d profile=%+v", inspection.SHA256, inc.RootNode().HasError(), FirstDivergenceDumpV1(inc.RootNode(), goLang, cTree.RootNode()), perlN31sDispatch(inc), inc.ParseRuntime().NormalizationNodesRewritten, profile)
+		})
+	}
+}
+
+func perlN31sDispatch(tree *gots.Tree) string {
+	if tree == nil || tree.ParseRuntime().NormalizationPasses == nil {
+		return "none"
+	}
+	for _, pass := range *tree.ParseRuntime().NormalizationPasses {
+		if pass.Name == "dispatch.perl" {
+			return fmt.Sprintf("%d/%d/%d/%d", pass.Checked, pass.Run, pass.NodesVisited, pass.NodesRewritten)
+		}
+	}
+	return "none"
+}
+
+func perlN31sPoint(source []byte) gots.Point {
+	var p gots.Point
+	for _, b := range source {
+		if b == '\n' {
+			p.Row++
+			p.Column = 0
+		} else {
+			p.Column++
+		}
+	}
+	return p
+}
+
+type perlN31sRoute struct {
+	digest, dispatch string
+	error            bool
+	diff             *DumpV1Divergence
+}
+
+type perlN31sExpectation struct {
+	sourceSHA, cDigest, incrementalDigest string
+	routes                                map[string]perlN31sRoute
+	compactRouted, compactFallback        uint64
+	compactReason                         string
+	forestOK, forestError                 bool
+	forestDigest, forestDispatch          string
+	incrementalError                      bool
+	incrementalDispatch                   string
+}
+
+func perlN31sExpected(name string) perlN31sExpectation {
+	baseDiff := &DumpV1Divergence{
+		Path:     "/source_file/expression_statement[0]/list_expression[0]",
+		Category: "type",
+		GoValue:  "list_expression",
+		CValue:   "ambiguous_function_call_expression",
+	}
+	if name == "push_two_args" {
+		const digest = "27dac6760d613fe9d554c1f4a73465d5ea5d339098540bd7bce136eead0d3916"
+		return perlN31sExpectation{
+			sourceSHA: "08ac06c62278aa8bb26361629ac930bbbfbe5031da04a54ee3aeec4875ce0b3b",
+			cDigest:   digest, incrementalDigest: digest,
+			routes: map[string]perlN31sRoute{
+				"raw":        {digest: "f084c77bb5f2c5824dbdf978f68b11f4069b85d9a2dd0a7d11c40ce5e9d2a4d9", diff: baseDiff, dispatch: "none"},
+				"production": {digest: digest, dispatch: "1/1/13/4"},
+				"compact":    {digest: digest, dispatch: "none"},
+			},
+			compactRouted: 1, compactFallback: 0,
+			forestOK: true, forestDigest: digest, forestDispatch: "1/1/13/0",
+			incrementalDispatch: "1/1/13/4",
+		}
+	}
+	const digest = "a18c7dba86442049b19f644c9db50b5d090340065698deb180e7b2088dff408e"
+	return perlN31sExpectation{
+		sourceSHA: "7be8389f1e6981c2e1e6324357df96ffb34063e9ea6811b8c332143e76015cd1",
+		cDigest:   digest, incrementalDigest: digest,
+		routes: map[string]perlN31sRoute{
+			"raw":        {digest: "6dfa1321087fae3d85fa419198d72c54cf3ee91258e49b1213c64ebf2192e20d", diff: baseDiff, dispatch: "none"},
+			"production": {digest: digest, dispatch: "1/1/17/4"},
+			"compact":    {digest: digest, dispatch: "none"},
+		},
+		compactRouted: 1, compactFallback: 0,
+		forestOK: true, forestDigest: digest, forestDispatch: "1/1/17/0",
+		incrementalDispatch: "1/1/17/4",
+	}
+}
+
+func perlN31sHashFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if len(b) == 0 {
+		t.Fatalf("evidence file %s is empty", path)
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(b))
+}

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -3354,6 +3354,106 @@ The authenticated corpus lock is absent; only its sidecar hash exists.
 Reopen this decision after a pinned corpus lock exists and all listed route digests match C.
 Require compact admission to accept every witness and the dispatcher to record zero rewrites.
 
+## 2026-08-24 Perl dispatcher blocker receipt
+
+Status: `KEEP LIVE / NO-GO`. Keep `dispatch.perl` live. Make no parser or registry change.
+
+### Perl selection proof
+
+The base is `af9ded2b77b7828b12b1d2da7c9fff8dd5ca053b`.
+The worktree is `/tmp/gotreesitter-n31s-next-arm.1787521201`.
+The excluded arms include every accepted receipt through WGSL.
+The base-main history search found no Perl receipt in the retirement document or changelog.
+The ownership record marks `dispatch.perl` as live with baseline corpus coverage only.
+The arm remains in `parser_result_compat.go` and calls `normalizePerlCompatibility`.
+The registry attaches `grammars.PerlExternalScanner` to Perl.
+The arm has one active sub-pass, `normalizePerlPushExpressionLists`.
+The existing local parity test identifies the `push` shape as load-bearing.
+
+The A0 and tracked manifests contain no Perl witness.
+Their hashes are `215df59aa56d28caa403f799733ef915db1c4ac07eb2bc96a9402f80cf67f80a`
+and `be584a0a4a26f0ca5268a7845cf3f04247e6b57259b9c7057e8eb2c9af26f839`.
+The receipt uses two deterministic source-hashed witnesses.
+The first source is `push @found, $_;` with hash
+`08ac06c62278aa8bb26361629ac930bbbfbe5031da04a54ee3aeec4875ce0b3b`.
+The second source is `push @found, $a, $b;` with hash
+`7be8389f1e6981c2e1e6324357df96ffb34063e9ea6811b8c332143e76015cd1`.
+
+### Perl identity and scanner
+
+The grammar lock hash is `9ddb6324afd014f6ecdd1cae3dd1ba238f1e62ce03d126e6d8b267ce34d72ecb`.
+The embedded Perl blob hash is `22388f06c2c54bb4748fd5f5f682ed25eecff8115a7e8e6a98f94f9c94bb9820`.
+The grammar is `https://github.com/tree-sitter-perl/tree-sitter-perl` at
+`ad74e6db234c35d537de9358799a8e0cc4f5dee0`.
+The C artifact hash is `3d8bb427c9043d5e4846f5cd83313afecf6b6e27be8fb82a7cd58f3b8f52ab87`.
+The C oracle uses `tree-sitter-c-v1`, binding `v0.25.0`, and runtime `0.25.1`.
+The binding commit is `adc13ffd8b2c0b01b878fda9f7c422ce0df5fad4`.
+The runtime commit is `f5afe475deb7c0bae6407fb776c76824f717bb61`.
+The compiler is `/usr/bin/cc`, version `cc (Debian 12.2.0-14+deb12u1) 12.2.0`.
+The scanner type is `grammars.PerlExternalScanner`.
+The scanner does not advertise incremental reuse.
+Included ranges are not applicable to this Perl registration.
+
+The corpus sidecar hash is `2b2209597d1701ccc813bd35d1685b5b13730e6ebd285e66485ce812e35877cf`.
+It names lock hash `41c744279c8b1d7c9fe7b1b8e26fba733423e77cd48efea46927309c22d163ea`.
+The lock file and the full Perl corpus are absent.
+
+### Perl route receipt
+
+The focused test is `cgo_harness/perl_n31s_dispatcher_blocker_receipt_test.go`.
+The test checks source and artifact identities without reading this document.
+The raw route bypasses normalization.
+The production route disables admission.
+The compact route enables admission.
+The forest and incremental routes use their normal parser entry points.
+The C oracle uses the pinned shared grammar artifact.
+
+The first witness uses locked-C digest `27dac6760d613fe9d554c1f4a73465d5ea5d339098540bd7bce136eead0d3916`.
+Raw digest is `f084c77bb5f2c5824dbdf978f68b11f4069b85d9a2dd0a7d11c40ce5e9d2a4d9`.
+Production, compact, forest, and incremental digest match locked C.
+Production dispatch is `1/1/13/4`.
+Forest dispatch is `1/1/13/0`.
+Incremental dispatch is `1/1/13/4`.
+Raw and compact dispatch are `none`.
+The raw divergence is a type mismatch at `/source_file/expression_statement[0]/list_expression[0]`.
+Go emits `list_expression`; locked C emits `ambiguous_function_call_expression`.
+
+The second witness uses locked-C digest `a18c7dba86442049b19f644c9db50b5d090340065698deb180e7b2088dff408e`.
+Raw digest is `6dfa1321087fae3d85fa419198d72c54cf3ee91258e49b1213c64ebf2192e20d`.
+Production, compact, forest, and incremental digest match locked C.
+Production dispatch is `1/1/17/4`.
+Forest dispatch is `1/1/17/0`.
+Incremental dispatch is `1/1/17/4`.
+Raw and compact dispatch are `none`.
+The raw divergence has the same path, category, and node-type values as the first witness.
+
+Each compact delta is one routed candidate and zero fallbacks.
+The fallback reason is empty.
+Forest accepts both witnesses.
+The runtime rewrite counter is zero on every route.
+Dispatch fourth fields record four compatibility node rewrites on production and incremental routes.
+Incremental reuse is unsupported because the Perl scanner lacks the reuse contract.
+Each incremental profile records `external_scanner_unsupported`, zero reused subtrees, and zero reused bytes.
+
+### Perl Docker evidence and decision
+
+Run the focused test in image `sha256:5060d2a11578710fdb0adc48e638efab98b3e7ff18bb5082596911fe86011b08`.
+Use one CPU, `GOMAXPROCS=1`, one C build job, and one test process.
+The artifact directory is `/tmp/gotreesitter-n31s-next-arm.1787521201/harness_out/docker/20260823T214723Z`.
+The container log hash is `6b6b27e69d4ed466cb2cbd424811184fae0ea053c5e62e240fa3f2cc328c04ff`.
+The inspection hash is `a10d105fdf3b7dc79ba23c26b8642690b63d755785eed4bae749a6077825348b`.
+The metadata hash is `d5ea890f83de3cf6baf0af78e59d38939ddcb2619de685162bdecc48bb4674b2`.
+The focused Docker test passed without an out-of-memory kill or timeout.
+
+Keep `dispatch.perl` live.
+The raw route still diverges from locked C on both witnesses.
+The normalized routes match locked C only after the compatibility arm runs.
+The authenticated Perl corpus lock is absent.
+Incremental reuse remains unsupported by the scanner.
+Reopen after a pinned Perl corpus lock exists and raw native trees match locked C.
+Require compact, forest, incremental, and locked-C routes to retain exact parity.
+Require the scanner to publish a sound incremental reuse contract before claiming reuse.
+
 ## Progress ledger
 
 | Ratchet | Status | Before | After | Evidence |


### PR DESCRIPTION
Remote durability checkpoint only — this draft PR is durable storage, not acceptance or a merge recommendation.

Preserves the exact authored working-tree blobs for entry #74, based on exact source HEAD `af9ded2b77b7828b12b1d2da7c9fff8dd5ca053b`. The original source state was staged; its exact staged file bytes were copied without altering the original index.

Validation performed before and after checkpoint:
- root `LICENSE` is tracked, non-empty, and MIT
- focused staged-patch gitleaks scan passed
- staged blob hashes matched the source worktree immediately before commit
- carrier commit parent equals the source HEAD
- local HEAD, upstream tracking ref, and live `git ls-remote` SHA are identical
- remote tree blobs match the captured source snapshot byte-for-byte
- carrier is clean and the original worktree was not edited

This branch is immutable archival evidence. Tests and review determine acceptance separately.