### PR TITLE
Record Kotlin normalization blocker receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,17 @@ for tags and release notes while still in `0.x`.
   witness flips the root error flag. The checked-in Julia source keeps a type
   divergence. Compact falls back on two witnesses, and the authenticated corpus
   lock is absent. Keep the arm live. No parser or registry change is included.
+- Recorded the next single-grammar normalization blocker, `dispatch.kotlin`,
+  at base `d72987b44b76cf39aa4ad0f5fff03860eed7cd0d`.
+  The focused Docker gate used the parser-produced witness
+  `tasks.named<KotlinCompile>("compile") {}`.
+  The raw and production deep digests differ.
+  Production records `dispatch.kotlin` as checked 1, run 1, visited 22,
+  and rewritten 23. The recovered-root subpass records zero rewrites.
+  Keep the parent arm live. Stop before compact, strict forest, edited
+  incremental, fatal locked-C, survivor, registry, or dead-reference proofs.
+  Reopen only after native Kotlin derivation emits every listed shape without
+  parent rewrites or parser-state changes. No parser or registry change ships.
   See `docs/root-normalization-retirement.md`.
 
 - Recorded the next unreceipted `dispatch.templ` blocker at base

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -113,6 +113,92 @@ Reopen retirement only after all conditions pass:
 6. Re-trigger or retire each of the five Julia sub-repairs under current grammar bytes.
 
 Keep the registry arm unchanged until every condition passes.
+## 2026-08-24 Kotlin dispatcher blocker receipt
+
+Status: `KEEP LIVE / NO-GO`. Keep `dispatch.kotlin` live.
+
+Base commit: `d72987b44b76cf39aa4ad0f5fff03860eed7cd0d`.
+This slice adds one focused test. It changes no parser or registry behavior.
+
+The Julia queue names `dispatch.kotlin` as the next single-grammar parent arm.
+The ownership registry assigns it index 47, language `kotlin`, and owner
+`derivation_election_selection`. The retired interpolation member remains a
+separate entry at index 48.
+
+Canopy finds the dispatcher call at `parser_result_compat.go:162`.
+It finds the parent definition at `parser_result_kotlin.go:9-23`.
+The parent calls the live generic-call, prefix-comparison, raw-string,
+callable-reference, and receiver-name members directly.
+The recovered-root member has its own census boundary.
+
+The Kotlin grammar lock has SHA-256
+`9ddb6324afd014f6ecdd1cae3dd1ba238f1e62ce03d126e6d8b267ce34d72ecb`.
+It pins `https://github.com/fwcd/tree-sitter-kotlin` at commit
+`cbed96ab13dbc082eeeb2e8333c342a62829c29d`.
+The embedded Kotlin grammar blob has SHA-256
+`643a3e6b60d07846dd972849b612159ff9bf09734b09fb00013229c8593a8c78`.
+The Kotlin normalizer has SHA-256
+`c0577c69e20d8e725692547eba72a764a08df1fe86c10c368e4c31f65c0a9926`.
+The Kotlin implementation, generated grammar, scanner, blob, and witness
+files are byte-identical between the N58 evidence base `bb09ff6978cb2e46d98b805c0e2f6bb7d4429e24`
+and this base. The ownership registry changed for unrelated retirements.
+Its Kotlin parent and retired-member entries remain unchanged.
+
+### Current-first gate
+
+The parser-produced witness is
+`tasks.named<KotlinCompile>("compile") {}`.
+Its source SHA-256 is
+`efc3157ca94245c59ff5d093ca456c319f2518882f4b9a28303baa25182ec4fc`.
+
+The focused Docker command used the single-grammar test below:
+
+```text
+bash cgo_harness/docker/run_parity_in_docker.sh --repo-root /tmp/gotreesitter-normalization-next-d729 --out-root /tmp/gotreesitter-normalization-next-d729/harness_out/docker --label n59-kotlin-current-first --memory 4g --cpus 1 --pids 512 --gomemlimit 3GiB --goflags '-p=1' --test-parallel 1 --timeout 20m --no-build -- 'cd /workspace && go test ./parser_result_test -run "^TestKotlinDispatcherCurrentFirstGate$" -count=1 -parallel 1 -timeout 20m -v'
+```
+
+The test passed with exit code zero.
+The container used image `gotreesitter/cgo-harness:go1.25-local`.
+It used 4 GiB memory, one central processing unit, 512 process IDs, and a
+3 GiB Go memory limit.
+The artifact log has SHA-256
+`74832c55994946b59838a2cbcddbd64ed580b951ce77bb0901339f2b405b58ac`.
+The metadata has SHA-256
+`c6f531add69b75e3ebe41fdfe384657d129ad49dfa340c0e0d36329c00325816`.
+The inspection record has SHA-256
+`440049970143662f5d1b47f711050e7e6f6ba0650b0e92c3eeb4bd5c37fdfd1d`.
+
+The raw route used deep digest
+`3d14ddefaa0623a36781cde5455f20fe798c63b6b62b4178500b3d4ab48653bc`.
+It recorded no compatibility pass.
+The production route used deep digest
+`3f89c1a3d1cc592c1c607a8bceeac417c4849e87e39de005efeb46e14ba629db`.
+It recorded `dispatch.kotlin` as checked 1, run 1, visited 22, and rewritten 23.
+The recovered-root subpass recorded checked 1, run 1, visited 22, and rewritten 0.
+The raw and production digests differ, so the parent arm remains live.
+
+Stop after this first live parent rewrite.
+Do not run compact, strict forest, edited incremental, fatal locked-C, survivor,
+registry, or dead-reference retirement proofs in this receipt.
+The focused gate does not claim route-complete retirement.
+
+### Reopening conditions
+
+Reopen `dispatch.kotlin` only after `derivation_election_selection` emits all
+listed Kotlin shapes without compatibility rewrites or parser-state changes:
+
+- generic calls with type arguments;
+- prefix comparisons;
+- callable references;
+- raw strings;
+- receiver function names;
+- recovered source-file roots.
+
+Then certify exact raw, production, compact, strict forest, edited incremental,
+fatal locked-C, survivor, registry, and dead-reference routes.
+Preserve the retired interpolation member and its exact receipt.
+
+Keep `dispatch.kotlin` unchanged until every condition passes.
 
 ## 2026-08-24 C and C++ dispatcher blocker receipt
 

