### PR TITLE
Record C26ak SQL CREATE DOMAIN AS blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,19 @@ for tags and release notes while still in `0.x`.
   Keep SQL compact admission gated. No parser, scanner, or grammar change
   ships. See `docs/compact-route-real-corpus-matrix.md`.
 
+- Recorded the C26ak generated SQL `CREATE DOMAIN AS` producer witness at base
+  `83e0cfbc30ad82e2f327d58e35eea9f438a0ffda`.
+  The 27-byte witness `CREATE DOMAIN test AS text;` has source SHA-256
+  `0cad93f1b70ffa192008df866587c05b206ee404cedd5a0025f542c39c6a504b`.
+  Generated and checked-in trees are both clean with two root children.
+  The generated `CREATE_DOMAIN` node has one child; locked C has none.
+  The generated digest is
+  `67366d68529459613040eb60c5eef47b371fd3091dbe3283c82d7bcff287ea9c`.
+  The checked-in and locked-C digest is
+  `d0daa4279f00eb8c7278992cff6a870c98bf3deee2292b28f997adbe2f434916`.
+  Keep SQL compact admission gated. No parser, scanner, or grammar change
+  ships. See `docs/compact-route-real-corpus-matrix.md`.
+
 - Added authenticated generated-SQL scanner identity to the grammargen C
   parity route. The route now reloads the generated blob through `LoadLanguage`
   before scanner adaptation. The scanner binds checkpoints to exact generated

