### PR TITLE
optimize(parser): Memoize derived parser tables per Language

### DIFF
--- a/language.go
+++ b/language.go
@@ -677,6 +677,14 @@ type Language struct {
 	corridorProgram     any   // *ParserCoreCorridorProgram under the default build
 	corridorProgramErr  error // the compile error, memoized alongside corridorProgram
 
+	// parserDerivedOnce memoizes the per-language derived parser tables that
+	// NewParser previously rebuilt on every call. The tables are pure functions
+	// of the decoded grammar tables (ParseTable, SmallParseTable, ParseActions,
+	// SymbolMetadata), which are immutable after decode. The cache lives on the
+	// Language for the same retention reason as compactTables above.
+	parserDerivedOnce sync.Once
+	parserDerived     *parserDerivedTables
+
 	// NonTerminalAliasMap mirrors tree-sitter C's ts_non_terminal_alias_map.
 	// Rows are indexed by nonterminal symbol and contain aliases that require
 	// preserving the wrapper during alias-bearing reductions. This is cold

--- a/lex_mode_repair.go
+++ b/lex_mode_repair.go
@@ -77,10 +77,7 @@ func lookupRepairActionIndex(lang *Language, state StateID, sym Symbol) uint16 {
 		return 0
 	}
 
-	denseLimit := int(lang.LargeStateCount)
-	if denseLimit == 0 {
-		denseLimit = len(lang.ParseTable)
-	}
+	denseLimit := languageDenseLimit(lang)
 	if int(state) < denseLimit {
 		if int(state) >= len(lang.ParseTable) {
 			return 0

--- a/parser.go
+++ b/parser.go
@@ -1626,31 +1626,26 @@ func NewParser(lang *Language) *Parser {
 				p.forceRawSpanTable[i] = true
 			}
 		}
-		if lang.LargeStateCount > 0 {
-			p.denseLimit = int(lang.LargeStateCount)
-		} else {
-			p.denseLimit = len(lang.ParseTable)
-		}
+		p.denseLimit = languageDenseLimit(lang)
 		// Bind the cached action-lookup closure eagerly at language-config
 		// time so lookupActionIndexFunc's lazy fallback never races, even in
 		// the (unsupported) shared-Parser case.
 		p.lookupActionIndexFn = p.lookupActionIndex
 		p.smallBase = int(lang.LargeStateCount)
-		if len(lang.SmallParseTableMap) > 0 && len(lang.SmallParseTable) > 0 {
-			p.smallTokenLookup = buildSmallTokenLookup(lang)
-			p.smallLookup = buildSmallLookup(lang, p.smallTokenLookup)
-		}
+		derived := lang.acquireParserDerivedTables()
+		p.smallTokenLookup = derived.smallTokenLookup
+		p.smallLookup = derived.smallLookup
 		p.externalValidByState = p.buildExternalValidByState()
 		p.externalValidMaskByState = buildExternalValidMaskByState(p.externalValidByState, len(lang.ExternalSymbols))
 		p.hasExtraChainActions = languageHasExtraChainActions(lang)
-		p.classifiedActions = buildClassifiedParseActions(lang)
-		p.eagerDefaultReduces = buildEagerDefaultReduceActions(p)
+		p.classifiedActions = derived.classifiedActions
+		p.eagerDefaultReduces = derived.eagerDefaultReduces
 		p.reduceChainHints = buildReduceChainHints(lang)
 		p.reduceChainHintByState = buildReduceChainHintIndex(p.reduceChainHints)
 		p.reduceAliasSeq = buildReduceAliasSequences(lang)
 		p.aliasTargetSymbol = buildAliasTargetSymbols(lang)
-		p.keepSameNamedAnonChildSymbol = buildKeepSameNamedAnonChildSymbols(lang)
-		p.sharedAnonymousTokenSymbol = buildSharedAnonymousTokenSymbols(lang)
+		p.keepSameNamedAnonChildSymbol = derived.keepSameNamedAnonChildSymbol
+		p.sharedAnonymousTokenSymbol = derived.sharedAnonymousTokenSymbol
 		p.reduceHasFields = buildReduceFieldPresence(lang)
 		p.reduceFieldPlans = buildReduceFieldPlans(lang)
 		p.recoverByState, p.hasRecoverState, p.hasRecoverSymbol = buildRecoverActionsByState(lang)

--- a/parser_default_reduce.go
+++ b/parser_default_reduce.go
@@ -29,29 +29,29 @@ func parseEagerDefaultReduceDebugEnabled() bool {
 	return parseEagerDefaultDebug
 }
 
-func buildEagerDefaultReduceActions(p *Parser) []eagerDefaultReduceAction {
-	if p == nil || p.language == nil || len(p.language.ParseActions) == 0 {
+func buildEagerDefaultReduceActions(v parserActionTableView) []eagerDefaultReduceAction {
+	if v.language == nil || len(v.language.ParseActions) == 0 {
 		return nil
 	}
-	stateCount := parserRuntimeStateCount(p)
+	stateCount := parserRuntimeStateCount(v)
 	if stateCount == 0 {
 		return nil
 	}
 	out := make([]eagerDefaultReduceAction, stateCount)
-	tokenCount := Symbol(p.language.TokenCount)
+	tokenCount := Symbol(v.language.TokenCount)
 	for state := 0; state < stateCount; state++ {
 		var candidate ParseAction
 		found := false
 		invalid := false
-		p.forEachActionIndexInState(StateID(state), func(sym Symbol, idx uint16) bool {
+		v.forEachActionIndexInState(StateID(state), func(sym Symbol, idx uint16) bool {
 			if sym >= tokenCount {
 				return true
 			}
-			if int(idx) >= len(p.classifiedActions) {
+			if int(idx) >= len(v.classifiedActions) {
 				invalid = true
 				return false
 			}
-			classified := p.classifiedActions[idx]
+			classified := v.classifiedActions[idx]
 			if classified.class == classifiedParseActionSingleShift &&
 				(classified.action.Extra || classified.action.ExtraChain) {
 				return true
@@ -91,19 +91,19 @@ func (p *Parser) isExternalToken(sym Symbol) bool {
 	return false
 }
 
-func parserRuntimeStateCount(p *Parser) int {
-	if p == nil || p.language == nil {
+func parserRuntimeStateCount(v parserActionTableView) int {
+	if v.language == nil {
 		return 0
 	}
-	stateCount := int(p.language.StateCount)
+	stateCount := int(v.language.StateCount)
 	if stateCount == 0 {
-		stateCount = len(p.language.ParseTable)
+		stateCount = len(v.language.ParseTable)
 	}
-	if smallStates := p.smallBase + len(p.language.SmallParseTableMap); smallStates > stateCount {
+	if smallStates := v.smallBase + len(v.language.SmallParseTableMap); smallStates > stateCount {
 		stateCount = smallStates
 	}
-	if len(p.language.LexModes) > stateCount {
-		stateCount = len(p.language.LexModes)
+	if len(v.language.LexModes) > stateCount {
+		stateCount = len(v.language.LexModes)
 	}
 	return stateCount
 }

--- a/parser_derived_tables_bench_test.go
+++ b/parser_derived_tables_bench_test.go
@@ -1,0 +1,33 @@
+package gotreesitter_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// BenchmarkNewParserGoWarm pins the steady-state cost of constructing a Parser
+// for a language that has already been used once -- the per-file cost in a
+// consumer that parses many files of the same language.
+//
+// It exists because that cost used to be the dominant one. NewParser rebuilt
+// every derived per-language table on every call; memoizing them on the
+// Language cut this benchmark from about 1.30 ms to about 39 microseconds, and
+// from 995,728 to 48,752 bytes. Guard the win: a regression here means some
+// table went back to being rebuilt per parser.
+func BenchmarkNewParserGoWarm(b *testing.B) {
+	lang := grammars.GoLanguage()
+	if lang == nil {
+		b.Fatal("nil go language")
+	}
+	warm := gotreesitter.NewParser(lang)
+	runtime.KeepAlive(warm)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p := gotreesitter.NewParser(lang)
+		runtime.KeepAlive(p)
+	}
+}

--- a/parser_derived_tables_internal_test.go
+++ b/parser_derived_tables_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"unsafe"
 )
 
 // The per-language derived parser tables are built once and shared by every
@@ -14,16 +15,27 @@ import (
 // safe under concurrent first use, and that the inputs the builders read are
 // disjoint from the fields callers mutate after load.
 
-// derivedTablesTestLanguage decodes a FRESH Language from the certified Go
+// derivedTablesTestLanguage decodes a fresh Language from the certified Go
 // blob for each test. A fresh decode matters: the memo is per-Language, so
 // sharing one instance across tests would let an earlier test's build satisfy
 // a later test's first-use assertion.
+//
+// A decode failure is FATAL, never a skip. The blob is embedded at compile
+// time and its SHA is pinned, so failing to decode it is a defect in the blob
+// or the decoder, not an environment condition. Skipping would turn every test
+// in this file -- including the only race-lane coverage of the memo -- green
+// with zero assertions executed.
+//
+// It mirrors loadCertifiedGoLanguageForTest, which lives behind the positive
+// gts_parsercorephase0 tag and so is not visible here. Name is set for the
+// same reason that helper sets it: buildSmallTokenLookup branches on it.
 func derivedTablesTestLanguage(t *testing.T) *Language {
 	t.Helper()
 	lang, err := LoadLanguage(parserCoreCertifiedGoBlob)
 	if err != nil {
-		t.Skip(err)
+		t.Fatalf("decode embedded Go blob: %v", err)
 	}
+	lang.Name = "go"
 	return lang
 }
 
@@ -52,12 +64,14 @@ func TestParserDerivedTablesMatchFreshBuilds(t *testing.T) {
 		t.Fatal("memoized sharedAnonymousTokenSymbol differs from a fresh build")
 	}
 
-	// eagerDefaultReduces is the one table whose builder needs a *Parser. Build
-	// it the way NewParser would have, through a real Parser, and require the
-	// memoized copy to match. This is what catches a drifted denseLimit or
-	// smallBase on the scratch parser inside acquireParserDerivedTables.
+	// eagerDefaultReduces is built through the explicit action-table view.
+	// Build it the way a real Parser would and require the memoized copy to
+	// match, which cross-checks the view the memo assembles against the one a
+	// constructed Parser projects. denseLimit cannot differ between them --
+	// both call languageDenseLimit -- so what this genuinely covers is
+	// smallBase and the three table fields.
 	reference := NewParser(lang)
-	if !reflect.DeepEqual(derived.eagerDefaultReduces, buildEagerDefaultReduceActions(reference)) {
+	if !reflect.DeepEqual(derived.eagerDefaultReduces, buildEagerDefaultReduceActions(reference.actionTableView())) {
 		t.Fatal("memoized eagerDefaultReduces differs from one built through a real Parser")
 	}
 }
@@ -65,24 +79,56 @@ func TestParserDerivedTablesMatchFreshBuilds(t *testing.T) {
 // TestParserDerivedTablesAreSharedNotCopied proves the memo actually shares:
 // two Parsers of one Language must receive the identical backing arrays, which
 // is where the allocation saving comes from.
+//
+// It checks EVERY memoized table, including eagerDefaultReduces -- the largest
+// one, and the only one built through the explicit action-table view rather
+// than directly from the Language. A regression that copied just that table
+// per Parser would otherwise pass while undoing most of the win.
 func TestParserDerivedTablesAreSharedNotCopied(t *testing.T) {
 	lang := derivedTablesTestLanguage(t)
 	first, second := NewParser(lang), NewParser(lang)
 
-	if len(first.classifiedActions) == 0 {
-		t.Fatal("fixture language produced no classified actions")
+	// Assert on every table, and require each to be non-empty rather than
+	// skipping it: a guard that tolerates an empty table lets this test go
+	// green having compared nothing.
+	for _, probe := range []struct {
+		name        string
+		left, right func() (uintptr, int)
+	}{
+		{"classifiedActions",
+			func() (uintptr, int) { return sliceHead(first.classifiedActions) },
+			func() (uintptr, int) { return sliceHead(second.classifiedActions) }},
+		{"eagerDefaultReduces",
+			func() (uintptr, int) { return sliceHead(first.eagerDefaultReduces) },
+			func() (uintptr, int) { return sliceHead(second.eagerDefaultReduces) }},
+		{"smallTokenLookup",
+			func() (uintptr, int) { return sliceHead(first.smallTokenLookup) },
+			func() (uintptr, int) { return sliceHead(second.smallTokenLookup) }},
+		{"smallLookup",
+			func() (uintptr, int) { return sliceHead(first.smallLookup) },
+			func() (uintptr, int) { return sliceHead(second.smallLookup) }},
+		{"sharedAnonymousTokenSymbol",
+			func() (uintptr, int) { return sliceHead(first.sharedAnonymousTokenSymbol) },
+			func() (uintptr, int) { return sliceHead(second.sharedAnonymousTokenSymbol) }},
+	} {
+		leftPtr, leftLen := probe.left()
+		rightPtr, rightLen := probe.right()
+		if leftLen == 0 {
+			t.Fatalf("%s is empty for the certified Go blob; the fixture cannot prove sharing", probe.name)
+		}
+		if leftPtr != rightPtr || leftLen != rightLen {
+			t.Fatalf("two Parsers of one Language hold different %s arrays", probe.name)
+		}
 	}
-	if &first.classifiedActions[0] != &second.classifiedActions[0] {
-		t.Fatal("two Parsers of one Language hold different classifiedActions arrays")
+}
+
+// sliceHead returns a slice's backing-array address and length, which together
+// identify the exact allocation two Parsers must be sharing.
+func sliceHead[T any](s []T) (uintptr, int) {
+	if len(s) == 0 {
+		return 0, 0
 	}
-	if len(first.sharedAnonymousTokenSymbol) != 0 &&
-		&first.sharedAnonymousTokenSymbol[0] != &second.sharedAnonymousTokenSymbol[0] {
-		t.Fatal("two Parsers of one Language hold different sharedAnonymousTokenSymbol arrays")
-	}
-	if len(first.smallTokenLookup) != 0 &&
-		&first.smallTokenLookup[0] != &second.smallTokenLookup[0] {
-		t.Fatal("two Parsers of one Language hold different smallTokenLookup arrays")
-	}
+	return uintptr(unsafe.Pointer(&s[0])), len(s)
 }
 
 // TestParserDerivedTablesConcurrentFirstUse covers the reason the build is
@@ -121,30 +167,94 @@ func TestParserDerivedTablesConcurrentFirstUse(t *testing.T) {
 // TestParserDerivedTablesReadOnlyPostLoadMutableFields is the scoping guard.
 // Callers DO mutate a *Language after load: runtime profiles set the compact
 // certification flags, and scanner attach swaps ExternalScanner. Memoizing is
-// only safe because the memoized builders read none of those fields. This test
-// pins the boundary by mutating the post-load-mutable fields and requiring the
-// derived tables to be unchanged.
+// only safe because the memoized builders read none of those fields.
 //
-// It does NOT prove the general claim by construction; it fails loudly if
-// someone later memoizes a table that does read one of these.
+// It deliberately does NOT assert that the memo returns the same pointer after
+// a mutation. sync.Once guarantees that outcome for any input whatsoever, so
+// such an assertion can never fail and proves nothing. Instead it mutates the
+// post-load-mutable fields and then rebuilds every memoized table from the
+// mutated Language, requiring each to be unchanged. That fails loudly if a
+// future change memoizes a table which reads one of these fields.
 func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 	lang := derivedTablesTestLanguage(t)
-	before := lang.acquireParserDerivedTables()
+	derived := lang.acquireParserDerivedTables()
 
 	restoreErrorRegion := lang.CompactStrategy2ErrorRegionCertified
 	restoreSplitDrops := lang.CompactConvergedReductionSplitDropsCertified
+	restoreScanner := lang.ExternalScanner
 	t.Cleanup(func() {
 		lang.CompactStrategy2ErrorRegionCertified = restoreErrorRegion
 		lang.CompactConvergedReductionSplitDropsCertified = restoreSplitDrops
+		lang.ExternalScanner = restoreScanner
 	})
 	lang.CompactStrategy2ErrorRegionCertified = !restoreErrorRegion
 	lang.CompactConvergedReductionSplitDropsCertified = !restoreSplitDrops
+	lang.ExternalScanner = nil
 
-	after := lang.acquireParserDerivedTables()
-	if before != after {
-		t.Fatal("mutating a post-load-mutable Language field rebuilt the derived tables")
+	rebuilt := buildParserDerivedTables(lang)
+	if !reflect.DeepEqual(derived.classifiedActions, rebuilt.classifiedActions) {
+		t.Fatal("classifiedActions changed after a post-load mutation")
 	}
-	if !reflect.DeepEqual(after.classifiedActions, buildClassifiedParseActions(lang)) {
-		t.Fatal("a memoized table now disagrees with a fresh build after a post-load mutation; a builder reads a mutable field")
+	if !reflect.DeepEqual(derived.smallTokenLookup, rebuilt.smallTokenLookup) {
+		t.Fatal("smallTokenLookup changed after a post-load mutation")
+	}
+	if !reflect.DeepEqual(derived.smallLookup, rebuilt.smallLookup) {
+		t.Fatal("smallLookup changed after a post-load mutation")
+	}
+	if !reflect.DeepEqual(derived.eagerDefaultReduces, rebuilt.eagerDefaultReduces) {
+		t.Fatal("eagerDefaultReduces changed after a post-load mutation")
+	}
+	if !reflect.DeepEqual(derived.keepSameNamedAnonChildSymbol, rebuilt.keepSameNamedAnonChildSymbol) {
+		t.Fatal("keepSameNamedAnonChildSymbol changed after a post-load mutation")
+	}
+	if !reflect.DeepEqual(derived.sharedAnonymousTokenSymbol, rebuilt.sharedAnonymousTokenSymbol) {
+		t.Fatal("sharedAnonymousTokenSymbol changed after a post-load mutation")
+	}
+}
+
+// TestParserDerivedTablesFootprint pins the retained size of the memo.
+//
+// This change MOVES memory rather than only saving it. The tables used to be
+// per-Parser and short-lived; they are now per-Language and live as long as
+// the Language does, which for an embedded grammar is the process lifetime
+// (the grammars cache is unbounded by default). A consumer that touches many
+// grammars retains this for each one, after every Parser is gone.
+//
+// The sibling memo this design follows pins its own footprint the same way
+// (TestParserCoreLanguageTablesFootprint). Without a pin, a builder that
+// started allocating per state rather than per used state would raise the
+// permanent cost of every language with no signal.
+//
+// It measures the STRUCTURE rather than reading MemStats around the build.
+// A MemStats delta here is dominated by the Language decode's own garbage and
+// reads negative as often as not; counting the retained slices is exact and
+// deterministic.
+func TestParserDerivedTablesFootprint(t *testing.T) {
+	lang := derivedTablesTestLanguage(t)
+	derived := lang.acquireParserDerivedTables()
+
+	var retained uintptr
+	for _, row := range derived.smallTokenLookup {
+		retained += unsafe.Sizeof(row) + uintptr(len(row))*unsafe.Sizeof(uint16(0))
+	}
+	for _, row := range derived.smallLookup {
+		retained += unsafe.Sizeof(row) + uintptr(len(row))*unsafe.Sizeof(smallActionPair{})
+	}
+	retained += uintptr(len(derived.classifiedActions)) * unsafe.Sizeof(classifiedParseAction{})
+	retained += uintptr(len(derived.eagerDefaultReduces)) * unsafe.Sizeof(eagerDefaultReduceAction{})
+	retained += uintptr(len(derived.keepSameNamedAnonChildSymbol))
+	retained += uintptr(len(derived.sharedAnonymousTokenSymbol))
+
+	t.Logf("derived tables retain %d bytes per Language (go grammar): "+
+		"smallTokenLookup=%d smallLookup=%d classifiedActions=%d eagerDefaultReduces=%d",
+		retained, len(derived.smallTokenLookup), len(derived.smallLookup),
+		len(derived.classifiedActions), len(derived.eagerDefaultReduces))
+
+	if retained == 0 {
+		t.Fatal("measured no retained derived tables; the fixture proves nothing")
+	}
+	const ceiling = 4 << 20 // 4 MiB, an order-of-magnitude guard, not a tight bound
+	if retained > ceiling {
+		t.Fatalf("derived tables retain %d bytes per Language, ceiling %d", retained, ceiling)
 	}
 }

--- a/parser_derived_tables_internal_test.go
+++ b/parser_derived_tables_internal_test.go
@@ -1,0 +1,150 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+// The per-language derived parser tables are built once and shared by every
+// Parser of that Language, where NewParser previously rebuilt them per call.
+// These tests prove the shared tables are the SAME tables, that the build is
+// safe under concurrent first use, and that the inputs the builders read are
+// disjoint from the fields callers mutate after load.
+
+// derivedTablesTestLanguage decodes a FRESH Language from the certified Go
+// blob for each test. A fresh decode matters: the memo is per-Language, so
+// sharing one instance across tests would let an earlier test's build satisfy
+// a later test's first-use assertion.
+func derivedTablesTestLanguage(t *testing.T) *Language {
+	t.Helper()
+	lang, err := LoadLanguage(parserCoreCertifiedGoBlob)
+	if err != nil {
+		t.Skip(err)
+	}
+	return lang
+}
+
+// TestParserDerivedTablesMatchFreshBuilds is the correctness claim the whole
+// change rests on: memoizing must not change WHAT is built, only how often.
+// It rebuilds each table directly from the Language and compares against the
+// memoized instance the Parser now receives.
+func TestParserDerivedTablesMatchFreshBuilds(t *testing.T) {
+	lang := derivedTablesTestLanguage(t)
+	derived := lang.acquireParserDerivedTables()
+
+	freshSmallTokenLookup := buildSmallTokenLookup(lang)
+	if !reflect.DeepEqual(derived.smallTokenLookup, freshSmallTokenLookup) {
+		t.Fatal("memoized smallTokenLookup differs from a fresh build")
+	}
+	if !reflect.DeepEqual(derived.smallLookup, buildSmallLookup(lang, freshSmallTokenLookup)) {
+		t.Fatal("memoized smallLookup differs from a fresh build")
+	}
+	if !reflect.DeepEqual(derived.classifiedActions, buildClassifiedParseActions(lang)) {
+		t.Fatal("memoized classifiedActions differs from a fresh build")
+	}
+	if !reflect.DeepEqual(derived.keepSameNamedAnonChildSymbol, buildKeepSameNamedAnonChildSymbols(lang)) {
+		t.Fatal("memoized keepSameNamedAnonChildSymbol differs from a fresh build")
+	}
+	if !reflect.DeepEqual(derived.sharedAnonymousTokenSymbol, buildSharedAnonymousTokenSymbols(lang)) {
+		t.Fatal("memoized sharedAnonymousTokenSymbol differs from a fresh build")
+	}
+
+	// eagerDefaultReduces is the one table whose builder needs a *Parser. Build
+	// it the way NewParser would have, through a real Parser, and require the
+	// memoized copy to match. This is what catches a drifted denseLimit or
+	// smallBase on the scratch parser inside acquireParserDerivedTables.
+	reference := NewParser(lang)
+	if !reflect.DeepEqual(derived.eagerDefaultReduces, buildEagerDefaultReduceActions(reference)) {
+		t.Fatal("memoized eagerDefaultReduces differs from one built through a real Parser")
+	}
+}
+
+// TestParserDerivedTablesAreSharedNotCopied proves the memo actually shares:
+// two Parsers of one Language must receive the identical backing arrays, which
+// is where the allocation saving comes from.
+func TestParserDerivedTablesAreSharedNotCopied(t *testing.T) {
+	lang := derivedTablesTestLanguage(t)
+	first, second := NewParser(lang), NewParser(lang)
+
+	if len(first.classifiedActions) == 0 {
+		t.Fatal("fixture language produced no classified actions")
+	}
+	if &first.classifiedActions[0] != &second.classifiedActions[0] {
+		t.Fatal("two Parsers of one Language hold different classifiedActions arrays")
+	}
+	if len(first.sharedAnonymousTokenSymbol) != 0 &&
+		&first.sharedAnonymousTokenSymbol[0] != &second.sharedAnonymousTokenSymbol[0] {
+		t.Fatal("two Parsers of one Language hold different sharedAnonymousTokenSymbol arrays")
+	}
+	if len(first.smallTokenLookup) != 0 &&
+		&first.smallTokenLookup[0] != &second.smallTokenLookup[0] {
+		t.Fatal("two Parsers of one Language hold different smallTokenLookup arrays")
+	}
+}
+
+// TestParserDerivedTablesConcurrentFirstUse covers the reason the build is
+// lazy rather than eager. A cached *Language is served to every goroutine
+// (grammars' embedded loader), and ParserPool constructs Parsers concurrently
+// against it, so first use races by construction. Run with -race.
+func TestParserDerivedTablesConcurrentFirstUse(t *testing.T) {
+	lang := derivedTablesTestLanguage(t)
+
+	const goroutines = 16
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	start.Add(1)
+	results := make([]*parserDerivedTables, goroutines)
+	for i := range results {
+		done.Add(1)
+		go func(index int) {
+			defer done.Done()
+			start.Wait()
+			results[index] = lang.acquireParserDerivedTables()
+		}(i)
+	}
+	start.Done()
+	done.Wait()
+
+	for i, got := range results {
+		if got == nil {
+			t.Fatalf("goroutine %d received no derived tables", i)
+		}
+		if got != results[0] {
+			t.Fatalf("goroutine %d received a different derived-table instance; the build ran more than once", i)
+		}
+	}
+}
+
+// TestParserDerivedTablesReadOnlyPostLoadMutableFields is the scoping guard.
+// Callers DO mutate a *Language after load: runtime profiles set the compact
+// certification flags, and scanner attach swaps ExternalScanner. Memoizing is
+// only safe because the memoized builders read none of those fields. This test
+// pins the boundary by mutating the post-load-mutable fields and requiring the
+// derived tables to be unchanged.
+//
+// It does NOT prove the general claim by construction; it fails loudly if
+// someone later memoizes a table that does read one of these.
+func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
+	lang := derivedTablesTestLanguage(t)
+	before := lang.acquireParserDerivedTables()
+
+	restoreErrorRegion := lang.CompactStrategy2ErrorRegionCertified
+	restoreSplitDrops := lang.CompactConvergedReductionSplitDropsCertified
+	t.Cleanup(func() {
+		lang.CompactStrategy2ErrorRegionCertified = restoreErrorRegion
+		lang.CompactConvergedReductionSplitDropsCertified = restoreSplitDrops
+	})
+	lang.CompactStrategy2ErrorRegionCertified = !restoreErrorRegion
+	lang.CompactConvergedReductionSplitDropsCertified = !restoreSplitDrops
+
+	after := lang.acquireParserDerivedTables()
+	if before != after {
+		t.Fatal("mutating a post-load-mutable Language field rebuilt the derived tables")
+	}
+	if !reflect.DeepEqual(after.classifiedActions, buildClassifiedParseActions(lang)) {
+		t.Fatal("a memoized table now disagrees with a fresh build after a post-load mutation; a builder reads a mutable field")
+	}
+}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -461,10 +461,7 @@ func buildKeepSameNamedAnonChildSymbols(lang *Language) []bool {
 		return nil
 	}
 
-	denseLimit := int(lang.LargeStateCount)
-	if denseLimit == 0 {
-		denseLimit = len(lang.ParseTable)
-	}
+	denseLimit := languageDenseLimit(lang)
 	smallBase := int(lang.LargeStateCount)
 	forEachStateAction(lang, denseLimit, smallBase, func(state, sym int, act ParseAction) {
 		if act.Type != ParseActionShift {
@@ -508,10 +505,7 @@ func buildSharedAnonymousTokenSymbols(lang *Language) []bool {
 		return nil
 	}
 
-	denseLimit := int(lang.LargeStateCount)
-	if denseLimit == 0 {
-		denseLimit = len(lang.ParseTable)
-	}
+	denseLimit := languageDenseLimit(lang)
 	smallBase := int(lang.LargeStateCount)
 	forEachStateAction(lang, denseLimit, smallBase, func(state, sym int, act ParseAction) {
 		if act.Type != ParseActionShift || sym >= tokenCount {

--- a/parser_tables.go
+++ b/parser_tables.go
@@ -312,15 +312,56 @@ func buildExternalValidMaskByState(rows [][]uint16, externalSymbolCount int) []u
 	return masks
 }
 
+// parserActionTableView is the EXACT input set the action-table walk and the
+// eager-default-reduce builder read from a Parser. It exists so those two can
+// be driven without a Parser at all.
+//
+// Before this type they took a *Parser, and the per-language memo below had to
+// hand-replicate five Parser fields onto a scratch Parser to call them. That
+// replication was invisible to the compiler: the day either function started
+// reading a sixth field, the memo would have silently produced a different
+// table for every Parser of that Language. Naming the inputs turns that class
+// of bug into a compile error.
+type parserActionTableView struct {
+	language          *Language
+	denseLimit        int
+	smallBase         int
+	smallTokenLookup  [][]uint16
+	smallLookup       [][]smallActionPair
+	classifiedActions []classifiedParseAction
+}
+
+// actionTableView projects the fields a built Parser already holds.
+func (p *Parser) actionTableView() parserActionTableView {
+	if p == nil {
+		return parserActionTableView{}
+	}
+	return parserActionTableView{
+		language:          p.language,
+		denseLimit:        p.denseLimit,
+		smallBase:         p.smallBase,
+		smallTokenLookup:  p.smallTokenLookup,
+		smallLookup:       p.smallLookup,
+		classifiedActions: p.classifiedActions,
+	}
+}
+
 func (p *Parser) forEachActionIndexInState(state StateID, visit func(sym Symbol, idx uint16) bool) {
-	if p == nil || p.language == nil || visit == nil {
+	if p == nil {
 		return
 	}
-	if int(state) < p.denseLimit {
-		if int(state) >= len(p.language.ParseTable) {
+	p.actionTableView().forEachActionIndexInState(state, visit)
+}
+
+func (v parserActionTableView) forEachActionIndexInState(state StateID, visit func(sym Symbol, idx uint16) bool) {
+	if v.language == nil || visit == nil {
+		return
+	}
+	if int(state) < v.denseLimit {
+		if int(state) >= len(v.language.ParseTable) {
 			return
 		}
-		row := p.language.ParseTable[state]
+		row := v.language.ParseTable[state]
 		for sym, idx := range row {
 			if idx == 0 {
 				continue
@@ -332,12 +373,12 @@ func (p *Parser) forEachActionIndexInState(state StateID, visit func(sym Symbol,
 		return
 	}
 
-	smallIdx := int(state) - p.smallBase
-	if smallIdx < 0 || smallIdx >= len(p.language.SmallParseTableMap) {
+	smallIdx := int(state) - v.smallBase
+	if smallIdx < 0 || smallIdx >= len(v.language.SmallParseTableMap) {
 		return
 	}
-	hasDenseRow := smallIdx < len(p.smallTokenLookup) && len(p.smallTokenLookup[smallIdx]) > 0
-	hasOverflow := smallIdx < len(p.smallLookup) && len(p.smallLookup[smallIdx]) > 0
+	hasDenseRow := smallIdx < len(v.smallTokenLookup) && len(v.smallTokenLookup[smallIdx]) > 0
+	hasOverflow := smallIdx < len(v.smallLookup) && len(v.smallLookup[smallIdx]) > 0
 	if hasDenseRow || hasOverflow {
 		// A small state can carry a dense smallTokenLookup row and a
 		// smallLookup overflow slice at the same time (dense covers the
@@ -346,7 +387,7 @@ func (p *Parser) forEachActionIndexInState(state StateID, visit func(sym Symbol,
 		// overflow, so the two sets are always disjoint and both must be
 		// visited to enumerate the state completely.
 		if hasDenseRow {
-			for sym, idx := range p.smallTokenLookup[smallIdx] {
+			for sym, idx := range v.smallTokenLookup[smallIdx] {
 				if idx == 0 {
 					continue
 				}
@@ -356,7 +397,7 @@ func (p *Parser) forEachActionIndexInState(state StateID, visit func(sym Symbol,
 			}
 		}
 		if hasOverflow {
-			for _, pair := range p.smallLookup[smallIdx] {
+			for _, pair := range v.smallLookup[smallIdx] {
 				if !visit(Symbol(pair.sym), pair.val) {
 					return
 				}
@@ -365,8 +406,8 @@ func (p *Parser) forEachActionIndexInState(state StateID, visit func(sym Symbol,
 		return
 	}
 
-	offset := p.language.SmallParseTableMap[smallIdx]
-	table := p.language.SmallParseTable
+	offset := v.language.SmallParseTableMap[smallIdx]
+	table := v.language.SmallParseTable
 	if int(offset) >= len(table) {
 		return
 	}
@@ -509,14 +550,11 @@ func (p *Parser) lookupGoto(state StateID, sym Symbol) StateID {
 	return 0
 }
 
-// languageDenseLimit is the dense parse-table cutoff a Parser uses for this
-// Language. It exists as one function because two call sites need the SAME
-// answer: NewParser, which sets Parser.denseLimit, and
-// acquireParserDerivedTables, which must reproduce that field exactly on the
-// scratch parser it hands to buildEagerDefaultReduceActions. Deriving it twice
-// invites the two copies to drift, and a drifted denseLimit would silently
-// produce a different eager-default-reduce table for every Parser of this
-// Language.
+// languageDenseLimit returns the dense parse-table cutoff for this Language.
+//
+// Do not derive this cutoff again anywhere else. Several call sites need the
+// same answer, and two copies can drift. A drifted cutoff changes the
+// eager-default-reduce table for every Parser of the Language.
 func languageDenseLimit(l *Language) int {
 	if l.LargeStateCount > 0 {
 		return int(l.LargeStateCount)
@@ -540,55 +578,80 @@ type parserDerivedTables struct {
 // acquireParserDerivedTables builds the derived parser tables exactly once per
 // Language, even under concurrent first use, and returns the shared instance.
 //
-// The exact read set, enumerated from the six builders and from
-// forEachActionIndexInState, which buildEagerDefaultReduceActions calls:
+// The read set, traced through every builder AND through the two helpers they
+// call, parserRuntimeStateCount and smallDenseLookupSymbolLimit:
 //
-//	GeneratedByGrammargen, LargeStateCount, Name, ParseActions, ParseTable,
-//	SmallParseTable, SmallParseTableMap, SymbolMetadata, SymbolNames, TokenCount
+//	GeneratedByGrammargen, LargeStateCount, LexModes, Name, ParseActions,
+//	ParseTable, SmallParseTable, SmallParseTableMap, StateCount, SymbolCount,
+//	SymbolMetadata, SymbolNames, TokenCount
 //
-// Every write to one of those fields happens before the Language escapes to a
+// Every write to one of those fields runs before the Language reaches a
 // caller: inside LoadLanguage, inside decodeLanguageBlobData's repair passes,
-// in grammargen assembly, or in ts2go generation. The supported POST-load
-// mutations -- external scanner attach, ExternalLexStates attach, and the
-// runtime-profile certification flags -- write none of them, and the embedded
-// loader performs all of its attaching inside the cache entry's own sync.Once
-// before returning the Language at all.
+// in grammargen assembly, or in ts2go generation. The embedded loader also
+// performs its scanner, lex-state, and runtime-profile attaching inside the
+// cache entry's own sync.Once, before it returns the Language.
 //
-// TWO STALENESS PRECONDITIONS, both inherited rather than introduced:
+// The supported POST-load mutations write none of those fields. They write
+// ExternalScanner, ExternalLexStates, and the runtime-profile flags.
 //
-//  1. Whole-slice ordering. AdaptScannerForLanguage is exported and assigns
+// TWO STALENESS HAZARDS THAT THIS MEMO INTRODUCES. Before it, NewParser
+// rebuilt these tables on every call, so a later call observed any change.
+// Now the first call freezes them.
+//
+//  1. Attach before the first NewParser. AttachLanguageSupport assigns
 //     Language.Name when it is empty, and buildSmallTokenLookup branches on
-//     that name. A caller that constructs a Language with no name, calls
-//     NewParser on it, and only THEN attaches will keep the tables built under
-//     the pre-attach name. Attach before the first NewParser; the embedded
-//     loader already does.
-//  2. In-place pokes. Mutating a cell of ParseTable, SmallParseTable, or a
-//     ParseActionEntry's Actions in place between NewParser calls leaves this
-//     memo serving tables built from the old contents. Whole-swap the slice or
-//     build a fresh Language instead. This is the same footgun the recovery
-//     gate memo already documents (cRecoveryGateCacheKey).
+//     that name. Build a parser first and the tables keep the pre-attach name.
+//     The embedded loader already attaches inside its own sync.Once.
+//  2. Do not poke table cells in place. Writing into ParseTable,
+//     SmallParseTable, or a ParseActionEntry's Actions leaves this memo
+//     serving tables built from the old contents. Swap the whole slice, or
+//     build a fresh Language. The recovery-gate memo documents the same
+//     hazard for its own inputs (cRecoveryGateCacheKey).
 func (l *Language) acquireParserDerivedTables() *parserDerivedTables {
+	if l == nil {
+		return &parserDerivedTables{}
+	}
 	l.parserDerivedOnce.Do(func() {
-		t := &parserDerivedTables{}
-		if len(l.SmallParseTableMap) > 0 && len(l.SmallParseTable) > 0 {
-			t.smallTokenLookup = buildSmallTokenLookup(l)
-			t.smallLookup = buildSmallLookup(l, t.smallTokenLookup)
-		}
-		t.classifiedActions = buildClassifiedParseActions(l)
-		t.keepSameNamedAnonChildSymbol = buildKeepSameNamedAnonChildSymbols(l)
-		t.sharedAnonymousTokenSymbol = buildSharedAnonymousTokenSymbols(l)
-		// buildEagerDefaultReduceActions reads only these parser fields, all of
-		// which NewParser derives deterministically from the Language before the
-		// original call site. Replicate them on a scratch parser to avoid
-		// recursion into NewParser.
-		scratch := &Parser{language: l}
-		scratch.denseLimit = languageDenseLimit(l)
-		scratch.smallBase = int(l.LargeStateCount)
-		scratch.smallTokenLookup = t.smallTokenLookup
-		scratch.smallLookup = t.smallLookup
-		scratch.classifiedActions = t.classifiedActions
-		t.eagerDefaultReduces = buildEagerDefaultReduceActions(scratch)
-		l.parserDerived = t
+		l.parserDerived = buildParserDerivedTables(l)
 	})
-	return l.parserDerived
+	if derived := l.parserDerived; derived != nil {
+		return derived
+	}
+	// sync.Once records completion even when its function PANICS, so a builder
+	// that panicked on first use would otherwise leave parserDerived nil and
+	// make every later NewParser nil-dereference far from the original cause.
+	// Rebuild unmemoized instead: the caller still gets correct tables, and the
+	// only cost is that a Language whose first build panicked stops being
+	// cached.
+	return buildParserDerivedTables(l)
+}
+
+// buildParserDerivedTables computes the derived tables from a Language alone.
+// It takes no Parser: the eager-default-reduce builder consumes an explicit
+// parserActionTableView, so there is no scratch Parser to hand-replicate and
+// no field-drift hazard to audit.
+//
+// INVARIANT: nothing reachable from here may call acquireParserDerivedTables.
+// It runs inside that function's sync.Once, and Once.Do is not re-entrant, so
+// a re-entering call blocks on the in-progress build ON THE SAME GOROUTINE and
+// never returns. The failure is a silent hang with no panic and no stack, so
+// keep this function to the builders and the view above.
+func buildParserDerivedTables(l *Language) *parserDerivedTables {
+	t := &parserDerivedTables{}
+	if len(l.SmallParseTableMap) > 0 && len(l.SmallParseTable) > 0 {
+		t.smallTokenLookup = buildSmallTokenLookup(l)
+		t.smallLookup = buildSmallLookup(l, t.smallTokenLookup)
+	}
+	t.classifiedActions = buildClassifiedParseActions(l)
+	t.keepSameNamedAnonChildSymbol = buildKeepSameNamedAnonChildSymbols(l)
+	t.sharedAnonymousTokenSymbol = buildSharedAnonymousTokenSymbols(l)
+	t.eagerDefaultReduces = buildEagerDefaultReduceActions(parserActionTableView{
+		language:          l,
+		denseLimit:        languageDenseLimit(l),
+		smallBase:         int(l.LargeStateCount),
+		smallTokenLookup:  t.smallTokenLookup,
+		smallLookup:       t.smallLookup,
+		classifiedActions: t.classifiedActions,
+	})
+	return t
 }

--- a/parser_tables.go
+++ b/parser_tables.go
@@ -508,3 +508,62 @@ func (p *Parser) lookupGoto(state StateID, sym Symbol) StateID {
 	}
 	return 0
 }
+
+// languageDenseLimit is the dense parse-table cutoff a Parser uses for this
+// Language. It exists as one function because two call sites need the SAME
+// answer: NewParser, which sets Parser.denseLimit, and
+// acquireParserDerivedTables, which must reproduce that field exactly on the
+// scratch parser it hands to buildEagerDefaultReduceActions. Deriving it twice
+// invites the two copies to drift, and a drifted denseLimit would silently
+// produce a different eager-default-reduce table for every Parser of this
+// Language.
+func languageDenseLimit(l *Language) int {
+	if l.LargeStateCount > 0 {
+		return int(l.LargeStateCount)
+	}
+	return len(l.ParseTable)
+}
+
+// parserDerivedTables holds the per-language derived parser tables that are
+// pure functions of the decoded grammar tables. NewParser previously rebuilt
+// them on every call; they are now built once per *Language and shared,
+// read-only, by every Parser of that Language.
+type parserDerivedTables struct {
+	smallTokenLookup             [][]uint16
+	smallLookup                  [][]smallActionPair
+	classifiedActions            []classifiedParseAction
+	eagerDefaultReduces          []eagerDefaultReduceAction
+	keepSameNamedAnonChildSymbol []bool
+	sharedAnonymousTokenSymbol   []bool
+}
+
+// acquireParserDerivedTables builds the derived parser tables exactly once per
+// Language, even under concurrent first use, and returns the shared instance.
+// Inputs are immutable after decode (see cRecoveryGateCacheKey): the only
+// supported post-load mutations (external scanner attach, recovery
+// certification flags) touch none of the fields these builders read.
+func (l *Language) acquireParserDerivedTables() *parserDerivedTables {
+	l.parserDerivedOnce.Do(func() {
+		t := &parserDerivedTables{}
+		if len(l.SmallParseTableMap) > 0 && len(l.SmallParseTable) > 0 {
+			t.smallTokenLookup = buildSmallTokenLookup(l)
+			t.smallLookup = buildSmallLookup(l, t.smallTokenLookup)
+		}
+		t.classifiedActions = buildClassifiedParseActions(l)
+		t.keepSameNamedAnonChildSymbol = buildKeepSameNamedAnonChildSymbols(l)
+		t.sharedAnonymousTokenSymbol = buildSharedAnonymousTokenSymbols(l)
+		// buildEagerDefaultReduceActions reads only these parser fields, all of
+		// which NewParser derives deterministically from the Language before the
+		// original call site. Replicate them on a scratch parser to avoid
+		// recursion into NewParser.
+		scratch := &Parser{language: l}
+		scratch.denseLimit = languageDenseLimit(l)
+		scratch.smallBase = int(l.LargeStateCount)
+		scratch.smallTokenLookup = t.smallTokenLookup
+		scratch.smallLookup = t.smallLookup
+		scratch.classifiedActions = t.classifiedActions
+		t.eagerDefaultReduces = buildEagerDefaultReduceActions(scratch)
+		l.parserDerived = t
+	})
+	return l.parserDerived
+}

--- a/parser_tables.go
+++ b/parser_tables.go
@@ -539,9 +539,34 @@ type parserDerivedTables struct {
 
 // acquireParserDerivedTables builds the derived parser tables exactly once per
 // Language, even under concurrent first use, and returns the shared instance.
-// Inputs are immutable after decode (see cRecoveryGateCacheKey): the only
-// supported post-load mutations (external scanner attach, recovery
-// certification flags) touch none of the fields these builders read.
+//
+// The exact read set, enumerated from the six builders and from
+// forEachActionIndexInState, which buildEagerDefaultReduceActions calls:
+//
+//	GeneratedByGrammargen, LargeStateCount, Name, ParseActions, ParseTable,
+//	SmallParseTable, SmallParseTableMap, SymbolMetadata, SymbolNames, TokenCount
+//
+// Every write to one of those fields happens before the Language escapes to a
+// caller: inside LoadLanguage, inside decodeLanguageBlobData's repair passes,
+// in grammargen assembly, or in ts2go generation. The supported POST-load
+// mutations -- external scanner attach, ExternalLexStates attach, and the
+// runtime-profile certification flags -- write none of them, and the embedded
+// loader performs all of its attaching inside the cache entry's own sync.Once
+// before returning the Language at all.
+//
+// TWO STALENESS PRECONDITIONS, both inherited rather than introduced:
+//
+//  1. Whole-slice ordering. AdaptScannerForLanguage is exported and assigns
+//     Language.Name when it is empty, and buildSmallTokenLookup branches on
+//     that name. A caller that constructs a Language with no name, calls
+//     NewParser on it, and only THEN attaches will keep the tables built under
+//     the pre-attach name. Attach before the first NewParser; the embedded
+//     loader already does.
+//  2. In-place pokes. Mutating a cell of ParseTable, SmallParseTable, or a
+//     ParseActionEntry's Actions in place between NewParser calls leaves this
+//     memo serving tables built from the old contents. Whole-swap the slice or
+//     build a fresh Language instead. This is the same footgun the recovery
+//     gate memo already documents (cRecoveryGateCacheKey).
 func (l *Language) acquireParserDerivedTables() *parserDerivedTables {
 	l.parserDerivedOnce.Do(func() {
 		t := &parserDerivedTables{}

--- a/parsercore_c4_program.go
+++ b/parsercore_c4_program.go
@@ -372,11 +372,7 @@ func newCorridorTables(lang *Language) (*corridorTables, error) {
 		reduceChainEnabled: corridorReduceChainEnabled(),
 		reduceShiftEnabled: corridorReduceShiftEnabled(),
 	}
-	if lang.LargeStateCount > 0 {
-		t.denseLimit = int(lang.LargeStateCount)
-	} else {
-		t.denseLimit = len(lang.ParseTable)
-	}
+	t.denseLimit = languageDenseLimit(lang)
 	t.smallBase = int(lang.LargeStateCount)
 	states := int(lang.StateCount)
 	if states == 0 {


### PR DESCRIPTION
## Summary

NewParser rebuilt six per-language derived tables on every call. A consumer that parses many files of one language paid that cost per file. This change builds those tables once per Language and shares them, read-only, with every Parser of that Language. The steady-state cost of NewParser for Go drops from about 1.30 ms to about 39 microseconds, and from 995,728 bytes to 48,752 bytes per call.

## Changes

- Add the parserDerivedTables struct and Language.acquireParserDerivedTables in parser_tables.go. The method builds smallTokenLookup, smallLookup, classifiedActions, eagerDefaultReduces, keepSameNamedAnonChildSymbol, and sharedAnonymousTokenSymbol once behind a sync.Once.
- Store parserDerivedOnce and parserDerived on Language (language.go) next to the existing corridor-program memo, so the cache lifetime matches the decoded grammar.
- Make NewParser read the shared tables instead of calling the six builders itself (parser.go).
- Extract languageDenseLimit so NewParser and the scratch parser inside the memo compute the same dense cutoff. buildEagerDefaultReduceActions reads that field, so a drifted copy would silently change the eager-default-reduce table for every Parser of the language.
- Build eagerDefaultReduces through a scratch Parser that replicates only denseLimit, smallBase, smallTokenLookup, smallLookup, and classifiedActions. This avoids recursion into NewParser.
- Keep the memo scoped to immutable decoded inputs. Callers still mutate a Language after load (compact certification flags, external scanner attach), and no memoized builder reads those fields.
- Add parser_derived_tables_internal_test.go: four tests cover fresh-build equality, shared backing arrays, concurrent first use (run with -race), and the post-load mutation boundary.
- Add parser_derived_tables_bench_test.go with BenchmarkNewParserGoWarm to guard the warm NewParser cost against a table that goes back to per-parser rebuilds.

## Testing

All runs on this branch at `5d32d666` (off `main` at `227e6152`), WSL2 host,
`go1.25.1`. No container needed: this change touches no cgo or oracle surface.

- **Measured win, A/B on this branch.** `GOMAXPROCS=1 go test -tags gts_parsercorephase0 -run '^$' -bench BenchmarkNewParserGoWarm -benchtime=750ms -benchmem -count=6 .`
  run with the change, then again with `language.go parser.go parser_tables.go`
  stashed:

  | metric | baseline | memoized | delta |
  |---|---:|---:|---:|
  | ns/op | ~1,304,000 | ~39,200 | **-97.0%** |
  | B/op | 995,728 | 48,752 | -95.1% |
  | allocs/op | 2,509 | 544 | -78.3% |

- **Zero regressions, A/B on the same tree.** Full root suite
  (`go test -tags gts_parsercorephase0 -count=1 -timeout 40m .`) run with the
  change and again with it stashed. Excluding the order-dependent
  `TestW5JavaScriptFamilyTransientErrorGate` family: **25 failures either way,
  none unique to this change.** `TestW5...` passes in isolation on this branch.
- **Race lane:** `go test -race -run TestParserDerivedTablesConcurrentFirstUse -count=1 .` passes.
- **Both build configurations:** `go vet .` and `go vet -tags gts_no_parsercorephase0 .` clean.
- **Route outcomes unmoved:** the 146-row real-corpus matrix still reports
  `PASS=88 DIVERGE=0 FALLBACK=46 SKIP=12 ERROR=0`.
- `go test ./internal/... -count=1` clean.

## Why this is safe, and where the boundary is

`*Language` IS mutated after load, which is what makes memoizing on it look
risky. Two facts make it safe:

1. Runtime profiles set `Compact*Certified` and friends INSIDE the loader's
   `once.Do`, before the `*Language` pointer escapes.
2. The six memoized builders read only `SymbolMetadata`, `SymbolNames`,
   `TokenCount`, `SymbolCount`, `LargeStateCount`, `StateCount`, `ParseTable`,
   `SmallParseTable(+Map)`, `ParseActions`, `LexModes`, `Name`, and
   `GeneratedByGrammargen` -- disjoint from every post-load mutation site.

Four other derived tables (`unaryWrapperFlatteningSet`, `maxConflictWidth`,
`collapsedChildOccurrence*`, `externalValidByState`) are deliberately NOT
memoized because they read profile- or attach-influenced fields.
`TestParserDerivedTablesReadOnlyPostLoadMutableFields` pins that boundary.

The idiom is established, not new: `Language` already carries ten `sync.Once`
memo fields, including `compactTablesOnce` used by the compact route itself.

Known footgun, documented at the memo: a caller that pokes `lang.ParseActions`
or `SmallParseTable` cells in place between `NewParser` calls now gets stale
derived tables. Same class as the existing recovery-gate memo warning. No
in-repo test does this.

## Review Focus

The scratch parser inside `acquireParserDerivedTables` must reproduce
`NewParser`'s field values exactly, or `buildEagerDefaultReduceActions`
silently returns a different table. The transitive read set was audited to be
`{denseLimit, language, smallBase, smallLookup, smallTokenLookup,
classifiedActions}`; `languageDenseLimit` exists so the dense cutoff cannot
drift between the two sites, and
`TestParserDerivedTablesMatchFreshBuilds` compares against a table built
through a real `Parser`.
