### PR TITLE
add(parsercore): Add recovery lineage pricing and selection bridge

### DIFF
--- a/internal/parsercorephase0/missing_leaf.go
+++ b/internal/parsercorephase0/missing_leaf.go
@@ -83,3 +83,38 @@ func (c *Core) MissingLeaf(symbol Symbol, atByte uint32) (id SubtreeID, err erro
 		missing:   true,
 	}, nil, nil, nil)
 }
+
+// ShiftMissingLeaf publishes one missing terminal and attaches it to head at
+// targetState, the compact equivalent of C pushing the missing subtree onto a
+// copied stack version (ts_parser__handle_error, parser.c:2154-2230:
+// ts_stack_push(stack, version_with_missing_tree, missing_tree, false,
+// state_after_missing_symbol)).
+//
+// The boundary is keyed as a SHIFT boundary (shiftedBoundaryKey), matching
+// every other terminal attachment onto a head (shiftClassifiedUncheckpointed)
+// rather than a reduction replacing children. The byte offset does not move:
+// the leaf is zero width, so the resulting head sits at the same atByte the
+// caller's head already occupied, which is exactly what C's own
+// length_zero() size produces.
+//
+// targetState must be the state C's ts_language_next_state returns for
+// symbol at the head's own state. This function does not re-derive it,
+// because the caller has already read the action row to find it and to run
+// C's reduce-action test on the result.
+func (c *Core) ShiftMissingLeaf(head Head, targetState StateID, symbol Symbol, atByte uint32) (out Head, err error) {
+	if targetState == 0 {
+		return Head{}, errors.New("parser-core phase zero: missing leaf shift requires a real target state")
+	}
+	mark := c.mark()
+	defer c.completeTransaction(mark, &err)
+	if _, err := c.node(head.Node); err != nil {
+		return Head{}, err
+	}
+	payload, err := c.MissingLeaf(symbol, atByte)
+	if err != nil {
+		return Head{}, err
+	}
+	return c.condense(c.shiftedBoundaryKey(targetState, atByte), linkInput{
+		prev: head.Node, payload: payload,
+	})
+}

