### PR TITLE
Carry graph-chain references in reduction outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,12 @@ for tags and release notes while still in `0.x`.
   drop-cohort reference indexes by LinkID. Compact routing and admission stay
   unchanged.
 
+- Added a default-off reduction output provenance handoff. It carries an
+  authenticated graph-chain reference from published node metadata. The
+  reference follows `next` links and does not require adjacent LinkID values.
+  It performs no adjacency walk and changes no derivation format, routing,
+  admission, or compact counters.
+
 - Included-range parsing now starts byte-seek sources at the first selected
   byte. The parser seeds its initial stack there and preserves the configured
   start point for recovery gaps. A non-seek source preserves a complete

--- a/docs/compact-g18-alternative-set-design.md
+++ b/docs/compact-g18-alternative-set-design.md
@@ -124,6 +124,12 @@ The Core now has a default-off link provenance substrate. It records finalized
 reference indexes after an authenticated bind. Routing and admission remain
 unchanged.
 
+Reduction construction now carries an authenticated graph-chain reference in
+each output. It reads published node metadata in constant time and performs no
+adjacency walk. The reference follows `next` links and does not require
+adjacent LinkID values. No current route consumes this field. Routing and
+admission remain unchanged.
+
 The current proof has two limits:
 
 - An inline set has no arena identity.

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -2401,14 +2401,16 @@ const (
 )
 
 // ReductionOutput is one final canonical boundary and its aggregate freshness
