### PR TITLE
Parse included-range gaps in the internal DFA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,11 @@ for tags and release notes while still in `0.x`.
   byte. The parser seeds its initial stack there and preserves the configured
   start point for recovery gaps. A non-seek source preserves a complete
   overlapping token because it cannot reproduce a trimmed boundary token.
+  For grammars without an external scanner or external symbols, the internal
+  DFA now advances across selected gaps before token acceptance. It preserves
+  logical text and cursor state during reset, relex, and generalized LR (GLR)
+  probes. A scannerless synthetic external token now advances the source to
+  its reported end before the next token.
   The locked Go route now matches C at root byte 26. Child counts remain 10
   for Go and seven for C. Compact and forest included-range routes remain
   uncertified. Keep `dispatch.go.source-file-root` live until exact shape and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,8 @@ for tags and release notes while still in `0.x`.
   DFA now advances across selected gaps before token acceptance. It preserves
   logical text and cursor state during reset, relex, and generalized LR (GLR)
   probes. A scannerless synthetic external token now advances the source to
-  its reported end before the next token.
+  its reported end before the next token. The cursor increases the AMD64
+  Parser layout by 40 bytes, from 2,184 to 2,224 bytes.
   The locked Go route now matches C at root byte 26. Child counts remain 10
   for Go and seven for C. Compact and forest included-range routes remain
   uncertified. Keep `dispatch.go.source-file-root` live until exact shape and