--- a/parser_result_test/kotlin_dispatcher_current_first_test.go
+++ b/parser_result_test/kotlin_dispatcher_current_first_test.go
@@ -1,0 +1,96 @@
+package parserresult_test
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+const (
+	kotlinDispatcherWitnessSHA256    = "efc3157ca94245c59ff5d093ca456c319f2518882f4b9a28303baa25182ec4fc"
+	kotlinDispatcherRawDigest        = "3d14ddefaa0623a36781cde5455f20fe798c63b6b62b4178500b3d4ab48653bc"
+	kotlinDispatcherProductionDigest = "3f89c1a3d1cc592c1c607a8bceeac417c4849e87e39de005efeb46e14ba629db"
+)
+
+// TestKotlinDispatcherCurrentFirstGate stops at the first live parent rewrite.
+func TestKotlinDispatcherCurrentFirstGate(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	lang := grammars.KotlinLanguage()
+	if lang == nil || lang.Name != "kotlin" {
+		t.Fatalf("language=%v, want kotlin", lang)
+	}
+	source := []byte(`tasks.named<KotlinCompile>("compile") {}`)
+	if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != kotlinDispatcherWitnessSHA256 {
+		t.Fatalf("source SHA-256=%s, want %s", got, kotlinDispatcherWitnessSHA256)
+	}
+
+	rawParser := gotreesitter.NewParser(lang)
+	rawParser.SetAdmissionCandidateRoute(false)
+	raw, err := rawParser.ParseNoResultCompatibilityBenchmarkOnly(source)
+	if err != nil {
+		t.Fatalf("raw parse: %v", err)
+	}
+	defer raw.Release()
+	rawInspection, err := benchfixtures.InspectGoTree(raw.RootNode(), lang)
+	if err != nil {
+		t.Fatalf("inspect raw tree: %v", err)
+	}
+	if rawInspection.SHA256 != kotlinDispatcherRawDigest {
+		t.Fatalf("raw digest=%s, want %s", rawInspection.SHA256, kotlinDispatcherRawDigest)
+	}
+	if pass, ok := kotlinDispatcherPass(raw); ok {
+		t.Fatalf("raw dispatch.kotlin pass=%+v, want no compatibility pass", pass)
+	}
+
+	productionParser := gotreesitter.NewParser(lang)
+	productionParser.SetAdmissionCandidateRoute(false)
+	production, err := productionParser.Parse(source)
+	if err != nil {
+		t.Fatalf("production parse: %v", err)
+	}
+	defer production.Release()
+	productionInspection, err := benchfixtures.InspectGoTree(production.RootNode(), lang)
+	if err != nil {
+		t.Fatalf("inspect production tree: %v", err)
+	}
+	if productionInspection.SHA256 != kotlinDispatcherProductionDigest {
+		t.Fatalf("production digest=%s, want %s", productionInspection.SHA256, kotlinDispatcherProductionDigest)
+	}
+	if rawInspection.SHA256 == productionInspection.SHA256 {
+		t.Fatal("raw and production digests match; the live parent rewrite is not reproduced")
+	}
+	pass, ok := kotlinDispatcherPass(production)
+	if !ok {
+		t.Fatal("production did not record dispatch.kotlin")
+	}
+	if pass.Checked != 1 || pass.Run != 1 || pass.NodesVisited != 22 || pass.NodesRewritten != 23 {
+		t.Fatalf("production dispatch.kotlin=%+v, want checked=1 run=1 visited=22 rewritten=23", pass)
+	}
+	recovered, ok := kotlinDispatcherSubpass(production, "dispatch.kotlin.recovered-source-file-root")
+	if !ok {
+		t.Fatal("production did not record dispatch.kotlin.recovered-source-file-root")
+	} else if recovered.Checked != 1 || recovered.Run != 1 || recovered.NodesVisited != 22 || recovered.NodesRewritten != 0 {
+		t.Fatalf("production recovered-root pass=%+v, want checked=1 run=1 visited=22 rewritten=0", recovered)
+	}
+	t.Logf("source_sha256=%s raw_digest=%s production_digest=%s dispatch.kotlin=%d/%d/%d/%d recovered_root=%d/%d/%d/%d", kotlinDispatcherWitnessSHA256, rawInspection.SHA256, productionInspection.SHA256, pass.Checked, pass.Run, pass.NodesVisited, pass.NodesRewritten, recovered.Checked, recovered.Run, recovered.NodesVisited, recovered.NodesRewritten)
+}
+
+func kotlinDispatcherPass(tree *gotreesitter.Tree) (gotreesitter.NormalizationPassRuntime, bool) {
+	return kotlinDispatcherSubpass(tree, "dispatch.kotlin")
+}
+
+func kotlinDispatcherSubpass(tree *gotreesitter.Tree, name string) (gotreesitter.NormalizationPassRuntime, bool) {
+	if tree == nil || tree.ParseRuntime().NormalizationPasses == nil {
+		return gotreesitter.NormalizationPassRuntime{}, false
+	}
+	for _, pass := range *tree.ParseRuntime().NormalizationPasses {
+		if pass.Name == name {
+			return pass, true
+		}
+	}
+	return gotreesitter.NormalizationPassRuntime{}, false
+}


### PR DESCRIPTION
Status: KEEP LIVE / NO-GO

Record the Kotlin `dispatch.kotlin` normalization blocker.

- The raw and production trees diverge for the parser-produced witness.
- Production records `dispatch.kotlin` as checked 1, run 1, visited 22, and rewritten 23.
- The recovered-root subpass records checked 1, run 1, visited 22, and rewritten 0.
- The focused Docker gate passed with one grammar, one CPU, and one Go test worker.
- The change adds one focused test and no parser or registry behavior.

Evidence:

- Artifact log and metadata are recorded in `docs/root-normalization-retirement.md` with SHA-256 values.
- The raw digest is `3d14ddefaa0623a36781cde5455f20fe798c63b6b62b4178500b3d4ab48653bc`.
- The production digest is `3f89c1a3d1cc592c1c607a8bceeac417c4849e87e39de005efeb46e14ba629db`.

Keep `dispatch.kotlin` live. Reopen after native Kotlin derivation emits every listed shape without compatibility rewrites or parser-state changes. Then certify raw, production, compact, strict forest, edited incremental, fatal locked-C, survivor, registry, and dead-reference routes.
