### PR TITLE
Graduate Meson compact acceptance election

### DIFF
--- a/admission_scorecard_test.go
+++ b/admission_scorecard_test.go
@@ -81,7 +81,7 @@ var admissionScorecardRequiredCompactPasses = map[string]struct{}{
 	"hlsl": {}, "html": {}, "http": {}, "hurl": {}, "hyprlang": {}, "ini": {}, "janet": {}, "javascript": {}, "jinja2": {}, "jq": {},
 	"json5": {}, "jsonnet": {}, "julia": {}, "just": {}, "kconfig": {}, "kdl": {}, "kotlin": {},
 	"ledger": {}, "less": {}, "linkerscript": {}, "liquid": {}, "llvm": {}, "lua": {},
-	"luau": {}, "make": {}, "markdown": {}, "matlab": {}, "mermaid": {}, "mojo": {},
+	"luau": {}, "make": {}, "markdown": {}, "matlab": {}, "mermaid": {}, "meson": {}, "mojo": {},
 	"move": {}, "nginx": {}, "nickel": {}, "nim": {}, "ninja": {}, "nix": {}, "norg": {}, "nushell": {},
 	"objc": {}, "ocaml": {}, "odin": {}, "org": {}, "pascal": {}, "pem": {}, "perl": {},
 	"php": {}, "pkl": {}, "powershell": {}, "prisma": {}, "prolog": {}, "promql": {},
@@ -147,45 +147,15 @@ func TestAdmissionCandidateScorecard206(t *testing.T) {
 		// registry drift, or surrendered route coverage require an explicit
 		// review and ratchet update.
 		//
-		// minPass moved 200 -> 198 and maxFallback 1 -> 3. Three languages
-		// carry the three FALLBACK rows counted here:
+		// The 199/2/5 ratchet includes Meson's locked-C structural election.
+		// Two languages retain fail-closed FALLBACK rows:
 		//
-		//   - markdown_inline: the pre-existing baseline FALLBACK, already
-		//     present before either landing below and unrelated to both.
-		//     Never in admissionScorecardRequiredCompactPasses, so it was
-		//     never counted in minPass either.
-		//   - meson moved PASS -> FALLBACK when
-		//     selectCompactAcceptanceDerivation's materiality gate
-		//     (parsercore_phase0_driver.go, compactAcceptanceElectionIsVacuous)
-		//     landed: meson's smoke sample ("message('hello')") has a genuine,
-		//     score-tied grammar ambiguity between two distinct real symbols
-		//     (variableunit and var_unit -- both present in the compiled
-		//     language's SymbolNames). The old positional rule happened to
-		//     pick the derivation that matches production; the gate cannot
-		//     prove that pick correct without a C oracle, so it now declines
-		//     instead of publishing an unproven tree.
-		//   - jsdoc moved PASS -> FALLBACK (campaign v7 class-e closure,
-		//     spore.2026-08-02.hornbeam-e.byte-continuity): retiring
-		//     bytesAreSingleByteDecorationTrivia (parsercore_phase0_driver.go)
-		//     closes a measured 189-input false-clean class across
-		//     javascript, haskell, html, and bash, and moves jsdoc from PASS
-		//     to FALLBACK (accepted-leaf-tiling-gap: its own interior
-		//     comment-continuation gap no longer has a tolerating exemption).
-		//     Every jsdoc full parse now pays a measured 2.2x-2.5x latency
-		//     cost relative to a plain production parse: the compact route
-		//     always attempts jsdoc first, always declines at this gate, and
-		//     production then parses the same source a second time from
-		//     scratch. Acceptable for a rare grammar on a fail-closed route;
-		//     not free.
-		//
-		// meson's and jsdoc's moves are both PASS-safe FALLBACKs, never a
-		// DIVERGE (see counts[scorecardDiverge] below, unaffected at 0). No
-		// other language's status changes; production still serves
-		// markdown_inline, meson, and jsdoc correctly.
+		//   - markdown_inline reaches its existing repetition-shift boundary.
+		//   - jsdoc reaches its accepted-leaf interior tiling gap.
 		const (
 			wantTotal   = 206
-			minPass     = 198
-			maxFallback = 3
+			minPass     = 199
+			maxFallback = 2
 			wantSkip    = 5
 		)
 		if got := len(admissionScorecardRequiredCompactPasses); got != minPass {

--- a/admission_switch_acceptance_frontier_test.go
+++ b/admission_switch_acceptance_frontier_test.go
@@ -3,6 +3,7 @@
 package gotreesitter_test
 
 import (
+	"strings"
 	"testing"
 
 	gts "github.com/odvcencio/gotreesitter"
@@ -11,15 +12,7 @@ import (
 )
 
 func TestAdmissionCandidateCertifiedAcceptanceFrontiers(t *testing.T) {
-	// meson is not in this list: its smoke sample has a genuine, score-tied
-	// grammar ambiguity (variableunit vs var_unit) that
-	// selectCompactAcceptanceDerivation's materiality gate
-	// (parsercore_phase0_driver.go, compactAcceptanceElectionIsVacuous) can
-	// no longer prove correct without a C oracle, so the route now declines
-	// and falls back to production instead of publishing an unproven pick.
-	// See admission_scorecard_test.go's admissionScorecardRequiredCompactPasses
-	// comment for the full account.
-	for _, name := range []string{"http", "robot"} {
+	for _, name := range []string{"http", "meson", "robot"} {
 		t.Run(name, func(t *testing.T) {
 			entry := grammars.DetectLanguageByName(name)
 			if entry == nil {
@@ -70,5 +63,50 @@ func TestAdmissionCandidateCertifiedAcceptanceFrontiers(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestMesonStructuralAcceptanceElectionFailsClosedWithoutArtifactCapability(t *testing.T) {
+	language := *grammars.MesonLanguage()
+	language.CompactAcceptanceStructuralElectionCertified = false
+	source := []byte(grammars.ParseSmokeSample("meson"))
+	t.Setenv("GTS_ADMISSION_CENSUS", "1")
+	gts.ResetAdmissionCensusEnabledForTest()
+	t.Cleanup(gts.ResetAdmissionCensusEnabledForTest)
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	parser := gts.NewParser(&language)
+	parser.SetAdmissionCandidateRoute(true)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	if routed, fallback := gts.AdmissionCandidateCounters(); routed != 0 || fallback != 1 {
+		t.Fatalf("route counters=%d/%d, want 0/1", routed, fallback)
+	}
+	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "material-acceptance-election") {
+		t.Fatalf("fallback reason=%q, want material acceptance election", reason)
+	}
+}
+
+func TestMesonStructuralAcceptanceElectionDoesNotDependOnPrimaryCapability(t *testing.T) {
+	language := *grammars.MesonLanguage()
+	language.CompactPrimaryAcceptanceDerivationCertified = false
+	source := []byte(grammars.ParseSmokeSample("meson"))
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	parser := gts.NewParser(&language)
+	parser.SetAdmissionCandidateRoute(true)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	if routed, fallback := gts.AdmissionCandidateCounters(); routed != 1 || fallback != 0 {
+		t.Fatalf("route counters=%d/%d, want 1/0", routed, fallback)
+	}
+	if got := tree.RootNode().SExpr(&language); got != "(source_file (normal_command (identifier) (variableunit (string))))" {
+		t.Fatalf("tree=%s, want the C-ordered variableunit branch", got)
 	}
 }

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -57,9 +57,10 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		// only for an exact two-head EOF frontier and proves its own immutable
 		// event topology. An explicit public sibling grant keeps the legacy
 		// bypass and takes precedence in dispatchPassActive.
-		allowMetadataEOFAcceptRecovery:  true,
-		allowPrimaryAcceptDerivation:    p.language.CompactPrimaryAcceptanceDerivationCertified,
-		allowConvergedSplitDropArtifact: p.language.CompactConvergedReductionSplitDropsCertified,
+		allowMetadataEOFAcceptRecovery:           true,
+		allowPrimaryAcceptDerivation:             p.language.CompactPrimaryAcceptanceDerivationCertified,
+		allowCompactAcceptanceStructuralElection: p.language.CompactAcceptanceStructuralElectionCertified,
+		allowConvergedSplitDropArtifact:          p.language.CompactConvergedReductionSplitDropsCertified,
 		// Recovery admits the certified S3 base mechanism. S5 also needs the
 		// insertion gate and the lineage-selection gate.
 		Recovery:                          p.language.CompactStrategy2ErrorRegionCertified,

--- a/cgo_harness/meson_acceptance_election_parity_test.go
+++ b/cgo_harness/meson_acceptance_election_parity_test.go
@@ -1,0 +1,105 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestMesonAcceptanceElectionLockedCParity(t *testing.T) {
+	language := grammars.MesonLanguage()
+	if language == nil {
+		t.Fatal("Meson Go language is nil")
+	}
+	if !language.CompactAcceptanceStructuralElectionCertified {
+		t.Fatal("Meson structural acceptance election is not certified")
+	}
+
+	cLanguage, err := COracleLanguage("meson")
+	if err != nil {
+		t.Fatalf("load locked Meson language: %v", err)
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatalf("set locked Meson language: %v", err)
+	}
+
+	// These sources cover command, assignment, nesting, collection, control,
+	// project, and ternary families from the exact grammar's corpus. Every
+	// compact-routed result must match locked C. Fallback results keep production.
+	tests := []struct {
+		name                string
+		source              string
+		wantRouted          bool
+		wantProductionExact bool
+		wantSExpr           string
+	}{
+		{
+			name: "command", source: "message('hello')\n", wantRouted: true, wantProductionExact: true,
+			wantSExpr: "(source_file (normal_command (identifier) (variableunit (string))))",
+		},
+		{name: "string assignment", source: "a = 'ssss'\n", wantProductionExact: true},
+		{name: "nested command", source: "libpam = cc.find_library('pam', required: get_option('pam'))\n"},
+		{name: "list", source: "command = [sh, '-c', output]\n"},
+		{name: "dictionary", source: "prefix = {a: true, 'b': abcd}\n"},
+		{name: "if condition", source: "if 1 in my_array\n# true\nendif\n", wantRouted: true, wantProductionExact: true},
+		{name: "project", source: "project('wayvnc', 'c', version: '0.5.0')\n"},
+		{name: "ternary", source: "x = condition ? true_value : false_value\n", wantRouted: true, wantProductionExact: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := []byte(test.source)
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("locked Meson parser returned no tree")
+			}
+			defer cTree.Close()
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			productionTree, err := productionParser.Parse(source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer productionTree.Release()
+			if test.wantProductionExact {
+				assertLockedCTreeExact(t, "Meson production", productionTree, language, cTree)
+			}
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			candidateParser := gotreesitter.NewParser(language)
+			candidateParser.SetAdmissionCandidateRoute(true)
+			candidateTree, err := candidateParser.Parse(source)
+			if err != nil {
+				t.Fatalf("compact candidate parse: %v", err)
+			}
+			defer candidateTree.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			routed, fallback := routedAfter-routedBefore, fallbackAfter-fallbackBefore
+			if test.wantRouted && (routed != 1 || fallback != 0) {
+				t.Fatalf("compact route delta=%d/%d reason=%q, want 1/0", routed, fallback, gotreesitter.AdmissionCandidateLastFallbackReason())
+			}
+			if routed+fallback != 1 || routed > 1 || fallback > 1 {
+				t.Fatalf("compact route delta=%d/%d, want one routed or fallback parse", routed, fallback)
+			}
+			if routed == 1 {
+				assertLockedCTreeExact(t, "Meson compact candidate", candidateTree, language, cTree)
+			}
+
+			if test.wantSExpr != "" {
+				root := candidateTree.RootNode()
+				if root == nil || root.ChildCount() == 0 {
+					t.Fatal("Meson compact result has no command")
+				}
+				if got := root.SExpr(language); got != test.wantSExpr {
+					t.Fatalf("Meson compact result=%s, want %s", got, test.wantSExpr)
+				}
+			}
+		})
+	}
+}

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -12,27 +12,28 @@ import (
 // parser core: loading the exact certified blob attaches its profile, while
 // caller-constructed and adapted languages retain conservative zero defaults.
 type builtinLanguageRuntimeProfile struct {
-	blobSHA256                         [32]byte
-	externalScannerFullParseRetry      gotreesitter.ExternalScannerFullParseRetryPolicy
-	fullParseAcceptedErrorRetryProfile gotreesitter.FullParseAcceptedErrorRetryProfile
-	automaticForestMemoryAllowance     int64
-	automaticForestEnabled             bool
-	fullParseArenaDensityCap           bool
-	fullParseGSSConvergence            bool
-	nativeResultCompatibility          gotreesitter.ResultCompatibilityCapability
-	nativeUnaryWrapperFlattening       []nativeUnaryWrapperFlatteningProfile
-	compactConvergedSplitDrops         bool
-	compactEOFAcceptNoActionSiblings   bool
-	compactPrimaryAcceptDerivation     bool
-	exactStackNodeEquivalence          bool
-	compactStrategy2ErrorRegion        bool
-	compactMissingTokenInsertion       bool
-	compactRecoveryTrailingRetirement  bool
-	compactRecoveryErrorModeKeyword    bool
-	compactRecoveryTerminalAliases     []compactRecoveryTerminalAliasProfile
-	compactRecoveryPlainFirst          bool
-	lineContinuationEscapeByte         byte
-	conflictPolicies                   []gotreesitter.ConflictPolicy
+	blobSHA256                          [32]byte
+	externalScannerFullParseRetry       gotreesitter.ExternalScannerFullParseRetryPolicy
+	fullParseAcceptedErrorRetryProfile  gotreesitter.FullParseAcceptedErrorRetryProfile
+	automaticForestMemoryAllowance      int64
+	automaticForestEnabled              bool
+	fullParseArenaDensityCap            bool
+	fullParseGSSConvergence             bool
+	nativeResultCompatibility           gotreesitter.ResultCompatibilityCapability
+	nativeUnaryWrapperFlattening        []nativeUnaryWrapperFlatteningProfile
+	compactConvergedSplitDrops          bool
+	compactEOFAcceptNoActionSiblings    bool
+	compactPrimaryAcceptDerivation      bool
+	compactAcceptanceStructuralElection bool
+	exactStackNodeEquivalence           bool
+	compactStrategy2ErrorRegion         bool
+	compactMissingTokenInsertion        bool
+	compactRecoveryTrailingRetirement   bool
+	compactRecoveryErrorModeKeyword     bool
+	compactRecoveryTerminalAliases      []compactRecoveryTerminalAliasProfile
+	compactRecoveryPlainFirst           bool
+	lineContinuationEscapeByte          byte
+	conflictPolicies                    []gotreesitter.ConflictPolicy
 }
 
 type nativeUnaryWrapperFlatteningProfile struct {
@@ -419,12 +420,13 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		blobSHA256:             mustRuntimeProfileSHA256("cca71a0e6385fd9b2791eb6fefc1fe493f93eb2bf58e903f8989096884c31fe4"),
 		automaticForestEnabled: true,
 	},
-	// Meson's retry ladder changes selected trees on small error-bearing files,
-	// but is redundant for complete accepted-error sources at or above this
-	// conservative exact-blob corpus-certified floor.
+	// Meson's tied smoke election compares variableunit with var_unit. The
+	// locked C runtime selects variableunit through its raw subtree comparator.
+	// The retry ladder still changes selected trees on small error-bearing files.
 	"meson": {
-		blobSHA256:                     mustRuntimeProfileSHA256("b3b7e74bcd35614419f5359c31eb8a05bd58c0b97529f133f2aea2f40796789d"),
-		compactPrimaryAcceptDerivation: true,
+		blobSHA256:                          mustRuntimeProfileSHA256("b3b7e74bcd35614419f5359c31eb8a05bd58c0b97529f133f2aea2f40796789d"),
+		compactPrimaryAcceptDerivation:      true,
+		compactAcceptanceStructuralElection: true,
 		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
 			SkipCompleteAcceptedErrorRetry: true,
 			SkipCompleteMinSourceBytes:     mesonAcceptedErrorRetryMinSourceBytes,
@@ -685,6 +687,10 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	}
 	if profile.compactPrimaryAcceptDerivation && !lang.CompactPrimaryAcceptanceDerivationCertified {
 		lang.CompactPrimaryAcceptanceDerivationCertified = true
+		changed = true
+	}
+	if profile.compactAcceptanceStructuralElection && !lang.CompactAcceptanceStructuralElectionCertified {
+		lang.CompactAcceptanceStructuralElectionCertified = true
 		changed = true
 	}
 	if profile.exactStackNodeEquivalence && !lang.ExactStackNodeEquivalenceCertified {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -290,7 +290,8 @@ func TestBuiltinCompactAcceptanceProfilesRequireExactBlobIdentity(t *testing.T) 
 		{
 			name: "meson", load: MesonLanguage,
 			want: func(lang *gotreesitter.Language) bool {
-				return lang.CompactPrimaryAcceptanceDerivationCertified
+				return lang.CompactPrimaryAcceptanceDerivationCertified &&
+					lang.CompactAcceptanceStructuralElectionCertified
 			},
 		},
 		// The tied-election family (A3 certification workstream,

--- a/internal/parsercorephase0/c_selection_compare.go
+++ b/internal/parsercorephase0/c_selection_compare.go
@@ -1,0 +1,76 @@
+package parsercorephase0
+
+import "errors"
+
+// ErrCSelectionComparisonBudget reports that a compact directed acyclic graph
+// repeated more raw-tree comparison work than its arena can justify. A caller
+// can treat this as an unsupported election shape and retain its fallback.
+var ErrCSelectionComparisonBudget = errors.New("parser-core phase zero: C subtree comparison exceeded the arena work budget")
+
+type cSelectionSubtreePair struct {
+	left  SubtreeID
+	right SubtreeID
+}
+
+// CompareCSelectionSubtrees ports tree-sitter's ts_subtree_compare ordering.
+// It compares only the raw symbol and child count, then visits children from
+// left to right. A negative result orders left first. A positive result orders
+// right first. Zero means the two raw trees are equal under C's comparator.
+//
+// Compact children always precede their parent. The walk checks this invariant
+// and fails closed if corrupt arena data could create a cycle.
+func (c *Core) CompareCSelectionSubtrees(left, right SubtreeID) (int, error) {
+	if c == nil {
+		return 0, errors.New("parser-core phase zero: C subtree comparison requires a core")
+	}
+	stack := make([]cSelectionSubtreePair, 1, 64)
+	stack[0] = cSelectionSubtreePair{left: left, right: right}
+	workBudget := uint64(len(c.subtrees)) + uint64(len(c.children))
+	if workBudget == 0 {
+		workBudget = 1
+	}
+	var work uint64
+	for len(stack) != 0 {
+		work++
+		if work > workBudget {
+			return 0, ErrCSelectionComparisonBudget
+		}
+		pair := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if pair.left == pair.right {
+			continue
+		}
+		leftRecord, err := c.subtree(pair.left)
+		if err != nil {
+			return 0, err
+		}
+		rightRecord, err := c.subtree(pair.right)
+		if err != nil {
+			return 0, err
+		}
+		if leftRecord.symbol < rightRecord.symbol {
+			return -1, nil
+		}
+		if rightRecord.symbol < leftRecord.symbol {
+			return 1, nil
+		}
+		if leftRecord.childCount < rightRecord.childCount {
+			return -1, nil
+		}
+		if rightRecord.childCount < leftRecord.childCount {
+			return 1, nil
+		}
+		for index := leftRecord.childCount; index > 0; index-- {
+			leftChild := c.children[leftRecord.firstChild+index-1]
+			rightChild := c.children[rightRecord.firstChild+index-1]
+			if leftChild >= pair.left || rightChild >= pair.right {
+				return 0, errors.New("parser-core phase zero: compact subtree child identifier is out of order during C selection comparison")
+			}
+			stack = append(stack, cSelectionSubtreePair{left: leftChild, right: rightChild})
+			if len(stack) > len(c.subtrees) {
+				return 0, errors.New("parser-core phase zero: C selection comparison exceeded the subtree arena")
+			}
+		}
+	}
+	return 0, nil
+}

--- a/internal/parsercorephase0/c_selection_compare_test.go
+++ b/internal/parsercorephase0/c_selection_compare_test.go
@@ -1,0 +1,110 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"testing"
+)
+
+func newCSelectionCompareTestCore(t *testing.T) *Core {
+	t.Helper()
+	compact, err := New(&fakeTable{}, Limits{MaxSubtrees: 32, MaxChildren: 32})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return compact
+}
+
+func TestCompareCSelectionSubtreesUsesRawCOrder(t *testing.T) {
+	compact := newCSelectionCompareTestCore(t)
+	leaf2, err := compact.appendSubtree(subtreeRecord{symbol: 2}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf3, err := compact.appendSubtree(subtreeRecord{symbol: 3}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := compact.appendSubtree(subtreeRecord{symbol: 10}, []SubtreeID{leaf2}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := compact.appendSubtree(subtreeRecord{symbol: 10}, []SubtreeID{leaf3}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, err := compact.CompareCSelectionSubtrees(left, right); err != nil || got != -1 {
+		t.Fatalf("recursive comparison=(%d, %v), want (-1, nil)", got, err)
+	}
+	if got, err := compact.CompareCSelectionSubtrees(right, left); err != nil || got != 1 {
+		t.Fatalf("reverse comparison=(%d, %v), want (1, nil)", got, err)
+	}
+	if got, err := compact.CompareCSelectionSubtrees(left, left); err != nil || got != 0 {
+		t.Fatalf("identity comparison=(%d, %v), want (0, nil)", got, err)
+	}
+}
+
+func TestCompareCSelectionSubtreesUsesChildCountBeforeChildren(t *testing.T) {
+	compact := newCSelectionCompareTestCore(t)
+	leaf, err := compact.appendSubtree(subtreeRecord{symbol: 2}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	short, err := compact.appendSubtree(subtreeRecord{symbol: 10}, []SubtreeID{leaf}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	long, err := compact.appendSubtree(subtreeRecord{symbol: 10}, []SubtreeID{leaf, leaf}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := compact.CompareCSelectionSubtrees(short, long); err != nil || got != -1 {
+		t.Fatalf("child-count comparison=(%d, %v), want (-1, nil)", got, err)
+	}
+}
+
+func TestCompareCSelectionSubtreesIgnoresNonCIdentityFields(t *testing.T) {
+	compact := newCSelectionCompareTestCore(t)
+	left, err := compact.appendSubtree(subtreeRecord{
+		symbol: 4, productionID: 1, dynamicPrecedence: -3,
+		startByte: 1, endByte: 2, extra: true, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := compact.appendSubtree(subtreeRecord{
+		symbol: 4, productionID: 9, dynamicPrecedence: 7,
+		startByte: 20, endByte: 30, missing: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := compact.CompareCSelectionSubtrees(left, right); err != nil || got != 0 {
+		t.Fatalf("non-C identity comparison=(%d, %v), want (0, nil)", got, err)
+	}
+}
+
+func TestCompareCSelectionSubtreesBoundsRepeatedDAGWork(t *testing.T) {
+	compact := newCSelectionCompareTestCore(t)
+	left, err := compact.appendSubtree(subtreeRecord{symbol: 2}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := compact.appendSubtree(subtreeRecord{symbol: 2}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for level := 0; level < 6; level++ {
+		left, err = compact.appendSubtree(subtreeRecord{symbol: 10}, []SubtreeID{left, left}, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		right, err = compact.appendSubtree(subtreeRecord{symbol: 10}, []SubtreeID{right, right}, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := compact.CompareCSelectionSubtrees(left, right); !errors.Is(err, ErrCSelectionComparisonBudget) {
+		t.Fatalf("repeated DAG comparison error=%v, want work-budget error", err)
+	}
+}

--- a/language.go
+++ b/language.go
@@ -772,6 +772,13 @@ type Language struct {
 	// profiles set this only after C-oracle parity proves production selects it.
 	CompactPrimaryAcceptanceDerivationCertified bool
 
+	// CompactAcceptanceStructuralElectionCertified permits the compact route
+	// to apply C's raw subtree ordering to a clean, tied acceptance frontier.
+	// Exact built-in profiles set this only after the locked C oracle proves
+	// the compact derivation order and result for that grammar artifact.
+	// Custom, adapted, and stale artifacts retain the false default.
+	CompactAcceptanceStructuralElectionCertified bool
+
 	// ExactStackNodeEquivalenceCertified preserves deep stack-node alternatives
 	// until generic result selection. Exact built-in profiles set this only when
 	// bounded equivalence can merge parity-relevant shapes. Custom, adapted, and

--- a/parser_derived_tables_internal_test.go
+++ b/parser_derived_tables_internal_test.go
@@ -180,18 +180,21 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 	derived := lang.acquireParserDerivedTables()
 
 	restoreErrorRegion := lang.CompactStrategy2ErrorRegionCertified
+	restoreStructuralElection := lang.CompactAcceptanceStructuralElectionCertified
 	restoreMissingInsertion := lang.CompactMissingTokenInsertionCertified
 	restoreErrorModeKeyword := lang.CompactRecoveryErrorModeKeywordCaptureCertified
 	restoreSplitDrops := lang.CompactConvergedReductionSplitDropsCertified
 	restoreScanner := lang.ExternalScanner
 	t.Cleanup(func() {
 		lang.CompactStrategy2ErrorRegionCertified = restoreErrorRegion
+		lang.CompactAcceptanceStructuralElectionCertified = restoreStructuralElection
 		lang.CompactMissingTokenInsertionCertified = restoreMissingInsertion
 		lang.CompactRecoveryErrorModeKeywordCaptureCertified = restoreErrorModeKeyword
 		lang.CompactConvergedReductionSplitDropsCertified = restoreSplitDrops
 		lang.ExternalScanner = restoreScanner
 	})
 	lang.CompactStrategy2ErrorRegionCertified = !restoreErrorRegion
+	lang.CompactAcceptanceStructuralElectionCertified = !restoreStructuralElection
 	lang.CompactMissingTokenInsertionCertified = !restoreMissingInsertion
 	lang.CompactRecoveryErrorModeKeywordCaptureCertified = !restoreErrorModeKeyword
 	lang.CompactConvergedReductionSplitDropsCertified = !restoreSplitDrops

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -84,10 +84,14 @@ type DiagnosticParserCorePrefixOptions struct {
 	freshSchedulerSession bool
 	// These acceptance options require exact artifact certification. Diagnostic
 	// callers retain the conservative false defaults.
-	allowEOFAcceptNoActionSiblings  bool
-	allowMetadataEOFAcceptRecovery  bool
-	allowPrimaryAcceptDerivation    bool
-	allowConvergedSplitDropArtifact bool
+	allowEOFAcceptNoActionSiblings bool
+	allowMetadataEOFAcceptRecovery bool
+	allowPrimaryAcceptDerivation   bool
+	// allowCompactAcceptanceStructuralElection permits C's raw subtree
+	// comparator for a clean, tied acceptance frontier. The admission route
+	// binds it only from an exact grammar-artifact capability.
+	allowCompactAcceptanceStructuralElection bool
+	allowConvergedSplitDropArtifact          bool
 	// allowCompactStrategy2ErrorRegion permits the generic scheduler to
 	// attempt native S3 recovery (error-region absorb and condense-resume)
 	// at a true no-table-action point instead of declining. Set only from
@@ -434,13 +438,16 @@ type DiagnosticParserCoreGenericAcceptance struct {
 	// MaterialityCertified records the bounded public-tree comparison that
 	// makes a multi-derivation selection safe without a certified primary.
 	MaterialityCertified bool
-	CoreWork             core.Work
-	Accepts              uint64
-	SelectedNodes        uint64
-	SelectedParents      uint64
-	SelectedLeaves       uint64
-	Stats                core.Stats
-	Work                 DiagnosticParserCoreGenericWork
+	// StructuralElectionCertified records an exact artifact's C-order proof.
+	// It makes a clean multi-derivation selection safe without a primary proof.
+	StructuralElectionCertified bool
+	CoreWork                    core.Work
+	Accepts                     uint64
+	SelectedNodes               uint64
+	SelectedParents             uint64
+	SelectedLeaves              uint64
+	Stats                       core.Stats
+	Work                        DiagnosticParserCoreGenericWork
 }
 
 // DiagnosticParserCoreGenericConflict records one table-driven conflict cell.
@@ -7796,20 +7803,27 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() (err error) 
 		s.censusAcceptanceDerivationSetTruncated()
 		return err
 	}
-	path, selected, materialityCertified := selectCompactAcceptanceDerivationWithMateriality(
-		paths, s.options.allowPrimaryAcceptDerivation,
+	selection, err := decideCompactAcceptanceElection(
+		s.compact,
+		paths,
+		compactAcceptanceElectionPolicy{
+			allowPrimary: s.options.allowPrimaryAcceptDerivation,
+			allowCStructural: s.options.allowCompactAcceptanceStructuralElection &&
+				!metadataAdmission && !s.s3RegionOpened && s.s5MissingInsertions == 0,
+		},
 	)
-	if !selected {
+	if err != nil {
+		return err
+	}
+	if !selection.selected {
 		s.censusAcceptanceDerivationSet(paths, core.Derivation{}, false, false)
 		return s.finish(DiagnosticParserCoreAccept, "generic scheduler requires one certified accepted derivation", 0)
 	}
-	// R1 materiality gate: selectCompactAcceptanceDerivation's tie guard has
-	// no C-faithful basis for choosing among score-tied derivations. A
-	// certified primary, or the provisional path selected above when no
-	// primary is certified, is safe only when every live derivation
-	// materializes to the identical tree. This is a vacuous election: any
-	// candidate produces the same public result. len(paths) > 1 here means
-	// that the bounded comparison must run.
+	path := selection.path
+	materialityCertified := selection.materialityCertified
+	// The R1 materiality gate remains the fallback for tied frontiers without
+	// an exact structural-election capability. A certified primary or a
+	// provisional path is safe only when all paths publish the same tree.
 	//
 	// COST, stated plainly, not special-cased away: Apex's class_literal_alias
 	// witness ("Object t = RecordPage.class;", apexA3TiedElectionWitnesses,
@@ -7820,13 +7834,10 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() (err error) 
 	// election where the primary is wrong: it declines class_literal_alias
 	// too, and the route now serves production's C-divergent tree instead of
 	// compact's C-exact one -- public output got worse on this one input.
-	// This is judged acceptable because it restores the pre-compact status
-	// quo (production already served every input before the compact route
-	// existed) and because the planned C-comparator port (R2) recovers it
-	// properly, by comparing error cost/dynamic precedence/structural order
-	// the way the C runtime does instead of requiring exact identity. It is
-	// not fixed by special-casing this witness.
-	if len(paths) > 1 {
+	// This restores the pre-compact result because production already served
+	// every input. The C comparator now exists, but Apex still needs its own
+	// exact artifact certification. This code does not special-case the witness.
+	if len(paths) > 1 && !selection.cStructuralCertified {
 		if detail := compactAcceptanceElectionMaterialityDeclineDetail(paths, s.options.materializationContextSet); detail != "" {
 			// The cap and context guard keep comparison cost bounded and keep
 			// callers without a materialization context fail-closed. Count
@@ -7889,8 +7900,9 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() (err error) 
 		ElectionIndex: s.electionIndex, Token: s.token, Header: header,
 		Payloads: payloads, Score: path.Score, BranchOrder: path.BranchOrder,
 		HasBranchOrder: path.HasBranchOrder, MaterialityCertified: materialityCertified,
-		CoreWork: s.compact.Work(),
-		Accepts:  s.work.Accepts, Stats: stats, Work: s.work,
+		StructuralElectionCertified: selection.cStructuralCertified,
+		CoreWork:                    s.compact.Work(),
+		Accepts:                     s.work.Accepts, Stats: stats, Work: s.work,
 	}
 	s.receipt.Acceptance = &s.receipt.acceptanceBacking
 	if mergeCensusEnabled {
@@ -7963,6 +7975,87 @@ func selectCompactAcceptanceDerivationWithMateriality(paths []core.Derivation, a
 		return path, selected, false
 	}
 	return paths[0], true, true
+}
+
+type compactAcceptanceElectionPolicy struct {
+	allowPrimary     bool
+	allowCStructural bool
+}
+
+type compactAcceptanceElectionDecision struct {
+	path                 core.Derivation
+	selected             bool
+	materialityCertified bool
+	cStructuralCertified bool
+}
+
+// decideCompactAcceptanceElection keeps the acceptance policy in one place.
+// An artifact-certified C election takes precedence. Every unsupported shape
+// returns to the existing primary or materiality rules and stays fail-closed.
+func decideCompactAcceptanceElection(
+	compact *core.Core,
+	paths []core.Derivation,
+	policy compactAcceptanceElectionPolicy,
+) (compactAcceptanceElectionDecision, error) {
+	if policy.allowCStructural && len(paths) > 1 {
+		path, selected, err := selectCompactAcceptanceDerivationByCOrder(compact, paths)
+		if err != nil {
+			return compactAcceptanceElectionDecision{}, err
+		}
+		if selected {
+			return compactAcceptanceElectionDecision{
+				path: path, selected: true, cStructuralCertified: true,
+			}, nil
+		}
+	}
+	path, selected, materialityCertified := selectCompactAcceptanceDerivationWithMateriality(paths, policy.allowPrimary)
+	return compactAcceptanceElectionDecision{
+		path: path, selected: selected, materialityCertified: materialityCertified,
+	}, nil
+}
+
+// selectCompactAcceptanceDerivationByCOrder ports the clean-tree portion of
+// ts_parser__select_tree. Derivation Score is the compact path's cumulative
+// dynamic precedence. CompareCSelectionSubtrees supplies C's final raw-tree
+// ordering. A single payload is required because C rebuilds that accepted
+// root without changing its symbol or children. Multi-payload acceptance needs
+// a separate exact root reconstruction and therefore remains fail-closed.
+func selectCompactAcceptanceDerivationByCOrder(
+	compact *core.Core,
+	paths []core.Derivation,
+) (core.Derivation, bool, error) {
+	if compact == nil || len(paths) < 2 || len(paths) > compactAcceptanceElectionMaxLiveDerivations {
+		return core.Derivation{}, false, nil
+	}
+	for _, path := range paths {
+		if len(path.Payloads) != 1 {
+			return core.Derivation{}, false, nil
+		}
+	}
+	winner := 0
+	for candidate := 1; candidate < len(paths); candidate++ {
+		if paths[candidate].Score > paths[winner].Score {
+			winner = candidate
+			continue
+		}
+		if paths[candidate].Score < paths[winner].Score {
+			continue
+		}
+		comparison, err := compact.CompareCSelectionSubtrees(
+			paths[winner].Payloads[0],
+			paths[candidate].Payloads[0],
+		)
+		if errors.Is(err, core.ErrCSelectionComparisonBudget) {
+			return core.Derivation{}, false, nil
+		}
+		if err != nil {
+			return core.Derivation{}, false, err
+		}
+		if comparison > 0 {
+			winner = candidate
+		}
+	}
+	return paths[winner], true, nil
 }
 
 func compactDerivationsForAcceptance(compact *core.Core, head core.Head) ([]core.Derivation, error) {

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -248,12 +248,14 @@ func requireParserCoreFreshFullAcceptance(scheduler *diagnosticParserCoreGeneric
 	selectedCertifiedPrimary := scheduler.options.allowPrimaryAcceptDerivation &&
 		header.ExactPaths > 1 && !acceptance.HasBranchOrder
 	selectedMaterialityCertified := acceptance.MaterialityCertified && header.ExactPaths > 1
+	selectedStructuralElectionCertified := acceptance.StructuralElectionCertified && header.ExactPaths > 1
 	acceptCountValid := (acceptance.Accepts == 1 && acceptance.Work.Accepts == 1) ||
 		(acceptance.Work.RecoveryLineageSelections == 1 &&
 			acceptance.Accepts >= 2 && acceptance.Accepts == acceptance.Work.Accepts)
 	if acceptance.Token.Symbol != 0 || acceptance.Token.StartByte != wantEOF || acceptance.Token.EndByte != wantEOF ||
 		acceptance.Token.Missing || acceptance.Token.NoLookahead || acceptance.Token.ExternalScannerToken ||
-		!header.Accepted || header.Paused || header.ExactPaths != 1 && !selectedCertifiedPrimary && !selectedMaterialityCertified ||
+		!header.Accepted || header.Paused || header.ExactPaths != 1 &&
+		!selectedCertifiedPrimary && !selectedMaterialityCertified && !selectedStructuralElectionCertified ||
 		!parserCoreFreshFullAcceptedTailIsClean(source, header.ByteOffset, continuationEscape) || !acceptCountValid {
 		// See the comment above: census classification is opt-in and additive.
 		if admissionCensusEnabled() {


### PR DESCRIPTION
## Summary

- Port the locked C raw subtree comparator for clean, tied acceptance frontiers.
- Gate structural election behind the exact Meson grammar artifact.
- Keep unsupported shapes fail closed and publish an independent structural certificate.
- Move Meson from FALLBACK to PASS in the admission scorecard.

## Correctness evidence

- The locked C suite covers eight Meson corpus families.
- Every compact-routed result matches symbols, fields, spans, points, flags, and the deep digest.
- The capability-off test records one fallback with the material-election reason.
- The primary-capability-off test proves the structural certificate is independent.
- The 206-language scorecard is PASS=199, DIVERGE=0, FALLBACK=2, SKIP=5.
- The 146-file matrix remains PASS=88, DIVERGE=0, FALLBACK=46, SKIP=12.
- Both normal and gts_no_parsercorephase0 builds pass their focused gates.
- Buckley spot review found no findings or blockers.

## Performance evidence

The required benchmark trio used 20 shuffle seeds and a 750 ms bench time.

- Full parse: no significant change, p=0.327.
- Incremental no-edit: no significant change, p=0.171.
- Incremental single-byte edit: 1.12 percent faster, p=0.009.
- Bytes per operation show no significant regression.
- Allocation counts remain unchanged.

The default mixed set showed order-dependent host noise. The isolated required trio removed that contamination.