### PR TITLE
fix: Defer contextual close-angle in the compact route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,11 @@ for tags and release notes while still in `0.x`.
 
 ### Correctness
 
+- Apply the production route's contextual close-angle deferral in the
+  compact dispatch and the C4 corridor (issue #983). Add the two Swift
+  witnesses to the committed route-equality seed corpus. Totals stay
+  unchanged: 69/0/30/10 canonical, 88/0/46/12 full.
+
 - Added bounded materiality-only acceptance for no-primary multi-derivation
   end-of-file (EOF) frontiers. The route selects a deterministic provisional
   candidate only for the existing bounded public-tree comparison. It routes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,10 @@ for tags and release notes while still in `0.x`.
 - Apply the production route's contextual close-angle deferral in the
   compact dispatch and the C4 corridor (issue #983). Add the two Swift
   witnesses to the committed route-equality seed corpus. Totals stay
-  unchanged: 69/0/30/10 canonical, 88/0/46/12 full.
+  unchanged: 69/0/30/10 canonical, 88/0/46/12 full. Re-adjudicate the
+  `swift_log_1` and `swift_log_2` rows in the T3 oracle witness manifest:
+  the compact route now reports the error tree, so `compact_has_error`
+  moves from false to true and all three runtimes agree on both rows.
 
 - Added bounded materiality-only acceptance for no-primary multi-derivation
   end-of-file (EOF) frontiers. The route selects a deterministic provisional

--- a/admission_route_equality_close_angle_deferral_test.go
+++ b/admission_route_equality_close_angle_deferral_test.go
@@ -1,0 +1,97 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// This file is gts_parsercorephase0-tagged (positive opt-in), matching
+// admission_route_equality_swift_residual_test.go's own reasoning: loading
+// the swift grammar retains memory no always-on (untagged) test should pay
+// for, so this pin stays out of the default suite.
+
+// TestCompactSchedulerDeclinesContextualCloseAngleDeferralWithDistinctDetail
+// pins finding F2: the shared token source splits Swift's ">>" into two
+// ">" tokens (issue #983); the generic scheduler's dispatch pass defers the
+// narrower one whenever the elected header's own lex mode reads the wider
+// ">>" with a real action. That deferral must not be reported as a
+// genuinely empty action row (diagnosticParserCoreNoTableActionDetail):
+// the row was never empty, production simply must not act on it this pass.
+// The decline still classifies as the typed recovery boundary (routing to
+// production is unchanged), but with a distinct, accurate detail.
+//
+// Both inputs are the two Swift witnesses already committed to
+// FuzzAdmissionRouteEquality's seed corpus (fuzz_admission_route_equality_test.go,
+// issue #983 pin) -- this test additionally proves those two witnesses
+// decline for the deferral-specific reason, not the empty-row one, which
+// the public Parse API's route-equality assertion alone cannot observe.
+func TestCompactSchedulerDeclinesContextualCloseAngleDeferralWithDistinctDetail(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	entry := grammars.DetectLanguageByName("swift")
+	if entry == nil {
+		t.Fatal("swift is absent from the language registry")
+	}
+	lang := entry.Language()
+
+	const wantDetail = "generic scheduler deferred a contextual close-angle action for the elected token"
+
+	for _, src := range [][]byte{[]byte("0>>"), []byte(" 0%0>>")} {
+		src := src
+		t.Run(string(src), func(t *testing.T) {
+			receipt, err := gts.RunStateDependentRelexSchedulerForTest(lang, src)
+			if err != nil {
+				t.Fatalf("compact scheduler: %v", err)
+			}
+			if receipt.Acceptance != nil {
+				t.Fatalf("compact scheduler unexpectedly accepted %q; the deferral shape did not trigger", src)
+			}
+			if receipt.Stop.Boundary != gts.DiagnosticParserCoreRecovery {
+				t.Fatalf("stop boundary = %q, want %q (routing must stay unchanged)",
+					receipt.Stop.Boundary, gts.DiagnosticParserCoreRecovery)
+			}
+			if receipt.Stop.Detail != wantDetail {
+				t.Fatalf("stop detail = %q, want %q (not the empty-row detail)", receipt.Stop.Detail, wantDetail)
+			}
+		})
+	}
+}
+
+// TestAdmissionRouteEqualitySwiftCloseAngleDeferralWitnessesStillFallBack
+// asserts no divergence for the same two seed-corpus witnesses through the
+// shipped public Parse route: the compact candidate must decline (an
+// engine-side fallback, never routed), so Parse already served the
+// production tree within the same call and the two routes cannot diverge.
+// This is the same invariant FuzzAdmissionRouteEquality's seed corpus
+// checks on every run; this test pins it directly for the two named
+// witnesses, independent of the fuzz corpus staying intact.
+func TestAdmissionRouteEqualitySwiftCloseAngleDeferralWitnessesStillFallBack(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	entry := grammars.DetectLanguageByName("swift")
+	if entry == nil {
+		t.Fatal("swift is absent from the language registry")
+	}
+	lang := entry.Language()
+
+	for _, src := range [][]byte{[]byte("0>>"), []byte(" 0%0>>")} {
+		src := src
+		t.Run(string(src), func(t *testing.T) {
+			gts.ResetAdmissionCandidateCountersForTest()
+			parser := gts.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(true)
+			tree, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			defer tree.Release()
+
+			routed, fallback := gts.AdmissionCandidateCounters()
+			if routed != 0 || fallback != 1 {
+				t.Fatalf("routed=%d fallback=%d, want routed=0 fallback=1 (compact must decline, not accept a divergent derivation)", routed, fallback)
+			}
+		})
+	}
+}

--- a/admission_route_equality_close_angle_deferral_test.go
+++ b/admission_route_equality_close_angle_deferral_test.go
@@ -37,7 +37,7 @@ func TestCompactSchedulerDeclinesContextualCloseAngleDeferralWithDistinctDetail(
 	}
 	lang := entry.Language()
 
-	const wantDetail = "generic scheduler deferred a contextual close-angle action for the elected token"
+	wantDetail := gts.DiagnosticParserCoreContextualCloseAngleDeferralDetailForTest()
 
 	for _, src := range [][]byte{[]byte("0>>"), []byte(" 0%0>>")} {
 		src := src

--- a/cgo_harness/testdata/compact_t3_oracle_witnesses_v2.json
+++ b/cgo_harness/testdata/compact_t3_oracle_witnesses_v2.json
@@ -542,7 +542,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -569,7 +569,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     }
   ]

--- a/fuzz_admission_route_equality_test.go
+++ b/fuzz_admission_route_equality_test.go
@@ -299,6 +299,15 @@ func seedAdmissionRouteEqualityCorpus(f *testing.F, languages []admissionRouteEq
 	f.Add([]byte("a; # ; b"), langIndex["javascript"])
 	f.Add([]byte("<html> & <body>Hello</body></html>"), langIndex["html"])
 	f.Add([]byte("e \\ cho hi"), langIndex["bash"])
+
+	// Issue #983 pin: the shared token source splits Swift's ">>" into two
+	// ">" tokens. Production's contextualActionIndex defers the narrow ">"
+	// shift whenever the header's own lex mode reads the wider ">>" with a
+	// real action; the compact dispatch loop lacked that deferral and
+	// elected a clean derivation production declines
+	// (deferContextualCloseAngleAction, parser_dfa_token_source.go).
+	f.Add([]byte(" 0%0>>"), langIndex["swift"])
+	f.Add([]byte("0>>"), langIndex["swift"])
 }
 
 // routeEqualityTreeCarriesNativeRecoveryErrorContainer reports whether root's

--- a/lexer.go
+++ b/lexer.go
@@ -41,11 +41,11 @@ type Token struct {
 	// lexerInternalDFALexed proves that Lexer.scan accepted this token from
 	// the internal DFA. External, generated, missing, and EOF tokens omit it.
 	lexerInternalDFALexed bool
-	// IsKeyword mirrors C's Subtree.is_keyword bit (subtree.h:131): the
+	// isKeyword mirrors C's Subtree.is_keyword bit (subtree.h:131): the
 	// keyword-capture word token was re-lexed as a keyword and the parser
 	// adopted that keyword symbol (parser.c:645-668). False for every other
 	// token, including a word token the keyword re-lex did not adopt.
-	IsKeyword bool
+	isKeyword bool
 }
 
 func bytesToStringNoCopy(b []byte) string {

--- a/lexer.go
+++ b/lexer.go
@@ -41,6 +41,11 @@ type Token struct {
 	// lexerInternalDFALexed proves that Lexer.scan accepted this token from
 	// the internal DFA. External, generated, missing, and EOF tokens omit it.
 	lexerInternalDFALexed bool
+	// IsKeyword mirrors C's Subtree.is_keyword bit (subtree.h:131): the
+	// keyword-capture word token was re-lexed as a keyword and the parser
+	// adopted that keyword symbol (parser.c:645-668). False for every other
+	// token, including a word token the keyword re-lex did not adopt.
+	IsKeyword bool
 }
 
 func bytesToStringNoCopy(b []byte) string {

--- a/parser_dfa_guard_test.go
+++ b/parser_dfa_guard_test.go
@@ -1238,19 +1238,87 @@ func TestTokenMaybeContextualCloseAngleShapeGate(t *testing.T) {
 // false, so a caller that pre-checks with the extracted helper before
 // resolving its own state (dispatchCorridor, parsercore_c4_vm.go) never
 // disagrees with the full predicate it defers to.
+//
+// This uses the same "artifact_probe" language and state/source
+// TestContextualActionDefersUnsignedShiftLineageAfterSingleCloseElection
+// already proves triggers a real deferral (a well-formed narrow ">" token,
+// state 1, source ">>>") specifically so the language has real LexModes and
+// LexStates: with a language that has none (an earlier, weaker version of
+// this test used a bare &Language{SymbolNames: ...}), every rejected-shape
+// token also fails deferContextualCloseAngleAction's SEPARATE missing-lex-
+// mode guard, so the test cannot tell "declined because of the shared shape
+// gate" apart from "declined because of an unrelated missing-table guard" --
+// a regression that deleted the internal tokenMaybeContextualCloseAngle
+// call from deferContextualCloseAngleAction entirely could still pass it.
+// Each malformed variant below shares the valid token's state, source, and
+// start byte, so if the shared shape-gate call were ever removed, the
+// downstream logic would run to completion and return true for every one of
+// them (verified by mutation: deleting that call flips all three cases).
 func TestDeferContextualCloseAngleActionSharesShapeGateWithPreCheck(t *testing.T) {
-	lang := &Language{SymbolNames: []string{"end", ">", ">>"}}
+	lang := &Language{
+		Name:        "artifact_probe",
+		SymbolNames: []string{"end", ">", ">>>"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "end", Visible: false, Named: false},
+			{Name: ">", Visible: true, Named: false},
+			{Name: ">>>", Visible: true, Named: false},
+		},
+		SymbolCount:     3,
+		TokenCount:      3,
+		StateCount:      2,
+		LargeStateCount: 2,
+		InitialState:    1,
+		LexStates: []LexState{
+			{Default: -1, EOF: -1},
+			{AcceptToken: 0, Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: '>', Hi: '>', NextState: 2}}},
+			{AcceptToken: 1, Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: '>', Hi: '>', NextState: 3}}},
+			{AcceptToken: 1, Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: '>', Hi: '>', NextState: 4}}},
+			{AcceptToken: 2, Default: -1, EOF: -1},
+		},
+		LexModes: []LexMode{
+			{LexState: 0},
+			{LexState: 1},
+		},
+		ParseTable: [][]uint16{
+			{0, 0, 0},
+			{0, 1, 2},
+		},
+		ParseActions: []ParseActionEntry{
+			{Actions: nil},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 1}}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 1}}},
+		},
+	}
+	const state = StateID(1)
+	source := []byte(">>>")
 	probe := &Lexer{}