--- a/cgo_harness/sql_c26ak_generated_create_domain_as_test.go
+++ b/cgo_harness/sql_c26ak_generated_create_domain_as_test.go
@@ -1,0 +1,121 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+func TestSQLC26akGeneratedCreateDomainAs(t *testing.T) {
+	var grammar grammargenCGOGrammar
+	for _, candidate := range grammargenCGOGrammars {
+		if candidate.name == "sql" {
+			grammar = candidate
+			break
+		}
+	}
+	if grammar.name == "" {
+		t.Fatal("missing sql grammargen CGO config")
+	}
+
+	gram, err := importGrammargenSource(grammar)
+	if err != nil {
+		t.Skipf("import unavailable: %v", err)
+	}
+	genLang, err := grammargenGenerate(gram, 90*time.Second)
+	if err != nil {
+		t.Fatalf("generate grammar: %v", err)
+	}
+	refLang := grammar.blobFunc()
+	adaptGrammargenCGOExternalScanner("sql", refLang, genLang)
+	grammarHash, ok := genLang.GrammarBlobSHA256()
+	if !ok {
+		t.Fatal("generated SQL language has no authenticated grammar identity")
+	}
+	provider, ok := genLang.ExternalScanner.(gotreesitter.ExternalScannerCheckpointIdentityProvider)
+	if !ok {
+		t.Fatal("generated SQL scanner has no checkpoint identity provider")
+	}
+	wantScanner := decodeSQLIdentity(t, "7e493677411a501e6d8592c6b9cc158e21a1bfed44c72ca914e2d81e4e34861d")
+	wantGrammar := decodeSQLIdentity(t, "4ffb2a6d09e2000126f10101db9028d28e0752ac3e4f83e401f045c3b028ca7c")
+	identity, ok := provider.CheckpointIdentity()
+	if !ok || !bytes.Equal(identity.Scanner, wantScanner) || !bytes.Equal(identity.Grammar, wantGrammar) || !bytes.Equal(identity.Grammar, grammarHash[:]) {
+		t.Fatalf("generated SQL identity changed: ok=%t scanner=%x grammar=%x blob=%x", ok, identity.Scanner, identity.Grammar, grammarHash)
+	}
+
+	cLang, err := ParityCLanguage("sql")
+	if err != nil {
+		t.Skipf("C parser unavailable: %v", err)
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatalf("C SetLanguage: %v", err)
+	}
+
+	source := []byte("CREATE DOMAIN test AS text;")
+	sourceHash := sha256.Sum256(source)
+	if got, want := hex.EncodeToString(sourceHash[:]), "0cad93f1b70ffa192008df866587c05b206ee404cedd5a0025f542c39c6a504b"; got != want {
+		t.Fatalf("source SHA-256=%s, want %s", got, want)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("C parser returned no tree")
+	}
+	t.Cleanup(cTree.Close)
+	if cTree.RootNode().HasError() {
+		t.Fatalf("locked C witness has an error: %s", dumpCTree(cTree.RootNode(), 0))
+	}
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatalf("locked C digest: %v", err)
+	}
+
+	genTree, err := gotreesitter.NewParser(genLang).Parse(source)
+	if err != nil {
+		t.Fatalf("generated SQL parse: %v", err)
+	}
+	t.Cleanup(genTree.Release)
+	genInspection, err := benchfixtures.InspectGoTree(genTree.RootNode(), genLang)
+	if err != nil {
+		t.Fatalf("generated SQL digest: %v", err)
+	}
+	var genVsCErrs []string
+	compareNodes(genTree.RootNode(), genLang, cTree.RootNode(), "root", &genVsCErrs)
+	if len(genVsCErrs) == 0 {
+		t.Fatal("generated SQL CREATE DOMAIN AS witness unexpectedly matches locked C")
+	}
+	if genVsCErrs[0] != `root[0][1]: ChildCount go=1 c=0 (goType="CREATE_DOMAIN" cType="CREATE_DOMAIN" goBytes=[7-13] cBytes=[7-13])` {
+		t.Fatalf("generated SQL CREATE DOMAIN AS first divergence=%q", genVsCErrs[0])
+	}
+	if genInspection.SHA256 != "67366d68529459613040eb60c5eef47b371fd3091dbe3283c82d7bcff287ea9c" || genTree.RootNode().ChildCount() != 2 || genTree.RootNode().HasError() {
+		t.Fatalf("generated SQL CREATE DOMAIN AS receipt changed: digest=%s children=%d error=%t", genInspection.SHA256, genTree.RootNode().ChildCount(), genTree.RootNode().HasError())
+	}
+
+	blobTree, err := gotreesitter.NewParser(refLang).Parse(source)
+	if err != nil {
+		t.Fatalf("checked-in SQL parse: %v", err)
+	}
+	t.Cleanup(blobTree.Release)
+	blobInspection, err := benchfixtures.InspectGoTree(blobTree.RootNode(), refLang)
+	if err != nil {
+		t.Fatalf("checked-in SQL digest: %v", err)
+	}
+	var blobVsCErrs []string
+	compareNodes(blobTree.RootNode(), refLang, cTree.RootNode(), "root", &blobVsCErrs)
+	if len(blobVsCErrs) != 0 || blobTree.RootNode().HasError() || blobInspection.SHA256 != cDigest || blobInspection.SHA256 != "d0daa4279f00eb8c7278992cff6a870c98bf3deee2292b28f997adbe2f434916" {
+		t.Fatalf("checked-in SQL differs from locked C: errors=%v has_error=%t blob_digest=%s c_digest=%s", blobVsCErrs, blobTree.RootNode().HasError(), blobInspection.SHA256, cDigest)
+	}
+
+	t.Logf("scanner_identity=%x generated_blob_identity=%x source_sha256=%s bytes=%d generated_digest=%s checked_in_digest=%s locked_c_digest=%s generated_children=%d checked_in_children=%d generated_error=%t checked_in_error=%t", identity.Scanner, identity.Grammar, hex.EncodeToString(sourceHash[:]), len(source), genInspection.SHA256, blobInspection.SHA256, cDigest, genTree.RootNode().ChildCount(), blobTree.RootNode().ChildCount(), genTree.RootNode().HasError(), blobTree.RootNode().HasError())
+	t.Logf("generated_vs_locked_c=%s", genVsCErrs[0])
+}

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -2799,6 +2799,98 @@ equality, incremental equality, and locked-C equality.
 
 No performance gate ran for C26aj. This receipt makes no performance claim.
 
