### PR TITLE
Graduate JavaScript error-mode keyword recovery

### DIFF
--- a/admission_route_equality_leaf_tiling_test.go
+++ b/admission_route_equality_leaf_tiling_test.go
@@ -202,7 +202,7 @@ func TestCompactRouteAdjudicatesFalseCleanWitnesses(t *testing.T) {
 	witnesses := loadRouteEqualityWitnesses(t)
 	ids := []string{
 		"html_min_a", "html_min_html", "html_log_1",
-		"js_log_1", "js_log_2", "js_log_3", "js_log_5", "js_log_7", "js_log_8",
+		"js_log_1", "js_log_2", "js_log_3", "js_log_5", "js_log_6", "js_log_7", "js_log_8",
 	}
 	for _, id := range ids {
 		id := id
@@ -251,7 +251,7 @@ func TestCompactRouteAdjudicatesFalseCleanWitnesses(t *testing.T) {
 
 			routed, fallback := gts.AdmissionCandidateCounters()
 			nativeRecovery := witness.Language == "html" || id == "js_log_1" || id == "js_log_2" || id == "js_log_3" ||
-				id == "js_log_5" || id == "js_log_7" || id == "js_log_8"
+				id == "js_log_5" || id == "js_log_6" || id == "js_log_7" || id == "js_log_8"
 			if nativeRecovery {
 				if routed != 1 || fallback != 0 {
 					t.Fatalf("witness %q: route counters routed=%d fallback=%d, want routed=1 fallback=0; reason=%q",

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -68,6 +68,7 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		allowCompactRecoveryLineageSelection: p.language.CompactStrategy2ErrorRegionCertified &&
 			p.language.CompactMissingTokenInsertionCertified,
 		allowCompactRecoveryTrailingLineageRetirement: p.language.CompactRecoveryTrailingLineageRetirementCertified,
+		allowCompactRecoveryErrorModeKeywordCapture:   p.language.CompactRecoveryErrorModeKeywordCaptureCertified,
 		noLookaheadRootSymbol:                         p.rootSymbol,
 		hasNoLookaheadRootSymbol:                      p.hasRootSymbol,
 		// Tranche B8 scheduler stop-control: bind this Parser so the scheduler

--- a/cgo_harness/compact_javascript_s5_scan_test.go
+++ b/cgo_harness/compact_javascript_s5_scan_test.go
@@ -121,9 +121,10 @@ func TestCompactJavaScriptS5RecoveryMutationDifferential(t *testing.T) {
 		}
 	}
 	// Trailing-lineage retirement adds 15 exact routes to the prior 26-route
-	// S5 frontier. The loop compared every expanded tree with C above.
-	if expanded != 41 || contracted != 0 {
-		t.Fatalf("S5 route delta expanded=%d contracted=%d, want 41/0 across %d cases", expanded, contracted, cases)
+	// S5 frontier. Error-mode keyword capture adds four more. The loop compares
+	// every expanded tree with C above.
+	if expanded != 45 || contracted != 0 {
+		t.Fatalf("S5 route delta expanded=%d contracted=%d, want 45/0 across %d cases", expanded, contracted, cases)
 	}
 	t.Logf("JavaScript S5 mutation differential: cases=%d expanded=%d contracted=%d", cases, expanded, contracted)
 }

--- a/cgo_harness/compact_t3_oracle_adjudication_test.go
+++ b/cgo_harness/compact_t3_oracle_adjudication_test.go
@@ -114,8 +114,8 @@ type compactT3ExpectedOutcome struct {
 
 // compactT3RecoveryCertifiedWitnesses lists witnesses where native compact
 // recovery reaches exact structural C-oracle parity. The exact HTML artifact
-// certifies its complete class. JavaScript certifies the current S3 frontier;
-// its remaining witness stays fail-closed.
+// certifies its complete class. JavaScript certifies all eight pinned recovery
+// witnesses.
 var compactT3RecoveryCertifiedWitnesses = map[string]bool{
 	"html_min_a":    true,
 	"html_min_html": true,
@@ -132,6 +132,7 @@ var compactT3RecoveryCertifiedWitnesses = map[string]bool{
 	"js_log_3":      true,
 	"js_log_4":      true,
 	"js_log_5":      true,
+	"js_log_6":      true,
 	"js_log_7":      true,
 	"js_log_8":      true,
 }
@@ -150,7 +151,7 @@ var compactT3RecoveryCertifiedWitnesses = map[string]bool{
 //   - compact vs. the C oracle: S3 and S5 cover all ten
 //     html_erroneous_end_tag witnesses. Every witness in
 //     compactT3RecoveryCertifiedWitnesses must match the C oracle exactly.
-//     JavaScript routes seven witnesses exactly and fails closed on one.
+//     JavaScript routes all eight witnesses exactly.
 //     Swift still has no compact recovery implementation.
 //   - production vs. the C oracle: the S1 design brief's stated gate is
 //     "the harness must pass with production serving every witness before
@@ -286,7 +287,7 @@ func TestCompactT3JavaScriptRecoveryProfileCharacterization(t *testing.T) {
 		"js_log_3": {routed: true},
 		"js_log_4": {routed: true},
 		"js_log_5": {routed: true},
-		"js_log_6": {fallbackDetail: "error-mode lex disagrees with the ordinary shared election"},
+		"js_log_6": {routed: true},
 		"js_log_7": {routed: true},
 		"js_log_8": {routed: true},
 	}
@@ -498,12 +499,12 @@ func TestCompactT3JavaScriptRecoveryMutationDifferential(t *testing.T) {
 	if routed == 0 || fallback == 0 {
 		t.Fatalf("mutation differential lacked both route outcomes: cases=%d routed=%d fallback=%d", cases, routed, fallback)
 	}
-	// The certified retirement adds 46 exact routes to the S3-only baseline.
-	// The loop compared every routed tree with C before this count check.
-	const trailingRetirementExpansions = 46
-	if missingExpanded != trailingRetirementExpansions || missingContracted != 0 {
+	// Trailing retirement adds 46 exact routes. Error-mode keyword capture and
+	// EOF pricing add 25 more. The loop compares each published tree with C.
+	const certifiedS5Expansions = 71
+	if missingExpanded != certifiedS5Expansions || missingContracted != 0 {
 		t.Fatalf("T3 neighborhood S5 boundary: expanded=%d contracted=%d, want %d/0",
-			missingExpanded, missingContracted, trailingRetirementExpansions)
+			missingExpanded, missingContracted, certifiedS5Expansions)
 	}
 	t.Logf("JavaScript compact recovery mutation differential: cases=%d routed=%d fallback=%d S3-only=%d missing-expanded=%d missing-contracted=%d",
 		cases, routed, fallback, s3OnlyRouted, missingExpanded, missingContracted)

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -28,6 +28,7 @@ type builtinLanguageRuntimeProfile struct {
 	compactStrategy2ErrorRegion        bool
 	compactMissingTokenInsertion       bool
 	compactRecoveryTrailingRetirement  bool
+	compactRecoveryErrorModeKeyword    bool
 	compactRecoveryTerminalAliases     []compactRecoveryTerminalAliasProfile
 	compactRecoveryPlainFirst          bool
 	lineContinuationEscapeByte         byte
@@ -108,9 +109,8 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// trees and outcomes across all files while cutting aggregate allocations;
 	// explicit forest parsing and non-certified languages keep the full budget.
 	//
-	// The same exact artifact certifies the current compact recovery frontier.
-	// Seven pinned witnesses route with exact C parity. One stops at a typed
-	// fail-closed boundary and remains production-owned.
+	// The same exact artifact certifies the complete pinned compact recovery
+	// frontier. All eight witnesses route with exact C parity.
 	"javascript": {
 		blobSHA256:                        mustRuntimeProfileSHA256("6706f93890f24d8ea90d6a140df5dde29c02ec8a3213bae16e8cc4df37e33ee0"),
 		automaticForestMemoryAllowance:    javascriptAutomaticForestMemoryAllowance,
@@ -118,7 +118,9 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		compactStrategy2ErrorRegion:       true,
 		compactMissingTokenInsertion:      true,
 		compactRecoveryTrailingRetirement: true,
+		compactRecoveryErrorModeKeyword:   true,
 		compactRecoveryTerminalAliases: []compactRecoveryTerminalAliasProfile{
+			{resumeState: 20, resumeSymbol: "class", aliasSymbol: "property_identifier"},
 			{resumeState: 231, resumeSymbol: "+", aliasSymbol: "property_identifier"},
 			{resumeState: 1042, resumeSymbol: "_automatic_semicolon", aliasSymbol: "property_identifier"},
 			{resumeState: 1367, resumeSymbol: "{", aliasSymbol: "property_identifier"},
@@ -701,6 +703,10 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 		lang.CompactRecoveryTrailingLineageRetirementCertified = true
 		changed = true
 	}
+	if profile.compactRecoveryErrorModeKeyword && !lang.CompactRecoveryErrorModeKeywordCaptureCertified {
+		lang.CompactRecoveryErrorModeKeywordCaptureCertified = true
+		changed = true
+	}
 	if rules := resolveCompactRecoveryTerminalAliasProfile(lang, profile.compactRecoveryTerminalAliases); len(rules) > 0 &&
 		!slices.Equal(lang.CompactRecoveryTerminalAliasRules, rules) {
 		lang.CompactRecoveryTerminalAliasRules = rules
@@ -774,7 +780,7 @@ func resolveCompactRecoveryTerminalAliasProfile(
 	}
 	rules := make([]gotreesitter.CompactRecoveryTerminalAliasRule, 0, len(profile))
 	for _, candidate := range profile {
-		resumeSymbol, resumeOK := runtimeProfileSymbol(lang, candidate.resumeSymbol)
+		resumeSymbol, resumeOK := runtimeProfileTerminalSymbol(lang, candidate.resumeSymbol)
 		aliasSymbol, aliasOK := runtimeProfileSymbol(lang, candidate.aliasSymbol)
 		if !resumeOK || !aliasOK || uint32(candidate.resumeState) >= lang.StateCount ||
 			uint32(resumeSymbol) >= lang.TokenCount || uint32(aliasSymbol) < lang.TokenCount {
@@ -787,6 +793,29 @@ func resolveCompactRecoveryTerminalAliasProfile(
 		})
 	}
 	return rules
+}
+
+func runtimeProfileTerminalSymbol(lang *gotreesitter.Language, name string) (gotreesitter.Symbol, bool) {
+	if lang == nil {
+		return 0, false
+	}
+	limit := len(lang.SymbolNames)
+	if uint64(lang.TokenCount) < uint64(limit) {
+		limit = int(lang.TokenCount)
+	}
+	var match gotreesitter.Symbol
+	found := false
+	for index := 0; index < limit; index++ {
+		if lang.SymbolNames[index] != name {
+			continue
+		}
+		if found {
+			return 0, false
+		}
+		match = gotreesitter.Symbol(index)
+		found = true
+	}
+	return match, found
 }
 
 func runtimeProfileSymbol(lang *gotreesitter.Language, name string) (gotreesitter.Symbol, bool) {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -75,10 +75,12 @@ func TestJavaScriptProfileCertifiesCompactRecoveryFrontier(t *testing.T) {
 	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
 	lang := JavascriptLanguage()
 	if !lang.CompactStrategy2ErrorRegionCertified || !lang.CompactMissingTokenInsertionCertified ||
-		!lang.CompactRecoveryPlainFirstCertified || !lang.CompactRecoveryTrailingLineageRetirementCertified {
+		!lang.CompactRecoveryPlainFirstCertified || !lang.CompactRecoveryTrailingLineageRetirementCertified ||
+		!lang.CompactRecoveryErrorModeKeywordCaptureCertified {
 		t.Fatal("the JavaScript profile did not attach its compact recovery capabilities")
 	}
 	wantAliases := []gotreesitter.CompactRecoveryTerminalAliasRule{
+		{ResumeState: 20, ResumeSymbol: 54, AliasSymbol: 261},
 		{ResumeState: 231, ResumeSymbol: 85, AliasSymbol: 261},
 		{ResumeState: 1042, ResumeSymbol: 129, AliasSymbol: 261},
 		{ResumeState: 1367, ResumeSymbol: 7, AliasSymbol: 261},
@@ -90,6 +92,7 @@ func TestJavaScriptProfileCertifiesCompactRecoveryFrontier(t *testing.T) {
 	if attachBuiltinLanguageRuntimeProfile("javascript", sha256.Sum256([]byte("wrong javascript blob")), uncertified) ||
 		uncertified.CompactStrategy2ErrorRegionCertified || uncertified.CompactMissingTokenInsertionCertified ||
 		uncertified.CompactRecoveryPlainFirstCertified || uncertified.CompactRecoveryTrailingLineageRetirementCertified ||
+		uncertified.CompactRecoveryErrorModeKeywordCaptureCertified ||
 		len(uncertified.CompactRecoveryTerminalAliasRules) != 0 {
 		t.Fatal("a mismatched JavaScript blob received compact recovery certification")
 	}
@@ -170,6 +173,9 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	if lang.CompactRecoveryTrailingLineageRetirementCertified {
 		t.Fatal("unknown runtime profile enabled compact trailing-lineage retirement")
 	}
+	if lang.CompactRecoveryErrorModeKeywordCaptureCertified {
+		t.Fatal("unknown runtime profile enabled compact error-mode keyword capture")
+	}
 	if len(lang.CompactRecoveryTerminalAliasRules) != 0 {
 		t.Fatal("unknown runtime profile attached compact recovery terminal aliases")
 	}
@@ -185,6 +191,20 @@ func TestRuntimeProfileSymbolRejectsDuplicateNames(t *testing.T) {
 	}
 	if symbol, ok := runtimeProfileSymbol(lang, "duplicate"); ok {
 		t.Fatalf("duplicate symbol=%d ok=true, want fail-closed", symbol)
+	}
+}
+
+func TestRuntimeProfileTerminalSymbolIgnoresNonterminalDuplicate(t *testing.T) {
+	lang := &gotreesitter.Language{
+		TokenCount:  2,
+		SymbolNames: []string{"end", "class", "class"},
+	}
+	if symbol, ok := runtimeProfileTerminalSymbol(lang, "class"); !ok || symbol != 1 {
+		t.Fatalf("terminal symbol=%d ok=%t, want 1/true", symbol, ok)
+	}
+	lang.SymbolNames[0] = "class"
+	if symbol, ok := runtimeProfileTerminalSymbol(lang, "class"); ok {
+		t.Fatalf("duplicate terminal symbol=%d ok=true, want fail-closed", symbol)
 	}
 }
 

--- a/language.go
+++ b/language.go
@@ -809,6 +809,14 @@ type Language struct {
 	// adapted, and stale artifacts retain the false default.
 	CompactRecoveryTrailingLineageRetirementCertified bool
 
+	// CompactRecoveryErrorModeKeywordCaptureCertified permits the compact
+	// scheduler to apply the grammar's keyword lexer after an error-mode lex
+	// returns the keyword-capture token. C performs this second lex while the
+	// recovery stack is in ERROR_STATE. Exact built-in profiles must certify
+	// the complete recovery election. Custom, adapted, and stale artifacts
+	// retain the false default.
+	CompactRecoveryErrorModeKeywordCaptureCertified bool
+
 	// CompactRecoveryTerminalAliasRules permits the accepted-root leaf audit to
 	// authenticate a materialized terminal alias after one certified recovery
 	// resume. The materializer must also prove the exact raw terminal and alias

--- a/parser_derived_tables_internal_test.go
+++ b/parser_derived_tables_internal_test.go
@@ -181,16 +181,19 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 
 	restoreErrorRegion := lang.CompactStrategy2ErrorRegionCertified
 	restoreMissingInsertion := lang.CompactMissingTokenInsertionCertified
+	restoreErrorModeKeyword := lang.CompactRecoveryErrorModeKeywordCaptureCertified
 	restoreSplitDrops := lang.CompactConvergedReductionSplitDropsCertified
 	restoreScanner := lang.ExternalScanner
 	t.Cleanup(func() {
 		lang.CompactStrategy2ErrorRegionCertified = restoreErrorRegion
 		lang.CompactMissingTokenInsertionCertified = restoreMissingInsertion
+		lang.CompactRecoveryErrorModeKeywordCaptureCertified = restoreErrorModeKeyword
 		lang.CompactConvergedReductionSplitDropsCertified = restoreSplitDrops
 		lang.ExternalScanner = restoreScanner
 	})
 	lang.CompactStrategy2ErrorRegionCertified = !restoreErrorRegion
 	lang.CompactMissingTokenInsertionCertified = !restoreMissingInsertion
+	lang.CompactRecoveryErrorModeKeywordCaptureCertified = !restoreErrorModeKeyword
 	lang.CompactConvergedReductionSplitDropsCertified = !restoreSplitDrops
 	lang.ExternalScanner = nil
 

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -116,8 +116,13 @@ type DiagnosticParserCorePrefixOptions struct {
 	// removal for one exact two-version S5 frontier. The admission route sets
 	// this only from an exact grammar-artifact capability.
 	allowCompactRecoveryTrailingLineageRetirement bool
-	noLookaheadRootSymbol                         Symbol
-	hasNoLookaheadRootSymbol                      bool
+	// allowCompactRecoveryErrorModeKeywordCapture permits s3ErrorModeRelex to
+	// run the keyword lexer in ERROR_STATE after the main lexer returns the
+	// grammar's keyword-capture token. The admission route sets this only from
+	// an exact grammar-artifact capability.
+	allowCompactRecoveryErrorModeKeywordCapture bool
+	noLookaheadRootSymbol                       Symbol
+	hasNoLookaheadRootSymbol                    bool
 	// stopControlParser, when non-nil, arms the scheduler's stop-control poll
 	// (spec.campaign.v7 tranche B8): once per dispatch-pass-loop iteration,
 	// diagnosticParserCoreGenericScheduler.run checks this Parser's deadline
@@ -2361,6 +2366,10 @@ type diagnosticParserCoreGenericScheduler struct {
 	s3ResumeState  StateID
 	s3ResumeSymbol Symbol
 	s3ResumeCount  uint32
+	// selectedRecoveryAbsorbLineage records that EOF pricing selected S5's
+	// original, earlier absorb version. Materialization uses this outcome to
+	// prevent the later missing version from borrowing an absorb-resume rule.
+	selectedRecoveryAbsorbLineage bool
 	// s5MissingInsertions counts recovery forks created by S5. The counter
 	// bounds zero-width progress across one parse.
 	s5MissingInsertions        uint32
@@ -7023,6 +7032,24 @@ func (s *diagnosticParserCoreGenericScheduler) s3ErrorModeRelex(startByte uint32
 	if relexed.Symbol == 0 && relexed.StartByte == relexed.EndByte {
 		return Token{}, false
 	}
+	if s.options.allowCompactRecoveryErrorModeKeywordCapture &&
+		relexed.Symbol == lang.KeywordCaptureToken {
+		savedState := s.tokenSource.state
+		savedGLRStates := s.tokenSource.glrStates
+		s.tokenSource.state = 0
+		s.tokenSource.glrStates = nil
+		promoted, demoted := s.tokenSource.promoteKeyword(relexed)
+		s.tokenSource.state = savedState
+		s.tokenSource.glrStates = savedGLRStates
+		// C accepts only a keyword that owns the complete capture span. Keep the
+		// raw capture token if the shared promoter did not prove that exact
+		// result. The caller then reaches its existing disagreement decline.
+		if !demoted && promoted.isKeyword && promoted.Symbol != relexed.Symbol &&
+			promoted.StartByte == relexed.StartByte && promoted.EndByte == relexed.EndByte &&
+			promoted.StartPoint == relexed.StartPoint && promoted.EndPoint == relexed.EndPoint {
+			relexed = promoted
+		}
+	}
 	return relexed, true
 }
 
@@ -7626,6 +7653,9 @@ func (s *diagnosticParserCoreGenericScheduler) collapseToRecoveryWinner(winner i
 		return
 	}
 	s.work.RecoveryLineageSelections++
+	s.selectedRecoveryAbsorbLineage = len(s.headers) == 2 && winner == 0 &&
+		s.s5MissingInsertions == 1 &&
+		s.headers[0].creationSeq < s.headers[1].creationSeq
 	winnerHeader := s.headers[winner]
 	winnerHeader.clearRecoveryLineage()
 	clear(s.headers[:cap(s.headers)])

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -305,15 +305,23 @@ func (r *parserCoreFreshFullRunner) compactRecoveryTerminalAliasSymbol(
 	scheduler *diagnosticParserCoreGenericScheduler,
 ) (Symbol, bool) {
 	if r == nil || r.lang == nil || scheduler == nil ||
-		!scheduler.s3RegionOpened || scheduler.s3ResumeCount != 1 ||
-		scheduler.work.RecoveryLineageSelections != 0 {
+		!scheduler.s3RegionOpened || scheduler.s3ResumeCount != 1 {
 		return 0, false
 	}
 	standaloneRegion := scheduler.s5MissingInsertions == 0 &&
+		scheduler.work.RecoveryLineageSelections == 0 &&
 		scheduler.work.RecoveryLineageRetirements == 0 && scheduler.work.NoActionDrops == 1
 	retiredMissingLineage := scheduler.s5MissingInsertions == 1 &&
+		scheduler.work.RecoveryLineageSelections == 0 &&
 		scheduler.work.RecoveryLineageRetirements == 1 && scheduler.work.NoActionDrops == 1
-	if !standaloneRegion && !retiredMissingLineage {
+	// S5 publishes the original absorb lineage before its missing sibling.
+	// collapseToRecoveryWinner records this proof before it clears the loser.
+	// A missing-lineage winner must not borrow the absorb lineage's resume rule.
+	selectedAbsorbLineage := scheduler.s5MissingInsertions == 1 &&
+		scheduler.work.RecoveryLineageSelections == 1 &&
+		scheduler.work.RecoveryLineageRetirements == 0 && scheduler.work.NoActionDrops == 1 &&
+		scheduler.selectedRecoveryAbsorbLineage
+	if !standaloneRegion && !retiredMissingLineage && !selectedAbsorbLineage {
 		return 0, false
 	}
 	for _, rule := range r.lang.CompactRecoveryTerminalAliasRules {
@@ -445,12 +453,14 @@ func (r *parserCoreFreshFullRunner) parseWithObserverAndErrorRuns(
 	savedMissingInsertion := r.options.allowCompactMissingTokenInsertion
 	savedLineageSelection := r.options.allowCompactRecoveryLineageSelection
 	savedTrailingRetirement := r.options.allowCompactRecoveryTrailingLineageRetirement
+	savedErrorModeKeyword := r.options.allowCompactRecoveryErrorModeKeywordCapture
 	if !recoveryEnabled {
 		r.options.Recovery = false
 		r.options.allowCompactStrategy2ErrorRegion = false
 		r.options.allowCompactMissingTokenInsertion = false
 		r.options.allowCompactRecoveryLineageSelection = false
 		r.options.allowCompactRecoveryTrailingLineageRetirement = false
+		r.options.allowCompactRecoveryErrorModeKeywordCapture = false
 	}
 	defer func() {
 		r.options.Recovery = savedRecovery
@@ -458,6 +468,7 @@ func (r *parserCoreFreshFullRunner) parseWithObserverAndErrorRuns(
 		r.options.allowCompactMissingTokenInsertion = savedMissingInsertion
 		r.options.allowCompactRecoveryLineageSelection = savedLineageSelection
 		r.options.allowCompactRecoveryTrailingLineageRetirement = savedTrailingRetirement
+		r.options.allowCompactRecoveryErrorModeKeywordCapture = savedErrorModeKeyword
 	}()
 	scheduler, tokenSource, err := r.executeSchedulerOpenWithObserverAndErrorRuns(
 		source, r.compact, true, observer, forceErrorRuns,

--- a/parsercore_phase0_recovery_error_mode_keyword_test.go
+++ b/parsercore_phase0_recovery_error_mode_keyword_test.go
@@ -1,0 +1,98 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+const compactJavaScriptErrorModeKeywordSource = "const f = (a) => a + 1;&\nclass A { m() { return 1 } }\n\n"
+
+func TestCompactJavaScriptErrorModeKeywordCaptureSelectsAbsorbLineage(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	lang := grammars.JavascriptLanguage()
+	if !lang.CompactRecoveryErrorModeKeywordCaptureCertified {
+		t.Fatal("the JavaScript artifact lacks error-mode keyword certification")
+	}
+	source := []byte(compactJavaScriptErrorModeKeywordSource)
+
+	token, ok := gts.ErrorModeRelexForTest(lang, source, 24)
+	if !ok || token.Symbol != 54 || token.StartByte != 25 || token.EndByte != 30 {
+		t.Fatalf("error-mode token=%+v ok=%t, want class/25..30", token, ok)
+	}
+	receipt, provenance, err := gts.RunStateDependentRecoveryRelexProvenanceForTest(lang, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Acceptance == nil || receipt.Acceptance.Accepts != 2 ||
+		receipt.Acceptance.Work.RecoveryLineageSelections != 1 {
+		t.Fatalf("acceptance=%+v stop=%+v, want two accepts and one selection", receipt.Acceptance, receipt.Stop)
+	}
+	if provenance.ResumeState != 20 || provenance.ResumeSymbol != 54 || provenance.ResumeCount != 1 ||
+		provenance.MissingInsertions != 1 || provenance.LineageSelections != 1 ||
+		provenance.LineageRetirements != 0 || !provenance.SelectedAbsorb || provenance.NoActionDrops != 1 {
+		t.Fatalf("provenance=%+v, want resume=20/54, one insertion, and one selection", provenance)
+	}
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tree.Release()
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if routed != 1 || fallback != 0 {
+		t.Fatalf("route counters=%d/%d, want 1/0; reason=%q", routed, fallback, gts.AdmissionCandidateLastFallbackReason())
+	}
+	want := "(program (lexical_declaration (variable_declarator (identifier) (arrow_function (formal_parameters (identifier)) (binary_expression (identifier) (number))))) (ERROR) (class_declaration (identifier) (class_body (method_definition (property_identifier) (formal_parameters) (statement_block (return_statement (number)))))))"
+	if got := tree.RootNode().SExpr(lang); got != want {
+		t.Fatalf("tree=%s, want %s", got, want)
+	}
+}
+
+func TestCompactJavaScriptErrorModeKeywordCaptureRequiresArtifact(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	lang := *grammars.JavascriptLanguage()
+	lang.CompactRecoveryErrorModeKeywordCaptureCertified = false
+	source := []byte(compactJavaScriptErrorModeKeywordSource)
+
+	token, ok := gts.ErrorModeRelexForTest(&lang, source, 24)
+	if !ok || token.Symbol != lang.KeywordCaptureToken {
+		t.Fatalf("uncertified error-mode token=%+v ok=%t, want the raw capture token", token, ok)
+	}
+	receipt, _, err := gts.RunStateDependentRecoveryRelexProvenanceForTest(&lang, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Acceptance != nil || !strings.Contains(receipt.Stop.Detail, "error-mode lex disagrees") {
+		t.Fatalf("acceptance=%+v stop=%+v, want the prior fail-closed election", receipt.Acceptance, receipt.Stop)
+	}
+}
+
+func TestCompactJavaScriptSelectedAbsorbAliasRequiresRule(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	lang := *grammars.JavascriptLanguage()
+	lang.CompactRecoveryTerminalAliasRules = nil
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	parser := gts.NewParser(&lang)
+	parser.SetAdmissionCandidateRoute(true)
+	tree, err := parser.Parse([]byte(compactJavaScriptErrorModeKeywordSource))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tree.Release()
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if routed != 0 || fallback != 1 {
+		t.Fatalf("route counters=%d/%d, want 0/1", routed, fallback)
+	}
+	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "accepted compact root leaves do not tile") {
+		t.Fatalf("fallback reason=%q, want an accepted-root leaf gap", reason)
+	}
+}

--- a/parsercore_phase0_recovery_lineage_selection_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_selection_internal_test.go
@@ -294,3 +294,26 @@ func TestCollapseToRecoveryWinnerSeatsTheWinnerAndClearsLosers(t *testing.T) {
 		}
 	}
 }
+
+func TestCollapseToRecoveryWinnerRecordsOnlyTheOriginalS5AbsorbLineage(t *testing.T) {
+	newScheduler := func() *diagnosticParserCoreGenericScheduler {
+		return &diagnosticParserCoreGenericScheduler{
+			s5MissingInsertions: 1,
+			headers: []diagnosticParserCoreHeader{
+				{creationSeq: 4},
+				{creationSeq: 5},
+			},
+		}
+	}
+	absorb := newScheduler()
+	absorb.collapseToRecoveryWinner(0)
+	if !absorb.selectedRecoveryAbsorbLineage {
+		t.Fatal("the earlier original S5 lineage was not recorded as the absorb winner")
+	}
+
+	missing := newScheduler()
+	missing.collapseToRecoveryWinner(1)
+	if missing.selectedRecoveryAbsorbLineage {
+		t.Fatal("the later missing lineage was recorded as the absorb winner")
+	}
+}

--- a/parsercore_phase0_state_relex_internal_test.go
+++ b/parsercore_phase0_state_relex_internal_test.go
@@ -174,6 +174,7 @@ type StateDependentRecoveryProvenanceForTest struct {
 	MissingInsertions  uint32
 	LineageSelections  uint64
 	LineageRetirements uint64
+	SelectedAbsorb     bool
 	NoActionDrops      uint64
 }
 
@@ -183,6 +184,22 @@ func RunStateDependentRecoveryRelexProvenanceForTest(lang *Language, source []by
 	return runStateDependentRecoveryRelexSchedulerForTest(lang, source)
 }
 
+func ErrorModeRelexForTest(lang *Language, source []byte, startByte uint32) (Token, bool) {
+	parser := NewParser(lang)
+	tokenSource := parser.acquireParserDFATokenSourceWithErrorRuns(source, true)
+	if tokenSource == nil {
+		return Token{}, false
+	}
+	defer tokenSource.Close()
+	scheduler := diagnosticParserCoreGenericScheduler{
+		tokenSource: tokenSource,
+		options: DiagnosticParserCorePrefixOptions{
+			allowCompactRecoveryErrorModeKeywordCapture: lang.CompactRecoveryErrorModeKeywordCaptureCertified,
+		},
+	}
+	return scheduler.s3ErrorModeRelex(startByte)
+}
+
 func runStateDependentRecoveryRelexSchedulerForTest(lang *Language, source []byte) (DiagnosticParserCoreGenericScheduler, StateDependentRecoveryProvenanceForTest, error) {
 	parser := NewParser(lang)
 	runner, err := newAdmissionCandidateRunner(parser)
@@ -190,6 +207,13 @@ func runStateDependentRecoveryRelexSchedulerForTest(lang *Language, source []byt
 		return DiagnosticParserCoreGenericScheduler{}, StateDependentRecoveryProvenanceForTest{}, err
 	}
 	runner.options.ReceiptMode = DiagnosticParserCoreReceiptFull
+	// executeSchedulerOpen normally binds this context. This test seam calls
+	// the scheduler directly, so bind the same production materialization and
+	// recovery-pricing inputs here.
+	runner.options.materializationParser = parser
+	runner.options.materializationSource = source
+	runner.options.materializationForceReplayParseStates = true
+	runner.options.materializationContextSet = true
 	tokenSource := parser.acquireParserDFATokenSourceWithErrorRuns(source, true)
 	if tokenSource == nil {
 		return DiagnosticParserCoreGenericScheduler{}, StateDependentRecoveryProvenanceForTest{}, nil
@@ -213,6 +237,7 @@ func runStateDependentRecoveryRelexSchedulerForTest(lang *Language, source []byt
 		MissingInsertions:  scheduler.s5MissingInsertions,
 		LineageSelections:  scheduler.work.RecoveryLineageSelections,
 		LineageRetirements: scheduler.work.RecoveryLineageRetirements,
+		SelectedAbsorb:     scheduler.selectedRecoveryAbsorbLineage,
 		NoActionDrops:      scheduler.work.NoActionDrops,
 	}
 	return *scheduler.receipt, provenance, runErr


### PR DESCRIPTION
## Summary

- Run JavaScript keyword capture in the compact error-mode relex path.
- Admit the path only for the exact certified JavaScript grammar artifact.
- Authenticate the terminal alias with the selected absorb lineage.
- Keep custom, adapted, and stale grammar artifacts on the fail-closed route.
- Route all eight pinned JavaScript recovery witnesses with exact C parity.

## Correctness

- Passed the focused parser, profile, lineage, and alias tests in Docker.
- Passed the JavaScript mutation differential: 2,954 cases, 71 expansions, and zero contractions.
- Passed the S5 mutation scan: 5,267 cases, 45 expansions, and zero contractions.
- Passed JavaScript parity: 25 no-error cases, 25 tree cases, and 25 deep-parity cases.
- Passed the focused race tests and 7,890 JavaScript fuzz executions.
- Passed both parser-core build-tag configurations.
- Completed two independent reviews with no actionable findings.

## Performance

The randomized 20-seed benchmark comparison found no significant change.

- Full parse: 11.22 ms to 12.31 ms, p=0.121.
- Single-byte edit: 1.247 us to 1.250 us, p=0.952.
- No-edit incremental parse: 3.751 ns to 3.809 ns, p=0.664.
- Allocation counts remained 0, 0, and 5 for the benchmark trio.