### PR TITLE
Graduate compact recursive precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,10 +115,18 @@ for tags and release notes while still in `0.x`.
   locked-C trees.
   The change grants no language profile or digest grant.
 
-- Added an authenticated cumulative maximum for dynamic precedence, which
-  ranks competing parse paths. Leaf payloads contribute zero. Discarded and
-  replacement edges preserve C operation order. Outer edges recompute nested
-  maxima once. The `nodeRecord` grows from 24 to 32 bytes. The Haskell small
+- Added a stored cumulative maximum for dynamic precedence, which ranks
+  competing parse paths. Each node keeps C's running value. Merge
+  transactions seed the fold from that stored value and apply the C rule
+  table from `stack_node_add_link`: a same-pair assignment overwrites the
+  value and can lower it, mergeable and appended links max the incoming
+  predecessor's stored value plus the payload contribution, and duplicate
+  or lower same-pair links change nothing. Publication never recomputes
+  the value from the final link array. Leaf payloads contribute zero. The
+  rule-table tests in `internal/parsercorephase0/precedence_rule_table_test.go`
+  pin one case per C branch. The canonical real-corpus ratchet now pins
+  69 PASS and at most 30 FALLBACK over 109 rows. The `nodeRecord` grows
+  from 24 to 32 bytes. The Haskell small
   `Main.hs` row has 260 bytes and source SHA-256
   `c60b55de99836dacb00a0f2808835895132996a95d52304cefab548b8cbdef65`.
   It routes with counters `1/0` and real recursive link-union work. Production,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,19 @@ for tags and release notes while still in `0.x`.
   locked-C trees.
   The change grants no language profile or digest grant.
 
+- Added an authenticated cumulative maximum for dynamic precedence, which
+  ranks competing parse paths. Leaf payloads contribute zero. Discarded and
+  replacement edges preserve C operation order. Outer edges recompute nested
+  maxima once. The `nodeRecord` grows from 24 to 32 bytes. The Haskell small
+  `Main.hs` row has 260 bytes and source SHA-256
+  `c60b55de99836dacb00a0f2808835895132996a95d52304cefab548b8cbdef65`.
+  It routes with counters `1/0` and real recursive link-union work. Production,
+  compact, and locked C report deep digest
+  `6e3806c54c39af93701157f87ac8ee9ef947108d66b7d6069d6908a4d5c71e9f`.
+  The matrix moves from 63 PASS, 26 FALLBACK, and 8 SKIP to 64 PASS,
+  25 FALLBACK, and 8 SKIP, with zero DIVERGE or ERROR rows. The eight-link
+  cap remains. No language profile or grammar digest grant was added.
+
 - Raw accepted-leaf coverage now preserves hidden terminals and exact `ERROR`
   provenance with bounded reusable scratch and cancellation polling. The
   authenticated matrix moves from 60 PASS, 29 FALLBACK, and 8 SKIP to 62 PASS,

--- a/admission_real_corpus_matrix_test.go
+++ b/admission_real_corpus_matrix_test.go
@@ -217,9 +217,11 @@ func TestAdmissionCandidateRealCorpusMatrix(t *testing.T) {
 		const (
 			// Pinned Rust has ast.rs at 66,281 bytes and weird-exprs.rs at 6,436 bytes.
 			// This gate excludes ast.rs, so the canonical manifest has 109 rows.
+			// The recursive-precedence graduation moved the canonical scope to
+			// 69 PASS / 30 FALLBACK; the floors pin those totals.
 			minRows     = 109
-			minPass     = 67
-			maxFallback = 33
+			minPass     = 69
+			maxFallback = 30
 			wantSkip    = 10
 		)
 		if len(rows) < minRows ||

--- a/admission_recursive_insert_corpus_test.go
+++ b/admission_recursive_insert_corpus_test.go
@@ -31,7 +31,7 @@ func TestAdmissionCandidateBoundedRecursiveInsertionCorpus(t *testing.T) {
 			language:   "elixir",
 			path:       "testdata/admission_direct/recursive_insert/elixir.ex",
 			sha256:     "7977e259f7e718177e568eedbb82ba8df72a149095718f3c563de5ec06db285c",
-			nextReason: "converged-path reduction split drops",
+			nextReason: "lacks alternative-set coverage",
 		},
 		// tree-sitter-perl@ad74e6db234c, test/highlight/statements.pm
 		{
@@ -45,7 +45,7 @@ func TestAdmissionCandidateBoundedRecursiveInsertionCorpus(t *testing.T) {
 			language:   "scala",
 			path:       "testdata/admission_direct/recursive_insert/scala.scala",
 			sha256:     "d53a16c04dd1ad917104a5f9ab6bf45c4c779188bafe7044d2fec06217a3b7d9",
-			nextReason: "converged-path reduction split drops",
+			nextReason: "lacks alternative-set coverage",
 		},
 	}
 	entries := make(map[string]grammars.LangEntry)

--- a/admission_recursive_insertion_haskell_small_contract_test.go
+++ b/admission_recursive_insertion_haskell_small_contract_test.go
@@ -1,0 +1,231 @@
+//go:build gts_parsercorephase0 && gts_merge_census
+
+package gotreesitter_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+type recursiveInsertionProfileExpectation struct {
+	grammarBlobSHA256            string
+	convergedReductionSplitDrops bool
+	eofAcceptNoActionSiblings    bool
+	primaryAcceptanceDerivation  bool
+	exactStackNodeEquivalence    bool
+	strategy2ErrorRegion         bool
+}
+
+type recursiveInsertionRealCorpusRow struct {
+	language     string
+	bucket       string
+	pathSuffix   string
+	bytes        int
+	sourceSHA256 string
+	profile      recursiveInsertionProfileExpectation
+}
+
+var recursiveInsertionRealCorpusRows = []recursiveInsertionRealCorpusRow{
+	{
+		language:     "haskell",
+		bucket:       "small",
+		pathSuffix:   "corpus_real/haskell/small__Main.hs",
+		bytes:        260,
+		sourceSHA256: "c60b55de99836dacb00a0f2808835895132996a95d52304cefab548b8cbdef65",
+		profile: recursiveInsertionProfileExpectation{
+			grammarBlobSHA256:            "fcfc8794bca4442ebf5688d88e2397c78a22c8f0b585c4e1b868986cfa52dd09",
+			convergedReductionSplitDrops: true,
+		},
+	},
+}
+
+type recursiveInsertionProfileSnapshot struct {
+	grammarBlobSHA256            [32]byte
+	grammarBlobSHA256OK          bool
+	convergedReductionSplitDrops bool
+	eofAcceptNoActionSiblings    bool
+	primaryAcceptanceDerivation  bool
+	exactStackNodeEquivalence    bool
+	strategy2ErrorRegion         bool
+}
+
+// TestAdmissionCandidateRecursiveInsertionHaskellSmall is a strict route contract.
+// It requires generic core support and permits no new language grant or digest.
+func TestAdmissionCandidateRecursiveInsertionHaskellSmall(t *testing.T) {
+	manifestPath := strings.TrimSpace(os.Getenv("GTS_ADMISSION_REAL_CORPUS_MANIFEST"))
+	if manifestPath == "" {
+		manifestPath = filepath.Join("cgo_harness", "corpus_real", "manifest.json")
+	}
+	manifestSource, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skipf("canonical real-corpus manifest is unavailable at %s: %v", manifestPath, err)
+		}
+		t.Fatal(err)
+	}
+	var manifest admissionRealCorpusManifest
+	if err := json.Unmarshal(manifestSource, &manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	languages := make(map[string]grammars.LangEntry)
+	for _, entry := range grammars.AllLanguages() {
+		languages[entry.Name] = entry
+	}
+	t.Cleanup(func() {
+		gts.ResetAdmissionCandidateCountersForTest()
+		grammars.PurgeEmbeddedLanguageCache()
+	})
+
+	for _, want := range recursiveInsertionRealCorpusRows {
+		want := want
+		t.Run(want.language+"/"+want.bucket+"/"+filepath.Base(want.pathSuffix), func(t *testing.T) {
+			corpus, ok := findRecursiveInsertionRealCorpusEntry(manifest, want)
+			if !ok {
+				t.Fatalf("canonical manifest has no unique row for %s/%s/%s", want.language, want.bucket, want.pathSuffix)
+			}
+			sourcePath := admissionRealCorpusPath(manifestPath, corpus.OutputPath)
+			source, err := os.ReadFile(sourcePath)
+			if err != nil {
+				t.Fatalf("read canonical source %s: %v", sourcePath, err)
+			}
+			if len(source) != want.bytes {
+				t.Fatalf("source bytes=%d, want %d", len(source), want.bytes)
+			}
+			sourceDigest := sha256.Sum256(source)
+			if got := hex.EncodeToString(sourceDigest[:]); got != want.sourceSHA256 {
+				t.Fatalf("source SHA-256=%s, want %s", got, want.sourceSHA256)
+			}
+
+			entry, ok := languages[want.language]
+			if !ok {
+				t.Fatalf("language %q is absent from the registry", want.language)
+			}
+			lang := entry.Language()
+			if lang == nil {
+				t.Fatalf("language %q returned nil", want.language)
+			}
+			beforeProfile := recursiveInsertionProfile(lang)
+			requireRecursiveInsertionProfile(t, want, beforeProfile)
+
+			gts.ResetAdmissionCandidateCountersForTest()
+			production := gts.NewParser(lang)
+			production.SetAdmissionCandidateRoute(false)
+			productionTree, err := production.Parse(source)
+			if err != nil || productionTree == nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer productionTree.Release()
+			productionRouted, productionFallback := gts.AdmissionCandidateCounters()
+			if productionRouted != 0 || productionFallback != 0 {
+				t.Fatalf("production route counters=%d/%d, want 0/0", productionRouted, productionFallback)
+			}
+			productionRoot := requireRecursiveInsertionCleanFullSpan(t, productionTree, len(source), "production")
+			productionInspection, err := benchfixtures.InspectGoTree(productionRoot, lang)
+			if err != nil {
+				t.Fatalf("production deep digest: %v", err)
+			}
+
+			candidate := gts.NewParser(lang)
+			candidate.SetAdmissionCandidateRoute(true)
+			gts.MergeEventCensusReset()
+			candidateTree, err := candidate.Parse(source)
+			if err != nil || candidateTree == nil {
+				t.Fatalf("compact candidate parse: %v; fallback reason=%q", err, gts.AdmissionCandidateLastFallbackReason())
+			}
+			defer candidateTree.Release()
+			candidateRouted, candidateFallback := gts.AdmissionCandidateCounters()
+			if candidateRouted-productionRouted != 1 || candidateFallback-productionFallback != 0 {
+				t.Fatalf("compact route delta=%d/%d, want 1/0; reason=%q", candidateRouted-productionRouted, candidateFallback-productionFallback, gts.AdmissionCandidateLastFallbackReason())
+			}
+			work := gts.MergeEventCensusSnapshot()
+			if work.CompactAcceptancesObserved != 1 || work.CompactLinkUnionRecursiveChanged == 0 {
+				t.Fatalf("compact non-vacuity work receipt=%+v, want one acceptance and recursive link-union work", work)
+			}
+			candidateRoot := requireRecursiveInsertionCleanFullSpan(t, candidateTree, len(source), "compact")
+			candidateInspection, err := benchfixtures.InspectGoTree(candidateRoot, lang)
+			if err != nil {
+				t.Fatalf("compact deep digest: %v", err)
+			}
+			if diff := firstAdmissionTreeDivergence(candidateRoot, productionRoot, lang, "root"); diff != "" {
+				t.Fatalf("compact public tree diverges: %s", diff)
+			}
+			if candidateInspection.SHA256 != productionInspection.SHA256 {
+				t.Fatalf("compact deep digest=%s, production=%s", candidateInspection.SHA256, productionInspection.SHA256)
+			}
+
+			afterProfile := recursiveInsertionProfile(lang)
+			if afterProfile != beforeProfile {
+				t.Fatalf("language profile or grammar digest changed during admission: before=%+v after=%+v", beforeProfile, afterProfile)
+			}
+			requireRecursiveInsertionProfile(t, want, afterProfile)
+		})
+	}
+}
+
+func findRecursiveInsertionRealCorpusEntry(manifest admissionRealCorpusManifest, want recursiveInsertionRealCorpusRow) (admissionRealCorpusEntry, bool) {
+	var match admissionRealCorpusEntry
+	found := 0
+	for _, corpus := range manifest.Entries {
+		if corpus.Language != want.language || corpus.Bucket != want.bucket || corpus.Bytes != want.bytes {
+			continue
+		}
+		if !strings.HasSuffix(filepath.ToSlash(corpus.OutputPath), want.pathSuffix) {
+			continue
+		}
+		match = corpus
+		found++
+	}
+	return match, found == 1
+}
+
+func requireRecursiveInsertionCleanFullSpan(t testing.TB, tree *gts.Tree, sourceBytes int, label string) *gts.Node {
+	t.Helper()
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatalf("%s tree has no root", label)
+	}
+	if root.IsError() || root.HasError() {
+		t.Fatalf("%s tree has an error: %s", label, root.SExpr(tree.Language()))
+	}
+	if root.StartByte() != 0 || root.EndByte() != uint32(sourceBytes) {
+		t.Fatalf("%s root span=[%d,%d), want [0,%d)", label, root.StartByte(), root.EndByte(), sourceBytes)
+	}
+	return root
+}
+
+func recursiveInsertionProfile(lang *gts.Language) recursiveInsertionProfileSnapshot {
+	grammarBlobSHA256, grammarBlobSHA256OK := lang.GrammarBlobSHA256()
+	return recursiveInsertionProfileSnapshot{
+		grammarBlobSHA256:            grammarBlobSHA256,
+		grammarBlobSHA256OK:          grammarBlobSHA256OK,
+		convergedReductionSplitDrops: lang.CompactConvergedReductionSplitDropsCertified,
+		eofAcceptNoActionSiblings:    lang.CompactEOFAcceptNoActionSiblingsCertified,
+		primaryAcceptanceDerivation:  lang.CompactPrimaryAcceptanceDerivationCertified,
+		exactStackNodeEquivalence:    lang.ExactStackNodeEquivalenceCertified,
+		strategy2ErrorRegion:         lang.CompactStrategy2ErrorRegionCertified,
+	}
+}
+
+func requireRecursiveInsertionProfile(t testing.TB, want recursiveInsertionRealCorpusRow, got recursiveInsertionProfileSnapshot) {
+	t.Helper()
+	if !got.grammarBlobSHA256OK || hex.EncodeToString(got.grammarBlobSHA256[:]) != want.profile.grammarBlobSHA256 {
+		t.Fatalf("grammar blob digest=%x (present=%t), want %s", got.grammarBlobSHA256, got.grammarBlobSHA256OK, want.profile.grammarBlobSHA256)
+	}
+	if got.convergedReductionSplitDrops != want.profile.convergedReductionSplitDrops ||
+		got.eofAcceptNoActionSiblings != want.profile.eofAcceptNoActionSiblings ||
+		got.primaryAcceptanceDerivation != want.profile.primaryAcceptanceDerivation ||
+		got.exactStackNodeEquivalence != want.profile.exactStackNodeEquivalence ||
+		got.strategy2ErrorRegion != want.profile.strategy2ErrorRegion {
+		t.Fatalf("compact profile changed for %s: got=%+v want=%+v", want.language, got, want.profile)
+	}
+}

