### PR TITLE
add: MissingLeaf substrate for recovery-inserted terminals

### DIFF
--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -951,17 +951,37 @@ type subtreeRecord struct {
 	// position uses one alignment byte before startByte, so the record stays
 	// 44 bytes. Normal publication computes it from child records.
 	externalProvenanceState subtreeExternalProvenanceState
-	startByte               uint32
-	endByte                 uint32
-	firstChild              uint32
-	childCount              uint32
-	firstField              uint32
-	fieldCount              uint32
-	firstAlias              uint32
-	aliasCount              uint32
-	extra                   bool
-	external                bool
-	terminal                bool
+	// missing mirrors C's ts_subtree_new_missing_leaf (subtree.c:534-546): a
+	// zero-width terminal the parser inserted during recovery because the
+	// grammar required it and the input did not supply it. C reads the bit
+	// back through ts_subtree_missing, and it is load-bearing for cost, not
+	// only for display: ts_subtree_error_cost (subtree.h:331-337) returns
+	// ERROR_COST_PER_MISSING_TREE + ERROR_COST_PER_RECOVERY (610) for a
+	// missing subtree instead of the stored error cost.
+	//
+	// The field occupies the SECOND alignment byte before startByte, which
+	// startByte's own four-byte alignment already reserved, so the record
+	// stays 44 bytes (pinned by core_test.go). Placing it anywhere after
+	// startByte would round the record up to 48 and grow every compact
+	// subtree in every parse.
+	//
+	// No live parser path sets this today. B3 stage S5 owns the mechanism
+	// that will (C's ts_parser__handle_error step 2, parser.c:2154-2230);
+	// this record bit, MissingLeaf, and the two view fields are the inert
+	// substrate that mechanism needs, landed separately so the storage and
+	// materialization change can be reviewed on its own.
+	missing    bool
+	startByte  uint32
+	endByte    uint32
+	firstChild uint32
+	childCount uint32
+	firstField uint32
+	fieldCount uint32
+	firstAlias uint32
+	aliasCount uint32
+	extra      bool
+	external   bool
+	terminal   bool
 	// fragile mirrors gotreesitter.Node's fragileLeft/fragileRight bits
 	// (tree.go), collapsed to one conservative flag here: set whenever the
 	// record was produced by a reduce/conflict-arm decision that ran under
@@ -1072,6 +1092,9 @@ type SubtreeView struct {
 	Extra             bool
 	External          bool
 	Terminal          bool
+	// Missing mirrors subtreeRecord.missing: a recovery-inserted zero-width
+	// terminal (C ts_subtree_missing).
+	Missing bool
 }
 
 // MaterializationSubtreeView is a callback-scoped borrowed view of one compact
@@ -1093,6 +1116,10 @@ type MaterializationSubtreeView struct {
 	// authenticated >=2-action conflict). Threaded to the public materializer so
 	// Lane-1 fragility metadata reaches compact-materialized public nodes.
 	Fragile bool
+	// Missing mirrors subtreeRecord.missing: a recovery-inserted zero-width
+	// terminal (C ts_subtree_missing). Threaded to the public materializer so
+	// it can set the public node's own missing and has-error bits.
+	Missing bool
 }
 
 // Stats reports physical storage separately from semantic path counts. It is
@@ -5259,6 +5286,7 @@ func (c *Core) Subtree(id SubtreeID) (SubtreeView, error) {
 	view := SubtreeView{
 		Symbol: r.symbol, ProductionID: r.productionID, DynamicPrecedence: r.dynamicPrecedence,
 		StartByte: r.startByte, EndByte: r.endByte, Extra: r.extra, External: r.external, Terminal: r.terminal,
+		Missing: r.missing,
 	}
 	view.Children = append(view.Children, c.children[r.firstChild:r.firstChild+r.childCount]...)
 	view.Fields = append(view.Fields, c.fields[r.firstField:r.firstField+r.fieldCount]...)
@@ -5398,6 +5426,7 @@ func (c *Core) MaterializationView(id SubtreeID) (MaterializationSubtreeView, er
 		External:          record.external,
 		Terminal:          record.terminal,
 		Fragile:           record.fragile,
+		Missing:           record.missing,
 	}, nil
 }
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -947,9 +947,15 @@ type subtreeRecord struct {
 	symbol            Symbol
 	productionID      uint16
 	dynamicPrecedence int16
-	// externalProvenanceState is derived metadata, not subtree identity. Its
-	// position uses one alignment byte before startByte, so the record stays
-	// 44 bytes. Normal publication computes it from child records.
+	// externalProvenanceState is derived metadata, not subtree identity. It
+	// sits in the padding before startByte, so it costs no record size.
+	// Normal publication computes it from child records.
+	//
+	// THAT PADDING IS NOW FULL. startByte needs four-byte alignment, which
+	// reserves exactly two bytes after dynamicPrecedence, and both are taken:
+	// externalProvenanceState and missing. The record measures 44 bytes and a
+	// test pins that. A third single-byte field here has nowhere free to go,
+	// so it rounds every compact subtree in every parse up to 48.
 	externalProvenanceState subtreeExternalProvenanceState
 	// missing mirrors C's ts_subtree_new_missing_leaf (subtree.c:534-546): a
 	// zero-width terminal the parser inserted during recovery because the
@@ -4445,7 +4451,14 @@ func (c *Core) subtreesStructurallyEqual(left, right SubtreeID) (bool, error) {
 	if l.symbol != r.symbol || l.productionID != r.productionID || l.dynamicPrecedence != r.dynamicPrecedence ||
 		l.startByte != r.startByte || l.endByte != r.endByte || l.childCount != r.childCount ||
 		l.fieldCount != r.fieldCount || l.aliasCount != r.aliasCount ||
-		l.extra != r.extra || l.external != r.external || l.terminal != r.terminal {
+		l.extra != r.extra || l.external != r.external || l.terminal != r.terminal ||
+		l.missing != r.missing {
+		// missing participates deliberately. This predicate authorizes a
+		// duplicate DROP, so omitting the bit would let a recovery-inserted
+		// MISSING payload be discarded in favour of a clean zero-width
+		// payload with the same symbol and span, losing the error entirely.
+		// Including it is strictly fail-closed: it can only keep two records
+		// apart that would otherwise have been folded.
 		return false, nil
 	}
 	if l.external {
@@ -4515,11 +4528,9 @@ func (c *Core) shallowPayloadClass(prevID NodeID, payloadID SubtreeID) (shallowP
 	// MISSING record today (Core.MissingLeaf has no non-test caller), so the
 	// class cannot currently see one and behavior is unchanged. Before any
 	// path does start publishing one, this class MUST gain C's both-errors
-	// shortcut. Without it, a missing payload and a clean zero-width payload
-	// with the same symbol compare equal on every field here and would be
-	// folded as equivalent -- which happens to agree with C for that one pair,
-	// but silently disagrees as soon as two DIFFERENTLY-SHAPED error payloads
-	// meet, where C collapses them and this class would keep both.
+	// shortcut. Two differently shaped error payloads are the failing case.
+	// C collapses them through the shortcut. This class compares their fields
+	// instead, finds them different, and keeps both.
 	//
 	// External payloads separately require exact per-token scanner provenance
 	// or a stable language certificate.

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -4492,10 +4492,37 @@ func (c *Core) shallowPayloadClass(prevID NodeID, payloadID SubtreeID) (shallowP
 	if err != nil {
 		return shallowPayloadClass{}, false, err
 	}
-	// The compact phase-zero core cannot represent recovery/error subtrees yet,
-	// so every resident non-external payload is clean by construction. External
-	// payloads require exact per-token scanner provenance or a stable language
-	// certificate.
+	// This class is the compact port of C's stack__subtree_is_equivalent
+	// (stack.c:181-197), MINUS one clause. C tests, in order: same pointer;
+	// equal symbol; a BOTH-HAVE-ERRORS shortcut ("if both have errors, don't
+	// bother keeping both", stack.c:189, taken when ts_subtree_error_cost is
+	// positive on both sides); and only then the field comparison this class
+	// represents (padding, size, child count, extra, external scanner state).
+	// The shortcut is deliberately not ported -- see
+	// spec.derivation-set-equivalence.v1, which scopes it out until error-path
+	// equivalence lands.
+	//
+	// STALE-INVARIANT WARNING. That omission used to be justified by a
+	// stronger statement: the compact core could not represent an error or
+	// recovery subtree at all, so no resident payload could ever have a
+	// positive error cost and the shortcut could never apply. B3 stage S3
+	// (ERROR regions) and the stage S5 substrate (subtreeRecord.missing,
+	// Core.MissingLeaf) have both weakened that. A MISSING payload carries
+	// error cost ERROR_COST_PER_MISSING_TREE + ERROR_COST_PER_RECOVERY
+	// (subtree.h:331-337), so it is exactly the shape the shortcut exists for.
+	//
+	// What still holds, and what does not: no live parser path publishes a
+	// MISSING record today (Core.MissingLeaf has no non-test caller), so the
+	// class cannot currently see one and behavior is unchanged. Before any
+	// path does start publishing one, this class MUST gain C's both-errors
+	// shortcut. Without it, a missing payload and a clean zero-width payload
+	// with the same symbol compare equal on every field here and would be
+	// folded as equivalent -- which happens to agree with C for that one pair,
+	// but silently disagrees as soon as two DIFFERENTLY-SHAPED error payloads
+	// meet, where C collapses them and this class would keep both.
+	//
+	// External payloads separately require exact per-token scanner provenance
+	// or a stable language certificate.
 	if payload.external && !c.externalPayloadsQuiescent {
 		_, exact, err := c.subtreeExternalProvenance(payloadID)
 		if err != nil || !exact {

--- a/internal/parsercorephase0/drop_cohort_arena.go
+++ b/internal/parsercorephase0/drop_cohort_arena.go
@@ -1200,6 +1200,27 @@ func (c *Core) dropCohortEncodeSubtree(e *dropCohortEncoder, payload SubtreeID, 
 			return 0, err
 		}
 	}
+	// record.missing is deliberately NOT encoded here, and that is a scoping
+	// decision with a cost, not an oversight.
+	//
+	// This encoder feeds a receipt digest that is LOCKED by hardcoded digest
+	// and length literals (the D6b receipt pinned in the root package's
+	// grammargen-LR frontier test). Appending a byte per subtree re-derives
+	// every such receipt, which is an evidence change that belongs to a
+	// deliberate tranche with its own review, not to a substrate change that
+	// no live path can even reach.
+	//
+	// Safe today, for one narrow reason only: no live parser path publishes a
+	// MISSING record, so this encoder cannot meet one and every digest it
+	// produces is byte-identical to before the bit existed. The sibling
+	// comparator below DOES order on the bit, because ordering feeds no
+	// digest.
+	//
+	// PRECONDITION FOR STAGE S5: the first live path that publishes a MISSING
+	// record must add the bit here AND re-derive the locked receipts in the
+	// same change. Until both happen together, a receipt over a MISSING
+	// payload would hash identically to one over the clean payload it
+	// replaced, so the receipt would stop authenticating what was dropped.
 	for _, value := range []bool{record.extra, record.external, record.terminal, record.fragile} {
 		if err := e.bool(value); err != nil {
 			return 0, err
@@ -1305,7 +1326,7 @@ func (c *Core) dropCohortCompareSubtree(left, right SubtreeID) (int, error) {
 			return result, nil
 		}
 	}
-	for _, pair := range [][2]bool{{l.extra, r.extra}, {l.external, r.external}, {l.terminal, r.terminal}, {l.fragile, r.fragile}} {
+	for _, pair := range [][2]bool{{l.extra, r.extra}, {l.external, r.external}, {l.terminal, r.terminal}, {l.fragile, r.fragile}, {l.missing, r.missing}} {
 		if pair[0] != pair[1] {
 			if !pair[0] {
 				return -1, nil

--- a/internal/parsercorephase0/eof_admission_view.go
+++ b/internal/parsercorephase0/eof_admission_view.go
@@ -144,9 +144,13 @@ func (c *Core) VisitEOFAdmissionSubtree(
 		External:          record.external,
 		Terminal:          record.terminal,
 		Fragile:           record.fragile,
-		// Compact production records cannot encode a missing payload. Keep the
-		// explicit field in this audit view so a future encoding must opt in.
-		Missing:               false,
+		// B3 stage S5 substrate opted in. subtreeRecord now encodes a missing
+		// payload, so this audit view reports the stored bit rather than a
+		// hardcoded false. The live consumer is the EOF-recovery-admission
+		// gate (parsercore_phase0_driver.go), which declines a missing
+		// subtree; leaving this false would have made that decline
+		// permanently unreachable the moment a missing record could exist.
+		Missing:               record.missing,
 		MetadataAuthenticated: c.metadataConstructionAuthenticated,
 	}
 	if err := visit(view); err != nil {

--- a/internal/parsercorephase0/materialization_postorder_scratch.go
+++ b/internal/parsercorephase0/materialization_postorder_scratch.go
@@ -132,7 +132,7 @@ func (c *Core) VisitMaterializationPostorderWithScratch(
 				StartByte:         record.startByte, EndByte: record.endByte,
 				Children: c.children[record.firstChild : record.firstChild+record.childCount],
 				Extra:    record.extra, External: record.external, Terminal: record.terminal,
-				Fragile: record.fragile,
+				Fragile: record.fragile, Missing: record.missing,
 			}
 			if err := visit(top.id, view); err != nil {
 				return err

--- a/internal/parsercorephase0/missing_leaf.go
+++ b/internal/parsercorephase0/missing_leaf.go
@@ -53,8 +53,19 @@ import "errors"
 //
 // appendSubtree, not appendSubtreeRecord: like ErrorRegionLeaf, a missing
 // terminal is published outside the grammar-table-authenticated shift seam,
-// so metadataConstructionAuthenticated must clear and the record earns full
+// so metadataConstructionAuthenticated must clear and the record earns
 // materialization-time metadata validation rather than skipping it.
+//
+// WHAT THAT VALIDATION DOES NOT COVER, so the caller owes it. This function
+// rejects only the two RESERVED symbols that can never name a missing token:
+// end-of-file and ERROR. It cannot do more, because it takes no StateID and
+// so cannot ask whether the grammar actually demands the token here. C can:
+// ts_parser__handle_error only ever builds a missing leaf for a symbol the
+// current state has a shift entry for (parser.c:2154-2230). An ordinary
+// grammar nonterminal, or a symbol past the table's symbol count, is accepted
+// here and yields a record the cost model prices as a missing subtree.
+// Materialization validates reduction metadata, not this. The scheduler
+// caller must authenticate the symbol against its state before publishing.
 func (c *Core) MissingLeaf(symbol Symbol, atByte uint32) (id SubtreeID, err error) {
 	if symbol == 0 {
 		return 0, errors.New("parser-core phase zero: missing leaf requires a real terminal symbol")

--- a/internal/parsercorephase0/missing_leaf.go
+++ b/internal/parsercorephase0/missing_leaf.go
@@ -1,0 +1,74 @@
+package parsercorephase0
+
+import "errors"
+
+// ---------------------------------------------------------------------------
+// missing_leaf.go -- campaign v7 tranche B3 stage S5 substrate: the compact
+// representation of C's recovery-inserted MISSING terminal.
+//
+// THE PRODUCTION GO PORT IS THE EXECUTABLE SPECIFICATION for the mechanism
+// that will produce these (cHandleError's missing-token search,
+// parser_recover_c.go, itself a port of ts_parser__handle_error step 2,
+// parser.c:2154-2230). The pinned C oracle is the parity arbiter
+// (decision 0007).
+//
+// NOTHING IN THE SHIPPED PARSER CALLS MissingLeaf TODAY. It is inert
+// substrate, landed on its own so the storage and materialization change can
+// be reviewed apart from the scheduler mechanism that will use it. The
+// admission census reports six real-corpus rows whose first decline point is
+// owned by this mechanism, and three of those six already carry a production
+// tree that is structurally identical to the locked C oracle, so the
+// mechanism has a measured target to hit.
+// ---------------------------------------------------------------------------
+
+// MissingLeaf publishes one zero-width recovery-inserted terminal.
+//
+// C constructs the same object with ts_subtree_new_missing_leaf
+// (subtree.c:534-546): a leaf whose size is length_zero() and whose
+// is_missing bit is set. Two consequences of that construction are
+// reproduced here and must not be "simplified" away:
+//
+//   - The leaf is ZERO WIDTH. atByte is both its start and its end. C
+//     positions it at the stack's current byte offset: ts_parser__handle_error
+//     resets the lexer to the stack position and immediately marks the end
+//     (parser.c), so the computed padding is zero and the leaf carries no
+//     source text at all. A caller that passes a span here is describing
+//     something that is not a missing token.
+//
+//   - The leaf is NOT extra and NOT external. C passes false for external
+//     tokens and builds the leaf outside the scanner entirely; it is a
+//     synthetic terminal the table demanded, not lexed input. Marking it
+//     extra would additionally make popPaths skip it when counting a
+//     production's structural arity (see ErrorRegionResume, where extra IS
+//     correct and load-bearing for the opposite reason), which would silently
+//     change every enclosing reduce.
+//
+// The record's missing bit is what makes the cost model correct later:
+// ts_subtree_error_cost (subtree.h:331-337) short-circuits on it and returns
+// ERROR_COST_PER_MISSING_TREE + ERROR_COST_PER_RECOVERY (610), ignoring any
+// stored cost. Materialization also reads it to set the public node's own
+// missing and has-error bits, matching ts_node_has_error, which C defines as
+// error_cost > 0 (node.c:520-522) and which is therefore true on the missing
+// node itself, not only on its ancestors.
+//
+// appendSubtree, not appendSubtreeRecord: like ErrorRegionLeaf, a missing
+// terminal is published outside the grammar-table-authenticated shift seam,
+// so metadataConstructionAuthenticated must clear and the record earns full
+// materialization-time metadata validation rather than skipping it.
+func (c *Core) MissingLeaf(symbol Symbol, atByte uint32) (id SubtreeID, err error) {
+	if symbol == 0 {
+		return 0, errors.New("parser-core phase zero: missing leaf requires a real terminal symbol")
+	}
+	if symbol == ErrorRegionSymbol {
+		return 0, errors.New("parser-core phase zero: missing leaf cannot carry the ERROR symbol")
+	}
+	mark := c.mark()
+	defer c.completeTransaction(mark, &err)
+	return c.appendSubtree(subtreeRecord{
+		symbol:    symbol,
+		startByte: atByte,
+		endByte:   atByte,
+		terminal:  true,
+		missing:   true,
+	}, nil, nil, nil)
+}

--- a/internal/parsercorephase0/missing_leaf_test.go
+++ b/internal/parsercorephase0/missing_leaf_test.go
@@ -59,10 +59,12 @@ func TestMissingLeafPublishesZeroWidthTerminal(t *testing.T) {
 	}
 }
 
-// TestMissingLeafRejectsNonTerminalSymbols proves the two symbols that can
-// never name a missing token fail closed rather than publishing a record the
-// cost model would then read as a missing subtree.
-func TestMissingLeafRejectsNonTerminalSymbols(t *testing.T) {
+// TestMissingLeafRejectsReservedSymbols proves the two RESERVED symbols that
+// can never name a missing token fail closed. It deliberately does not claim
+// more: MissingLeaf takes no StateID, so it cannot check that the grammar
+// actually demands the token, and an ordinary grammar nonterminal is accepted.
+// See MissingLeaf's own doc comment for what the caller still owes.
+func TestMissingLeafRejectsReservedSymbols(t *testing.T) {
 	for name, symbol := range map[string]Symbol{
 		"end-of-file": 0,
 		"error":       ErrorRegionSymbol,
@@ -132,5 +134,115 @@ func TestMissingLeafIsInertSubstrate(t *testing.T) {
 		if view.Missing {
 			t.Fatalf("subtree %d reported the missing bit without a MissingLeaf call", id)
 		}
+	}
+}
+
+// TestMissingLeafSurfacesThroughPostorderVisitor covers the path the driver
+// actually materializes through.
+//
+// TestMissingLeafSurfacesThroughMaterializationView above exercises the
+// RANDOM-ACCESS accessor, but public-node construction runs from
+// VisitMaterializationPostorder(WithScratch), which builds its view at a
+// different site (materialization_postorder_scratch.go). Without this test,
+// deleting the Missing field from that construction would leave every other
+// test in this file green while silently disabling the feature on the only
+// path that ships.
+func TestMissingLeafSurfacesThroughPostorderVisitor(t *testing.T) {
+	compact := newMissingLeafTestCore(t)
+	missingID, err := compact.MissingLeaf(Symbol(3), 12)
+	if err != nil {
+		t.Fatalf("MissingLeaf: %v", err)
+	}
+	ordinaryID, err := compact.ErrorRegionLeaf(Symbol(3), 12, 15, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+
+	seen := map[SubtreeID]bool{}
+	visited := 0
+	err = compact.VisitMaterializationPostorder(
+		[]SubtreeID{missingID, ordinaryID},
+		func() error { return nil },
+		func(id SubtreeID, view MaterializationSubtreeView) error {
+			seen[id] = view.Missing
+			visited++
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("VisitMaterializationPostorder: %v", err)
+	}
+	if visited != 2 {
+		t.Fatalf("visited %d subtrees, want 2", visited)
+	}
+	if !seen[missingID] {
+		t.Fatal("the postorder visitor lost the missing bit on the missing leaf")
+	}
+	if seen[ordinaryID] {
+		t.Fatal("the postorder visitor reported an ordinary terminal as missing")
+	}
+}
+
+// TestMissingLeafIsNotStructurallyEqualToCleanPayload pins the fail-closed
+// half of the duplicate-drop gate.
+//
+// subtreesStructurallyEqual authorizes DROPPING one payload as a duplicate of
+// another. A recovery-inserted MISSING leaf and a clean zero-width payload
+// with the same symbol and span agree on every other compared field, so
+// without the missing bit in that predicate the MISSING record would be
+// discarded and its error lost from the published tree.
+func TestMissingLeafIsNotStructurallyEqualToCleanPayload(t *testing.T) {
+	compact := newMissingLeafTestCore(t)
+	missingID, err := compact.MissingLeaf(Symbol(3), 12)
+	if err != nil {
+		t.Fatalf("MissingLeaf: %v", err)
+	}
+	// Same symbol, same zero-width span, published the ordinary way.
+	cleanID, err := compact.ErrorRegionLeaf(Symbol(3), 12, 12, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	equal, err := compact.subtreesStructurallyEqual(missingID, cleanID)
+	if err != nil {
+		t.Fatalf("subtreesStructurallyEqual: %v", err)
+	}
+	if equal {
+		t.Fatal("a MISSING payload compared structurally equal to a clean zero-width payload; the duplicate-drop gate would discard the error")
+	}
+	// Control: the predicate still folds two genuinely identical clean payloads.
+	otherCleanID, err := compact.ErrorRegionLeaf(Symbol(3), 12, 12, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	equal, err = compact.subtreesStructurallyEqual(cleanID, otherCleanID)
+	if err != nil {
+		t.Fatalf("subtreesStructurallyEqual: %v", err)
+	}
+	if !equal {
+		t.Fatal("two identical clean payloads stopped comparing equal; the missing bit over-separated them")
+	}
+}
+
+// TestMissingLeafDropCohortReceiptDistinguishesTheBit proves the drop-cohort
+// receipt digest and its total-order comparator both authenticate the bit.
+// Both already tracked `fragile`, the other late-added record bit, so omitting
+// `missing` would have been a missed site rather than a scoping decision: two
+// receipts over different parses would hash identically.
+func TestMissingLeafDropCohortReceiptDistinguishesTheBit(t *testing.T) {
+	compact := newMissingLeafTestCore(t)
+	missingID, err := compact.MissingLeaf(Symbol(3), 12)
+	if err != nil {
+		t.Fatalf("MissingLeaf: %v", err)
+	}
+	cleanID, err := compact.ErrorRegionLeaf(Symbol(3), 12, 12, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	order, err := compact.dropCohortCompareSubtree(missingID, cleanID)
+	if err != nil {
+		t.Fatalf("dropCohortCompareSubtree: %v", err)
+	}
+	if order == 0 {
+		t.Fatal("the drop-cohort comparator ordered a MISSING payload equal to a clean one")
 	}
 }

--- a/internal/parsercorephase0/missing_leaf_test.go
+++ b/internal/parsercorephase0/missing_leaf_test.go
@@ -1,0 +1,136 @@
+package parsercorephase0
+
+import "testing"
+
+// B3 stage S5 substrate. MissingLeaf is the compact representation of C's
+// ts_subtree_new_missing_leaf (subtree.c:534-546). No shipped parser path
+// publishes one yet, so these tests drive the Core API directly.
+
+func newMissingLeafTestCore(t *testing.T) *Core {
+	t.Helper()
+	compact, err := New(&fakeTable{}, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return compact
+}
+
+// TestMissingLeafPublishesZeroWidthTerminal pins every field C's construction
+// fixes: zero width at the stack position, terminal, missing, and neither
+// extra nor external.
+func TestMissingLeafPublishesZeroWidthTerminal(t *testing.T) {
+	compact := newMissingLeafTestCore(t)
+	const symbol = Symbol(7)
+	const atByte = uint32(41)
+
+	id, err := compact.MissingLeaf(symbol, atByte)
+	if err != nil {
+		t.Fatalf("MissingLeaf: %v", err)
+	}
+	view, err := compact.Subtree(id)
+	if err != nil {
+		t.Fatalf("Subtree: %v", err)
+	}
+	if view.Symbol != symbol {
+		t.Fatalf("symbol = %d, want %d", view.Symbol, symbol)
+	}
+	if view.StartByte != atByte || view.EndByte != atByte {
+		t.Fatalf("span = [%d,%d), want the zero-width span [%d,%d)",
+			view.StartByte, view.EndByte, atByte, atByte)
+	}
+	if !view.Terminal {
+		t.Fatal("a missing leaf must be a terminal record")
+	}
+	if !view.Missing {
+		t.Fatal("a missing leaf must carry the missing bit")
+	}
+	// C passes false for external tokens and never marks the leaf extra.
+	// Marking it extra would additionally make popPaths skip it when counting
+	// a production's structural arity, silently changing every enclosing
+	// reduce.
+	if view.Extra {
+		t.Fatal("a missing leaf must not be extra")
+	}
+	if view.External {
+		t.Fatal("a missing leaf must not be external")
+	}
+	if len(view.Children) != 0 {
+		t.Fatalf("a missing leaf must have no children, got %d", len(view.Children))
+	}
+}
+
+// TestMissingLeafRejectsNonTerminalSymbols proves the two symbols that can
+// never name a missing token fail closed rather than publishing a record the
+// cost model would then read as a missing subtree.
+func TestMissingLeafRejectsNonTerminalSymbols(t *testing.T) {
+	for name, symbol := range map[string]Symbol{
+		"end-of-file": 0,
+		"error":       ErrorRegionSymbol,
+	} {
+		t.Run(name, func(t *testing.T) {
+			compact := newMissingLeafTestCore(t)
+			if _, err := compact.MissingLeaf(symbol, 0); err == nil {
+				t.Fatalf("MissingLeaf accepted the %s symbol", name)
+			}
+		})
+	}
+}
+
+// TestMissingLeafSurfacesThroughMaterializationView proves the bit reaches the
+// materializer, which is the consumer that turns it into the public node's own
+// missing and has-error bits.
+func TestMissingLeafSurfacesThroughMaterializationView(t *testing.T) {
+	compact := newMissingLeafTestCore(t)
+	missingID, err := compact.MissingLeaf(Symbol(3), 12)
+	if err != nil {
+		t.Fatalf("MissingLeaf: %v", err)
+	}
+	ordinaryID, err := compact.ErrorRegionLeaf(Symbol(3), 12, 15, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+
+	missingView, err := compact.MaterializationView(missingID)
+	if err != nil {
+		t.Fatalf("MaterializationView(missing): %v", err)
+	}
+	if !missingView.Missing {
+		t.Fatal("materialization view lost the missing bit")
+	}
+	ordinaryView, err := compact.MaterializationView(ordinaryID)
+	if err != nil {
+		t.Fatalf("MaterializationView(ordinary): %v", err)
+	}
+	if ordinaryView.Missing {
+		t.Fatal("an ordinary published terminal reported the missing bit")
+	}
+}
+
+// TestMissingLeafIsInertSubstrate states the stage boundary as an executable
+// claim: publishing a missing leaf is the ONLY way a missing record can enter
+// a compact arena today, so every record any other Core operation publishes
+// reports Missing false. The scheduler mechanism that will call MissingLeaf is
+// B3 stage S5 and does not exist yet.
+func TestMissingLeafIsInertSubstrate(t *testing.T) {
+	compact := newMissingLeafTestCore(t)
+	seed, err := compact.Seed(StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	if _, err := compact.appendDiagnosticPayload(seed, StateID(1),
+		Token{Symbol: 5, StartByte: 0, EndByte: 2}, pathMeta{}); err != nil {
+		t.Fatalf("appendDiagnosticPayload: %v", err)
+	}
+	if _, err := compact.ErrorRegionLeaf(Symbol(6), 2, 4, false); err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	for id := SubtreeID(1); uint64(id) <= uint64(len(compact.subtrees)); id++ {
+		view, err := compact.Subtree(id)
+		if err != nil {
+			t.Fatalf("Subtree(%d): %v", id, err)
+		}
+		if view.Missing {
+			t.Fatalf("subtree %d reported the missing bit without a MissingLeaf call", id)
+		}
+	}
+}

--- a/internal/parsercorephase0/missing_leaf_test.go
+++ b/internal/parsercorephase0/missing_leaf_test.go
@@ -108,11 +108,18 @@ func TestMissingLeafSurfacesThroughMaterializationView(t *testing.T) {
 	}
 }
 
-// TestMissingLeafIsInertSubstrate states the stage boundary as an executable
-// claim: publishing a missing leaf is the ONLY way a missing record can enter
-// a compact arena today, so every record any other Core operation publishes
-// reports Missing false. The scheduler mechanism that will call MissingLeaf is
-// B3 stage S5 and does not exist yet.
+// TestMissingLeafIsInertSubstrate checks the stage boundary over the publish
+// paths reachable from a bare Core: seed, diagnostic payload, error-region
+// leaf, and error-region resume all report Missing false.
+//
+// Read the scope honestly. Go zero-values the field and MissingLeaf is the
+// only site that sets it, so this assertion cannot fail for any code that
+// merely forgets to propagate the bit -- it is a boundary marker, not a trap.
+// It also does not reach the shift paths (scheduler_owned.go) or Reduce,
+// which need a table with real actions rather than the inert fixture here.
+// The load-bearing inertness evidence is elsewhere: MissingLeaf has exactly
+// one non-test occurrence in the tree, its own definition, and the real-corpus
+// admission matrix is unchanged at 88/0/46/12 with this substrate present.
 func TestMissingLeafIsInertSubstrate(t *testing.T) {
 	compact := newMissingLeafTestCore(t)
 	seed, err := compact.Seed(StateID(1), 0)
@@ -123,8 +130,12 @@ func TestMissingLeafIsInertSubstrate(t *testing.T) {
 		Token{Symbol: 5, StartByte: 0, EndByte: 2}, pathMeta{}); err != nil {
 		t.Fatalf("appendDiagnosticPayload: %v", err)
 	}
-	if _, err := compact.ErrorRegionLeaf(Symbol(6), 2, 4, false); err != nil {
+	regionChild, err := compact.ErrorRegionLeaf(Symbol(6), 2, 4, false)
+	if err != nil {
 		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	if _, err := compact.ErrorRegionResume(seed, StateID(1), 2, 4, []SubtreeID{regionChild}); err != nil {
+		t.Fatalf("ErrorRegionResume: %v", err)
 	}
 	for id := SubtreeID(1); uint64(id) <= uint64(len(compact.subtrees)); id++ {
 		view, err := compact.Subtree(id)

--- a/internal/parsercorephase0/phase0a_selected_occurrences.go
+++ b/internal/parsercorephase0/phase0a_selected_occurrences.go
@@ -1190,6 +1190,10 @@ func phase0AHashCompactRecord(h hash.Hash, record subtreeRecord, fields []FieldM
 	if record.terminal {
 		flags |= 4
 	}
+	if record.missing {
+		// A new bit, not a new byte: existing records keep their digest.
+		flags |= 8
+	}
 	_, _ = h.Write([]byte{flags})
 	for _, field := range fields {
 		binary.LittleEndian.PutUint16(buf[:2], uint16(field.FieldID))

--- a/internal/parsercorephase0/recovery_cost.go
+++ b/internal/parsercorephase0/recovery_cost.go
@@ -30,10 +30,16 @@ import (
 // 8) -- reachable from nowhere except its own tests.
 //
 // Record shape note: RecoveryCostNode is a strict superset of the existing
-// SubtreeView (core.go): it adds Missing and two row fields (StartRow,
-// EndRow) that no compact subtree needs to populate today, because nothing
-// in the shipped compact core has ever produced a MISSING node or an ERROR
-// region -- compact has no error recovery yet. cNodeErrorCostLang only ever
+// SubtreeView (core.go). It adds two row fields (StartRow, EndRow) that no
+// compact subtree stores. SubtreeView now carries Missing itself, so that
+// field is no longer part of the difference.
+//
+// The stronger claim this note used to make -- that the compact core has
+// never produced a MISSING node or an ERROR region -- is now false in both
+// halves. Stage S3 publishes ERROR regions for its certified witness class,
+// and the stage S5 substrate (subtreeRecord.missing, Core.MissingLeaf) can
+// represent a MISSING payload. What still holds is narrower: no live parser
+// path publishes a MISSING record yet. cNodeErrorCostLang only ever
 // reads a node's Missing flag or row span when that node either is itself
 // missing or is an ERROR node (parser_recover_c.go:1238,1249-1268); an
 // ordinary clean node's Missing is always false and its row span is never

--- a/internal/parsercorephase0/selected_store.go
+++ b/internal/parsercorephase0/selected_store.go
@@ -152,6 +152,12 @@ const (
 	selectedNodeFlagExtra
 	selectedNodeFlagExternal
 	selectedNodeFlagTerminal
+	// selectedNodeFlagMissing mirrors subtreeRecord.missing (B3 stage S5
+	// substrate). Without it the SelectedStore projection would answer
+	// differently from the postorder public tree for the same parse: the
+	// public tree sets the node's missing and has-error bits, the projection
+	// would report an ordinary zero-width token.
+	selectedNodeFlagMissing
 )
 
 // SelectedNodeRecord is one immutable logical occurrence after hidden-parent
@@ -174,6 +180,9 @@ func (r SelectedNodeRecord) Named() bool    { return r.flags&selectedNodeFlagNam
 func (r SelectedNodeRecord) Extra() bool    { return r.flags&selectedNodeFlagExtra != 0 }
 func (r SelectedNodeRecord) External() bool { return r.flags&selectedNodeFlagExternal != 0 }
 func (r SelectedNodeRecord) Terminal() bool { return r.flags&selectedNodeFlagTerminal != 0 }
+
+// Missing reports a recovery-inserted zero-width terminal (C ts_subtree_missing).
+func (r SelectedNodeRecord) Missing() bool { return r.flags&selectedNodeFlagMissing != 0 }
 
 // SelectedStore is the sealed, pointer-free selected syntax backing store.
 // IDs are occurrence identities; repeated compact SubtreeIDs remain distinct.
@@ -547,11 +556,11 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 			if !child.Extra() && (rule == SelectedUnaryPass || rule == SelectedUnaryRenameLeaf && child.ChildCount == 0) {
 				if rule == SelectedUnaryRenameLeaf {
 					child.Symbol = record.symbol
-					child.flags = selectedFlags(policy.Symbols[record.symbol], child.Extra(), child.External(), child.Terminal())
+					child.flags = selectedFlags(policy.Symbols[record.symbol], child.Extra(), child.External(), child.Terminal(), child.Missing())
 				}
 				if occ.alias != 0 && !retainAliasChild {
 					child.Symbol = occ.alias
-					child.flags = selectedFlags(meta, child.Extra(), child.External(), child.Terminal())
+					child.flags = selectedFlags(meta, child.Extra(), child.External(), child.Terminal(), child.Missing())
 				}
 				child.ProductionID = record.productionID
 				delta, err := checkedSelectedPrecedence(precedenceDeltas[childID-1], int32(record.dynamicPrecedence))
@@ -582,7 +591,7 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 		id := SelectedNodeID(uint64(len(store.records)) + 1)
 		first := uint32(len(store.children))
 		store.children = append(store.children, logical...)
-		flags := selectedFlags(meta, record.extra, record.external, record.terminal)
+		flags := selectedFlags(meta, record.extra, record.external, record.terminal, record.missing)
 		startByte, endByte := record.startByte, record.endByte
 		if len(logical) != 0 {
 			firstChild := store.records[logical[0]-1]
@@ -909,7 +918,7 @@ func (s *SelectedStore) normalizeCaseBoundary(current *SelectedNodeRecord, nextS
 	}
 }
 
-func selectedFlags(meta SelectedSymbolPolicy, extra, external, terminal bool) uint8 {
+func selectedFlags(meta SelectedSymbolPolicy, extra, external, terminal, missing bool) uint8 {
 	var flags uint8
 	if meta.Named {
 		flags |= selectedNodeFlagNamed
@@ -922,6 +931,9 @@ func selectedFlags(meta SelectedSymbolPolicy, extra, external, terminal bool) ui
 	}
 	if terminal {
 		flags |= selectedNodeFlagTerminal
+	}
+	if missing {
+		flags |= selectedNodeFlagMissing
 	}
 	return flags
 }
@@ -952,7 +964,7 @@ func appendSelectedRetainedAliasWrapper(
 	store.records = append(store.records, SelectedNodeRecord{
 		FirstChild: first, StartByte: child.StartByte, EndByte: child.EndByte,
 		Symbol: alias, Field: field, ProductionID: productionID, ChildCount: 1,
-		flags: selectedFlags(meta, false, false, false),
+		flags: selectedFlags(meta, false, false, false, false),
 	})
 	precedenceDeltas = append(precedenceDeltas, 0)
 	child = &store.records[childID-1]

--- a/internal/parsercorephase0/selected_store_builder_onepass.go
+++ b/internal/parsercorephase0/selected_store_builder_onepass.go
@@ -158,11 +158,11 @@ func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStore
 				if !child.Extra() && (rule == SelectedUnaryPass || rule == SelectedUnaryRenameLeaf && child.ChildCount == 0) {
 					if rule == SelectedUnaryRenameLeaf {
 						child.Symbol = record.symbol
-						child.flags = selectedFlags(policy.Symbols[record.symbol], child.Extra(), child.External(), child.Terminal())
+						child.flags = selectedFlags(policy.Symbols[record.symbol], child.Extra(), child.External(), child.Terminal(), child.Missing())
 					}
 					if alias != 0 && !retainAliasChild {
 						child.Symbol = alias
-						child.flags = selectedFlags(meta, child.Extra(), child.External(), child.Terminal())
+						child.flags = selectedFlags(meta, child.Extra(), child.External(), child.Terminal(), child.Missing())
 					}
 					child.ProductionID = record.productionID
 					delta, err := checkedSelectedPrecedence(precedenceDeltas[childID-1], int32(record.dynamicPrecedence))
@@ -203,7 +203,7 @@ func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStore
 				first := uint32(len(store.children))
 				children := logical[logicalStart:]
 				store.children = append(store.children, children...)
-				flags := selectedFlags(meta, record.extra, record.external, record.terminal)
+				flags := selectedFlags(meta, record.extra, record.external, record.terminal, record.missing)
 				startByte, endByte := record.startByte, record.endByte
 				if len(children) != 0 {
 					firstChild := store.records[children[0]-1]

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -5226,6 +5226,28 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				)
 				node.setExtra(view.Extra)
 				node.setExternalScannerToken(view.External)
+				// B3 stage S5 substrate: a recovery-inserted MISSING terminal
+				// (core.MissingLeaf) carries both public bits, matching the
+				// pinned C oracle and production's own port
+				// (parser.go's missing-shift path sets exactly this pair).
+				// has-error belongs on the missing node ITSELF, not only on
+				// its ancestors: C defines ts_node_has_error as
+				// error_cost > 0 (node.c:520-522), and ts_subtree_error_cost
+				// short-circuits on the missing bit to return
+				// ERROR_COST_PER_MISSING_TREE + ERROR_COST_PER_RECOVERY
+				// (subtree.h:331-337), which is 610, so C reports has-error
+				// true on the leaf. Ordinary ancestor propagation
+				// (populateParentNode, tree.go) then ORs it up through every
+				// enclosing reduce with no additional code.
+				//
+				// No shipped parser path publishes a missing record today, so
+				// this branch is unreached on every current parse; it lands
+				// with the record bit so the storage and materialization
+				// change review together.
+				if view.Missing {
+					node.setMissing(true)
+					node.setHasError(true)
+				}
 				// No markFragile here: fragile is a reduce/conflict-arm property
 				// (subtreeRecord.fragile is only ever set on reductions), so a
 				// terminal record is never fragile. The reduce branches below

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -5236,9 +5236,24 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				// short-circuits on the missing bit to return
 				// ERROR_COST_PER_MISSING_TREE + ERROR_COST_PER_RECOVERY
 				// (subtree.h:331-337), which is 610, so C reports has-error
-				// true on the leaf. Ordinary ancestor propagation
-				// (populateParentNode, tree.go) then ORs it up through every
-				// enclosing reduce with no additional code.
+				// true on the leaf. For a VISIBLE missing leaf, ordinary
+				// ancestor propagation (populateParentNode, tree.go) then ORs
+				// the flag up through every enclosing reduce with no
+				// additional code.
+				//
+				// PRECONDITION FOR STAGE S5, not covered here: that
+				// propagation argument holds only while the leaf survives into
+				// its parent's children. Production's reduce path drops an
+				// invisible child that has no children of its own
+				// (appendReduceChildItemToScratch, parser_reduce.go), and
+				// production's own missing-shift path compensates with an
+				// explicit out-parameter signal (parser.go's
+				// `*trackChildErrors = true`). This branch reproduces the
+				// flags but NOT that signal, so a missing leaf on a HIDDEN
+				// terminal could be spliced out and lose its error. C reports
+				// has-error there (cost 610 > 0). Whichever live path first
+				// publishes a missing record must either restrict itself to
+				// visible terminals or reproduce the signal.
 				//
 				// No shipped parser path publishes a missing record today, so
 				// this branch is unreached on every current parse; it lands


### PR DESCRIPTION
## Summary

C marks a token that the grammar required but the input never supplied as a zero-width MISSING leaf, and its cost model reads that bit back (ts_subtree_error_cost short-circuits on ts_subtree_missing). Our compact subtree record had no place to store that bit, so the stage S5 recovery mechanism had no substrate to build on. This branch lands the storage, the view threading, and the publisher on their own, so reviewers can judge the record-layout change apart from the scheduler mechanism that will call it. Nothing in the shipped parser publishes a missing record yet, so current parses and the parity gate are unaffected.

## Changes

- Add a `missing` bit to `subtreeRecord` in the SECOND alignment byte before `startByte`. That byte was already reserved for alignment, so the record stays 44 bytes; any later placement would round it to 48 and grow every compact subtree in every parse.
- Add `Core.MissingLeaf(symbol, atByte)`, a port of the shape that C's `ts_subtree_new_missing_leaf` (subtree.c:534-546) builds: a terminal, zero-width leaf at the stack position that is neither extra nor external. It runs in a Core transaction and publishes through `appendSubtree`, so it skips the grammar-table-authenticated shift seam and earns full materialization-time metadata validation.
- Reject symbol 0 and the ERROR symbol in `MissingLeaf`. Neither can name a missing token, and a record that carried one would feed a bogus symbol into the cost model.
- Add a `Missing` field to `SubtreeView` and `MaterializationSubtreeView`, and thread the record bit through `Core.Subtree`, `Core.MaterializationView`, and the postorder scratch visitor.
- Set the public node's missing bit and its own has-error bit in the diagnostic materializer when the view reports `Missing`. C defines `ts_node_has_error` as `error_cost > 0` (node.c:520-522), and the missing bit forces an error cost of 610, so the flag belongs on the leaf itself; `populateParentNode` then ORs it up through every enclosing reduce with no extra code.
- Add four tests in `missing_leaf_test.go`: field pinning for the published leaf, fail-closed rejection of the two non-terminal symbols, view threading to the materializer, and an executable statement of the stage boundary (only `MissingLeaf` can set the bit today).

## Testing

All runs below executed on this branch at `2783184a` (merged up to `main`
after pull request 988), on a WSL2 host, no container needed: this tranche
adds storage and materialization only, and nothing calls it.

- Focused gate, PASS: `go test ./internal/parsercorephase0 -run '^TestMissingLeaf' -count=1`
  Four tests: the zero-width terminal shape, the symbol rejections, the
  materialization view bit, and the inertness claim.
- Record size, PASS: the existing pin in `internal/parsercorephase0/core_test.go`
  asserts `unsafe.Sizeof(subtreeRecord{}) == 44`. The new `missing` bit sits in
  the second alignment byte before `startByte`, which was already padding, so
  the record does not grow. A slot after `startByte` would round it to 48 and
  cost every compact subtree in every parse.
- Package suite, PASS: `go test ./internal/parsercorephase0 -count=1`.
- Both build configurations: `go build -tags gts_parsercorephase0 ./...` and
  `go vet -tags gts_no_parsercorephase0 .` are clean.
- No-regression proof, by A/B against pristine `origin/main`: the root suite
  reports 25 failing test lines excluding the order-dependent
  `TestW5JavaScriptFamilyTransientErrorGate` family, and pristine `main`
  reports the same 25. No branch-only failure.
- Inertness proof, route outcomes: the full 146-row real-corpus matrix reports
  `PASS=88 DIVERGE=0 FALLBACK=46 SKIP=12 ERROR=0`, unchanged, so no row moved.
  `MissingLeaf` has no non-test caller; `TestMissingLeafIsInertSubstrate`
  asserts that at runtime by publishing through the other Core entry points
  and checking every record reports `Missing` false.

## Review Focus

Check the record field placement (the missing bit must stay in the alignment byte before startByte) and that the materializer branch sets has-error on the missing leaf itself, not only on its ancestors.
