### PR TITLE
Retain static C oracle identity without a corpus

### DIFF
--- a/cgo_harness/static_c_perf_oracle_test.go
+++ b/cgo_harness/static_c_perf_oracle_test.go
@@ -790,7 +790,7 @@ func perfScanOracleBoardFromRowsForMode(rows []*perfScanLanguage, mode string) (
 	allowReportClosures := mode == perfScanReduceModeReport
 	board := &perfScanOracleBoardIdentity{}
 	for _, row := range rows {
-		if allowReportClosures && row != nil && perfScanReportClosureStatus(row.Status) {
+		if allowReportClosures && perfScanReportClosureRow(row) {
 			if err := perfScanValidateReportClosureRow(row); err != nil {
 				return nil, err
 			}
@@ -882,7 +882,7 @@ func perfScanValidateOracleEvidenceForMode(board *perfScanScoreboard, mode strin
 	wantOracleLanguages := len(board.Languages)
 	if allowReportClosures {
 		for _, row := range board.Languages {
-			if row != nil && perfScanReportClosureStatus(row.Status) {
+			if perfScanReportClosureRow(row) {
 				if err := perfScanValidateReportClosureRow(row); err != nil {
 					return fmt.Errorf("language %q report closure: %w", row.Language, err)
 				}
@@ -897,7 +897,7 @@ func perfScanValidateOracleEvidenceForMode(board *perfScanScoreboard, mode strin
 		return fmt.Errorf("oracle identity has %d languages, scoreboard requires %d", len(boardByLanguage), wantOracleLanguages)
 	}
 	for _, row := range board.Languages {
-		if allowReportClosures && row != nil && perfScanReportClosureStatus(row.Status) {
+		if allowReportClosures && perfScanReportClosureRow(row) {
 			continue
 		}
 		if row == nil || row.Oracle == nil {

--- a/cgo_harness/zz_perf_scan_reduce_test.go
+++ b/cgo_harness/zz_perf_scan_reduce_test.go
@@ -304,7 +304,11 @@ func perfScanReduceScoreboardsForMode(paths []string, lockPath, lockSHA string, 
 				return nil, fmt.Errorf("shard %s language %q file %q classification: %w", shardPath, lang, file.Path, err)
 			}
 		}
-		reportClosure := perfScanReportClosureStatus(row.Status)
+		if perfScanReportClosureStatus(row.Status) && row.Oracle != nil &&
+			(row.Status == "no_static_c_oracle" || shard.Oracle == nil) {
+			return nil, fmt.Errorf("shard %s typed closure status %q contradicts a language oracle identity", shardPath, row.Status)
+		}
+		reportClosure := perfScanReportClosureRow(row)
 		if reportClosure {
 			if mode != perfScanReduceModeReport {
 				return nil, fmt.Errorf("shard %s status %q is authenticated failure evidence only in report mode", shardPath, row.Status)
@@ -398,7 +402,7 @@ func perfScanReduceScoreboardsForMode(paths []string, lockPath, lockSHA string, 
 	}
 	for _, lang := range wantLanguages {
 		row := rowsByLang[lang]
-		if mode != perfScanReduceModeReport || !perfScanReportClosureStatus(row.Status) {
+		if mode != perfScanReduceModeReport || !perfScanReportClosureRow(row) {
 			perfScanRefreshLanguageAggregates(row, outputConfig)
 		}
 		board.Languages = append(board.Languages, row)
@@ -425,6 +429,10 @@ func perfScanReportClosureStatus(status string) bool {
 	default:
 		return false
 	}
+}
+
+func perfScanReportClosureRow(row *perfScanLanguage) bool {
+	return row != nil && row.Oracle == nil && perfScanReportClosureStatus(row.Status)
 }
 
 func perfScanValidateReportClosureShard(shard *perfScanScoreboard) error {
@@ -824,6 +832,35 @@ func TestPerfScanReduceScoreboards(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("no corpus retains authenticated static oracle identity", func(t *testing.T) {
+		paths := makeInputs(t, func(_ *perfScanScoreboard, pythonShard *perfScanScoreboard) {
+			row := pythonShard.Languages[0]
+			row.Status = "no_corpus"
+			row.Detail = "no corpus directory at /corpus/corpus_sources/python"
+			row.FilesSelected = 0
+			row.FilesMeasured = 0
+			row.BytesMeasured = 0
+			row.Files = nil
+			row.Axes = map[string]*perfScanLangAxis{}
+			row.FullParseSplit = nil
+			pythonShard.FullParseSplit = nil
+			gate := perfScanEvaluateHardGate(pythonShard)
+			pythonShard.Gate = &gate
+		})
+		board, err := reduce(paths)
+		if err != nil {
+			t.Fatalf("reduce authenticated no-corpus evidence: %v", err)
+		}
+		if board.Oracle == nil || len(board.Oracle.Languages) != 2 || board.Languages[1].Oracle == nil {
+			t.Fatalf("reduced no-corpus identity = %+v", board.Oracle)
+		}
+		for _, finding := range board.Gate.Failures {
+			if finding.Kind == "oracle" {
+				t.Fatalf("authenticated no-corpus row produced an oracle defect: %+v", finding)
+			}
+		}
+	})
 
 	t.Run("typed C admission timeout remains authenticated failing evidence", func(t *testing.T) {
 		paths := makeInputs(t, func(_ *perfScanScoreboard, pythonShard *perfScanScoreboard) {

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -1550,6 +1550,53 @@ func TestPerfScanMissingCorpusPinsStaticOracleIdentityUnit(t *testing.T) {
 	}
 }
 
+func TestPerfScanEmptyCorpusPinsStaticOracleIdentityUnit(t *testing.T) {
+	corpusRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(corpusRoot, "go"), 0o755); err != nil {
+		t.Fatalf("create empty corpus: %v", err)
+	}
+	cfg := perfScanConfig{
+		CorpusRoot: corpusRoot,
+		Axes:       []string{perfScanAxisFull},
+	}
+	want := perfScanTestOracleIdentity("go")
+	buildCalls := 0
+	closeCalls := 0
+	row := perfScanMeasureLanguageWithStaticOracleBuilder(t, "go", cfg, nil, func(language string) (*staticCPerfOracle, error) {
+		buildCalls++
+		if language != "go" {
+			t.Fatalf("static oracle language = %q, want go", language)
+		}
+		return &staticCPerfOracle{
+			identity: *want,
+			cleanup:  func() { closeCalls++ },
+		}, nil
+	})
+	if row.Status != "no_corpus_files" {
+		t.Fatalf("empty corpus status = %q, want no_corpus_files: %s", row.Status, row.Detail)
+	}
+	if row.Oracle == nil || row.Oracle.Common != want.Common ||
+		row.Oracle.Language.Language != want.Language.Language ||
+		row.Oracle.Language.GrammarCommit != want.Language.GrammarCommit ||
+		row.Oracle.Language.BuildKeySHA256 != want.Language.BuildKeySHA256 ||
+		row.Oracle.Language.ArtifactSHA256 != want.Language.ArtifactSHA256 {
+		t.Fatalf("empty corpus lost locked static C identity: got=%+v want=%+v", row.Oracle, want)
+	}
+	if buildCalls != 1 || closeCalls != 1 {
+		t.Fatalf("static oracle lifecycle builds=%d closes=%d, want 1/1", buildCalls, closeCalls)
+	}
+	if row.FilesSelected != 0 || row.FilesMeasured != 0 || len(row.Files) != 0 {
+		t.Fatalf("identity preparation widened measurement scope: %+v", row)
+	}
+	board, err := perfScanOracleBoardFromRows([]*perfScanLanguage{row})
+	if err != nil {
+		t.Fatalf("assemble empty-corpus oracle board: %v", err)
+	}
+	if len(board.Languages) != 1 || board.Languages[0].Language != "go" {
+		t.Fatalf("empty-corpus oracle board = %+v", board)
+	}
+}
+
 func TestPerfScanMissingCorpusFailsClosedOnStaticOracleErrorUnit(t *testing.T) {
 	cfg := perfScanConfig{CorpusRoot: filepath.Join(t.TempDir(), "missing")}
 	row := perfScanMeasureLanguageWithStaticOracleBuilder(t, "go", cfg, nil, func(string) (*staticCPerfOracle, error) {

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -1288,6 +1288,16 @@ func perfScanClearActiveFile(row *perfScanLanguage) {
 }
 
 func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flush func(*perfScanLanguage)) *perfScanLanguage {
+	return perfScanMeasureLanguageWithStaticOracleBuilder(t, lang, cfg, flush, buildStaticCPerfOracle)
+}
+
+func perfScanMeasureLanguageWithStaticOracleBuilder(
+	t *testing.T,
+	lang string,
+	cfg perfScanConfig,
+	flush func(*perfScanLanguage),
+	buildStaticOracle func(string) (*staticCPerfOracle, error),
+) *perfScanLanguage {
 	start := time.Now()
 	row := &perfScanLanguage{
 		Language: lang,
@@ -1318,12 +1328,41 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 		row.Notes = append(row.Notes, "known structural mismatch (timed anyway): "+reason)
 	}
 
+	var staticOracle *staticCPerfOracle
+	defer func() { staticOracle.Close() }()
+	prepareStaticOracle := func() error {
+		if staticOracle != nil {
+			return nil
+		}
+		if buildStaticOracle == nil {
+			return errors.New("builder is not configured")
+		}
+		oracle, err := buildStaticOracle(lang)
+		if err != nil {
+			return err
+		}
+		if oracle == nil {
+			return errors.New("builder returned no oracle")
+		}
+		staticOracle = oracle
+		identity := staticOracle.identity
+		row.Oracle = &identity
+		return nil
+	}
+
 	langRoot := realCorpusBenchmarkLanguageRoot(t, cfg.CorpusRoot, lang)
 	if st, err := os.Stat(langRoot); err != nil || !st.IsDir() {
-		return finish("no_corpus", fmt.Sprintf("no corpus directory at %s", langRoot))
+		detail := fmt.Sprintf("no corpus directory at %s", langRoot)
+		if err := prepareStaticOracle(); err != nil {
+			return finish("no_corpus", fmt.Sprintf("%s; build locked static C oracle: %v", detail, err))
+		}
+		return finish("no_corpus", detail)
 	}
 	files, err := perfScanSelectFiles(t, lang, cfg, langRoot)
 	if err != nil {
+		if oracleErr := prepareStaticOracle(); oracleErr != nil {
+			return finish("no_corpus_files", fmt.Sprintf("%v; build locked static C oracle: %v", err, oracleErr))
+		}
 		return finish("no_corpus_files", err.Error())
 	}
 	row.FilesSelected = len(files)
@@ -1343,13 +1382,9 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 	if err != nil {
 		return finish("no_c_reference", fmt.Sprintf("load C parser identity: %v", err))
 	}
-	staticOracle, err := buildStaticCPerfOracle(lang)
-	if err != nil {
+	if err := prepareStaticOracle(); err != nil {
 		return finish("no_static_c_oracle", fmt.Sprintf("build locked static C oracle: %v", err))
 	}
-	defer staticOracle.Close()
-	identity := staticOracle.identity
-	row.Oracle = &identity
 
 	goLang := entry.Language()
 	if goLang == nil {
@@ -1470,6 +1505,62 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 		return finish(measurementStatus, strings.Join(measurementDetails, "; "))
 	}
 	return finish(perfScanStatusOK, "")
+}
+
+func TestPerfScanMissingCorpusPinsStaticOracleIdentityUnit(t *testing.T) {
+	cfg := perfScanConfig{
+		CorpusRoot: filepath.Join(t.TempDir(), "missing"),
+		Axes:       []string{perfScanAxisFull},
+	}
+	want := perfScanTestOracleIdentity("go")
+	buildCalls := 0
+	closeCalls := 0
+	row := perfScanMeasureLanguageWithStaticOracleBuilder(t, "go", cfg, nil, func(language string) (*staticCPerfOracle, error) {
+		buildCalls++
+		if language != "go" {
+			t.Fatalf("static oracle language = %q, want go", language)
+		}
+		return &staticCPerfOracle{
+			identity: *want,
+			cleanup:  func() { closeCalls++ },
+		}, nil
+	})
+	if row.Status != "no_corpus" {
+		t.Fatalf("missing corpus status = %q, want no_corpus: %s", row.Status, row.Detail)
+	}
+	if row.Oracle == nil || row.Oracle.Common != want.Common ||
+		row.Oracle.Language.Language != want.Language.Language ||
+		row.Oracle.Language.GrammarCommit != want.Language.GrammarCommit ||
+		row.Oracle.Language.BuildKeySHA256 != want.Language.BuildKeySHA256 ||
+		row.Oracle.Language.ArtifactSHA256 != want.Language.ArtifactSHA256 {
+		t.Fatalf("missing corpus lost locked static C identity: got=%+v want=%+v", row.Oracle, want)
+	}
+	if buildCalls != 1 || closeCalls != 1 {
+		t.Fatalf("static oracle lifecycle builds=%d closes=%d, want 1/1", buildCalls, closeCalls)
+	}
+	if row.FilesSelected != 0 || row.FilesMeasured != 0 || len(row.Files) != 0 {
+		t.Fatalf("identity preparation widened measurement scope: %+v", row)
+	}
+	board, err := perfScanOracleBoardFromRows([]*perfScanLanguage{row})
+	if err != nil {
+		t.Fatalf("assemble no-corpus oracle board: %v", err)
+	}
+	if len(board.Languages) != 1 || board.Languages[0].Language != "go" {
+		t.Fatalf("no-corpus oracle board = %+v", board)
+	}
+}
+
+func TestPerfScanMissingCorpusFailsClosedOnStaticOracleErrorUnit(t *testing.T) {
+	cfg := perfScanConfig{CorpusRoot: filepath.Join(t.TempDir(), "missing")}
+	row := perfScanMeasureLanguageWithStaticOracleBuilder(t, "go", cfg, nil, func(string) (*staticCPerfOracle, error) {
+		return nil, errors.New("fixture build failure")
+	})
+	if row.Status != "no_corpus" || row.Oracle != nil || !strings.Contains(row.Detail, "fixture build failure") {
+		t.Fatalf("static oracle failure did not fail the missing-corpus row closed: %+v", row)
+	}
+	if _, err := perfScanOracleBoardFromRows([]*perfScanLanguage{row}); err == nil {
+		t.Fatal("missing static oracle identity produced an authenticated board")
+	}
 }
 
 type perfScanCorpusFile struct {


### PR DESCRIPTION
Summary

- Build the locked static C oracle before each corpus-closure return.
- Keep missing-corpus rows authenticated without selecting or measuring files.
- Keep builder failures closed and reject unauthenticated strict boards.
- Preserve report-mode closure classification for rows without an oracle.

Verification

- Focused identity, builder-failure, reducer, and report tests pass in Docker.
- Five no-corpus fleet languages retain static executable identities.
- The empty-directory test pins the no_corpus_files path.
- Independent review found no defects.