### PR TITLE
add(admission-census): Classify recovery declines by owning C mechanism

### DIFF
--- a/admission_census.go
+++ b/admission_census.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 	"sync"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
 )
 
 // Compact-route decline census instrumentation.
@@ -221,6 +223,164 @@ func admissionCensusClassify(boundary DiagnosticParserCoreBoundaryKind, detail s
 	}
 }
 
+// admissionCensusRecoveryShape sub-classifies a recovery-boundary decline by
+// the C recovery mechanism that would own the input at that exact point.
+//
+// censusMechanismRecovery already tells an operator "only production
+// implements recovery here". That answer is too coarse to schedule work
+// against: the real-corpus recovery cohort is not one mechanism but four,
+// and they sit in different B3 stages with different costs
+// (spec.compact-recovery-ownership.v1 section 4). This classification splits
+// the cohort the way C's own ts_parser__handle_error / ts_parser__recover
+// split it, so the census reports which stage owns each declining row.
+//
+// Evaluation order mirrors C exactly, because C's mechanisms are tried in a
+// fixed order and the first one that applies is the one that runs:
+//
+//  1. missing-token insertion (ts_parser__handle_error step 2,
+//     parser.c:2154-2230; the Go port is cHandleError's missingTokenSearch,
+//     parser_recover_c.go);
+//  2. strategy 1, the stack-summary resume election (ts_parser__recover's
+//     summary scan, cRecoverStrategy1Election); C runs this for every
+//     non-error lookahead INCLUDING end-of-file;
+//  3. the end-of-file whole-file wrap (ts_parser__recover's recover_eof,
+//     cRecoverEOFAccept);
+//  4. strategy 2, error-region absorb (ts_parser__recover's skip_token tail,
+//     cAbsorbTokenIntoError).
+//
+// Every probe below is READ-ONLY. It reads action rows and walks recorded
+// link adjacency; it publishes no record and mutates no header. In
+// particular it deliberately does NOT run the compact analogue of C's step 1
+// (s3CloseInProgressProductions), which performs real reductions and appends
+// arena records: a diagnostic classification must not change what the parse
+// did. The consequence is stated in the shape's own name -- the scan happens
+// at the declining state, not at C's post-closure state -- so a row whose
+// missing-token opportunity only appears after closure classifies here as a
+// later mechanism. That is a floor on the missing-token cohort, never an
+// overcount.
+//
+// Read the answer as "the mechanism that owns THIS decline point", not "the
+// only mechanism this source needs". A source can require several recovery
+// mechanisms in sequence, and the compact route reports only the first point
+// at which it gave up. Measured on the shipped real corpus: widening the
+// native strategy-2 owner to four uncertified grammars opened twenty error
+// regions and still graduated no row, because each row went on to reach an
+// end-of-file wrap, a missing-token insertion, or an error-mode lex
+// disagreement that strategy 2 does not own. Use this classification to size
+// and order the stages, not to predict a per-row graduation.
+type admissionCensusRecoveryShape string
+
+const (
+	// censusRecoveryShapeMissingToken: some terminal has a genuine shift from
+	// the declining state to a different state whose leading action for the
+	// elected token is a reduce -- C's step-2 predicate
+	// (ts_language_next_state + ts_language_has_reduce_action). C would insert
+	// a zero-width MISSING leaf for that terminal and keep parsing. B3 stage
+	// S5 owns this mechanism.
+	censusRecoveryShapeMissingToken admissionCensusRecoveryShape = "missing-token-insertion"
+	// censusRecoveryShapeDeeperResume: no missing-token opportunity, but some
+	// ancestor boundary within cRecoverMaxSummaryDepth has an action for the
+	// elected token. C's strategy-1 summary election would recover to that
+	// state and wrap the skipped span in one ERROR. B3 stage S4 owns this.
+	censusRecoveryShapeDeeperResume admissionCensusRecoveryShape = "stack-summary-resume"
+	// censusRecoveryShapeEOFWrap: the elected token is authenticated
+	// end-of-file and neither earlier mechanism applies, so C reaches
+	// recover_eof and wraps the whole remaining stack in one ERROR root. B3
+	// stage S5 owns this wrap.
+	censusRecoveryShapeEOFWrap admissionCensusRecoveryShape = "recover-eof-wrap"
+	// censusRecoveryShapeAbsorb: none of the above -- C falls through to
+	// strategy 2 and absorbs the elected token into an open error region.
+	// B3 stage S3 owns this mechanism; it is native today only for the
+	// grammar-blob-keyed certified witness class
+	// (CompactStrategy2ErrorRegionCertified).
+	censusRecoveryShapeAbsorb admissionCensusRecoveryShape = "error-region-absorb"
+)
+
+// admissionCensusMissingTokenCandidates counts the terminals that satisfy C's
+// step-2 missing-token predicate at state for lookahead, and reports the
+// lowest such terminal id. C scans terminals in ascending id order and takes
+// the first that also survives do_all_potential_reductions, so the lowest id
+// is the candidate C would try first.
+//
+// The predicate is the same one s3MissingTokenOpportunityExists already
+// applies as an S3 decline guard (parsercore_phase0_driver.go), kept as a
+// separate counting variant here rather than widening that one: the S3 guard
+// answers a yes/no question on the hot decline path and must stay cheap to
+// read, while the census wants the population.
+func admissionCensusMissingTokenCandidates(scheduler *diagnosticParserCoreGenericScheduler, state StateID, lookahead Symbol) (count int, first Symbol, err error) {
+	if scheduler == nil || scheduler.tokenSource == nil || scheduler.tokenSource.language == nil {
+		return 0, 0, nil
+	}
+	tokenCount := Symbol(scheduler.tokenSource.language.TokenCount)
+	for ms := Symbol(1); ms < tokenCount; ms++ {
+		row, rowErr := scheduler.compact.Actions(core.StateID(state), core.Symbol(ms))
+		if rowErr != nil {
+			return 0, 0, rowErr
+		}
+		if row.Len() == 0 {
+			continue
+		}
+		last := row.At(row.Len() - 1)
+		if last.Type != core.ActionShift {
+			continue
+		}
+		nextState := core.StateID(last.State)
+		if last.Extra {
+			nextState = core.StateID(state)
+		}
+		if nextState == 0 || nextState == core.StateID(state) {
+			continue
+		}
+		nextRow, nextErr := scheduler.compact.Actions(nextState, core.Symbol(lookahead))
+		if nextErr != nil {
+			return 0, 0, nextErr
+		}
+		if nextRow.Len() == 0 || nextRow.At(0).Type != core.ActionReduce {
+			continue
+		}
+		if count == 0 {
+			first = ms
+		}
+		count++
+	}
+	return count, first, nil
+}
+
+// admissionCensusRecoveryShapeFor classifies one recovery-boundary decline.
+// It returns an empty shape when the stop receipt does not describe a
+// classifiable recovery point, in which case the caller leaves the decline
+// text unchanged.
+func admissionCensusRecoveryShapeFor(scheduler *diagnosticParserCoreGenericScheduler, stop DiagnosticParserCoreGenericStop) (admissionCensusRecoveryShape, string) {
+	if scheduler == nil || scheduler.compact == nil {
+		return "", ""
+	}
+	lookahead := Symbol(stop.Token.Symbol)
+	// An unlexable-run lookahead is C's error subtree: C skips strategy 1 for
+	// it entirely (cRecoverStrategy1Election's own guard) and absorbs. Leave
+	// it to the absorb class without probing.
+	if lookahead == errorSymbol {
+		return censusRecoveryShapeAbsorb, ""
+	}
+	missingCount, missingFirst, err := admissionCensusMissingTokenCandidates(scheduler, stop.State, lookahead)
+	if err != nil {
+		return "", ""
+	}
+	if missingCount > 0 {
+		return censusRecoveryShapeMissingToken, fmt.Sprintf("candidates=%d first=%d", missingCount, missingFirst)
+	}
+	if stop.HeaderIndex >= 0 && stop.HeaderIndex < len(scheduler.headers) {
+		deeper, deeperErr := scheduler.compact.AncestorStateWithActionExists(
+			scheduler.headers[stop.HeaderIndex].head, core.Symbol(lookahead), cRecoverMaxSummaryDepth)
+		if deeperErr == nil && deeper {
+			return censusRecoveryShapeDeeperResume, ""
+		}
+	}
+	if lookahead == 0 && stop.Token.StartByte == stop.Token.EndByte {
+		return censusRecoveryShapeEOFWrap, ""
+	}
+	return censusRecoveryShapeAbsorb, ""
+}
+
 // Synthetic boundary kinds for the strict-acceptance decompositions that have
 // no natural DiagnosticParserCoreBoundaryKind of their own: the scheduler DID
 // accept, so none of the scheduler's own mid-run unsupported-construct
