### PR TITLE
add(parsercore): authenticate compact recovery terminal aliases

### DIFF
--- a/admission_route_equality_leaf_tiling_test.go
+++ b/admission_route_equality_leaf_tiling_test.go
@@ -150,7 +150,7 @@ func TestCompactRouteAcceptedHiddenDoctypeLeafTiles(t *testing.T) {
 }
 
 // TestCompactRouteAdjudicatesFalseCleanWitnesses pulls a focused
-// subset (3 html, 3 javascript) from the 20-witness committed manifest (10
+// subset (3 html, 4 javascript) from the 20-witness committed manifest (10
 // html, 8 javascript, 2 swift). Each entry was, before the B1 tiling gate,
 // accepted by the compact route with HasError()==false while production and
 // the locked C oracle both report an error (compact_t3_oracle_witnesses_v2.
@@ -166,8 +166,7 @@ func TestCompactRouteAcceptedHiddenDoctypeLeafTiles(t *testing.T) {
 // asserted separately, under cgo, by
 // cgo_harness/compact_t3_oracle_adjudication_test.go's
 // compactT3RecoveryCertifiedWitnesses). The certified JavaScript artifact now
-// routes js_log_1 and js_log_2 with exact C parity. js_log_3 still fails closed
-// when the accepted root leaves expose its unaccounted byte range.
+// routes js_log_1, js_log_2, js_log_3, and js_log_7 with exact C parity.
 //
 // Scope note: the manifest's 2 swift entries (swift_log_1, swift_log_2) are
 // NOT in this list. Root-cause (verified by direct tree inspection):
@@ -202,7 +201,7 @@ func TestCompactRouteAdjudicatesFalseCleanWitnesses(t *testing.T) {
 	witnesses := loadRouteEqualityWitnesses(t)
 	ids := []string{
 		"html_min_a", "html_min_html", "html_log_1",
-		"js_log_1", "js_log_2", "js_log_3",
+		"js_log_1", "js_log_2", "js_log_3", "js_log_7",
 	}
 	for _, id := range ids {
 		id := id
@@ -250,7 +249,7 @@ func TestCompactRouteAdjudicatesFalseCleanWitnesses(t *testing.T) {
 			defer tree.Release()
 
 			routed, fallback := gts.AdmissionCandidateCounters()
-			nativeRecovery := witness.Language == "html" || id == "js_log_1" || id == "js_log_2"
+			nativeRecovery := witness.Language == "html" || id == "js_log_1" || id == "js_log_2" || id == "js_log_3" || id == "js_log_7"
 			if nativeRecovery {
 				if routed != 1 || fallback != 0 {
 					t.Fatalf("witness %q: route counters routed=%d fallback=%d, want routed=1 fallback=0", id, routed, fallback)
@@ -270,6 +269,33 @@ func TestCompactRouteAdjudicatesFalseCleanWitnesses(t *testing.T) {
 					id, got, *witness.Expected.ProductionHasError)
 			}
 		})
+	}
+}
+
+// TestCompactRouteDeclinesUncertifiedRecoveryAliasResume pins a mutation
+// where the same property_identifier alias appears after a different resume.
+// The compact tree swallows the next class into the arrow expression. The
+// exact JavaScript artifact has no alias rule for that resume state.
+func TestCompactRouteDeclinesUncertifiedRecoveryAliasResume(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	lang := grammars.JavascriptLanguage()
+	source := []byte("const f = (a) => a + 1#&\nclass A { m() { return 1 } }\n\n")
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if routed != 0 || fallback != 1 {
+		t.Fatalf("route counters routed=%d fallback=%d, want 0/1", routed, fallback)
+	}
+	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "accepted compact root leaves do not tile the accepted span") {
+		t.Fatalf("fallback reason=%q, want an accepted-root leaf gap", reason)
 	}
 }
 