-// relative to the boundary map at entry to ReduceOutputs. Field order groups
-// Head with HistoricalAlternativeSet up front (both 4-byte aligned, so the
-// set immediately follows Head with no gap) and the byte/uint16-sized fields
-// after; every construction site uses keyed fields
-// (reduceOutputsClassifiedIntoActive, scheduler_owned.go), so this reorder
-// is layout-only (b4b-width-repair audit, 2026-08).
+// relative to the boundary map at entry to ReduceOutputs. The Links field
+// carries the authenticated graph-chain reference published for Head. The
+// reference is metadata only; no current route consumes it. Every construction
+// site uses keyed fields (reduceOutputsClassifiedIntoActive, scheduler_owned.go).
 type ReductionOutput struct {
-	Head           Head
+	Head Head
+	// Links is the bounded graph-chain reference produced for Head. Its Count
+	// follows link.next and does not imply physically adjacent LinkID values.
+	// This value does not enable the default-off sidecar or allocate storage.
+	Links          LinkChainRef
 	DropCohortRefs DropCohortRefSet
 	// HistoricalAlternativeSet is the union of every dead predecessor's
 	// recorded alternative set discovered while producing this boundary
@@ -2433,13 +2435,12 @@ type ReductionOutput struct {
 
 const inlineReductionBoundaryOutputs = 2
 
-// Field order groups key (8-byte aligned), head and historicalSet (4-byte
-// aligned) up front, then the byte/uint16-sized fields; the sole
-// construction site (scratch.store, scheduler_owned.go) uses keyed fields,
-// so this reorder is layout-only (b4b-width-repair audit, 2026-08).
+// Field order groups key, head, links, and the value-owned provenance sets up
+// front. The sole construction site uses keyed fields.
 type reductionBoundaryOutput struct {
 	key                           boundaryKey
 	head                          Head
+	links                         LinkChainRef
 	dropCohortRefs                DropCohortRefSet
 	historicalSet                 AlternativeSet
 	historicalLineage             uint16

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -2722,10 +2722,13 @@ func TestCompactArenaRecordsRemainPointerFree(t *testing.T) {
 	if got := unsafe.Sizeof(linkRecord{}); got != 32 {
 		t.Fatalf("linkRecord size = %d, want 32", got)
 	}
-	// G18 adds one value-owned reference set beside the historical set. Keep
-	// the 104-byte output width explicit for scheduler copies.
-	if got := unsafe.Sizeof(ReductionOutput{}); got != 104 {
-		t.Fatalf("ReductionOutput size = %d, want 104", got)
+	// G18 adds one value-owned reference set beside the historical set. The
+	// reduction provenance handoff adds one value-owned LinkChainRef.
+	if got := unsafe.Sizeof(ReductionOutput{}); got != 112 {
+		t.Fatalf("ReductionOutput size = %d, want 112", got)
+	}
+	if got := unsafe.Sizeof(LinkChainRef{}); got != 8 {
+		t.Fatalf("LinkChainRef size = %d, want 8", got)
 	}
 	if got := unsafe.Sizeof(popPath{}); got != 88 {
 		t.Fatalf("popPath size = %d, want 88", got)

--- a/internal/parsercorephase0/g18_refset_test.go
+++ b/internal/parsercorephase0/g18_refset_test.go
@@ -227,8 +227,11 @@ func TestG18RefSetRecordSizes(t *testing.T) {
 	if got := unsafe.Sizeof(nodeLineageMutation{}); got != 96 {
 		t.Fatalf("nodeLineageMutation size=%d, want 96", got)
 	}
-	if got := unsafe.Sizeof(ReductionOutput{}); got != 104 {
-		t.Fatalf("ReductionOutput size=%d, want 104", got)
+	if got := unsafe.Sizeof(ReductionOutput{}); got != 112 {
+		t.Fatalf("ReductionOutput size=%d, want 112", got)
+	}
+	if got := unsafe.Sizeof(LinkChainRef{}); got != 8 {
+		t.Fatalf("LinkChainRef size=%d, want 8", got)
 	}
 	if got := unsafe.Sizeof(CondenseCandidate{}); got != 88 {
 		t.Fatalf("CondenseCandidate size=%d, want 88", got)

--- a/internal/parsercorephase0/link_provenance.go
+++ b/internal/parsercorephase0/link_provenance.go
@@ -16,6 +16,17 @@ type LinkRange struct {
 // Empty reports whether both range fields use their zero value.
 func (r LinkRange) Empty() bool { return r.First == 0 && r.Count == 0 }
 
+// LinkChainRef identifies one published graph adjacency chain. First names
+// the newest link, and Count bounds traversal through link.next. Link IDs need
+// not be physically contiguous.
+type LinkChainRef struct {
+	First LinkID
+	Count uint32
+}
+
+// Empty reports whether both chain reference fields use their zero value.
+func (r LinkChainRef) Empty() bool { return r.First == 0 && r.Count == 0 }
+
 // appendGraphLink keeps the optional sidecar aligned with the link arena. A
 // newly published link starts unbound; authentication binds it later.
 func (c *Core) appendGraphLink(link linkRecord) LinkID {
@@ -89,6 +100,34 @@ func (c *Core) LinkRangeForHead(head Head) (LinkRange, error) {
 		return LinkRange{}, err
 	}
 	return rangeValue, nil
+}
+
+// reductionLinkChainForHead returns the O(1) chain metadata for a reduction
+// output. appendNodeAt authenticates the complete chain before publication,
+// so this handoff reads the stored first link and count. It does not allocate,
+// require physical LinkID contiguity, or walk adjacency.
+func (c *Core) reductionLinkChainForHead(head Head) (LinkChainRef, error) {
+	if c == nil {
+		return LinkChainRef{}, errors.New("parser-core phase zero: reduction link chain on nil core")
+	}
+	node, err := c.node(head.Node)
+	if err != nil {
+		return LinkChainRef{}, err
+	}
+	chain := LinkChainRef{First: LinkID(node.firstLink), Count: node.linkCount}
+	if node.firstLink == 0 && node.linkCount == 0 {
+		return LinkChainRef{}, nil
+	}
+	if chain.First == 0 || chain.Count == 0 {
+		return LinkChainRef{}, errors.New("parser-core phase zero: reduction link chain is mixed-empty")
+	}
+	if uint64(chain.First) > uint64(len(c.links)) {
+		return LinkChainRef{}, errors.New("parser-core phase zero: reduction link chain starts outside the graph")
+	}
+	if uint64(chain.Count) > uint64(len(c.links)) {
+		return LinkChainRef{}, errors.New("parser-core phase zero: reduction link chain exceeds the graph")
+	}
+	return chain, nil
 }
 
 // DropCohortLinkRefIndex returns the one-based certificate index attached to

--- a/internal/parsercorephase0/link_provenance_test.go
+++ b/internal/parsercorephase0/link_provenance_test.go
@@ -246,3 +246,160 @@ func TestLinkProvenanceRejectsAuthenticationMismatches(t *testing.T) {
 		t.Fatal("negative action ordinal was accepted")
 	}
 }
+
+func TestReductionOutputCarriesAuthenticatedLinkChain(t *testing.T) {
+	action := Action{Type: ActionReduce, State: 3, Symbol: 9, ChildCount: 1, ProductionID: 17}
+	core, err := New(&fakeTable{
+		actions: map[tableCell][]Action{{state: 3, symbol: 9}: {action}},
+		gotos:   map[tableCell]StateID{{state: 1, symbol: 9}: 4},
+	}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := core.appendDiagnosticPayload(seed, 3, Token{Symbol: 1, StartByte: 0, EndByte: 1}, pathMeta{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary, err := core.ClassifyBoundary(head, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputs, err := core.ReduceOutputsClassifiedInto(nil, boundary, 0, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(outputs) != 1 {
+		t.Fatalf("reduction outputs=%d, want one", len(outputs))
+	}
+	node, err := core.node(outputs[0].Head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := LinkChainRef{First: LinkID(node.firstLink), Count: node.linkCount}
+	if outputs[0].Links != want {
+		t.Fatalf("output link chain=%+v, want %+v", outputs[0].Links, want)
+	}
+	if core.dropCohortLinkRefIndexes != nil {
+		t.Fatalf("default reduction allocated sidecar=%v", core.dropCohortLinkRefIndexes)
+	}
+	allocs := testing.AllocsPerRun(100, func() {
+		got, err := core.reductionLinkChainForHead(outputs[0].Head)
+		if err != nil || got != want {
+			t.Fatalf("allocation probe chain=%+v err=%v, want %+v", got, err, want)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("reduction link chain handoff allocations=%v, want zero", allocs)
+	}
+}
+
+func TestReductionLinkChainHandoffPreservesNoncontiguousIDs(t *testing.T) {
+	fixture := newLinkProvenanceFixture(t, 8)
+	chainLink := fixture.core.appendGraphLink(linkRecord{
+		prev: fixture.nodes[0], next: fixture.rangeValue.First - 1,
+	})
+	nodeID, err := fixture.core.appendNode(nodeRecord{
+		state: 3, byteOffset: 2, firstLink: uint32(chainLink), linkCount: 2, pathCount: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := LinkChainRef{First: chainLink, Count: 2}
+	got, err := fixture.core.reductionLinkChainForHead(Head{Node: nodeID})
+	if err != nil || got != want {
+		t.Fatalf("noncontiguous chain=%+v err=%v, want %+v", got, err, want)
+	}
+	if _, err := fixture.core.LinkRangeForHead(Head{Node: nodeID}); err == nil {
+		t.Fatal("sidecar LinkRange accepted a noncontiguous chain")
+	}
+}
+
+func TestReductionLinkChainHandoffRejectsMalformedMetadata(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*Core, NodeID, LinkChainRef)
+	}{
+		{name: "mixed empty", edit: func(core *Core, nodeID NodeID, _ LinkChainRef) {
+			core.nodes[nodeID-1].firstLink = 0
+		}},
+		{name: "first out of bounds", edit: func(core *Core, nodeID NodeID, value LinkChainRef) {
+			core.nodes[nodeID-1].firstLink = uint32(len(core.links) + 1)
+			core.nodes[nodeID-1].linkCount = value.Count
+		}},
+		{name: "count exceeds arena", edit: func(core *Core, nodeID NodeID, value LinkChainRef) {
+			core.nodes[nodeID-1].firstLink = uint32(value.First)
+			core.nodes[nodeID-1].linkCount = uint32(len(core.links) + 1)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newLinkProvenanceFixture(t, 8)
+			nodeID, err := fixture.core.appendNode(nodeRecord{
+				state: 3, byteOffset: 2, firstLink: uint32(fixture.rangeValue.First),
+				linkCount: fixture.rangeValue.Count, pathCount: 1,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.edit(fixture.core, nodeID, LinkChainRef{
+				First: fixture.rangeValue.First, Count: fixture.rangeValue.Count,
+			})
+			if _, err := fixture.core.reductionLinkChainForHead(Head{Node: nodeID}); err == nil {
+				t.Fatalf("malformed node metadata was accepted: %s", test.name)
+			}
+		})
+	}
+}
+
+func TestReductionLinkChainHandoffRollbackAndReset(t *testing.T) {
+	fixture := newLinkProvenanceFixture(t, 8)
+	beforeNodes, beforeLinks := len(fixture.core.nodes), len(fixture.core.links)
+	var escaped Head
+	err := fixture.core.ApplySchedulerAtomic(func(_ SchedulerTransactionToken) error {
+		id, err := fixture.core.appendNode(nodeRecord{
+			state: 3, byteOffset: 2, firstLink: uint32(fixture.rangeValue.First),
+			linkCount: fixture.rangeValue.Count, pathCount: 1,
+		})
+		if err != nil {
+			return err
+		}
+		escaped = Head{Node: id}
+		if _, err := fixture.core.reductionLinkChainForHead(escaped); err != nil {
+			return err
+		}
+		return errors.New("force reduction handoff rollback")
+	})
+	if err == nil {
+		t.Fatal("forced rollback returned nil")
+	}
+	if len(fixture.core.nodes) != beforeNodes || len(fixture.core.links) != beforeLinks {
+		t.Fatalf("rollback arena lengths=%d/%d, want %d/%d", len(fixture.core.nodes), len(fixture.core.links), beforeNodes, beforeLinks)
+	}
+	if _, err := fixture.core.reductionLinkChainForHead(escaped); err == nil {
+		t.Fatal("rolled-back reduction output head remained readable")
+	}
+	if _, err := fixture.core.reductionLinkChainForHead(Head{Node: escaped.Node + 100}); err == nil {
+		t.Fatal("out-of-bounds reduction output head was accepted")
+	}
+
+	validID, err := fixture.core.appendNode(nodeRecord{
+		state: 3, byteOffset: 2, firstLink: uint32(fixture.rangeValue.First),
+		linkCount: fixture.rangeValue.Count, pathCount: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fixture.core.reductionLinkChainForHead(Head{Node: validID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.core.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fixture.core.reductionLinkChainForHead(Head{Node: validID}); err == nil {
+		t.Fatal("reset retained a reduction handoff head")
+	}
+}

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -1208,8 +1208,12 @@ func (c *Core) reduceOutputsClassifiedIntoActive(owner SchedulerTransactionToken
 				freshness = ReductionUpdated
 			}
 		}
+		linkChain, err := c.reductionLinkChainForHead(out)
+		if err != nil {
+			return nil, err
+		}
 		scratch.store(boundaryIndex, seen, reductionBoundaryOutput{
-			key: key, head: out, freshness: freshness, cleanPathRank: cleanPathRank,
+			key: key, head: out, links: linkChain, freshness: freshness, cleanPathRank: cleanPathRank,
 			dropCohortRefs:                dropCohortRefs,
 			historicalBoundarySplit:       historicalBoundarySplit,
 			historicalConvergedSplit:      historicalConvergedSplit,
@@ -1232,6 +1236,7 @@ func (c *Core) reduceOutputsClassifiedIntoActive(owner SchedulerTransactionToken
 		}
 		frontier = append(frontier, ReductionOutput{
 			Head:                         output.head,
+			Links:                        output.links,
 			DropCohortRefs:               output.dropCohortRefs,
 			Freshness:                    output.freshness,
 			CleanPathRank:                output.cleanPathRank,


### PR DESCRIPTION
## Summary

- Carry `LinkChainRef` from authenticated node metadata into `ReductionOutput`.
- Read the reference in O(1) time without allocation or adjacency walks.
- Follow `next` links without requiring adjacent `LinkID` values.
- Keep the default-off sidecar `LinkRange` API unchanged.
- Keep derivation format, route selection, admission, and compact counters unchanged.

## Tests

- `go test ./internal/parsercorephase0 -run approved focused suite -count=1`
- `canopy search symbols internal/parsercorephase0 --name LinkRange|LinkChainRef|ReductionOutput|reductionLinkChainForHead --limit 60 --no-cache`
- `git diff --check`

The regression test `TestConvergedReductionPathsCondenseOnlyAfterTrailingExtraRepush` passes.

Do not merge this pull request until review completes.