### PR TITLE
Record SQL normalization dispatcher blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,6 +391,18 @@ for tags and release notes while still in `0.x`.
   `docs/root-normalization-retirement.md` for the artifact hashes and
   reopening conditions.
 
+- Recorded the SQL dispatcher blocker at base
+  `ac90e46ace3c4ac6fb6bbc9f0897e449c949cfad`.
+  The focused Docker receipt covers raw, production, compact, forest,
+  incremental, and locked-C routes for a trailing select-list recovery.
+  Raw Go output differs from locked C at the source-file child count.
+  Production, compact, and incremental routes match locked C after
+  `dispatch.sql` runs. Compact falls back, forest declines, and incremental
+  reuse records zero subtrees and zero bytes. Container inspection records
+  `GOMAXPROCS=1`, one CPU, and a 4 GiB memory limit. The receipt does not cover
+  the other two SQL helpers. Keep `dispatch.sql` live. No parser or registry
+  change ships. See `docs/root-normalization-retirement.md`.
+
 - Recorded the N31i Cooklang dispatcher blocker at evidence base
   `7498a678c52029a82f312e9637ecb66b15defa0b` and publication base
   `675697a1144fad306489c5142aedaae0825545d9`. Keep `dispatch.cooklang` live.

--- a/cgo_harness/sql_n31v_dispatcher_blocker_receipt_test.go
+++ b/cgo_harness/sql_n31v_dispatcher_blocker_receipt_test.go
@@ -1,0 +1,220 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	gots "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const (
+	sqlN31vSourceSHA        = "c2826e3d8fc7ec0a99c4e2ecc37514a3d6bd0a4aa60b4ff65dc2382629d1b11e"
+	sqlN31vRawDigest        = "8c4095130f0da24ad8d3ce0dd9c56becfe3e70e4eaed118ef132933b2f492848"
+	sqlN31vNormalizedDigest = "9f256e76a2192f6e3f6d98bf57d773eb02d362ca525efe0caec163567a272bd1"
+	sqlN31vCArtifactSHA     = "f13ad13cdc0f748a362e50f92e06f685736905db0bbbdbd2b3dffd0307232ec2"
+	sqlN31vCompactFallback  = "compact route declined at recovery [mechanism=recovery-entered]: did not accept EOF: generic scheduler has no table action for the elected token"
+)
+
+func TestSQLN31vDispatcherBlockerRoutes(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	source := []byte("SELECT a, b,\n")
+	base := []byte("SELECT a, b")
+	goLang := grammars.SqlLanguage()
+	if goLang == nil || goLang.Name != "sql" {
+		t.Fatalf("language=%v, want sql", goLang)
+	}
+	cLang, err := COracleLanguage("sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := COracleIdentity("sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider, ok := goLang.ExternalScanner.(gots.ExternalScannerCheckpointIdentityProvider)
+	if !ok {
+		t.Fatal("SQL scanner has no checkpoint identity provider")
+	}
+	scannerIdentity, ok := provider.CheckpointIdentity()
+	if !ok {
+		t.Fatal("SQL scanner did not provide checkpoint identity")
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != sqlN31vSourceSHA {
+		t.Fatalf("source SHA-256=%s, want %s", got, sqlN31vSourceSHA)
+	}
+	if got, want := fmt.Sprintf("%x", scannerIdentity.Scanner), "7e493677411a501e6d8592c6b9cc158e21a1bfed44c72ca914e2d81e4e34861d"; got != want {
+		t.Fatalf("SQL scanner identity=%s, want %s", got, want)
+	}
+	if got, want := fmt.Sprintf("%x", scannerIdentity.Grammar), "e21421cbab52b54cf5ba15c8f78a2bb4729bf4e8c0da14368069e897de451268"; got != want {
+		t.Fatalf("SQL grammar identity=%s, want %s", got, want)
+	}
+	if identity.GrammarArtifactSHA256 != sqlN31vCArtifactSHA {
+		t.Fatalf("locked-C SQL artifact=%s, want %s", identity.GrammarArtifactSHA256, sqlN31vCArtifactSHA)
+	}
+	t.Logf("grammar_lock_sha256=9ddb6324afd014f6ecdd1cae3dd1ba238f1e62ce03d126e6d8b267ce34d72ecb blob_sha256=e21421cbab52b54cf5ba15c8f78a2bb4729bf4e8c0da14368069e897de451268 scanner_identity=%x grammar_identity=%x c_contract=%s c_runtime=%s@%s c_grammar=%s@%s c_artifact_sha256=%s", scannerIdentity.Scanner, scannerIdentity.Grammar, identity.Contract, identity.RuntimeVersion, identity.RuntimeCommit, identity.GrammarRepo, identity.GrammarCommit, identity.GrammarArtifactSHA256)
+	cTree := sqlN31vCTree(t, cLang, source)
+	defer cTree.Close()
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cDigest != sqlN31vNormalizedDigest || !cTree.RootNode().HasError() || cTree.RootNode().ChildCount() != 1 {
+		t.Fatalf("locked-C receipt changed: digest=%s error=%t children=%d", cDigest, cTree.RootNode().HasError(), cTree.RootNode().ChildCount())
+	}
+	t.Logf("source_sha256=%x bytes=%d c_digest=%s c_error=%t c_children=%d", sha256.Sum256(source), len(source), cDigest, cTree.RootNode().HasError(), cTree.RootNode().ChildCount())
+
+	parse := func(route string, candidate bool, fn func(*gots.Parser) (*gots.Tree, error)) {
+		parser := gots.NewParser(goLang)
+		parser.SetAdmissionCandidateRoute(candidate)
+		tree, err := fn(parser)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tree.Release()
+		inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), goLang)
+		if err != nil {
+			t.Fatal(err)
+		}
+		diff := FirstDivergenceDumpV1(tree.RootNode(), goLang, cTree.RootNode())
+		wantDigest := sqlN31vNormalizedDigest
+		wantDiff := (*DumpV1Divergence)(nil)
+		wantDispatch := "1/1/10/7"
+		if route == "raw" {
+			wantDigest = sqlN31vRawDigest
+			wantDiff = &DumpV1Divergence{Path: "/source_file", Category: "shape", GoValue: "children=2", CValue: "children=1"}
+			wantDispatch = "none"
+		}
+		if inspection.SHA256 != wantDigest || tree.RootNode().HasError() != true || (diff == nil) != (wantDiff == nil) || (diff != nil && *diff != *wantDiff) || sqlN31vDispatch(tree) != wantDispatch {
+			t.Fatalf("%s receipt changed: digest=%s error=%t divergence=%+v dispatch=%s", route, inspection.SHA256, tree.RootNode().HasError(), diff, sqlN31vDispatch(tree))
+		}
+		t.Logf("route=%s digest=%s c_digest=%s error=%t c_error=%t children=%d divergence=%+v dispatch=%s rewrites=%d runtime=%s", route, inspection.SHA256, cDigest, tree.RootNode().HasError(), cTree.RootNode().HasError(), tree.RootNode().ChildCount(), diff, sqlN31vDispatch(tree), tree.ParseRuntime().NormalizationNodesRewritten, tree.ParseRuntime().Summary())
+	}
+	parse("raw", false, func(p *gots.Parser) (*gots.Tree, error) {
+		return p.ParseNoResultCompatibilityBenchmarkOnly(source)
+	})
+	parse("production", false, func(p *gots.Parser) (*gots.Tree, error) {
+		return p.Parse(source)
+	})
+	beforeRouted, beforeFallback := gots.AdmissionCandidateCounters()
+	parse("compact", true, func(p *gots.Parser) (*gots.Tree, error) {
+		return p.Parse(source)
+	})
+	afterRouted, afterFallback := gots.AdmissionCandidateCounters()
+	if afterRouted-beforeRouted != 0 || afterFallback-beforeFallback != 1 || gots.AdmissionCandidateLastFallbackReason() != sqlN31vCompactFallback {
+		t.Fatalf("compact receipt changed: routed=%d fallback=%d reason=%q", afterRouted-beforeRouted, afterFallback-beforeFallback, gots.AdmissionCandidateLastFallbackReason())
+	}
+	t.Logf("compact routed_delta=%d fallback_delta=%d reason=%q", afterRouted-beforeRouted, afterFallback-beforeFallback, gots.AdmissionCandidateLastFallbackReason())
+
+	forestParser := gots.NewParser(goLang)
+	forest, forestOK := forestParser.ParseForestExperimental(source)
+	if forestOK && forest != nil {
+		forest.Release()
+		t.Fatal("forest route accepted a recovery witness")
+	} else {
+		t.Logf("route=forest accepted=false")
+	}
+
+	incParser := gots.NewParser(goLang)
+	oldTree, err := incParser.Parse(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oldTree.Release()
+	oldTree.Edit(gots.InputEdit{StartByte: uint32(len(base)), OldEndByte: uint32(len(base)), NewEndByte: uint32(len(source)), StartPoint: sqlN31vPoint(base), OldEndPoint: sqlN31vPoint(base), NewEndPoint: sqlN31vPoint(source)})
+	incremental, profile, err := incParser.ParseIncrementalProfiled(source, oldTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer incremental.Release()
+	inspection, err := benchfixtures.InspectGoTree(incremental.RootNode(), goLang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.SHA256 != sqlN31vNormalizedDigest || !incremental.RootNode().HasError() || FirstDivergenceDumpV1(incremental.RootNode(), goLang, cTree.RootNode()) != nil || sqlN31vDispatch(incremental) != "1/1/10/7" || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+		t.Fatalf("incremental receipt changed: digest=%s error=%t divergence=%+v dispatch=%s profile=%+v", inspection.SHA256, incremental.RootNode().HasError(), FirstDivergenceDumpV1(incremental.RootNode(), goLang, cTree.RootNode()), sqlN31vDispatch(incremental), profile)
+	}
+	t.Logf("route=incremental digest=%s c_digest=%s error=%t divergence=%+v dispatch=%s rewrites=%d profile=%+v runtime=%s", inspection.SHA256, cDigest, incremental.RootNode().HasError(), FirstDivergenceDumpV1(incremental.RootNode(), goLang, cTree.RootNode()), sqlN31vDispatch(incremental), incremental.ParseRuntime().NormalizationNodesRewritten, profile, incremental.ParseRuntime().Summary())
+}
+
+func TestSQLN31vDispatcherBlockerReceiptDocument(t *testing.T) {
+	doc, err := os.ReadFile("../docs/root-normalization-retirement.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	changelog, err := os.ReadFile("../CHANGELOG.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, marker := range []string{
+		"## 2026-08-24 SQL dispatcher blocker receipt",
+		"Status: `KEEP LIVE / NO-GO`. Keep `dispatch.sql` live.",
+		"ac90e46ace3c4ac6fb6bbc9f0897e449c949cfad",
+		sqlN31vSourceSHA,
+		sqlN31vRawDigest,
+		sqlN31vNormalizedDigest,
+		"The compact route falls back.",
+		"The forest route declines.",
+		"The container inspection record contains `GOMAXPROCS=1`.",
+		"No parser or registry change ships.",
+	} {
+		if !strings.Contains(string(doc), marker) {
+			t.Fatalf("retirement document lacks marker %q", marker)
+		}
+	}
+	for _, marker := range []string{
+		"Recorded the SQL dispatcher blocker",
+		"Keep `dispatch.sql` live",
+		"No parser or registry change ships.",
+	} {
+		if !strings.Contains(string(changelog), marker) {
+			t.Fatalf("changelog lacks marker %q", marker)
+		}
+	}
+}
+
+func sqlN31vDispatch(tree *gots.Tree) string {
+	if tree == nil || tree.ParseRuntime().NormalizationPasses == nil {
+		return "none"
+	}
+	for _, pass := range *tree.ParseRuntime().NormalizationPasses {
+		if pass.Name == "dispatch.sql" {
+			return fmt.Sprintf("%d/%d/%d/%d", pass.Checked, pass.Run, pass.NodesVisited, pass.NodesRewritten)
+		}
+	}
+	return "none"
+}
+
+func sqlN31vPoint(source []byte) gots.Point {
+	var point gots.Point
+	for _, b := range source {
+		if b == '\n' {
+			point.Row++
+			point.Column = 0
+		} else {
+			point.Column++
+		}
+	}
+	return point
+}
+
+func sqlN31vCTree(t *testing.T, language *sitter.Language, source []byte) *sitter.Tree {
+	t.Helper()
+	parser := sitter.NewParser()
+	t.Cleanup(parser.Close)
+	if err := parser.SetLanguage(language); err != nil {
+		t.Fatal(err)
+	}
+	tree := parser.Parse(source, nil)
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("C parser returned no root")
+	}
+	return tree
+}

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -530,6 +530,98 @@ Trace any correction to scheduler action semantics. Keep the registry arm
 unchanged. Ship no parser, registry, grammar, scanner, or test behavior
 change.
 
+## 2026-08-24 SQL dispatcher blocker receipt
+
+Status: `KEEP LIVE / NO-GO`. Keep `dispatch.sql` live.
+
+Base commit: `ac90e46ace3c4ac6fb6bbc9f0897e449c949cfad`.
+This slice adds one focused test. It changes no parser, registry, or generated grammar.
+
+The registry arm is `dispatch.sql`. It calls
+`normalizeSQLRecoveredSelectRoot`, `normalizeSQLTrailingSelectListError`, and
+`normalizeSQLRecoveredTopLevelSelectStatements` in `parser_result_sql.go`.
+Its authoritative owner is `scheduler_action_semantics`.
+
+This receipt covers one trailing select-list recovery witness:
+`SELECT a, b,` followed by a newline. It exercises the second SQL normalizer.
+It does not certify the other two SQL normalizers.
+
+### Identity and witness
+
+The grammar lock SHA-256 is
+`9ddb6324afd014f6ecdd1cae3dd1ba238f1e62ce03d126e6d8b267ce34d72ecb`.
+The SQL grammar is `https://github.com/m-novikov/tree-sitter-sql` at commit
+`587f30d184b058450be2a2330878210c5f33b3f9`.
+The embedded SQL blob SHA-256 is
+`e21421cbab52b54cf5ba15c8f78a2bb4729bf4e8c0da14368069e897de451268`.
+The scanner identity is
+`7e493677411a501e6d8592c6b9cc158e21a1bfed44c72ca914e2d81e4e34861d`.
+The scanner binds the embedded grammar identity.
+
+The locked-C contract is `tree-sitter-c-v1`.
+The runtime is `0.25.1` at commit
+`f5afe475deb7c0bae6407fb776c76824f717bb61`.
+The locked SQL grammar artifact SHA-256 is
+`f13ad13cdc0f748a362e50f92e06f685736905db0bbbdbd2b3dffd0307232ec2`.
+
+The witness source has 13 bytes and SHA-256
+`c2826e3d8fc7ec0a99c4e2ecc37514a3d6bd0a4aa60b4ff65dc2382629d1b11e`.
+The locked-C deep digest is
+`9f256e76a2192f6e3f6d98bf57d773eb02d362ca525efe0caec163567a272bd1`.
+The locked-C root has an error and one child.
+
+### Route evidence
+
+The raw Go digest is
+`8c4095130f0da24ad8d3ce0dd9c56becfe3e70e4eaed118ef132933b2f492848`.
+Its first divergence is `/source_file`, category `shape`, with Go children 2
+and locked-C children 1.
+The raw route records no SQL dispatch.
+
+The production, compact, and incremental Go digests match locked C.
+The production and incremental routes record
+`dispatch.sql` as `1/1/10/7`.
+The compact route uses the same normalizer after its recovery fallback.
+The compact counters record zero routed candidates and one fallback.
+The fallback reason is:
+
+```text
+compact route declined at recovery [mechanism=recovery-entered]: did not accept EOF: generic scheduler has no table action for the elected token
+```
+
+The forest route declines the recovery witness.
+The incremental route matches locked C after an appended recovery edit.
+It reuses zero subtrees and zero bytes.
+
+The focused Docker run used one SQL grammar and one central processing unit.
+It set a 4 GiB memory limit, a 3 GiB Go memory limit, `GOMAXPROCS=1`, and `-p=1`.
+The container inspection record contains `GOMAXPROCS=1`.
+It passed without timeout or out-of-memory failure.
+
+The artifact directory is
+`/tmp/gotreesitter-normalization-next.t8Btcx/harness_out/sql-n31v-de197-final-check/20260824T075804Z-sql-n31v-de197-final-check`.
+Its container log, metadata, and inspection hashes are
+`02ad324011cf5a4a52cc83026b0902bf6276ba282ca319283216ab1e657e247e`,
+`6a4d7e0285c0a91d6967a03f4a043c32fac7416f9fafa061ec6223e8be33aab6`, and
+`e248667b64b7c39e5b1dac1d45447cbc50dbe7cebf08d43122c792b844042022`.
+
+### Decision
+
+Keep `dispatch.sql` live. The raw producer still diverges on the registered
+recovery shape. The compact route falls back. The forest route declines.
+This receipt does not cover the recovered-root or top-level-statement helpers.
+No parser or registry change ships.
+
+Reopen SQL retirement only after all conditions pass:
+
+1. Add witnesses for all three SQL compatibility helpers.
+2. Match locked C on raw, production, compact, forest, and incremental routes.
+3. Prove exact native recovery for the trailing-list witness.
+4. Add authenticated SQL corpus entries to the census denominator.
+5. Preserve the SQL scanner identity and a sound incremental reuse contract.
+
+Keep the registry arm unchanged until every condition passes.
+
 ## End state
 
 The root is clean when all of the following are true:


### PR DESCRIPTION
## Summary

Record the SQL N31v dispatcher blocker as a focused parity receipt.

- Add a focused SQL trailing-select-list recovery test.
- Update the normalization retirement guide and changelog.

## Evidence

- Run focused Docker evidence with one worker.
- Use one CPU and a 4 GiB memory limit.
- Set `GOMAXPROCS=1` and `GOFLAGS=-p=1`.
- Record no timeout and no out-of-memory result.
- Match five parsing routes to the locked C baseline.
- Keep tree shape, digest hashes, fallback counters, and incremental reuse counters stable.

## Decision

KEEP LIVE / NO-GO. Preserve this blocker until the dispatcher path passes the recorded parity gates.