### PR TITLE
Gate C-correct compact route exceptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,17 +119,11 @@ jobs:
       - name: Route-equality seed corpus regression (required)
         run: |
           set -euo pipefail
-          GOMAXPROCS=1 go test . -run '^FuzzAdmissionRouteEquality$' -count=1 -v
+          GOMAXPROCS=1 go test . -run '^(FuzzAdmissionRouteEquality|TestAdmissionRouteEqualityLockedCExceptions)$' -count=1 -v
 
       - name: Route-equality bounded live fuzzing, 45s (advisory)
-        # Non-blocking, mirroring the grammargen_visibility job's pattern
-        # below for a known, currently-open backlog: live mutation finds a
-        # false-clean divergence in the compact route's root-reduce leaf-
-        # tiling exemption in seconds, on any curated language, independent
-        # of this PR's changes (see the FuzzAdmissionRouteEquality doc
-        # comment in fuzz_admission_route_equality_test.go and this
-        # tranche's spore for the full root-cause writeup). Promote this
-        # step to blocking once that follow-up lands.
+        # Keep this non-blocking until clean-cache, per-language soaks bound
+        # the workload and reproduce or retire the reported Haskell residual.
         run: |
           set +e
           GOMAXPROCS=1 go test . -run '^$' -fuzz '^FuzzAdmissionRouteEquality$' -fuzztime=45s
@@ -137,13 +131,13 @@ jobs:
           set -e
 
           if [ "$status" -ne 0 ]; then
