### PR TITLE
Graduate compact JSDoc prefix tiling

### DIFF
--- a/admission_scorecard_test.go
+++ b/admission_scorecard_test.go
@@ -78,7 +78,7 @@ var admissionScorecardRequiredCompactPasses = map[string]struct{}{
 	"gdscript": {}, "git_config": {}, "git_rebase": {}, "gitattributes": {}, "gitcommit": {}, "gitignore": {}, "gleam": {},
 	"glsl": {}, "gn": {}, "go": {}, "godot_resource": {}, "gomod": {}, "graphql": {},
 	"groovy": {}, "hack": {}, "hare": {}, "haskell": {}, "haxe": {}, "hcl": {}, "heex": {},
-	"hlsl": {}, "html": {}, "http": {}, "hurl": {}, "hyprlang": {}, "ini": {}, "janet": {}, "javascript": {}, "jinja2": {}, "jq": {},
+	"hlsl": {}, "html": {}, "http": {}, "hurl": {}, "hyprlang": {}, "ini": {}, "janet": {}, "javascript": {}, "jinja2": {}, "jq": {}, "jsdoc": {},
 	"json5": {}, "jsonnet": {}, "julia": {}, "just": {}, "kconfig": {}, "kdl": {}, "kotlin": {},
 	"ledger": {}, "less": {}, "linkerscript": {}, "liquid": {}, "llvm": {}, "lua": {},
 	"luau": {}, "make": {}, "markdown": {}, "matlab": {}, "mermaid": {}, "meson": {}, "mojo": {},
@@ -147,15 +147,14 @@ func TestAdmissionCandidateScorecard206(t *testing.T) {
 		// registry drift, or surrendered route coverage require an explicit
 		// review and ratchet update.
 		//
-		// The 199/2/5 ratchet includes Meson's locked-C structural election.
-		// Two languages retain fail-closed FALLBACK rows:
+		// The 200/1/5 ratchet includes JSDoc's locked-C lexer skipped-prefix
+		// tiling route. One language retains a fail-closed FALLBACK row:
 		//
 		//   - markdown_inline reaches its existing repetition-shift boundary.
-		//   - jsdoc reaches its accepted-leaf interior tiling gap.
 		const (
 			wantTotal   = 206
-			minPass     = 199
-			maxFallback = 2
+			minPass     = 200
+			maxFallback = 1
 			wantSkip    = 5
 		)
 		if got := len(admissionScorecardRequiredCompactPasses); got != minPass {
@@ -190,17 +189,11 @@ func TestAdmissionCandidateScorecard206(t *testing.T) {
 }
 
 func TestAdmissionCandidateNoLookaheadSmokeRatchet(t *testing.T) {
-	// jsdoc dropped from this set (campaign v7 class-e closure,
-	// spore.2026-08-02.hornbeam-e.byte-continuity): its smoke sample now
-	// correctly declines at accepted-leaf-tiling-gap once
-	// bytesAreSingleByteDecorationTrivia (parsercore_phase0_driver.go) no
-	// longer excuses its interior comment-continuation gap. That decline is
-	// unrelated to the no-lookahead root-reduce shape this test otherwise
-	// covers; see admissionScorecardRequiredCompactPasses's own ratchet
-	// comment (above) for the full accounting. doxygen and vhdl are
-	// unaffected and keep the PASS assertion below.
+	// JSDoc rejoins this set through exact internal-DFA skipped-prefix
+	// provenance. The route does not restore the retired source-byte exception.
 	wanted := map[string]struct{}{
 		"doxygen": {},
+		"jsdoc":   {},
 		"vhdl":    {},
 	}
 	var doxygen grammars.LangEntry

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -61,6 +61,7 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		allowPrimaryAcceptDerivation:             p.language.CompactPrimaryAcceptanceDerivationCertified,
 		allowCompactAcceptanceStructuralElection: p.language.CompactAcceptanceStructuralElectionCertified,
 		allowConvergedSplitDropArtifact:          p.language.CompactConvergedReductionSplitDropsCertified,
+		captureLexerSkippedPrefixProvenance:      p.language.CompactLexerSkippedPrefixTilingCertified,
 		// Recovery admits the certified S3 base mechanism. S5 also needs the
 		// insertion gate and the lineage-selection gate.
 		Recovery:                          p.language.CompactStrategy2ErrorRegionCertified,

--- a/cgo_harness/jsdoc_retirement_parity_test.go
+++ b/cgo_harness/jsdoc_retirement_parity_test.go
@@ -60,6 +60,19 @@ func TestJsdocLexerSkipProvenanceLockedCParity(t *testing.T) {
 			}
 			t.Cleanup(production.Release)
 
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			candidateParser := gotreesitter.NewParser(language)
+			candidateParser.SetAdmissionCandidateRoute(true)
+			candidate, err := candidateParser.Parse(test.source)
+			if err != nil {
+				t.Fatalf("candidate parse: %v", err)
+			}
+			t.Cleanup(candidate.Release)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			if routedAfter != routedBefore+1 || fallbackAfter != fallbackBefore {
+				t.Fatalf("candidate route counters routed=%d/%d fallback=%d/%d", routedBefore, routedAfter, fallbackBefore, fallbackAfter)
+			}
+
 			cParser := sitter.NewParser()
 			t.Cleanup(cParser.Close)
 			if err := cParser.SetLanguage(cLanguage); err != nil {
@@ -77,14 +90,96 @@ func TestJsdocLexerSkipProvenanceLockedCParity(t *testing.T) {
 			}
 			rawRuntime := raw.ParseRuntime()
 			productionRuntime := production.ParseRuntime()
-			if rawRuntime.NormalizationNodesRewritten != 0 || productionRuntime.NormalizationNodesRewritten != 0 {
-				t.Fatalf("JSDoc normalization rewrote nodes: raw=%d production=%d", rawRuntime.NormalizationNodesRewritten, productionRuntime.NormalizationNodesRewritten)
+			candidateRuntime := candidate.ParseRuntime()
+			if rawRuntime.NormalizationNodesRewritten != 0 || productionRuntime.NormalizationNodesRewritten != 0 || candidateRuntime.NormalizationNodesRewritten != 0 {
+				t.Fatalf("JSDoc normalization rewrote nodes: raw=%d production=%d candidate=%d", rawRuntime.NormalizationNodesRewritten, productionRuntime.NormalizationNodesRewritten, candidateRuntime.NormalizationNodesRewritten)
 			}
-			t.Logf("witness=%s bytes=%d source_sha256=%s raw_rewrites=%d production_rewrites=%d c_digest=%s", test.name, len(test.source), test.sha256, rawRuntime.NormalizationNodesRewritten, productionRuntime.NormalizationNodesRewritten, cDigest)
+			t.Logf("witness=%s bytes=%d source_sha256=%s raw_rewrites=%d production_rewrites=%d candidate_rewrites=%d c_digest=%s", test.name, len(test.source), test.sha256, rawRuntime.NormalizationNodesRewritten, productionRuntime.NormalizationNodesRewritten, candidateRuntime.NormalizationNodesRewritten, cDigest)
 
 			assertJsdocLockedCTreeExact(t, "raw", raw, language, cTree, cDigest)
 			assertJsdocLockedCTreeExact(t, "production", production, language, cTree, cDigest)
+			assertJsdocLockedCTreeExact(t, "candidate", candidate, language, cTree, cDigest)
 		})
+	}
+}
+
+func TestJsdocLexerSkippedPrefixMutationsLockedCParity(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	entry, ok := parityEntriesByName["jsdoc"]
+	if !ok {
+		t.Fatal("missing JSDoc grammar entry")
+	}
+	language := entry.Language()
+	cLanguage, err := COracleLanguage("jsdoc")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		source []byte
+	}{
+		{name: "space_only_prefix", source: []byte("/**\n * @param {string} name\n   @returns {number}\n */\n")},
+		{name: "double_decoration", source: []byte("/**\n * @param {string} name\n ** @returns {number}\n */\n")},
+		{name: "content_before_tag", source: []byte("/**\n * @param {string} name\n * x @returns {number}\n */\n")},
+		{name: "unterminated_type", source: []byte("/**\n * @param {string name\n * @returns {number}\n */\n")},
+		{name: "missing_comment_close", source: []byte("/**\n * @param {string} name\n * @returns {number}\n")},
+		{name: "crlf_prefix", source: []byte("/**\r\n * @param {string} name\r\n * @returns {number}\r\n */\r\n")},
+		{name: "tabbed_prefix", source: []byte("/**\n * @param {string} name\n\t* @returns {number}\n */\n")},
+		{name: "empty_decorated_line", source: []byte("/**\n * @param {string} name\n *\n * @returns {number}\n */\n")},
+	}
+	direct, fallback := 0, 0
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(test.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C oracle returned a nil tree")
+			}
+			t.Cleanup(cTree.Close)
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(test.source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			t.Cleanup(production.Release)
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			candidateParser := gotreesitter.NewParser(language)
+			candidateParser.SetAdmissionCandidateRoute(true)
+			candidate, err := candidateParser.Parse(test.source)
+			if err != nil {
+				t.Fatalf("candidate parse: %v", err)
+			}
+			t.Cleanup(candidate.Release)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			switch {
+			case routedAfter == routedBefore+1 && fallbackAfter == fallbackBefore:
+				direct++
+				t.Log("candidate route=direct")
+			case routedAfter == routedBefore && fallbackAfter == fallbackBefore+1:
+				fallback++
+				t.Logf("candidate route=fallback reason=%s", gotreesitter.AdmissionCandidateLastFallbackReason())
+			default:
+				t.Fatalf("candidate route counters routed=%d/%d fallback=%d/%d", routedBefore, routedAfter, fallbackBefore, fallbackAfter)
+			}
+
+			assertJsdocLockedCTreeExact(t, "mutation_production", production, language, cTree, cDigest)
+			assertJsdocLockedCTreeExact(t, "mutation_candidate", candidate, language, cTree, cDigest)
+		})
+	}
+	if direct == 0 || fallback == 0 {
+		t.Fatalf("mutation routes direct=%d fallback=%d, want both exercised", direct, fallback)
 	}
 }
 