@@ -248,9 +408,24 @@ func admissionCensusStopDecline(scheduler *diagnosticParserCoreGenericScheduler)
 		}
 	}
 	stop := scheduler.receipt.Stop
+	detail := "did not accept EOF: " + stop.Detail
+	// A recovery-boundary decline is the largest real-corpus fallback cohort
+	// and the only one whose members sit in different B3 stages. Sub-classify
+	// it by the C mechanism that owns the input (admissionCensusRecoveryShape)
+	// so the census reports a schedulable cohort instead of one undivided
+	// "recovery" bucket. Every other boundary keeps its text byte-identical.
+	if stop.Boundary == DiagnosticParserCoreRecovery {
+		if shape, extra := admissionCensusRecoveryShapeFor(scheduler, stop); shape != "" {
+			detail += " [c-mechanism=" + string(shape)
+			if extra != "" {
+				detail += " " + extra
+			}
+			detail += "]"
+		}
+	}
 	return &diagnosticParserCoreDecline{
 		boundary: stop.Boundary,
-		detail:   "did not accept EOF: " + stop.Detail,
+		detail:   detail,
 	}
 }
 

--- a/admission_census.go
+++ b/admission_census.go
@@ -147,7 +147,38 @@ const (
 var (
 	admissionCensusEnabledOnce sync.Once
 	admissionCensusEnabledVal  bool
+
+	admissionCensusRecoveryShapeOnce sync.Once
+	admissionCensusRecoveryShapeVal  bool
 )
+
+// admissionCensusRecoveryShapeEnabled reports whether the operator asked for
+// the recovery sub-classification on top of the ordinary census.
+//
+// It is a SEPARATE opt-in from GTS_ADMISSION_CENSUS, for two reasons.
+//
+// First, blast radius. cgo_harness/testmain_cgo_test.go sets
+// GTS_ADMISSION_CENSUS=1 process-wide for that whole package, and six tests
+// there pin the recovery decline reason by EXACT equality (for example
+// sqlC26ahCompactFallback). Appending to the census detail under the existing
+// flag silently breaks all six, and those tests are container-only -- they
+// authenticate a pinned compiler and grammar artifact, so a host run cannot
+// verify a change to them. Keeping this behind its own flag leaves that
+// harness byte-identical.
+//
+// Second, cost. The classification walks every terminal in the grammar's
+// action table for each classified decline, which is far heavier than the
+// existing census's constant-time boundary mapping. An operator who wants
+// only the coarse mechanism should not pay for the fine one.
+func admissionCensusRecoveryShapeEnabled() bool {
+	admissionCensusRecoveryShapeOnce.Do(func() {
+		switch os.Getenv("GTS_ADMISSION_CENSUS_RECOVERY_SHAPE") {
+		case "1", "true", "TRUE", "True", "on", "ON", "yes", "YES":
+			admissionCensusRecoveryShapeVal = true
+		}
+	})
+	return admissionCensusRecoveryShapeVal
+}
 
 // admissionCensusEnabled reports whether GTS_ADMISSION_CENSUS requests the
 // fine-grained decline classification. The result is cached after the first
@@ -282,6 +313,17 @@ const (
 	// ancestor boundary within cRecoverMaxSummaryDepth has an action for the
 	// elected token. C's strategy-1 summary election would recover to that
 	// state and wrap the skipped span in one ERROR. B3 stage S4 owns this.
+	//
+	// This bucket OVER-APPROXIMATES strategy 1, so read it as an S4 ceiling
+	// and, correspondingly, an S3 floor. AncestorStateWithActionExists is a
+	// bounded existence probe with no cost comparison and no election, while
+	// C's summary scan additionally skips entries at ERROR_STATE, skips
+	// entries whose position equals the current position, and ABORTS the whole
+	// scan when a cheaper live version exists -- even where the lookahead
+	// would have had actions. None of those three are modeled here, and every
+	// row this bucket over-reports is a row taken from the absorb bucket
+	// below. An operator sizing S3 against S4 from this census will therefore
+	// under-size S3.
 	censusRecoveryShapeDeeperResume admissionCensusRecoveryShape = "stack-summary-resume"
 	// censusRecoveryShapeEOFWrap: the elected token is authenticated
 	// end-of-file and neither earlier mechanism applies, so C reaches
@@ -347,21 +389,37 @@ func admissionCensusMissingTokenCandidates(scheduler *diagnosticParserCoreGeneri
 	return count, first, nil
 }
 
-// admissionCensusRecoveryShapeFor classifies one recovery-boundary decline.
-// It returns an empty shape when the stop receipt does not describe a
-// classifiable recovery point, in which case the caller leaves the decline
-// text unchanged.
+// admissionCensusRecoveryShapeFor classifies one recovery-boundary decline,
+// or reports an empty shape when the decline is not a classifiable recovery
+// point, in which case the caller leaves the decline text unchanged.
+//
+// DiagnosticParserCoreRecovery is a ROUTING bucket, not a proof that C is in
+// recovery. The driver publishes it with four different details, and three of
+// them are Go-side deferrals where C never enters ts_parser__handle_error at
+// all: the D2-1 ragged-relex decline, the issue-983 contextual close-angle
+// deferral (whose state DOES have an action for the elected token), and an
+// ActionRecover cell reached inside a conflict. Classifying those would
+// attribute a C mechanism to a point C never reaches. The ragged-relex case is
+// worse than merely wrong: `finish` records the SHARED election token, while
+// the decline is about a different relexed token with a different EndByte, so
+// any probe here would run against a lookahead that was never the stop point.
+//
+// So this classifies exactly one detail -- the genuine no-table-action shape
+// that is C's own error-entry point -- and declines to guess on the rest.
 func admissionCensusRecoveryShapeFor(scheduler *diagnosticParserCoreGenericScheduler, stop DiagnosticParserCoreGenericStop) (admissionCensusRecoveryShape, string) {
 	if scheduler == nil || scheduler.compact == nil {
 		return "", ""
 	}
-	lookahead := Symbol(stop.Token.Symbol)
-	// An unlexable-run lookahead is C's error subtree: C skips strategy 1 for
-	// it entirely (cRecoverStrategy1Election's own guard) and absorbs. Leave
-	// it to the absorb class without probing.
-	if lookahead == errorSymbol {
-		return censusRecoveryShapeAbsorb, ""
+	if stop.Detail != diagnosticParserCoreNoTableActionDetail {
+		return "", ""
 	}
+	lookahead := Symbol(stop.Token.Symbol)
+
+	// Step 2, missing-token insertion. C applies NO error-lookahead guard
+	// here: ts_parser__handle_error wraps its missingTokenSearch only in the
+	// graphql triple-quote exclusion, and the errorSymbol guard lives solely
+	// in cRecoverStrategy1Election. Probing this first, for every lookahead,
+	// is what keeps stage S5 from being under-credited.
 	missingCount, missingFirst, err := admissionCensusMissingTokenCandidates(scheduler, stop.State, lookahead)
 	if err != nil {
 		return "", ""
@@ -369,13 +427,29 @@ func admissionCensusRecoveryShapeFor(scheduler *diagnosticParserCoreGenericSched
 	if missingCount > 0 {
 		return censusRecoveryShapeMissingToken, fmt.Sprintf("candidates=%d first=%d", missingCount, missingFirst)
 	}
-	if stop.HeaderIndex >= 0 && stop.HeaderIndex < len(scheduler.headers) {
+
+	// Strategy 1, the stack-summary resume election. C skips it for an
+	// error-subtree lookahead and for a WIDE symbol-0 token, which is this
+	// engine's unlexable run (cRecoverStrategy1Election's own guards). Both
+	// fall straight through to strategy 2.
+	wideUnlexable := lookahead == 0 && stop.Token.StartByte != stop.Token.EndByte
+	if lookahead != errorSymbol && !wideUnlexable {
+		if stop.HeaderIndex < 0 || stop.HeaderIndex >= len(scheduler.headers) {
+			return "", ""
+		}
 		deeper, deeperErr := scheduler.compact.AncestorStateWithActionExists(
 			scheduler.headers[stop.HeaderIndex].head, core.Symbol(lookahead), cRecoverMaxSummaryDepth)
-		if deeperErr == nil && deeper {
+		if deeperErr != nil {
+			// The strategy-1 question was never answered. Emitting the last
+			// bucket in the ladder here would publish a confident S3 verdict
+			// on an unrun probe, so report no classification instead.
+			return "", ""
+		}
+		if deeper {
 			return censusRecoveryShapeDeeperResume, ""
 		}
 	}
+
 	if lookahead == 0 && stop.Token.StartByte == stop.Token.EndByte {
 		return censusRecoveryShapeEOFWrap, ""
 	}
@@ -414,8 +488,13 @@ func admissionCensusStopDecline(scheduler *diagnosticParserCoreGenericScheduler)
 	// and the only one whose members sit in different B3 stages. Sub-classify
 	// it by the C mechanism that owns the input (admissionCensusRecoveryShape)
 	// so the census reports a schedulable cohort instead of one undivided
-	// "recovery" bucket. Every other boundary keeps its text byte-identical.
-	if stop.Boundary == DiagnosticParserCoreRecovery {
+	// "recovery" bucket.
+	//
+	// Behind its own opt-in: with GTS_ADMISSION_CENSUS alone every decline
+	// text, recovery included, stays byte-identical to before this tranche.
+	// See admissionCensusRecoveryShapeEnabled for why that separation is
+	// load-bearing rather than tidy.
+	if stop.Boundary == DiagnosticParserCoreRecovery && admissionCensusRecoveryShapeEnabled() {
 		if shape, extra := admissionCensusRecoveryShapeFor(scheduler, stop); shape != "" {
 			detail += " [c-mechanism=" + string(shape)
 			if extra != "" {

--- a/admission_census.go
+++ b/admission_census.go
@@ -406,6 +406,14 @@ func admissionCensusMissingTokenCandidates(scheduler *diagnosticParserCoreGeneri
 //
 // So this classifies exactly one detail -- the genuine no-table-action shape
 // that is C's own error-entry point -- and declines to guess on the rest.
+//
+// One modeled gap remains, recorded rather than silently carried: the Go
+// port suppresses BOTH the missing-token search and the strategy-1 election
+// for a graphql triple-quote lookahead (isGraphQLRecoveryTripleQuote). This
+// ladder does not apply that predicate, so a graphql decline on that token
+// can report missing-token-insertion or stack-summary-resume where the port
+// would go straight to absorb. No graphql row reaches this path on the
+// shipped corpus today; a census that adds one must model the predicate.
 func admissionCensusRecoveryShapeFor(scheduler *diagnosticParserCoreGenericScheduler, stop DiagnosticParserCoreGenericStop) (admissionCensusRecoveryShape, string) {
 	if scheduler == nil || scheduler.compact == nil {
 		return "", ""

--- a/admission_census.go
+++ b/admission_census.go
@@ -308,7 +308,8 @@ const (
 // answers a yes/no question on the hot decline path and must stay cheap to
 // read, while the census wants the population.
 func admissionCensusMissingTokenCandidates(scheduler *diagnosticParserCoreGenericScheduler, state StateID, lookahead Symbol) (count int, first Symbol, err error) {
-	if scheduler == nil || scheduler.tokenSource == nil || scheduler.tokenSource.language == nil {
+	if scheduler == nil || scheduler.compact == nil ||
+		scheduler.tokenSource == nil || scheduler.tokenSource.language == nil {
 		return 0, 0, nil
 	}
 	tokenCount := Symbol(scheduler.tokenSource.language.TokenCount)

--- a/admission_census_internal_test.go
+++ b/admission_census_internal_test.go
@@ -76,4 +76,18 @@ func TestAdmissionCensusClassifiesMaterialAcceptanceElection(t *testing.T) {
 func ResetAdmissionCensusEnabledForTest() {
 	admissionCensusEnabledOnce = sync.Once{}
 	admissionCensusEnabledVal = false
+	admissionCensusRecoveryShapeOnce = sync.Once{}
+	admissionCensusRecoveryShapeVal = false
+}
+
+// AdmissionCensusRecoveryShapesForTest returns the closed vocabulary of
+// recovery sub-classifications the decline census can emit, so a test can
+// assert against the shipped constants instead of retyping their literals.
+func AdmissionCensusRecoveryShapesForTest() []string {
+	return []string{
+		string(censusRecoveryShapeMissingToken),
+		string(censusRecoveryShapeDeeperResume),
+		string(censusRecoveryShapeEOFWrap),
+		string(censusRecoveryShapeAbsorb),
+	}
 }

--- a/admission_census_recovery_shape_test.go
+++ b/admission_census_recovery_shape_test.go
@@ -91,8 +91,15 @@ func admissionCensusRecoveryShapeWitnesses() []admissionCensusRecoveryShapeWitne
 	}
 }
 
-// admissionCensusDeclineReason parses source through the compact candidate
-// route and returns the decline reason, or "" when the route admitted it.
+// admissionCensusDeclineReason drives the compact route's own accept-or-decline
+// seam and returns the decline reason, or "" when the route admitted the
+// source.
+//
+// It uses TryCompactFullParseRouteForTest rather than
+// SetAdmissionCandidateRoute plus Parse plus the counter triple. That seam
+// exists precisely to expose the decline detail without the public-Parse
+// eligibility gates, and it avoids mutating the process-global admission
+// counters that other tests in this package read.
 func admissionCensusDeclineReason(t *testing.T, language, source string) string {
 	t.Helper()
 	var entry grammars.LangEntry
@@ -114,24 +121,17 @@ func admissionCensusDeclineReason(t *testing.T, language, source string) string 
 	if lang == nil {
 		t.Fatalf("grammar %q has no loadable language", language)
 	}
-	parser := gts.NewParser(lang)
-	parser.SetAdmissionCandidateRoute(true)
-	gts.ResetAdmissionCandidateCountersForTest()
-	tree, err := parser.Parse([]byte(source))
-	if err != nil {
-		t.Fatalf("%s: parse failed: %v", language, err)
-	}
+	tree, ok, reason := gts.TryCompactFullParseRouteForTest(gts.NewParser(lang), []byte(source))
 	if tree != nil {
 		defer tree.Release()
 	}
-	routed, fallbacks := gts.AdmissionCandidateCounters()
-	if routed != 0 {
+	if ok {
 		return ""
 	}
-	if fallbacks == 0 {
-		t.Fatalf("%s: compact route neither routed nor fell back for %q", language, source)
+	if reason == "" {
+		t.Fatalf("%s: compact route declined %q with no reason", language, source)
 	}
-	return gts.AdmissionCandidateLastFallbackReason()
+	return reason
 }
 
 // TestAdmissionCensusRecoveryShapeClassification pins the C-mechanism

--- a/admission_census_recovery_shape_test.go
+++ b/admission_census_recovery_shape_test.go
@@ -31,6 +31,7 @@ import (
 func enableAdmissionCensus(t *testing.T) {
 	t.Helper()
 	t.Setenv("GTS_ADMISSION_CENSUS", "1")
+	t.Setenv("GTS_ADMISSION_CENSUS_RECOVERY_SHAPE", "1")
 	gts.ResetAdmissionCensusEnabledForTest()
 	t.Cleanup(gts.ResetAdmissionCensusEnabledForTest)
 }
@@ -40,6 +41,7 @@ func enableAdmissionCensus(t *testing.T) {
 func disableAdmissionCensus(t *testing.T) {
 	t.Helper()
 	t.Setenv("GTS_ADMISSION_CENSUS", "0")
+	t.Setenv("GTS_ADMISSION_CENSUS_RECOVERY_SHAPE", "0")
 	gts.ResetAdmissionCensusEnabledForTest()
 	t.Cleanup(gts.ResetAdmissionCensusEnabledForTest)
 }
@@ -102,11 +104,15 @@ func admissionCensusDeclineReason(t *testing.T, language, source string) string 
 		}
 	}
 	if !found {
-		t.Skipf("grammar %q is not registered in this build", language)
+		// Deliberately fatal, not a skip. The whole point of using embedded
+		// grammars instead of the gitignored corpus was that a corpus gate
+		// silently skips and reports ok; skipping here would reproduce that
+		// exact failure mode on a build with a trimmed registry.
+		t.Fatalf("grammar %q is not registered in this build", language)
 	}
 	lang := entry.Language()
 	if lang == nil {
-		t.Skipf("grammar %q has no loadable language", language)
+		t.Fatalf("grammar %q has no loadable language", language)
 	}
 	parser := gts.NewParser(lang)
 	parser.SetAdmissionCandidateRoute(true)
@@ -176,11 +182,31 @@ func TestAdmissionCensusRecoveryShapeIsDiagnosticOnly(t *testing.T) {
 			if on == "" {
 				t.Fatalf("compact route admitted %q with the census enabled", witness.source)
 			}
-			// The census-enabled text is the census-disabled classification
-			// plus the appended tag; the routing outcome (a decline) is
-			// identical either way.
-			if !strings.Contains(on, "[c-mechanism=") {
+			// State the relationship precisely. The census does NOT append to
+			// the census-off text: with the census disabled the runner reports
+			// its FOLDED message ("did not accept EOF"), and enabling the
+			// census replaces that with the scheduler's own fine-grained
+			// boundary and detail. That replacement is pre-existing behavior.
+			// What this tranche adds is only the trailing tag, so the property
+			// to prove is that stripping the tag leaves the census detail the
+			// census already produced, intact.
+			tagIndex := strings.Index(on, " [c-mechanism=")
+			if tagIndex < 0 {
 				t.Fatalf("census-enabled decline reason carries no classification: %q", on)
+			}
+			base, tag := on[:tagIndex], on[tagIndex:]
+			if !strings.HasSuffix(tag, "]") || strings.Count(tag, "[c-mechanism=") != 1 {
+				t.Fatalf("census-enabled reason appended %q, want exactly one [c-mechanism=...] tag", tag)
+			}
+			// The untagged remainder must still be the census's own
+			// classification of this decline, unaltered.
+			if !strings.Contains(base, "mechanism=recovery-entered") ||
+				!strings.Contains(base, gts.DiagnosticParserCoreNoTableActionDetailForTest()) {
+				t.Fatalf("the tag displaced part of the census detail; remainder = %q", base)
+			}
+			// And the routing outcome is identical either way: both declined.
+			if off == "" || on == "" {
+				t.Fatalf("census toggling changed the routing outcome")
 			}
 		})
 	}
@@ -192,11 +218,14 @@ func TestAdmissionCensusRecoveryShapeIsDiagnosticOnly(t *testing.T) {
 func TestAdmissionCensusRecoveryShapeVocabulary(t *testing.T) {
 	enableAdmissionCensus(t)
 
-	known := map[string]bool{
-		"missing-token-insertion": true,
-		"stack-summary-resume":    true,
-		"recover-eof-wrap":        true,
-		"error-region-absorb":     true,
+	// Derived from the shipped constants, not retyped: renaming a constant
+	// must not leave this test asserting the old vocabulary.
+	known := map[string]bool{}
+	for _, shape := range gts.AdmissionCensusRecoveryShapesForTest() {
+		known[shape] = true
+	}
+	if len(known) != 4 {
+		t.Fatalf("census exposes %d recovery shapes, want the 4 documented ones", len(known))
 	}
 	for _, witness := range admissionCensusRecoveryShapeWitnesses() {
 		if !known[witness.mechanism] {
@@ -205,7 +234,7 @@ func TestAdmissionCensusRecoveryShapeVocabulary(t *testing.T) {
 		reason := admissionCensusDeclineReason(t, witness.language, witness.source)
 		index := strings.Index(reason, "[c-mechanism=")
 		if index < 0 {
-			continue
+			t.Fatalf("witness %q emitted no classification tag: %q", witness.source, reason)
 		}
 		tail := reason[index+len("[c-mechanism="):]
 		end := strings.IndexAny(tail, " ]")
@@ -214,6 +243,36 @@ func TestAdmissionCensusRecoveryShapeVocabulary(t *testing.T) {
 		}
 		if !known[tail[:end]] {
 			t.Fatalf("census reported mechanism %q outside the documented vocabulary (%q)", tail[:end], reason)
+		}
+	}
+}
+
+// TestAdmissionCensusRecoveryShapeNeedsItsOwnOptIn proves the separation that
+// keeps cgo_harness byte-identical: with the ordinary census enabled but the
+// recovery sub-classification NOT requested, no decline carries the tag.
+//
+// cgo_harness/testmain_cgo_test.go sets GTS_ADMISSION_CENSUS=1 for its whole
+// package, and six tests there pin the recovery decline reason by exact
+// equality. Those tests are container-only, so a regression here would not
+// surface on a host run; this gate stands in for them.
+func TestAdmissionCensusRecoveryShapeNeedsItsOwnOptIn(t *testing.T) {
+	t.Setenv("GTS_ADMISSION_CENSUS", "1")
+	t.Setenv("GTS_ADMISSION_CENSUS_RECOVERY_SHAPE", "")
+	gts.ResetAdmissionCensusEnabledForTest()
+	t.Cleanup(gts.ResetAdmissionCensusEnabledForTest)
+
+	for _, witness := range admissionCensusRecoveryShapeWitnesses() {
+		reason := admissionCensusDeclineReason(t, witness.language, witness.source)
+		if reason == "" {
+			t.Fatalf("compact route admitted %q", witness.source)
+		}
+		if strings.Contains(reason, "c-mechanism") {
+			t.Fatalf("the ordinary census leaked a recovery sub-classification: %q", reason)
+		}
+		// The census's own coarse classification must still be present, so
+		// this proves a narrower gate, not a disabled census.
+		if !strings.Contains(reason, "mechanism=") {
+			t.Fatalf("the ordinary census stopped classifying entirely: %q", reason)
 		}
 	}
 }

--- a/admission_census_recovery_shape_test.go
+++ b/admission_census_recovery_shape_test.go
@@ -21,6 +21,29 @@ import (
 // gate silently skips and reports ok on a checkout that never staged the
 // corpus; these witnesses cannot skip.
 
+// enableAdmissionCensus turns the decline census on for the calling test,
+// using the pattern the existing census tests already established
+// (admission_switch_kotlin_certification_test.go): set the environment
+// variable, then clear the sync.Once that caches it so the new value takes
+// effect regardless of what an earlier test in this binary already read.
+// t.Setenv restores the variable, and the cleanup clears the cache again so
+// later tests re-read rather than inherit this test's value.
+func enableAdmissionCensus(t *testing.T) {
+	t.Helper()
+	t.Setenv("GTS_ADMISSION_CENSUS", "1")
+	gts.ResetAdmissionCensusEnabledForTest()
+	t.Cleanup(gts.ResetAdmissionCensusEnabledForTest)
+}
+
+// disableAdmissionCensus is enableAdmissionCensus's counterpart, proving the
+// census-off path rather than assuming it.
+func disableAdmissionCensus(t *testing.T) {
+	t.Helper()
+	t.Setenv("GTS_ADMISSION_CENSUS", "0")
+	gts.ResetAdmissionCensusEnabledForTest()
+	t.Cleanup(gts.ResetAdmissionCensusEnabledForTest)
+}
+
 // admissionCensusRecoveryShapeWitness is one pinned (source, mechanism) pair.
 type admissionCensusRecoveryShapeWitness struct {
 	language string
@@ -108,8 +131,7 @@ func admissionCensusDeclineReason(t *testing.T, language, source string) string 
 // TestAdmissionCensusRecoveryShapeClassification pins the C-mechanism
 // sub-class the census reports for each recovery-boundary decline.
 func TestAdmissionCensusRecoveryShapeClassification(t *testing.T) {
-	restore := gts.SetAdmissionCensusEnabledForTest(true)
-	defer restore()
+	enableAdmissionCensus(t)
 
 	for _, witness := range admissionCensusRecoveryShapeWitnesses() {
 		t.Run(witness.language+"/"+witness.mechanism, func(t *testing.T) {
@@ -138,9 +160,10 @@ func TestAdmissionCensusRecoveryShapeClassification(t *testing.T) {
 func TestAdmissionCensusRecoveryShapeIsDiagnosticOnly(t *testing.T) {
 	for _, witness := range admissionCensusRecoveryShapeWitnesses() {
 		t.Run(witness.language, func(t *testing.T) {
-			restoreOff := gts.SetAdmissionCensusEnabledForTest(false)
-			off := admissionCensusDeclineReason(t, witness.language, witness.source)
-			restoreOff()
+			off := func() string {
+				disableAdmissionCensus(t)
+				return admissionCensusDeclineReason(t, witness.language, witness.source)
+			}()
 			if off == "" {
 				t.Fatalf("compact route admitted %q with the census disabled", witness.source)
 			}
@@ -148,9 +171,8 @@ func TestAdmissionCensusRecoveryShapeIsDiagnosticOnly(t *testing.T) {
 				t.Fatalf("census-disabled decline reason leaked a classification: %q", off)
 			}
 
-			restoreOn := gts.SetAdmissionCensusEnabledForTest(true)
+			enableAdmissionCensus(t)
 			on := admissionCensusDeclineReason(t, witness.language, witness.source)
-			restoreOn()
 			if on == "" {
 				t.Fatalf("compact route admitted %q with the census enabled", witness.source)
 			}
@@ -168,8 +190,7 @@ func TestAdmissionCensusRecoveryShapeIsDiagnosticOnly(t *testing.T) {
 // census can emit comes from the closed, documented set. A new mechanism must
 // be added here deliberately, not leak out as free text.
 func TestAdmissionCensusRecoveryShapeVocabulary(t *testing.T) {
-	restore := gts.SetAdmissionCensusEnabledForTest(true)
-	defer restore()
+	enableAdmissionCensus(t)
 
 	known := map[string]bool{
 		"missing-token-insertion": true,

--- a/admission_census_recovery_shape_test.go
+++ b/admission_census_recovery_shape_test.go
@@ -1,0 +1,198 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// The compact-route decline census sub-classifies a recovery-boundary decline
+// by the C recovery mechanism that owns the input at that point
+// (admissionCensusRecoveryShape, admission_census.go). These tests pin that
+// classification.
+//
+// Every witness below is a short literal source over an embedded grammar, not
+// a corpus file. cgo_harness/corpus_real is gitignored, so a corpus-backed
+// gate silently skips and reports ok on a checkout that never staged the
+// corpus; these witnesses cannot skip.
+
+// admissionCensusRecoveryShapeWitness is one pinned (source, mechanism) pair.
+type admissionCensusRecoveryShapeWitness struct {
+	language string
+	source   string
+	// mechanism is the c-mechanism value the census must report.
+	mechanism string
+	// candidates, when non-zero, additionally pins the reported
+	// missing-token candidate population. It is asserted only where the
+	// count is a structural claim worth pinning (exactly one candidate
+	// terminal, so C's ascending-order "first surviving candidate" scan is
+	// unambiguous), not for every witness.
+	candidates int
+}
+
+func admissionCensusRecoveryShapeWitnesses() []admissionCensusRecoveryShapeWitness {
+	return []admissionCensusRecoveryShapeWitness{
+		// C ts_parser__handle_error step 2 (parser.c:2154-2230): a terminal
+		// shifts from the declining state into a state whose leading action
+		// for the elected token is a reduce, so C inserts a zero-width
+		// MISSING leaf and keeps parsing. B3 stage S5 owns this.
+		{language: "go", source: "package p\nfunc f() {\n", mechanism: "missing-token-insertion", candidates: 1},
+		{language: "python", source: "def f(:\n    pass\n", mechanism: "missing-token-insertion", candidates: 1},
+		{language: "ini", source: "[a\nb=c\n", mechanism: "missing-token-insertion", candidates: 1},
+		{language: "c", source: "int x = ;", mechanism: "missing-token-insertion"},
+
+		// C ts_parser__recover strategy 1 (cRecoverStrategy1Election): no
+		// missing-token opportunity, but an ancestor boundary within
+		// cRecoverMaxSummaryDepth has an action for the elected token, so C
+		// recovers to that state. B3 stage S4 owns this.
+		{language: "json", source: `{"a": 1`, mechanism: "stack-summary-resume"},
+		{language: "c", source: "int main() { return 0; ", mechanism: "stack-summary-resume"},
+		{language: "lua", source: "function f( end", mechanism: "stack-summary-resume"},
+
+		// C ts_parser__recover strategy 2 (cAbsorbTokenIntoError): neither
+		// earlier mechanism applies, so C absorbs the elected token into an
+		// open error region. B3 stage S3 owns this.
+		{language: "sql", source: "SELECT a b c FROM;", mechanism: "error-region-absorb"},
+
+		// C ts_parser__recover recover_eof: the elected token is
+		// authenticated end-of-file and no earlier mechanism applies, so C
+		// wraps the remaining stack in one ERROR root.
+		{language: "yaml", source: "a: [1\n", mechanism: "recover-eof-wrap"},
+	}
+}
+
+// admissionCensusDeclineReason parses source through the compact candidate
+// route and returns the decline reason, or "" when the route admitted it.
+func admissionCensusDeclineReason(t *testing.T, language, source string) string {
+	t.Helper()
+	var entry grammars.LangEntry
+	found := false
+	for _, candidate := range grammars.AllLanguages() {
+		if candidate.Name == language {
+			entry, found = candidate, true
+			break
+		}
+	}
+	if !found {
+		t.Skipf("grammar %q is not registered in this build", language)
+	}
+	lang := entry.Language()
+	if lang == nil {
+		t.Skipf("grammar %q has no loadable language", language)
+	}
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	gts.ResetAdmissionCandidateCountersForTest()
+	tree, err := parser.Parse([]byte(source))
+	if err != nil {
+		t.Fatalf("%s: parse failed: %v", language, err)
+	}
+	if tree != nil {
+		defer tree.Release()
+	}
+	routed, fallbacks := gts.AdmissionCandidateCounters()
+	if routed != 0 {
+		return ""
+	}
+	if fallbacks == 0 {
+		t.Fatalf("%s: compact route neither routed nor fell back for %q", language, source)
+	}
+	return gts.AdmissionCandidateLastFallbackReason()
+}
+
+// TestAdmissionCensusRecoveryShapeClassification pins the C-mechanism
+// sub-class the census reports for each recovery-boundary decline.
+func TestAdmissionCensusRecoveryShapeClassification(t *testing.T) {
+	restore := gts.SetAdmissionCensusEnabledForTest(true)
+	defer restore()
+
+	for _, witness := range admissionCensusRecoveryShapeWitnesses() {
+		t.Run(witness.language+"/"+witness.mechanism, func(t *testing.T) {
+			reason := admissionCensusDeclineReason(t, witness.language, witness.source)
+			if reason == "" {
+				t.Fatalf("compact route admitted %q; expected a recovery decline", witness.source)
+			}
+			want := "[c-mechanism=" + witness.mechanism
+			if !strings.Contains(reason, want) {
+				t.Fatalf("source %q: decline reason %q does not report %q", witness.source, reason, want)
+			}
+			if witness.candidates != 0 {
+				wantCandidates := want + " candidates=" + strconv.Itoa(witness.candidates) + " "
+				if !strings.Contains(reason, wantCandidates) {
+					t.Fatalf("source %q: decline reason %q does not report %q", witness.source, reason, wantCandidates)
+				}
+			}
+		})
+	}
+}
+
+// TestAdmissionCensusRecoveryShapeIsDiagnosticOnly proves the classification
+// changes decline TEXT only: with the census disabled every witness still
+// declines, still declines for the same recorded reason, and carries no
+// c-mechanism tag at all.
+func TestAdmissionCensusRecoveryShapeIsDiagnosticOnly(t *testing.T) {
+	for _, witness := range admissionCensusRecoveryShapeWitnesses() {
+		t.Run(witness.language, func(t *testing.T) {
+			restoreOff := gts.SetAdmissionCensusEnabledForTest(false)
+			off := admissionCensusDeclineReason(t, witness.language, witness.source)
+			restoreOff()
+			if off == "" {
+				t.Fatalf("compact route admitted %q with the census disabled", witness.source)
+			}
+			if strings.Contains(off, "c-mechanism") {
+				t.Fatalf("census-disabled decline reason leaked a classification: %q", off)
+			}
+
+			restoreOn := gts.SetAdmissionCensusEnabledForTest(true)
+			on := admissionCensusDeclineReason(t, witness.language, witness.source)
+			restoreOn()
+			if on == "" {
+				t.Fatalf("compact route admitted %q with the census enabled", witness.source)
+			}
+			// The census-enabled text is the census-disabled classification
+			// plus the appended tag; the routing outcome (a decline) is
+			// identical either way.
+			if !strings.Contains(on, "[c-mechanism=") {
+				t.Fatalf("census-enabled decline reason carries no classification: %q", on)
+			}
+		})
+	}
+}
+
+// TestAdmissionCensusRecoveryShapeVocabulary proves every classification the
+// census can emit comes from the closed, documented set. A new mechanism must
+// be added here deliberately, not leak out as free text.
+func TestAdmissionCensusRecoveryShapeVocabulary(t *testing.T) {
+	restore := gts.SetAdmissionCensusEnabledForTest(true)
+	defer restore()
+
+	known := map[string]bool{
+		"missing-token-insertion": true,
+		"stack-summary-resume":    true,
+		"recover-eof-wrap":        true,
+		"error-region-absorb":     true,
+	}
+	for _, witness := range admissionCensusRecoveryShapeWitnesses() {
+		if !known[witness.mechanism] {
+			t.Fatalf("witness pins mechanism %q outside the documented vocabulary", witness.mechanism)
+		}
+		reason := admissionCensusDeclineReason(t, witness.language, witness.source)
+		index := strings.Index(reason, "[c-mechanism=")
+		if index < 0 {
+			continue
+		}
+		tail := reason[index+len("[c-mechanism="):]
+		end := strings.IndexAny(tail, " ]")
+		if end < 0 {
+			t.Fatalf("malformed classification tag in %q", reason)
+		}
+		if !known[tail[:end]] {
+			t.Fatalf("census reported mechanism %q outside the documented vocabulary (%q)", tail[:end], reason)
+		}
+	}
+}

--- a/export_test.go
+++ b/export_test.go
@@ -437,3 +437,21 @@ func ParserPoolCheckoutForTest(pp *ParserPool) *Parser { return pp.checkout() }
 
 // ParserPoolReleaseForTest returns a parser to the pool (applying defaults).
 func ParserPoolReleaseForTest(pp *ParserPool, p *Parser) { pp.release(p) }
+
+// SetAdmissionCensusEnabledForTest forces the compact-route decline census
+// (admission_census.go) on or off for the calling test and returns a restore
+// function. The census normally latches one os.Getenv read behind a sync.Once,
+// which a test cannot influence once any earlier decline in the same process
+// has already consumed it; this helper consumes the Once itself and then sets
+// the latched value directly, so a census assertion does not depend on test
+// ordering or on the harness environment.
+//
+// Callers must not run parses in parallel across the returned restore: the
+// census flag is a plain latched bool that the decline path reads without
+// synchronization, exactly as the env-seeded value already is.
+func SetAdmissionCensusEnabledForTest(enabled bool) func() {
+	admissionCensusEnabledOnce.Do(func() {})
+	previous := admissionCensusEnabledVal
+	admissionCensusEnabledVal = enabled
+	return func() { admissionCensusEnabledVal = previous }
+}

--- a/export_test.go
+++ b/export_test.go
@@ -437,21 +437,3 @@ func ParserPoolCheckoutForTest(pp *ParserPool) *Parser { return pp.checkout() }
 
 // ParserPoolReleaseForTest returns a parser to the pool (applying defaults).
 func ParserPoolReleaseForTest(pp *ParserPool, p *Parser) { pp.release(p) }
-
-// SetAdmissionCensusEnabledForTest forces the compact-route decline census
-// (admission_census.go) on or off for the calling test and returns a restore
-// function. The census normally latches one os.Getenv read behind a sync.Once,
-// which a test cannot influence once any earlier decline in the same process
-// has already consumed it; this helper consumes the Once itself and then sets
-// the latched value directly, so a census assertion does not depend on test
-// ordering or on the harness environment.
-//
-// Callers must not run parses in parallel across the returned restore: the
-// census flag is a plain latched bool that the decline path reads without
-// synchronization, exactly as the env-seeded value already is.
-func SetAdmissionCensusEnabledForTest(enabled bool) func() {
-	admissionCensusEnabledOnce.Do(func() {})
-	previous := admissionCensusEnabledVal
-	admissionCensusEnabledVal = enabled
-	return func() { admissionCensusEnabledVal = previous }
-}


### PR DESCRIPTION
## Summary

The compact-route decline census reports every recovery-boundary fallback as one undivided "recovery" bucket, so an operator cannot tell which B3 stage owns the work. This branch splits that cohort the way C's own ts_parser__handle_error and ts_parser__recover split it, and tags each declining row with the mechanism that owns its stop point. The classification is read-only diagnostic text: it publishes no parse record, mutates no header, and changes no routing outcome.

## Changes

- Add admissionCensusRecoveryShape with a closed, four-value vocabulary: missing-token-insertion (S5), stack-summary-resume (S4), recover-eof-wrap (S5), and error-region-absorb (S3).
- Add admissionCensusMissingTokenCandidates, which counts terminals that satisfy C's step-2 predicate (shift to a different state whose leading action for the elected token is a reduce) and returns the lowest such terminal id, mirroring C's ascending-order scan.
- Keep the S3 decline guard s3MissingTokenOpportunityExists separate from the new counting variant: the hot decline path stays a cheap yes/no read, while the census needs the population.
- Add admissionCensusRecoveryShapeFor, which evaluates the four mechanisms in C's fixed order and short-circuits on the first match, and skips straight to absorb for an unlexable-run (errorSymbol) lookahead because C skips strategy 1 for it.
- Append `[c-mechanism=<shape> candidates=N first=T]` to the decline detail for DiagnosticParserCoreRecovery stops only; every other boundary keeps its text byte-identical.
- State the known limitation in the doc comment: the probes run at the declining state, not at C's post-closure state, because running the s3CloseInProgressProductions analogue would append arena records and change the parse. This makes the missing-token cohort a floor, never an overcount.
- Add admission_census_recovery_shape_test.go with nine pinned (language, source, mechanism) witnesses over embedded grammars, so the gate cannot silently skip on a checkout that never staged the gitignored corpus_real.
- Add a diagnostic-only test that asserts each witness still declines with the census off, carries no c-mechanism tag when off, and carries one when on.
- Add a vocabulary test that rejects any reported mechanism outside the documented set, so a new stage cannot leak out as free text.
- Export SetAdmissionCensusEnabledForTest in export_test.go: it consumes the sync.Once that latches the env read and sets the latched value directly, so census assertions do not depend on test ordering or harness environment.

## Testing

All runs below executed on this branch at `61a90bb5`, on a WSL2 host, with
`-tags gts_parsercorephase0`. No Docker or locked-C oracle run was needed:
this tranche changes decline text only and adds no mechanism.

- Focused gate, PASS: `go test -tags gts_parsercorephase0 -run '^TestAdmissionCensusRecoveryShape' -count=1 .`
  Three tests pass: `...Classification`, `...IsDiagnosticOnly`, `...Vocabulary`.
- No-regression proof, by A/B against pristine `origin/main`. The same root
  suite ran on this branch and on a detached `origin/main` worktree. The
  branch reports 25 failing test lines; `origin/main` reports 60. Every
  branch failure also fails on `origin/main`, so the branch adds no new
  failure. The extra failures on `origin/main` are the order-dependent
  `TestW5JavaScriptFamilyTransientErrorGate` family, already recorded as
  pre-existing. `TestDiagnosticParserCoreConflictAllUnchangedPauses` is also
  already recorded, as `finding.conflict-sequence-overflow-latent`. This
  branch fixes none of them and is not the cause of any of them.
- Route-outcome proof, real corpus. The full 146-row manifest matrix reports
  `PASS=88 DIVERGE=0 FALLBACK=46 SKIP=12 ERROR=0` both before and after this
  change, so the classification moved no row.
  Command: `GTS_ADMISSION_REAL_CORPUS=1 GTS_ADMISSION_CENSUS=1 GOMAXPROCS=1 GOFLAGS=-p=1 GOMEMLIMIT=12GiB go test -tags gts_parsercorephase0 -run '^TestAdmissionCandidateRealCorpusMatrix$' -count=1 .`
  Note: `cgo_harness/corpus_real` is gitignored. Without it this matrix skips
  and reports `ok`; the run above used a staged corpus.

## What the classification measured

On the full manifest the 46 fallback rows carry five mechanisms: 20
converged-split coverage, 18 recovery, 4 live-link-cap, 3 unproved
resurrection, and 1 end-of-file scanner quiescence. This tranche splits the
18-row recovery cohort into exactly three equal groups of six:

| Rows | C mechanism | Owning stage | Languages |
|---:|---|---|---|
| 6 | missing-token insertion | S5 | awk, dart, objc, php x2, sql |
| 6 | stack-summary resume | S4 | gomod, powershell x2, swift x2, typescript |
| 6 | error-region absorb | S3 | awk, ini x2, make x2, sql |

Four of the six missing-token rows report `candidates=1`, so C's ascending
first-surviving-candidate scan is unambiguous on them.

## Review Focus

Check that the read-only probes stay read-only: no arena record publication, no header mutation, and no s3CloseInProgressProductions analogue. Also check the evaluation order against C's ts_parser__handle_error and ts_parser__recover.
