### PR TITLE
fix(highlighting): key injected queries by source

### DIFF
--- a/highlight_injections_exec.go
+++ b/highlight_injections_exec.go
@@ -132,7 +132,10 @@ func (h *Highlighter) collectInjectedHighlightRanges(ctx injectedHighlightContex
 }
 
 func (h *Highlighter) childHighlightQuery(cacheKey string, querySource string, lang *Language) (*Query, bool) {
-	childQuery := h.childQueries[cacheKey]
+	// Combine the language resolver key and the exact query source so queries
+	// compiled from different sources are never confused for one another.
+	compositeKey := cacheKey + "\x00" + querySource
+	childQuery := h.childQueries[compositeKey]
 	if childQuery != nil {
 		return childQuery, true
 	}
@@ -140,7 +143,7 @@ func (h *Highlighter) childHighlightQuery(cacheKey string, querySource string, l
 	if err != nil {
 		return nil, false
 	}
-	h.childQueries[cacheKey] = childQuery
+	h.childQueries[compositeKey] = childQuery
 	return childQuery, true
 }
 

--- a/highlight_injections_exec_test.go
+++ b/highlight_injections_exec_test.go
@@ -1,0 +1,33 @@
+package gotreesitter
+
+import "testing"
+
+func TestChildHighlightQueryCacheIncludesQuerySource(t *testing.T) {
+	lang := queryTestLanguage()
+	h := &Highlighter{childQueries: make(map[string]*Query)}
+
+	first, ok := h.childHighlightQuery("shared-language", `(identifier) @first`, lang)
+	if !ok {
+		t.Fatal("first child query did not compile")
+	}
+	firstAgain, ok := h.childHighlightQuery("shared-language", `(identifier) @first`, lang)
+	if !ok {
+		t.Fatal("repeated child query did not compile")
+	}
+	if firstAgain != first {
+		t.Fatal("identical resolver query sources did not reuse one cached query")
+	}
+
+	second, ok := h.childHighlightQuery("shared-language", `(identifier) @second`, lang)
+	if !ok {
+		t.Fatal("second child query did not compile")
+	}
+	if first == second {
+		t.Fatal("different resolver query sources reused one cached query")
+	}
+
+	matches := second.Execute(buildSimpleTree(lang))
+	if len(matches) != 1 || len(matches[0].Captures) != 1 || matches[0].Captures[0].Name != "second" {
+		t.Fatalf("second query captures = %#v, want @second", matches)
+	}
+}


### PR DESCRIPTION
## Summary

- Include the exact injection query source in the child-query cache key.
- Keep cache reuse for an identical language key and query source.
- Add a regression for two query sources that use the same language key.

## Validation

- `go test . -run '^TestChildHighlightQueryCacheIncludesQuerySource$' -count=20`
- `go test . -run '^(TestHighlight|TestHighlighter|TestChildHighlight)' -count=1`
- `go test ./roottest/highlight ./roottest/query -count=1`
- Focused Docker race test passed.
- `git diff --check` passed.
- Gitleaks passed for both changed files.
- Docker `go test ./... -count=1 -timeout 20m` passed outside `grammargen`.

The `grammargen` package still reports its existing Markdown CST parity, YAML inventory and compact-blob, `markdown_inline` table-limit, and YAML compact-blob failures. This change has no `grammargen` diff. The container had no out-of-memory kill or wall timeout.

The branch started at `d72987b44b76cf39aa4ad0f5fff03860eed7cd0d`. Current `main` adds only a compact-parser receipt after that commit. It does not overlap the two files in this change, and the merge tree is clean.