-            echo "::warning::route-equality live fuzzing found a divergence (status ${status}); informational until the known root-reduce leaf-tiling exemption gap is fixed (see fuzz_admission_route_equality_test.go)."
+            echo "::warning::route-equality live fuzzing found a divergence (status ${status}); informational until the clean-cache promotion gate completes."
             {
               echo "### Admission Route-Equality Live Fuzzing"
               echo
               echo "\`go test . -run '^\$' -fuzz FuzzAdmissionRouteEquality -fuzztime=45s\` exited with status \`${status}\`."
               echo
-              echo "This step is informational until the documented root-reduce leaf-tiling exemption gap is fixed."
+              echo "This step is informational until clean-cache, per-language promotion soaks complete."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
@@ -855,7 +849,7 @@ jobs:
             --test-parallel 1 \
             --c-ref-build-jobs 1 \
             --timeout 20m \
-            --run '^(TestCompactT3OracleAdjudication|TestCompactT3JavaScriptRecoveryProfileCharacterization|TestCompactT3JavaScriptRecoveryRouteSeedOracleParity|TestCompactT3JavaScriptRecoveryMutationDifferential|TestCompactJavaScriptS5RecoveryMutationDifferential)$'
+            --run '^(TestCompactT3OracleAdjudication|TestCompactT3JavaScriptRecoveryProfileCharacterization|TestCompactT3JavaScriptRecoveryRouteSeedOracleParity|TestCompactT3JavaScriptRecoveryMutationDifferential|TestCompactJavaScriptS5RecoveryMutationDifferential|TestCompactRouteLockedCExceptions)$'
 
   # merge-event-census-cgo runs stage M0 of spec.merge-time-election.v1: the
   # census that counts stack-merge events on both sides and breaks production's

--- a/admission_route_equality_locked_c_manifest_test.go
+++ b/admission_route_equality_locked_c_manifest_test.go
@@ -1,0 +1,158 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+)
+
+const (
+	routeEqualityLockedCManifestPath    = "cgo_harness/testdata/compact_route_locked_c_exceptions_v1.json"
+	routeEqualityLockedCManifestSchema  = "compact-route-locked-c-exceptions-v1"
+	routeEqualityLockedCManifestVersion = 1
+	routeEqualityLockedCWitnessCount    = 2
+)
+
+var routeEqualityLockedCWitnessIDs = map[string]bool{
+	"erlang_issue984_no_newline":       true,
+	"erlang_issue984_trailing_newline": true,
+}
+
+type routeEqualityLockedCManifest struct {
+	Schema        string                        `json:"schema"`
+	Version       int                           `json:"version"`
+	TrackingIssue string                        `json:"tracking_issue"`
+	WitnessCount  int                           `json:"witness_count"`
+	Witnesses     []routeEqualityLockedCWitness `json:"witnesses"`
+}
+
+type routeEqualityLockedCWitness struct {
+	ID           string                       `json:"id"`
+	Language     string                       `json:"language"`
+	SourceUTF8   string                       `json:"source_utf8"`
+	SourceBytes  int                          `json:"source_bytes"`
+	SourceSHA256 string                       `json:"source_sha256"`
+	COracle      routeEqualityLockedCOracle   `json:"c_oracle"`
+	Expected     routeEqualityLockedCExpected `json:"expected"`
+}
+
+type routeEqualityLockedCOracle struct {
+	Contract              string `json:"contract"`
+	BindingModule         string `json:"binding_module"`
+	BindingVersion        string `json:"binding_version"`
+	BindingCommit         string `json:"binding_commit"`
+	RuntimeVersion        string `json:"runtime_version"`
+	RuntimeCommit         string `json:"runtime_commit"`
+	GrammarRepository     string `json:"grammar_repository"`
+	GrammarCommit         string `json:"grammar_commit"`
+	CompilerPath          string `json:"compiler_path"`
+	CompilerVersion       string `json:"compiler_version"`
+	GrammarCompileFlags   string `json:"grammar_compile_flags"`
+	GrammarArtifactSHA256 string `json:"grammar_artifact_sha256"`
+}
+
+type routeEqualityLockedCExpected struct {
+	CHasError              *bool  `json:"c_has_error"`
+	CompactHasError        *bool  `json:"compact_has_error"`
+	ProductionHasError     *bool  `json:"production_has_error"`
+	CompactCDeepSHA256     string `json:"compact_c_deep_sha256"`
+	ProductionDeepSHA256   string `json:"production_deep_sha256"`
+	CompactRootChildren    int    `json:"compact_root_children"`
+	ProductionRootChildren int    `json:"production_root_children"`
+}
+
+func loadRouteEqualityLockedCWitnesses(t testing.TB) []routeEqualityLockedCWitness {
+	t.Helper()
+	raw, err := os.ReadFile(routeEqualityLockedCManifestPath)
+	if err != nil {
+		t.Fatalf("read locked C exception manifest: %v", err)
+	}
+	var manifest routeEqualityLockedCManifest
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&manifest); err != nil {
+		t.Fatalf("decode locked C exception manifest: %v", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("locked C exception manifest has trailing data: %v", err)
+	}
+	if manifest.Schema != routeEqualityLockedCManifestSchema || manifest.Version != routeEqualityLockedCManifestVersion {
+		t.Fatalf("locked C exception manifest identity=%q/%d, want %q/%d", manifest.Schema, manifest.Version, routeEqualityLockedCManifestSchema, routeEqualityLockedCManifestVersion)
+	}
+	if manifest.TrackingIssue != "https://github.com/odvcencio/gotreesitter/issues/984" {
+		t.Fatalf("locked C exception tracking issue=%q, want issue #984", manifest.TrackingIssue)
+	}
+	if manifest.WitnessCount != routeEqualityLockedCWitnessCount || len(manifest.Witnesses) != routeEqualityLockedCWitnessCount {
+		t.Fatalf("locked C exception witness counts=%d/%d, want %d/%d", manifest.WitnessCount, len(manifest.Witnesses), routeEqualityLockedCWitnessCount, routeEqualityLockedCWitnessCount)
+	}
+
+	seenIDs := make(map[string]bool, len(manifest.Witnesses))
+	seenInputs := make(map[string]bool, len(manifest.Witnesses))
+	for _, witness := range manifest.Witnesses {
+		if !routeEqualityLockedCWitnessIDs[witness.ID] {
+			t.Fatalf("unexpected locked C exception ID %q", witness.ID)
+		}
+		if seenIDs[witness.ID] {
+			t.Fatalf("duplicate locked C exception ID %q", witness.ID)
+		}
+		seenIDs[witness.ID] = true
+		key := witness.Language + "\x00" + witness.SourceUTF8
+		if seenInputs[key] {
+			t.Fatalf("duplicate locked C exception input for %q", witness.ID)
+		}
+		seenInputs[key] = true
+		if witness.Language == "" || witness.SourceBytes != len([]byte(witness.SourceUTF8)) {
+			t.Fatalf("locked C exception %q language=%q source_bytes=%d actual=%d", witness.ID, witness.Language, witness.SourceBytes, len([]byte(witness.SourceUTF8)))
+		}
+		if got := fmt.Sprintf("%x", sha256.Sum256([]byte(witness.SourceUTF8))); got != witness.SourceSHA256 {
+			t.Fatalf("locked C exception %q source SHA-256=%s, want %s", witness.ID, got, witness.SourceSHA256)
+		}
+		validateRouteEqualityLockedCDigest(t, witness.ID, "compact/C", witness.Expected.CompactCDeepSHA256)
+		validateRouteEqualityLockedCDigest(t, witness.ID, "production", witness.Expected.ProductionDeepSHA256)
+		validateRouteEqualityLockedCDigest(t, witness.ID, "grammar artifact", witness.COracle.GrammarArtifactSHA256)
+		if witness.Expected.CHasError == nil || witness.Expected.CompactHasError == nil || witness.Expected.ProductionHasError == nil {
+			t.Fatalf("locked C exception %q omits a HasError expectation", witness.ID)
+		}
+		oracleFields := []string{
+			witness.COracle.Contract,
+			witness.COracle.BindingModule,
+			witness.COracle.BindingVersion,
+			witness.COracle.BindingCommit,
+			witness.COracle.RuntimeVersion,
+			witness.COracle.RuntimeCommit,
+			witness.COracle.GrammarRepository,
+			witness.COracle.GrammarCommit,
+			witness.COracle.CompilerPath,
+			witness.COracle.CompilerVersion,
+			witness.COracle.GrammarCompileFlags,
+		}
+		for fieldIndex, value := range oracleFields {
+			if value == "" {
+				t.Fatalf("locked C exception %q C-oracle field %d is empty", witness.ID, fieldIndex)
+			}
+		}
+	}
+	for id := range routeEqualityLockedCWitnessIDs {
+		if !seenIDs[id] {
+			t.Fatalf("locked C exception manifest omits required ID %q", id)
+		}
+	}
+	return manifest.Witnesses
+}
+
+func validateRouteEqualityLockedCDigest(t testing.TB, id, label, digest string) {
+	t.Helper()
+	if len(digest) != sha256.Size*2 {
+		t.Fatalf("locked C exception %q %s digest has length %d", id, label, len(digest))
+	}
+	if _, err := hex.DecodeString(digest); err != nil {
+		t.Fatalf("locked C exception %q %s digest is not hexadecimal", id, label)
+	}
+}

