### PR TITLE
fix(query): protect capture names from caller mutation

### DIFF
--- a/query.go
+++ b/query.go
@@ -1076,7 +1076,7 @@ func (q *Query) CaptureCount() uint32 {
 
 // CaptureNames returns the list of unique capture names used in the query.
 func (q *Query) CaptureNames() []string {
-	return q.captures
+	return slices.Clone(q.captures)
 }
 
 // CaptureNameForID returns the capture name for the given capture id.

--- a/query_test.go
+++ b/query_test.go
@@ -1120,6 +1120,45 @@ func TestCaptureNames(t *testing.T) {
 	}
 }
 
+func TestProbeCaptureNamesCallerMutationDoesNotAffectQuery(t *testing.T) {
+	lang := queryTestLanguage()
+	q, err := NewQuery(`(identifier) @ident`, lang)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	names := q.CaptureNames()
+	if len(names) != 1 || names[0] != "ident" {
+		t.Fatalf("CaptureNames: got %v, want [ident]", names)
+	}
+
+	names[0] = "corrupted"
+
+	if got := q.CaptureNames(); len(got) != 1 || got[0] != "ident" {
+		t.Errorf("CaptureNames after caller mutation: got %q want %q", got[0], "ident")
+	}
+	if got, ok := q.CaptureNameForID(0); !ok || got != "ident" {
+		t.Errorf("CaptureNameForID(0) after caller mutation: got %q want %q", got, "ident")
+	}
+
+	tree := buildSimpleTree(lang)
+	matches := q.Execute(tree)
+	found := false
+	for _, m := range matches {
+		for _, c := range m.Captures {
+			if c.Name == "ident" {
+				found = true
+			}
+			if c.Name == "corrupted" {
+				t.Errorf("query execution returned corrupted capture name")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected match with capture name %q", "ident")
+	}
+}
+
 func TestCaptureDeduplicated(t *testing.T) {
 	lang := queryTestLanguage()
 	q, err := NewQuery(`


### PR DESCRIPTION
## Summary

- return a caller-owned copy from `Query.CaptureNames`
- preserve compiled query metadata when callers mutate the returned slice
- cover subsequent capture lookup and ordinary query execution

## Evidence

On `ac90e46ace3c4ac6fb6bbc9f0897e449c949cfad`, mutating element zero of the
slice returned by `CaptureNames` changes a subsequent `CaptureNames` result to
`"corrupted"`. The mutation also reaches the query's capture table used by
public lookup and match output.

## Validation

- `go test . -run '^TestProbeCaptureNamesCallerMutationDoesNotAffectQuery$' -count=20`
- adjacent capture/query API tests
- focused `-race`
- complete root package: patch-specific tests pass; the existing
  `TestResultCompatibilityRetiredCommitProvenance` failure reproduces exactly on
  pristine `origin/main`
- `go test ./... -count=1`: all completed packages pass except the same root
  baseline failure; `grammargen` reaches its existing 10-minute package timeout
- isolated `grammargen` Fortran timeout subcase passes in 175.311s
- `gofmt`, `git diff --check`, and staged `gitleaks`

Raw response evidence is preserved byte-for-byte on
`evidence/query-capture-names-defensive-copy-20260824`; no evidence PR was
opened.
