### PR TITLE
add(grammars): certify JavaScript compact recovery and guard S3 regions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -855,7 +855,7 @@ jobs:
             --test-parallel 1 \
             --c-ref-build-jobs 1 \
             --timeout 20m \
-            --run '^TestCompactT3OracleAdjudication$'
+            --run '^(TestCompactT3OracleAdjudication|TestCompactT3JavaScriptRecoveryProfileCharacterization|TestCompactT3JavaScriptRecoveryRouteSeedOracleParity|TestCompactT3JavaScriptRecoveryMutationDifferential|TestCompactJavaScriptS5RecoveryMutationDifferential)$'
 
   # merge-event-census-cgo runs stage M0 of spec.merge-time-election.v1: the
   # census that counts stack-merge events on both sides and breaks production's

--- a/admission_route_equality_leaf_tiling_test.go
+++ b/admission_route_equality_leaf_tiling_test.go
@@ -427,16 +427,19 @@ func TestCompactRouteAcceptedRootTrailingErrorExtraDeclines(t *testing.T) {
 	}
 	lang := entry.Language()
 
-	sources := []string{
-		"<html><body>x</body>\x00>",
-		"<html><body>x</body>\x00/h>",
-		"<html><body>x</body>\x00/h>\x00/html>",
-		"<html><body>-->Hello</body>\x00/h>\x00/html>\n",
+	sources := []struct {
+		source     string
+		wantReason string
+	}{
+		{"<html><body>x</body>\x00>", "error-bearing trailing extra"},
+		{"<html><body>x</body>\x00/h>", "error-bearing trailing extra"},
+		{"<html><body>x</body>\x00/h>\x00/html>", "error-bearing trailing extra"},
+		{"<html><body>-->Hello</body>\x00/h>\x00/html>\n", "one error region per parse"},
 	}
-	for _, src := range sources {
-		src := src
-		t.Run(src, func(t *testing.T) {
-			source := []byte(src)
+	for _, test := range sources {
+		test := test
+		t.Run(test.source, func(t *testing.T) {
+			source := []byte(test.source)
 
 			gts.ResetAdmissionCandidateCountersForTest()
 			candidate := gts.NewParser(lang)
@@ -449,11 +452,11 @@ func TestCompactRouteAcceptedRootTrailingErrorExtraDeclines(t *testing.T) {
 
 			routed, fallback := gts.AdmissionCandidateCounters()
 			if routed != 0 || fallback != 1 {
-				t.Fatalf("%q: route counters routed=%d fallback=%d, want routed=0 fallback=1 (accept-time splice gap must decline)", src, routed, fallback)
+				t.Fatalf("%q: route counters routed=%d fallback=%d, want routed=0 fallback=1", test.source, routed, fallback)
 			}
 			reason := gts.AdmissionCandidateLastFallbackReason()
-			if !strings.Contains(reason, "error-bearing trailing extra") {
-				t.Fatalf("%q: fallback reason=%q, want it to cite the trailing extra splice gap", src, reason)
+			if !strings.Contains(reason, test.wantReason) {
+				t.Fatalf("%q: fallback reason=%q, want %q", test.source, reason, test.wantReason)
 			}
 		})
 	}

--- a/admission_route_equality_leaf_tiling_test.go
+++ b/admission_route_equality_leaf_tiling_test.go
@@ -149,7 +149,7 @@ func TestCompactRouteAcceptedHiddenDoctypeLeafTiles(t *testing.T) {
 	}
 }
 
-// TestCompactRouteDeclinesAdjudicatedFalseCleanWitnesses pulls a focused
+// TestCompactRouteAdjudicatesFalseCleanWitnesses pulls a focused
 // subset (3 html, 3 javascript) from the 20-witness committed manifest (10
 // html, 8 javascript, 2 swift). Each entry was, before the B1 tiling gate,
 // accepted by the compact route with HasError()==false while production and
@@ -165,9 +165,9 @@ func TestCompactRouteAcceptedHiddenDoctypeLeafTiles(t *testing.T) {
 // same root HasError as production (exact structural C-oracle parity is
 // asserted separately, under cgo, by
 // cgo_harness/compact_t3_oracle_adjudication_test.go's
-// compactT3RecoveryCertifiedWitnesses). The 3 javascript entries are outside B3's
-// witness classes staged so far and still decline at the tiling gate exactly
-// as B1 left them.
+// compactT3RecoveryCertifiedWitnesses). The certified JavaScript artifact now
+// routes js_log_1 and js_log_2 with exact C parity. js_log_3 still fails closed
+// when the accepted root leaves expose its unaccounted byte range.
 //
 // Scope note: the manifest's 2 swift entries (swift_log_1, swift_log_2) are
 // NOT in this list. Root-cause (verified by direct tree inspection):
@@ -193,7 +193,7 @@ func TestCompactRouteAcceptedHiddenDoctypeLeafTiles(t *testing.T) {
 // out-of-scope finding for a follow-up tranche rather than folded into this
 // fix (campaign v7 delegation protocol: scope changes route back through
 // the specification, not through an ad hoc widening of one tranche's check).
-func TestCompactRouteDeclinesAdjudicatedFalseCleanWitnesses(t *testing.T) {
+func TestCompactRouteAdjudicatesFalseCleanWitnesses(t *testing.T) {
 	// html and javascript are not otherwise loaded by the always-on (untagged)
 	// suite; purge the process-wide embedded cache afterward so this test does
 	// not inflate heap for later whole-process tests (matches
@@ -250,23 +250,23 @@ func TestCompactRouteDeclinesAdjudicatedFalseCleanWitnesses(t *testing.T) {
 			defer tree.Release()
 
 			routed, fallback := gts.AdmissionCandidateCounters()
-			if witness.Language == "html" {
-				// B3 stage S3: html_erroneous_end_tag now routes natively.
+			nativeRecovery := witness.Language == "html" || id == "js_log_1" || id == "js_log_2"
+			if nativeRecovery {
 				if routed != 1 || fallback != 0 {
-					t.Fatalf("witness %q: route counters routed=%d fallback=%d, want routed=1 fallback=0 (B3 stage S3: compact now handles this witness natively)", id, routed, fallback)
+					t.Fatalf("witness %q: route counters routed=%d fallback=%d, want routed=1 fallback=0", id, routed, fallback)
 				}
 			} else {
 				if routed != 0 || fallback != 1 {
 					t.Fatalf("witness %q: route counters routed=%d fallback=%d, want routed=0 fallback=1 (compact must decline)", id, routed, fallback)
 				}
 				reason := gts.AdmissionCandidateLastFallbackReason()
-				if !strings.Contains(reason, "accepted-leaf-tiling-gap") {
-					t.Fatalf("witness %q: fallback reason=%q, want it to cite accepted-leaf-tiling-gap", id, reason)
+				if !strings.Contains(reason, "accepted compact root leaves do not tile the accepted span") {
+					t.Fatalf("witness %q: fallback reason=%q, want an accepted-root leaf-tiling gap", id, reason)
 				}
 			}
 
 			if got := tree.RootNode().HasError(); got != *witness.Expected.ProductionHasError {
-				t.Fatalf("witness %q: production-served HasError=%t, want %t (manifest production_has_error, C-adjudicated)",
+				t.Fatalf("witness %q: served HasError=%t, want %t (manifest production_has_error, C-adjudicated)",
 					id, got, *witness.Expected.ProductionHasError)
 			}
 		})

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -94,6 +94,7 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		// for the proof and still fails closed per tree when it is incomplete.
 		replayParseStates:                 true,
 		allowConvergedReductionSplitDrops: p.language.CompactConvergedReductionSplitDropsCertified,
+		recoveryPlainFirst:                p.language.CompactRecoveryPlainFirstCertified,
 	}, nil
 }
 

--- a/cgo_harness/compact_javascript_s5_scan_test.go
+++ b/cgo_harness/compact_javascript_s5_scan_test.go
@@ -1,0 +1,127 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"fmt"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestCompactJavaScriptS5RecoveryMutationDifferential finds S5-only routes in
+// a deterministic mutation set. Every expanded route must match C exactly.
+func TestCompactJavaScriptS5RecoveryMutationDifferential(t *testing.T) {
+	cLanguage, err := ParityCLanguage("javascript")
+	if err != nil {
+		t.Fatal(err)
+	}
+	goLanguage := grammars.JavascriptLanguage()
+	if !goLanguage.CompactStrategy2ErrorRegionCertified || !goLanguage.CompactMissingTokenInsertionCertified {
+		t.Fatal("the exact JavaScript artifact lacks complete compact recovery certification")
+	}
+	s3OnlyLanguage := *goLanguage
+	s3OnlyLanguage.CompactMissingTokenInsertionCertified = false
+	fullParser := gotreesitter.NewParser(goLanguage)
+	fullParser.SetAdmissionCandidateRoute(true)
+	s3OnlyParser := gotreesitter.NewParser(&s3OnlyLanguage)
+	s3OnlyParser.SetAdmissionCandidateRoute(true)
+
+	parseRoute := func(parser *gotreesitter.Parser, source []byte) (*gotreesitter.Tree, bool) {
+		t.Helper()
+		beforeRouted, beforeFallback := gotreesitter.AdmissionCandidateCounters()
+		tree, parseErr := parser.Parse(source)
+		if parseErr != nil {
+			t.Fatalf("parse %q: %v", source, parseErr)
+		}
+		if tree == nil || tree.RootNode() == nil {
+			t.Fatalf("parse %q returned no root", source)
+		}
+		afterRouted, afterFallback := gotreesitter.AdmissionCandidateCounters()
+		switch {
+		case afterRouted-beforeRouted == 1 && afterFallback-beforeFallback == 0:
+			return tree, true
+		case afterRouted-beforeRouted == 0 && afterFallback-beforeFallback == 1:
+			return tree, false
+		default:
+			t.Fatalf("parse %q route counters=%d/%d, want 1/0 or 0/1",
+				source, afterRouted-beforeRouted, afterFallback-beforeFallback)
+			return nil, false
+		}
+	}
+
+	seeds := []string{
+		"function f(a) { return a; }",
+		"function f(a, b) { return a + b; }",
+		"const f = (a, b) => a + b;",
+		"const f = async (a) => await a;",
+		"const x = foo(1, 2, 3);",
+		"const x = (1 + 2) * 3;",
+		"const x = [1, 2, 3];",
+		"const x = {a: 1, b: 2};",
+		"if (x) { y(); } else { z(); }",
+		"while (x) { y(); }",
+		"for (let i = 0; i < 3; i++) { x(i); }",
+		"for (const x of xs) { y(x); }",
+		"class A { m(a) { return a; } }",
+		"try { x(); } catch (e) { y(e); }",
+		"switch (x) { case 1: y(); break; default: z(); }",
+		"const x = a ? b : c;",
+		"const x = `hello ${name}`;",
+		"export function f() { return 1; }",
+		"import {a, b} from 'm';",
+		"const {a, b} = value;",
+		"const [a, b] = value;",
+		"async function f() { await x(); }",
+		"function* f() { yield 1; }",
+		"const x = new A(1, 2);",
+		"a.b.c(1, 2);",
+	}
+	replacements := []byte{'?', '#', ';', ')', '}', ']', ':'}
+	var cases, expanded, contracted int
+	check := func(name string, source []byte) {
+		t.Helper()
+		cases++
+		fullTree, fullRouted := parseRoute(fullParser, source)
+		s3Tree, s3Routed := parseRoute(s3OnlyParser, source)
+		if !fullRouted && s3Routed {
+			contracted++
+		}
+		if !fullRouted || s3Routed {
+			fullTree.Release()
+			s3Tree.Release()
+			return
+		}
+		expanded++
+		cTree := compactT3ParseC(t, cLanguage, source)
+		if divergences := compactT3StructuralDivergences(fullTree.RootNode(), goLanguage, cTree.RootNode()); len(divergences) != 0 {
+			t.Fatalf("%s: S5-expanded tree diverges from C at %d node(s); first: %s; source=%q",
+				name, len(divergences), compactT3FormatDivergence(divergences[0]), source)
+		}
+		cTree.Close()
+		fullTree.Release()
+		s3Tree.Release()
+	}
+	for seedIndex, seedText := range seeds {
+		seed := []byte(seedText)
+		check(fmt.Sprintf("seed-%d", seedIndex), seed)
+		for offset := range seed {
+			deleted := append([]byte(nil), seed[:offset]...)
+			deleted = append(deleted, seed[offset+1:]...)
+			check(fmt.Sprintf("delete-%d-%d", seedIndex, offset), deleted)
+			for _, replacement := range replacements {
+				if seed[offset] == replacement {
+					continue
+				}
+				replaced := append([]byte(nil), seed...)
+				replaced[offset] = replacement
+				check(fmt.Sprintf("replace-%d-%d-%02x", seedIndex, offset, replacement), replaced)
+			}
+		}
+	}
+	if expanded != 26 || contracted != 0 {
+		t.Fatalf("S5 route delta expanded=%d contracted=%d, want 26/0 across %d cases", expanded, contracted, cases)
+	}
+	t.Logf("JavaScript S5 mutation differential: cases=%d expanded=%d contracted=%d", cases, expanded, contracted)
+}

--- a/cgo_harness/compact_t3_oracle_adjudication_test.go
+++ b/cgo_harness/compact_t3_oracle_adjudication_test.go
@@ -112,9 +112,10 @@ type compactT3ExpectedOutcome struct {
 	CompactHasError    *bool `json:"compact_has_error"`
 }
 
-// compactT3RecoveryCertifiedWitnesses lists HTML witnesses where native
-// compact recovery reaches exact structural C-oracle parity. The exact HTML
-// artifact certifies S3 error absorption and S5 version competition.
+// compactT3RecoveryCertifiedWitnesses lists witnesses where native compact
+// recovery reaches exact structural C-oracle parity. The exact HTML artifact
+// certifies its complete class. JavaScript certifies the current S3 frontier;
+// its remaining five witnesses stay fail-closed.
 var compactT3RecoveryCertifiedWitnesses = map[string]bool{
 	"html_min_a":    true,
 	"html_min_html": true,
@@ -126,6 +127,9 @@ var compactT3RecoveryCertifiedWitnesses = map[string]bool{
 	"html_log_6":    true,
 	"html_log_7":    true,
 	"html_log_8":    true,
+	"js_log_1":      true,
+	"js_log_2":      true,
+	"js_log_4":      true,
 }
 
 // TestCompactT3OracleAdjudication verifies each committed false-clean witness
@@ -142,7 +146,8 @@ var compactT3RecoveryCertifiedWitnesses = map[string]bool{
 //   - compact vs. the C oracle: S3 and S5 cover all ten
 //     html_erroneous_end_tag witnesses. Every witness in
 //     compactT3RecoveryCertifiedWitnesses must match the C oracle exactly.
-//     JavaScript and Swift still have no compact recovery implementation.
+//     JavaScript routes three witnesses exactly and fails closed on five.
+//     Swift still has no compact recovery implementation.
 //   - production vs. the C oracle: the S1 design brief's stated gate is
 //     "the harness must pass with production serving every witness before
 //     any compact change." Verified in the pinned parity container
@@ -251,6 +256,249 @@ func TestCompactT3OracleAdjudication(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCompactT3JavaScriptRecoveryProfileCharacterization pins the exact compact
+// recovery frontier for the certified JavaScript artifact. A routed row must match C
+// structurally. Every other row must fail closed at its recorded mechanism
+// boundary and return to the production parser.
+func TestCompactT3JavaScriptRecoveryProfileCharacterization(t *testing.T) {
+	manifest := loadCompactT3WitnessManifest(t)
+	cLanguage, err := ParityCLanguage("javascript")
+	if err != nil {
+		t.Fatalf("load C oracle: %v", err)
+	}
+	goLanguage := grammars.JavascriptLanguage()
+	if !goLanguage.CompactStrategy2ErrorRegionCertified || !goLanguage.CompactMissingTokenInsertionCertified {
+		t.Fatal("the exact JavaScript artifact lacks compact recovery certification")
+	}
+
+	expectations := map[string]struct {
+		routed         bool
+		fallbackDetail string
+	}{
+		"js_log_1": {routed: true},
+		"js_log_2": {routed: true},
+		"js_log_3": {fallbackDetail: "accepted compact root leaves do not tile the accepted span: gap=34..36"},
+		"js_log_4": {routed: true},
+		"js_log_5": {fallbackDetail: "generic scheduler has no table action for the elected token"},
+		"js_log_6": {fallbackDetail: "error-mode lex disagrees with the ordinary shared election"},
+		"js_log_7": {fallbackDetail: "accepted compact root leaves do not tile the accepted span: gap=34..36"},
+		"js_log_8": {fallbackDetail: "generic scheduler has no table action for the elected token"},
+	}
+
+	for _, witness := range compactT3WitnessesForLanguage(manifest, "javascript") {
+		witness := witness
+		expectation, ok := expectations[witness.ID]
+		if !ok {
+			t.Fatalf("JavaScript witness %q has no forced-profile expectation", witness.ID)
+		}
+		t.Run(witness.ID, func(t *testing.T) {
+			source := []byte(witness.SourceUTF8)
+			cTree := compactT3ParseC(t, cLanguage, source)
+			defer cTree.Close()
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactTree := compactT3ParseGo(t, goLanguage, source, true)
+			defer compactTree.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			routed := routedAfter - routedBefore
+			fallback := fallbackAfter - fallbackBefore
+
+			if expectation.routed {
+				if routed != 1 || fallback != 0 {
+					t.Fatalf("route counters=%d/%d, want 1/0; reason=%q", routed, fallback, gotreesitter.AdmissionCandidateLastFallbackReason())
+				}
+				if divergences := compactT3StructuralDivergences(compactTree.RootNode(), goLanguage, cTree.RootNode()); len(divergences) != 0 {
+					t.Fatalf("forced compact recovery diverges from C at %d node(s); first: %s", len(divergences), compactT3FormatDivergence(divergences[0]))
+				}
+				return
+			}
+
+			if routed != 0 || fallback != 1 {
+				t.Fatalf("route counters=%d/%d, want 0/1", routed, fallback)
+			}
+			if reason := gotreesitter.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, expectation.fallbackDetail) {
+				t.Fatalf("fallback reason=%q, want substring %q", reason, expectation.fallbackDetail)
+			}
+		})
+	}
+}
+
+// TestCompactT3JavaScriptRecoveryRouteSeedOracleParity adjudicates recovery
+// trees that the required route-equality seed corpus reaches outside the
+// compact T3 manifest. They must match C before the seed gate can treat their
+// compact-versus-production difference as certified recovery behavior.
+func TestCompactT3JavaScriptRecoveryRouteSeedOracleParity(t *testing.T) {
+	cLanguage, err := ParityCLanguage("javascript")
+	if err != nil {
+		t.Fatalf("load C oracle: %v", err)
+	}
+	goLanguage := grammars.JavascriptLanguage()
+	if !goLanguage.CompactStrategy2ErrorRegionCertified || !goLanguage.CompactMissingTokenInsertionCertified {
+		t.Fatal("the exact JavaScript artifact lacks compact recovery certification")
+	}
+	for _, test := range []struct {
+		name   string
+		source string
+	}{
+		{name: "hash_after_identifier_run", source: "function A(){A000000} # 0"},
+		{name: "hash_between_statements", source: "a; # ; b"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			source := []byte(test.source)
+			cTree := compactT3ParseC(t, cLanguage, source)
+			defer cTree.Close()
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactTree := compactT3ParseGo(t, goLanguage, source, true)
+			defer compactTree.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			if routedAfter-routedBefore != 1 || fallbackAfter-fallbackBefore != 0 {
+				t.Fatalf("route counters delta=%d/%d, want 1/0; reason=%q",
+					routedAfter-routedBefore, fallbackAfter-fallbackBefore, gotreesitter.AdmissionCandidateLastFallbackReason())
+			}
+			if divergences := compactT3StructuralDivergences(compactTree.RootNode(), goLanguage, cTree.RootNode()); len(divergences) != 0 {
+				t.Fatalf("compact recovery diverges from C at %d node(s); first: %s",
+					len(divergences), compactT3FormatDivergence(divergences[0]))
+			}
+		})
+	}
+}
+
+// TestCompactT3JavaScriptRecoveryMutationDifferential checks a deterministic
+// one-byte neighborhood around every pinned JavaScript witness. A compact
+// result can publish only when its complete tree matches C. Unsupported
+// mutations must return to production through the existing fallback route.
+func TestCompactT3JavaScriptRecoveryMutationDifferential(t *testing.T) {
+	manifest := loadCompactT3WitnessManifest(t)
+	cLanguage, err := ParityCLanguage("javascript")
+	if err != nil {
+		t.Fatalf("load C oracle: %v", err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatalf("set C oracle language: %v", err)
+	}
+	goLanguage := grammars.JavascriptLanguage()
+	if !goLanguage.CompactStrategy2ErrorRegionCertified || !goLanguage.CompactMissingTokenInsertionCertified {
+		t.Fatal("the exact JavaScript artifact lacks compact recovery certification")
+	}
+	compactParser := gotreesitter.NewParser(goLanguage)
+	compactParser.SetAdmissionCandidateRoute(true)
+	s3OnlyLanguage := *goLanguage
+	s3OnlyLanguage.CompactMissingTokenInsertionCertified = false
+	s3OnlyParser := gotreesitter.NewParser(&s3OnlyLanguage)
+	s3OnlyParser.SetAdmissionCandidateRoute(true)
+
+	var cases, routed, fallback, s3OnlyRouted, missingExpanded, missingContracted int
+	check := func(witnessID, mutation string, source []byte) {
+		t.Helper()
+		cases++
+		cTree := cParser.Parse(source, nil)
+		if cTree == nil || cTree.RootNode() == nil {
+			t.Fatalf("%s/%s: C oracle returned no root", witnessID, mutation)
+		}
+
+		routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+		compactTree, parseErr := compactParser.Parse(source)
+		if parseErr != nil {
+			t.Fatalf("%s/%s: compact parse: %v", witnessID, mutation, parseErr)
+		}
+		if compactTree == nil || compactTree.RootNode() == nil {
+			t.Fatalf("%s/%s: compact parse returned no root", witnessID, mutation)
+		}
+		routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+		compactRouted := false
+		switch {
+		case routedAfter-routedBefore == 1 && fallbackAfter-fallbackBefore == 0:
+			compactRouted = true
+			routed++
+			if divergences := compactT3StructuralDivergences(compactTree.RootNode(), goLanguage, cTree.RootNode()); len(divergences) != 0 {
+				t.Fatalf("%s/%s: routed compact tree diverges from C at %d node(s); first: %s; source=%q",
+					witnessID, mutation, len(divergences), compactT3FormatDivergence(divergences[0]), source)
+			}
+		case routedAfter-routedBefore == 0 && fallbackAfter-fallbackBefore == 1:
+			fallback++
+		default:
+			t.Fatalf("%s/%s: route counters delta=%d/%d, want 1/0 or 0/1",
+				witnessID, mutation, routedAfter-routedBefore, fallbackAfter-fallbackBefore)
+		}
+
+		s3RoutedBefore, s3FallbackBefore := gotreesitter.AdmissionCandidateCounters()
+		s3Tree, s3Err := s3OnlyParser.Parse(source)
+		if s3Err != nil {
+			t.Fatalf("%s/%s: S3-only compact parse: %v", witnessID, mutation, s3Err)
+		}
+		if s3Tree == nil || s3Tree.RootNode() == nil {
+			t.Fatalf("%s/%s: S3-only compact parse returned no root", witnessID, mutation)
+		}
+		s3RoutedAfter, s3FallbackAfter := gotreesitter.AdmissionCandidateCounters()
+		s3Routed := false
+		switch {
+		case s3RoutedAfter-s3RoutedBefore == 1 && s3FallbackAfter-s3FallbackBefore == 0:
+			s3Routed = true
+			s3OnlyRouted++
+			if divergences := compactT3StructuralDivergences(s3Tree.RootNode(), &s3OnlyLanguage, cTree.RootNode()); len(divergences) != 0 {
+				t.Fatalf("%s/%s: S3-only tree diverges from C at %d node(s); first: %s; source=%q",
+					witnessID, mutation, len(divergences), compactT3FormatDivergence(divergences[0]), source)
+			}
+		case s3RoutedAfter-s3RoutedBefore == 0 && s3FallbackAfter-s3FallbackBefore == 1:
+		default:
+			t.Fatalf("%s/%s: S3-only route counters delta=%d/%d, want 1/0 or 0/1",
+				witnessID, mutation, s3RoutedAfter-s3RoutedBefore, s3FallbackAfter-s3FallbackBefore)
+		}
+		if compactRouted && !s3Routed {
+			missingExpanded++
+		}
+		if !compactRouted && s3Routed {
+			missingContracted++
+		}
+
+		s3Tree.Release()
+		compactTree.Release()
+		cTree.Close()
+	}
+
+	replacements := []byte{'?', '#', ')', '}'}
+	insertions := []byte{'?', '#'}
+	for _, witness := range compactT3WitnessesForLanguage(manifest, "javascript") {
+		source := []byte(witness.SourceUTF8)
+		check(witness.ID, "original", source)
+		for offset := range source {
+			deleted := make([]byte, 0, len(source)-1)
+			deleted = append(deleted, source[:offset]...)
+			deleted = append(deleted, source[offset+1:]...)
+			check(witness.ID, fmt.Sprintf("delete-%d", offset), deleted)
+
+			for _, replacement := range replacements {
+				if source[offset] == replacement {
+					continue
+				}
+				replaced := append([]byte(nil), source...)
+				replaced[offset] = replacement
+				check(witness.ID, fmt.Sprintf("replace-%d-%02x", offset, replacement), replaced)
+			}
+		}
+		for offset := 0; offset <= len(source); offset++ {
+			for _, insertion := range insertions {
+				inserted := make([]byte, 0, len(source)+1)
+				inserted = append(inserted, source[:offset]...)
+				inserted = append(inserted, insertion)
+				inserted = append(inserted, source[offset:]...)
+				check(witness.ID, fmt.Sprintf("insert-%d-%02x", offset, insertion), inserted)
+			}
+		}
+	}
+	if routed == 0 || fallback == 0 {
+		t.Fatalf("mutation differential lacked both route outcomes: cases=%d routed=%d fallback=%d", cases, routed, fallback)
+	}
+	if missingExpanded != 0 || missingContracted != 0 {
+		t.Fatalf("T3 neighborhood crossed the S5 boundary: expanded=%d contracted=%d", missingExpanded, missingContracted)
+	}
+	t.Logf("JavaScript compact recovery mutation differential: cases=%d routed=%d fallback=%d S3-only=%d missing-expanded=%d missing-contracted=%d",
+		cases, routed, fallback, s3OnlyRouted, missingExpanded, missingContracted)
 }
 
 func loadCompactT3WitnessManifest(t *testing.T) compactT3WitnessManifest {

--- a/fuzz_admission_route_equality_test.go
+++ b/fuzz_admission_route_equality_test.go
@@ -156,45 +156,107 @@ func FuzzAdmissionRouteEquality(f *testing.F) {
 			t.Skip("input at or above the fuzz latency safety cap")
 		}
 		lp := languages[int(langSel)%len(languages)]
-
-		defer func() {
-			if r := recover(); r != nil {
-				t.Fatalf("panic during route-equality fuzz (lang=%s bytes=%d): %v\ninput=%s",
-					lp.name, len(src), r, previewRouteEqualityInput(src))
-			}
-		}()
-
-		gts.ResetAdmissionCandidateCountersForTest()
-		compactTree, err := lp.compact.Parse(src)
-		if err != nil {
-			t.Fatalf("lang=%s compact-lane Parse: %v (input=%s)", lp.name, err, previewRouteEqualityInput(src))
-		}
-		if compactTree == nil {
-			t.Fatalf("lang=%s compact-lane Parse returned a nil tree with no error (input=%s)", lp.name, previewRouteEqualityInput(src))
-		}
-		defer compactTree.Release()
-
-		routed, _ := gts.AdmissionCandidateCounters()
-		if routed != 1 {
-			// Compact declined -- engine-side, or never attempted. Parse
-			// already served production internally within this same call
-			// (the B1 fail-closed guarantee), so compactTree already IS the
-			// production tree. Vacuous for route equality; still exercised
-			// for panic and hang coverage.
-			return
-		}
-
-		productionTree, err := lp.production.Parse(src)
-		if err != nil {
-			t.Fatalf("lang=%s production-lane Parse: %v (input=%s)", lp.name, err, previewRouteEqualityInput(src))
-		}
-		if productionTree == nil {
-			t.Fatalf("lang=%s production-lane Parse returned a nil tree with no error (input=%s)", lp.name, previewRouteEqualityInput(src))
-		}
-		defer productionTree.Release()
-
-		assertAdmissionRouteEquality(t, lp, src, compactTree, productionTree)
+		exerciseAdmissionRouteEquality(t, lp, src, false)
 	})
+}
+
+// FuzzJavaScriptAdmissionRouteEquality keeps live compact recovery mutations
+// on JavaScript. The C differential owns recovered-tree equality because
+// production can disagree with C on both structure and the error result.
+func FuzzJavaScriptAdmissionRouteEquality(f *testing.F) {
+	f.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	entry := grammars.DetectLanguageByName("javascript")
+	if entry == nil {
+		f.Fatal("JavaScript is not registered")
+	}
+	lang := entry.Language()
+	if lang == nil {
+		f.Fatal("JavaScript resolved a nil Language")
+	}
+	if support := grammars.EvaluateParseSupport(*entry, lang); support.Backend != grammars.ParseBackendDFA {
+		f.Fatalf("JavaScript is not DFA-routable: backend=%s reason=%s", support.Backend, support.Reason)
+	}
+	lp := admissionRouteEqualityLanguage{
+		name:       "javascript",
+		lang:       lang,
+		compact:    gts.NewParser(lang),
+		production: gts.NewParser(lang),
+	}
+	lp.compact.SetAdmissionCandidateRoute(true)
+	lp.production.SetAdmissionCandidateRoute(false)
+
+	f.Add([]byte(grammars.ParseSmokeSample("javascript")))
+	witnesses := loadRouteEqualityWitnesses(f)
+	ids := make([]string, 0, len(witnesses))
+	for id, witness := range witnesses {
+		if witness.Language == "javascript" {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		f.Add([]byte(witnesses[id].SourceUTF8))
+	}
+	f.Add([]byte("function A(){A000000} # 0"))
+	f.Add([]byte("a; # ; b"))
+	f.Add([]byte("function f(, b) { return a + b; }"))
+	f.Add([]byte("const x = a ? b :;c;"))
+
+	f.Fuzz(func(t *testing.T, src []byte) {
+		if len(src) >= routeEqualityFuzzMaxInputBytes {
+			t.Skip("input at or above the fuzz latency safety cap")
+		}
+		exerciseAdmissionRouteEquality(t, lp, src, true)
+	})
+}
+
+func exerciseAdmissionRouteEquality(t *testing.T, lp admissionRouteEqualityLanguage, src []byte, recoveryOracleOwned bool) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panic during route-equality fuzz (lang=%s bytes=%d): %v\ninput=%s",
+				lp.name, len(src), r, previewRouteEqualityInput(src))
+		}
+	}()
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	compactTree, err := lp.compact.Parse(src)
+	if err != nil {
+		t.Fatalf("lang=%s compact-lane Parse: %v (input=%s)", lp.name, err, previewRouteEqualityInput(src))
+	}
+	if compactTree == nil {
+		t.Fatalf("lang=%s compact-lane Parse returned a nil tree with no error (input=%s)", lp.name, previewRouteEqualityInput(src))
+	}
+	defer compactTree.Release()
+
+	routed, _ := gts.AdmissionCandidateCounters()
+	if routed != 1 {
+		// Compact declined -- engine-side, or never attempted. Parse
+		// already served production internally within this same call
+		// (the B1 fail-closed guarantee), so compactTree already IS the
+		// production tree. Vacuous for route equality; still exercised
+		// for panic and hang coverage.
+		return
+	}
+
+	productionTree, err := lp.production.Parse(src)
+	if err != nil {
+		t.Fatalf("lang=%s production-lane Parse: %v (input=%s)", lp.name, err, previewRouteEqualityInput(src))
+	}
+	if productionTree == nil {
+		t.Fatalf("lang=%s production-lane Parse returned a nil tree with no error (input=%s)", lp.name, previewRouteEqualityInput(src))
+	}
+	defer productionTree.Release()
+	if recoveryOracleOwned && lp.lang.CompactStrategy2ErrorRegionCertified &&
+		routeEqualityTreeCarriesNativeRecoveryNode(compactTree.RootNode()) {
+		if diff := routeEqualityFirstDivergence(compactTree.RootNode(), productionTree.RootNode(), lp.lang, "root"); diff != "" {
+			t.Logf("lang=%s bytes=%d recovery tree is C-oracle-owned: %s (input=%s)",
+				lp.name, len(src), diff, previewRouteEqualityInput(src))
+		}
+		return
+	}
+
+	assertAdmissionRouteEquality(t, lp, src, compactTree, productionTree)
 }
 
 // seedAdmissionRouteEqualityCorpus commits the B2 seed corpus: the 20-witness
@@ -356,7 +418,7 @@ func assertAdmissionRouteEquality(t *testing.T, lp admissionRouteEqualityLanguag
 			lp.name, len(src), compactRoot.HasError(), productionRoot.HasError(), previewRouteEqualityInput(src))
 	}
 
-	if lp.name == "html" && routeEqualityTreeCarriesNativeRecoveryNode(compactRoot) {
+	if lp.lang.CompactStrategy2ErrorRegionCertified && routeEqualityTreeCarriesNativeRecoveryNode(compactRoot) {
 		if diff := routeEqualityFirstDivergence(compactRoot, productionRoot, lp.lang, "root"); diff != "" {
 			t.Logf("lang=%s bytes=%d native recovery node present: compact follows the C oracle instead of production: %s (input=%s)",
 				lp.name, len(src), diff, previewRouteEqualityInput(src))

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -98,10 +98,16 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// from the production fallback. The exact locked corpus retained identical
 	// trees and outcomes across all files while cutting aggregate allocations;
 	// explicit forest parsing and non-certified languages keep the full budget.
+	//
+	// The same exact artifact certifies the current compact recovery frontier.
+	// Three pinned witnesses route with exact C parity. Five stop at
+	// typed fail-closed boundaries and remain production-owned.
 	"javascript": {
 		blobSHA256:                     mustRuntimeProfileSHA256("6706f93890f24d8ea90d6a140df5dde29c02ec8a3213bae16e8cc4df37e33ee0"),
 		automaticForestMemoryAllowance: javascriptAutomaticForestMemoryAllowance,
 		compactConvergedSplitDrops:     true,
+		compactStrategy2ErrorRegion:    true,
+		compactMissingTokenInsertion:   true,
 	},
 	// These scanner-backed grammars have certified the first retry ladder's
 	// selected accepted-error tree as authoritative. Repeating the whole ladder

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -27,6 +27,7 @@ type builtinLanguageRuntimeProfile struct {
 	exactStackNodeEquivalence          bool
 	compactStrategy2ErrorRegion        bool
 	compactMissingTokenInsertion       bool
+	compactRecoveryPlainFirst          bool
 	lineContinuationEscapeByte         byte
 	conflictPolicies                   []gotreesitter.ConflictPolicy
 }
@@ -108,6 +109,7 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		compactConvergedSplitDrops:     true,
 		compactStrategy2ErrorRegion:    true,
 		compactMissingTokenInsertion:   true,
+		compactRecoveryPlainFirst:      true,
 	},
 	// These scanner-backed grammars have certified the first retry ladder's
 	// selected accepted-error tree as authoritative. Repeating the whole ladder
@@ -679,6 +681,10 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	}
 	if profile.compactMissingTokenInsertion && !lang.CompactMissingTokenInsertionCertified {
 		lang.CompactMissingTokenInsertionCertified = true
+		changed = true
+	}
+	if profile.compactRecoveryPlainFirst && !lang.CompactRecoveryPlainFirstCertified {
+		lang.CompactRecoveryPlainFirstCertified = true
 		changed = true
 	}
 	if profile.lineContinuationEscapeByte != 0 && lang.LineContinuationEscapeByte != profile.lineContinuationEscapeByte {

--- a/grammars/runtime_profiles_eof_retirement_test.go
+++ b/grammars/runtime_profiles_eof_retirement_test.go
@@ -33,6 +33,7 @@ func TestCompactGraduationGrantDenominatorAfterEOFRetirement(t *testing.T) {
 			profile.compactPrimaryAcceptDerivation,
 			profile.compactStrategy2ErrorRegion,
 			profile.compactMissingTokenInsertion,
+			profile.compactRecoveryPlainFirst,
 		}
 		for _, active := range flags {
 			if !active {
@@ -50,9 +51,9 @@ func TestCompactGraduationGrantDenominatorAfterEOFRetirement(t *testing.T) {
 	if len(eofSiblingGrants) != 0 {
 		t.Errorf("EOF sibling grants remain: %v", eofSiblingGrants)
 	}
-	if activeFlags != 18 || len(activeGrammars) != 12 {
+	if activeFlags != 19 || len(activeGrammars) != 12 {
 		t.Errorf(
-			"compact profile denominator is %d flags across %d grammars, want 18 across 12",
+			"compact profile denominator is %d flags across %d grammars, want 19 across 12",
 			activeFlags,
 			len(activeGrammars),
 		)

--- a/grammars/runtime_profiles_eof_retirement_test.go
+++ b/grammars/runtime_profiles_eof_retirement_test.go
@@ -50,9 +50,9 @@ func TestCompactGraduationGrantDenominatorAfterEOFRetirement(t *testing.T) {
 	if len(eofSiblingGrants) != 0 {
 		t.Errorf("EOF sibling grants remain: %v", eofSiblingGrants)
 	}
-	if activeFlags != 16 || len(activeGrammars) != 12 {
+	if activeFlags != 18 || len(activeGrammars) != 12 {
 		t.Errorf(
-			"compact profile denominator is %d flags across %d grammars, want 16 across 12",
+			"compact profile denominator is %d flags across %d grammars, want 18 across 12",
 			activeFlags,
 			len(activeGrammars),
 		)

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -66,6 +66,19 @@ func TestHTMLProfileCertifiesCompleteCompactRecovery(t *testing.T) {
 	}
 }
 
+func TestJavaScriptProfileCertifiesCompactRecoveryFrontier(t *testing.T) {
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+	lang := JavascriptLanguage()
+	if !lang.CompactStrategy2ErrorRegionCertified || !lang.CompactMissingTokenInsertionCertified {
+		t.Fatal("the JavaScript profile did not attach both compact recovery capabilities")
+	}
+	uncertified := &gotreesitter.Language{}
+	if attachBuiltinLanguageRuntimeProfile("javascript", sha256.Sum256([]byte("wrong javascript blob")), uncertified) ||
+		uncertified.CompactStrategy2ErrorRegionCertified || uncertified.CompactMissingTokenInsertionCertified {
+		t.Fatal("a mismatched JavaScript blob received compact recovery certification")
+	}
+}
+
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	// 42 = the prior 41 plus the F# unary-wrapper materialization profile.
 	// Bash, Haskell, and JavaScript reuse their existing exact profiles.

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -59,9 +59,13 @@ func TestHTMLProfileCertifiesCompleteCompactRecovery(t *testing.T) {
 	if !lang.CompactStrategy2ErrorRegionCertified || !lang.CompactMissingTokenInsertionCertified {
 		t.Fatal("the HTML profile did not attach both compact recovery capabilities")
 	}
+	if lang.CompactRecoveryPlainFirstCertified {
+		t.Fatal("the HTML profile unexpectedly enabled plain-first recovery")
+	}
 	uncertified := &gotreesitter.Language{}
 	if attachBuiltinLanguageRuntimeProfile("html", sha256.Sum256([]byte("wrong html blob")), uncertified) ||
-		uncertified.CompactStrategy2ErrorRegionCertified || uncertified.CompactMissingTokenInsertionCertified {
+		uncertified.CompactStrategy2ErrorRegionCertified || uncertified.CompactMissingTokenInsertionCertified ||
+		uncertified.CompactRecoveryPlainFirstCertified {
 		t.Fatal("a mismatched HTML blob received compact recovery certification")
 	}
 }
@@ -69,12 +73,14 @@ func TestHTMLProfileCertifiesCompleteCompactRecovery(t *testing.T) {
 func TestJavaScriptProfileCertifiesCompactRecoveryFrontier(t *testing.T) {
 	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
 	lang := JavascriptLanguage()
-	if !lang.CompactStrategy2ErrorRegionCertified || !lang.CompactMissingTokenInsertionCertified {
-		t.Fatal("the JavaScript profile did not attach both compact recovery capabilities")
+	if !lang.CompactStrategy2ErrorRegionCertified || !lang.CompactMissingTokenInsertionCertified ||
+		!lang.CompactRecoveryPlainFirstCertified {
+		t.Fatal("the JavaScript profile did not attach its compact recovery capabilities")
 	}
 	uncertified := &gotreesitter.Language{}
 	if attachBuiltinLanguageRuntimeProfile("javascript", sha256.Sum256([]byte("wrong javascript blob")), uncertified) ||
-		uncertified.CompactStrategy2ErrorRegionCertified || uncertified.CompactMissingTokenInsertionCertified {
+		uncertified.CompactStrategy2ErrorRegionCertified || uncertified.CompactMissingTokenInsertionCertified ||
+		uncertified.CompactRecoveryPlainFirstCertified {
 		t.Fatal("a mismatched JavaScript blob received compact recovery certification")
 	}
 }
@@ -147,6 +153,9 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	}
 	if lang.ExactStackNodeEquivalenceCertified {
 		t.Fatal("unknown runtime profile enabled exact stack-node equivalence")
+	}
+	if lang.CompactRecoveryPlainFirstCertified {
+		t.Fatal("unknown runtime profile enabled compact plain-first recovery")
 	}
 	if lang.LineContinuationEscapeByte != 0 {
 		t.Fatalf("unknown runtime profile set a line-continuation escape byte: %q", lang.LineContinuationEscapeByte)

--- a/language.go
+++ b/language.go
@@ -789,6 +789,15 @@ type Language struct {
 	// Custom and adapted languages retain the false default.
 	CompactMissingTokenInsertionCertified bool
 
+	// CompactRecoveryPlainFirstCertified preserves the ordinary compact lexer
+	// for the first attempt. After a fail-closed decline, the route retries with
+	// C error-mode lexing and the certified S3/S5 recovery mechanisms.
+	//
+	// Exact built-in profiles set this only when C-oracle differentials prove
+	// that the retry adds recovery routes without removing clean routes. Custom,
+	// adapted, and stale artifacts keep the direct recovery attempt.
+	CompactRecoveryPlainFirstCertified bool
+
 	// LineContinuationEscapeByte declares the single byte this language's
 	// scanner treats as a line-continuation escape when immediately followed
 	// by a newline (LF, or CR+LF) — for example PowerShell's backtick. C

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2302,6 +2302,9 @@ type diagnosticParserCoreGenericScheduler struct {
 	// recoveryIsolation becomes true only after S5 publishes its two versions.
 	// Clean parses retain the canonical scheduler fast path.
 	recoveryIsolation bool
+	// s3RegionOpened records one S3 recovery episode across this parse. A later
+	// episode starts a new C recovery election that this route cannot model.
+	s3RegionOpened bool
 	// s5MissingInsertions counts recovery forks created by S5. The counter
 	// bounds zero-width progress across one parse.
 	s5MissingInsertions        uint32
@@ -7307,6 +7310,9 @@ func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegionWithMissingFo
 		// ordinary dispatch loop redispatch this pass against the closed head.
 		return true, nil
 	}
+	if s.s3RegionOpened {
+		return false, nil
+	}
 	// EOF at the very first no-action point, nothing absorbed yet:
 	// cRecoverEOFAccept's whole-file wrap is out of S3 scope. No committed
 	// html_erroneous_end_tag witness needs it (verified against the pinned C
@@ -7358,6 +7364,7 @@ func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegionWithMissingFo
 		endByte:   s.token.EndByte,
 		children:  []core.SubtreeID{leafID},
 	}
+	s.s3RegionOpened = true
 	header.shifted = true
 	return true, nil
 }

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -7311,7 +7311,10 @@ func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegionWithMissingFo
 		return true, nil
 	}
 	if s.s3RegionOpened {
-		return false, nil
+		return false, &diagnosticParserCoreDecline{
+			boundary: DiagnosticParserCoreRecovery,
+			detail:   "compact recovery permits one error region per parse",
+		}
 	}
 	// EOF at the very first no-action point, nothing absorbed yet:
 	// cRecoverEOFAccept's whole-file wrap is out of S3 scope. No committed

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -5,6 +5,7 @@ package gotreesitter
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
 )
@@ -31,6 +32,9 @@ type parserCoreFreshFullRunner struct {
 	options                           DiagnosticParserCorePrefixOptions
 	replayParseStates                 bool
 	allowConvergedReductionSplitDrops bool
+	// recoveryPlainFirst preserves ordinary lexing for the first attempt. A
+	// fail-closed decline then retries with C error-mode lexing enabled.
+	recoveryPlainFirst bool
 	// certificateAdmissionEnabled is armed only by the private D3 test seam.
 	// It is copied into options for each cached parse after Core.Reset.
 	certificateAdmissionEnabled bool
@@ -111,6 +115,17 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpenWithObserver(
 	reset bool,
 	observer diagnosticParserCoreSeedObserver,
 ) (*diagnosticParserCoreGenericScheduler, *dfaTokenSource, error) {
+	forceErrorRuns := r != nil && r.options.Recovery && r.options.allowCompactStrategy2ErrorRegion
+	return r.executeSchedulerOpenWithObserverAndErrorRuns(source, compact, reset, observer, forceErrorRuns)
+}
+
+func (r *parserCoreFreshFullRunner) executeSchedulerOpenWithObserverAndErrorRuns(
+	source []byte,
+	compact *core.Core,
+	reset bool,
+	observer diagnosticParserCoreSeedObserver,
+	forceErrorRuns bool,
+) (*diagnosticParserCoreGenericScheduler, *dfaTokenSource, error) {
 	if r == nil || r.parser == nil || r.lang == nil || r.tables == nil || compact == nil {
 		return nil, nil, errors.New("parser-core fresh-full runner is incomplete")
 	}
@@ -135,7 +150,6 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpenWithObserver(
 	// plain lexer silently skipping it -- the silent-skip shape a true no-
 	// table-action dispatch point can never observe, verified against every
 	// committed html_erroneous_end_tag witness.
-	forceErrorRuns := r.options.Recovery && r.options.allowCompactStrategy2ErrorRegion
 	tokenSource := r.parser.acquireParserDFATokenSourceWithErrorRuns(source, forceErrorRuns)
 	if tokenSource == nil {
 		return nil, nil, errors.New("parser-core fresh-full runner: production DFA unavailable")
@@ -381,16 +395,67 @@ func (r *parserCoreFreshFullRunner) parseWithObserver(
 			err = errors.Join(err, fmt.Errorf("parser-core fresh-full runner: reset after decline: %w", resetErr))
 		}
 	}()
-	scheduler, tokenSource, err2 := r.executeSchedulerOpenWithObserver(source, r.compact, true, observer)
-	if err2 != nil {
-		return nil, err2
+	recoveryEnabled := r.options.Recovery && r.options.allowCompactStrategy2ErrorRegion
+	if r.recoveryPlainFirst && recoveryEnabled {
+		tree, err = r.parseWithObserverAndErrorRuns(source, observer, false, false)
+		if err == nil {
+			return tree, nil
+		}
+		if !compactRecoveryRetryAfterPlainEligible(err) {
+			return nil, err
+		}
+		return r.parseWithObserverAndErrorRuns(source, observer, true, true)
 	}
-	defer tokenSource.Close()
-	tree, err = r.materializeSelection(source, r.compact, scheduler)
+	return r.parseWithObserverAndErrorRuns(source, observer, recoveryEnabled, recoveryEnabled)
+}
+
+func (r *parserCoreFreshFullRunner) parseWithObserverAndErrorRuns(
+	source []byte,
+	observer diagnosticParserCoreSeedObserver,
+	recoveryEnabled bool,
+	forceErrorRuns bool,
+) (*Tree, error) {
+	savedRecovery := r.options.Recovery
+	savedErrorRegion := r.options.allowCompactStrategy2ErrorRegion
+	savedMissingInsertion := r.options.allowCompactMissingTokenInsertion
+	savedLineageSelection := r.options.allowCompactRecoveryLineageSelection
+	if !recoveryEnabled {
+		r.options.Recovery = false
+		r.options.allowCompactStrategy2ErrorRegion = false
+		r.options.allowCompactMissingTokenInsertion = false
+		r.options.allowCompactRecoveryLineageSelection = false
+	}
+	defer func() {
+		r.options.Recovery = savedRecovery
+		r.options.allowCompactStrategy2ErrorRegion = savedErrorRegion
+		r.options.allowCompactMissingTokenInsertion = savedMissingInsertion
+		r.options.allowCompactRecoveryLineageSelection = savedLineageSelection
+	}()
+	scheduler, tokenSource, err := r.executeSchedulerOpenWithObserverAndErrorRuns(
+		source, r.compact, true, observer, forceErrorRuns,
+	)
 	if err != nil {
 		return nil, err
 	}
+	tree, materializeErr := r.materializeSelection(source, r.compact, scheduler)
+	tokenSource.Close()
+	if materializeErr != nil {
+		if tree != nil {
+			tree.Release()
+		}
+		return nil, materializeErr
+	}
 	return tree, nil
+}
+
+func compactRecoveryRetryAfterPlainEligible(err error) bool {
+	var decline *diagnosticParserCoreDecline
+	if errors.As(err, &decline) {
+		return decline.boundary != DiagnosticParserCoreCap
+	}
+	message := err.Error()
+	return strings.HasPrefix(message, "parser-core fresh-full runner did not accept EOF") ||
+		strings.HasPrefix(message, "parser-core fresh-full runner acceptance is not sole exact EOF")
 }
 
 func (r *parserCoreFreshFullRunner) parseSelectedStore(source []byte) (*core.SelectedStore, error) {

--- a/parsercore_phase0_fresh_full_runner_internal_test.go
+++ b/parsercore_phase0_fresh_full_runner_internal_test.go
@@ -118,13 +118,16 @@ func TestResetDiagnosticParserCoreGenericSchedulerRejectsActiveScratch(t *testin
 	}
 }
 
-func TestResetDiagnosticParserCoreGenericSchedulerClearsMissingInsertionCount(t *testing.T) {
-	scheduler := diagnosticParserCoreGenericScheduler{s5MissingInsertions: 7, recoveryIsolation: true}
+func TestResetDiagnosticParserCoreGenericSchedulerClearsRecoveryState(t *testing.T) {
+	scheduler := diagnosticParserCoreGenericScheduler{s5MissingInsertions: 7, s3RegionOpened: true, recoveryIsolation: true}
 	if err := resetDiagnosticParserCoreGenericScheduler(&scheduler); err != nil {
 		t.Fatal(err)
 	}
 	if scheduler.s5MissingInsertions != 0 {
 		t.Fatalf("missing insertion count=%d, want zero", scheduler.s5MissingInsertions)
+	}
+	if scheduler.s3RegionOpened {
+		t.Fatal("the error region marker remained set after reset")
 	}
 	if scheduler.recoveryIsolation {
 		t.Fatal("recovery isolation remained active after reset")

--- a/parsercore_phase0_recovery_lineage_fork_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_fork_internal_test.go
@@ -3,6 +3,7 @@
 package gotreesitter
 
 import (
+	"strings"
 	"testing"
 
 	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
@@ -136,8 +137,8 @@ func TestS3SecondIndependentErrorRegionDeclines(t *testing.T) {
 	original := scheduler.headers[0]
 
 	handled, err := scheduler.s3TryOpenErrorRegionWithMissingFork(0, true)
-	if err != nil {
-		t.Fatalf("s3TryOpenErrorRegionWithMissingFork: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "one error region per parse") {
+		t.Fatalf("s3TryOpenErrorRegionWithMissingFork error=%v, want typed single-region decline", err)
 	}
 	if handled || scheduler.headers[0] != original {
 		t.Fatalf("second region changed the frontier: handled=%t header=%+v", handled, scheduler.headers[0])

--- a/parsercore_phase0_recovery_lineage_fork_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_fork_internal_test.go
@@ -98,6 +98,9 @@ func TestS5MissingInsertionForkPublishesBothRecoveryLineages(t *testing.T) {
 	if scheduler.s5MissingInsertions != 1 {
 		t.Fatalf("missing insertion count=%d, want 1", scheduler.s5MissingInsertions)
 	}
+	if !scheduler.s3RegionOpened {
+		t.Fatal("the S5 absorb lineage did not record its S3 region")
+	}
 
 	derivations, err := scheduler.compact.Derivations(scheduler.headers[1].head)
 	if err != nil {
@@ -124,6 +127,54 @@ func TestS5MissingInsertionForkPublishesBothRecoveryLineages(t *testing.T) {
 	}
 	if absorbed.Symbol != 4 || absorbed.StartByte != 1 || absorbed.EndByte != 2 {
 		t.Fatalf("absorbed payload=%+v, want symbol 4 over bytes 1..2", absorbed)
+	}
+}
+
+func TestS3SecondIndependentErrorRegionDeclines(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	scheduler.s3RegionOpened = true
+	original := scheduler.headers[0]
+
+	handled, err := scheduler.s3TryOpenErrorRegionWithMissingFork(0, true)
+	if err != nil {
+		t.Fatalf("s3TryOpenErrorRegionWithMissingFork: %v", err)
+	}
+	if handled || scheduler.headers[0] != original {
+		t.Fatalf("second region changed the frontier: handled=%t header=%+v", handled, scheduler.headers[0])
+	}
+	if !scheduler.s3RegionOpened {
+		t.Fatal("the second-region decline cleared the first-region marker")
+	}
+}
+
+func TestS3RegionMarkerAllowsClosureOnlyRedispatch(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	shifted, err := scheduler.compact.Shift(
+		scheduler.headers[0].head,
+		core.Symbol(2),
+		0,
+		core.Token{Symbol: 2, StartByte: 1, EndByte: 1},
+		core.ForkOrder{},
+	)
+	if err != nil {
+		t.Fatalf("shift closure input: %v", err)
+	}
+	scheduler.headers[0].head = shifted
+	scheduler.s3RegionOpened = true
+
+	handled, err := scheduler.s3TryOpenErrorRegion(0)
+	if err != nil {
+		t.Fatalf("s3TryOpenErrorRegion: %v", err)
+	}
+	if !handled || scheduler.headers[0].s3Region != nil {
+		t.Fatalf("closure-only redispatch handled=%t region=%+v", handled, scheduler.headers[0].s3Region)
+	}
+	state, _, err := scheduler.compact.Boundary(scheduler.headers[0].head)
+	if err != nil {
+		t.Fatalf("closed boundary: %v", err)
+	}
+	if state != 3 || !scheduler.s3RegionOpened {
+		t.Fatalf("closure-only state=%d marker=%t, want 3/true", state, scheduler.s3RegionOpened)
 	}
 }
 


### PR DESCRIPTION
## Summary

Certify the exact JavaScript artifact for the compact S3 and S5 recovery routes.

Preserve ordinary compact parsing first. Retry with C error-mode lexing only after a fail-closed decline.

The parser now declines a second independent S3 region. That event starts a C recovery election which the compact route cannot model.

Three pinned recovery witnesses now route with exact C structure. Five witnesses remain at typed fail-closed boundaries.

## Changes

- Enable `compactStrategy2ErrorRegion` and `compactMissingTokenInsertion` for the pinned JavaScript artifact.
- Track one opened S3 region in scheduler padding, and clear the marker during scheduler reset.
- Preserve closure-only redispatch before the one-region check.
- Add an exact JavaScript plain-first recovery capability. HTML keeps its direct recovery path.
- Add JavaScript recovery characterization and route-seed oracle tests.
- Add T3 and S5 mutation differentials against the C parser.
- Add a JavaScript admission-route equality fuzz target.
- Extend the compact recovery CI job with the new C differential tests.

## Verification

- The T3 differential tested 2,954 mutations. It routed 112 exact cases and rejected 2,842 cases.
- The S5 scan tested 5,267 mutations. It added 26 exact routes and removed no S3 routes.
- JavaScript grammar parity passed all 25 cases.
- Direct C parity passed all 20 grammar-generation cases.
- A 45-second JavaScript fuzz run completed 52,873 executions without a failure.
- Tagged builds and the targeted race tests passed in Docker.
- A 20-seed interleaved benchmark found no significant change in time, bytes, or allocations.

## Review focus

Check the single-region S3 guard and its position after closure-only redispatch.

Confirm that each rejected witness retains its typed fallback reason.
