### PR TITLE
Add default-off link provenance sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ for tags and release notes while still in `0.x`.
 
 ### Correctness
 
+- Added a default-off Core link provenance sidecar. It stores finalized
+  drop-cohort reference indexes by LinkID. Compact routing and admission stay
+  unchanged.
+
 - Included-range parsing now starts byte-seek sources at the first selected
   byte. The parser seeds its initial stack there and preserves the configured
   start point for recovery gaps. A non-seek source preserves a complete

--- a/docs/compact-g18-alternative-set-design.md
+++ b/docs/compact-g18-alternative-set-design.md
@@ -120,6 +120,10 @@ The total is `198 + 3 + 5 + 0 = 206`. Keep the denominator and the scorecard unc
 
 `dropGenericNoActionHeads` makes the final drop decision. The current proof requires exact event and branch containment.
 
+The Core now has a default-off link provenance substrate. It records finalized
+reference indexes after an authenticated bind. Routing and admission remain
+unchanged.
+
 The current proof has two limits:
 
 - An inline set has no arena identity.

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -909,6 +909,12 @@ type Core struct {
 	nodeLineages       []nodeLineageRecord
 	nodeCheckpoints    []CheckpointID
 	links              []linkRecord
+
+	// dropCohortLinkRefIndexes is an optional, LinkID-indexed sidecar. A zero
+	// entry means that no finalized drop-cohort reference is bound.
+	dropCohortLinkRefIndexes []uint32
+	dropCohortLinkRefJournal []dropCohortLinkRefMutation
+
 	subtrees           []subtreeRecord
 	externalProvenance []externalPayloadProvenance
 	children           []SubtreeID
@@ -1081,6 +1087,8 @@ type diagnosticOptions struct {
 type checkpoint struct {
 	nodes, nodeLineages, nodeCheckpoints, links, subtrees, externalProvenance int
 	children, fields, aliases                                                 int
+	dropCohortLinkRefIndexes                                                  int
+	dropCohortLinkRefJournal                                                  int
 	frontier                                                                  uint64
 	checkpoint                                                                CheckpointID
 	boundaryIndex                                                             boundaryIndexSnapshot
@@ -1134,6 +1142,8 @@ type checkpoint struct {
 	dropCohortJournalCap                                                      int
 	dropCohortFrontierJournalCap                                              int
 	dropCohortReservationsCap                                                 int
+	dropCohortLinkRefIndexesHeader                                            []uint32
+	dropCohortLinkRefJournalHeader                                            []dropCohortLinkRefMutation
 	dropCohortRefSpillHeader                                                  []DropCohortRef
 	dropCohortActionsHeader                                                   []dropCohortActionIdentity
 	dropCohortRecordsHeader                                                   []dropCohortRecord
@@ -1194,6 +1204,10 @@ func (c *Core) markInto(mark *checkpoint) {
 		nodeCheckpoints:    len(c.nodeCheckpoints),
 		externalProvenance: len(c.externalProvenance),
 		children:           len(c.children), fields: len(c.fields), aliases: len(c.aliases),
+
+		dropCohortLinkRefIndexes: len(c.dropCohortLinkRefIndexes),
+		dropCohortLinkRefJournal: len(c.dropCohortLinkRefJournal),
+
 		frontier: c.frontier, checkpoint: c.checkpoint,
 		boundaryIndex:                        c.boundaries.snapshot(),
 		journal:                              len(c.boundaryJournal),
@@ -1246,6 +1260,8 @@ func (c *Core) markInto(mark *checkpoint) {
 		dropCohortJournalCap:                 cap(c.dropCohortJournal),
 		dropCohortFrontierJournalCap:         cap(c.dropCohortFrontierJournal),
 		dropCohortReservationsCap:            cap(c.dropCohortReservations),
+		dropCohortLinkRefIndexesHeader:       c.dropCohortLinkRefIndexes,
+		dropCohortLinkRefJournalHeader:       c.dropCohortLinkRefJournal,
 		dropCohortRefSpillHeader:             c.dropCohortRefSpill,
 		dropCohortActionsHeader:              c.dropCohortActions,
 		dropCohortRecordsHeader:              c.dropCohortRecords,
@@ -1301,6 +1317,13 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 	c.frontier = mark.frontier
 	c.checkpoint = mark.checkpoint
 	c.work = mark.work
+	for index := len(c.dropCohortLinkRefJournal) - 1; index >= mark.dropCohortLinkRefJournal; index-- {
+		mutation := c.dropCohortLinkRefJournal[index]
+		if mutation.index >= 0 && mutation.index < len(c.dropCohortLinkRefIndexes) {
+			c.dropCohortLinkRefIndexes[mutation.index] = mutation.previous
+		}
+	}
+	c.dropCohortLinkRefIndexes = mark.dropCohortLinkRefIndexesHeader
 	for index := len(c.boundaryJournal) - 1; index >= mark.journal; index-- {
 		mutation := c.boundaryJournal[index]
 		mutation.slots[mutation.index] = mutation.previous
@@ -1375,6 +1398,7 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 	c.boundaryJournal = c.boundaryJournal[:mark.journal]
 	clear(c.nodeLineageJournal[mark.nodeLineageJournal:])
 	c.nodeLineageJournal = c.nodeLineageJournal[:mark.nodeLineageJournal]
+	c.dropCohortLinkRefJournal = mark.dropCohortLinkRefJournalHeader
 	phase0AObserveRollback(c, mark.transaction, phase0ATakeRollbackCause(c))
 	c.finishTransaction()
 }
@@ -1406,6 +1430,8 @@ func (c *Core) finishTransaction() {
 		c.boundaryJournal = c.boundaryJournal[:0]
 		clear(c.nodeLineageJournal)
 		c.nodeLineageJournal = c.nodeLineageJournal[:0]
+		clear(c.dropCohortLinkRefJournal)
+		c.dropCohortLinkRefJournal = c.dropCohortLinkRefJournal[:0]
 	}
 }
 
@@ -1753,6 +1779,8 @@ func (c *Core) Reset() error {
 	c.nodeLineages = c.nodeLineages[:0]
 	c.nodeCheckpoints = c.nodeCheckpoints[:0]
 	c.links = c.links[:0]
+	clear(c.dropCohortLinkRefIndexes)
+	c.dropCohortLinkRefIndexes = c.dropCohortLinkRefIndexes[:0]
 	c.subtrees = c.subtrees[:0]
 	c.externalProvenance = c.externalProvenance[:0]
 	c.children = c.children[:0]
@@ -1766,6 +1794,8 @@ func (c *Core) Reset() error {
 	c.boundaryJournal = c.boundaryJournal[:0]
 	clear(c.nodeLineageJournal)
 	c.nodeLineageJournal = c.nodeLineageJournal[:0]
+	clear(c.dropCohortLinkRefJournal)
+	c.dropCohortLinkRefJournal = c.dropCohortLinkRefJournal[:0]
 	c.alternativeSpillArena = c.alternativeSpillArena[:0]
 	c.dropCohortRefSpill = c.dropCohortRefSpill[:0]
 	c.dropCohortActions = c.dropCohortActions[:0]
@@ -2814,8 +2844,7 @@ func (c *Core) appendPrivate(state StateID, byteOffset uint32, in linkInput) (He
 	if in.order.Present {
 		flags |= linkFlagHasOrder
 	}
-	linkID := LinkID(uint64(len(c.links)) + 1)
-	c.links = append(c.links, linkRecord{
+	linkID := c.appendGraphLink(linkRecord{
 		prev: in.prev, payload: in.payload, scoreDelta: in.scoreDelta,
 		order: in.order.Value, flags: flags,
 	})
@@ -3171,12 +3200,11 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 		}
 		linkCount += old.linkCount
 	}
-	linkID := LinkID(uint64(len(c.links)) + 1)
 	flags := uint32(0)
 	if in.order.Present {
 		flags |= linkFlagHasOrder
 	}
-	c.links = append(c.links, linkRecord{
+	linkID := c.appendGraphLink(linkRecord{
 		prev: in.prev, payload: in.payload, scoreDelta: in.scoreDelta,
 		order: in.order.Value, flags: flags, next: LinkID(old.firstLink),
 	})
@@ -3222,12 +3250,11 @@ func (c *Core) condenseDirectAppend(key boundaryKey, probe boundaryProbe, prevPa
 	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || uint64(len(c.nodes)) >= math.MaxUint32 {
 		return condenseOutcome{}, errors.New("parser-core phase zero: node arena cap")
 	}
-	linkID := LinkID(uint64(len(c.links)) + 1)
 	flags := uint32(0)
 	if in.order.Present {
 		flags |= linkFlagHasOrder
 	}
-	c.links = append(c.links, linkRecord{
+	linkID := c.appendGraphLink(linkRecord{
 		prev: in.prev, payload: in.payload, scoreDelta: in.scoreDelta,
 		order: in.order.Value, flags: flags,
 	})
@@ -3913,7 +3940,7 @@ func (c *Core) appendAdjacencyNodeAt(state StateID, byteOffset uint32, checkpoin
 	for _, stored := range links {
 		copy := stored
 		copy.next = first
-		c.links = append(c.links, copy)
+		c.appendGraphLink(copy)
 		c.addWork(&c.work.GraphLinkAdditionsProxy, 1)
 		first = LinkID(len(c.links))
 	}
@@ -4042,6 +4069,7 @@ func (c *Core) replaceBoundaryLink(key boundaryKey, probe boundaryProbe, old nod
 	}
 
 	linkMark := len(c.links)
+	linkRefMark := len(c.dropCohortLinkRefIndexes)
 	var first LinkID
 	for index, stored := range oldLinks {
 		copy := stored
@@ -4056,7 +4084,7 @@ func (c *Core) replaceBoundaryLink(key boundaryKey, probe boundaryProbe, old nod
 			}
 		}
 		copy.next = first
-		c.links = append(c.links, copy)
+		c.appendGraphLink(copy)
 		c.addWork(&c.work.GraphLinkAdditionsProxy, 1)
 		first = LinkID(len(c.links))
 	}
@@ -4066,6 +4094,9 @@ func (c *Core) replaceBoundaryLink(key boundaryKey, probe boundaryProbe, old nod
 	}, key.checkpoint)
 	if err != nil {
 		c.links = c.links[:linkMark]
+		if c.dropCohortLinkRefIndexes != nil {
+			c.dropCohortLinkRefIndexes = c.dropCohortLinkRefIndexes[:linkRefMark]
+		}
 		return Head{}, err
 	}
 	if err := c.publishBoundary(probe, id); err != nil {

--- a/internal/parsercorephase0/link_provenance.go
+++ b/internal/parsercorephase0/link_provenance.go
@@ -1,0 +1,312 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+// LinkRange identifies one complete, bounded adjacency chain. First names the
+// newest link and Count includes every link through the zero next pointer.
+type LinkRange struct {
+	First LinkID
+	Count uint32
+}
+
+// Empty reports whether both range fields use their zero value.
+func (r LinkRange) Empty() bool { return r.First == 0 && r.Count == 0 }
+
+// appendGraphLink keeps the optional sidecar aligned with the link arena. A
+// newly published link starts unbound; authentication binds it later.
+func (c *Core) appendGraphLink(link linkRecord) LinkID {
+	id := LinkID(len(c.links) + 1)
+	c.links = append(c.links, link)
+	if c.dropCohortLinkRefIndexes != nil {
+		c.dropCohortLinkRefIndexes = append(c.dropCohortLinkRefIndexes, 0)
+	}
+	return id
+}
+
+// resolveDropCohortLinkRange authenticates one exact graph adjacency chain.
+// The production graph prepends links, so valid next identifiers decrease by
+// one and the final link points to zero.
+func (c *Core) resolveDropCohortLinkRange(r LinkRange) ([]LinkID, error) {
+	if c == nil {
+		return nil, errors.New("parser-core phase zero: link range on nil core")
+	}
+	if r.Empty() {
+		return nil, nil
+	}
+	if r.First == 0 || r.Count == 0 {
+		return nil, errors.New("parser-core phase zero: mixed-empty link range")
+	}
+	if uint64(r.Count) > uint64(c.limits.MaxLinksPerBoundary) {
+		return nil, errors.New("parser-core phase zero: link range exceeds boundary cap")
+	}
+	if uint64(r.First) > uint64(len(c.links)) {
+		return nil, errors.New("parser-core phase zero: link range starts outside the graph")
+	}
+	ids := make([]LinkID, r.Count)
+	current := r.First
+	for index := range ids {
+		if current == 0 || uint64(current) > uint64(len(c.links)) {
+			return nil, errors.New("parser-core phase zero: link range leaves the graph")
+		}
+		link := c.links[current-1]
+		if link.prev == 0 || uint64(link.prev) > uint64(len(c.nodes)) {
+			return nil, errors.New("parser-core phase zero: link range has an invalid predecessor")
+		}
+		ids[index] = current
+		if index+1 == len(ids) {
+			if link.next != 0 {
+				return nil, errors.New("parser-core phase zero: link range does not terminate at the graph boundary")
+			}
+			break
+		}
+		if current <= 1 || link.next != current-1 {
+			return nil, errors.New("parser-core phase zero: link range is noncontiguous")
+		}
+		current = link.next
+	}
+	return ids, nil
+}
+
+// LinkRangeForHead returns the authenticated adjacency range stored on head.
+// This helper is cold-path metadata access; it does not affect routing.
+func (c *Core) LinkRangeForHead(head Head) (LinkRange, error) {
+	if c == nil {
+		return LinkRange{}, errors.New("parser-core phase zero: link range on nil core")
+	}
+	node, err := c.node(head.Node)
+	if err != nil {
+		return LinkRange{}, err
+	}
+	rangeValue := LinkRange{First: LinkID(node.firstLink), Count: node.linkCount}
+	if rangeValue.Empty() {
+		return LinkRange{}, nil
+	}
+	if _, err := c.resolveDropCohortLinkRange(rangeValue); err != nil {
+		return LinkRange{}, err
+	}
+	return rangeValue, nil
+}
+
+// DropCohortLinkRefIndex returns the one-based certificate index attached to
+// link. It fails closed for an unbound or malformed sidecar entry.
+func (c *Core) DropCohortLinkRefIndex(link LinkID) (uint32, bool) {
+	if c == nil || link == 0 || uint64(link) > uint64(len(c.links)) ||
+		len(c.dropCohortLinkRefIndexes) > len(c.links) ||
+		uint64(link) > uint64(len(c.dropCohortLinkRefIndexes)) {
+		return 0, false
+	}
+	index := c.dropCohortLinkRefIndexes[link-1]
+	if index == 0 || uint64(index) > uint64(len(c.dropCohortCertificateRefs)) {
+		return 0, false
+	}
+	return index, true
+}
+
+// finalizedDropCohortCertificateIndex proves one current, complete reference
+// and returns its one-based certificate-store index.
+func (c *Core) finalizedDropCohortCertificateIndex(ref DropCohortRef) (uint32, DropCohortHandle, bool) {
+	if c == nil {
+		return 0, DropCohortHandle{}, false
+	}
+	recordIndex, handle, reason := c.dropCohortVerifierLookup(ref, false)
+	if reason != dropCohortVerifierProved || recordIndex < 0 || recordIndex >= len(c.dropCohortRecords) {
+		return 0, handle, false
+	}
+	record := c.dropCohortRecords[recordIndex]
+	if record.handle != handle || dropCohortVerifierClassifyRecord(record) != dropCohortVerifierProved {
+		return 0, handle, false
+	}
+	if _, ok := c.findDropCohortMember(record, ref.Branch); !ok {
+		return 0, handle, false
+	}
+	for index, stored := range c.dropCohortCertificateRefs {
+		if stored != ref {
+			continue
+		}
+		if uint64(index) >= uint64(math.MaxUint32) {
+			return 0, handle, false
+		}
+		return uint32(index + 1), handle, true
+	}
+	return 0, handle, false
+}
+
+// DropCohortLinkRef returns the finalized reference attached to link.
+func (c *Core) DropCohortLinkRef(link LinkID) (DropCohortRef, bool) {
+	index, ok := c.DropCohortLinkRefIndex(link)
+	if !ok {
+		return DropCohortRef{}, false
+	}
+	ref := c.dropCohortCertificateRefs[index-1]
+	certificateIndex, _, ok := c.finalizedDropCohortCertificateIndex(ref)
+	if !ok || certificateIndex != index {
+		return DropCohortRef{}, false
+	}
+	return ref, true
+}
+
+func equalReductionPlan(left, right ReductionPlan) bool {
+	if left.productionID != right.productionID || left.childCount != right.childCount ||
+		len(left.fields) != len(right.fields) || len(left.aliases) != len(right.aliases) {
+		return false
+	}
+	for index := range left.fields {
+		if left.fields[index] != right.fields[index] {
+			return false
+		}
+	}
+	for index := range left.aliases {
+		if left.aliases[index] != right.aliases[index] {
+			return false
+		}
+	}
+	return true
+}
+
+// authenticatedDropCohortAction derives action identity from authenticated
+// scheduler inputs. Callers cannot supply an unchecked identity value.
+func (c *Core) authenticatedDropCohortAction(boundary ClassifiedBoundary, descriptor ActionRowDescriptor, selectedOrdinal int, plan ReductionPlan) (DropCohortActionIdentity, error) {
+	if err := c.validateClassification(boundary); err != nil {
+		return DropCohortActionIdentity{}, err
+	}
+	if descriptor != boundary.actions.Descriptor() {
+		return DropCohortActionIdentity{}, errors.New("parser-core phase zero: link bind action descriptor mismatch")
+	}
+	act, err := c.classifiedActionRef(boundary, selectedOrdinal)
+	if err != nil {
+		return DropCohortActionIdentity{}, err
+	}
+	if act.Type != ActionReduce || !descriptor.HasReduce() {
+		return DropCohortActionIdentity{}, errors.New("parser-core phase zero: link bind action is not a reduction")
+	}
+	authenticatedPlan, err := c.reductionPlan(*act)
+	if err != nil {
+		return DropCohortActionIdentity{}, err
+	}
+	if !equalReductionPlan(plan, authenticatedPlan) {
+		return DropCohortActionIdentity{}, errors.New("parser-core phase zero: link bind reduction plan mismatch")
+	}
+	if selectedOrdinal > math.MaxInt32 {
+		return DropCohortActionIdentity{}, errors.New("parser-core phase zero: link bind action ordinal overflow")
+	}
+	return DropCohortActionIdentity{
+		BoundaryState: boundary.state,
+		Lookahead:     boundary.lookahead,
+		ActionOrdinal: int32(selectedOrdinal),
+		Action:        *act,
+		NoLookahead:   c.reduceNoLookaheadContext,
+		Selection:     c.dropCohortSelectionContext,
+	}, nil
+}
+
+func (c *Core) bindDropCohortLinkRefsOwned(owner SchedulerTransactionToken, boundary ClassifiedBoundary, descriptor ActionRowDescriptor, selectedOrdinal int, plan ReductionPlan, links LinkRange, refs []DropCohortRef) error {
+	if err := c.beginSchedulerOwned(owner); err != nil {
+		return err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	return c.finishSchedulerOwned(owner, c.bindDropCohortLinkRefs(boundary, descriptor, selectedOrdinal, plan, links, refs))
+}
+
+func (c *Core) bindDropCohortLinkRefs(boundary ClassifiedBoundary, descriptor ActionRowDescriptor, selectedOrdinal int, plan ReductionPlan, links LinkRange, refs []DropCohortRef) error {
+	if c == nil {
+		return errors.New("parser-core phase zero: link bind on nil core")
+	}
+	expectedAction, err := c.authenticatedDropCohortAction(boundary, descriptor, selectedOrdinal, plan)
+	if err != nil {
+		return err
+	}
+	linkIDs, err := c.resolveDropCohortLinkRange(links)
+	if err != nil {
+		return err
+	}
+	if len(refs) != len(linkIDs) {
+		return fmt.Errorf("parser-core phase zero: link bind reference count %d does not match link count %d", len(refs), len(linkIDs))
+	}
+	if len(linkIDs) == 0 {
+		return nil
+	}
+	if c.dropCohortLinkRefIndexes != nil && len(c.dropCohortLinkRefIndexes) > len(c.links) {
+		return errors.New("parser-core phase zero: link bind sidecar is longer than the graph")
+	}
+	indexes := make([]uint32, len(refs))
+	for index, ref := range refs {
+		certificateIndex, _, ok := c.finalizedDropCohortCertificateIndex(ref)
+		if !ok {
+			return errors.New("parser-core phase zero: link bind reference is not finalized")
+		}
+		recordIndex, handle, reason := c.dropCohortVerifierLookup(ref, false)
+		if reason != dropCohortVerifierProved || recordIndex < 0 || recordIndex >= len(c.dropCohortRecords) {
+			return errors.New("parser-core phase zero: link bind reference is not finalized")
+		}
+		record := c.dropCohortRecords[recordIndex]
+		memberIndex, ok := c.findDropCohortMember(record, ref.Branch)
+		if !ok || memberIndex < 0 || memberIndex >= len(c.dropCohortMembers) {
+			return errors.New("parser-core phase zero: link bind member is missing")
+		}
+		member := c.dropCohortMembers[memberIndex]
+		if member.cohort != handle || member.action != expectedAction {
+			return errors.New("parser-core phase zero: link bind action authentication failed")
+		}
+		link := c.links[linkIDs[index]-1]
+		if member.head.Node != link.prev {
+			return errors.New("parser-core phase zero: link bind graph identity mismatch")
+		}
+		indexes[index] = certificateIndex
+		if prior := c.sidecarValue(linkIDs[index]); prior != 0 && prior != certificateIndex {
+			return errors.New("parser-core phase zero: link bind would overwrite a different certificate")
+		}
+	}
+	if c.dropCohortLinkRefIndexes == nil {
+		c.dropCohortLinkRefIndexes = make([]uint32, len(c.links))
+	} else if len(c.dropCohortLinkRefIndexes) < len(c.links) {
+		c.dropCohortLinkRefIndexes = append(c.dropCohortLinkRefIndexes, make([]uint32, len(c.links)-len(c.dropCohortLinkRefIndexes))...)
+	}
+	for index, certificateIndex := range indexes {
+		linkIndex := int(linkIDs[index]) - 1
+		prior := c.dropCohortLinkRefIndexes[linkIndex]
+		if prior == certificateIndex {
+			continue
+		}
+		if len(c.transactions) != 0 {
+			c.dropCohortLinkRefJournal = append(c.dropCohortLinkRefJournal, dropCohortLinkRefMutation{index: linkIndex, previous: prior})
+		}
+		c.dropCohortLinkRefIndexes[linkIndex] = certificateIndex
+	}
+	return nil
+}
+
+func (c *Core) sidecarValue(link LinkID) uint32 {
+	if c == nil || link == 0 || uint64(link) > uint64(len(c.dropCohortLinkRefIndexes)) {
+		return 0
+	}
+	return c.dropCohortLinkRefIndexes[link-1]
+}
+
+// BindDropCohortLinkRefsOwned binds one finalized reference per exact graph
+// link under the caller's scheduler transaction.
+func (c *Core) BindDropCohortLinkRefsOwned(owner SchedulerTransactionToken, boundary ClassifiedBoundary, descriptor ActionRowDescriptor, selectedOrdinal int, plan ReductionPlan, links LinkRange, refs []DropCohortRef) error {
+	if c == nil {
+		return errors.New("parser-core phase zero: link bind on nil core")
+	}
+	return c.bindDropCohortLinkRefsOwned(owner, boundary, descriptor, selectedOrdinal, plan, links, refs)
+}
+
+// BindDropCohortLinkRefs binds one finalized reference per exact graph link
+// inside an atomic scheduler transaction.
+func (c *Core) BindDropCohortLinkRefs(boundary ClassifiedBoundary, descriptor ActionRowDescriptor, selectedOrdinal int, plan ReductionPlan, links LinkRange, refs []DropCohortRef) error {
+	if c == nil {
+		return errors.New("parser-core phase zero: link bind on nil core")
+	}
+	return c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return c.BindDropCohortLinkRefsOwned(owner, boundary, descriptor, selectedOrdinal, plan, links, refs)
+	})
+}
+
+type dropCohortLinkRefMutation struct {
+	index    int
+	previous uint32
+}

--- a/internal/parsercorephase0/link_provenance_test.go
+++ b/internal/parsercorephase0/link_provenance_test.go
@@ -1,0 +1,248 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type linkProvenanceFixture struct {
+	core       *Core
+	boundary   ClassifiedBoundary
+	descriptor ActionRowDescriptor
+	plan       ReductionPlan
+	rangeValue LinkRange
+	refs       []DropCohortRef
+	action     Action
+	nodes      []NodeID
+}
+
+func newLinkProvenanceFixture(t *testing.T, maxLinksPerBoundary uint32) linkProvenanceFixture {
+	t.Helper()
+	action := Action{Type: ActionReduce, State: 3, Symbol: 9, ProductionID: 17}
+	table := &fakeTable{
+		actions: map[tableCell][]Action{{state: 3, symbol: 9}: {action}},
+	}
+	core, err := New(table, Limits{MaxLinksPerBoundary: maxLinksPerBoundary})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstNode, err := core.appendNode(nodeRecord{state: 3, byteOffset: 0, pathCount: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondNode, err := core.appendNode(nodeRecord{state: 3, byteOffset: 1, pathCount: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstLink := core.appendGraphLink(linkRecord{prev: firstNode})
+	secondLink := core.appendGraphLink(linkRecord{prev: secondNode, next: firstLink})
+	boundary, err := core.ClassifyBoundary(Head{Node: firstNode}, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := NewReductionPlan(action.ProductionID, int(action.ChildCount), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle := core.dropCohortHandle(1)
+	identity := DropCohortActionIdentity{
+		BoundaryState: boundary.state,
+		Lookahead:     boundary.lookahead,
+		ActionOrdinal: 0,
+		Action:        action,
+		Selection:     DropCohortSelectionNone,
+	}
+	core.dropCohortRecords = []dropCohortRecord{{
+		handle: handle, state: DropCohortComplete, expected: 2, written: 2,
+	}}
+	core.dropCohortMembers = []dropCohortMember{
+		{cohort: handle, head: Head{Node: firstNode}, branch: 0, action: identity},
+		{cohort: handle, head: Head{Node: secondNode}, branch: 1, action: identity},
+	}
+	refs := []DropCohortRef{
+		{Owner: handle.Owner, Epoch: handle.Epoch, Sequence: handle.Sequence, Branch: 1},
+		{Owner: handle.Owner, Epoch: handle.Epoch, Sequence: handle.Sequence, Branch: 0},
+	}
+	core.dropCohortCertificateRefs = append(core.dropCohortCertificateRefs, refs...)
+	return linkProvenanceFixture{
+		core: core, boundary: boundary, descriptor: boundary.actions.Descriptor(), plan: plan,
+		rangeValue: LinkRange{First: secondLink, Count: 2}, refs: refs, action: action,
+		nodes: []NodeID{firstNode, secondNode},
+	}
+}
+
+func bindFixture(t *testing.T, fixture linkProvenanceFixture) error {
+	t.Helper()
+	return fixture.core.BindDropCohortLinkRefs(
+		fixture.boundary, fixture.descriptor, 0, fixture.plan,
+		fixture.rangeValue, fixture.refs,
+	)
+}
+
+func TestLinkProvenanceDefaultOffAndAccounting(t *testing.T) {
+	fixture := newLinkProvenanceFixture(t, 8)
+	core := fixture.core
+	if core.dropCohortLinkRefIndexes != nil {
+		t.Fatal("new core allocated link provenance sidecar")
+	}
+	want := uint64(len(core.nodes))*coreNodeRecordBytes + uint64(len(core.links))*coreLinkRecordBytes +
+		uint64(len(core.dropCohortRecords))*coreDropCohortRecordBytes +
+		uint64(len(core.dropCohortMembers))*coreDropCohortMemberBytes +
+		uint64(len(core.dropCohortCertificateRefs))*coreDropCohortRefBytes
+	if got := core.StorageBytes(); got != want {
+		t.Fatalf("default storage=%d, want %d", got, want)
+	}
+	before := core.StorageBytes()
+	if err := bindFixture(t, fixture); err != nil {
+		t.Fatal(err)
+	}
+	if len(core.dropCohortLinkRefIndexes) != len(core.links) {
+		t.Fatalf("sidecar length=%d, want %d", len(core.dropCohortLinkRefIndexes), len(core.links))
+	}
+	if got, want := core.StorageBytes()-before, uint64(len(core.links))*coreUint32Bytes; got != want {
+		t.Fatalf("sidecar storage delta=%d, want %d", got, want)
+	}
+	if got := core.dropCohortLinkRefJournal; len(got) != 0 {
+		t.Fatalf("committed sidecar journal length=%d, want zero", len(got))
+	}
+	if got := core.FootprintBytes(); got < core.StorageBytes() {
+		t.Fatalf("footprint=%d is below storage=%d", got, core.StorageBytes())
+	}
+	for index, ref := range fixture.refs {
+		link := fixture.rangeValue.First - LinkID(index)
+		if got, ok := core.DropCohortLinkRef(link); !ok || got != ref {
+			t.Fatalf("link %d ref=(%+v,%t), want %+v", link, got, ok, ref)
+		}
+	}
+	if got, ok := core.DropCohortLinkRef(0); ok || got != (DropCohortRef{}) {
+		t.Fatalf("zero link lookup=(%+v,%t), want empty", got, ok)
+	}
+}
+
+func TestLinkProvenanceManyToOneAndExactGraphAuthentication(t *testing.T) {
+	many := newLinkProvenanceFixture(t, 8)
+	many.core.links[many.rangeValue.First-1].prev = many.nodes[0]
+	many.core.dropCohortMembers[1].head = Head{Node: many.nodes[0]}
+	many.refs[1] = many.refs[0]
+	many.core.dropCohortCertificateRefs = many.core.dropCohortCertificateRefs[:1]
+	if err := bindFixture(t, many); err != nil {
+		t.Fatalf("many-to-one bind failed: %v", err)
+	}
+	if many.core.dropCohortLinkRefIndexes[0] != 1 || many.core.dropCohortLinkRefIndexes[1] != 1 {
+		t.Fatalf("many-to-one sidecar=%v, want [1 1]", many.core.dropCohortLinkRefIndexes)
+	}
+
+	negative := newLinkProvenanceFixture(t, 8)
+	negative.core.dropCohortMembers[0].head = Head{Node: negative.nodes[1]}
+	if err := bindFixture(t, negative); err == nil {
+		t.Fatal("same-action member with a different graph head was accepted")
+	}
+	if negative.core.dropCohortLinkRefIndexes != nil {
+		t.Fatalf("failed graph authentication allocated sidecar=%v", negative.core.dropCohortLinkRefIndexes)
+	}
+}
+
+func TestLinkProvenanceRejectsMalformedRangesAndReferences(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*Core, LinkRange) LinkRange
+	}{
+		{name: "mixed first zero", edit: func(_ *Core, _ LinkRange) LinkRange { return LinkRange{Count: 1} }},
+		{name: "mixed count zero", edit: func(_ *Core, _ LinkRange) LinkRange { return LinkRange{First: 1} }},
+		{name: "first out of bounds", edit: func(_ *Core, _ LinkRange) LinkRange { return LinkRange{First: 99, Count: 1} }},
+		{name: "noncontiguous", edit: func(core *Core, value LinkRange) LinkRange {
+			core.links[value.First-1].next = 0
+			return value
+		}},
+		{name: "chain skips", edit: func(core *Core, value LinkRange) LinkRange {
+			core.links[value.First-1].next = value.First - 1
+			core.links[value.First-2].next = value.First + 1
+			return value
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newLinkProvenanceFixture(t, 8)
+			value := test.edit(fixture.core, fixture.rangeValue)
+			if _, err := fixture.core.resolveDropCohortLinkRange(value); err == nil {
+				t.Fatalf("range %+v was accepted", value)
+			}
+		})
+	}
+
+	capFixture := newLinkProvenanceFixture(t, 1)
+	if _, err := capFixture.core.resolveDropCohortLinkRange(capFixture.rangeValue); err == nil {
+		t.Fatal("range above boundary cap was accepted")
+	}
+	zero := newLinkProvenanceFixture(t, 8)
+	if err := zero.core.BindDropCohortLinkRefs(zero.boundary, zero.descriptor, 0, zero.plan, LinkRange{}, nil); err != nil {
+		t.Fatalf("zero range with zero refs failed: %v", err)
+	}
+	for _, value := range []LinkRange{{Count: 1}, {First: 1}} {
+		if err := zero.core.BindDropCohortLinkRefs(zero.boundary, zero.descriptor, 0, zero.plan, value, nil); err == nil {
+			t.Fatalf("mixed-empty range %+v was accepted", value)
+		}
+	}
+	stale := newLinkProvenanceFixture(t, 8)
+	stale.refs[0].Owner++
+	if err := bindFixture(t, stale); err == nil || stale.core.dropCohortLinkRefIndexes != nil {
+		t.Fatalf("foreign owner result err=%v sidecar=%v", err, stale.core.dropCohortLinkRefIndexes)
+	}
+	stale = newLinkProvenanceFixture(t, 8)
+	stale.refs[0].Epoch = 0
+	if err := bindFixture(t, stale); err == nil || stale.core.dropCohortLinkRefIndexes != nil {
+		t.Fatalf("stale epoch result err=%v sidecar=%v", err, stale.core.dropCohortLinkRefIndexes)
+	}
+}
+
+func TestLinkProvenanceRollbackRestoresContentAllocationAndLength(t *testing.T) {
+	fixture := newLinkProvenanceFixture(t, 8)
+	fixture.core.dropCohortLinkRefIndexes = make([]uint32, len(fixture.core.links), len(fixture.core.links))
+	before := append([]uint32(nil), fixture.core.dropCohortLinkRefIndexes...)
+	beforeLen, beforeCap := len(fixture.core.dropCohortLinkRefIndexes), cap(fixture.core.dropCohortLinkRefIndexes)
+	beforePtr := &fixture.core.dropCohortLinkRefIndexes[0]
+	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if err := fixture.core.BindDropCohortLinkRefsOwned(owner, fixture.boundary, fixture.descriptor, 0, fixture.plan, fixture.rangeValue, fixture.refs); err != nil {
+			return err
+		}
+		return errors.New("force sidecar rollback")
+	})
+	if err == nil {
+		t.Fatal("forced rollback returned nil")
+	}
+	if !reflect.DeepEqual(fixture.core.dropCohortLinkRefIndexes, before) || len(fixture.core.dropCohortLinkRefIndexes) != beforeLen || cap(fixture.core.dropCohortLinkRefIndexes) != beforeCap || &fixture.core.dropCohortLinkRefIndexes[0] != beforePtr {
+		t.Fatalf("rollback sidecar=%v len/cap=%d/%d, want %v %d/%d", fixture.core.dropCohortLinkRefIndexes, len(fixture.core.dropCohortLinkRefIndexes), cap(fixture.core.dropCohortLinkRefIndexes), before, beforeLen, beforeCap)
+	}
+
+	fresh := newLinkProvenanceFixture(t, 8)
+	if err := fresh.core.BindDropCohortLinkRefs(fresh.boundary, fresh.descriptor, 0, fresh.plan, fresh.rangeValue, fresh.refs); err != nil {
+		t.Fatal(err)
+	}
+	if err := fresh.core.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	if len(fresh.core.dropCohortLinkRefIndexes) != 0 || len(fresh.core.dropCohortLinkRefJournal) != 0 {
+		t.Fatalf("reset sidecar lengths=%d/%d, want zero", len(fresh.core.dropCohortLinkRefIndexes), len(fresh.core.dropCohortLinkRefJournal))
+	}
+	if _, ok := fresh.core.DropCohortLinkRef(1); ok {
+		t.Fatal("reset retained a link provenance reference")
+	}
+}
+
+func TestLinkProvenanceRejectsAuthenticationMismatches(t *testing.T) {
+	fixture := newLinkProvenanceFixture(t, 8)
+	badPlan, err := NewReductionPlan(fixture.action.ProductionID+1, int(fixture.action.ChildCount), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.core.BindDropCohortLinkRefs(fixture.boundary, fixture.descriptor, 0, badPlan, fixture.rangeValue, fixture.refs); err == nil {
+		t.Fatal("mismatched reduction plan was accepted")
+	}
+	if err := fixture.core.BindDropCohortLinkRefs(fixture.boundary, ActionRowDescriptor{}, 0, fixture.plan, fixture.rangeValue, fixture.refs); err == nil {
+		t.Fatal("mismatched row descriptor was accepted")
+	}
+	if err := fixture.core.BindDropCohortLinkRefs(fixture.boundary, fixture.descriptor, -1, fixture.plan, fixture.rangeValue, fixture.refs); err == nil {
+		t.Fatal("negative action ordinal was accepted")
+	}
+}

--- a/internal/parsercorephase0/storage_bytes.go
+++ b/internal/parsercorephase0/storage_bytes.go
@@ -25,6 +25,7 @@ var (
 	coreDropCohortFrontierParticipantBytes = uint64(unsafe.Sizeof(dropCohortFrontierParticipant{}))
 	coreDropCohortFrontierMemberBytes      = uint64(unsafe.Sizeof(dropCohortFrontierMember{}))
 	coreDropCohortFrontierMutationBytes    = uint64(unsafe.Sizeof(dropCohortFrontierMutation{}))
+	coreDropCohortLinkRefMutationBytes     = uint64(unsafe.Sizeof(dropCohortLinkRefMutation{}))
 )
 
 // StorageBytes returns a cheap, deterministic, O(1) estimate of the compact
@@ -60,6 +61,7 @@ func (c *Core) StorageBytes() uint64 {
 	}
 	return uint64(len(c.nodes))*coreNodeRecordBytes +
 		uint64(len(c.links))*coreLinkRecordBytes +
+		uint64(len(c.dropCohortLinkRefIndexes))*coreUint32Bytes +
 		uint64(len(c.subtrees))*coreSubtreeRecordBytes +
 		uint64(len(c.children))*coreChildRecordBytes +
 		uint64(len(c.fields))*coreFieldRecordBytes +
@@ -79,7 +81,8 @@ func (c *Core) StorageBytes() uint64 {
 		uint64(len(c.dropCohortFrontierMembers))*coreDropCohortFrontierMemberBytes +
 		uint64(len(c.dropCohortFrontierJournal))*coreDropCohortFrontierMutationBytes +
 		uint64(len(c.dropCohortReservations))*coreDropCohortReservationBytes +
-		uint64(len(c.dropCohortJournal))*coreDropCohortMutationBytes
+		uint64(len(c.dropCohortJournal))*coreDropCohortMutationBytes +
+		uint64(len(c.dropCohortLinkRefJournal))*coreDropCohortLinkRefMutationBytes
 }
 
 // Byte footprints for the additional families FootprintBytes covers that
@@ -155,6 +158,8 @@ func (c *Core) FootprintBytes() uint64 {
 	total += uint64(cap(c.externalProvenance)) * coreExternalProvenanceBytes
 	total += uint64(cap(c.boundaryJournal)) * coreBoundaryMutationBytes
 	total += uint64(cap(c.nodeLineageJournal)) * coreNodeLineageMutationBytes
+	total += uint64(cap(c.dropCohortLinkRefIndexes)) * coreUint32Bytes
+	total += uint64(cap(c.dropCohortLinkRefJournal)) * coreDropCohortLinkRefMutationBytes
 	total += uint64(cap(c.alternativeSpillArena)) * coreUint32Bytes
 	total += uint64(cap(c.dropCohortRefSpill)) * coreDropCohortRefBytes
 	total += uint64(cap(c.dropCohortActions)) * coreDropCohortActionBytes
@@ -303,6 +308,8 @@ func (c *Core) releaseRecordArenaReserve() {
 	c.nodes = nil
 	c.nodeLineages = nil
 	c.links = nil
+	c.dropCohortLinkRefIndexes = nil
+	c.dropCohortLinkRefJournal = nil
 	c.subtrees = nil
 	c.children = nil
 	c.dropCohortRefSpill = nil
@@ -332,6 +339,8 @@ func (c *Core) releaseOversizedRetention() {
 	c.nodeLineages = nil
 	c.nodeCheckpoints = nil
 	c.links = nil
+	c.dropCohortLinkRefIndexes = nil
+	c.dropCohortLinkRefJournal = nil
 	c.subtrees = nil
 	c.externalProvenance = nil
 	c.children = nil


### PR DESCRIPTION
## Summary

- Add a nil-by-default `uint32` sidecar indexed by `LinkID`.
- Bind finalized drop-cohort references only after authenticating the classified boundary, action descriptor, selected ordinal, reduction plan, and exact graph predecessor.
- Add scheduler transaction rollback, reset, append alignment, and storage accounting.

## Scope

This change does not alter derivation format, `ReductionOutput`, compact routing, or admission behavior.

## Validation

- `go test ./internal/parsercorephase0 -run '^(TestLinkProvenance|TestSchedulerTransaction|TestG18DropCohortActionIdentityAcceptsSignedPrecedenceAndChecksWidths)$' -count=1`
- `git diff --check`
- Narrow Canopy symbol query for the new sidecar API