--- a/cgo_harness/haskell_small_admission_locked_c_parity_test.go
+++ b/cgo_harness/haskell_small_admission_locked_c_parity_test.go
@@ -1,0 +1,129 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const (
+	haskellSmallSourceSHA256 = "c60b55de99836dacb00a0f2808835895132996a95d52304cefab548b8cbdef65"
+	haskellSmallDeepSHA256   = "6e3806c54c39af93701157f87ac8ee9ef947108d66b7d6069d6908a4d5c71e9f"
+)
+
+const haskellSmallSource = `module Main (main) where
+
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Data.ByteString.Lazy.Char8 qualified as LBS
+import Hasura.Server.MetadataOpenAPI (metadataOpenAPI)
+import Prelude
+
+main :: IO ()
+main = LBS.putStrLn $ encodePretty metadataOpenAPI
+`
+
+func TestHaskellSmallAdmissionLockedCParity(t *testing.T) {
+	source := []byte(haskellSmallSource)
+	if len(source) != 260 {
+		t.Fatalf("source bytes=%d, want 260", len(source))
+	}
+	sum := sha256.Sum256(source)
+	if got := hex.EncodeToString(sum[:]); got != haskellSmallSourceSHA256 {
+		t.Fatalf("source SHA-256=%s, want %s", got, haskellSmallSourceSHA256)
+	}
+
+	language := grammars.HaskellLanguage()
+	if language == nil {
+		t.Fatal("Haskell Go language is nil")
+	}
+	cLanguage, err := COracleLanguage("haskell")
+	if err != nil {
+		t.Fatalf("load locked Haskell language: %v", err)
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatalf("set locked Haskell language: %v", err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("locked Haskell parser returned no tree")
+	}
+	t.Cleanup(cTree.Close)
+	requireHaskellSmallCRoot(t, cTree.RootNode(), len(source))
+
+	productionParser := gotreesitter.NewParser(language)
+	productionParser.SetAdmissionCandidateRoute(false)
+	productionTree, err := productionParser.Parse(source)
+	if err != nil {
+		t.Fatalf("production parse: %v", err)
+	}
+	t.Cleanup(func() { productionTree.Release() })
+	requireHaskellSmallRoot(t, "production", productionTree.RootNode(), len(source))
+	assertLockedCTreeExact(t, "Haskell small production", productionTree, language, cTree)
+
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	candidateParser := gotreesitter.NewParser(language)
+	candidateParser.SetAdmissionCandidateRoute(true)
+	candidateTree, err := candidateParser.Parse(source)
+	if err != nil {
+		t.Fatalf("compact candidate parse: %v", err)
+	}
+	t.Cleanup(func() { candidateTree.Release() })
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter-routedBefore != 1 || fallbackAfter-fallbackBefore != 0 {
+		t.Fatalf("compact route delta=%d/%d reason=%q, want 1/0", routedAfter-routedBefore, fallbackAfter-fallbackBefore, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+	requireHaskellSmallRoot(t, "compact candidate", candidateTree.RootNode(), len(source))
+	assertLockedCTreeExact(t, "Haskell small compact candidate", candidateTree, language, cTree)
+
+	productionInspection, err := benchfixtures.InspectGoTree(productionTree.RootNode(), language)
+	if err != nil {
+		t.Fatalf("inspect production deep tree: %v", err)
+	}
+	candidateInspection, err := benchfixtures.InspectGoTree(candidateTree.RootNode(), language)
+	if err != nil {
+		t.Fatalf("inspect compact deep tree: %v", err)
+	}
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatalf("inspect locked C deep tree: %v", err)
+	}
+	if productionInspection.SHA256 != haskellSmallDeepSHA256 || candidateInspection.SHA256 != haskellSmallDeepSHA256 || cDigest != haskellSmallDeepSHA256 {
+		t.Fatalf("Haskell small deep digest production=%s compact=%s locked_c=%s, want %s", productionInspection.SHA256, candidateInspection.SHA256, cDigest, haskellSmallDeepSHA256)
+	}
+	t.Logf("Haskell small exact locked-C parity deep_digest=%s route_delta=%d/%d", cDigest, routedAfter-routedBefore, fallbackAfter-fallbackBefore)
+}
+
+func requireHaskellSmallRoot(t *testing.T, label string, root *gotreesitter.Node, sourceLen int) {
+	t.Helper()
+	if root == nil {
+		t.Fatalf("%s root is nil", label)
+	}
+	if root.HasError() {
+		t.Fatalf("%s root has an error", label)
+	}
+	if root.StartByte() != 0 || root.EndByte() != uint32(sourceLen) {
+		t.Fatalf("%s root span=%d..%d, want 0..%d", label, root.StartByte(), root.EndByte(), sourceLen)
+	}
+}
+
+func requireHaskellSmallCRoot(t *testing.T, root *sitter.Node, sourceLen int) {
+	t.Helper()
+	if root == nil {
+		t.Fatal("locked C root is nil")
+	}
+	if root.HasError() {
+		t.Fatal("locked C root has an error")
+	}
+	if root.StartByte() != 0 || root.EndByte() != uint(sourceLen) {
+		t.Fatalf("locked C root span=%d..%d, want 0..%d", root.StartByte(), root.EndByte(), sourceLen)
+	}
+}

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -1,8 +1,23 @@
 # Compact route real-corpus matrix
 
 Current evidence date: 2026-08-25.
-Current base commit: `e4557bac36ec1794922a1ecce9ca5772d31f1a31` from `main`.
-Current candidate base commit: `e4557bac36ec1794922a1ecce9ca5772d31f1a31`.
+Current base commit: `6dab5c9516c1372c87fa4ea08da1e155f9599dec` from `main`.
+Current candidate base commit: `6dab5c9516c1372c87fa4ea08da1e155f9599dec`.
+
+## Current compact-graduation matrix
+
+Evidence date: 2026-08-25.
+
+- Matrix totals: 64 PASS, 25 FALLBACK, and 8 SKIP.
+- Divergence and error rows: zero.
+- Execution: 49 sequential processes.
+- Corpus manifest SHA-256: `14e811c4c278570e795a4a79f387dd15c61ff20718e3430f2091fe386e35c92b`.
+- Haskell `small__Main.hs`: 260 bytes; source SHA-256
+  `c60b55de99836dacb00a0f2808835895132996a95d52304cefab548b8cbdef65`;
+  route `1/0`; one compact acceptance; recursive link-union work is non-zero;
+  production, compact, and locked-C deep SHA-256
+  `6e3806c54c39af93701157f87ac8ee9ef947108d66b7d6069d6908a4d5c71e9f`.
+- The `nodeRecord` is 32 bytes. The eight-link cap is unchanged.
 
 ## Latest Swift issue #576 parser recovery candidate
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -448,15 +448,25 @@ type nodeRecord struct {
 	precedenceMax int64
 }
 
-// precedenceCandidate is a recomputed precedence value. It never crosses a
-// publication boundary without the link that authenticated it.
+// precedenceCandidate is a computed precedence value. It carries no
+// verification of its own; the fold rules in precedenceMaximumWitness and
+// their C sources (stack.c stack_node_add_link) are the model it comes from.
 type precedenceCandidate struct {
 	value int64
 }
 
-// precedenceMaximumWitness stores authenticated discarded link provenance.
-// Publication recomputes each stored link against its immutable predecessor.
+// precedenceMaximumWitness folds C's per-node dynamic_precedence running
+// value across one bounded merge transaction. seed carries the mutated
+// node's stored value (C's self->dynamic_precedence before the transaction);
+// replacement models the C same-pair assignment, which overwrites the
+// running value and can lower it; discarded and postReplacement each hold
+// the highest max-rule contribution observed before and after the last
+// assignment. Publication folds seed, assignment, and contributions in that
+// order; it never recomputes from the final link array, because C never
+// does.
 type precedenceMaximumWitness struct {
+	seed               int64
+	hasSeed            bool
 	discarded          linkRecord
 	hasDiscarded       bool
 	replacement        linkRecord
@@ -828,6 +838,47 @@ func (c *Core) computePrecedenceMaximumFromNode(r nodeRecord, folded precedenceM
 }
 
 func (c *Core) computePrecedenceMaximum(links []linkRecord, folded precedenceMaximumWitness) (precedenceCandidate, error) {
+	// A seeded witness folds C's stored running value: start from the mutated
+	// node's stored maximum, let the last same-pair assignment overwrite it,
+	// and max in the contributions observed around that assignment. The final
+	// link array plays no part, matching stack_node_add_link, which never
+	// recomputes self->dynamic_precedence from the link set.
+	if folded.hasSeed {
+		maximum := precedenceCandidate{value: folded.seed}
+		if folded.hasReplacement {
+			replacement, err := c.linkPrecedenceMaximum(folded.replacement)
+			if err != nil {
+				return precedenceCandidate{}, err
+			}
+			matched := false
+			for _, link := range links {
+				if link.prev == folded.replacement.prev && c.linkEdgesEqual(link, folded.replacement) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return precedenceCandidate{}, errors.New("parser-core phase zero: replacement witness is not present in final adjacency")
+			}
+			maximum = replacement
+			if folded.hasPostReplacement {
+				postReplacement, err := c.linkPrecedenceMaximum(folded.postReplacement)
+				if err != nil {
+					return precedenceCandidate{}, err
+				}
+				if postReplacement.value > maximum.value {
+					maximum = postReplacement
+				}
+			}
+			return maximum, nil
+		}
+		if discarded, ok, err := c.discardedPrecedenceMaximum(folded); err != nil {
+			return precedenceCandidate{}, err
+		} else if ok && discarded.value > maximum.value {
+			maximum = discarded
+		}
+		return maximum, nil
+	}
 	var maximum precedenceCandidate
 	haveMaximum := false
 	for _, link := range links {
@@ -3678,16 +3729,19 @@ func (c *Core) factorExactPredecessorMerge(key boundaryKey, probe boundaryProbe,
 		}
 		return condenseOutcome{}, true, mergeErr
 	}
-	// The nested merge already authenticated and published its maximum on the
-	// merged predecessor. Recompute the outer edge exactly once. Do not carry
-	// nested discarded or replacement records into the outer adjacency.
-	*folded = precedenceMaximumWitness{}
+	// The nested merge already published its own maximum on the merged
+	// predecessor. The boundary node folds separately: C rule 3 maxes the
+	// boundary's stored value with the INCOMING predecessor's stored value
+	// plus the payload contribution (stack.c:237-243 reads link.node, which
+	// the recursion never mutates). Do not carry nested discarded or
+	// replacement records into the outer adjacency.
 	oldMaximum, mergeErr := c.nodePrecedenceMaximum(oldID)
 	if mergeErr != nil {
 		return condenseOutcome{}, true, mergeErr
 	}
+	*folded = precedenceMaximumWitness{seed: oldMaximum.value, hasSeed: true}
 	outerDiscarded := linkRecord{
-		prev: merged, payload: in.payload, scoreDelta: in.scoreDelta,
+		prev: in.prev, payload: in.payload, scoreDelta: in.scoreDelta,
 	}
 	if in.order.Present {
 		outerDiscarded.order = in.order.Value
@@ -3762,7 +3816,9 @@ func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int, folde
 	if err != nil {
 		return 0, false, err
 	}
-	*folded = precedenceMaximumWitness{}
+	// The merge mutates the left node in C terms, so the fold starts from the
+	// left node's stored running value (stack_node_add_link's self).
+	*folded = precedenceMaximumWitness{seed: leftMaximum.value, hasSeed: true}
 	leftCheckpoint, leftExact := c.nodeScannerCheckpoint(leftID)
 	rightCheckpoint, rightExact := c.nodeScannerCheckpoint(rightID)
 	if left.state != right.state || left.byteOffset != right.byteOffset ||
@@ -3800,8 +3856,8 @@ func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int, folde
 		return leftID, false, nil
 	}
 	// C updates the containing node's maximum even when the incoming edge is
-	// shallow-equivalent and the link set stays unchanged. Recompute the final
-	// links and every authenticated discarded link before making that decision.
+	// shallow-equivalent and the link set stays unchanged. Fold the stored
+	// seed with the observed rule contributions before making that decision.
 	maximum, err := c.computePrecedenceMaximum(links, *folded)
 	if err != nil {
 		return 0, false, err
@@ -3836,6 +3892,10 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 		return nil, false, err
 	}
 	if len(links) == 0 {
+		if err := c.observeDiscardedLink(folded, incoming); err != nil {
+			c.recordLinkUnionRejected()
+			return nil, false, err
+		}
 		return append(slices.Clone(links), incoming), true, nil
 	}
 	c.recordLinkUnionAttempt()
@@ -3859,10 +3919,8 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 			return nil, false, errors.New("parser-core phase zero: recursive insertion declined inexact external payload provenance")
 		}
 		if c.linkRecordsEqual(incumbent, incoming) {
-			if err := c.observeDiscardedLink(folded, incoming); err != nil {
-				c.recordLinkUnionRejected()
-				return nil, false, err
-			}
+			// C rule 2: an exact duplicate performs no update at all
+			// (stack.c:225), so the fold observes nothing.
 			c.recordLinkUnionDuplicateNoop()
 			if phase0AEnabled {
 				phase0AMergeDecision(c, index, phase0ATransitionDuplicateDrop)
@@ -3889,20 +3947,17 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 				return nil, false, err
 			}
 			if incomingPrecedence <= incumbentPrecedence {
-				if err := c.observeDiscardedLink(folded, incoming); err != nil {
-					c.recordLinkUnionRejected()
-					return nil, false, err
-				}
+				// C rule 2: a same-pair link that does not raise the subtree
+				// precedence performs no update (stack.c:225).
 				c.recordLinkUnionDuplicateNoop()
 				if phase0AEnabled {
 					phase0AMergeDecision(c, index, phase0ATransitionPrecedenceDrop)
 				}
 				return links, false, nil
 			}
-			if err := c.observeDiscardedLink(folded, incumbent); err != nil {
-				c.recordLinkUnionRejected()
-				return nil, false, err
-			}
+			// C rule 1: the assignment overwrites the running value
+			// (stack.c:222-223), so the incumbent's value is discarded, not
+			// recorded, and any post-assignment contributions start fresh.
 			updated := slices.Clone(links)
 			updated[index] = incoming
 			folded.replacement = incoming
@@ -3958,29 +4013,18 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 			phase0AObserveAdjacencyPublished(c, merged)
 			phase0AMergeRecursiveDecision(c, index, merged)
 		}
-		mergedMaximum, err := c.nodePrecedenceMaximum(merged)
-		if err != nil {
+		// C rule 3 runs whether or not the recursion changed the incumbent
+		// predecessor: it maxes the containing node with the INCOMING
+		// predecessor's stored value plus the payload contribution
+		// (stack.c:237-243 reads link.node, which the recursion never
+		// mutates). The published link points at the merged predecessor, but
+		// the fold contribution does not.
+		if err := c.observeDiscardedLink(folded, incoming); err != nil {
 			c.recordLinkUnionRejected()
 			return nil, false, err
-		}
-		contribution, err := c.effectivePayloadPrecedence(incoming.payload, incoming.scoreDelta)
-		if err != nil {
-			c.recordLinkUnionRejected()
-			return nil, false, err
-		}
-		_, err = checkedAddScore(mergedMaximum.value, contribution)
-		if err != nil {
-			c.recordLinkUnionRejected()
-			return nil, false, errors.New("parser-core phase zero: precedence maximum overflow")
 		}
 		updated := slices.Clone(links)
 		updated[index].prev = merged
-		if folded.hasReplacement {
-			if err := c.observePostReplacementLink(folded, updated[index]); err != nil {
-				c.recordLinkUnionRejected()
-				return nil, false, err
-			}
-		}
 		c.recordLinkUnionRecursiveChanged()
 		return updated, true, nil
 	}
@@ -3988,11 +4032,12 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 		c.recordLinkUnionRejected()
 		return nil, false, &LiveLinkCapacityError{State: state, ByteOffset: byteOffset, ObservedLinks: uint64(len(links)) + 1, Limit: c.limits.MaxLinksPerBoundary}
 	}
-	if folded.hasReplacement {
-		if err := c.observePostReplacementLink(folded, incoming); err != nil {
-			c.recordLinkUnionRejected()
-			return nil, false, err
-		}
+	// C rule 5: an appended link maxes its contribution into the running
+	// value (stack.c:253-263). The seeded fold no longer recomputes from the
+	// final adjacency, so every append observes its contribution here.
+	if err := c.observeDiscardedLink(folded, incoming); err != nil {
+		c.recordLinkUnionRejected()
+		return nil, false, err
 	}
 	c.recordLinkUnionAlternateAppended()
 	if phase0AEnabled {
@@ -4274,9 +4319,12 @@ func (c *Core) appendAdjacencyNodeAt(state StateID, byteOffset uint32, checkpoin
 	return c.appendAdjacencyNodeAtWithPrecedence(state, byteOffset, checkpoint, links, precedenceMaximumWitness{})
 }
 
-// appendAdjacencyNodeAtWithPrecedence authenticates the complete final link
-// slice before it appends any link. folded is private and is built only from
-// checked predecessor records and discarded incoming links.
+// appendAdjacencyNodeAtWithPrecedence publishes an adjacency with its folded
+// precedence maximum. A seeded witness carries C's stored running value
+// through a merge transaction; an unseeded witness computes a fresh node's
+// value from its link contributions, matching stack_node_new plus appends.
+// Neither shape verifies the value against outside evidence; the C rule
+// table in the precedence rule-table tests is the behavioral contract.
 func (c *Core) appendAdjacencyNodeAtWithPrecedence(state StateID, byteOffset uint32, checkpoint CheckpointID, links []linkRecord, folded precedenceMaximumWitness) (NodeID, error) {
 	if len(links) == 0 {
 		return 0, errors.New("parser-core phase zero: recursive insertion produced empty adjacency")

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -440,11 +440,29 @@ type BoundaryIndexStats struct {
 }
 
 type nodeRecord struct {
-	state      StateID
-	byteOffset uint32
-	firstLink  uint32
-	linkCount  uint32
-	pathCount  uint64
+	state         StateID
+	byteOffset    uint32
+	firstLink     uint32
+	linkCount     uint32
+	pathCount     uint64
+	precedenceMax int64
+}
+
+// precedenceCandidate is a recomputed precedence value. It never crosses a
+// publication boundary without the link that authenticated it.
+type precedenceCandidate struct {
+	value int64
+}
+
+// precedenceMaximumWitness stores authenticated discarded link provenance.
+// Publication recomputes each stored link against its immutable predecessor.
+type precedenceMaximumWitness struct {
+	discarded          linkRecord
+	hasDiscarded       bool
+	replacement        linkRecord
+	hasReplacement     bool
+	postReplacement    linkRecord
+	hasPostReplacement bool
 }
 
 type nodeLineageRecord struct {
@@ -694,6 +712,171 @@ type linkRecord struct {
 const linkFlagHasOrder uint32 = 1 << iota
 
 func (l linkRecord) hasOrder() bool { return l.flags&linkFlagHasOrder != 0 }
+
+func (c *Core) nodePrecedenceMaximum(id NodeID) (precedenceCandidate, error) {
+	node, err := c.node(id)
+	if err != nil {
+		return precedenceCandidate{}, err
+	}
+	return precedenceCandidate{value: node.precedenceMax}, nil
+}
+
+func (c *Core) linkPrecedenceMaximum(link linkRecord) (precedenceCandidate, error) {
+	predecessor, err := c.nodePrecedenceMaximum(link.prev)
+	if err != nil {
+		return precedenceCandidate{}, err
+	}
+	contribution, err := c.effectivePayloadPrecedence(link.payload, link.scoreDelta)
+	if err != nil {
+		return precedenceCandidate{}, err
+	}
+	value, err := checkedAddScore(predecessor.value, contribution)
+	if err != nil {
+		return precedenceCandidate{}, errors.New("parser-core phase zero: precedence maximum overflow")
+	}
+	return precedenceCandidate{value: value}, nil
+}
+
+func (c *Core) observeDiscardedLink(w *precedenceMaximumWitness, link linkRecord) error {
+	if w.hasReplacement {
+		return c.observePostReplacementLink(w, link)
+	}
+	candidate, err := c.linkPrecedenceMaximum(link)
+	if err != nil {
+		return err
+	}
+	if !w.hasDiscarded {
+		w.discarded = link
+		w.hasDiscarded = true
+		return nil
+	}
+	previous, err := c.linkPrecedenceMaximum(w.discarded)
+	if err != nil {
+		return err
+	}
+	if candidate.value > previous.value {
+		w.discarded = link
+	}
+	return nil
+}
+
+func (c *Core) observePostReplacementLink(w *precedenceMaximumWitness, link linkRecord) error {
+	candidate, err := c.linkPrecedenceMaximum(link)
+	if err != nil {
+		return err
+	}
+	if !w.hasPostReplacement {
+		w.postReplacement = link
+		w.hasPostReplacement = true
+		return nil
+	}
+	previous, err := c.linkPrecedenceMaximum(w.postReplacement)
+	if err != nil {
+		return err
+	}
+	if candidate.value > previous.value {
+		w.postReplacement = link
+	}
+	return nil
+}
+
+func (c *Core) discardedPrecedenceMaximum(w precedenceMaximumWitness) (precedenceCandidate, bool, error) {
+	if !w.hasDiscarded {
+		return precedenceCandidate{}, false, nil
+	}
+	candidate, err := c.linkPrecedenceMaximum(w.discarded)
+	if err != nil {
+		return precedenceCandidate{}, false, err
+	}
+	return candidate, true, nil
+}
+
+func (c *Core) computePrecedenceMaximumFromNode(r nodeRecord, folded precedenceMaximumWitness) (precedenceCandidate, error) {
+	if folded.hasReplacement {
+		return precedenceCandidate{}, errors.New("parser-core phase zero: replacement witness requires final adjacency")
+	}
+	id := LinkID(r.firstLink)
+	var maximum precedenceCandidate
+	haveMaximum := false
+	for remaining := r.linkCount; remaining > 0; remaining-- {
+		if id == 0 || uint64(id) > uint64(len(c.links)) {
+			return precedenceCandidate{}, errors.New("parser-core phase zero: adjacency shorter than recorded link count")
+		}
+		candidate, err := c.linkPrecedenceMaximum(c.links[id-1])
+		if err != nil {
+			return precedenceCandidate{}, err
+		}
+		if !haveMaximum || candidate.value > maximum.value {
+			maximum = candidate
+			haveMaximum = true
+		}
+		id = c.links[id-1].next
+	}
+	if id != 0 {
+		return precedenceCandidate{}, errors.New("parser-core phase zero: adjacency exceeds recorded link count or cycles")
+	}
+	if discarded, ok, err := c.discardedPrecedenceMaximum(folded); err != nil {
+		return precedenceCandidate{}, err
+	} else if ok && (!haveMaximum || discarded.value > maximum.value) {
+		maximum = discarded
+		haveMaximum = true
+	}
+	if !haveMaximum {
+		return precedenceCandidate{}, errors.New("parser-core phase zero: missing precedence maximum certificate")
+	}
+	return maximum, nil
+}
+
+func (c *Core) computePrecedenceMaximum(links []linkRecord, folded precedenceMaximumWitness) (precedenceCandidate, error) {
+	var maximum precedenceCandidate
+	haveMaximum := false
+	for _, link := range links {
+		candidate, err := c.linkPrecedenceMaximum(link)
+		if err != nil {
+			return precedenceCandidate{}, err
+		}
+		if !haveMaximum || candidate.value > maximum.value {
+			maximum = candidate
+			haveMaximum = true
+		}
+	}
+	if folded.hasReplacement {
+		matched := false
+		for _, link := range links {
+			if link.prev == folded.replacement.prev && c.linkEdgesEqual(link, folded.replacement) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return precedenceCandidate{}, errors.New("parser-core phase zero: replacement witness is not present in final adjacency")
+		}
+		replacement, err := c.linkPrecedenceMaximum(folded.replacement)
+		if err != nil {
+			return precedenceCandidate{}, err
+		}
+		maximum = replacement
+		haveMaximum = true
+		if folded.hasPostReplacement {
+			postReplacement, err := c.linkPrecedenceMaximum(folded.postReplacement)
+			if err != nil {
+				return precedenceCandidate{}, err
+			}
+			if postReplacement.value > maximum.value {
+				maximum = postReplacement
+			}
+		}
+	} else if discarded, ok, err := c.discardedPrecedenceMaximum(folded); err != nil {
+		return precedenceCandidate{}, err
+	} else if ok && (!haveMaximum || discarded.value > maximum.value) {
+		maximum = discarded
+		haveMaximum = true
+	}
+	if !haveMaximum {
+		return precedenceCandidate{}, errors.New("parser-core phase zero: missing precedence maximum certificate")
+	}
+	return maximum, nil
+}
 
 type subtreeRecord struct {
 	symbol            Symbol
@@ -2835,6 +3018,12 @@ func (c *Core) appendPrivate(state StateID, byteOffset uint32, in linkInput) (He
 	if _, err := c.subtree(in.payload); err != nil {
 		return Head{}, err
 	}
+	maximum, err := c.linkPrecedenceMaximum(linkRecord{
+		prev: in.prev, payload: in.payload, scoreDelta: in.scoreDelta,
+	})
+	if err != nil {
+		return Head{}, err
+	}
 	if uint64(len(c.links))+1 > uint64(c.limits.MaxLinks) || uint64(len(c.links)) >= math.MaxUint32 {
 		return Head{}, errors.New("parser-core phase zero: link arena cap")
 	}
@@ -2850,10 +3039,10 @@ func (c *Core) appendPrivate(state StateID, byteOffset uint32, in linkInput) (He
 		order: in.order.Value, flags: flags,
 	})
 	c.addWork(&c.work.GraphLinkAdditionsProxy, 1)
-	id, err := c.appendNode(nodeRecord{
+	id, err := c.appendNodeAtWithMaximum(nodeRecord{
 		state: state, byteOffset: byteOffset,
 		firstLink: uint32(linkID), linkCount: 1, pathCount: prev.pathCount,
-	})
+	}, c.checkpoint, maximum.value)
 	if err != nil {
 		return Head{}, err
 	}
@@ -3155,7 +3344,8 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 			// surviving alternate below. With no shallow-class incumbent the factor
 			// still runs, preserving the recursive-insertion path unchanged.
 			if !foldDeclined && shallowCount == 0 {
-				outcome, handled, err := c.factorExactPredecessor(key, probe, oldID, oldLinks, in)
+				folded := precedenceMaximumWitness{}
+				outcome, handled, err := c.factorExactPredecessor(key, probe, oldID, oldLinks, in, &folded)
 				if err != nil || handled {
 					if handled {
 						if err != nil {
@@ -3201,6 +3391,26 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 		}
 		linkCount += old.linkCount
 	}
+	var finalMaximum precedenceCandidate
+	haveFinalMaximum := false
+	if oldID != 0 {
+		oldMaximum, err := c.nodePrecedenceMaximum(oldID)
+		if err != nil {
+			return condenseOutcome{}, err
+		}
+		finalMaximum = oldMaximum
+		haveFinalMaximum = true
+	}
+	incomingMaximum, err := c.linkPrecedenceMaximum(linkRecord{
+		prev: in.prev, payload: in.payload, scoreDelta: in.scoreDelta,
+	})
+	if err != nil {
+		return condenseOutcome{}, err
+	}
+	if !haveFinalMaximum || incomingMaximum.value > finalMaximum.value {
+		finalMaximum = incomingMaximum
+		haveFinalMaximum = true
+	}
 	flags := uint32(0)
 	if in.order.Present {
 		flags |= linkFlagHasOrder
@@ -3210,10 +3420,10 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 		order: in.order.Value, flags: flags, next: LinkID(old.firstLink),
 	})
 	c.addWork(&c.work.GraphLinkAdditionsProxy, 1)
-	id, err := c.appendNodeAt(nodeRecord{
+	id, err := c.appendNodeAtWithMaximum(nodeRecord{
 		state: key.state, byteOffset: key.byteOffset,
 		firstLink: uint32(linkID), linkCount: linkCount, pathCount: newPathCount,
-	}, key.checkpoint)
+	}, key.checkpoint, finalMaximum.value)
 	if err != nil {
 		return condenseOutcome{}, err
 	}
@@ -3251,6 +3461,12 @@ func (c *Core) condenseDirectAppend(key boundaryKey, probe boundaryProbe, prevPa
 	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || uint64(len(c.nodes)) >= math.MaxUint32 {
 		return condenseOutcome{}, errors.New("parser-core phase zero: node arena cap")
 	}
+	maximum, err := c.linkPrecedenceMaximum(linkRecord{
+		prev: in.prev, payload: in.payload, scoreDelta: in.scoreDelta,
+	})
+	if err != nil {
+		return condenseOutcome{}, err
+	}
 	flags := uint32(0)
 	if in.order.Present {
 		flags |= linkFlagHasOrder
@@ -3260,10 +3476,10 @@ func (c *Core) condenseDirectAppend(key boundaryKey, probe boundaryProbe, prevPa
 		order: in.order.Value, flags: flags,
 	})
 	c.addWork(&c.work.GraphLinkAdditionsProxy, 1)
-	id, err := c.appendNodeAt(nodeRecord{
+	id, err := c.appendNodeAtWithMaximum(nodeRecord{
 		state: key.state, byteOffset: key.byteOffset,
 		firstLink: uint32(linkID), linkCount: 1, pathCount: prevPathCount,
-	}, key.checkpoint)
+	}, key.checkpoint, maximum.value)
 	if err != nil {
 		return condenseOutcome{}, err
 	}
@@ -3389,11 +3605,10 @@ func (c *Core) effectivePayloadPrecedence(payloadID SubtreeID, aggregate int64) 
 
 // factorExactPredecessor applies the narrow persistent one-layer form of C's
 // recursive stack-link insertion that phase zero can represent exactly. The
-// outer edge must match in every stored field except predecessor identity. A merely
-// shallow-equivalent outer edge is deliberately declined: tree-sitter also
-// updates a node-level maximum precedence in that case, and nodeRecord has no
-// authenticated equivalent yet.
-func (c *Core) factorExactPredecessor(key boundaryKey, probe boundaryProbe, oldID NodeID, oldLinks []linkRecord, in linkInput) (out condenseOutcome, handled bool, err error) {
+// outer edge must match in every stored field except predecessor identity, or
+// belong to the same shallow class. The private folded maximum records the
+// node-level precedence that C updates for the shallow non-exact case.
+func (c *Core) factorExactPredecessor(key boundaryKey, probe boundaryProbe, oldID NodeID, oldLinks []linkRecord, in linkInput, folded *precedenceMaximumWitness) (out condenseOutcome, handled bool, err error) {
 	for index, incumbent := range oldLinks {
 		if incumbent.prev == in.prev {
 			continue
@@ -3425,7 +3640,13 @@ func (c *Core) factorExactPredecessor(key boundaryKey, probe boundaryProbe, oldI
 			return condenseOutcome{}, true, errors.New("parser-core phase zero: recursive insertion declined inexact external payload provenance")
 		}
 		if !exactEdge {
-			return condenseOutcome{}, true, errors.New("parser-core phase zero: recursive insertion declined shallow non-exact outer edge")
+			pairsEqual, pairErr := c.subtreeScannerStatePairsEqual(incumbent.payload, in.payload)
+			if pairErr != nil {
+				return condenseOutcome{}, true, pairErr
+			}
+			if !pairsEqual {
+				return condenseOutcome{}, true, errors.New("parser-core phase zero: recursive insertion declined scanner-state pair mismatch")
+			}
 		}
 		if !shallow {
 			return condenseOutcome{}, true, errors.New("parser-core phase zero: exact recursive edge is not a clean shallow payload")
@@ -3434,7 +3655,7 @@ func (c *Core) factorExactPredecessor(key boundaryKey, probe boundaryProbe, oldI
 		// The merge-and-republish body owns a bounded transaction. It lives in a
 		// dedicated method so its completion defer is open-coded, not heap-
 		// allocated once per exact-predecessor factor by a loop-scoped defer.
-		return c.factorExactPredecessorMerge(key, probe, oldID, oldLinks, index, incumbent, in)
+		return c.factorExactPredecessorMerge(key, probe, oldID, oldLinks, index, incumbent, in, folded)
 	}
 	return condenseOutcome{}, false, nil
 }
@@ -3443,21 +3664,43 @@ func (c *Core) factorExactPredecessor(key boundaryKey, probe boundaryProbe, oldI
 // incoming edge and republishes the boundary. Callers pass the matched
 // incumbent link and its index. The transaction completion runs through a
 // single function-scoped defer, so it is open-coded and does not allocate.
-func (c *Core) factorExactPredecessorMerge(key boundaryKey, probe boundaryProbe, oldID NodeID, oldLinks []linkRecord, index int, incumbent linkRecord, in linkInput) (out condenseOutcome, handled bool, err error) {
+func (c *Core) factorExactPredecessorMerge(key boundaryKey, probe boundaryProbe, oldID NodeID, oldLinks []linkRecord, index int, incumbent linkRecord, in linkInput, folded *precedenceMaximumWitness) (out condenseOutcome, handled bool, err error) {
 	handled = true
 	mark := c.mark()
 	defer c.completeTransaction(mark, &err)
 	if phase0AEnabled {
 		phase0ABeginPredecessorMerge(c, incumbent.prev, in.prev)
 	}
-	merged, changed, mergeErr := c.mergePredecessorsBounded(incumbent.prev, in.prev, 0)
+	merged, changed, mergeErr := c.mergePredecessorsBounded(incumbent.prev, in.prev, 0, folded)
 	if mergeErr != nil {
 		if phase0AEnabled {
 			phase0AAbortPredecessorMerge(c)
 		}
 		return condenseOutcome{}, true, mergeErr
 	}
-	if !changed {
+	// The nested merge already authenticated and published its maximum on the
+	// merged predecessor. Recompute the outer edge exactly once. Do not carry
+	// nested discarded or replacement records into the outer adjacency.
+	*folded = precedenceMaximumWitness{}
+	oldMaximum, mergeErr := c.nodePrecedenceMaximum(oldID)
+	if mergeErr != nil {
+		return condenseOutcome{}, true, mergeErr
+	}
+	outerDiscarded := linkRecord{
+		prev: merged, payload: in.payload, scoreDelta: in.scoreDelta,
+	}
+	if in.order.Present {
+		outerDiscarded.order = in.order.Value
+		outerDiscarded.flags |= linkFlagHasOrder
+	}
+	if mergeErr := c.observeDiscardedLink(folded, outerDiscarded); mergeErr != nil {
+		return condenseOutcome{}, true, mergeErr
+	}
+	outerMaximum, mergeErr := c.linkPrecedenceMaximum(outerDiscarded)
+	if mergeErr != nil {
+		return condenseOutcome{}, true, mergeErr
+	}
+	if !changed && outerMaximum.value <= oldMaximum.value {
 		if phase0AEnabled {
 			phase0AAbortPredecessorMerge(c)
 			phase0AObserveFactorNoChange(c, key, in, oldID, index)
@@ -3476,7 +3719,7 @@ func (c *Core) factorExactPredecessorMerge(key boundaryKey, probe boundaryProbe,
 	if phase0AEnabled {
 		phase0APrepareFactorOuter(c, key, in, oldID, index, merged)
 	}
-	id, appendErr := c.appendAdjacencyNode(key.state, key.byteOffset, rebuilt)
+	id, appendErr := c.appendAdjacencyNodeAtWithPrecedence(key.state, key.byteOffset, key.checkpoint, rebuilt, *folded)
 	if appendErr != nil {
 		return condenseOutcome{}, true, appendErr
 	}
@@ -3497,7 +3740,7 @@ func (c *Core) factorExactPredecessorMerge(key boundaryKey, probe boundaryProbe,
 // family while keeping pathological graphs on a small, fixed stack budget.
 const maxRecursiveInsertDepth = 16
 
-func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int) (NodeID, bool, error) {
+func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int, folded *precedenceMaximumWitness) (NodeID, bool, error) {
 	if depth > maxRecursiveInsertDepth {
 		return 0, false, errors.New("parser-core phase zero: recursive insertion depth limit")
 	}
@@ -3512,6 +3755,14 @@ func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int) (Node
 	if err != nil {
 		return 0, false, err
 	}
+	if folded == nil {
+		return 0, false, errors.New("parser-core phase zero: missing folded precedence maximum witness")
+	}
+	leftMaximum, err := c.nodePrecedenceMaximum(leftID)
+	if err != nil {
+		return 0, false, err
+	}
+	*folded = precedenceMaximumWitness{}
 	leftCheckpoint, leftExact := c.nodeScannerCheckpoint(leftID)
 	rightCheckpoint, rightExact := c.nodeScannerCheckpoint(rightID)
 	if left.state != right.state || left.byteOffset != right.byteOffset ||
@@ -3539,16 +3790,29 @@ func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int) (Node
 	changed := false
 	for _, incoming := range rightLinks {
 		var inserted bool
-		links, inserted, err = c.insertLinkBounded(left.state, left.byteOffset, links, incoming, depth)
+		links, inserted, err = c.insertLinkBounded(left.state, left.byteOffset, links, incoming, depth, folded)
 		if err != nil {
 			return 0, false, err
 		}
 		changed = changed || inserted
 	}
+	if len(links) == 0 && !changed {
+		return leftID, false, nil
+	}
+	// C updates the containing node's maximum even when the incoming edge is
+	// shallow-equivalent and the link set stays unchanged. Recompute the final
+	// links and every authenticated discarded link before making that decision.
+	maximum, err := c.computePrecedenceMaximum(links, *folded)
+	if err != nil {
+		return 0, false, err
+	}
+	if !changed && maximum.value > leftMaximum.value {
+		changed = true
+	}
 	if !changed {
 		return leftID, false, nil
 	}
-	merged, err := c.appendAdjacencyNodeAt(left.state, left.byteOffset, leftCheckpoint, links)
+	merged, err := c.appendAdjacencyNodeAtWithPrecedence(left.state, left.byteOffset, leftCheckpoint, links, *folded)
 	if err != nil {
 		return 0, false, err
 	}
@@ -3560,7 +3824,17 @@ func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int) (Node
 // shallow payloads select the higher effective subtree precedence; every
 // other clean class remains in stable incumbent-first order. Boundary-equal
 // predecessors recurse only when their complete outer edges are exact.
-func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkRecord, incoming linkRecord, depth int) ([]linkRecord, bool, error) {
+
+func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkRecord, incoming linkRecord, depth int, folded *precedenceMaximumWitness) ([]linkRecord, bool, error) {
+	if folded == nil {
+		c.recordLinkUnionRejected()
+		return nil, false, errors.New("parser-core phase zero: missing folded precedence maximum witness")
+	}
+	_, err := c.linkPrecedenceMaximum(incoming)
+	if err != nil {
+		c.recordLinkUnionRejected()
+		return nil, false, err
+	}
 	if len(links) == 0 {
 		return append(slices.Clone(links), incoming), true, nil
 	}
@@ -3585,6 +3859,10 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 			return nil, false, errors.New("parser-core phase zero: recursive insertion declined inexact external payload provenance")
 		}
 		if c.linkRecordsEqual(incumbent, incoming) {
+			if err := c.observeDiscardedLink(folded, incoming); err != nil {
+				c.recordLinkUnionRejected()
+				return nil, false, err
+			}
 			c.recordLinkUnionDuplicateNoop()
 			if phase0AEnabled {
 				phase0AMergeDecision(c, index, phase0ATransitionDuplicateDrop)
@@ -3611,14 +3889,25 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 				return nil, false, err
 			}
 			if incomingPrecedence <= incumbentPrecedence {
+				if err := c.observeDiscardedLink(folded, incoming); err != nil {
+					c.recordLinkUnionRejected()
+					return nil, false, err
+				}
 				c.recordLinkUnionDuplicateNoop()
 				if phase0AEnabled {
 					phase0AMergeDecision(c, index, phase0ATransitionPrecedenceDrop)
 				}
 				return links, false, nil
 			}
+			if err := c.observeDiscardedLink(folded, incumbent); err != nil {
+				c.recordLinkUnionRejected()
+				return nil, false, err
+			}
 			updated := slices.Clone(links)
 			updated[index] = incoming
+			folded.replacement = incoming
+			folded.hasReplacement = true
+			folded.hasPostReplacement = false
 			c.recordLinkUnionPrecedenceReplaced()
 			if phase0AEnabled {
 				phase0AMergeDecision(c, index, phase0ATransitionPrecedenceReplacement)
@@ -3644,7 +3933,8 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 		if phase0AEnabled {
 			phase0ABeginPredecessorMerge(c, incumbent.prev, incoming.prev)
 		}
-		merged, changed, err := c.mergePredecessorsBounded(incumbent.prev, incoming.prev, depth+1)
+		nestedFolded := precedenceMaximumWitness{}
+		merged, changed, err := c.mergePredecessorsBounded(incumbent.prev, incoming.prev, depth+1, &nestedFolded)
 		if err != nil {
 			if phase0AEnabled {
 				phase0AAbortPredecessorMerge(c)
@@ -3653,6 +3943,10 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 			return nil, false, err
 		}
 		if !changed {
+			if err := c.observeDiscardedLink(folded, incoming); err != nil {
+				c.recordLinkUnionRejected()
+				return nil, false, err
+			}
 			if phase0AEnabled {
 				phase0AAbortPredecessorMerge(c)
 				phase0AMergeDecision(c, index, phase0ATransitionDuplicateDrop)
@@ -3664,14 +3958,41 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 			phase0AObserveAdjacencyPublished(c, merged)
 			phase0AMergeRecursiveDecision(c, index, merged)
 		}
+		mergedMaximum, err := c.nodePrecedenceMaximum(merged)
+		if err != nil {
+			c.recordLinkUnionRejected()
+			return nil, false, err
+		}
+		contribution, err := c.effectivePayloadPrecedence(incoming.payload, incoming.scoreDelta)
+		if err != nil {
+			c.recordLinkUnionRejected()
+			return nil, false, err
+		}
+		_, err = checkedAddScore(mergedMaximum.value, contribution)
+		if err != nil {
+			c.recordLinkUnionRejected()
+			return nil, false, errors.New("parser-core phase zero: precedence maximum overflow")
+		}
 		updated := slices.Clone(links)
 		updated[index].prev = merged
+		if folded.hasReplacement {
+			if err := c.observePostReplacementLink(folded, updated[index]); err != nil {
+				c.recordLinkUnionRejected()
+				return nil, false, err
+			}
+		}
 		c.recordLinkUnionRecursiveChanged()
 		return updated, true, nil
 	}
 	if uint32(len(links)) >= c.limits.MaxLinksPerBoundary {
 		c.recordLinkUnionRejected()
 		return nil, false, &LiveLinkCapacityError{State: state, ByteOffset: byteOffset, ObservedLinks: uint64(len(links)) + 1, Limit: c.limits.MaxLinksPerBoundary}
+	}
+	if folded.hasReplacement {
+		if err := c.observePostReplacementLink(folded, incoming); err != nil {
+			c.recordLinkUnionRejected()
+			return nil, false, err
+		}
 	}
 	c.recordLinkUnionAlternateAppended()
 	if phase0AEnabled {
@@ -3741,6 +4062,43 @@ func (c *Core) subtreeExternalProvenance(root SubtreeID) (hasExternal, exact boo
 		return has, true, nil
 	}
 	return walk(root)
+}
+
+// subtreeScannerStatePairsEqual compares the root post-scan state used by the
+// locked C route. Nonterminal roots carry empty scanner state. The helper
+// reads only interned checkpoint identities and allocates no scratch storage.
+func (c *Core) subtreeScannerStatePairsEqual(left, right SubtreeID) (bool, error) {
+	if c.externalPayloadsQuiescent {
+		return true, nil
+	}
+	rootEnd := func(id SubtreeID) (CheckpointID, error) {
+		record, err := c.subtree(id)
+		if err != nil {
+			return 0, err
+		}
+		if !record.external || !record.terminal {
+			return 0, nil
+		}
+		provenance, ok := c.externalPayloadScannerProvenance(id)
+		if !ok {
+			return 0, errors.New("parser-core phase zero: scanner-state pair proof is unavailable")
+		}
+		if provenance.end != 0 {
+			if _, ok := c.checkpoints.record(provenance.end); !ok {
+				return 0, errors.New("parser-core phase zero: scanner-state pair checkpoint is unavailable")
+			}
+		}
+		return provenance.end, nil
+	}
+	leftEnd, err := rootEnd(left)
+	if err != nil {
+		return false, err
+	}
+	rightEnd, err := rootEnd(right)
+	if err != nil {
+		return false, err
+	}
+	return leftEnd == rightEnd, nil
 }
 
 func (state subtreeExternalProvenanceState) result() (hasExternal, exact, cached bool) {
@@ -3913,6 +4271,13 @@ func (c *Core) appendAdjacencyNode(state StateID, byteOffset uint32, links []lin
 }
 
 func (c *Core) appendAdjacencyNodeAt(state StateID, byteOffset uint32, checkpoint CheckpointID, links []linkRecord) (NodeID, error) {
+	return c.appendAdjacencyNodeAtWithPrecedence(state, byteOffset, checkpoint, links, precedenceMaximumWitness{})
+}
+
+// appendAdjacencyNodeAtWithPrecedence authenticates the complete final link
+// slice before it appends any link. folded is private and is built only from
+// checked predecessor records and discarded incoming links.
+func (c *Core) appendAdjacencyNodeAtWithPrecedence(state StateID, byteOffset uint32, checkpoint CheckpointID, links []linkRecord, folded precedenceMaximumWitness) (NodeID, error) {
 	if len(links) == 0 {
 		return 0, errors.New("parser-core phase zero: recursive insertion produced empty adjacency")
 	}
@@ -3937,6 +4302,10 @@ func (c *Core) appendAdjacencyNodeAt(state StateID, byteOffset uint32, checkpoin
 		}
 		pathCount = saturatingAddPaths(pathCount, prev.pathCount)
 	}
+	maximum, err := c.computePrecedenceMaximum(links, folded)
+	if err != nil {
+		return 0, err
+	}
 	var first LinkID
 	for _, stored := range links {
 		copy := stored
@@ -3945,10 +4314,10 @@ func (c *Core) appendAdjacencyNodeAt(state StateID, byteOffset uint32, checkpoin
 		c.addWork(&c.work.GraphLinkAdditionsProxy, 1)
 		first = LinkID(len(c.links))
 	}
-	return c.appendNodeAt(nodeRecord{
+	return c.appendNodeAtWithMaximum(nodeRecord{
 		state: state, byteOffset: byteOffset, firstLink: uint32(first),
 		linkCount: uint32(len(links)), pathCount: pathCount,
-	}, checkpoint)
+	}, checkpoint, maximum.value)
 }
 
 // subtreesStructurallyEqual reports whether two compact payload subtrees are the
@@ -4068,31 +4437,37 @@ func (c *Core) replaceBoundaryLink(key boundaryKey, probe boundaryProbe, old nod
 	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || uint64(len(c.nodes)) >= math.MaxUint32 {
 		return Head{}, errors.New("parser-core phase zero: node arena cap")
 	}
+	rebuilt := slices.Clone(oldLinks)
+	rebuilt[candidate].prev = in.prev
+	rebuilt[candidate].payload = in.payload
+	rebuilt[candidate].scoreDelta = in.scoreDelta
+	rebuilt[candidate].order = in.order.Value
+	rebuilt[candidate].flags &^= linkFlagHasOrder
+	if in.order.Present {
+		rebuilt[candidate].flags |= linkFlagHasOrder
+	}
+	replacementWitness := precedenceMaximumWitness{
+		replacement: rebuilt[candidate], hasReplacement: true,
+	}
+	maximum, err := c.computePrecedenceMaximum(rebuilt, replacementWitness)
+	if err != nil {
+		return Head{}, err
+	}
 
 	linkMark := len(c.links)
 	linkRefMark := len(c.dropCohortLinkRefIndexes)
 	var first LinkID
-	for index, stored := range oldLinks {
+	for _, stored := range rebuilt {
 		copy := stored
-		if index == candidate {
-			copy.prev = in.prev
-			copy.payload = in.payload
-			copy.scoreDelta = in.scoreDelta
-			copy.order = in.order.Value
-			copy.flags &^= linkFlagHasOrder
-			if in.order.Present {
-				copy.flags |= linkFlagHasOrder
-			}
-		}
 		copy.next = first
 		c.appendGraphLink(copy)
 		c.addWork(&c.work.GraphLinkAdditionsProxy, 1)
 		first = LinkID(len(c.links))
 	}
-	id, err := c.appendNodeAt(nodeRecord{
+	id, err := c.appendNodeAtWithMaximum(nodeRecord{
 		state: key.state, byteOffset: key.byteOffset,
-		firstLink: uint32(first), linkCount: old.linkCount, pathCount: old.pathCount,
-	}, key.checkpoint)
+		firstLink: uint32(first), linkCount: uint32(len(rebuilt)), pathCount: old.pathCount,
+	}, key.checkpoint, maximum.value)
 	if err != nil {
 		c.links = c.links[:linkMark]
 		if c.dropCohortLinkRefIndexes != nil {
@@ -5104,6 +5479,24 @@ func (c *Core) appendNode(r nodeRecord) (NodeID, error) {
 }
 
 func (c *Core) appendNodeAt(r nodeRecord, checkpoint CheckpointID) (NodeID, error) {
+	if r.linkCount == 0 {
+		r.precedenceMax = 0
+	} else {
+		maximum, err := c.computePrecedenceMaximumFromNode(r, precedenceMaximumWitness{})
+		if err != nil {
+			return 0, err
+		}
+		r.precedenceMax = maximum.value
+	}
+	return c.appendNodeRecord(r, checkpoint)
+}
+
+func (c *Core) appendNodeAtWithMaximum(r nodeRecord, checkpoint CheckpointID, maximum int64) (NodeID, error) {
+	r.precedenceMax = maximum
+	return c.appendNodeRecord(r, checkpoint)
+}
+
+func (c *Core) appendNodeRecord(r nodeRecord, checkpoint CheckpointID) (NodeID, error) {
 	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || uint64(len(c.nodes)) >= math.MaxUint32 {
 		return 0, errors.New("parser-core phase zero: node arena cap")
 	}

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -2711,8 +2711,8 @@ func TestCompactArenaRecordsRemainPointerFree(t *testing.T) {
 			}
 		}
 	}
-	if got := unsafe.Sizeof(nodeRecord{}); got != 24 {
-		t.Fatalf("nodeRecord size = %d, want 24", got)
+	if got := unsafe.Sizeof(nodeRecord{}); got != 32 {
+		t.Fatalf("nodeRecord size = %d, want 32", got)
 	}
 	// G18 adds the value-owned drop-cohort reference set to this lineage
 	// record. Keep the 104-byte width explicit because every node pays it.

--- a/internal/parsercorephase0/dag_invariant_test.go
+++ b/internal/parsercorephase0/dag_invariant_test.go
@@ -45,7 +45,7 @@ func TestAppendNodeAuthenticatesCompleteAdjacency(t *testing.T) {
 	beforeNodes := len(compact.nodes)
 	if _, err := compact.appendNode(nodeRecord{
 		state: 2, byteOffset: 1, firstLink: uint32(len(compact.links)), linkCount: 1, pathCount: 1,
-	}); err == nil || !strings.Contains(err.Error(), "must be lower than new node") {
+	}); err == nil || !strings.Contains(err.Error(), "invalid node id 2") {
 		t.Fatalf("raw publication error=%v", err)
 	}
 	if len(compact.nodes) != beforeNodes {

--- a/internal/parsercorephase0/link_fold_test.go
+++ b/internal/parsercorephase0/link_fold_test.go
@@ -346,6 +346,10 @@ func TestDiagnosticShallowNonExactOuterEdgeUsesPrecedenceMaximum(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	beforeRecord, err := core.node(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
 	newHead, err := core.condense(key, linkInput{prev: rightSeed.Node, payload: right, scoreDelta: 2})
 	if err != nil {
 		t.Fatalf("shallow non-exact outer edge error=%v", err)
@@ -353,6 +357,8 @@ func TestDiagnosticShallowNonExactOuterEdgeUsesPrecedenceMaximum(t *testing.T) {
 	if newHead == head {
 		t.Fatal("shallow non-exact outer edge did not publish the higher private maximum")
 	}
+	// Arena-global stats fields (Nodes, Links) grow with the new publication;
+	// the historical head's own path count and full node record must not move.
 	after, statErr := core.Stats(head)
 	if statErr != nil || after.CurrentExactPaths != before.CurrentExactPaths {
 		t.Fatalf("historical head path count changed: before=%+v after=%+v err=%v", before, after, statErr)
@@ -360,6 +366,9 @@ func TestDiagnosticShallowNonExactOuterEdgeUsesPrecedenceMaximum(t *testing.T) {
 	oldRecord, err := core.node(head.Node)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if *oldRecord != *beforeRecord {
+		t.Fatalf("historical head record changed: before=%+v after=%+v", *beforeRecord, *oldRecord)
 	}
 	newRecord, err := core.node(newHead.Node)
 	if err != nil {

--- a/internal/parsercorephase0/link_fold_test.go
+++ b/internal/parsercorephase0/link_fold_test.go
@@ -314,7 +314,7 @@ func TestDiagnosticShallowFoldKeepsDistinctClasses(t *testing.T) {
 	}
 }
 
-func TestDiagnosticShallowNonExactOuterEdgeDeclinesRecursiveInsertion(t *testing.T) {
+func TestDiagnosticShallowNonExactOuterEdgeUsesPrecedenceMaximum(t *testing.T) {
 	core, leftSeed := newDiagnosticShallowFoldCore(t, Limits{MaxDerivations: 4})
 	rightNode, err := core.appendNode(nodeRecord{state: 1, byteOffset: 10, pathCount: 1})
 	if err != nil {
@@ -335,8 +335,8 @@ func TestDiagnosticShallowNonExactOuterEdgeDeclinesRecursiveInsertion(t *testing
 	if leftState != rightState || leftByte != rightByte {
 		t.Fatalf("predecessor boundaries differ: left=(%d,%d) right=(%d,%d)", leftState, leftByte, rightState, rightByte)
 	}
-	left := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 20, startByte: 12, endByte: 17})
-	right := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 20, productionID: 7, startByte: 12, endByte: 17})
+	left := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 20, startByte: 12, endByte: 17, childSymbols: []Symbol{30}})
+	right := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 20, productionID: 7, startByte: 12, endByte: 17, childSymbols: []Symbol{31}})
 	key := core.boundaryKey(2, 17)
 	head, err := core.condense(key, linkInput{prev: leftSeed.Node, payload: left, scoreDelta: 1})
 	if err != nil {
@@ -346,12 +346,27 @@ func TestDiagnosticShallowNonExactOuterEdgeDeclinesRecursiveInsertion(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = core.condense(key, linkInput{prev: rightSeed.Node, payload: right, scoreDelta: 2}); err == nil || !strings.Contains(err.Error(), "shallow non-exact outer edge") {
+	newHead, err := core.condense(key, linkInput{prev: rightSeed.Node, payload: right, scoreDelta: 2})
+	if err != nil {
 		t.Fatalf("shallow non-exact outer edge error=%v", err)
 	}
+	if newHead == head {
+		t.Fatal("shallow non-exact outer edge did not publish the higher private maximum")
+	}
 	after, statErr := core.Stats(head)
-	if statErr != nil || after != before {
-		t.Fatalf("decline mutated core: before=%+v after=%+v err=%v", before, after, statErr)
+	if statErr != nil || after.CurrentExactPaths != before.CurrentExactPaths {
+		t.Fatalf("historical head path count changed: before=%+v after=%+v err=%v", before, after, statErr)
+	}
+	oldRecord, err := core.node(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newRecord, err := core.node(newHead.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldRecord.precedenceMax != 1 || newRecord.precedenceMax != 2 {
+		t.Fatalf("old/new precedence maxima=%d/%d, want 1/2", oldRecord.precedenceMax, newRecord.precedenceMax)
 	}
 }
 

--- a/internal/parsercorephase0/link_provenance_test.go
+++ b/internal/parsercorephase0/link_provenance_test.go
@@ -14,6 +14,7 @@ type linkProvenanceFixture struct {
 	rangeValue LinkRange
 	refs       []DropCohortRef
 	action     Action
+	payload    SubtreeID
 	nodes      []NodeID
 }
 
@@ -35,8 +36,12 @@ func newLinkProvenanceFixture(t *testing.T, maxLinksPerBoundary uint32) linkProv
 	if err != nil {
 		t.Fatal(err)
 	}
-	firstLink := core.appendGraphLink(linkRecord{prev: firstNode})
-	secondLink := core.appendGraphLink(linkRecord{prev: secondNode, next: firstLink})
+	payload := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 20, productionID: action.ProductionID, startByte: 0, endByte: 1,
+		childSymbols: []Symbol{30},
+	})
+	firstLink := core.appendGraphLink(linkRecord{prev: firstNode, payload: payload})
+	secondLink := core.appendGraphLink(linkRecord{prev: secondNode, payload: payload, next: firstLink})
 	boundary, err := core.ClassifyBoundary(Head{Node: firstNode}, 9)
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +72,7 @@ func newLinkProvenanceFixture(t *testing.T, maxLinksPerBoundary uint32) linkProv
 	core.dropCohortCertificateRefs = append(core.dropCohortCertificateRefs, refs...)
 	return linkProvenanceFixture{
 		core: core, boundary: boundary, descriptor: boundary.actions.Descriptor(), plan: plan,
-		rangeValue: LinkRange{First: secondLink, Count: 2}, refs: refs, action: action,
+		rangeValue: LinkRange{First: secondLink, Count: 2}, refs: refs, action: action, payload: payload,
 		nodes: []NodeID{firstNode, secondNode},
 	}
 }
@@ -87,6 +92,7 @@ func TestLinkProvenanceDefaultOffAndAccounting(t *testing.T) {
 		t.Fatal("new core allocated link provenance sidecar")
 	}
 	want := uint64(len(core.nodes))*coreNodeRecordBytes + uint64(len(core.links))*coreLinkRecordBytes +
+		uint64(len(core.subtrees))*coreSubtreeRecordBytes + uint64(len(core.children))*coreChildRecordBytes +
 		uint64(len(core.dropCohortRecords))*coreDropCohortRecordBytes +
 		uint64(len(core.dropCohortMembers))*coreDropCohortMemberBytes +
 		uint64(len(core.dropCohortCertificateRefs))*coreDropCohortRefBytes
@@ -300,7 +306,7 @@ func TestReductionOutputCarriesAuthenticatedLinkChain(t *testing.T) {
 func TestReductionLinkChainHandoffPreservesNoncontiguousIDs(t *testing.T) {
 	fixture := newLinkProvenanceFixture(t, 8)
 	chainLink := fixture.core.appendGraphLink(linkRecord{
-		prev: fixture.nodes[0], next: fixture.rangeValue.First - 1,
+		prev: fixture.nodes[0], payload: fixture.payload, next: fixture.rangeValue.First - 1,
 	})
 	nodeID, err := fixture.core.appendNode(nodeRecord{
 		state: 3, byteOffset: 2, firstLink: uint32(chainLink), linkCount: 2, pathCount: 1,

--- a/internal/parsercorephase0/precedence_maximum_test.go
+++ b/internal/parsercorephase0/precedence_maximum_test.go
@@ -1,0 +1,495 @@
+package parsercorephase0
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestPrecedenceMaximumCertificateValues(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		score int64
+	}{
+		{name: "positive", score: 7},
+		{name: "zero", score: 0},
+		{name: "negative", score: -7},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			core := newTinyCoreWithLimits(t, Limits{})
+			seed, err := core.Seed(1, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			seedRecord, err := core.node(seed.Node)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if seedRecord.precedenceMax != 0 {
+				t.Fatalf("seed certificate=%+v, want zero", seedRecord)
+			}
+			payload := appendShallowPayload(t, core, shallowPayloadSpec{
+				symbol: 20, startByte: 0, endByte: 1, childSymbols: []Symbol{30},
+			})
+			child, err := core.appendAdjacencyNode(2, 1, []linkRecord{{
+				prev: seed.Node, payload: payload, scoreDelta: test.score,
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			record, err := core.node(child)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if record.precedenceMax != test.score {
+				t.Fatalf("certificate=%+v, want %d", record, test.score)
+			}
+		})
+	}
+}
+
+func TestPrecedenceMaximumLeafContributionIsZero(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{})
+	seed, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 20, startByte: 0, endByte: 1})
+	child, err := core.appendAdjacencyNode(2, 1, []linkRecord{{
+		prev: seed.Node, payload: payload, scoreDelta: math.MaxInt64,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := core.node(child)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.precedenceMax != 0 {
+		t.Fatalf("leaf certificate=%+v, want zero contribution", record)
+	}
+}
+
+func TestPrecedenceMaximumMissingCertificateFailsClosed(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{})
+	if _, err := core.computePrecedenceMaximum(nil, precedenceMaximumWitness{}); err == nil || !strings.Contains(err.Error(), "missing precedence maximum certificate") {
+		t.Fatalf("missing certificate error=%v", err)
+	}
+	left, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := core.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := core.mergePredecessorsBounded(left.Node, right.Node, 0, nil); err == nil || !strings.Contains(err.Error(), "missing folded precedence maximum witness") {
+		t.Fatalf("missing folded witness error=%v", err)
+	}
+}
+
+func TestPrecedenceMaximumOverflowFailsClosed(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{})
+	seed, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 20, startByte: 0, endByte: 1, childSymbols: []Symbol{30}})
+	maximum, err := core.appendAdjacencyNode(2, 1, []linkRecord{{
+		prev: seed.Node, payload: payload, scoreDelta: math.MaxInt64,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := core.appendAdjacencyNode(3, 2, []linkRecord{{
+		prev: maximum, payload: payload, scoreDelta: 1,
+	}}); err == nil || !strings.Contains(err.Error(), "precedence maximum overflow") {
+		t.Fatalf("overflow error=%v", err)
+	}
+}
+
+func TestPrecedenceMaximumDiscardedIncomingEdgeIsRetained(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	root, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	incumbent := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 20, productionID: 1, startByte: 0, endByte: 1, childSymbols: []Symbol{30},
+	})
+	incoming := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 20, productionID: 2, startByte: 0, endByte: 1, childSymbols: []Symbol{31},
+	})
+	left, err := core.appendAdjacencyNode(7, 0, []linkRecord{{
+		prev: root.Node, payload: incumbent, scoreDelta: 1,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := core.appendAdjacencyNode(7, 0, []linkRecord{{
+		prev: root.Node, payload: incoming, scoreDelta: 9,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	incumbentTop := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 30, productionID: 1, startByte: 1, endByte: 2, childSymbols: []Symbol{40},
+	})
+	incomingTop := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 30, productionID: 2, startByte: 1, endByte: 2, childSymbols: []Symbol{41},
+	})
+	key := core.boundaryKey(8, 2)
+	oldTop, err := core.condense(key, linkInput{prev: left, payload: incumbentTop, scoreDelta: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	merged, err := core.condense(key, linkInput{prev: right, payload: incomingTop, scoreDelta: 9})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if merged == oldTop {
+		t.Fatal("discarded incoming maximum did not publish a certified replacement")
+	}
+	oldRecord, err := core.node(oldTop.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newRecord, err := core.node(merged.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldRecord.precedenceMax != 2 || newRecord.precedenceMax != 18 {
+		t.Fatalf("old/new certificates=%+v/%+v, want 2/18", oldRecord, newRecord)
+	}
+	links, err := core.nodeLinks(*newRecord)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 1 || links[0].prev == right {
+		t.Fatalf("replacement links=%#v, want the incumbent lower edge", links)
+	}
+}
+
+func TestPrecedenceMaximumReplacementThenLaterCandidateUsesOrder(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		laterScore int64
+		want       int64
+	}{
+		{name: "higher later candidate", laterScore: 9, want: 9},
+		{name: "lower later candidate", laterScore: 3, want: 5},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			core := newTinyCoreWithLimits(t, Limits{})
+			root, err := core.Seed(1, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			incumbent := appendShallowPayload(t, core, shallowPayloadSpec{
+				symbol: 20, productionID: 1, startByte: 0, endByte: 1, childSymbols: []Symbol{30},
+			})
+			replacement := appendShallowPayload(t, core, shallowPayloadSpec{
+				symbol: 20, productionID: 2, startByte: 0, endByte: 1, childSymbols: []Symbol{31},
+			})
+			preReplacementSibling := appendShallowPayload(t, core, shallowPayloadSpec{
+				symbol: 21, startByte: 0, endByte: 1, childSymbols: []Symbol{32},
+			})
+			later := appendShallowPayload(t, core, shallowPayloadSpec{
+				symbol: 22, startByte: 0, endByte: 1, childSymbols: []Symbol{33},
+			})
+			left, err := core.appendAdjacencyNode(7, 0, []linkRecord{
+				{prev: root.Node, payload: incumbent, scoreDelta: 1},
+				{prev: root.Node, payload: preReplacementSibling, scoreDelta: 100},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			right, err := core.appendAdjacencyNode(7, 0, []linkRecord{
+				{prev: root.Node, payload: replacement, scoreDelta: 5},
+				{prev: root.Node, payload: later, scoreDelta: test.laterScore},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			merged, changed, err := core.mergePredecessorsBounded(left, right, 0, &precedenceMaximumWitness{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !changed {
+				t.Fatal("ordered replacement did not publish a new node")
+			}
+			record, err := core.node(merged)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if record.precedenceMax != test.want {
+				t.Fatalf("ordered precedence maximum=%d, want %d", record.precedenceMax, test.want)
+			}
+		})
+	}
+}
+
+func TestPrecedenceMaximumNestedOuterNegativeRecomputesFromMergedPredecessor(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	base, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	innerIncumbent := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 20, productionID: 1, startByte: 0, endByte: 1, childSymbols: []Symbol{30},
+	})
+	innerReplacement := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 20, productionID: 2, startByte: 0, endByte: 1, childSymbols: []Symbol{31},
+	})
+	leftPredecessor, err := core.appendAdjacencyNode(7, 1, []linkRecord{{
+		prev: base.Node, payload: innerIncumbent, scoreDelta: 9,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightPredecessor, err := core.appendAdjacencyNode(7, 1, []linkRecord{{
+		prev: base.Node, payload: innerReplacement, scoreDelta: 10,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outerPayload := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 30, startByte: 1, endByte: 2, childSymbols: []Symbol{40},
+	})
+	key := core.boundaryKey(8, 2)
+	old, err := core.condense(key, linkInput{
+		prev: leftPredecessor, payload: outerPayload, scoreDelta: -20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	merged, err := core.condense(key, linkInput{
+		prev: rightPredecessor, payload: outerPayload, scoreDelta: -20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if merged == old {
+		t.Fatal("nested outer merge did not publish a fresh boundary")
+	}
+	record, err := core.node(merged.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.precedenceMax != -10 {
+		t.Fatalf("nested outer precedence maximum=%d, want -10", record.precedenceMax)
+	}
+}
+
+func TestPrecedenceMaximumReplacementThenNestedNegativeUsesOuterCandidate(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	base, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	directIncumbent := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 20, productionID: 1, startByte: 0, endByte: 1, childSymbols: []Symbol{30},
+	})
+	directReplacement := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 20, productionID: 2, startByte: 0, endByte: 1, childSymbols: []Symbol{31},
+	})
+	innerIncumbent := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 21, productionID: 3, startByte: 0, endByte: 1, childSymbols: []Symbol{40},
+	})
+	innerReplacement := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 21, productionID: 4, startByte: 0, endByte: 1, childSymbols: []Symbol{41},
+	})
+	leftPredecessor, err := core.appendAdjacencyNode(7, 1, []linkRecord{{
+		prev: base.Node, payload: innerIncumbent, scoreDelta: 9,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightPredecessor, err := core.appendAdjacencyNode(7, 1, []linkRecord{{
+		prev: base.Node, payload: innerReplacement, scoreDelta: 11,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outerPayload := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 30, startByte: 1, endByte: 2, childSymbols: []Symbol{50},
+	})
+	leftLinks := []linkRecord{
+		{prev: base.Node, payload: directIncumbent, scoreDelta: 1},
+		{prev: leftPredecessor, payload: outerPayload, scoreDelta: -20},
+	}
+	rightLinks := []linkRecord{
+		{prev: base.Node, payload: directReplacement, scoreDelta: 5},
+		{prev: rightPredecessor, payload: outerPayload, scoreDelta: -20},
+	}
+	left, err := core.appendAdjacencyNode(8, 2, leftLinks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := core.appendAdjacencyNode(8, 2, rightLinks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	witness := precedenceMaximumWitness{}
+	merged, changed, err := core.mergePredecessorsBounded(left, right, 0, &witness)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("replacement and nested merge did not publish a fresh node")
+	}
+	record, err := core.node(merged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.precedenceMax != 5 {
+		t.Fatalf("replacement and nested precedence maximum=%d, want 5", record.precedenceMax)
+	}
+	if !witness.hasPostReplacement {
+		t.Fatal("replacement and nested merge lost the authenticated outer post-replacement candidate")
+	}
+	post, err := core.linkPrecedenceMaximum(witness.postReplacement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if post.value != -9 {
+		t.Fatalf("post-replacement candidate=%d, want outer candidate -9", post.value)
+	}
+}
+
+func TestPrecedenceMaximumOverflowRollsBackCondense(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{})
+	seed, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 20, startByte: 0, endByte: 1, childSymbols: []Symbol{30}})
+	first, err := core.condense(core.boundaryKey(2, 1), linkInput{
+		prev: seed.Node, payload: payload, scoreDelta: math.MaxInt64,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeNodes, beforeLinks, beforeWork := len(core.nodes), len(core.links), core.Work()
+	if _, err := core.condense(core.boundaryKey(3, 2), linkInput{
+		prev: first.Node, payload: payload, scoreDelta: 1,
+	}); err == nil || !strings.Contains(err.Error(), "precedence maximum overflow") {
+		t.Fatalf("rollback overflow error=%v", err)
+	}
+	if len(core.nodes) != beforeNodes || len(core.links) != beforeLinks || core.Work() != beforeWork {
+		t.Fatalf("overflow rollback changed graph: nodes=%d/%d links=%d/%d work=%+v/%+v", len(core.nodes), beforeNodes, len(core.links), beforeLinks, core.Work(), beforeWork)
+	}
+}
+
+func newScannerPairCheckpoint(t *testing.T, core *Core, value byte) CheckpointID {
+	t.Helper()
+	return mustInternCheckpoint(t, core, []byte{value})
+}
+
+func TestScannerStatePairNonterminalRootsIgnoreDescendants(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{})
+	start := newScannerPairCheckpoint(t, core, 1)
+	endLeft := newScannerPairCheckpoint(t, core, 2)
+	endRight := newScannerPairCheckpoint(t, core, 3)
+	if err := core.SetPhaseExternalTokenScannerCheckpoints(start, endLeft); err != nil {
+		t.Fatal(err)
+	}
+	leftChild, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := core.SetPhaseExternalTokenScannerCheckpoints(start, endRight); err != nil {
+		t.Fatal(err)
+	}
+	rightChild, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 21, external: true, terminal: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := core.appendSubtree(subtreeRecord{symbol: 30}, []SubtreeID{leftChild}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := core.appendSubtree(subtreeRecord{symbol: 31}, []SubtreeID{rightChild}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	equal, err := core.subtreeScannerStatePairsEqual(left, right)
+	if err != nil || !equal {
+		t.Fatalf("nonterminal scanner state equal=%t err=%v, want empty-state equality", equal, err)
+	}
+}
+
+func TestScannerStatePairDistinctPayloadsEqualEndState(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{})
+	leftStart := newScannerPairCheckpoint(t, core, 1)
+	rightStart := newScannerPairCheckpoint(t, core, 2)
+	end := newScannerPairCheckpoint(t, core, 3)
+	if err := core.SetPhaseExternalTokenScannerCheckpoints(leftStart, end); err != nil {
+		t.Fatal(err)
+	}
+	left, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := core.SetPhaseExternalTokenScannerCheckpoints(rightStart, end); err != nil {
+		t.Fatal(err)
+	}
+	right, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 21, external: true, terminal: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	equal, err := core.subtreeScannerStatePairsEqual(left, right)
+	if err != nil || !equal {
+		t.Fatalf("equal-end scanner state equal=%t err=%v, want equal", equal, err)
+	}
+}
+
+func TestScannerStatePairUnequalEndStateDeclines(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{})
+	start := newScannerPairCheckpoint(t, core, 1)
+	leftEnd := newScannerPairCheckpoint(t, core, 2)
+	rightEnd := newScannerPairCheckpoint(t, core, 3)
+	if err := core.SetPhaseExternalTokenScannerCheckpoints(start, leftEnd); err != nil {
+		t.Fatal(err)
+	}
+	left, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := core.SetPhaseExternalTokenScannerCheckpoints(start, rightEnd); err != nil {
+		t.Fatal(err)
+	}
+	right, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	equal, err := core.subtreeScannerStatePairsEqual(left, right)
+	if err != nil || equal {
+		t.Fatalf("unequal-end scanner state equal=%t err=%v, want mismatch", equal, err)
+	}
+}
+
+func TestScannerStatePairIgnoresStartStateDifference(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{})
+	leftStart := newScannerPairCheckpoint(t, core, 1)
+	rightStart := newScannerPairCheckpoint(t, core, 2)
+	end := newScannerPairCheckpoint(t, core, 3)
+	if err := core.SetPhaseExternalTokenScannerCheckpoints(leftStart, end); err != nil {
+		t.Fatal(err)
+	}
+	left, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := core.SetPhaseExternalTokenScannerCheckpoints(rightStart, end); err != nil {
+		t.Fatal(err)
+	}
+	right, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	equal, err := core.subtreeScannerStatePairsEqual(left, right)
+	if err != nil || !equal {
+		t.Fatalf("start-only scanner difference equal=%t err=%v, want equal", equal, err)
+	}
+}

--- a/internal/parsercorephase0/precedence_rule_table_test.go
+++ b/internal/parsercorephase0/precedence_rule_table_test.go
@@ -1,0 +1,304 @@
+package parsercorephase0
+
+import (
+	"testing"
+)
+
+// The tests below pin the C dynamic-precedence rule table from
+// stack_node_add_link (stack.c:199-264) and stack_node_new (stack.c:137-176)
+// against the persistent core, one case per C branch:
+//
+//	rule 1  same pair, higher subtree precedence: assign (can lower)
+//	rule 2  same pair, not higher, or exact duplicate: no update
+//	rule 3  mergeable predecessors: max with the INCOMING predecessor's
+//	        stored value plus the payload contribution
+//	rule 5  append: max with the appended link's contribution
+//
+// C keeps one stored running value per node. Rule 1 assignment can leave the
+// stored value BELOW the maximum over the node's own links; every later
+// operation folds from the stored value, never from a link recompute.
+
+type ruleTableFixture struct {
+	core       *Core
+	rootP      NodeID
+	rootQ      NodeID
+	lowA       SubtreeID // shallow class X, production 1
+	lowB       SubtreeID // shallow class X, production 2 (shallow-equal to lowA)
+	high       SubtreeID // distinct shallow class
+	top        SubtreeID // boundary payload, child-bearing
+	checkpoint CheckpointID
+}
+
+func newRuleTableFixture(t *testing.T) ruleTableFixture {
+	t.Helper()
+	core := newTinyCoreWithLimits(t, Limits{MaxDerivations: 32, MaxPopPaths: 32})
+	rootP, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootQ, err := core.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lowA := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 20, productionID: 1, startByte: 0, endByte: 10, childSymbols: []Symbol{40},
+	})
+	lowB := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 20, productionID: 2, startByte: 0, endByte: 10, childSymbols: []Symbol{41},
+	})
+	high := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 21, productionID: 3, startByte: 0, endByte: 10, childSymbols: []Symbol{42},
+	})
+	top := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 30, startByte: 10, endByte: 11, childSymbols: []Symbol{50},
+	})
+	checkpoint := mustInternCheckpoint(t, core, make([]byte, 32))
+	if err := core.SetPhaseCheckpoint(checkpoint); err != nil {
+		t.Fatal(err)
+	}
+	return ruleTableFixture{
+		core: core, rootP: rootP.Node, rootQ: rootQ.Node,
+		lowA: lowA, lowB: lowB, high: high, top: top, checkpoint: checkpoint,
+	}
+}
+
+func (f ruleTableFixture) nodeMaximum(t *testing.T, id NodeID) int64 {
+	t.Helper()
+	record, err := f.core.node(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return record.precedenceMax
+}
+
+// storedBelowLinkMaximum builds the rule-1 gadget: a node whose stored
+// maximum (3) sits below the maximum over its own links (100). The gadget is
+// the merge product of {P lowA 2, Q high 100} with an incoming same-pair
+// replacement {P lowB 3}: C assigns 0+3 and never revisits the Q link.
+func (f ruleTableFixture) storedBelowLinkMaximum(t *testing.T) NodeID {
+	t.Helper()
+	left, err := f.core.appendAdjacencyNode(7, 10, []linkRecord{
+		{prev: f.rootP, payload: f.lowA, scoreDelta: 2},
+		{prev: f.rootQ, payload: f.high, scoreDelta: 100},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := f.nodeMaximum(t, left); got != 100 {
+		t.Fatalf("fresh left maximum=%d, want 100", got)
+	}
+	right, err := f.core.appendAdjacencyNode(7, 10, []linkRecord{
+		{prev: f.rootP, payload: f.lowB, scoreDelta: 3},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	folded := precedenceMaximumWitness{}
+	merged, changed, err := f.core.mergePredecessorsBounded(left, right, 0, &folded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("gadget merge must replace the same-pair link")
+	}
+	if got := f.nodeMaximum(t, merged); got != 3 {
+		t.Fatalf("gadget stored maximum=%d, want the rule-1 assignment 3", got)
+	}
+	return merged
+}
+
+// Rule 1 assignment must lower the stored value below the link maximum, and
+// rule 2 exact duplicates must then leave both the value and the graph
+// untouched: C performs zero mutation, so the merge must return the incumbent
+// node without publishing a duplicate.
+func TestPrecedenceRuleTableDuplicateMergeKeepsStoredValue(t *testing.T) {
+	f := newRuleTableFixture(t)
+	gadget := f.storedBelowLinkMaximum(t)
+	gadgetRecord, err := f.core.node(gadget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var inline [inlineAdjacencyCapacity]linkRecord
+	links, err := f.core.publishedNodeLinksInto(inline[:0], *gadgetRecord)
+	if err != nil {
+		t.Fatal(err)
+	}
+	duplicate, err := f.core.appendAdjacencyNode(7, 10, links)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodesBefore := len(f.core.nodes)
+	folded := precedenceMaximumWitness{}
+	merged, changed, err := f.core.mergePredecessorsBounded(gadget, duplicate, 0, &folded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed || merged != gadget {
+		t.Fatalf("duplicate merge changed=%v merged=%d, want unchanged incumbent %d", changed, merged, gadget)
+	}
+	if nodesAfter := len(f.core.nodes); nodesAfter != nodesBefore {
+		t.Fatalf("duplicate merge published %d new nodes, want zero", nodesAfter-nodesBefore)
+	}
+	if got := f.nodeMaximum(t, gadget); got != 3 {
+		t.Fatalf("stored maximum=%d after duplicate merge, want 3", got)
+	}
+}
+
+// Rule 3 at the boundary reads the INCOMING predecessor's stored value. When
+// the nested merge is a no-op and the incoming predecessor's stored value
+// exceeds the boundary's, C still raises the boundary value. The incumbent
+// here is the gadget (stored 3); the incoming twin stores 100 over an equal
+// link set, so only the incoming read produces the update.
+func TestPrecedenceRuleTableOuterMergeReadsIncomingPredecessor(t *testing.T) {
+	f := newRuleTableFixture(t)
+	gadget := f.storedBelowLinkMaximum(t)
+	gadgetRecord, err := f.core.node(gadget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var inline [inlineAdjacencyCapacity]linkRecord
+	links, err := f.core.publishedNodeLinksInto(inline[:0], *gadgetRecord)
+	if err != nil {
+		t.Fatal(err)
+	}
+	twin, err := f.core.appendAdjacencyNode(7, 10, links)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := f.nodeMaximum(t, twin); got != 100 {
+		t.Fatalf("twin stored maximum=%d, want 100", got)
+	}
+	key := f.core.boundaryKey(8, 11)
+	oldTop, err := f.core.condense(key, linkInput{prev: gadget, payload: f.top})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := f.nodeMaximum(t, oldTop.Node); got != 3 {
+		t.Fatalf("boundary stored maximum=%d, want the gadget seed 3", got)
+	}
+	merged, err := f.core.condense(key, linkInput{prev: twin, payload: f.top})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := f.nodeMaximum(t, merged.Node); got != 100 {
+		t.Fatalf("boundary maximum=%d after outer merge, want the incoming predecessor's 100", got)
+	}
+}
+
+// Rule 3 on the changed path must also fold the incoming predecessor's
+// PRE-MERGE stored value. The nested merge processes the incoming links in
+// order {high assign 40, low assign 3}, so the merged node stores 3 while the
+// incoming predecessor stores 40. C maxes the containing node with 40.
+func TestPrecedenceRuleTableChangedMergeFoldsIncomingValue(t *testing.T) {
+	f := newRuleTableFixture(t)
+	lowD := appendShallowPayload(t, f.core, shallowPayloadSpec{
+		symbol: 22, productionID: 4, startByte: 0, endByte: 10, childSymbols: []Symbol{43},
+	})
+	lowC := appendShallowPayload(t, f.core, shallowPayloadSpec{
+		symbol: 22, productionID: 5, startByte: 0, endByte: 10, childSymbols: []Symbol{44},
+	})
+	inner, err := f.core.appendAdjacencyNode(7, 10, []linkRecord{
+		{prev: f.rootP, payload: f.lowA, scoreDelta: 2},
+		{prev: f.rootQ, payload: lowD, scoreDelta: 39},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	incoming, err := f.core.appendAdjacencyNode(7, 10, []linkRecord{
+		{prev: f.rootQ, payload: lowC, scoreDelta: 40},
+		{prev: f.rootP, payload: f.lowB, scoreDelta: 3},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := f.nodeMaximum(t, incoming); got != 40 {
+		t.Fatalf("incoming stored maximum=%d, want 40", got)
+	}
+	outerLeft, err := f.core.appendAdjacencyNode(9, 10, []linkRecord{
+		{prev: inner, payload: f.top, scoreDelta: 0},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outerRight, err := f.core.appendAdjacencyNode(9, 10, []linkRecord{
+		{prev: incoming, payload: f.top, scoreDelta: 0},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := f.nodeMaximum(t, outerLeft); got != 39 {
+		t.Fatalf("outer left stored maximum=%d, want 39", got)
+	}
+	folded := precedenceMaximumWitness{}
+	merged, changed, err := f.core.mergePredecessorsBounded(outerLeft, outerRight, 0, &folded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("outer merge must rewrite the nested predecessor link")
+	}
+	if got := f.nodeMaximum(t, merged); got != 40 {
+		t.Fatalf("outer maximum=%d, want the incoming pre-merge fold 40", got)
+	}
+}
+
+// Rule 2 after a rule-1 assignment must record nothing. The incoming set
+// first replaces the same-pair link (assign 3) and then presents an exact
+// duplicate of the high sibling link. C leaves the assigned 3 in place.
+func TestPrecedenceRuleTableDuplicateAfterReplacementRecordsNothing(t *testing.T) {
+	f := newRuleTableFixture(t)
+	left, err := f.core.appendAdjacencyNode(7, 10, []linkRecord{
+		{prev: f.rootP, payload: f.lowA, scoreDelta: 2},
+		{prev: f.rootQ, payload: f.high, scoreDelta: 100},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := f.core.appendAdjacencyNode(7, 10, []linkRecord{
+		{prev: f.rootP, payload: f.lowB, scoreDelta: 3},
+		{prev: f.rootQ, payload: f.high, scoreDelta: 100},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	folded := precedenceMaximumWitness{}
+	merged, changed, err := f.core.mergePredecessorsBounded(left, right, 0, &folded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("replacement merge must change the adjacency")
+	}
+	if got := f.nodeMaximum(t, merged); got != 3 {
+		t.Fatalf("merged maximum=%d, want the rule-1 assignment 3", got)
+	}
+}
+
+// Rule 5 appends must max the appended link's contribution into the stored
+// value even though publication no longer recomputes over the adjacency.
+func TestPrecedenceRuleTableAppendFoldsContribution(t *testing.T) {
+	f := newRuleTableFixture(t)
+	left, err := f.core.appendAdjacencyNode(7, 10, []linkRecord{
+		{prev: f.rootP, payload: f.lowA, scoreDelta: 2},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := f.core.appendAdjacencyNode(7, 10, []linkRecord{
+		{prev: f.rootQ, payload: f.high, scoreDelta: 77},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	folded := precedenceMaximumWitness{}
+	merged, changed, err := f.core.mergePredecessorsBounded(left, right, 0, &folded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("append merge must change the adjacency")
+	}
+	if got := f.nodeMaximum(t, merged); got != 77 {
+		t.Fatalf("merged maximum=%d, want the appended contribution 77", got)
+	}
+}

--- a/internal/parsercorephase0/recursive_insert_test.go
+++ b/internal/parsercorephase0/recursive_insert_test.go
@@ -897,13 +897,13 @@ func TestRecursiveInsertExactExternalRollback(t *testing.T) {
 func TestRecursiveInsertDeclinesSelfAndAncestry(t *testing.T) {
 	core := newTinyCoreWithLimits(t, Limits{})
 	seed, _ := core.Seed(1, 0)
-	if _, _, err := core.mergePredecessorsBounded(seed.Node, seed.Node, 0); err == nil || !strings.Contains(err.Error(), "self-merge") {
+	if _, _, err := core.mergePredecessorsBounded(seed.Node, seed.Node, 0, &precedenceMaximumWitness{}); err == nil || !strings.Contains(err.Error(), "self-merge") {
 		t.Fatalf("self merge error=%v", err)
 	}
 	payload := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 20, endByte: 1})
 	rightID, _ := core.appendNode(nodeRecord{state: 7, byteOffset: 1, pathCount: 1})
 	leftID, _ := core.appendAdjacencyNode(7, 1, []linkRecord{{prev: rightID, payload: payload}})
-	if _, _, err := core.mergePredecessorsBounded(leftID, rightID, 0); err == nil || !strings.Contains(err.Error(), "ancestry-related") {
+	if _, _, err := core.mergePredecessorsBounded(leftID, rightID, 0, &precedenceMaximumWitness{}); err == nil || !strings.Contains(err.Error(), "ancestry-related") {
 		t.Fatalf("ancestry merge error=%v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Add an authenticated cumulative precedence maximum for recursive insertion.
- Admit the Haskell small direct compact route with exact locked-C tree parity.
- Keep the eight-link cap unchanged.

## Validation

- Run focused Docker tests with `gts_parsercorephase0 gts_merge_census`, `GOMAXPROCS=1`, and `GOFLAGS=-p=1`.
- Run the 97-row matrix: 64 PASS, 25 FALLBACK, 8 SKIP, with zero divergence and error.
- Match the locked-C digest `6e3806c54c39af93701157f87ac8ee9ef947108d66b7d6069d6908a4d5c71e9f` for Haskell small.