+
+	// The valid, well-formed token this exact fixture defers for (sanity
+	// control: proves the fixture and probe are wired correctly).
+	valid := Token{Symbol: 1, StartByte: 0, EndByte: 1, StartPoint: Point{}, EndPoint: Point{Column: 1}}
+	if !tokenMaybeContextualCloseAngle(lang, valid) {
+		t.Fatal("the valid narrow \">\" token unexpectedly failed the shape gate")
+	}
+	if !deferContextualCloseAngleAction(lang, source, state, valid, nil, probe) {
+		t.Fatal("the valid narrow \">\" token unexpectedly did not defer")
+	}
+
 	rejectedShapes := []Token{
-		{Symbol: 2, StartByte: 0, EndByte: 1},                          // wrong symbol name
-		{Symbol: 1, StartByte: 0, EndByte: 2},                          // width != 1
-		{Symbol: 1, StartByte: 0, EndByte: 1, EndPoint: Point{Row: 1}}, // crosses a row
+		// wrong symbol name: same span as valid, but tagged as ">>>" (the
+		// wide token's own symbol), not ">".
+		{Symbol: 2, StartByte: 0, EndByte: 1, StartPoint: Point{}, EndPoint: Point{Column: 1}},
+		// width != 1: same start byte and symbol as valid, but spans two
+		// bytes instead of one.
+		{Symbol: 1, StartByte: 0, EndByte: 2, StartPoint: Point{}, EndPoint: Point{Column: 2}},
+		// crosses a row: same span and symbol as valid, but EndPoint reports
+		// a different row than StartPoint.
+		{Symbol: 1, StartByte: 0, EndByte: 1, StartPoint: Point{}, EndPoint: Point{Row: 1}},
 	}
 	for _, tok := range rejectedShapes {
 		if tokenMaybeContextualCloseAngle(lang, tok) {
 			t.Fatalf("token %+v unexpectedly passed the shape gate", tok)
 		}
-		if deferContextualCloseAngleAction(lang, []byte(">>"), 0, tok, nil, probe) {
+		if deferContextualCloseAngleAction(lang, source, state, tok, nil, probe) {
 			t.Fatalf("token %+v unexpectedly deferred despite failing the shared shape gate", tok)
 		}
 	}

--- a/parser_dfa_guard_test.go
+++ b/parser_dfa_guard_test.go
@@ -1191,6 +1191,71 @@ func TestContextualActionDefersUnsignedShiftLineageAfterSingleCloseElection(t *t
 	}
 }
 