--- a/cgo_harness/compact_t3_oracle_adjudication_test.go
+++ b/cgo_harness/compact_t3_oracle_adjudication_test.go
@@ -115,7 +115,7 @@ type compactT3ExpectedOutcome struct {
 // compactT3RecoveryCertifiedWitnesses lists witnesses where native compact
 // recovery reaches exact structural C-oracle parity. The exact HTML artifact
 // certifies its complete class. JavaScript certifies the current S3 frontier;
-// its remaining five witnesses stay fail-closed.
+// its remaining three witnesses stay fail-closed.
 var compactT3RecoveryCertifiedWitnesses = map[string]bool{
 	"html_min_a":    true,
 	"html_min_html": true,
@@ -129,7 +129,9 @@ var compactT3RecoveryCertifiedWitnesses = map[string]bool{
 	"html_log_8":    true,
 	"js_log_1":      true,
 	"js_log_2":      true,
+	"js_log_3":      true,
 	"js_log_4":      true,
+	"js_log_7":      true,
 }
 
 // TestCompactT3OracleAdjudication verifies each committed false-clean witness
@@ -146,7 +148,7 @@ var compactT3RecoveryCertifiedWitnesses = map[string]bool{
 //   - compact vs. the C oracle: S3 and S5 cover all ten
 //     html_erroneous_end_tag witnesses. Every witness in
 //     compactT3RecoveryCertifiedWitnesses must match the C oracle exactly.
-//     JavaScript routes three witnesses exactly and fails closed on five.
+//     JavaScript routes five witnesses exactly and fails closed on three.
 //     Swift still has no compact recovery implementation.
 //   - production vs. the C oracle: the S1 design brief's stated gate is
 //     "the harness must pass with production serving every witness before
@@ -279,11 +281,11 @@ func TestCompactT3JavaScriptRecoveryProfileCharacterization(t *testing.T) {
 	}{
 		"js_log_1": {routed: true},
 		"js_log_2": {routed: true},
-		"js_log_3": {fallbackDetail: "accepted compact root leaves do not tile the accepted span: gap=34..36"},
+		"js_log_3": {routed: true},
 		"js_log_4": {routed: true},
 		"js_log_5": {fallbackDetail: "generic scheduler has no table action for the elected token"},
 		"js_log_6": {fallbackDetail: "error-mode lex disagrees with the ordinary shared election"},
-		"js_log_7": {fallbackDetail: "accepted compact root leaves do not tile the accepted span: gap=34..36"},
+		"js_log_7": {routed: true},
 		"js_log_8": {fallbackDetail: "generic scheduler has no table action for the elected token"},
 	}
 

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -27,6 +27,7 @@ type builtinLanguageRuntimeProfile struct {
 	exactStackNodeEquivalence          bool
 	compactStrategy2ErrorRegion        bool
 	compactMissingTokenInsertion       bool
+	compactRecoveryTerminalAliases     []compactRecoveryTerminalAliasProfile
 	compactRecoveryPlainFirst          bool
 	lineContinuationEscapeByte         byte
 	conflictPolicies                   []gotreesitter.ConflictPolicy
@@ -37,6 +38,12 @@ type nativeUnaryWrapperFlatteningProfile struct {
 	wrapper             string
 	leaf                string
 	wrapperPreGotoState gotreesitter.StateID
+}
+
+type compactRecoveryTerminalAliasProfile struct {
+	resumeState  gotreesitter.StateID
+	resumeSymbol string
+	aliasSymbol  string
 }
 
 const (
@@ -101,7 +108,7 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// explicit forest parsing and non-certified languages keep the full budget.
 	//
 	// The same exact artifact certifies the current compact recovery frontier.
-	// Three pinned witnesses route with exact C parity. Five stop at
+	// Five pinned witnesses route with exact C parity. Three stop at
 	// typed fail-closed boundaries and remain production-owned.
 	"javascript": {
 		blobSHA256:                     mustRuntimeProfileSHA256("6706f93890f24d8ea90d6a140df5dde29c02ec8a3213bae16e8cc4df37e33ee0"),
@@ -109,7 +116,11 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		compactConvergedSplitDrops:     true,
 		compactStrategy2ErrorRegion:    true,
 		compactMissingTokenInsertion:   true,
-		compactRecoveryPlainFirst:      true,
+		compactRecoveryTerminalAliases: []compactRecoveryTerminalAliasProfile{
+			{resumeState: 1042, resumeSymbol: "_automatic_semicolon", aliasSymbol: "property_identifier"},
+			{resumeState: 1367, resumeSymbol: "{", aliasSymbol: "property_identifier"},
+		},
+		compactRecoveryPlainFirst: true,
 	},
 	// These scanner-backed grammars have certified the first retry ladder's
 	// selected accepted-error tree as authoritative. Repeating the whole ladder
@@ -683,6 +694,11 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 		lang.CompactMissingTokenInsertionCertified = true
 		changed = true
 	}
+	if rules := resolveCompactRecoveryTerminalAliasProfile(lang, profile.compactRecoveryTerminalAliases); len(rules) > 0 &&
+		!slices.Equal(lang.CompactRecoveryTerminalAliasRules, rules) {
+		lang.CompactRecoveryTerminalAliasRules = rules
+		changed = true
+	}
 	if profile.compactRecoveryPlainFirst && !lang.CompactRecoveryPlainFirstCertified {
 		lang.CompactRecoveryPlainFirstCertified = true
 		changed = true
@@ -740,6 +756,49 @@ func runtimeProfileNamedSymbol(lang *gotreesitter.Language, name string) (gotree
 		}
 	}
 	return 0, false
+}
+
+func resolveCompactRecoveryTerminalAliasProfile(
+	lang *gotreesitter.Language,
+	profile []compactRecoveryTerminalAliasProfile,
+) []gotreesitter.CompactRecoveryTerminalAliasRule {
+	if lang == nil || len(profile) == 0 {
+		return nil
+	}
+	rules := make([]gotreesitter.CompactRecoveryTerminalAliasRule, 0, len(profile))
+	for _, candidate := range profile {
+		resumeSymbol, resumeOK := runtimeProfileSymbol(lang, candidate.resumeSymbol)
+		aliasSymbol, aliasOK := runtimeProfileSymbol(lang, candidate.aliasSymbol)
+		if !resumeOK || !aliasOK || uint32(candidate.resumeState) >= lang.StateCount ||
+			uint32(resumeSymbol) >= lang.TokenCount || uint32(aliasSymbol) < lang.TokenCount {
+			return nil
+		}
+		rules = append(rules, gotreesitter.CompactRecoveryTerminalAliasRule{
+			ResumeState:  candidate.resumeState,
+			ResumeSymbol: resumeSymbol,
+			AliasSymbol:  aliasSymbol,
+		})
+	}
+	return rules
+}
+
+func runtimeProfileSymbol(lang *gotreesitter.Language, name string) (gotreesitter.Symbol, bool) {
+	if lang == nil {
+		return 0, false
+	}
+	var match gotreesitter.Symbol
+	found := false
+	for index, symbolName := range lang.SymbolNames {
+		if symbolName != name {
+			continue
+		}
+		if found {
+			return 0, false
+		}
+		match = gotreesitter.Symbol(index)
+		found = true
+	}
+	return match, found
 }
 
 func languageHasConflictPolicy(lang *gotreesitter.Language, want gotreesitter.ConflictPolicy) bool {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -2,6 +2,7 @@ package grammars
 
 import (
 	"crypto/sha256"
+	"slices"
 	"testing"
 
 	gotreesitter "github.com/odvcencio/gotreesitter"
@@ -77,10 +78,17 @@ func TestJavaScriptProfileCertifiesCompactRecoveryFrontier(t *testing.T) {
 		!lang.CompactRecoveryPlainFirstCertified {
 		t.Fatal("the JavaScript profile did not attach its compact recovery capabilities")
 	}
+	wantAliases := []gotreesitter.CompactRecoveryTerminalAliasRule{
+		{ResumeState: 1042, ResumeSymbol: 129, AliasSymbol: 261},
+		{ResumeState: 1367, ResumeSymbol: 7, AliasSymbol: 261},
+	}
+	if !slices.Equal(lang.CompactRecoveryTerminalAliasRules, wantAliases) {
+		t.Fatalf("terminal alias rules=%+v, want %+v", lang.CompactRecoveryTerminalAliasRules, wantAliases)
+	}
 	uncertified := &gotreesitter.Language{}
 	if attachBuiltinLanguageRuntimeProfile("javascript", sha256.Sum256([]byte("wrong javascript blob")), uncertified) ||
 		uncertified.CompactStrategy2ErrorRegionCertified || uncertified.CompactMissingTokenInsertionCertified ||
-		uncertified.CompactRecoveryPlainFirstCertified {
+		uncertified.CompactRecoveryPlainFirstCertified || len(uncertified.CompactRecoveryTerminalAliasRules) != 0 {
 		t.Fatal("a mismatched JavaScript blob received compact recovery certification")
 	}
 }
@@ -157,8 +165,21 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	if lang.CompactRecoveryPlainFirstCertified {
 		t.Fatal("unknown runtime profile enabled compact plain-first recovery")
 	}
+	if len(lang.CompactRecoveryTerminalAliasRules) != 0 {
+		t.Fatal("unknown runtime profile attached compact recovery terminal aliases")
+	}
 	if lang.LineContinuationEscapeByte != 0 {
 		t.Fatalf("unknown runtime profile set a line-continuation escape byte: %q", lang.LineContinuationEscapeByte)
+	}
+}
+
+func TestRuntimeProfileSymbolRejectsDuplicateNames(t *testing.T) {
+	lang := &gotreesitter.Language{SymbolNames: []string{"first", "duplicate", "duplicate"}}
+	if symbol, ok := runtimeProfileSymbol(lang, "first"); !ok || symbol != 0 {
+		t.Fatalf("unique symbol=%d ok=%t, want 0/true", symbol, ok)
+	}
+	if symbol, ok := runtimeProfileSymbol(lang, "duplicate"); ok {
+		t.Fatalf("duplicate symbol=%d ok=true, want fail-closed", symbol)
 	}
 }
 

--- a/language.go
+++ b/language.go
@@ -351,6 +351,18 @@ type ConflictPolicy struct {
 	ReduceSymbols []Symbol
 }
 
+// CompactRecoveryTerminalAliasRule certifies one terminal alias that can
+// survive compact strategy-2 recovery. ResumeState and ResumeSymbol identify
+// the exact recovery resume. AliasSymbol identifies the published leaf.
+//
+// Exact built-in profiles bind these values to one grammar blob. Languages
+// without a rule keep the accepted-root leaf audit fail-closed.
+type CompactRecoveryTerminalAliasRule struct {
+	ResumeState  StateID
+	ResumeSymbol Symbol
+	AliasSymbol  Symbol
+}
+
 // ConflictPolicyAnyState and ConflictPolicyAnyLookahead are sentinel State/
 // Lookahead values matching every state or every lookahead symbol instead of
 // one exact table row. They support policies scoped by state and/or reduce
@@ -788,6 +800,13 @@ type Language struct {
 	// the result. Exact built-in profiles must certify the complete competition.
 	// Custom and adapted languages retain the false default.
 	CompactMissingTokenInsertionCertified bool
+
+	// CompactRecoveryTerminalAliasRules permits the accepted-root leaf audit to
+	// authenticate a materialized terminal alias after one certified recovery
+	// resume. The materializer must also prove the exact raw terminal and alias
+	// node relationship. Exact built-in profiles bind each rule to one grammar
+	// blob. Custom, adapted, and stale artifacts retain an empty rule set.
+	CompactRecoveryTerminalAliasRules []CompactRecoveryTerminalAliasRule
 
 	// CompactRecoveryPlainFirstCertified preserves the ordinary compact lexer
 	// for the first attempt. After a fail-closed decline, the route retries with

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2305,6 +2305,11 @@ type diagnosticParserCoreGenericScheduler struct {
 	// s3RegionOpened records one S3 recovery episode across this parse. A later
 	// episode starts a new C recovery election that this route cannot model.
 	s3RegionOpened bool
+	// s3ResumeState and s3ResumeSymbol record the sole strategy-2 resume. The
+	// accepted-tree audit uses them only with an exact artifact rule.
+	s3ResumeState  StateID
+	s3ResumeSymbol Symbol
+	s3ResumeCount  uint32
 	// s5MissingInsertions counts recovery forks created by S5. The counter
 	// bounds zero-width progress across one parse.
 	s5MissingInsertions        uint32
@@ -4458,11 +4463,15 @@ type parserCoreRunnerScratch struct {
 	materialization diagnosticParserCoreMaterializationScratch
 	postorder       core.MaterializationPostorderScratch
 	acceptedLeaves  diagnosticParserCoreAcceptedLeafCoverageScratch
-	nodesByID       []*Node
-	nodes           []*Node
-	linkScratch     []*Node
-	lineStarts      []uint32
-	goCompatFrames  []goCompatSubtreeFrame
+	// recoveryTerminalAliasSymbol is valid only when the exact artifact rule
+	// also set recoveryTerminalAliasCertified for this materialization.
+	recoveryTerminalAliasSymbol    Symbol
+	recoveryTerminalAliasCertified bool
+	nodesByID                      []*Node
+	nodes                          []*Node
+	linkScratch                    []*Node
+	lineStarts                     []uint32
+	goCompatFrames                 []goCompatSubtreeFrame
 }
 
 // parserCoreMaxRetainedAcceptedLeafSpans bounds the caller-owned coverage
@@ -4477,7 +4486,8 @@ type diagnosticParserCoreAcceptedLeafSpan struct {
 }
 
 type diagnosticParserCoreAcceptedLeafCoverageScratch struct {
-	spans []diagnosticParserCoreAcceptedLeafSpan
+	spans                []diagnosticParserCoreAcceptedLeafSpan
+	authenticatedAliases []*Node
 }
 
 func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) reset() {
@@ -4486,10 +4496,16 @@ func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) reset() {
 	}
 	if cap(scratch.spans) > parserCoreMaxRetainedAcceptedLeafSpans {
 		scratch.spans = nil
-		return
+	} else {
+		clear(scratch.spans)
+		scratch.spans = scratch.spans[:0]
 	}
-	clear(scratch.spans)
-	scratch.spans = scratch.spans[:0]
+	if cap(scratch.authenticatedAliases) > parserCoreMaxRetainedAcceptedLeafSpans {
+		scratch.authenticatedAliases = nil
+	} else {
+		clear(scratch.authenticatedAliases)
+		scratch.authenticatedAliases = scratch.authenticatedAliases[:0]
+	}
 }
 
 func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) append(
@@ -4539,6 +4555,69 @@ func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) hasVisibleTermin
 	return false
 }
 
+func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) hasAuthenticatedAlias(node *Node) bool {
+	if scratch == nil {
+		return false
+	}
+	for _, alias := range scratch.authenticatedAliases {
+		if alias == node {
+			return true
+		}
+	}
+	return false
+}
+
+func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) authenticateDirectTerminalAliases(
+	parser *Parser,
+	entries []stackEntry,
+	children []*Node,
+	productionID uint16,
+	aliasSymbol Symbol,
+	nodesByID []*Node,
+) {
+	if scratch == nil || parser == nil || parser.language == nil || aliasSymbol == 0 {
+		return
+	}
+	aliases := parser.reduceAliasSequence(productionID)
+	if len(aliases) == 0 {
+		return
+	}
+	structuralChild := 0
+	for _, entry := range entries {
+		raw := stackEntryNode(entry)
+		if raw == nil || raw.isExtra() {
+			continue
+		}
+		alias := Symbol(0)
+		if structuralChild < len(aliases) {
+			alias = aliases[structuralChild]
+		}
+		structuralChild++
+		if alias != aliasSymbol || raw.symbol == alias ||
+			uint32(raw.symbol) >= parser.language.TokenCount ||
+			nodeChildCountNoMaterialize(raw) != 0 ||
+			!scratch.hasVisibleTerminalNode(raw.startByte, raw.endByte, raw, nodesByID) {
+			continue
+		}
+		var match *Node
+		for _, child := range children {
+			if child == nil || child == raw || child.symbol != alias ||
+				child.startByte != raw.startByte || child.endByte != raw.endByte ||
+				nodeChildCountNoMaterialize(child) != 0 {
+				continue
+			}
+			if match != nil {
+				match = nil
+				break
+			}
+			match = child
+		}
+		if match != nil {
+			scratch.authenticatedAliases = append(scratch.authenticatedAliases, match)
+		}
+	}
+}
+
 // nodeSlice returns a zeroed length-n *Node slice, reusing buf's capacity when
 // it fits. Clearing every entry prevents a stale node pointer from an earlier
 // parse leaking into this one.
@@ -4580,6 +4659,8 @@ func (s *parserCoreRunnerScratch) resetTreeBuffers() {
 	}
 	s.postorder.Reset()
 	s.acceptedLeaves.reset()
+	s.recoveryTerminalAliasSymbol = 0
+	s.recoveryTerminalAliasCertified = false
 	s.nodesByID = clearNodeScratch(s.nodesByID)
 	s.nodes = clearNodeScratch(s.nodes)
 	s.linkScratch = clearNodeScratch(s.linkScratch)
@@ -4923,10 +5004,11 @@ func diagnosticParserCoreAcceptedTreeLeafCoverageGap(root *Node, source []byte, 
 		count := n.ChildCount()
 		if count == 0 {
 			sym := n.Symbol()
-			if uint32(sym) >= tokenCount && sym != errorSymbol {
-				return nil
-			}
-			if sym == errorSymbol && !coverage.hasVisibleTerminalNode(n.startByte, n.endByte, n, nodesByID) {
+			// A terminal alias publishes a cloned grammar nonterminal leaf.
+			// Accept only a clone authenticated at its exact reduce site.
+			if uint32(sym) >= tokenCount &&
+				!coverage.hasVisibleTerminalNode(n.startByte, n.endByte, n, nodesByID) &&
+				!coverage.hasAuthenticatedAlias(n) {
 				return nil
 			}
 			if n.startByte > cur {
@@ -5348,6 +5430,10 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 	if !allowErrorRoot {
 		acceptedLeaves = nil
 	}
+	recoveryTerminalAlias := Symbol(0)
+	if scratch != nil && scratch.recoveryTerminalAliasCertified {
+		recoveryTerminalAlias = scratch.recoveryTerminalAliasSymbol
+	}
 	materializeVisit := func(materializationScratch *diagnosticParserCoreMaterializationScratch) error {
 		visit := func(id core.SubtreeID, view core.MaterializationSubtreeView) error {
 			if view.EndByte < view.StartByte || view.EndByte > uint32(len(source)) {
@@ -5451,12 +5537,9 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 			// javadoc/doxygen-style comments that close with "*/" (no leading
 			// space) put the decoration marker
 			// on the trailing edge of the root reduce's own gap, indistinguishable
-			// in isolation from a genuine drop (js_log_3 and js_log_7 have the
-			// identical trailing-edge shape and must still be rejected -- verified
-			// directly, byte for byte: both keep declining under this exemption,
-			// since their gaps are not at the root symbol). All 18 fixed html/js
-			// witnesses were re-verified with this exemption active and none sit
-			// at their language's root symbol, so none are affected by it.
+			// in isolation from a genuine drop. The exemption stays limited to the
+			// grammar root. Every internal reduce still passes the ordinary tiling
+			// check before materialization can publish it.
 			isDerivationRootReduce := parser.hasRootSymbol && Symbol(view.Symbol) == parser.rootSymbol
 			if gapStart, gapEnd, gapped := diagnosticParserCoreReduceChildrenTilingGap(view.StartByte, view.EndByte, entries, source); !isDerivationRootReduce && gapped {
 				return &diagnosticParserCoreDecline{
@@ -5485,6 +5568,11 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 					entries, 0, len(entries), structuralChildren,
 					Symbol(view.Symbol), view.ProductionID, arena,
 				)
+				if recoveryTerminalAlias != 0 {
+					acceptedLeaves.authenticateDirectTerminalAliases(
+						parser, entries, children, view.ProductionID, recoveryTerminalAlias, nodesByID,
+					)
+				}
 				parent := newParentNodeInArenaWithFieldSources(
 					arena, Symbol(view.Symbol), named, children, fieldIDs, fieldSources, view.ProductionID,
 				)
@@ -5526,6 +5614,11 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				entries, 0, len(entries), structuralChildren,
 				Symbol(view.Symbol), view.ProductionID, arena,
 			)
+			if recoveryTerminalAlias != 0 {
+				acceptedLeaves.authenticateDirectTerminalAliases(
+					parser, entries, children, view.ProductionID, recoveryTerminalAlias, nodesByID,
+				)
+			}
 			if child := parser.collapsibleUnarySelfReduction(action, Token{}, arena, entries, 0, len(entries), children, fieldIDs); child != nil {
 				child.productionID = view.ProductionID
 				child.dynamicPrecedence += int32(view.DynamicPrecedence)
@@ -6276,6 +6369,12 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			}
 			switch {
 			case hasAction:
+				if s.s3ResumeCount == math.MaxUint32 {
+					return nil, errors.New("parser-core phase zero: strategy-2 resume count overflow")
+				}
+				s.s3ResumeState = StateID(region.state)
+				s.s3ResumeSymbol = Symbol(resumeToken.Symbol)
+				s.s3ResumeCount++
 				// Depth-0 resume: the pre-error state now accepts the current
 				// token. Publish the ERROR container over the absorbed
 				// children and condense it onto the pre-error head (the

--- a/parsercore_phase0_driver_coverage_internal_test.go
+++ b/parsercore_phase0_driver_coverage_internal_test.go
@@ -93,9 +93,10 @@ func TestDiagnosticParserCoreAcceptedLeafCoverageScratchResetsAndReuses(t *testi
 	if err := coverage.append(1, core.MaterializationSubtreeView{StartByte: 0, EndByte: 1, Terminal: true}, 2, false); err != nil {
 		t.Fatal(err)
 	}
+	coverage.authenticatedAliases = append(coverage.authenticatedAliases, &Node{})
 	coverage.reset()
-	if len(coverage.spans) != 0 {
-		t.Fatalf("reset retained %d spans", len(coverage.spans))
+	if len(coverage.spans) != 0 || len(coverage.authenticatedAliases) != 0 {
+		t.Fatalf("reset retained %d spans and %d aliases", len(coverage.spans), len(coverage.authenticatedAliases))
 	}
 	if err := coverage.append(2, core.MaterializationSubtreeView{StartByte: 1, EndByte: 2, Terminal: true}, 2, false); err != nil {
 		t.Fatalf("reuse append: %v", err)
@@ -147,6 +148,57 @@ func TestDiagnosticParserCoreAcceptedLeafCoverageRejectsUnrelatedVisibleTerminal
 	nodesByID[1] = unrelated
 	if _, _, gapped, err := diagnosticParserCoreAcceptedTreeLeafCoverageGap(root, []byte("x"), 0, 1, 100, &coverage, nodesByID, nil); err != nil || !gapped {
 		t.Fatalf("unrelated terminal audit err=%v gapped=%t, want gapped", err, gapped)
+	}
+}
+
+func TestDiagnosticParserCoreAcceptedLeafCoverageAcceptsAuthenticatedTerminalAlias(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	raw := newLeafNodeInArena(arena, Symbol(1), true, 0, 1, Point{}, Point{Column: 1})
+	parser := &Parser{
+		language:       &Language{TokenCount: 100, SymbolMetadata: make([]SymbolMetadata, 102)},
+		reduceAliasSeq: [][]Symbol{nil, {101}},
+	}
+	root := parser.aliasedNodeInArena(arena, raw, Symbol(101))
+	var coverage diagnosticParserCoreAcceptedLeafCoverageScratch
+	if err := coverage.append(1, core.MaterializationSubtreeView{
+		Symbol: 1, StartByte: 0, EndByte: 1, Terminal: true,
+	}, 1, false); err != nil {
+		t.Fatal(err)
+	}
+	nodesByID := make([]*Node, 2)
+	nodesByID[1] = raw
+	coverage.authenticateDirectTerminalAliases(
+		parser, []stackEntry{newStackEntryNode(0, raw)}, []*Node{root}, 1, Symbol(101), nodesByID,
+	)
+	if _, _, gapped, err := diagnosticParserCoreAcceptedTreeLeafCoverageGap(root, []byte("x"), 0, 1, 100, &coverage, nodesByID, nil); err != nil || gapped {
+		t.Fatalf("terminal alias audit err=%v gapped=%t, want complete", err, gapped)
+	}
+}
+
+func TestDiagnosticParserCoreAcceptedLeafCoverageRejectsUnrelatedTerminalAlias(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	raw := newLeafNodeInArena(arena, Symbol(1), true, 0, 1, Point{}, Point{Column: 1})
+	parser := &Parser{
+		language:       &Language{TokenCount: 100, SymbolMetadata: make([]SymbolMetadata, 102)},
+		reduceAliasSeq: [][]Symbol{nil, {101}},
+	}
+	authenticated := parser.aliasedNodeInArena(arena, raw, Symbol(101))
+	unrelated := parser.aliasedNodeInArena(arena, raw, Symbol(101))
+	var coverage diagnosticParserCoreAcceptedLeafCoverageScratch
+	if err := coverage.append(1, core.MaterializationSubtreeView{
+		Symbol: 1, StartByte: 0, EndByte: 1, Terminal: true,
+	}, 1, false); err != nil {
+		t.Fatal(err)
+	}
+	nodesByID := make([]*Node, 2)
+	nodesByID[1] = raw
+	coverage.authenticateDirectTerminalAliases(
+		parser, []stackEntry{newStackEntryNode(0, raw)}, []*Node{authenticated}, 1, Symbol(101), nodesByID,
+	)
+	if _, _, gapped, err := diagnosticParserCoreAcceptedTreeLeafCoverageGap(unrelated, []byte("x"), 0, 1, 100, &coverage, nodesByID, nil); err != nil || !gapped {
+		t.Fatalf("unrelated terminal alias audit err=%v gapped=%t, want gapped", err, gapped)
 	}
 }
 

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -301,6 +301,24 @@ func (r *parserCoreFreshFullRunner) s3AllowErrorRoot() bool {
 	return r != nil && r.options.Recovery && r.options.allowCompactStrategy2ErrorRegion
 }
 
+func (r *parserCoreFreshFullRunner) compactRecoveryTerminalAliasSymbol(
+	scheduler *diagnosticParserCoreGenericScheduler,
+) (Symbol, bool) {
+	if r == nil || r.lang == nil || scheduler == nil ||
+		!scheduler.s3RegionOpened || scheduler.s3ResumeCount != 1 ||
+		scheduler.s5MissingInsertions != 0 ||
+		scheduler.work.RecoveryLineageSelections != 0 ||
+		scheduler.work.NoActionDrops != 1 {
+		return 0, false
+	}
+	for _, rule := range r.lang.CompactRecoveryTerminalAliasRules {
+		if rule.ResumeState == scheduler.s3ResumeState && rule.ResumeSymbol == scheduler.s3ResumeSymbol {
+			return rule.AliasSymbol, true
+		}
+	}
+	return 0, false
+}
+
 func (r *parserCoreFreshFullRunner) materialize(source []byte, compact *core.Core, head core.Head) (*Tree, error) {
 	if r == nil {
 		return nil, errors.New("parser-core fresh-full runner is nil")
@@ -319,6 +337,8 @@ func (r *parserCoreFreshFullRunner) materializeSelection(source []byte, compact 
 	if err != nil {
 		return nil, err
 	}
+	r.scratch.recoveryTerminalAliasSymbol, r.scratch.recoveryTerminalAliasCertified =
+		r.compactRecoveryTerminalAliasSymbol(scheduler)
 	tree, err := materializeDiagnosticParserCoreAcceptedSelection(
 		compact,
 		scheduler.acceptedHead,

--- a/parsercore_phase0_fresh_full_runner_internal_test.go
+++ b/parsercore_phase0_fresh_full_runner_internal_test.go
@@ -119,7 +119,14 @@ func TestResetDiagnosticParserCoreGenericSchedulerRejectsActiveScratch(t *testin
 }
 
 func TestResetDiagnosticParserCoreGenericSchedulerClearsRecoveryState(t *testing.T) {
-	scheduler := diagnosticParserCoreGenericScheduler{s5MissingInsertions: 7, s3RegionOpened: true, recoveryIsolation: true}
+	scheduler := diagnosticParserCoreGenericScheduler{
+		s5MissingInsertions: 7,
+		s3RegionOpened:      true,
+		s3ResumeState:       11,
+		s3ResumeSymbol:      12,
+		s3ResumeCount:       1,
+		recoveryIsolation:   true,
+	}
 	if err := resetDiagnosticParserCoreGenericScheduler(&scheduler); err != nil {
 		t.Fatal(err)
 	}
@@ -128,6 +135,10 @@ func TestResetDiagnosticParserCoreGenericSchedulerClearsRecoveryState(t *testing
 	}
 	if scheduler.s3RegionOpened {
 		t.Fatal("the error region marker remained set after reset")
+	}
+	if scheduler.s3ResumeState != 0 || scheduler.s3ResumeSymbol != 0 || scheduler.s3ResumeCount != 0 {
+		t.Fatalf("the recovery resume remained set after reset: %d/%d/%d",
+			scheduler.s3ResumeState, scheduler.s3ResumeSymbol, scheduler.s3ResumeCount)
 	}
 	if scheduler.recoveryIsolation {
 		t.Fatal("recovery isolation remained active after reset")


### PR DESCRIPTION
## Summary

- Bind two JavaScript strategy-2 resume tuples to the exact embedded grammar blob.
- Authenticate each published terminal alias at its direct reduce site.
- Route `js_log_3` and `js_log_7` with exact C parity.
- Keep all unknown blobs, resumes, and alias clones fail-closed.

## Verification

- Focused root and grammar tests pass in Docker.
- The locked C oracle and JavaScript characterization pass.
- The 2,954-case mutation differential reports 183 routes and 2,771 fallbacks with zero divergence.
- A 30-second admission-route fuzz run passes 9,450 executions.
- Focused race tests pass in Docker.
- The default and `gts_no_parsercorephase0` builds pass.
- The 20-seed clean-route benchmark improves `ns/op` by 21.21%.
- `B/op` remains 2,548, and `allocs/op` remains 80.

## Review

- Two Buckley review analyses report no findings.
- Buckley rejected both report artifacts because its generated output omitted required schema sections.