--- a/cgo_harness/included_ranges_json_dfa_cgo_test.go
+++ b/cgo_harness/included_ranges_json_dfa_cgo_test.go
@@ -1,0 +1,93 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// TestIncludedRangesJSONInternalDFAParity checks one token across a source gap.
+func TestIncludedRangesJSONInternalDFAParity(t *testing.T) {
+	source := []byte("xx{\"abZZcd\":1}yy")
+	spans := [][2]int{{2, 6}, {8, 14}}
+
+	goLanguage := grammars.JsonLanguage()
+	if goLanguage == nil {
+		t.Fatal("JSON language is unavailable")
+	}
+	if goLanguage.ExternalScanner != nil {
+		t.Fatal("JSON unexpectedly uses an external scanner")
+	}
+	cLanguage, err := COracleLanguage("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cRanges := make([]sitter.Range, 0, len(spans))
+	goRanges := make([]gotreesitter.Range, 0, len(spans))
+	for _, span := range spans {
+		sr, sc := includedRangesPointAt(source, span[0])
+		er, ec := includedRangesPointAt(source, span[1])
+		cRanges = append(cRanges, sitter.Range{
+			StartByte:  uint(span[0]),
+			EndByte:    uint(span[1]),
+			StartPoint: sitter.Point{Row: sr, Column: sc},
+			EndPoint:   sitter.Point{Row: er, Column: ec},
+		})
+		goRanges = append(goRanges, gotreesitter.Range{
+			StartByte:  uint32(span[0]),
+			EndByte:    uint32(span[1]),
+			StartPoint: gotreesitter.Point{Row: uint32(sr), Column: uint32(sc)},
+			EndPoint:   gotreesitter.Point{Row: uint32(er), Column: uint32(ec)},
+		})
+	}
+
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatal(err)
+	}
+	if err := cParser.SetIncludedRanges(cRanges); err != nil {
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("C parser returned no tree")
+	}
+	defer cTree.Close()
+
+	goParser := gotreesitter.NewParser(goLanguage)
+	goParser.SetIncludedRanges(goRanges)
+	goTree, err := goParser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if goTree == nil || goTree.RootNode() == nil {
+		t.Fatal("Go parser returned no tree")
+	}
+	defer goTree.Release()
+
+	if diff := FirstDivergenceDumpV1(goTree.RootNode(), goLanguage, cTree.RootNode()); diff != nil {
+		t.Fatalf("first divergence = %+v, want exact JSON parity", diff)
+	}
+	goInspection, err := benchfixtures.InspectGoTree(goTree.RootNode(), goLanguage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if goInspection.SHA256 != cDigest {
+		t.Fatalf("Go digest = %s, C digest = %s", goInspection.SHA256, cDigest)
+	}
+	if root := goTree.RootNode(); root.StartByte() != 2 || root.EndByte() != 14 || root.HasError() {
+		t.Fatalf("Go root = %s [%d,%d) error=%t, want document [2,14) without error",
+			root.Type(goLanguage), root.StartByte(), root.EndByte(), root.HasError())
+	}
+}

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -2980,6 +2980,24 @@ seeking preserves the complete overlapping token. Such a token can start
 before the selected boundary. This limitation does not provide strict trim
 parity for non-seek sources.
 
+The internal deterministic finite automaton (DFA) now owns range gaps only
+when the grammar has no external scanner and no external symbols. It keeps the
+DFA state across each gap. It builds logical token text from selected bytes
+when one token crosses a gap. It restores the range cursor during reset,
+relex, frontier, and generalized LR (GLR) probes. The ordinary no-range lexer
+path stays allocation-free.
+
+Grammars with external scanners still use the token filter. Custom token
+sources also use that filter. Scannerless synthetic external tokens advance to
+their reported end before the next read. The Go grammar uses an external
+scanner, so this tranche does not change its 10-child result or its seven-child
+C oracle. Compact and forest range routes remain uncertified.
+
+The focused JSON C-oracle test crosses one string token over a selected gap.
+Its Go and C trees match exactly. The Docker run passed without timeout or an
+out-of-memory failure. The artifact is
+`/tmp/gts-internal-dfa-range-cursor-artifacts/20260825T010353Z-json-internal-dfa-range-p2-main776`.
+
 The included-range production route now proves the root-start correction.
 Focused unit coverage also checks the supported incremental API path.
 Compact and forest included-range routes remain uncertified. Do not use this

--- a/included_ranges.go
+++ b/included_ranges.go
@@ -8,6 +8,10 @@ type includedRangeTokenSource struct {
 	idx    int
 }
 
+type includedRangeAwareTokenSource interface {
+	setIncludedRanges([]Range) bool
+}
+
 func newIncludedRangeTokenSource(base TokenSource, ranges []Range) TokenSource {
 	if base == nil || len(ranges) == 0 {
 		return base

--- a/included_ranges_test.go
+++ b/included_ranges_test.go
@@ -105,6 +105,104 @@ func TestIncludedRangeTokenSourceDropsAllEmptyRanges(t *testing.T) {
 	}
 }
 
+func TestParserIncludedRangesUseDFAOnlyWithoutExternalScanner(t *testing.T) {
+	p := NewParser(nil)
+	p.SetIncludedRanges([]Range{{StartByte: 1, EndByte: 2}})
+
+	internal := newIncludedRangeTestDFASource([]byte("xa"))
+	if got := p.wrapIncludedRanges(internal); got != internal {
+		t.Fatalf("internal DFA wrapper type = %T, want the producer source", got)
+	}
+	p.SetIncludedRanges(nil)
+	if got := p.wrapIncludedRanges(internal); got != internal || len(internal.lexer.includedRanges) != 0 {
+		t.Fatalf("cleared internal DFA source = %T with %d ranges, want the producer source with no ranges",
+			got, len(internal.lexer.includedRanges))
+	}
+	p.SetIncludedRanges([]Range{{StartByte: 1, EndByte: 2}})
+
+	external := newIncludedRangeTestDFASource([]byte("xa"))
+	external.language.ExternalScanner = dualChoiceExternalScanner{}
+	external.hasExternalScanner = true
+	if _, ok := p.wrapIncludedRanges(external).(*includedRangeTokenSource); !ok {
+		t.Fatal("external-scanner DFA did not use the fallback wrapper")
+	}
+
+	custom := &nextOnlyTokenSource{tokens: []Token{{Symbol: 1, StartByte: 1, EndByte: 2}}}
+	if _, ok := p.wrapIncludedRanges(custom).(*includedRangeTokenSource); !ok {
+		t.Fatal("custom source did not use the fallback wrapper")
+	}
+}
+
+func TestParserIncludedRangesExternalSymbolsWithoutScannerUseWrapper(t *testing.T) {
+	states := buildIdentNumberWSDFA()
+	language := &Language{
+		Name:            "scannerless-external-range-test",
+		SymbolNames:     []string{"end", "identifier", "number", extNameAutomaticSemicolon},
+		ExternalSymbols: []Symbol{3},
+		ExternalLexStates: [][]bool{
+			{true},
+		},
+		LexStates: states,
+		LexModes: []LexMode{{
+			LexState:         0,
+			ExternalLexState: 0,
+		}},
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 0}}},
+		},
+	}
+	lookup := func(state StateID, symbol Symbol) uint16 {
+		if state == 0 && symbol == 3 {
+			return 1
+		}
+		return 0
+	}
+	source := newDFATokenSourceDirect(NewLexer(states, []byte("\n++abc")), language, lookup, nil, nil, nil)
+	parser := NewParser(nil)
+	parser.SetIncludedRanges([]Range{
+		{StartByte: 0, EndByte: 1, EndPoint: Point{Row: 1}},
+		{StartByte: 3, EndByte: 6, StartPoint: Point{Row: 1, Column: 2}, EndPoint: Point{Row: 1, Column: 5}},
+	})
+
+	wrapped := parser.wrapIncludedRanges(source)
+	filter, ok := wrapped.(*includedRangeTokenSource)
+	if !ok {
+		t.Fatalf("external-symbol source type = %T, want the fallback wrapper", wrapped)
+	}
+	synthetic := filter.SkipToByteWithPoint(0, Point{})
+	if synthetic.Symbol != 3 || synthetic.StartByte != 0 || synthetic.EndByte != 1 {
+		t.Fatalf("synthetic token = %+v, want symbol 3 at [0,1)", synthetic)
+	}
+	if synthetic.StartByte < 3 && synthetic.EndByte > 1 {
+		t.Fatalf("synthetic token spans excluded bytes [1,3): %+v", synthetic)
+	}
+	selected := filter.Next()
+	if selected.Symbol != 1 || selected.Text != "abc" || selected.StartByte != 3 || selected.EndByte != 6 {
+		t.Fatalf("selected token = %+v, want abc at [3,6) after the excluded gap", selected)
+	}
+}
+
+func TestParserIncludedRangesUseInternalDFACursor(t *testing.T) {
+	lang := buildArithmeticLanguage()
+	p := NewParser(lang)
+	p.SetIncludedRanges([]Range{{
+		StartByte:  1,
+		EndByte:    4,
+		StartPoint: Point{Column: 1},
+		EndPoint:   Point{Column: 4},
+	}})
+
+	tree := mustParse(t, p, []byte("x1+2y"))
+	root := tree.RootNode()
+	if root == nil || root.Type(lang) != "expression" || root.HasError() {
+		t.Fatalf("included-range root = %v, want a clean expression", root)
+	}
+	if root.StartByte() != 1 || root.EndByte() != 4 {
+		t.Fatalf("included-range root bytes = [%d,%d), want [1,4)", root.StartByte(), root.EndByte())
+	}
+}
+
 func TestIncludedRangeTokenSourceFiltersTokens(t *testing.T) {
 	base := &stubTokenSource{
 		tokens: []Token{

--- a/lexer.go
+++ b/lexer.go
@@ -52,21 +52,24 @@ func bytesToStringNoCopy(b []byte) string {
 
 // Lexer tokenizes source text using a table-driven DFA.
 type Lexer struct {
-	states          []LexState
-	asciiTable      [][128]int32 // ASCII fast-path transition table (nil = not available)
-	source          []byte
-	pos             int
-	row             uint32
-	col             uint32
-	immediateTokens []bool // symbol IDs that are token.immediate(); rejected after whitespace skip
-	zeroWidthTokens []bool // symbol IDs whose terminal pattern can intentionally match empty input
+	states           []LexState
+	asciiTable       [][128]int32 // ASCII fast-path transition table (nil = not available)
+	source           []byte
+	pos              int
+	row              uint32
+	col              uint32
+	includedRanges   []Range
+	includedRangeIdx int
+	immediateTokens  []bool // symbol IDs that are token.immediate(); rejected after whitespace skip
+	zeroWidthTokens  []bool // symbol IDs whose terminal pattern can intentionally match empty input
 
 	// Set by scan on failure: where the token attempt began after the DFA
 	// consumed skip (whitespace) transitions. errorRunToken uses this so an
 	// unlexable run starts after legitimately skipped whitespace, like C.
-	failTokenStartPos int
-	failTokenStartRow uint32
-	failTokenStartCol uint32
+	failTokenStartPos      int
+	failTokenStartRow      uint32
+	failTokenStartCol      uint32
+	failTokenStartRangeIdx int
 
 	// The grammar's most permissive lex state (LexModes[0], C's ERROR_STATE
 	// mode). NextWithErrorRuns only emits an error-run token when even this
@@ -114,15 +117,17 @@ func (l *Lexer) NextWithErrorRuns(startState uint32) Token {
 }
 
 func (l *Lexer) next(startState uint32, emitErrorRuns bool) Token {
+	l.normalizeIncludedPosition()
 	l.skipLeadingBOM()
 	// C ts_parser__lex resets to the lex call's start position (before any
 	// whitespace the failed attempt skipped) when it switches to error-mode
 	// lexing; capture it for the errorModeRetry branch below.
 	callStartPos, callStartRow, callStartCol := l.pos, l.row, l.col
+	callStartRangeIdx := l.includedRangeIdx
 	skippedPrefix := false
 	for {
 		// EOF check.
-		if l.pos >= len(l.source) {
+		if l.atLogicalEOF() {
 			return Token{
 				StartByte:  uint32(l.pos),
 				EndByte:    uint32(l.pos),
@@ -165,6 +170,7 @@ func (l *Lexer) next(startState uint32, emitErrorRuns bool) Token {
 			// recursive call has startState == errorRunLexState, so it takes
 			// the error-run branch below on failure instead of recursing.
 			l.pos, l.row, l.col = callStartPos, callStartRow, callStartCol
+			l.includedRangeIdx = callStartRangeIdx
 			return l.next(l.errorRunLexState, true)
 		}
 		if emitErrorRuns && l.hasErrorRunLexState && !l.canLexAt(l.errorRunLexState, tokenStartPos, tokenStartRow, tokenStartCol) {
@@ -187,8 +193,10 @@ func (l *Lexer) skipLeadingBOM() {
 // starting at the given position, without moving the lexer.
 func (l *Lexer) canLexAt(lexState uint32, pos int, row, col uint32) bool {
 	savedPos, savedRow, savedCol := l.pos, l.row, l.col
+	savedRangeIdx := l.includedRangeIdx
 	_, ok := l.scan(lexState, pos, row, col)
 	l.pos, l.row, l.col = savedPos, savedRow, savedCol
+	l.includedRangeIdx = savedRangeIdx
 	return ok
 }
 
@@ -204,8 +212,10 @@ func (l *Lexer) errorRunToken() Token {
 		l.pos = l.failTokenStartPos
 		l.row = l.failTokenStartRow
 		l.col = l.failTokenStartCol
+		l.includedRangeIdx = l.failTokenStartRangeIdx
 	}
-	if l.pos >= len(l.source) {
+	l.normalizeIncludedPosition()
+	if l.atLogicalEOF() {
 		// Only whitespace remained: this is end-of-input, not an error run.
 		return Token{
 			StartByte:  uint32(l.pos),
@@ -217,7 +227,7 @@ func (l *Lexer) errorRunToken() Token {
 	startPos, startRow, startCol := l.pos, l.row, l.col
 
 	l.skipOneRune()
-	for l.pos < len(l.source) {
+	for !l.atLogicalEOF() {
 		if l.canLexAt(l.errorRunLexState, l.pos, l.row, l.col) {
 			break
 		}
@@ -225,7 +235,7 @@ func (l *Lexer) errorRunToken() Token {
 	}
 	return Token{
 		Symbol:     errorSymbol,
-		Text:       bytesToStringNoCopy(l.source[startPos:l.pos]),
+		Text:       l.tokenText(startPos, l.pos),
 		StartByte:  uint32(startPos),
 		EndByte:    uint32(l.pos),
 		StartPoint: Point{Row: startRow, Column: startCol},
@@ -237,6 +247,13 @@ func (l *Lexer) errorRunToken() Token {
 // a token and true if an accepting state was reached, or false if not.
 // On a skip (whitespace) match, it returns a zero-Symbol token and true.
 func (l *Lexer) scan(startState uint32, startPos int, startRow, startCol uint32) (Token, bool) {
+	if len(l.includedRanges) != 0 {
+		return l.scanIncluded(startState, startPos, startRow, startCol)
+	}
+	return l.scanContiguous(startState, startPos, startRow, startCol)
+}
+
+func (l *Lexer) scanContiguous(startState uint32, startPos int, startRow, startCol uint32) (Token, bool) {
 	// work-count-assembly: raw main-lexer invocation seam
 	workCountRecordRawMainLexerInvocation()
 	curState := int32(startState)
@@ -392,6 +409,7 @@ func (l *Lexer) scan(startState uint32, startPos int, startRow, startCol uint32)
 		l.failTokenStartPos = tokenStartPos
 		l.failTokenStartRow = tokenStartRow
 		l.failTokenStartCol = tokenStartCol
+		l.failTokenStartRangeIdx = 0
 		return Token{}, false
 	}
 
@@ -427,6 +445,10 @@ func (l *Lexer) scan(startState uint32, startPos int, startRow, startCol uint32)
 
 // skipOneRune advances the lexer position by one rune, updating row/column.
 func (l *Lexer) skipOneRune() {
+	if len(l.includedRanges) != 0 {
+		l.skipOneIncludedRune()
+		return
+	}
 	if l.pos >= len(l.source) {
 		return
 	}

--- a/lexer_included_ranges.go
+++ b/lexer_included_ranges.go
@@ -1,0 +1,407 @@
+package gotreesitter
+
+import "unicode/utf8"
+
+type includedLexerCursor struct {
+	pos      int
+	row      uint32
+	col      uint32
+	rangeIdx int
+}
+
+// setIncludedRanges moves the internal DFA cursor to the first selected byte.
+func (l *Lexer) setIncludedRanges(ranges []Range) {
+	l.includedRanges = ranges
+	l.includedRangeIdx = 0
+	l.normalizeIncludedPosition()
+}
+
+func (l *Lexer) normalizeIncludedPosition() {
+	if l == nil || len(l.includedRanges) == 0 {
+		return
+	}
+	cursor := includedLexerCursor{
+		pos:      l.pos,
+		row:      l.row,
+		col:      l.col,
+		rangeIdx: l.includedRangeIdx,
+	}
+	l.normalizeIncludedCursor(&cursor)
+	l.pos = cursor.pos
+	l.row = cursor.row
+	l.col = cursor.col
+	l.includedRangeIdx = cursor.rangeIdx
+}
+
+func (l *Lexer) normalizeIncludedCursor(cursor *includedLexerCursor) {
+	if l == nil || cursor == nil || len(l.includedRanges) == 0 {
+		return
+	}
+	if cursor.rangeIdx < 0 || cursor.rangeIdx > len(l.includedRanges) {
+		cursor.rangeIdx = 0
+	}
+	if cursor.rangeIdx > 0 && cursor.rangeIdx <= len(l.includedRanges) {
+		_, previousEnd := l.includedRangeBounds(cursor.rangeIdx - 1)
+		if cursor.pos < previousEnd {
+			cursor.rangeIdx = 0
+		}
+	}
+	for cursor.rangeIdx < len(l.includedRanges) {
+		start, end := l.includedRangeBounds(cursor.rangeIdx)
+		if end <= start {
+			cursor.rangeIdx++
+			continue
+		}
+		if cursor.pos < start {
+			r := l.includedRanges[cursor.rangeIdx]
+			cursor.pos = start
+			cursor.row = r.StartPoint.Row
+			cursor.col = r.StartPoint.Column
+			return
+		}
+		if cursor.pos < end {
+			return
+		}
+		cursor.rangeIdx++
+	}
+
+	endPos, endPoint := l.includedEOFPosition()
+	cursor.pos = endPos
+	cursor.row = endPoint.Row
+	cursor.col = endPoint.Column
+}
+
+func (l *Lexer) includedRangeBounds(index int) (int, int) {
+	if l == nil || index < 0 || index >= len(l.includedRanges) {
+		return 0, 0
+	}
+	r := l.includedRanges[index]
+	start := len(l.source)
+	if uint64(r.StartByte) < uint64(len(l.source)) {
+		start = int(r.StartByte)
+	}
+	end := len(l.source)
+	if uint64(r.EndByte) < uint64(len(l.source)) {
+		end = int(r.EndByte)
+	}
+	return start, end
+}
+
+func (l *Lexer) includedEOFPosition() (int, Point) {
+	if l == nil || len(l.includedRanges) == 0 {
+		if l == nil {
+			return 0, Point{}
+		}
+		return len(l.source), advancePointByBytes(Point{}, l.source)
+	}
+	for i := len(l.includedRanges) - 1; i >= 0; i-- {
+		start, end := l.includedRangeBounds(i)
+		if end <= start {
+			continue
+		}
+		last := l.includedRanges[i]
+		if uint64(last.EndByte) <= uint64(len(l.source)) {
+			return end, last.EndPoint
+		}
+		return len(l.source), advancePointByBytes(Point{}, l.source)
+	}
+	return len(l.source), advancePointByBytes(Point{}, l.source)
+}
+
+func (l *Lexer) includedRangeIndexForPosition(pos int) int {
+	if l == nil || len(l.includedRanges) == 0 {
+		return 0
+	}
+	for i := range l.includedRanges {
+		_, end := l.includedRangeBounds(i)
+		if pos < end {
+			return i
+		}
+	}
+	return len(l.includedRanges)
+}
+
+func (l *Lexer) atLogicalEOF() bool {
+	if l == nil {
+		return true
+	}
+	if len(l.includedRanges) == 0 {
+		return l.pos >= len(l.source)
+	}
+	return l.includedRangeIdx >= len(l.includedRanges)
+}
+
+func (l *Lexer) skipOneIncludedRune() {
+	if l == nil {
+		return
+	}
+	cursor := includedLexerCursor{
+		pos:      l.pos,
+		row:      l.row,
+		col:      l.col,
+		rangeIdx: l.includedRangeIdx,
+	}
+	if _, _, ok := l.advanceIncludedCursor(&cursor); !ok {
+		return
+	}
+	l.pos = cursor.pos
+	l.row = cursor.row
+	l.col = cursor.col
+	l.includedRangeIdx = cursor.rangeIdx
+}
+
+func (l *Lexer) advanceIncludedCursor(cursor *includedLexerCursor) (rune, int, bool) {
+	l.normalizeIncludedCursor(cursor)
+	if cursor.rangeIdx >= len(l.includedRanges) {
+		return 0, 0, false
+	}
+	_, end := l.includedRangeBounds(cursor.rangeIdx)
+	if cursor.pos >= end {
+		return 0, 0, false
+	}
+	b := l.source[cursor.pos]
+	r := rune(b)
+	size := 1
+	if b >= utf8.RuneSelf {
+		r, size = utf8.DecodeRune(l.source[cursor.pos:end])
+	}
+	cursor.pos += size
+	if r == '\n' {
+		cursor.row++
+		cursor.col = 0
+	} else {
+		cursor.col += uint32(size)
+	}
+	if cursor.pos >= end {
+		cursor.rangeIdx++
+		l.normalizeIncludedCursor(cursor)
+	}
+	return r, size, true
+}
+
+// includedMarkEnd ends a boundary token at the prior range end.
+func (l *Lexer) includedMarkEnd(cursor includedLexerCursor) (int, Point) {
+	if cursor.rangeIdx > 0 && cursor.rangeIdx < len(l.includedRanges) {
+		start, _ := l.includedRangeBounds(cursor.rangeIdx)
+		if cursor.pos == start {
+			previous := l.includedRanges[cursor.rangeIdx-1]
+			_, previousEnd := l.includedRangeBounds(cursor.rangeIdx - 1)
+			if uint64(previous.EndByte) <= uint64(len(l.source)) {
+				return previousEnd, previous.EndPoint
+			}
+			return previousEnd, advancePointByBytes(Point{}, l.source[:previousEnd])
+		}
+	}
+	return cursor.pos, Point{Row: cursor.row, Column: cursor.col}
+}
+
+// tokenText excludes source gaps when one DFA token crosses selected ranges.
+func (l *Lexer) tokenText(start, end int) string {
+	if start >= end {
+		return ""
+	}
+	if len(l.includedRanges) == 0 {
+		return bytesToStringNoCopy(l.source[start:end])
+	}
+	segmentCount := 0
+	total := 0
+	firstStart := 0
+	firstEnd := 0
+	for i := range l.includedRanges {
+		rangeStart, rangeEnd := l.includedRangeBounds(i)
+		segmentStart := max(start, rangeStart)
+		segmentEnd := min(end, rangeEnd)
+		if segmentEnd <= segmentStart {
+			continue
+		}
+		if segmentCount == 0 {
+			firstStart = segmentStart
+			firstEnd = segmentEnd
+		}
+		segmentCount++
+		total += segmentEnd - segmentStart
+	}
+	if segmentCount == 0 {
+		return ""
+	}
+	if segmentCount == 1 {
+		return bytesToStringNoCopy(l.source[firstStart:firstEnd])
+	}
+	text := make([]byte, 0, total)
+	for i := range l.includedRanges {
+		rangeStart, rangeEnd := l.includedRangeBounds(i)
+		segmentStart := max(start, rangeStart)
+		segmentEnd := min(end, rangeEnd)
+		if segmentEnd > segmentStart {
+			text = append(text, l.source[segmentStart:segmentEnd]...)
+		}
+	}
+	return bytesToStringNoCopy(text)
+}
+
+// scanIncluded keeps the DFA state when the source cursor crosses a range gap.
+func (l *Lexer) scanIncluded(startState uint32, startPos int, startRow, startCol uint32) (Token, bool) {
+	workCountRecordRawMainLexerInvocation()
+	curState := int32(startState)
+	if curState < 0 || int(curState) >= len(l.states) {
+		return Token{}, false
+	}
+
+	scanCursor := includedLexerCursor{
+		pos:      startPos,
+		row:      startRow,
+		col:      startCol,
+		rangeIdx: l.includedRangeIdx,
+	}
+	l.normalizeIncludedCursor(&scanCursor)
+	startPos = scanCursor.pos
+	startRow = scanCursor.row
+	startCol = scanCursor.col
+	tokenStart := scanCursor
+	skippedPrefix := false
+
+	acceptProgressPos := -1
+	acceptPos := -1
+	acceptRow := uint32(0)
+	acceptCol := uint32(0)
+	acceptRangeIdx := 0
+	acceptStart := includedLexerCursor{}
+	acceptSymbol := Symbol(0)
+	acceptSkip := false
+	acceptPriorityBest := int16(32767)
+
+	eofHops := 0
+	for {
+		if curState < 0 || int(curState) >= len(l.states) {
+			break
+		}
+		st := &l.states[int(curState)]
+
+		if st.AcceptToken > 0 || st.Skip {
+			isImmediate := st.AcceptToken > 0 && int(st.AcceptToken) < len(l.immediateTokens) && l.immediateTokens[st.AcceptToken]
+			skippedWhitespace := tokenStart.pos > startPos
+			zeroWidthVisible := st.AcceptToken > 0 && scanCursor.pos == tokenStart.pos && !l.allowsZeroWidthToken(st.AcceptToken)
+			if !(isImmediate && skippedWhitespace) && !zeroWidthVisible {
+				newPrio := st.AcceptPriority
+				if acceptPos < 0 || newPrio < acceptPriorityBest || (newPrio == acceptPriorityBest && scanCursor.pos > acceptProgressPos) {
+					acceptProgressPos = scanCursor.pos
+					var endPoint Point
+					acceptPos, endPoint = l.includedMarkEnd(scanCursor)
+					acceptRow = endPoint.Row
+					acceptCol = endPoint.Column
+					acceptRangeIdx = scanCursor.rangeIdx
+					acceptStart = tokenStart
+					acceptSymbol = st.AcceptToken
+					acceptSkip = st.Skip
+					acceptPriorityBest = newPrio
+				}
+			}
+		}
+
+		if scanCursor.rangeIdx >= len(l.includedRanges) {
+			if st.EOF >= 0 && eofHops <= len(l.states) {
+				curState = int32(st.EOF)
+				eofHops++
+				continue
+			}
+			break
+		}
+		eofHops = 0
+
+		b := l.source[scanCursor.pos]
+		var r rune
+		if b < utf8.RuneSelf {
+			r = rune(b)
+		} else {
+			_, end := l.includedRangeBounds(scanCursor.rangeIdx)
+			r, _ = utf8.DecodeRune(l.source[scanCursor.pos:end])
+		}
+		nextState := int32(-1)
+		skipTransition := false
+		if b < utf8.RuneSelf && l.asciiTable != nil && int(curState) < len(l.asciiTable) {
+			v := l.asciiTable[curState][b]
+			if v != lexAsciiNoMatch {
+				nextState = v & ^lexAsciiSkipBit
+				skipTransition = v&lexAsciiSkipBit != 0
+			}
+		} else {
+			for i := range st.Transitions {
+				tr := &st.Transitions[i]
+				if r >= tr.Lo && r <= tr.Hi {
+					nextState = int32(tr.NextState)
+					skipTransition = tr.Skip
+					break
+				}
+			}
+		}
+		skipTransition = skipTransition && nextState >= 0
+		if nextState < 0 && st.Default >= 0 {
+			nextState = int32(st.Default)
+			skipTransition = false
+		}
+		if nextState < 0 {
+			break
+		}
+
+		if _, _, ok := l.advanceIncludedCursor(&scanCursor); !ok {
+			break
+		}
+		if skipTransition {
+			skippedPrefix = true
+			tokenStart = scanCursor
+			acceptProgressPos = -1
+			acceptPos = -1
+			acceptSymbol = 0
+			acceptSkip = false
+		}
+		curState = nextState
+	}
+
+	if acceptPos < 0 && eofHops > 0 {
+		acceptProgressPos = scanCursor.pos
+		var endPoint Point
+		acceptPos, endPoint = l.includedMarkEnd(scanCursor)
+		acceptRow = endPoint.Row
+		acceptCol = endPoint.Column
+		acceptRangeIdx = scanCursor.rangeIdx
+		acceptStart = tokenStart
+		acceptSymbol = 0
+		acceptSkip = true
+	}
+
+	if acceptPos < 0 {
+		l.failTokenStartPos = tokenStart.pos
+		l.failTokenStartRow = tokenStart.row
+		l.failTokenStartCol = tokenStart.col
+		l.failTokenStartRangeIdx = tokenStart.rangeIdx
+		return Token{}, false
+	}
+
+	l.pos = acceptPos
+	l.row = acceptRow
+	l.col = acceptCol
+	l.includedRangeIdx = acceptRangeIdx
+
+	if acceptSkip {
+		return Token{
+			StartByte:               uint32(acceptStart.pos),
+			EndByte:                 uint32(acceptPos),
+			StartPoint:              Point{Row: acceptStart.row, Column: acceptStart.col},
+			EndPoint:                Point{Row: acceptRow, Column: acceptCol},
+			lexerSkippedPrefix:      skippedPrefix,
+			lexerSkippedPrefixStart: uint32(startPos),
+		}, true
+	}
+
+	return Token{
+		Symbol:                  acceptSymbol,
+		Text:                    l.tokenText(acceptStart.pos, acceptPos),
+		StartByte:               uint32(acceptStart.pos),
+		EndByte:                 uint32(acceptPos),
+		StartPoint:              Point{Row: acceptStart.row, Column: acceptStart.col},
+		EndPoint:                Point{Row: acceptRow, Column: acceptCol},
+		lexerSkippedPrefix:      skippedPrefix,
+		lexerSkippedPrefixStart: uint32(startPos),
+		lexerInternalDFALexed:   true,
+	}, true
+}

--- a/lexer_included_ranges_test.go
+++ b/lexer_included_ranges_test.go
@@ -1,0 +1,274 @@
+package gotreesitter
+
+import "testing"
+
+var includedRangeLexerTokenSink Token
+
+func TestLexerIncludedRangesRespectTokenBoundaries(t *testing.T) {
+	lex := NewLexer(buildIdentNumberWSDFA(), []byte("xxalpha"))
+	lex.setIncludedRanges([]Range{{
+		StartByte:  2,
+		EndByte:    5,
+		StartPoint: Point{Column: 2},
+		EndPoint:   Point{Column: 5},
+	}})
+
+	tok := lex.Next(0)
+	if tok.Symbol != 1 || tok.Text != "alp" {
+		t.Fatalf("token = (%d, %q), want identifier alp", tok.Symbol, tok.Text)
+	}
+	if tok.StartByte != 2 || tok.EndByte != 5 {
+		t.Fatalf("token bytes = [%d,%d), want [2,5)", tok.StartByte, tok.EndByte)
+	}
+
+	eof := lex.Next(0)
+	if eof.Symbol != 0 || eof.StartByte != 5 || eof.EndByte != 5 {
+		t.Fatalf("EOF = %+v, want byte 5", eof)
+	}
+}
+
+func TestLexerIncludedRangesEndTokenBeforeNextRange(t *testing.T) {
+	lex := NewLexer(buildIdentNumberWSDFA(), []byte("ab+12"))
+	lex.setIncludedRanges([]Range{
+		{StartByte: 0, EndByte: 2, EndPoint: Point{Column: 2}},
+		{StartByte: 3, EndByte: 5, StartPoint: Point{Column: 3}, EndPoint: Point{Column: 5}},
+	})
+
+	first := lex.Next(0)
+	if first.Text != "ab" || first.StartByte != 0 || first.EndByte != 2 {
+		t.Fatalf("first token = %+v, want ab at [0,2)", first)
+	}
+	second := lex.Next(0)
+	if second.Symbol != 2 || second.Text != "12" || second.StartByte != 3 || second.EndByte != 5 {
+		t.Fatalf("second token = %+v, want number 12 at [3,5)", second)
+	}
+}
+
+func TestLexerIncludedRangesBuildLogicalCrossRangeText(t *testing.T) {
+	lex := NewLexer(buildIdentNumberWSDFA(), []byte("ab__cd"))
+	lex.setIncludedRanges([]Range{
+		{StartByte: 0, EndByte: 2, EndPoint: Point{Column: 2}},
+		{StartByte: 4, EndByte: 6, StartPoint: Point{Column: 4}, EndPoint: Point{Column: 6}},
+	})
+
+	tok := lex.Next(0)
+	if tok.Symbol != 1 || tok.Text != "abcd" {
+		t.Fatalf("token = (%d, %q), want identifier abcd", tok.Symbol, tok.Text)
+	}
+	if tok.StartByte != 0 || tok.EndByte != 6 {
+		t.Fatalf("token bytes = [%d,%d), want [0,6)", tok.StartByte, tok.EndByte)
+	}
+}
+
+func TestLexerIncludedRangesUseUTF8PointsAcrossRanges(t *testing.T) {
+	states := []LexState{
+		{Default: 1, EOF: -1},
+		{AcceptToken: 1, Default: 1, EOF: -1},
+	}
+	lex := NewLexer(states, []byte("éx\n__yz"))
+	lex.setIncludedRanges([]Range{
+		{
+			StartByte:  2,
+			EndByte:    4,
+			StartPoint: Point{Column: 2},
+			EndPoint:   Point{Row: 1},
+		},
+		{
+			StartByte:  6,
+			EndByte:    8,
+			StartPoint: Point{Row: 1, Column: 2},
+			EndPoint:   Point{Row: 1, Column: 4},
+		},
+	})
+
+	tok := lex.Next(0)
+	if tok.Text != "x\nyz" {
+		t.Fatalf("token text = %q, want %q", tok.Text, "x\nyz")
+	}
+	if tok.StartPoint != (Point{Column: 2}) {
+		t.Fatalf("start point = %+v, want row 0 column 2", tok.StartPoint)
+	}
+	if tok.EndPoint != (Point{Row: 1, Column: 4}) {
+		t.Fatalf("end point = %+v, want row 1 column 4", tok.EndPoint)
+	}
+}
+
+func TestLexerIncludedRangesClampPastSourceToEOF(t *testing.T) {
+	lex := NewLexer(buildIdentNumberWSDFA(), []byte("a\nβ"))
+	lex.setIncludedRanges([]Range{{
+		StartByte:  99,
+		EndByte:    100,
+		StartPoint: Point{Row: 99, Column: 99},
+		EndPoint:   Point{Row: 99, Column: 100},
+	}})
+
+	tok := lex.Next(0)
+	if tok.Symbol != 0 || tok.StartByte != 4 || tok.EndByte != 4 {
+		t.Fatalf("EOF = %+v, want byte 4", tok)
+	}
+	wantPoint := Point{Row: 1, Column: 2}
+	if tok.StartPoint != wantPoint || tok.EndPoint != wantPoint {
+		t.Fatalf("EOF points = %+v-%+v, want %+v", tok.StartPoint, tok.EndPoint, wantPoint)
+	}
+}
+
+func TestLexerIncludedRangesIgnorePastSourceRangeAfterValidRange(t *testing.T) {
+	lex := NewLexer(buildIdentNumberWSDFA(), []byte("a___"))
+	lex.setIncludedRanges([]Range{
+		{StartByte: 0, EndByte: 1, EndPoint: Point{Column: 1}},
+		{StartByte: 99, EndByte: 100, StartPoint: Point{Row: 99}, EndPoint: Point{Row: 100}},
+	})
+
+	tok := lex.Next(0)
+	if tok.Text != "a" || tok.StartByte != 0 || tok.EndByte != 1 {
+		t.Fatalf("token = %+v, want a at [0,1)", tok)
+	}
+	eof := lex.Next(0)
+	if eof.StartByte != 1 || eof.EndByte != 1 || eof.StartPoint != (Point{Column: 1}) {
+		t.Fatalf("EOF = %+v, want the last valid range end", eof)
+	}
+}
+
+func TestLexerIncludedRangesBuildLogicalErrorRun(t *testing.T) {
+	lex := NewLexer(buildIdentNumberWSDFA(), []byte("@__#a"))
+	lex.hasErrorRunLexState = true
+	lex.errorRunLexState = 0
+	lex.setIncludedRanges([]Range{
+		{StartByte: 0, EndByte: 1, EndPoint: Point{Column: 1}},
+		{StartByte: 3, EndByte: 5, StartPoint: Point{Column: 3}, EndPoint: Point{Column: 5}},
+	})
+
+	errTok := lex.NextWithErrorRuns(0)
+	if errTok.Symbol != errorSymbol || errTok.Text != "@#" {
+		t.Fatalf("error token = (%d, %q), want logical error text @#", errTok.Symbol, errTok.Text)
+	}
+	if errTok.StartByte != 0 || errTok.EndByte != 4 {
+		t.Fatalf("error token bytes = [%d,%d), want [0,4)", errTok.StartByte, errTok.EndByte)
+	}
+	next := lex.NextWithErrorRuns(0)
+	if next.Symbol != 1 || next.Text != "a" || next.StartByte != 4 || next.EndByte != 5 {
+		t.Fatalf("next token = %+v, want a at [4,5)", next)
+	}
+}
+
+func TestLexerNoIncludedRangesKeepsNextAllocationFree(t *testing.T) {
+	lex := NewLexer(buildIdentNumberWSDFA(), []byte("alpha"))
+	allocs := testing.AllocsPerRun(1000, func() {
+		lex.pos = 0
+		lex.row = 0
+		lex.col = 0
+		includedRangeLexerTokenSink = lex.Next(0)
+	})
+	if allocs != 0 {
+		t.Fatalf("ordinary Next allocations = %.1f, want 0", allocs)
+	}
+}
+
+func newIncludedRangeTestDFASource(source []byte) *dfaTokenSource {
+	states := buildIdentNumberWSDFA()
+	lang := &Language{
+		LexStates: states,
+		LexModes:  []LexMode{{LexState: 0}},
+	}
+	return newDFATokenSourceDirect(NewLexer(states, source), lang, nil, nil, nil, nil)
+}
+
+func TestDFATokenSourceIncludedRangesResetAndRelexRestoreCursor(t *testing.T) {
+	ranges := []Range{{
+		StartByte:  2,
+		EndByte:    5,
+		StartPoint: Point{Column: 2},
+		EndPoint:   Point{Column: 5},
+	}}
+	d := newIncludedRangeTestDFASource([]byte("xxabc"))
+	if !d.setIncludedRanges(ranges) {
+		t.Fatal("DFA source rejected included ranges")
+	}
+	first := d.Next()
+	if first.Text != "abc" {
+		t.Fatalf("first token = %+v, want abc", first)
+	}
+
+	d.Reset([]byte("xxdef"))
+	reset := d.Next()
+	if reset.Text != "def" || reset.StartByte != 2 || reset.EndByte != 5 {
+		t.Fatalf("reset token = %+v, want def at [2,5)", reset)
+	}
+
+	d.lexer.pos = 2
+	d.lexer.row = 0
+	d.lexer.col = 2
+	d.lexer.includedRangeIdx = 0
+	before := d.snapshotRelexState()
+	if _, ok := d.RelexFromTokenStart(Token{
+		StartByte:  1,
+		EndByte:    2,
+		StartPoint: Point{Column: 1},
+		EndPoint:   Point{Column: 2},
+	}); ok {
+		t.Fatal("relex accepted a token outside the selected range")
+	}
+	if d.lexer.pos != before.lexerPos || d.lexer.includedRangeIdx != before.lexerRangeIdx {
+		t.Fatalf("relex rollback cursor = byte %d range %d, want byte %d range %d",
+			d.lexer.pos, d.lexer.includedRangeIdx, before.lexerPos, before.lexerRangeIdx)
+	}
+}
+
+func TestDFATokenSourceIncludedRangesRestoreGLRScans(t *testing.T) {
+	states := buildIdentNumberWSDFA()
+	states = append(states, LexState{
+		Default: -1,
+		EOF:     -1,
+		Transitions: []LexTransition{
+			{Lo: 'a', Hi: 'z', NextState: 1},
+		},
+	})
+	lang := &Language{
+		LexStates: states,
+		LexModes: []LexMode{
+			{LexState: 0},
+			{LexState: 4},
+		},
+		ParseActions:   []ParseActionEntry{{}, {}},
+		SymbolMetadata: []SymbolMetadata{{}, {Visible: true}},
+	}
+	d := newDFATokenSourceDirect(NewLexer(states, []byte("xxabc")), lang, func(StateID, Symbol) uint16 {
+		return 1
+	}, nil, nil, nil)
+	if !d.setIncludedRanges([]Range{{
+		StartByte:  2,
+		EndByte:    5,
+		StartPoint: Point{Column: 2},
+		EndPoint:   Point{Column: 5},
+	}}) {
+		t.Fatal("DFA source rejected included ranges")
+	}
+
+	startPos := d.lexer.pos
+	startRangeIdx := d.lexer.includedRangeIdx
+	tok, _, _, _ := d.scanDFATokenForState(0, 0)
+	if tok.Text != "abc" {
+		t.Fatalf("speculative token = %+v, want abc", tok)
+	}
+	if d.lexer.pos != startPos || d.lexer.includedRangeIdx != startRangeIdx {
+		t.Fatalf("speculative scan cursor = byte %d range %d, want byte %d range %d",
+			d.lexer.pos, d.lexer.includedRangeIdx, startPos, startRangeIdx)
+	}
+
+	d.state = 0
+	d.glrStates = []StateID{0, 1}
+	winner, ok := d.nextGLRUnionDFAToken()
+	if !ok || winner.Text != "abc" {
+		t.Fatalf("GLR winner = (%+v, %t), want abc", winner, ok)
+	}
+	if d.lexer.pos != 5 || d.lexer.includedRangeIdx != 1 {
+		t.Fatalf("GLR winner cursor = byte %d range %d, want byte 5 range 1",
+			d.lexer.pos, d.lexer.includedRangeIdx)
+	}
+
+	d.SeekTokenFrontier(0, Point{})
+	if d.lexer.pos != 2 || d.lexer.includedRangeIdx != 0 {
+		t.Fatalf("frontier cursor = byte %d range %d, want byte 2 range 0",
+			d.lexer.pos, d.lexer.includedRangeIdx)
+	}
+}

--- a/parser_api.go
+++ b/parser_api.go
@@ -960,7 +960,13 @@ func (p *Parser) IncludedRanges() []Range {
 }
 
 func (p *Parser) wrapIncludedRanges(ts TokenSource) TokenSource {
-	if p == nil || len(p.included) == 0 || ts == nil {
+	if p == nil || ts == nil {
+		return ts
+	}
+	if aware, ok := ts.(includedRangeAwareTokenSource); ok && aware.setIncludedRanges(p.included) {
+		return ts
+	}
+	if len(p.included) == 0 {
 		return ts
 	}
 	return newIncludedRangeTokenSource(ts, p.included)

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -384,6 +384,8 @@ func (d *dfaTokenSource) Reset(source []byte) {
 	d.lexer.pos = 0
 	d.lexer.row = 0
 	d.lexer.col = 0
+	d.lexer.includedRangeIdx = 0
+	d.lexer.normalizeIncludedPosition()
 	if d.language != nil {
 		d.lexer.states = d.language.LexStates
 		d.lexer.immediateTokens = d.language.ImmediateTokens
@@ -422,6 +424,15 @@ func (d *dfaTokenSource) Reset(source []byte) {
 		d.language.ExternalScanner.Destroy(d.externalPayload)
 	}
 	d.externalPayload = d.language.ExternalScanner.Create()
+}
+
+func (d *dfaTokenSource) setIncludedRanges(ranges []Range) bool {
+	if d == nil || d.lexer == nil || d.hasExternalScanner ||
+		(d.language != nil && (d.language.ExternalScanner != nil || len(d.language.ExternalSymbols) != 0)) {
+		return false
+	}
+	d.lexer.setIncludedRanges(ranges)
+	return true
 }
 
 func (d *dfaTokenSource) Close() {
@@ -752,6 +763,7 @@ func (d *dfaTokenSource) nextDFAToken() Token {
 	d.lexer.pos = endPos
 	d.lexer.row = endRow
 	d.lexer.col = endCol
+	d.lexer.includedRangeIdx = d.lexer.includedRangeIndexForPosition(endPos)
 	return tok
 }
 
@@ -1001,6 +1013,8 @@ func (d *dfaTokenSource) SeekTokenFrontier(pos uint32, pt Point) {
 	d.lexer.pos = int(pos)
 	d.lexer.row = pt.Row
 	d.lexer.col = pt.Column
+	d.lexer.includedRangeIdx = 0
+	d.lexer.normalizeIncludedPosition()
 }
 
 func (d *dfaTokenSource) PeekTokenFrontier(states []StateID, dst []tokenCandidate) (tokenFrontier, bool) {
@@ -1043,10 +1057,12 @@ func (d *dfaTokenSource) PeekTokenFrontier(states []StateID, dst []tokenCandidat
 	startPos := d.lexer.pos
 	startRow := d.lexer.row
 	startCol := d.lexer.col
+	startRangeIdx := d.lexer.includedRangeIdx
 	defer func() {
 		d.lexer.pos = startPos
 		d.lexer.row = startRow
 		d.lexer.col = startCol
+		d.lexer.includedRangeIdx = startRangeIdx
 	}()
 
 	type lexModeKey struct {
@@ -1170,6 +1186,7 @@ func (d *dfaTokenSource) nextGLRUnionDFAToken() (Token, bool) {
 	startPos := d.lexer.pos
 	startRow := d.lexer.row
 	startCol := d.lexer.col
+	startRangeIdx := d.lexer.includedRangeIdx
 	d.beginGLRUnionScanCache()
 
 	bestScore := 0
@@ -1296,12 +1313,14 @@ func (d *dfaTokenSource) nextGLRUnionDFAToken() (Token, bool) {
 		d.lexer.pos = startPos
 		d.lexer.row = startRow
 		d.lexer.col = startCol
+		d.lexer.includedRangeIdx = startRangeIdx
 		return Token{}, false
 	}
 
 	d.lexer.pos = bestEndPos
 	d.lexer.row = bestEndRow
 	d.lexer.col = bestEndCol
+	d.lexer.includedRangeIdx = d.lexer.includedRangeIndexForPosition(bestEndPos)
 	return bestTok, true
 }
 
@@ -1445,6 +1464,7 @@ func (d *dfaTokenSource) scanDFATokenForState(state StateID, lexState uint32) (T
 	savedPos := d.lexer.pos
 	savedRow := d.lexer.row
 	savedCol := d.lexer.col
+	savedRangeIdx := d.lexer.includedRangeIdx
 	savedState := d.state
 
 	d.state = state
@@ -1461,6 +1481,7 @@ func (d *dfaTokenSource) scanDFATokenForState(state StateID, lexState uint32) (T
 			d.lexer.pos = savedPos
 			d.lexer.row = savedRow
 			d.lexer.col = savedCol
+			d.lexer.includedRangeIdx = savedRangeIdx
 			d.state = savedState
 			if DebugDFA.Load() {
 				fmt.Printf("  SCHEME-ERR run %d-%d state=%d\n", errTok.StartByte, errTok.EndByte, state)
@@ -1473,6 +1494,7 @@ func (d *dfaTokenSource) scanDFATokenForState(state StateID, lexState uint32) (T
 		d.lexer.pos = savedPos
 		d.lexer.row = savedRow
 		d.lexer.col = savedCol
+		d.lexer.includedRangeIdx = savedRangeIdx
 	}
 	if tok.Symbol == errorSymbol {
 		// Unlexable-run error token from the lexer (mirrors C skipped-error
@@ -1481,6 +1503,7 @@ func (d *dfaTokenSource) scanDFATokenForState(state StateID, lexState uint32) (T
 		d.lexer.pos = savedPos
 		d.lexer.row = savedRow
 		d.lexer.col = savedCol
+		d.lexer.includedRangeIdx = savedRangeIdx
 		d.state = savedState
 		if DebugDFA.Load() {
 			fmt.Printf("  LEX-ERR run %d-%d state=%d\n", tok.StartByte, tok.EndByte, state)
@@ -1493,6 +1516,7 @@ func (d *dfaTokenSource) scanDFATokenForState(state StateID, lexState uint32) (T
 			d.lexer.pos = savedPos
 			d.lexer.row = savedRow
 			d.lexer.col = savedCol
+			d.lexer.includedRangeIdx = savedRangeIdx
 		}
 	}
 	var keywordDemoted bool
@@ -1506,6 +1530,7 @@ func (d *dfaTokenSource) scanDFATokenForState(state StateID, lexState uint32) (T
 	d.lexer.pos = savedPos
 	d.lexer.row = savedRow
 	d.lexer.col = savedCol
+	d.lexer.includedRangeIdx = savedRangeIdx
 	d.state = savedState
 
 	return tok, endPos, endRow, endCol
@@ -1542,6 +1567,7 @@ func (d *dfaTokenSource) scanRawDFATokenForLexState(lexState uint32) (Token, int
 	savedPos := d.lexer.pos
 	savedRow := d.lexer.row
 	savedCol := d.lexer.col
+	savedRangeIdx := d.lexer.includedRangeIdx
 
 	tok := d.nextTokenForLexState(lexState)
 	endPos := d.lexer.pos
@@ -1551,6 +1577,7 @@ func (d *dfaTokenSource) scanRawDFATokenForLexState(lexState uint32) (Token, int
 	d.lexer.pos = savedPos
 	d.lexer.row = savedRow
 	d.lexer.col = savedCol
+	d.lexer.includedRangeIdx = savedRangeIdx
 	return tok, endPos, endRow, endCol
 }
 
@@ -2268,6 +2295,9 @@ func (p *Parser) shouldDeferContextualCloseAngleAction(source []byte, state Stat
 		immediateTokens: lang.ImmediateTokens,
 		zeroWidthTokens: lang.ZeroWidthTokens,
 	}
+	if len(p.included) != 0 && lang.ExternalScanner == nil && len(lang.ExternalSymbols) == 0 {
+		probe.setIncludedRanges(p.included)
+	}
 	stateToken, ok := probe.scan(uint32(lexState), probe.pos, probe.row, probe.col)
 	if !ok || int(stateToken.Symbol) >= len(lang.SymbolNames) {
 		return false
@@ -2829,6 +2859,8 @@ func (d *dfaTokenSource) SkipToByteWithPoint(offset uint32, pt Point) Token {
 		d.lexer.pos = target
 		d.lexer.row = pt.Row
 		d.lexer.col = pt.Column
+		d.lexer.includedRangeIdx = 0
+		d.lexer.normalizeIncludedPosition()
 	}
 	return d.Next()
 }
@@ -2858,9 +2890,10 @@ func (d *dfaTokenSource) CanRelexFromTokenStart(tok Token) bool {
 }
 
 type dfaRelexSnapshot struct {
-	lexerPos int
-	lexerRow uint32
-	lexerCol uint32
+	lexerPos      int
+	lexerRow      uint32
+	lexerCol      uint32
+	lexerRangeIdx int
 
 	externalPayload []byte
 
@@ -2893,6 +2926,7 @@ func (d *dfaTokenSource) snapshotRelexStateWithExternalBuffer(buf []byte) (dfaRe
 		lexerPos:                    d.lexer.pos,
 		lexerRow:                    d.lexer.row,
 		lexerCol:                    d.lexer.col,
+		lexerRangeIdx:               d.lexer.includedRangeIdx,
 		lastExternalTokenStartByte:  d.lastExternalTokenStartByte,
 		lastExternalTokenEndByte:    d.lastExternalTokenEndByte,
 		lastExternalTokenValid:      d.lastExternalTokenValid,
@@ -2930,6 +2964,7 @@ func (s dfaRelexSnapshot) restore(d *dfaTokenSource) {
 	d.lexer.pos = s.lexerPos
 	d.lexer.row = s.lexerRow
 	d.lexer.col = s.lexerCol
+	d.lexer.includedRangeIdx = s.lexerRangeIdx
 	if d.hasExternalScanner && d.language != nil && d.language.ExternalScanner != nil {
 		d.language.ExternalScanner.Deserialize(d.externalPayload, s.externalPayload)
 	}
@@ -3051,6 +3086,8 @@ func (d *dfaTokenSource) beginRelexAt(target int, pt Point) {
 	d.lexer.pos = target
 	d.lexer.row = pt.Row
 	d.lexer.col = pt.Column
+	d.lexer.includedRangeIdx = 0
+	d.lexer.normalizeIncludedPosition()
 	if d.hasExternalScanner && d.usesExternalCheckpoints {
 		d.restoreExternalScannerState(d.externalTokenStart)
 	}
@@ -3256,6 +3293,9 @@ func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
 			return Token{}, false
 		}
 		d.trackZeroWidthExternalToken(tok)
+		d.lexer.pos = int(tok.EndByte)
+		d.lexer.row = tok.EndPoint.Row
+		d.lexer.col = tok.EndPoint.Column
 		return tok, true
 	}
 
@@ -4667,13 +4707,17 @@ func (d *dfaTokenSource) stateLexModeProducesSameSpan(state StateID, tok Token, 
 	savedPos := d.lexer.pos
 	savedRow := d.lexer.row
 	savedCol := d.lexer.col
+	savedRangeIdx := d.lexer.includedRangeIdx
 	d.lexer.pos = scanStartPos
 	d.lexer.row = scanStartRow
 	d.lexer.col = scanStartCol
+	d.lexer.includedRangeIdx = 0
+	d.lexer.normalizeIncludedPosition()
 	rawTok, rawEndPos, _, _ := d.scanRawPreferredTokenForState(state)
 	d.lexer.pos = savedPos
 	d.lexer.row = savedRow
 	d.lexer.col = savedCol
+	d.lexer.includedRangeIdx = savedRangeIdx
 	if rawTok.Symbol == 0 || rawTok.Symbol == errorSymbol {
 		return false
 	}

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -859,6 +859,9 @@ func (p *Parser) cRecoverResumeLookahead(ts TokenSource, source []byte, s *glrSt
 			immediateTokens: lang.ImmediateTokens,
 			zeroWidthTokens: lang.ZeroWidthTokens,
 		}
+		if len(p.included) != 0 && lang.ExternalScanner == nil && len(lang.ExternalSymbols) == 0 {
+			probe.setIncludedRanges(p.included)
+		}
 		stateLexFails := false
 		for {
 			if probe.pos >= len(source) {
@@ -903,6 +906,9 @@ func (p *Parser) cRecoverResumeLookahead(ts TokenSource, source []byte, s *glrSt
 		zeroWidthTokens:     lang.ZeroWidthTokens,
 		errorRunLexState:    uint32(errLS),
 		hasErrorRunLexState: true,
+	}
+	if len(p.included) != 0 && lang.ExternalScanner == nil && len(lang.ExternalSymbols) == 0 {
+		lx.setIncludedRanges(p.included)
 	}
 	relexed := lx.NextWithErrorRuns(uint32(errLS))
 	relexed.lexerErrorModeLexed = true
@@ -1025,6 +1031,9 @@ func (p *Parser) cRecoverInternalErrorModeToken(ts TokenSource, stacks []glrStac
 		zeroWidthTokens:     lang.ZeroWidthTokens,
 		errorRunLexState:    uint32(ls),
 		hasErrorRunLexState: true,
+	}
+	if len(p.included) != 0 && lang.ExternalScanner == nil && len(lang.ExternalSymbols) == 0 {
+		lx.setIncludedRanges(p.included)
 	}
 	tok := lx.NextWithErrorRuns(uint32(ls))
 	tok.lexerErrorModeLexed = true
@@ -3910,6 +3919,9 @@ func (p *Parser) cRecoverElectionLookaheadSymbol(source []byte, member *glrStack
 		errorRunLexState:    uint32(ls),
 		hasErrorRunLexState: true,
 	}
+	if len(p.included) != 0 && lang.ExternalScanner == nil && len(lang.ExternalSymbols) == 0 {
+		lx.setIncludedRanges(p.included)
+	}
 	relexed := lx.NextWithErrorRuns(uint32(ls))
 	if relexed.Symbol == 0 && relexed.StartByte == relexed.EndByte {
 		// Whitespace-only tail: C would see `end` here while the shared
@@ -5295,6 +5307,9 @@ func (p *Parser) relexTokenForStackLexState(source []byte, state StateID, tok To
 		col:             tok.StartPoint.Column,
 		immediateTokens: lang.ImmediateTokens,
 		zeroWidthTokens: lang.ZeroWidthTokens,
+	}
+	if len(p.included) != 0 && lang.ExternalScanner == nil && len(lang.ExternalSymbols) == 0 {
+		probe.setIncludedRanges(p.included)
 	}
 	relexed, ok := probe.scan(uint32(ls), probe.pos, probe.row, probe.col)
 	if !ok || relexed.Symbol == 0 || relexed.Symbol == tok.Symbol {

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -2550,7 +2550,8 @@ func TestRecoveryMemoTelemetryPreservesAMD64HotLayouts(t *testing.T) {
 	if unsafe.Sizeof(uintptr(0)) != 8 {
 		t.Skip("amd64 layout ratchet")
 	}
-	if got, want := unsafe.Sizeof(Parser{}), uintptr(2184); got != want {
+	// The internal range cursor adds one range slice and two indexes: 40 bytes.
+	if got, want := unsafe.Sizeof(Parser{}), uintptr(2224); got != want {
 		t.Fatalf("Parser size = %d, want %d", got, want)
 	}
 	if got, want := unsafe.Sizeof(ParseRuntime{}), uintptr(3040); got != want {
@@ -2562,7 +2563,7 @@ func TestRecoveryMemoTelemetryPreservesAMD64HotLayouts(t *testing.T) {
 	if got, want := unsafe.Offsetof(Parser{}.cNodeMemoPeakTier), unsafe.Offsetof(Parser{}.crecoveryCostCompetitionRelevant)+2; got != want {
 		t.Fatalf("Parser memo peak offset = %d, want %d", got, want)
 	}
-	if got, want := unsafe.Offsetof(Parser{}.fullParseRetryPassesTaken), uintptr(984); got != want {
+	if got, want := unsafe.Offsetof(Parser{}.fullParseRetryPassesTaken), uintptr(1024); got != want {
 		t.Fatalf("Parser full-parse retry offset = %d, want %d", got, want)
 	}
 	if got, want := unsafe.Offsetof(Tree{}.recoveryNodeMemoPeakTier), unsafe.Offsetof(Tree{}.released)+1; got != want {


### PR DESCRIPTION
## Change

- Move included-range gap traversal into the internal deterministic finite automaton (DFA) only.
- Enable this path only when the grammar has no external scanner and no external symbols.
- Keep the existing wrapper for custom sources and all external-token surfaces.
- Advance scannerless synthetic external tokens to their reported end before the next read.
- Preserve the ordinary no-range path. Its focused allocation test reports zero allocations.

## Evidence

- Both focused host test sets pass.
- Narrow changed-file Canopy checks pass.
- `git diff --check` passes.
- The locked-C JSON test has exact tree parity across a string token that crosses a selected gap.
- Docker artifact: `/tmp/gts-internal-dfa-range-cursor-artifacts/20260825T010353Z-json-internal-dfa-range-p2-main776`.
- Container log SHA-256: `bc3d442e1b10edd87e7a38c854c1809a3a241ac79319d50b081a4a0e6204325b`.
- The Docker run exited zero without a timeout or an out-of-memory event.

## Limits

- Keep the Go normalization arm live. Go uses an external scanner and retains the wrapper.
- Compact and forest included-range routes remain uncertified.
- Do not treat this slice as normalization campaign closure.