### PR TITLE
fix: Bound transient conflict-frontier growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
-- Bound temporary conflict-frontier growth with the resolved stack-cull
-  trigger. The reported pinned-file result was 250.8 seconds with an error
-  root. The changed parser completes in 2.335 seconds with a clean root. It
-  uses 88,930 nodes and 232,480 KiB maximum resident set size (RSS), without
-  truncation. Uniform initializer parity remains exact through 72 entries. The
-  cap does not fix the separate 87-byte branch limitation.
+- Bound temporary conflict-frontier growth with the maximum of the resolved
+  stack-cull trigger and the four-stack full-parse overflow window. The
+  reported pinned-file result was 250.8 seconds with an error root. The
+  changed parser completes the pinned file in about 3 seconds with a clean
+  root and no truncation. The raw non-API benchmark route retains its
+  historical unbounded frontier search. Exact C# route and census checks pass,
+  as does uniform initializer parity through 72 entries. The cap does not fix
+  the separate 87-byte branch limitation.
 
 - Reduced the temporary recovery memo tier from 262,144 entries to 131,072
   entries. The active table now uses 3 MiB on 64-bit systems. The retained

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- Bound temporary conflict-frontier growth with the resolved stack-cull
+  trigger. The reported pinned-file result was 250.8 seconds with an error
+  root. The changed parser completes in 2.335 seconds with a clean root. It
+  uses 88,930 nodes and 232,480 KiB maximum resident set size (RSS), without
+  truncation. Uniform initializer parity remains exact through 72 entries. The
+  cap does not fix the separate 87-byte branch limitation.
+
 - Reduced the temporary recovery memo tier from 262,144 entries to 131,072
   entries. The active table now uses 3 MiB on 64-bit systems. The retained
   standard table uses 384 KiB. Total memo storage is 3.375 MiB before slice