+// TestTokenMaybeContextualCloseAngleShapeGate pins tokenMaybeContextualCloseAngle,
+// the cheap, state-free shape pre-check extracted from
+// deferContextualCloseAngleAction's own first guard (finding F9): a
+// narrow, same-row, single ">" token passes; anything else fails.
+func TestTokenMaybeContextualCloseAngleShapeGate(t *testing.T) {
+	lang := &Language{SymbolNames: []string{"end", ">", ">>"}}
+	sameRowNarrowClose := Token{
+		Symbol:     1,
+		StartByte:  4,
+		EndByte:    5,
+		StartPoint: Point{Row: 2, Column: 1},
+		EndPoint:   Point{Row: 2, Column: 2},
+	}
+
+	if !tokenMaybeContextualCloseAngle(lang, sameRowNarrowClose) {
+		t.Fatal("a same-row, single-byte \">\" token must pass the shape gate")
+	}
+	if tokenMaybeContextualCloseAngle(nil, sameRowNarrowClose) {
+		t.Fatal("a nil language must fail the shape gate")
+	}
+	if tokenMaybeContextualCloseAngle(lang, Token{Symbol: 99, StartByte: 0, EndByte: 1}) {
+		t.Fatal("a symbol outside the language's SymbolNames must fail the shape gate")
+	}
+	wideClose := sameRowNarrowClose
+	wideClose.Symbol = 2 // ">>"
+	if tokenMaybeContextualCloseAngle(lang, wideClose) {
+		t.Fatal("a token whose symbol name is not exactly \">\" must fail the shape gate")
+	}
+	wideSpan := sameRowNarrowClose
+	wideSpan.EndByte = sameRowNarrowClose.StartByte + 2
+	if tokenMaybeContextualCloseAngle(lang, wideSpan) {
+		t.Fatal("a \">\" token wider than one byte must fail the shape gate")
+	}
+	crossRow := sameRowNarrowClose
+	crossRow.EndPoint.Row++
+	if tokenMaybeContextualCloseAngle(lang, crossRow) {
+		t.Fatal("a \">\" token crossing a line must fail the shape gate")
+	}
+}
+
+// TestDeferContextualCloseAngleActionSharesShapeGateWithPreCheck pins the
+// single-source-of-truth property finding F9 requires: every shape
+// tokenMaybeContextualCloseAngle rejects must also make
+// deferContextualCloseAngleAction's own (identical) first guard return
+// false, so a caller that pre-checks with the extracted helper before
+// resolving its own state (dispatchCorridor, parsercore_c4_vm.go) never
+// disagrees with the full predicate it defers to.
+func TestDeferContextualCloseAngleActionSharesShapeGateWithPreCheck(t *testing.T) {
+	lang := &Language{SymbolNames: []string{"end", ">", ">>"}}
+	probe := &Lexer{}
+	rejectedShapes := []Token{
+		{Symbol: 2, StartByte: 0, EndByte: 1},                          // wrong symbol name
+		{Symbol: 1, StartByte: 0, EndByte: 2},                          // width != 1
+		{Symbol: 1, StartByte: 0, EndByte: 1, EndPoint: Point{Row: 1}}, // crosses a row
+	}
+	for _, tok := range rejectedShapes {
+		if tokenMaybeContextualCloseAngle(lang, tok) {
+			t.Fatalf("token %+v unexpectedly passed the shape gate", tok)
+		}
+		if deferContextualCloseAngleAction(lang, []byte(">>"), 0, tok, nil, probe) {
+			t.Fatalf("token %+v unexpectedly deferred despite failing the shared shape gate", tok)
+		}
+	}
+}
+
 func TestPromoteActiveLiteralDoesNotUndoContextualKeywordDemotion(t *testing.T) {
 	lang := &Language{
 		Name:                "javascript",

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -2267,8 +2267,20 @@ func (p *Parser) contextualActionIndex(source []byte, state StateID, tok Token) 
 // reads an adjacent pair as one operator. Another live stack selected the
 // single close-angle prefix, so this stack must not consume that prefix.
 func (p *Parser) shouldDeferContextualCloseAngleAction(source []byte, state StateID, tok Token) bool {
-	lang := p.language
-	if lang == nil || int(tok.Symbol) >= len(lang.SymbolNames) ||
+	return deferContextualCloseAngleAction(p.language, source, state, tok, p.included, &p.relexProbeLexer)
+}
+
+// deferContextualCloseAngleAction reports whether state's own lex mode reads
+// the bytes under tok as one wider close-angle operator that carries a real
+// parse action in state. When it does, a different, narrower-lexing route
+// already elected tok, and state must defer rather than consume tok's
+// prefix. The check is symbol-shape based (an adjacent run of `>` bytes),
+// not tied to any one language, so both the production stack route and the
+// compact admission route can share it. included and probe let the
+// production route reuse its own included-range handling and scratch
+// lexer; the compact route passes nil and its own scratch lexer.
+func deferContextualCloseAngleAction(lang *Language, source []byte, state StateID, tok Token, included []Range, probe *Lexer) bool {
+	if lang == nil || probe == nil || int(tok.Symbol) >= len(lang.SymbolNames) ||
 		lang.SymbolNames[tok.Symbol] != ">" ||
 		tok.EndByte != tok.StartByte+1 ||
 		tok.EndPoint.Row != tok.StartPoint.Row {
@@ -2284,7 +2296,6 @@ func (p *Parser) shouldDeferContextualCloseAngleAction(source []byte, state Stat
 		return false
 	}
 
-	probe := &p.relexProbeLexer
 	*probe = Lexer{
 		states:          lang.LexStates,
 		asciiTable:      lang.LexAsciiTable(),
@@ -2295,25 +2306,26 @@ func (p *Parser) shouldDeferContextualCloseAngleAction(source []byte, state Stat
 		immediateTokens: lang.ImmediateTokens,
 		zeroWidthTokens: lang.ZeroWidthTokens,
 	}
-	if len(p.included) != 0 && lang.ExternalScanner == nil && len(lang.ExternalSymbols) == 0 {
-		probe.setIncludedRanges(p.included)
+	if len(included) != 0 && lang.ExternalScanner == nil && len(lang.ExternalSymbols) == 0 {
+		probe.setIncludedRanges(included)
 	}
 	stateToken, ok := probe.scan(uint32(lexState), probe.pos, probe.row, probe.col)
 	if !ok || int(stateToken.Symbol) >= len(lang.SymbolNames) {
 		return false
 	}
 	stateTokenName := lang.SymbolNames[stateToken.Symbol]
+	shiftIdx := lookupRepairActionIndex(lang, state, stateToken.Symbol)
+	stateHasShiftAction := shiftIdx != 0 && int(shiftIdx) < len(lang.ParseActions) && len(lang.ParseActions[shiftIdx].Actions) > 0
 	if !isWideCloseAngleTokenName(stateTokenName) ||
 		stateToken.StartByte != tok.StartByte ||
-		!p.stateHasActionForSymbol(state, stateToken.Symbol) {
+		!stateHasShiftAction {
 		return false
 	}
 	width := uint32(len(stateTokenName))
 	if stateToken.EndByte != tok.StartByte+width {
 		return false
 	}
-	closeIdx := p.lookupActionIndex(state, tok.Symbol)
-	shiftIdx := p.lookupActionIndex(state, stateToken.Symbol)
+	closeIdx := lookupRepairActionIndex(lang, state, tok.Symbol)
 	if closeIdx != 0 && closeIdx == shiftIdx && int(closeIdx) < len(lang.ParseActions) {
 		actions := lang.ParseActions[closeIdx].Actions
 		if len(actions) > 0 {

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -1017,6 +1017,14 @@ func (d *dfaTokenSource) SeekTokenFrontier(pos uint32, pt Point) {
 	d.lexer.normalizeIncludedPosition()
 }
 
+// tokensSameLex compares tokenization identity, not the lex path that
+// produced the token. isKeyword records the promotion path, so it must
+// not take part in a same-tokenization test.
+func tokensSameLex(a, b Token) bool {
+	a.isKeyword, b.isKeyword = false, false
+	return a == b
+}
+
 func (d *dfaTokenSource) PeekTokenFrontier(states []StateID, dst []tokenCandidate) (tokenFrontier, bool) {
 	dst = dst[:0]
 	if d == nil || d.lexer == nil || d.language == nil || d.lookupActionIndex == nil {
@@ -1098,7 +1106,7 @@ func (d *dfaTokenSource) PeekTokenFrontier(states []StateID, dst []tokenCandidat
 
 		merged := false
 		for i := range dst {
-			if dst[i].Tok == candTok && dst[i].EndPos == candEndPos && dst[i].EndRow == candEndRow && dst[i].EndCol == candEndCol {
+			if tokensSameLex(dst[i].Tok, candTok) && dst[i].EndPos == candEndPos && dst[i].EndRow == candEndRow && dst[i].EndCol == candEndCol {
 				dst[i].RouteMask |= routeMask
 				merged = true
 				break
@@ -1146,7 +1154,7 @@ func (d *dfaTokenSource) tokenFrontierRouteMask(states []StateID, tok Token, end
 
 func (d *dfaTokenSource) stateProducesTokenFrontierCandidate(state StateID, tok Token, endPos int, endRow, endCol uint32) bool {
 	stateTok, stateEndPos, stateEndRow, stateEndCol := d.scanPreferredTokenForState(state)
-	return stateTok == tok && stateEndPos == endPos && stateEndRow == endRow && stateEndCol == endCol
+	return tokensSameLex(stateTok, tok) && stateEndPos == endPos && stateEndRow == endRow && stateEndCol == endCol
 }
 
 // nextGLRUnionDFAToken tries each unique GLR stack state's lex mode and
@@ -1235,7 +1243,7 @@ func (d *dfaTokenSource) nextGLRUnionDFAToken() (Token, bool) {
 				continue
 			}
 			stateTok, stateEndPos, stateEndRow, stateEndCol := d.glrUnionScanForState(liveState)
-			if stateTok != candTok || stateEndPos != candEndPos || stateEndRow != candEndRow || stateEndCol != candEndCol {
+			if !tokensSameLex(stateTok, candTok) || stateEndPos != candEndPos || stateEndRow != candEndRow || stateEndCol != candEndCol {
 				continue
 			}
 			score++
@@ -2270,6 +2278,25 @@ func (p *Parser) shouldDeferContextualCloseAngleAction(source []byte, state Stat
 	return deferContextualCloseAngleAction(p.language, source, state, tok, p.included, &p.relexProbeLexer)
 }
 
+// tokenMaybeContextualCloseAngle reports whether tok could possibly be the
+// narrow half of a contextual close-angle pair: a single ">" byte that does
+// not cross a line. This is exactly deferContextualCloseAngleAction's own
+// first guard, extracted so a caller that resolves its own state lazily
+// (dispatchCorridor's corridor pre-check, parsercore_c4_vm.go) can rule out
+// the common non-">"-token case before paying for that resolve, without a
+// second, independently-maintained copy of the shape check.
+// deferContextualCloseAngleAction is still the single source of truth for
+// the full predicate: it calls this helper for its own first guard rather
+// than re-deriving it.
+func tokenMaybeContextualCloseAngle(lang *Language, tok Token) bool {
+	if lang == nil || int(tok.Symbol) >= len(lang.SymbolNames) {
+		return false
+	}
+	return lang.SymbolNames[tok.Symbol] == ">" &&
+		tok.EndByte == tok.StartByte+1 &&
+		tok.EndPoint.Row == tok.StartPoint.Row
+}
+
 // deferContextualCloseAngleAction reports whether state's own lex mode reads
 // the bytes under tok as one wider close-angle operator that carries a real
 // parse action in state. When it does, a different, narrower-lexing route
@@ -2278,12 +2305,13 @@ func (p *Parser) shouldDeferContextualCloseAngleAction(source []byte, state Stat
 // not tied to any one language, so both the production stack route and the
 // compact admission route can share it. included and probe let the
 // production route reuse its own included-range handling and scratch
-// lexer; the compact route passes nil and its own scratch lexer.
+// lexer; the compact callers (parsercore_c4_vm.go, parsercore_phase0_driver.go)
+// always pass included=nil and their own scratch lexer instead, because the
+// compact route declines any included-range parse outright before it ever
+// reaches here (admission_switch.go:208's own eligibility check) — there is
+// no included-range case for a compact caller to reuse.
 func deferContextualCloseAngleAction(lang *Language, source []byte, state StateID, tok Token, included []Range, probe *Lexer) bool {
-	if lang == nil || probe == nil || int(tok.Symbol) >= len(lang.SymbolNames) ||
-		lang.SymbolNames[tok.Symbol] != ">" ||
-		tok.EndByte != tok.StartByte+1 ||
-		tok.EndPoint.Row != tok.StartPoint.Row {
+	if probe == nil || !tokenMaybeContextualCloseAngle(lang, tok) {
 		return false
 	}
 	start := int(tok.StartByte)
@@ -2314,11 +2342,15 @@ func deferContextualCloseAngleAction(lang *Language, source []byte, state StateI
 		return false
 	}
 	stateTokenName := lang.SymbolNames[stateToken.Symbol]
+	// Short-circuit order matches the pre-extraction code: the table lookup
+	// below only runs once the cheap shape checks (wide close-angle name,
+	// same start byte) already passed, not unconditionally on every call.
+	if !isWideCloseAngleTokenName(stateTokenName) || stateToken.StartByte != tok.StartByte {
+		return false
+	}
 	shiftIdx := lookupRepairActionIndex(lang, state, stateToken.Symbol)
 	stateHasShiftAction := shiftIdx != 0 && int(shiftIdx) < len(lang.ParseActions) && len(lang.ParseActions[shiftIdx].Actions) > 0
-	if !isWideCloseAngleTokenName(stateTokenName) ||
-		stateToken.StartByte != tok.StartByte ||
-		!stateHasShiftAction {
+	if !stateHasShiftAction {
 		return false
 	}
 	width := uint32(len(stateTokenName))
@@ -4619,7 +4651,7 @@ func (d *dfaTokenSource) promoteKeyword(tok Token) (Token, bool) {
 		if !kwHasAction {
 			if altSym, ok := d.activeLiteralKeywordSymbol(tok); ok {
 				tok.Symbol = altSym
-				tok.IsKeyword = true
+				tok.isKeyword = true
 				return tok, false
 			}
 		}
@@ -4635,7 +4667,7 @@ func (d *dfaTokenSource) promoteKeyword(tok Token) (Token, bool) {
 	}
 
 	tok.Symbol = kwTok.Symbol
-	tok.IsKeyword = true
+	tok.isKeyword = true
 	return tok, false
 }
 

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -4607,6 +4607,7 @@ func (d *dfaTokenSource) promoteKeyword(tok Token) (Token, bool) {
 		if !kwHasAction {
 			if altSym, ok := d.activeLiteralKeywordSymbol(tok); ok {
 				tok.Symbol = altSym
+				tok.IsKeyword = true
 				return tok, false
 			}
 		}
@@ -4622,6 +4623,7 @@ func (d *dfaTokenSource) promoteKeyword(tok Token) (Token, bool) {
 	}
 
 	tok.Symbol = kwTok.Symbol
+	tok.IsKeyword = true
 	return tok, false
 }
 

--- a/parser_dfa_token_source_keyword_flag_test.go
+++ b/parser_dfa_token_source_keyword_flag_test.go
@@ -216,3 +216,127 @@ func TestPeekTokenFrontierMergesSameLexDespiteIsKeywordMismatch(t *testing.T) {
 		t.Fatalf("candidate route mask = %#x, want %#x (both states must vote for the merged tokenization)", cand.RouteMask, want)
 	}
 }
+
+// unionSameLexKeywordLanguageWithDecoy extends unionSameLexKeywordLanguage
+// with a second, unrelated pair of GLR states (3 and 4) that both lex "if"
+// as a same-span, differently-symbolled decoy token ("other", symbol 3)
+// through two independently-dedup-safe lex modes (DFA states 5 and 8). The
+// decoy pair always scores 2 (each votes for the other; neither promotion
+// nor isKeyword ever enters their comparison), which is exactly high enough
+// to beat the keyword pair's score if — and only if — nextGLRUnionDFAToken's
+// keyword-adoption pair (states 1 and 2) loses ITS mutual vote to the
+// isKeyword-mismatch bug fixed at parser_dfa_token_source.go's tokensSameLex
+// call in that function's own score loop. With the bug: keyword-pair score
+// stays at 1 (self only), the decoy's constant 2 wins outright, and
+// Next() elects the wrong token (symbol 3, "other") for source "if". Fixed:
+// the keyword pair also scores 2, ties the decoy under identical span/
+// visibility/specificity, and the first-processed state (1) keeps the
+// correctly-elected keyword (symbol 2, isKeyword = true).
+//
+// This isolates the SPECIFIC production call site the F1 mutation-testing
+// gap flagged (nextGLRUnionDFAToken's own tokensSameLex call): unlike
+// TestPeekTokenFrontierMergesSameLexDespiteIsKeywordMismatch, reverting only
+// that one call site to a raw != comparison flips this test's elected
+// token, because here the decoy pair's constant score of 2 only wins when
+// the keyword pair's score is wrongly held down to 1.
+//
+// Symbols:
+//
+//	0: end
+//	1: identifier (terminal, named) — keyword capture token
+//	2: if (terminal, anonymous) — keyword, reachable via promotion or direct
+//	3: other (terminal, anonymous) — same-span decoy, never keyword-related
+//
+// Parser states: 1 (identifier-capture path, DFA state 0), 2 (direct
+// keyword-literal path, DFA state 2), 3 (decoy path A, DFA state 5), 4
+// (decoy path B, DFA state 8).
+func unionSameLexKeywordLanguageWithDecoy() *Language {
+	lang := unionSameLexKeywordLanguage()
+	lang.Name = "keyword_union_samelex_decoy_test"
+	lang.SymbolCount = 4
+	// TokenCount stays at the base fixture's 2 (not 4): buildSymbolMaps only
+	// registers a symbol's name in the anonymous-token shape index when its
+	// index is below TokenCount. Registering "if" there would let
+	// promoteActiveLiteralForCurrentState's UNRELATED literal-promotion path
+	// (triggered by matching raw source text against any live-actionable
+	// anonymous token name, not by symbol identity) silently rewrite the
+	// decoy's own Symbol 3 token back to Symbol 2, because both tokens
+	// share the literal source text "if" and Symbol 2 has live actions in
+	// states 1 and 2. Leaving TokenCount at 2 keeps "if" (and "other") out
+	// of that registry, exactly as the base two-state fixture already
+	// relies on, so this decoy exercises only the score-based tie-break
+	// nextGLRUnionDFAToken itself performs.
+	lang.SymbolNames = []string{"end", "identifier", "if", "other"}
+	lang.LexStates = append(lang.LexStates,
+		// state 5: decoy path A start — dispatch 'i'
+		LexState{Default: -1, EOF: -1, Transitions: []LexTransition{
+			{Lo: 'i', Hi: 'i', NextState: 6},
+		}},
+		// state 6: saw 'i' — dispatch 'f'
+		LexState{Default: -1, EOF: -1, Transitions: []LexTransition{
+			{Lo: 'f', Hi: 'f', NextState: 7},
+		}},
+		// state 7: saw "if" — accept the decoy (symbol 3), independent of
+		// both the identifier-capture and direct-keyword paths.
+		LexState{AcceptToken: 3, Default: -1, EOF: -1},
+		// state 8: decoy path B start — an independent DFA chain that
+		// accepts the identical decoy token as path A, so the two decoy
+		// parser states are never dedup-merged (different LexState indexes)
+		// but always agree on their own tokenization.
+		LexState{Default: -1, EOF: -1, Transitions: []LexTransition{
+			{Lo: 'i', Hi: 'i', NextState: 9},
+		}},
+		LexState{Default: -1, EOF: -1, Transitions: []LexTransition{
+			{Lo: 'f', Hi: 'f', NextState: 10},
+		}},
+		LexState{AcceptToken: 3, Default: -1, EOF: -1},
+	)
+	lang.LexModes = append(lang.LexModes,
+		LexMode{LexState: 5}, // parser state 3: decoy path A
+		LexMode{LexState: 8}, // parser state 4: decoy path B
+	)
+	return lang
+}
+
+// TestNextGLRUnionDFATokenElectsMergedKeywordOverCompetingDecoy closes the
+// F1 mutation-testing gap: it fails when tokensSameLex's call inside
+// nextGLRUnionDFAToken's own score loop (parser_dfa_token_source.go) is
+// reverted to a raw != comparison, even though
+// TestPeekTokenFrontierMergesSameLexDespiteIsKeywordMismatch (which pins the
+// other two call sites) keeps passing under that exact mutation.
+//
+// See unionSameLexKeywordLanguageWithDecoy's doc comment for the scoring
+// argument. Verified by mutation: reverting nextGLRUnionDFAToken's
+// tokensSameLex call to `stateTok != candTok` makes this test fail (elects
+// symbol 3, "other") and leaves
+// TestPeekTokenFrontierMergesSameLexDespiteIsKeywordMismatch passing;
+// restoring the call makes both pass.
+func TestNextGLRUnionDFATokenElectsMergedKeywordOverCompetingDecoy(t *testing.T) {
+	lang := unionSameLexKeywordLanguageWithDecoy()
+	lookup := func(state StateID, sym Symbol) uint16 {
+		switch {
+		case sym == 2 && (state == 1 || state == 2):
+			return 1
+		case sym == 3 && (state == 3 || state == 4):
+			return 1
+		}
+		return 0
+	}
+
+	source := []byte("if")
+	ts := acquireDFATokenSource(NewLexer(lang.LexStates, source), lang, lookup, nil, nil, nil)
+	defer ts.Close()
+	ts.SetParserState(1)
+	ts.SetGLRStates([]StateID{1, 2, 3, 4})
+
+	tok := ts.Next()
+	if tok.Symbol != 2 {
+		t.Fatalf("elected symbol = %d, want 2 (if keyword — the merged keyword pair must outscore the decoy pair)", tok.Symbol)
+	}
+	if !tok.isKeyword {
+		t.Fatal("elected keyword token: isKeyword = false, want true (elected via the identifier-capture path's own promotion)")
+	}
+	if tok.StartByte != 0 || tok.EndByte != 2 {
+		t.Fatalf("elected span = %d..%d, want 0..2", tok.StartByte, tok.EndByte)
+	}
+}

--- a/parser_dfa_token_source_keyword_flag_test.go
+++ b/parser_dfa_token_source_keyword_flag_test.go
@@ -1,0 +1,112 @@
+package gotreesitter
+
+import "testing"
+
+// keywordAdoptionLanguage builds a minimal language with a word-shaped main
+// lexer (any run of lowercase letters) and a keyword lexer that recognizes
+// only the literal "if". Symbols:
+//
+//	0: EOF
+//	1: identifier (terminal, named) — keyword capture token
+//	2: if (terminal, anonymous) — keyword matched by the keyword DFA
+//
+// lookupActionIndex is left nil so promoteKeyword's context-aware gating
+// (parser_dfa_token_source.go ~4588-4622) is skipped and every full-length
+// keyword match adopts unconditionally, matching this fixture's single,
+// context-free parser state.
+func keywordAdoptionLanguage() *Language {
+	return &Language{
+		Name:                "keyword_adoption_test",
+		SymbolCount:         3,
+		TokenCount:          2,
+		KeywordCaptureToken: 1, // identifier
+		SymbolNames:         []string{"end", "identifier", "if"},
+		LexStates: []LexState{
+			// state 0: start of a word — dispatch any lowercase letter
+			{Default: -1, EOF: -1, Transitions: []LexTransition{
+				{Lo: 'a', Hi: 'z', NextState: 1},
+			}},
+			// state 1: accept identifier, loop on further lowercase letters
+			{AcceptToken: 1, Default: -1, EOF: -1, Transitions: []LexTransition{
+				{Lo: 'a', Hi: 'z', NextState: 1},
+			}},
+		},
+		LexModes: []LexMode{{LexState: 0}},
+		KeywordLexStates: []LexState{
+			// kw state 0: start — dispatch 'i'
+			{AcceptToken: 0, Default: -1, EOF: -1, Transitions: []LexTransition{
+				{Lo: 'i', Hi: 'i', NextState: 1},
+			}},
+			// kw state 1: saw 'i' — dispatch 'f'
+			{AcceptToken: 0, Default: -1, EOF: -1, Transitions: []LexTransition{
+				{Lo: 'f', Hi: 'f', NextState: 2},
+			}},
+			// kw state 2: saw "if" — accept the keyword (symbol 2)
+			{AcceptToken: 2, Default: -1, EOF: -1},
+		},
+	}
+}
+
+// TestPromoteKeywordSetsIsKeywordOnAdoption drives the token source's real
+// Next() entry point over a source that is exactly the keyword-lexer's
+// literal ("if"). The main lexer produces the keyword-capture (identifier)
+// token; the keyword re-lex fully consumes the same span, so the token is
+// adopted: its symbol becomes the "if" keyword and IsKeyword records the
+// adoption, mirroring C's Subtree.is_keyword (subtree.h:131).
+func TestPromoteKeywordSetsIsKeywordOnAdoption(t *testing.T) {
+	lang := keywordAdoptionLanguage()
+	source := []byte("if")
+	ts := acquireDFATokenSource(NewLexer(lang.LexStates, source), lang, nil, nil, nil, nil)
+	defer ts.Close()
+
+	tok := ts.Next()
+	if tok.Symbol != 2 {
+		t.Fatalf("token symbol = %d, want 2 (if keyword — adopted)", tok.Symbol)
+	}
+	if !tok.IsKeyword {
+		t.Fatal("adopted keyword token: IsKeyword = false, want true")
+	}
+}
+
+// TestPromoteKeywordLeavesIsKeywordFalseForNonKeywordWord drives Next() over
+// a word-shaped span the keyword lexer cannot fully match: "ifx" shares the
+// keyword's "if" prefix, but the keyword DFA only accepts the exact literal
+// "if" (parser_dfa_token_source.go's lexKeywordSource requires the keyword to
+// consume the entire captured span). The token stays an identifier and is
+// never adopted, so IsKeyword must be false.
+func TestPromoteKeywordLeavesIsKeywordFalseForNonKeywordWord(t *testing.T) {
+	lang := keywordAdoptionLanguage()
+	source := []byte("ifx")
+	ts := acquireDFATokenSource(NewLexer(lang.LexStates, source), lang, nil, nil, nil, nil)
+	defer ts.Close()
+
+	tok := ts.Next()
+	if tok.Symbol != 1 {
+		t.Fatalf("token symbol = %d, want 1 (identifier — not adopted)", tok.Symbol)
+	}
+	if tok.IsKeyword {
+		t.Fatal("non-keyword word token: IsKeyword = true, want false")
+	}
+}
+
+// TestPromoteKeywordIsKeywordFalseWithoutKeywordCapture drives Next() over
+// the keyword's own literal spelling ("if") in a language that has no
+// keyword-capture token at all. promoteKeyword must return unmodified
+// (parser_dfa_token_source.go:4500-4502), so no token from this language is
+// ever adopted and IsKeyword stays false.
+func TestPromoteKeywordIsKeywordFalseWithoutKeywordCapture(t *testing.T) {
+	lang := keywordAdoptionLanguage()
+	lang.KeywordCaptureToken = 0
+	lang.KeywordLexStates = nil
+	source := []byte("if")
+	ts := acquireDFATokenSource(NewLexer(lang.LexStates, source), lang, nil, nil, nil, nil)
+	defer ts.Close()
+
+	tok := ts.Next()
+	if tok.Symbol != 1 {
+		t.Fatalf("token symbol = %d, want 1 (identifier — no keyword capture)", tok.Symbol)
+	}
+	if tok.IsKeyword {
+		t.Fatal("language without keyword capture: IsKeyword = true, want false")
+	}
+}

--- a/parser_dfa_token_source_keyword_flag_test.go
+++ b/parser_dfa_token_source_keyword_flag_test.go
@@ -63,7 +63,7 @@ func TestPromoteKeywordSetsIsKeywordOnAdoption(t *testing.T) {
 	if tok.Symbol != 2 {
 		t.Fatalf("token symbol = %d, want 2 (if keyword — adopted)", tok.Symbol)
 	}
-	if !tok.IsKeyword {
+	if !tok.isKeyword {
 		t.Fatal("adopted keyword token: IsKeyword = false, want true")
 	}
 }
@@ -84,7 +84,7 @@ func TestPromoteKeywordLeavesIsKeywordFalseForNonKeywordWord(t *testing.T) {
 	if tok.Symbol != 1 {
 		t.Fatalf("token symbol = %d, want 1 (identifier — not adopted)", tok.Symbol)
 	}
-	if tok.IsKeyword {
+	if tok.isKeyword {
 		t.Fatal("non-keyword word token: IsKeyword = true, want false")
 	}
 }
@@ -106,7 +106,113 @@ func TestPromoteKeywordIsKeywordFalseWithoutKeywordCapture(t *testing.T) {
 	if tok.Symbol != 1 {
 		t.Fatalf("token symbol = %d, want 1 (identifier — no keyword capture)", tok.Symbol)
 	}
-	if tok.IsKeyword {
+	if tok.isKeyword {
 		t.Fatal("language without keyword capture: IsKeyword = true, want false")
+	}
+}
+
+// unionSameLexKeywordLanguage builds a two-lex-mode language where one GLR
+// stack state reaches the "if" keyword through the identifier-capture path
+// (promoted, IsKeyword = true) and another reaches the literal "if"
+// spelling directly in the main DFA (IsKeyword = false). Both lex the same
+// span and symbol for source "if", so they are the same tokenization and
+// the live-GLR union election must treat them as such, regardless of which
+// lex path produced the token. Symbols:
+//
+//	0: end
+//	1: identifier (terminal, named) — keyword capture token
+//	2: if (terminal, anonymous) — keyword, reachable via promotion or direct
+//
+// Parser states used by the test: state 1 selects the identifier-capture
+// lex mode (DFA state 0); state 2 selects the direct keyword-literal lex
+// mode (DFA state 2).
+func unionSameLexKeywordLanguage() *Language {
+	return &Language{
+		Name:                "keyword_union_samelex_test",
+		SymbolCount:         3,
+		TokenCount:          2,
+		KeywordCaptureToken: 1, // identifier
+		SymbolNames:         []string{"end", "identifier", "if"},
+		LexStates: []LexState{
+			// state 0: identifier path start — dispatch any lowercase letter
+			{Default: -1, EOF: -1, Transitions: []LexTransition{
+				{Lo: 'a', Hi: 'z', NextState: 1},
+			}},
+			// state 1: accept identifier, loop on further lowercase letters
+			{AcceptToken: 1, Default: -1, EOF: -1, Transitions: []LexTransition{
+				{Lo: 'a', Hi: 'z', NextState: 1},
+			}},
+			// state 2: direct keyword path start — dispatch 'i'
+			{Default: -1, EOF: -1, Transitions: []LexTransition{
+				{Lo: 'i', Hi: 'i', NextState: 3},
+			}},
+			// state 3: saw 'i' — dispatch 'f'
+			{Default: -1, EOF: -1, Transitions: []LexTransition{
+				{Lo: 'f', Hi: 'f', NextState: 4},
+			}},
+			// state 4: saw "if" directly — accept the keyword (symbol 2)
+			// without going through the identifier-capture promotion path.
+			{AcceptToken: 2, Default: -1, EOF: -1},
+		},
+		LexModes: []LexMode{
+			{},            // parser state 0: unused placeholder
+			{LexState: 0}, // parser state 1: identifier-capture path
+			{LexState: 2}, // parser state 2: direct keyword-literal path
+		},
+		KeywordLexStates: []LexState{
+			// kw state 0: start — dispatch 'i'
+			{AcceptToken: 0, Default: -1, EOF: -1, Transitions: []LexTransition{
+				{Lo: 'i', Hi: 'i', NextState: 1},
+			}},
+			// kw state 1: saw 'i' — dispatch 'f'
+			{AcceptToken: 0, Default: -1, EOF: -1, Transitions: []LexTransition{
+				{Lo: 'f', Hi: 'f', NextState: 2},
+			}},
+			// kw state 2: saw "if" — accept the keyword (symbol 2)
+			{AcceptToken: 2, Default: -1, EOF: -1},
+		},
+	}
+}
+
+// TestPeekTokenFrontierMergesSameLexDespiteIsKeywordMismatch pins the F1
+// finding: PeekTokenFrontier must not let IsKeyword split one tokenization
+// across two candidates in the live GLR union election. One state lexes
+// "if" through the identifier-capture path and adopts the keyword
+// (IsKeyword = true); another lexes the same span directly as the keyword
+// literal (IsKeyword = false). Same symbol, same span — the union election
+// must merge them into a single candidate whose route mask covers both
+// states, not split the vote across two candidates that each look
+// unsupported by the other state.
+func TestPeekTokenFrontierMergesSameLexDespiteIsKeywordMismatch(t *testing.T) {
+	lang := unionSameLexKeywordLanguage()
+	lookup := func(state StateID, sym Symbol) uint16 {
+		if sym == 2 && (state == 1 || state == 2) {
+			return 1
+		}
+		return 0
+	}
+
+	source := []byte("if")
+	ts := acquireDFATokenSource(NewLexer(lang.LexStates, source), lang, lookup, nil, nil, nil)
+	defer ts.Close()
+	ts.SetParserState(1)
+
+	states := []StateID{1, 2}
+	frontier, ok := ts.PeekTokenFrontier(states, nil)
+	if !ok {
+		t.Fatal("PeekTokenFrontier returned false")
+	}
+	if len(frontier.Candidates) != 1 {
+		t.Fatalf("candidates = %d, want 1 (identifier-promoted and direct-literal \"if\" must merge into one candidate)", len(frontier.Candidates))
+	}
+	cand := frontier.Candidates[0]
+	if cand.Tok.Symbol != 2 {
+		t.Fatalf("candidate symbol = %d, want 2 (if keyword)", cand.Tok.Symbol)
+	}
+	if cand.Tok.StartByte != 0 || cand.Tok.EndByte != 2 {
+		t.Fatalf("candidate span = %d..%d, want 0..2", cand.Tok.StartByte, cand.Tok.EndByte)
+	}
+	if want := uint16(1<<0 | 1<<1); cand.RouteMask != want {
+		t.Fatalf("candidate route mask = %#x, want %#x (both states must vote for the merged tokenization)", cand.RouteMask, want)
 	}
 }

--- a/parsercore_c4_vm.go
+++ b/parsercore_c4_vm.go
@@ -185,7 +185,18 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchCorridor() (progressed bo
 		// elected token either. Refusing before any counter is spent hands
 		// the untouched election back to the generic pass, which re-runs full
 		// classification and reaches the identical no-action outcome.
-		if s.tokenSource != nil && s.tokenSource.lexer != nil {
+		//
+		// tokenMaybeContextualCloseAngle is a cheap, state-free shape check
+		// on the elected token (symbol name and width) that rules out the
+		// overwhelming majority of tokens before paying for
+		// corridorHeaderState()'s resolve below; deferContextualCloseAngleAction
+		// still runs its own full guard, including this same check, as the
+		// single source of truth. A refusal here when progressed is already
+		// true (finding F13) costs exactly one extra run-loop iteration and
+		// cannot livelock: progressed is a fresh local for this call, so the
+		// next dispatchCorridor call always starts it over at false.
+		if s.tokenSource != nil && s.tokenSource.lexer != nil &&
+			tokenMaybeContextualCloseAngle(s.tokenSource.language, s.token) {
 			corridorState, stateErr := s.corridorHeaderState()
 			if stateErr != nil {
 				return progressed, stateErr

--- a/parsercore_c4_vm.go
+++ b/parsercore_c4_vm.go
@@ -176,6 +176,31 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchCorridor() (progressed bo
 		if !s.corridorTokenGateOpen(op) {
 			return progressed, nil
 		}
+		// body != 0 means this exact (state, elected-token) pair carries a
+		// real compiled action -- the corridor's compiled equivalent of a
+		// non-empty generic action row for the shared token. Apply the same
+		// shared-token deferral dispatchPassActive applies at that point
+		// (issue #983): a header whose own lex mode reads a wider close-angle
+		// operator with a real action here must not act on the narrower
+		// elected token either. Refusing before any counter is spent hands
+		// the untouched election back to the generic pass, which re-runs full
+		// classification and reaches the identical no-action outcome.
+		if s.tokenSource != nil && s.tokenSource.lexer != nil {
+			corridorState, stateErr := s.corridorHeaderState()
+			if stateErr != nil {
+				return progressed, stateErr
+			}
+			probe := s.tokenSource.relexProbeLexer
+			if probe == nil {
+				probe = &Lexer{}
+				s.tokenSource.relexProbeLexer = probe
+			}
+			if deferContextualCloseAngleAction(
+				s.tokenSource.language, s.tokenSource.lexer.source, corridorState, s.token, nil, probe,
+			) {
+				return progressed, nil
+			}
+		}
 		switch op {
 		case corridorOpShift:
 			handled, err := s.corridorShift(prog[body+1])

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -3809,6 +3809,13 @@ func diagnosticParserCoreRelexedSymbol(shared, relexed Token) (Symbol, bool) {
 	candidate.Symbol = relexed.Symbol
 	candidate.ExternalScannerToken = false
 	candidate.ExternalScannerStartByte = 0
+	// IsKeyword is a promotion-path artifact of the DFA token source's
+	// keyword re-lex (promoteKeyword), not a property probe.scan's raw
+	// DFA-only relex can ever report; clear it here too, alongside the
+	// external-scanner fields above, so a promoted keyword token's relex
+	// probe is judged on tokenization identity, not on which lex path
+	// produced it.
+	candidate.IsKeyword = false
 	if candidate != relexed {
 		return 0, false
 	}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -3752,6 +3752,12 @@ func (cell *diagnosticParserCoreGenericCell) dispatchToken(shared Token) Token {
 		shared.Symbol = cell.relexedSymbol
 		shared.ExternalScannerToken = false
 		shared.ExternalScannerStartByte = 0
+		// isKeyword is a promotion-path artifact of the shared token's own
+		// lex, not a property of the relexed symbol replacing it here;
+		// clear it alongside the external-scanner fields above so a
+		// promoted keyword token's dispatch view is judged on the relexed
+		// symbol, not on which lex path produced the original.
+		shared.isKeyword = false
 	}
 	return shared
 }
@@ -3809,13 +3815,13 @@ func diagnosticParserCoreRelexedSymbol(shared, relexed Token) (Symbol, bool) {
 	candidate.Symbol = relexed.Symbol
 	candidate.ExternalScannerToken = false
 	candidate.ExternalScannerStartByte = 0
-	// IsKeyword is a promotion-path artifact of the DFA token source's
+	// isKeyword is a promotion-path artifact of the DFA token source's
 	// keyword re-lex (promoteKeyword), not a property probe.scan's raw
 	// DFA-only relex can ever report; clear it here too, alongside the
 	// external-scanner fields above, so a promoted keyword token's relex
 	// probe is judged on tokenization identity, not on which lex path
 	// produced it.
-	candidate.IsKeyword = false
+	candidate.isKeyword = false
 	if candidate != relexed {
 		return 0, false
 	}
@@ -5842,6 +5848,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 	cells := singletonCells[:0]
 	scratchCells := s.dispatchScratch.cells
 	pausedNoActionHeads := 0
+	deferredNoActionHeads := 0
 	for index, header := range s.headers {
 		if header.shifted || header.accepted {
 			continue
@@ -6013,7 +6020,6 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 		}
 		s.work.ActionLookups++
 		actions := boundary.Actions()
-		workCountRecordResolvedActionCell(actions.Len())
 		// Production's per-stack contextualActionIndex (parser_dfa_token_source.go)
 		// zeroes an action for this exact shared token shape when the header's own
 		// lex mode reads a wider close-angle operator that itself carries a real
@@ -6022,7 +6028,11 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 		// check would let the compact route accept a derivation the production
 		// route provably declines (issue #983). A header this defers falls into
 		// the ordinary no-action machinery below -- it never gets a synthesized
-		// token or an altered election.
+		// token or an altered election. The work-count record below is skipped
+		// for a deferred cell (recorded as zero instead, matching production's
+		// zeroed action index) and deferredNoActionHeads is tracked separately
+		// from pausedNoActionHeads so the no-action classification below can
+		// tell a deferral apart from a genuinely empty action row.
 		if actions.Len() != 0 && s.tokenSource != nil && s.tokenSource.lexer != nil {
 			probe := s.tokenSource.relexProbeLexer
 			if probe == nil {
@@ -6032,10 +6042,13 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			if deferContextualCloseAngleAction(
 				s.tokenSource.language, s.tokenSource.lexer.source, StateID(boundary.State()), cellToken, nil, probe,
 			) {
+				workCountRecordResolvedActionCell(0)
 				s.dispatchScratch.noActionIndices = append(s.dispatchScratch.noActionIndices, index)
+				deferredNoActionHeads++
 				continue
 			}
 		}
+		workCountRecordResolvedActionCell(actions.Len())
 		if actions.Len() == 0 {
 			state := StateID(boundary.State())
 			if len(s.headers) > 1 {
@@ -6161,20 +6174,24 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			return nil, s.dropGenericNoActionHeads(noActionIndices)
 		}
 		if len(noActionIndices) != 0 {
-			// pausedNoActionHeads == 0 means every no-action head reached this
-			// point through a genuinely empty action row (no table action for
-			// the elected token), not through the unrelated group-election
-			// pause tracked by header.paused above. That exact shape is the
-			// error-entry point locked-C production pauses on for recovery
-			// (glr.go cPaused: "the stack hit a no-action point"; the
-			// real-corpus matrix's 13 recovery-handoff rows trigger here with
-			// "the elected token has no table action at end-of-file"). Publish
-			// the typed recovery boundary for that shape instead of the
-			// generic no-action boundary so census and receipts can tell a
-			// recovery handoff apart from an internal election pause. This is
-			// a dispatch classification only: both boundaries still decline
-			// and fall back to production unchanged (B3 stage S1).
-			if pausedNoActionHeads == 0 {
+			// pausedNoActionHeads == 0 && deferredNoActionHeads == 0 means
+			// every no-action head reached this point through a genuinely
+			// empty action row (no table action for the elected token), not
+			// through the unrelated group-election pause tracked by
+			// header.paused above, and not through the issue #983 contextual
+			// close-angle deferral tracked by deferredNoActionHeads above
+			// (that shape has a real, non-empty action row the header simply
+			// must not take this pass). That exact genuinely-empty shape is
+			// the error-entry point locked-C production pauses on for
+			// recovery (glr.go cPaused: "the stack hit a no-action point";
+			// the real-corpus matrix's 13 recovery-handoff rows trigger here
+			// with "the elected token has no table action at end-of-file").
+			// Publish the typed recovery boundary for that shape instead of
+			// the generic no-action boundary so census and receipts can tell
+			// a recovery handoff apart from an internal election pause. This
+			// is a dispatch classification only: both boundaries still
+			// decline and fall back to production unchanged (B3 stage S1).
+			if pausedNoActionHeads == 0 && deferredNoActionHeads == 0 {
 				// B3 stage S3: attempt native strategy-2 recovery for the
 				// certified witness class instead of declining outright.
 				// Scoped to the sole-header, sole-no-action-head shape only
@@ -6196,6 +6213,22 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				return &diagnosticParserCoreGenericUnsupported{
 					boundary:    DiagnosticParserCoreRecovery,
 					detail:      diagnosticParserCoreNoTableActionDetail,
+					headerIndex: noActionIndices[0],
+				}, nil
+			}
+			if pausedNoActionHeads == 0 {
+				// deferredNoActionHeads > 0: at least one no-action head
+				// reached this point through the issue #983 contextual
+				// close-angle deferral, not a genuinely empty action row.
+				// Never route a deferred header through s3TryOpenErrorRegion:
+				// the S3 resume path re-reads the raw table without the
+				// deferral and can bounce forever if the certification gate
+				// ever widens beyond html. Keep the boundary class Recovery
+				// so routing is unchanged, but give the decline a distinct,
+				// accurate detail instead of claiming the row had no action.
+				return &diagnosticParserCoreGenericUnsupported{
+					boundary:    DiagnosticParserCoreRecovery,
+					detail:      "generic scheduler deferred a contextual close-angle action for the elected token",
 					headerIndex: noActionIndices[0],
 				}, nil
 			}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -5807,6 +5807,22 @@ type diagnosticParserCoreGenericUnsupported struct {
 
 const diagnosticParserCoreNoTableActionDetail = "generic scheduler has no table action for the elected token"
 
+// diagnosticParserCoreContextualCloseAngleDeferralDetail is the decline
+// detail for a no-action head that reached dispatchPassActive's no-action
+// classification through the issue #983 contextual close-angle deferral,
+// not a genuinely empty action row. Kept distinct from
+// diagnosticParserCoreNoTableActionDetail so census, receipts, and tests can
+// tell the two shapes apart even though both share the Recovery boundary.
+const diagnosticParserCoreContextualCloseAngleDeferralDetail = "generic scheduler deferred a contextual close-angle action for the elected token"
+
+// DiagnosticParserCoreContextualCloseAngleDeferralDetailForTest exposes
+// diagnosticParserCoreContextualCloseAngleDeferralDetail so the external
+// test package can assert on the issue #983 deferral's decline detail
+// without duplicating the literal string.
+func DiagnosticParserCoreContextualCloseAngleDeferralDetailForTest() string {
+	return diagnosticParserCoreContextualCloseAngleDeferralDetail
+}
+
 func (s *diagnosticParserCoreGenericScheduler) dispatchPass() (*diagnosticParserCoreGenericUnsupported, error) {
 	if err := s.dispatchScratch.begin(); err != nil {
 		return nil, err
@@ -6228,7 +6244,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				// accurate detail instead of claiming the row had no action.
 				return &diagnosticParserCoreGenericUnsupported{
 					boundary:    DiagnosticParserCoreRecovery,
-					detail:      "generic scheduler deferred a contextual close-angle action for the elected token",
+					detail:      diagnosticParserCoreContextualCloseAngleDeferralDetail,
 					headerIndex: noActionIndices[0],
 				}, nil
 			}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -6014,6 +6014,28 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 		s.work.ActionLookups++
 		actions := boundary.Actions()
 		workCountRecordResolvedActionCell(actions.Len())
+		// Production's per-stack contextualActionIndex (parser_dfa_token_source.go)
+		// zeroes an action for this exact shared token shape when the header's own
+		// lex mode reads a wider close-angle operator that itself carries a real
+		// action here: a differently-lexing stack already claimed the elected
+		// narrow prefix, so this header must not shift it either. Skipping this
+		// check would let the compact route accept a derivation the production
+		// route provably declines (issue #983). A header this defers falls into
+		// the ordinary no-action machinery below -- it never gets a synthesized
+		// token or an altered election.
+		if actions.Len() != 0 && s.tokenSource != nil && s.tokenSource.lexer != nil {
+			probe := s.tokenSource.relexProbeLexer
+			if probe == nil {
+				probe = &Lexer{}
+				s.tokenSource.relexProbeLexer = probe
+			}
+			if deferContextualCloseAngleAction(
+				s.tokenSource.language, s.tokenSource.lexer.source, StateID(boundary.State()), cellToken, nil, probe,
+			) {
+				s.dispatchScratch.noActionIndices = append(s.dispatchScratch.noActionIndices, index)
+				continue
+			}
+		}
 		if actions.Len() == 0 {
 			state := StateID(boundary.State())
 			if len(s.headers) > 1 {

--- a/parsercore_phase0_state_relex_internal_test.go
+++ b/parsercore_phase0_state_relex_internal_test.go
@@ -30,6 +30,56 @@ func TestDiagnosticParserCoreRelexedSymbolReconstructsExactToken(t *testing.T) {
 	}
 }
 
+// TestDispatchTokenClearsIsKeywordOnRelexedSymbolOverride pins finding F7:
+// when relexedSymbol overrides the shared token's symbol, dispatchToken must
+// clear isKeyword alongside the external-scanner fields. isKeyword records
+// that the ORIGINAL symbol was reached through the keyword-adoption
+// promotion path; that fact does not carry over to an unrelated relexed
+// symbol replacing it, so a dispatch view built from a promoted keyword
+// token must not still claim the relexed token is a keyword adoption.
+func TestDispatchTokenClearsIsKeywordOnRelexedSymbolOverride(t *testing.T) {
+	shared := Token{
+		Symbol:                   2,
+		Text:                     "if",
+		StartByte:                0,
+		EndByte:                  2,
+		EndPoint:                 Point{Column: 2},
+		ExternalScannerToken:     true,
+		ExternalScannerStartByte: 1,
+		isKeyword:                true,
+	}
+	cell := diagnosticParserCoreGenericCell{relexedSymbol: 9}
+
+	got := cell.dispatchToken(shared)
+	if got.isKeyword {
+		t.Fatal("dispatchToken with a relexedSymbol override: isKeyword = true, want false")
+	}
+	if got.Symbol != 9 {
+		t.Fatalf("dispatchToken symbol = %d, want 9 (the relexed symbol)", got.Symbol)
+	}
+	if got.ExternalScannerToken || got.ExternalScannerStartByte != 0 {
+		t.Fatalf("dispatchToken external-scanner fields = %v/%d, want false/0",
+			got.ExternalScannerToken, got.ExternalScannerStartByte)
+	}
+}
+
+// TestDispatchTokenPreservesIsKeywordWithoutRelexedSymbolOverride pins the
+// other half of finding F7: dispatchToken must leave isKeyword untouched
+// when there is no relexedSymbol override at all (cell.relexedSymbol == 0),
+// so the clear above is scoped to the override branch only.
+func TestDispatchTokenPreservesIsKeywordWithoutRelexedSymbolOverride(t *testing.T) {
+	shared := Token{Symbol: 2, isKeyword: true}
+	cell := diagnosticParserCoreGenericCell{}
+
+	got := cell.dispatchToken(shared)
+	if !got.isKeyword {
+		t.Fatal("dispatchToken without a relexedSymbol override: isKeyword = false, want true (unmodified)")
+	}
+	if got != shared {
+		t.Fatalf("dispatchToken without an override = %+v, want unmodified %+v", got, shared)
+	}
+}
+
 func TestDiagnosticParserCoreRelexedSymbolRejectsTokenFieldChanges(t *testing.T) {
 	shared := Token{
 		Symbol:                   3,

--- a/parsercore_phase0_token_reuse.go
+++ b/parsercore_phase0_token_reuse.go
@@ -8,10 +8,17 @@ package gotreesitter
 // re-lexing. Nothing consumes it yet; the per-epoch token cell and the
 // scheduler election land in later tranches of the same lane.
 
-// tokenReuseLeaf carries the leaf facts C reads from a Subtree. A bare
-// token cell sets LeafState and ParseState equal; a reused subtree keeps
-// them distinct (the first leaf's lex state against the root's parse
-// state, per ts_subtree_leaf_parse_state and ts_subtree_parse_state).
+// tokenReuseLeaf carries the leaf facts C reads from a Subtree, split
+// across two different accessors exactly as
+// ts_parser__can_reuse_first_leaf (parser.c:472-505) reads them: Symbol
+// and LeafState come from the first leaf (ts_subtree_leaf_symbol and
+// ts_subtree_leaf_parse_state, which both read through the subtree's
+// leftmost leaf); ParseState, SizeBytes, and IsKeyword come from the root
+// subtree itself (ts_subtree_parse_state, ts_subtree_size, and
+// ts_subtree_is_keyword). A bare token cell sets LeafState and ParseState
+// equal; a reused subtree keeps them distinct (the first leaf's lex state
+// against the root's parse state, per ts_subtree_leaf_parse_state and
+// ts_subtree_parse_state).
 type tokenReuseLeaf struct {
 	Symbol     Symbol
 	LeafState  StateID
@@ -20,21 +27,31 @@ type tokenReuseLeaf struct {
 	IsKeyword  bool
 }
 
-// lexerModeTriple is C's TSLexerMode (parser.h:89-93): exactly the three
-// fields the C reuse test compares with memcmp. Go's LexMode carries
-// additional derived fields (AfterWhitespaceLexState, LexStateID, and
-// friends) that are functions of the same state row; the literal port
-// compares only the C triple.
+// lexerModeTriple starts from C's TSLexerMode (parser.h:89-93), the three
+// fields the C reuse test compares with memcmp, but widens and extends it
+// for this engine's own table layout rather than reading Go's LexMode raw
+// fields directly:
+//
+//   - lexState uses LexStateIndex() (uint32), not the raw uint16 LexState
+//     field, because grammargen tables can exceed 64K lexer states and the
+//     widened index is the only field that stays collision-free at that
+//     size (Language.LexStateID / LexMode.LexStateIndex's own doc comment).
+//   - afterWhitespaceLexState (via AfterWhitespaceLexStateIndex()) is
+//     included even though C's TSLexerMode has no equivalent field: in this
+//     engine, after-whitespace is an independent table entry populated by a
+//     separate pass over the DFA (grammargen/assemble.go:138-142), so two
+//     states with an identical C triple can still lex differently here if
+//     their after-whitespace entries differ. Leaving it out of the identity
+//     would let the reuse rule below fire on a match C never has to prove
+//     safe. Including it keeps the comparison aligned with actual lexer
+//     behavior and errs fail-closed relative to C rather than risking an
+//     unsound reuse.
 type lexerModeTriple struct {
-	lexState          uint16
-	externalLexState  uint16
-	reservedWordSetID uint16
+	lexState                uint32
+	externalLexState        uint16
+	reservedWordSetID       uint16
+	afterWhitespaceLexState uint32
 }
-
-// nonTerminalExtraLexState mirrors C's (uint16_t)-1 sentinel: at the end
-// of a non-terminal extra the lexer returns no token, so nothing may be
-// reused there (parser.c:483-487).
-const nonTerminalExtraLexState = ^uint16(0)
 
 func lexerModeTripleForState(lang *Language, state StateID) (lexerModeTriple, bool) {
 	if lang == nil || int(state) >= len(lang.LexModes) {
@@ -42,9 +59,10 @@ func lexerModeTripleForState(lang *Language, state StateID) (lexerModeTriple, bo
 	}
 	mode := lang.LexModes[state]
 	return lexerModeTriple{
-		lexState:          mode.LexState,
-		externalLexState:  mode.ExternalLexState,
-		reservedWordSetID: mode.ReservedWordSetID,
+		lexState:                mode.LexStateIndex(),
+		externalLexState:        mode.ExternalLexState,
+		reservedWordSetID:       mode.ReservedWordSetID,
+		afterWhitespaceLexState: mode.AfterWhitespaceLexStateIndex(),
 	}, true
 }
 
@@ -62,8 +80,13 @@ func canReuseFirstLeaf(lang *Language, state StateID, leaf tokenReuseLeaf, entry
 		return false
 	}
 
-	// parser.c:487 -- never reuse at the end of a non-terminal extra.
-	if currentMode.lexState == nonTerminalExtraLexState {
+	// parser.c:487 -- never reuse at the end of a non-terminal extra. C's
+	// sentinel is (uint16_t)-1 on the raw LexState field; this engine's
+	// package-wide noLookaheadLexState sentinel is the same value widened
+	// through LexStateIndex() (parser_dfa_token_source.go), so comparing
+	// against it here follows the same convention every other no-lookahead
+	// check in this package uses instead of duplicating a private sentinel.
+	if currentMode.lexState == noLookaheadLexState {
 		return false
 	}
 

--- a/parsercore_phase0_token_reuse.go
+++ b/parsercore_phase0_token_reuse.go
@@ -1,0 +1,88 @@
+package gotreesitter
+
+// This file opens the D2 first-leaf token-cache lane
+// (spec.derivation-set-equivalence.v1, section 3) with a literal port of
+// C's ts_parser__can_reuse_first_leaf (parser.c:472-505 at the locked C
+// revision f5afe475). The predicate decides whether a token lexed under one
+// parse state's lexer mode is reusable under another state without
+// re-lexing. Nothing consumes it yet; the per-epoch token cell and the
+// scheduler election land in later tranches of the same lane.
+
+// tokenReuseLeaf carries the leaf facts C reads from a Subtree. A bare
+// token cell sets LeafState and ParseState equal; a reused subtree keeps
+// them distinct (the first leaf's lex state against the root's parse
+// state, per ts_subtree_leaf_parse_state and ts_subtree_parse_state).
+type tokenReuseLeaf struct {
+	Symbol     Symbol
+	LeafState  StateID
+	ParseState StateID
+	SizeBytes  uint32
+	IsKeyword  bool
+}
+
+// lexerModeTriple is C's TSLexerMode (parser.h:89-93): exactly the three
+// fields the C reuse test compares with memcmp. Go's LexMode carries
+// additional derived fields (AfterWhitespaceLexState, LexStateID, and
+// friends) that are functions of the same state row; the literal port
+// compares only the C triple.
+type lexerModeTriple struct {
+	lexState          uint16
+	externalLexState  uint16
+	reservedWordSetID uint16
+}
+
+// nonTerminalExtraLexState mirrors C's (uint16_t)-1 sentinel: at the end
+// of a non-terminal extra the lexer returns no token, so nothing may be
+// reused there (parser.c:483-487).
+const nonTerminalExtraLexState = ^uint16(0)
+
+func lexerModeTripleForState(lang *Language, state StateID) (lexerModeTriple, bool) {
+	if lang == nil || int(state) >= len(lang.LexModes) {
+		return lexerModeTriple{}, false
+	}
+	mode := lang.LexModes[state]
+	return lexerModeTriple{
+		lexState:          mode.LexState,
+		externalLexState:  mode.ExternalLexState,
+		reservedWordSetID: mode.ReservedWordSetID,
+	}, true
+}
+
+// canReuseFirstLeaf ports ts_parser__can_reuse_first_leaf clause for
+// clause; the rule order and every short-circuit match the C source. The
+// only addition is a fail-closed false when either state has no lexer-mode
+// row, a case C's complete tables cannot present.
+func canReuseFirstLeaf(lang *Language, state StateID, leaf tokenReuseLeaf, entry ParseActionEntry) bool {
+	currentMode, ok := lexerModeTripleForState(lang, state)
+	if !ok {
+		return false
+	}
+	leafMode, ok := lexerModeTripleForState(lang, leaf.LeafState)
+	if !ok {
+		return false
+	}
+
+	// parser.c:487 -- never reuse at the end of a non-terminal extra.
+	if currentMode.lexState == nonTerminalExtraLexState {
+		return false
+	}
+
+	// parser.c:490-497 -- a token created under the same lookahead set is
+	// reusable, unless it is the keyword-capture token and either was
+	// adopted as a keyword or came from a different parse state.
+	if len(entry.Actions) > 0 && leafMode == currentMode &&
+		(leaf.Symbol != lang.KeywordCaptureToken ||
+			(!leaf.IsKeyword && leaf.ParseState == state)) {
+		return true
+	}
+
+	// parser.c:500 -- zero-width tokens other than end-of-file never cross
+	// into a different lookahead set.
+	if leaf.SizeBytes == 0 && leaf.Symbol != 0 {
+		return false
+	}
+
+	// parser.c:504 -- otherwise reuse requires a lex context with no
+	// external scanner and the table entry's reusable bit.
+	return currentMode.externalLexState == 0 && entry.Reusable
+}

--- a/parsercore_phase0_token_reuse_internal_test.go
+++ b/parsercore_phase0_token_reuse_internal_test.go
@@ -4,9 +4,11 @@ import "testing"
 
 // The cases below pin canReuseFirstLeaf to C's rule order in
 // ts_parser__can_reuse_first_leaf (parser.c:472-505), one case per clause.
-// State rows: 0 and 1 share the C lexer-mode triple; 2 differs in lex
+// State rows: 0 and 1 share the compared mode identity; 2 differs in lex
 // state; 3 is the non-terminal-extra sentinel; 4 has an external lex
-// state; 5 differs only in the reserved word set.
+// state; 5 differs only in the reserved word set; 6 differs only in the
+// after-whitespace lex state, this engine's own extension to C's
+// lexer-mode triple (lexerModeTriple's doc comment).
 func tokenReuseTestLanguage() *Language {
 	return &Language{
 		KeywordCaptureToken: 7,
@@ -14,9 +16,10 @@ func tokenReuseTestLanguage() *Language {
 			{LexState: 1},
 			{LexState: 1},
 			{LexState: 2},
-			{LexState: nonTerminalExtraLexState},
+			{LexState: ^uint16(0)},
 			{LexState: 1, ExternalLexState: 5},
 			{LexState: 1, ReservedWordSetID: 9},
+			{LexState: 1, AfterWhitespaceLexState: 3},
 		},
 	}
 }
@@ -135,6 +138,48 @@ func TestCanReuseFirstLeafRuleTable(t *testing.T) {
 			leaf:  tokenReuseLeaf{Symbol: 9, LeafState: 0, ParseState: 0, SizeBytes: 3},
 			entry: withActions,
 			want:  false,
+		},
+		{
+			// The compared mode identity extends C's triple with the
+			// after-whitespace lex state (lexerModeTriple's doc comment,
+			// grammargen/assemble.go:138-142): states 0 and 6 differ only
+			// there, so the fast path must not fire.
+			name:  "after_whitespace_lex_state_breaks_mode_equality",
+			state: 6,
+			leaf:  tokenReuseLeaf{Symbol: 9, LeafState: 0, ParseState: 0, SizeBytes: 3},
+			entry: withActions,
+			want:  false,
+		},
+		{
+			// F11 pin: parser.c:487 reads the CURRENT state's lex mode only.
+			// A sentinel on the LEAF's state (state 3) must not trip that
+			// rule; it only breaks the leafMode == currentMode fast path,
+			// same as any other mode mismatch, and the reusable bit still
+			// carries the result to true.
+			name:  "leaf_state_sentinel_does_not_trigger_current_state_rule",
+			state: 0,
+			leaf:  tokenReuseLeaf{Symbol: 9, LeafState: 3, ParseState: 0, SizeBytes: 3},
+			entry: withActionsReusable,
+			want:  true,
+		},
+		{
+			// F11 pin: a non-nil but empty Actions slice must skip the fast
+			// path exactly like a nil one (the clause is action_count > 0,
+			// not Actions != nil), then decline without the reusable bit.
+			name:  "non_nil_empty_actions_skips_fast_path_without_bit",
+			state: 0,
+			leaf:  tokenReuseLeaf{Symbol: 9, LeafState: 1, ParseState: 1, SizeBytes: 3},
+			entry: ParseActionEntry{Actions: []ParseAction{}},
+			want:  false,
+		},
+		{
+			// F11 pin: the same non-nil-but-empty Actions shape, now with
+			// the reusable bit set, must reach parser.c:504 and reuse.
+			name:  "non_nil_empty_actions_reaches_bit_clause",
+			state: 0,
+			leaf:  tokenReuseLeaf{Symbol: 9, LeafState: 1, ParseState: 1, SizeBytes: 3},
+			entry: ParseActionEntry{Reusable: true, Actions: []ParseAction{}},
+			want:  true,
 		},
 		{
 			name:  "missing_mode_row_fails_closed",

--- a/parsercore_phase0_token_reuse_internal_test.go
+++ b/parsercore_phase0_token_reuse_internal_test.go
@@ -1,0 +1,153 @@
+package gotreesitter
+
+import "testing"
+
+// The cases below pin canReuseFirstLeaf to C's rule order in
+// ts_parser__can_reuse_first_leaf (parser.c:472-505), one case per clause.
+// State rows: 0 and 1 share the C lexer-mode triple; 2 differs in lex
+// state; 3 is the non-terminal-extra sentinel; 4 has an external lex
+// state; 5 differs only in the reserved word set.
+func tokenReuseTestLanguage() *Language {
+	return &Language{
+		KeywordCaptureToken: 7,
+		LexModes: []LexMode{
+			{LexState: 1},
+			{LexState: 1},
+			{LexState: 2},
+			{LexState: nonTerminalExtraLexState},
+			{LexState: 1, ExternalLexState: 5},
+			{LexState: 1, ReservedWordSetID: 9},
+		},
+	}
+}
+
+func TestCanReuseFirstLeafRuleTable(t *testing.T) {
+	lang := tokenReuseTestLanguage()
+	withActions := ParseActionEntry{Actions: make([]ParseAction, 1)}
+	withActionsReusable := ParseActionEntry{Reusable: true, Actions: make([]ParseAction, 1)}
+	emptyReusable := ParseActionEntry{Reusable: true}
+	empty := ParseActionEntry{}
+
+	for _, test := range []struct {
+		name  string
+		state StateID
+		leaf  tokenReuseLeaf
+		entry ParseActionEntry
+		want  bool
+	}{
+		{
+			// parser.c:487.
+			name:  "sentinel_state_never_reuses",
+			state: 3,
+			leaf:  tokenReuseLeaf{Symbol: 9, LeafState: 3, ParseState: 3, SizeBytes: 2},
+			entry: withActionsReusable,
+			want:  false,
+		},
+		{
+			// parser.c:490-497, the same-lookahead fast path. The reusable
+			// bit plays no part here.
+			name:  "equal_modes_with_actions_reuses",
+			state: 0,
+			leaf:  tokenReuseLeaf{Symbol: 9, LeafState: 1, ParseState: 1, SizeBytes: 3},
+			entry: withActions,
+			want:  true,
+		},
+		{
+			// An empty action row skips the fast path; parser.c:504 then
+			// requires the reusable bit.
+			name:  "equal_modes_without_actions_needs_reusable_bit",
+			state: 0,
+			leaf:  tokenReuseLeaf{Symbol: 9, LeafState: 1, ParseState: 1, SizeBytes: 3},
+			entry: emptyReusable,
+			want:  true,
+		},
+		{
+			name:  "equal_modes_without_actions_and_without_bit_declines",
+			state: 0,
+			leaf:  tokenReuseLeaf{Symbol: 9, LeafState: 1, ParseState: 1, SizeBytes: 3},
+			entry: empty,
+			want:  false,
+		},
+		{
+			// parser.c:494-496 -- an adopted keyword blocks the fast path;
+			// parser.c:504 then declines without the bit.
+			name:  "adopted_keyword_blocks_fast_path",
+			state: 0,
+			leaf:  tokenReuseLeaf{Symbol: 7, LeafState: 1, ParseState: 0, SizeBytes: 3, IsKeyword: true},
+			entry: withActions,
+			want:  false,
+		},
+		{
+			name:  "adopted_keyword_still_reusable_through_the_bit",
+			state: 0,
+			leaf:  tokenReuseLeaf{Symbol: 7, LeafState: 1, ParseState: 0, SizeBytes: 3, IsKeyword: true},
+			entry: withActionsReusable,
+			want:  true,
+		},
+		{
+			// parser.c:495-496 -- a non-adopted capture token from the same
+			// parse state keeps the fast path.
+			name:  "capture_token_same_state_reuses",
+			state: 0,
+			leaf:  tokenReuseLeaf{Symbol: 7, LeafState: 1, ParseState: 0, SizeBytes: 3},
+			entry: withActions,
+			want:  true,
+		},
+		{
+			// A capture token from another parse state loses the fast path
+			// and falls to the reusable bit.
+			name:  "capture_token_other_state_falls_to_bit",
+			state: 0,
+			leaf:  tokenReuseLeaf{Symbol: 7, LeafState: 1, ParseState: 2, SizeBytes: 3},
+			entry: withActions,
+			want:  false,
+		},
+		{
+			// parser.c:500 -- zero-width non-EOF under a different
+			// lookahead set, even with the bit set.
+			name:  "zero_width_non_eof_never_crosses",
+			state: 0,
+			leaf:  tokenReuseLeaf{Symbol: 9, LeafState: 2, ParseState: 2, SizeBytes: 0},
+			entry: withActionsReusable,
+			want:  false,
+		},
+		{
+			// Zero-width end-of-file falls through to parser.c:504.
+			name:  "zero_width_eof_falls_to_bit",
+			state: 0,
+			leaf:  tokenReuseLeaf{Symbol: 0, LeafState: 2, ParseState: 2, SizeBytes: 0},
+			entry: emptyReusable,
+			want:  true,
+		},
+		{
+			// parser.c:504 -- an external lex state blocks the bit.
+			name:  "external_lex_state_blocks_bit",
+			state: 4,
+			leaf:  tokenReuseLeaf{Symbol: 9, LeafState: 2, ParseState: 2, SizeBytes: 3},
+			entry: withActionsReusable,
+			want:  false,
+		},
+		{
+			// The C triple includes the reserved word set: states 0 and 5
+			// differ only there, so the fast path must not fire.
+			name:  "reserved_word_set_breaks_mode_equality",
+			state: 5,
+			leaf:  tokenReuseLeaf{Symbol: 9, LeafState: 0, ParseState: 0, SizeBytes: 3},
+			entry: withActions,
+			want:  false,
+		},
+		{
+			name:  "missing_mode_row_fails_closed",
+			state: 9,
+			leaf:  tokenReuseLeaf{Symbol: 9, LeafState: 0, ParseState: 0, SizeBytes: 3},
+			entry: withActionsReusable,
+			want:  false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := canReuseFirstLeaf(lang, test.state, test.leaf, test.entry); got != test.want {
+				t.Fatalf("canReuseFirstLeaf=%v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The compact admission route elected a clean Swift derivation that the production route provably declines, because production zeroes the action for a narrow ">" when another live stack reads the wider ">>". This branch ports that contextual close-angle deferral into the compact dispatch and the C4 corridor, and records the decline with its own accurate detail. It also adds the IsKeyword flag that C carries on a promoted keyword, so token comparisons judge tokenization identity instead of lex path, and lands the C token-reuse predicate that opens the first-leaf token-cache lane.

## Changes

- Apply the contextual close-angle deferral in `dispatchPassActive` (parsercore_phase0_driver.go) and in `dispatchCorridor` (parsercore_c4_vm.go), so the compact route declines the split ">>" shape the production route declines (issue #983).
- Extract the predicate into `tokenMaybeContextualCloseAngle` (cheap, state-free shape pre-check) and `deferContextualCloseAngleAction` (full predicate, single source of truth) so production, the compact dispatch, and the C4 corridor share one implementation. The corridor pays for its header-state resolve only after the shape pre-check passes.
- Report a deferred head with the new detail `generic scheduler deferred a contextual close-angle action for the elected token` instead of the empty-row detail. Routing stays on the Recovery boundary, and deferred heads are excluded from the S3 native strategy-2 recovery attempt, whose re-read of the raw table could bounce forever.
- Track `deferredNoActionHeads` separately from `pausedNoActionHeads`, and record a zero resolved-action count for a deferred cell to match production's zeroed action index.
- Add `Token.isKeyword`, mirroring C's `Subtree.is_keyword` (subtree.h:131), and set it in `dfaTokenSource.promoteKeyword` whenever the keyword re-lex adopts the captured word.
- Compare tokens through the new `tokensSameLex` helper at the three GLR union sites (`PeekTokenFrontier` candidate merge, `stateProducesTokenFrontierCandidate`, `nextGLRUnionDFAToken`) so a promotion-path flag never splits one tokenization across two candidates.
- Clear `isKeyword` in `dispatchToken` and `diagnosticParserCoreRelexedSymbol` when a relexed symbol replaces the shared token, alongside the existing external-scanner fields.
- Add `parsercore_phase0_token_reuse.go`: a clause-by-clause port of C's `ts_parser__can_reuse_first_leaf` (parser.c:472-505) with `tokenReuseLeaf` and `lexerModeTriple`. The triple widens lex-state indexes to uint32 for tables past 64K states and adds this engine's after-whitespace lex state, so the identity test fails closed relative to C. Nothing consumes it yet.
- Add the Swift witnesses `0>>` and ` 0%0>>` to the `FuzzAdmissionRouteEquality` seed corpus, and a tag-gated test file that pins both the deferral-specific decline detail and the routed=0/fallback=1 counters through the public Parse route.
- Close the mutation gaps in the new guards: a rule table for `canReuseFirstLeaf` (one case per C clause, plus pins for the leaf-state sentinel and non-nil empty action rows), keyword-adoption tests with a competing decoy that isolates the `nextGLRUnionDFAToken` call site, and shape-gate parity tests between the pre-check and the full predicate.
- Record the correctness entry in CHANGELOG.md. Canonical and full census totals stay unchanged: 69/0/30/10 and 88/0/46/12.

## Testing

- go test . -run 'TestCanReuseFirstLeafRuleTable' -count=1
- go test . -run 'TestPromoteKeyword|TestPeekTokenFrontierMergesSameLexDespiteIsKeywordMismatch|TestNextGLRUnionDFATokenElectsMergedKeywordOverCompetingDecoy' -count=1
- go test . -run 'TestTokenMaybeContextualCloseAngleShapeGate|TestDeferContextualCloseAngleActionSharesShapeGateWithPreCheck|TestContextualActionDefersUnsignedShiftLineageAfterSingleCloseElection|TestDispatchToken.*IsKeyword' -count=1
- go test -tags gts_parsercorephase0 . -run 'CloseAngleDeferral' -count=1
- bash cgo_harness/docker/run_single_grammar_parity.sh swift
- bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs swift

## Related Issues

- Refs #983

## Review Focus

Check that `deferContextualCloseAngleAction` keeps the original short-circuit order (the table lookup must not run before the cheap shape checks) and that the compact callers correctly pass included=nil. Also confirm the `lexerModeTriple` extension past C's three fields is the intended fail-closed choice for the token-reuse lane.

Closes #983.