### PR TITLE
fix(injection): handle nil incremental result

### DIFF
--- a/injection.go
+++ b/injection.go
@@ -198,6 +198,10 @@ func (ip *InjectionParser) ParseUTF16Bytes(source []byte, parentLang string, ord
 func (ip *InjectionParser) ParseIncremental(source []byte, parentLang string,
 	oldResult *InjectionResult) (*InjectionResult, error) {
 
+	if oldResult == nil {
+		return ip.Parse(source, parentLang)
+	}
+
 	// Detach prevResult now; release it after parsing so that oldResult.Tree
 	// (which may be the same object) remains valid throughout the parse.
 	prev := ip.prevResult

--- a/injection_test.go
+++ b/injection_test.go
@@ -449,6 +449,27 @@ func TestInjectionParserEmptySource(t *testing.T) {
 	}
 }
 
+func TestProbeInjectionParserParseIncrementalNilOldResult(t *testing.T) {
+	parentLang := buildContainerLanguage()
+	ip := NewInjectionParser()
+	ip.RegisterLanguage("container", parentLang)
+
+	result, err := ip.ParseIncremental([]byte("[value]"), "container", nil)
+	if err != nil {
+		t.Fatalf("ParseIncremental with nil old result: %v", err)
+	}
+	if result == nil || result.Tree == nil {
+		t.Fatal("ParseIncremental with nil old result returned no tree")
+	}
+	if result.Tree.RootNode() == nil {
+		t.Fatal("ParseIncremental with nil old result returned no root node")
+	}
+	root := result.Tree.RootNode()
+	if got := string(root.Text([]byte("[value]"))); got != "[value]" {
+		t.Errorf("root text = %q, want %q", got, "[value]")
+	}
+}
+
 func TestInjectionResultRanges(t *testing.T) {
 	parentLang := buildContainerLanguage()
 	childLang := buildArithmeticLanguage()


### PR DESCRIPTION
## Summary

- make byte-oriented injection incremental parsing fall back to an initial parse when no prior result is supplied
- add a regression proving the fallback returns a rooted tree with the supplied source text

## Validation

- baseline `go test . -run '^TestInjectionParser' -count=1`
- failing baseline probe: nil prior result panics at `injection.go:215`
- `go test . -run '^TestProbeInjectionParserParseIncrementalNilOldResult$' -count=20`
- `go test . -run '^TestInjectionParser' -count=1`
- `go test -race . -run '^TestProbeInjectionParserParseIncrementalNilOldResult$' -count=1`
- `GOFLAGS=-buildvcs=false go test ./cmd/grammarblobprobe -count=1`
- `git diff --check`
- gitleaks on both changed files

Paired baseline and feature `go test ./... -count=1` runs reached the same
unrelated retired-commit provenance failure and the same long-running
`grammargen` timeout. All remaining reported packages passed. The feature's
linked-worktree grammar-blob probe initially hit Go VCS stamping against the
worktree gitdir; the isolated rerun above passed with VCS stamping disabled.