+## C26ak generated SQL `CREATE DOMAIN AS` producer witness
+
+C26ak used publication base
+`83e0cfbc30ad82e2f327d58e35eea9f438a0ffda`.
+It follows the queued C26aj `CREATE DOMAIN` receipt.
+
+Status: **NO-GO / KEEP LIVE**. Keep SQL compact admission gated.
+This slice adds one producer witness, one focused Docker probe, one changelog
+entry, and this section. It adds no parser or route change.
+
+### Producer and witness
+
+The pinned SQL producer is `m-novikov/tree-sitter-sql` at commit
+`587f30d184b058450be2a2330878210c5f33b3f9`.
+The grammar source SHA-256 is
+`42f011860137175a5a0cb820d1a694e5ccca1d17f226729ff6a4e886910cde1c`.
+The scanner source SHA-256 is
+`d437ad9f517d7a1f4248ccd05abe58370b5040c0037c877dab1f0aefeaa04af6`.
+
+The generated blob identity is
+`4ffb2a6d09e2000126f10101db9028d28e0752ac3e4f83e401f045c3b028ca7c`.
+The scanner identity is
+`7e493677411a501e6d8592c6b9cc158e21a1bfed44c72ca914e2d81e4e34861d`.
+The checked-in SQL blob identity is
+`e21421cbab52b54cf5ba15c8f78a2bb4729bf4e8c0da14368069e897de451268`.
+
+The witness is the 27-byte source `CREATE DOMAIN test AS text;`.
+Its source SHA-256 is
+`0cad93f1b70ffa192008df866587c05b206ee404cedd5a0025f542c39c6a504b`.
+The generated tree digest is
+`67366d68529459613040eb60c5eef47b371fd3091dbe3283c82d7bcff287ea9c`.
+The checked-in and locked-C tree digest is
+`d0daa4279f00eb8c7278992cff6a870c98bf3deee2292b28f997adbe2f434916`.
+
+Both generated and checked-in trees are clean with two root children.
+The generated `CREATE_DOMAIN` node has one child. Locked C has no child.
+The first divergence is:
+
+```text
+root[0][1]: ChildCount go=1 c=0 (goType="CREATE_DOMAIN" cType="CREATE_DOMAIN" goBytes=[7-13] cBytes=[7-13])
+```
+
+The difference starts in generated producer output, before compact replay.
+This witness is distinct from C26ah, C26ai, and the queued C26aj witness.
+
+### Focused Docker gate
+
+The probe is
+`cgo_harness/sql_c26ak_generated_create_domain_as_test.go`.
+It checks generated identity, checked-in parity, and locked-C parity.
+Run one SQL grammar with one CPU and one Go test worker:
+
+```sh
+GOMAXPROCS=1 bash cgo_harness/docker/run_parity_in_docker.sh \
+  --repo-root /tmp/gotreesitter-graduation-next.e5Kf8Z \
+  --out-root /tmp/gotreesitter-c26ak-artifacts \
+  --label c26ak-sql-create-domain-as-final --no-build --memory 4g --cpus 1 \
+  --gomemlimit 3GiB --goflags -p=1 --test-parallel 1 --timeout 10m \
+  --mount /tmp/gotreesitter-sql-seed.ada3CT:/tmp/grammar_parity:ro -- \
+  'cd /workspace/cgo_harness && \
+   go test -tags "cgo treesitter_c_parity" . \
+   -run "^TestSQLC26akGeneratedCreateDomainAs$" -count=1 \
+   -parallel=1 -timeout=10m -v'
+```
+
+The run passed with exit code zero.
+It used one SQL grammar, one CPU, `GOMAXPROCS=1`, and `GOFLAGS=-p=1`.
+It reported no out-of-memory kill and no wall timeout.
+
+The artifact is
+`/tmp/gotreesitter-c26ak-artifacts/20260824T054920Z-c26ak-sql-create-domain-as-final`.
+
+- `container.log`: `50452ea4d162b689cf5fcf59233f055b6715f8acdc168ef28cd993aae694ef08`.
+- `metadata.txt`: `44da1ae400911935701d1507342454873b6ecad7f1a9dd0b8d3c695f8e159f00`.
+- `inspect.json`: `9faae0b5768c81811cbc843bcc02c1d3b01f664a4a86bd8446cd664557e31b05`.
+
+The generated tree remains different from locked C.
+The probe records a producer blocker, not a compact parity claim.
+
+### C26ak decision and reopening condition
+
+Keep SQL compact admission gated. Do not add a parser-state remap.
+Do not add a SQL-specific symbol map.
+
+Reopen only after the SQL producer or grammar revision makes both
+`CREATE DOMAIN` witnesses match the checked-in and locked-C trees.
+Then rerun the C26ak gate with C26ah, C26ai, and the queued C26aj coverage.
+Require equal table identity, scanner identity, fresh-tree equality, compact
+equality, incremental equality, and locked-C equality.
+
+No performance gate ran for C26ak. This receipt makes no performance claim.
+
 ## Corpus state
 
 The current manifest has these properties:


