### PR TITLE
graduate JavaScript compact recovery lineage retirement

### DIFF
--- a/admission_route_equality_leaf_tiling_test.go
+++ b/admission_route_equality_leaf_tiling_test.go
@@ -150,7 +150,7 @@ func TestCompactRouteAcceptedHiddenDoctypeLeafTiles(t *testing.T) {
 }
 
 // TestCompactRouteAdjudicatesFalseCleanWitnesses pulls a focused
-// subset (3 html, 4 javascript) from the 20-witness committed manifest (10
+// subset (3 html, 6 javascript) from the 20-witness committed manifest (10
 // html, 8 javascript, 2 swift). Each entry was, before the B1 tiling gate,
 // accepted by the compact route with HasError()==false while production and
 // the locked C oracle both report an error (compact_t3_oracle_witnesses_v2.
@@ -166,7 +166,8 @@ func TestCompactRouteAcceptedHiddenDoctypeLeafTiles(t *testing.T) {
 // asserted separately, under cgo, by
 // cgo_harness/compact_t3_oracle_adjudication_test.go's
 // compactT3RecoveryCertifiedWitnesses). The certified JavaScript artifact now
-// routes js_log_1, js_log_2, js_log_3, and js_log_7 with exact C parity.
+// routes js_log_1, js_log_2, js_log_3, js_log_5, js_log_7, and js_log_8
+// with exact C parity.
 //
 // Scope note: the manifest's 2 swift entries (swift_log_1, swift_log_2) are
 // NOT in this list. Root-cause (verified by direct tree inspection):
@@ -201,7 +202,7 @@ func TestCompactRouteAdjudicatesFalseCleanWitnesses(t *testing.T) {
 	witnesses := loadRouteEqualityWitnesses(t)
 	ids := []string{
 		"html_min_a", "html_min_html", "html_log_1",
-		"js_log_1", "js_log_2", "js_log_3", "js_log_7",
+		"js_log_1", "js_log_2", "js_log_3", "js_log_5", "js_log_7", "js_log_8",
 	}
 	for _, id := range ids {
 		id := id
@@ -249,10 +250,12 @@ func TestCompactRouteAdjudicatesFalseCleanWitnesses(t *testing.T) {
 			defer tree.Release()
 
 			routed, fallback := gts.AdmissionCandidateCounters()
-			nativeRecovery := witness.Language == "html" || id == "js_log_1" || id == "js_log_2" || id == "js_log_3" || id == "js_log_7"
+			nativeRecovery := witness.Language == "html" || id == "js_log_1" || id == "js_log_2" || id == "js_log_3" ||
+				id == "js_log_5" || id == "js_log_7" || id == "js_log_8"
 			if nativeRecovery {
 				if routed != 1 || fallback != 0 {
-					t.Fatalf("witness %q: route counters routed=%d fallback=%d, want routed=1 fallback=0", id, routed, fallback)
+					t.Fatalf("witness %q: route counters routed=%d fallback=%d, want routed=1 fallback=0; reason=%q",
+						id, routed, fallback, gts.AdmissionCandidateLastFallbackReason())
 				}
 			} else {
 				if routed != 0 || fallback != 1 {
@@ -287,6 +290,30 @@ func TestCompactRouteDeclinesUncertifiedRecoveryAliasResume(t *testing.T) {
 	tree, err := parser.Parse(source)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if routed != 0 || fallback != 1 {
+		t.Fatalf("route counters routed=%d fallback=%d, want 0/1", routed, fallback)
+	}
+	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "accepted compact root leaves do not tile the accepted span") {
+		t.Fatalf("fallback reason=%q, want an accepted-root leaf gap", reason)
+	}
+}
+
+func TestCompactRouteDeclinesRetiredRecoveryWithoutAliasRule(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	lang := *grammars.JavascriptLanguage()
+	lang.CompactRecoveryTerminalAliasRules = nil
+	source := []byte("const f = (a) =. + + 1;\nclass A { m() { return 1 } }\n\n")
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	parser := gts.NewParser(&lang)
+	parser.SetAdmissionCandidateRoute(true)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
 	}
 	defer tree.Release()
 

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -67,8 +67,9 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		allowCompactMissingTokenInsertion: p.language.CompactMissingTokenInsertionCertified,
 		allowCompactRecoveryLineageSelection: p.language.CompactStrategy2ErrorRegionCertified &&
 			p.language.CompactMissingTokenInsertionCertified,
-		noLookaheadRootSymbol:    p.rootSymbol,
-		hasNoLookaheadRootSymbol: p.hasRootSymbol,
+		allowCompactRecoveryTrailingLineageRetirement: p.language.CompactRecoveryTrailingLineageRetirementCertified,
+		noLookaheadRootSymbol:                         p.rootSymbol,
+		hasNoLookaheadRootSymbol:                      p.hasRootSymbol,
 		// Tranche B8 scheduler stop-control: bind this Parser so the scheduler
 		// polls its deadline, cancellation flag, and (via
 		// stopControlMemoryBudgetBytes, recomputed per parse in

--- a/benchmark_admission_candidate_route_test.go
+++ b/benchmark_admission_candidate_route_test.go
@@ -61,3 +61,42 @@ func BenchmarkAdmissionCandidateGoQueryCompileWarmRoute(b *testing.B) {
 	b.ReportMetric(float64(routed)/float64(b.N), "candidate-routes/op")
 	b.ReportMetric(float64(fallback)/float64(b.N), "candidate-fallbacks/op")
 }
+
+// BenchmarkAdmissionCandidateJavaScriptCleanWarmRoute measures a clean source
+// that completes on the plain-first compact attempt. Recovery remains idle.
+func BenchmarkAdmissionCandidateJavaScriptCleanWarmRoute(b *testing.B) {
+	source := []byte("const x = (a) => a + 1;\nclass A { m() { return x(1) } }\n")
+	parser := gotreesitter.NewParser(grammars.JavascriptLanguage())
+	parser.SetAdmissionCandidateRoute(true)
+
+	gotreesitter.ResetAdmissionCandidateCountersForTest()
+	warm, err := parser.Parse(source)
+	if err != nil || warm == nil || warm.RootNode() == nil {
+		b.Fatalf("compact warm parse failed: tree=%v err=%v", warm != nil, err)
+	}
+	warm.Release()
+	if routed, fallback := gotreesitter.AdmissionCandidateCounters(); routed != 1 || fallback != 0 {
+		b.Fatalf("compact warm parse did not route: routed=%d fallback=%d reason=%q",
+			routed, fallback, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+
+	gotreesitter.ResetAdmissionCandidateCountersForTest()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(source)))
+	b.ResetTimer()
+	for range b.N {
+		tree, parseErr := parser.Parse(source)
+		if parseErr != nil || tree == nil || tree.RootNode() == nil {
+			b.Fatalf("compact timed parse failed: tree=%v err=%v", tree != nil, parseErr)
+		}
+		tree.Release()
+	}
+	b.StopTimer()
+	routed, fallback := gotreesitter.AdmissionCandidateCounters()
+	if routed != uint64(b.N) || fallback != 0 {
+		b.Fatalf("compact timed loop changed route: routed=%d want=%d fallback=%d reason=%q",
+			routed, b.N, fallback, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+	b.ReportMetric(float64(routed)/float64(b.N), "candidate-routes/op")
+	b.ReportMetric(float64(fallback)/float64(b.N), "candidate-fallbacks/op")
+}

--- a/cgo_harness/compact_javascript_s5_scan_test.go
+++ b/cgo_harness/compact_javascript_s5_scan_test.go
@@ -120,8 +120,10 @@ func TestCompactJavaScriptS5RecoveryMutationDifferential(t *testing.T) {
 			}
 		}
 	}
-	if expanded != 26 || contracted != 0 {
-		t.Fatalf("S5 route delta expanded=%d contracted=%d, want 26/0 across %d cases", expanded, contracted, cases)
+	// Trailing-lineage retirement adds 15 exact routes to the prior 26-route
+	// S5 frontier. The loop compared every expanded tree with C above.
+	if expanded != 41 || contracted != 0 {
+		t.Fatalf("S5 route delta expanded=%d contracted=%d, want 41/0 across %d cases", expanded, contracted, cases)
 	}
 	t.Logf("JavaScript S5 mutation differential: cases=%d expanded=%d contracted=%d", cases, expanded, contracted)
 }

--- a/cgo_harness/compact_t3_oracle_adjudication_test.go
+++ b/cgo_harness/compact_t3_oracle_adjudication_test.go
@@ -115,7 +115,7 @@ type compactT3ExpectedOutcome struct {
 // compactT3RecoveryCertifiedWitnesses lists witnesses where native compact
 // recovery reaches exact structural C-oracle parity. The exact HTML artifact
 // certifies its complete class. JavaScript certifies the current S3 frontier;
-// its remaining three witnesses stay fail-closed.
+// its remaining witness stays fail-closed.
 var compactT3RecoveryCertifiedWitnesses = map[string]bool{
 	"html_min_a":    true,
 	"html_min_html": true,
@@ -131,7 +131,9 @@ var compactT3RecoveryCertifiedWitnesses = map[string]bool{
 	"js_log_2":      true,
 	"js_log_3":      true,
 	"js_log_4":      true,
+	"js_log_5":      true,
 	"js_log_7":      true,
+	"js_log_8":      true,
 }
 
 // TestCompactT3OracleAdjudication verifies each committed false-clean witness
@@ -148,7 +150,7 @@ var compactT3RecoveryCertifiedWitnesses = map[string]bool{
 //   - compact vs. the C oracle: S3 and S5 cover all ten
 //     html_erroneous_end_tag witnesses. Every witness in
 //     compactT3RecoveryCertifiedWitnesses must match the C oracle exactly.
-//     JavaScript routes five witnesses exactly and fails closed on three.
+//     JavaScript routes seven witnesses exactly and fails closed on one.
 //     Swift still has no compact recovery implementation.
 //   - production vs. the C oracle: the S1 design brief's stated gate is
 //     "the harness must pass with production serving every witness before
@@ -283,10 +285,10 @@ func TestCompactT3JavaScriptRecoveryProfileCharacterization(t *testing.T) {
 		"js_log_2": {routed: true},
 		"js_log_3": {routed: true},
 		"js_log_4": {routed: true},
-		"js_log_5": {fallbackDetail: "generic scheduler has no table action for the elected token"},
+		"js_log_5": {routed: true},
 		"js_log_6": {fallbackDetail: "error-mode lex disagrees with the ordinary shared election"},
 		"js_log_7": {routed: true},
-		"js_log_8": {fallbackDetail: "generic scheduler has no table action for the elected token"},
+		"js_log_8": {routed: true},
 	}
 
 	for _, witness := range compactT3WitnessesForLanguage(manifest, "javascript") {
@@ -496,8 +498,12 @@ func TestCompactT3JavaScriptRecoveryMutationDifferential(t *testing.T) {
 	if routed == 0 || fallback == 0 {
 		t.Fatalf("mutation differential lacked both route outcomes: cases=%d routed=%d fallback=%d", cases, routed, fallback)
 	}
-	if missingExpanded != 0 || missingContracted != 0 {
-		t.Fatalf("T3 neighborhood crossed the S5 boundary: expanded=%d contracted=%d", missingExpanded, missingContracted)
+	// The certified retirement adds 46 exact routes to the S3-only baseline.
+	// The loop compared every routed tree with C before this count check.
+	const trailingRetirementExpansions = 46
+	if missingExpanded != trailingRetirementExpansions || missingContracted != 0 {
+		t.Fatalf("T3 neighborhood S5 boundary: expanded=%d contracted=%d, want %d/0",
+			missingExpanded, missingContracted, trailingRetirementExpansions)
 	}
 	t.Logf("JavaScript compact recovery mutation differential: cases=%d routed=%d fallback=%d S3-only=%d missing-expanded=%d missing-contracted=%d",
 		cases, routed, fallback, s3OnlyRouted, missingExpanded, missingContracted)

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -27,6 +27,7 @@ type builtinLanguageRuntimeProfile struct {
 	exactStackNodeEquivalence          bool
 	compactStrategy2ErrorRegion        bool
 	compactMissingTokenInsertion       bool
+	compactRecoveryTrailingRetirement  bool
 	compactRecoveryTerminalAliases     []compactRecoveryTerminalAliasProfile
 	compactRecoveryPlainFirst          bool
 	lineContinuationEscapeByte         byte
@@ -108,15 +109,17 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// explicit forest parsing and non-certified languages keep the full budget.
 	//
 	// The same exact artifact certifies the current compact recovery frontier.
-	// Five pinned witnesses route with exact C parity. Three stop at
-	// typed fail-closed boundaries and remain production-owned.
+	// Seven pinned witnesses route with exact C parity. One stops at a typed
+	// fail-closed boundary and remains production-owned.
 	"javascript": {
-		blobSHA256:                     mustRuntimeProfileSHA256("6706f93890f24d8ea90d6a140df5dde29c02ec8a3213bae16e8cc4df37e33ee0"),
-		automaticForestMemoryAllowance: javascriptAutomaticForestMemoryAllowance,
-		compactConvergedSplitDrops:     true,
-		compactStrategy2ErrorRegion:    true,
-		compactMissingTokenInsertion:   true,
+		blobSHA256:                        mustRuntimeProfileSHA256("6706f93890f24d8ea90d6a140df5dde29c02ec8a3213bae16e8cc4df37e33ee0"),
+		automaticForestMemoryAllowance:    javascriptAutomaticForestMemoryAllowance,
+		compactConvergedSplitDrops:        true,
+		compactStrategy2ErrorRegion:       true,
+		compactMissingTokenInsertion:      true,
+		compactRecoveryTrailingRetirement: true,
 		compactRecoveryTerminalAliases: []compactRecoveryTerminalAliasProfile{
+			{resumeState: 231, resumeSymbol: "+", aliasSymbol: "property_identifier"},
 			{resumeState: 1042, resumeSymbol: "_automatic_semicolon", aliasSymbol: "property_identifier"},
 			{resumeState: 1367, resumeSymbol: "{", aliasSymbol: "property_identifier"},
 		},
@@ -692,6 +695,10 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	}
 	if profile.compactMissingTokenInsertion && !lang.CompactMissingTokenInsertionCertified {
 		lang.CompactMissingTokenInsertionCertified = true
+		changed = true
+	}
+	if profile.compactRecoveryTrailingRetirement && !lang.CompactRecoveryTrailingLineageRetirementCertified {
+		lang.CompactRecoveryTrailingLineageRetirementCertified = true
 		changed = true
 	}
 	if rules := resolveCompactRecoveryTerminalAliasProfile(lang, profile.compactRecoveryTerminalAliases); len(rules) > 0 &&

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -75,10 +75,11 @@ func TestJavaScriptProfileCertifiesCompactRecoveryFrontier(t *testing.T) {
 	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
 	lang := JavascriptLanguage()
 	if !lang.CompactStrategy2ErrorRegionCertified || !lang.CompactMissingTokenInsertionCertified ||
-		!lang.CompactRecoveryPlainFirstCertified {
+		!lang.CompactRecoveryPlainFirstCertified || !lang.CompactRecoveryTrailingLineageRetirementCertified {
 		t.Fatal("the JavaScript profile did not attach its compact recovery capabilities")
 	}
 	wantAliases := []gotreesitter.CompactRecoveryTerminalAliasRule{
+		{ResumeState: 231, ResumeSymbol: 85, AliasSymbol: 261},
 		{ResumeState: 1042, ResumeSymbol: 129, AliasSymbol: 261},
 		{ResumeState: 1367, ResumeSymbol: 7, AliasSymbol: 261},
 	}
@@ -88,7 +89,8 @@ func TestJavaScriptProfileCertifiesCompactRecoveryFrontier(t *testing.T) {
 	uncertified := &gotreesitter.Language{}
 	if attachBuiltinLanguageRuntimeProfile("javascript", sha256.Sum256([]byte("wrong javascript blob")), uncertified) ||
 		uncertified.CompactStrategy2ErrorRegionCertified || uncertified.CompactMissingTokenInsertionCertified ||
-		uncertified.CompactRecoveryPlainFirstCertified || len(uncertified.CompactRecoveryTerminalAliasRules) != 0 {
+		uncertified.CompactRecoveryPlainFirstCertified || uncertified.CompactRecoveryTrailingLineageRetirementCertified ||
+		len(uncertified.CompactRecoveryTerminalAliasRules) != 0 {
 		t.Fatal("a mismatched JavaScript blob received compact recovery certification")
 	}
 }
@@ -164,6 +166,9 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	}
 	if lang.CompactRecoveryPlainFirstCertified {
 		t.Fatal("unknown runtime profile enabled compact plain-first recovery")
+	}
+	if lang.CompactRecoveryTrailingLineageRetirementCertified {
+		t.Fatal("unknown runtime profile enabled compact trailing-lineage retirement")
 	}
 	if len(lang.CompactRecoveryTerminalAliasRules) != 0 {
 		t.Fatal("unknown runtime profile attached compact recovery terminal aliases")

--- a/language.go
+++ b/language.go
@@ -801,6 +801,14 @@ type Language struct {
 	// Custom and adapted languages retain the false default.
 	CompactMissingTokenInsertionCertified bool
 
+	// CompactRecoveryTrailingLineageRetirementCertified permits the compact
+	// scheduler to retire one trailing no-action missing lineage after the
+	// earlier error-absorb lineage consumed the same elected token. This is the
+	// exact two-version shape that C removes in its recovery condense tail.
+	// Exact built-in profiles must certify the complete transition. Custom,
+	// adapted, and stale artifacts retain the false default.
+	CompactRecoveryTrailingLineageRetirementCertified bool
+
 	// CompactRecoveryTerminalAliasRules permits the accepted-root leaf audit to
 	// authenticate a materialized terminal alias after one certified recovery
 	// resume. The materializer must also prove the exact raw terminal and alias

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -112,8 +112,12 @@ type DiagnosticParserCorePrefixOptions struct {
 	// The admission route sets this only when one artifact certifies both
 	// recovery mechanisms. Other parses retain the conservative false default.
 	allowCompactRecoveryLineageSelection bool
-	noLookaheadRootSymbol                Symbol
-	hasNoLookaheadRootSymbol             bool
+	// allowCompactRecoveryTrailingLineageRetirement permits C's condense-tail
+	// removal for one exact two-version S5 frontier. The admission route sets
+	// this only from an exact grammar-artifact capability.
+	allowCompactRecoveryTrailingLineageRetirement bool
+	noLookaheadRootSymbol                         Symbol
+	hasNoLookaheadRootSymbol                      bool
 	// stopControlParser, when non-nil, arms the scheduler's stop-control poll
 	// (spec.campaign.v7 tranche B8): once per dispatch-pass-loop iteration,
 	// diagnosticParserCoreGenericScheduler.run checks this Parser's deadline
@@ -354,6 +358,9 @@ type DiagnosticParserCoreGenericWork struct {
 	// in the receipt from one that never competed, and no differential harness
 	// could confirm the port picks what C picks.
 	RecoveryLineageSelections uint64
+	// RecoveryLineageRetirements counts C-condense-tail transitions that remove
+	// one trailing no-action recovery version after an earlier version shifts.
+	RecoveryLineageRetirements uint64
 	// SingleHeaderPasses counts dispatch passes executed against a
 	// single-header frontier (spec.c4-bytecode-isa.v1 section 5, obligation
 	// R6). It is count-only and published on the gts_workcount board so
@@ -1224,6 +1231,50 @@ func (s *diagnosticParserCoreGenericScheduler) competingRecoveryFrontier() bool 
 		}
 	}
 	return true
+}
+
+// retireTrailingRecoveryNoActionLineage ports one exact C condense-tail
+// transition. S5 orders the absorbing version before the missing version. If
+// the absorbing version consumes the elected token and the later missing
+// version cannot act on it, C keeps the earlier unpaused version and removes
+// the later paused version without another recovery election.
+//
+// Keep the proof deliberately narrow. Both versions must share the elected
+// checkpoint, carry no open error region, and preserve creation order. The
+// survivor must end exactly at the elected token boundary. Every other
+// recovery frontier continues to fail closed.
+func (s *diagnosticParserCoreGenericScheduler) retireTrailingRecoveryNoActionLineage(indices []int) (bool, error) {
+	if s == nil || !s.options.allowCompactRecoveryTrailingLineageRetirement ||
+		!s.competingRecoveryFrontier() || len(s.headers) != 2 || len(indices) != 1 || indices[0] != 1 ||
+		!diagnosticParserCoreGenericNoActionDropEligible(s.headers, indices, s.epochProgress) {
+		return false, nil
+	}
+	survivor := &s.headers[0]
+	loser := &s.headers[1]
+	if !survivor.shifted || survivor.accepted || survivor.paused || loser.shifted || loser.accepted || loser.paused ||
+		survivor.s3Region != nil || loser.s3Region != nil || survivor.creationSeq >= loser.creationSeq ||
+		survivor.checkpoint != loser.checkpoint || survivor.checkpoint != s.checkpointID ||
+		s.token.Symbol == 0 || s.token.EndByte <= s.token.StartByte {
+		return false, nil
+	}
+	_, survivorByte, err := s.compact.Boundary(survivor.head)
+	if err != nil {
+		return false, err
+	}
+	_, loserByte, err := s.compact.Boundary(loser.head)
+	if err != nil {
+		return false, err
+	}
+	if survivorByte != s.token.EndByte || loserByte > s.token.StartByte {
+		return false, nil
+	}
+
+	survivor.clearRecoveryLineage()
+	clear(s.headers[1:])
+	s.headers = s.headers[:1]
+	s.recoveryIsolation = false
+	s.work.add(&s.work.RecoveryLineageRetirements, 1)
+	return true, nil
 }
 
 // recoveryOpenSegments returns the open-recovery segment count pricing charges
@@ -6677,6 +6728,13 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			// classification only: every one of these boundaries still
 			// declines and falls back to production unchanged (B3 stage S1).
 			if pausedNoActionHeads == 0 && deferredNoActionHeads == 0 && raggedRelexNoActionHeads == 0 {
+				retired, retireErr := s.retireTrailingRecoveryNoActionLineage(noActionIndices)
+				if retireErr != nil {
+					return nil, retireErr
+				}
+				if retired {
+					return nil, nil
+				}
 				// Try the certified S5 competition before standalone S3.
 				// Both routes own only the sole-header, sole-no-action shape.
 				// Unmodeled ambiguity falls through to the existing decline.

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -306,9 +306,14 @@ func (r *parserCoreFreshFullRunner) compactRecoveryTerminalAliasSymbol(
 ) (Symbol, bool) {
 	if r == nil || r.lang == nil || scheduler == nil ||
 		!scheduler.s3RegionOpened || scheduler.s3ResumeCount != 1 ||
-		scheduler.s5MissingInsertions != 0 ||
-		scheduler.work.RecoveryLineageSelections != 0 ||
-		scheduler.work.NoActionDrops != 1 {
+		scheduler.work.RecoveryLineageSelections != 0 {
+		return 0, false
+	}
+	standaloneRegion := scheduler.s5MissingInsertions == 0 &&
+		scheduler.work.RecoveryLineageRetirements == 0 && scheduler.work.NoActionDrops == 1
+	retiredMissingLineage := scheduler.s5MissingInsertions == 1 &&
+		scheduler.work.RecoveryLineageRetirements == 1 && scheduler.work.NoActionDrops == 1
+	if !standaloneRegion && !retiredMissingLineage {
 		return 0, false
 	}
 	for _, rule := range r.lang.CompactRecoveryTerminalAliasRules {
@@ -439,17 +444,20 @@ func (r *parserCoreFreshFullRunner) parseWithObserverAndErrorRuns(
 	savedErrorRegion := r.options.allowCompactStrategy2ErrorRegion
 	savedMissingInsertion := r.options.allowCompactMissingTokenInsertion
 	savedLineageSelection := r.options.allowCompactRecoveryLineageSelection
+	savedTrailingRetirement := r.options.allowCompactRecoveryTrailingLineageRetirement
 	if !recoveryEnabled {
 		r.options.Recovery = false
 		r.options.allowCompactStrategy2ErrorRegion = false
 		r.options.allowCompactMissingTokenInsertion = false
 		r.options.allowCompactRecoveryLineageSelection = false
+		r.options.allowCompactRecoveryTrailingLineageRetirement = false
 	}
 	defer func() {
 		r.options.Recovery = savedRecovery
 		r.options.allowCompactStrategy2ErrorRegion = savedErrorRegion
 		r.options.allowCompactMissingTokenInsertion = savedMissingInsertion
 		r.options.allowCompactRecoveryLineageSelection = savedLineageSelection
+		r.options.allowCompactRecoveryTrailingLineageRetirement = savedTrailingRetirement
 	}()
 	scheduler, tokenSource, err := r.executeSchedulerOpenWithObserverAndErrorRuns(
 		source, r.compact, true, observer, forceErrorRuns,

--- a/parsercore_phase0_recovery_lineage_retirement_test.go
+++ b/parsercore_phase0_recovery_lineage_retirement_test.go
@@ -1,0 +1,64 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestCompactJavaScriptRetiresTrailingRecoveryLineage(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	lang := grammars.JavascriptLanguage()
+	for name, test := range map[string]struct {
+		source        []byte
+		resumeState   gts.StateID
+		resumeSymbol  gts.Symbol
+		noActionDrops uint64
+	}{
+		"js_log_5": {
+			source:      []byte("const f = (a) =. + + 1;\nclass A { m() { return 1 } }\n\n"),
+			resumeState: 231, resumeSymbol: 85, noActionDrops: 1,
+		},
+		"js_log_8": {
+			source:      []byte("function f() { return 1; ^}\ncon\nconst x = () => x + 1;\n"),
+			resumeState: 22, resumeSymbol: 9,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			receipt, provenance, err := gts.RunStateDependentRecoveryRelexProvenanceForTest(lang, test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if receipt.Acceptance == nil {
+				t.Fatalf("stop=%+v, want acceptance", receipt.Stop)
+			}
+			if got := receipt.Acceptance.Work.RecoveryLineageRetirements; got != 1 {
+				t.Fatalf("recovery lineage retirements=%d, want 1", got)
+			}
+			if provenance.ResumeState != test.resumeState || provenance.ResumeSymbol != test.resumeSymbol ||
+				provenance.ResumeCount != 1 || provenance.MissingInsertions != 1 ||
+				provenance.LineageSelections != 0 || provenance.LineageRetirements != 1 ||
+				provenance.NoActionDrops != test.noActionDrops {
+				t.Fatalf("provenance=%+v, want resume=%d/%d count=1 missing=1 selection=0 retirement=1 drops=%d",
+					provenance, test.resumeState, test.resumeSymbol, test.noActionDrops)
+			}
+		})
+	}
+}
+
+func TestCompactJavaScriptTrailingRecoveryRetirementRequiresArtifact(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	lang := *grammars.JavascriptLanguage()
+	lang.CompactRecoveryTrailingLineageRetirementCertified = false
+	source := []byte("function f() { return 1; ^}\ncon\nconst x = () => x + 1;\n")
+	receipt, _, err := gts.RunStateDependentRecoveryRelexProvenanceForTest(&lang, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Acceptance != nil || receipt.Stop.Detail != gts.DiagnosticParserCoreNoTableActionDetailForTest() {
+		t.Fatalf("acceptance=%+v stop=%+v, want the prior fail-closed boundary", receipt.Acceptance, receipt.Stop)
+	}
+}

--- a/parsercore_phase0_state_relex_internal_test.go
+++ b/parsercore_phase0_state_relex_internal_test.go
@@ -165,6 +165,59 @@ func RunStateDependentRelexSchedulerForTest(lang *Language, source []byte) (Diag
 	return runStateDependentRelexSchedulerForTest(lang, source, false)
 }
 
+// StateDependentRecoveryProvenanceForTest records the recovery lifecycle that
+// produced one forced error-mode scheduler receipt.
+type StateDependentRecoveryProvenanceForTest struct {
+	ResumeState        StateID
+	ResumeSymbol       Symbol
+	ResumeCount        uint32
+	MissingInsertions  uint32
+	LineageSelections  uint64
+	LineageRetirements uint64
+	NoActionDrops      uint64
+}
+
+// RunStateDependentRecoveryRelexProvenanceForTest runs the forced error-mode
+// compact attempt that follows a certified plain-first decline.
+func RunStateDependentRecoveryRelexProvenanceForTest(lang *Language, source []byte) (DiagnosticParserCoreGenericScheduler, StateDependentRecoveryProvenanceForTest, error) {
+	return runStateDependentRecoveryRelexSchedulerForTest(lang, source)
+}
+
+func runStateDependentRecoveryRelexSchedulerForTest(lang *Language, source []byte) (DiagnosticParserCoreGenericScheduler, StateDependentRecoveryProvenanceForTest, error) {
+	parser := NewParser(lang)
+	runner, err := newAdmissionCandidateRunner(parser)
+	if err != nil {
+		return DiagnosticParserCoreGenericScheduler{}, StateDependentRecoveryProvenanceForTest{}, err
+	}
+	runner.options.ReceiptMode = DiagnosticParserCoreReceiptFull
+	tokenSource := parser.acquireParserDFATokenSourceWithErrorRuns(source, true)
+	if tokenSource == nil {
+		return DiagnosticParserCoreGenericScheduler{}, StateDependentRecoveryProvenanceForTest{}, nil
+	}
+	defer tokenSource.Close()
+	scheduler, runErr := executeDiagnosticParserCoreGenericSchedulerFromSeed(
+		runner.compact,
+		tokenSource,
+		&runner.scannerScratch,
+		lang.InitialState,
+		runner.options,
+		diagnosticParserCoreSeedObserver{},
+	)
+	if scheduler == nil || scheduler.receipt == nil {
+		return DiagnosticParserCoreGenericScheduler{}, StateDependentRecoveryProvenanceForTest{}, runErr
+	}
+	provenance := StateDependentRecoveryProvenanceForTest{
+		ResumeState:        scheduler.s3ResumeState,
+		ResumeSymbol:       scheduler.s3ResumeSymbol,
+		ResumeCount:        scheduler.s3ResumeCount,
+		MissingInsertions:  scheduler.s5MissingInsertions,
+		LineageSelections:  scheduler.work.RecoveryLineageSelections,
+		LineageRetirements: scheduler.work.RecoveryLineageRetirements,
+		NoActionDrops:      scheduler.work.NoActionDrops,
+	}
+	return *scheduler.receipt, provenance, runErr
+}
+
 // RunStateDependentRelexSchedulerWithSpanUnlockedRelexDisabledForTest is
 // RunStateDependentRelexSchedulerForTest with
 // DisablePerHeaderSpanUnlockedRelex forced on, for the D2-1 gate test


### PR DESCRIPTION
## Summary

- Retire one exact trailing no-action recovery lineage.
- Gate the transition with the exact JavaScript artifact.
- Add the resume-state 231 terminal alias rule.
- Route js_log_5 and js_log_8 through the compact parser.
- Keep js_log_6 fail-closed.

## Correctness

- The retirement requires the exact two-version C shape.
- Both versions must share the elected checkpoint.
- Neither version can own an open error region.
- The survivor must end at the token boundary.
- Every other frontier declines unchanged.

## Verification

- The full 20-witness T3 adjudication passes.
- The mutation differential checked 2,954 cases.
- The S5 scan checked 5,267 cases.
- The change adds 61 exact routes with zero contractions.
- Every new route matched the C tree.
- The focused race tests pass.
- A 30-second JavaScript route fuzz run passes.
- The default root package suite passes in Docker.
- Both parser build-tag configurations compile.

## Performance

The 20-seed warm clean-route benchmark found no significant time change.

- Time: 52.07 microseconds to 54.22 microseconds, p=0.142.
- Bytes: 100 per operation, unchanged.
- Allocations: 4 per operation, unchanged.