### PR TITLE
Fix Swift recovery replay checkpoint correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,28 @@ for tags and release notes while still in `0.x`.
 
 ### Correctness
 
+- Recorded a generic Swift issue #576 recovery candidate at base
+  `da6f71471aaaa835503accaa1bc2083ced90b4e6`. The active deterministic finite
+  automaton (DFA) source now replays recovery from the exact skipped-prefix
+  offset. It requires the original span, points, token identity, and unchanged
+  scanner state. It resynchronizes the source before it emits `errorSymbol`.
+  Recovery replay requires a non-empty scanner checkpoint and live state. A
+  checkpointless scanner rejects recovery replay without changing the scanner.
+  Generic relex still accepts stateless scanners with empty serialization. The
+  Swift scanner now serializes its complete state for the recovery proof. The
+  scanner no longer claims that failed scans preserve this state. The token
+  source records distinct start and end checkpoints when a failed scan changes
+  the state. Incremental fast-forward restores the recorded end checkpoint.
+  The parser records error-mode lexing only after the DFA produces the token.
+  An outer parse operation resets the recovery memo size. Nested retries stay
+  warm. Two pooled control-to-witness tests protect the recovery lifecycle. The
+  parser returns a rejected recovery probe before its legacy retry. Entry
+  scratch now restores the required large-parse reservation after a small
+  pooled parse. The 20-byte witness matches the locked C tree. The
+  `stdlib_FloatingPointToString.swift` and `stdlib_CollectionAlgorithms.swift`
+  witnesses still differ from locked C. Keep issue #576 open. See
+  `docs/swift-576-compact-correctness-blocker.md`.
+
 - Recorded the unreceipted `dispatch.julia` blocker at base
   `b35b86cb84d620305515abf970d5598c9573a48b`. The focused Docker receipt
   covers raw, production, compact, forest, incremental, and locked-C routes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,17 +90,24 @@ for tags and release notes while still in `0.x`.
   Generic relex still accepts stateless scanners with empty serialization. The
   Swift scanner now serializes its complete state for the recovery proof. The
   scanner no longer claims that failed scans preserve this state. The token
-  source records distinct start and end checkpoints when a failed scan changes
-  the state. Incremental fast-forward restores the recorded end checkpoint.
+  source restores failed scans by default. A scanner can explicitly retain a
+  required failed-scan state change. Swift uses that capability and records
+  distinct start and end checkpoints. Incremental fast-forward restores the
+  recorded end checkpoint. Generic relex rejects a synthetic end-of-file
+  lookahead that would replace a real token. Swift defers `>?` to the DFA only
+  when an unmatched `<` exists in the active scope.
   The parser records error-mode lexing only after the DFA produces the token.
   An outer parse operation resets the recovery memo size. Nested retries stay
-  warm. Two pooled control-to-witness tests protect the recovery lifecycle. The
-  parser returns a rejected recovery probe before its legacy retry. Entry
+  warm. Temporary memo growth restores an existing 16,384-entry standard slab.
+  A shorter retained slab remains short. Two pooled tests protect the recovery
+  lifecycle. The parser returns a rejected recovery probe before its legacy retry. Entry
   scratch now restores the required large-parse reservation after a small
   pooled parse. The 20-byte witness matches the locked C tree. The
   `stdlib_FloatingPointToString.swift` and `stdlib_CollectionAlgorithms.swift`
-  witnesses still differ from locked C. Keep issue #576 open. See
-  `docs/swift-576-compact-correctness-blocker.md`.
+  witnesses still differ from locked C. The 20-seed repair comparison found no
+  significant primary timing change. Bytes and allocations stayed unchanged.
+  One warmed large-witness sample decreased 0.113090 percent. Keep issue #576
+  open. See `docs/swift-576-compact-correctness-blocker.md`.
 
 - Recorded the unreceipted `dispatch.julia` blocker at base
   `b35b86cb84d620305515abf970d5598c9573a48b`. The focused Docker receipt

