### PR TITLE
Graduate Markdown inline compact parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,15 @@ for tags and release notes while still in `0.x`.
 
 ### Correctness
 
+- Graduated the Markdown inline smoke route with four exact, compact-only
+  conflict policies bound to the built-in grammar blob. Three repetition
+  reductions require at least two live compact headers. The HTML entry row
+  selects its sole shift. All other repetition rows still fail closed.
+  The locked upstream corpus reports 15 direct routes and 348 fallbacks across
+  363 cases. Every direct tree matches C exactly. The nested-emphasis
+  counterexample remains a required fallback. The admission scorecard now
+  reports 201 PASS, zero DIVERGE, zero FALLBACK, five SKIP, and zero ERROR rows.
+
 - Apply the production route's contextual close-angle deferral in the
   compact dispatch and the C4 corridor (issue #983). Add the two Swift
   witnesses to the committed route-equality seed corpus. Totals stay

--- a/admission_scorecard_test.go
+++ b/admission_scorecard_test.go
@@ -81,7 +81,7 @@ var admissionScorecardRequiredCompactPasses = map[string]struct{}{
 	"hlsl": {}, "html": {}, "http": {}, "hurl": {}, "hyprlang": {}, "ini": {}, "janet": {}, "javascript": {}, "jinja2": {}, "jq": {}, "jsdoc": {},
 	"json5": {}, "jsonnet": {}, "julia": {}, "just": {}, "kconfig": {}, "kdl": {}, "kotlin": {},
 	"ledger": {}, "less": {}, "linkerscript": {}, "liquid": {}, "llvm": {}, "lua": {},
-	"luau": {}, "make": {}, "markdown": {}, "matlab": {}, "mermaid": {}, "meson": {}, "mojo": {},
+	"luau": {}, "make": {}, "markdown": {}, "markdown_inline": {}, "matlab": {}, "mermaid": {}, "meson": {}, "mojo": {},
 	"move": {}, "nginx": {}, "nickel": {}, "nim": {}, "ninja": {}, "nix": {}, "norg": {}, "nushell": {},
 	"objc": {}, "ocaml": {}, "odin": {}, "org": {}, "pascal": {}, "pem": {}, "perl": {},
 	"php": {}, "pkl": {}, "powershell": {}, "prisma": {}, "prolog": {}, "promql": {},
@@ -147,14 +147,12 @@ func TestAdmissionCandidateScorecard206(t *testing.T) {
 		// registry drift, or surrendered route coverage require an explicit
 		// review and ratchet update.
 		//
-		// The 200/1/5 ratchet includes JSDoc's locked-C lexer skipped-prefix
-		// tiling route. One language retains a fail-closed FALLBACK row:
-		//
-		//   - markdown_inline reaches its existing repetition-shift boundary.
+		// The 201/0/5 ratchet includes Markdown inline's exact compact conflict
+		// policies. Its smoke route now reaches authenticated EOF.
 		const (
 			wantTotal   = 206
-			minPass     = 200
-			maxFallback = 1
+			minPass     = 201
+			maxFallback = 0
 			wantSkip    = 5
 		)
 		if got := len(admissionScorecardRequiredCompactPasses); got != minPass {

--- a/cgo_harness/markdown_inline_retirement_parity_test.go
+++ b/cgo_harness/markdown_inline_retirement_parity_test.go
@@ -1,0 +1,391 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestMarkdownInlineConflictPolicyLockedCParity(t *testing.T) {
+	language := grammars.MarkdownInlineLanguage()
+	if language == nil {
+		t.Fatal("Markdown inline Go language is nil")
+	}
+	if got := len(language.ConflictPolicies); got != 4 {
+		t.Fatalf("Markdown inline conflict policies = %d, want 4", got)
+	}
+	cLanguage, err := COracleLanguage("markdown_inline")
+	if err != nil {
+		t.Fatalf("load locked Markdown inline language: %v", err)
+	}
+
+	tests := []struct {
+		name            string
+		source          string
+		requireDirect   bool
+		requireFallback bool
+	}{
+		{name: "scorecard smoke", source: "hello **world**\n", requireDirect: true},
+		{name: "attribute link tag", source: `<link rel="stylesheet" href="x">`, requireDirect: true},
+		{name: "simple link tag", source: `<link>`},
+		{name: "unquoted attribute", source: `<link rel=x>`},
+		{name: "image attributes", source: `<img src="x" alt="y">`},
+		{name: "paired anchor", source: `<a href="x">text</a>`},
+		{name: "custom paired tag", source: `<custom data-x="1">body</custom>`},
+		{name: "embedded tag", source: `before <link rel="stylesheet" href="x"> after`},
+		{name: "plain text", source: "plain text"},
+		{name: "emphasis families", source: "**bold** and *emphasis*"},
+		{name: "literal tilde link", source: `[Context](https://example.com/~user/file.pdf)`, requireFallback: true},
+		{name: "nested emphasis counterexample", source: `*foo**bar**baz*`, requireFallback: true},
+		{name: "comment", source: `<!-- comment -->`},
+	}
+
+	direct, fallback := 0, 0
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := []byte(test.source)
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("locked C parser returned no tree")
+			}
+			t.Cleanup(cTree.Close)
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			t.Cleanup(production.Release)
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			candidateParser := gotreesitter.NewParser(language)
+			candidateParser.SetAdmissionCandidateRoute(true)
+			candidate, err := candidateParser.Parse(source)
+			if err != nil {
+				t.Fatalf("candidate parse: %v", err)
+			}
+			t.Cleanup(candidate.Release)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			routedDelta := routedAfter - routedBefore
+			fallbackDelta := fallbackAfter - fallbackBefore
+			switch {
+			case routedDelta == 1 && fallbackDelta == 0:
+				direct++
+				t.Log("candidate route=direct")
+			case routedDelta == 0 && fallbackDelta == 1:
+				fallback++
+				t.Logf("candidate route=fallback reason=%s", gotreesitter.AdmissionCandidateLastFallbackReason())
+			default:
+				t.Fatalf("candidate route delta=%d/%d, want one direct or fallback route", routedDelta, fallbackDelta)
+			}
+			if test.requireDirect && routedDelta != 1 {
+				t.Fatalf("candidate route delta=%d/%d, want direct", routedDelta, fallbackDelta)
+			}
+			if test.requireFallback && fallbackDelta != 1 {
+				t.Fatalf("candidate route delta=%d/%d, want fallback", routedDelta, fallbackDelta)
+			}
+
+			assertJsdocLockedCTreeExact(t, "Markdown inline production", production, language, cTree, cDigest)
+			assertJsdocLockedCTreeExact(t, "Markdown inline candidate", candidate, language, cTree, cDigest)
+		})
+	}
+	if direct == 0 || fallback == 0 {
+		t.Fatalf("candidate routes direct=%d fallback=%d, want both", direct, fallback)
+	}
+}
+
+func TestMarkdownInlineConflictPolicyCorpusLockedCParity(t *testing.T) {
+	language := grammars.MarkdownInlineLanguage()
+	baseline, err := grammars.LoadLanguage("markdown_inline", grammars.BlobByName("markdown_inline"))
+	if err != nil {
+		t.Fatalf("load baseline Markdown inline language: %v", err)
+	}
+	baseline.ConflictPolicies = nil
+	cLanguage, err := COracleLanguage("markdown_inline")
+	if err != nil {
+		t.Fatalf("load locked Markdown inline language: %v", err)
+	}
+	cases, err := markdownInlineLockedCorpusCases()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cases) < 100 {
+		t.Fatalf("Markdown inline locked corpus cases = %d, want at least 100", len(cases))
+	}
+
+	direct, fallback := 0, 0
+	for _, test := range cases {
+		baselineParser := gotreesitter.NewParser(baseline)
+		baselineParser.SetAdmissionCandidateRoute(false)
+		baselineTree, err := baselineParser.Parse(test.source)
+		if err != nil {
+			t.Fatalf("%s baseline parse: %v", test.label, err)
+		}
+
+		productionParser := gotreesitter.NewParser(language)
+		productionParser.SetAdmissionCandidateRoute(false)
+		productionTree, err := productionParser.Parse(test.source)
+		if err != nil {
+			baselineTree.Release()
+			t.Fatalf("%s production parse: %v", test.label, err)
+		}
+
+		baselineDigest := markdownInlineGoDigest(t, test.label+" baseline", baselineTree, baseline)
+		productionDigest := markdownInlineGoDigest(t, test.label+" production", productionTree, language)
+		baselineTree.Release()
+		if productionDigest != baselineDigest {
+			productionTree.Release()
+			t.Fatalf("%s policy changed production tree: baseline=%s production=%s", test.label, baselineDigest, productionDigest)
+		}
+
+		routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+		candidateParser := gotreesitter.NewParser(language)
+		candidateParser.SetAdmissionCandidateRoute(true)
+		candidateTree, err := candidateParser.Parse(test.source)
+		if err != nil {
+			productionTree.Release()
+			t.Fatalf("%s candidate parse: %v", test.label, err)
+		}
+		routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+		routedDelta := routedAfter - routedBefore
+		fallbackDelta := fallbackAfter - fallbackBefore
+		candidateDigest := markdownInlineGoDigest(t, test.label+" candidate", candidateTree, language)
+		if candidateDigest != productionDigest {
+			candidateTree.Release()
+			productionTree.Release()
+			t.Fatalf("%s candidate=%s production=%s", test.label, candidateDigest, productionDigest)
+		}
+
+		switch {
+		case routedDelta == 1 && fallbackDelta == 0:
+			direct++
+			cParser := sitter.NewParser()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				cParser.Close()
+				candidateTree.Release()
+				productionTree.Release()
+				t.Fatalf("%s set C language: %v", test.label, err)
+			}
+			cTree := cParser.Parse(test.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				cParser.Close()
+				candidateTree.Release()
+				productionTree.Release()
+				t.Fatalf("%s locked C parser returned no tree", test.label)
+			}
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				cTree.Close()
+				cParser.Close()
+				candidateTree.Release()
+				productionTree.Release()
+				t.Fatalf("%s C digest: %v", test.label, err)
+			}
+			if candidateDigest != cDigest {
+				cTree.Close()
+				cParser.Close()
+				candidateTree.Release()
+				productionTree.Release()
+				t.Fatalf("%s direct compact tree diverges from C: compact=%s C=%s", test.label, candidateDigest, cDigest)
+			}
+			cTree.Close()
+			cParser.Close()
+		case routedDelta == 0 && fallbackDelta == 1:
+			fallback++
+		default:
+			candidateTree.Release()
+			productionTree.Release()
+			t.Fatalf("%s candidate route delta=%d/%d", test.label, routedDelta, fallbackDelta)
+		}
+		candidateTree.Release()
+		productionTree.Release()
+	}
+	if direct == 0 || fallback == 0 {
+		t.Fatalf("Markdown inline locked corpus routes direct=%d fallback=%d, want both", direct, fallback)
+	}
+	t.Logf("Markdown inline locked corpus cases=%d direct=%d fallback=%d", len(cases), direct, fallback)
+}
+
+type markdownInlineCorpusCase struct {
+	label  string
+	source []byte
+}
+
+func markdownInlineLockedCorpusCases() ([]markdownInlineCorpusCase, error) {
+	entry, ok := parityCRefState.lock["markdown_inline"]
+	if !ok {
+		return nil, fmt.Errorf("locked Markdown inline entry is unavailable")
+	}
+	repo := filepath.Join(parityCRefState.rootDir, "repos", "markdown_inline")
+	if _, err := os.Stat(repo); os.IsNotExist(err) {
+		commitShort := entry.Commit
+		if len(commitShort) > 12 {
+			commitShort = commitShort[:12]
+		}
+		if cacheDir := parityRepoCacheDir(); cacheDir != "" {
+			cachedRepo, cacheErr := findCachedParityRepo(cacheDir, entry.Name, commitShort)
+			if cacheErr != nil {
+				return nil, cacheErr
+			}
+			if err := clonePinnedRepoFromLocalCache(cachedRepo, entry.Commit, repo); err != nil {
+				return nil, err
+			}
+		} else if err := clonePinnedRepo(entry.RepoURL, entry.Commit, repo); err != nil {
+			return nil, err
+		}
+	}
+	if err := verifyPinnedRepo(repo, entry.Commit); err != nil {
+		return nil, err
+	}
+	corpus := filepath.Join(repo, filepath.Dir(entry.Subdir), "test", "corpus")
+	if info, err := os.Stat(corpus); err != nil || !info.IsDir() {
+		var corpusDirs []string
+		findErr := filepath.WalkDir(repo, func(path string, item fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if item.IsDir() && item.Name() == "corpus" && filepath.Base(filepath.Dir(path)) == "test" {
+				corpusDirs = append(corpusDirs, path)
+			}
+			return nil
+		})
+		if findErr != nil {
+			return nil, findErr
+		}
+		corpus = ""
+		for _, candidate := range corpusDirs {
+			if strings.Contains(filepath.ToSlash(candidate), "markdown-inline") {
+				corpus = candidate
+				break
+			}
+		}
+		if corpus == "" && len(corpusDirs) == 1 {
+			corpus = corpusDirs[0]
+		}
+		if corpus == "" {
+			return nil, fmt.Errorf("locked Markdown inline corpus directory is unavailable under %s; candidates=%v", repo, corpusDirs)
+		}
+	}
+	var cases []markdownInlineCorpusCase
+	err := filepath.WalkDir(corpus, func(path string, item fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if item.IsDir() {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(corpus, path)
+		if err != nil {
+			return err
+		}
+		fileCases, ok := markdownInlineSplitCorpusSources(content)
+		if !ok {
+			return fmt.Errorf("parse Markdown inline corpus file %s", rel)
+		}
+		for index, test := range fileCases {
+			cases = append(cases, markdownInlineCorpusCase{
+				label:  fmt.Sprintf("%s:%d:%s", filepath.ToSlash(rel), index, test.label),
+				source: test.source,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return cases, nil
+}
+
+func markdownInlineSplitCorpusSources(content []byte) ([]markdownInlineCorpusCase, bool) {
+	text := strings.ReplaceAll(string(content), "\r\n", "\n")
+	lines := strings.SplitAfter(text, "\n")
+	cases := make([]markdownInlineCorpusCase, 0, 4)
+	for index := 0; index < len(lines); {
+		if !markdownInlineRepeatedCorpusLine(lines[index], '=') {
+			index++
+			continue
+		}
+		if index+1 >= len(lines) {
+			return nil, false
+		}
+		label := strings.TrimSpace(lines[index+1])
+		index += 2
+		for index < len(lines) && !markdownInlineRepeatedCorpusLine(lines[index], '=') {
+			line := strings.TrimSpace(lines[index])
+			if line != "" && !strings.HasPrefix(line, ":") {
+				return nil, false
+			}
+			index++
+		}
+		if index >= len(lines) {
+			return nil, false
+		}
+		index++
+		if index < len(lines) && strings.TrimSpace(lines[index]) == "" {
+			index++
+		}
+		start := index
+		for index < len(lines) && !markdownInlineRepeatedCorpusLine(lines[index], '-') {
+			index++
+		}
+		if index >= len(lines) {
+			return nil, false
+		}
+		source := strings.Join(lines[start:index], "")
+		if strings.TrimSpace(source) == "" {
+			return nil, false
+		}
+		cases = append(cases, markdownInlineCorpusCase{label: label, source: []byte(source)})
+		index++
+		for index < len(lines) && !markdownInlineRepeatedCorpusLine(lines[index], '=') {
+			index++
+		}
+	}
+	return cases, len(cases) > 0
+}
+
+func markdownInlineRepeatedCorpusLine(line string, want rune) bool {
+	line = strings.TrimSpace(line)
+	if len(line) < 3 {
+		return false
+	}
+	for _, current := range line {
+		if current != want {
+			return false
+		}
+	}
+	return true
+}
+
+func markdownInlineGoDigest(t *testing.T, label string, tree *gotreesitter.Tree, language *gotreesitter.Language) string {
+	t.Helper()
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatalf("%s digest: %v", label, err)
+	}
+	return inspection.SHA256
+}

--- a/conflict_policy.go
+++ b/conflict_policy.go
@@ -1,14 +1,18 @@
 package gotreesitter
 
 func conflictPolicyChoice(lang *Language, tok Token, currentState StateID, actions []ParseAction) (ParseAction, bool) {
-	return conflictPolicyChoiceForContext(lang, nil, false, tok, currentState, actions)
+	return conflictPolicyChoiceForContextAndCompactFrontier(lang, nil, false, tok, currentState, actions, 0, false)
 }
 
 func conflictPolicyChoiceForDispatch(lang *Language, stack *glrStack, tok Token, currentState StateID, actions []ParseAction) (ParseAction, bool) {
-	return conflictPolicyChoiceForContext(lang, stack, true, tok, currentState, actions)
+	return conflictPolicyChoiceForContextAndCompactFrontier(lang, stack, true, tok, currentState, actions, 0, false)
 }
 
-func conflictPolicyChoiceForContext(lang *Language, stack *glrStack, allowRecovered bool, tok Token, currentState StateID, actions []ParseAction) (ParseAction, bool) {
+func conflictPolicyChoiceForCompact(lang *Language, tok Token, currentState StateID, actions []ParseAction, frontierHeaders int) (ParseAction, bool) {
+	return conflictPolicyChoiceForContextAndCompactFrontier(lang, nil, false, tok, currentState, actions, frontierHeaders, true)
+}
+
+func conflictPolicyChoiceForContextAndCompactFrontier(lang *Language, stack *glrStack, allowRecovered bool, tok Token, currentState StateID, actions []ParseAction, frontierHeaders int, compact bool) (ParseAction, bool) {
 	if lang == nil || len(lang.ConflictPolicies) == 0 {
 		return ParseAction{}, false
 	}
@@ -18,6 +22,12 @@ func conflictPolicyChoiceForContext(lang *Language, stack *glrStack, allowRecove
 			continue
 		}
 		if policy.Lookahead != tok.Symbol && policy.Lookahead != ConflictPolicyAnyLookahead {
+			continue
+		}
+		if policy.CompactOnly && !compact {
+			continue
+		}
+		if compact && int(policy.CompactMinFrontierHeaders) > frontierHeaders {
 			continue
 		}
 		if policy.Kind == ConflictPolicyRecoveredRepetitionReduce {

--- a/conflict_policy_test.go
+++ b/conflict_policy_test.go
@@ -57,6 +57,30 @@ func TestConflictPolicyChoiceRepetitionReduce(t *testing.T) {
 	}
 }
 
+func TestConflictPolicyChoiceCompactFrontierMinimum(t *testing.T) {
+	lang := &Language{
+		ConflictPolicies: []ConflictPolicy{{
+			State: 42, Lookahead: 7, Kind: ConflictPolicyRepetitionReduce,
+			CompactOnly: true, CompactMinFrontierHeaders: 2, ReduceSymbols: []Symbol{3},
+		}},
+	}
+	reduce := ParseAction{Type: ParseActionReduce, Symbol: 3, ChildCount: 2}
+	actions := []ParseAction{
+		reduce,
+		{Type: ParseActionShift, State: 99, Repetition: true},
+	}
+
+	if chosen, ok := conflictPolicyChoice(lang, Token{Symbol: 7}, 42, actions); ok {
+		t.Fatalf("production conflict policy choice = %+v, want no choice", chosen)
+	}
+	if chosen, ok := conflictPolicyChoiceForCompact(lang, Token{Symbol: 7}, 42, actions, 1); ok {
+		t.Fatalf("single-header compact choice = %+v, want no choice", chosen)
+	}
+	if chosen, ok := conflictPolicyChoiceForCompact(lang, Token{Symbol: 7}, 42, actions, 2); !ok || chosen != reduce {
+		t.Fatalf("two-header compact choice = %+v, %t, want reduce", chosen, ok)
+	}
+}
+
 func TestConflictPolicyChoiceShift(t *testing.T) {
 	lang := &Language{
 		Name:                  "synthetic_policy_test",
@@ -577,7 +601,7 @@ func TestConflictPolicyGobRoundTrip(t *testing.T) {
 	lang := &Language{
 		Name: "synthetic_policy_test",
 		ConflictPolicies: []ConflictPolicy{
-			{State: 42, Lookahead: 7, Kind: ConflictPolicyRepetitionShift, ReduceSymbols: []Symbol{3, 4}},
+			{State: 42, Lookahead: 7, Kind: ConflictPolicyRepetitionShift, CompactOnly: true, CompactMinFrontierHeaders: 2, ReduceSymbols: []Symbol{3, 4}},
 			{State: 86, Lookahead: 25, Kind: ConflictPolicyRecoveredRepetitionReduce, ReduceSymbols: []Symbol{68}},
 		},
 	}
@@ -594,7 +618,7 @@ func TestConflictPolicyGobRoundTrip(t *testing.T) {
 		t.Fatalf("decoded %d policies, want 2", len(decoded.ConflictPolicies))
 	}
 	got := decoded.ConflictPolicies[0]
-	if got.State != 42 || got.Lookahead != 7 || got.Kind != ConflictPolicyRepetitionShift {
+	if got.State != 42 || got.Lookahead != 7 || got.Kind != ConflictPolicyRepetitionShift || !got.CompactOnly || got.CompactMinFrontierHeaders != 2 {
 		t.Fatalf("decoded policy = %+v, want state/lookahead/kind preserved", got)
 	}
 	if len(got.ReduceSymbols) != 2 || got.ReduceSymbols[0] != 3 || got.ReduceSymbols[1] != 4 {

--- a/grammars/markdown_inline_retirement_route_receipt_test.go
+++ b/grammars/markdown_inline_retirement_route_receipt_test.go
@@ -1,0 +1,127 @@
+//go:build !grammar_subset
+
+package grammars
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+func TestMarkdownInlineConflictPolicyRoutes(t *testing.T) {
+	language := MarkdownInlineLanguage()
+	tests := []struct {
+		name            string
+		source          []byte
+		sha256          string
+		wantRoutePrefix string
+		rootChild       string
+	}{
+		{
+			name:            "scorecard_smoke",
+			source:          []byte("hello **world**\n"),
+			sha256:          "88b7bf652dde424406390fbe63851869eb11050a5569c2773e9744cc8ca5ac90",
+			wantRoutePrefix: "direct",
+		},
+		{
+			name:            "attribute_html_tag",
+			source:          []byte(`<link rel="stylesheet" href="x">`),
+			sha256:          "b3499e8d88dcc40917d566772bc94bea47f92018c864e575b113ccfa6290066c",
+			wantRoutePrefix: "direct",
+			rootChild:       "html_tag",
+		},
+		{
+			name:            "literal_tilde_link_destination",
+			source:          []byte(`[Context](https://example.com/~user/file.pdf)`),
+			sha256:          "4a2bbb87bef0ba0c446fc35f86391a4f5f1eee0da508b2249c68c8e141741398",
+			wantRoutePrefix: "fallback:compact route error: parser-core fresh-full runner did not accept EOF",
+		},
+		{
+			name:            "nested_emphasis_counterexample",
+			source:          []byte(`*foo**bar**baz*`),
+			sha256:          "35d595d10fb333d2b45c1364ee00ae6e8a3d7c5464184ba46a893e4a75058327",
+			wantRoutePrefix: "fallback:compact route error: parser-core fresh-full runner did not accept EOF",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := fmt.Sprintf("%x", sha256.Sum256(test.source)); got != test.sha256 {
+				t.Fatalf("source SHA-256 = %s, want %s", got, test.sha256)
+			}
+			production := markdownInlineParseRoute(t, language, test.source, false)
+			candidate := markdownInlineParseRoute(t, language, test.source, true)
+			if !strings.HasPrefix(candidate.route, test.wantRoutePrefix) {
+				t.Fatalf("compact route = %q, want prefix %q", candidate.route, test.wantRoutePrefix)
+			}
+			if candidate.digest != production.digest {
+				t.Fatalf("compact digest = %s, production digest = %s", candidate.digest, production.digest)
+			}
+			if test.rootChild != "" {
+				root := candidate.tree.RootNode()
+				if root.HasError() || root.ChildCount() != 1 || root.Child(0).Type(language) != test.rootChild {
+					t.Fatalf("compact tree = %s, want one clean %s child", root.SExpr(language), test.rootChild)
+				}
+			}
+		})
+	}
+
+	uncertified, err := LoadLanguage("markdown_inline", BlobByName("markdown_inline"))
+	if err != nil {
+		t.Fatalf("load uncertified Markdown inline language: %v", err)
+	}
+	uncertified.ConflictPolicies = nil
+	production := markdownInlineParseRoute(t, language, tests[1].source, false)
+	candidate := markdownInlineParseRoute(t, uncertified, tests[1].source, true)
+	if !strings.HasPrefix(candidate.route, "fallback:compact route error: parser-core fresh-full runner did not accept EOF") {
+		t.Fatalf("uncertified compact route = %q, want fail-closed EOF fallback", candidate.route)
+	}
+	if candidate.digest != production.digest {
+		t.Fatalf("uncertified digest = %s, production digest = %s", candidate.digest, production.digest)
+	}
+}
+
+type markdownInlineRouteResult struct {
+	route  string
+	digest string
+	tree   *gotreesitter.Tree
+}
+
+func markdownInlineParseRoute(t *testing.T, language *gotreesitter.Language, source []byte, compact bool) markdownInlineRouteResult {
+	t.Helper()
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	parser := gotreesitter.NewParser(language)
+	parser.SetAdmissionCandidateRoute(compact)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse compact=%t: %v", compact, err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatalf("parse compact=%t returned no root", compact)
+	}
+	t.Cleanup(tree.Release)
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compact {
+		return markdownInlineRouteResult{route: "production", digest: inspection.SHA256, tree: tree}
+	}
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	switch {
+	case routedAfter == routedBefore+1 && fallbackAfter == fallbackBefore:
+		return markdownInlineRouteResult{route: "direct", digest: inspection.SHA256, tree: tree}
+	case routedAfter == routedBefore && fallbackAfter == fallbackBefore+1:
+		reason := gotreesitter.AdmissionCandidateLastFallbackReason()
+		if reason == "" {
+			t.Fatal("compact fallback has no reason")
+		}
+		return markdownInlineRouteResult{route: "fallback:" + reason, digest: inspection.SHA256, tree: tree}
+	default:
+		t.Fatalf("compact counters routed=%d/%d fallback=%d/%d", routedBefore, routedAfter, fallbackBefore, fallbackAfter)
+		return markdownInlineRouteResult{}
+	}
+}

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -99,6 +99,18 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		blobSHA256:                      mustRuntimeProfileSHA256("e5688e60d41d6ef2d0922de7687b597de0c880761064e9e7b994d401c5508312"),
 		compactLexerSkippedPrefixTiling: true,
 	},
+	// The compact Markdown inline route reduces three proved emphasis rows.
+	// It starts an HTML tag through the sole shift in the fourth exact row.
+	// All other repetition rows remain outside compact admission.
+	"markdown_inline": {
+		blobSHA256: mustRuntimeProfileSHA256("6a9064afbce4db62ab6cca8c143a9d3ae465e639a7ed81109eb65afd85469e0d"),
+		conflictPolicies: []gotreesitter.ConflictPolicy{
+			{State: 18, Lookahead: 56, Kind: gotreesitter.ConflictPolicyRepetitionReduce, CompactOnly: true, CompactMinFrontierHeaders: 2, ReduceSymbols: []gotreesitter.Symbol{107}},
+			{State: 18, Lookahead: 50, Kind: gotreesitter.ConflictPolicyRepetitionReduce, CompactOnly: true, CompactMinFrontierHeaders: 2, ReduceSymbols: []gotreesitter.Symbol{107}},
+			{State: 18, Lookahead: 36, Kind: gotreesitter.ConflictPolicyRepetitionReduce, CompactOnly: true, CompactMinFrontierHeaders: 2, ReduceSymbols: []gotreesitter.Symbol{107}},
+			{State: 209, Lookahead: 50, Kind: gotreesitter.ConflictPolicyShift, CompactOnly: true, ReduceSymbols: []gotreesitter.Symbol{104}},
+		},
+	},
 	// C-oracle parity certifies the complete compact recovery competition for
 	// this exact artifact against the ten pinned HTML witnesses.
 	"html": {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -138,7 +138,9 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	// C-native reading during dispatch.
 	// 49 = the prior 48 plus the JSDoc entry. It certifies exact internal-DFA
 	// skipped-prefix evidence for compact reduce tiling.
-	if got, want := len(builtinLanguageRuntimeProfiles), 49; got != want {
+	// 50 = the prior 49 plus the Markdown inline entry. It certifies four exact
+	// compact conflict rows while production parsing ignores them.
+	if got, want := len(builtinLanguageRuntimeProfiles), 50; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -660,6 +660,50 @@ func TestBuiltinDartConflictPoliciesAttach(t *testing.T) {
 	}
 }
 
+func TestBuiltinMarkdownInlineConflictPolicyRequiresExactBlob(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+
+	builtin := MarkdownInlineLanguage()
+	if got := len(builtin.ConflictPolicies); got != 4 {
+		t.Fatalf("Markdown inline conflict policies = %d, want 4", got)
+	}
+	fold := builtin.ConflictPolicies[0]
+	if fold.State != 18 || fold.Lookahead != 56 || fold.Kind != gotreesitter.ConflictPolicyRepetitionReduce ||
+		!fold.CompactOnly || fold.CompactMinFrontierHeaders != 2 || len(fold.ReduceSymbols) != 1 || fold.ReduceSymbols[0] != 107 {
+		t.Fatalf("Markdown inline fold policy = %+v, want state 18 reduce symbol 107 for lookahead 56", fold)
+	}
+	wordFold := builtin.ConflictPolicies[1]
+	if wordFold.State != 18 || wordFold.Lookahead != 50 || wordFold.Kind != gotreesitter.ConflictPolicyRepetitionReduce ||
+		!wordFold.CompactOnly || wordFold.CompactMinFrontierHeaders != 2 || len(wordFold.ReduceSymbols) != 1 || wordFold.ReduceSymbols[0] != 107 {
+		t.Fatalf("Markdown inline word fold policy = %+v, want state 18 reduce symbol 107 for lookahead 50", wordFold)
+	}
+	lineEndFold := builtin.ConflictPolicies[2]
+	if lineEndFold.State != 18 || lineEndFold.Lookahead != 36 || lineEndFold.Kind != gotreesitter.ConflictPolicyRepetitionReduce ||
+		!lineEndFold.CompactOnly || lineEndFold.CompactMinFrontierHeaders != 2 || len(lineEndFold.ReduceSymbols) != 1 || lineEndFold.ReduceSymbols[0] != 107 {
+		t.Fatalf("Markdown inline line-end fold policy = %+v, want state 18 reduce symbol 107 for lookahead 36", lineEndFold)
+	}
+	policy := builtin.ConflictPolicies[3]
+	if policy.State != 209 || policy.Lookahead != 50 || policy.Kind != gotreesitter.ConflictPolicyShift ||
+		!policy.CompactOnly || len(policy.ReduceSymbols) != 1 || policy.ReduceSymbols[0] != 104 {
+		t.Fatalf("Markdown inline conflict policy = %+v, want state 209 shift over symbol 104 for lookahead 50", policy)
+	}
+
+	custom := &gotreesitter.Language{Name: "markdown_inline"}
+	AttachLanguageSupport("markdown_inline", custom)
+	if len(custom.ConflictPolicies) != 0 {
+		t.Fatal("same-name custom grammar received the Markdown inline conflict policy")
+	}
+
+	stale := &gotreesitter.Language{Name: "markdown_inline"}
+	if attachBuiltinLanguageRuntimeProfile("markdown_inline", sha256.Sum256([]byte("stale")), stale) {
+		t.Fatal("stale Markdown inline blob reported a runtime-profile attachment")
+	}
+	if len(stale.ConflictPolicies) != 0 {
+		t.Fatal("stale Markdown inline blob received the conflict policy")
+	}
+}
+
 // TestBuiltinGomodConflictPoliciesAttach covers the certified go.mod
 // require-list rows that replaced gomodRepetitionShiftConflictChoice
 // through the generic policy path.

--- a/language.go
+++ b/language.go
@@ -344,6 +344,13 @@ type ConflictPolicy struct {
 	State     StateID
 	Lookahead Symbol
 	Kind      ConflictPolicyKind
+	// CompactOnly prevents the production GLR parser from applying this
+	// policy. The compact scheduler can still use it after its safety gates.
+	CompactOnly bool
+	// CompactMinFrontierHeaders limits this policy to a compact scheduler
+	// frontier with at least this many live headers. Production ignores this
+	// gate when CompactOnly is false.
+	CompactMinFrontierHeaders uint16
 
 	// ReduceSymbols, when non-empty, requires every reduce in the conflict to
 	// reduce one of these symbols. The generic action-shape validator still

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -4118,8 +4118,8 @@ func diagnosticParserCoreSameSpanRelex(shared, relexed Token) (Token, bool) {
 }
 
 var diagnosticParserCoreRepetitionFoldOptOut = map[string]bool{
-	// The compact reduction frontier splits an attribute-bearing HTML tag.
-	// TestMarkdownInlineAttributeHTMLTagStaysWhole protects the production shape.
+	// Most Markdown inline repetition rows are not certified for the compact
+	// frontier. Exact runtime-profile policies admit the proved rows.
 	"markdown_inline": true,
 }
 
@@ -4169,6 +4169,7 @@ func diagnosticParserCoreConflictPolicyOrdinal(
 	token Token,
 	state core.StateID,
 	actions core.ActionRow,
+	frontierHeaders int,
 ) (int, bool) {
 	if language == nil || len(language.ConflictPolicies) == 0 || actions.Len() < 2 {
 		return 0, false
@@ -4183,7 +4184,7 @@ func diagnosticParserCoreConflictPolicyOrdinal(
 	for ordinal := 0; ordinal < actions.Len(); ordinal++ {
 		decoded[ordinal] = rootParserCoreAction(actions.At(ordinal))
 	}
-	selected, ok := conflictPolicyChoice(language, token, StateID(state), decoded)
+	selected, ok := conflictPolicyChoiceForCompact(language, token, StateID(state), decoded, frontierHeaders)
 	if !ok {
 		return 0, false
 	}
@@ -6747,6 +6748,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				cell.dispatchToken(s.token),
 				boundary.State(),
 				actions,
+				len(s.headers),
 			); ok {
 				cell.selectedOrdinal = ordinal
 				cell.selectedBy = diagnosticParserCoreCellSelectionConflictPolicy

--- a/parsercore_phase0_generic_conflict_internal_test.go
+++ b/parsercore_phase0_generic_conflict_internal_test.go
@@ -300,12 +300,12 @@ func TestDiagnosticParserCoreGenericConflictPolicyRequiresExactRow(t *testing.T)
 			ReduceSymbols: []Symbol{4},
 		}},
 	}
-	if _, ok := diagnosticParserCoreConflictPolicyOrdinal(language, Token{Symbol: 9}, 1, actions); ok {
+	if _, ok := diagnosticParserCoreConflictPolicyOrdinal(language, Token{Symbol: 9}, 1, actions, 1); ok {
 		t.Fatal("conflict policy admitted an unmatched state")
 	}
 	language.ConflictPolicies[0].State = 1
 	language.ConflictPolicies[0].ReduceSymbols = []Symbol{5}
-	if _, ok := diagnosticParserCoreConflictPolicyOrdinal(language, Token{Symbol: 9}, 1, actions); ok {
+	if _, ok := diagnosticParserCoreConflictPolicyOrdinal(language, Token{Symbol: 9}, 1, actions, 1); ok {
 		t.Fatal("conflict policy admitted an unmatched reduce symbol")
 	}
 }


### PR DESCRIPTION
## Summary

- Bind four exact compact-only conflict policies to the built-in Markdown inline grammar blob.
- Require two live headers for the three certified repetition reductions.
- Keep all uncertified repetition rows on the fail-closed production fallback.
- Preserve production parsing by excluding compact-only policies from the Generalized LR parser.

## Correctness evidence

- The pinned upstream corpus contains 363 cases. The compact route admits 15 cases and falls back for 348 cases.
- Every admitted tree matches the locked C parser exactly.
- The nested-emphasis counterexample remains a required fallback.
- The strict admission scorecard reports 201 PASS, zero DIVERGE, zero FALLBACK, five SKIP, and zero ERROR rows.
- Both compact build tags pass focused tests.
- Focused root and grammar race tests pass.
- The in-depth review found no code findings or blockers. Its verifier declined formal approval because repository policy forbids host tests.

## Performance evidence

The standard 20-seed randomized benchmark used GOMAXPROCS=1, 750 ms runs, and the primary benchmark trio.

- Full parsing stayed neutral at 7.535 ms versus 7.513 ms, with p=0.461.
- Single-byte incremental parsing stayed neutral at 817.2 ns versus 815.0 ns, with p=0.495.
- Full-parse bytes and allocations stayed unchanged.
- No-edit reuse increased by 0.033 ns. That immediate reuse path does not execute conflict policy selection.
- Maximum resident memory increased by 1,528 KiB on the one-shot 5,000-function probe. No run crashed or exhausted memory.

## Baseline limitation

The Markdown inline generator import reaches the existing unsigned 16-bit action-group limit at index 65,536.

The exact isolated command fails at the merge base and this branch with the same error. This change does not affect that path.

## Verification

- Post-review Docker gate: harness_out/docker/20260830T132558Z
- Locked-C corpus gate: harness_out/docker/20260830T131840Z
- Standard randomized benchmarks: 20 seeds per revision