### PR DESCRIPTION
## Summary

Record the C26ak SQL producer blocker.
Add one focused parity witness, one changelog entry, and one matrix section.
Preserve the C26aj receipt and the current-main AWK and P25bb receipts.
Add no parser, scanner, grammar, or route change.

## Witness

The witness is `CREATE DOMAIN test AS text;` with 27 bytes.
Its source SHA-256 is `0cad93f1b70ffa192008df866587c05b206ee404cedd5a0025f542c39c6a504b`.
The generated blob identity is `4ffb2a6d09e2000126f10101db9028d28e0752ac3e4f83e401f045c3b028ca7c`.
The scanner identity is `7e493677411a501e6d8592c6b9cc158e21a1bfed44c72ca914e2d81e4e34861d`.
The checked-in SQL blob identity is `e21421cbab52b54cf5ba15c8f78a2bb4729bf4e8c0da14368069e897de451268`.

The generated tree digest is `67366d68529459613040eb60c5eef47b371fd3091dbe3283c82d7bcff287ea9c`.
The checked-in and locked-C digest is `d0daa4279f00eb8c7278992cff6a870c98bf3deee2292b28f997adbe2f434916`.
The first divergence is the generated child count under `CREATE_DOMAIN`.

## Validation

Run the focused SQL gate in Docker with one CPU and one Go test worker.
Set `GOMAXPROCS=1`, `GOFLAGS=-p=1`, and `GOMEMLIMIT=3GiB`.
The gate passed with exit code zero.
It reported no out-of-memory kill and no wall timeout.

The fresh artifact is `/tmp/gotreesitter-c26ak-artifacts/20260824T081029Z-c26ak-sql-create-domain-as-c0e8-recheck`.

- `container.log`: `287f1b14a234b351b19f1203f8b5422ddb4eecd9255e88af3697bdad61bad5d9`
- `metadata.txt`: `05cf4d64bd2b41b1cbbc22fb09d0e8527a397061d73dfcf082776423f2d0f3f5`
- `inspect.json`: `3e658dc8e5e9fe8629a15ec10f88a42357961b93f12801ca1473bc6947b6c9c0`

The publication base is `c0e8af1b63329b13484a228a86dd397baab4e3bf`.
The three-file diff SHA-256 is `85e3a15078c831784fb4701de78b5b65ebfa78a2ffac52bf330c168b5dbe0027`.

## Decision

Keep SQL compact admission gated.
Do not add a parser-state remap or a SQL-specific symbol map.
Reopen after the SQL producer or grammar revision makes both `CREATE DOMAIN` witnesses match the checked-in and locked-C trees.
Then rerun the C26ak gate with C26ah, C26ai, and C26aj coverage.
Require equal table identity, scanner identity, fresh-tree equality, compact equality, incremental equality, and locked-C equality.

Status: **NO-GO / KEEP LIVE**.