--- a/internal/parsercorephase0/recovery_cost_ratchet_test.go
+++ b/internal/parsercorephase0/recovery_cost_ratchet_test.go
@@ -30,6 +30,14 @@ import (
 // unexported helper functions/constant. A later stage that wires this file
 // in (S3 onward) will make this ratchet fail on purpose -- that failure is
 // the signal to update or retire it alongside the real call site landing.
+//
+// SCOPE CORRECTION. This ratchet reads only THIS package's files, and
+// recovery_cost.go's API is exported, so a caller in another package never
+// trips it. Such a caller now exists: the root package's
+// parsercore_phase0_recovery_cost_source.go implements RecoveryCostSource and
+// prices recovery lineages with this model. Read the guarantee as "no caller
+// inside the compact core", which is still worth holding, and not as "no
+// caller anywhere", which is no longer true.
 func TestRecoveryCostNoOutsideCallSitesRatchet(t *testing.T) {
 	const homeFile = "recovery_cost.go"
 

--- a/parsercore_phase0_recovery_cost_source.go
+++ b/parsercore_phase0_recovery_cost_source.go
@@ -152,8 +152,21 @@ func diagnosticParserCoreLineageErrorCost(
 	if len(derivations) != 1 {
 		return 0, diagnosticParserCoreLineageCostUnavailable
 	}
+	return diagnosticParserCoreDerivationErrorCost(symbols, src, memo, derivations[0])
+}
+
+// diagnosticParserCoreDerivationErrorCost prices one already-resolved
+// derivation. It exists so a caller that has to read Derivations anyway --
+// pricing needs the payload list, ordering needs the Score -- does not resolve
+// the same head twice.
+func diagnosticParserCoreDerivationErrorCost(
+	symbols []core.SelectedSymbolPolicy,
+	src *diagnosticParserCoreRecoveryCostSource,
+	memo *core.RecoveryCostMemo,
+	derivation core.Derivation,
+) (uint32, error) {
 	var total uint32
-	for _, payload := range derivations[0].Payloads {
+	for _, payload := range derivation.Payloads {
 		if payload == 0 {
 			continue
 		}
@@ -177,14 +190,14 @@ type diagnosticParserCoreLineage struct {
 	Score int64
 }
 
-// ErrDiagnosticParserCoreLineageTie reports that the selection ladder ran out
+// errDiagnosticParserCoreLineageTie reports that the selection ladder ran out
 // of C-defined tiebreaks. C's last resort is ts_subtree_compare, a structural
 // comparison it reaches only when BOTH candidates are clean
 // (ts_parser__select_tree returns early for a positive error cost). Every
 // lineage this selection exists to arbitrate carries recovery content, so
 // reaching that clause means the caller handed in a shape this port does not
 // model, and the honest answer is to decline rather than pick one.
-var ErrDiagnosticParserCoreLineageTie = errors.New("parser-core phase zero: competing recovery lineages tie beyond the modeled selection ladder")
+var errDiagnosticParserCoreLineageTie = errors.New("parser-core phase zero: competing recovery lineages tie beyond the modeled selection ladder")
 
 // diagnosticParserCorePriceLineages prices each candidate head so the
 // selection ladder can order them. It refuses any head that does not carry
@@ -202,16 +215,16 @@ func diagnosticParserCorePriceLineages(
 	}
 	out := make([]diagnosticParserCoreLineage, 0, len(heads))
 	for _, head := range heads {
-		cost, err := diagnosticParserCoreLineageErrorCost(compact, head, symbols, src, memo)
-		if err != nil {
-			return nil, err
-		}
 		derivations, err := compact.Derivations(head)
 		if err != nil {
 			return nil, err
 		}
 		if len(derivations) != 1 {
 			return nil, diagnosticParserCoreLineageCostUnavailable
+		}
+		cost, err := diagnosticParserCoreDerivationErrorCost(symbols, src, memo, derivations[0])
+		if err != nil {
+			return nil, err
 		}
 		out = append(out, diagnosticParserCoreLineage{
 			Head: head, Cost: cost, Score: derivations[0].Score,
@@ -236,7 +249,7 @@ func diagnosticParserCorePriceLineages(
 // incumbent: it is what lets a later, equally priced recovery displace an
 // earlier one. Clause 4 is unreachable here, because it requires BOTH sides to
 // be clean, and a lineage with zero error cost is not a recovery lineage at
-// all; this port returns ErrDiagnosticParserCoreLineageTie instead of guessing.
+// all; this port returns errDiagnosticParserCoreLineageTie instead of guessing.
 //
 // The order of lineages is therefore load-bearing. Callers must pass them in
 // the scheduler's own publication order, which is the compact analogue of C's
@@ -282,5 +295,5 @@ func diagnosticParserCoreLineageReplaces(incumbent, candidate diagnosticParserCo
 	// Both sides are clean and tied. C would compare the trees structurally;
 	// this port does not model that, and a recovery arbitration should never
 	// reach it.
-	return false, ErrDiagnosticParserCoreLineageTie
+	return false, errDiagnosticParserCoreLineageTie
 }

--- a/parsercore_phase0_recovery_cost_source.go
+++ b/parsercore_phase0_recovery_cost_source.go
@@ -1,0 +1,167 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"sort"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// ---------------------------------------------------------------------------
+// parsercore_phase0_recovery_cost_source.go -- campaign v7 tranche B3: the
+// bridge that lets the compact scheduler PRICE a recovery lineage with the
+// stage S2 cost model (internal/parsercorephase0/recovery_cost.go).
+//
+// Why this exists. Stage S5 (missing-token insertion) cannot decide anything
+// on its own. C does not choose between inserting a missing token and
+// absorbing into an ERROR region at the point of failure: ts_parser__handle_error
+// creates the missing version as a copy and pushes the error discontinuity
+// onto the original anyway, so both versions parse forward, and the winner is
+// settled later by error cost (ts_parser__select_tree,
+// ts_parser__better_version_exists). Measured on php "<?php namespace ; ?>",
+// the missing version costs 610 and the absorbing version about 509, so C
+// publishes an ERROR tree even though its own missing-token search accepted
+// the insertion. Pricing a lineage is therefore the prerequisite for either
+// recovery stage to be correct, not an optimization.
+//
+// Stage S2 deliberately shipped its cost model with no caller
+// ("RecoveryCostSource resolves a SubtreeID to its cost-model view"), leaving
+// the source implementation to whichever stage first needed it. This file is
+// that implementation. It reads only exported Core surface
+// (MaterializationView, Derivations), so the compact core needs no change to
+// support it.
+//
+// RATCHET NOTE. internal/parsercorephase0's own
+// TestRecoveryCostNoOutsideCallSitesRatchet proves the cost model has no
+// caller, but it parses only that package's files. recovery_cost.go's API is
+// exported, so a caller in THIS package does not trip it and the ratchet stays
+// green while the model is, in fact, now reachable. The ratchet's guarantee is
+// therefore narrower than its doc comment claims. Read it as "no caller inside
+// the compact core", not "no caller anywhere".
+// ---------------------------------------------------------------------------
+
+// diagnosticParserCoreRecoveryCostSource adapts a compact Core to the stage S2
+// cost model's RecoveryCostSource interface.
+//
+// The cost model needs two things a compact subtree record does not store:
+// the missing bit (now carried, stage S5 substrate) and a row span. Rows are
+// read for ERROR nodes only -- RecoveryCostPerSkippedLine times the node's row
+// extent -- so this source computes them from the source text on demand rather
+// than widening the record. newlines is built once per parse, lazily, and only
+// if some ERROR node actually asks.
+type diagnosticParserCoreRecoveryCostSource struct {
+	compact *core.Core
+	source  []byte
+	// newlines holds the byte offset of every '\n' in source, ascending. A
+	// nil slice with newlinesBuilt false means "not computed yet"; a source
+	// with no newline at all builds an empty non-nil slice, so the flag, not
+	// the length, records whether the scan ran.
+	newlines      []uint32
+	newlinesBuilt bool
+}
+
+// rowAt returns the zero-based row containing byteOffset, matching how the
+// public tree numbers points: the row is the count of newlines strictly
+// before the offset.
+func (s *diagnosticParserCoreRecoveryCostSource) rowAt(byteOffset uint32) uint32 {
+	if !s.newlinesBuilt {
+		s.newlines = s.newlines[:0]
+		for index, b := range s.source {
+			if b == '\n' {
+				s.newlines = append(s.newlines, uint32(index))
+			}
+		}
+		s.newlinesBuilt = true
+	}
+	if len(s.newlines) == 0 {
+		return 0
+	}
+	return uint32(sort.Search(len(s.newlines), func(i int) bool {
+		return s.newlines[i] >= byteOffset
+	}))
+}
+
+// RecoveryCostNode implements core.RecoveryCostSource.
+//
+// Children are COPIED, not aliased. MaterializationView documents its
+// Children slice as borrowed arena storage that must not be retained, and the
+// cost model holds a node's children across recursive calls that re-enter this
+// method. Copying is the cheap, obviously-correct response; this path runs at
+// a recovery decision point, never on the clean hot path.
+func (s *diagnosticParserCoreRecoveryCostSource) RecoveryCostNode(id core.SubtreeID) (core.RecoveryCostNode, error) {
+	if s == nil || s.compact == nil {
+		return core.RecoveryCostNode{}, errors.New("parser-core phase zero: recovery cost source has no compact core")
+	}
+	view, err := s.compact.MaterializationView(id)
+	if err != nil {
+		return core.RecoveryCostNode{}, err
+	}
+	node := core.RecoveryCostNode{
+		Symbol:    view.Symbol,
+		Extra:     view.Extra,
+		Missing:   view.Missing,
+		StartByte: view.StartByte,
+		EndByte:   view.EndByte,
+	}
+	// Only an ERROR node's row extent is ever read (recovery_cost.go), so
+	// every other node skips the newline scan entirely.
+	if view.Symbol == core.RecoveryErrorSymbol {
+		node.StartRow = s.rowAt(view.StartByte)
+		node.EndRow = s.rowAt(view.EndByte)
+	}
+	if len(view.Children) != 0 {
+		node.Children = append(make([]core.SubtreeID, 0, len(view.Children)), view.Children...)
+	}
+	return node, nil
+}
+
+// diagnosticParserCoreLineageCostUnavailable reports that a head could not be
+// priced because it does not carry exactly one derivation. Every recovery
+// arbitration this supports is defined on a single lineage; an ambiguous head
+// is a shape the caller must decline rather than price arbitrarily.
+var diagnosticParserCoreLineageCostUnavailable = errors.New("parser-core phase zero: recovery lineage cost requires exactly one derivation")
+
+// diagnosticParserCoreLineageErrorCost prices one head the way C prices a
+// stack version: ts_stack_error_cost sums ts_subtree_error_cost over the
+// version's stack nodes (stack.c:482-490, ported as cStackErrorCost in
+// parser_recover_c.go). The compact equivalent of "the version's stack nodes"
+// is the payload list of the head's single derivation, which is exactly the
+// list materialization already walks.
+//
+// The +500 that C adds for a version parked at ERROR_STATE with no open node
+// is NOT added here. That term belongs to the head's live recovery state, not
+// to its published subtrees, so it is RecoveryVersionStatus's hasOpenRecovery
+// input and stays the caller's to supply -- the same split stage S2 already
+// documented when it declined to port cNodeCountSinceError.
+func diagnosticParserCoreLineageErrorCost(
+	compact *core.Core,
+	head core.Head,
+	symbols []core.SelectedSymbolPolicy,
+	src *diagnosticParserCoreRecoveryCostSource,
+	memo *core.RecoveryCostMemo,
+) (uint32, error) {
+	if compact == nil || src == nil {
+		return 0, errors.New("parser-core phase zero: recovery lineage cost requires a compact core and source")
+	}
+	derivations, err := compact.Derivations(head)
+	if err != nil {
+		return 0, err
+	}
+	if len(derivations) != 1 {
+		return 0, diagnosticParserCoreLineageCostUnavailable
+	}
+	var total uint32
+	for _, payload := range derivations[0].Payloads {
+		if payload == 0 {
+			continue
+		}
+		cost, err := core.RecoveryNodeErrorCostMemo(symbols, src, memo, payload)
+		if err != nil {
+			return 0, err
+		}
+		total += cost
+	}
+	return total, nil
+}

--- a/parsercore_phase0_recovery_cost_source.go
+++ b/parsercore_phase0_recovery_cost_source.go
@@ -21,9 +21,11 @@ import (
 // onto the original anyway, so both versions parse forward, and the winner is
 // settled later by error cost (ts_parser__select_tree,
 // ts_parser__better_version_exists). Measured on php "<?php namespace ; ?>",
-// the missing version costs 610 and the absorbing version about 509, so C
-// publishes an ERROR tree even though its own missing-token search accepted
-// the insertion. Pricing a lineage is therefore the prerequisite for either
+// the missing version costs 610 and the absorbing version 609
+// (500 recovery + 9 skipped chars + 100 for one visible child), so C publishes
+// an ERROR tree even though its own missing-token search accepted the
+// insertion. The margin is ONE point: every term of this model has to be
+// present, or the arbitration inverts. Pricing a lineage is therefore the prerequisite for either
 // recovery stage to be correct, not an optimization.
 //
 // Stage S2 deliberately shipped its cost model with no caller
@@ -54,17 +56,45 @@ import (
 type diagnosticParserCoreRecoveryCostSource struct {
 	compact *core.Core
 	source  []byte
-	// newlines holds the byte offset of every '\n' in source, ascending. A
-	// nil slice with newlinesBuilt false means "not computed yet"; a source
-	// with no newline at all builds an empty non-nil slice, so the flag, not
-	// the length, records whether the scan ran.
+	// newlines holds the byte offset of every '\n' in source, ascending.
+	// newlinesBuilt, not the slice length, records whether the scan has run: a
+	// source with no newline leaves the slice empty, which is indistinguishable
+	// from "not scanned yet" by length alone.
+	//
+	// Neither field is reset. Bind one source per cost source and build a new
+	// one for the next parse; reassigning `source` in place would keep
+	// answering row queries from the previous text.
 	newlines      []uint32
 	newlinesBuilt bool
 }
 
-// rowAt returns the zero-based row containing byteOffset, matching how the
-// public tree numbers points: the row is the count of newlines strictly
-// before the offset.
+// newDiagnosticParserCoreRecoveryCostSource binds a cost source to one Core
+// and one source text.
+//
+// It is the only supported way to build one. Constructing the struct by
+// literal makes `source` look optional, and an absent or short source is not a
+// harmless default: rowAt would answer 0 for every offset, silently dropping
+// RecoveryCostPerSkippedLine (30 per line) from every ERROR region. A
+// twenty-line region would then be under-priced by 600, which is more than an
+// entire missing insertion costs, and the arbitration inverts.
+func newDiagnosticParserCoreRecoveryCostSource(compact *core.Core, source []byte) (*diagnosticParserCoreRecoveryCostSource, error) {
+	if compact == nil {
+		return nil, errors.New("parser-core phase zero: recovery cost source requires a compact core")
+	}
+	if uint64(len(source)) > uint64(^uint32(0)) {
+		return nil, errors.New("parser-core phase zero: recovery cost source exceeds uint32 offsets")
+	}
+	return &diagnosticParserCoreRecoveryCostSource{compact: compact, source: source}, nil
+}
+
+// rowAt returns the zero-based row containing byteOffset: the count of
+// newlines strictly before the offset.
+//
+// It does NOT reuse diagnosticParserCorePointIndex (parsercore_phase0_driver.go),
+// which answers the same question with a cancellation poll and a reusable
+// buffer. That helper is built per materialization against a runner scratch;
+// this source is built per arbitration and may outlive no scratch at all.
+// The scan is bounded by the source length and runs once per source.
 func (s *diagnosticParserCoreRecoveryCostSource) rowAt(byteOffset uint32) uint32 {
 	if !s.newlinesBuilt {
 		s.newlines = s.newlines[:0]
@@ -75,9 +105,8 @@ func (s *diagnosticParserCoreRecoveryCostSource) rowAt(byteOffset uint32) uint32
 		}
 		s.newlinesBuilt = true
 	}
-	if len(s.newlines) == 0 {
-		return 0
-	}
+	// sort.Search over an empty slice already returns 0 without calling the
+	// predicate, so no length guard is needed here.
 	return uint32(sort.Search(len(s.newlines), func(i int) bool {
 		return s.newlines[i] >= byteOffset
 	}))
@@ -183,11 +212,30 @@ func diagnosticParserCoreDerivationErrorCost(
 // accepting frontier, together with the price the selection ladder reads.
 type diagnosticParserCoreLineage struct {
 	Head core.Head
-	// Cost is the lineage's total error cost, C's ts_stack_error_cost.
+	// Cost is the lineage's total error cost: C's ts_stack_error_cost, which
+	// is the sum over published subtrees PLUS the open-recovery term below.
 	Cost uint32
 	// Score is the summed dynamic precedence of the lineage's sole
 	// derivation, C's ts_subtree_dynamic_precedence.
 	Score int64
+}
+
+// diagnosticParserCoreLineageInput names one candidate head together with the
+// live recovery state that pricing cannot read off the published subtrees.
+//
+// OpenRecoverySegments is the compact analogue of cStackOpenRecoveryCost
+// (parser_recover_c.go:2475-2489), which is the half of C's
+// ts_stack_error_cost that does NOT come from the arena. C charges
+// ERROR_COST_PER_RECOVERY once for a version that is paused or sitting at
+// ERROR_STATE with no open error node yet, and once more for each extra
+// error_repeat segment an unlexable-run re-pause opened. Count both here.
+//
+// Omitting this term is not a rounding error. A head paused with an empty
+// open region prices at 0 instead of 500, and the arbitration this module
+// exists for turns on a margin of one point.
+type diagnosticParserCoreLineageInput struct {
+	Head                 core.Head
+	OpenRecoverySegments int
 }
 
 // errDiagnosticParserCoreLineageTie reports that the selection ladder ran out
@@ -204,19 +252,27 @@ var errDiagnosticParserCoreLineageTie = errors.New("parser-core phase zero: comp
 // exactly one derivation, for the reason diagnosticParserCoreLineageErrorCost
 // already states: the comparison is defined on one lineage.
 func diagnosticParserCorePriceLineages(
-	compact *core.Core,
-	heads []core.Head,
+	inputs []diagnosticParserCoreLineageInput,
 	symbols []core.SelectedSymbolPolicy,
 	src *diagnosticParserCoreRecoveryCostSource,
 	memo *core.RecoveryCostMemo,
 ) ([]diagnosticParserCoreLineage, error) {
-	if compact == nil || src == nil {
-		return nil, errors.New("parser-core phase zero: lineage pricing requires a compact core and source")
+	if src == nil || src.compact == nil {
+		return nil, errors.New("parser-core phase zero: lineage pricing requires a bound cost source")
 	}
-	out := make([]diagnosticParserCoreLineage, 0, len(heads))
-	for _, head := range heads {
-		derivations, err := compact.Derivations(head)
+	out := make([]diagnosticParserCoreLineage, 0, len(inputs))
+	for _, in := range inputs {
+		// One Derivations call per head: pricing needs the payloads and
+		// ordering needs the Score. The Core comes from src, so the
+		// derivations and the arena they are priced against cannot disagree.
+		derivations, err := src.compact.Derivations(in.Head)
 		if err != nil {
+			if errors.Is(err, core.ErrDerivationEnumerationCap) {
+				// A head with more paths than the enumeration cap is the most
+				// ambiguous shape there is. Report it as the same decline every
+				// other ambiguous head gets, not as a hard failure.
+				return nil, diagnosticParserCoreLineageCostUnavailable
+			}
 			return nil, err
 		}
 		if len(derivations) != 1 {
@@ -226,8 +282,12 @@ func diagnosticParserCorePriceLineages(
 		if err != nil {
 			return nil, err
 		}
+		if in.OpenRecoverySegments < 0 {
+			return nil, errors.New("parser-core phase zero: negative open-recovery segment count")
+		}
+		cost += uint32(core.RecoveryCostPerRecovery) * uint32(in.OpenRecoverySegments)
 		out = append(out, diagnosticParserCoreLineage{
-			Head: head, Cost: cost, Score: derivations[0].Score,
+			Head: in.Head, Cost: cost, Score: derivations[0].Score,
 		})
 	}
 	return out, nil
@@ -258,14 +318,26 @@ func diagnosticParserCoreSelectRecoveryLineage(lineages []diagnosticParserCoreLi
 	if len(lineages) == 0 {
 		return 0, errors.New("parser-core phase zero: no recovery lineage to select")
 	}
+	// Fold left to right, keeping the incumbent when a pair is unresolvable.
+	// An unresolvable PAIR is not an unresolvable RESULT: C folds the same way
+	// and a later candidate can dominate both sides of an earlier tie on cost
+	// or precedence. Declining at the pair would refuse inputs C decides.
 	winner := 0
 	for candidate := 1; candidate < len(lineages); candidate++ {
-		replace, err := diagnosticParserCoreLineageReplaces(lineages[winner], lineages[candidate])
-		if err != nil {
-			return 0, err
-		}
-		if replace {
+		replace, resolved := diagnosticParserCoreLineageReplaces(lineages[winner], lineages[candidate])
+		if resolved && replace {
 			winner = candidate
+		}
+	}
+	// Only the FINAL winner has to be decided. If any other lineage still ties
+	// with it unresolvably, the answer genuinely depends on the structural
+	// comparison this port does not model, so decline rather than guess.
+	for other := range lineages {
+		if other == winner {
+			continue
+		}
+		if _, resolved := diagnosticParserCoreLineageReplaces(lineages[winner], lineages[other]); !resolved {
+			return 0, errDiagnosticParserCoreLineageTie
 		}
 	}
 	return winner, nil
@@ -274,26 +346,29 @@ func diagnosticParserCoreSelectRecoveryLineage(lineages []diagnosticParserCoreLi
 // diagnosticParserCoreLineageReplaces reports whether candidate should replace
 // incumbent, mirroring ts_parser__select_tree's return value exactly (true
 // means "take the right-hand side").
-func diagnosticParserCoreLineageReplaces(incumbent, candidate diagnosticParserCoreLineage) (bool, error) {
+//
+// resolved is false only for C's final clause, the structural
+// ts_subtree_compare, which this port does not model. That clause is reachable
+// only when BOTH sides are clean, because parser.c:864 returns early for a
+// positive error cost.
+func diagnosticParserCoreLineageReplaces(incumbent, candidate diagnosticParserCoreLineage) (replace, resolved bool) {
 	if candidate.Cost < incumbent.Cost {
-		return true, nil
+		return true, true
 	}
 	if incumbent.Cost < candidate.Cost {
-		return false, nil
+		return false, true
 	}
 	if candidate.Score > incumbent.Score {
-		return true, nil
+		return true, true
 	}
 	if incumbent.Score > candidate.Score {
-		return false, nil
+		return false, true
 	}
 	if incumbent.Cost > 0 {
 		// C parser.c:864. Equal cost, equal precedence, and the incumbent
 		// carries error content: the later candidate wins.
-		return true, nil
+		return true, true
 	}
-	// Both sides are clean and tied. C would compare the trees structurally;
-	// this port does not model that, and a recovery arbitration should never
-	// reach it.
-	return false, errDiagnosticParserCoreLineageTie
+	// Both sides are clean and tied. C would compare the trees structurally.
+	return false, false
 }

--- a/parsercore_phase0_recovery_cost_source.go
+++ b/parsercore_phase0_recovery_cost_source.go
@@ -165,3 +165,122 @@ func diagnosticParserCoreLineageErrorCost(
 	}
 	return total, nil
 }
+
+// diagnosticParserCoreLineage is one competing recovery lineage at an
+// accepting frontier, together with the price the selection ladder reads.
+type diagnosticParserCoreLineage struct {
+	Head core.Head
+	// Cost is the lineage's total error cost, C's ts_stack_error_cost.
+	Cost uint32
+	// Score is the summed dynamic precedence of the lineage's sole
+	// derivation, C's ts_subtree_dynamic_precedence.
+	Score int64
+}
+
+// ErrDiagnosticParserCoreLineageTie reports that the selection ladder ran out
+// of C-defined tiebreaks. C's last resort is ts_subtree_compare, a structural
+// comparison it reaches only when BOTH candidates are clean
+// (ts_parser__select_tree returns early for a positive error cost). Every
+// lineage this selection exists to arbitrate carries recovery content, so
+// reaching that clause means the caller handed in a shape this port does not
+// model, and the honest answer is to decline rather than pick one.
+var ErrDiagnosticParserCoreLineageTie = errors.New("parser-core phase zero: competing recovery lineages tie beyond the modeled selection ladder")
+
+// diagnosticParserCorePriceLineages prices each candidate head so the
+// selection ladder can order them. It refuses any head that does not carry
+// exactly one derivation, for the reason diagnosticParserCoreLineageErrorCost
+// already states: the comparison is defined on one lineage.
+func diagnosticParserCorePriceLineages(
+	compact *core.Core,
+	heads []core.Head,
+	symbols []core.SelectedSymbolPolicy,
+	src *diagnosticParserCoreRecoveryCostSource,
+	memo *core.RecoveryCostMemo,
+) ([]diagnosticParserCoreLineage, error) {
+	if compact == nil || src == nil {
+		return nil, errors.New("parser-core phase zero: lineage pricing requires a compact core and source")
+	}
+	out := make([]diagnosticParserCoreLineage, 0, len(heads))
+	for _, head := range heads {
+		cost, err := diagnosticParserCoreLineageErrorCost(compact, head, symbols, src, memo)
+		if err != nil {
+			return nil, err
+		}
+		derivations, err := compact.Derivations(head)
+		if err != nil {
+			return nil, err
+		}
+		if len(derivations) != 1 {
+			return nil, diagnosticParserCoreLineageCostUnavailable
+		}
+		out = append(out, diagnosticParserCoreLineage{
+			Head: head, Cost: cost, Score: derivations[0].Score,
+		})
+	}
+	return out, nil
+}
+
+// diagnosticParserCoreSelectRecoveryLineage returns the index of the lineage C
+// would publish, porting ts_parser__select_tree's ordering (parser.c:836-878).
+//
+// C folds every accepted root into one winner pairwise, asking for each new
+// candidate whether it should REPLACE the incumbent. Its ladder, in order:
+//
+//  1. lower error cost wins;
+//  2. then higher dynamic precedence wins;
+//  3. then, when the incumbent's error cost is positive, the LATER candidate
+//     wins (parser.c:864, `if (ts_subtree_error_cost(left) > 0) return true`);
+//  4. otherwise C compares the trees structurally (ts_subtree_compare).
+//
+// Clause 3 is not a coin flip and must not be "simplified" to keeping the
+// incumbent: it is what lets a later, equally priced recovery displace an
+// earlier one. Clause 4 is unreachable here, because it requires BOTH sides to
+// be clean, and a lineage with zero error cost is not a recovery lineage at
+// all; this port returns ErrDiagnosticParserCoreLineageTie instead of guessing.
+//
+// The order of lineages is therefore load-bearing. Callers must pass them in
+// the scheduler's own publication order, which is the compact analogue of C's
+// version index order.
+func diagnosticParserCoreSelectRecoveryLineage(lineages []diagnosticParserCoreLineage) (int, error) {
+	if len(lineages) == 0 {
+		return 0, errors.New("parser-core phase zero: no recovery lineage to select")
+	}
+	winner := 0
+	for candidate := 1; candidate < len(lineages); candidate++ {
+		replace, err := diagnosticParserCoreLineageReplaces(lineages[winner], lineages[candidate])
+		if err != nil {
+			return 0, err
+		}
+		if replace {
+			winner = candidate
+		}
+	}
+	return winner, nil
+}
+
+// diagnosticParserCoreLineageReplaces reports whether candidate should replace
+// incumbent, mirroring ts_parser__select_tree's return value exactly (true
+// means "take the right-hand side").
+func diagnosticParserCoreLineageReplaces(incumbent, candidate diagnosticParserCoreLineage) (bool, error) {
+	if candidate.Cost < incumbent.Cost {
+		return true, nil
+	}
+	if incumbent.Cost < candidate.Cost {
+		return false, nil
+	}
+	if candidate.Score > incumbent.Score {
+		return true, nil
+	}
+	if incumbent.Score > candidate.Score {
+		return false, nil
+	}
+	if incumbent.Cost > 0 {
+		// C parser.c:864. Equal cost, equal precedence, and the incumbent
+		// carries error content: the later candidate wins.
+		return true, nil
+	}
+	// Both sides are clean and tied. C would compare the trees structurally;
+	// this port does not model that, and a recovery arbitration should never
+	// reach it.
+	return false, ErrDiagnosticParserCoreLineageTie
+}

--- a/parsercore_phase0_recovery_cost_source_internal_test.go
+++ b/parsercore_phase0_recovery_cost_source_internal_test.go
@@ -30,7 +30,11 @@ func newRecoveryCostFixture(t *testing.T, source string) (*core.Core, *diagnosti
 	if err != nil {
 		t.Fatal(err)
 	}
-	return compact, &diagnosticParserCoreRecoveryCostSource{compact: compact, source: []byte(source)}
+	src, err := newDiagnosticParserCoreRecoveryCostSource(compact, []byte(source))
+	if err != nil {
+		t.Fatalf("new cost source: %v", err)
+	}
+	return compact, src
 }
 
 // visibleSymbols marks every symbol below the given ceiling visible, which is
@@ -120,10 +124,13 @@ func TestRecoveryCostSourcePricesErrorRegionSpanAndRows(t *testing.T) {
 	if cost != want {
 		t.Fatalf("error region cost = %d, want %d", cost, want)
 	}
-	// The measured php arbitration turns on exactly this comparison: an
-	// absorbed span must beat a missing insertion's flat 610 to win.
-	if want >= core.RecoveryCostPerMissingTree+core.RecoveryCostPerRecovery {
-		t.Logf("note: this fixture's absorb cost %d does not beat a missing insertion (610)", want)
+	// This fixture spans two rows, so it prices ABOVE a missing insertion
+	// (667 against 610). That direction is itself worth pinning: the row term
+	// is what pushes a multi-line absorb past an insertion, and dropping it
+	// would silently flip this fixture to the other side.
+	if want <= core.RecoveryCostPerMissingTree+core.RecoveryCostPerRecovery {
+		t.Fatalf("multi-row absorb priced at %d, expected above a missing insertion's %d",
+			want, core.RecoveryCostPerMissingTree+core.RecoveryCostPerRecovery)
 	}
 }
 
@@ -392,7 +399,7 @@ func TestPriceLineagesRefusesAmbiguousHead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ErrorRegionResume: %v", err)
 	}
-	if _, err := diagnosticParserCorePriceLineages(compact, []core.Head{ambiguous}, visibleSymbols(8), src, nil); !errors.Is(err, diagnosticParserCoreLineageCostUnavailable) {
+	if _, err := diagnosticParserCorePriceLineages([]diagnosticParserCoreLineageInput{{Head: ambiguous}}, visibleSymbols(8), src, nil); !errors.Is(err, diagnosticParserCoreLineageCostUnavailable) {
 		t.Fatalf("pricing an ambiguous head returned %v, want a refusal", err)
 	}
 }
@@ -423,7 +430,7 @@ func TestPriceLineagesPricesEachHeadIndependently(t *testing.T) {
 		t.Fatalf("ErrorRegionResume: %v", err)
 	}
 
-	priced, err := diagnosticParserCorePriceLineages(compact, []core.Head{wide, narrow}, visibleSymbols(8), src, nil)
+	priced, err := diagnosticParserCorePriceLineages([]diagnosticParserCoreLineageInput{{Head: wide}, {Head: narrow}}, visibleSymbols(8), src, nil)
 	if err != nil {
 		t.Fatalf("price: %v", err)
 	}
@@ -439,5 +446,137 @@ func TestPriceLineagesPricesEachHeadIndependently(t *testing.T) {
 	}
 	if winner != 1 {
 		t.Fatalf("winner=%d, want 1: the cheaper, narrower region", winner)
+	}
+}
+
+// TestSelectArbitratesMissingInsertionAgainstErrorAbsorb is the end-to-end
+// claim this whole module exists to make correct, driven through real heads
+// rather than hand-written costs.
+//
+// It reconstructs the measured php witness "<?php namespace ; ?>": one lineage
+// inserts a single MISSING leaf, the other absorbs the nine bytes of
+// "namespace" into an ERROR region with one visible child. C publishes the
+// ERROR tree, because 500 + 9 + 100 = 609 beats a missing insertion's flat
+// 610. The margin is one point, so this exercises every term of the model at
+// once -- a dropped skipped-tree charge, a dropped row term, or a missing
+// short circuit on the missing bit all flip the answer.
+func TestSelectArbitratesMissingInsertionAgainstErrorAbsorb(t *testing.T) {
+	const source = "<?php namespace ; ?>"
+	compact, src := newRecoveryCostFixture(t, source)
+	seed, err := compact.Seed(core.StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+
+	// Lineage A: insert one zero-width MISSING leaf.
+	missingHead, err := compact.ShiftMissingLeaf(seed, core.StateID(2), core.Symbol(3), 16)
+	if err != nil {
+		t.Fatalf("ShiftMissingLeaf: %v", err)
+	}
+
+	// Lineage B: absorb "namespace" (bytes 6..15, nine characters, one
+	// visible child, no newline) into an ERROR region.
+	absorbed, err := compact.ErrorRegionLeaf(core.Symbol(4), 6, 15, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	absorbHead, err := compact.ErrorRegionResume(seed, core.StateID(3), 6, 15, []core.SubtreeID{absorbed})
+	if err != nil {
+		t.Fatalf("ErrorRegionResume: %v", err)
+	}
+
+	priced, err := diagnosticParserCorePriceLineages([]diagnosticParserCoreLineageInput{
+		{Head: missingHead}, {Head: absorbHead},
+	}, visibleSymbols(8), src, nil)
+	if err != nil {
+		t.Fatalf("price: %v", err)
+	}
+
+	const wantMissing = core.RecoveryCostPerMissingTree + core.RecoveryCostPerRecovery // 610
+	const wantAbsorb = core.RecoveryCostPerRecovery +
+		core.RecoveryCostPerSkippedChar*9 + core.RecoveryCostPerSkippedTree // 609
+	if priced[0].Cost != wantMissing {
+		t.Fatalf("missing lineage priced %d, want %d", priced[0].Cost, wantMissing)
+	}
+	if priced[1].Cost != wantAbsorb {
+		t.Fatalf("absorb lineage priced %d, want %d", priced[1].Cost, wantAbsorb)
+	}
+	if wantAbsorb >= wantMissing {
+		t.Fatalf("fixture lost the one-point margin: absorb %d, missing %d", wantAbsorb, wantMissing)
+	}
+
+	winner, err := diagnosticParserCoreSelectRecoveryLineage(priced)
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if winner != 1 {
+		t.Fatalf("winner=%d, want 1: C publishes the ERROR tree for this witness", winner)
+	}
+}
+
+// TestPriceLineagesChargesOpenRecoverySegments pins C's non-subtree stack
+// cost, cStackOpenRecoveryCost (parser_recover_c.go:2475-2489). A head paused
+// with no open error node yet carries 500 that no published subtree accounts
+// for, and each extra error_repeat segment adds another 500.
+func TestPriceLineagesChargesOpenRecoverySegments(t *testing.T) {
+	compact, src := newRecoveryCostFixture(t, "abcdef")
+	seed, err := compact.Seed(core.StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	head, err := compact.ShiftMissingLeaf(seed, core.StateID(2), core.Symbol(3), 0)
+	if err != nil {
+		t.Fatalf("ShiftMissingLeaf: %v", err)
+	}
+
+	priced, err := diagnosticParserCorePriceLineages([]diagnosticParserCoreLineageInput{
+		{Head: head, OpenRecoverySegments: 0},
+		{Head: head, OpenRecoverySegments: 1},
+		{Head: head, OpenRecoverySegments: 3},
+	}, visibleSymbols(8), src, nil)
+	if err != nil {
+		t.Fatalf("price: %v", err)
+	}
+	base := priced[0].Cost
+	if priced[1].Cost != base+core.RecoveryCostPerRecovery {
+		t.Fatalf("one open-recovery segment added %d, want %d",
+			priced[1].Cost-base, core.RecoveryCostPerRecovery)
+	}
+	if priced[2].Cost != base+3*core.RecoveryCostPerRecovery {
+		t.Fatalf("three open-recovery segments added %d, want %d",
+			priced[2].Cost-base, 3*core.RecoveryCostPerRecovery)
+	}
+	// The term is large enough to invert the arbitration on its own: an
+	// otherwise-cheaper absorb loses once it is charged for a paused segment.
+	if base+core.RecoveryCostPerRecovery <= base {
+		t.Fatal("open-recovery term did not raise the price at all")
+	}
+}
+
+// TestSelectRecoveryLineageResolvesWhenALaterCandidateDominates proves the
+// fold declines only when the FINAL winner is undetermined, not whenever some
+// pair along the way is.
+//
+// C folds pairwise too, and a later candidate can dominate both sides of an
+// earlier unresolvable tie. Aborting at the pair would refuse an input C
+// decides unambiguously.
+func TestSelectRecoveryLineageResolvesWhenALaterCandidateDominates(t *testing.T) {
+	// Two clean, tied lineages that this port cannot order against each
+	// other, followed by one that beats both on cost.
+	winner, err := diagnosticParserCoreSelectRecoveryLineage([]diagnosticParserCoreLineage{
+		lineage(0, 0), lineage(0, 0), lineage(0, 5),
+	})
+	if err != nil {
+		t.Fatalf("select declined an input with a dominating candidate: %v", err)
+	}
+	if winner != 2 {
+		t.Fatalf("winner=%d, want 2 (higher precedence beats both tied lineages)", winner)
+	}
+
+	// But an unresolvable tie involving the eventual winner still declines.
+	if _, err := diagnosticParserCoreSelectRecoveryLineage([]diagnosticParserCoreLineage{
+		lineage(0, 5), lineage(0, 5),
+	}); !errors.Is(err, errDiagnosticParserCoreLineageTie) {
+		t.Fatalf("a tie with the winner returned %v, want errDiagnosticParserCoreLineageTie", err)
 	}
 }

--- a/parsercore_phase0_recovery_cost_source_internal_test.go
+++ b/parsercore_phase0_recovery_cost_source_internal_test.go
@@ -348,8 +348,8 @@ func TestSelectRecoveryLineageRefusesACleanTie(t *testing.T) {
 	_, err := diagnosticParserCoreSelectRecoveryLineage([]diagnosticParserCoreLineage{
 		lineage(0, 0), lineage(0, 0),
 	})
-	if !errors.Is(err, ErrDiagnosticParserCoreLineageTie) {
-		t.Fatalf("clean tie returned %v, want ErrDiagnosticParserCoreLineageTie", err)
+	if !errors.Is(err, errDiagnosticParserCoreLineageTie) {
+		t.Fatalf("clean tie returned %v, want errDiagnosticParserCoreLineageTie", err)
 	}
 }
 

--- a/parsercore_phase0_recovery_cost_source_internal_test.go
+++ b/parsercore_phase0_recovery_cost_source_internal_test.go
@@ -1,0 +1,234 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// recoveryCostSourceTable is an inert table: pricing a published subtree
+// never dispatches, it only resolves records the caller already published.
+type recoveryCostSourceTable struct{}
+
+func (recoveryCostSourceTable) Actions(core.StateID, core.Symbol) (core.ActionRow, error) {
+	return core.ActionRow{}, nil
+}
+func (recoveryCostSourceTable) Goto(core.StateID, core.Symbol) (core.StateID, error) { return 0, nil }
+func (recoveryCostSourceTable) ProductionFields(uint16, int) ([]core.FieldMapEntry, error) {
+	return nil, nil
+}
+func (recoveryCostSourceTable) ProductionAliases(uint16, int) ([]core.Symbol, error) {
+	return nil, nil
+}
+
+func newRecoveryCostFixture(t *testing.T, source string) (*core.Core, *diagnosticParserCoreRecoveryCostSource) {
+	t.Helper()
+	compact, err := core.New(recoveryCostSourceTable{}, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return compact, &diagnosticParserCoreRecoveryCostSource{compact: compact, source: []byte(source)}
+}
+
+// visibleSymbols marks every symbol below the given ceiling visible, which is
+// what RecoverySymbolVisible reads when pricing an ERROR node's children.
+func visibleSymbols(count int) []core.SelectedSymbolPolicy {
+	out := make([]core.SelectedSymbolPolicy, count)
+	for i := range out {
+		out[i] = core.SelectedSymbolPolicy{Visible: true, Named: true}
+	}
+	return out
+}
+
+// TestRecoveryCostSourcePricesMissingLeaf pins C's missing-subtree cost.
+// ts_subtree_error_cost short-circuits on the missing bit and returns
+// ERROR_COST_PER_MISSING_TREE + ERROR_COST_PER_RECOVERY (subtree.h:331-337),
+// which is 610 -- NOT ERROR_COST_PER_MISSING_TREE alone. Getting this wrong
+// inverts every arbitration against an absorbing version, whose floor is 500.
+func TestRecoveryCostSourcePricesMissingLeaf(t *testing.T) {
+	compact, src := newRecoveryCostFixture(t, "abc")
+	id, err := compact.MissingLeaf(core.Symbol(3), 1)
+	if err != nil {
+		t.Fatalf("MissingLeaf: %v", err)
+	}
+	cost, err := core.RecoveryNodeErrorCost(visibleSymbols(8), src, id)
+	if err != nil {
+		t.Fatalf("cost: %v", err)
+	}
+	const want = core.RecoveryCostPerMissingTree + core.RecoveryCostPerRecovery
+	if cost != want {
+		t.Fatalf("missing leaf cost = %d, want %d", cost, want)
+	}
+	if want != 610 {
+		t.Fatalf("the C constants no longer sum to 610 (got %d); re-derive every arbitration that depends on it", want)
+	}
+}
+
+// TestRecoveryCostSourcePricesCleanTerminalZero proves an ordinary published
+// terminal costs nothing, so pricing never charges a clean lineage.
+func TestRecoveryCostSourcePricesCleanTerminalZero(t *testing.T) {
+	compact, src := newRecoveryCostFixture(t, "abc")
+	id, err := compact.ErrorRegionLeaf(core.Symbol(4), 0, 3, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	cost, err := core.RecoveryNodeErrorCost(visibleSymbols(8), src, id)
+	if err != nil {
+		t.Fatalf("cost: %v", err)
+	}
+	if cost != 0 {
+		t.Fatalf("clean terminal cost = %d, want 0", cost)
+	}
+}
+
+// TestRecoveryCostSourcePricesErrorRegionSpanAndRows pins the ERROR-node
+// formula: ERROR_COST_PER_RECOVERY, plus one per skipped byte, plus thirty per
+// skipped row, plus ERROR_COST_PER_SKIPPED_TREE per visible child
+// (subtree.c:400-402,442-444). The row term is why this source computes rows
+// from the source text at all.
+func TestRecoveryCostSourcePricesErrorRegionSpanAndRows(t *testing.T) {
+	// Two rows spanned: the region covers bytes 0..7 of "ab\ncd\nef".
+	compact, src := newRecoveryCostFixture(t, "ab\ncd\nef")
+	child, err := compact.ErrorRegionLeaf(core.Symbol(5), 0, 7, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	seed, err := compact.Seed(core.StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	head, err := compact.ErrorRegionResume(seed, core.StateID(1), 0, 7, []core.SubtreeID{child})
+	if err != nil {
+		t.Fatalf("ErrorRegionResume: %v", err)
+	}
+	derivations, err := compact.Derivations(head)
+	if err != nil || len(derivations) != 1 || len(derivations[0].Payloads) != 1 {
+		t.Fatalf("expected one derivation carrying the ERROR container, got %v (err %v)", derivations, err)
+	}
+	cost, err := core.RecoveryNodeErrorCost(visibleSymbols(8), src, derivations[0].Payloads[0])
+	if err != nil {
+		t.Fatalf("cost: %v", err)
+	}
+	// span 0..7 = 7 bytes, rows 0..2 = 2 rows, one visible child.
+	const want = core.RecoveryCostPerRecovery +
+		core.RecoveryCostPerSkippedChar*7 +
+		core.RecoveryCostPerSkippedLine*2 +
+		core.RecoveryCostPerSkippedTree
+	if cost != want {
+		t.Fatalf("error region cost = %d, want %d", cost, want)
+	}
+	// The measured php arbitration turns on exactly this comparison: an
+	// absorbed span must beat a missing insertion's flat 610 to win.
+	if want >= core.RecoveryCostPerMissingTree+core.RecoveryCostPerRecovery {
+		t.Logf("note: this fixture's absorb cost %d does not beat a missing insertion (610)", want)
+	}
+}
+
+// TestRecoveryCostSourceRowsTrackNewlines pins the row computation the ERROR
+// formula depends on.
+func TestRecoveryCostSourceRowsTrackNewlines(t *testing.T) {
+	_, src := newRecoveryCostFixture(t, "ab\ncd\nef")
+	for _, tc := range []struct {
+		offset uint32
+		want   uint32
+	}{{0, 0}, {2, 0}, {3, 1}, {5, 1}, {6, 2}, {8, 2}} {
+		if got := src.rowAt(tc.offset); got != tc.want {
+			t.Fatalf("rowAt(%d) = %d, want %d", tc.offset, got, tc.want)
+		}
+	}
+	noNewlines := &diagnosticParserCoreRecoveryCostSource{source: []byte("abc")}
+	if got := noNewlines.rowAt(3); got != 0 {
+		t.Fatalf("rowAt on a single-line source = %d, want 0", got)
+	}
+}
+
+// TestRecoveryLineageErrorCostSumsPayloads proves lineage pricing is C's
+// ts_stack_error_cost: the sum over the version's stack nodes.
+func TestRecoveryLineageErrorCostSumsPayloads(t *testing.T) {
+	compact, src := newRecoveryCostFixture(t, "abcdef")
+	seed, err := compact.Seed(core.StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	head, err := compact.ShiftMissingLeaf(seed, core.StateID(2), core.Symbol(3), 0)
+	if err != nil {
+		t.Fatalf("ShiftMissingLeaf: %v", err)
+	}
+	head, err = compact.ShiftMissingLeaf(head, core.StateID(3), core.Symbol(4), 0)
+	if err != nil {
+		t.Fatalf("ShiftMissingLeaf: %v", err)
+	}
+	cost, err := diagnosticParserCoreLineageErrorCost(compact, head, visibleSymbols(8), src, nil)
+	if err != nil {
+		t.Fatalf("lineage cost: %v", err)
+	}
+	const want = 2 * (core.RecoveryCostPerMissingTree + core.RecoveryCostPerRecovery)
+	if cost != want {
+		t.Fatalf("lineage cost = %d, want %d (two missing insertions)", cost, want)
+	}
+}
+
+// TestRecoveryLineageErrorCostMemoAgrees proves the memoized and unmemoized
+// walks agree, since arbitration will run the memoized one.
+func TestRecoveryLineageErrorCostMemoAgrees(t *testing.T) {
+	compact, src := newRecoveryCostFixture(t, "abcdef")
+	seed, err := compact.Seed(core.StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	head, err := compact.ShiftMissingLeaf(seed, core.StateID(2), core.Symbol(3), 0)
+	if err != nil {
+		t.Fatalf("ShiftMissingLeaf: %v", err)
+	}
+	plain, err := diagnosticParserCoreLineageErrorCost(compact, head, visibleSymbols(8), src, nil)
+	if err != nil {
+		t.Fatalf("plain: %v", err)
+	}
+	var memo core.RecoveryCostMemo
+	memoized, err := diagnosticParserCoreLineageErrorCost(compact, head, visibleSymbols(8), src, &memo)
+	if err != nil {
+		t.Fatalf("memoized: %v", err)
+	}
+	if plain != memoized {
+		t.Fatalf("memoized cost %d disagrees with unmemoized %d", memoized, plain)
+	}
+}
+
+// TestRecoveryLineageErrorCostDeclinesAmbiguousHead proves an ambiguous head
+// is refused rather than priced along one arbitrary path. Every arbitration
+// this supports is defined on a single lineage, and silently pricing one of
+// several paths would make the comparison meaningless in exactly the case
+// where it matters most.
+func TestRecoveryLineageErrorCostDeclinesAmbiguousHead(t *testing.T) {
+	compact, src := newRecoveryCostFixture(t, "abcdef")
+	seedA, err := compact.Seed(core.StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	seedB, err := compact.Seed(core.StateID(2), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	if _, err := compact.ShiftMissingLeaf(seedA, core.StateID(9), core.Symbol(3), 0); err != nil {
+		t.Fatalf("ShiftMissingLeaf: %v", err)
+	}
+	// Two distinct predecessors attaching at the same (state, byte offset)
+	// boundary leave the resulting head carrying two root-to-head paths.
+	ambiguous, err := compact.ShiftMissingLeaf(seedB, core.StateID(9), core.Symbol(4), 0)
+	if err != nil {
+		t.Fatalf("ShiftMissingLeaf: %v", err)
+	}
+	derivations, err := compact.Derivations(ambiguous)
+	if err != nil {
+		t.Fatalf("Derivations: %v", err)
+	}
+	if len(derivations) < 2 {
+		t.Fatalf("fixture did not build an ambiguous head: %d derivations", len(derivations))
+	}
+	if _, err := diagnosticParserCoreLineageErrorCost(compact, ambiguous, visibleSymbols(8), src, nil); !errors.Is(err, diagnosticParserCoreLineageCostUnavailable) {
+		t.Fatalf("ambiguous head priced without refusing: %v", err)
+	}
+}

--- a/parsercore_phase0_recovery_cost_source_internal_test.go
+++ b/parsercore_phase0_recovery_cost_source_internal_test.go
@@ -146,42 +146,64 @@ func TestRecoveryCostSourceRowsTrackNewlines(t *testing.T) {
 }
 
 // TestRecoveryLineageErrorCostSumsPayloads proves lineage pricing is C's
-// ts_stack_error_cost: the sum over the version's stack nodes.
+// ts_stack_error_cost: the SUM over the version's stack nodes, not the cost of
+// the last one. The fixture puts two ERROR regions on one lineage and requires
+// the total to be both regions added together.
 func TestRecoveryLineageErrorCostSumsPayloads(t *testing.T) {
-	compact, src := newRecoveryCostFixture(t, "abcdef")
+	compact, src := newRecoveryCostFixture(t, "ab\ncd\nef")
 	seed, err := compact.Seed(core.StateID(1), 0)
 	if err != nil {
 		t.Fatalf("Seed: %v", err)
 	}
-	head, err := compact.ShiftMissingLeaf(seed, core.StateID(2), core.Symbol(3), 0)
+	firstChild, err := compact.ErrorRegionLeaf(core.Symbol(5), 0, 2, false)
 	if err != nil {
-		t.Fatalf("ShiftMissingLeaf: %v", err)
+		t.Fatalf("ErrorRegionLeaf: %v", err)
 	}
-	head, err = compact.ShiftMissingLeaf(head, core.StateID(3), core.Symbol(4), 0)
+	head, err := compact.ErrorRegionResume(seed, core.StateID(1), 0, 2, []core.SubtreeID{firstChild})
 	if err != nil {
-		t.Fatalf("ShiftMissingLeaf: %v", err)
+		t.Fatalf("ErrorRegionResume: %v", err)
 	}
+	secondChild, err := compact.ErrorRegionLeaf(core.Symbol(6), 2, 7, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	head, err = compact.ErrorRegionResume(head, core.StateID(2), 2, 7, []core.SubtreeID{secondChild})
+	if err != nil {
+		t.Fatalf("ErrorRegionResume: %v", err)
+	}
+
 	cost, err := diagnosticParserCoreLineageErrorCost(compact, head, visibleSymbols(8), src, nil)
 	if err != nil {
 		t.Fatalf("lineage cost: %v", err)
 	}
-	const want = 2 * (core.RecoveryCostPerMissingTree + core.RecoveryCostPerRecovery)
-	if cost != want {
-		t.Fatalf("lineage cost = %d, want %d (two missing insertions)", cost, want)
+	// First region: span 0..2 = 2 bytes, 0 rows, one visible child.
+	// Second region: span 2..7 = 5 bytes, 2 rows, one visible child.
+	const firstRegion = core.RecoveryCostPerRecovery +
+		core.RecoveryCostPerSkippedChar*2 + core.RecoveryCostPerSkippedTree
+	const secondRegion = core.RecoveryCostPerRecovery +
+		core.RecoveryCostPerSkippedChar*5 + core.RecoveryCostPerSkippedLine*2 +
+		core.RecoveryCostPerSkippedTree
+	if cost != firstRegion+secondRegion {
+		t.Fatalf("lineage cost = %d, want %d (%d + %d): pricing did not sum the payloads",
+			cost, firstRegion+secondRegion, firstRegion, secondRegion)
 	}
 }
 
 // TestRecoveryLineageErrorCostMemoAgrees proves the memoized and unmemoized
 // walks agree, since arbitration will run the memoized one.
 func TestRecoveryLineageErrorCostMemoAgrees(t *testing.T) {
-	compact, src := newRecoveryCostFixture(t, "abcdef")
+	compact, src := newRecoveryCostFixture(t, "ab\ncd\nef")
 	seed, err := compact.Seed(core.StateID(1), 0)
 	if err != nil {
 		t.Fatalf("Seed: %v", err)
 	}
-	head, err := compact.ShiftMissingLeaf(seed, core.StateID(2), core.Symbol(3), 0)
+	child, err := compact.ErrorRegionLeaf(core.Symbol(5), 0, 7, false)
 	if err != nil {
-		t.Fatalf("ShiftMissingLeaf: %v", err)
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	head, err := compact.ErrorRegionResume(seed, core.StateID(1), 0, 7, []core.SubtreeID{child})
+	if err != nil {
+		t.Fatalf("ErrorRegionResume: %v", err)
 	}
 	plain, err := diagnosticParserCoreLineageErrorCost(compact, head, visibleSymbols(8), src, nil)
 	if err != nil {
@@ -194,6 +216,9 @@ func TestRecoveryLineageErrorCostMemoAgrees(t *testing.T) {
 	}
 	if plain != memoized {
 		t.Fatalf("memoized cost %d disagrees with unmemoized %d", memoized, plain)
+	}
+	if plain == 0 {
+		t.Fatal("fixture priced at zero; it proves nothing about agreement")
 	}
 }
 
@@ -212,14 +237,22 @@ func TestRecoveryLineageErrorCostDeclinesAmbiguousHead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Seed: %v", err)
 	}
-	if _, err := compact.ShiftMissingLeaf(seedA, core.StateID(9), core.Symbol(3), 0); err != nil {
-		t.Fatalf("ShiftMissingLeaf: %v", err)
-	}
-	// Two distinct predecessors attaching at the same (state, byte offset)
-	// boundary leave the resulting head carrying two root-to-head paths.
-	ambiguous, err := compact.ShiftMissingLeaf(seedB, core.StateID(9), core.Symbol(4), 0)
+	childA, err := compact.ErrorRegionLeaf(core.Symbol(5), 0, 3, false)
 	if err != nil {
-		t.Fatalf("ShiftMissingLeaf: %v", err)
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	childB, err := compact.ErrorRegionLeaf(core.Symbol(6), 0, 3, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	if _, err := compact.ErrorRegionResume(seedA, core.StateID(9), 0, 3, []core.SubtreeID{childA}); err != nil {
+		t.Fatalf("ErrorRegionResume: %v", err)
+	}
+	// A second predecessor attaching at the same (state, byte offset) boundary
+	// leaves the resulting head carrying two root-to-head paths.
+	ambiguous, err := compact.ErrorRegionResume(seedB, core.StateID(9), 0, 3, []core.SubtreeID{childB})
+	if err != nil {
+		t.Fatalf("ErrorRegionResume: %v", err)
 	}
 	derivations, err := compact.Derivations(ambiguous)
 	if err != nil {
@@ -230,5 +263,181 @@ func TestRecoveryLineageErrorCostDeclinesAmbiguousHead(t *testing.T) {
 	}
 	if _, err := diagnosticParserCoreLineageErrorCost(compact, ambiguous, visibleSymbols(8), src, nil); !errors.Is(err, diagnosticParserCoreLineageCostUnavailable) {
 		t.Fatalf("ambiguous head priced without refusing: %v", err)
+	}
+}
+
+// The selection ladder is the compact port of ts_parser__select_tree
+// (parser.c:836-878). Each test below pins one rung, in C's own order.
+
+func lineage(cost uint32, score int64) diagnosticParserCoreLineage {
+	return diagnosticParserCoreLineage{Cost: cost, Score: score}
+}
+
+// TestSelectRecoveryLineagePrefersLowerCost pins rung 1, the rung the whole
+// arbitration exists for: a missing insertion costs a flat 610 and an absorbed
+// span costs 500 plus its length, so the cheaper tree is the one C publishes.
+func TestSelectRecoveryLineagePrefersLowerCost(t *testing.T) {
+	// 609 is the measured cost of absorbing the nine bytes of php "namespace"
+	// (500 recovery + 9 chars + 100 for one visible child); 610 is a single
+	// missing insertion. C publishes the ERROR tree, and so must this.
+	winner, err := diagnosticParserCoreSelectRecoveryLineage([]diagnosticParserCoreLineage{
+		lineage(610, 0), lineage(609, 0),
+	})
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if winner != 1 {
+		t.Fatalf("winner=%d, want 1 (the 609 absorb beats the 610 insertion)", winner)
+	}
+	// And the same pair in the opposite order must give the same answer.
+	winner, err = diagnosticParserCoreSelectRecoveryLineage([]diagnosticParserCoreLineage{
+		lineage(609, 0), lineage(610, 0),
+	})
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if winner != 0 {
+		t.Fatalf("winner=%d, want 0; the ladder is order-sensitive on cost", winner)
+	}
+}
+
+// TestSelectRecoveryLineagePrefersHigherPrecedenceOnCostTie pins rung 2.
+func TestSelectRecoveryLineagePrefersHigherPrecedenceOnCostTie(t *testing.T) {
+	winner, err := diagnosticParserCoreSelectRecoveryLineage([]diagnosticParserCoreLineage{
+		lineage(700, 3), lineage(700, 9),
+	})
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if winner != 1 {
+		t.Fatalf("winner=%d, want 1 (higher dynamic precedence on a cost tie)", winner)
+	}
+	winner, err = diagnosticParserCoreSelectRecoveryLineage([]diagnosticParserCoreLineage{
+		lineage(700, 9), lineage(700, 3),
+	})
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if winner != 0 {
+		t.Fatalf("winner=%d, want 0", winner)
+	}
+}
+
+// TestSelectRecoveryLineageTakesTheLaterErroredCandidateOnFullTie pins rung 3,
+// the rung easiest to get backwards. C returns TRUE at parser.c:864 -- when
+// cost and precedence both tie and the incumbent carries error content, the
+// LATER candidate replaces it. Keeping the incumbent instead would look like a
+// harmless stability choice and would silently diverge from C.
+func TestSelectRecoveryLineageTakesTheLaterErroredCandidateOnFullTie(t *testing.T) {
+	winner, err := diagnosticParserCoreSelectRecoveryLineage([]diagnosticParserCoreLineage{
+		lineage(610, 0), lineage(610, 0), lineage(610, 0),
+	})
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if winner != 2 {
+		t.Fatalf("winner=%d, want 2: C takes the later candidate when both sides are errored and tied", winner)
+	}
+}
+
+// TestSelectRecoveryLineageRefusesACleanTie pins rung 4 as OUT OF SCOPE. C
+// falls back to a structural tree comparison, which this port does not model,
+// and it can only be reached when both candidates are clean -- which no
+// recovery lineage is. Declining beats guessing.
+func TestSelectRecoveryLineageRefusesACleanTie(t *testing.T) {
+	_, err := diagnosticParserCoreSelectRecoveryLineage([]diagnosticParserCoreLineage{
+		lineage(0, 0), lineage(0, 0),
+	})
+	if !errors.Is(err, ErrDiagnosticParserCoreLineageTie) {
+		t.Fatalf("clean tie returned %v, want ErrDiagnosticParserCoreLineageTie", err)
+	}
+}
+
+// TestSelectRecoveryLineageSingletonAndEmpty covers the degenerate inputs.
+func TestSelectRecoveryLineageSingletonAndEmpty(t *testing.T) {
+	winner, err := diagnosticParserCoreSelectRecoveryLineage([]diagnosticParserCoreLineage{lineage(610, 0)})
+	if err != nil || winner != 0 {
+		t.Fatalf("singleton select = (%d, %v), want (0, nil)", winner, err)
+	}
+	if _, err := diagnosticParserCoreSelectRecoveryLineage(nil); err == nil {
+		t.Fatal("selecting among no lineages returned no error")
+	}
+}
+
+// TestPriceLineagesRefusesAmbiguousHead proves pricing carries the
+// single-lineage requirement through to the selection entry point, rather than
+// silently pricing one arbitrary path of an ambiguous head.
+func TestPriceLineagesRefusesAmbiguousHead(t *testing.T) {
+	compact, src := newRecoveryCostFixture(t, "abcdef")
+	seedA, err := compact.Seed(core.StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	seedB, err := compact.Seed(core.StateID(2), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	childA, err := compact.ErrorRegionLeaf(core.Symbol(5), 0, 3, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	childB, err := compact.ErrorRegionLeaf(core.Symbol(6), 0, 3, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	if _, err := compact.ErrorRegionResume(seedA, core.StateID(9), 0, 3, []core.SubtreeID{childA}); err != nil {
+		t.Fatalf("ErrorRegionResume: %v", err)
+	}
+	ambiguous, err := compact.ErrorRegionResume(seedB, core.StateID(9), 0, 3, []core.SubtreeID{childB})
+	if err != nil {
+		t.Fatalf("ErrorRegionResume: %v", err)
+	}
+	if _, err := diagnosticParserCorePriceLineages(compact, []core.Head{ambiguous}, visibleSymbols(8), src, nil); !errors.Is(err, diagnosticParserCoreLineageCostUnavailable) {
+		t.Fatalf("pricing an ambiguous head returned %v, want a refusal", err)
+	}
+}
+
+// TestPriceLineagesPricesEachHeadIndependently proves pricing walks each head
+// rather than reusing one answer, and that the prices it produces are the ones
+// the ladder then orders.
+func TestPriceLineagesPricesEachHeadIndependently(t *testing.T) {
+	compact, src := newRecoveryCostFixture(t, "ab\ncd\nef")
+	seed, err := compact.Seed(core.StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	narrowChild, err := compact.ErrorRegionLeaf(core.Symbol(5), 0, 2, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	narrow, err := compact.ErrorRegionResume(seed, core.StateID(3), 0, 2, []core.SubtreeID{narrowChild})
+	if err != nil {
+		t.Fatalf("ErrorRegionResume: %v", err)
+	}
+	wideChild, err := compact.ErrorRegionLeaf(core.Symbol(6), 0, 7, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	wide, err := compact.ErrorRegionResume(seed, core.StateID(4), 0, 7, []core.SubtreeID{wideChild})
+	if err != nil {
+		t.Fatalf("ErrorRegionResume: %v", err)
+	}
+
+	priced, err := diagnosticParserCorePriceLineages(compact, []core.Head{wide, narrow}, visibleSymbols(8), src, nil)
+	if err != nil {
+		t.Fatalf("price: %v", err)
+	}
+	if len(priced) != 2 {
+		t.Fatalf("priced %d lineages, want 2", len(priced))
+	}
+	if priced[0].Cost <= priced[1].Cost {
+		t.Fatalf("the wider absorbed span priced at %d, not above the narrower %d", priced[0].Cost, priced[1].Cost)
+	}
+	winner, err := diagnosticParserCoreSelectRecoveryLineage(priced)
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if winner != 1 {
+		t.Fatalf("winner=%d, want 1: the cheaper, narrower region", winner)
 	}
 }


### PR DESCRIPTION
## Summary

Stage S5 cannot decide between a missing-token insertion and an absorbing ERROR region at the point of failure, because C parses both versions forward and settles the winner later by error cost. Stage S2 shipped its cost model with no caller, waiting for the first stage that needed one. This bridge gives the compact scheduler that caller, so recovery arbitration can price a lineage the way `ts_stack_error_cost` does.

## Changes

- Add `diagnosticParserCoreRecoveryCostSource`, which resolves a `core.SubtreeID` to the stage S2 cost model's view through exported Core surface only (`MaterializationView`, `Derivations`), so the compact core needs no change.
- Compute row spans from the source text on demand: a newline index is built lazily and only when an ERROR node asks, so the source does not widen the subtree record and clean nodes skip the scan.
- Copy a node's children instead of aliasing the borrowed arena slice that `MaterializationView` documents as non-retained, because the cost model holds children across re-entrant calls.
- Add `diagnosticParserCoreLineageErrorCost`, the port of `ts_stack_error_cost`: it sums node error cost over the payload list of a head's single derivation and takes an optional `RecoveryCostMemo`.
- Add `diagnosticParserCorePriceLineages` and the `diagnosticParserCoreLineage` record (head, error cost, summed dynamic precedence score) that feeds the ladder.
- Add `diagnosticParserCoreSelectRecoveryLineage`, a pairwise fold over `ts_parser__select_tree`: lower cost, then higher precedence, then the later candidate when the incumbent carries error content, then a refusal.
- Return `ErrDiagnosticParserCoreLineageTie` for the last clause instead of guessing: C's structural `ts_subtree_compare` needs both sides clean, a shape no recovery lineage has.
- Refuse any head that does not carry exactly one derivation with `diagnosticParserCoreLineageCostUnavailable`, rather than pricing one arbitrary path of an ambiguous head.
- Keep C's `+500` ERROR_STATE term out of pricing; it belongs to `RecoveryVersionStatus.hasOpenRecovery` and stays the caller's input.
- Document that `TestRecoveryCostNoOutsideCallSitesRatchet` parses only `internal/parsercorephase0` files, so its "no caller" claim does not cover this package.
- Add 13 internal tests that pin C's constants and every rung of the ladder, including the 610-vs-609 php missing/absorb arbitration and memo/unmemo agreement.

## Testing

All runs on this branch at `186b495b` (off `main` at `f5eecbe9`), WSL2 host.
No container needed: nothing here is reachable from a parse.

- Focused gate, 14 tests PASS:
  `go test -tags gts_parsercorephase0 -run 'TestRecoveryCostSource|TestRecoveryLineage|TestSelectRecoveryLineage|TestPriceLineages' -count=1 .`
- No-regression proof against pristine `origin/main`: root suite reports 25
  failing test lines excluding the order-dependent
  `TestW5JavaScriptFamilyTransientErrorGate` family; `main` reports the same
  25. No branch-only failure.
- Route outcomes unmoved: the 146-row real-corpus matrix still reports
  `PASS=88 DIVERGE=0 FALLBACK=46 SKIP=12 ERROR=0`.
- Both build configurations clean: `go build ./...` and
  `go vet -tags gts_no_parsercorephase0 .`.

## Why this exists

Missing-token insertion cannot be a correct standalone stage. C does not
choose between inserting and absorbing at the point of failure:
`ts_parser__handle_error` copies the version, pushes the error discontinuity
onto the original anyway, and both parse forward. The winner is settled later
by error cost.

Measured on php `<?php namespace ; ?>`: absorbing the nine bytes of
`namespace` prices at `500 + 9 + 100 = 609`, against a single insertion's flat
`610` (`ERROR_COST_PER_MISSING_TREE + ERROR_COST_PER_RECOVERY`,
subtree.h:331-337). C publishes the ERROR tree, and the locked oracle confirms
it. A route that follows only the missing version publishes the loser.

This lands the arbitration half: price a lineage, and order competing ones.

## What is NOT here

No forking, no scheduler wiring, no capability flag. Nothing calls the
selection ladder; it is reachable only from its own tests. The stage that
forks the header at the failure point and carries both lineages forward comes
next, and it needs this first.

## Review Focus

`diagnosticParserCoreLineageReplaces` ports `ts_parser__select_tree`
(parser.c:836-878). Rung 3 is the one to check: at parser.c:864 C returns TRUE
when cost and precedence both tie and the incumbent carries error content, so
the LATER candidate wins. Keeping the incumbent there would read as a harmless
stability choice and silently diverge.
`TestSelectRecoveryLineageTakesTheLaterErroredCandidateOnFullTie` pins it.

Rung 4 (C's structural `ts_subtree_compare`) is deliberately unimplemented: it
is reachable only when both candidates are clean, which no recovery lineage
is. It returns a named error rather than a guess.
