### PR TITLE
add(parsercore): Carry token-reuse bit and cache elected token

### DIFF
--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -110,6 +110,7 @@ func (d ActionRowDescriptor) DispatchSupported() bool { return d.dispatchSupport
 type actionRowData struct {
 	actions    []Action
 	descriptor ActionRowDescriptor
+	reusable   bool
 }
 
 // ActionRow is an immutable decoded parse-table cell. Its backing storage is
@@ -146,14 +147,17 @@ func (b ClassifiedBoundary) ByteOffset() uint32 { return b.byteOffset }
 // Actions returns the immutable decoded action row for this classification.
 func (b ClassifiedBoundary) Actions() ActionRow { return b.actions }
 
-// NewActionRow snapshots actions into an immutable row.
-func NewActionRow(actions []Action) ActionRow {
+// NewActionRow snapshots actions into an immutable row. reusable carries the
+// language table's per-entry token-reuse eligibility bit (Language.
+// ParseActions[i].Reusable) through to the decoded row unchanged; it is not
+// derived from actions and does not affect Descriptor's dispatch shape.
+func NewActionRow(actions []Action, reusable bool) ActionRow {
 	if len(actions) == 0 {
 		return ActionRow{}
 	}
 	snapshot := append([]Action(nil), actions...)
 	return ActionRow{data: &actionRowData{
-		actions: snapshot, descriptor: describeActionRow(snapshot),
+		actions: snapshot, descriptor: describeActionRow(snapshot), reusable: reusable,
 	}}
 }
 
@@ -175,6 +179,16 @@ func (r ActionRow) Descriptor() ActionRowDescriptor {
 		return ActionRowDescriptor{kind: ActionRowEmpty}
 	}
 	return r.data.descriptor
+}
+
+// Reusable reports the language table's token-reuse eligibility bit for this
+// row, unchanged from Language.ParseActions[i].Reusable. Nothing reads it
+// yet; it is substrate for a later forced-reuse tranche.
+func (r ActionRow) Reusable() bool {
+	if r.data == nil {
+		return false
+	}
+	return r.data.reusable
 }
 
 func (r ActionRow) actionRef(index int) *Action { return &r.data.actions[index] }

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -2764,7 +2764,7 @@ func TestActionRowDescriptorClassifiesImmutableRows(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			row := NewActionRow(test.actions)
+			row := NewActionRow(test.actions, false)
 			descriptor := row.Descriptor()
 			if descriptor.Kind() != test.kind || descriptor.HasShift() != test.hasShift || descriptor.HasReduce() != test.hasReduce {
 				t.Fatalf("descriptor=(kind=%v shift=%t reduce=%t), want (%v %t %t)", descriptor.Kind(), descriptor.HasShift(), descriptor.HasReduce(), test.kind, test.hasShift, test.hasReduce)
@@ -2779,6 +2779,42 @@ func TestActionRowDescriptorClassifiesImmutableRows(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestActionRowReusableCarriesLanguageTableBitUnchanged pins that NewActionRow's
+// reusable argument (Language.ParseActions[i].Reusable) round-trips through
+// Reusable() unchanged. This is substrate for a later forced-reuse tranche:
+// nothing reads Reusable() yet, and it does not affect Descriptor's dispatch
+// shape (describeActionRow never sees it; it is derived only from actions).
+func TestActionRowReusableCarriesLanguageTableBitUnchanged(t *testing.T) {
+	tests := []struct {
+		name     string
+		reusable bool
+	}{
+		{name: "reusable-true", reusable: true},
+		{name: "reusable-false", reusable: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			row := NewActionRow([]Action{{Type: ActionShift, State: 2}}, test.reusable)
+			if got := row.Reusable(); got != test.reusable {
+				t.Fatalf("row.Reusable() = %t, want %t", got, test.reusable)
+			}
+		})
+	}
+}
+
+// TestActionRowReusableZeroValueIsFalse pins that a zero-value ActionRow
+// (returned for an empty action list, matching NewActionRow's pre-existing
+// empty-row short circuit) reports Reusable() == false regardless of the
+// reusable argument, since the empty row never allocates actionRowData.
+func TestActionRowReusableZeroValueIsFalse(t *testing.T) {
+	if got := (ActionRow{}).Reusable(); got != false {
+		t.Fatalf("zero-value ActionRow.Reusable() = %t, want false", got)
+	}
+	if got := NewActionRow(nil, true).Reusable(); got != false {
+		t.Fatalf("NewActionRow(nil, true).Reusable() = %t, want false (empty row drops the bit)", got)
 	}
 }
 

--- a/internal/parsercorephase0/fake_table_test.go
+++ b/internal/parsercorephase0/fake_table_test.go
@@ -23,7 +23,7 @@ func (f *fakeTable) Actions(state StateID, symbol Symbol) (ActionRow, error) {
 	if f == nil {
 		return ActionRow{}, errors.New("fake table is nil")
 	}
-	return NewActionRow(f.actions[tableCell{state: state, symbol: symbol}]), nil
+	return NewActionRow(f.actions[tableCell{state: state, symbol: symbol}], false), nil
 }
 
 func actionRowValues(row ActionRow) []Action {

--- a/internal/parsercorephase0/gotreesitter_adapter_test.go
+++ b/internal/parsercorephase0/gotreesitter_adapter_test.go
@@ -37,7 +37,7 @@ func (a gotreesitterTableAdapter) Actions(state core.StateID, symbol core.Symbol
 	if int(index) >= len(a.language.ParseActions) {
 		return core.ActionRow{}, errors.New("test adapter: action index out of range")
 	}
-	return core.NewActionRow(adaptActions(a.language.ParseActions[index].Actions)), nil
+	return core.NewActionRow(adaptActions(a.language.ParseActions[index].Actions), a.language.ParseActions[index].Reusable), nil
 }
 
 func actionRowValues(row core.ActionRow) []core.Action {

--- a/parsercore_c4_program.go
+++ b/parsercore_c4_program.go
@@ -521,7 +521,7 @@ func (t *corridorTables) row(state StateID, sym Symbol) (core.ActionRow, uint16,
 			return core.ActionRow{}, idx, err
 		}
 	}
-	return core.NewActionRow(converted), idx, nil
+	return core.NewActionRow(converted, entry.Reusable), idx, nil
 }
 
 // externalState reports whether the state's external-token row is non-empty,

--- a/parsercore_phase0_action_test.go
+++ b/parsercore_phase0_action_test.go
@@ -169,8 +169,8 @@ func TestParserCoreSameLookaheadGuardsDeclineBeforeMutation(t *testing.T) {
 		token   Token
 		actions core.ActionRow
 	}{
-		{name: "no-lookahead", token: Token{NoLookahead: true}, actions: core.NewActionRow([]core.Action{{Type: core.ActionShift, State: 2}})},
-		{name: "repetition", actions: core.NewActionRow([]core.Action{{Type: core.ActionShift, State: 2, Repetition: true}})},
+		{name: "no-lookahead", token: Token{NoLookahead: true}, actions: core.NewActionRow([]core.Action{{Type: core.ActionShift, State: 2}}, false)},
+		{name: "repetition", actions: core.NewActionRow([]core.Action{{Type: core.ActionShift, State: 2, Repetition: true}}, false)},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -625,7 +625,7 @@ func buildParserCoreLanguageTables(parser *Parser) (*parserCoreLanguageTables, e
 				return nil, fmt.Errorf("parser-core phase zero: convert action row %d ordinal %d: %w", index, ordinal, err)
 			}
 		}
-		rows[index] = core.NewActionRow(converted)
+		rows[index] = core.NewActionRow(converted, entry.Reusable)
 	}
 	tables := &parserCoreLanguageTables{actionRows: rows}
 	maxProductionID, maxChildCount := 0, 0
@@ -2120,6 +2120,19 @@ func diagnosticParserCoreHeaderPathReceipts(compact *core.Core, headers []diagno
 	return out, nil
 }
 
+// diagnosticParserCoreTokenCell caches the epoch's elected token identity for
+// the forced-reuse tranche: the token, the lexer-mode identity it was lexed
+// under, and its scanner checkpoints. One cell per election; nothing reads it
+// yet.
+type diagnosticParserCoreTokenCell struct {
+	token            Token
+	state            StateID
+	byteOffset       uint32
+	beforeCheckpoint core.CheckpointID
+	afterCheckpoint  core.CheckpointID
+	valid            bool
+}
+
 type diagnosticParserCoreGenericScheduler struct {
 	compact                    *core.Core
 	tokenSource                *dfaTokenSource
@@ -2130,6 +2143,7 @@ type diagnosticParserCoreGenericScheduler struct {
 	checkpointBeforeID         core.CheckpointID
 	checkpointID               core.CheckpointID
 	currentElection            DiagnosticParserCoreElection
+	tokenCell                  diagnosticParserCoreTokenCell
 	electionIndex              int
 	noLookaheadSteps           uint8
 	tokens                     uint64
@@ -5585,6 +5599,7 @@ func diagnosticParserCoreSchedulerFootprintBytes(s *diagnosticParserCoreGenericS
 	add(cap(s.acceptedPayloads), unsafe.Sizeof(core.SubtreeID(0)))
 	add(len(s.seedHeaders), unsafe.Sizeof(diagnosticParserCoreHeader{}))
 	add(len(s.corridorCells), unsafe.Sizeof(diagnosticParserCoreGenericCell{}))
+	add(1, unsafe.Sizeof(s.tokenCell))
 	if s.compact != nil {
 		coreBytes := s.compact.FootprintBytes()
 		if math.MaxUint64-total < coreBytes {
@@ -6010,6 +6025,10 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 					// from where this absorb actually left off, not from
 					// the shared token's own (now-stale) end.
 					s.tokenSource.SeekTokenFrontier(resumeToken.EndByte, resumeToken.EndPoint)
+					// The lexer moved without an election: the cell's elected
+					// token/checkpoints no longer describe the token source's
+					// position, so invalidate it rather than leave it stale.
+					s.tokenCell.valid = false
 				}
 				// Return this pass immediately: a header can only reach
 				// s3Region!=nil through s3TryOpenErrorRegion, which requires
@@ -6825,6 +6844,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericAccept(before []Diagn
 		return err
 	}
 	dispatchesBefore, workBefore, epochProgressBefore := s.dispatches, s.work, s.epochProgress
+	tokenCellBefore := s.tokenCell
 	roundsBefore := len(s.receipt.Rounds)
 	defer func() {
 		s.headerRollbackScratch.finish(&s.headers, err != nil)
@@ -6832,6 +6852,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericAccept(before []Diagn
 			return
 		}
 		s.dispatches, s.work, s.epochProgress = dispatchesBefore, workBefore, epochProgressBefore
+		s.tokenCell = tokenCellBefore
 		s.receipt.Rounds = s.receipt.Rounds[:roundsBefore]
 	}()
 	return s.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
@@ -7791,6 +7812,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReduction(before []Di
 	dispatchesBefore, nextSeqBefore := s.dispatches, s.nextSeq
 	nextCleanPathLineageBefore := s.nextCleanPathLineage
 	workBefore, epochProgressBefore := s.work, s.epochProgress
+	tokenCellBefore := s.tokenCell
 	roundsBefore := len(s.receipt.Rounds)
 	defer func() {
 		s.headerRollbackScratch.finish(&s.headers, err != nil)
@@ -7800,6 +7822,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReduction(before []Di
 		s.dispatches, s.nextSeq = dispatchesBefore, nextSeqBefore
 		s.nextCleanPathLineage = nextCleanPathLineageBefore
 		s.work, s.epochProgress = workBefore, epochProgressBefore
+		s.tokenCell = tokenCellBefore
 		s.receipt.Rounds = s.receipt.Rounds[:roundsBefore]
 	}()
 	return s.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
@@ -8358,6 +8381,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflict(before []Dia
 	dispatchesBefore, branchOrderBefore, nextSeqBefore := s.dispatches, s.branchOrder, s.nextSeq
 	nextCleanPathLineageBefore := s.nextCleanPathLineage
 	workBefore, epochProgressBefore := s.work, s.epochProgress
+	tokenCellBefore := s.tokenCell
 	roundsBefore, conflictsBefore := len(s.receipt.Rounds), len(s.receipt.Conflicts)
 	externalShiftsBefore := len(s.receipt.ExternalShifts)
 	defer func() {
@@ -8368,6 +8392,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflict(before []Dia
 		s.dispatches, s.branchOrder, s.nextSeq = dispatchesBefore, branchOrderBefore, nextSeqBefore
 		s.nextCleanPathLineage = nextCleanPathLineageBefore
 		s.work, s.epochProgress = workBefore, epochProgressBefore
+		s.tokenCell = tokenCellBefore
 		s.receipt.Rounds = s.receipt.Rounds[:roundsBefore]
 		s.receipt.Conflicts = s.receipt.Conflicts[:conflictsBefore]
 		s.receipt.ExternalShifts = s.receipt.ExternalShifts[:externalShiftsBefore]
@@ -8560,6 +8585,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShifts(before []Diagn
 		return err
 	}
 	dispatchesBefore, workBefore, epochProgressBefore := s.dispatches, s.work, s.epochProgress
+	tokenCellBefore := s.tokenCell
 	roundsBefore, externalBefore := len(s.receipt.Rounds), len(s.receipt.ExternalShifts)
 	defer func() {
 		s.headerRollbackScratch.finish(&s.headers, err != nil)
@@ -8567,6 +8593,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShifts(before []Diagn
 			return
 		}
 		s.dispatches, s.work, s.epochProgress = dispatchesBefore, workBefore, epochProgressBefore
+		s.tokenCell = tokenCellBefore
 		s.receipt.Rounds = s.receipt.Rounds[:roundsBefore]
 		s.receipt.ExternalShifts = s.receipt.ExternalShifts[:externalBefore]
 	}()
@@ -8673,6 +8700,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 		return err
 	}
 	dispatchesBefore, workBefore, epochProgressBefore := s.dispatches, s.work, s.epochProgress
+	tokenCellBefore := s.tokenCell
 	roundsBefore, externalShiftsBefore := len(s.receipt.Rounds), len(s.receipt.ExternalShifts)
 	defer func() {
 		s.headerRollbackScratch.finish(&s.headers, err != nil)
@@ -8680,6 +8708,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 			return
 		}
 		s.dispatches, s.work, s.epochProgress = dispatchesBefore, workBefore, epochProgressBefore
+		s.tokenCell = tokenCellBefore
 		s.receipt.Rounds = s.receipt.Rounds[:roundsBefore]
 		s.receipt.ExternalShifts = s.receipt.ExternalShifts[:externalShiftsBefore]
 	}()
@@ -9087,6 +9116,15 @@ func (s *diagnosticParserCoreGenericScheduler) elect(first bool) error {
 	s.token = token
 	s.checkpoint = after
 	s.checkpointID = afterID
+	// tokenCell mirrors this election's freshly elected token identity for the
+	// forced-reuse tranche (substrate only; nothing reads it yet). state is
+	// the primary election state passed to SetParserState above;
+	// beforeCheckpoint/afterCheckpoint are the same interned checkpoint IDs
+	// just assigned to checkpointBeforeID/checkpointID.
+	s.tokenCell = diagnosticParserCoreTokenCell{
+		token: token, state: states[0], byteOffset: token.StartByte,
+		beforeCheckpoint: beforeID, afterCheckpoint: afterID, valid: true,
+	}
 	s.epochProgress = false
 	// Summary receipts read currentElection.States only within this round, so
 	// the reused scratch is safe. Full receipts retain the election, so clone

--- a/parsercore_phase0_eof_recovery_metadata_contract_test.go
+++ b/parsercore_phase0_eof_recovery_metadata_contract_test.go
@@ -137,7 +137,7 @@ type g4EOFTable struct {
 }
 
 func (t *g4EOFTable) Actions(state core.StateID, symbol core.Symbol) (core.ActionRow, error) {
-	return core.NewActionRow(t.cells[g4EOFCell{state: state, symbol: symbol}]), nil
+	return core.NewActionRow(t.cells[g4EOFCell{state: state, symbol: symbol}], false), nil
 }
 
 func (t *g4EOFTable) Goto(state core.StateID, symbol core.Symbol) (core.StateID, error) {

--- a/parsercore_phase0_generic_conflict_internal_test.go
+++ b/parsercore_phase0_generic_conflict_internal_test.go
@@ -31,7 +31,7 @@ func TestDiagnosticParserCoreGenericRepetitionFoldMatchesProductionScope(t *test
 	actions := core.NewActionRow([]core.Action{
 		{Type: core.ActionShift, State: 2, Repetition: true},
 		{Type: core.ActionReduce, Symbol: 4},
-	})
+	}, false)
 	if ordinal, ok := diagnosticParserCoreRepetitionFoldOrdinal(&Language{Name: "bash"}, actions); !ok || ordinal != 1 {
 		t.Fatalf("bash repetition fold ordinal=%d ok=%t, want 1 true", ordinal, ok)
 	}
@@ -45,16 +45,16 @@ func TestDiagnosticParserCoreGenericRepetitionFoldMatchesProductionScope(t *test
 		t.Fatal("nil-language repetition fold was admitted")
 	}
 	malformed := []core.ActionRow{
-		core.NewActionRow([]core.Action{{Type: core.ActionShift, State: 2, Repetition: true}}),
+		core.NewActionRow([]core.Action{{Type: core.ActionShift, State: 2, Repetition: true}}, false),
 		core.NewActionRow([]core.Action{
 			{Type: core.ActionShift, State: 2},
 			{Type: core.ActionReduce, Symbol: 4},
-		}),
+		}, false),
 		core.NewActionRow([]core.Action{
 			{Type: core.ActionShift, State: 2, Repetition: true},
 			{Type: core.ActionReduce, Symbol: 4},
 			{Type: core.ActionReduce, Symbol: 5},
-		}),
+		}, false),
 	}
 	for index, row := range malformed {
 		if _, ok := diagnosticParserCoreRepetitionFoldOrdinal(&Language{Name: "bash"}, row); ok {
@@ -292,7 +292,7 @@ func TestDiagnosticParserCoreGenericConflictPolicyRequiresExactRow(t *testing.T)
 	actions := core.NewActionRow([]core.Action{
 		{Type: core.ActionShift, State: 3, Repetition: true},
 		{Type: core.ActionReduce, Symbol: 4},
-	})
+	}, false)
 	language := &Language{
 		Name: "haskell",
 		ConflictPolicies: []ConflictPolicy{{
@@ -360,7 +360,7 @@ func TestDiagnosticParserCoreDescriptorPreservesUnsupportedOrdinalOrdering(t *te
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			row := core.NewActionRow(test.actions)
+			row := core.NewActionRow(test.actions, false)
 			if got := row.Descriptor().Kind(); got != core.ActionRowUnsupported {
 				t.Fatalf("descriptor=%v, want unsupported", got)
 			}
@@ -383,7 +383,7 @@ func TestDiagnosticParserCoreDescriptorAdmitsZeroWidthOrdinaryShift(t *testing.T
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			row := core.NewActionRow(test.actions)
+			row := core.NewActionRow(test.actions, false)
 			if unsupported := diagnosticParserCoreGenericUnsupportedCell(0, token, row); unsupported != nil {
 				t.Fatalf("zero-width ordinary shift declined: %+v", unsupported)
 			}
@@ -497,10 +497,10 @@ type genericConflictTable struct {
 
 func (t *genericConflictTable) Actions(state core.StateID, symbol core.Symbol) (core.ActionRow, error) {
 	if actions := t.cells[genericConflictCell{state: state, symbol: symbol}]; actions != nil {
-		return core.NewActionRow(actions), nil
+		return core.NewActionRow(actions, false), nil
 	}
 	if state == 1 && symbol == 9 {
-		return core.NewActionRow(t.actions), nil
+		return core.NewActionRow(t.actions, false), nil
 	}
 	return core.ActionRow{}, nil
 }

--- a/parsercore_phase0_token_cell_internal_test.go
+++ b/parsercore_phase0_token_cell_internal_test.go
@@ -1,0 +1,164 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// TestDiagnosticParserCoreTokenCellStartsInvalidAfterConstruction pins that a
+// freshly constructed scheduler's tokenCell is the zero value: reset's
+// full-struct-literal reinitialization does not list tokenCell (mirroring
+// corridorCells), and the constructor's initialization path does not
+// populate it either, so it starts invalid until the first election.
+func TestDiagnosticParserCoreTokenCellStartsInvalidAfterConstruction(t *testing.T) {
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkpoint := parserCoreCheckpoint(nil)
+	var scratch []byte
+	scheduler, err := newDiagnosticParserCoreGenericScheduler(
+		compact, &dfaTokenSource{}, &scratch, seed, 0, checkpoint, diagnosticParserCoreSeedObserver{}, DiagnosticParserCorePrefixOptions{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scheduler.tokenCell != (diagnosticParserCoreTokenCell{}) {
+		t.Fatalf("freshly constructed scheduler.tokenCell = %+v, want the zero value", scheduler.tokenCell)
+	}
+}
+
+// TestDiagnosticParserCoreTokenCellDirectInvalidationLeavesStaleFieldsUntouched
+// pins the invalidation contract used at the sole SeekTokenFrontier resync
+// call site in dispatchPassActive: once the lexer moves without an election,
+// that site writes only tokenCell.valid = false, leaving the stale
+// token/state/checkpoint fields in place (they are simply no longer
+// trustworthy, not zeroed). This exercises the same write in isolation
+// because driving a real S3 error-region resync from a from-scratch unit
+// test is disproportionate for inert, unread substrate.
+func TestDiagnosticParserCoreTokenCellDirectInvalidationLeavesStaleFieldsUntouched(t *testing.T) {
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkpoint := parserCoreCheckpoint(nil)
+	var scratch []byte
+	scheduler, err := newDiagnosticParserCoreGenericScheduler(
+		compact, &dfaTokenSource{}, &scratch, seed, 0, checkpoint, diagnosticParserCoreSeedObserver{}, DiagnosticParserCorePrefixOptions{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler.tokenCell = diagnosticParserCoreTokenCell{
+		token: Token{Symbol: 5, StartByte: 3, EndByte: 4}, state: 7,
+		byteOffset: 3, beforeCheckpoint: 1, afterCheckpoint: 2, valid: true,
+	}
+	scheduler.tokenCell.valid = false
+	if scheduler.tokenCell.valid {
+		t.Fatal("scheduler.tokenCell.valid = true after direct invalidation, want false")
+	}
+	if scheduler.tokenCell.token.StartByte != 3 || scheduler.tokenCell.state != 7 ||
+		scheduler.tokenCell.byteOffset != 3 || scheduler.tokenCell.beforeCheckpoint != 1 || scheduler.tokenCell.afterCheckpoint != 2 {
+		t.Fatalf("direct invalidation mutated stale fields it should leave untouched: %+v", scheduler.tokenCell)
+	}
+}
+
+// TestDiagnosticParserCoreTokenCellMatchesElectedTokenAndCheckpoints pins the
+// D2 tranche C wiring: after elect() runs, scheduler.tokenCell holds the same
+// token, primary election state, and scanner checkpoints as the scheduler's
+// own token/checkpointBeforeID/checkpointID fields for that same election.
+// tokenCell is inert substrate for a later forced-reuse tranche -- nothing
+// reads it yet -- so this test is the only thing that would catch its
+// population wiring breaking.
+func TestDiagnosticParserCoreTokenCellMatchesElectedTokenAndCheckpoints(t *testing.T) {
+	lang, err := authenticatedParserCoreGoLanguage(parserCoreWarmGoScanner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parser := NewParser(lang)
+	tables, err := newParserCoreRootTables(parser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact, err := core.New(tables, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := []byte("package p\n")
+	tokenSource := parser.acquireParserDFATokenSource(source)
+	if tokenSource == nil {
+		t.Fatal("parser-core phase zero: production DFA unavailable")
+	}
+	defer tokenSource.Close()
+
+	var (
+		gotCell   diagnosticParserCoreTokenCell
+		gotToken  Token
+		gotBefore core.CheckpointID
+		gotAfter  core.CheckpointID
+		gotState  StateID
+		captured  bool
+	)
+	observer := diagnosticParserCoreSeedObserver{
+		afterElection: func(s *diagnosticParserCoreGenericScheduler) (bool, error) {
+			if s.electionIndex != 0 {
+				return false, nil
+			}
+			// headers have not been dispatched this epoch yet, so this
+			// independently recomputes the same primary state elect() just
+			// captured into tokenCell.state, without reading tokenCell itself.
+			state, err := s.electHeaderState(s.headers[0])
+			if err != nil {
+				return false, err
+			}
+			gotCell = s.tokenCell
+			gotToken = s.token
+			gotBefore = s.checkpointBeforeID
+			gotAfter = s.checkpointID
+			gotState = state
+			captured = true
+			return true, nil
+		},
+	}
+	var scannerScratch []byte
+	scheduler, err := executeDiagnosticParserCoreGenericSchedulerFromSeed(
+		compact, tokenSource, &scannerScratch, lang.InitialState,
+		DiagnosticParserCorePrefixOptions{MaxDispatches: 100000, MaxTokens: 100000},
+		observer,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scheduler == nil || !captured {
+		t.Fatal("first-election observer did not fire")
+	}
+	if !gotCell.valid {
+		t.Fatal("tokenCell.valid = false after the first election, want true")
+	}
+	if gotCell.token != gotToken {
+		t.Fatalf("tokenCell.token = %+v, want %+v (scheduler.token)", gotCell.token, gotToken)
+	}
+	if gotCell.byteOffset != gotToken.StartByte {
+		t.Fatalf("tokenCell.byteOffset = %d, want %d (token.StartByte)", gotCell.byteOffset, gotToken.StartByte)
+	}
+	if gotCell.state != gotState {
+		t.Fatalf("tokenCell.state = %d, want %d (the primary election state passed to SetParserState)", gotCell.state, gotState)
+	}
+	if gotCell.beforeCheckpoint != gotBefore {
+		t.Fatalf("tokenCell.beforeCheckpoint = %d, want %d (scheduler.checkpointBeforeID)", gotCell.beforeCheckpoint, gotBefore)
+	}
+	if gotCell.afterCheckpoint != gotAfter {
+		t.Fatalf("tokenCell.afterCheckpoint = %d, want %d (scheduler.checkpointID)", gotCell.afterCheckpoint, gotAfter)
+	}
+}


### PR DESCRIPTION
## Summary

The forced token-reuse tranche needs two inputs the parser core does not keep today: per-row token-reuse eligibility, and the identity of the token an epoch elected. This branch wires both as inert substrate. Nothing reads either one yet, so parse behavior does not change.

## Changes

- `NewActionRow` takes a `reusable` bool, and the new `ActionRow.Reusable()` accessor returns the language table bit (`Language.ParseActions[i].Reusable`) unchanged. The bit is not derived from the actions, so `Descriptor()` keeps the same dispatch shape. An empty row still short-circuits, so it reports false.
- `buildParserCoreLanguageTables` and `corridorTables.row` now pass `entry.Reusable` into the decoded row instead of dropping it.
- Add the `diagnosticParserCoreTokenCell` type to the generic scheduler. It holds one elected token, its lexer-mode state, its byte offset, both interned checkpoint IDs, and a valid flag.
- `elect` populates the cell from the same token, primary state, and checkpoint IDs it assigns to the scheduler fields.
- `dispatchPassActive` clears the valid flag at the `SeekTokenFrontier` resync in the S3 error region, because the lexer moved without an election. That site leaves the stale fields in place.
- `applyGenericAccept`, `applyGenericReduction`, `applyGenericConflict`, `applyGenericShifts`, and `applyGenericExtraShifts` save and restore the cell on rollback, so a failed atomic step restores the prior election identity.
- `diagnosticParserCoreSchedulerFootprintBytes` counts the cell, which keeps the memory-budget contract accurate.
- Update every `NewActionRow` call site for the new argument: the gotreesitter test adapter forwards the real bit; the fake tables and test rows pass false.

## Testing

- bash cgo_harness/docker/run_parity_in_docker.sh -- "cd /workspace && go test ./internal/parsercorephase0 -run '^TestActionRow' -count=1"
- bash cgo_harness/docker/run_parity_in_docker.sh -- "cd /workspace && go test -tags gts_parsercorephase0 . -run '^TestDiagnosticParserCoreTokenCell' -count=1"
- bash cgo_harness/docker/run_single_grammar_parity.sh go
- bash scripts/run_randomized_benchmarks.sh --output /tmp/gotreesitter-bench.txt

## Review Focus

Both additions are unread substrate. Confirm the rollback paths restore tokenCell in every atomic apply, and confirm no dispatch or reuse decision changes behavior in this branch.