--- a/cgo_harness/issue972_frontier_cap_only_test.go
+++ b/cgo_harness/issue972_frontier_cap_only_test.go
@@ -1,0 +1,115 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const (
+	issue972Uniform72MaxStacks = 512
+	issue972Uniform72MaxNodes  = 50000
+)
+
+func issue972UniformCSharpSource(entries int) []byte {
+	var source strings.Builder
+	source.WriteString("class C\n{\n    object x = new D()\n    {\n")
+	for index := 0; index < entries; index++ {
+		source.WriteString("        { typeof(int), Formatter.Instance },\n")
+	}
+	source.WriteString("    };\n}\n")
+	return []byte(source.String())
+}
+
+func issue972ParseCSharp(t *testing.T, cLanguage *sitter.Language, source []byte) (*sitter.Tree, string) {
+	t.Helper()
+	cParser := sitter.NewParser()
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		cParser.Close()
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		cParser.Close()
+		t.Fatal("locked C parser returned a nil tree")
+	}
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		cTree.Close()
+		cParser.Close()
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cTree.Close()
+		cParser.Close()
+	})
+	return cTree, cDigest
+}
+
+func issue972ParseGoCSharp(t *testing.T, source []byte) (*gotreesitter.Tree, *gotreesitter.Language, time.Duration) {
+	t.Helper()
+	language := grammars.CSharpLanguage()
+	started := time.Now()
+	parser := gotreesitter.NewParser(language)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("gotreesitter parse: %v", err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		if tree != nil {
+			tree.Release()
+		}
+		t.Fatal("gotreesitter returned a nil tree")
+	}
+	t.Cleanup(tree.Release)
+	return tree, language, time.Since(started)
+}
+
+func issue972GoDigest(t *testing.T, tree *gotreesitter.Tree, language *gotreesitter.Language) string {
+	t.Helper()
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return inspection.SHA256
+}
+
+// TestIssue972FrontierCapOnlyUniformParity keeps the cap-only candidate exact
+// on the uniform C# initializer family from four through 72 entries.
+func TestIssue972FrontierCapOnlyUniformParity(t *testing.T) {
+	cLanguage, err := COracleLanguage("c_sharp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entries := range []int{4, 8, 16, 32, 40, 48, 64, 72} {
+		entries := entries
+		t.Run(fmt.Sprintf("entries-%d", entries), func(t *testing.T) {
+			source := issue972UniformCSharpSource(entries)
+			cTree, cDigest := issue972ParseCSharp(t, cLanguage, source)
+			goTree, goLanguage, elapsed := issue972ParseGoCSharp(t, source)
+			goDigest := issue972GoDigest(t, goTree, goLanguage)
+			diff := FirstDivergenceDumpV1(goTree.RootNode(), goLanguage, cTree.RootNode())
+			if diff != nil || goDigest != cDigest {
+				t.Fatalf("cap-only uniform parity diverged: digest=%s C=%s first=%+v runtime=%s", goDigest, cDigest, diff, goTree.ParseRuntime().Summary())
+			}
+			if goTree.RootNode().HasError() || goTree.RootNode().EndByte() != uint32(len(source)) || goTree.ParseRuntime().Truncated {
+				t.Fatalf("cap-only uniform parse is incomplete: root_error=%t root_end=%d source=%d runtime=%s", goTree.RootNode().HasError(), goTree.RootNode().EndByte(), len(source), goTree.ParseRuntime().Summary())
+			}
+			if entries == 72 {
+				runtime := goTree.ParseRuntime()
+				if runtime.MaxStacksSeen > issue972Uniform72MaxStacks || runtime.NodesAllocated > issue972Uniform72MaxNodes {
+					t.Fatalf("cap-only 72-entry workload exceeded conservative bounds: max_stacks=%d/%d nodes=%d/%d runtime=%s", runtime.MaxStacksSeen, issue972Uniform72MaxStacks, runtime.NodesAllocated, issue972Uniform72MaxNodes, runtime.Summary())
+				}
+			}
+			t.Logf("entries=%d bytes=%d elapsed=%s digest=%s runtime=%s", entries, len(source), elapsed, goDigest, goTree.ParseRuntime().Summary())
+		})
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -5304,11 +5304,9 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	maxDepth := caps.maxDepth
 	maxNodes := caps.maxNodes
 	// Select the larger of the resolved cull trigger and full-parse overflow window.
-	// The no-result compatibility benchmark disables frontier admission separately.
-	frontierForkPopulationCap := maxTransientFrontierPopulationCap(maxStacks, maxStackCullTrigger)
-	if p.noResultCompatibilityBenchmarkOnly {
-		frontierForkPopulationCap = 0
-	}
+	// Keep its historical zero-cap rule only when the trigger does not exceed
+	// maxStacks.
+	frontierForkPopulationCap := transientFrontierPopulationCap(maxStacks, maxStackCullTrigger, p.noResultCompatibilityBenchmarkOnly)
 	parseRuntime.IterationLimit = maxIter
 	parseRuntime.StackDepthLimit = maxDepth
 	parseRuntime.NodeLimit = maxNodes
@@ -8628,6 +8626,14 @@ func maxTransientFrontierPopulationCap(maxStacks, maxStackCullTrigger int) int {
 		return maxStackCullTrigger
 	}
 	return overflowWindow
+}
+
+func transientFrontierPopulationCap(maxStacks, maxStackCullTrigger int, noResultCompatibilityBenchmarkOnly bool) int {
+	cap := maxTransientFrontierPopulationCap(maxStacks, maxStackCullTrigger)
+	if noResultCompatibilityBenchmarkOnly && maxStackCullTrigger <= maxStacks {
+		return 0
+	}
+	return cap
 }
 
 func (p *Parser) promotePrimaryStack(stacks []glrStack) {

--- a/parser.go
+++ b/parser.go
@@ -5303,8 +5303,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	maxIter := caps.maxIter
 	maxDepth := caps.maxDepth
 	maxNodes := caps.maxNodes
-	// Keep frontier admission above the resolved cull trigger by the full-parse
-	// overflow window. A non-positive trigger keeps the gate disabled.
+	// Select the larger of the resolved cull trigger and full-parse overflow window.
+	// The no-result compatibility benchmark disables frontier admission separately.
 	frontierForkPopulationCap := maxTransientFrontierPopulationCap(maxStacks, maxStackCullTrigger)
 	if p.noResultCompatibilityBenchmarkOnly {
 		frontierForkPopulationCap = 0

--- a/parser.go
+++ b/parser.go
@@ -5303,16 +5303,10 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	maxIter := caps.maxIter
 	maxDepth := caps.maxDepth
 	maxNodes := caps.maxNodes
-	// Population cap for transient conflict-frontier fork admission
-	// (completeConflictReduceFrontier): active exactly where the boundary
-	// cull's overflow window exists (full parses outside c_sharp, where
-	// glrStackCullTrigger returns maxStacks+fullParseGLRStackOverflow).
-	// Zero disables the gate so incremental and c_sharp behavior is
-	// unchanged.
-	frontierForkPopulationCap := 0
-	if maxStackCullTrigger > maxStacks {
-		frontierForkPopulationCap = maxStackCullTrigger
-	}
+	// Use the resolved cull trigger as the transient frontier population cap.
+	// This keeps frontier admission aligned with boundary culling.
+	// A non-positive trigger keeps the gate disabled.
+	frontierForkPopulationCap := maxStackCullTrigger
 	parseRuntime.IterationLimit = maxIter
 	parseRuntime.StackDepthLimit = maxDepth
 	parseRuntime.NodeLimit = maxNodes

--- a/parser.go
+++ b/parser.go
@@ -5303,10 +5303,12 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	maxIter := caps.maxIter
 	maxDepth := caps.maxDepth
 	maxNodes := caps.maxNodes
-	// Use the resolved cull trigger as the transient frontier population cap.
-	// This keeps frontier admission aligned with boundary culling.
-	// A non-positive trigger keeps the gate disabled.
-	frontierForkPopulationCap := maxStackCullTrigger
+	// Keep frontier admission above the resolved cull trigger by the full-parse
+	// overflow window. A non-positive trigger keeps the gate disabled.
+	frontierForkPopulationCap := maxTransientFrontierPopulationCap(maxStacks, maxStackCullTrigger)
+	if p.noResultCompatibilityBenchmarkOnly {
+		frontierForkPopulationCap = 0
+	}
 	parseRuntime.IterationLimit = maxIter
 	parseRuntime.StackDepthLimit = maxDepth
 	parseRuntime.NodeLimit = maxNodes
@@ -8611,6 +8613,21 @@ func glrStackCullTrigger(maxStacks int, langName string) int {
 		return maxInt
 	}
 	return maxStacks + fullParseGLRStackOverflow
+}
+
+func maxTransientFrontierPopulationCap(maxStacks, maxStackCullTrigger int) int {
+	if maxStacks <= 0 {
+		return maxStackCullTrigger
+	}
+	maxInt := int(^uint(0) >> 1)
+	overflowWindow := maxInt
+	if maxStacks <= maxInt-fullParseGLRStackOverflow {
+		overflowWindow = maxStacks + fullParseGLRStackOverflow
+	}
+	if maxStackCullTrigger > overflowWindow {
+		return maxStackCullTrigger
+	}
+	return overflowWindow
 }
 
 func (p *Parser) promotePrimaryStack(stacks []glrStack) {

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -2515,6 +2515,7 @@ func TestMaxTransientFrontierPopulationCap(t *testing.T) {
 	}{
 		{name: "zero disabled", maxStacks: 0, cull: 0, want: 0},
 		{name: "zero keeps explicit cull", maxStacks: 0, cull: 7, want: 7},
+		{name: "overflow window with zero trigger", maxStacks: 8, cull: 0, want: 12},
 		{name: "overflow window", maxStacks: 8, cull: 8, want: 12},
 		{name: "cull trigger wins", maxStacks: 8, cull: 16, want: 16},
 		{name: "integer overflow", maxStacks: maxInt, cull: 0, want: maxInt},

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -2505,6 +2505,29 @@ func TestGLRStackCullTrigger(t *testing.T) {
 	}
 }
 
+func TestMaxTransientFrontierPopulationCap(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	tests := []struct {
+		name      string
+		maxStacks int
+		cull      int
+		want      int
+	}{
+		{name: "zero disabled", maxStacks: 0, cull: 0, want: 0},
+		{name: "zero keeps explicit cull", maxStacks: 0, cull: 7, want: 7},
+		{name: "overflow window", maxStacks: 8, cull: 8, want: 12},
+		{name: "cull trigger wins", maxStacks: 8, cull: 16, want: 16},
+		{name: "integer overflow", maxStacks: maxInt, cull: 0, want: maxInt},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := maxTransientFrontierPopulationCap(tt.maxStacks, tt.cull); got != tt.want {
+				t.Fatalf("maxTransientFrontierPopulationCap(%d, %d) = %d, want %d", tt.maxStacks, tt.cull, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveParseMaxStacks(t *testing.T) {
 	if got, retry := resolveParseMaxStacks(6, 0, 2); got != 6 || retry {
 		t.Fatalf("resolveParseMaxStacks(default) = (%d, %t), want (6, false)", got, retry)

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -2529,6 +2529,30 @@ func TestMaxTransientFrontierPopulationCap(t *testing.T) {
 	}
 }
 
+func TestTransientFrontierPopulationCap(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	tests := []struct {
+		name      string
+		maxStacks int
+		cull      int
+		noResult  bool
+		want      int
+	}{
+		{name: "production csharp-like", maxStacks: 8, cull: 8, want: 12},
+		{name: "no-result tight", maxStacks: 8, cull: 8, noResult: true, want: 0},
+		{name: "no-result overflow", maxStacks: 8, cull: 12, noResult: true, want: 12},
+		{name: "zero", maxStacks: 0, cull: 0, want: 0},
+		{name: "overflow", maxStacks: maxInt, cull: 0, want: maxInt},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := transientFrontierPopulationCap(tt.maxStacks, tt.cull, tt.noResult); got != tt.want {
+				t.Fatalf("transientFrontierPopulationCap(%d, %d, %t) = %d, want %d", tt.maxStacks, tt.cull, tt.noResult, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveParseMaxStacks(t *testing.T) {
 	if got, retry := resolveParseMaxStacks(6, 0, 2); got != 6 || retry {
 		t.Fatalf("resolveParseMaxStacks(default) = (%d, %t), want (6, false)", got, retry)


### PR DESCRIPTION
## Summary

Bound transient conflict-frontier admission for full parses.

Production now uses an overflow-safe cap of `max(maxStackCullTrigger, maxStacks+4)`.
The raw no-result compatibility benchmark sets this cap to zero.
This preserves its historical unbounded frontier search and its locked receipt.

## Evidence

- The pinned real file completes in about three seconds with a clean root and no truncation.
- Uniform C# initializer parity remains exact from four through 72 entries.
- The exact `a0-jsontextreader` route passes without a race and with a race.
- The raw route retains digest `b68127ae4dc6e4f18ac52af73e4c12ca97d7e4ae23166a7fc9d449cb227508dc`.
- Production, compact, and incremental dispatch each retain the `2093/2085` pass receipt.
- The tracked dispatcher census passes with a race.
- The frontier-cap unit tests cover zero, overflow, and maximum behavior.

No receipt changed in this update.

The separate 87-byte heterogeneous witness still selects the wrong branch.
This pull request does not claim to fix that limitation.

Fixes #972
