### PR TITLE
archive: preserve final campaign prong C delta

### DIFF
--- a/campaign/c1-universal-perf-profile.md
+++ b/campaign/c1-universal-perf-profile.md
@@ -1,0 +1,60 @@
+# C1 universal perf profile
+
+Evidence only. This profile ranks mechanism cohorts by their
+`projected_saved_go_ns` treatment under the C0f selection formula. It claims no
+performance credit: per `docs/c0e-c0f-attribution.md` (conflict
+`fleet-mechanism-facts`, line 54), no mechanism may be admitted and no 2%
+selection ceiling claimed until a trace lane supplies runtime facts.
+
+## Selection formula and threshold
+
+- Formula: `projected_saved_go_ns / sum(go_median_ns over measured signal rows) >= 0.02`
+  (`docs/c0e-c0f-attribution.md` line 48; `docs/c0e-c0f-attribution.json`
+  `formulas[4]`).
+- Denominator (measured signal Go time): **436,257,955,255 ns** over **1,315**
+  signal rows (`docs/c0e-c0f-attribution.md` line 28;
+  `docs/c0e-c0f-attribution.json` `c0f.signal_go_median_ns`,
+  `c0f.signal_rows`).
+- Threshold numerator at 0.02: **8,725,159,105 ns** (computed from the two
+  values above).
+- Signal definition: `axis.status == "ok" and predicates.ratio_interpretable ==
+  true`; timer threshold 1000 ns (`docs/c0e-c0f-attribution.md` line 26).
+
+## Ranked cohort table
+
+Ranked by admissible `projected_saved_go_ns` treatment. "Gap-bound projection"
+is `(1 - local_go_gap) applied in reverse`: `go_median_ns * local_go_gap`, i.e.
+the error-class excess Go time. It is an upper bound, not credit.
+
+| Rank | Cohort | Languages | Fleet ratio contribution | projected_saved_go_ns treatment | Evidence that admits it | Evidence that blocks it |
+|---:|---|---|---|---|---|---|
+| 1 | `recovery` | Fleet-wide error-class rows (444 rows across the V10 fleet's 206 validated languages, `docs/v10-fleet-manifest.md` lines 5–10). Memo-tier witnesses include Python, Elixir, Scala, Solidity, Enforce, Liquid, PureScript (`docs/t0-tail-cards.md` top-20 census, ranks 1–20) — witnesses, not code selectors | Error class ratio-by-total **13.569865x**; Go share of signal **72.2586%**; excess share of signal Go **66.9336%** (`docs/c0e-c0f-attribution.md` line 33; JSON `c0f.classes.error`) | Gap-bound projection **292,003,268,251 ns** = 66.93% of signal ≥ 0.02 threshold (**passes as upper bound only**) | Observable error-class proxy: `semantic_class == error` over 444 ratio-eligible rows (JSON `c0f.cohorts.recovery`) | No recovery-cost counter or retry count exists in V10/F0 (`docs/c0e-c0f-attribution.md` line 54). The proxy is "not a causal recovery counter" (JSON `c0f.cohorts.recovery.note`). No C0f receipt exists |
+| 2 | `alternative_lifetime` | None attributable; no per-row live-version lifetime exists for any of the 206 languages | **0 observed rows**; weight of signal Go **0.0000%** (`docs/c0e-c0f-attribution.md` line 44; JSON `c0f.cohorts.alternative_lifetime`) | Numerator **unevaluable**: C0f cannot evaluate it (`docs/c0e-c0f-attribution.md` line 48); evidence bound is 0..100% of signal Go time, no credit (JSON note) | Nothing yet | Missing runtime fact: live-version lifetime counter (`docs/c0e-c0f-attribution.md` line 54). Cannot pass or fail the 0.02 formula |
+| 3 | `scanner_boundary` | None attributable; no per-row scanner-call density exists | **0 observed rows**; weight of signal Go **0.0000%** (`docs/c0e-c0f-attribution.md` line 45; JSON `c0f.cohorts.scanner_boundary`) | Numerator **unevaluable**, same treatment as rank 2 | Nothing yet | Missing runtime fact: scanner-call density / scanner boundary predicate (`docs/c0e-c0f-attribution.md` line 54) |
+| 4 | `materialization` | None attributable; no materialization-work counter exists | **0 observed rows**; weight of signal Go **0.0000%** (`docs/c0e-c0f-attribution.md` line 46; JSON `c0f.cohorts.materialization`) | Numerator **unevaluable**, same treatment as rank 2 | Nothing yet | Missing runtime fact: materialization-work counter (`docs/c0e-c0f-attribution.md` line 54) |
+
+Context row (not a mechanism cohort): the clean class contributes ratio-by-total
+**7.286223x** and Go share **27.7414%**, with a gap-bound projection of
+104,414,251,192 ns = 23.93% of signal (`docs/c0e-c0f-attribution.md` lines
+32–33; JSON `c0f.classes.clean`). It is background against which mechanism
+cohorts are measured, not a selectable cohort.
+
+## Ranking rules and caveats
+
+1. Only `recovery` has an observable proxy, so only it can be ranked with a
+   number today; its number is a ceiling, not a claim.
+2. Ranks 2–4 tie at "unevaluable". Their order is alphabetical from the board,
+   not evidentiary.
+3. Cohort ceilings are non-exclusive: the three unobserved cohorts each carry a
+   100%-of-signal upper bound, so ceilings must never be summed
+   (`docs/c0e-c0f-attribution.md` line 39: "Their 100% values are upper bounds").
+4. Hygiene rows (2 rows below the 1000 ns timer threshold) stay outside the
+   signal denominator (`docs/c0e-c0f-attribution.md` line 35;
+   `docs/v10-fleet-manifest.md` lines 28–31).
+5. The Perl tail card stays not-actionable pending a size series
+   (`docs/t0-tail-cards.md` card 6); zero-byte HTTP rows are hygiene-excluded
+   from ratio credit (`docs/t0-tail-cards.md` census ranks 8–9).
+6. Next evidence gate: a trace lane supplying retry counts, recovery-cost
+   counters, live-version lifetimes, scanner-call density, and
+   materialization-work counters, after which the numerator becomes evaluable
+   and a C0f receipt may be authored.

--- a/campaign/c2-hygiene-provenance-plan.md
+++ b/campaign/c2-hygiene-provenance-plan.md
@@ -1,0 +1,79 @@
+# C2 hygiene provenance plan
+
+Evidence-only plan. It states exactly what must attach to the F0 hygiene
+denominator before it is sealed-acceptable, per the unresolved conflict
+`hygiene-provenance` in `docs/c0e-c0f-attribution.md` (line 55):
+
+> F0 records 1000 ns as a fixed reporting policy, but the V10 metadata has no
+> timer calibration or pre-run threshold record. Treat the F0 hygiene
+> denominator as queryable evidence, not sealed C6f acceptance proof, until
+> threshold provenance is attached.
+
+## What is missing today
+
+1. **No timer-calibration record.** The V10 scoreboard metadata carries no
+   calibration of the Go and C timers used for `go_median_ns` /
+   `c_median_ns` (`docs/v10-fleet-manifest.md` lines 5–12 record only source
+   revision, scoreboard SHA-256, axis, and validation counts).
+2. **No pre-run threshold declaration.** The 1000 ns hygiene threshold appears
+   only as a fixed reporting policy at manifest generation time
+   (`docs/v10-fleet-manifest.md` line 33: "The fixed F0 hygiene threshold is
+   `1000 ns`. The threshold applies to reporting only."), i.e. after the fact,
+   not as a pre-registered run parameter.
+3. **Uncontrolled host.** The only published noise evidence is a local shared
+   WSL2 A/A floor of 7.367%–10.803% p95 (`docs/c0e-c0f-attribution.md`
+   line 22), explicitly "not a sealed-v9 noise floor". The fleet host's noise
+   floor is unpublished.
+
+## What must attach to make the denominator sealed-acceptable
+
+| # | Artifact | Required content |
+|---:|---|---|
+| 1 | Timer calibration record | Per-timer (Go and C) calibration against a reference clock on the fleet measurement host, with method, sample count, and drift bound; taken in the same epoch as the scoreboard |
+| 2 | Pre-run threshold declaration | The `timer_threshold_ns = 1000` value recorded as a run parameter *before* measurement, with author and timestamp, hash-bound into the scoreboard metadata |
+| 3 | Host noise-floor receipt | An A/A null distribution from the fleet host itself (the local WSL2 floor cannot substitute — `docs/c0e-c0f-attribution.md` line 22) |
+| 4 | Threshold-sensitivity statement | Which rows move across the 1000 ns boundary under plausible timer error; today 2 hygiene rows and 1,315 ratio-eligible rows depend on this cut (`docs/v10-fleet-manifest.md` lines 28–29) |
+
+## Receipt skeleton
+
+```json
+{
+  "schema": "gts-f0-hygiene-provenance/v1",
+  "subject_scoreboard_sha256": "<sha256 of v10 scoreboard>",
+  "threshold": {
+    "timer_threshold_ns": 1000,
+    "declared_before_run": true,
+    "declared_at": "<ISO-8601 timestamp preceding epoch start>",
+    "declared_by": "<author identity>"
+  },
+  "timer_calibration": {
+    "host_id": "<fleet measurement host identifier>",
+    "epoch": "<measurement epoch id matching the scoreboard>",
+    "go_timer": { "reference_clock": "<clock>", "method": "<method>",
+                  "samples": <n>, "drift_bound_pct": <pct> },
+    "c_timer":  { "reference_clock": "<clock>", "method": "<method>",
+                  "samples": <n>, "drift_bound_pct": <pct> }
+  },
+  "host_noise_floor": {
+    "aa_null_runs": <n>,
+    "p95_abs_delta_pct": { "min": <pct>, "max": <pct> }
+  },
+  "threshold_sensitivity": {
+    "rows_at_cut": { "hygiene_below_1000ns": 2, "ratio_eligible": 1315 },
+    "rows_moving_under_drift_bound": <n>
+  },
+  "seal": { "receipt_sha256": "<self-hash>", "signed_by": "<signer>" }
+}
+```
+
+Fixed values already citable: `hygiene_below_1000ns = 2` and
+`ratio_eligible = 1315` come from `docs/c0e-c0f-attribution.md` line 35
+("2 hygiene rows; 1,315 ratio-eligible"). All other fields are unfilled until
+the calibration lane runs.
+
+## Acceptance rule
+
+The F0 hygiene denominator becomes sealed-acceptable when items 1–4 above are
+attached and hash-bound to the scoreboard they describe. Until then, any
+number that depends on the 1000 ns cut (including the C0f signal row count and
+the selection-formula denominator) remains queryable evidence, not sealed proof.

--- a/campaign/c3-sealed-share-join-note.md
+++ b/campaign/c3-sealed-share-join-note.md
@@ -1,0 +1,60 @@
+# C3 sealed-share join note
+
+Evidence-only note. It defines how C0e board ratios and C0f fleet shares may
+be cited together without conflation, resolving the citation-side practice for
+the unresolved conflict `sealed-share-join` in
+`docs/c0e-c0f-attribution.md` (line 53):
+
+> The sealed board contains ratios and A/A nulls, but no component profile.
+> The local C0 profile is a different host and diagnostic instrument. Keep C0e
+> ratios and C0e noise evidence separate from C0f fleet shares.
+
+## The two instruments
+
+| | C0e sealed equal-fixture board | C0f fleet board |
+|---|---|---|
+| Epoch / commit | `strictboundary-20260802T062212Z-v9`, commit `492cd600…` (`docs/c0e-c0f-attribution.md` line 11) | V10 scoreboard, revision `5003ffba…` (`docs/c0e-c0f-attribution.md` line 28; `docs/v10-fleet-manifest.md` lines 5–8) |
+| Fixture scope | 4 compact Go/C fixtures (`docs/c0e-c0f-attribution.md` lines 13–18) | 1,315 ratio-eligible signal rows across 206 languages (`docs/v10-fleet-manifest.md` line 12; `docs/c0e-c0f-attribution.md` line 29) |
+| What it publishes | Per-fixture ratios and a geomean (3.986x) | Class totals, shares, distributions, cohort ceilings |
+| Noise evidence | Local WSL2 A/A p95 floor 7.367%–10.803% (`docs/c0e-c0f-attribution.md` line 22) | None published for its own host |
+
+## Citation rules
+
+1. **Never derive a share from a ratio or a ratio from a share.** The C0e
+   geomean 3.986x describes four named fixtures; the C0f ratio-by-total
+   10.950130x describes fleet signal totals (`docs/c0e-c0f-attribution.md`
+   lines 11, 28). They measure different populations on different hosts and
+   must not be averaged, blended, or used to scale each other.
+2. **Tag every number with its board.** Acceptable forms:
+   "C0e(v9) fixture ratio 4.348x (`rewrite.go`)" and
+   "C0f(V10) error-class Go share 72.2586%". Unacceptable: "the ratio is
+   3.986x so recovery saves …".
+3. **Keep each board's noise with it.** The 7.367%–10.803% A/A floor belongs to
+   the local C0 host only; it may qualify C0e fixture deltas but never C0f
+   fleet shares (`docs/c0e-c0f-attribution.md` line 22).
+4. **A join sentence is permitted only in the form of adjacency, not
+   arithmetic**: e.g. "C0e(v9) reports compact geomean 3.986x against its
+   ≤2.0x target (geomean pass false); separately, C0f(V10) attributes
+   72.2586% of signal Go time to the error class." Both clauses cite their own
+   source; neither implies the other.
+5. **No mechanism admission via join.** Citing a C0e ratio next to a C0f cohort
+   share does not satisfy the `fleet-mechanism-facts` gate
+   (`docs/c0e-c0f-attribution.md` line 54): runtime trace facts are still
+   required before any cohort's projected_saved_go_ns numerator is evaluable.
+6. **Byte denominators stay separate too.** The R1 39.0% error-byte share and
+   the F0 signal-byte 32.2343% (84,094,345 / 260,884,819) must both be
+   published with their own denominators and never reconciled by fiat
+   (`docs/c0e-c0f-attribution.md` line 56).
+
+## Join table template
+
+Any document citing both boards should use rows of this shape:
+
+| Claim | Board | Value | Source anchor |
+|---|---|---|---|
+| Compact equal-fixture geomean | C0e(v9) | 3.986x | `docs/c0e-c0f-attribution.md` line 11 |
+| Fleet signal ratio-by-total | C0f(V10) | 10.950130x | `docs/c0e-c0f-attribution.md` line 28 |
+| Error-class Go share of signal | C0f(V10) | 72.2586% | `docs/c0e-c0f-attribution.md` line 33 |
+
+Rows from different boards may appear in one table but never combine into a
+computed column.

--- a/campaign/c3-sealed-share-join-note.md
+++ b/campaign/c3-sealed-share-join-note.md
@@ -46,6 +46,100 @@ the unresolved conflict `sealed-share-join` in
    published with their own denominators and never reconciled by fiat
    (`docs/c0e-c0f-attribution.md` line 56).
 
+## Worked examples
+
+Each example states the sentence form, why it passes or fails, and its anchors.
+All values are quoted unchanged from their own boards
+(`docs/c0e-c0f-attribution.md` lines 11, 15, 20, 22, 28, 33, 48, 54, 56).
+
+### Correct claims
+
+**C1 — C0e ratio cited alone, board-tagged.**
+> "C0e(v9) reports fixture `rewrite.go` at compact Go/C **4.348x**
+> (`docs/c0e-c0f-attribution.md` line 15), against the sealed target of
+> ≤3.0x per fixture (line 20)."
+
+*Passes:* single board, named fixture, ratio kept as a ratio, target cited
+from the same board. No share is implied.
+
+**C2 — C0f share cited alone, denominator explicit.**
+> "C0f(V10) attributes **72.2586%** of measured signal Go time (436,257,955,255 ns
+> over 1,315 rows) to the error class (`docs/c0e-c0f-attribution.md` lines
+> 28, 33)."
+
+*Passes:* the share names its denominator (signal Go ns) and row population,
+both from the C0f board.
+
+**C3 — Adjacency join, no arithmetic.**
+> "C0e(v9) reports a compact Go/C geomean of **3.986x**, failing its ≤2.0x
+> target (geomean pass false, `docs/c0e-c0f-attribution.md` lines 11, 20);
+> separately, C0f(V10) attributes **72.2586%** of signal Go time to the error
+> class (line 33). The two statements concern different hosts and populations;
+> neither scales the other."
+
+*Passes:* rule 4's permitted form. Each clause cites its own board; the final
+sentence restates non-derivability rather than computing anything.
+
+**C4 — Byte denominators published side by side, unreconciled.**
+> "R1 reports a **39.0%** error-byte share under an R1-defined byte
+> denominator; F0 signal bytes give **32.2343%** (84,094,345 / 260,884,819)
+> (`docs/c0e-c0f-attribution.md` line 56). Both are published with their own
+> denominators; they are not reconciled here."
+
+*Passes:* rule 6. Two byte figures coexist without blending because their
+denominators differ and one is undefined in this artifact.
+
+### Incorrect claims
+
+**W1 — Deriving a fleet share from the C0e geomean (arithmetic conflation).**
+> ✗ "The compact geomean is 3.986x and the error class holds 72.2586% of Go
+> time, so error-class code is 3.986 × 0.722586 = **2.8802x slower** overall."
+
+*Fails:* rules 1–2. It multiplies a four-fixture C0e(v9) geomean by a C0f(V10)
+fleet share — different hosts, different populations. The product
+**2.8802x** is meaningless and must not appear in any document. No source
+supports it.
+
+**W2 — Borrowing the C0e noise floor to qualify a C0f number.**
+> ✗ "The C0f error-class share 72.2586% carries ±7.367%–10.803% measurement
+> noise."
+
+*Fails:* rule 3. The 7.367%–10.803% p95 A/A floor is a local WSL2 C0-host
+result and is explicitly not a sealed-v9 or fleet noise floor
+(`docs/c0e-c0f-attribution.md` line 22); per `campaign/c2-hygiene-provenance-plan.md`
+(item 3) the fleet host's noise floor is unpublished until its own A/A receipt
+attaches. Attaching the local floor to a C0f share fabricates provenance.
+
+**W3 — Using a join to admit a mechanism or claim the selection ceiling.**
+> ✗ "Since the error class is 72.2586% of signal and C0e shows ~4x compact
+> ratios, the recovery cohort clears the 2% selection threshold and may be
+> credited."
+
+*Fails:* rule 5. The 0.02 selection formula needs an evaluable
+`projected_saved_go_ns` numerator from runtime trace facts (retry counts,
+recovery-cost counters), which V10/F0 do not contain
+(`docs/c0e-c0f-attribution.md` lines 48, 54; conflict `fleet-mechanism-facts`).
+Adjacency cannot substitute for the trace lane, and no performance credit may
+be claimed before a C0f receipt exists.
+
+**W4 — Dropping board tags so the two totals read as one scale.**
+> ✗ "The boards show ratios of 3.986x and 10.950130x, i.e. roughly a 4x-to-11x
+> improvement range across the project."
+
+*Fails:* rules 1–2. 3.986x is a four-fixture compact geomean on C0e(v9)
+(line 11); 10.950130x is a fleet-wide ratio-by-total over 1,315 signal rows on
+C0f(V10) (line 28). Presenting them as points on one range implies a common
+population that does not exist.
+
+**W5 — Reconciling byte shares by fiat.**
+> ✗ "The 39.0% R1 byte share and the 32.2343% F0 byte share agree within
+> rounding after hygiene adjustments."
+
+*Fails:* rule 6 and the unresolved `error-byte-denominator` conflict
+(`docs/c0e-c0f-attribution.md` line 56): R1's byte denominator is undefined in
+this artifact, so no reconciliation — including "within rounding" — is
+licensed.
+
 ## Join table template
 
 Any document citing both boards should use rows of this shape:


### PR DESCRIPTION
Remote durability checkpoint for the final quiescent prong C delta after its Buckley owner exited.

This draft is based on the already-preserved commit `d8fecafb8f73cb21b53a0dfdc7efe59c68807a1f` and adds the exact final `c3` blob. It is durable storage for review and is not merge acceptance.