### PR TITLE
add(parsercore): price competing recovery lineages at acceptance

### DIFF
--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -95,8 +95,21 @@ type DiagnosticParserCorePrefixOptions struct {
 	// name-keyed -- design section 7). Recovery must also be true: this
 	// option alone does not admit the fresh-full runner's recovery guard.
 	allowCompactStrategy2ErrorRegion bool
-	noLookaheadRootSymbol            Symbol
-	hasNoLookaheadRootSymbol         bool
+	// allowCompactRecoveryLineageSelection permits completeAcceptance to
+	// resolve MORE THAN ONE accepted head by pricing the competing recovery
+	// lineages and publishing the cheaper tree, instead of declining.
+	//
+	// This is the acceptance half of C's version competition. C does not pick
+	// between a missing-token insertion and an error-region absorb where they
+	// diverge; it carries both versions to the end and keeps the cheaper tree
+	// (ts_parser__select_tree). A compact route that requires a sole accepted
+	// head cannot express that outcome at all.
+	//
+	// Unset by default and set from nothing today, so the multi-head path
+	// stays unreachable and every parse declines exactly where it did before.
+	allowCompactRecoveryLineageSelection bool
+	noLookaheadRootSymbol                Symbol
+	hasNoLookaheadRootSymbol             bool
 	// stopControlParser, when non-nil, arms the scheduler's stop-control poll
 	// (spec.campaign.v7 tranche B8): once per dispatch-pass-loop iteration,
 	// diagnosticParserCoreGenericScheduler.run checks this Parser's deadline
@@ -1145,6 +1158,27 @@ type diagnosticParserCoreHeader struct {
 	// witness (section 5).
 	blended              bool
 	lastPersistedBlended bool
+	// recoveryCompetition packs the two facts acceptance-time lineage
+	// selection needs, in ONE byte, placed before s3Region so it lands in the
+	// single padding byte the header already had (offset 215). Two separate
+	// fields would push the pointer past its alignment and grow every header
+	// from 224 to 232 bytes, which two size ratchets pin deliberately.
+	//
+	// Bit 7 marks the header as a recovery lineage: a head some native
+	// recovery mechanism created or advanced, and therefore one that may
+	// compete at acceptance. A frontier that merely forked on ordinary grammar
+	// ambiguity must NOT be marked; error cost answers "which recovery is
+	// cheaper", which is not the question that frontier asks.
+	//
+	// Bits 0..6 count open-recovery segments, the compact analogue of
+	// cStackOpenRecoveryCost's inputs (parser_recover_c.go:2475-2489): one for
+	// a paused head or an opened-but-empty error region, plus one per extra
+	// error_repeat segment. Pricing charges RecoveryCostPerRecovery each.
+	// Omitting them under-prices a paused lineage by 500 on an arbitration
+	// decided by single digits.
+	//
+	// Read and write it through the accessors below, never directly.
+	recoveryCompetition uint8
 	// s3Region marks a header carrying an open native strategy-2 recovery
 	// region (campaign v7 tranche B3 stage S3: error-region absorb and
 	// condense-resume). nil for every header outside recovery, mirroring
@@ -1156,6 +1190,41 @@ type diagnosticParserCoreHeader struct {
 	// (a plain by-value struct copy) restores a correct, independent region
 	// state on rollback without aliasing the live one.
 	s3Region *diagnosticParserCoreS3Region
+}
+
+const (
+	// diagnosticParserCoreRecoveryLineageBit marks a header as a recovery
+	// lineage; the remaining bits hold the open-recovery segment count.
+	diagnosticParserCoreRecoveryLineageBit uint8 = 1 << 7
+	// diagnosticParserCoreMaxRecoveryOpenSegments is what the seven remaining
+	// bits hold. C's own recovery bounds sit far below it, so a count that
+	// reaches this ceiling is a defect, not a deep parse.
+	diagnosticParserCoreMaxRecoveryOpenSegments = int(^diagnosticParserCoreRecoveryLineageBit)
+)
+
+// isRecoveryLineage reports whether this header may compete at acceptance.
+func (h *diagnosticParserCoreHeader) isRecoveryLineage() bool {
+	return h.recoveryCompetition&diagnosticParserCoreRecoveryLineageBit != 0
+}
+
+// recoveryOpenSegments returns the open-recovery segment count pricing charges
+// for. It is meaningful only on a header marked as a recovery lineage.
+func (h *diagnosticParserCoreHeader) recoveryOpenSegments() int {
+	return int(h.recoveryCompetition &^ diagnosticParserCoreRecoveryLineageBit)
+}
+
+// markRecoveryLineage marks this header as a competing recovery lineage
+// carrying segments open-recovery segments. It fails closed rather than
+// truncating: a count that does not fit means the caller's own bookkeeping is
+// wrong, and silently storing a smaller number would under-price the lineage
+// by 500 per lost segment.
+func (h *diagnosticParserCoreHeader) markRecoveryLineage(segments int) error {
+	if segments < 0 || segments > diagnosticParserCoreMaxRecoveryOpenSegments {
+		return fmt.Errorf("parser-core phase zero: open-recovery segment count %d is outside 0..%d",
+			segments, diagnosticParserCoreMaxRecoveryOpenSegments)
+	}
+	h.recoveryCompetition = diagnosticParserCoreRecoveryLineageBit | uint8(segments)
+	return nil
 }
 
 // diagnosticParserCoreS3Region is the open ERROR container a native S3
@@ -7102,6 +7171,74 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericAcceptOwned(owner cor
 	return nil
 }
 
+// selectCompetingRecoveryLineage resolves an accepting frontier that carries
+// more than one head, by pricing every competitor and returning the index C
+// would publish.
+//
+// resolved is false whenever this route must decline instead, and every one of
+// those conditions is a deliberate fail-closed gate rather than an oversight:
+//
+//   - the capability is not armed;
+//   - any competitor is NOT a recovery lineage, so the frontier is ordinary
+//     grammar ambiguity and error cost is the wrong question to ask of it;
+//   - the language or source needed to price a lineage is unavailable;
+//   - pricing refuses a head (an ambiguous head, or one past the derivation
+//     enumeration cap);
+//   - the selection ladder cannot order the winner against some competitor,
+//     which is C's structural comparison and out of this port's scope.
+//
+// A returned error means something is wrong with the compact state itself; a
+// false resolved means the shape is simply not ours to decide.
+func (s *diagnosticParserCoreGenericScheduler) selectCompetingRecoveryLineage() (int, bool, error) {
+	if s == nil || !s.options.allowCompactRecoveryLineageSelection {
+		return 0, false, nil
+	}
+	if len(s.headers) < 2 {
+		return 0, false, nil
+	}
+	for index := range s.headers {
+		if !s.headers[index].isRecoveryLineage() {
+			return 0, false, nil
+		}
+	}
+	if s.tokenSource == nil || s.tokenSource.language == nil {
+		return 0, false, nil
+	}
+	source := s.options.materializationSource
+	if source == nil {
+		return 0, false, nil
+	}
+	costSource, err := newDiagnosticParserCoreRecoveryCostSource(s.compact, source)
+	if err != nil {
+		return 0, false, err
+	}
+	inputs := make([]diagnosticParserCoreLineageInput, 0, len(s.headers))
+	for index := range s.headers {
+		inputs = append(inputs, diagnosticParserCoreLineageInput{
+			Head:                 s.headers[index].head,
+			OpenRecoverySegments: s.headers[index].recoveryOpenSegments(),
+		})
+	}
+	var memo core.RecoveryCostMemo
+	priced, err := diagnosticParserCorePriceLineages(
+		inputs, diagnosticParserCoreRecoverySymbolPolicy(s.tokenSource.language), costSource, &memo,
+	)
+	if err != nil {
+		if errors.Is(err, diagnosticParserCoreLineageCostUnavailable) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	winner, err := diagnosticParserCoreSelectRecoveryLineage(priced)
+	if err != nil {
+		if errors.Is(err, errDiagnosticParserCoreLineageTie) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	return winner, true, nil
+}
+
 func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() (err error) {
 	metadataAdmission := s != nil && s.eofRecoveryAdmission.active &&
 		s.eofRecoveryAdmission.valid &&
@@ -7118,7 +7255,20 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() (err error) 
 		return s.finish(DiagnosticParserCoreAccept, "generic scheduler accept is not authenticated EOF", 0)
 	}
 	if len(s.headers) != 1 {
-		return s.finish(DiagnosticParserCoreAccept, "generic scheduler requires one accepted compact head", 0)
+		// More than one head accepted. C would already have folded these into
+		// one winner by error cost; the compact route can only do that when
+		// every competitor is a recovery lineage it knows how to price.
+		winner, resolved, selectErr := s.selectCompetingRecoveryLineage()
+		if selectErr != nil {
+			return selectErr
+		}
+		if !resolved {
+			return s.finish(DiagnosticParserCoreAccept, "generic scheduler requires one accepted compact head", 0)
+		}
+		// Keep only the winner. C drops the losing versions at the same point
+		// (ts_parser__select_tree keeps one finished_tree), and every step
+		// below reads headers[0].
+		s.headers = append(s.headers[:0], s.headers[winner])
 	}
 	if metadataAdmission {
 		if err := s.validateCompactEOFRecoveryAdmission(

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -343,6 +343,13 @@ type DiagnosticParserCoreHeaderPathReceipt struct {
 // from the compact core's physical arena storage.
 type DiagnosticParserCoreGenericWork struct {
 	Passes uint64
+	// RecoveryLineageSelections counts accepting frontiers resolved by pricing
+	// competing recovery lineages instead of declining. Every other
+	// head-removal site in this scheduler accounts for itself; without this
+	// counter a parse that arbitrated three competitors is indistinguishable
+	// in the receipt from one that never competed, and no differential harness
+	// could confirm the port picks what C picks.
+	RecoveryLineageSelections uint64
 	// SingleHeaderPasses counts dispatch passes executed against a
 	// single-header frontier (spec.c4-bytecode-isa.v1 section 5, obligation
 	// R6). It is count-only and published on the gts_workcount board so
@@ -1158,27 +1165,22 @@ type diagnosticParserCoreHeader struct {
 	// witness (section 5).
 	blended              bool
 	lastPersistedBlended bool
-	// recoveryCompetition packs the two facts acceptance-time lineage
-	// selection needs, in ONE byte, placed before s3Region so it lands in the
-	// single padding byte the header already had (offset 215). Two separate
-	// fields would push the pointer past its alignment and grow every header
-	// from 224 to 232 bytes, which two size ratchets pin deliberately.
+	// recoveryCompetitor marks a header that a native recovery mechanism
+	// created or advanced, and so may compete at acceptance. It sits before
+	// s3Region so it lands in the one padding byte the header already had
+	// (offset 215); placed after the pointer it would grow every header from
+	// 224 to 232 bytes, which two size ratchets pin.
 	//
-	// Bit 7 marks the header as a recovery lineage: a head some native
-	// recovery mechanism created or advanced, and therefore one that may
-	// compete at acceptance. A frontier that merely forked on ordinary grammar
-	// ambiguity must NOT be marked; error cost answers "which recovery is
-	// cheaper", which is not the question that frontier asks.
+	// A frontier that merely forked on ordinary grammar ambiguity must NOT be
+	// marked. Error cost answers "which recovery is cheaper", which is not the
+	// question that frontier asks.
 	//
-	// Bits 0..6 count open-recovery segments, the compact analogue of
-	// cStackOpenRecoveryCost's inputs (parser_recover_c.go:2475-2489): one for
-	// a paused head or an opened-but-empty error region, plus one per extra
-	// error_repeat segment. Pricing charges RecoveryCostPerRecovery each.
-	// Omitting them under-prices a paused lineage by 500 on an arbitration
-	// decided by single digits.
-	//
-	// Read and write it through the accessors below, never directly.
-	recoveryCompetition uint8
+	// The open-recovery segment count is deliberately NOT stored beside this.
+	// It is derived from live header state at pricing time -- see
+	// recoveryOpenSegments -- because paused and s3Region are mutated by the
+	// ordinary reduce and pause paths, and a stored copy would go stale
+	// without them noticing.
+	recoveryCompetitor bool
 	// s3Region marks a header carrying an open native strategy-2 recovery
 	// region (campaign v7 tranche B3 stage S3: error-region absorb and
 	// condense-resume). nil for every header outside recovery, mirroring
@@ -1192,39 +1194,43 @@ type diagnosticParserCoreHeader struct {
 	s3Region *diagnosticParserCoreS3Region
 }
 
-const (
-	// diagnosticParserCoreRecoveryLineageBit marks a header as a recovery
-	// lineage; the remaining bits hold the open-recovery segment count.
-	diagnosticParserCoreRecoveryLineageBit uint8 = 1 << 7
-	// diagnosticParserCoreMaxRecoveryOpenSegments is what the seven remaining
-	// bits hold. C's own recovery bounds sit far below it, so a count that
-	// reaches this ceiling is a defect, not a deep parse.
-	diagnosticParserCoreMaxRecoveryOpenSegments = int(^diagnosticParserCoreRecoveryLineageBit)
-)
-
 // isRecoveryLineage reports whether this header may compete at acceptance.
-func (h *diagnosticParserCoreHeader) isRecoveryLineage() bool {
-	return h.recoveryCompetition&diagnosticParserCoreRecoveryLineageBit != 0
-}
+func (h *diagnosticParserCoreHeader) isRecoveryLineage() bool { return h.recoveryCompetitor }
+
+// markRecoveryLineage marks this header as a competing recovery lineage.
+func (h *diagnosticParserCoreHeader) markRecoveryLineage() { h.recoveryCompetitor = true }
+
+// clearRecoveryLineage demotes this header out of the competition.
+//
+// Every header-rewrite path copies the whole struct, so a fork of a marked
+// head produces marked children. A fork on ORDINARY grammar ambiguity must
+// call this on its replacements, or acceptance would decide that frontier by
+// error cost -- a different decision procedure than the one C applies to it.
+func (h *diagnosticParserCoreHeader) clearRecoveryLineage() { h.recoveryCompetitor = false }
 
 // recoveryOpenSegments returns the open-recovery segment count pricing charges
-// for. It is meaningful only on a header marked as a recovery lineage.
+// RecoveryCostPerRecovery for, DERIVED from live header state rather than
+// stored.
+//
+// It ports cStackOpenRecoveryCost's predicate (parser_recover_c.go:2475-2489),
+// `s.cPaused || (s.cRec != nil && s.cRec.openErr == nil)`: a paused head, or
+// an error region opened but still empty, carries one segment that no
+// published subtree accounts for.
+//
+// Deriving rather than storing is the point. paused is written by the
+// ordinary reduce and pause paths (they set it false on a fresh reduction and
+// true on a reduction pause) and s3Region is replaced wholesale by the region
+// advance, none of which would update a stored count. A stale count
+// mis-prices the lineage by 500, which is ten times the margin this
+// arbitration turns on.
+//
+// C's extraRecoveries term has no compact analogue yet: stage S3 does not
+// track unlexable-run re-pauses. When it does, add it here.
 func (h *diagnosticParserCoreHeader) recoveryOpenSegments() int {
-	return int(h.recoveryCompetition &^ diagnosticParserCoreRecoveryLineageBit)
-}
-
-// markRecoveryLineage marks this header as a competing recovery lineage
-// carrying segments open-recovery segments. It fails closed rather than
-// truncating: a count that does not fit means the caller's own bookkeeping is
-// wrong, and silently storing a smaller number would under-price the lineage
-// by 500 per lost segment.
-func (h *diagnosticParserCoreHeader) markRecoveryLineage(segments int) error {
-	if segments < 0 || segments > diagnosticParserCoreMaxRecoveryOpenSegments {
-		return fmt.Errorf("parser-core phase zero: open-recovery segment count %d is outside 0..%d",
-			segments, diagnosticParserCoreMaxRecoveryOpenSegments)
+	if h.paused || (h.s3Region != nil && len(h.s3Region.children) == 0) {
+		return 1
 	}
-	h.recoveryCompetition = diagnosticParserCoreRecoveryLineageBit | uint8(segments)
-	return nil
+	return 0
 }
 
 // diagnosticParserCoreS3Region is the open ERROR container a native S3
@@ -7171,6 +7177,25 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericAcceptOwned(owner cor
 	return nil
 }
 
+// collapseToRecoveryWinner keeps only the priced winner, the way C keeps one
+// finished_tree and drops the losing versions.
+//
+// It clears the whole frontier before re-seating the winner, matching
+// dropGenericNoActionHeads: a plain reslice leaves every loser byte-for-byte
+// intact past len, and each one retains its open error region and its drop-
+// cohort spill for the scheduler's lifetime, invisible to accounting that
+// measures capacity rather than content.
+func (s *diagnosticParserCoreGenericScheduler) collapseToRecoveryWinner(winner int) {
+	if winner < 0 || winner >= len(s.headers) {
+		return
+	}
+	s.work.RecoveryLineageSelections++
+	winnerHeader := s.headers[winner]
+	clear(s.headers)
+	s.headers = s.headers[:1]
+	s.headers[0] = winnerHeader
+}
+
 // selectCompetingRecoveryLineage resolves an accepting frontier that carries
 // more than one head, by pricing every competitor and returning the index C
 // would publish.
@@ -7204,13 +7229,20 @@ func (s *diagnosticParserCoreGenericScheduler) selectCompetingRecoveryLineage() 
 	if s.tokenSource == nil || s.tokenSource.language == nil {
 		return 0, false, nil
 	}
+	// Non-EMPTY, not merely non-nil. rowAt answers from this text, so a zero
+	// or short source silently drops RecoveryCostPerSkippedLine (30 per line)
+	// from every ERROR region. A twenty-line region would lose 600, more than
+	// an entire missing insertion costs, and the arbitration inverts.
 	source := s.options.materializationSource
-	if source == nil {
+	if len(source) == 0 {
 		return 0, false, nil
 	}
 	costSource, err := newDiagnosticParserCoreRecoveryCostSource(s.compact, source)
 	if err != nil {
-		return 0, false, err
+		// A source past uint32 is a shape this route cannot price, not a
+		// broken parse. The sole-head path turns the same condition into a
+		// counted decline, so match it rather than aborting the whole route.
+		return 0, false, nil
 	}
 	inputs := make([]diagnosticParserCoreLineageInput, 0, len(s.headers))
 	for index := range s.headers {
@@ -7224,17 +7256,16 @@ func (s *diagnosticParserCoreGenericScheduler) selectCompetingRecoveryLineage() 
 		inputs, diagnosticParserCoreRecoverySymbolPolicy(s.tokenSource.language), costSource, &memo,
 	)
 	if err != nil {
-		if errors.Is(err, diagnosticParserCoreLineageCostUnavailable) {
-			return 0, false, nil
-		}
-		return 0, false, err
+		// Every pricing failure is a decline here, matching how the sole-head
+		// path classifies the identical conditions (compactDerivationsForAcceptance
+		// wraps the enumeration cap into a decline one step later). Returning a
+		// raw error instead would abort the compact route uncounted, and would
+		// classify the same condition two different ways in the census.
+		return 0, false, nil
 	}
 	winner, err := diagnosticParserCoreSelectRecoveryLineage(priced)
 	if err != nil {
-		if errors.Is(err, errDiagnosticParserCoreLineageTie) {
-			return 0, false, nil
-		}
-		return 0, false, err
+		return 0, false, nil
 	}
 	return winner, true, nil
 }
@@ -7254,21 +7285,22 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() (err error) 
 	if s.token.Symbol != 0 || s.token.StartByte != s.token.EndByte || s.token.Missing || s.token.NoLookahead || s.token.ExternalScannerToken {
 		return s.finish(DiagnosticParserCoreAccept, "generic scheduler accept is not authenticated EOF", 0)
 	}
+	// Resolve the winner BEFORE collapsing anything, and collapse only after
+	// the EOF-recovery-admission validation below has seen the real frontier.
+	// That validation treats len(s.headers) == 1 as proof the sanctioned
+	// recovery drop already happened, so truncating first would manufacture
+	// the very shape it checks for.
+	competitionWinner := 0
+	competitionResolved := false
 	if len(s.headers) != 1 {
-		// More than one head accepted. C would already have folded these into
-		// one winner by error cost; the compact route can only do that when
-		// every competitor is a recovery lineage it knows how to price.
-		winner, resolved, selectErr := s.selectCompetingRecoveryLineage()
+		var selectErr error
+		competitionWinner, competitionResolved, selectErr = s.selectCompetingRecoveryLineage()
 		if selectErr != nil {
 			return selectErr
 		}
-		if !resolved {
+		if !competitionResolved {
 			return s.finish(DiagnosticParserCoreAccept, "generic scheduler requires one accepted compact head", 0)
 		}
-		// Keep only the winner. C drops the losing versions at the same point
-		// (ts_parser__select_tree keeps one finished_tree), and every step
-		// below reads headers[0].
-		s.headers = append(s.headers[:0], s.headers[winner])
 	}
 	if metadataAdmission {
 		if err := s.validateCompactEOFRecoveryAdmission(
@@ -7277,6 +7309,9 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() (err error) 
 		); err != nil {
 			return err
 		}
+	}
+	if competitionResolved {
+		s.collapseToRecoveryWinner(competitionWinner)
 	}
 	paths, err := compactDerivationsForAcceptance(s.compact, s.headers[0].head)
 	if err != nil {

--- a/parsercore_phase0_recovery_cost_source.go
+++ b/parsercore_phase0_recovery_cost_source.go
@@ -376,18 +376,33 @@ func diagnosticParserCoreLineageReplaces(incumbent, candidate diagnosticParserCo
 // diagnosticParserCoreRecoverySymbolPolicy projects the visibility signal the
 // cost model reads out of a Language's own symbol metadata.
 //
-// RecoverySymbolVisible consumes SelectedStorePolicy.Symbols, and that slice
-// is built from exactly this field (see buildParserCoreSelectedStorePolicy).
-// Projecting it directly keeps lineage pricing from depending on the whole
-// selected-store policy, which an accepting scheduler has no other reason to
-// construct.
+// It reproduces buildParserCoreSelectedStorePolicy's width and default rule
+// EXACTLY, and both halves are load-bearing:
+//
+//   - Width is max(len(SymbolMetadata), len(SymbolNames), SymbolCount), not
+//     len(SymbolMetadata). SymbolMetadata can be shorter than the symbol space
+//     -- the embedded loader pads it up to len(SymbolNames) precisely because
+//     some blobs arrive short.
+//   - Symbols past the metadata end default to VISIBLE. RecoverySymbolVisible
+//     answers false for an out-of-range index, so a short slice would price
+//     every such child invisible.
+//
+// Getting either wrong drops RecoveryCostPerSkippedTree (100) per absorbed
+// visible child. The measured php arbitration turns on a single point, so an
+// under-counted child inverts it and the route publishes a tree C would not.
 func diagnosticParserCoreRecoverySymbolPolicy(lang *Language) []core.SelectedSymbolPolicy {
 	if lang == nil {
 		return nil
 	}
-	out := make([]core.SelectedSymbolPolicy, len(lang.SymbolMetadata))
-	for index, meta := range lang.SymbolMetadata {
-		out[index] = core.SelectedSymbolPolicy{Visible: meta.Visible, Named: meta.Named}
+	width := max(len(lang.SymbolMetadata), len(lang.SymbolNames), int(lang.SymbolCount))
+	out := make([]core.SelectedSymbolPolicy, width)
+	for index := range out {
+		visible, named := true, false
+		if index < len(lang.SymbolMetadata) {
+			visible = lang.SymbolMetadata[index].Visible
+			named = lang.SymbolMetadata[index].Named
+		}
+		out[index] = core.SelectedSymbolPolicy{Visible: visible, Named: named}
 	}
 	return out
 }

--- a/parsercore_phase0_recovery_cost_source.go
+++ b/parsercore_phase0_recovery_cost_source.go
@@ -372,3 +372,22 @@ func diagnosticParserCoreLineageReplaces(incumbent, candidate diagnosticParserCo
 	// Both sides are clean and tied. C would compare the trees structurally.
 	return false, false
 }
+
+// diagnosticParserCoreRecoverySymbolPolicy projects the visibility signal the
+// cost model reads out of a Language's own symbol metadata.
+//
+// RecoverySymbolVisible consumes SelectedStorePolicy.Symbols, and that slice
+// is built from exactly this field (see buildParserCoreSelectedStorePolicy).
+// Projecting it directly keeps lineage pricing from depending on the whole
+// selected-store policy, which an accepting scheduler has no other reason to
+// construct.
+func diagnosticParserCoreRecoverySymbolPolicy(lang *Language) []core.SelectedSymbolPolicy {
+	if lang == nil {
+		return nil
+	}
+	out := make([]core.SelectedSymbolPolicy, len(lang.SymbolMetadata))
+	for index, meta := range lang.SymbolMetadata {
+		out[index] = core.SelectedSymbolPolicy{Visible: meta.Visible, Named: meta.Named}
+	}
+	return out
+}

--- a/parsercore_phase0_recovery_lineage_selection_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_selection_internal_test.go
@@ -1,0 +1,202 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// selectCompetingRecoveryLineage is the acceptance half of C's version
+// competition: when more than one head accepts, price the competitors and
+// publish the cheaper tree instead of declining. These tests drive it through
+// a hand-built scheduler, because no live path forks a recovery lineage yet.
+
+type lineageSelectionTable struct{}
+
+func (lineageSelectionTable) Actions(core.StateID, core.Symbol) (core.ActionRow, error) {
+	return core.ActionRow{}, nil
+}
+func (lineageSelectionTable) Goto(core.StateID, core.Symbol) (core.StateID, error) { return 0, nil }
+func (lineageSelectionTable) ProductionFields(uint16, int) ([]core.FieldMapEntry, error) {
+	return nil, nil
+}
+func (lineageSelectionTable) ProductionAliases(uint16, int) ([]core.Symbol, error) { return nil, nil }
+
+// newLineageSelectionScheduler builds a scheduler carrying two competing
+// accepted heads: one that inserted a MISSING leaf, one that absorbed a span
+// into an ERROR region. The spans reproduce the measured php witness, where
+// absorbing nine bytes with one visible child costs 609 against the
+// insertion's flat 610.
+func newLineageSelectionScheduler(t *testing.T, armed bool) *diagnosticParserCoreGenericScheduler {
+	t.Helper()
+	compact, err := core.New(lineageSelectionTable{}, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(core.StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	missingHead, err := compact.ShiftMissingLeaf(seed, core.StateID(2), core.Symbol(3), 16)
+	if err != nil {
+		t.Fatalf("ShiftMissingLeaf: %v", err)
+	}
+	absorbed, err := compact.ErrorRegionLeaf(core.Symbol(4), 6, 15, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	absorbHead, err := compact.ErrorRegionResume(seed, core.StateID(3), 6, 15, []core.SubtreeID{absorbed})
+	if err != nil {
+		t.Fatalf("ErrorRegionResume: %v", err)
+	}
+
+	lang := &Language{SymbolMetadata: make([]SymbolMetadata, 16)}
+	for i := range lang.SymbolMetadata {
+		lang.SymbolMetadata[i] = SymbolMetadata{Visible: true, Named: true}
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{compact: compact}
+	scheduler.tokenSource = &dfaTokenSource{language: lang}
+	scheduler.options.materializationSource = []byte("<?php namespace ; ?>")
+	scheduler.options.allowCompactRecoveryLineageSelection = armed
+	scheduler.headers = make([]diagnosticParserCoreHeader, 2)
+	scheduler.headers[0].head = missingHead
+	scheduler.headers[1].head = absorbHead
+	for index := range scheduler.headers {
+		if err := scheduler.headers[index].markRecoveryLineage(0); err != nil {
+			t.Fatalf("markRecoveryLineage: %v", err)
+		}
+	}
+	return scheduler
+}
+
+// TestSelectCompetingRecoveryLineagePublishesTheCheaperTree is the claim: on
+// the php witness C keeps the ERROR tree, and so must this.
+func TestSelectCompetingRecoveryLineagePublishesTheCheaperTree(t *testing.T) {
+	scheduler := newLineageSelectionScheduler(t, true)
+	winner, resolved, err := scheduler.selectCompetingRecoveryLineage()
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if !resolved {
+		t.Fatal("two priceable recovery lineages were not resolved")
+	}
+	if winner != 1 {
+		t.Fatalf("winner=%d, want 1: the 609 absorb beats the 610 insertion", winner)
+	}
+}
+
+// TestSelectCompetingRecoveryLineageDeclinesUnarmed proves the capability
+// actually gates the path, which is what keeps this unreachable today.
+func TestSelectCompetingRecoveryLineageDeclinesUnarmed(t *testing.T) {
+	scheduler := newLineageSelectionScheduler(t, false)
+	_, resolved, err := scheduler.selectCompetingRecoveryLineage()
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if resolved {
+		t.Fatal("an unarmed scheduler resolved a competing frontier")
+	}
+}
+
+// TestSelectCompetingRecoveryLineageDeclinesNonRecoveryHead proves the route
+// refuses ordinary grammar ambiguity. Error cost answers "which recovery is
+// cheaper", which is not the question a plain ambiguous frontier is asking, so
+// pricing one would silently substitute a different decision procedure.
+func TestSelectCompetingRecoveryLineageDeclinesNonRecoveryHead(t *testing.T) {
+	scheduler := newLineageSelectionScheduler(t, true)
+	scheduler.headers[1].recoveryCompetition = 0
+	_, resolved, err := scheduler.selectCompetingRecoveryLineage()
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if resolved {
+		t.Fatal("a frontier containing a non-recovery head was resolved by error cost")
+	}
+}
+
+// TestSelectCompetingRecoveryLineageChargesOpenSegments proves the header's
+// open-recovery count reaches pricing. Charging the missing lineage nothing
+// and the absorbing lineage one paused segment inverts the winner, because the
+// margin between them is a single point.
+func TestSelectCompetingRecoveryLineageChargesOpenSegments(t *testing.T) {
+	scheduler := newLineageSelectionScheduler(t, true)
+	if err := scheduler.headers[1].markRecoveryLineage(1); err != nil {
+		t.Fatalf("markRecoveryLineage: %v", err)
+	}
+
+	winner, resolved, err := scheduler.selectCompetingRecoveryLineage()
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if !resolved {
+		t.Fatal("frontier was not resolved")
+	}
+	if winner != 0 {
+		t.Fatalf("winner=%d, want 0: charging the absorb one paused segment (+500) puts it above the insertion", winner)
+	}
+}
+
+// TestSelectCompetingRecoveryLineageDeclinesWithoutSource proves pricing
+// refuses to run without the source text. Rows are read from it, and a missing
+// source would silently price every ERROR region at zero rows.
+func TestSelectCompetingRecoveryLineageDeclinesWithoutSource(t *testing.T) {
+	scheduler := newLineageSelectionScheduler(t, true)
+	scheduler.options.materializationSource = nil
+	_, resolved, err := scheduler.selectCompetingRecoveryLineage()
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if resolved {
+		t.Fatal("pricing ran without a source text")
+	}
+}
+
+// TestSelectCompetingRecoveryLineageDeclinesSingleHead proves the helper only
+// speaks to genuinely competing frontiers; a sole head takes the ordinary
+// path.
+func TestSelectCompetingRecoveryLineageDeclinesSingleHead(t *testing.T) {
+	scheduler := newLineageSelectionScheduler(t, true)
+	scheduler.headers = scheduler.headers[:1]
+	_, resolved, err := scheduler.selectCompetingRecoveryLineage()
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if resolved {
+		t.Fatal("a single-head frontier was routed through competition")
+	}
+}
+
+// TestRecoveryLineageMarkerPacksIntoOneByte pins the encoding, because it is
+// the reason the header did not grow. Two plain fields would push s3Region
+// past its alignment and take the header from 224 to 232 bytes, which two
+// separate size ratchets pin.
+func TestRecoveryLineageMarkerPacksIntoOneByte(t *testing.T) {
+	var header diagnosticParserCoreHeader
+	if header.isRecoveryLineage() {
+		t.Fatal("a zero header reported itself as a recovery lineage")
+	}
+	if got := header.recoveryOpenSegments(); got != 0 {
+		t.Fatalf("zero header reported %d open segments", got)
+	}
+	for _, segments := range []int{0, 1, 7, diagnosticParserCoreMaxRecoveryOpenSegments} {
+		if err := header.markRecoveryLineage(segments); err != nil {
+			t.Fatalf("markRecoveryLineage(%d): %v", segments, err)
+		}
+		if !header.isRecoveryLineage() {
+			t.Fatalf("marking with %d segments lost the lineage bit", segments)
+		}
+		if got := header.recoveryOpenSegments(); got != segments {
+			t.Fatalf("stored %d segments, read back %d", segments, got)
+		}
+	}
+	// Fail closed rather than truncate: a silently smaller count under-prices
+	// the lineage by 500 per lost segment.
+	if err := header.markRecoveryLineage(diagnosticParserCoreMaxRecoveryOpenSegments + 1); err == nil {
+		t.Fatal("an out-of-range segment count was accepted")
+	}
+	if err := header.markRecoveryLineage(-1); err == nil {
+		t.Fatal("a negative segment count was accepted")
+	}
+}

--- a/parsercore_phase0_recovery_lineage_selection_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_selection_internal_test.go
@@ -4,6 +4,7 @@ package gotreesitter
 
 import (
 	"testing"
+	"unsafe"
 
 	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
 )
@@ -64,9 +65,7 @@ func newLineageSelectionScheduler(t *testing.T, armed bool) *diagnosticParserCor
 	scheduler.headers[0].head = missingHead
 	scheduler.headers[1].head = absorbHead
 	for index := range scheduler.headers {
-		if err := scheduler.headers[index].markRecoveryLineage(0); err != nil {
-			t.Fatalf("markRecoveryLineage: %v", err)
-		}
+		scheduler.headers[index].markRecoveryLineage()
 	}
 	return scheduler
 }
@@ -106,7 +105,7 @@ func TestSelectCompetingRecoveryLineageDeclinesUnarmed(t *testing.T) {
 // pricing one would silently substitute a different decision procedure.
 func TestSelectCompetingRecoveryLineageDeclinesNonRecoveryHead(t *testing.T) {
 	scheduler := newLineageSelectionScheduler(t, true)
-	scheduler.headers[1].recoveryCompetition = 0
+	scheduler.headers[1].clearRecoveryLineage()
 	_, resolved, err := scheduler.selectCompetingRecoveryLineage()
 	if err != nil {
 		t.Fatalf("select: %v", err)
@@ -122,9 +121,9 @@ func TestSelectCompetingRecoveryLineageDeclinesNonRecoveryHead(t *testing.T) {
 // margin between them is a single point.
 func TestSelectCompetingRecoveryLineageChargesOpenSegments(t *testing.T) {
 	scheduler := newLineageSelectionScheduler(t, true)
-	if err := scheduler.headers[1].markRecoveryLineage(1); err != nil {
-		t.Fatalf("markRecoveryLineage: %v", err)
-	}
+	// A paused head carries one open-recovery segment, derived rather than
+	// stored, so pricing charges it RecoveryCostPerRecovery.
+	scheduler.headers[1].paused = true
 
 	winner, resolved, err := scheduler.selectCompetingRecoveryLineage()
 	if err != nil {
@@ -168,35 +167,86 @@ func TestSelectCompetingRecoveryLineageDeclinesSingleHead(t *testing.T) {
 	}
 }
 
-// TestRecoveryLineageMarkerPacksIntoOneByte pins the encoding, because it is
-// the reason the header did not grow. Two plain fields would push s3Region
-// past its alignment and take the header from 224 to 232 bytes, which two
-// separate size ratchets pin.
-func TestRecoveryLineageMarkerPacksIntoOneByte(t *testing.T) {
+// TestRecoveryLineageMarkerDoesNotGrowTheHeader pins the reason the marker is
+// a single field placed before s3Region. Two fields, or one placed after the
+// pointer, take the header from 224 to 232 bytes -- measured -- and two
+// separate size ratchets pin 224. Asserting it here means a reader who splits
+// the field finds out from this test rather than from an unrelated ratchet.
+func TestRecoveryLineageMarkerDoesNotGrowTheHeader(t *testing.T) {
+	if got := unsafe.Sizeof(diagnosticParserCoreHeader{}); got != 224 {
+		t.Fatalf("scheduler header is %d bytes, want 224", got)
+	}
 	var header diagnosticParserCoreHeader
 	if header.isRecoveryLineage() {
 		t.Fatal("a zero header reported itself as a recovery lineage")
 	}
+	header.markRecoveryLineage()
+	if !header.isRecoveryLineage() {
+		t.Fatal("marking did not take")
+	}
+	header.clearRecoveryLineage()
+	if header.isRecoveryLineage() {
+		t.Fatal("clearing did not demote the header")
+	}
+}
+
+// TestRecoveryOpenSegmentsDerivesFromLiveState proves the open-recovery term
+// tracks the header fields the ordinary reduce and pause paths mutate, rather
+// than a stored copy those paths would leave stale. A stale count mis-prices a
+// lineage by 500, ten times the margin this arbitration turns on.
+func TestRecoveryOpenSegmentsDerivesFromLiveState(t *testing.T) {
+	var header diagnosticParserCoreHeader
 	if got := header.recoveryOpenSegments(); got != 0 {
-		t.Fatalf("zero header reported %d open segments", got)
+		t.Fatalf("a clean header reported %d open segments", got)
 	}
-	for _, segments := range []int{0, 1, 7, diagnosticParserCoreMaxRecoveryOpenSegments} {
-		if err := header.markRecoveryLineage(segments); err != nil {
-			t.Fatalf("markRecoveryLineage(%d): %v", segments, err)
-		}
-		if !header.isRecoveryLineage() {
-			t.Fatalf("marking with %d segments lost the lineage bit", segments)
-		}
-		if got := header.recoveryOpenSegments(); got != segments {
-			t.Fatalf("stored %d segments, read back %d", segments, got)
-		}
+
+	// C: `s.cPaused || (s.cRec != nil && s.cRec.openErr == nil)`.
+	header.paused = true
+	if got := header.recoveryOpenSegments(); got != 1 {
+		t.Fatalf("a paused header reported %d open segments, want 1", got)
 	}
-	// Fail closed rather than truncate: a silently smaller count under-prices
-	// the lineage by 500 per lost segment.
-	if err := header.markRecoveryLineage(diagnosticParserCoreMaxRecoveryOpenSegments + 1); err == nil {
-		t.Fatal("an out-of-range segment count was accepted")
+	header.paused = false
+
+	header.s3Region = &diagnosticParserCoreS3Region{}
+	if got := header.recoveryOpenSegments(); got != 1 {
+		t.Fatalf("an opened-but-empty error region reported %d open segments, want 1", got)
 	}
-	if err := header.markRecoveryLineage(-1); err == nil {
-		t.Fatal("a negative segment count was accepted")
+	// Once the region holds absorbed content, its cost lives in the published
+	// subtrees and the open term must stop applying.
+	header.s3Region = &diagnosticParserCoreS3Region{children: []core.SubtreeID{1}}
+	if got := header.recoveryOpenSegments(); got != 0 {
+		t.Fatalf("a region with absorbed content reported %d open segments, want 0", got)
+	}
+}
+
+// TestCollapseToRecoveryWinnerSeatsTheWinnerAndClearsLosers covers the one
+// line that actually changes acceptance behaviour. A transposed index or a
+// wrong-slot write here would publish the loser's tree, and no other test in
+// this package would notice.
+func TestCollapseToRecoveryWinnerSeatsTheWinnerAndClearsLosers(t *testing.T) {
+	scheduler := newLineageSelectionScheduler(t, true)
+	scheduler.headers = append(scheduler.headers, diagnosticParserCoreHeader{})
+	scheduler.headers[2].markRecoveryLineage()
+	scheduler.headers[2].s3Region = &diagnosticParserCoreS3Region{}
+	want := scheduler.headers[1]
+
+	scheduler.collapseToRecoveryWinner(1)
+
+	if len(scheduler.headers) != 1 {
+		t.Fatalf("frontier has %d headers after collapse, want 1", len(scheduler.headers))
+	}
+	if scheduler.headers[0].head != want.head {
+		t.Fatal("collapse seated a head other than the winner at index 0")
+	}
+	if scheduler.work.RecoveryLineageSelections != 1 {
+		t.Fatalf("collapse recorded %d selections, want 1", scheduler.work.RecoveryLineageSelections)
+	}
+	// The losers must not stay live in the backing array: each retains an open
+	// error region for the scheduler's lifetime otherwise.
+	tail := scheduler.headers[:cap(scheduler.headers)][1:3]
+	for index := range tail {
+		if tail[index].s3Region != nil || tail[index].isRecoveryLineage() {
+			t.Fatalf("dropped header %d is still live in the backing array", index+1)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

The compact parser route required exactly one accepted head, so a frontier where a MISSING insertion and an error-region absorb both accepted could only decline. C carries both versions to the end and publishes the cheaper tree (ts_parser__select_tree). This adds the acceptance half of that competition: the scheduler now prices each competing recovery lineage and keeps the winner. The new capability is off by default and set from nothing today, so the multi-head path stays unreachable and every parse declines exactly where it did before.

## Changes

- Add the allowCompactRecoveryLineageSelection option on DiagnosticParserCorePrefixOptions. It gates the new path and is unset everywhere, so behavior does not change for any current caller.
- Add selectCompetingRecoveryLineage on the generic scheduler. It prices every accepted head through the existing lineage cost model and returns the index C would publish.
- Route completeAcceptance through that helper when more than one head accepts, then keep only the winner. It still finishes with the old decline message whenever the helper cannot resolve the frontier.
- Gate the route fail-closed on each unsupported shape: unarmed capability, fewer than two heads, any non-recovery head (ordinary grammar ambiguity), missing language or source, priced ambiguity, enumeration-cap refusal, and an unordered tie. An error now means the compact state itself is wrong; a false resolution means the shape is not this route's to decide.
- Add one packed header byte, recoveryCompetition: bit 7 marks a recovery lineage, bits 0..6 count open-recovery segments, the compact analogue of cStackOpenRecoveryCost. It fills the padding byte at offset 215, so the header stays 224 bytes and the two size ratchets hold. Two plain fields would have grown it to 232.
- Add the isRecoveryLineage, recoveryOpenSegments, and markRecoveryLineage accessors. markRecoveryLineage rejects an out-of-range count instead of truncating, because a silently smaller count under-prices a lineage by 500 per lost segment.
- Add diagnosticParserCoreRecoverySymbolPolicy, which projects Visible and Named straight out of Language.SymbolMetadata. Lineage pricing no longer depends on the whole selected-store policy, which an accepting scheduler has no other reason to build.
- Add parsercore_phase0_recovery_lineage_selection_internal_test.go: it drives a hand-built scheduler over the measured php witness (609 absorb beats 610 insertion), and covers the unarmed, non-recovery-head, missing-source, single-head, open-segment pricing, and byte-packing cases.

## Testing

All runs on this branch at `ce71b407` (off `main` at `17532dd4`), WSL2 host.

- Focused gate, 7 tests PASS:
  `go test -tags gts_parsercorephase0 -run 'TestSelectCompetingRecoveryLineage|TestRecoveryLineageMarker' -count=1 .`
- Size ratchets PASS: `TestDiagnosticParserCoreCheckpointCompactLayoutsAMD64`
  and `TestG18RefSetSchedulerRecordSizeRatchets` both still pin the scheduler
  header at 224 bytes. See "Why one byte" below.
- No-regression proof against pristine `origin/main`: root suite reports 25
  failing test lines excluding the order-dependent
  `TestW5JavaScriptFamilyTransientErrorGate` family; `main` reports the same
  25. No branch-only failure. `./internal/parsercorephase0` clean.
- Route outcomes unmoved: the 146-row real-corpus matrix still reports
  `PASS=88 DIVERGE=0 FALLBACK=46 SKIP=12 ERROR=0`.
- Both build configurations clean: `go vet .` and
  `go vet -tags gts_no_parsercorephase0 .`.

## Inertness

`allowCompactRecoveryLineageSelection` is set from nowhere, and nothing marks a
header as a recovery lineage, so `completeAcceptance` declines a multi-head
frontier exactly where it did before. Verified by grep and by the unchanged
matrix. The tests drive the path through a hand-built scheduler.

## Why one byte

The marker and the open-recovery segment count are packed into a single
`uint8` placed BEFORE `s3Region`, where the header already had one padding
byte at offset 215. Two plain fields land after the pointer instead and take
the header from 224 to 232 bytes -- measured -- which two separate size
ratchets pin on purpose. Bit 7 is the lineage marker; bits 0..6 hold the
count, and `markRecoveryLineage` fails closed rather than truncating, because
a silently smaller count under-prices the lineage by 500 per lost segment.

## Review Focus

The fail-closed gates in `selectCompetingRecoveryLineage`. The one that
carries the most weight is the requirement that EVERY competitor be a recovery
lineage: error cost answers "which recovery is cheaper", which is not the
question an ordinarily ambiguous frontier is asking, so pricing one would
quietly substitute a different decision procedure for C's own.
