### PR TITLE
Account for packed GSS link capacity

### DIFF
--- a/glr.go
+++ b/glr.go
@@ -4483,7 +4483,11 @@ func gssMainAddLinkSeenMutate(scratch *glrMergeScratch, n *gssNode, prev *gssNod
 		}
 		return false
 	}
-	n.appendExtraLink(gssMainLink{prev: prev, entry: entry})
+	var owner *gssScratch
+	if scratch != nil {
+		owner = scratch.gssOwner
+	}
+	n.appendExtraLinkWithOwner(gssMainLink{prev: prev, entry: entry}, owner)
 	n.hash = 0
 	return true
 }

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -136,6 +136,13 @@ func (n *gssNode) setExtraLink(i int, link gssMainLink) {
 }
 
 func (n *gssNode) appendExtraLink(link gssMainLink) {
+	n.appendExtraLinkWithOwner(link, nil)
+}
+
+// appendExtraLinkWithOwner bills current packed-link capacity to the scratch
+// that owns n. Standalone callers pass nil because they do not own a parser
+// scratch budget.
+func (n *gssNode) appendExtraLinkWithOwner(link gssMainLink, owner *gssScratch) {
 	if n == nil || int(n.extraLinkCount) >= maxMainLinkCount-1 {
 		panic("gssNode.appendExtraLink: link limit exceeded")
 	}
@@ -165,6 +172,11 @@ func (n *gssNode) appendExtraLink(link gssMainLink) {
 	n.extraLinks = &links[0]
 	n.extraLinkCount++
 	n.extraLinkCap = uint8(newCapacity)
+	if owner != nil {
+		delta := gssMainLinkBytesForCap(newCapacity) - gssMainLinkBytesForCap(capacity)
+		owner.allocatedBytes += delta
+		owner.packedLinkBytes += delta
+	}
 	workCountRecordGraphLinkAddition()
 	workCountRecordAlternatePredecessorLinkAppended() // work-count-assembly: alternate predecessor append-grow seam
 	workCountRecordGSSMutation()                      // work-count-assembly: GSS mutation append-grow seam
@@ -210,6 +222,7 @@ type gssScratch struct {
 	usedTotal           int
 	peakUsed            int
 	allocatedBytes      int64
+	packedLinkBytes     int64
 	singleStackMode     bool
 	singleStackAllocs   uint64
 	multiStackAllocs    uint64
@@ -988,7 +1001,15 @@ func (s *gssScratch) allocNodeSlow(entry stackEntry, prev *gssNode, depth uint32
 // outside this allocator makes accidental address reuse impossible from lower
 // level allocation call sites.
 func (s *gssScratch) recycleForParse() {
-	if s == nil || s.usedTotal == 0 {
+	if s == nil {
+		return
+	}
+	packedLinkBytes := s.packedLinkBytes
+	s.packedLinkBytes = 0
+	if s.usedTotal == 0 {
+		if packedLinkBytes != 0 {
+			s.recomputeAllocatedBytes()
+		}
 		return
 	}
 	for i := range s.slabs {
@@ -1004,6 +1025,12 @@ func (s *gssScratch) recycleForParse() {
 	}
 	s.slabCursor = 0
 	s.usedTotal = 0
+	if packedLinkBytes < 0 || packedLinkBytes > s.allocatedBytes {
+		// Repair an inconsistent counter without allowing signed underflow.
+		s.recomputeAllocatedBytes()
+		return
+	}
+	s.allocatedBytes -= packedLinkBytes
 }
 
 func (s *gssScratch) reset() {
@@ -1015,6 +1042,7 @@ func (s *gssScratch) reset() {
 		s.stackEntries = s.stackEntries[:0]
 	}
 	if len(s.slabs) == 0 {
+		s.packedLinkBytes = 0
 		s.singleStackMode = false
 		s.everForked = false
 		s.singleStackAllocs = 0
@@ -1077,6 +1105,7 @@ func (s *gssScratch) reset() {
 		}
 		s.slabs[i].used = 0
 	}
+	s.packedLinkBytes = 0
 	s.slabCursor = 0
 	s.skipClear = false
 	s.usedTotal = 0
@@ -1125,6 +1154,13 @@ func gssNodeBytesForCap(n int) int64 {
 	return int64(n) * int64(unsafe.Sizeof(gssNode{}))
 }
 
+func gssMainLinkBytesForCap(n int) int64 {
+	if n <= 0 {
+		return 0
+	}
+	return int64(n) * int64(unsafe.Sizeof(gssMainLink{}))
+}
+
 func (s *gssScratch) capacityNodes() int {
 	if s == nil {
 		return 0
@@ -1145,6 +1181,7 @@ func (s *gssScratch) recomputeAllocatedBytes() {
 		total += gssNodeBytesForCap(len(s.slabs[i].data))
 		total += gssReachMarkBytesForCap(len(s.slabs[i].reachMarks))
 	}
+	total += s.packedLinkBytes
 	for i := range s.summaryChunks {
 		bytes, ok := gssSummaryBytesForCap(cap(s.summaryChunks[i].data))
 		if ok {

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -34,6 +34,142 @@ func TestGSSNodeLayoutSizeBudget(t *testing.T) {
 	}
 }
 
+func TestGSSPackedLinkCapacityIsTrackedAndReleasedOnRecycle(t *testing.T) {
+	var owner gssScratch
+	base := owner.allocNode(stackEntry{state: 1}, nil, 1)
+	head := owner.allocNode(newStackEntryNode(2, &Node{symbol: 1}), base, 2)
+	merge := glrMergeScratch{gssOwner: &owner}
+	baseline := owner.allocatedBytes
+
+	for i := 0; i < maxMainLinkCount-1; i++ {
+		prev := owner.allocNode(stackEntry{state: StateID(10 + i)}, nil, 1)
+		entry := newStackEntryNode(2, &Node{symbol: Symbol(10 + i)})
+		if !gssMainAddLinkSeenMutate(&merge, head, prev, entry, make(map[gssMergePair]bool)) {
+			t.Fatalf("append packed link %d failed", i)
+		}
+		wantCap := 1
+		switch {
+		case i >= 4:
+			wantCap = maxMainLinkCount - 1
+		case i >= 2:
+			wantCap = 4
+		case i >= 1:
+			wantCap = 2
+		}
+		if got := int(head.extraLinkCap); got != wantCap {
+			t.Fatalf("packed link capacity after append %d = %d, want %d", i, got, wantCap)
+		}
+		wantBytes := baseline + gssMainLinkBytesForCap(wantCap)
+		if got := owner.allocatedBytes; got != wantBytes {
+			t.Fatalf("tracked bytes after append %d = %d, want %d", i, got, wantBytes)
+		}
+		if got := owner.packedLinkBytes; got != gssMainLinkBytesForCap(wantCap) {
+			t.Fatalf("packed link bytes after append %d = %d, want %d", i, got, gssMainLinkBytesForCap(wantCap))
+		}
+	}
+	owner.ensureReachMarks()
+	retainedBaseline := baseline
+	for i := range owner.slabs {
+		retainedBaseline += gssReachMarkBytesForCap(len(owner.slabs[i].reachMarks))
+	}
+	if got, want := owner.allocatedBytes, retainedBaseline+gssMainLinkBytesForCap(maxMainLinkCount-1); got != want {
+		t.Fatalf("tracked bytes after reach-mark recompute = %d, want %d", got, want)
+	}
+
+	owner.recycleForParse()
+	if got := owner.allocatedBytes; got != retainedBaseline {
+		t.Fatalf("tracked bytes after recycle = %d, want retained baseline %d", got, retainedBaseline)
+	}
+	if owner.packedLinkBytes != 0 {
+		t.Fatalf("packed link bytes after recycle = %d, want 0", owner.packedLinkBytes)
+	}
+}
+
+func TestGSSPackedLinkRecycleRepairsCounterUnderflow(t *testing.T) {
+	var owner gssScratch
+	base := owner.allocNode(stackEntry{state: 1}, nil, 1)
+	head := owner.allocNode(newStackEntryNode(2, &Node{symbol: 1}), base, 2)
+	prev := owner.allocNode(stackEntry{state: 3}, nil, 1)
+	merge := glrMergeScratch{gssOwner: &owner}
+	entry := newStackEntryNode(4, &Node{symbol: 2})
+	if !gssMainAddLinkSeenMutate(&merge, head, prev, entry, make(map[gssMergePair]bool)) {
+		t.Fatal("packed link append failed")
+	}
+	retainedBytes := owner.allocatedBytes - owner.packedLinkBytes
+	owner.allocatedBytes = owner.packedLinkBytes - 1
+
+	owner.recycleForParse()
+
+	if got := owner.allocatedBytes; got != retainedBytes {
+		t.Fatalf("tracked bytes after underflow repair = %d, want %d", got, retainedBytes)
+	}
+	if owner.packedLinkBytes != 0 {
+		t.Fatalf("packed link bytes after underflow repair = %d, want 0", owner.packedLinkBytes)
+	}
+}
+
+func TestGSSPackedLinkCapacityIsReleasedOnReset(t *testing.T) {
+	var owner gssScratch
+	base := owner.allocNode(stackEntry{state: 1}, nil, 1)
+	head := owner.allocNode(newStackEntryNode(2, &Node{symbol: 1}), base, 2)
+	prev := owner.allocNode(stackEntry{state: 3}, nil, 1)
+	merge := glrMergeScratch{gssOwner: &owner}
+	entry := newStackEntryNode(4, &Node{symbol: 2})
+	if !gssMainAddLinkSeenMutate(&merge, head, prev, entry, make(map[gssMergePair]bool)) {
+		t.Fatal("packed link append failed")
+	}
+	retainedBytes := owner.allocatedBytes - owner.packedLinkBytes
+
+	owner.reset()
+
+	if got := owner.allocatedBytes; got != retainedBytes {
+		t.Fatalf("tracked bytes after reset = %d, want %d", got, retainedBytes)
+	}
+	if owner.packedLinkBytes != 0 {
+		t.Fatalf("packed link bytes after reset = %d, want 0", owner.packedLinkBytes)
+	}
+	if head.extraLinks != nil || head.extraLinkCount != 0 || head.extraLinkCap != 0 {
+		t.Fatalf("reset node retained packed links: %+v", *head)
+	}
+}
+
+func TestGSSPackedLinkCounterIsClearedByEmptyReset(t *testing.T) {
+	owner := gssScratch{
+		allocatedBytes:  gssMainLinkBytesForCap(1),
+		packedLinkBytes: gssMainLinkBytesForCap(1),
+	}
+
+	owner.reset()
+
+	if owner.allocatedBytes != 0 || owner.packedLinkBytes != 0 {
+		t.Fatalf("empty reset retained packed-link accounting: allocated=%d packed=%d", owner.allocatedBytes, owner.packedLinkBytes)
+	}
+}
+
+func TestGSSPackedLinkCapacityCountsTowardParserScratchBudget(t *testing.T) {
+	var scratch parserScratch
+	base := scratch.gss.allocNode(stackEntry{state: 1}, nil, 1)
+	head := scratch.gss.allocNode(newStackEntryNode(2, &Node{symbol: 1}), base, 2)
+	prev := scratch.gss.allocNode(stackEntry{state: 3}, nil, 1)
+	scratch.merge.gssOwner = &scratch.gss
+	scratch.setBudget(gssMainLinkBytesForCap(1))
+
+	entry := newStackEntryNode(4, &Node{symbol: 2})
+	if !gssMainAddLinkSeenMutate(&scratch.merge, head, prev, entry, make(map[gssMergePair]bool)) {
+		t.Fatal("packed link append failed")
+	}
+	if !scratch.budgetExhausted() {
+		t.Fatal("parser scratch budget did not observe packed link capacity")
+	}
+	var stats ParseRuntime
+	if !captureParseScratchStats(&stats, &scratch, nil, nil) {
+		t.Fatal("captureParseScratchStats returned false")
+	}
+	if got, want := stats.GSSBytesAllocated, scratch.gssBaselineBytes+gssMainLinkBytesForCap(1); got != want {
+		t.Fatalf("runtime GSS bytes = %d, want %d", got, want)
+	}
+}
+
 func TestCRecoverSummaryArenaCrossesChunkBoundary(t *testing.T) {
 	parser := &Parser{}
 	var scratch gssScratch


### PR DESCRIPTION
## Summary

- Charge packed-link array capacity to the owning graph-structured stack scratch.
- Release current capacity at recycle and reset boundaries.
- Include packed-link capacity in parser budget and runtime statistics.

## Safety

- Preserve untracked behavior for standalone callers without an owner.
- Repair inconsistent counters before subtraction can underflow.
- Keep heap polling responsible for superseded arrays pending collection.

## Verification

- Focused Docker unit tests pass.
- Focused Docker race and checkptr tests pass.
- Default assembly and tagged work-count tests pass.