### PR TITLE
Add gated C action-cell transactions

### DIFF
--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -27,6 +27,7 @@ type builtinLanguageRuntimeProfile struct {
 	compactAcceptanceStructuralElection bool
 	compactLexerSkippedPrefixTiling     bool
 	exactStackNodeEquivalence           bool
+	compactPackedGSSVersionOrder        bool
 	compactStrategy2ErrorRegion         bool
 	compactMissingTokenInsertion        bool
 	compactRecoveryTrailingRetirement   bool
@@ -719,6 +720,10 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	}
 	if profile.exactStackNodeEquivalence && !lang.ExactStackNodeEquivalenceCertified {
 		lang.ExactStackNodeEquivalenceCertified = true
+		changed = true
+	}
+	if profile.compactPackedGSSVersionOrder && !lang.CompactPackedGSSVersionOrderCertified {
+		lang.CompactPackedGSSVersionOrderCertified = true
 		changed = true
 	}
 	if profile.compactStrategy2ErrorRegion && !lang.CompactStrategy2ErrorRegionCertified {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -174,6 +174,9 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	if lang.ExactStackNodeEquivalenceCertified {
 		t.Fatal("unknown runtime profile enabled exact stack-node equivalence")
 	}
+	if lang.CompactPackedGSSVersionOrderCertified {
+		t.Fatal("unknown runtime profile enabled packed GSS version ordering")
+	}
 	if lang.CompactRecoveryPlainFirstCertified {
 		t.Fatal("unknown runtime profile enabled compact plain-first recovery")
 	}

--- a/language.go
+++ b/language.go
@@ -799,6 +799,15 @@ type Language struct {
 	// stale artifacts retain bounded equivalence unless callers opt in.
 	ExactStackNodeEquivalenceCertified bool
 
+	// CompactPackedGSSVersionOrderCertified permits the compact parser to use
+	// C's physical stack-version transaction order for packed graph-structured
+	// stack reductions. The transaction includes action-slot ownership,
+	// same-round scheduling, bounded wave-order pop traversal, and packed-child
+	// election. Exact built-in profiles set this only after locked-C receipts and
+	// memory-budget tests certify the complete bundle. Custom, adapted, and stale
+	// artifacts retain the false default.
+	CompactPackedGSSVersionOrderCertified bool
+
 	// CompactStrategy2ErrorRegionCertified permits the compact fresh-full route
 	// to attempt native strategy-2 recovery (error-region absorb and
 	// condense-resume, campaign v7 tranche B3 stage S3) for a true no-table-

--- a/parser.go
+++ b/parser.go
@@ -79,10 +79,10 @@ type Parser struct {
 	// mirroring C tree-sitter's live action_count/version_count checks
 	// rather than a whole-parse latch.
 	//
-	// reduceMultiVersion mirrors C's "ts_stack_version_count > 1": set once
-	// per token-dispatch pass, before the per-stack loop, to numStacks > 1
-	// (see parseInternal). It stays constant for every stack dispatched
-	// against the current token.
+	// reduceMultiVersion mirrors C's "ts_stack_version_count > 1". The ordinary
+	// path sets it once per token-dispatch pass. The packed-version transaction
+	// path recomputes it before each same-round retry because that path can add
+	// and promote physical versions while it scans one action cell.
 	reduceMultiVersion bool
 	// reduceActionConflict mirrors C's "action_count > 1": true only while
 	// the "if len(actions) > 1" conflict-dispatch block (parseInternal) is
@@ -4534,6 +4534,22 @@ func incrementalOldTreeMayCarryErrorCost(reuse *reuseCursor, oldTree *Tree) bool
 	return oldTree.root.hasError()
 }
 
+func compactPackedGSSActionCellRequiresTransaction(actions []ParseAction) bool {
+	if len(actions) > 1 {
+		return true
+	}
+	return len(actions) == 1 &&
+		(actions[0].Type == ParseActionReduce ||
+			(actions[0].Type == ParseActionShift && actions[0].Repetition))
+}
+
+func compactPackedGSSDispatchVersionCount(certified bool, roundVersionCount, currentVersionCount int) int {
+	if certified {
+		return currentVersionCount
+	}
+	return roundVersionCount
+}
+
 // parseInternal is the core GLR parsing loop shared by Parse and
 // ParseWithTokenSource.
 //
@@ -5859,7 +5875,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		// never handed a token it cannot use.
 		stackRelexRestoreTok := Token{}
 		stackRelexActive := false
-		for si := 0; si < numStacks; si++ {
+		packedVersionOrder := p.language != nil && p.language.CompactPackedGSSVersionOrderCertified
+		for si := 0; si < numStacks || (packedVersionOrder && si < len(stacks)); si++ {
 			s := &stacks[si]
 			if stackRelexActive {
 				tok = stackRelexRestoreTok
@@ -5910,7 +5927,16 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			}
 			currentState := s.top().state
 			noteStopDiagnosticStack(s)
+			packedVersionReductionSteps := 0
 		retryAction:
+			if packedVersionOrder {
+				// A transaction can append reduction versions and then remove its
+				// promoted source before this retry. Recompute both live C signals;
+				// do not carry the prior action cell's conflict state forward.
+				p.reduceMultiVersion = len(stacks) > 1
+				p.reduceActionConflict = false
+			}
+			dispatchVersionCount := compactPackedGSSDispatchVersionCount(packedVersionOrder, numStacks, len(stacks))
 			actionStart := time.Time{}
 			if phaseTiming {
 				actionStart = time.Now()
@@ -5926,7 +5952,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			if phaseTiming {
 				actionLookupNanos += time.Since(actionStart).Nanoseconds()
 			}
-			if keywordSym, ok := p.typeScriptContextualPropertyKeywordSymbol(tok, source); ok && parseStacksShareState(stacks[:numStacks], currentState) {
+			if keywordSym, ok := p.typeScriptContextualPropertyKeywordSymbol(tok, source); ok && parseStacksShareState(stacks[:dispatchVersionCount], currentState) {
 				if p.typeScriptContextualPropertyKeywordHasAction(keywordSym, currentState) {
 					tok.Symbol = keywordSym
 					workCountRefreshConvergenceLookahead(tok)
@@ -5936,14 +5962,85 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			}
 			p.traceStackActions(si, currentState, tok.Symbol, actions)
 			if p.ambiguityProfile != nil {
-				p.ambiguityProfile.record(currentState, tok.Symbol, actions, numStacks)
+				p.ambiguityProfile.record(currentState, tok.Symbol, actions, dispatchVersionCount)
+			}
+			if packedVersionOrder && compactPackedGSSActionCellRequiresTransaction(actions) {
+				p.reduceActionConflict = len(actions) > 1
+				if len(actions) > 1 {
+					scratch.gss.everForked = true
+				}
+				s.ensureGSS(&scratch.gss)
+				var lastReductionVersion int
+				var terminalOrdinal int
+				var reason ParseStopReason
+				stacks, lastReductionVersion, terminalOrdinal, reason = p.cAppendActionCellReductionVersions(
+					source, stacks, si, actions, tok, &nodeCount, arena,
+					&scratch.entries, &scratch.gss, &scratch.tmpEntries, trackChildErrors, &anyReduced,
+				)
+				if reason != ParseStopNone {
+					return finalize(stacks, reason)
+				}
+				p.reduceMultiVersion = len(stacks) > 1
+				s = &stacks[si]
+				if terminalOrdinal >= 0 {
+					terminal := actions[terminalOrdinal]
+					if terminal.Type == ParseActionShift && !p.guardRealShiftGap(source, s, tok) {
+						continue
+					}
+					if terminal.Type == ParseActionRecover && !p.guardRealTokenAttachmentGap(source, s, tok, "packed-version-recover") {
+						continue
+					}
+					traceVisit(si, s, "packed-version-terminal", terminalOrdinal, len(actions), terminal)
+					setPendingTrace("packed-version-terminal", si, terminalOrdinal, len(actions), terminal)
+					p.noteStopActionDiagnostic("packed-version-terminal", s, tok, terminal, terminalOrdinal, len(actions), false, 0, 0, false)
+					p.applyAction(source, s, terminal, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
+					p.noteStopActionResult(s)
+					traceAfterPrimary(si, s)
+					if terminal.Type == ParseActionShift || terminal.Type == ParseActionRecover {
+						consumeCurrentToken(s)
+					}
+					continue
+				}
+				if lastReductionVersion >= 0 {
+					var renumbered bool
+					stacks, renumbered = cRenumberReductionVersion(stacks, lastReductionVersion, si)
+					if !renumbered {
+						return finalize(stacks, ParseStopInvariantViolation)
+					}
+					packedVersionReductionSteps++
+					if packedVersionReductionSteps > maxConsecutivePrimaryReduces {
+						return finalize(stacks, ParseStopIterationLimit)
+					}
+					s = &stacks[si]
+					currentState = s.top().state
+					if tok.NoLookahead {
+						// C sets needs_lex after it promotes a reduction made at
+						// the end of a nonterminal extra. Do not dispatch the EOF
+						// table again against the promoted state.
+						needToken = true
+						continue
+					}
+					needToken = false
+					goto retryAction
+				}
+				if tok.NoLookahead {
+					// C halts a nonterminal-extra version whose fixed reduction
+					// produced no surviving physical version.
+					s.dead = true
+					continue
+				}
+				// A real lookahead remains invalid on the unchanged source slot.
+				// Continue through the ordinary no-action path so keyword repair,
+				// re-lexing, and recovery retain their existing ownership.
+				p.reduceActionConflict = false
+				actions = nil
 			}
 			if len(actions) > 0 && actions[0].Type == ParseActionShift && actions[0].Extra {
 				actionKindStart := time.Time{}
 				if actionTiming != nil {
 					actionKindStart = time.Now()
 				}
-				if numStacks == 1 && p.tryMaterializeSkippedRealGap(source, s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
+				if dispatchVersionCount == 1 && p.tryMaterializeSkippedRealGap(source, s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 					anyReduced = true
 					needToken = false
 					goto retryAction
@@ -6581,7 +6678,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			} else {
 				switch act.Type {
 				case ParseActionShift:
-					if numStacks == 1 && p.tryMaterializeSkippedRealGap(source, s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
+					if dispatchVersionCount == 1 && p.tryMaterializeSkippedRealGap(source, s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 						anyReduced = true
 						needToken = false
 						goto retryAction
@@ -6612,7 +6709,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 						recordActionTiming(currentState, tok.Symbol, actions, ambiguityActionSingleAccept, ns)
 					}
 				case ParseActionRecover:
-					if numStacks == 1 && p.tryMaterializeSkippedRealGap(source, s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
+					if dispatchVersionCount == 1 && p.tryMaterializeSkippedRealGap(source, s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 						anyReduced = true
 						needToken = false
 						goto retryAction
@@ -6664,7 +6761,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			return finalize(stacks, reason)
 		}
 
-		if numStacks > 1 && retryPass && allParseStacksDead(stacks) {
+		postDispatchVersionCount := compactPackedGSSDispatchVersionCount(packedVersionOrder, numStacks, len(stacks))
+		if postDispatchVersionCount > 1 && retryPass && allParseStacksDead(stacks) {
 			bestIdx := bestRetryRecoveryStack(stacks)
 			stacks[bestIdx].dead = false
 			stacks[0] = stacks[bestIdx]
@@ -7003,7 +7101,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				noTokenProgressHaveLast = true
 			}
 			if consecutiveNoTokenDispatches > maxConsecutiveNoTokenDispatches {
-				stopDiagFrontier = p.buildStopFrontierDiagnostics(stacks, tok, numStacks, dispatchTrace)
+				stopDiagFrontier = p.buildStopFrontierDiagnostics(stacks, tok, postDispatchVersionCount, dispatchTrace)
 				if progress.enabled {
 					extra := fmt.Sprintf("count=%d cap=%d any_reduced=%t consumed_token=%t", consecutiveNoTokenDispatches, maxConsecutiveNoTokenDispatches, anyReduced, dispatchConsumedCurrentToken)
 					if actionExtra := stopActionDiag.progressString(); actionExtra != "" {

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -3113,7 +3113,7 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 			var reason ParseStopReason
 			versions, actionReductionVersion, reason = p.cAppendReductionActionVersions(
 				source, versions, v, act, tok, nodeCount, arena, entryScratch,
-				gssScratch, tmpEntries, trackChildErrors, &singletonCandidate,
+				gssScratch, tmpEntries, trackChildErrors, &singletonCandidate, nil,
 			)
 			if reason != ParseStopNone {
 				return versions, canShift, reason
@@ -3162,7 +3162,7 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 
 func (p *Parser) cReductionCandidatesForAction(source []byte, start glrStack, act ParseAction, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, tmpEntries *[]stackEntry, trackChildErrors *bool) ([]glrStack, ParseStopReason) {
 	var singletonCandidate glrStack
-	candidates, hasSingletonCandidate, reason := p.cReductionCandidatesForActionInto(source, start, act, tok, nodeCount, arena, entryScratch, gssScratch, tmpEntries, trackChildErrors, &singletonCandidate)
+	candidates, hasSingletonCandidate, reason := p.cReductionCandidatesForActionInto(source, start, act, tok, nodeCount, arena, entryScratch, gssScratch, tmpEntries, trackChildErrors, &singletonCandidate, nil)
 	if hasSingletonCandidate {
 		return []glrStack{singletonCandidate}, reason
 	}
@@ -3173,13 +3173,13 @@ func (p *Parser) cReductionCandidatesForAction(source []byte, start glrStack, ac
 // version. It appends every surviving pop result in C stack-version order and
 // merges each result into earlier compatible versions before the caller can
 // promote a result into the source slot.
-func (p *Parser) cAppendReductionActionVersions(source []byte, versions []glrStack, originalVersion int, act ParseAction, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, tmpEntries *[]stackEntry, trackChildErrors *bool, singletonCandidate *glrStack) ([]glrStack, int, ParseStopReason) {
+func (p *Parser) cAppendReductionActionVersions(source []byte, versions []glrStack, originalVersion int, act ParseAction, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, tmpEntries *[]stackEntry, trackChildErrors *bool, singletonCandidate *glrStack, anyReduced *bool) ([]glrStack, int, ParseStopReason) {
 	if originalVersion < 0 || originalVersion >= len(versions) || singletonCandidate == nil {
 		return versions, -1, ParseStopInvariantViolation
 	}
 	actionCandidates, hasSingletonCandidate, reason := p.cReductionCandidatesForActionInto(
 		source, versions[originalVersion], act, tok, nodeCount, arena,
-		entryScratch, gssScratch, tmpEntries, trackChildErrors, singletonCandidate,
+		entryScratch, gssScratch, tmpEntries, trackChildErrors, singletonCandidate, anyReduced,
 	)
 	if reason != ParseStopNone {
 		return versions, -1, reason
@@ -3199,9 +3199,57 @@ func (p *Parser) cAppendReductionActionVersions(source []byte, versions []glrSta
 	return versions, reductionVersion, ParseStopNone
 }
 
-func (p *Parser) cReductionCandidatesForActionInto(source []byte, start glrStack, act ParseAction, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, tmpEntries *[]stackEntry, trackChildErrors *bool, singletonCandidate *glrStack) ([]glrStack, bool, ParseStopReason) {
+// cAppendActionCellReductionVersions applies the reductions in one parse-table
+// cell to an unchanged physical source slot. A repetition shift is a no-op.
+// The first ordinary shift, accept, or recover action owns the source slot and
+// stops the scan. Without a terminal action, the caller promotes the first
+// surviving result from the last successful reduction.
+func (p *Parser) cAppendActionCellReductionVersions(source []byte, versions []glrStack, originalVersion int, actions []ParseAction, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, tmpEntries *[]stackEntry, trackChildErrors *bool, anyReduced *bool) ([]glrStack, int, int, ParseStopReason) {
+	if originalVersion < 0 || originalVersion >= len(versions) {
+		return versions, -1, -1, ParseStopInvariantViolation
+	}
+	if len(p.pendingForkStacks) != 0 || len(p.pendingFrontierForkStacks) != 0 {
+		return versions, -1, -1, ParseStopInvariantViolation
+	}
+	oldDisablePostReduceForkMerge := p.disablePostReduceForkMerge
+	p.disablePostReduceForkMerge = true
+	defer func() {
+		p.disablePostReduceForkMerge = oldDisablePostReduceForkMerge
+	}()
+
+	lastReductionVersion := -1
+	var singletonCandidate glrStack
+	for actionOrdinal, action := range actions {
+		switch action.Type {
+		case ParseActionReduce:
+			var reductionVersion int
+			var reason ParseStopReason
+			versions, reductionVersion, reason = p.cAppendReductionActionVersions(
+				source, versions, originalVersion, action, tok, nodeCount, arena,
+				entryScratch, gssScratch, tmpEntries, trackChildErrors, &singletonCandidate, anyReduced,
+			)
+			if reason != ParseStopNone {
+				return versions, lastReductionVersion, -1, reason
+			}
+			if reductionVersion >= 0 {
+				lastReductionVersion = reductionVersion
+			}
+		case ParseActionShift:
+			if action.Repetition {
+				continue
+			}
+			return versions, lastReductionVersion, actionOrdinal, ParseStopNone
+		case ParseActionAccept, ParseActionRecover:
+			return versions, lastReductionVersion, actionOrdinal, ParseStopNone
+		}
+	}
+	return versions, lastReductionVersion, -1, ParseStopNone
+}
+
+func (p *Parser) cReductionCandidatesForActionInto(source []byte, start glrStack, act ParseAction, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, tmpEntries *[]stackEntry, trackChildErrors *bool, singletonCandidate *glrStack, anyReduced *bool) ([]glrStack, bool, ParseStopReason) {
 	p.pendingForkStacks = p.pendingForkStacks[:0]
 	defer func() {
+		clear(p.pendingForkStacks)
 		p.pendingForkStacks = p.pendingForkStacks[:0]
 	}()
 	if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
@@ -3215,6 +3263,9 @@ func (p *Parser) cReductionCandidatesForActionInto(source []byte, start glrStack
 		localTmpEntries = *tmpEntries
 	}
 	p.applyAction(source, &fork, act, tok, &dummy, nodeCount, arena, entryScratch, gssScratch, &localTmpEntries, deferParentLinks, trackChildErrors)
+	if dummy && anyReduced != nil {
+		*anyReduced = true
+	}
 	if tmpEntries != nil {
 		if localTmpEntries != nil {
 			*tmpEntries = localTmpEntries[:0]

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -1639,6 +1639,406 @@ func TestCAppendActionReductionVersionsCollapsesSamePopBeforeOlderMerge(t *testi
 	}
 }
 
+func cActionCellTransactionParser() *Parser {
+	lang := &Language{
+		TokenCount:  2,
+		StateCount:  10,
+		SymbolCount: 6,
+		ParseTable:  make([][]uint16, 10),
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 7}}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 8}}},
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "end", Visible: true, Named: true},
+			{Name: "token", Visible: true, Named: true},
+			{Name: "leaf", Visible: true, Named: true},
+			{Name: "unused", Visible: true, Named: true},
+			{Name: "left_parent", Visible: true, Named: true},
+			{Name: "right_parent", Visible: true, Named: true},
+		},
+	}
+	lang.ParseTable[1] = []uint16{0, 0, 0, 0, 1, 2}
+	return &Parser{language: lang, denseLimit: len(lang.ParseTable)}
+}
+
+func cActionCellTransactionStart(arena *nodeArena) glrStack {
+	leaf := newLeafNodeInArena(arena, 2, true, 0, 1, Point{}, Point{Column: 1})
+	start := newGLRStack(1)
+	start.pushEntry(newStackEntryNode(3, leaf), nil, nil)
+	return start
+}
+
+type cActionCellTokenSource struct {
+	tokens []Token
+	index  int
+}
+
+func (s *cActionCellTokenSource) Next() Token {
+	if s.index >= len(s.tokens) {
+		return Token{}
+	}
+	tok := s.tokens[s.index]
+	s.index++
+	return tok
+}
+
+func cActionCellIntegrationLanguage(actions []ParseAction) *Language {
+	return &Language{
+		Name:                                  "c_action_cell_integration",
+		SymbolCount:                           4,
+		TokenCount:                            2,
+		StateCount:                            5,
+		InitialState:                          1,
+		CompactPackedGSSVersionOrderCertified: true,
+		SymbolNames:                           []string{"end", "x", "low_root", "high_root"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "end", Visible: false},
+			{Name: "x", Visible: true},
+			{Name: "low_root", Visible: true, Named: true},
+			{Name: "high_root", Visible: true, Named: true},
+		},
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 3}}},
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 2, ChildCount: 1}}},
+			{Actions: actions},
+			{Actions: []ParseAction{{Type: ParseActionAccept}}},
+		},
+		ParseTable: [][]uint16{
+			make([]uint16, 4),
+			{0, 1, 2, 4},
+			{3, 0, 0, 0},
+			{2, 0, 0, 0},
+			{4, 0, 0, 0},
+		},
+	}
+}
+
+func TestCompactPackedGSSActionTransactionProcessesReductionVersionSameRound(t *testing.T) {
+	tests := []struct {
+		name    string
+		actions []ParseAction
+		want    string
+	}{
+		{
+			name: "reduction before terminal survives",
+			actions: []ParseAction{
+				{Type: ParseActionReduce, Symbol: 3, ChildCount: 1, DynamicPrecedence: 1},
+				{Type: ParseActionAccept},
+			},
+			want: "high_root",
+		},
+		{
+			name: "terminal before reduction stops scan",
+			actions: []ParseAction{
+				{Type: ParseActionAccept},
+				{Type: ParseActionReduce, Symbol: 3, ChildCount: 1, DynamicPrecedence: 1},
+			},
+			want: "low_root",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			language := cActionCellIntegrationLanguage(test.actions)
+			parser := NewParser(language)
+			parser.hasRootSymbol = false
+			tree, err := parser.ParseWithTokenSource([]byte("x"), &cActionCellTokenSource{tokens: []Token{
+				{Symbol: 1, StartByte: 0, EndByte: 1, EndPoint: Point{Column: 1}},
+				{Symbol: 0, StartByte: 1, EndByte: 1, StartPoint: Point{Column: 1}, EndPoint: Point{Column: 1}},
+			}})
+			if err != nil {
+				t.Fatalf("ParseWithTokenSource() error = %v", err)
+			}
+			if got := tree.RootNode().Type(language); got != test.want {
+				t.Fatalf("root type = %q, want %q; tree=%s", got, test.want, tree.RootNode().SExpr(language))
+			}
+			if got := tree.ParseStopReason(); got != ParseStopAccepted {
+				t.Fatalf("parse stop reason = %q, want accepted", got)
+			}
+		})
+	}
+}
+
+func TestCompactPackedGSSActionTransactionRecomputesRetryFragility(t *testing.T) {
+	language := cActionCellIntegrationLanguage([]ParseAction{
+		{Type: ParseActionReduce, Symbol: 3, ChildCount: 1},
+	})
+	parser := NewParser(language)
+	parser.hasRootSymbol = false
+	tree, err := parser.ParseWithTokenSource([]byte("x"), &cActionCellTokenSource{tokens: []Token{
+		{Symbol: 1, StartByte: 0, EndByte: 1, EndPoint: Point{Column: 1}},
+		{Symbol: 0, StartByte: 1, EndByte: 1, StartPoint: Point{Column: 1}, EndPoint: Point{Column: 1}},
+	}})
+	if err != nil {
+		t.Fatalf("ParseWithTokenSource() error = %v", err)
+	}
+	if got := tree.ParseStopReason(); got != ParseStopAccepted {
+		t.Fatalf("parse stop reason = %q, want accepted", got)
+	}
+	root := tree.RootNode()
+	if got := root.Type(language); got != "high_root" {
+		t.Fatalf("root type = %q, want high_root; tree=%s", got, root.SExpr(language))
+	}
+	if root.isFragile() {
+		t.Fatal("single surviving reduction version stayed fragile after promotion retry")
+	}
+}
+
+func TestCompactPackedGSSActionTransactionRelexesAfterNoLookaheadReduction(t *testing.T) {
+	language := &Language{
+		Name:                                  "c_action_cell_no_lookahead",
+		SymbolCount:                           3,
+		TokenCount:                            2,
+		StateCount:                            4,
+		InitialState:                          1,
+		CompactPackedGSSVersionOrderCertified: true,
+		SymbolNames:                           []string{"end", "x", "root"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "end", Visible: false},
+			{Name: "x", Visible: true},
+			{Name: "root", Visible: true, Named: true},
+		},
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 2}}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 3}}},
+			{Actions: []ParseAction{{Type: ParseActionAccept}}},
+		},
+		ParseTable: [][]uint16{
+			make([]uint16, 3),
+			{1, 0, 2},
+			{0, 2, 0},
+			{3, 0, 0},
+		},
+	}
+	parser := NewParser(language)
+	parser.hasRootSymbol = false
+	tokens := &cActionCellTokenSource{tokens: []Token{
+		{Symbol: 0, NoLookahead: true},
+		{Symbol: 1, StartByte: 0, EndByte: 1, EndPoint: Point{Column: 1}},
+		{Symbol: 0, StartByte: 1, EndByte: 1, StartPoint: Point{Column: 1}, EndPoint: Point{Column: 1}},
+	}}
+	tree, err := parser.ParseWithTokenSource([]byte("x"), tokens)
+	if err != nil {
+		t.Fatalf("ParseWithTokenSource() error = %v", err)
+	}
+	if got := tree.ParseStopReason(); got != ParseStopAccepted {
+		t.Fatalf("parse stop reason = %q, want accepted", got)
+	}
+	if tokens.index != len(tokens.tokens) {
+		t.Fatalf("token reads = %d, want %d; promoted reduction reused null lookahead", tokens.index, len(tokens.tokens))
+	}
+}
+
+func TestCAppendActionCellReductionVersionsPromotesLastSuccessfulReduction(t *testing.T) {
+	parser := cActionCellTransactionParser()
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	start := cActionCellTransactionStart(arena)
+	actions := []ParseAction{
+		{Type: ParseActionReduce, Symbol: 4, ChildCount: 1},
+		{Type: ParseActionReduce, Symbol: 5, ChildCount: 1},
+		// This result merges into the first reduction. C keeps the last
+		// successful result instead of overwriting it with NONE.
+		{Type: ParseActionReduce, Symbol: 4, ChildCount: 1},
+	}
+	nodeCount := 0
+	anyReduced := false
+	versions, lastReduction, terminalOrdinal, reason := parser.cAppendActionCellReductionVersions(
+		nil, []glrStack{start}, 0, actions, Token{}, &nodeCount, arena,
+		nil, nil, nil, nil, &anyReduced,
+	)
+	if reason != ParseStopNone {
+		t.Fatalf("action-cell transaction stop reason = %v, want none", reason)
+	}
+	if terminalOrdinal != -1 || lastReduction != 2 {
+		t.Fatalf("action-cell result terminal=%d reduction=%d, want -1/2", terminalOrdinal, lastReduction)
+	}
+	if !anyReduced {
+		t.Fatal("action-cell reductions did not report round progress")
+	}
+	if got, want := len(versions), 3; got != want {
+		t.Fatalf("version count = %d, want %d", got, want)
+	}
+	for i, want := range []StateID{3, 7, 8} {
+		if got := versions[i].top().state; got != want {
+			t.Fatalf("pre-promotion version[%d] state = %d, want %d", i, got, want)
+		}
+	}
+	for i, want := range []Symbol{4, 5} {
+		if got := stackEntryNode(versions[i+1].top()).symbol; got != want {
+			t.Fatalf("reduction version[%d] symbol = %d, want %d", i+1, got, want)
+		}
+	}
+	versions, ok := cRenumberReductionVersion(versions, lastReduction, 0)
+	if !ok {
+		t.Fatal("last successful reduction did not promote")
+	}
+	for i, want := range []Symbol{5, 4} {
+		if got := stackEntryNode(versions[i].top()).symbol; got != want {
+			t.Fatalf("post-promotion version[%d] symbol = %d, want %d", i, got, want)
+		}
+	}
+}
+
+func TestCAppendActionCellReductionVersionsStopsAtFirstTerminal(t *testing.T) {
+	parser := cActionCellTransactionParser()
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	start := cActionCellTransactionStart(arena)
+	actions := []ParseAction{
+		{Type: ParseActionReduce, Symbol: 4, ChildCount: 1},
+		{Type: ParseActionShift, Repetition: true},
+		{Type: ParseActionReduce, Symbol: 5, ChildCount: 1},
+		{Type: ParseActionShift, State: 8},
+		{Type: ParseActionReduce, Symbol: 4, ChildCount: 1},
+	}
+	nodeCount := 0
+	anyReduced := false
+	versions, lastReduction, terminalOrdinal, reason := parser.cAppendActionCellReductionVersions(
+		nil, []glrStack{start}, 0, actions, Token{}, &nodeCount, arena,
+		nil, nil, nil, nil, &anyReduced,
+	)
+	if reason != ParseStopNone {
+		t.Fatalf("action-cell transaction stop reason = %v, want none", reason)
+	}
+	if terminalOrdinal != 3 || lastReduction != 2 {
+		t.Fatalf("action-cell result terminal=%d reduction=%d, want 3/2", terminalOrdinal, lastReduction)
+	}
+	if !anyReduced {
+		t.Fatal("action-cell reductions did not report round progress")
+	}
+	if got, want := len(versions), 3; got != want {
+		t.Fatalf("version count = %d, want %d", got, want)
+	}
+	for i, want := range []Symbol{4, 5} {
+		if got := stackEntryNode(versions[i+1].top()).symbol; got != want {
+			t.Fatalf("reduction version[%d] symbol = %d, want %d", i+1, got, want)
+		}
+	}
+}
+
+func TestCAppendActionCellReductionVersionsTerminalOwnsOriginal(t *testing.T) {
+	parser := cActionCellTransactionParser()
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	start := cActionCellTransactionStart(arena)
+	actions := []ParseAction{
+		{Type: ParseActionShift, State: 8},
+		{Type: ParseActionReduce, Symbol: 4, ChildCount: 1},
+	}
+	nodeCount := 0
+	anyReduced := false
+	versions, lastReduction, terminalOrdinal, reason := parser.cAppendActionCellReductionVersions(
+		nil, []glrStack{start}, 0, actions, Token{}, &nodeCount, arena,
+		nil, nil, nil, nil, &anyReduced,
+	)
+	if reason != ParseStopNone {
+		t.Fatalf("action-cell transaction stop reason = %v, want none", reason)
+	}
+	if terminalOrdinal != 0 || lastReduction != -1 {
+		t.Fatalf("action-cell result terminal=%d reduction=%d, want 0/-1", terminalOrdinal, lastReduction)
+	}
+	if anyReduced || len(versions) != 1 {
+		t.Fatalf("later reduction ran: anyReduced=%t versions=%d", anyReduced, len(versions))
+	}
+	if parser.disablePostReduceForkMerge {
+		t.Fatal("action-cell transaction did not restore post-reduce merge policy")
+	}
+}
+
+func TestCAppendActionCellReductionVersionsRepetitionShiftIsNoOp(t *testing.T) {
+	parser := cActionCellTransactionParser()
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	start := cActionCellTransactionStart(arena)
+	nodeCount := 0
+	anyReduced := false
+	versions, lastReduction, terminalOrdinal, reason := parser.cAppendActionCellReductionVersions(
+		nil, []glrStack{start}, 0,
+		[]ParseAction{{Type: ParseActionShift, Repetition: true}},
+		Token{}, &nodeCount, arena, nil, nil, nil, nil, &anyReduced,
+	)
+	if reason != ParseStopNone {
+		t.Fatalf("action-cell transaction stop reason = %v, want none", reason)
+	}
+	if terminalOrdinal != -1 || lastReduction != -1 {
+		t.Fatalf("action-cell result terminal=%d reduction=%d, want -1/-1", terminalOrdinal, lastReduction)
+	}
+	if anyReduced || len(versions) != 1 {
+		t.Fatalf("repetition shift changed transaction: anyReduced=%t versions=%d", anyReduced, len(versions))
+	}
+}
+
+func TestCAppendActionCellReductionVersionsRejectsForeignPendingOwnership(t *testing.T) {
+	tests := []struct {
+		name  string
+		queue func(*Parser) *[]glrStack
+	}{
+		{name: "post-reduce queue", queue: func(p *Parser) *[]glrStack { return &p.pendingForkStacks }},
+		{name: "frontier queue", queue: func(p *Parser) *[]glrStack { return &p.pendingFrontierForkStacks }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parser := cActionCellTransactionParser()
+			queue := test.queue(parser)
+			*queue = append(*queue, newGLRStack(9))
+			arena := acquireNodeArena(arenaClassFull)
+			defer arena.Release()
+			start := cActionCellTransactionStart(arena)
+			nodeCount := 0
+
+			versions, lastReduction, terminalOrdinal, reason := parser.cAppendActionCellReductionVersions(
+				nil, []glrStack{start}, 0,
+				[]ParseAction{{Type: ParseActionReduce, Symbol: 4, ChildCount: 1}},
+				Token{}, &nodeCount, arena, nil, nil, nil, nil, nil,
+			)
+			if reason != ParseStopInvariantViolation {
+				t.Fatalf("action-cell transaction stop reason = %v, want invariant violation", reason)
+			}
+			if lastReduction != -1 || terminalOrdinal != -1 || len(versions) != 1 {
+				t.Fatalf("rejected transaction changed result: reduction=%d terminal=%d versions=%d", lastReduction, terminalOrdinal, len(versions))
+			}
+			if len(*queue) != 1 {
+				t.Fatal("rejected transaction discarded a foreign pending fork")
+			}
+		})
+	}
+}
+
+func TestCompactPackedGSSActionCellRequiresTransaction(t *testing.T) {
+	tests := []struct {
+		name    string
+		actions []ParseAction
+		want    bool
+	}{
+		{name: "empty"},
+		{name: "single ordinary shift", actions: []ParseAction{{Type: ParseActionShift}}},
+		{name: "single accept", actions: []ParseAction{{Type: ParseActionAccept}}},
+		{name: "single reduction", actions: []ParseAction{{Type: ParseActionReduce}}, want: true},
+		{name: "single repetition shift", actions: []ParseAction{{Type: ParseActionShift, Repetition: true}}, want: true},
+		{name: "multiple terminals", actions: []ParseAction{{Type: ParseActionShift}, {Type: ParseActionAccept}}, want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := compactPackedGSSActionCellRequiresTransaction(test.actions); got != test.want {
+				t.Fatalf("requires transaction = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCompactPackedGSSDispatchVersionCount(t *testing.T) {
+	if got := compactPackedGSSDispatchVersionCount(false, 1, 3); got != 1 {
+		t.Fatalf("uncertified dispatch version count = %d, want round snapshot 1", got)
+	}
+	if got := compactPackedGSSDispatchVersionCount(true, 1, 3); got != 3 {
+		t.Fatalf("certified dispatch version count = %d, want current physical count 3", got)
+	}
+}
+
 func newCRecoverySyntheticReduceParser() *Parser {
 	lang := &Language{
 		TokenCount:  3,


### PR DESCRIPTION
## Summary

- Process each reduce action from the unchanged physical source slot.
- Stop the action scan when the first terminal action owns that slot.
- Promote the last successful reduction and process new versions in the same round.
- Recompute live version and conflict state before each retry.
- Clear owned fork queues and reject foreign queue ownership.

## Safety

No built-in profile enables `CompactPackedGSSVersionOrderCertified`. The capability stays dormant until topology and packed-child gates pass.

The forced Erlang probe accepts without a crash. It still needs wave scheduling and exact child election for C tree parity.

## Verification

- Focused Docker suite: `20260831T041120Z`
- Docker race suite: `20260831T041130Z`
- Telemetry-tag suite: `20260831T041139Z`
- Default Erlang parity: `20260831T035427Z-diag-erlang`
- Forced Erlang diagnostic: `20260831T034904Z`