### PR TITLE
fix: Preserve C conflict version order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ for tags and release notes while still in `0.x`.
 
 ### Correctness
 
+- Preserved C conflict version order for generic object creation in C#
+  collection initializers.
+
 - Added a default-off Core link provenance sidecar. It stores finalized
   drop-cohort reference indexes by LinkID. Compact routing and admission stay
   unchanged.

--- a/cgo_harness/csharp_invocation_statement_parity_test.go
+++ b/cgo_harness/csharp_invocation_statement_parity_test.go
@@ -74,3 +74,9 @@ func TestCSharpGenericBaseListParity(t *testing.T) {
 	tc := parityCase{name: "c_sharp", source: string(src)}
 	runParityCase(t, tc, "generic-base-list", src)
 }
+
+func TestCSharpGenericObjectCreationInCollectionInitializerParity(t *testing.T) {
+	src := []byte("class C { object x = new D() { { typeof(T?), new F<T>(G.I) }, }; }\n")
+	tc := parityCase{name: "c_sharp", source: string(src)}
+	runParityCase(t, tc, "generic-object-creation-in-collection-initializer", src)
+}

--- a/grammars/csharp_collection_initializer_regression_test.go
+++ b/grammars/csharp_collection_initializer_regression_test.go
@@ -1,0 +1,37 @@
+package grammars
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+func TestCSharpGenericObjectCreationInCollectionInitializer(t *testing.T) {
+	source := []byte("class C { object x = new D() { { typeof(T?), new F<T>(G.I) }, }; }")
+	language := CSharpLanguage()
+	parser := gotreesitter.NewParser(language)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tree.Release()
+
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("collection initializer returned no root")
+	}
+	if root.HasError() {
+		t.Fatalf("collection initializer did not parse cleanly: %s", root.SExpr(language))
+	}
+	creation := findFirstNamedDescendantWhere(root, language, "object_creation_expression", func(node *gotreesitter.Node) bool {
+		return node.Text(source) == "new F<T>(G.I)"
+	})
+	if creation == nil {
+		t.Fatalf("generic object creation is absent: %s", root.SExpr(language))
+	}
+	if binary := findFirstNamedDescendantWhere(root, language, "binary_expression", func(node *gotreesitter.Node) bool {
+		return node.Text(source) == "new F<T>(G.I)"
+	}); binary != nil {
+		t.Fatalf("generic object creation became a comparison: %s", binary.SExpr(language))
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -6480,10 +6480,24 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					continue
 				}
 				base := *s
+				// C keeps the current stack version for a non-repetition shift.
+				// It creates separate versions for reductions before it shifts.
+				// Preserve that version order because equal-precedence links keep
+				// the first subtree when the versions merge.
+				primaryActionIndex := 0
+				for ai := range actions {
+					if actions[ai].Type == ParseActionShift && !actions[ai].Repetition {
+						primaryActionIndex = ai
+						break
+					}
+				}
 				if p.glrTrace {
 					p.traceParseFork(currentState, actions)
 				}
-				for ai := 1; ai < len(actions); ai++ {
+				for ai := range actions {
+					if ai == primaryActionIndex {
+						continue
+					}
 					fork := base.cloneWithScratch(&scratch.gss)
 					fork.branchOrder = allocBranchOrder()
 					if actions[ai].Type != ParseActionShift || p.guardRealShiftGap(source, &fork, tok) {
@@ -6529,23 +6543,24 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					}
 				}
 				s = &stacks[si]
-				if actions[0].Type == ParseActionShift && !p.guardRealShiftGap(source, s, tok) {
+				primaryAction := actions[primaryActionIndex]
+				if primaryAction.Type == ParseActionShift && !p.guardRealShiftGap(source, s, tok) {
 					continue
 				}
-				if actions[0].Type == ParseActionRecover && !p.guardRealTokenAttachmentGap(source, s, tok, "recover") {
+				if primaryAction.Type == ParseActionRecover && !p.guardRealTokenAttachmentGap(source, s, tok, "recover") {
 					continue
 				}
-				traceVisit(si, s, "conflict-original", 0, len(actions), actions[0])
-				setPendingTrace("conflict-original", si, 0, len(actions), actions[0])
-				p.noteStopActionDiagnostic("conflict-original", s, tok, actions[0], 0, len(actions), false, 0, 0, false)
+				traceVisit(si, s, "conflict-original", primaryActionIndex, len(actions), primaryAction)
+				setPendingTrace("conflict-original", si, primaryActionIndex, len(actions), primaryAction)
+				p.noteStopActionDiagnostic("conflict-original", s, tok, primaryAction, primaryActionIndex, len(actions), false, 0, 0, false)
 				actionBeforeState, actionBeforeByte, actionBeforeDepth := stackTraceState(s)
-				p.applyAction(source, s, actions[0], tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
+				p.applyAction(source, s, primaryAction, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 				p.noteStopActionResult(s)
 				actionAfterState, actionAfterByte, actionAfterDepth := stackTraceState(s)
 				traceAfterPrimary(si, s)
-				if actions[0].Type == ParseActionReduce {
+				if primaryAction.Type == ParseActionReduce {
 					p.completeConflictReduceFrontier(source, s, tok, conflictReduceFrontierSeed{
-						action:      actions[0],
+						action:      primaryAction,
 						beforeState: actionBeforeState,
 						beforeByte:  actionBeforeByte,
 						beforeDepth: actionBeforeDepth,
@@ -6556,8 +6571,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					traceFrontier(si, s, traceFrontierResult(actionAfterState, actionAfterByte, actionAfterDepth, s))
 				}
 				if p.glrTrace {
-					fmt.Printf("[GLR] orig[%d] after action[0]: st=%d dead=%v shift=%v dep=%d byte=%d\n",
-						si, s.top().state, s.dead, s.shifted, s.depth(), s.byteOffset)
+					fmt.Printf("[GLR] orig[%d] after action[%d]: st=%d dead=%v shift=%v dep=%d byte=%d\n",
+						si, primaryActionIndex, s.top().state, s.dead, s.shifted, s.depth(), s.byteOffset)
 				}
 				drainPendingForkStacks()
 				drainPendingFrontierForkStacks()


### PR DESCRIPTION
## Summary

- Keep the first non-repetition shift on the original conflict version.
- Fork the other actions in grammar order.
- Add host and locked-C tests for a valid C# collection initializer.

This fixes the valid generic object-creation tree divergence. It does not close #972.

Large-file performance and forest election remain open.

## Tests

- `go test ./grammars -run '^TestCSharpGenericObjectCreationInCollectionInitializer$' -count=1`
- `go test . -run '^(TestConflictReduceFrontierSameHeaderFirstReduceStaysLive|TestConflictReduceFrontierDepthChangingSameReduceDoesNotFakeDuplicate|TestConflictReduceFrontierRuntimeReduceTerminalPreservesReduceBranch|TestCSharpDesignerStyleBlockStaysBounded|TestCSharpCJKPartialClassesStayBounded|TestCSharpNamespaceRecoveryStaysBoundedDottedBitorArg)$' -count=1`
- `go test . -run 'Conflict' -count=1`
- `GTS_PARITY_ALLOW_HOST=1 go test . -tags treesitter_c_parity -run '^TestCSharpGenericObjectCreationInCollectionInitializerParity$' -count=1 -v -timeout 45s`
- Narrow changed-file Canopy checks.
- `git diff --check`

Docker artifact: `/tmp/gts-csharp-972-artifacts/20260825T023112Z-issue972-publication-cgo-regression`

Change hash: `259057335e702903ae9cbc9b0c95e172c123d747364010bb51ca492029e4bdaa`

Refs #972
