### PR TITLE
add(parsercore): compete missing and absorb recovery lineages

### DIFF
--- a/admission_recursive_insertion_haskell_small_contract_test.go
+++ b/admission_recursive_insertion_haskell_small_contract_test.go
@@ -23,6 +23,7 @@ type recursiveInsertionProfileExpectation struct {
 	primaryAcceptanceDerivation  bool
 	exactStackNodeEquivalence    bool
 	strategy2ErrorRegion         bool
+	missingTokenInsertion        bool
 }
 
 type recursiveInsertionRealCorpusRow struct {
@@ -56,6 +57,7 @@ type recursiveInsertionProfileSnapshot struct {
 	primaryAcceptanceDerivation  bool
 	exactStackNodeEquivalence    bool
 	strategy2ErrorRegion         bool
+	missingTokenInsertion        bool
 }
 
 // TestAdmissionCandidateRecursiveInsertionHaskellSmall is a strict route contract.
@@ -213,6 +215,7 @@ func recursiveInsertionProfile(lang *gts.Language) recursiveInsertionProfileSnap
 		primaryAcceptanceDerivation:  lang.CompactPrimaryAcceptanceDerivationCertified,
 		exactStackNodeEquivalence:    lang.ExactStackNodeEquivalenceCertified,
 		strategy2ErrorRegion:         lang.CompactStrategy2ErrorRegionCertified,
+		missingTokenInsertion:        lang.CompactMissingTokenInsertionCertified,
 	}
 }
 