--- a/grammars/jsdoc_retirement_route_receipt_test.go
+++ b/grammars/jsdoc_retirement_route_receipt_test.go
@@ -16,6 +16,7 @@ const (
 	jsdocProducerControl       = "/**\n * @param {string} name\n */\n"
 	jsdocProducerTriggerSHA256 = "8a1683a43035994f3abf03f2f9556b96514a745018c5373ff77d3127fb27d201"
 	jsdocProducerControlSHA256 = "0f4dbe6ca5d62b8c033c09ac26689c787a66298540c46b3af7a9760a7240b5ce"
+	jsdocUncertifiedGapRoute   = "fallback:compact route declined at accept_without_materialization: accepted-leaf-tiling-gap: compact subtree symbol=38 span=7..48 has an unaccounted byte range 27..31 not covered by any child"
 )
 
 func TestJsdocLexerSkipProvenanceRoutes(t *testing.T) {
@@ -33,7 +34,7 @@ func TestJsdocLexerSkipProvenanceRoutes(t *testing.T) {
 			name:             "multi_tag_trigger",
 			source:           []byte(jsdocProducerTrigger),
 			sha256:           jsdocProducerTriggerSHA256,
-			compactRoute:     "fallback:compact route declined at accept_without_materialization: accepted-leaf-tiling-gap: compact subtree symbol=38 span=7..48 has an unaccounted byte range 27..31 not covered by any child",
+			compactRoute:     "direct",
 			forestRoute:      "fallback:51:22:dead_end",
 			incrementalRoute: "fallback:external_scanner_unsupported",
 		},
@@ -81,6 +82,15 @@ func TestJsdocLexerSkipProvenanceRoutes(t *testing.T) {
 				t.Fatalf("compact route=%q, want %q", compactRoute, test.compactRoute)
 			}
 			t.Logf("compact route=%s digest=%s", compactRoute, compactDigest)
+			if test.name == "multi_tag_trigger" {
+				uncertified := *language
+				uncertified.CompactLexerSkippedPrefixTilingCertified = false
+				uncertifiedRoute, uncertifiedDigest := jsdocCompactRoute(t, &uncertified, test.source, productionDigest)
+				if uncertifiedRoute != jsdocUncertifiedGapRoute {
+					t.Fatalf("uncertified compact route=%q, want %q", uncertifiedRoute, jsdocUncertifiedGapRoute)
+				}
+				t.Logf("uncertified compact route=%s digest=%s", uncertifiedRoute, uncertifiedDigest)
+			}
 
 			forestRoute, forestDigest := jsdocForestRoute(t, language, test.source, productionDigest)
 			if forestRoute != test.forestRoute {

--- a/grammars/jsdoc_retirement_route_receipt_test.go
+++ b/grammars/jsdoc_retirement_route_receipt_test.go
@@ -83,9 +83,12 @@ func TestJsdocLexerSkipProvenanceRoutes(t *testing.T) {
 			}
 			t.Logf("compact route=%s digest=%s", compactRoute, compactDigest)
 			if test.name == "multi_tag_trigger" {
-				uncertified := *language
+				uncertified, err := LoadLanguage("jsdoc", BlobByName("jsdoc"))
+				if err != nil {
+					t.Fatalf("load uncertified JSDoc language: %v", err)
+				}
 				uncertified.CompactLexerSkippedPrefixTilingCertified = false
-				uncertifiedRoute, uncertifiedDigest := jsdocCompactRoute(t, &uncertified, test.source, productionDigest)
+				uncertifiedRoute, uncertifiedDigest := jsdocCompactRoute(t, uncertified, test.source, productionDigest)
 				if uncertifiedRoute != jsdocUncertifiedGapRoute {
 					t.Fatalf("uncertified compact route=%q, want %q", uncertifiedRoute, jsdocUncertifiedGapRoute)
 				}

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -25,6 +25,7 @@ type builtinLanguageRuntimeProfile struct {
 	compactEOFAcceptNoActionSiblings    bool
 	compactPrimaryAcceptDerivation      bool
 	compactAcceptanceStructuralElection bool
+	compactLexerSkippedPrefixTiling     bool
 	exactStackNodeEquivalence           bool
 	compactStrategy2ErrorRegion         bool
 	compactMissingTokenInsertion        bool
@@ -90,6 +91,13 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	},
 	"robot": {
 		blobSHA256: mustRuntimeProfileSHA256("25075ecf5323eeb88af4f71b55f51867cef38a277aaa60f01b879ee8abb4c74f"),
+	},
+	// The internal DFA skips each JSDoc line decoration before it produces the
+	// next tag token. The compact materializer admits the resulting interior
+	// gap only when the accepted terminal carries that exact prefix evidence.
+	"jsdoc": {
+		blobSHA256:                      mustRuntimeProfileSHA256("e5688e60d41d6ef2d0922de7687b597de0c880761064e9e7b994d401c5508312"),
+		compactLexerSkippedPrefixTiling: true,
 	},
 	// C-oracle parity certifies the complete compact recovery competition for
 	// this exact artifact against the ten pinned HTML witnesses.
@@ -691,6 +699,10 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	}
 	if profile.compactAcceptanceStructuralElection && !lang.CompactAcceptanceStructuralElectionCertified {
 		lang.CompactAcceptanceStructuralElectionCertified = true
+		changed = true
+	}
+	if profile.compactLexerSkippedPrefixTiling && !lang.CompactLexerSkippedPrefixTilingCertified {
+		lang.CompactLexerSkippedPrefixTilingCertified = true
 		changed = true
 	}
 	if profile.exactStackNodeEquivalence && !lang.ExactStackNodeEquivalenceCertified {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -136,7 +136,9 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	// ConflictPolicyDeclaredReduceReduceHighestSymbol row that resolves the
 	// grammar-declared simpleId/className reduce-reduce conflict to the
 	// C-native reading during dispatch.
-	if got, want := len(builtinLanguageRuntimeProfiles), 48; got != want {
+	// 49 = the prior 48 plus the JSDoc entry. It certifies exact internal-DFA
+	// skipped-prefix evidence for compact reduce tiling.
+	if got, want := len(builtinLanguageRuntimeProfiles), 49; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -163,6 +165,9 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	}
 	if lang.CompactPrimaryAcceptanceDerivationCertified {
 		t.Fatal("unknown runtime profile enabled compact primary derivation selection")
+	}
+	if lang.CompactLexerSkippedPrefixTilingCertified {
+		t.Fatal("unknown runtime profile enabled compact lexer skipped-prefix tiling")
 	}
 	if lang.ExactStackNodeEquivalenceCertified {
 		t.Fatal("unknown runtime profile enabled exact stack-node equivalence")
@@ -356,6 +361,38 @@ func TestBuiltinCompactAcceptanceProfilesRequireExactBlobIdentity(t *testing.T) 
 				t.Fatal("wrong blob identity enabled compact acceptance certification")
 			}
 		})
+	}
+}
+
+func TestBuiltinJsdocLexerSkippedPrefixProfileRequiresExactBlobIdentity(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+
+	builtin := JsdocLanguage()
+	if !builtin.CompactLexerSkippedPrefixTilingCertified {
+		t.Fatal("exact built-in JSDoc artifact did not receive skipped-prefix certification")
+	}
+
+	custom := &gotreesitter.Language{Name: "jsdoc"}
+	AttachLanguageSupport("jsdoc", custom)
+	if custom.CompactLexerSkippedPrefixTilingCertified {
+		t.Fatal("same-name custom JSDoc grammar enabled skipped-prefix certification")
+	}
+
+	stale := &gotreesitter.Language{Name: "jsdoc"}
+	if attachBuiltinLanguageRuntimeProfile("jsdoc", sha256.Sum256([]byte("stale")), stale) {
+		t.Fatal("stale JSDoc blob unexpectedly attached a runtime profile")
+	}
+	if stale.CompactLexerSkippedPrefixTilingCertified {
+		t.Fatal("stale JSDoc blob enabled skipped-prefix certification")
+	}
+
+	exact := &gotreesitter.Language{Name: "jsdoc"}
+	if !attachBuiltinLanguageRuntimeProfile("jsdoc", sha256.Sum256(BlobByName("jsdoc")), exact) {
+		t.Fatal("exact JSDoc blob did not attach its runtime profile")
+	}
+	if !exact.CompactLexerSkippedPrefixTilingCertified {
+		t.Fatal("exact JSDoc blob did not enable skipped-prefix certification")
 	}
 }
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1008,6 +1008,14 @@ type externalPayloadProvenance struct {
 	end     CheckpointID
 }
 