--- a/cgo_harness/parity_swift_recovery_probe_test.go
+++ b/cgo_harness/parity_swift_recovery_probe_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 	sitter "github.com/tree-sitter/go-tree-sitter"
@@ -130,7 +131,7 @@ func TestSwiftUnsafeWitnessRemainsKnownCStructuralMismatch(t *testing.T) {
 	// must never cause. This Go digest matches
 	// grammars.TestSwiftUnsafeWitnessKeepsCurrentGoTreeAcrossRecoveryProbe's
 	// pinned digest for the same file.
-	const wantGoDigest = "ec51c633a3f99515cc0cd1c0cff435a44ddc7db8e83705977d28f78bdfb0fc0e"
+	const wantGoDigest = "7cb588c1f7b44cf490d8fcddd11adb0cc56238e891156687c26660568a7f7447"
 	if goInspection.SHA256 != wantGoDigest {
 		t.Fatalf("Go Swift witness digest = %s, want %s", goInspection.SHA256, wantGoDigest)
 	}
@@ -147,11 +148,11 @@ func TestSwiftUnsafeWitnessRemainsKnownCStructuralMismatch(t *testing.T) {
 	t.Logf("Swift unsafe witness known C mismatch: Go=%s C=%s", goInspection.SHA256, cDigest)
 }
 
-func TestSwiftUnsafeMinimalWitnessRemainsKnownCStructuralMismatch(t *testing.T) {
+func TestSwiftUnsafeMinimalWitnessMatchesLockedC(t *testing.T) {
 	const sourceText = "let x = unsafe bar()"
 	const wantSourceSHA256 = "b511d81ace2a89b05e8e5e0ca6730c10f2ac9295111dae013097c7c6be8861fe"
 	const swiftGoBlobSHA256 = "be4575bc0acc3c60324aab635d067f940ac5f0557b80a8e3565d1e7d02d53582"
-	const wantGoDigest = "860b79483c37e217690deae43036bada15b259bed77713606124fa851702e62f"
+	const wantGoDigest = "c64b894edc4a20e15f2b4127bad4223f698c8996dba091c06c34aa89386d3c68"
 	const wantCDigest = "c64b894edc4a20e15f2b4127bad4223f698c8996dba091c06c34aa89386d3c68"
 	const wantSwiftGrammarCommit = "41d6e5fe811ec94229ee71771174a8cce558dfee"
 	const wantCRuntimeVersion = "0.25.1"
@@ -227,22 +228,138 @@ func TestSwiftUnsafeMinimalWitnessRemainsKnownCStructuralMismatch(t *testing.T) 
 	if err != nil {
 		t.Fatalf("inspect C Swift unsafe minimal witness: %v", err)
 	}
-	if goInspection.SHA256 == cDigest {
-		t.Fatal("Swift unsafe minimal witness unexpectedly reached C structural parity")
-	}
 	if goInspection.SHA256 != wantGoDigest {
 		t.Fatalf("Go Swift unsafe minimal witness digest = %s, want %s", goInspection.SHA256, wantGoDigest)
 	}
 	if cDigest != wantCDigest {
 		t.Fatalf("locked C Swift unsafe minimal witness digest = %s, want %s", cDigest, wantCDigest)
 	}
-	diff := FirstDivergenceDumpV1(goRoot, goLang, cRoot)
-	if diff == nil {
-		t.Fatal("Swift unsafe minimal witness digest differs without a structural divergence")
+	if diff := FirstDivergenceDumpV1(goRoot, goLang, cRoot); diff != nil {
+		t.Fatalf("Swift unsafe minimal witness still diverges from locked C: %+v", *diff)
 	}
-	if diff.Path != "/source_file/property_declaration[0]/call_expression[3]/ERROR[1]" ||
-		diff.Category != "shape" || diff.GoValue != "children=0" || diff.CValue != "children=1" {
-		t.Fatalf("Swift unsafe minimal first divergence changed: %+v", *diff)
+	t.Logf("SWIFT_576_MINIMAL_C_WITNESS version=1 disposition=locked_C_parity issue=#576 source_sha256=%s source_bytes=%d grammar=swift grammar_lock_commit=%s c_runtime=%s@%s c_grammar_repo=%s c_grammar_commit=%s c_grammar_artifact_sha256=%s go_blob_sha256=%s go_deep_sha256=%s c_deep_sha256=%s", wantSourceSHA256, len(source), identity.GrammarCommit, identity.RuntimeVersion, identity.RuntimeCommit, identity.GrammarRepo, identity.GrammarCommit, identity.GrammarArtifactSHA256, swiftGoBlobSHA256, goInspection.SHA256, cDigest)
+}
+
+func TestSwiftUnsafeMinimalWitnessMatchesLockedCAfterPooledRecoveryControl(t *testing.T) {
+	const wantMinimalDigest = "c64b894edc4a20e15f2b4127bad4223f698c8996dba091c06c34aa89386d3c68"
+	control := []byte("func f(n: Int) -> Int {\n" +
+		"  var total = 0\n" +
+		"  for i in 0..<n { total += i }\n" +
+		"  return total\n" +
+		"}\n")
+	minimal := []byte("let x = unsafe bar()")
+
+	goLang := grammars.SwiftLanguage()
+	pool := gotreesitter.NewParserPool(goLang)
+	cLang, err := ParityCLanguage("swift")
+	if err != nil {
+		t.Fatalf("load locked Swift C parser: %v", err)
 	}
-	t.Logf("SWIFT_576_MINIMAL_C_WITNESS version=1 disposition=known_locked_C_structural_mismatch issue=#576 source_sha256=%s source_bytes=%d grammar=swift grammar_lock_commit=%s c_runtime=%s@%s c_grammar_repo=%s c_grammar_commit=%s c_grammar_artifact_sha256=%s go_blob_sha256=%s go_deep_sha256=%s c_deep_sha256=%s first_difference=%+v", wantSourceSHA256, len(source), identity.GrammarCommit, identity.RuntimeVersion, identity.RuntimeCommit, identity.GrammarRepo, identity.GrammarCommit, identity.GrammarArtifactSHA256, swiftGoBlobSHA256, goInspection.SHA256, cDigest, *diff)
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatalf("set locked Swift C parser language: %v", err)
+	}
+
+	assertPooledParity := func(label string, source []byte) string {
+		t.Helper()
+		goTree, err := pool.Parse(source)
+		if err != nil {
+			t.Fatalf("%s pooled Go parse: %v", label, err)
+		}
+		if goTree == nil || goTree.RootNode() == nil {
+			t.Fatalf("%s pooled Go parser returned no tree", label)
+		}
+		defer goTree.Release()
+
+		cTree := cParser.Parse(source, nil)
+		if cTree == nil || cTree.RootNode() == nil {
+			t.Fatalf("%s locked C parser returned no tree", label)
+		}
+		defer cTree.Close()
+		if diff := FirstDivergenceDumpV1(goTree.RootNode(), goLang, cTree.RootNode()); diff != nil {
+			t.Fatalf("%s pooled Go tree diverges from locked C: %+v", label, *diff)
+		}
+		inspection, err := benchfixtures.InspectGoTree(goTree.RootNode(), goLang)
+		if err != nil {
+			t.Fatalf("inspect %s pooled Go tree: %v", label, err)
+		}
+		return inspection.SHA256
+	}
+
+	assertPooledParity("for-range control", control)
+	if got := assertPooledParity("unsafe minimal witness", minimal); got != wantMinimalDigest {
+		t.Fatalf("pooled Swift unsafe minimal digest = %s, want %s", got, wantMinimalDigest)
+	}
+}
+
+func TestSwiftUnsafeLargeWitnessKeepsDigestAfterPooledRecoveryControl(t *testing.T) {
+	const wantGoDigest = "7cb588c1f7b44cf490d8fcddd11adb0cc56238e891156687c26660568a7f7447"
+	const wantCDigest = "ab96dddf088487acc700d72af9342c338901504dcf1d32b9644e9f6f6638190d"
+	control := []byte("func f(n: Int) -> Int {\n" +
+		"  var total = 0\n" +
+		"  for i in 0..<n { total += i }\n" +
+		"  return total\n" +
+		"}\n")
+	large, err := os.ReadFile(filepath.Join("..", "grammars", "testdata", "swift_corpus", "stdlib_FloatingPointToString.swift"))
+	if err != nil {
+		t.Fatalf("read Swift unsafe witness: %v", err)
+	}
+
+	goLang := grammars.SwiftLanguage()
+	pool := gotreesitter.NewParserPool(goLang)
+	cLang, err := ParityCLanguage("swift")
+	if err != nil {
+		t.Fatalf("load locked Swift C parser: %v", err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatalf("set locked Swift C parser language: %v", err)
+	}
+
+	controlGo, err := pool.Parse(control)
+	if err != nil {
+		t.Fatalf("parse for-range control with pooled Go parser: %v", err)
+	}
+	controlC := cParser.Parse(control, nil)
+	if controlC == nil || controlC.RootNode() == nil {
+		controlGo.Release()
+		t.Fatal("locked C parser returned no for-range control tree")
+	}
+	if diff := FirstDivergenceDumpV1(controlGo.RootNode(), goLang, controlC.RootNode()); diff != nil {
+		controlC.Close()
+		controlGo.Release()
+		t.Fatalf("for-range control diverges from locked C: %+v", *diff)
+	}
+	controlC.Close()
+	controlGo.Release()
+
+	largeGo, err := pool.Parse(large)
+	if err != nil {
+		t.Fatalf("parse Swift unsafe witness with pooled Go parser: %v", err)
+	}
+	defer largeGo.Release()
+	largeC := cParser.Parse(large, nil)
+	if largeC == nil || largeC.RootNode() == nil {
+		t.Fatal("locked C parser returned no Swift unsafe witness tree")
+	}
+	defer largeC.Close()
+	inspection, err := benchfixtures.InspectGoTree(largeGo.RootNode(), goLang)
+	if err != nil {
+		t.Fatalf("inspect pooled Swift unsafe witness: %v", err)
+	}
+	if inspection.SHA256 != wantGoDigest {
+		t.Fatalf("pooled Swift unsafe witness digest = %s, want %s", inspection.SHA256, wantGoDigest)
+	}
+	cDigest, err := COracleDeepDigest(largeC)
+	if err != nil {
+		t.Fatalf("inspect locked C Swift unsafe witness: %v", err)
+	}
+	if cDigest != wantCDigest {
+		t.Fatalf("locked C Swift unsafe witness digest = %s, want %s", cDigest, wantCDigest)
+	}
+	if diff := FirstDivergenceDumpV1(largeGo.RootNode(), goLang, largeC.RootNode()); diff == nil {
+		t.Fatal("Swift unsafe witness reached C structural parity; ratchet the known-mismatch test")
+	}
 }

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -1,8 +1,81 @@
 # Compact route real-corpus matrix
 
-Current evidence date: 2026-08-22.
-Current base commit: `f298328a` from `main`.
-Current candidate base commit: `f298328a`.
+Current evidence date: 2026-08-24.
+Current base commit: `da6f71471aaaa835503accaa1bc2083ced90b4e6` from `main`.
+Current candidate base commit: `da6f71471aaaa835503accaa1bc2083ced90b4e6`.
+
+## Latest Swift issue #576 parser recovery candidate
+
+Receipt base: `da6f71471aaaa835503accaa1bc2083ced90b4e6`.
+
+Status: **GO FOR REVIEW / KEEP ISSUE #576 OPEN**. This candidate changes the
+generic C-style recovery path. It does not change compact-route admission.
+
+During recovery, the active DFA source replays from the exact skipped-prefix
+offset. It verifies the stack offset, token span, points, token identity, and
+scanner state. It resynchronizes the source before it emits `errorSymbol`.
+Recovery replay requires a non-empty scanner checkpoint and live state. A
+checkpointless scanner rejects recovery replay without changing the scanner.
+Generic relex still accepts stateless scanners with empty serialization. The
+Swift scanner now serializes its complete state. The parser records error-mode
+lexing only after the DFA produces the token. The recovery path excludes tokens
+from an external scanner. Each outer parse operation resets the recovery memo size.
+Nested retries keep the larger memo. The parser returns a rejected recovery
+probe before the legacy retry. Merge scratch drops its preflight state at a
+pool boundary.
+
+Entry scratch also enforces the source-sized reservation after pool reuse. It
+moves an adequate retained slab to the front when possible. Otherwise, it adds
+the required slab and keeps smaller slabs for later growth. This policy stops a
+small control parse from changing the next large parse.
+
+Swift no longer claims that failed scans preserve scanner state. The token
+source records the actual start and end checkpoints for an internal token.
+Recovery replay still requires equal checkpoints. Incremental fast-forward
+restores the recorded end checkpoint.
+
+The 20-byte witness now matches locked C. The two corpus witnesses still
+differ:
+
+| Witness | Go deep SHA-256 | Locked C deep SHA-256 | Result |
+|---|---|---|---|
+| `let x = unsafe bar()` | `c64b894edc4a20e15f2b4127bad4223f698c8996dba091c06c34aa89386d3c68` | `c64b894edc4a20e15f2b4127bad4223f698c8996dba091c06c34aa89386d3c68` | exact |
+| `stdlib_FloatingPointToString.swift` | `7cb588c1f7b44cf490d8fcddd11adb0cc56238e891156687c26660568a7f7447` | `ab96dddf088487acc700d72af9342c338901504dcf1d32b9644e9f6f6638190d` | mismatch |
+| `stdlib_CollectionAlgorithms.swift` | `a3e737087be92518dbe1f8481a2b5169529b4f557b7f00033ab9da21d7aa32c9` | `132d332f511f12735d80e846f52ec1fddf5f3d0dcd7a097779640a7710497487` | mismatch |
+
+Focused Docker gates passed with one Swift grammar, one CPU, and one test
+worker. The artifacts are:
+
+- Failed-scan mutation: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T104928Z-swift576-second-review-failed-scan`
+- Incremental fast-forward: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105001Z-swift576-second-review-fast-forward`
+- Swift checkpoint grammar tests: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105029Z-swift576-second-review-swift-checkpoints-v2`
+- Generic relex contract: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105035Z-swift576-second-review-generic-relex`
+- Parser and scanner tests: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105047Z-swift576-second-review-focused`
+- Repeated clean-to-large sequence: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105132Z-swift576-second-review-clean-large`
+- Memory contract: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105237Z-swift576-second-review-memory-contract`
+- AWK recovery control: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105100Z-swift576-second-review-awk`
+- Both Swift corpus witnesses: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105216Z-swift576-second-review-large-telemetry`
+
+The TypeScript receipt changed only documentation and a focused test. The
+Swift production inputs stayed unchanged during the rebase. These identity
+gates passed on `da6f71471aaaa835503accaa1bc2083ced90b4e6`:
+
+- Transition and generic relex tests: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T110309Z-swift576-da6-identity-root`
+- Swift checkpoint grammar tests: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T110323Z-swift576-da6-swift-checkpoints`
+- AWK recovery control: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T110332Z-swift576-da6-awk`
+- Pooled minimal Swift parity: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T110349Z-swift576-da6-pooled-minimal`
+
+The scanner repair benchmark used 20 seeds and a 750 millisecond duration.
+No timing or allocation result regressed. The geometric mean time decreased
+3.57 percent. Bytes per operation stayed unchanged. The warmed large-witness
+maximum resident set size had one 594240 KiB before sample and one 597160 KiB
+after sample. The observed increase is 0.491384 percent, or about 0.49 percent.
+The raw benchmark files are
+`/tmp/swift576-scanner-checkpoint-before.txt` and
+`/tmp/swift576-scanner-checkpoint-after.txt`.
+
+The large witnesses still fail correctness. Keep issue #576 open until both
+corpus witnesses match locked C.
 
 ## C26a Swift issue #576 token-production blocker
 

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -19,10 +19,12 @@ checkpointless scanner rejects recovery replay without changing the scanner.
 Generic relex still accepts stateless scanners with empty serialization. The
 Swift scanner now serializes its complete state. The parser records error-mode
 lexing only after the DFA produces the token. The recovery path excludes tokens
-from an external scanner. Each outer parse operation resets the recovery memo size.
-Nested retries keep the larger memo. The parser returns a rejected recovery
-probe before the legacy retry. Merge scratch drops its preflight state at a
-pool boundary.
+from an external scanner. Each outer parse operation resets the recovery memo
+size. Nested retries keep the larger memo. Temporary growth retains an existing
+16,384-entry standard slab. Cleanup restores that slab without an allocation.
+A shorter retained slab remains short. The parser returns a rejected recovery
+probe before the legacy retry. Merge scratch drops its preflight state at a pool
+boundary.
 
 Entry scratch also enforces the source-sized reservation after pool reuse. It
 moves an adequate retained slab to the front when possible. Otherwise, it adds
@@ -30,9 +32,15 @@ the required slab and keeps smaller slabs for later growth. This policy stops a
 small control parse from changing the next large parse.
 
 Swift no longer claims that failed scans preserve scanner state. The token
-source records the actual start and end checkpoints for an internal token.
-Recovery replay still requires equal checkpoints. Incremental fast-forward
-restores the recorded end checkpoint.
+source restores failed scans by default. Swift explicitly retains its required
+failed-scan state change. Retention takes precedence over failure preservation.
+The source records actual start and end checkpoints for an internal token.
+Each alternate retry starts from the original snapshot. After terminal
+failure, only the last failed attempt remains live. Recovery replay still
+requires equal checkpoints.
+Incremental fast-forward restores the recorded end checkpoint. Generic relex
+rejects a synthetic end-of-file lookahead that would replace a real token.
+Swift defers `>?` to the DFA only when an unmatched `<` exists.
 
 The 20-byte witness now matches locked C. The two corpus witnesses still
 differ:
@@ -73,6 +81,21 @@ after sample. The observed increase is 0.491384 percent, or about 0.49 percent.
 The raw benchmark files are
 `/tmp/swift576-scanner-checkpoint-before.txt` and
 `/tmp/swift576-scanner-checkpoint-after.txt`.
+
+PR #967 exposed Templ, Swift operator, recovery memo, and Markdown reuse
+regressions. The repair restores default failed-scan rollback. Swift keeps an
+explicit failure-retention capability. The final scanner, Swift, Templ, and
+Markdown artifacts are:
+
+- `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T121348Z-swift967-repair-final-scanner`
+- `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T121422Z-swift967-repair-final-swift`
+- `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T121436Z-swift967-repair-final-templ`
+- `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T121446Z-swift967-repair-final-markdown-race`
+
+The 20-seed primary trio changed by 1.242879 percent in the median geomean.
+No primary timing lane changed significantly. Bytes and allocations per
+operation stayed unchanged. One warmed large-witness sample changed from
+565920 KiB to 565280 KiB. The observed decrease is 0.113090 percent.
 
 The large witnesses still fail correctness. Keep issue #576 open until both
 corpus witnesses match locked C.

--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -122,8 +122,9 @@ Here is the lifecycle, as the runtime actually drives it
   empty snapshot as a reset to initial state.
 - `Scan` returns true if it recognized a token. On true, the runtime reads
   the result from the lexer (symbol + span). On false, the runtime
-  discards position effects (it does not discard state effects — see
-  `FailurePreservingExternalScanner` below).
+  discards position effects and restores the serialized start state by
+  default. Implement `FailureStateRetainingExternalScanner` only when the
+  failed-scan state change is required by the next scan.
 
 ### The dual numbering contract (differs from C!)
 
@@ -330,6 +331,13 @@ numbering, use the public remapper:
 - `FailurePreservingExternalScanner` (`PreservesStateOnScanFailure() bool`):
   declare true if `Scan` returning false never mutated the payload — this
   lets the runtime skip defensive state snapshots on the hot path.
+- `FailureStateRetainingExternalScanner` (`RetainsStateOnScanFailure() bool`):
+  declare true only when a failed scan changes serialized state that the next
+  scan must read. The runtime records that actual end state at an internal
+  token boundary. Swift uses this route for its carried trivia rune. Retention
+  takes precedence if a scanner reports both failure capabilities. Each
+  alternate retry starts from the original snapshot. If all retries fail, only
+  the terminal failed attempt remains live.
 
 ### Incremental-reuse certification matrix
 

--- a/docs/swift-576-compact-correctness-blocker.md
+++ b/docs/swift-576-compact-correctness-blocker.md
@@ -2,7 +2,107 @@
 
 Status: NO-GO. Keep [issue #576](https://github.com/odvcencio/gotreesitter/issues/576) open.
 
-Base commit: `97a7bde26bac9b1a110bbf9216cc681ca59cc5aa`.
+Original receipt base: `97a7bde26bac9b1a110bbf9216cc681ca59cc5aa`.
+
+## Candidate receipt at `da6f71471aaaa835503accaa1bc2083ced90b4e6`
+
+Candidate disposition: GO for review of the generic fix. Issue disposition:
+NO-GO for closure. The large Swift witnesses still differ from locked C.
+
+The active deterministic finite automaton (DFA) source now replays a paused
+lookahead from its exact skipped-prefix start. The path requires these proofs:
+
+- The stack offset equals the skipped-prefix offset.
+- The replay token keeps the original byte span and points.
+- The replay token is internal and invisible.
+- Parser state zero has no action for the replay token.
+- Recovery replay has a non-empty external-scanner start and live state.
+- The active source ends at the replay token end.
+
+The DFA source resynchronizes before it emits `errorSymbol`. The parser records
+error-mode lexing only after the DFA produces the replay. A rejected probe
+restores the lexer, scanner, parser state, and Graph-Structured Stack (GSS)
+state. The parser keeps the error flag on the enclosing `ERROR` node. It leaves
+the lexer-produced `ERROR` leaf without a second error flag.
+
+An absent scanner checkpoint rejects replay before the recovery transaction.
+The rejection does not call `Deserialize` and does not change live scanner
+state. This requirement applies only to recovery replay from a skipped prefix.
+Generic relex still accepts stateless scanners with empty serialization. The
+Swift scanner serializes the raw-string count and carried rune.
+
+The Swift scanner no longer claims that failed scans preserve its state. A
+failed scan can change its carried rune. The token source now retains that
+change and records both checkpoints for an internal token. Recovery replay
+still requires equal checkpoints. Incremental fast-forward restores the actual
+end checkpoint.
+
+Each outer parse operation resets the recovery memo to its initial logical
+size. Nested retry attempts keep the larger memo. This reset makes pooled and
+fresh large-witness digests equal. The parser returns a rejected initial probe
+before the legacy retry. This return applies the normal snippet-parser reset.
+
+Merge scratch clears and drops its preflight object at a pool boundary. Entry
+scratch enforces the required source-sized reservation after pool reuse. It
+moves a large retained slab to the front when possible. Otherwise, it adds the
+required slab and keeps smaller slabs for later growth. A small control parse
+cannot reduce the next large parse reservation.
+
+This change uses no Swift grammar rule and no language-name exception. It does
+not change compact-route admission. The compact route remains outside this
+candidate.
+
+The 20-byte witness now matches locked C:
+
+| Witness | Go deep SHA-256 | C deep SHA-256 | Result |
+|---|---|---|---|
+| `let x = unsafe bar()` | `c64b894edc4a20e15f2b4127bad4223f698c8996dba091c06c34aa89386d3c68` | `c64b894edc4a20e15f2b4127bad4223f698c8996dba091c06c34aa89386d3c68` | exact |
+| `stdlib_FloatingPointToString.swift` | `7cb588c1f7b44cf490d8fcddd11adb0cc56238e891156687c26660568a7f7447` | `ab96dddf088487acc700d72af9342c338901504dcf1d32b9644e9f6f6638190d` | mismatch |
+| `stdlib_CollectionAlgorithms.swift` | `a3e737087be92518dbe1f8481a2b5169529b4f557b7f00033ab9da21d7aa32c9` | `132d332f511f12735d80e846f52ec1fddf5f3d0dcd7a097779640a7710497487` | mismatch |
+
+The minimal source SHA-256 remains
+`b511d81ace2a89b05e8e5e0ca6730c10f2ac9295111dae013097c7c6be8861fe`.
+The CollectionAlgorithms source SHA-256 is
+`1aae0051b0bfb50e17c7ac94961ee7cab7332367dcc16e827d2482be7a2dc5a1`.
+
+The focused tests passed in Docker with one Swift grammar, one CPU, and one
+test worker. No run timed out or hit the memory limit.
+
+- Failed-scan mutation: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T104928Z-swift576-second-review-failed-scan`
+- Incremental fast-forward: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105001Z-swift576-second-review-fast-forward`
+- Swift checkpoint grammar tests: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105029Z-swift576-second-review-swift-checkpoints-v2`
+- Generic relex contract: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105035Z-swift576-second-review-generic-relex`
+- Parser and scanner tests: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105047Z-swift576-second-review-focused`
+- Repeated clean-to-large sequence: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105132Z-swift576-second-review-clean-large`
+- Memory contract: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105237Z-swift576-second-review-memory-contract`
+- AWK recovery control: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105100Z-swift576-second-review-awk`
+- Both corpus witnesses: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T105216Z-swift576-second-review-large-telemetry`
+
+The TypeScript receipt changed only documentation and a focused test. The
+Swift production inputs stayed unchanged during the rebase. These identity
+gates passed on `da6f71471aaaa835503accaa1bc2083ced90b4e6`:
+
+- Transition and generic relex tests: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T110309Z-swift576-da6-identity-root`
+- Swift checkpoint grammar tests: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T110323Z-swift576-da6-swift-checkpoints`
+- AWK recovery control: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T110332Z-swift576-da6-awk`
+- Pooled minimal Swift parity: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T110349Z-swift576-da6-pooled-minimal`
+
+The scanner repair benchmark used 20 seeds and a 750 millisecond duration.
+No timing or allocation result regressed. The geometric mean time decreased
+3.57 percent. Bytes per operation stayed unchanged. The warmed large-witness
+maximum resident set size had one 594240 KiB before sample and one 597160 KiB
+after sample. The observed increase is 0.491384 percent, or about 0.49 percent.
+The raw files are:
+
+- `/tmp/swift576-scanner-checkpoint-before.txt`
+- `/tmp/swift576-scanner-checkpoint-after.txt`
+- `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T110004Z-swift576-scanner-checkpoint-rss-before-warm`
+- `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T110048Z-swift576-scanner-checkpoint-rss-after-warm`
+
+The large witnesses still fail the correctness gate. Keep issue #576 open
+until both corpus witnesses match locked C.
+
+## Original blocker receipt
 
 This receipt records the Swift `unsafe` expression-prefix mismatch. It does not
 change parser behavior or admit a compact recovery path.
@@ -13,8 +113,9 @@ The Swift corpus ratchet records both #576 files in
 `grammars/swift_corpus_test.go`.
 
 The locked-C parity tests record the corpus witness and the 20-byte minimal
-witness in `cgo_harness/parity_swift_recovery_probe_test.go`. The minimal test
-also pins the first divergence path and both child counts.
+witness in `cgo_harness/parity_swift_recovery_probe_test.go`. A pooled test
+parses the clean for-range control before the minimal witness. Both parses must
+match locked C.
 
 ## Locked evidence
 

--- a/docs/swift-576-compact-correctness-blocker.md
+++ b/docs/swift-576-compact-correctness-blocker.md
@@ -32,15 +32,27 @@ Generic relex still accepts stateless scanners with empty serialization. The
 Swift scanner serializes the raw-string count and carried rune.
 
 The Swift scanner no longer claims that failed scans preserve its state. A
-failed scan can change its carried rune. The token source now retains that
-change and records both checkpoints for an internal token. Recovery replay
-still requires equal checkpoints. Incremental fast-forward restores the actual
-end checkpoint.
+failed scan can change its carried rune. Scanners restore their start state
+after failure by default. Swift explicitly retains its required state change.
+Retention takes precedence if a scanner reports both failure capabilities.
+The token source records both checkpoints for an internal token. Recovery
+replay still requires equal checkpoints. Incremental fast-forward restores the
+actual end checkpoint. A successful external token always records its actual
+end checkpoint. Each alternate retry starts from the original snapshot. If all
+retries fail, only the terminal failed attempt remains live.
+
+Generic relex rejects a synthetic end-of-file lookahead when a real token
+still starts before the source end. Swift defers `>?` to the DFA only when an
+unmatched `<` exists in the active scope. A trailing `>?` remains one custom
+operator.
 
 Each outer parse operation resets the recovery memo to its initial logical
 size. Nested retry attempts keep the larger memo. This reset makes pooled and
-fresh large-witness digests equal. The parser returns a rejected initial probe
-before the legacy retry. This return applies the normal snippet-parser reset.
+fresh large-witness digests equal. Temporary growth retains an existing
+16,384-entry standard slab. Cleanup restores that slab without an allocation.
+A shorter retained slab remains short. The parser returns a rejected initial
+probe before the legacy retry. This return applies the normal snippet-parser
+reset.
 
 Merge scratch clears and drops its preflight object at a pool boundary. Entry
 scratch enforces the required source-sized reservation after pool reuse. It
@@ -48,8 +60,9 @@ moves a large retained slab to the front when possible. Otherwise, it adds the
 required slab and keeps smaller slabs for later growth. A small control parse
 cannot reduce the next large parse reservation.
 
-This change uses no Swift grammar rule and no language-name exception. It does
-not change compact-route admission. The compact route remains outside this
+Recovery substitution uses no Swift grammar rule or source exception. The
+operator repair stays inside the existing Swift token-source guard. This change
+does not affect compact-route admission. The compact route remains outside this
 candidate.
 
 The 20-byte witness now matches locked C:
@@ -98,6 +111,32 @@ The raw files are:
 - `/tmp/swift576-scanner-checkpoint-after.txt`
 - `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T110004Z-swift576-scanner-checkpoint-rss-before-warm`
 - `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T110048Z-swift576-scanner-checkpoint-rss-after-warm`
+
+PR #967 exposed four CI regressions. The repair restores default failed-scan
+rollback and keeps Swift retention explicit. It also repairs Swift operator
+relex and the recovery memo lifecycle. These final focused gates passed:
+
+- Scanner and generic relex: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T121348Z-swift967-repair-final-scanner`
+- Swift checkpoints and operator: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T121422Z-swift967-repair-final-swift`
+- Templ census: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T121436Z-swift967-repair-final-templ`
+- Markdown race reuse: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T121446Z-swift967-repair-final-markdown-race`
+- Recovery memo race: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T114020Z-swift967-repair-memo-race`
+- AWK recovery control: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T114203Z-swift967-repair-awk`
+- Repeated clean-to-large sequence: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T114224Z-swift967-repair-clean-large`
+- Both large witnesses: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T114333Z-swift967-repair-large-telemetry`
+- Memory contract: `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T114419Z-swift967-repair-memory-contract`
+
+The PR repair used 20 seeds and a 750 millisecond duration. No primary lane
+changed significantly. The primary trio median geomean increased 1.242879
+percent. Bytes and allocations per operation stayed unchanged. One warmed
+large-witness sample changed from 565920 KiB to 565280 KiB. The observed
+decrease is 0.113090 percent. The raw files are:
+
+- `/tmp/swift967-repair-before.txt`
+- `/tmp/swift967-repair-after.txt`
+- `/tmp/swift967-repair-benchstat.txt`
+- `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T121155Z-swift967-repair-rss-before-warm`
+- `/tmp/gotreesitter-swift576-push-20260824/harness_out/docker/20260824T121225Z-swift967-repair-rss-after-warm`
 
 The large witnesses still fail the correctness gate. Keep issue #576 open
 until both corpus witnesses match locked C.

--- a/external_scanner_adapter.go
+++ b/external_scanner_adapter.go
@@ -88,6 +88,11 @@ func (a *externalScannerOrderAdapter) PreservesStateOnScanFailure() bool {
 	return ok && preserving.PreservesStateOnScanFailure()
 }
 
+func (a *externalScannerOrderAdapter) RetainsStateOnScanFailure() bool {
+	retaining, ok := a.optionalInner().(FailureStateRetainingExternalScanner)
+	return ok && retaining.RetainsStateOnScanFailure()
+}
+
 func (a *externalScannerOrderAdapter) optionalInner() ExternalScanner {
 	if a == nil {
 		return nil

--- a/external_scanner_adapter_test.go
+++ b/external_scanner_adapter_test.go
@@ -47,6 +47,10 @@ func (*capabilityExternalScanner) PreservesStateOnScanFailure() bool {
 	return true
 }
 
+type retainingCapabilityExternalScanner struct{ recordingExternalScanner }
+
+func (*retainingCapabilityExternalScanner) RetainsStateOnScanFailure() bool { return true }
+
 func TestExternalScannerOrderAdapterPreservesOptionalCapabilities(t *testing.T) {
 	scanner := &capabilityExternalScanner{}
 	sourceLang := &Language{
@@ -76,6 +80,32 @@ func TestExternalScannerOrderAdapterPreservesOptionalCapabilities(t *testing.T) 
 	}
 	if preserving, ok := adapted.(FailurePreservingExternalScanner); !ok || !preserving.PreservesStateOnScanFailure() {
 		t.Fatal("failure-preserving capability was not preserved")
+	}
+	if retaining, ok := adapted.(FailureStateRetainingExternalScanner); !ok || retaining.RetainsStateOnScanFailure() {
+		t.Fatal("adapter reported failure retention for a preserving scanner")
+	}
+}
+
+func TestExternalScannerOrderAdapterPreservesFailureRetention(t *testing.T) {
+	scanner := &retainingCapabilityExternalScanner{}
+	sourceLang := &Language{
+		SymbolNames:     []string{"", "a"},
+		ExternalSymbols: []Symbol{1},
+		ExternalScanner: scanner,
+	}
+	targetLang := &Language{
+		SymbolNames:     []string{"", "", "a"},
+		ExternalSymbols: []Symbol{2},
+	}
+	adapted, ok := AdaptExternalScannerByExternalOrder(sourceLang, targetLang)
+	if !ok {
+		t.Fatal("adapter not created")
+	}
+	if retaining, ok := adapted.(FailureStateRetainingExternalScanner); !ok || !retaining.RetainsStateOnScanFailure() {
+		t.Fatal("failure-state-retaining capability was not preserved")
+	}
+	if preserving, ok := adapted.(FailurePreservingExternalScanner); !ok || preserving.PreservesStateOnScanFailure() {
+		t.Fatal("adapter reported failure preservation for a retaining scanner")
 	}
 }
 

--- a/glr.go
+++ b/glr.go
@@ -520,12 +520,34 @@ type stackEntrySlab struct {
 }
 
 func (s *glrEntryScratch) ensureInitialCap(minEntries int) {
-	if minEntries <= 0 || len(s.slabs) != 0 {
+	if minEntries <= 0 {
 		return
 	}
 	capacity := defaultStackEntrySlabCap
 	if minEntries > capacity {
 		capacity = minEntries
+	}
+	if len(s.slabs) != 0 {
+		if len(s.slabs[0].data) >= capacity {
+			return
+		}
+		// A smaller retained slab must not define the next full parse. Move
+		// an adequate retained slab to the front when one is available.
+		for i := 1; i < len(s.slabs); i++ {
+			if len(s.slabs[i].data) >= capacity {
+				s.slabs[0], s.slabs[i] = s.slabs[i], s.slabs[0]
+				s.slabCursor = 0
+				return
+			}
+		}
+		// Keep smaller slabs for later stack growth. Add the required fresh
+		// reservation at the front so the first stack has stable capacity.
+		s.slabs = append(s.slabs, stackEntrySlab{data: make([]stackEntry, capacity)})
+		last := len(s.slabs) - 1
+		s.slabs[0], s.slabs[last] = s.slabs[last], s.slabs[0]
+		s.allocatedBytes += stackEntryBytesForCap(capacity)
+		s.slabCursor = 0
+		return
 	}
 	s.slabs = append(s.slabs, stackEntrySlab{data: make([]stackEntry, capacity)})
 	s.allocatedBytes += stackEntryBytesForCap(capacity)
@@ -3891,6 +3913,10 @@ func (p *gssMainPreflight) clearGSSPointersForReuse() {
 	clear(p.cleanCache)
 	clear(p.cleanSeen)
 	clear(p.offsetSeen)
+	if cap(p.reachCache) > 0 {
+		clear(p.reachCache[:cap(p.reachCache)])
+		p.reachCache = p.reachCache[:0]
+	}
 	if cap(p.reachStack) > 0 {
 		clear(p.reachStack[:cap(p.reachStack)])
 		p.reachStack = p.reachStack[:0]
@@ -5764,7 +5790,9 @@ func (s *glrMergeScratch) reset() {
 	s.spineEquivBytes = glrSpineEquivCacheBytesForCap(cap(s.spineEquivCache))
 	s.frontierHashBytes = glrStackFrontierHashCacheBytesForCap(cap(s.frontierHashCache))
 	if s.preflight != nil {
-		s.preflightReachCacheBytes = int64(cap(s.preflight.reachCache)) * int64(unsafe.Sizeof(gssReachCacheEntry{}))
+		s.preflight.clearGSSPointersForReuse()
+		s.preflight = nil
+		s.preflightReachCacheBytes = 0
 	}
 	s.frontierMergeHash = false
 	s.cErrorCostParser = nil

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -1563,6 +1563,33 @@ func TestParserRecycleDemotedGSSInvalidatesPointerHolders(t *testing.T) {
 	}
 }
 
+func TestGLRMergeScratchResetClearsPreflightReachCache(t *testing.T) {
+	from := &gssNode{}
+	target := &gssNode{}
+	scratch := glrMergeScratch{
+		preflight: newGSSMainPreflight(nil),
+	}
+	preflight := scratch.preflight
+	preflight.reachCache = make([]gssReachCacheEntry, maxGSSPreflightReachCacheEntries)
+	preflight.reachCache[0] = gssReachCacheEntry{
+		from:       uintptr(unsafe.Pointer(from)),
+		target:     uintptr(unsafe.Pointer(target)),
+		generation: preflight.reachCacheGeneration,
+		reachable:  true,
+	}
+
+	scratch.reset()
+	if scratch.preflight != nil {
+		t.Fatal("preflight survived merge-scratch reset")
+	}
+	if len(preflight.reachCache) != 0 {
+		t.Fatalf("reset preflight reach-cache length = %d, want 0", len(preflight.reachCache))
+	}
+	if got := preflight.reachCache[:cap(preflight.reachCache)][0]; got != (gssReachCacheEntry{}) {
+		t.Fatalf("reset preflight retained reach-cache entry: %+v", got)
+	}
+}
+
 func TestGSSReuseRetainsOnlyFingerprintedSpineCache(t *testing.T) {
 	var nodes gssScratch
 	a := nodes.allocNode(stackEntry{state: 1}, nil, 1)

--- a/grammars/swift_corpus_test.go
+++ b/grammars/swift_corpus_test.go
@@ -77,6 +77,8 @@ var swiftCorpusExpectations = map[string]swiftCorpusExpectation{
 	"stdlib_CollectionAlgorithms.swift": {
 		status: swiftCorpusKnownFailing,
 		// Same root cause as stdlib_FloatingPointToString.swift: the
+		// focused minimal witness now matches locked C, but this full file
+		// still reports an error.
 		// `unsafe` expression-prefix keyword. Verified by bisection: the
 		// file parses clean through the `_halfStablePartition` function
 		// (byte 13232) and only starts failing once `partition(by:)`
@@ -87,6 +89,8 @@ var swiftCorpusExpectations = map[string]swiftCorpusExpectation{
 	"stdlib_FloatingPointToString.swift": {
 		status: swiftCorpusKnownFailing,
 		// Tracks #576. Minimal repro: `let x = unsafe bar()`.
+		// The focused 20-byte witness now matches locked C through generic
+		// recovery. This corpus file still reports an error.
 		// The `unsafe` keyword used as an expression prefix (Swift's
 		// strict-memory-safety opt-in, used throughout this file as
 		// `unsafe buffer.storeBytes(...)`, `let x = unsafe

--- a/grammars/swift_recovery_probe_test.go
+++ b/grammars/swift_recovery_probe_test.go
@@ -107,7 +107,7 @@ func TestSwiftUnsafeWitnessKeepsCurrentGoTreeAcrossRecoveryProbe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("inspect Swift unsafe witness: %v", err)
 	}
-	const wantDigest = "ec51c633a3f99515cc0cd1c0cff435a44ddc7db8e83705977d28f78bdfb0fc0e"
+	const wantDigest = "7cb588c1f7b44cf490d8fcddd11adb0cc56238e891156687c26660568a7f7447"
 	if inspection.SHA256 != wantDigest {
 		t.Fatalf("Swift unsafe witness digest = %s, want %s", inspection.SHA256, wantDigest)
 	}

--- a/grammars/swift_scanner.go
+++ b/grammars/swift_scanner.go
@@ -434,6 +434,10 @@ func (SwiftExternalScanner) Deserialize(payload any, buf []byte) {
 
 func (SwiftExternalScanner) UsesExternalScannerCheckpoints() bool { return true }
 
+// RetainsStateOnScanFailure reports that a failed scan can carry one trivia
+// boundary rune into the next scan. The runtime must record that end state.
+func (SwiftExternalScanner) RetainsStateOnScanFailure() bool { return true }
+
 func (s SwiftExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	state := payload.(*swtScannerState)
 	if len(s.externalToToken) > 0 {

--- a/grammars/swift_scanner.go
+++ b/grammars/swift_scanner.go
@@ -393,44 +393,46 @@ func (SwiftExternalScanner) Destroy(payload any) {}
 func (SwiftExternalScanner) Serialize(payload any, buf []byte) int {
 	s := payload.(*swtScannerState)
 	hc := s.ongoingRawStrHashCount
-	if len(buf) < 4 {
+	if len(buf) < 9 {
 		return 0
 	}
 	buf[0] = byte(hc >> 24)
 	buf[1] = byte(hc >> 16)
 	buf[2] = byte(hc >> 8)
 	buf[3] = byte(hc)
-	return 4
+	if s.carriedPreviousValid {
+		buf[4] = 1
+	} else {
+		buf[4] = 0
+	}
+	previous := uint32(s.carriedPreviousRune)
+	buf[5] = byte(previous >> 24)
+	buf[6] = byte(previous >> 16)
+	buf[7] = byte(previous >> 8)
+	buf[8] = byte(previous)
+	return 9
 }
 
 func (SwiftExternalScanner) Deserialize(payload any, buf []byte) {
 	s := payload.(*swtScannerState)
 	s.ongoingRawStrHashCount = 0
-	// carriedPreviousRune/carriedPreviousValid are not serialized: they only
-	// bridge two back-to-back invocations within the same forward-scanning
-	// trivia run and are not meaningful across a restored checkpoint. Clear
-	// them so a restore falls back to a fresh lexer.Previous() read, never a
-	// stale carried rune from a discarded branch.
+	s.carriedPreviousRune = 0
 	s.carriedPreviousValid = false
-	if len(buf) < 4 {
+	if len(buf) < 9 {
 		return
 	}
 	s.ongoingRawStrHashCount = uint32(buf[0])<<24 |
 		uint32(buf[1])<<16 |
 		uint32(buf[2])<<8 |
 		uint32(buf[3])
+	s.carriedPreviousValid = buf[4] != 0
+	s.carriedPreviousRune = rune(uint32(buf[5])<<24 |
+		uint32(buf[6])<<16 |
+		uint32(buf[7])<<8 |
+		uint32(buf[8]))
 }
 
-// PreservesStateOnScanFailure holds because Scan only writes
-// swtScannerState.ongoingRawStrHashCount on a path that itself returns true
-// (see swtEatRawStrPart), so a false return never leaves that field
-// mutated. swtEatWhitespace does write carriedPreviousRune/carriedPreviousValid
-// on some false-returning paths, and that write is intentional: it must
-// survive the false return so the next Scan call sees it (see swtScannerState
-// doc comment). Declaring this true tells the token source to stop
-// snapshotting and restoring scanner state around every failed scan, which
-// would otherwise erase that carried value before the caller could use it.
-func (SwiftExternalScanner) PreservesStateOnScanFailure() bool { return true }
+func (SwiftExternalScanner) UsesExternalScannerCheckpoints() bool { return true }
 
 func (s SwiftExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	state := payload.(*swtScannerState)

--- a/grammars/swift_scanner_checkpoint_test.go
+++ b/grammars/swift_scanner_checkpoint_test.go
@@ -1,0 +1,69 @@
+package grammars
+
+import (
+	"bytes"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+func TestSwiftExternalScannerCheckpointRoundTrip(t *testing.T) {
+	scanner := SwiftExternalScanner{}
+	checkpointed, ok := any(scanner).(interface {
+		UsesExternalScannerCheckpoints() bool
+	})
+	if !ok || !checkpointed.UsesExternalScannerCheckpoints() {
+		t.Fatal("Swift scanner does not advertise complete checkpoints")
+	}
+
+	original := &swtScannerState{
+		ongoingRawStrHashCount: 17,
+		carriedPreviousRune:    '\u03bb',
+		carriedPreviousValid:   true,
+	}
+	buf := make([]byte, 9)
+	if got := scanner.Serialize(original, buf); got != len(buf) {
+		t.Fatalf("serialized checkpoint bytes = %d, want %d", got, len(buf))
+	}
+
+	restored := &swtScannerState{
+		ongoingRawStrHashCount: 99,
+		carriedPreviousRune:    'x',
+		carriedPreviousValid:   true,
+	}
+	scanner.Deserialize(restored, buf)
+	if *restored != *original {
+		t.Fatalf("restored scanner state = %+v, want %+v", *restored, *original)
+	}
+
+	scanner.Deserialize(restored, nil)
+	if *restored != (swtScannerState{}) {
+		t.Fatalf("empty checkpoint did not clear scanner state: %+v", *restored)
+	}
+}
+
+func TestSwiftExternalScannerFailedScanMutatesCarryCheckpoint(t *testing.T) {
+	scanner := SwiftExternalScanner{}
+	state := &swtScannerState{
+		carriedPreviousRune:  'x',
+		carriedPreviousValid: true,
+	}
+	start := make([]byte, 9)
+	if got := scanner.Serialize(state, start); got != len(start) {
+		t.Fatalf("start checkpoint bytes = %d, want %d", got, len(start))
+	}
+
+	if scanner.Scan(state, &gotreesitter.ExternalLexer{}, make([]bool, swtTokenCount)) {
+		t.Fatal("empty-source scanner produced a token")
+	}
+	end := make([]byte, 9)
+	if got := scanner.Serialize(state, end); got != len(end) {
+		t.Fatalf("end checkpoint bytes = %d, want %d", got, len(end))
+	}
+	if bytes.Equal(start, end) {
+		t.Fatalf("failed scan kept one checkpoint: start=%v end=%v", start, end)
+	}
+	if state.carriedPreviousValid {
+		t.Fatalf("failed scan kept stale carry state: %+v", state)
+	}
+}

--- a/language.go
+++ b/language.go
@@ -268,6 +268,18 @@ type FailurePreservingExternalScanner interface {
 	PreservesStateOnScanFailure() bool
 }
 
+// FailureStateRetainingExternalScanner is implemented by scanners that can
+// change serialized state before Scan returns false. The changed state is part
+// of the scanner contract and must remain live for the next scan.
+//
+// Scanners without this capability keep the default transactional contract.
+// The token source restores their start state after a failed scan.
+// Retention takes precedence if a scanner reports both failure capabilities.
+type FailureStateRetainingExternalScanner interface {
+	ExternalScanner
+	RetainsStateOnScanFailure() bool
+}
+
 // ReduceChainTerminalAction describes the action class expected after a
 // generated reduce-chain hint finishes applying deterministic reductions.
 type ReduceChainTerminalAction uint8

--- a/lexer.go
+++ b/lexer.go
@@ -35,6 +35,9 @@ type Token struct {
 	// transitions before producing this token.
 	lexerSkippedPrefix      bool
 	lexerSkippedPrefixStart uint32
+	// lexerErrorModeLexed proves that the active DFA source produced this
+	// recovery token while parser state zero selected the error lex mode.
+	lexerErrorModeLexed bool
 }
 
 func bytesToStringNoCopy(b []byte) string {

--- a/parser.go
+++ b/parser.go
@@ -1127,6 +1127,10 @@ func (p *Parser) resetCRecoveryCostCompetitionState() {
 	}
 	p.crecoveryCostCompetitionRelevant = false
 	p.crecoveryCostCompetitionWalkEnabled = false
+	p.cRecoverSharedTokenErrorModeLexed = false
+	p.cRecoverCustomResyncActive = false
+	p.cRecoverCustomResyncByte = 0
+	p.cRecoverCustomSourceEligible = false
 	p.syncCRecoveryMergeScratch(p.mergeScratch)
 }
 
@@ -6709,9 +6713,9 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			condenseRan = true
 			var reason ParseStopReason
 			if recoveryRuntimeDetailedBuildEnabled {
-				stacks, resumed, tok, reason = p.cCondenseAndResumeDetailed(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, trackChildErrors)
+				stacks, resumed, tok, reason = p.cCondenseAndResumeDetailed(stacks, source, ts, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, scratch, trackChildErrors)
 			} else {
-				stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, trackChildErrors)
+				stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, ts, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, scratch, trackChildErrors)
 			}
 			workCountRefreshConvergenceLookahead(tok)
 			if resultMaterializationShouldStop(reason) {
@@ -6875,9 +6879,9 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			condenseRan = true
 			var reason ParseStopReason
 			if recoveryRuntimeDetailedBuildEnabled {
-				stacks, resumed, tok, reason = p.cCondenseAndResumeDetailed(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, trackChildErrors)
+				stacks, resumed, tok, reason = p.cCondenseAndResumeDetailed(stacks, source, ts, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, scratch, trackChildErrors)
 			} else {
-				stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, trackChildErrors)
+				stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, ts, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, scratch, trackChildErrors)
 			}
 			if resultMaterializationShouldStop(reason) {
 				return finalize(stacks, reason)

--- a/parser_api.go
+++ b/parser_api.go
@@ -559,6 +559,9 @@ func (p *Parser) parseForRecoveryInitialOnlyOrLegacy(source []byte, accept func(
 	if initial != nil {
 		initial.Release()
 	}
+	// Do not let the rejected initial-only attempt seed the legacy retry.
+	// Return the recovery parser so the snippet reset scrubs transient state.
+	p.clearRecoveryParser()
 
 	legacy, legacyErr := p.parseForRecovery(source)
 	p.recordRecoveryProbeLegacyFallback(p.recoveryParserRetryPasses())

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -37,6 +37,9 @@ type dfaTokenSource struct {
 	lastExternalTokenValid      bool
 	lastExternalTokenWasExtra   bool
 	externalTokenEndSameAsStart bool
+	lastTokenStartByte          uint32
+	lastTokenEndByte            uint32
+	lastTokenValid              bool
 	singleState                 [1]StateID
 	glrStates                   []StateID // all active GLR stack states
 	hasExternalScanner          bool
@@ -409,6 +412,9 @@ func (d *dfaTokenSource) Reset(source []byte) {
 	d.lastExternalTokenValid = false
 	d.lastExternalTokenWasExtra = false
 	d.externalTokenEndSameAsStart = false
+	d.lastTokenStartByte = 0
+	d.lastTokenEndByte = 0
+	d.lastTokenValid = false
 	if d.language == nil || d.language.ExternalScanner == nil {
 		return
 	}
@@ -453,6 +459,9 @@ func (d *dfaTokenSource) Close() {
 	d.lastExternalTokenValid = false
 	d.lastExternalTokenWasExtra = false
 	d.externalTokenEndSameAsStart = false
+	d.lastTokenStartByte = 0
+	d.lastTokenEndByte = 0
+	d.lastTokenValid = false
 	if !d.noPool {
 		dfaTokenSourcePool.Put(d)
 	}
@@ -490,6 +499,7 @@ func (d *dfaTokenSource) Next() Token {
 		}
 		if d.shouldForceEOFLookahead() {
 			tok := d.syntheticEOFLookaheadToken()
+			d.lastTokenValid = false
 			d.lastExternalTokenValid = false
 			d.lastExternalTokenWasExtra = false
 			d.externalTokenEndSameAsStart = false
@@ -656,10 +666,20 @@ func (d *dfaTokenSource) Next() Token {
 			}
 			fmt.Printf("  %s tok %d %s %d %d %s state=%d\n", prefix, tok.Symbol, name, tok.StartByte, tok.EndByte, tok.Text, d.state)
 		}
+		if tok.Symbol != 0 && !tok.NoLookahead {
+			d.lastTokenStartByte = tok.StartByte
+			d.lastTokenEndByte = tok.EndByte
+			d.lastTokenValid = true
+		} else {
+			d.lastTokenValid = false
+		}
 		if d.usesExternalCheckpoints && tok.Symbol != 0 && !tok.NoLookahead {
 			if tokenFromExternal {
 				d.captureExternalScannerStateInto(&d.externalTokenEnd)
 				d.externalTokenEndSameAsStart = false
+			} else if !d.externalScannerPreservesStateOnScanFailure() {
+				d.captureExternalScannerStateInto(&d.externalTokenEnd)
+				d.externalTokenEndSameAsStart = bytes.Equal(d.externalTokenStart, d.externalTokenEnd)
 			} else {
 				d.externalTokenEnd = d.externalTokenEnd[:0]
 				d.externalTokenEndSameAsStart = true
@@ -683,6 +703,10 @@ func (d *dfaTokenSource) Next() Token {
 			d.lastExternalTokenWasExtra = false
 			d.externalTokenEndSameAsStart = false
 		}
+		// Record provenance only when this source selected the error lex mode.
+		// A checkpointless external scanner cannot prove the complete lex path.
+		tok.lexerErrorModeLexed = d.cRecoveryEnabled && d.state == cErrorState && !tokenFromExternal &&
+			(!d.hasExternalScanner || d.usesExternalCheckpoints)
 		return tok
 	}
 }
@@ -713,6 +737,9 @@ func (d *dfaTokenSource) setExternalScannerCheckpointsEnabled(enabled bool) {
 	d.lastExternalTokenValid = false
 	d.lastExternalTokenWasExtra = false
 	d.externalTokenEndSameAsStart = false
+	d.lastTokenStartByte = 0
+	d.lastTokenEndByte = 0
+	d.lastTokenValid = false
 	d.externalTokenStart = d.externalTokenStart[:0]
 	d.externalTokenEnd = d.externalTokenEnd[:0]
 }
@@ -2842,6 +2869,9 @@ type dfaRelexSnapshot struct {
 	lastExternalTokenValid      bool
 	lastExternalTokenWasExtra   bool
 	externalTokenEndSameAsStart bool
+	lastTokenStartByte          uint32
+	lastTokenEndByte            uint32
+	lastTokenValid              bool
 	externalTokenStart          []byte
 	externalTokenEnd            []byte
 
@@ -2868,6 +2898,9 @@ func (d *dfaTokenSource) snapshotRelexStateWithExternalBuffer(buf []byte) (dfaRe
 		lastExternalTokenValid:      d.lastExternalTokenValid,
 		lastExternalTokenWasExtra:   d.lastExternalTokenWasExtra,
 		externalTokenEndSameAsStart: d.externalTokenEndSameAsStart,
+		lastTokenStartByte:          d.lastTokenStartByte,
+		lastTokenEndByte:            d.lastTokenEndByte,
+		lastTokenValid:              d.lastTokenValid,
 		externalTokenStart:          append([]byte(nil), d.externalTokenStart...),
 		externalTokenEnd:            append([]byte(nil), d.externalTokenEnd...),
 		extZeroPos:                  d.extZeroPos,
@@ -2905,6 +2938,9 @@ func (s dfaRelexSnapshot) restore(d *dfaTokenSource) {
 	d.lastExternalTokenValid = s.lastExternalTokenValid
 	d.lastExternalTokenWasExtra = s.lastExternalTokenWasExtra
 	d.externalTokenEndSameAsStart = s.externalTokenEndSameAsStart
+	d.lastTokenStartByte = s.lastTokenStartByte
+	d.lastTokenEndByte = s.lastTokenEndByte
+	d.lastTokenValid = s.lastTokenValid
 	d.externalTokenStart = append(d.externalTokenStart[:0], s.externalTokenStart...)
 	d.externalTokenEnd = append(d.externalTokenEnd[:0], s.externalTokenEnd...)
 	d.extZeroPos = s.extZeroPos
@@ -2930,26 +2966,7 @@ func (d *dfaTokenSource) RelexFromTokenStart(tok Token) (Token, bool) {
 // The caller must restore its transaction when it rejects the result.
 func (d *dfaTokenSource) relexFromTokenStartInTransaction(tok Token) (Token, bool) {
 	target := int(tok.StartByte)
-	d.lexer.pos = target
-	d.lexer.row = tok.StartPoint.Row
-	d.lexer.col = tok.StartPoint.Column
-	if d.hasExternalScanner && d.usesExternalCheckpoints {
-		d.restoreExternalScannerState(d.externalTokenStart)
-	}
-	d.lastExternalTokenValid = false
-	d.lastExternalTokenWasExtra = false
-	d.lastExternalTokenStartByte = 0
-	d.lastExternalTokenEndByte = 0
-	if len(d.externalTokenEnd) > 0 {
-		d.externalTokenEnd = d.externalTokenEnd[:0]
-	}
-	d.extZeroPos = -1
-	d.extZeroState = 0
-	if len(d.extZeroTried) > 0 {
-		d.extZeroTried = d.extZeroTried[:0]
-	}
-	d.zeroWidthPos = -1
-	d.zeroWidthCount = 0
+	d.beginRelexAt(target, tok.StartPoint)
 	if DebugDFA.Load() {
 		fmt.Printf("  RELEX from %d state=%d\n", tok.StartByte, d.state)
 	}
@@ -2962,6 +2979,93 @@ func (d *dfaTokenSource) relexFromTokenStartInTransaction(tok Token) (Token, boo
 		next.ExternalScannerStartByte = tok.ExternalScannerStartByte
 	}
 	return next, true
+}
+
+// relexRecoveryTokenFromSkippedPrefixInTransaction re-reads tok from its exact
+// lexer-call start. It converts an aligned, invisible error-mode token only
+// when state zero cannot act on that token. The caller owns rollback.
+func (d *dfaTokenSource) relexRecoveryTokenFromSkippedPrefixInTransaction(tok Token, startByte uint32, startPoint Point) (Token, bool) {
+	if !d.canRelexFromSkippedPrefix(tok) || !tok.lexerSkippedPrefix ||
+		tok.lexerSkippedPrefixStart != startByte || startByte >= tok.StartByte ||
+		d.lexer.pos != int(tok.EndByte) || d.lexer.row != tok.EndPoint.Row || d.lexer.col != tok.EndPoint.Column {
+		return Token{}, false
+	}
+	d.beginRelexAt(int(startByte), startPoint)
+	if DebugDFA.Load() {
+		fmt.Printf("  RELEX skipped-prefix from %d state=%d\n", startByte, d.state)
+	}
+	next := d.Next()
+	if next.StartByte < startByte || d.lexer.pos != int(next.EndByte) ||
+		d.lexer.row != next.EndPoint.Row || d.lexer.col != next.EndPoint.Column {
+		return Token{}, false
+	}
+	next.lexerErrorModeLexed = true
+	if next.Symbol != errorSymbol {
+		meta, known := d.symbolMetadata(next.Symbol)
+		if !known || meta.Visible || next.Symbol != tok.Symbol || next.ExternalScannerToken ||
+			d.lookupActionIndex == nil || d.lookupActionIndex(cErrorState, next.Symbol) != 0 ||
+			next.StartByte != tok.StartByte || next.EndByte != tok.EndByte ||
+			next.StartPoint != tok.StartPoint || next.EndPoint != tok.EndPoint {
+			return Token{}, false
+		}
+		next.Symbol = errorSymbol
+	}
+	return next, true
+}
+
+// canRelexFromSkippedPrefix proves that the active source still owns the
+// scanner state for tok. Internal tokens must leave that state unchanged.
+// Checkpoint-capable scanners need representable start and live states.
+// External scanners must provide representable start and live checkpoints.
+func (d *dfaTokenSource) canRelexFromSkippedPrefix(tok Token) bool {
+	if d == nil || d.lexer == nil || tok.ExternalScannerToken {
+		return false
+	}
+	target := int(tok.StartByte)
+	if target < 0 || target > len(d.lexer.source) {
+		return false
+	}
+	if !d.hasExternalScanner {
+		return true
+	}
+	if !d.lastTokenValid || d.lastTokenStartByte != tok.StartByte || d.lastTokenEndByte != tok.EndByte {
+		return false
+	}
+	if !d.usesExternalCheckpoints {
+		return false
+	}
+	return d.lastExternalTokenValid &&
+		d.lastExternalTokenStartByte == tok.StartByte &&
+		d.lastExternalTokenEndByte == tok.EndByte &&
+		d.externalTokenEndSameAsStart &&
+		len(d.externalTokenStart) > 0 &&
+		len(d.captureExternalScannerStateInto(&d.externalCompare)) > 0
+}
+
+func (d *dfaTokenSource) beginRelexAt(target int, pt Point) {
+	d.lexer.pos = target
+	d.lexer.row = pt.Row
+	d.lexer.col = pt.Column
+	if d.hasExternalScanner && d.usesExternalCheckpoints {
+		d.restoreExternalScannerState(d.externalTokenStart)
+	}
+	d.lastExternalTokenValid = false
+	d.lastExternalTokenWasExtra = false
+	d.lastExternalTokenStartByte = 0
+	d.lastExternalTokenEndByte = 0
+	d.lastTokenStartByte = 0
+	d.lastTokenEndByte = 0
+	d.lastTokenValid = false
+	if len(d.externalTokenEnd) > 0 {
+		d.externalTokenEnd = d.externalTokenEnd[:0]
+	}
+	d.extZeroPos = -1
+	d.extZeroState = 0
+	if len(d.extZeroTried) > 0 {
+		d.extZeroTried = d.extZeroTried[:0]
+	}
+	d.zeroWidthPos = -1
+	d.zeroWidthCount = 0
 }
 
 func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
@@ -3814,7 +3918,6 @@ func (d *dfaTokenSource) runExternalScannerWithRetry(el *ExternalLexer, valid []
 			return true
 		}
 		if !el.hasResult {
-			d.restoreExternalScannerState(snapshot)
 			return false
 		}
 	}
@@ -3829,7 +3932,6 @@ func (d *dfaTokenSource) runExternalScannerWithRetry(el *ExternalLexer, valid []
 	for {
 		idx := d.externalSymbolIndex(el.resultSymbol)
 		if idx < 0 || idx >= len(masked) || !masked[idx] {
-			d.restoreExternalScannerState(snapshot)
 			return false
 		}
 		masked[idx] = false
@@ -3841,7 +3943,6 @@ func (d *dfaTokenSource) runExternalScannerWithRetry(el *ExternalLexer, valid []
 			}
 		}
 		if !anyValid {
-			d.restoreExternalScannerState(snapshot)
 			return false
 		}
 
@@ -3853,7 +3954,6 @@ func (d *dfaTokenSource) runExternalScannerWithRetry(el *ExternalLexer, valid []
 			return true
 		}
 		if !retryLexer.hasResult {
-			d.restoreExternalScannerState(snapshot)
 			return false
 		}
 		*el = *retryLexer

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -677,7 +677,7 @@ func (d *dfaTokenSource) Next() Token {
 			if tokenFromExternal {
 				d.captureExternalScannerStateInto(&d.externalTokenEnd)
 				d.externalTokenEndSameAsStart = false
-			} else if !d.externalScannerPreservesStateOnScanFailure() {
+			} else if d.externalScannerRetainsStateOnScanFailure() {
 				d.captureExternalScannerStateInto(&d.externalTokenEnd)
 				d.externalTokenEndSameAsStart = bytes.Equal(d.externalTokenStart, d.externalTokenEnd)
 			} else {
@@ -2974,6 +2974,11 @@ func (d *dfaTokenSource) relexFromTokenStartInTransaction(tok Token) (Token, boo
 	if next.StartByte != tok.StartByte || next.StartPoint != tok.StartPoint {
 		return Token{}, false
 	}
+	// A no-lookahead state closes the active parser branch. It does not
+	// reinterpret a real token that still starts before the source end.
+	if next.NoLookahead || (next.Symbol == 0 && target < len(d.lexer.source)) {
+		return Token{}, false
+	}
 	if tok.ExternalScannerToken && next.ExternalScannerToken &&
 		next.StartByte == tok.StartByte && next.EndByte == tok.EndByte {
 		next.ExternalScannerStartByte = tok.ExternalScannerStartByte
@@ -3449,7 +3454,7 @@ func (d *dfaTokenSource) shouldDeferSwiftOptionalGenericCloseToDFA(valid []bool,
 			continue
 		}
 		if d.swiftCloseAngleActionReduces(actionIdx) {
-			return true
+			return d.hasSwiftUnclosedAngleBefore(pos)
 		}
 	}
 	return false
@@ -3904,11 +3909,21 @@ func (d *dfaTokenSource) runExternalScannerWithRetry(el *ExternalLexer, valid []
 		return false
 	}
 	var snapshot []byte
-	if d.externalScannerPreservesStateOnScanFailure() {
+	retainFailureState := d.externalScannerRetainsStateOnScanFailure()
+	// Retention takes precedence if a scanner reports both capabilities.
+	// A retained mutation is incompatible with the preservation claim.
+	preserveFailureState := !retainFailureState && d.externalScannerPreservesStateOnScanFailure()
+	restoreFailedScan := func() {
+		if !preserveFailureState && !retainFailureState {
+			d.restoreExternalScannerState(snapshot)
+		}
+	}
+	if preserveFailureState {
 		if RunExternalScanner(d.language, d.externalPayload, el, valid) {
 			return true
 		}
 		if !el.hasResult {
+			restoreFailedScan()
 			return false
 		}
 		snapshot = d.captureExternalScannerStateInto(&d.externalRetrySnap)
@@ -3918,6 +3933,7 @@ func (d *dfaTokenSource) runExternalScannerWithRetry(el *ExternalLexer, valid []
 			return true
 		}
 		if !el.hasResult {
+			restoreFailedScan()
 			return false
 		}
 	}
@@ -3932,6 +3948,7 @@ func (d *dfaTokenSource) runExternalScannerWithRetry(el *ExternalLexer, valid []
 	for {
 		idx := d.externalSymbolIndex(el.resultSymbol)
 		if idx < 0 || idx >= len(masked) || !masked[idx] {
+			restoreFailedScan()
 			return false
 		}
 		masked[idx] = false
@@ -3943,6 +3960,7 @@ func (d *dfaTokenSource) runExternalScannerWithRetry(el *ExternalLexer, valid []
 			}
 		}
 		if !anyValid {
+			restoreFailedScan()
 			return false
 		}
 
@@ -3954,6 +3972,7 @@ func (d *dfaTokenSource) runExternalScannerWithRetry(el *ExternalLexer, valid []
 			return true
 		}
 		if !retryLexer.hasResult {
+			restoreFailedScan()
 			return false
 		}
 		*el = *retryLexer
@@ -3966,6 +3985,14 @@ func (d *dfaTokenSource) externalScannerPreservesStateOnScanFailure() bool {
 	}
 	preserving, ok := d.language.ExternalScanner.(FailurePreservingExternalScanner)
 	return ok && preserving.PreservesStateOnScanFailure()
+}
+
+func (d *dfaTokenSource) externalScannerRetainsStateOnScanFailure() bool {
+	if d == nil || d.language == nil || d.language.ExternalScanner == nil {
+		return false
+	}
+	retaining, ok := d.language.ExternalScanner.(FailureStateRetainingExternalScanner)
+	return ok && retaining.RetainsStateOnScanFailure()
 }
 
 func (d *dfaTokenSource) captureExternalScannerStateInto(dst *[]byte) []byte {

--- a/parser_dfa_token_source_test.go
+++ b/parser_dfa_token_source_test.go
@@ -1,6 +1,9 @@
 package gotreesitter
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestDFATokenSourceSkipToByteClampsBeforeNarrowing(t *testing.T) {
 	source := []byte("a\nβ")
@@ -142,6 +145,64 @@ func (s failedScanMutationExternalScanner) Scan(payload any, _ *ExternalLexer, _
 	return false
 }
 func (failedScanMutationExternalScanner) UsesExternalScannerCheckpoints() bool { return true }
+func (failedScanMutationExternalScanner) RetainsStateOnScanFailure() bool      { return true }
+
+type rollbackFailedScanMutationExternalScanner struct {
+	failedScanMutationExternalScanner
+}
+
+func (rollbackFailedScanMutationExternalScanner) RetainsStateOnScanFailure() bool { return false }
+
+type retainingRetryExternalScanner struct {
+	observed        *[]byte
+	succeedOnSecond bool
+	staleResult     bool
+}
+
+func (retainingRetryExternalScanner) Create() any {
+	state := byte(3)
+	return &state
+}
+func (retainingRetryExternalScanner) Destroy(any) {}
+func (retainingRetryExternalScanner) Serialize(payload any, buf []byte) int {
+	if len(buf) == 0 {
+		return 0
+	}
+	buf[0] = *payload.(*byte)
+	return 1
+}
+func (retainingRetryExternalScanner) Deserialize(payload any, buf []byte) {
+	state := payload.(*byte)
+	*state = 0
+	if len(buf) != 0 {
+		*state = buf[0]
+	}
+}
+func (s retainingRetryExternalScanner) Scan(payload any, lexer *ExternalLexer, valid []bool) bool {
+	state := payload.(*byte)
+	*s.observed = append(*s.observed, *state)
+	*state++
+	if s.staleResult {
+		lexer.SetResultSymbol(30)
+		return false
+	}
+	if len(valid) > 0 && valid[0] {
+		lexer.SetResultSymbol(10)
+		return false
+	}
+	if len(valid) > 1 && valid[1] {
+		lexer.SetResultSymbol(20)
+		return s.succeedOnSecond
+	}
+	return false
+}
+func (retainingRetryExternalScanner) RetainsStateOnScanFailure() bool { return true }
+
+type contradictoryFailureCapabilityScanner struct {
+	retainingRetryExternalScanner
+}
+
+func (contradictoryFailureCapabilityScanner) PreservesStateOnScanFailure() bool { return true }
 
 func failedScanMutationLanguage(observed *[]byte) *Language {
 	return &Language{
@@ -187,6 +248,123 @@ func TestInternalTokenCapturesFailedExternalScannerMutation(t *testing.T) {
 	}
 	if ts.externalTokenEndSameAsStart {
 		t.Fatal("failed scanner mutation was classified as an unchanged state")
+	}
+}
+
+func TestInternalTokenRestoresUnmarkedFailedExternalScannerMutation(t *testing.T) {
+	lang := failedScanMutationLanguage(nil)
+	lang.ExternalScanner = rollbackFailedScanMutationExternalScanner{}
+	lookup := func(StateID, Symbol) uint16 { return 1 }
+	ts := acquireDFATokenSource(NewLexer(lang.LexStates, []byte("x")), lang, lookup, nil, nil, nil)
+	defer ts.Close()
+
+	tok := ts.Next()
+	if tok.Symbol != 1 || tok.ExternalScannerToken {
+		t.Fatalf("token = %+v, want internal symbol 1", tok)
+	}
+	cp, _, _, ok := ts.lastExternalScannerCheckpoint()
+	if !ok {
+		t.Fatal("internal token did not record a complete scanner checkpoint")
+	}
+	if len(cp.start) != 1 || cp.start[0] != 3 || len(cp.end) != 1 || cp.end[0] != 3 {
+		t.Fatalf("checkpoint = start %v end %v, want [3] to [3]", cp.start, cp.end)
+	}
+	if got := *ts.externalPayload.(*byte); got != 3 {
+		t.Fatalf("live scanner state = %d, want restored state 3", got)
+	}
+	if !ts.externalTokenEndSameAsStart {
+		t.Fatal("restored scanner mutation was classified as a changed state")
+	}
+}
+
+func TestRetainingExternalScannerRetryStartsFromOriginalSnapshot(t *testing.T) {
+	var observed []byte
+	lang := &Language{
+		Name:            "retaining-retry-test",
+		SymbolNames:     make([]string, 21),
+		ExternalSymbols: []Symbol{10, 20},
+		ExternalScanner: retainingRetryExternalScanner{observed: &observed, succeedOnSecond: true},
+	}
+	ts := acquireDFATokenSource(NewLexer(nil, nil), lang, nil, nil, nil, nil)
+	defer ts.Close()
+	el := &ExternalLexer{}
+	el.reset(nil, 0, 0, 0)
+
+	if !ts.runExternalScannerWithRetry(el, []bool{true, true}) {
+		t.Fatal("runExternalScannerWithRetry = false, want retry success")
+	}
+	if el.resultSymbol != 20 {
+		t.Fatalf("retry symbol = %d, want 20", el.resultSymbol)
+	}
+	if len(observed) != 2 || observed[0] != 3 || observed[1] != 3 {
+		t.Fatalf("scanner entry states = %v, want [3 3]", observed)
+	}
+	if got := *ts.externalPayload.(*byte); got != 4 {
+		t.Fatalf("live scanner state = %d, want successful retry end state 4", got)
+	}
+}
+
+func TestRetainingExternalScannerKeepsFinalFailedRetryState(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		staleResult  bool
+		wantObserved []byte
+	}{
+		{name: "exhausted alternatives", wantObserved: []byte{3, 3}},
+		{name: "stale result", staleResult: true, wantObserved: []byte{3}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var observed []byte
+			lang := &Language{
+				Name:            "retaining-final-failure-test",
+				SymbolNames:     make([]string, 31),
+				ExternalSymbols: []Symbol{10, 20},
+				ExternalScanner: retainingRetryExternalScanner{observed: &observed, staleResult: test.staleResult},
+			}
+			ts := acquireDFATokenSource(NewLexer(nil, nil), lang, nil, nil, nil, nil)
+			defer ts.Close()
+			el := &ExternalLexer{}
+			el.reset(nil, 0, 0, 0)
+
+			if ts.runExternalScannerWithRetry(el, []bool{true, true}) {
+				t.Fatal("runExternalScannerWithRetry = true, want final failure")
+			}
+			if !bytes.Equal(observed, test.wantObserved) {
+				t.Fatalf("scanner entry states = %v, want %v", observed, test.wantObserved)
+			}
+			if got := *ts.externalPayload.(*byte); got != 4 {
+				t.Fatalf("live scanner state = %d, want final failed attempt state 4", got)
+			}
+		})
+	}
+}
+
+func TestFailureRetentionTakesPrecedenceOverPreservationClaim(t *testing.T) {
+	var observed []byte
+	lang := &Language{
+		Name:            "contradictory-failure-capability-test",
+		SymbolNames:     make([]string, 31),
+		ExternalSymbols: []Symbol{10, 20},
+		ExternalScanner: contradictoryFailureCapabilityScanner{
+			retainingRetryExternalScanner: retainingRetryExternalScanner{
+				observed:    &observed,
+				staleResult: true,
+			},
+		},
+	}
+	ts := acquireDFATokenSource(NewLexer(nil, nil), lang, nil, nil, nil, nil)
+	defer ts.Close()
+	el := &ExternalLexer{}
+	el.reset(nil, 0, 0, 0)
+
+	if ts.runExternalScannerWithRetry(el, []bool{true, true}) {
+		t.Fatal("runExternalScannerWithRetry = true, want final failure")
+	}
+	if len(observed) != 1 || observed[0] != 3 {
+		t.Fatalf("scanner entry states = %v, want [3]", observed)
+	}
+	if got := *ts.externalPayload.(*byte); got != 4 {
+		t.Fatalf("live scanner state = %d, want retained state 4", got)
 	}
 }
 
@@ -428,6 +606,47 @@ func TestRelexExternalScannerTokenPreservesSkippedGapProvenance(t *testing.T) {
 	stack := newGLRStack(0)
 	if !realShiftGapIsParserPadding(source, &stack, relexed, 0) {
 		t.Fatalf("relexed scanner-owned gap rejected for %q; token=%+v", source[:relexed.StartByte], relexed)
+	}
+}
+
+func TestRelexExternalScannerTokenRejectsSyntheticEOFLookahead(t *testing.T) {
+	lang := &Language{
+		Name:            "external-no-lookahead-relex-test",
+		SymbolCount:     3,
+		TokenCount:      3,
+		SymbolNames:     []string{"end", "internal", "external"},
+		ExternalSymbols: []Symbol{2},
+		ExternalScanner: checkpointByteExternalScanner{},
+		LexModes:        []LexMode{{LexState: ^uint16(0)}},
+	}
+	ts := acquireDFATokenSource(NewLexer(nil, []byte("x")), lang, nil, nil, nil, nil)
+	defer ts.Close()
+	*ts.externalPayload.(*byte) = 3
+	ts.lexer.pos = 1
+	ts.lexer.col = 1
+	ts.externalTokenStart = append(ts.externalTokenStart[:0], 3)
+	ts.lastExternalTokenStartByte = 0
+	ts.lastExternalTokenEndByte = 1
+	ts.lastExternalTokenValid = true
+	tok := Token{
+		Symbol:               2,
+		StartByte:            0,
+		EndByte:              1,
+		EndPoint:             Point{Column: 1},
+		ExternalScannerToken: true,
+	}
+
+	if !ts.CanRelexFromTokenStart(tok) {
+		t.Fatal("checkpointed scanner did not permit the relex probe")
+	}
+	if got, ok := ts.RelexFromTokenStart(tok); ok {
+		t.Fatalf("relex = %+v, want rejection for a synthetic EOF lookahead", got)
+	}
+	if ts.lexer.pos != 1 || ts.lexer.col != 1 {
+		t.Fatalf("rejected relex kept lexer position (%d,%d), want (1,1)", ts.lexer.pos, ts.lexer.col)
+	}
+	if got := *ts.externalPayload.(*byte); got != 3 {
+		t.Fatalf("rejected relex kept scanner state %d, want 3", got)
 	}
 }
 

--- a/parser_dfa_token_source_test.go
+++ b/parser_dfa_token_source_test.go
@@ -110,6 +110,130 @@ func (checkpointByteExternalScanner) Scan(payload any, lexer *ExternalLexer, val
 }
 func (checkpointByteExternalScanner) UsesExternalScannerCheckpoints() bool { return true }
 
+type failedScanMutationExternalScanner struct {
+	observed *[]byte
+}
+
+func (failedScanMutationExternalScanner) Create() any {
+	state := byte(3)
+	return &state
+}
+func (failedScanMutationExternalScanner) Destroy(any) {}
+func (failedScanMutationExternalScanner) Serialize(payload any, buf []byte) int {
+	if len(buf) == 0 {
+		return 0
+	}
+	buf[0] = *payload.(*byte)
+	return 1
+}
+func (failedScanMutationExternalScanner) Deserialize(payload any, buf []byte) {
+	state := payload.(*byte)
+	*state = 0
+	if len(buf) != 0 {
+		*state = buf[0]
+	}
+}
+func (s failedScanMutationExternalScanner) Scan(payload any, _ *ExternalLexer, _ []bool) bool {
+	state := payload.(*byte)
+	if s.observed != nil {
+		*s.observed = append(*s.observed, *state)
+	}
+	*state++
+	return false
+}
+func (failedScanMutationExternalScanner) UsesExternalScannerCheckpoints() bool { return true }
+
+func failedScanMutationLanguage(observed *[]byte) *Language {
+	return &Language{
+		Name:            "failed-scan-mutation-test",
+		SymbolCount:     3,
+		TokenCount:      2,
+		SymbolNames:     []string{"end", "internal", "external"},
+		ExternalSymbols: []Symbol{2},
+		ExternalScanner: failedScanMutationExternalScanner{observed: observed},
+		ExternalLexStates: [][]bool{
+			{true},
+		},
+		LexModes: []LexMode{{LexState: 0, ExternalLexState: 0}},
+		LexStates: []LexState{
+			{
+				Default: -1,
+				EOF:     -1,
+				Transitions: []LexTransition{
+					{Lo: 'x', Hi: 'x', NextState: 1},
+				},
+			},
+			{AcceptToken: 1, Default: -1, EOF: -1},
+		},
+	}
+}
+
+func TestInternalTokenCapturesFailedExternalScannerMutation(t *testing.T) {
+	lang := failedScanMutationLanguage(nil)
+	lookup := func(StateID, Symbol) uint16 { return 1 }
+	ts := acquireDFATokenSource(NewLexer(lang.LexStates, []byte("x")), lang, lookup, nil, nil, nil)
+	defer ts.Close()
+
+	tok := ts.Next()
+	if tok.Symbol != 1 || tok.ExternalScannerToken {
+		t.Fatalf("token = %+v, want internal symbol 1", tok)
+	}
+	cp, _, _, ok := ts.lastExternalScannerCheckpoint()
+	if !ok {
+		t.Fatal("internal token did not record a complete scanner checkpoint")
+	}
+	if len(cp.start) != 1 || cp.start[0] != 3 || len(cp.end) != 1 || cp.end[0] != 4 {
+		t.Fatalf("checkpoint = start %v end %v, want [3] to [4]", cp.start, cp.end)
+	}
+	if ts.externalTokenEndSameAsStart {
+		t.Fatal("failed scanner mutation was classified as an unchanged state")
+	}
+}
+
+func TestIncrementalCheckpointFastForwardRestoresFailedScanEndState(t *testing.T) {
+	var observed []byte
+	lang := failedScanMutationLanguage(&observed)
+	lookup := func(StateID, Symbol) uint16 { return 1 }
+	producer := acquireDFATokenSource(NewLexer(lang.LexStates, []byte("x")), lang, lookup, nil, nil, nil)
+	defer producer.Close()
+
+	tok := producer.Next()
+	cp, _, _, ok := producer.lastExternalScannerCheckpoint()
+	if !ok {
+		t.Fatal("producer did not record a complete scanner checkpoint")
+	}
+
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	node := arena.allocNode()
+	node.ownerArena = arena
+	node.startByte = tok.StartByte
+	node.endByte = tok.EndByte
+	node.startPoint = tok.StartPoint
+	node.endPoint = tok.EndPoint
+	if !arena.recordExternalScannerLeafCheckpoint(node, cp.start, cp.end) {
+		t.Fatal("failed to record the internal-token checkpoint")
+	}
+	checkpointRef, ok := externalScannerCheckpointRefForNode(node)
+	if !ok {
+		t.Fatal("recorded checkpoint is unavailable")
+	}
+
+	consumer := acquireDFATokenSource(NewLexer(lang.LexStates, []byte("x")), lang, lookup, nil, nil, nil)
+	defer consumer.Close()
+	*consumer.externalPayload.(*byte) = 9
+	observed = observed[:0]
+	if _, ok := fastForwardWithExternalScannerCheckpoint(consumer, node, checkpointRef); !ok {
+		t.Fatal("incremental checkpoint fast-forward failed")
+	}
+	if len(observed) == 0 || observed[0] != cp.end[0] {
+		t.Fatalf("scanner state at fast-forward read = %v, want end checkpoint %v", observed, cp.end)
+	}
+	if observed[0] == cp.start[0] {
+		t.Fatalf("fast-forward restored start checkpoint %v instead of end %v", cp.start, cp.end)
+	}
+}
+
 func TestCanRelexCheckpointScannerRequiresRepresentableStartAndLiveState(t *testing.T) {
 	scanner := checkpointByteExternalScanner{}
 	lang := &Language{ExternalScanner: scanner}
@@ -279,6 +403,12 @@ func TestRelexExternalScannerTokenPreservesSkippedGapProvenance(t *testing.T) {
 	}
 	if got, want := tok.ExternalScannerStartByte, uint32(0); got != want {
 		t.Fatalf("token scanner start = %d, want %d; token=%+v", got, want, tok)
+	}
+	if ts.usesExternalCheckpoints {
+		t.Fatal("stateless scanner unexpectedly enabled checkpoints")
+	}
+	if !ts.CanRelexFromTokenStart(tok) {
+		t.Fatal("generic relex rejected a stateless external scanner")
 	}
 
 	relexed, ok := ts.RelexFromTokenStart(tok)

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -819,24 +819,24 @@ func (p *Parser) cRecoverCustomSourceEligibleFor(ts TokenSource, source []byte) 
 	return ls != noLookaheadLexState && int(ls) < len(lang.LexStates)
 }
 
-// cRecoverResumeLookahead ports the error-mode half of ts_parser__lex for the
-// pause lookahead of a custom (non-DFA) token source. In C the lookahead that
-// triggers detect_error is already the product of the in-lex fallback chain:
-// the paused state's own lex mode first, then the ERROR-state mode, then the
-// skipped-character error subtree. A custom source that only lexes
-// normal-mode tokens hands handle_error/recover a lookahead C would never see
-// at this position (authzed: int_literal "1" where C's error-mode DFA lexes a
-// 13-byte hidden string-content run). When the paused state's own DFA mode
-// cannot lex here — C's fallback trigger — substitute the ERROR-mode token
-// and schedule the source resync.
-func (p *Parser) cRecoverResumeLookahead(source []byte, s *glrStack, tok Token) (Token, bool) {
-	if !p.cRecoverCustomSourceEligible || p.cRecoverSharedTokenErrorModeLexed {
+// cRecoverResumeLookahead ports the error-mode half of ts_parser__lex for a
+// paused lookahead. It accepts a direct DFA replacement only after that source
+// re-lexes from the exact skipped-prefix start and reaches the same token end.
+// Custom sources keep the existing internal-DFA path and deferred resync.
+func (p *Parser) cRecoverResumeLookahead(ts TokenSource, source []byte, s *glrStack, tok Token, scratch *parserScratch) (Token, bool) {
+	if p.cRecoverSharedTokenErrorModeLexed {
 		return tok, false
 	}
 	if tok.Symbol == 0 || tok.Symbol == errorSymbol || tok.Missing || tok.NoLookahead {
 		return tok, false
 	}
 	if s == nil || int(s.byteOffset) >= len(source) {
+		return tok, false
+	}
+	if relexed, ok := p.cRecoverResumeDFALookahead(ts, source, s, tok, scratch); ok {
+		return relexed, true
+	}
+	if !p.cRecoverCustomSourceEligible {
 		return tok, false
 	}
 	lang := p.language
@@ -912,6 +912,52 @@ func (p *Parser) cRecoverResumeLookahead(source []byte, s *glrStack, tok Token) 
 	p.cRecoverCustomResyncActive = true
 	p.cRecoverCustomResyncByte = relexed.EndByte
 	p.recordRecoveryErrorModeToken()
+	return relexed, true
+}
+
+// cRecoverResumeDFALookahead verifies C error-mode lexing on the active source.
+// It commits the replacement only when the re-lexed error token has the exact
+// original span and leaves the source at that token's end.
+func (p *Parser) cRecoverResumeDFALookahead(ts TokenSource, source []byte, s *glrStack, tok Token, scratch *parserScratch) (Token, bool) {
+	dts, ok := ts.(*dfaTokenSource)
+	if !ok || dts == nil || scratch == nil || dts.lexer == nil || dts.language != p.language || !dts.cRecoveryEnabled ||
+		tok.ExternalScannerToken || p.cSymbolVisible(tok.Symbol) ||
+		p.lookupActionIndex(cErrorState, tok.Symbol) != 0 ||
+		!dts.canRelexFromSkippedPrefix(tok) ||
+		!tok.lexerSkippedPrefix || tok.lexerSkippedPrefixStart != s.byteOffset ||
+		tok.StartByte <= s.byteOffset || tok.EndByte <= tok.StartByte ||
+		int(tok.EndByte) > len(source) || len(dts.lexer.source) != len(source) {
+		return Token{}, false
+	}
+	startPoint := cStackPosPoint(s)
+	if startPoint.Row != tok.StartPoint.Row || startPoint.Column >= tok.StartPoint.Column {
+		return Token{}, false
+	}
+
+	snapshot, retainedSnapshot := scratch.snapshotDFARelexState(dts)
+	savedState := dts.state
+	savedGLRStates := dts.glrStates
+	restore := func() {
+		snapshot.restore(dts)
+		scratch.releaseDFARelexSnapshot(retainedSnapshot)
+		dts.state = savedState
+		dts.glrStates = savedGLRStates
+	}
+	dts.SetParserState(cErrorState)
+	dts.SetGLRStates(nil)
+	relexed, relexedOK := dts.relexRecoveryTokenFromSkippedPrefixInTransaction(tok, s.byteOffset, startPoint)
+	if !relexedOK || !relexed.lexerErrorModeLexed || relexed.Symbol != errorSymbol || relexed.ExternalScannerToken ||
+		relexed.StartByte != tok.StartByte || relexed.EndByte != tok.EndByte ||
+		relexed.StartPoint != tok.StartPoint || relexed.EndPoint != tok.EndPoint ||
+		dts.lexer.pos != int(relexed.EndByte) || dts.lexer.row != relexed.EndPoint.Row ||
+		dts.lexer.col != relexed.EndPoint.Column {
+		restore()
+		return Token{}, false
+	}
+	scratch.releaseDFARelexSnapshot(retainedSnapshot)
+	p.cRecoverSharedTokenErrorModeLexed = true
+	p.recordRecoveryErrorModeToken()
+	p.recordRecoveryScannerResync()
 	return relexed, true
 }
 
@@ -4277,7 +4323,11 @@ func (p *Parser) cAbsorbTokenIntoError(v *glrStack, tok Token, nodeCount *int, a
 	if leafVisible {
 		leaf = newLeafNodeInArena(arena, tok.Symbol, tok.Symbol == errorSymbol || p.isNamedSymbol(tok.Symbol),
 			tok.StartByte, tok.EndByte, tok.StartPoint, tok.EndPoint)
-		leaf.setHasError(true)
+		// C marks the enclosing ERROR node as erroneous. Only a proven
+		// lexer-produced ERROR leaf omits the second has-error flag.
+		if tok.Symbol != errorSymbol || !tok.lexerErrorModeLexed {
+			leaf.setHasError(true)
+		}
 		// C: if the token shifts as extra in state 1, mark it extra so it is
 		// not counted in error cost calculations.
 		if idx := p.lookupActionIndex(1, tok.Symbol); idx != 0 && int(idx) < len(p.language.ParseActions) {
@@ -4459,7 +4509,7 @@ func (p *Parser) isGraphQLRecoveryTripleQuote(sym Symbol) bool {
 // (see cRecoverResumeLookahead) which the caller must adopt so redispatched
 // versions act on the same lookahead the resumed group consumed, and any
 // active budget/timeout stop reason encountered while condensing.
-func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, tmpEntries *[]stackEntry, trackChildErrors *bool) ([]glrStack, bool, Token, ParseStopReason) {
+func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, ts TokenSource, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, tmpEntries *[]stackEntry, parseScratch *parserScratch, trackChildErrors *bool) ([]glrStack, bool, Token, ParseStopReason) {
 	checkStop := func() ParseStopReason {
 		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 			return reason
@@ -4656,7 +4706,7 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token,
 			// C's pause lookahead already went through ts_parser__lex's
 			// error-mode fallback; a custom source's normal-mode token must
 			// be substituted the same way before handle_error consumes it.
-			if replacement, replaced := p.cRecoverResumeLookahead(source, &stacks[i], tok); replaced {
+			if replacement, replaced := p.cRecoverResumeLookahead(ts, source, &stacks[i], tok, parseScratch); replaced {
 				if p.glrTrace {
 					fmt.Printf("      -> C-RESUME-RELEX sym=%d [%d-%d] -> sym=%d [%d-%d]\n",
 						tok.Symbol, tok.StartByte, tok.EndByte,

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -1676,7 +1676,13 @@ func (p *Parser) growCNodeMemoCacheTo(target int) {
 	if target > cNodeMemoCacheSize {
 		cold := p.ensureParserColdState()
 		if cold != nil && cold.cNodeMemoRetainedCache == nil {
-			cold.cNodeMemoRetainedCache = p.cNodeMemoCache
+			retained := p.cNodeMemoCache
+			// An operation starts with a deterministic 128-entry view. Keep
+			// the full standard slab when its backing array is already warm.
+			if cap(retained) >= cNodeMemoCacheSize {
+				retained = retained[:cNodeMemoCacheSize]
+			}
+			cold.cNodeMemoRetainedCache = retained
 		}
 	}
 	p.cNodeMemoCache = make([]cNodeMemoCacheEntry, target)

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -288,12 +288,19 @@ func TestCRecoveryParseRetryPoolAndSnippetResetsClearState(t *testing.T) {
 
 	parser.crecoveryCostCompetitionRelevant = true
 	parser.crecoveryCostCompetitionWalkEnabled = true
+	parser.cRecoverSharedTokenErrorModeLexed = true
+	parser.cRecoverCustomResyncActive = true
+	parser.cRecoverCustomResyncByte = 42
+	parser.cRecoverCustomSourceEligible = true
 	scratch.cRecoveryCostWalk = true
 	scratch.cRecoveryConvergence = true
 	scratch.cRecoveryFallbackSuppression = true
 	pool := &ParserPool{language: parser.language}
 	pool.applyDefaults(parser)
-	if parser.crecoveryCostCompetitionRelevant || parser.crecoveryCostCompetitionWalkEnabled || scratch.cRecoveryCostWalk || scratch.cRecoveryConvergence || scratch.cRecoveryFallbackSuppression {
+	if parser.crecoveryCostCompetitionRelevant || parser.crecoveryCostCompetitionWalkEnabled ||
+		parser.cRecoverSharedTokenErrorModeLexed || parser.cRecoverCustomResyncActive ||
+		parser.cRecoverCustomResyncByte != 0 || parser.cRecoverCustomSourceEligible ||
+		scratch.cRecoveryCostWalk || scratch.cRecoveryConvergence || scratch.cRecoveryFallbackSuppression {
 		t.Fatal("parser pool reset retained recovery state")
 	}
 
@@ -316,49 +323,335 @@ func TestCRecoveryParseRetryPoolAndSnippetResetsClearState(t *testing.T) {
 	}
 }
 
-func TestCAbsorbErrorRunKeepsErrorLeafNamed(t *testing.T) {
-	parser := cRecoveryElectionTestParser()
-	arena := acquireNodeArena(arenaClassFull)
-	defer arena.Release()
+func TestParseOperationBoundaryResetsRetainedRecoveryMemoSize(t *testing.T) {
+	parser := &Parser{cNodeMemoCache: make([]cNodeMemoCacheEntry, cNodeMemoCacheSize)}
+	outer := parser.beginParseOperationBudget()
+	if got := len(parser.cNodeMemoCache); got != cNodeMemoCacheInitialSize {
+		t.Fatalf("outer operation memo entries = %d, want %d", got, cNodeMemoCacheInitialSize)
+	}
 
-	openErr := newParentNodeInArena(arena, errorSymbol, true, nil, nil, 0)
-	cSetNodeSpan(openErr, 10, 10, Point{Column: 10}, Point{Column: 10})
-	openErr.setHasError(true)
-	stack := newGLRStack(1)
-	stack.pushEntry(newStackEntryNode(cErrorState, openErr), nil, nil)
-	stack.byteOffset = 10
-	stack.cRec = &cRecoverState{group: &cRecGroup{}, openErr: openErr}
-	nodeCount := 0
+	parser.cNodeMemoCache = parser.cNodeMemoCache[:cNodeMemoCacheSize]
+	inner := parser.beginParseOperationBudget()
+	if got := len(parser.cNodeMemoCache); got != cNodeMemoCacheSize {
+		t.Fatalf("nested retry memo entries = %d, want %d", got, cNodeMemoCacheSize)
+	}
+	parser.endParseOperationBudget(inner)
+	parser.endParseOperationBudget(outer)
 
-	parser.cAbsorbTokenIntoError(
-		&stack,
-		Token{
-			Symbol:    errorSymbol,
-			StartByte: 10,
-			EndByte:   18,
-			StartPoint: Point{
-				Column: 10,
+	next := parser.beginParseOperationBudget()
+	defer parser.endParseOperationBudget(next)
+	if got := len(parser.cNodeMemoCache); got != cNodeMemoCacheInitialSize {
+		t.Fatalf("next operation memo entries = %d, want %d", got, cNodeMemoCacheInitialSize)
+	}
+}
+
+func TestCAbsorbErrorRunUsesLexerProvenanceForLeafErrorFlag(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		lexerProduced  bool
+		wantChildError bool
+	}{
+		{name: "lexer-produced", lexerProduced: true},
+		{name: "unproven", wantChildError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			parser := cRecoveryElectionTestParser()
+			arena := acquireNodeArena(arenaClassFull)
+			defer arena.Release()
+
+			openErr := newParentNodeInArena(arena, errorSymbol, true, nil, nil, 0)
+			cSetNodeSpan(openErr, 10, 10, Point{Column: 10}, Point{Column: 10})
+			openErr.setHasError(true)
+			stack := newGLRStack(1)
+			stack.pushEntry(newStackEntryNode(cErrorState, openErr), nil, nil)
+			stack.byteOffset = 10
+			stack.cRec = &cRecoverState{group: &cRecGroup{}, openErr: openErr}
+			nodeCount := 0
+
+			parser.cAbsorbTokenIntoError(
+				&stack,
+				Token{
+					Symbol:              errorSymbol,
+					StartByte:           10,
+					EndByte:             18,
+					StartPoint:          Point{Column: 10},
+					EndPoint:            Point{Column: 18},
+					lexerErrorModeLexed: test.lexerProduced,
+				},
+				&nodeCount,
+				arena,
+				nil,
+				nil,
+				nil,
+			)
+
+			if got, want := openErr.ChildCount(), 1; got != want {
+				t.Fatalf("open error ChildCount = %d, want %d", got, want)
+			}
+			child := openErr.Child(0)
+			if !child.IsError() {
+				t.Fatalf("absorbed child type = %q, want ERROR", child.Type(parser.language))
+			}
+			if !child.IsNamed() {
+				t.Fatal("absorbed ERROR leaf is not named")
+			}
+			if got := child.HasError(); got != test.wantChildError {
+				t.Fatalf("absorbed ERROR leaf HasError = %t, want %t", got, test.wantChildError)
+			}
+		})
+	}
+}
+
+func TestCRecoverResumeDFALookaheadRequiresLexedAlignedErrorToken(t *testing.T) {
+	newFixture := func(errorModeAcceptsToken bool) (*Parser, *dfaTokenSource, Token, glrStack) {
+		lexStates := []LexState{
+			{
+				Default: -1,
+				EOF:     -1,
+				Transitions: []LexTransition{
+					{Lo: ' ', Hi: ' ', NextState: 0, Skip: true},
+				},
 			},
-			EndPoint: Point{
-				Column: 18,
+			{},
+			{
+				Default: -1,
+				EOF:     -1,
+				Transitions: []LexTransition{
+					{Lo: ' ', Hi: ' ', NextState: 2, Skip: true},
+					{Lo: 'b', Hi: 'b', NextState: 3},
+				},
+			},
+			{AcceptToken: 1, Default: -1, EOF: -1},
+		}
+		if errorModeAcceptsToken {
+			lexStates[0].Transitions = append(lexStates[0].Transitions, LexTransition{Lo: 'b', Hi: 'b', NextState: 3})
+		}
+		lang := &Language{
+			Name:        "recovery-relex-fixture",
+			TokenCount:  2,
+			StateCount:  2,
+			SymbolCount: 2,
+			SymbolMetadata: []SymbolMetadata{
+				{Name: "end", Visible: true, Named: true},
+				{Name: "hidden"},
+			},
+			LexStates: lexStates,
+			LexModes:  []LexMode{{LexState: 0}, {LexState: 2}},
+		}
+		parser := &Parser{language: lang, errorCostCompetition: true}
+		source := []byte(" b")
+		ts := newDFATokenSourceDirectWithCRecovery(NewLexer(lang.LexStates, source), lang, parser.lookupActionIndex, nil, nil, nil, true)
+		ts.SetParserState(1)
+		tok := ts.Next()
+		stack := newGLRStack(1)
+		return parser, ts, tok, stack
+	}
+
+	t.Run("verified-error-run", func(t *testing.T) {
+		parser, ts, tok, stack := newFixture(false)
+		scratch := &parserScratch{}
+		got, ok := parser.cRecoverResumeDFALookahead(ts, ts.lexer.source, &stack, tok, scratch)
+		if !ok {
+			t.Fatal("aligned error-mode re-lex was rejected")
+		}
+		if got.Symbol != errorSymbol || got.StartByte != tok.StartByte || got.EndByte != tok.EndByte {
+			t.Fatalf("replacement = %+v, want ERROR at %d..%d", got, tok.StartByte, tok.EndByte)
+		}
+		if !got.lexerErrorModeLexed {
+			t.Fatal("replacement lacks the lexer error-mode proof")
+		}
+		if ts.lexer.pos != int(got.EndByte) || ts.lexer.row != got.EndPoint.Row || ts.lexer.col != got.EndPoint.Column {
+			t.Fatalf("source position = %d/%d/%d, want %d/%d/%d", ts.lexer.pos, ts.lexer.row, ts.lexer.col, got.EndByte, got.EndPoint.Row, got.EndPoint.Column)
+		}
+		if !parser.cRecoverSharedTokenErrorModeLexed {
+			t.Fatal("verified error-mode token was not recorded")
+		}
+		if scratch.relexSnapshotInUse {
+			t.Fatal("accepted re-lex retained its snapshot")
+		}
+	})
+
+	t.Run("stack-offset-mismatch", func(t *testing.T) {
+		parser, ts, tok, stack := newFixture(false)
+		stack.byteOffset = tok.StartByte
+		if got, ok := parser.cRecoverResumeDFALookahead(ts, ts.lexer.source, &stack, tok, &parserScratch{}); ok {
+			t.Fatalf("misaligned re-lex = %+v, want rejection", got)
+		}
+		if parser.cRecoverSharedTokenErrorModeLexed {
+			t.Fatal("misaligned token was marked as error-mode lexed")
+		}
+	})
+
+	t.Run("aligned-invisible-error-mode-token", func(t *testing.T) {
+		parser, ts, tok, stack := newFixture(true)
+		got, ok := parser.cRecoverResumeDFALookahead(ts, ts.lexer.source, &stack, tok, &parserScratch{})
+		if !ok {
+			t.Fatal("aligned invisible error-mode token was rejected")
+		}
+		if got.Symbol != errorSymbol || !got.lexerErrorModeLexed {
+			t.Fatalf("replacement = %+v, want lexer-proven ERROR", got)
+		}
+		if !parser.cRecoverSharedTokenErrorModeLexed {
+			t.Fatal("lexer-produced token was not marked as error-mode lexed")
+		}
+	})
+
+	t.Run("visible-error-mode-token", func(t *testing.T) {
+		parser, ts, tok, stack := newFixture(true)
+		parser.language.SymbolMetadata[tok.Symbol].Visible = true
+		savedState := ts.state
+		if got, ok := parser.cRecoverResumeDFALookahead(ts, ts.lexer.source, &stack, tok, &parserScratch{}); ok {
+			t.Fatalf("visible error-mode token = %+v, want rejection", got)
+		}
+		if parser.cRecoverSharedTokenErrorModeLexed {
+			t.Fatal("visible token was marked as error-mode lexed")
+		}
+		if ts.state != savedState || ts.lexer.pos != int(tok.EndByte) || ts.lexer.row != tok.EndPoint.Row || ts.lexer.col != tok.EndPoint.Column {
+			t.Fatalf("rejected probe did not preserve source: state=%d pos=%d/%d/%d", ts.state, ts.lexer.pos, ts.lexer.row, ts.lexer.col)
+		}
+	})
+}
+
+func TestCRecoverResumeDFARejectsAbsentExternalScannerCheckpoint(t *testing.T) {
+	lexStates := []LexState{
+		{
+			Default: -1,
+			EOF:     -1,
+			Transitions: []LexTransition{
+				{Lo: ' ', Hi: ' ', NextState: 0, Skip: true},
 			},
 		},
-		&nodeCount,
-		arena,
+		{},
+		{
+			Default: -1,
+			EOF:     -1,
+			Transitions: []LexTransition{
+				{Lo: ' ', Hi: ' ', NextState: 2, Skip: true},
+				{Lo: 'b', Hi: 'b', NextState: 3},
+			},
+		},
+		{AcceptToken: 1, Default: -1, EOF: -1},
+	}
+	scanner := checkpointByteExternalScanner{}
+	lang := &Language{
+		Name:            "recovery-empty-checkpoint-fixture",
+		TokenCount:      2,
+		StateCount:      2,
+		SymbolCount:     2,
+		ExternalScanner: scanner,
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "end", Visible: true, Named: true},
+			{Name: "hidden"},
+		},
+		LexStates: lexStates,
+		LexModes:  []LexMode{{LexState: 0}, {LexState: 2}},
+	}
+	parser := &Parser{language: lang, errorCostCompetition: true}
+	source := []byte(" b")
+	ts := newDFATokenSourceDirectWithCRecovery(
+		NewLexer(lang.LexStates, source),
+		lang,
+		parser.lookupActionIndex,
 		nil,
 		nil,
 		nil,
+		true,
 	)
+	defer ts.Close()
+	liveState := ts.externalPayload.(*byte)
+	*liveState = 0xff
+	ts.SetParserState(1)
+	tok := ts.Next()
+	if !tok.lexerSkippedPrefix || len(ts.externalTokenStart) != 0 {
+		t.Fatalf("fixture token lacks the absent checkpoint proof: token=%+v checkpoint=%v", tok, ts.externalTokenStart)
+	}
+	if ts.CanRelexFromTokenStart(tok) || ts.canRelexFromSkippedPrefix(tok) {
+		t.Fatal("absent checkpoint admitted direct token reuse")
+	}
+	stack := newGLRStack(1)
+	savedParserState := ts.state
+	if got, ok := parser.cRecoverResumeDFALookahead(ts, source, &stack, tok, &parserScratch{}); ok {
+		t.Fatalf("absent-checkpoint replay = %+v, want rejection", got)
+	}
+	if *liveState != 0xff {
+		t.Fatalf("rejected replay changed live scanner state to %#x, want 0xff", *liveState)
+	}
+	if ts.state != savedParserState || ts.lexer.pos != int(tok.EndByte) ||
+		ts.lexer.row != tok.EndPoint.Row || ts.lexer.col != tok.EndPoint.Column {
+		t.Fatalf("rejected replay changed source state: parser=%d pos=%d/%d/%d", ts.state, ts.lexer.pos, ts.lexer.row, ts.lexer.col)
+	}
+	if parser.cRecoverSharedTokenErrorModeLexed {
+		t.Fatal("absent-checkpoint token was marked as error-mode lexed")
+	}
+}
 
-	if got, want := openErr.ChildCount(), 1; got != want {
-		t.Fatalf("open error ChildCount = %d, want %d", got, want)
+func TestCRecoverResumeDFARejectsCheckpointlessExternalScanner(t *testing.T) {
+	lexStates := []LexState{
+		{
+			Default: -1,
+			EOF:     -1,
+			Transitions: []LexTransition{
+				{Lo: ' ', Hi: ' ', NextState: 0, Skip: true},
+			},
+		},
+		{},
+		{
+			Default: -1,
+			EOF:     -1,
+			Transitions: []LexTransition{
+				{Lo: ' ', Hi: ' ', NextState: 2, Skip: true},
+				{Lo: 'b', Hi: 'b', NextState: 3},
+			},
+		},
+		{AcceptToken: 1, Default: -1, EOF: -1},
 	}
-	child := openErr.Child(0)
-	if !child.IsError() {
-		t.Fatalf("absorbed child type = %q, want ERROR", child.Type(parser.language))
+	lang := &Language{
+		Name:            "recovery-checkpointless-scanner-fixture",
+		TokenCount:      2,
+		StateCount:      2,
+		SymbolCount:     2,
+		ExternalScanner: skipPrefixExternalScanner{},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "end", Visible: true, Named: true},
+			{Name: "hidden"},
+		},
+		LexStates: lexStates,
+		LexModes:  []LexMode{{LexState: 0}, {LexState: 2}},
 	}
-	if !child.IsNamed() {
-		t.Fatal("absorbed ERROR leaf is not named")
+	parser := &Parser{language: lang, errorCostCompetition: true}
+	source := []byte(" b")
+	ts := newDFATokenSourceDirectWithCRecovery(
+		NewLexer(lang.LexStates, source),
+		lang,
+		parser.lookupActionIndex,
+		nil,
+		nil,
+		nil,
+		true,
+	)
+	defer ts.Close()
+	ts.SetParserState(1)
+	tok := ts.Next()
+	if !tok.lexerSkippedPrefix {
+		t.Fatalf("fixture token lacks the skipped-prefix proof: token=%+v", tok)
+	}
+	if !ts.CanRelexFromTokenStart(tok) {
+		t.Fatal("generic relex rejected a stateless external scanner")
+	}
+	if ts.canRelexFromSkippedPrefix(tok) {
+		t.Fatal("checkpointless external scanner admitted recovery replay")
+	}
+	stack := newGLRStack(1)
+	savedParserState := ts.state
+	if got, ok := parser.cRecoverResumeDFALookahead(ts, source, &stack, tok, &parserScratch{}); ok {
+		t.Fatalf("checkpointless scanner replay = %+v, want rejection", got)
+	}
+	if ts.state != savedParserState || ts.lexer.pos != int(tok.EndByte) ||
+		ts.lexer.row != tok.EndPoint.Row || ts.lexer.col != tok.EndPoint.Column {
+		t.Fatalf("rejected replay changed source state: parser=%d pos=%d/%d/%d", ts.state, ts.lexer.pos, ts.lexer.row, ts.lexer.col)
+	}
+	if parser.cRecoverSharedTokenErrorModeLexed {
+		t.Fatal("checkpointless scanner token was marked as error-mode lexed")
 	}
 }
 
@@ -1571,12 +1864,14 @@ func TestCRecoveryCondenseAndResumeThreadsTmpEntries(t *testing.T) {
 	_, _, _, reason := parser.cCondenseAndResumeDetailed(
 		stacks,
 		nil,
+		nil,
 		Token{Symbol: 1, StartByte: 2, EndByte: 3, EndPoint: Point{Column: 3}},
 		&nodeCount,
 		arena,
 		&entryScratch,
 		&gss,
 		&tmpEntries,
+		nil,
 		&trackChildErrors,
 	)
 	if reason != ParseStopNone {
@@ -1998,7 +2293,7 @@ func TestCCondenseAndResumeComparesMissingGroupStacks(t *testing.T) {
 	}
 
 	var nodeCount int
-	condensed, resumed, _, reason := parser.cCondenseAndResume([]glrStack{missing, clean}, nil, Token{Symbol: 1}, &nodeCount, nil, nil, nil, nil, nil)
+	condensed, resumed, _, reason := parser.cCondenseAndResume([]glrStack{missing, clean}, nil, nil, Token{Symbol: 1}, &nodeCount, nil, nil, nil, nil, nil, nil)
 	if reason != ParseStopNone {
 		t.Fatalf("cCondenseAndResume stop reason = %v, want none", reason)
 	}

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -335,8 +335,18 @@ func TestParseOperationBoundaryResetsRetainedRecoveryMemoSize(t *testing.T) {
 	if got := len(parser.cNodeMemoCache); got != cNodeMemoCacheSize {
 		t.Fatalf("nested retry memo entries = %d, want %d", got, cNodeMemoCacheSize)
 	}
+	parser.growCNodeMemoCacheTo(cNodeMemoRecoveryCacheSize)
+	if got := len(parser.cNodeMemoCache); got != cNodeMemoRecoveryCacheSize {
+		t.Fatalf("temporary memo entries = %d, want %d", got, cNodeMemoRecoveryCacheSize)
+	}
 	parser.endParseOperationBudget(inner)
+	if got := len(parser.cNodeMemoCache); got != cNodeMemoRecoveryCacheSize {
+		t.Fatalf("nested cleanup memo entries = %d, want %d", got, cNodeMemoRecoveryCacheSize)
+	}
 	parser.endParseOperationBudget(outer)
+	if got := len(parser.cNodeMemoCache); got != cNodeMemoCacheSize {
+		t.Fatalf("outer cleanup memo entries = %d, want %d", got, cNodeMemoCacheSize)
+	}
 
 	next := parser.beginParseOperationBudget()
 	defer parser.endParseOperationBudget(next)
@@ -2762,6 +2772,24 @@ func TestCNodeMemoTemporaryTierLivesForParseOperation(t *testing.T) {
 	}
 	if collisions != 0 {
 		t.Fatalf("operation collisions = %d, want 0", collisions)
+	}
+}
+
+func TestCNodeMemoTemporaryTierKeepsShortRetainedSlab(t *testing.T) {
+	p := &Parser{
+		cNodeMemoCache:    make([]cNodeMemoCacheEntry, cNodeMemoCacheInitialSize),
+		cNodeMemoPeakTier: RecoveryNodeMemoTierInitial,
+	}
+	retained := &p.cNodeMemoCache[0]
+	operation := p.beginParseOperationBudget()
+	p.growCNodeMemoCacheTo(cNodeMemoRecoveryCacheSize)
+	p.endParseOperationBudget(operation)
+
+	if got := len(p.cNodeMemoCache); got != cNodeMemoCacheInitialSize {
+		t.Fatalf("finished cache length = %d, want %d", got, cNodeMemoCacheInitialSize)
+	}
+	if got := &p.cNodeMemoCache[0]; got != retained {
+		t.Fatal("operation cleanup did not restore the short cache")
 	}
 }
 

--- a/parser_relex_frontier_lifecycle_test.go
+++ b/parser_relex_frontier_lifecycle_test.go
@@ -74,6 +74,12 @@ func TestSingleStateRelexRefreshesFrontierBeforeNextToken(t *testing.T) {
 	valid := make([][]uint16, lang.StateCount)
 	valid[3], valid[4] = []uint16{0}, []uint16{1}
 	ts := newDFATokenSourceDirect(NewLexer(lang.LexStates, []byte("ax")), lang, p.lookupActionIndex, nil, valid, nil)
+	if ts.usesExternalCheckpoints {
+		t.Fatal("stateless scanner unexpectedly enabled checkpoints")
+	}
+	if !ts.CanRelexFromTokenStart(Token{StartByte: 0, EndByte: 1}) {
+		t.Fatal("generic relex rejected a stateless external scanner")
+	}
 	tree := p.parseInternal([]byte("ax"), ts, nil, nil, arenaClassFull, nil, 0, 0, 0, false)
 	if tree == nil {
 		t.Fatal("parse returned nil tree")

--- a/parser_relex_state_test.go
+++ b/parser_relex_state_test.go
@@ -167,6 +167,12 @@ func TestTryRelexSingleParserStateAcceptsOnlyZeroWidthExternalShift(t *testing.T
 	ts.lexer.col = 1
 	ts.state = 2
 	ts.glrStates = []StateID{1, 2}
+	if ts.usesExternalCheckpoints {
+		t.Fatal("stateless scanner unexpectedly enabled checkpoints")
+	}
+	if !ts.CanRelexFromTokenStart(original) {
+		t.Fatal("generic relex rejected a stateless external scanner")
+	}
 
 	got, ok := p.tryRelexSingleParserState(original, 1, ts, stacks, &parserScratch{})
 	if !ok {

--- a/parser_scratch_reset_test.go
+++ b/parser_scratch_reset_test.go
@@ -192,6 +192,28 @@ func TestInitialParseStackTinyReservationGrowsAndResetsSafely(t *testing.T) {
 	}
 }
 
+func TestEntryScratchReplacesTooSmallRetainedInitialSlab(t *testing.T) {
+	var scratch glrEntryScratch
+	scratch.ensureInitialCap(defaultStackEntrySlabCap)
+	retained := scratch.slabs[0].data
+	scratch.reset()
+
+	want := 64 * 1024
+	scratch.ensureInitialCap(want)
+	if got := len(scratch.slabs); got != 2 {
+		t.Fatalf("entry scratch slab count = %d, want 2", got)
+	}
+	if got := len(scratch.slabs[0].data); got != want {
+		t.Fatalf("entry scratch initial capacity = %d, want %d", got, want)
+	}
+	if &scratch.slabs[0].data[0] == &retained[0] {
+		t.Fatal("entry scratch retained the undersized initial slab")
+	}
+	if got, wantBytes := scratch.allocatedBytes, stackEntryBytesForCap(want+defaultStackEntrySlabCap); got != wantBytes {
+		t.Fatalf("entry scratch allocated bytes = %d, want %d", got, wantBytes)
+	}
+}
+
 func TestFullEntryScratchReservationNeverExceedsPhysicalCapacity(t *testing.T) {
 	threshold := maxFullParseEntryScratchEntries / fullParseEntryScratchEntriesPerSourceByte
 	for _, tc := range []struct {

--- a/parser_stop.go
+++ b/parser_stop.go
@@ -9,6 +9,11 @@ func (p *Parser) beginParseOperationBudget() parseOperationBudgetState {
 		return parseOperationBudgetState{}
 	}
 	if p.cNodeMemoOperationDepth == 0 {
+		// Keep retries in one operation warm. Start each independent operation
+		// with the same logical cache size so parser reuse cannot change shape.
+		if len(p.cNodeMemoCache) > cNodeMemoCacheInitialSize {
+			p.cNodeMemoCache = p.cNodeMemoCache[:cNodeMemoCacheInitialSize]
+		}
 		p.cNodeMemoOperationPeakTier = RecoveryNodeMemoTierNone
 		if cold := p.forestDeclineMemo; cold != nil {
 			cold.cNodeMemoCollisions = 0

--- a/recovery_runtime_detailed_disabled.go
+++ b/recovery_runtime_detailed_disabled.go
@@ -23,15 +23,17 @@ func (p *Parser) clearRecoveryRuntimeRetryTreesDetailed() {}
 func (p *Parser) cCondenseAndResumeDetailed(
 	stacks []glrStack,
 	source []byte,
+	ts TokenSource,
 	tok Token,
 	nodeCount *int,
 	arena *nodeArena,
 	entryScratch *glrEntryScratch,
 	gssScratch *gssScratch,
 	tmpEntries *[]stackEntry,
+	parseScratch *parserScratch,
 	trackChildErrors *bool,
 ) ([]glrStack, bool, Token, ParseStopReason) {
-	return p.cCondenseAndResume(stacks, source, tok, nodeCount, arena, entryScratch, gssScratch, tmpEntries, trackChildErrors)
+	return p.cCondenseAndResume(stacks, source, ts, tok, nodeCount, arena, entryScratch, gssScratch, tmpEntries, parseScratch, trackChildErrors)
 }
 
 // DebugRecoveryRuntimeAttempts returns no attempt receipt in production builds.

--- a/recovery_runtime_detailed_enabled.go
+++ b/recovery_runtime_detailed_enabled.go
@@ -223,19 +223,21 @@ func (p *Parser) clearRecoveryRuntimeRetryTreesDetailed() {
 func (p *Parser) cCondenseAndResumeDetailed(
 	stacks []glrStack,
 	source []byte,
+	ts TokenSource,
 	tok Token,
 	nodeCount *int,
 	arena *nodeArena,
 	entryScratch *glrEntryScratch,
 	gssScratch *gssScratch,
 	tmpEntries *[]stackEntry,
+	parseScratch *parserScratch,
 	trackChildErrors *bool,
 ) ([]glrStack, bool, Token, ParseStopReason) {
 	if !recoveryRuntimeTelemetryEnabled {
-		return p.cCondenseAndResume(stacks, source, tok, nodeCount, arena, entryScratch, gssScratch, tmpEntries, trackChildErrors)
+		return p.cCondenseAndResume(stacks, source, ts, tok, nodeCount, arena, entryScratch, gssScratch, tmpEntries, parseScratch, trackChildErrors)
 	}
 	started := time.Now()
-	resultStacks, resumed, resultToken, reason := p.cCondenseAndResume(stacks, source, tok, nodeCount, arena, entryScratch, gssScratch, tmpEntries, trackChildErrors)
+	resultStacks, resumed, resultToken, reason := p.cCondenseAndResume(stacks, source, ts, tok, nodeCount, arena, entryScratch, gssScratch, tmpEntries, parseScratch, trackChildErrors)
 	if state := p.detailedRecoveryRuntimeState(false); state != nil {
 		state.activeCondense += detailedNonNegativeUint64(time.Since(started).Nanoseconds())
 	}


### PR DESCRIPTION
## Summary

- Replay recovery lookaheads from the exact skipped-prefix offset after all alignment proofs pass.
- Record complete Swift scanner checkpoints across failed scans and incremental fast-forward.
- Reset recovery and pooled scratch state at each required lifecycle boundary.

## Correctness

The 20-byte `let x = unsafe bar()` witness now matches locked C.

These large witnesses still differ from locked C:

- `stdlib_FloatingPointToString.swift`
- `stdlib_CollectionAlgorithms.swift`

Keep issue #576 open.

All focused Docker gates pass. They cover:

- The generic relex contract and scanner transitions
- The pooled Swift minimal witness and clean-to-large sequence
- Both large Swift telemetry witnesses
- The pinned AWK recovery control
- The parser memory contract

## CI repair

External scanners now restore their start state after a terminal failed scan by default. Swift explicitly retains its required failed-scan state.

Generic relex rejects a synthetic end-of-file token before the source end. The Swift repair preserves a trailing `custom_operator` token.

Temporary CNode memo growth now restores an existing warm standard slab. A shorter retained slab stays short.

These exact private Docker gates pass:

- Templ `TestDispatcherArmCensusA0Manifest`
- Swift `TestSwiftOptionalGenericCloseDoesNotStarveCustomOperator/trailing_after_function`
- Race `TestCNodeMemoTemporaryTierLivesForParseOperation`
- Race `TestMarkdownIncrementalScannerCertification/256KiB/replace/middle`, with 73424/262341 bytes reused

Public continuous integration for exact head `d5c38cd8a06be1ae2a980b0d081927bb20064baf` is pending.

## Performance

The original 20-seed randomized benchmark geometric mean improves 3.57 percent. Bytes per operation and allocations per operation stay unchanged.

One original warmed before sample uses 594240 KiB. One original warmed after sample uses 597160 KiB. The observed increase is 0.491384 percent.

For the CI repair, the primary trio median geomean changes by +1.242879 percent across 20 randomized seeds. Each p-value exceeds 0.60. Bytes and allocations per operation stay unchanged.

The repair's warmed large-witness sample changes from 565920 KiB to 565280 KiB.