@@ -225,7 +228,8 @@ func requireRecursiveInsertionProfile(t testing.TB, want recursiveInsertionRealC
 		got.eofAcceptNoActionSiblings != want.profile.eofAcceptNoActionSiblings ||
 		got.primaryAcceptanceDerivation != want.profile.primaryAcceptanceDerivation ||
 		got.exactStackNodeEquivalence != want.profile.exactStackNodeEquivalence ||
-		got.strategy2ErrorRegion != want.profile.strategy2ErrorRegion {
+		got.strategy2ErrorRegion != want.profile.strategy2ErrorRegion ||
+		got.missingTokenInsertion != want.profile.missingTokenInsertion {
 		t.Fatalf("compact profile changed for %s: got=%+v want=%+v", want.language, got, want.profile)
 	}
 }

--- a/admission_route_equality_leaf_tiling_test.go
+++ b/admission_route_equality_leaf_tiling_test.go
@@ -67,7 +67,7 @@ func loadRouteEqualityWitnesses(t testing.TB) map[string]routeEqualityWitness {
 // (html_erroneous_end_tag): compact now routes this input itself instead of
 // declining, publishing an ERROR-wrapped tree that matches the pinned C
 // oracle exactly (cgo_harness/compact_t3_oracle_adjudication_test.go's
-// compactT3S3CertifiedWitnesses asserts the full structural comparison
+// compactT3RecoveryCertifiedWitnesses asserts the full structural comparison
 // under cgo; this always-on test pins only the route decision and root
 // HasError, which do not need cgo). Before either gate landed, the compact
 // route accepted this input and published document[0:8] clean.
@@ -165,7 +165,7 @@ func TestCompactRouteAcceptedHiddenDoctypeLeafTiles(t *testing.T) {
 // same root HasError as production (exact structural C-oracle parity is
 // asserted separately, under cgo, by
 // cgo_harness/compact_t3_oracle_adjudication_test.go's
-// compactT3S3CertifiedWitnesses). The 3 javascript entries are outside B3's
+// compactT3RecoveryCertifiedWitnesses). The 3 javascript entries are outside B3's
 // witness classes staged so far and still decline at the tiling gate exactly
 // as B1 left them.
 //
@@ -271,6 +271,49 @@ func TestCompactRouteDeclinesAdjudicatedFalseCleanWitnesses(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCompactRouteCompetesMissingInsertionWithErrorAbsorb(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	lang := grammars.HtmlLanguage()
+	if !lang.CompactStrategy2ErrorRegionCertified || !lang.CompactMissingTokenInsertionCertified {
+		t.Fatal("the HTML artifact lacks complete compact recovery certification")
+	}
+	gts.ResetAdmissionCandidateCountersForTest()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	tree, err := parser.Parse([]byte("<html><bodyHello</body></html>\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if routed != 1 || fallback != 0 {
+		t.Fatalf("route counters routed=%d fallback=%d, want routed=1 fallback=0; reason=%q",
+			routed, fallback, gts.AdmissionCandidateLastFallbackReason())
+	}
+	if !tree.RootNode().HasError() {
+		t.Fatal("the selected recovery tree lost its error")
+	}
+	if !routeEqualityTreeContainsMissing(tree.RootNode()) {
+		t.Fatal("the selected recovery tree contains no missing terminal")
+	}
+}
+
+func routeEqualityTreeContainsMissing(node *gts.Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.IsMissing() {
+		return true
+	}
+	for index := 0; index < node.ChildCount(); index++ {
+		if routeEqualityTreeContainsMissing(node.Child(index)) {
+			return true
+		}
+	}
+	return false
 }
 
 // TestCompactRouteAcceptedRootLeafCoverageGapDeclines pins the adversarial

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -60,17 +60,15 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		allowMetadataEOFAcceptRecovery:  true,
 		allowPrimaryAcceptDerivation:    p.language.CompactPrimaryAcceptanceDerivationCertified,
 		allowConvergedSplitDropArtifact: p.language.CompactConvergedReductionSplitDropsCertified,
-		// B3 stage S3: Recovery declares that this operation may attempt
-		// native strategy-2 recovery; allowCompactStrategy2ErrorRegion is the
-		// certified-capability gate the scheduler actually checks
-		// (dispatchPassActive's s3ErrorRegionAdmitted). Both come from the
-		// same grammar-blob-keyed certification, so an uncertified grammar
-		// (every grammar but the one B3 stage S3 witness class covers today)
-		// gets both false and this parse's behavior is unchanged.
-		Recovery:                         p.language.CompactStrategy2ErrorRegionCertified,
-		allowCompactStrategy2ErrorRegion: p.language.CompactStrategy2ErrorRegionCertified,
-		noLookaheadRootSymbol:            p.rootSymbol,
-		hasNoLookaheadRootSymbol:         p.hasRootSymbol,
+		// Recovery admits the certified S3 base mechanism. S5 also needs the
+		// insertion gate and the lineage-selection gate.
+		Recovery:                          p.language.CompactStrategy2ErrorRegionCertified,
+		allowCompactStrategy2ErrorRegion:  p.language.CompactStrategy2ErrorRegionCertified,
+		allowCompactMissingTokenInsertion: p.language.CompactMissingTokenInsertionCertified,
+		allowCompactRecoveryLineageSelection: p.language.CompactStrategy2ErrorRegionCertified &&
+			p.language.CompactMissingTokenInsertionCertified,
+		noLookaheadRootSymbol:    p.rootSymbol,
+		hasNoLookaheadRootSymbol: p.hasRootSymbol,
 		// Tranche B8 scheduler stop-control: bind this Parser so the scheduler
 		// polls its deadline, cancellation flag, and (via
 		// stopControlMemoryBudgetBytes, recomputed per parse in

--- a/cgo_harness/compact_t3_oracle_adjudication_test.go
+++ b/cgo_harness/compact_t3_oracle_adjudication_test.go
@@ -112,19 +112,10 @@ type compactT3ExpectedOutcome struct {
 	CompactHasError    *bool `json:"compact_has_error"`
 }
 
-// compactT3S3CertifiedWitnesses lists witnesses where native compact
-// recovery is certified to reach exact structural C-oracle parity (B3 stage
-// S3: error-region absorb and condense-resume, Language.
-// CompactStrategy2ErrorRegionCertified, gated on the html grammar blob's own
-// SHA-256, not on Language.Name -- design section 7). html_log_7 is
-// deliberately excluded: its next real token after a dangling start_tag is
-// a valid "</" the parser cannot place without first inserting a synthetic
-// MISSING ">", which stage S5, not S3, owns (design section 4's stop rule:
-// "if any html witness needs strategy 1 or missing insertion, leave it
-// fail-closed and record it for S4/S5; do not widen S3"). Compact detects
-// that shape and declines it, falling back to production exactly as it did
-// before this stage landed; see the dedicated assertion below.
-var compactT3S3CertifiedWitnesses = map[string]bool{
+// compactT3RecoveryCertifiedWitnesses lists HTML witnesses where native
+// compact recovery reaches exact structural C-oracle parity. The exact HTML
+// artifact certifies S3 error absorption and S5 version competition.
+var compactT3RecoveryCertifiedWitnesses = map[string]bool{
 	"html_min_a":    true,
 	"html_min_html": true,
 	"html_log_1":    true,
@@ -133,6 +124,7 @@ var compactT3S3CertifiedWitnesses = map[string]bool{
 	"html_log_4":    true,
 	"html_log_5":    true,
 	"html_log_6":    true,
+	"html_log_7":    true,
 	"html_log_8":    true,
 }
 
@@ -147,17 +139,10 @@ var compactT3S3CertifiedWitnesses = map[string]bool{
 // and per-node HasError) for both production and compact against the C
 // oracle.
 //
-//   - compact vs. the C oracle: B3 stage S3 lands native strategy-2 recovery
-//     (error-region absorb and condense-resume) for the html_erroneous_end_tag
-//     class. Every witness in compactT3S3CertifiedWitnesses is asserted
-//     (not logged) to match the C oracle exactly: a divergence there is a
-//     stage S3 regression, not an expected gap. The one witness S3 does not
-//     own (html_log_7; needs missing-token insertion, S5 scope) stays
-//     logged, with its own assertion that compact's decline is faithful
-//     to production (below) -- unowned shapes fail closed, they do not
-//     guess. Every other language in this manifest (javascript, swift)
-//     still has no compact recovery implementation and stays logged only,
-//     exactly as stage S1 left it.
+//   - compact vs. the C oracle: S3 and S5 cover all ten
+//     html_erroneous_end_tag witnesses. Every witness in
+//     compactT3RecoveryCertifiedWitnesses must match the C oracle exactly.
+//     JavaScript and Swift still have no compact recovery implementation.
 //   - production vs. the C oracle: the S1 design brief's stated gate is
 //     "the harness must pass with production serving every witness before
 //     any compact change." Verified in the pinned parity container
@@ -233,14 +218,14 @@ func TestCompactT3OracleAdjudication(t *testing.T) {
 					switch {
 					case len(divergences) == 0:
 						t.Logf("witness %q: compact matches the C oracle structurally", witness.ID)
-					case compactT3S3CertifiedWitnesses[witness.ID]:
+					case compactT3RecoveryCertifiedWitnesses[witness.ID]:
 						t.Fatalf(
-							"witness %q: B3 stage S3 certifies native compact recovery for this witness, but compact diverges from the C oracle at %d node(s); first: %s",
+							"witness %q: compact recovery certification requires C parity, but compact diverges at %d node(s); first: %s",
 							witness.ID, len(divergences), compactT3FormatDivergence(divergences[0]),
 						)
 					default:
 						t.Logf(
-							"witness %q: compact diverges from the C oracle at %d node(s) (expected pre-B3-S3+ recovery, or -- for html_erroneous_end_tag -- an owned-class witness B3 stage S3 declines); first: %s",
+							"witness %q: compact diverges from the C oracle at %d node(s) outside the certified recovery set; first: %s",
 							witness.ID, len(divergences), compactT3FormatDivergence(divergences[0]),
 						)
 						// The faithful-decline check only applies inside the

--- a/fuzz_admission_route_equality_test.go
+++ b/fuzz_admission_route_equality_test.go
@@ -69,17 +69,12 @@ type admissionRouteEqualityLanguage struct {
 // evidence for large-input route equality instead.
 const routeEqualityFuzzMaxInputBytes = 4096
 
-// FuzzAdmissionRouteEquality is the campaign v7 tranche B2 standing
-// generative gate: on every fuzz input where the compact admission
-// candidate route accepts a fresh full parse, its published tree must equal
-// the production route's tree exactly -- HasError, deep structure (type,
-// byte span, point span, field name, and the named/extra/missing/error
-// flags), and full leaf byte coverage. When the compact route declines
-// (an engine-side fallback, or a never-attempted eligibility decline), the
-// shipped Parse call already served the parse via production within the
-// same call (the B1 fail-closed guarantee), so the input is vacuous for
-// this assertion; it still runs for panic and hang coverage and stays in
-// the corpus.
+// FuzzAdmissionRouteEquality is the campaign v7 tranche B2 generative gate.
+// An accepted compact tree must equal production unless certified recovery
+// publishes an ERROR container or a missing terminal. Those recovery trees
+// must keep the same HasError result and match the separate C oracle gate.
+// When the compact route declines, Parse serves production within the same
+// call. The input remains useful for panic and hang coverage.
 //
 // The fuzz entry point is the shipped Parser.Parse route, reached through
 // the same public per-Parser admission switch every caller can use
@@ -310,34 +305,21 @@ func seedAdmissionRouteEqualityCorpus(f *testing.F, languages []admissionRouteEq
 	f.Add([]byte("0>>"), langIndex["swift"])
 }
 
-// routeEqualityTreeCarriesNativeRecoveryErrorContainer reports whether root's
-// subtree contains a native compact recovery ERROR container: an extra
-// ERROR node (IsError() && IsExtra()), the exact shape ErrorRegionResume
-// (internal/parsercorephase0/error_region.go) publishes -- and the sole
-// mechanism by which the admission-candidate route can ever grow an ERROR
-// node at all. Every other compact-native (routed=1) admission path either
-// accepts a source cleanly or declines outright; none of them construct
-// their own ERROR nodes. A language only reaches this shape once certified
-// (Language.CompactStrategy2ErrorRegionCertified; html is the only grammar
-// certified as of B3 stage S3), so for every other curated fuzz language
-// this predicate is always false and the full equality gate below stays in
-// force unconditionally, exactly as before.
+// routeEqualityTreeCarriesNativeRecoveryNode reports whether root contains a
+// node that only native compact recovery can publish. S3 publishes an extra
+// ERROR container. S5 publishes a missing terminal.
 //
-// A tree carrying this shape is a witness the certified recovery mechanism
-// touched it, which -- by design (spec.compact-recovery-ownership.v1) --
-// intentionally serves the C oracle's shape rather than production's own,
-// pre-existing, documented divergence from the oracle on recovered trees
-// (finding production-recovery-structural-divergence) on exactly that
-// subtree. Route equality does not, and must not, hold there.
-func routeEqualityTreeCarriesNativeRecoveryErrorContainer(n *gts.Node) bool {
+// Such a tree follows the C oracle instead of production's divergent recovery
+// shape. Route equality does not apply to that tree.
+func routeEqualityTreeCarriesNativeRecoveryNode(n *gts.Node) bool {
 	if n == nil {
 		return false
 	}
-	if n.IsError() && n.IsExtra() {
+	if n.IsMissing() || (n.IsError() && n.IsExtra()) {
 		return true
 	}
 	for i := 0; i < n.ChildCount(); i++ {
-		if routeEqualityTreeCarriesNativeRecoveryErrorContainer(n.Child(i)) {
+		if routeEqualityTreeCarriesNativeRecoveryNode(n.Child(i)) {
 			return true
 		}
 	}
@@ -349,23 +331,13 @@ func routeEqualityTreeCarriesNativeRecoveryErrorContainer(n *gts.Node) bool {
 // names -- HasError, deep structure (type, span, field, flags, named-ness),
 // and full leaf byte coverage.
 //
-// B3 stage S3 carves out one deliberate exception, keyed on tree shape
-// rather than an enumerated source allowlist
-// (routeEqualityTreeCarriesNativeRecoveryErrorContainer): whenever compact's
-// own tree carries a native recovery ERROR container, it diverges from
-// production ON PURPOSE (it matches the C oracle instead), so only HasError
-// is asserted there; the deep-structure and digest checks are logged, not
-// required. A byte-exact allowlist of the ten committed witnesses caught
-// only literal replays of those seeds -- live mutation constantly produces
-// new inputs this same certified mechanism legitimately accepts (adversarial
-// review finding: "00&" fails in under 3 seconds of live fuzzing, ~38% of
-// natively routed html mutations hit this class), which starved the fuzzer
-// on its very first generation and made seed-only CI green meaningless. The
-// shape predicate instead recognizes every input the mechanism touches, by
-// construction, so live fuzzing exercises the corpus again -- and keeps
-// catching a genuine compact break, since an ordinary clean parse or any
-// non-recovery structural regression carries no such container and still
-// gets the full, unweakened check below.
+// Certified native recovery has one deliberate exception, keyed on tree
+// shape instead of an enumerated source allowlist. When compact publishes an
+// ERROR container or a missing terminal, it follows the C oracle. Production
+// can differ, so only HasError is required there. The deep checks are logged.
+// A byte-exact allowlist covers only the committed witnesses. Live fuzzing
+// finds new inputs for the same certified mechanism. The shape check keeps
+// the full equality gate for ordinary compact parses.
 func assertAdmissionRouteEquality(t *testing.T, lp admissionRouteEqualityLanguage, src []byte, compactTree, productionTree *gts.Tree) {
 	t.Helper()
 
@@ -384,9 +356,9 @@ func assertAdmissionRouteEquality(t *testing.T, lp admissionRouteEqualityLanguag
 			lp.name, len(src), compactRoot.HasError(), productionRoot.HasError(), previewRouteEqualityInput(src))
 	}
 
-	if lp.name == "html" && routeEqualityTreeCarriesNativeRecoveryErrorContainer(compactRoot) {
+	if lp.name == "html" && routeEqualityTreeCarriesNativeRecoveryNode(compactRoot) {
 		if diff := routeEqualityFirstDivergence(compactRoot, productionRoot, lp.lang, "root"); diff != "" {
-			t.Logf("lang=%s bytes=%d native recovery ERROR container present: compact intentionally diverges from production (matches the C oracle instead): %s (input=%s)",
+			t.Logf("lang=%s bytes=%d native recovery node present: compact follows the C oracle instead of production: %s (input=%s)",
 				lp.name, len(src), diff, previewRouteEqualityInput(src))
 		}
 		return

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -26,6 +26,7 @@ type builtinLanguageRuntimeProfile struct {
 	compactPrimaryAcceptDerivation     bool
 	exactStackNodeEquivalence          bool
 	compactStrategy2ErrorRegion        bool
+	compactMissingTokenInsertion       bool
 	lineContinuationEscapeByte         byte
 	conflictPolicies                   []gotreesitter.ConflictPolicy
 }
@@ -79,13 +80,12 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	"robot": {
 		blobSHA256: mustRuntimeProfileSHA256("25075ecf5323eeb88af4f71b55f51867cef38a277aaa60f01b879ee8abb4c74f"),
 	},
-	// html_erroneous_end_tag (campaign v7 tranche B3 stage S3): C-oracle parity
-	// certifies native strategy-2 recovery (error-region absorb and
-	// condense-resume) for this exact artifact against the ten pinned
-	// html_erroneous_end_tag witnesses (cgo_harness/testdata/compact_t3_oracle_witnesses_v2.json).
+	// C-oracle parity certifies the complete compact recovery competition for
+	// this exact artifact against the ten pinned HTML witnesses.
 	"html": {
-		blobSHA256:                  mustRuntimeProfileSHA256("76d3d788ec44b5eaeaa0b3b0069bf52ffc4b125791059ff743301b9938dffd3d"),
-		compactStrategy2ErrorRegion: true,
+		blobSHA256:                   mustRuntimeProfileSHA256("76d3d788ec44b5eaeaa0b3b0069bf52ffc4b125791059ff743301b9938dffd3d"),
+		compactStrategy2ErrorRegion:  true,
+		compactMissingTokenInsertion: true,
 	},
 	// Objective-C keeps parity-relevant alternatives below the bounded stack
 	// comparison frontier. Exact comparison preserves them until generic result
@@ -669,6 +669,10 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	}
 	if profile.compactStrategy2ErrorRegion && !lang.CompactStrategy2ErrorRegionCertified {
 		lang.CompactStrategy2ErrorRegionCertified = true
+		changed = true
+	}
+	if profile.compactMissingTokenInsertion && !lang.CompactMissingTokenInsertionCertified {
+		lang.CompactMissingTokenInsertionCertified = true
 		changed = true
 	}
 	if profile.lineContinuationEscapeByte != 0 && lang.LineContinuationEscapeByte != profile.lineContinuationEscapeByte {

--- a/grammars/runtime_profiles_eof_retirement_test.go
+++ b/grammars/runtime_profiles_eof_retirement_test.go
@@ -32,6 +32,7 @@ func TestCompactGraduationGrantDenominatorAfterEOFRetirement(t *testing.T) {
 			profile.compactEOFAcceptNoActionSiblings,
 			profile.compactPrimaryAcceptDerivation,
 			profile.compactStrategy2ErrorRegion,
+			profile.compactMissingTokenInsertion,
 		}
 		for _, active := range flags {
 			if !active {
@@ -49,9 +50,9 @@ func TestCompactGraduationGrantDenominatorAfterEOFRetirement(t *testing.T) {
 	if len(eofSiblingGrants) != 0 {
 		t.Errorf("EOF sibling grants remain: %v", eofSiblingGrants)
 	}
-	if activeFlags != 15 || len(activeGrammars) != 12 {
+	if activeFlags != 16 || len(activeGrammars) != 12 {
 		t.Errorf(
-			"compact profile denominator is %d flags across %d grammars, want 15 across 12",
+			"compact profile denominator is %d flags across %d grammars, want 16 across 12",
 			activeFlags,
 			len(activeGrammars),
 		)

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -53,6 +53,19 @@ func TestCrystalAndMatlabKeepAcceptedErrorRetryLadder(t *testing.T) {
 	}
 }
 
+func TestHTMLProfileCertifiesCompleteCompactRecovery(t *testing.T) {
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+	lang := HtmlLanguage()
+	if !lang.CompactStrategy2ErrorRegionCertified || !lang.CompactMissingTokenInsertionCertified {
+		t.Fatal("the HTML profile did not attach both compact recovery capabilities")
+	}
+	uncertified := &gotreesitter.Language{}
+	if attachBuiltinLanguageRuntimeProfile("html", sha256.Sum256([]byte("wrong html blob")), uncertified) ||
+		uncertified.CompactStrategy2ErrorRegionCertified || uncertified.CompactMissingTokenInsertionCertified {
+		t.Fatal("a mismatched HTML blob received compact recovery certification")
+	}
+}
+
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	// 42 = the prior 41 plus the F# unary-wrapper materialization profile.
 	// Bash, Haskell, and JavaScript reuse their existing exact profiles.

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -971,11 +971,8 @@ type subtreeRecord struct {
 	// startByte would round the record up to 48 and grow every compact
 	// subtree in every parse.
 	//
-	// No live parser path sets this today. B3 stage S5 owns the mechanism
-	// that will (C's ts_parser__handle_error step 2, parser.c:2154-2230);
-	// this record bit, MissingLeaf, and the two view fields are the inert
-	// substrate that mechanism needs, landed separately so the storage and
-	// materialization change can be reviewed on its own.
+	// The compact S5 recovery stage sets this through MissingLeaf after its
+	// artifact gate admits the complete recovery competition.
 	missing    bool
 	startByte  uint32
 	endByte    uint32
@@ -4515,22 +4512,11 @@ func (c *Core) shallowPayloadClass(prevID NodeID, payloadID SubtreeID) (shallowP
 	// spec.derivation-set-equivalence.v1, which scopes it out until error-path
 	// equivalence lands.
 	//
-	// STALE-INVARIANT WARNING. That omission used to be justified by a
-	// stronger statement: the compact core could not represent an error or
-	// recovery subtree at all, so no resident payload could ever have a
-	// positive error cost and the shortcut could never apply. B3 stage S3
-	// (ERROR regions) and the stage S5 substrate (subtreeRecord.missing,
-	// Core.MissingLeaf) have both weakened that. A MISSING payload carries
-	// error cost ERROR_COST_PER_MISSING_TREE + ERROR_COST_PER_RECOVERY
-	// (subtree.h:331-337), so it is exactly the shape the shortcut exists for.
-	//
-	// What still holds, and what does not: no live parser path publishes a
-	// MISSING record today (Core.MissingLeaf has no non-test caller), so the
-	// class cannot currently see one and behavior is unchanged. Before any
-	// path does start publishing one, this class MUST gain C's both-errors
-	// shortcut. Two differently shaped error payloads are the failing case.
-	// C collapses them through the shortcut. This class compares their fields
-	// instead, finds them different, and keeps both.
+	// Error payloads can now reach this class through S3 and S5. The omitted
+	// shortcut keeps alternatives that C can merge. That difference is
+	// fail-closed: recovery pricing rejects an ambiguous compact head instead
+	// of publishing one guessed alternative. Exact error-path equivalence
+	// remains outside spec.derivation-set-equivalence.v1.
 	//
 	// External payloads separately require exact per-token scanner provenance
 	// or a stable language certificate.

--- a/internal/parsercorephase0/eof_admission_view.go
+++ b/internal/parsercorephase0/eof_admission_view.go
@@ -144,12 +144,8 @@ func (c *Core) VisitEOFAdmissionSubtree(
 		External:          record.external,
 		Terminal:          record.terminal,
 		Fragile:           record.fragile,
-		// B3 stage S5 substrate opted in. subtreeRecord now encodes a missing
-		// payload, so this audit view reports the stored bit rather than a
-		// hardcoded false. The live consumer is the EOF-recovery-admission
-		// gate (parsercore_phase0_driver.go), which declines a missing
-		// subtree; leaving this false would have made that decline
-		// permanently unreachable the moment a missing record could exist.
+		// S5 recovery stores the missing bit on its synthetic payload. The EOF
+		// admission gate reads this view and declines that payload shape.
 		Missing:               record.missing,
 		MetadataAuthenticated: c.metadataConstructionAuthenticated,
 	}

--- a/internal/parsercorephase0/missing_leaf.go
+++ b/internal/parsercorephase0/missing_leaf.go
@@ -3,22 +3,18 @@ package parsercorephase0
 import "errors"
 
 // ---------------------------------------------------------------------------
-// missing_leaf.go -- campaign v7 tranche B3 stage S5 substrate: the compact
-// representation of C's recovery-inserted MISSING terminal.
+// missing_leaf.go -- compact support for C's recovery-inserted MISSING
+// terminal.
 //
 // THE PRODUCTION GO PORT IS THE EXECUTABLE SPECIFICATION for the mechanism
-// that will produce these (cHandleError's missing-token search,
+// that produces these (cHandleError's missing-token search,
 // parser_recover_c.go, itself a port of ts_parser__handle_error step 2,
 // parser.c:2154-2230). The pinned C oracle is the parity arbiter
 // (decision 0007).
 //
-// NOTHING IN THE SHIPPED PARSER CALLS MissingLeaf TODAY. It is inert
-// substrate, landed on its own so the storage and materialization change can
-// be reviewed apart from the scheduler mechanism that will use it. The
-// admission census reports six real-corpus rows whose first decline point is
-// owned by this mechanism, and three of those six already carry a production
-// tree that is structurally identical to the locked C oracle, so the
-// mechanism has a measured target to hit.
+// The compact S5 recovery stage calls MissingLeaf after it creates competing
+// missing-insertion and error-absorb lineages. Artifact certification gates
+// that stage.
 // ---------------------------------------------------------------------------
 
 // MissingLeaf publishes one zero-width recovery-inserted terminal.
@@ -117,4 +113,142 @@ func (c *Core) ShiftMissingLeaf(head Head, targetState StateID, symbol Symbol, a
 	return c.condense(c.shiftedBoundaryKey(targetState, atByte), linkInput{
 		prev: head.Node, payload: payload,
 	})
+}
+
+// UniqueStateSpine returns the state stack below head, from the seed to head.
+// It succeeds only when each node has one predecessor.
+//
+// A compact head can represent many graph-structured stack paths. Recovery
+// simulations need one concrete version, so ambiguity and truncation decline.
+func (c *Core) UniqueStateSpine(head Head, maxDepth int) ([]StateID, bool, error) {
+	if maxDepth <= 0 {
+		return nil, false, nil
+	}
+	reversed := make([]StateID, 0, min(maxDepth, 64))
+	id := head.Node
+	for depth := 0; depth < maxDepth; depth++ {
+		node, err := c.node(id)
+		if err != nil {
+			return nil, false, err
+		}
+		reversed = append(reversed, node.state)
+		if node.linkCount == 0 {
+			for left, right := 0, len(reversed)-1; left < right; left, right = left+1, right-1 {
+				reversed[left], reversed[right] = reversed[right], reversed[left]
+			}
+			return reversed, true, nil
+		}
+		if node.linkCount != 1 {
+			return nil, false, nil
+		}
+		linkID := LinkID(node.firstLink)
+		if linkID == 0 || uint64(linkID) > uint64(len(c.links)) {
+			return nil, false, errors.New("parser-core phase zero: state spine adjacency is out of range")
+		}
+		link := c.links[linkID-1]
+		if link.prev == 0 {
+			return nil, false, errors.New("parser-core phase zero: state spine link has no predecessor")
+		}
+		id = link.prev
+	}
+	return nil, false, nil
+}
+
+const (
+	canShiftAfterReductionsMaxSteps       = 4096
+	canShiftAfterReductionsMaxStackGrowth = 64
+)
+
+type recoverySimulationStackNode struct {
+	prev  int
+	state StateID
+	depth int
+}
+
+type recoverySimulationStackKey struct {
+	prev  int
+	state StateID
+}
+
+// CanShiftAfterReductions reports whether lookahead can make progress after
+// zero or more reductions. It explores each reduction arm.
+//
+// The simulation interns persistent stack nodes. Thus, its memory grows with
+// explored states instead of multiplying each state by the source stack depth.
+func (c *Core) CanShiftAfterReductions(spine []StateID, lookahead Symbol) (bool, error) {
+	if len(spine) == 0 {
+		return false, nil
+	}
+
+	nodes := make([]recoverySimulationStackNode, 1, len(spine)+64)
+	interned := make(map[recoverySimulationStackKey]int, len(spine)+64)
+	top := 0
+	for _, state := range spine {
+		key := recoverySimulationStackKey{prev: top, state: state}
+		id, ok := interned[key]
+		if !ok {
+			id = len(nodes)
+			nodes = append(nodes, recoverySimulationStackNode{
+				prev: top, state: state, depth: nodes[top].depth + 1,
+			})
+			interned[key] = id
+		}
+		top = id
+	}
+
+	frontier := []int{top}
+	seen := map[int]struct{}{top: {}}
+	steps := 0
+	maxDepth := len(spine) + canShiftAfterReductionsMaxStackGrowth
+	for len(frontier) != 0 {
+		current := frontier[len(frontier)-1]
+		frontier = frontier[:len(frontier)-1]
+		row, err := c.tables.Actions(nodes[current].state, lookahead)
+		if err != nil {
+			return false, err
+		}
+		for ordinal := 0; ordinal < row.Len(); ordinal++ {
+			action := row.At(ordinal)
+			switch action.Type {
+			case ActionShift, ActionRecover:
+				if !action.Extra && !action.Repetition {
+					return true, nil
+				}
+			case ActionReduce:
+				steps++
+				if steps > canShiftAfterReductionsMaxSteps {
+					return false, nil
+				}
+				base := current
+				for count := 0; count < int(action.ChildCount) && base != 0; count++ {
+					base = nodes[base].prev
+				}
+				if base == 0 {
+					continue
+				}
+				gotoState, err := c.tables.Goto(nodes[base].state, action.Symbol)
+				if err != nil {
+					return false, err
+				}
+				if gotoState == 0 || nodes[base].depth+1 > maxDepth {
+					continue
+				}
+				key := recoverySimulationStackKey{prev: base, state: gotoState}
+				next, ok := interned[key]
+				if !ok {
+					next = len(nodes)
+					nodes = append(nodes, recoverySimulationStackNode{
+						prev: base, state: gotoState, depth: nodes[base].depth + 1,
+					})
+					interned[key] = next
+				}
+				if _, ok := seen[next]; ok {
+					continue
+				}
+				seen[next] = struct{}{}
+				frontier = append(frontier, next)
+			}
+		}
+	}
+	return false, nil
 }

--- a/internal/parsercorephase0/missing_leaf_test.go
+++ b/internal/parsercorephase0/missing_leaf_test.go
@@ -2,9 +2,9 @@ package parsercorephase0
 
 import "testing"
 
-// B3 stage S5 substrate. MissingLeaf is the compact representation of C's
-// ts_subtree_new_missing_leaf (subtree.c:534-546). No shipped parser path
-// publishes one yet, so these tests drive the Core API directly.
+// MissingLeaf is the compact representation of C's
+// ts_subtree_new_missing_leaf (subtree.c:534-546). These tests drive the Core
+// API directly.
 
 func newMissingLeafTestCore(t *testing.T) *Core {
 	t.Helper()
@@ -108,19 +108,12 @@ func TestMissingLeafSurfacesThroughMaterializationView(t *testing.T) {
 	}
 }
 
-// TestMissingLeafIsInertSubstrate checks the stage boundary over the publish
-// paths reachable from a bare Core: seed, diagnostic payload, error-region
-// leaf, and error-region resume all report Missing false.
+// TestMissingLeafIsExplicit checks the stage boundary over the publish paths
+// reachable from a bare Core. Only an explicit MissingLeaf call sets the bit.
 //
-// Read the scope honestly. Go zero-values the field and MissingLeaf is the
-// only site that sets it, so this assertion cannot fail for any code that
-// merely forgets to propagate the bit -- it is a boundary marker, not a trap.
-// It also does not reach the shift paths (scheduler_owned.go) or Reduce,
-// which need a table with real actions rather than the inert fixture here.
-// The load-bearing inertness evidence is elsewhere: MissingLeaf has exactly
-// one non-test occurrence in the tree, its own definition, and the real-corpus
-// admission matrix is unchanged at 88/0/46/12 with this substrate present.
-func TestMissingLeafIsInertSubstrate(t *testing.T) {
+// The test does not reach scheduler shift paths or Reduce. Those paths need a
+// table with real actions instead of this inert fixture.
+func TestMissingLeafIsExplicit(t *testing.T) {
 	compact := newMissingLeafTestCore(t)
 	seed, err := compact.Seed(StateID(1), 0)
 	if err != nil {
@@ -255,5 +248,110 @@ func TestMissingLeafDropCohortReceiptDistinguishesTheBit(t *testing.T) {
 	}
 	if order == 0 {
 		t.Fatal("the drop-cohort comparator ordered a MISSING payload equal to a clean one")
+	}
+}
+
+func TestUniqueStateSpineRequiresOneCompletePath(t *testing.T) {
+	compact := newMissingLeafTestCore(t)
+	seed, err := compact.Seed(StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	shifted, err := compact.ShiftMissingLeaf(seed, StateID(2), Symbol(7), 0)
+	if err != nil {
+		t.Fatalf("ShiftMissingLeaf: %v", err)
+	}
+	spine, ok, err := compact.UniqueStateSpine(shifted, 2)
+	if err != nil {
+		t.Fatalf("UniqueStateSpine: %v", err)
+	}
+	if !ok || len(spine) != 2 || spine[0] != 1 || spine[1] != 2 {
+		t.Fatalf("spine=%v ok=%t, want [1 2] true", spine, ok)
+	}
+	if _, ok, err := compact.UniqueStateSpine(shifted, 1); err != nil || ok {
+		t.Fatalf("truncated spine returned ok=%t err=%v", ok, err)
+	}
+
+	first, err := compact.MissingLeaf(Symbol(8), 0)
+	if err != nil {
+		t.Fatalf("first payload: %v", err)
+	}
+	second, err := compact.MissingLeaf(Symbol(9), 0)
+	if err != nil {
+		t.Fatalf("second payload: %v", err)
+	}
+	key := compact.shiftedBoundaryKey(StateID(3), 0)
+	ambiguous, err := compact.condense(key, linkInput{prev: seed.Node, payload: first})
+	if err != nil {
+		t.Fatalf("first condense: %v", err)
+	}
+	ambiguous, err = compact.condense(key, linkInput{prev: shifted.Node, payload: second})
+	if err != nil {
+		t.Fatalf("second condense: %v", err)
+	}
+	if _, ok, err := compact.UniqueStateSpine(ambiguous, 8); err != nil || ok {
+		t.Fatalf("ambiguous spine returned ok=%t err=%v", ok, err)
+	}
+}
+
+// TestCanShiftAfterReductionsKeepsDistinctStackPrefixes pins a subtle
+// simulation rule. Equal depth and top state do not identify a whole stack.
+func TestCanShiftAfterReductionsKeepsDistinctStackPrefixes(t *testing.T) {
+	const lookahead = Symbol(9)
+	tables := &fakeTable{
+		actions: map[tableCell][]Action{
+			{state: 3, symbol: lookahead}: {
+				{Type: ActionReduce, Symbol: 10, ChildCount: 1},
+				{Type: ActionReduce, Symbol: 11, ChildCount: 2},
+			},
+			{state: 6, symbol: lookahead}: {
+				{Type: ActionReduce, Symbol: 12, ChildCount: 0},
+			},
+			{state: 4, symbol: lookahead}: {
+				{Type: ActionReduce, Symbol: 13, ChildCount: 1},
+			},
+			{state: 8, symbol: lookahead}: {
+				{Type: ActionShift, State: 9},
+			},
+		},
+		gotos: map[tableCell]StateID{
+			{state: 2, symbol: 10}: 4,
+			{state: 1, symbol: 11}: 6,
+			{state: 6, symbol: 12}: 4,
+			{state: 2, symbol: 13}: 7,
+			{state: 6, symbol: 13}: 8,
+		},
+	}
+	compact, err := New(tables, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := compact.CanShiftAfterReductions([]StateID{1, 2, 3}, lookahead)
+	if err != nil {
+		t.Fatalf("CanShiftAfterReductions: %v", err)
+	}
+	if !got {
+		t.Fatal("the viable reduction path was lost after two stacks reached the same depth and top state")
+	}
+}
+
+func TestCanShiftAfterReductionsRejectsNonProgressShifts(t *testing.T) {
+	const lookahead = Symbol(9)
+	tables := &fakeTable{actions: map[tableCell][]Action{
+		{state: 2, symbol: lookahead}: {
+			{Type: ActionShift, State: 2, Extra: true},
+			{Type: ActionShift, State: 2, Repetition: true},
+		},
+	}}
+	compact, err := New(tables, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := compact.CanShiftAfterReductions([]StateID{1, 2}, lookahead)
+	if err != nil {
+		t.Fatalf("CanShiftAfterReductions: %v", err)
+	}
+	if got {
+		t.Fatal("an extra or repetition shift reported grammatical progress")
 	}
 }

--- a/internal/parsercorephase0/recovery_cost.go
+++ b/internal/parsercorephase0/recovery_cost.go
@@ -6,8 +6,8 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// recovery_cost.go -- campaign v7 tranche B3 stage S2: an inert error-cost
-// model over immutable compact subtree records.
+// recovery_cost.go -- C-compatible recovery costs over immutable compact
+// subtree records.
 //
 // THE PRODUCTION GO PORT IS THE EXECUTABLE SPECIFICATION for this file
 // (spec.compact-recovery-ownership.v1, section 6): parser_recover_c.go's
@@ -19,38 +19,21 @@ import (
 // exactly; a divergence gets a receipt, not a silent "improvement"
 // (decision 0007, hypha://m31labs/gotreesitter).
 //
-// Nothing in this package calls into this file. It is a pure, on-demand
-// library: no Core method, no scheduler path, and no driver file references
-// any declaration here. TestRecoveryCostNoOutsideCallSitesRatchet enforces
-// this as a compile-time property, in the style of
-// condense_outcome_provenance_ratchet_test.go. Stage S3 wires the ERROR-
-// region records this model reads over; stage S4 wires the recovery
-// election that reads RecoveryErrorStatus/RecoveryCompareVersions. Until
-// then this file is dead code by construction (gates G2/G3, design section
-// 8) -- reachable from nowhere except its own tests.
+// No code in this package calls this model. The root scheduler calls its
+// exported pricing surface during recovery selection. The internal ratchet
+// preserves the package boundary.
 //
 // Record shape note: RecoveryCostNode is a strict superset of the existing
 // SubtreeView (core.go). It adds two row fields (StartRow, EndRow) that no
 // compact subtree stores. SubtreeView now carries Missing itself, so that
 // field is no longer part of the difference.
 //
-// The stronger claim this note used to make -- that the compact core has
-// never produced a MISSING node or an ERROR region -- is now false in both
-// halves. Stage S3 publishes ERROR regions for its certified witness class,
-// and the stage S5 substrate (subtreeRecord.missing, Core.MissingLeaf) can
-// represent a MISSING payload. What still holds is narrower: no live parser
-// path publishes a MISSING record yet. cNodeErrorCostLang only ever
-// reads a node's Missing flag or row span when that node either is itself
-// missing or is an ERROR node (parser_recover_c.go:1238,1249-1268); an
-// ordinary clean node's Missing is always false and its row span is never
-// read. So every real SubtreeView-backed RecoveryCostNode in service today
-// leaves Missing=false and StartRow==EndRow==0, and this cost model still
-// returns exactly 0 for it (see the parity corpus test in
-// recovery_cost_test.go and the root-package differential test). The two
-// added fields exist for the paused-header MISSING/ERROR records stage
-// S3/S5 construct (design section 4); this stage defines the shape those
-// stages populate, and does not approximate production *Node state -- it
-// defines a compact record able to carry all of it.
+// Stage S3 publishes ERROR regions. Stage S5 publishes MISSING payloads after
+// the exact artifact gate admits recovery competition. cNodeErrorCostLang
+// reads Missing only for a missing node. It reads row spans only for ERROR
+// nodes (parser_recover_c.go:1238,1249-1268). Ordinary clean nodes keep zero
+// values for both fields. The model therefore preserves zero cost on clean
+// nodes while pricing both live recovery forms.
 // ---------------------------------------------------------------------------
 
 // Cost weights: a literal port of parser_recover_c.go:52-58's error_costs.h
@@ -331,23 +314,16 @@ type RecoveryErrorStatus struct {
 }
 
 // RecoveryVersionStatus is the compact equivalent of cVersionStatus
-// (parser_recover_c.go:2189-2201). Stage S2 owns no header type: the paused
-// flag, the node-count-since-error baseline, dynamic precedence, and
-// open-recovery existence all live on the paused header stage S3
-// introduces ("The open error region is the only mutable piece and lives
-// on the header, not in the arena", design section 4), so this function
-// takes them as explicit parameters instead of reading them off a header
-// that does not exist yet. subtreeCost is the caller-supplied result of
-// RecoveryNodeErrorCost(Memo) over the head's accumulated subtrees -- the
-// compact analogue of cStackErrorCost(s).
+// (parser_recover_c.go:2189-2201). The cost package owns no header type.
+// The scheduler supplies paused state, node count, precedence, and open
+// recovery state. subtreeCost is the accumulated subtree cost for one head.
 //
 // cNodeVisibleSubtreeCount and cNodeCountSinceError
 // (parser_recover_c.go:1178-1214,2155-2166) are deliberately not ported
 // here: they accumulate a visible-node count across a live GLR stack since
 // an error baseline, which is per-head bookkeeping, not a property of one
-// compact subtree. That machinery belongs to the stage that owns paused
-// headers (S3/S4), not this inert stage; NodeCount stays an explicit input
-// for the same reason.
+// compact subtree. The scheduler owns that bookkeeping, so NodeCount remains
+// an explicit input.
 func RecoveryVersionStatus(subtreeCost uint32, paused bool, nodeCount int, dynPrec int, hasOpenRecovery bool) RecoveryErrorStatus {
 	cost := subtreeCost
 	if paused {

--- a/internal/parsercorephase0/recovery_cost_ratchet_test.go
+++ b/internal/parsercorephase0/recovery_cost_ratchet_test.go
@@ -26,10 +26,8 @@ import (
 // as bare package-scope identifiers, and some are common enough (Core.Reset,
 // for one) that banning them by name would false-positive on unrelated
 // methods. What this ratchet protects is the set of package-scope
-// declarations recovery_cost.go introduces: its exported API plus its two
-// unexported helper functions/constant. A later stage that wires this file
-// in (S3 onward) will make this ratchet fail on purpose -- that failure is
-// the signal to update or retire it alongside the real call site landing.
+// declarations recovery_cost.go introduces: its exported API plus its
+// unexported helpers. The root scheduler uses only the exported API.
 //
 // SCOPE CORRECTION. This ratchet reads only THIS package's files, and
 // recovery_cost.go's API is exported, so a caller in another package never
@@ -96,9 +94,8 @@ func TestRecoveryCostNoOutsideCallSitesRatchet(t *testing.T) {
 				return true
 			}
 			violations++
-			t.Errorf("%s references %s, a recovery_cost.go (stage S2, inert) declaration -- "+
-				"the clean path must not call into the recovery cost model; if a later stage "+
-				"intentionally wires this in, update this ratchet in the same change",
+			t.Errorf("%s references %s from recovery_cost.go; "+
+				"the compact core must not call the recovery model directly",
 				fset.Position(ident.Pos()), ident.Name)
 			return true
 		})

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -394,6 +394,33 @@ func (c *Core) ShiftClassifiedWithLiveCondenseCandidatesOwned(owner SchedulerTra
 	return c.shiftClassifiedMaybeLiveScopedOwned(owner, candidates, true, boundary, actionOrdinal, shifted, fork)
 }
 
+// ErrorRegionResumeWithLiveCondenseCandidatesOwned isolates one recovery
+// version from unrelated live versions while it publishes its ERROR payload.
+func (c *Core) ErrorRegionResumeWithLiveCondenseCandidatesOwned(
+	owner SchedulerTransactionToken,
+	candidates []CondenseCandidate,
+	preErrorHead Head,
+	preErrorState StateID,
+	startByte, endByte uint32,
+	children []SubtreeID,
+) (out Head, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return out, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if err = c.enterLiveCondenseCandidates(candidates); err != nil {
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	if c.schedulerFrame.fresh {
+		out, err = c.ErrorRegionResume(preErrorHead, preErrorState, startByte, endByte, children)
+		c.clearLiveCondenseCandidates()
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	defer c.clearLiveCondenseCandidates()
+	out, err = c.ErrorRegionResume(preErrorHead, preErrorState, startByte, endByte, children)
+	return out, c.finishSchedulerOwned(owner, err)
+}
+
 // ShiftDirectWithLiveCondenseCandidatesOwned applies a corridor-proven shift
 // without rebuilding a ClassifiedBoundary or running the generic shift path.
 // The caller must validate the action shape from the immutable corridor program.

--- a/language.go
+++ b/language.go
@@ -779,6 +779,16 @@ type Language struct {
 	// no-action point exactly as before this stage landed.
 	CompactStrategy2ErrorRegionCertified bool
 
+	// CompactMissingTokenInsertionCertified permits the compact fresh-full
+	// route to scan for C's missing-token recovery candidate. A successful
+	// scan forks the head into missing and error-absorb lineages.
+	//
+	// The fork also requires CompactStrategy2ErrorRegionCertified. Both
+	// lineages continue to acceptance, where C-compatible error pricing selects
+	// the result. Exact built-in profiles must certify the complete competition.
+	// Custom and adapted languages retain the false default.
+	CompactMissingTokenInsertionCertified bool
+
 	// LineContinuationEscapeByte declares the single byte this language's
 	// scanner treats as a line-continuation escape when immediately followed
 	// by a newline (LF, or CR+LF) — for example PowerShell's backtick. C

--- a/parser_derived_tables_internal_test.go
+++ b/parser_derived_tables_internal_test.go
@@ -180,14 +180,17 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 	derived := lang.acquireParserDerivedTables()
 
 	restoreErrorRegion := lang.CompactStrategy2ErrorRegionCertified
+	restoreMissingInsertion := lang.CompactMissingTokenInsertionCertified
 	restoreSplitDrops := lang.CompactConvergedReductionSplitDropsCertified
 	restoreScanner := lang.ExternalScanner
 	t.Cleanup(func() {
 		lang.CompactStrategy2ErrorRegionCertified = restoreErrorRegion
+		lang.CompactMissingTokenInsertionCertified = restoreMissingInsertion
 		lang.CompactConvergedReductionSplitDropsCertified = restoreSplitDrops
 		lang.ExternalScanner = restoreScanner
 	})
 	lang.CompactStrategy2ErrorRegionCertified = !restoreErrorRegion
+	lang.CompactMissingTokenInsertionCertified = !restoreMissingInsertion
 	lang.CompactConvergedReductionSplitDropsCertified = !restoreSplitDrops
 	lang.ExternalScanner = nil
 

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -95,6 +95,10 @@ type DiagnosticParserCorePrefixOptions struct {
 	// name-keyed -- design section 7). Recovery must also be true: this
 	// option alone does not admit the fresh-full runner's recovery guard.
 	allowCompactStrategy2ErrorRegion bool
+	// allowCompactMissingTokenInsertion permits the scheduler to fork one
+	// no-action head into missing-token and error-absorb recovery lineages.
+	// Language.CompactMissingTokenInsertionCertified is its artifact gate.
+	allowCompactMissingTokenInsertion bool
 	// allowCompactRecoveryLineageSelection permits completeAcceptance to
 	// resolve MORE THAN ONE accepted head by pricing the competing recovery
 	// lineages and publishing the cheaper tree, instead of declining.
@@ -105,8 +109,8 @@ type DiagnosticParserCorePrefixOptions struct {
 	// (ts_parser__select_tree). A compact route that requires a sole accepted
 	// head cannot express that outcome at all.
 	//
-	// Unset by default and set from nothing today, so the multi-head path
-	// stays unreachable and every parse declines exactly where it did before.
+	// The admission route sets this only when one artifact certifies both
+	// recovery mechanisms. Other parses retain the conservative false default.
 	allowCompactRecoveryLineageSelection bool
 	noLookaheadRootSymbol                Symbol
 	hasNoLookaheadRootSymbol             bool
@@ -1208,6 +1212,20 @@ func (h *diagnosticParserCoreHeader) markRecoveryLineage() { h.recoveryCompetito
 // error cost -- a different decision procedure than the one C applies to it.
 func (h *diagnosticParserCoreHeader) clearRecoveryLineage() { h.recoveryCompetitor = false }
 
+// competingRecoveryFrontier reports whether every live version belongs to
+// one recovery competition. Such versions can accept independently at EOF.
+func (s *diagnosticParserCoreGenericScheduler) competingRecoveryFrontier() bool {
+	if s == nil || !s.recoveryIsolation || !s.options.allowCompactRecoveryLineageSelection || len(s.headers) < 2 {
+		return false
+	}
+	for index := range s.headers {
+		if !s.headers[index].isRecoveryLineage() {
+			return false
+		}
+	}
+	return true
+}
+
 // recoveryOpenSegments returns the open-recovery segment count pricing charges
 // RecoveryCostPerRecovery for, DERIVED from live header state rather than
 // stored.
@@ -1628,6 +1646,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 		return diagnosticParserCoreConflictExecution{}, errors.New("parser-core phase zero: conflict branch order overflow")
 	}
 	trialOrder := branchOrder
+	recoveryAmbiguity := incoming.isRecoveryLineage()
 	var receipts []DiagnosticParserCoreRoundAction
 	err := compact.RunSchedulerOwned(owner, func() error {
 		for ordinal := 1; ordinal < actions.Len(); ordinal++ {
@@ -1644,6 +1663,11 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 			start := len(scratch.outputs)
 			for _, output := range scratch.actionOutputs {
 				secondary := incoming
+				// A table conflict is ordinary grammar ambiguity. Recovery cost
+				// must not select among its arms.
+				if recoveryAmbiguity {
+					secondary.clearRecoveryLineage()
+				}
 				secondary.head = output.head
 				secondary.shifted = action.Type == core.ActionShift
 				secondary.freshness = output.freshness
@@ -1691,6 +1715,10 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 		start := len(scratch.outputs)
 		for _, output := range scratch.actionOutputs {
 			primary := incoming
+			// Clear the marker on every arm, including the primary arm.
+			if recoveryAmbiguity {
+				primary.clearRecoveryLineage()
+			}
 			primary.head = output.head
 			primary.shifted = primaryAction.Type == core.ActionShift
 			primary.freshness = output.freshness
@@ -1944,6 +1972,48 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeWithMutation(
 	s.headerBuffers[target] = out
 	s.nextBuffer = uint8(target ^ 1)
 	return out, mutation, nil
+}
+
+func (s *diagnosticParserCoreCanonicalScratch) canonicalizeRecovery(
+	compact *core.Core, headers []diagnosticParserCoreHeader,
+) ([]diagnosticParserCoreHeader, error) {
+	out, _, err := s.canonicalizeRecoveryWithMutation(compact, headers)
+	return out, err
+}
+
+// canonicalizeRecoveryWithMutation preserves each recovery version until
+// acceptance can price it. It does not remap or merge any live header.
+// A mixed marked and unmarked frontier therefore remains fail-closed.
+func (s *diagnosticParserCoreCanonicalScratch) canonicalizeRecoveryWithMutation(
+	compact *core.Core, headers []diagnosticParserCoreHeader,
+) ([]diagnosticParserCoreHeader, core.DropCohortProducerMutation, error) {
+	if s == nil || compact == nil {
+		return nil, 0, errors.New("parser-core phase zero: recovery canonicalization requires scratch and core")
+	}
+	target := int(s.nextBuffer & 1)
+	if len(headers) != 0 && cap(s.headerBuffers[target]) != 0 && &headers[0] == &s.headerBuffers[target][:1][0] {
+		target ^= 1
+	}
+	normalized := s.headerBuffers[target]
+	if cap(normalized) < len(headers) {
+		if len(headers) <= len(s.inlineHeaders[target]) {
+			normalized = s.inlineHeaders[target][:len(headers)]
+		} else {
+			normalized = make([]diagnosticParserCoreHeader, len(headers))
+		}
+	} else {
+		normalized = normalized[:len(headers)]
+	}
+	copy(normalized, headers)
+	for index := range normalized {
+		if _, _, err := compact.Boundary(normalized[index].head); err != nil {
+			return nil, 0, err
+		}
+		normalized[index].freshness = 0
+	}
+	s.headerBuffers[target] = normalized
+	s.nextBuffer = uint8(target ^ 1)
+	return normalized, 0, nil
 }
 
 func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinear(compact *core.Core, normalized []diagnosticParserCoreHeader) []diagnosticParserCoreHeader {
@@ -2217,18 +2287,24 @@ type diagnosticParserCoreTokenCell struct {
 }
 
 type diagnosticParserCoreGenericScheduler struct {
-	compact                    *core.Core
-	tokenSource                *dfaTokenSource
-	scannerScratch             *[]byte
-	headers                    []diagnosticParserCoreHeader
-	token                      Token
-	checkpoint                 DiagnosticParserCoreScannerCheckpoint
-	checkpointBeforeID         core.CheckpointID
-	checkpointID               core.CheckpointID
-	currentElection            DiagnosticParserCoreElection
-	tokenCell                  diagnosticParserCoreTokenCell
-	electionIndex              int
-	noLookaheadSteps           uint8
+	compact            *core.Core
+	tokenSource        *dfaTokenSource
+	scannerScratch     *[]byte
+	headers            []diagnosticParserCoreHeader
+	token              Token
+	checkpoint         DiagnosticParserCoreScannerCheckpoint
+	checkpointBeforeID core.CheckpointID
+	checkpointID       core.CheckpointID
+	currentElection    DiagnosticParserCoreElection
+	tokenCell          diagnosticParserCoreTokenCell
+	electionIndex      int
+	noLookaheadSteps   uint8
+	// recoveryIsolation becomes true only after S5 publishes its two versions.
+	// Clean parses retain the canonical scheduler fast path.
+	recoveryIsolation bool
+	// s5MissingInsertions counts recovery forks created by S5. The counter
+	// bounds zero-width progress across one parse.
+	s5MissingInsertions        uint32
 	tokens                     uint64
 	dispatches                 uint64
 	branchOrder                uint64
@@ -3654,6 +3730,9 @@ func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGe
 }
 
 const maxDiagnosticParserCoreNoLookaheadSteps = 64
+
+// maxDiagnosticParserCoreMissingInsertions bounds zero-width S5 forks.
+const maxDiagnosticParserCoreMissingInsertions = 256
 
 func (s *diagnosticParserCoreGenericScheduler) fullReceipts() bool {
 	return s != nil && s.options.ReceiptMode == DiagnosticParserCoreReceiptFull
@@ -5301,7 +5380,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				)
 				node.setExtra(view.Extra)
 				node.setExternalScannerToken(view.External)
-				// B3 stage S5 substrate: a recovery-inserted MISSING terminal
+				// S5 recovery: a recovery-inserted MISSING terminal
 				// (core.MissingLeaf) carries both public bits, matching the
 				// pinned C oracle and production's own port
 				// (parser.go's missing-shift path sets exactly this pair).
@@ -5316,24 +5395,15 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				// the flag up through every enclosing reduce with no
 				// additional code.
 				//
-				// PRECONDITION FOR STAGE S5, not covered here: that
-				// propagation argument holds only while the leaf survives into
+				// The propagation argument holds only while the leaf survives into
 				// its parent's children. Production's reduce path drops an
 				// invisible child that has no children of its own
 				// (appendReduceChildItemToScratch, parser_reduce.go), and
 				// production's own missing-shift path compensates with an
 				// explicit out-parameter signal (parser.go's
 				// `*trackChildErrors = true`). This branch reproduces the
-				// flags but NOT that signal, so a missing leaf on a HIDDEN
-				// terminal could be spliced out and lose its error. C reports
-				// has-error there (cost 610 > 0). Whichever live path first
-				// publishes a missing record must either restrict itself to
-				// visible terminals or reproduce the signal.
-				//
-				// No shipped parser path publishes a missing record today, so
-				// this branch is unreached on every current parse; it lands
-				// with the record bit so the storage and materialization
-				// change review together.
+				// flags but not that signal. The S5 scan therefore declines its
+				// first viable candidate when that terminal is hidden.
 				if view.Missing {
 					node.setMissing(true)
 					node.setHasError(true)
@@ -5827,9 +5897,9 @@ func (s *diagnosticParserCoreGenericScheduler) stopControlMemoryBudgetReason() P
 // pollStopControl is the bounded scheduler-boundary poll (spec.campaign.v7
 // tranche B8): the memory-budget check above, then the exact production
 // deadline and cancellation check. Admission candidates also run the node-cap
-// predictor after those controls. The poll runs before the first election and
-// once per dispatch loop. This cadence bounds a runaway dispatch or election
-// cycle. Diagnostic callers bind no Parser, so they do not run the predictor.
+// predictor after those controls. The poll runs before the first election,
+// once per dispatch loop, and during an S5 terminal scan. Diagnostic callers
+// bind no Parser, so they do not run the predictor.
 func (s *diagnosticParserCoreGenericScheduler) pollStopControl() error {
 	if reason := s.stopControlMemoryBudgetReason(); reason != ParseStopNone {
 		return diagnosticParserCoreStopControlTripped(reason)
@@ -6082,8 +6152,18 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 	if unsupported := diagnosticParserCoreGenericUnsupportedToken(s.token); unsupported != nil {
 		return unsupported, nil
 	}
+	recoveryCompetition := s.competingRecoveryFrontier()
+	if s.recoveryIsolation && !recoveryCompetition {
+		return &diagnosticParserCoreGenericUnsupported{
+			boundary: DiagnosticParserCoreRecovery,
+			detail:   "recovery competition crossed ordinary grammar ambiguity",
+		}, nil
+	}
 	for index, header := range s.headers {
 		if header.accepted {
+			if recoveryCompetition {
+				continue
+			}
 			return &diagnosticParserCoreGenericUnsupported{
 				boundary: DiagnosticParserCoreAccept, detail: "generic scheduler found an accepted head before sole-frontier completion", headerIndex: index,
 			}, nil
@@ -6199,7 +6279,26 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				// compact equivalent of cRecoverToState's
 				// pushStackNode(fork, goal, errNode, ...)), then fall through
 				// to ordinary classification below using the refreshed head.
-				newHead, resumeErr := s.compact.ErrorRegionResume(header.head, region.state, region.startByte, region.endByte, region.children)
+				var newHead core.Head
+				var resumeErr error
+				if s.recoveryIsolation {
+					resume := func(owner core.SchedulerTransactionToken) error {
+						newHead, resumeErr = s.compact.ErrorRegionResumeWithLiveCondenseCandidatesOwned(
+							owner, s.collectCondenseCandidates(index), header.head, region.state,
+							region.startByte, region.endByte, region.children,
+						)
+						return resumeErr
+					}
+					if s.freshSessionOwner != nil {
+						resumeErr = resume(*s.freshSessionOwner)
+					} else {
+						resumeErr = s.compact.ApplySchedulerAtomic(resume)
+					}
+				} else {
+					newHead, resumeErr = s.compact.ErrorRegionResume(
+						header.head, region.state, region.startByte, region.endByte, region.children,
+					)
+				}
 				if resumeErr != nil {
 					return nil, resumeErr
 				}
@@ -6255,15 +6354,11 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 					// position, so invalidate it rather than leave it stale.
 					s.tokenCell.valid = false
 				}
-				// Return this pass immediately: a header can only reach
-				// s3Region!=nil through s3TryOpenErrorRegion, which requires
-				// len(s.headers)==1 (S3 owns no forking), so this absorb is
-				// the whole pass's work. Falling through to the per-header
-				// loop's tail (as a bare `continue` would, once the sole
-				// header's iteration ends) reaches the "len(cells)==0, no
-				// runnable head" branch with nothing recorded in cells or
-				// noActionIndices for this pass, an unsupported_route decline
-				// this stage does not own -- confirmed necessary:
+				// Return this pass after one recovery absorb. A paired missing
+				// version remains unshifted and dispatches on the next pass. A
+				// standalone S3 version otherwise reaches the "no runnable head"
+				// branch if this loop falls through without recording a cell.
+				// Confirmed necessary:
 				// html_erroneous_end_tag/html_log_8 needs a second
 				// consecutive absorb (the region opened by
 				// s3TryOpenErrorRegion for '>' does not resume until the
@@ -6441,7 +6536,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 		}
 	}
 	if len(cells) == 0 {
-		if diagnosticParserCoreGenericNoActionDropEligible(s.headers, noActionIndices, s.epochProgress) {
+		if !s.recoveryIsolation && diagnosticParserCoreGenericNoActionDropEligible(s.headers, noActionIndices, s.epochProgress) {
 			if s.options.recordDropCohortFrontiers {
 				if err := s.publishDropCohortFrontierOwned(noActionIndices); err != nil {
 					return nil, err
@@ -6480,16 +6575,17 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			// classification only: every one of these boundaries still
 			// declines and falls back to production unchanged (B3 stage S1).
 			if pausedNoActionHeads == 0 && deferredNoActionHeads == 0 && raggedRelexNoActionHeads == 0 {
-				// B3 stage S3: attempt native strategy-2 recovery for the
-				// certified witness class instead of declining outright.
-				// Scoped to the sole-header, sole-no-action-head shape only
-				// (design section 4's "at most one fork" ceiling starts here
-				// at zero forks: S3 owns no election and no forking at all).
-				// Any other shape, and any ownership attempt that hits
-				// genuine ambiguity, falls through unchanged to the existing
-				// decline -- fail-closed, never a guess (design section 4's
-				// fail-closed rule).
+				// Try the certified S5 competition before standalone S3.
+				// Both routes own only the sole-header, sole-no-action shape.
+				// Unmodeled ambiguity falls through to the existing decline.
 				if len(s.headers) == 1 && len(noActionIndices) == 1 {
+					handled, s5Err := s.s5TryMissingTokenInsertion(noActionIndices[0])
+					if s5Err != nil {
+						return nil, s5Err
+					}
+					if handled {
+						return nil, nil
+					}
 					handled, s3Err := s.s3TryOpenErrorRegion(noActionIndices[0])
 					if s3Err != nil {
 						return nil, s3Err
@@ -6564,7 +6660,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 	}
 	if acceptCell >= 0 {
 		cell := cells[acceptCell]
-		if !s.options.allowEOFAcceptNoActionSiblings &&
+		if !recoveryCompetition && !s.options.allowEOFAcceptNoActionSiblings &&
 			s.options.allowMetadataEOFAcceptRecovery &&
 			len(s.headers) == 2 && len(cells) == 1 && len(noActionIndices) == 1 {
 			handled, err := s.applyCompactEOFRecoveryAdmission(before, cell)
@@ -6588,7 +6684,8 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 		certifiedAcceptWithDeadSiblings := s.options.allowEOFAcceptNoActionSiblings &&
 			len(s.headers) > 1 && len(cells) == 1 &&
 			len(noActionIndices) == len(s.headers)-1
-		if !soleAccept && !certifiedAcceptWithDeadSiblings {
+		competingRecoveryAccept := recoveryCompetition && s.headers[cell.headerIndex].isRecoveryLineage()
+		if !soleAccept && !certifiedAcceptWithDeadSiblings && !competingRecoveryAccept {
 			return &diagnosticParserCoreGenericUnsupported{
 				boundary: DiagnosticParserCoreAccept, detail: "generic scheduler requires a sole homogeneous accept frontier", headerIndex: cell.headerIndex,
 			}, nil
@@ -6601,6 +6698,9 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 		}
 		if err := s.applyGenericAccept(before, cell); err != nil {
 			return nil, err
+		}
+		if competingRecoveryAccept {
+			return nil, nil
 		}
 		if !certifiedAcceptWithDeadSiblings {
 			return nil, nil
@@ -6774,8 +6874,7 @@ func (s *diagnosticParserCoreGenericScheduler) s3ErrorModeRelex(startByte uint32
 // same state, matching cTerminalNextState) to some other state, and that
 // state's leading action for the actual current token is a reduce, a
 // missing-token insertion here would let the parse continue -- exactly the
-// shape S5 owns (design section 4's stop rule), so the caller must decline
-// rather than absorb the real token that opportunity would have consumed.
+// shape S5 owns. Standalone S3 declines. Paired S5 keeps both versions.
 func (s *diagnosticParserCoreGenericScheduler) s3MissingTokenOpportunityExists(state core.StateID) (bool, error) {
 	if s.tokenSource == nil || s.tokenSource.language == nil {
 		return false, nil
@@ -6940,6 +7039,176 @@ func (s *diagnosticParserCoreGenericScheduler) s3CloseInProgressProductions(head
 	return current, changed, false, nil
 }
 
+// s5MissingTokenAdmitted reports whether the complete recovery competition is
+// available. S5 needs the insertion, absorb, and acceptance capabilities.
+func (s *diagnosticParserCoreGenericScheduler) s5MissingTokenAdmitted() bool {
+	return s.options.Recovery &&
+		s.options.allowCompactMissingTokenInsertion &&
+		s.options.allowCompactStrategy2ErrorRegion &&
+		s.options.allowCompactRecoveryLineageSelection
+}
+
+const (
+	s5MissingTokenMaxSpineDepth  = 4096
+	s5MissingTokenMaxSimulations = 256
+)
+
+// s5TryMissingTokenInsertion forks one no-action head into two versions.
+// The original version absorbs the real token through S3. Its copied sibling
+// inserts C's lowest viable missing terminal. This order matches C's version
+// list, which is load-bearing for equal-cost recovery selection.
+func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertion(index int) (handled bool, err error) {
+	if !s.s5MissingTokenAdmitted() || len(s.headers) != 1 || index != 0 {
+		return false, nil
+	}
+	original := s.headers[index]
+	if original.s3Region != nil || s.token.Missing || s.token.NoLookahead ||
+		s.token.Symbol == errorSymbol || s.s5MissingInsertions >= maxDiagnosticParserCoreMissingInsertions {
+		return false, nil
+	}
+	if s.tokenSource == nil || s.tokenSource.language == nil {
+		return false, nil
+	}
+	tokenCount := s.tokenSource.language.TokenCount
+	if tokenCount <= 1 || tokenCount > uint32(math.MaxUint16) {
+		return false, nil
+	}
+
+	// C closes productions before it scans for a missing terminal. Keep the
+	// original header unchanged unless the complete two-version fork succeeds.
+	closedHead, closedChanged, closeOK, closeErr := s.s3CloseInProgressProductions(original.head)
+	if closeErr != nil {
+		return false, closeErr
+	}
+	if !closeOK {
+		return false, nil
+	}
+	scanHead := original.head
+	if closedChanged {
+		scanHead = closedHead
+	}
+	state, byteOffset, boundaryErr := s.compact.Boundary(scanHead)
+	if boundaryErr != nil {
+		return false, boundaryErr
+	}
+	if byteOffset > s.token.StartByte {
+		return false, nil
+	}
+	spine, spineOK, spineErr := s.compact.UniqueStateSpine(scanHead, s5MissingTokenMaxSpineDepth)
+	if spineErr != nil {
+		return false, spineErr
+	}
+	if !spineOK || len(spine) == 0 || spine[len(spine)-1] != state {
+		return false, nil
+	}
+
+	simulation := make([]core.StateID, len(spine)+1)
+	copy(simulation, spine)
+	var missing Symbol
+	var targetState core.StateID
+	simulations := 0
+	for rawSymbol := uint32(1); rawSymbol < tokenCount; rawSymbol++ {
+		if rawSymbol%64 == 0 {
+			if pollErr := s.pollStopControl(); pollErr != nil {
+				return false, pollErr
+			}
+		}
+		candidate := Symbol(rawSymbol)
+		row, rowErr := s.compact.Actions(state, core.Symbol(candidate))
+		if rowErr != nil {
+			return false, rowErr
+		}
+		if row.Len() == 0 {
+			continue
+		}
+		last := row.At(row.Len() - 1)
+		if last.Type != core.ActionShift {
+			continue
+		}
+		nextState := core.StateID(last.State)
+		if last.Extra {
+			nextState = state
+		}
+		if nextState == 0 || nextState == state {
+			continue
+		}
+		nextRow, nextErr := s.compact.Actions(nextState, core.Symbol(s.token.Symbol))
+		if nextErr != nil {
+			return false, nextErr
+		}
+		if nextRow.Len() == 0 || nextRow.At(0).Type != core.ActionReduce {
+			continue
+		}
+		simulations++
+		if simulations > s5MissingTokenMaxSimulations {
+			return false, nil
+		}
+		simulation[len(simulation)-1] = nextState
+		canShift, shiftErr := s.compact.CanShiftAfterReductions(simulation, core.Symbol(s.token.Symbol))
+		if shiftErr != nil {
+			return false, shiftErr
+		}
+		if !canShift {
+			continue
+		}
+		// This materializer cannot propagate the error bit after a hidden,
+		// childless missing terminal is spliced out. C selects the first viable
+		// symbol, so decline the whole scan instead of trying a later symbol.
+		if index := int(candidate); index < len(s.tokenSource.language.SymbolMetadata) &&
+			!s.tokenSource.language.SymbolMetadata[index].Visible {
+			return false, nil
+		}
+		missing = candidate
+		targetState = nextState
+		break
+	}
+	if missing == 0 {
+		return false, nil
+	}
+	if s.nextSeq == math.MaxUint64 {
+		return false, errors.New("parser-core phase zero: recovery fork creation sequence overflow")
+	}
+
+	// Replace the sole head temporarily. This lets the existing S3 primitive
+	// build the absorb lineage without duplicating its fail-closed checks.
+	absorbHeader := original
+	absorbHeader.head = scanHead
+	absorbHeader.paused = false
+	absorbHeader.shifted = false
+	missingHeader := absorbHeader
+	missingHeader.creationSeq = s.nextSeq
+	replacements := [...]diagnosticParserCoreHeader{absorbHeader, missingHeader}
+	s.headers = replaceDiagnosticParserCoreHeader(s.headers, index, replacements[:])
+	restore := func() {
+		clear(s.headers)
+		s.headers = s.headers[:1]
+		s.headers[0] = original
+	}
+
+	absorbed, absorbErr := s.s3TryOpenErrorRegionWithMissingFork(index, true)
+	if absorbErr != nil {
+		restore()
+		return false, absorbErr
+	}
+	if !absorbed || s.headers[index].s3Region == nil || !s.headers[index].shifted {
+		restore()
+		return false, nil
+	}
+
+	missingHead, insertErr := s.compact.ShiftMissingLeaf(scanHead, targetState, core.Symbol(missing), byteOffset)
+	if insertErr != nil {
+		restore()
+		return false, insertErr
+	}
+	s.headers[index+1].head = missingHead
+	s.headers[index].markRecoveryLineage()
+	s.headers[index+1].markRecoveryLineage()
+	s.recoveryIsolation = true
+	s.nextSeq++
+	s.s5MissingInsertions++
+	return true, nil
+}
+
 // s3TryOpenErrorRegion attempts to open (and immediately begin absorbing
 // into) a native S3 error region for the sole no-action header index.
 // handled=true means this pass is fully accounted for: either closure alone
@@ -6950,6 +7219,13 @@ func (s *diagnosticParserCoreGenericScheduler) s3CloseInProgressProductions(head
 // unchanged: recovery is not admitted, the shape is not a single deterministic
 // path, or absorbing would require the EOF wrap S3 does not own.
 func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegion(index int) (handled bool, err error) {
+	return s.s3TryOpenErrorRegionWithMissingFork(index, false)
+}
+
+// s3TryOpenErrorRegionWithMissingFork opens the absorb side of an S5 fork
+// when pairedMissing is true. The paired missing lineage replaces S3's normal
+// reason to decline a missing-token opportunity.
+func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegionWithMissingFork(index int, pairedMissing bool) (handled bool, err error) {
 	if !s.s3ErrorRegionAdmitted() {
 		return false, nil
 	}
@@ -7038,39 +7314,35 @@ func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegion(index int) (
 	if s.token.Symbol == 0 {
 		return false, nil
 	}
-	// C's cHandleError tries missing-token insertion (step 2, "once across
-	// the version set, in order") before it ever tries strategy 2 absorb.
-	// This stage does not own missing-token insertion (S5) or strategy-1
-	// election (S4; design section 4's stop rule: "if any html witness needs
-	// strategy 1 or missing insertion, leave it fail-closed"), so it must
-	// decline whenever a missing-token insertion opportunity exists here,
-	// rather than silently absorbing the real token that opportunity would
-	// have consumed instead. Confirmed necessary: html_erroneous_end_tag/
+	// C tries missing-token insertion before strategy 2 absorb. A standalone
+	// S3 call must decline when an insertion opportunity exists. The paired S5
+	// fork already preserved that alternative and can proceed with absorption.
+	// Confirmed necessary: html_erroneous_end_tag/
 	// html_log_7 (a dangling start_tag whose next real token is a valid "</"
 	// it cannot use) needs a MISSING ">" here; absorbing "</" as an ordinary
 	// error-region token instead produced a confirmed wrong tree.
-	missingOpportunity, missingErr := s.s3MissingTokenOpportunityExists(state)
-	if missingErr != nil {
-		return false, missingErr
+	if !pairedMissing {
+		missingOpportunity, missingErr := s.s3MissingTokenOpportunityExists(state)
+		if missingErr != nil {
+			return false, missingErr
+		}
+		if missingOpportunity {
+			return false, nil
+		}
 	}
-	if missingOpportunity {
-		return false, nil
-	}
-	// REQUIRED 2b (adversarial review): before absorbing the first token
-	// into a brand-new region, also rule out a deeper (depth 1..
-	// cRecoverMaxSummaryDepth) stack-summary resume -- the same existence
-	// probe Hook A runs before every subsequent absorb (dispatchPassActive's
-	// s3Region branch). A live C stack would try that deeper resume
-	// (strategy 1) before ever falling through to strategy 2's absorb; S3
-	// owns only depth-0 resume, so finding one here means this shape is out
-	// of scope and must decline instead of guessing which one C's election
-	// would pick.
-	deeperResumeExists, deeperErr := s.compact.AncestorStateWithActionExists(header.head, core.Symbol(s.token.Symbol), cRecoverMaxSummaryDepth)
-	if deeperErr != nil {
-		return false, deeperErr
-	}
-	if deeperResumeExists {
-		return false, nil
+	// A standalone S3 route declines when a deeper stack-summary resume exists.
+	// It cannot model C's strategy-1 election by itself. The paired S5 route
+	// retains the strategy-2 version because C keeps that version beside its
+	// recovery forks. The artifact gate must prove that the carried versions
+	// produce C's selected result.
+	if !pairedMissing {
+		deeperResumeExists, deeperErr := s.compact.AncestorStateWithActionExists(header.head, core.Symbol(s.token.Symbol), cRecoverMaxSummaryDepth)
+		if deeperErr != nil {
+			return false, deeperErr
+		}
+		if deeperResumeExists {
+			return false, nil
+		}
 	}
 	tokenExtra, extraErr := s3TokenIsExtraShift(s.compact, s.token.Symbol)
 	if extraErr != nil {
@@ -7180,20 +7452,25 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericAcceptOwned(owner cor
 // collapseToRecoveryWinner keeps only the priced winner, the way C keeps one
 // finished_tree and drops the losing versions.
 //
-// It clears the whole frontier before re-seating the winner, matching
-// dropGenericNoActionHeads: a plain reslice leaves every loser byte-for-byte
-// intact past len, and each one retains its open error region and its drop-
-// cohort spill for the scheduler's lifetime, invisible to accounting that
-// measures capacity rather than content.
+// It clears the active frontier and both canonical buffers before it seats the
+// winner. A plain reslice would retain each loser's region and reference set.
 func (s *diagnosticParserCoreGenericScheduler) collapseToRecoveryWinner(winner int) {
 	if winner < 0 || winner >= len(s.headers) {
 		return
 	}
 	s.work.RecoveryLineageSelections++
 	winnerHeader := s.headers[winner]
-	clear(s.headers)
+	winnerHeader.clearRecoveryLineage()
+	clear(s.headers[:cap(s.headers)])
+	for target := range s.canonicalScratch.headerBuffers {
+		buffer := s.canonicalScratch.headerBuffers[target]
+		if cap(buffer) != 0 {
+			clear(buffer[:cap(buffer)])
+		}
+	}
 	s.headers = s.headers[:1]
 	s.headers[0] = winnerHeader
+	s.recoveryIsolation = false
 }
 
 // selectCompetingRecoveryLineage resolves an accepting frontier that carries
@@ -7976,6 +8253,12 @@ func (s *diagnosticParserCoreGenericScheduler) consumeDropCohortFrontierOwned(in
 // runs outside any rollback transaction, so mutating the s.headers backing is
 // safe.
 func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices []int) error {
+	if s.recoveryIsolation {
+		return &diagnosticParserCoreDecline{
+			boundary: DiagnosticParserCoreNoAction,
+			detail:   "recovery competition cannot use an ordinary no-action drop",
+		}
+	}
 	frontierProofVerified := s.frontierProofMatchesDrop(indices)
 	defer func() {
 		s.frontierProofVerified = false
@@ -8483,6 +8766,13 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		replacements = append(replacements, replacement)
 	}
 	s.reductionReplacements = replacements
+	if s.recoveryIsolation && len(replacements) > 1 {
+		// Multiple pop-path outputs form ordinary grammar ambiguity. A marked
+		// recovery lineage can continue only through one exact reduction path.
+		for index := range replacements {
+			replacements[index].clearRecoveryLineage()
+		}
+	}
 	if len(replacements) == 0 {
 		// The canonical outputs already exist and have been processed in this
 		// election. Keep this version paused until a sibling makes real progress;
@@ -8537,8 +8827,27 @@ func (s *diagnosticParserCoreGenericScheduler) reindexCondenseCandidatesOwned(ow
 
 func (s *diagnosticParserCoreGenericScheduler) collectCondenseCandidates(source int) []core.CondenseCandidate {
 	candidates := s.condenseCandidates[:0]
+	if !s.recoveryIsolation {
+		for index, header := range s.headers {
+			if index == source || header.accepted || header.paused {
+				continue
+			}
+			candidates = append(candidates, core.CondenseCandidate{
+				Head: header.head, DropCohortRefs: header.dropCohortRefs,
+				Shifted: header.shifted, Checkpoint: header.checkpoint,
+			})
+		}
+		s.condenseCandidates = candidates
+		return candidates
+	}
+	sourceRecovery := source >= 0 && source < len(s.headers) && s.headers[source].isRecoveryLineage()
 	for index, header := range s.headers {
 		if index == source || header.accepted || header.paused {
+			continue
+		}
+		// Marked recovery versions must remain separate until acceptance can
+		// price them. Ordinary unmarked versions retain normal condensation.
+		if sourceRecovery || header.isRecoveryLineage() {
 			continue
 		}
 		candidates = append(candidates, core.CondenseCandidate{
@@ -8598,6 +8907,10 @@ func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(
 	}
 	for index := range s.headers {
 		if index == source {
+			continue
+		}
+		if s.recoveryIsolation &&
+			(s.headers[source].isRecoveryLineage() || s.headers[index].isRecoveryLineage()) {
 			continue
 		}
 		header := s.headers[index]
@@ -9001,12 +9314,14 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 	if err != nil {
 		return err
 	}
-	ordinaryCohort := len(cells) > 1
-	for index := range cells {
-		cell := &cells[index]
-		if cell.selectedActionOrdinal() != 0 || cell.dispatchToken(s.token) != cells[0].dispatchToken(s.token) {
-			ordinaryCohort = false
-			break
+	ordinaryCohort := len(cells) > 1 && !s.recoveryIsolation
+	if ordinaryCohort {
+		for index := range cells {
+			cell := &cells[index]
+			if cell.selectedActionOrdinal() != 0 || cell.dispatchToken(s.token) != cells[0].dispatchToken(s.token) {
+				ordinaryCohort = false
+				break
+			}
 		}
 	}
 	if ordinaryCohort {
@@ -9120,24 +9435,44 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 		if err != nil {
 			return err
 		}
-		s.classifiedBoundaries = s.classifiedBoundaries[:0]
-		for index := range cells {
-			cell := &cells[index]
-			s.classifiedBoundaries = append(s.classifiedBoundaries, cell.boundary)
-		}
 		token := cells[0].dispatchToken(s.token)
-		heads, err := s.compact.ShiftExtraClassifiedCohortWithLiveCondenseCandidatesOwned(owner, nil, s.classifiedBoundaries, core.Token{
-			Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte,
-			Extra: true, External: token.ExternalScannerToken,
-		})
-		if err != nil {
-			return err
-		}
-		for index := range cells {
-			cell := &cells[index]
-			s.headers[cell.headerIndex].head = heads[index]
-			s.headers[cell.headerIndex].shifted = true
-			markDiagnosticParserCoreExternalLineage(&s.headers[cell.headerIndex], token)
+		isolatedRecovery := s.recoveryIsolation
+		if isolatedRecovery {
+			for index := range cells {
+				cell := &cells[index]
+				head, shiftErr := s.compact.ShiftClassifiedWithLiveCondenseCandidatesOwned(
+					owner, s.collectCondenseCandidates(cell.headerIndex), cell.boundary, 0,
+					core.Token{
+						Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte,
+						Extra: true, External: token.ExternalScannerToken,
+					},
+					core.ForkOrder{},
+				)
+				if shiftErr != nil {
+					return shiftErr
+				}
+				s.headers[cell.headerIndex].head = head
+				s.headers[cell.headerIndex].shifted = true
+				markDiagnosticParserCoreExternalLineage(&s.headers[cell.headerIndex], token)
+			}
+		} else {
+			s.classifiedBoundaries = s.classifiedBoundaries[:0]
+			for index := range cells {
+				s.classifiedBoundaries = append(s.classifiedBoundaries, cells[index].boundary)
+			}
+			heads, shiftErr := s.compact.ShiftExtraClassifiedCohortWithLiveCondenseCandidatesOwned(owner, nil, s.classifiedBoundaries, core.Token{
+				Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte,
+				Extra: true, External: token.ExternalScannerToken,
+			})
+			if shiftErr != nil {
+				return shiftErr
+			}
+			for index := range cells {
+				cell := &cells[index]
+				s.headers[cell.headerIndex].head = heads[index]
+				s.headers[cell.headerIndex].shifted = true
+				markDiagnosticParserCoreExternalLineage(&s.headers[cell.headerIndex], token)
+			}
 		}
 		if s.extraPostExecutionFault != nil {
 			if err := s.extraPostExecutionFault(); err != nil {
@@ -9146,7 +9481,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 		}
 		s.epochProgress = true
 		s.work.ExtraShifts += uint64(len(cells))
-		if len(cells) > 1 {
+		if len(cells) > 1 && !isolatedRecovery {
 			s.work.ExtraCohorts++
 		}
 		s.work.Dispatches += uint64(len(cells))
@@ -9363,7 +9698,14 @@ func (s *diagnosticParserCoreGenericScheduler) canonicalizeOwned(owner core.Sche
 }
 
 func (s *diagnosticParserCoreGenericScheduler) canonicalizeOwnedWithMutation(owner core.SchedulerTransactionToken, expected core.DropCohortProducerMutation) error {
-	headers, mutation, err := s.canonicalScratch.canonicalizeWithMutation(s.compact, s.headers)
+	var headers []diagnosticParserCoreHeader
+	var mutation core.DropCohortProducerMutation
+	var err error
+	if s.recoveryIsolation {
+		headers, mutation, err = s.canonicalScratch.canonicalizeRecoveryWithMutation(s.compact, s.headers)
+	} else {
+		headers, mutation, err = s.canonicalScratch.canonicalizeWithMutation(s.compact, s.headers)
+	}
 	if err != nil {
 		return err
 	}

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -55,12 +55,8 @@ type parserCoreFreshFullRunner struct {
 }
 
 func newParserCoreFreshFullRunner(scanner ExternalScanner, options DiagnosticParserCorePrefixOptions) (*parserCoreFreshFullRunner, error) {
-	// B3 stage S3: admit options.Recovery only when it is paired with the
-	// certified-capability gate (allowCompactStrategy2ErrorRegion, set only
-	// from a grammar's own CompactStrategy2ErrorRegionCertified flag). Every
-	// other Recovery request -- and Retry/Incremental/IncludedRanges/closed-
-	// prefix, none of which this stage touches -- still declines exactly as
-	// before this stage landed.
+	// S3 supplies the base recovery mechanism. S5 separately requires its
+	// insertion and acceptance-selection gates.
 	if (options.Recovery && !options.allowCompactStrategy2ErrorRegion) ||
 		options.Retry || options.Incremental || options.IncludedRanges || options.GenericStopAtClosedByte != nil {
 		return nil, &diagnosticParserCoreDecline{
@@ -238,10 +234,13 @@ func requireParserCoreFreshFullAcceptance(scheduler *diagnosticParserCoreGeneric
 	selectedCertifiedPrimary := scheduler.options.allowPrimaryAcceptDerivation &&
 		header.ExactPaths > 1 && !acceptance.HasBranchOrder
 	selectedMaterialityCertified := acceptance.MaterialityCertified && header.ExactPaths > 1
+	acceptCountValid := (acceptance.Accepts == 1 && acceptance.Work.Accepts == 1) ||
+		(acceptance.Work.RecoveryLineageSelections == 1 &&
+			acceptance.Accepts >= 2 && acceptance.Accepts == acceptance.Work.Accepts)
 	if acceptance.Token.Symbol != 0 || acceptance.Token.StartByte != wantEOF || acceptance.Token.EndByte != wantEOF ||
 		acceptance.Token.Missing || acceptance.Token.NoLookahead || acceptance.Token.ExternalScannerToken ||
 		!header.Accepted || header.Paused || header.ExactPaths != 1 && !selectedCertifiedPrimary && !selectedMaterialityCertified ||
-		!parserCoreFreshFullAcceptedTailIsClean(source, header.ByteOffset, continuationEscape) || acceptance.Accepts != 1 || acceptance.Work.Accepts != 1 {
+		!parserCoreFreshFullAcceptedTailIsClean(source, header.ByteOffset, continuationEscape) || !acceptCountValid {
 		// See the comment above: census classification is opt-in and additive.
 		if admissionCensusEnabled() {
 			return admissionCensusAcceptanceDecline(acceptance, wantEOF)

--- a/parsercore_phase0_fresh_full_runner_internal_test.go
+++ b/parsercore_phase0_fresh_full_runner_internal_test.go
@@ -118,6 +118,19 @@ func TestResetDiagnosticParserCoreGenericSchedulerRejectsActiveScratch(t *testin
 	}
 }
 
+func TestResetDiagnosticParserCoreGenericSchedulerClearsMissingInsertionCount(t *testing.T) {
+	scheduler := diagnosticParserCoreGenericScheduler{s5MissingInsertions: 7, recoveryIsolation: true}
+	if err := resetDiagnosticParserCoreGenericScheduler(&scheduler); err != nil {
+		t.Fatal(err)
+	}
+	if scheduler.s5MissingInsertions != 0 {
+		t.Fatalf("missing insertion count=%d, want zero", scheduler.s5MissingInsertions)
+	}
+	if scheduler.recoveryIsolation {
+		t.Fatal("recovery isolation remained active after reset")
+	}
+}
+
 func TestParserCoreFreshFullRunnerScratchDoesNotAliasLiveTree(t *testing.T) {
 	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
 	if err != nil {

--- a/parsercore_phase0_generic_conflict_internal_test.go
+++ b/parsercore_phase0_generic_conflict_internal_test.go
@@ -550,6 +550,7 @@ func TestDiagnosticParserCoreGenericConflictArbitraryNOrdering(t *testing.T) {
 		{head: incoming, creationSeq: 4},
 		{head: suffix, creationSeq: 6},
 	}
+	headers[2].markRecoveryLineage()
 	before, err := diagnosticParserCoreHeaderReceipts(compact, headers)
 	if err != nil {
 		t.Fatal(err)
@@ -581,6 +582,11 @@ func TestDiagnosticParserCoreGenericConflictArbitraryNOrdering(t *testing.T) {
 	}
 	if !reflect.DeepEqual(states, []StateID{9, 2, 8, 3, 4}) || !reflect.DeepEqual(sequences, []uint64{2, 4, 6, 10, 11}) {
 		t.Fatalf("physical conflict order states=%v sequences=%v", states, sequences)
+	}
+	for index := range scheduler.headers {
+		if scheduler.headers[index].isRecoveryLineage() {
+			t.Fatalf("ordinary conflict output %d retained the recovery marker", index)
+		}
 	}
 	if scheduler.branchOrder != 9 || scheduler.nextSeq != 12 || scheduler.dispatches != 1 || scheduler.work != (DiagnosticParserCoreGenericWork{
 		Dispatches: 1, Conflicts: 1, ConflictActions: 3, Forks: 2, ConflictHeads: 3,
@@ -696,9 +702,11 @@ func TestDiagnosticParserCoreGenericConflictMultiOutputSequencing(t *testing.T) 
 			receipt := &DiagnosticParserCoreGenericScheduler{}
 			scheduler := &diagnosticParserCoreGenericScheduler{
 				compact: compact, headers: append([]diagnosticParserCoreHeader(nil), headers...),
-				token:       Token{Symbol: 10, StartByte: 1, EndByte: 2},
-				branchOrder: test.branchOrder, nextSeq: test.nextSeq,
-				options: DiagnosticParserCorePrefixOptions{MaxDispatches: 100}, receipt: receipt,
+				token:                Token{Symbol: 10, StartByte: 1, EndByte: 2},
+				branchOrder:          test.branchOrder,
+				nextSeq:              test.nextSeq,
+				nextCleanPathLineage: 1,
+				options:              DiagnosticParserCorePrefixOptions{MaxDispatches: 100}, receipt: receipt,
 			}
 			cell := mustDiagnosticParserCoreGenericCell(t, compact, 1, headers[1], 10)
 			err := scheduler.applyGenericConflict(before, cell)
@@ -711,6 +719,7 @@ func TestDiagnosticParserCoreGenericConflictMultiOutputSequencing(t *testing.T) 
 			}
 			if beforeStats != afterStats || !reflect.DeepEqual(scheduler.headers, headers) ||
 				scheduler.branchOrder != test.branchOrder || scheduler.nextSeq != test.nextSeq ||
+				scheduler.nextCleanPathLineage != 1 ||
 				scheduler.dispatches != 0 || scheduler.work != (DiagnosticParserCoreGenericWork{}) ||
 				!reflect.DeepEqual(receipt, &DiagnosticParserCoreGenericScheduler{}) {
 				t.Fatalf("overflow rollback leaked: before=%+v after=%+v scheduler=%+v receipt=%+v", beforeStats, afterStats, scheduler, receipt)
@@ -719,8 +728,8 @@ func TestDiagnosticParserCoreGenericConflictMultiOutputSequencing(t *testing.T) 
 	}
 	scheduler := &diagnosticParserCoreGenericScheduler{
 		compact: compact, headers: headers, token: Token{Symbol: 10, StartByte: 1, EndByte: 2},
-		branchOrder: 7, nextSeq: 10, options: DiagnosticParserCorePrefixOptions{MaxDispatches: 100},
-		receipt: &DiagnosticParserCoreGenericScheduler{},
+		branchOrder: 7, nextSeq: 10, nextCleanPathLineage: 1,
+		options: DiagnosticParserCorePrefixOptions{MaxDispatches: 100}, receipt: &DiagnosticParserCoreGenericScheduler{},
 	}
 	cell := mustDiagnosticParserCoreGenericCell(t, compact, 1, headers[1], 10)
 	if err := scheduler.applyGenericConflict(before, cell); err != nil {

--- a/parsercore_phase0_generic_freshness_internal_test.go
+++ b/parsercore_phase0_generic_freshness_internal_test.go
@@ -131,6 +131,76 @@ func TestDiagnosticParserCoreGenericReductionSequenceOverflowRollsBack(t *testin
 	}
 }
 
+func TestDiagnosticParserCoreRecoveryReductionForkClearsMarkers(t *testing.T) {
+	table := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 8}: {{Type: core.ActionShift, State: 3}},
+			{state: 2, symbol: 8}: {{Type: core.ActionShift, State: 3}},
+			{state: 3, symbol: 9}: {{Type: core.ActionReduce, Symbol: 4, ChildCount: 1}},
+		},
+		gotos: map[genericConflictCell]core.StateID{
+			{state: 1, symbol: 4}: 5,
+			{state: 2, symbol: 4}: 6,
+		},
+	}
+	compact, err := core.New(table, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = compact.Shift(first, 8, 0, core.Token{Symbol: 8, EndByte: 1}, core.ForkOrder{}); err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Shift(second, 8, 0, core.Token{Symbol: 8, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact:              compact,
+		headers:              []diagnosticParserCoreHeader{{head: head, creationSeq: 3}},
+		token:                Token{Symbol: 9, StartByte: 1, EndByte: 2},
+		nextSeq:              10,
+		nextCleanPathLineage: 1,
+		options:              DiagnosticParserCorePrefixOptions{MaxDispatches: 20},
+		receipt:              &DiagnosticParserCoreGenericScheduler{},
+	}
+	scheduler.headers[0].markRecoveryLineage()
+	scheduler.recoveryIsolation = true
+	before, err := diagnosticParserCoreHeaderReceipts(compact, scheduler.headers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cell := mustDiagnosticParserCoreGenericCell(t, compact, 0, scheduler.headers[0], 9)
+	if err := scheduler.applyGenericReduction(before, cell); err != nil {
+		t.Fatal(err)
+	}
+	if len(scheduler.headers) != 2 {
+		t.Fatalf("reduction produced %d heads, want 2", len(scheduler.headers))
+	}
+	for index := range scheduler.headers {
+		if scheduler.headers[index].isRecoveryLineage() {
+			t.Fatalf("ordinary reduction output %d retained the recovery marker", index)
+		}
+	}
+	if !scheduler.recoveryIsolation {
+		t.Fatal("ordinary reduction disabled the fail-closed recovery guard")
+	}
+	unsupported, err := scheduler.dispatchPass()
+	if err != nil {
+		t.Fatalf("dispatchPass: %v", err)
+	}
+	if unsupported == nil || unsupported.boundary != DiagnosticParserCoreRecovery {
+		t.Fatalf("unsupported=%+v, want recovery decline", unsupported)
+	}
+}
+
 func TestDiagnosticParserCoreCanonicalizeRunnableDominatesPaused(t *testing.T) {
 	compact, err := core.New(&genericConflictTable{}, core.Limits{})
 	if err != nil {

--- a/parsercore_phase0_recovery_cost_source.go
+++ b/parsercore_phase0_recovery_cost_source.go
@@ -47,12 +47,9 @@ import (
 // diagnosticParserCoreRecoveryCostSource adapts a compact Core to the stage S2
 // cost model's RecoveryCostSource interface.
 //
-// The cost model needs two things a compact subtree record does not store:
-// the missing bit (now carried, stage S5 substrate) and a row span. Rows are
-// read for ERROR nodes only -- RecoveryCostPerSkippedLine times the node's row
-// extent -- so this source computes them from the source text on demand rather
-// than widening the record. newlines is built once per parse, lazily, and only
-// if some ERROR node actually asks.
+// The compact view supplies the missing bit. The compact record does not store
+// row spans. This source computes rows from the text only for ERROR nodes.
+// It builds the newline index once per parse and only when pricing needs it.
 type diagnosticParserCoreRecoveryCostSource struct {
 	compact *core.Core
 	source  []byte

--- a/parsercore_phase0_recovery_lineage_fork_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_fork_internal_test.go
@@ -1,0 +1,315 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+type recoveryLineageForkTable struct{}
+
+func (recoveryLineageForkTable) Actions(state core.StateID, symbol core.Symbol) (core.ActionRow, error) {
+	var actions []core.Action
+	switch {
+	case state == 1 && symbol == 2:
+		actions = []core.Action{{Type: core.ActionShift, State: 2}}
+	case state == 2 && symbol == 4:
+		actions = []core.Action{{Type: core.ActionReduce, Symbol: 5, ChildCount: 1}}
+	case state == 3 && symbol == 4:
+		actions = []core.Action{{Type: core.ActionShift, State: 4}}
+	}
+	return core.NewActionRow(actions, false), nil
+}
+
+func (recoveryLineageForkTable) Goto(state core.StateID, symbol core.Symbol) (core.StateID, error) {
+	if state == 1 && symbol == 5 {
+		return 3, nil
+	}
+	return 0, nil
+}
+
+func (recoveryLineageForkTable) ProductionFields(uint16, int) ([]core.FieldMapEntry, error) {
+	return nil, nil
+}
+
+func (recoveryLineageForkTable) ProductionAliases(uint16, int) ([]core.Symbol, error) {
+	return nil, nil
+}
+
+func newRecoveryLineageForkScheduler(t *testing.T, armed bool) *diagnosticParserCoreGenericScheduler {
+	t.Helper()
+	compact, err := core.New(recoveryLineageForkTable{}, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(core.StateID(1), 1)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	lang := &Language{TokenCount: 5}
+	return &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		tokenSource: &dfaTokenSource{
+			language: lang,
+			lexer:    &Lexer{source: []byte("a?")},
+		},
+		headers: []diagnosticParserCoreHeader{{head: seed, creationSeq: 3}},
+		token:   Token{Symbol: 4, StartByte: 1, EndByte: 2},
+		nextSeq: 10,
+		options: DiagnosticParserCorePrefixOptions{
+			Recovery:                             true,
+			allowCompactStrategy2ErrorRegion:     true,
+			allowCompactMissingTokenInsertion:    true,
+			allowCompactRecoveryLineageSelection: armed,
+		},
+	}
+}
+
+func TestS5MissingInsertionForkPublishesBothRecoveryLineages(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	handled, err := scheduler.s5TryMissingTokenInsertion(0)
+	if err != nil {
+		t.Fatalf("s5TryMissingTokenInsertion: %v", err)
+	}
+	if !handled {
+		t.Fatal("the viable missing-token candidate did not fork")
+	}
+	if len(scheduler.headers) != 2 {
+		t.Fatalf("headers=%d, want two recovery lineages", len(scheduler.headers))
+	}
+	if !scheduler.headers[0].isRecoveryLineage() || !scheduler.headers[1].isRecoveryLineage() {
+		t.Fatal("the fork did not mark both recovery lineages")
+	}
+	if !scheduler.recoveryIsolation {
+		t.Fatal("the fork did not activate recovery isolation")
+	}
+	if scheduler.headers[1].shifted || scheduler.headers[1].s3Region != nil {
+		t.Fatalf("missing lineage consumed the real token: %+v", scheduler.headers[1])
+	}
+	if !scheduler.headers[0].shifted || scheduler.headers[0].s3Region == nil {
+		t.Fatalf("absorb lineage did not consume the real token: %+v", scheduler.headers[0])
+	}
+	if scheduler.headers[0].creationSeq != 3 || scheduler.headers[1].creationSeq != 10 || scheduler.nextSeq != 11 {
+		t.Fatalf("creation sequence=%d/%d next=%d, want 3/10 next 11",
+			scheduler.headers[0].creationSeq, scheduler.headers[1].creationSeq, scheduler.nextSeq)
+	}
+	if scheduler.s5MissingInsertions != 1 {
+		t.Fatalf("missing insertion count=%d, want 1", scheduler.s5MissingInsertions)
+	}
+
+	derivations, err := scheduler.compact.Derivations(scheduler.headers[1].head)
+	if err != nil {
+		t.Fatalf("missing derivation: %v", err)
+	}
+	if len(derivations) != 1 || len(derivations[0].Payloads) != 1 {
+		t.Fatalf("missing derivations=%+v, want one payload", derivations)
+	}
+	missing, err := scheduler.compact.MaterializationView(derivations[0].Payloads[0])
+	if err != nil {
+		t.Fatalf("missing payload: %v", err)
+	}
+	if !missing.Missing || missing.Symbol != 2 || missing.StartByte != 1 || missing.EndByte != 1 {
+		t.Fatalf("missing payload=%+v, want symbol 2 at byte 1", missing)
+	}
+
+	region := scheduler.headers[0].s3Region
+	if len(region.children) != 1 || region.startByte != 1 || region.endByte != 2 {
+		t.Fatalf("absorb region=%+v, want one child over bytes 1..2", region)
+	}
+	absorbed, err := scheduler.compact.MaterializationView(region.children[0])
+	if err != nil {
+		t.Fatalf("absorbed payload: %v", err)
+	}
+	if absorbed.Symbol != 4 || absorbed.StartByte != 1 || absorbed.EndByte != 2 {
+		t.Fatalf("absorbed payload=%+v, want symbol 4 over bytes 1..2", absorbed)
+	}
+}
+
+func TestS5MissingInsertionForkRequiresAcceptanceSelection(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, false)
+	original := scheduler.headers[0]
+	handled, err := scheduler.s5TryMissingTokenInsertion(0)
+	if err != nil {
+		t.Fatalf("s5TryMissingTokenInsertion: %v", err)
+	}
+	if handled || len(scheduler.headers) != 1 || scheduler.headers[0] != original {
+		t.Fatalf("unarmed fork changed the frontier: handled=%t headers=%+v", handled, scheduler.headers)
+	}
+	if scheduler.s5MissingInsertions != 0 || scheduler.nextSeq != 10 || scheduler.recoveryIsolation {
+		t.Fatalf("unarmed fork changed state: insertions=%d next=%d isolated=%t",
+			scheduler.s5MissingInsertions, scheduler.nextSeq, scheduler.recoveryIsolation)
+	}
+}
+
+func TestS5MissingInsertionForkDeclinesUnrepresentableTokenCount(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	scheduler.tokenSource.language.TokenCount = uint32(^Symbol(0)) + 1
+	original := scheduler.headers[0]
+
+	handled, err := scheduler.s5TryMissingTokenInsertion(0)
+	if err != nil {
+		t.Fatalf("s5TryMissingTokenInsertion: %v", err)
+	}
+	if handled || len(scheduler.headers) != 1 || scheduler.headers[0] != original {
+		t.Fatalf("wide token table changed the frontier: handled=%t headers=%+v", handled, scheduler.headers)
+	}
+}
+
+func TestS5MissingInsertionForkDeclinesHiddenFirstCandidate(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	scheduler.tokenSource.language.SymbolMetadata = make([]SymbolMetadata, 5)
+	for index := range scheduler.tokenSource.language.SymbolMetadata {
+		scheduler.tokenSource.language.SymbolMetadata[index].Visible = true
+	}
+	scheduler.tokenSource.language.SymbolMetadata[2].Visible = false
+	original := scheduler.headers[0]
+
+	handled, err := scheduler.s5TryMissingTokenInsertion(0)
+	if err != nil {
+		t.Fatalf("s5TryMissingTokenInsertion: %v", err)
+	}
+	if handled || len(scheduler.headers) != 1 || scheduler.headers[0] != original {
+		t.Fatalf("hidden candidate changed the frontier: handled=%t headers=%+v", handled, scheduler.headers)
+	}
+	if scheduler.s5MissingInsertions != 0 || scheduler.nextSeq != 10 || scheduler.recoveryIsolation {
+		t.Fatalf("hidden candidate changed state: insertions=%d next=%d isolated=%t",
+			scheduler.s5MissingInsertions, scheduler.nextSeq, scheduler.recoveryIsolation)
+	}
+}
+
+func TestS5MissingInsertionForkRestoresFrontierWhenAbsorbDeclines(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	seed, err := scheduler.compact.Seed(core.StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	scheduler.headers[0].head = seed
+	scheduler.token = Token{Symbol: 4, StartByte: 0, EndByte: 1}
+	scheduler.tokenSource.lexer.source = []byte("?")
+	original := scheduler.headers[0]
+
+	handled, err := scheduler.s5TryMissingTokenInsertion(0)
+	if err != nil {
+		t.Fatalf("s5TryMissingTokenInsertion: %v", err)
+	}
+	if handled || len(scheduler.headers) != 1 || scheduler.headers[0] != original {
+		t.Fatalf("declined absorb changed the frontier: handled=%t headers=%+v", handled, scheduler.headers)
+	}
+	if scheduler.s5MissingInsertions != 0 || scheduler.nextSeq != 10 || scheduler.recoveryIsolation {
+		t.Fatalf("declined absorb changed state: insertions=%d next=%d isolated=%t",
+			scheduler.s5MissingInsertions, scheduler.nextSeq, scheduler.recoveryIsolation)
+	}
+}
+
+func TestRecoveryCompetitionDoesNotUseOrdinaryNoActionDrop(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	handled, err := scheduler.s5TryMissingTokenInsertion(0)
+	if err != nil || !handled {
+		t.Fatalf("fork: handled=%t err=%v", handled, err)
+	}
+	scheduler.token = Token{Symbol: 3, StartByte: 1, EndByte: 2}
+	scheduler.epochProgress = true
+
+	unsupported, err := scheduler.dispatchPass()
+	if err != nil {
+		t.Fatalf("dispatchPass: %v", err)
+	}
+	if unsupported == nil || unsupported.boundary != DiagnosticParserCoreRecovery {
+		t.Fatalf("unsupported=%+v, want a recovery decline", unsupported)
+	}
+	if len(scheduler.headers) != 2 {
+		t.Fatalf("ordinary no-action logic dropped a recovery version: headers=%d", len(scheduler.headers))
+	}
+}
+
+func TestRecoveryCompetitionDeclinesAfterOrdinaryAmbiguity(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	handled, err := scheduler.s5TryMissingTokenInsertion(0)
+	if err != nil || !handled {
+		t.Fatalf("fork: handled=%t err=%v", handled, err)
+	}
+	scheduler.headers[1].clearRecoveryLineage()
+
+	unsupported, err := scheduler.dispatchPass()
+	if err != nil {
+		t.Fatalf("dispatchPass: %v", err)
+	}
+	if unsupported == nil || unsupported.boundary != DiagnosticParserCoreRecovery {
+		t.Fatalf("unsupported=%+v, want a recovery decline", unsupported)
+	}
+	if unsupported.detail != "recovery competition crossed ordinary grammar ambiguity" {
+		t.Fatalf("detail=%q", unsupported.detail)
+	}
+	if len(scheduler.headers) != 2 {
+		t.Fatalf("decline changed the recovery frontier: headers=%d", len(scheduler.headers))
+	}
+}
+
+func TestRecoveryCanonicalizationKeepsMarkedOwnersSeparate(t *testing.T) {
+	compact, err := core.New(lineageSelectionTable{}, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(core.StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	leftPayload, err := compact.ErrorRegionLeaf(core.Symbol(3), 0, 1, false)
+	if err != nil {
+		t.Fatalf("left payload: %v", err)
+	}
+	rightPayload, err := compact.MissingLeaf(core.Symbol(4), 1)
+	if err != nil {
+		t.Fatalf("right payload: %v", err)
+	}
+	var left, right core.Head
+	err = compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		var publishErr error
+		left, publishErr = compact.ErrorRegionResumeWithLiveCondenseCandidatesOwned(
+			owner, nil, seed, core.StateID(2), 0, 1, []core.SubtreeID{leftPayload},
+		)
+		if publishErr != nil {
+			return publishErr
+		}
+		right, publishErr = compact.ErrorRegionResumeWithLiveCondenseCandidatesOwned(
+			owner, nil, seed, core.StateID(2), 0, 1, []core.SubtreeID{rightPayload},
+		)
+		return publishErr
+	})
+	if err != nil {
+		t.Fatalf("publish isolated heads: %v", err)
+	}
+	if left == right {
+		t.Fatal("isolated recovery publications returned one compact head")
+	}
+
+	headers := []diagnosticParserCoreHeader{
+		{head: left, creationSeq: 1},
+		{head: right, creationSeq: 2},
+	}
+	for index := range headers {
+		headers[index].markRecoveryLineage()
+	}
+	var scratch diagnosticParserCoreCanonicalScratch
+	isolated, err := scratch.canonicalizeRecovery(compact, headers)
+	if err != nil {
+		t.Fatalf("canonicalize marked: %v", err)
+	}
+	if len(isolated) != 2 || isolated[0].head == isolated[1].head {
+		t.Fatalf("marked recovery owners reconverged: %+v", isolated)
+	}
+
+	for index := range headers {
+		headers[index].clearRecoveryLineage()
+		headers[index].shifted = true
+	}
+	ordinary, err := scratch.canonicalize(compact, headers)
+	if err != nil {
+		t.Fatalf("canonicalize ordinary: %v", err)
+	}
+	if len(ordinary) != 1 {
+		t.Fatalf("ordinary canonicalization retained %d heads, want 1", len(ordinary))
+	}
+}

--- a/parsercore_phase0_recovery_lineage_selection_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_selection_internal_test.go
@@ -12,7 +12,7 @@ import (
 // selectCompetingRecoveryLineage is the acceptance half of C's version
 // competition: when more than one head accepts, price the competitors and
 // publish the cheaper tree instead of declining. These tests drive it through
-// a hand-built scheduler, because no live path forks a recovery lineage yet.
+// a hand-built scheduler to isolate the acceptance policy from the live fork.
 
 type lineageSelectionTable struct{}
 
@@ -87,7 +87,7 @@ func TestSelectCompetingRecoveryLineagePublishesTheCheaperTree(t *testing.T) {
 }
 
 // TestSelectCompetingRecoveryLineageDeclinesUnarmed proves the capability
-// actually gates the path, which is what keeps this unreachable today.
+// keeps uncertified parses on the conservative path.
 func TestSelectCompetingRecoveryLineageDeclinesUnarmed(t *testing.T) {
 	scheduler := newLineageSelectionScheduler(t, false)
 	_, resolved, err := scheduler.selectCompetingRecoveryLineage()
@@ -96,6 +96,32 @@ func TestSelectCompetingRecoveryLineageDeclinesUnarmed(t *testing.T) {
 	}
 	if resolved {
 		t.Fatal("an unarmed scheduler resolved a competing frontier")
+	}
+}
+
+func TestCompleteAcceptancePricesRecoveryFrontierBeforeCollapse(t *testing.T) {
+	scheduler := newLineageSelectionScheduler(t, true)
+	scheduler.recoveryIsolation = true
+	scheduler.options.ReceiptMode = DiagnosticParserCoreReceiptSummary
+	scheduler.receipt = &scheduler.receiptBacking
+	for index := range scheduler.headers {
+		scheduler.headers[index].accepted = true
+	}
+	scheduler.work.Accepts = uint64(len(scheduler.headers))
+	eof := uint32(len(scheduler.options.materializationSource))
+	scheduler.token = Token{StartByte: eof, EndByte: eof}
+	want := scheduler.headers[1].head
+
+	if err := scheduler.completeAcceptance(); err != nil {
+		t.Fatalf("completeAcceptance: %v", err)
+	}
+	if scheduler.acceptedHead != want || len(scheduler.headers) != 1 {
+		t.Fatalf("accepted head=%v headers=%d, want absorb head %v", scheduler.acceptedHead, len(scheduler.headers), want)
+	}
+	acceptance := scheduler.receipt.Acceptance
+	if acceptance == nil || acceptance.Accepts != 2 || acceptance.Work.Accepts != 2 ||
+		acceptance.Work.RecoveryLineageSelections != 1 {
+		t.Fatalf("acceptance=%+v, want two accepts and one recovery selection", acceptance)
 	}
 }
 
@@ -228,6 +254,14 @@ func TestCollapseToRecoveryWinnerSeatsTheWinnerAndClearsLosers(t *testing.T) {
 	scheduler.headers = append(scheduler.headers, diagnosticParserCoreHeader{})
 	scheduler.headers[2].markRecoveryLineage()
 	scheduler.headers[2].s3Region = &diagnosticParserCoreS3Region{}
+	scheduler.recoveryIsolation = true
+	retainedRegion := &diagnosticParserCoreS3Region{}
+	for target := range scheduler.canonicalScratch.headerBuffers {
+		buffer := make([]diagnosticParserCoreHeader, 2, 4)
+		buffer[1].markRecoveryLineage()
+		buffer[1].s3Region = retainedRegion
+		scheduler.canonicalScratch.headerBuffers[target] = buffer
+	}
 	want := scheduler.headers[1]
 
 	scheduler.collapseToRecoveryWinner(1)
@@ -241,12 +275,22 @@ func TestCollapseToRecoveryWinnerSeatsTheWinnerAndClearsLosers(t *testing.T) {
 	if scheduler.work.RecoveryLineageSelections != 1 {
 		t.Fatalf("collapse recorded %d selections, want 1", scheduler.work.RecoveryLineageSelections)
 	}
+	if scheduler.recoveryIsolation || scheduler.headers[0].isRecoveryLineage() {
+		t.Fatal("collapse retained recovery competition state on the winner")
+	}
 	// The losers must not stay live in the backing array: each retains an open
 	// error region for the scheduler's lifetime otherwise.
 	tail := scheduler.headers[:cap(scheduler.headers)][1:3]
 	for index := range tail {
 		if tail[index].s3Region != nil || tail[index].isRecoveryLineage() {
 			t.Fatalf("dropped header %d is still live in the backing array", index+1)
+		}
+	}
+	for target, buffer := range scheduler.canonicalScratch.headerBuffers {
+		for index, header := range buffer[:cap(buffer)] {
+			if header.s3Region == retainedRegion || header.isRecoveryLineage() {
+				t.Fatalf("canonical buffer %d retained loser %d", target, index)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The compact parser now forks one no-action head into two recovery versions. One version inserts a missing token. The other absorbs the real token into an error region.

Both versions continue to acceptance. The merged selection path prices them and publishes the same winner as C.

This closes the named `html_log_7` Stage S5 gap. All ten committed HTML recovery witnesses now match the locked C oracle exactly.

## Changes

- Add the certified missing-token insertion capability.
- Scan terminal symbols in ascending order, as C does.
- Apply the required reduction prefix before the missing shift.
- Fork the original absorb version and the missing-token copy in C order.
- Isolate recovery versions from ordinary condense and no-action drops.
- Carry all marked accepting versions into the merged cost selection path.
- Clear recovery markers when ordinary ambiguity forks a version.
- Add bounded spine and reduction simulation helpers in the compact core.
- Materialize zero-width missing terminals with exact spans and flags.
- Certify the exact HTML grammar artifact against all ten witnesses.
- Record fork, selection, decline, and missing-insertion work counters.

## Correctness

The implementation fails closed for unsupported shapes. It declines on ambiguous spines, hidden first candidates, wide symbol tables, failed absorb forks, and ordinary ambiguity.

The fork order is load-bearing. C keeps the absorb version first and appends the missing version. Equal-cost selection can depend on that order.

The selection gate stays disabled unless one artifact certifies absorption, insertion, and acceptance selection together.

## Testing

All final runs used commit `38ca150e`.

- The focused Docker gate passed.
- The locked C oracle passed for all ten HTML witnesses.
- The HTML parity corpus passed 25 of 25 files.
- The HTML run used 1,250,420 KiB maximum resident memory. No out-of-memory event occurred.
- The live fuzz gate passed 4,892 executions.
- The focused root and compact-core tests passed.
- Both compact build-tag configurations passed.
- `go vet` passed for the compact core and grammar packages.
- Root `go vet` reported only the baseline `Language` copy warning.
- The 20-seed randomized benchmark trio found no significant timing change.
- Allocation counts stayed identical on all three benchmarks.

## Review focus

Review `s5TryMissingTokenInsertion` and the recovery isolation rules first. The rollback must restore the sole original header when either fork cannot publish.

Review every ambiguity fork for `clearRecoveryLineage`. Error cost must never replace ordinary grammar ambiguity selection.

Review the hidden-terminal decline. The current materializer cannot preserve the error flag after it removes a hidden missing terminal.