+// lexerSkippedPrefixProvenance stores the exact start of one prefix that the
+// internal DFA skipped before it produced a terminal. Sparse storage keeps the
+// 44-byte subtree record unchanged for terminals that have no skipped prefix.
+type lexerSkippedPrefixProvenance struct {
+	payload SubtreeID
+	start   uint32
+}
+
 type subtreeExternalProvenanceState uint8
 
 const (
@@ -1041,6 +1049,9 @@ type Token struct {
 	EndByte   uint32
 	Extra     bool
 	External  bool
+	// LexerSkippedPrefixLength is the exact internal-DFA prefix length.
+	// Zero means that no bounded proof accompanies this terminal.
+	LexerSkippedPrefixLength uint16
 }
 
 // OrdinaryCohortShiftInput identifies one distinct scheduler head and its
@@ -1098,6 +1109,10 @@ type SubtreeView struct {
 	// Missing mirrors subtreeRecord.missing: a recovery-inserted zero-width
 	// terminal (C ts_subtree_missing).
 	Missing bool
+	// LexerSkippedPrefix proves that the internal DFA skipped the byte range
+	// [LexerSkippedPrefixStart, StartByte) before it produced this terminal.
+	LexerSkippedPrefix      bool
+	LexerSkippedPrefixStart uint32
 }
 
 // MaterializationSubtreeView is a callback-scoped borrowed view of one compact
@@ -1123,6 +1138,10 @@ type MaterializationSubtreeView struct {
 	// terminal (C ts_subtree_missing). Threaded to the public materializer so
 	// it can set the public node's own missing and has-error bits.
 	Missing bool
+	// LexerSkippedPrefix is exact terminal provenance from the internal DFA.
+	// It is false for reductions, external tokens, and synthetic terminals.
+	LexerSkippedPrefix      bool
+	LexerSkippedPrefixStart uint32
 }
 
 // Stats reports physical storage separately from semantic path counts. It is
@@ -1193,17 +1212,18 @@ type Core struct {
 	dropCohortLinkRefIndexes []uint32
 	dropCohortLinkRefJournal []dropCohortLinkRefMutation
 
-	subtrees           []subtreeRecord
-	externalProvenance []externalPayloadProvenance
-	children           []SubtreeID
-	fields             []FieldMapEntry
-	aliases            []Symbol
-	frontier           uint64
-	checkpoint         CheckpointID
-	checkpoints        checkpointInterner
-	boundaries         boundaryIndex
-	boundaryJournal    []boundaryMutation
-	nodeLineageJournal []nodeLineageMutation
+	subtrees             []subtreeRecord
+	externalProvenance   []externalPayloadProvenance
+	lexerSkippedPrefixes []lexerSkippedPrefixProvenance
+	children             []SubtreeID
+	fields               []FieldMapEntry
+	aliases              []Symbol
+	frontier             uint64
+	checkpoint           CheckpointID
+	checkpoints          checkpointInterner
+	boundaries           boundaryIndex
+	boundaryJournal      []boundaryMutation
+	nodeLineageJournal   []nodeLineageMutation
 	// alternativeSpillArena backs every AlternativeSet beyond
 	// alternativeSetInlineCapacity members, shared by nodeLineages and every
 	// diagnosticParserCoreHeader.altSet (parsercore_phase0_driver.go). It
@@ -1364,6 +1384,7 @@ type diagnosticOptions struct {
 
 type checkpoint struct {
 	nodes, nodeLineages, nodeCheckpoints, links, subtrees, externalProvenance int
+	lexerSkippedPrefixes                                                      int
 	children, fields, aliases                                                 int
 	dropCohortLinkRefIndexes                                                  int
 	dropCohortLinkRefJournal                                                  int
@@ -1479,9 +1500,10 @@ func (c *Core) markInto(mark *checkpoint) {
 	*mark = checkpoint{
 		nodes: len(c.nodes), nodeLineages: len(c.nodeLineages),
 		links: len(c.links), subtrees: len(c.subtrees),
-		nodeCheckpoints:    len(c.nodeCheckpoints),
-		externalProvenance: len(c.externalProvenance),
-		children:           len(c.children), fields: len(c.fields), aliases: len(c.aliases),
+		nodeCheckpoints:      len(c.nodeCheckpoints),
+		externalProvenance:   len(c.externalProvenance),
+		lexerSkippedPrefixes: len(c.lexerSkippedPrefixes),
+		children:             len(c.children), fields: len(c.fields), aliases: len(c.aliases),
 
 		dropCohortLinkRefIndexes: len(c.dropCohortLinkRefIndexes),
 		dropCohortLinkRefJournal: len(c.dropCohortLinkRefJournal),
@@ -1589,6 +1611,7 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 	c.links = c.links[:mark.links]
 	c.subtrees = c.subtrees[:mark.subtrees]
 	c.externalProvenance = c.externalProvenance[:mark.externalProvenance]
+	c.lexerSkippedPrefixes = c.lexerSkippedPrefixes[:mark.lexerSkippedPrefixes]
 	c.children = c.children[:mark.children]
 	c.fields = c.fields[:mark.fields]
 	c.aliases = c.aliases[:mark.aliases]
@@ -2061,6 +2084,7 @@ func (c *Core) Reset() error {
 	c.dropCohortLinkRefIndexes = c.dropCohortLinkRefIndexes[:0]
 	c.subtrees = c.subtrees[:0]
 	c.externalProvenance = c.externalProvenance[:0]
+	c.lexerSkippedPrefixes = c.lexerSkippedPrefixes[:0]
 	c.children = c.children[:0]
 	c.fields = c.fields[:0]
 	c.aliases = c.aliases[:0]
@@ -2634,7 +2658,7 @@ func (c *Core) appendDiagnosticPayload(head Head, state StateID, token Token, me
 	payload, err := c.appendAuthenticatedTerminal(subtreeRecord{
 		symbol: token.Symbol, startByte: token.StartByte, endByte: token.EndByte,
 		extra: token.Extra, external: token.External, terminal: true,
-	})
+	}, token.LexerSkippedPrefixLength)
 	if err != nil {
 		return Head{}, err
 	}
@@ -5312,6 +5336,7 @@ func (c *Core) Subtree(id SubtreeID) (SubtreeView, error) {
 		StartByte: r.startByte, EndByte: r.endByte, Extra: r.extra, External: r.external, Terminal: r.terminal,
 		Missing: r.missing,
 	}
+	view.LexerSkippedPrefixStart, view.LexerSkippedPrefix = c.lexerSkippedPrefix(id)
 	view.Children = append(view.Children, c.children[r.firstChild:r.firstChild+r.childCount]...)
 	view.Fields = append(view.Fields, c.fields[r.firstField:r.firstField+r.fieldCount]...)
 	view.Aliases = append(view.Aliases, c.aliases[r.firstAlias:r.firstAlias+r.aliasCount]...)
@@ -5439,7 +5464,7 @@ func (c *Core) MaterializationView(id SubtreeID) (MaterializationSubtreeView, er
 	if err != nil {
 		return MaterializationSubtreeView{}, err
 	}
-	return MaterializationSubtreeView{
+	view := MaterializationSubtreeView{
 		Symbol:            record.symbol,
 		ProductionID:      record.productionID,
 		DynamicPrecedence: record.dynamicPrecedence,
@@ -5451,7 +5476,9 @@ func (c *Core) MaterializationView(id SubtreeID) (MaterializationSubtreeView, er
 		Terminal:          record.terminal,
 		Fragile:           record.fragile,
 		Missing:           record.missing,
-	}, nil
+	}
+	view.LexerSkippedPrefixStart, view.LexerSkippedPrefix = c.lexerSkippedPrefix(id)
+	return view, nil
 }
 
 // SubtreeArenaLen returns the number of subtree records currently allocated,
@@ -5679,10 +5706,21 @@ func (c *Core) appendSubtree(r subtreeRecord, children []SubtreeID, fields []Fie
 	return c.appendSubtreeRecord(r, children, fields, aliases)
 }
 
-func (c *Core) appendAuthenticatedTerminal(r subtreeRecord) (SubtreeID, error) {
+func (c *Core) appendAuthenticatedTerminal(
+	r subtreeRecord,
+	lexerSkippedPrefixLength uint16,
+) (SubtreeID, error) {
 	// The AST provenance ratchet requires every caller to pass a subtreeRecord
 	// literal with terminal:true. Publish the terminal once. Then append its
-	// sparse scanner proof when the current election supplied one.
+	// sparse scanner and lexer proofs when the current election supplied them.
+	if !r.terminal {
+		return 0, errors.New("parser-core phase zero: authenticated terminal is not terminal")
+	}
+	if lexerSkippedPrefixLength != 0 {
+		if r.external || uint32(lexerSkippedPrefixLength) > r.startByte {
+			return 0, errors.New("parser-core phase zero: invalid lexer skipped-prefix provenance")
+		}
+	}
 	payload, err := c.appendSubtreeRecord(r, nil, nil, nil)
 	if err != nil {
 		return 0, err
@@ -5697,7 +5735,29 @@ func (c *Core) appendAuthenticatedTerminal(r subtreeRecord) (SubtreeID, error) {
 			c.subtrees[payload-1].externalProvenanceState = subtreeExternalProvenanceExactHasExternal
 		}
 	}
+	if lexerSkippedPrefixLength != 0 {
+		c.lexerSkippedPrefixes = append(c.lexerSkippedPrefixes, lexerSkippedPrefixProvenance{
+			payload: payload,
+			start:   r.startByte - uint32(lexerSkippedPrefixLength),
+		})
+	}
 	return payload, nil
+}
+
+func (c *Core) lexerSkippedPrefix(payload SubtreeID) (uint32, bool) {
+	low, high := 0, len(c.lexerSkippedPrefixes)
+	for low < high {
+		mid := low + (high-low)/2
+		if c.lexerSkippedPrefixes[mid].payload < payload {
+			low = mid + 1
+		} else {
+			high = mid
+		}
+	}
+	if low >= len(c.lexerSkippedPrefixes) || c.lexerSkippedPrefixes[low].payload != payload {
+		return 0, false
+	}
+	return c.lexerSkippedPrefixes[low].start, true
 }
 
 func (c *Core) appendSubtreeRecord(r subtreeRecord, children []SubtreeID, fields []FieldMapEntry, aliases []Symbol) (SubtreeID, error) {

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -2698,6 +2698,7 @@ func TestCompactArenaRecordsRemainPointerFree(t *testing.T) {
 		"link":                   reflect.TypeFor[linkRecord](),
 		"subtree":                reflect.TypeFor[subtreeRecord](),
 		"external-provenance":    reflect.TypeFor[externalPayloadProvenance](),
+		"lexer-skipped-prefix":   reflect.TypeFor[lexerSkippedPrefixProvenance](),
 		"drop-cohort-action":     reflect.TypeFor[dropCohortActionIdentity](),
 		"drop-cohort-record":     reflect.TypeFor[dropCohortRecord](),
 		"drop-cohort-member":     reflect.TypeFor[dropCohortMember](),
@@ -2738,6 +2739,14 @@ func TestCompactArenaRecordsRemainPointerFree(t *testing.T) {
 	}
 	if got := unsafe.Sizeof(externalPayloadProvenance{}); got != 12 {
 		t.Fatalf("externalPayloadProvenance size = %d, want 12", got)
+	}
+	if got := unsafe.Sizeof(lexerSkippedPrefixProvenance{}); got != 8 {
+		t.Fatalf("lexerSkippedPrefixProvenance size = %d, want 8", got)
+	}
+	// Store the bounded prefix length in Token's existing tail padding. Every
+	// compact shift copies this value, including grammars that do not use it.
+	if got := unsafe.Sizeof(Token{}); got != 16 {
+		t.Fatalf("Token size = %d, want 16", got)
 	}
 }
 

--- a/internal/parsercorephase0/eof_recovery_shadow.go
+++ b/internal/parsercorephase0/eof_recovery_shadow.go
@@ -292,6 +292,7 @@ func planDiagnosticEOFRecoveryClone(live *Core, payloads []SubtreeID, providerWr
 		{len(live.links), coreLinkRecordBytes},
 		{len(live.subtrees), coreSubtreeRecordBytes},
 		{len(live.externalProvenance), coreExternalProvenanceBytes},
+		{len(live.lexerSkippedPrefixes), coreLexerSkippedPrefixBytes},
 		{len(live.children), coreChildRecordBytes},
 		{len(live.fields), coreFieldRecordBytes},
 		{len(live.aliases), coreAliasRecordBytes},
@@ -452,6 +453,7 @@ func cloneDiagnosticEOFRecoveryCore(
 	shadow.links = cloneDiagnosticSlice(live.links, 0)
 	shadow.subtrees = cloneDiagnosticSlice(live.subtrees, 1)
 	shadow.externalProvenance = cloneDiagnosticSlice(live.externalProvenance, 0)
+	shadow.lexerSkippedPrefixes = cloneDiagnosticSlice(live.lexerSkippedPrefixes, 0)
 	shadow.children = cloneDiagnosticSlice(live.children, payloadCount)
 	shadow.fields = cloneDiagnosticSlice(live.fields, 0)
 	shadow.aliases = cloneDiagnosticSlice(live.aliases, 0)
@@ -527,6 +529,7 @@ func diagnosticEOFRecoveryCopiedArenasEqual(live, shadow *Core) bool {
 		equalDiagnosticSlice(live.links, shadow.links) &&
 		equalDiagnosticSlice(live.subtrees, shadow.subtrees[:len(live.subtrees)]) &&
 		equalDiagnosticSlice(live.externalProvenance, shadow.externalProvenance) &&
+		equalDiagnosticSlice(live.lexerSkippedPrefixes, shadow.lexerSkippedPrefixes) &&
 		equalDiagnosticSlice(live.children, shadow.children[:len(live.children)]) &&
 		equalDiagnosticSlice(live.fields, shadow.fields) &&
 		equalDiagnosticSlice(live.aliases, shadow.aliases) &&
@@ -580,6 +583,7 @@ func diagnosticEOFRecoveryStorageDisjoint(live, shadow *Core) bool {
 		disjointDiagnosticSlice(live.links, shadow.links) &&
 		disjointDiagnosticSlice(live.subtrees, shadow.subtrees) &&
 		disjointDiagnosticSlice(live.externalProvenance, shadow.externalProvenance) &&
+		disjointDiagnosticSlice(live.lexerSkippedPrefixes, shadow.lexerSkippedPrefixes) &&
 		disjointDiagnosticSlice(live.children, shadow.children) &&
 		disjointDiagnosticSlice(live.fields, shadow.fields) &&
 		disjointDiagnosticSlice(live.aliases, shadow.aliases) &&

--- a/internal/parsercorephase0/eof_recovery_shadow_test.go
+++ b/internal/parsercorephase0/eof_recovery_shadow_test.go
@@ -19,6 +19,7 @@ func TestDiagnosticEOFRecoveryClonePlanAccountsEveryRequestedByte(t *testing.T) 
 		links:                             make([]linkRecord, 3),
 		subtrees:                          make([]subtreeRecord, 4),
 		externalProvenance:                make([]externalPayloadProvenance, 1),
+		lexerSkippedPrefixes:              make([]lexerSkippedPrefixProvenance, 2),
 		children:                          make([]SubtreeID, 5),
 		fields:                            make([]FieldMapEntry, 6),
 		aliases:                           make([]Symbol, 7),
@@ -46,6 +47,7 @@ func TestDiagnosticEOFRecoveryClonePlanAccountsEveryRequestedByte(t *testing.T) 
 		uint64(3)*coreLinkRecordBytes +
 		uint64(4)*coreSubtreeRecordBytes +
 		coreExternalProvenanceBytes +
+		uint64(2)*coreLexerSkippedPrefixBytes +
 		uint64(5)*coreChildRecordBytes +
 		uint64(6)*coreFieldRecordBytes +
 		uint64(7)*coreAliasRecordBytes +

--- a/internal/parsercorephase0/lexer_skipped_prefix_test.go
+++ b/internal/parsercorephase0/lexer_skipped_prefix_test.go
@@ -1,0 +1,111 @@
+package parsercorephase0
+
+import "testing"
+
+func TestLexerSkippedPrefixProvenanceIsSparseAndMaterialized(t *testing.T) {
+	tables := &fakeTable{actions: map[tableCell][]Action{
+		{state: 1, symbol: 9}: {{Type: ActionShift, State: 2}},
+	}}
+	compact, err := New(tables, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	shifted, err := compact.Shift(seed, 9, 0, Token{
+		Symbol: 9, StartByte: 5, EndByte: 6,
+		LexerSkippedPrefixLength: 4,
+	}, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	derivations, err := compact.Derivations(shifted)
+	if err != nil || len(derivations) != 1 || len(derivations[0].Payloads) != 1 {
+		t.Fatalf("derivations=%+v err=%v", derivations, err)
+	}
+	payload := derivations[0].Payloads[0]
+	view, err := compact.MaterializationView(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !view.LexerSkippedPrefix || view.LexerSkippedPrefixStart != 1 {
+		t.Fatalf("materialization provenance=%t/%d, want true/1", view.LexerSkippedPrefix, view.LexerSkippedPrefixStart)
+	}
+	if len(compact.lexerSkippedPrefixes) != 1 || compact.lexerSkippedPrefixes[0] != (lexerSkippedPrefixProvenance{payload: payload, start: 1}) {
+		t.Fatalf("sparse provenance=%+v", compact.lexerSkippedPrefixes)
+	}
+	if err := compact.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	if len(compact.lexerSkippedPrefixes) != 0 {
+		t.Fatalf("reset retained %d skipped-prefix records", len(compact.lexerSkippedPrefixes))
+	}
+}
+
+func TestLexerSkippedPrefixProvenanceRollsBackWithFailedShift(t *testing.T) {
+	tables := &fakeTable{actions: map[tableCell][]Action{
+		{state: 1, symbol: 9}: {{Type: ActionShift, State: 2}},
+	}}
+	compact, err := New(tables, Limits{MaxNodes: 1, MaxLinks: 8, MaxSubtrees: 8, MaxChildren: 8, MaxMetadata: 8, MaxLinksPerBoundary: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := compact.Shift(seed, 9, 0, Token{
+		Symbol: 9, StartByte: 5, EndByte: 6,
+		LexerSkippedPrefixLength: 4,
+	}, ForkOrder{}); err == nil {
+		t.Fatal("node-cap shift unexpectedly succeeded")
+	}
+	if len(compact.subtrees) != 0 || len(compact.lexerSkippedPrefixes) != 0 {
+		t.Fatalf("failed shift retained subtrees=%d skipped_prefixes=%d", len(compact.subtrees), len(compact.lexerSkippedPrefixes))
+	}
+}
+
+func TestLexerSkippedPrefixProvenanceRejectsInvalidProof(t *testing.T) {
+	tests := []struct {
+		name  string
+		token Token
+	}{
+		{
+			name: "external_token",
+			token: Token{
+				Symbol: 9, StartByte: 5, EndByte: 6, External: true,
+				LexerSkippedPrefixLength: 4,
+			},
+		},
+		{
+			name: "prefix_before_source",
+			token: Token{
+				Symbol: 9, StartByte: 5, EndByte: 6,
+				LexerSkippedPrefixLength: 6,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tables := &fakeTable{actions: map[tableCell][]Action{
+				{state: 1, symbol: 9}: {{Type: ActionShift, State: 2}},
+			}}
+			compact, err := New(tables, Limits{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			seed, err := compact.Seed(1, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := compact.Shift(seed, 9, 0, test.token, ForkOrder{}); err == nil {
+				t.Fatal("invalid skipped-prefix proof unexpectedly succeeded")
+			}
+			if len(compact.subtrees) != 0 || len(compact.lexerSkippedPrefixes) != 0 {
+				t.Fatalf("invalid proof retained subtrees=%d skipped_prefixes=%d", len(compact.subtrees), len(compact.lexerSkippedPrefixes))
+			}
+		})
+	}
+}

--- a/internal/parsercorephase0/materialization_order_test.go
+++ b/internal/parsercorephase0/materialization_order_test.go
@@ -181,7 +181,7 @@ func TestMaterializationMetadataAuthenticationIsConstructionScoped(t *testing.T)
 
 	// The authenticated terminal seam preserves the Core invariant and accepts
 	// only statically ratcheted metadata-trivial terminal literals in production.
-	trustedLeaf, err := compact.appendAuthenticatedTerminal(subtreeRecord{symbol: 4, endByte: 1, terminal: true})
+	trustedLeaf, err := compact.appendAuthenticatedTerminal(subtreeRecord{symbol: 4, endByte: 1, terminal: true}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/parsercorephase0/materialization_postorder_scratch.go
+++ b/internal/parsercorephase0/materialization_postorder_scratch.go
@@ -134,6 +134,7 @@ func (c *Core) VisitMaterializationPostorderWithScratch(
 				Extra:    record.extra, External: record.external, Terminal: record.terminal,
 				Fragile: record.fragile, Missing: record.missing,
 			}
+			view.LexerSkippedPrefixStart, view.LexerSkippedPrefix = c.lexerSkippedPrefix(top.id)
 			if err := visit(top.id, view); err != nil {
 				return err
 			}

--- a/internal/parsercorephase0/metadata_auth_ratchet_test.go
+++ b/internal/parsercorephase0/metadata_auth_ratchet_test.go
@@ -96,7 +96,7 @@ func TestMetadataAuthenticationLexicalProvenanceRatchet(t *testing.T) {
 						} else {
 							allowedTerminalCallers[functionName]++
 							if !authenticatedTerminalLiteral(node) {
-								t.Errorf("%s: appendAuthenticatedTerminal in %s must receive one subtreeRecord literal with terminal:true", fset.Position(node.Pos()), functionName)
+								t.Errorf("%s: appendAuthenticatedTerminal in %s must receive one subtreeRecord literal with terminal:true and one lexer provenance length", fset.Position(node.Pos()), functionName)
 							}
 						}
 					}
@@ -129,7 +129,7 @@ func TestMetadataAuthenticationLexicalProvenanceRatchet(t *testing.T) {
 }
 
 func authenticatedTerminalLiteral(call *ast.CallExpr) bool {
-	if len(call.Args) != 1 {
+	if len(call.Args) != 2 {
 		return false
 	}
 	literal, ok := call.Args[0].(*ast.CompositeLit)

--- a/internal/parsercorephase0/precedence_maximum_test.go
+++ b/internal/parsercorephase0/precedence_maximum_test.go
@@ -394,14 +394,14 @@ func TestScannerStatePairNonterminalRootsIgnoreDescendants(t *testing.T) {
 	if err := core.SetPhaseExternalTokenScannerCheckpoints(start, endLeft); err != nil {
 		t.Fatal(err)
 	}
-	leftChild, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true})
+	leftChild, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := core.SetPhaseExternalTokenScannerCheckpoints(start, endRight); err != nil {
 		t.Fatal(err)
 	}
-	rightChild, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 21, external: true, terminal: true})
+	rightChild, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 21, external: true, terminal: true}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -427,14 +427,14 @@ func TestScannerStatePairDistinctPayloadsEqualEndState(t *testing.T) {
 	if err := core.SetPhaseExternalTokenScannerCheckpoints(leftStart, end); err != nil {
 		t.Fatal(err)
 	}
-	left, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true})
+	left, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := core.SetPhaseExternalTokenScannerCheckpoints(rightStart, end); err != nil {
 		t.Fatal(err)
 	}
-	right, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 21, external: true, terminal: true})
+	right, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 21, external: true, terminal: true}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -452,14 +452,14 @@ func TestScannerStatePairUnequalEndStateDeclines(t *testing.T) {
 	if err := core.SetPhaseExternalTokenScannerCheckpoints(start, leftEnd); err != nil {
 		t.Fatal(err)
 	}
-	left, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true})
+	left, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := core.SetPhaseExternalTokenScannerCheckpoints(start, rightEnd); err != nil {
 		t.Fatal(err)
 	}
-	right, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true})
+	right, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -477,14 +477,14 @@ func TestScannerStatePairIgnoresStartStateDifference(t *testing.T) {
 	if err := core.SetPhaseExternalTokenScannerCheckpoints(leftStart, end); err != nil {
 		t.Fatal(err)
 	}
-	left, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true})
+	left, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := core.SetPhaseExternalTokenScannerCheckpoints(rightStart, end); err != nil {
 		t.Fatal(err)
 	}
-	right, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true})
+	right, err := core.appendAuthenticatedTerminal(subtreeRecord{symbol: 20, external: true, terminal: true}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/parsercorephase0/recursive_insert_test.go
+++ b/internal/parsercorephase0/recursive_insert_test.go
@@ -165,7 +165,7 @@ func newExactExternalRecursiveInsertFixture(t *testing.T, externalDescendant boo
 	}
 	externalChild, err := core.appendAuthenticatedTerminal(subtreeRecord{
 		symbol: 31, startByte: 10, endByte: 11, external: true, terminal: true,
-	})
+	}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -670,7 +670,7 @@ func TestSubtreeExternalProvenanceUsesPackedCache(t *testing.T) {
 	}
 	external, err := core.appendAuthenticatedTerminal(subtreeRecord{
 		symbol: 11, external: true, terminal: true,
-	})
+	}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -739,7 +739,7 @@ func TestRecursiveInsertKeepsScannerCheckpointMismatchSeparate(t *testing.T) {
 	}
 	top, err := core.appendAuthenticatedTerminal(subtreeRecord{
 		symbol: 30, startByte: 10, endByte: 11, external: true, terminal: true,
-	})
+	}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/parsercorephase0/reset_test.go
+++ b/internal/parsercorephase0/reset_test.go
@@ -55,6 +55,7 @@ func TestResetRetainsConfigurationAndArenaCapacity(t *testing.T) {
 	wantCaps := [...]int{
 		cap(compact.nodes), cap(compact.nodeCheckpoints), cap(compact.links), cap(compact.subtrees),
 		cap(compact.externalProvenance),
+		cap(compact.lexerSkippedPrefixes),
 		cap(compact.children), cap(compact.fields), cap(compact.aliases),
 		cap(compact.boundaries.slots), cap(compact.boundaryJournal), cap(compact.transactions),
 		cap(compact.reductionScratch.boundaries), cap(compact.reductionScratch.batchParents),
@@ -69,6 +70,7 @@ func TestResetRetainsConfigurationAndArenaCapacity(t *testing.T) {
 	gotCaps := [...]int{
 		cap(compact.nodes), cap(compact.nodeCheckpoints), cap(compact.links), cap(compact.subtrees),
 		cap(compact.externalProvenance),
+		cap(compact.lexerSkippedPrefixes),
 		cap(compact.children), cap(compact.fields), cap(compact.aliases),
 		cap(compact.boundaries.slots), cap(compact.boundaryJournal), cap(compact.transactions),
 		cap(compact.reductionScratch.boundaries), cap(compact.reductionScratch.batchParents),
@@ -76,8 +78,8 @@ func TestResetRetainsConfigurationAndArenaCapacity(t *testing.T) {
 	if gotCaps != wantCaps {
 		t.Fatalf("reset changed retained capacities: got=%v want=%v", gotCaps, wantCaps)
 	}
-	if len(compact.nodes) != 0 || len(compact.nodeCheckpoints) != 0 || len(compact.links) != 0 || len(compact.subtrees) != 0 || len(compact.externalProvenance) != 0 || len(compact.children) != 0 || len(compact.fields) != 0 || len(compact.aliases) != 0 || compact.boundaries.count != 0 || len(compact.boundaryJournal) != 0 || len(compact.transactions) != 0 {
-		t.Fatalf("reset retained logical state: nodes=%d node_checkpoints=%d links=%d subtrees=%d external_provenance=%d children=%d fields=%d aliases=%d boundaries=%d journal=%d transactions=%d", len(compact.nodes), len(compact.nodeCheckpoints), len(compact.links), len(compact.subtrees), len(compact.externalProvenance), len(compact.children), len(compact.fields), len(compact.aliases), compact.boundaries.count, len(compact.boundaryJournal), len(compact.transactions))
+	if len(compact.nodes) != 0 || len(compact.nodeCheckpoints) != 0 || len(compact.links) != 0 || len(compact.subtrees) != 0 || len(compact.externalProvenance) != 0 || len(compact.lexerSkippedPrefixes) != 0 || len(compact.children) != 0 || len(compact.fields) != 0 || len(compact.aliases) != 0 || compact.boundaries.count != 0 || len(compact.boundaryJournal) != 0 || len(compact.transactions) != 0 {
+		t.Fatalf("reset retained logical state: nodes=%d node_checkpoints=%d links=%d subtrees=%d external_provenance=%d lexer_skipped_prefixes=%d children=%d fields=%d aliases=%d boundaries=%d journal=%d transactions=%d", len(compact.nodes), len(compact.nodeCheckpoints), len(compact.links), len(compact.subtrees), len(compact.externalProvenance), len(compact.lexerSkippedPrefixes), len(compact.children), len(compact.fields), len(compact.aliases), compact.boundaries.count, len(compact.boundaryJournal), len(compact.transactions))
 	}
 	if compact.frontier != 1 || compact.checkpoint != 0 || compact.nextTransaction != 0 || compact.Work() != (Work{}) {
 		t.Fatalf("reset scalar drift: frontier=%d checkpoint=%x next_transaction=%d work=%+v", compact.frontier, compact.checkpoint, compact.nextTransaction, compact.Work())
@@ -117,6 +119,7 @@ func TestResetRejectsNilAndActiveTransactionWithoutMutation(t *testing.T) {
 		beforeLinks := append([]linkRecord(nil), compact.links...)
 		beforeSubtrees := append([]subtreeRecord(nil), compact.subtrees...)
 		beforeExternalProvenance := append([]externalPayloadProvenance(nil), compact.externalProvenance...)
+		beforeLexerSkippedPrefixes := append([]lexerSkippedPrefixProvenance(nil), compact.lexerSkippedPrefixes...)
 		beforeChildren := append([]SubtreeID(nil), compact.children...)
 		beforeFields := append([]FieldMapEntry(nil), compact.fields...)
 		beforeAliases := append([]Symbol(nil), compact.aliases...)
@@ -130,7 +133,7 @@ func TestResetRejectsNilAndActiveTransactionWithoutMutation(t *testing.T) {
 		if err := compact.Reset(); err == nil {
 			t.Fatal("reset during active transaction unexpectedly succeeded")
 		}
-		if !reflect.DeepEqual(compact.nodes, beforeNodes) || !reflect.DeepEqual(compact.nodeCheckpoints, beforeNodeCheckpoints) || !reflect.DeepEqual(compact.links, beforeLinks) || !reflect.DeepEqual(compact.subtrees, beforeSubtrees) || !reflect.DeepEqual(compact.externalProvenance, beforeExternalProvenance) || !reflect.DeepEqual(compact.children, beforeChildren) || !reflect.DeepEqual(compact.fields, beforeFields) || !reflect.DeepEqual(compact.aliases, beforeAliases) || !reflect.DeepEqual(compact.boundaries.logicalMap(), beforeBoundaries) || !reflect.DeepEqual(compact.boundaries.snapshot(), beforeBoundaryIndex) || !reflect.DeepEqual(compact.boundaryJournal, beforeJournal) || !reflect.DeepEqual(compact.transactions, beforeTransactions) || compact.frontier != beforeFrontier || compact.checkpoint != beforeCheckpoint || compact.nextTransaction != beforeNext || compact.work != beforeWork {
+		if !reflect.DeepEqual(compact.nodes, beforeNodes) || !reflect.DeepEqual(compact.nodeCheckpoints, beforeNodeCheckpoints) || !reflect.DeepEqual(compact.links, beforeLinks) || !reflect.DeepEqual(compact.subtrees, beforeSubtrees) || !reflect.DeepEqual(compact.externalProvenance, beforeExternalProvenance) || !reflect.DeepEqual(compact.lexerSkippedPrefixes, beforeLexerSkippedPrefixes) || !reflect.DeepEqual(compact.children, beforeChildren) || !reflect.DeepEqual(compact.fields, beforeFields) || !reflect.DeepEqual(compact.aliases, beforeAliases) || !reflect.DeepEqual(compact.boundaries.logicalMap(), beforeBoundaries) || !reflect.DeepEqual(compact.boundaries.snapshot(), beforeBoundaryIndex) || !reflect.DeepEqual(compact.boundaryJournal, beforeJournal) || !reflect.DeepEqual(compact.transactions, beforeTransactions) || compact.frontier != beforeFrontier || compact.checkpoint != beforeCheckpoint || compact.nextTransaction != beforeNext || compact.work != beforeWork {
 			t.Fatal("rejected active reset mutated compact state")
 		}
 		if state, offset, err := compact.Boundary(seed); err != nil || state != 1 || offset != 0 {

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -502,7 +502,7 @@ func (c *Core) shiftClassifiedUncheckpointed(boundary ClassifiedBoundary, action
 	payload, err := c.appendAuthenticatedTerminal(subtreeRecord{
 		symbol: shifted.Symbol, startByte: shifted.StartByte, endByte: shifted.EndByte,
 		extra: act.Extra, external: shifted.External, terminal: true,
-	})
+	}, shifted.LexerSkippedPrefixLength)
 	if err != nil {
 		return Head{}, err
 	}
@@ -541,7 +541,7 @@ func (c *Core) shiftDirectUncheckpointed(
 	payload, err := c.appendAuthenticatedTerminal(subtreeRecord{
 		symbol: shifted.Symbol, startByte: shifted.StartByte, endByte: shifted.EndByte,
 		extra: extra, external: shifted.External, terminal: true,
-	})
+	}, shifted.LexerSkippedPrefixLength)
 	if err != nil {
 		return Head{}, err
 	}
@@ -658,7 +658,7 @@ func (c *Core) shiftOrdinaryClassifiedCohortUncheckpointed(boundaries []Classifi
 	payload, err := c.appendAuthenticatedTerminal(subtreeRecord{
 		symbol: shifted.Symbol, startByte: shifted.StartByte, endByte: shifted.EndByte,
 		external: shifted.External, terminal: true,
-	})
+	}, shifted.LexerSkippedPrefixLength)
 	if err != nil {
 		return nil, err
 	}
@@ -784,7 +784,7 @@ func (c *Core) shiftExtraClassifiedCohortUncheckpointed(boundaries []ClassifiedB
 	payload, err := c.appendAuthenticatedTerminal(subtreeRecord{
 		symbol: shifted.Symbol, startByte: shifted.StartByte, endByte: shifted.EndByte,
 		extra: true, external: shifted.External, terminal: true,
-	})
+	}, shifted.LexerSkippedPrefixLength)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/parsercorephase0/storage_bytes.go
+++ b/internal/parsercorephase0/storage_bytes.go
@@ -93,6 +93,7 @@ var (
 	coreNodeLineageRecordBytes    = uint64(unsafe.Sizeof(nodeLineageRecord{}))
 	coreCheckpointIDBytes         = uint64(unsafe.Sizeof(CheckpointID(0)))
 	coreExternalProvenanceBytes   = uint64(unsafe.Sizeof(externalPayloadProvenance{}))
+	coreLexerSkippedPrefixBytes   = uint64(unsafe.Sizeof(lexerSkippedPrefixProvenance{}))
 	coreCheckpointRecordBytes     = uint64(unsafe.Sizeof(checkpointRecord{}))
 	coreCheckpointBucketBytes     = uint64(unsafe.Sizeof([32]byte{})) + uint64(unsafe.Sizeof(CheckpointID(0)))
 	coreBoundarySlotBytes         = uint64(unsafe.Sizeof(boundarySlot{}))
@@ -156,6 +157,7 @@ func (c *Core) FootprintBytes() uint64 {
 	total += uint64(cap(c.nodeLineages)) * coreNodeLineageRecordBytes
 	total += uint64(cap(c.nodeCheckpoints)) * coreCheckpointIDBytes
 	total += uint64(cap(c.externalProvenance)) * coreExternalProvenanceBytes
+	total += uint64(cap(c.lexerSkippedPrefixes)) * coreLexerSkippedPrefixBytes
 	total += uint64(cap(c.boundaryJournal)) * coreBoundaryMutationBytes
 	total += uint64(cap(c.nodeLineageJournal)) * coreNodeLineageMutationBytes
 	total += uint64(cap(c.dropCohortLinkRefIndexes)) * coreUint32Bytes
@@ -343,6 +345,7 @@ func (c *Core) releaseOversizedRetention() {
 	c.dropCohortLinkRefJournal = nil
 	c.subtrees = nil
 	c.externalProvenance = nil
+	c.lexerSkippedPrefixes = nil
 	c.children = nil
 	c.fields = nil
 	c.aliases = nil

--- a/language.go
+++ b/language.go
@@ -779,6 +779,13 @@ type Language struct {
 	// Custom, adapted, and stale artifacts retain the false default.
 	CompactAcceptanceStructuralElectionCertified bool
 
+	// CompactLexerSkippedPrefixTilingCertified permits an internal compact
+	// reduction gap when the next accepted terminal carries exact DFA evidence
+	// for the complete skipped prefix. Exact built-in profiles set this only
+	// after locked-C parity proves the result for that grammar artifact.
+	// Custom, adapted, and stale artifacts retain the false default.
+	CompactLexerSkippedPrefixTilingCertified bool
+
 	// ExactStackNodeEquivalenceCertified preserves deep stack-node alternatives
 	// until generic result selection. Exact built-in profiles set this only when
 	// bounded equivalence can merge parity-relevant shapes. Custom, adapted, and

--- a/parser_derived_tables_internal_test.go
+++ b/parser_derived_tables_internal_test.go
@@ -181,6 +181,7 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 
 	restoreErrorRegion := lang.CompactStrategy2ErrorRegionCertified
 	restoreStructuralElection := lang.CompactAcceptanceStructuralElectionCertified
+	restoreLexerSkippedPrefix := lang.CompactLexerSkippedPrefixTilingCertified
 	restoreMissingInsertion := lang.CompactMissingTokenInsertionCertified
 	restoreErrorModeKeyword := lang.CompactRecoveryErrorModeKeywordCaptureCertified
 	restoreSplitDrops := lang.CompactConvergedReductionSplitDropsCertified
@@ -188,6 +189,7 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 	t.Cleanup(func() {
 		lang.CompactStrategy2ErrorRegionCertified = restoreErrorRegion
 		lang.CompactAcceptanceStructuralElectionCertified = restoreStructuralElection
+		lang.CompactLexerSkippedPrefixTilingCertified = restoreLexerSkippedPrefix
 		lang.CompactMissingTokenInsertionCertified = restoreMissingInsertion
 		lang.CompactRecoveryErrorModeKeywordCaptureCertified = restoreErrorModeKeyword
 		lang.CompactConvergedReductionSplitDropsCertified = restoreSplitDrops
@@ -195,6 +197,7 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 	})
 	lang.CompactStrategy2ErrorRegionCertified = !restoreErrorRegion
 	lang.CompactAcceptanceStructuralElectionCertified = !restoreStructuralElection
+	lang.CompactLexerSkippedPrefixTilingCertified = !restoreLexerSkippedPrefix
 	lang.CompactMissingTokenInsertionCertified = !restoreMissingInsertion
 	lang.CompactRecoveryErrorModeKeywordCaptureCertified = !restoreErrorModeKeyword
 	lang.CompactConvergedReductionSplitDropsCertified = !restoreSplitDrops

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -92,6 +92,9 @@ type DiagnosticParserCorePrefixOptions struct {
 	// binds it only from an exact grammar-artifact capability.
 	allowCompactAcceptanceStructuralElection bool
 	allowConvergedSplitDropArtifact          bool
+	// captureLexerSkippedPrefixProvenance preserves exact DFA evidence only
+	// for an artifact that consumes it during accepted-tree tiling.
+	captureLexerSkippedPrefixProvenance bool
 	// allowCompactStrategy2ErrorRegion permits the generic scheduler to
 	// attempt native S3 recovery (error-region absorb and condense-resume)
 	// at a true no-table-action point instead of declining. Set only from
@@ -186,6 +189,17 @@ type DiagnosticParserCorePrefixOptions struct {
 	materializationSource                 []byte
 	materializationForceReplayParseStates bool
 	materializationContextSet             bool
+}
+
+func diagnosticParserCoreLexerSkippedPrefixLength(token Token, capture bool) uint16 {
+	if !capture || !token.lexerSkippedPrefix || token.lexerSkippedPrefixStart >= token.StartByte {
+		return 0
+	}
+	length := token.StartByte - token.lexerSkippedPrefixStart
+	if length > math.MaxUint16 {
+		return 0
+	}
+	return uint16(length)
 }
 
 type compactEOFRecoveryAdmissionState uint8
@@ -1665,6 +1679,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 	classified core.ClassifiedBoundary,
 	branchOrder uint64,
 	nextCleanPathLineage *uint16,
+	captureLexerSkippedPrefixProvenance bool,
 	allowRepetitionFork bool,
 	collectReceipts bool,
 	scratch *diagnosticParserCoreConflictScratch,
@@ -1719,6 +1734,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 			scratch.actionOutputs, scratch.reductionOutputs, applyErr = applyParserCoreConflictActionInto(
 				scratch.actionOutputs[:0], scratch.reductionOutputs[:0], compact, owner, classified, token,
 				action, ordinal, core.ForkOrder{Present: true, Value: trialOrder}, nextCleanPathLineage,
+				captureLexerSkippedPrefixProvenance,
 			)
 			if applyErr != nil {
 				return applyErr
@@ -1771,6 +1787,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 		scratch.actionOutputs, scratch.reductionOutputs, applyErr = applyParserCoreConflictActionInto(
 			scratch.actionOutputs[:0], scratch.reductionOutputs[:0], compact, owner, classified, token,
 			primaryAction, 0, core.ForkOrder{}, nextCleanPathLineage,
+			captureLexerSkippedPrefixProvenance,
 		)
 		if applyErr != nil {
 			return applyErr
@@ -4553,8 +4570,9 @@ type diagnosticParserCoreAcceptedLeafSpan struct {
 }
 
 type diagnosticParserCoreAcceptedLeafCoverageScratch struct {
-	spans                []diagnosticParserCoreAcceptedLeafSpan
-	authenticatedAliases []*Node
+	spans                           []diagnosticParserCoreAcceptedLeafSpan
+	authenticatedAliases            []*Node
+	leadingLexerSkippedPrefixStarts []uint32
 }
 
 func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) reset() {
@@ -4573,6 +4591,78 @@ func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) reset() {
 		clear(scratch.authenticatedAliases)
 		scratch.authenticatedAliases = scratch.authenticatedAliases[:0]
 	}
+	if cap(scratch.leadingLexerSkippedPrefixStarts) > parserCoreMaxRetainedAcceptedLeafSpans {
+		scratch.leadingLexerSkippedPrefixStarts = nil
+	} else {
+		clear(scratch.leadingLexerSkippedPrefixStarts)
+		scratch.leadingLexerSkippedPrefixStarts = scratch.leadingLexerSkippedPrefixStarts[:0]
+	}
+}
+
+func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) prepareLexerSkippedPrefixes(subtrees int) {
+	if scratch == nil || subtrees <= 0 {
+		return
+	}
+	if cap(scratch.leadingLexerSkippedPrefixStarts) < subtrees+1 {
+		scratch.leadingLexerSkippedPrefixStarts = make([]uint32, subtrees+1)
+		return
+	}
+	scratch.leadingLexerSkippedPrefixStarts = scratch.leadingLexerSkippedPrefixStarts[:subtrees+1]
+	clear(scratch.leadingLexerSkippedPrefixStarts)
+}
+
+func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) recordLexerSkippedPrefix(
+	id core.SubtreeID,
+	view core.MaterializationSubtreeView,
+) {
+	if scratch == nil || !view.Terminal || !view.LexerSkippedPrefix ||
+		uint64(id) >= uint64(len(scratch.leadingLexerSkippedPrefixStarts)) {
+		return
+	}
+	scratch.leadingLexerSkippedPrefixStarts[id] = view.LexerSkippedPrefixStart + 1
+}
+
+func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) propagateLeadingLexerSkippedPrefix(
+	id core.SubtreeID,
+	startByte uint32,
+	children []core.SubtreeID,
+	nodesByID []*Node,
+) {
+	if scratch == nil || uint64(id) >= uint64(len(scratch.leadingLexerSkippedPrefixStarts)) {
+		return
+	}
+	for _, childID := range children {
+		if uint64(childID) >= uint64(len(nodesByID)) || uint64(childID) >= uint64(len(scratch.leadingLexerSkippedPrefixStarts)) {
+			return
+		}
+		child := nodesByID[childID]
+		if child == nil || child.startByte > startByte {
+			return
+		}
+		if child.startByte < startByte {
+			continue
+		}
+		if encoded := scratch.leadingLexerSkippedPrefixStarts[childID]; encoded != 0 {
+			scratch.leadingLexerSkippedPrefixStarts[id] = encoded
+			return
+		}
+		if child.endByte > startByte {
+			return
+		}
+	}
+}
+
+func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) childHasLexerSkippedPrefix(
+	id core.SubtreeID,
+	startByte, endByte uint32,
+	nodesByID []*Node,
+) bool {
+	if scratch == nil || startByte >= endByte || uint64(id) >= uint64(len(scratch.leadingLexerSkippedPrefixStarts)) ||
+		uint64(id) >= uint64(len(nodesByID)) || nodesByID[id] == nil || nodesByID[id].startByte != endByte {
+		return false
+	}
+	encoded := scratch.leadingLexerSkippedPrefixStarts[id]
+	return encoded != 0 && encoded-1 == startByte
 }
 
 func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) append(
@@ -5248,19 +5338,39 @@ func diagnosticParserCoreAcceptedRootTrailingErrorExtraGap(root *Node) bool {
 // root, against a different boundary (the whole source, not a reduce's own
 // declared span) and is unaffected by this one.
 //
-// O(children) per call and allocation-free: entries are the slice
-// materializeVisit already built this call from already-materialized nodes
-// (nodesByID lookups done moments earlier); this only reads existing
-// uint32 spans and does not walk further into any child's own subtree.
+// The common path is O(children) and allocation-free. A certified non-trivia
+// gap adds one indexed lookup for the aligned raw child. The lookup admits only
+// an exact prefix whose start equals the prior coverage frontier and whose
+// terminal lineage starts at the next child boundary.
 func diagnosticParserCoreReduceChildrenTilingGap(startByte, endByte uint32, entries []stackEntry, source []byte) (gapStart, gapEnd uint32, gapped bool) {
+	return diagnosticParserCoreReduceChildrenTilingGapWithLexerProvenance(
+		startByte, endByte, entries, nil, source, nil, nil, false,
+	)
+}
+
+func diagnosticParserCoreReduceChildrenTilingGapWithLexerProvenance(
+	startByte, endByte uint32,
+	entries []stackEntry,
+	childIDs []core.SubtreeID,
+	source []byte,
+	coverage *diagnosticParserCoreAcceptedLeafCoverageScratch,
+	nodesByID []*Node,
+	allowLexerSkippedPrefix bool,
+) (gapStart, gapEnd uint32, gapped bool) {
 	lastEnd := startByte
-	for _, entry := range entries {
+	for index, entry := range entries {
 		child := stackEntryNode(entry)
 		if child == nil {
 			continue
 		}
 		if child.startByte > lastEnd && !diagnosticParserCoreGapIsTolerated(source[lastEnd:child.startByte]) {
-			return lastEnd, child.startByte, true
+			var childID core.SubtreeID
+			if index < len(childIDs) {
+				childID = childIDs[index]
+			}
+			if !allowLexerSkippedPrefix || !coverage.childHasLexerSkippedPrefix(childID, lastEnd, child.startByte, nodesByID) {
+				return lastEnd, child.startByte, true
+			}
 		}
 		if child.endByte > lastEnd {
 			lastEnd = child.endByte
@@ -5297,13 +5407,11 @@ func diagnosticParserCoreReduceChildrenTilingGap(startByte, endByte uint32, entr
 // hcl (12 instances) and doxygen (22 instances) -- both a different
 // mechanism from this class-e closure, neither touched by this predicate's
 // removal, and neither in scope here; they need their own adjudication,
-// same as the haskell residual. Retiring this predicate moves jsdoc from PASS to
-// FALLBACK on the 206-language admission scorecard (its own gap now
-// correctly declines at accepted-leaf-tiling-gap below); doxygen does not
-// regress -- verified directly, its gap sits at the derivation root
-// (isDerivationRootReduce, materializeDiagnosticParserCoreAcceptedSelection's
-// reduce visitor below), a position this predicate's retirement does not
-// touch.
+// same as the haskell residual. Retiring this predicate first moved JSDoc from
+// PASS to FALLBACK. The later exact-artifact route restores that case through
+// lexer skipped-prefix provenance in the wrapper above. This source-byte
+// predicate remains retired. Doxygen does not regress: its gap sits at the
+// derivation root, which this predicate does not check.
 //
 // A companion dispatch-time byte-continuity guard in dispatchPassActive
 // (declining before any shift crosses an unexplained gap, one site upstream
@@ -5494,8 +5602,11 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 		scratch.acceptedLeaves.reset()
 		acceptedLeaves = &scratch.acceptedLeaves
 	}
-	if !allowErrorRoot {
+	allowLexerSkippedPrefix := parser.language.CompactLexerSkippedPrefixTilingCertified
+	if !allowErrorRoot && !allowLexerSkippedPrefix {
 		acceptedLeaves = nil
+	} else if allowLexerSkippedPrefix {
+		acceptedLeaves.prepareLexerSkippedPrefixes(int(stats.Subtrees))
 	}
 	recoveryTerminalAlias := Symbol(0)
 	if scratch != nil && scratch.recoveryTerminalAliasCertified {
@@ -5507,12 +5618,17 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				return errors.New("parser-core phase zero: compact subtree extent is outside source")
 			}
 			if acceptedLeaves != nil && view.Terminal {
-				hidden := !parser.isVisibleSymbol(Symbol(view.Symbol))
-				if view.Symbol == core.RecoveryErrorSymbol {
-					hidden = false
+				if allowLexerSkippedPrefix {
+					acceptedLeaves.recordLexerSkippedPrefix(id, view)
 				}
-				if err := acceptedLeaves.append(id, view, uint32(len(source)), hidden); err != nil {
-					return err
+				if allowErrorRoot {
+					hidden := !parser.isVisibleSymbol(Symbol(view.Symbol))
+					if view.Symbol == core.RecoveryErrorSymbol {
+						hidden = false
+					}
+					if err := acceptedLeaves.append(id, view, uint32(len(source)), hidden); err != nil {
+						return err
+					}
 				}
 			}
 			named := parser.isNamedSymbol(Symbol(view.Symbol))
@@ -5608,7 +5724,12 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 			// grammar root. Every internal reduce still passes the ordinary tiling
 			// check before materialization can publish it.
 			isDerivationRootReduce := parser.hasRootSymbol && Symbol(view.Symbol) == parser.rootSymbol
-			if gapStart, gapEnd, gapped := diagnosticParserCoreReduceChildrenTilingGap(view.StartByte, view.EndByte, entries, source); !isDerivationRootReduce && gapped {
+			if allowLexerSkippedPrefix {
+				acceptedLeaves.propagateLeadingLexerSkippedPrefix(id, view.StartByte, view.Children, nodesByID)
+			}
+			if gapStart, gapEnd, gapped := diagnosticParserCoreReduceChildrenTilingGapWithLexerProvenance(
+				view.StartByte, view.EndByte, entries, view.Children, source, acceptedLeaves, nodesByID, allowLexerSkippedPrefix,
+			); !isDerivationRootReduce && gapped {
 				return &diagnosticParserCoreDecline{
 					boundary: DiagnosticParserCoreAccept,
 					detail: fmt.Sprintf(
@@ -9416,6 +9537,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	execution, err := executeDiagnosticParserCoreGenericConflictDetailed(
 		s.compact, owner, s.headers[cell.headerIndex], cell.headerIndex, cell.dispatchToken(s.token), cell.boundary,
 		s.branchOrder, &s.nextCleanPathLineage,
+		s.options.captureLexerSkippedPrefixProvenance,
 		cell.selectedBy == diagnosticParserCoreCellSelectionRepetitionFork,
 		s.fullReceipts(), &s.conflictScratch,
 	)
@@ -9623,6 +9745,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 		token := cells[0].dispatchToken(s.token)
 		heads, err := s.compact.ShiftOrdinaryClassifiedCohortWithLiveCondenseCandidatesOwned(owner, nil, s.classifiedBoundaries, core.Token{
 			Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte, External: token.ExternalScannerToken,
+			LexerSkippedPrefixLength: diagnosticParserCoreLexerSkippedPrefixLength(token, s.options.captureLexerSkippedPrefixProvenance),
 		})
 		if err != nil {
 			return err
@@ -9645,6 +9768,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 			token := cell.dispatchToken(s.token)
 			shifted := core.Token{
 				Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte, External: token.ExternalScannerToken,
+				LexerSkippedPrefixLength: diagnosticParserCoreLexerSkippedPrefixLength(token, s.options.captureLexerSkippedPrefixProvenance),
 			}
 			head, err := s.compact.ShiftClassifiedWithLiveCondenseCandidatesOwned(
 				owner, s.collectCondenseCandidates(cell.headerIndex),
@@ -9735,6 +9859,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 					core.Token{
 						Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte,
 						Extra: true, External: token.ExternalScannerToken,
+						LexerSkippedPrefixLength: diagnosticParserCoreLexerSkippedPrefixLength(token, s.options.captureLexerSkippedPrefixProvenance),
 					},
 					core.ForkOrder{},
 				)
@@ -9753,6 +9878,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 			heads, shiftErr := s.compact.ShiftExtraClassifiedCohortWithLiveCondenseCandidatesOwned(owner, nil, s.classifiedBoundaries, core.Token{
 				Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte,
 				Extra: true, External: token.ExternalScannerToken,
+				LexerSkippedPrefixLength: diagnosticParserCoreLexerSkippedPrefixLength(token, s.options.captureLexerSkippedPrefixProvenance),
 			})
 			if shiftErr != nil {
 				return shiftErr
@@ -10282,7 +10408,10 @@ func authenticatedParserCoreGoLanguage(scanner ExternalScanner) (*Language, erro
 func applyParserCorePrefixAction(compact *core.Core, head core.Head, token Token, action core.Action, ordinal int, fork core.ForkOrder) ([]core.Head, error) {
 	switch action.Type {
 	case core.ActionShift:
-		out, err := compact.Shift(head, core.Symbol(token.Symbol), ordinal, core.Token{Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte, Extra: action.Extra, External: token.ExternalScannerToken}, fork)
+		out, err := compact.Shift(head, core.Symbol(token.Symbol), ordinal, core.Token{
+			Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte,
+			Extra: action.Extra, External: token.ExternalScannerToken,
+		}, fork)
 		return []core.Head{out}, err
 	case core.ActionReduce:
 		return compact.Reduce(head, core.Symbol(token.Symbol), ordinal, fork)
@@ -10306,11 +10435,16 @@ func applyParserCoreConflictActionInto(
 	ordinal int,
 	fork core.ForkOrder,
 	nextCleanPathLineage *uint16,
+	captureLexerSkippedPrefixProvenance bool,
 ) ([]diagnosticParserCoreActionOutput, []core.ReductionOutput, error) {
 	if action.Type != core.ActionReduce {
 		switch action.Type {
 		case core.ActionShift:
-			head, err := compact.ShiftClassifiedOwned(owner, classified, ordinal, core.Token{Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte, Extra: action.Extra, External: token.ExternalScannerToken}, fork)
+			head, err := compact.ShiftClassifiedOwned(owner, classified, ordinal, core.Token{
+				Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte,
+				Extra: action.Extra, External: token.ExternalScannerToken,
+				LexerSkippedPrefixLength: diagnosticParserCoreLexerSkippedPrefixLength(token, captureLexerSkippedPrefixProvenance),
+			}, fork)
 			if err != nil {
 				return nil, reductionDst, err
 			}

--- a/parsercore_phase0_lexer_skip_tiling_test.go
+++ b/parsercore_phase0_lexer_skip_tiling_test.go
@@ -1,0 +1,64 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func TestCompactLexerSkippedPrefixTilingRequiresAlignedChildProof(t *testing.T) {
+	source := []byte("a^b")
+	left := &Node{startByte: 0, endByte: 1}
+	right := &Node{startByte: 2, endByte: 3}
+	entries := []stackEntry{newStackEntryNode(0, left), newStackEntryNode(0, right)}
+	childIDs := []core.SubtreeID{1, 2}
+	nodesByID := []*Node{nil, left, right, right}
+	coverage := &diagnosticParserCoreAcceptedLeafCoverageScratch{
+		leadingLexerSkippedPrefixStarts: []uint32{0, 0, 2, 2},
+	}
+
+	if gapStart, gapEnd, gapped := diagnosticParserCoreReduceChildrenTilingGapWithLexerProvenance(
+		0, 3, entries, childIDs, source, coverage, nodesByID, true,
+	); gapped {
+		t.Fatalf("exact aligned prefix produced gap=%d..%d", gapStart, gapEnd)
+	}
+
+	tests := []struct {
+		name      string
+		ids       []core.SubtreeID
+		proofs    []uint32
+		certified bool
+	}{
+		{name: "uncertified", ids: childIDs, proofs: []uint32{0, 0, 2}, certified: false},
+		{name: "wrong_prefix_start", ids: childIDs, proofs: []uint32{0, 0, 1}, certified: true},
+		{name: "proof_on_unrelated_subtree", ids: childIDs, proofs: []uint32{0, 0, 0, 2}, certified: true},
+		{name: "misaligned_child_id", ids: []core.SubtreeID{1, 3}, proofs: []uint32{0, 0, 2, 0}, certified: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			coverage.leadingLexerSkippedPrefixStarts = test.proofs
+			gapStart, gapEnd, gapped := diagnosticParserCoreReduceChildrenTilingGapWithLexerProvenance(
+				0, 3, entries, test.ids, source, coverage, nodesByID, test.certified,
+			)
+			if !gapped || gapStart != 1 || gapEnd != 2 {
+				t.Fatalf("gap=%d..%d gapped=%t, want 1..2 true", gapStart, gapEnd, gapped)
+			}
+		})
+	}
+}
+
+func TestCompactLexerSkippedPrefixLengthFailsClosedWhenUnbounded(t *testing.T) {
+	bounded := Token{StartByte: 65535, lexerSkippedPrefix: true, lexerSkippedPrefixStart: 0}
+	if got := diagnosticParserCoreLexerSkippedPrefixLength(bounded, true); got != 65535 {
+		t.Fatalf("bounded prefix length=%d, want 65535", got)
+	}
+	unbounded := Token{StartByte: 65536, lexerSkippedPrefix: true, lexerSkippedPrefixStart: 0}
+	if got := diagnosticParserCoreLexerSkippedPrefixLength(unbounded, true); got != 0 {
+		t.Fatalf("unbounded prefix length=%d, want fail-closed zero", got)
+	}
+	if got := diagnosticParserCoreLexerSkippedPrefixLength(bounded, false); got != 0 {
+		t.Fatalf("uncertified prefix length=%d, want zero", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Capture exact internal deterministic finite automaton skipped-prefix evidence at every live compact shift seam.
- Store proofs in a sparse sidecar while keeping Token at 16 bytes and subtreeRecord at 44 bytes.
- Admit an interior reduce gap only when the aligned child proves the complete prefix.
- Bind the capability to the exact built-in JSDoc blob hash.
- Keep custom, adapted, stale, unbounded, and misaligned inputs fail closed.
- Move the admission scorecard from 199/2/5 to 200/1/5.

## Safety

- Checkpoint, rollback, reset, memory accounting, retention release, and EOF shadow clones include the new sidecar.
- Prefixes longer than 65,535 bytes decline to production.
- External tokens and invalid prefix geometry reject before publication.
- The retired source-byte decoration exception remains retired.

## Verification

- Docker core suites pass with default and EOF shadow tags.
- Default and no-parsercore build tags compile.
- The focused JSDoc route test passes under the race detector.
- The measured scorecard is 200 PASS, 0 DIVERGE, 1 FALLBACK, 5 SKIP, and 0 ERROR.
- Locked-C originals and eight mutations match symbols, fields, spans, points, extras, missing flags, error flags, and deep digests.
- The exhaustive embedded JSDoc C parity test passes.
- Canopy validates 2,250 files with zero stale entries or parse errors.
- Buckley found no code defects. Its approval harness cannot execute the repository-required Docker commands.

## Performance

An alternating 20-seed comparison used 750 ms samples and one process per seed.

- Full parse: no significant change, p=0.904.
- Incremental single-byte edit: no significant change, p=0.251.
- Incremental no-edit: no significant change, p=0.273.
- Allocation counts are unchanged.
- The timing geomean improves 0.29 percent.

## Harness note

The generic regenerated JSDoc corpus harness cannot attach the embedded external scanner. Exact embedded-artifact locked-C tests provide the applicable gate.