--- a/admission_route_equality_locked_c_test.go
+++ b/admission_route_equality_locked_c_test.go
@@ -1,0 +1,79 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+func TestAdmissionRouteEqualityLockedCExceptions(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	for _, witness := range loadRouteEqualityLockedCWitnesses(t) {
+		witness := witness
+		t.Run(witness.ID, func(t *testing.T) {
+			entry := grammars.DetectLanguageByName(witness.Language)
+			if entry == nil {
+				t.Fatalf("language %q is not registered", witness.Language)
+			}
+			language := entry.Language()
+			source := []byte(witness.SourceUTF8)
+
+			production := gts.NewParser(language)
+			production.SetAdmissionCandidateRoute(false)
+			productionTree, err := production.Parse(source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer productionTree.Release()
+
+			gts.ResetAdmissionCandidateCountersForTest()
+			candidate := gts.NewParser(language)
+			candidate.SetAdmissionCandidateRoute(true)
+			candidateTree, err := candidate.Parse(source)
+			if err != nil {
+				t.Fatalf("compact parse: %v", err)
+			}
+			defer candidateTree.Release()
+			if routed, fallback := gts.AdmissionCandidateCounters(); routed != 1 || fallback != 0 {
+				t.Fatalf("route counters=%d/%d, want 1/0; reason=%q", routed, fallback, gts.AdmissionCandidateLastFallbackReason())
+			}
+
+			compactRoot := candidateTree.RootNode()
+			productionRoot := productionTree.RootNode()
+			if got, want := compactRoot.HasError(), *witness.Expected.CompactHasError; got != want {
+				t.Fatalf("compact root HasError=%t, want %t", got, want)
+			}
+			if got, want := productionRoot.HasError(), *witness.Expected.ProductionHasError; got != want {
+				t.Fatalf("production root HasError=%t, want %t", got, want)
+			}
+			compactInspection, err := benchfixtures.InspectGoTree(compactRoot, language)
+			if err != nil {
+				t.Fatalf("inspect compact tree: %v", err)
+			}
+			if compactInspection.SHA256 != witness.Expected.CompactCDeepSHA256 {
+				t.Fatalf("compact digest=%s, want locked C digest %s", compactInspection.SHA256, witness.Expected.CompactCDeepSHA256)
+			}
+			productionInspection, err := benchfixtures.InspectGoTree(productionRoot, language)
+			if err != nil {
+				t.Fatalf("inspect production tree: %v", err)
+			}
+			if productionInspection.SHA256 != witness.Expected.ProductionDeepSHA256 {
+				t.Fatalf("production digest=%s, want %s", productionInspection.SHA256, witness.Expected.ProductionDeepSHA256)
+			}
+			if compactRoot.ChildCount() != witness.Expected.CompactRootChildren || productionRoot.ChildCount() != witness.Expected.ProductionRootChildren {
+				t.Fatalf(
+					"root child counts compact=%d production=%d, want %d/%d",
+					compactRoot.ChildCount(), productionRoot.ChildCount(),
+					witness.Expected.CompactRootChildren, witness.Expected.ProductionRootChildren,
+				)
+			}
+			if diff := routeEqualityFirstDivergence(compactRoot, productionRoot, language, "root"); diff == "" {
+				t.Fatal("production now matches compact; remove the byte-exact exception")
+			}
+		})
+	}
+}

--- a/cgo_harness/compact_route_locked_c_exceptions_test.go
+++ b/cgo_harness/compact_route_locked_c_exceptions_test.go
@@ -1,0 +1,237 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const compactRouteLockedCManifestPath = "testdata/compact_route_locked_c_exceptions_v1.json"
+
+type compactRouteLockedCManifest struct {
+	Schema        string                       `json:"schema"`
+	Version       int                          `json:"version"`
+	TrackingIssue string                       `json:"tracking_issue"`
+	WitnessCount  int                          `json:"witness_count"`
+	Witnesses     []compactRouteLockedCWitness `json:"witnesses"`
+}
+
+type compactRouteLockedCWitness struct {
+	ID           string                      `json:"id"`
+	Language     string                      `json:"language"`
+	SourceUTF8   string                      `json:"source_utf8"`
+	SourceBytes  int                         `json:"source_bytes"`
+	SourceSHA256 string                      `json:"source_sha256"`
+	COracle      compactRouteLockedCOracle   `json:"c_oracle"`
+	Expected     compactRouteLockedCExpected `json:"expected"`
+}
+
+type compactRouteLockedCOracle struct {
+	Contract              string `json:"contract"`
+	BindingModule         string `json:"binding_module"`
+	BindingVersion        string `json:"binding_version"`
+	BindingCommit         string `json:"binding_commit"`
+	RuntimeVersion        string `json:"runtime_version"`
+	RuntimeCommit         string `json:"runtime_commit"`
+	GrammarRepository     string `json:"grammar_repository"`
+	GrammarCommit         string `json:"grammar_commit"`
+	CompilerPath          string `json:"compiler_path"`
+	CompilerVersion       string `json:"compiler_version"`
+	GrammarCompileFlags   string `json:"grammar_compile_flags"`
+	GrammarArtifactSHA256 string `json:"grammar_artifact_sha256"`
+}
+
+type compactRouteLockedCExpected struct {
+	CHasError              *bool  `json:"c_has_error"`
+	CompactHasError        *bool  `json:"compact_has_error"`
+	ProductionHasError     *bool  `json:"production_has_error"`
+	CompactCDeepSHA256     string `json:"compact_c_deep_sha256"`
+	ProductionDeepSHA256   string `json:"production_deep_sha256"`
+	CompactRootChildren    int    `json:"compact_root_children"`
+	ProductionRootChildren int    `json:"production_root_children"`
+}
+
+func TestCompactRouteLockedCExceptions(t *testing.T) {
+	manifest := loadCompactRouteLockedCManifest(t)
+	for _, witness := range manifest.Witnesses {
+		witness := witness
+		t.Run(witness.ID, func(t *testing.T) {
+			entry, ok := parityEntriesByName[witness.Language]
+			if !ok {
+				t.Fatalf("language %q is not registered", witness.Language)
+			}
+			language := entry.Language()
+			cLanguage, err := COracleLanguage(witness.Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			identity, err := COracleIdentity(witness.Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertCompactRouteLockedCIdentity(t, witness.COracle, identity)
+
+			source := []byte(witness.SourceUTF8)
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C oracle returned a nil tree")
+			}
+			defer cTree.Close()
+			if got, err := COracleDeepDigest(cTree); err != nil {
+				t.Fatal(err)
+			} else if got != witness.Expected.CompactCDeepSHA256 {
+				t.Fatalf("C deep digest=%s, want %s", got, witness.Expected.CompactCDeepSHA256)
+			}
+
+			productionParser := gotreesitter.NewParser(language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			productionTree, err := productionParser.Parse(source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer productionTree.Release()
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactParser := gotreesitter.NewParser(language)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compactTree, err := compactParser.Parse(source)
+			if err != nil {
+				t.Fatalf("compact parse: %v", err)
+			}
+			defer compactTree.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			if routedAfter-routedBefore != 1 || fallbackAfter-fallbackBefore != 0 {
+				t.Fatalf("route counter delta=%d/%d, want 1/0", routedAfter-routedBefore, fallbackAfter-fallbackBefore)
+			}
+
+			cRoot := cTree.RootNode()
+			compactRoot := compactTree.RootNode()
+			productionRoot := productionTree.RootNode()
+			if got, want := cRoot.HasError(), *witness.Expected.CHasError; got != want {
+				t.Fatalf("C root HasError=%t, want %t", got, want)
+			}
+			if got, want := compactRoot.HasError(), *witness.Expected.CompactHasError; got != want {
+				t.Fatalf("compact root HasError=%t, want %t", got, want)
+			}
+			if got, want := productionRoot.HasError(), *witness.Expected.ProductionHasError; got != want {
+				t.Fatalf("production root HasError=%t, want %t", got, want)
+			}
+			if diff := FirstDivergenceDumpV1(compactRoot, language, cRoot); diff != nil {
+				t.Fatalf("compact tree diverges from locked C: %+v", diff)
+			}
+			if diff := firstLockedCTreeFlagDivergence(compactRoot, language, cRoot, "/"+compactRoot.Type(language)); diff != nil {
+				t.Fatalf("compact flags diverge from locked C: %v", diff)
+			}
+
+			compactInspection, err := benchfixtures.InspectGoTree(compactRoot, language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if compactInspection.SHA256 != witness.Expected.CompactCDeepSHA256 {
+				t.Fatalf("compact digest=%s, want C digest %s", compactInspection.SHA256, witness.Expected.CompactCDeepSHA256)
+			}
+			productionInspection, err := benchfixtures.InspectGoTree(productionRoot, language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if productionInspection.SHA256 != witness.Expected.ProductionDeepSHA256 {
+				t.Fatalf("production digest=%s, want %s", productionInspection.SHA256, witness.Expected.ProductionDeepSHA256)
+			}
+			if diff := FirstDivergenceDumpV1(productionRoot, language, cRoot); diff == nil {
+				t.Fatal("production now matches locked C; remove the route-equality exception")
+			}
+			if compactRoot.ChildCount() != witness.Expected.CompactRootChildren || productionRoot.ChildCount() != witness.Expected.ProductionRootChildren {
+				t.Fatalf(
+					"root child counts compact=%d production=%d, want %d/%d",
+					compactRoot.ChildCount(), productionRoot.ChildCount(),
+					witness.Expected.CompactRootChildren, witness.Expected.ProductionRootChildren,
+				)
+			}
+		})
+	}
+}
+
+func loadCompactRouteLockedCManifest(t *testing.T) compactRouteLockedCManifest {
+	t.Helper()
+	raw, err := os.ReadFile(compactRouteLockedCManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest compactRouteLockedCManifest
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&manifest); err != nil {
+		t.Fatal(err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("manifest has trailing data: %v", err)
+	}
+	if manifest.Schema != "compact-route-locked-c-exceptions-v1" || manifest.Version != 1 {
+		t.Fatalf("manifest identity=%q/%d, want compact-route-locked-c-exceptions-v1/1", manifest.Schema, manifest.Version)
+	}
+	if manifest.TrackingIssue != "https://github.com/odvcencio/gotreesitter/issues/984" {
+		t.Fatalf("tracking issue=%q, want issue #984", manifest.TrackingIssue)
+	}
+	if manifest.WitnessCount != 2 || len(manifest.Witnesses) != 2 {
+		t.Fatalf("witness counts=%d/%d, want 2/2", manifest.WitnessCount, len(manifest.Witnesses))
+	}
+	seen := make(map[string]bool, len(manifest.Witnesses))
+	for _, witness := range manifest.Witnesses {
+		if witness.ID == "" || seen[witness.ID] {
+			t.Fatalf("empty or duplicate witness ID %q", witness.ID)
+		}
+		seen[witness.ID] = true
+		if witness.SourceBytes != len([]byte(witness.SourceUTF8)) {
+			t.Fatalf("witness %q source bytes=%d, want %d", witness.ID, witness.SourceBytes, len([]byte(witness.SourceUTF8)))
+		}
+		if got := fmt.Sprintf("%x", sha256.Sum256([]byte(witness.SourceUTF8))); got != witness.SourceSHA256 {
+			t.Fatalf("witness %q source SHA-256=%s, want %s", witness.ID, got, witness.SourceSHA256)
+		}
+		if witness.Expected.CHasError == nil || witness.Expected.CompactHasError == nil || witness.Expected.ProductionHasError == nil {
+			t.Fatalf("witness %q omits a HasError expectation", witness.ID)
+		}
+	}
+	return manifest
+}
+
+func assertCompactRouteLockedCIdentity(t *testing.T, want compactRouteLockedCOracle, got COracleBuildIdentity) {
+	t.Helper()
+	checks := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "contract", got: got.Contract, want: want.Contract},
+		{name: "binding module", got: got.BindingModule, want: want.BindingModule},
+		{name: "binding version", got: got.BindingVersion, want: want.BindingVersion},
+		{name: "binding commit", got: got.BindingCommit, want: want.BindingCommit},
+		{name: "runtime version", got: got.RuntimeVersion, want: want.RuntimeVersion},
+		{name: "runtime commit", got: got.RuntimeCommit, want: want.RuntimeCommit},
+		{name: "grammar repository", got: got.GrammarRepo, want: want.GrammarRepository},
+		{name: "grammar commit", got: got.GrammarCommit, want: want.GrammarCommit},
+		{name: "compiler path", got: got.CompilerPath, want: want.CompilerPath},
+		{name: "compiler version", got: got.CompilerVersion, want: want.CompilerVersion},
+		{name: "grammar compile flags", got: got.GrammarCompileFlags, want: want.GrammarCompileFlags},
+		{name: "grammar artifact SHA-256", got: got.GrammarArtifactSHA256, want: want.GrammarArtifactSHA256},
+	}
+	for _, check := range checks {
+		if check.got != check.want {
+			t.Fatalf("C oracle %s=%q, want %q", check.name, check.got, check.want)
+		}
+	}
+}

--- a/cgo_harness/testdata/compact_route_locked_c_exceptions_v1.json
+++ b/cgo_harness/testdata/compact_route_locked_c_exceptions_v1.json
@@ -1,0 +1,68 @@
+{
+  "schema": "compact-route-locked-c-exceptions-v1",
+  "version": 1,
+  "tracking_issue": "https://github.com/odvcencio/gotreesitter/issues/984",
+  "witness_count": 2,
+  "witnesses": [
+    {
+      "id": "erlang_issue984_no_newline",
+      "language": "erlang",
+      "source_utf8": "000\"0A!A \"A\"=0:A0!)A\"0%0000",
+      "source_bytes": 27,
+      "source_sha256": "ad9482f4aabfc3f348a20f6071a2732dcf0473d87b61fa8df4f960e84d4b1ab4",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_module": "github.com/tree-sitter/go-tree-sitter",
+        "binding_version": "v0.25.0",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_version": "0.25.1",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/WhatsApp/tree-sitter-erlang",
+        "grammar_commit": "1d78195c4fbb1fc027eb3e4220427f1eb8bfc89e",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "361e3332e8d16e13df8621dc9d599be36ce045b23567543b421b551b8ca68085"
+      },
+      "expected": {
+        "c_has_error": false,
+        "compact_has_error": false,
+        "production_has_error": false,
+        "compact_c_deep_sha256": "93429d2e59861512ce66b0d09a095889b67b640cda8bb916c61b93ba4195811e",
+        "production_deep_sha256": "f530ee827cfa989ca778f3187874d5e92d4cbad2582a05d6326c53f179e182e3",
+        "compact_root_children": 6,
+        "production_root_children": 4
+      }
+    },
+    {
+      "id": "erlang_issue984_trailing_newline",
+      "language": "erlang",
+      "source_utf8": "000\"0A!A \"A\"=0:A0!)A\"0%0000\n",
+      "source_bytes": 28,
+      "source_sha256": "8498d7be6e53209fab56a0a9af04a3b26940ec901d31b85da22a8faf6b3f3db6",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_module": "github.com/tree-sitter/go-tree-sitter",
+        "binding_version": "v0.25.0",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_version": "0.25.1",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/WhatsApp/tree-sitter-erlang",
+        "grammar_commit": "1d78195c4fbb1fc027eb3e4220427f1eb8bfc89e",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "361e3332e8d16e13df8621dc9d599be36ce045b23567543b421b551b8ca68085"
+      },
+      "expected": {
+        "c_has_error": false,
+        "compact_has_error": false,
+        "production_has_error": false,
+        "compact_c_deep_sha256": "dcfdecf279b3537deb52c3a47d5a7a7f3ef66085f6b1a4249156618c26cd718e",
+        "production_deep_sha256": "0d785c786fc75c9e24bb516ca017a7ab345891fd890a99158da0b750b158d461",
+        "compact_root_children": 6,
+        "production_root_children": 4
+      }
+    }
+  ]
+}

--- a/fuzz_admission_route_equality_test.go
+++ b/fuzz_admission_route_equality_test.go
@@ -70,9 +70,10 @@ type admissionRouteEqualityLanguage struct {
 const routeEqualityFuzzMaxInputBytes = 4096
 
 // FuzzAdmissionRouteEquality is the campaign v7 tranche B2 generative gate.
-// An accepted compact tree must equal production unless certified recovery
-// publishes an ERROR container or a missing terminal. Those recovery trees
-// must keep the same HasError result and match the separate C oracle gate.
+// An accepted compact tree must equal production unless a byte-exact witness
+// carries a pinned C deep digest. Certified recovery has a separate C gate.
+// The shared locked-C manifest supplies every byte-exact exception and its
+// required cgo proof.
 // When the compact route declines, Parse serves production within the same
 // call. The input remains useful for panic and hang coverage.
 //
@@ -109,16 +110,11 @@ const routeEqualityFuzzMaxInputBytes = 4096
 // the fail-open control (a legitimate leading comment still routes through
 // the compact candidate).
 //
-// The bounded CI fuzz lane (.github/workflows/ci.yml) still runs this
-// target's live-mutation step as ADVISORY, not blocking: a 90-second local
-// session with this finding fixed found zero occurrences of this class
-// across go, javascript, html, swift, python, bash, erlang, and rust, but
-// surfaced a separate, unrelated, pre-existing structural divergence on
-// haskell (matching HasError, differing child count -- a different
-// mechanism from this finding's HasError divergence). Promote the live-
-// mutation step once that residual is filed and resolved. The seed-corpus
-// regression step (this file's committed f.Add corpus) is unaffected and
-// stays required.
+// The bounded CI mutation step remains advisory. Its shared fuzz cache and
+// 4 KiB cap do not provide a stable 45-second workload. A prior run also
+// reported an uncommitted Haskell structural residual. Promote the step only
+// after clean-cache, per-language soaks resolve both risks. The committed seed
+// corpus remains required.
 func FuzzAdmissionRouteEquality(f *testing.F) {
 	// Several curated languages (html, javascript, swift, ...) are not
 	// otherwise loaded by the always-on suite; purge the process-wide
@@ -149,14 +145,25 @@ func FuzzAdmissionRouteEquality(f *testing.F) {
 		languages[i] = admissionRouteEqualityLanguage{name: name, lang: lang, compact: compact, production: production}
 	}
 
-	seedAdmissionRouteEqualityCorpus(f, languages)
+	lockedCWitnesses := loadRouteEqualityLockedCWitnesses(f)
+	lockedCOracleDigests := make(map[string]string, len(lockedCWitnesses))
+	for _, witness := range lockedCWitnesses {
+		key := witness.Language + "\x00" + witness.SourceUTF8
+		if prior := lockedCOracleDigests[key]; prior != "" && prior != witness.Expected.CompactCDeepSHA256 {
+			f.Fatalf("conflicting locked C digests for witness %q", witness.ID)
+		}
+		lockedCOracleDigests[key] = witness.Expected.CompactCDeepSHA256
+	}
+
+	seedAdmissionRouteEqualityCorpus(f, languages, lockedCWitnesses)
 
 	f.Fuzz(func(t *testing.T, src []byte, langSel byte) {
 		if len(src) >= routeEqualityFuzzMaxInputBytes {
 			t.Skip("input at or above the fuzz latency safety cap")
 		}
 		lp := languages[int(langSel)%len(languages)]
-		exerciseAdmissionRouteEquality(t, lp, src, false)
+		lockedCDeepSHA256 := lockedCOracleDigests[lp.name+"\x00"+string(src)]
+		exerciseAdmissionRouteEquality(t, lp, src, false, lockedCDeepSHA256)
 	})
 }
 
@@ -206,11 +213,11 @@ func FuzzJavaScriptAdmissionRouteEquality(f *testing.F) {
 		if len(src) >= routeEqualityFuzzMaxInputBytes {
 			t.Skip("input at or above the fuzz latency safety cap")
 		}
-		exerciseAdmissionRouteEquality(t, lp, src, true)
+		exerciseAdmissionRouteEquality(t, lp, src, true, "")
 	})
 }
 
-func exerciseAdmissionRouteEquality(t *testing.T, lp admissionRouteEqualityLanguage, src []byte, recoveryOracleOwned bool) {
+func exerciseAdmissionRouteEquality(t *testing.T, lp admissionRouteEqualityLanguage, src []byte, recoveryOracleOwned bool, lockedCDeepSHA256 string) {
 	t.Helper()
 	defer func() {
 		if r := recover(); r != nil {
@@ -247,6 +254,24 @@ func exerciseAdmissionRouteEquality(t *testing.T, lp admissionRouteEqualityLangu
 		t.Fatalf("lang=%s production-lane Parse returned a nil tree with no error (input=%s)", lp.name, previewRouteEqualityInput(src))
 	}
 	defer productionTree.Release()
+	if lockedCDeepSHA256 != "" {
+		inspection, err := benchfixtures.InspectGoTree(compactTree.RootNode(), lp.lang)
+		if err != nil {
+			t.Fatalf("lang=%s bytes=%d inspect locked-C compact tree: %v", lp.name, len(src), err)
+		}
+		if inspection.SHA256 != lockedCDeepSHA256 {
+			t.Fatalf("lang=%s bytes=%d compact deep digest=%s, want locked C digest %s (input=%s)",
+				lp.name, len(src), inspection.SHA256, lockedCDeepSHA256, previewRouteEqualityInput(src))
+		}
+		if diff := routeEqualityFirstDivergence(compactTree.RootNode(), productionTree.RootNode(), lp.lang, "root"); diff == "" {
+			t.Fatalf("lang=%s bytes=%d locked-C exception is stale because production now matches compact (input=%s)",
+				lp.name, len(src), previewRouteEqualityInput(src))
+		} else {
+			t.Logf("lang=%s bytes=%d compact tree matches the locked C digest instead of production: %s (input=%s)",
+				lp.name, len(src), diff, previewRouteEqualityInput(src))
+		}
+		return
+	}
 	if recoveryOracleOwned && lp.lang.CompactStrategy2ErrorRegionCertified &&
 		routeEqualityTreeCarriesNativeRecoveryNode(compactTree.RootNode()) {
 		if diff := routeEqualityFirstDivergence(compactTree.RootNode(), productionTree.RootNode(), lp.lang, "root"); diff != "" {
@@ -266,7 +291,7 @@ func exerciseAdmissionRouteEquality(t *testing.T, lp admissionRouteEqualityLangu
 // needed), one smoke snippet per curated language, and an empty-source edge
 // case. languages supplies the language-selector byte for each language
 // name.
-func seedAdmissionRouteEqualityCorpus(f *testing.F, languages []admissionRouteEqualityLanguage) {
+func seedAdmissionRouteEqualityCorpus(f *testing.F, languages []admissionRouteEqualityLanguage, lockedCWitnesses []routeEqualityLockedCWitness) {
 	f.Helper()
 
 	langIndex := make(map[string]byte, len(languages))
@@ -303,7 +328,7 @@ func seedAdmissionRouteEqualityCorpus(f *testing.F, languages []admissionRouteEq
 	}
 
 	// The 20-witness B0/B1 adjudication manifest (cgo_harness/testdata/
-	// compact_t3_oracle_witnesses_v2.json): 10 html, 8 javascript, 2 swift.
+	// compact_t3_oracle_witnesses_v2.json): 10 HTML, 8 JavaScript, 2 Swift.
 	// These are the false-clean witnesses the B1 leaf-tiling gate now
 	// declines (admission_route_equality_leaf_tiling_test.go). html_min_a is
 	// the literal B1 reference witness "<a></a^>"
@@ -365,6 +390,16 @@ func seedAdmissionRouteEqualityCorpus(f *testing.F, languages []admissionRouteEq
 	// (deferContextualCloseAngleAction, parser_dfa_token_source.go).
 	f.Add([]byte(" 0%0>>"), langIndex["swift"])
 	f.Add([]byte("0>>"), langIndex["swift"])
+
+	// Issue #984 pins two byte-exact Erlang forms. Compact matches locked C.
+	// Production instead merges three root children into one concatables node.
+	for _, witness := range lockedCWitnesses {
+		idx, ok := langIndex[witness.Language]
+		if !ok {
+			f.Fatalf("locked C witness %q language %q is outside the curated route-equality set", witness.ID, witness.Language)
+		}
+		f.Add([]byte(witness.SourceUTF8), idx)
+	}
 }
 
 // routeEqualityTreeCarriesNativeRecoveryNode reports whether root contains a


### PR DESCRIPTION
## Summary

- Add one strict manifest for byte-exact compact route exceptions.
- Pin both Erlang issue #984 forms against the locked C oracle.
- Require the root seed gate and the C parity gate to consume the same manifest.
- Fail when production becomes C-correct, so each exception must be removed.

## Evidence

- Required root seed and receipt gate passes in Docker.
- Locked-C structural, flag, identity, and digest gate passes in Docker.
- The focused race gate passes in Docker.
- The opt-in and no-compact build tags compile cleanly.

Compact and C produce six clean root children. Production produces four clean root children.

Refs #984