### PR TITLE
Add an exact C subtree comparator

### DIFF
--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -3212,6 +3212,210 @@ func setReduceNodeDynamicPrecedence(n *Node, entries []stackEntry, start, end in
 	}
 }
 
+type cRawSubtreeCompareFrame struct {
+	left  rawStackWalkEntry
+	right rawStackWalkEntry
+}
+
+type cRawSubtreeCompareHeader struct {
+	symbol          Symbol
+	childCount      int
+	childCountExact bool
+	canDescend      bool
+}
+
+func cRawSubtreeHeaderForCompare(arena *nodeArena, item rawStackWalkEntry) (cRawSubtreeCompareHeader, bool) {
+	if !cRawSubtreeEntrySupported(item.entry) {
+		return cRawSubtreeCompareHeader{}, false
+	}
+	ref := stackEntryRawShapeRef(item.entry)
+	if item.shapeRefKnown {
+		ref = item.shapeRef
+	}
+	if ref != 0 {
+		shape, ok := arena.rawShapeForRef(ref)
+		if !ok {
+			return cRawSubtreeCompareHeader{}, false
+		}
+		return cRawSubtreeCompareHeader{
+			symbol:          shape.symbol,
+			childCount:      shape.childCount(),
+			childCountExact: true,
+			canDescend:      true,
+		}, true
+	}
+	childCount := stackEntryNodeChildCount(item.entry)
+	return cRawSubtreeCompareHeader{
+		symbol:          stackEntryNodeSymbol(item.entry),
+		childCount:      childCount,
+		childCountExact: childCount == 0,
+		canDescend:      childCount == 0,
+	}, true
+}
+
+func cRawSubtreeChildrenForCompare(arena *nodeArena, shape *rawShape) ([]rawShapeChild, bool) {
+	if arena == nil || shape == nil || shape.childCount() == 0 || shape.childRange == 0 {
+		return nil, false
+	}
+	slabIndex := shape.childRange.slabIndex()
+	if slabIndex < 0 || slabIndex >= len(arena.rawShapeChildSlabs) {
+		return nil, false
+	}
+	slab := &arena.rawShapeChildSlabs[slabIndex]
+	start64 := (uint64(shape.childRange) >> 16) & uint64(^uint32(0))
+	if start64 > uint64(slab.used) || start64 > uint64(len(slab.data)) {
+		return nil, false
+	}
+	start := int(start64)
+	count := shape.childCount()
+	if count > slab.used-start || count > len(slab.data)-start {
+		return nil, false
+	}
+	return slab.data[start : start+count], true
+}
+
+func cRawSubtreeChildForCompare(arena *nodeArena, item rawStackWalkEntry, index int) (rawStackWalkEntry, bool) {
+	shape, parentRef, ok := rawShapeForStackWalkEntry(arena, item)
+	if !ok {
+		return rawStackWalkEntry{}, false
+	}
+	children, ok := cRawSubtreeChildrenForCompare(arena, shape)
+	if !ok {
+		return rawStackWalkEntry{}, false
+	}
+	if index < 0 || index >= len(children) {
+		return rawStackWalkEntry{}, false
+	}
+	child := children[index]
+	childRef := child.shapeRef()
+	if childRef != 0 && childRef >= parentRef {
+		return rawStackWalkEntry{}, false
+	}
+	entry := child.entry()
+	return rawStackWalkEntry{
+		entry:         entry,
+		shapeRef:      childRef,
+		shapeRefKnown: true,
+	}, stackEntryHasNode(entry)
+}
+
+func cRawSubtreeEntrySupported(entry stackEntry) bool {
+	if !stackEntryHasNode(entry) {
+		return false
+	}
+	switch entry.kind {
+	case stackEntryKindNode, stackEntryKindNoTreeNode, stackEntryKindCompactFullLeaf, stackEntryKindPendingParent:
+		return true
+	default:
+		return false
+	}
+}
+
+func cRawSubtreeItemsShareSnapshot(arena *nodeArena, left, right rawStackWalkEntry) (shared, valid bool) {
+	if left.entry.node != right.entry.node || left.entry.kind != right.entry.kind {
+		return false, true
+	}
+	if !cRawSubtreeEntrySupported(left.entry) || !cRawSubtreeEntrySupported(right.entry) {
+		return true, false
+	}
+	if left.shapeRefKnown || right.shapeRefKnown {
+		if !left.shapeRefKnown || !right.shapeRefKnown || left.shapeRef != right.shapeRef {
+			return false, true
+		}
+		if left.shapeRef == 0 {
+			// A captured zero does not identify a non-leaf snapshot. The live
+			// payload can have changed since either parent captured its edge.
+			return true, stackEntryNodeChildCount(left.entry) == 0
+		}
+		shape, ok := arena.rawShapeForRef(left.shapeRef)
+		if !ok {
+			return true, false
+		}
+		if _, ok := cRawSubtreeChildrenForCompare(arena, shape); !ok {
+			return true, false
+		}
+		return true, true
+	}
+	ref := stackEntryRawShapeRef(left.entry)
+	if ref == 0 {
+		// Both roots name the same current payload. This is the Go equivalent
+		// of comparing the same C Subtree value, even without a sidecar.
+		return true, true
+	}
+	shape, ok := arena.rawShapeForRef(ref)
+	if !ok {
+		return true, false
+	}
+	if _, ok := cRawSubtreeChildrenForCompare(arena, shape); !ok {
+		return true, false
+	}
+	return true, true
+}
+
+// compareRawStackEntriesCExact ports ts_subtree_compare. It compares symbols,
+// then child counts, then children from left to right. It returns complete=false
+// when a distinct non-leaf lacks captured raw topology or the work limit would
+// be exceeded. A caller must decline the exact-C route in that case.
+func compareRawStackEntriesCExact(arena *nodeArena, left, right stackEntry, workLimit int) (cmp int, complete bool) {
+	if workLimit <= 0 || !stackEntryHasNode(left) || !stackEntryHasNode(right) {
+		return 0, false
+	}
+	frames := []cRawSubtreeCompareFrame{{
+		left:  rawStackWalkEntry{entry: left},
+		right: rawStackWalkEntry{entry: right},
+	}}
+	scheduled := 1
+	for len(frames) > 0 {
+		last := len(frames) - 1
+		frame := frames[last]
+		frames[last] = cRawSubtreeCompareFrame{}
+		frames = frames[:last]
+
+		if shared, valid := cRawSubtreeItemsShareSnapshot(arena, frame.left, frame.right); shared {
+			if !valid {
+				return 0, false
+			}
+			continue
+		}
+		leftHeader, leftOK := cRawSubtreeHeaderForCompare(arena, frame.left)
+		rightHeader, rightOK := cRawSubtreeHeaderForCompare(arena, frame.right)
+		if !leftOK || !rightOK {
+			return 0, false
+		}
+		if leftHeader.symbol != rightHeader.symbol {
+			if leftHeader.symbol < rightHeader.symbol {
+				return -1, true
+			}
+			return 1, true
+		}
+		if !leftHeader.childCountExact || !rightHeader.childCountExact {
+			return 0, false
+		}
+		if leftHeader.childCount != rightHeader.childCount {
+			if leftHeader.childCount < rightHeader.childCount {
+				return -1, true
+			}
+			return 1, true
+		}
+		if leftHeader.childCount == 0 {
+			continue
+		}
+		if !leftHeader.canDescend || !rightHeader.canDescend || leftHeader.childCount > workLimit-scheduled {
+			return 0, false
+		}
+		scheduled += leftHeader.childCount
+		for i := leftHeader.childCount - 1; i >= 0; i-- {
+			leftChild, leftChildOK := cRawSubtreeChildForCompare(arena, frame.left, i)
+			rightChild, rightChildOK := cRawSubtreeChildForCompare(arena, frame.right, i)
+			if !leftChildOK || !rightChildOK {
+				return 0, false
+			}
+			frames = append(frames, cRawSubtreeCompareFrame{left: leftChild, right: rightChild})
+		}
+	}
+	return 0, true
+}
+
 func (p *Parser) compareRawStackEntries(arena *nodeArena, a, b stackEntry) int {
 	return p.compareRawStackEntriesRec(arena, a, b, 0)
 }

--- a/parser_reduce_test.go
+++ b/parser_reduce_test.go
@@ -68,6 +68,255 @@ func setSyntheticPostReducePackingSafeEOF(t *testing.T, parser *Parser, states .
 	}
 }
 
+func cExactCompareLeaf(symbol Symbol) stackEntry {
+	return newStackEntryNode(1, &Node{symbol: symbol, flags: nodeFlagNamed})
+}
+
+func cExactCompareParent(t *testing.T, parser *Parser, arena *nodeArena, symbol Symbol, children ...stackEntry) stackEntry {
+	t.Helper()
+	node := &Node{symbol: symbol, flags: nodeFlagNamed}
+	node.rawShape = parser.captureRawShape(nil, arena, symbol, 0, children, 0, len(children))
+	if node.rawShape == 0 {
+		t.Fatal("raw parent shape was not captured")
+	}
+	return newStackEntryNode(1, node)
+}
+
+func TestCompareRawStackEntriesCExactUsesCPreorder(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser := &Parser{}
+	left := cExactCompareParent(t, parser, arena, 10,
+		cExactCompareLeaf(2),
+		cExactCompareLeaf(9),
+	)
+	right := cExactCompareParent(t, parser, arena, 10,
+		cExactCompareLeaf(3),
+		cExactCompareLeaf(1),
+	)
+
+	cmp, complete := compareRawStackEntriesCExact(arena, left, right, 8)
+	if !complete || cmp != -1 {
+		t.Fatalf("C exact comparison = %d, complete=%t; want -1, true", cmp, complete)
+	}
+	cmp, complete = compareRawStackEntriesCExact(arena, right, left, 8)
+	if !complete || cmp != 1 {
+		t.Fatalf("reverse C exact comparison = %d, complete=%t; want 1, true", cmp, complete)
+	}
+}
+
+func TestCompareRawStackEntriesCExactUsesChildCountBeforeChildren(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser := &Parser{}
+	left := cExactCompareParent(t, parser, arena, 10, cExactCompareLeaf(9))
+	right := cExactCompareParent(t, parser, arena, 10, cExactCompareLeaf(1), cExactCompareLeaf(1))
+
+	cmp, complete := compareRawStackEntriesCExact(arena, left, right, 8)
+	if !complete || cmp != -1 {
+		t.Fatalf("C exact comparison = %d, complete=%t; want -1, true", cmp, complete)
+	}
+}
+
+func TestCompareRawStackEntriesCExactIgnoresSpansAndHashShortcuts(t *testing.T) {
+	leftNode := &Node{symbol: 7, startByte: 1, endByte: 2, flags: nodeFlagNamed}
+	rightNode := &Node{symbol: 7, startByte: 20, endByte: 40, flags: nodeFlagNamed}
+	cmp, complete := compareRawStackEntriesCExact(nil, newStackEntryNode(1, leftNode), newStackEntryNode(1, rightNode), 1)
+	if !complete || cmp != 0 {
+		t.Fatalf("span-only comparison = %d, complete=%t; want 0, true", cmp, complete)
+	}
+
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser := &Parser{}
+	left := cExactCompareParent(t, parser, arena, 10, cExactCompareLeaf(2))
+	right := cExactCompareParent(t, parser, arena, 10, cExactCompareLeaf(3))
+	cmp, complete = compareRawStackEntriesCExact(arena, left, right, 4)
+	if !complete || cmp != -1 {
+		t.Fatalf("distinct raw children comparison = %d, complete=%t; want -1, true", cmp, complete)
+	}
+}
+
+func TestCompareRawStackEntriesCExactUsesCapturedShapeSnapshot(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser := &Parser{}
+	sharedChild := &Node{symbol: 9, flags: nodeFlagNamed}
+	sharedChild.rawShape = parser.captureRawShape(nil, arena, 9, 0, []stackEntry{cExactCompareLeaf(2)}, 0, 1)
+	if sharedChild.rawShape == 0 {
+		t.Fatal("first child shape was not captured")
+	}
+	left := cExactCompareParent(t, parser, arena, 10, newStackEntryNode(1, sharedChild))
+
+	sharedChild.rawShape = parser.captureRawShape(nil, arena, 9, 0, []stackEntry{cExactCompareLeaf(3)}, 0, 1)
+	if sharedChild.rawShape == 0 {
+		t.Fatal("second child shape was not captured")
+	}
+	right := cExactCompareParent(t, parser, arena, 10, newStackEntryNode(1, sharedChild))
+
+	cmp, complete := compareRawStackEntriesCExact(arena, left, right, 8)
+	if !complete || cmp != -1 {
+		t.Fatalf("captured-snapshot comparison = %d, complete=%t; want -1, true", cmp, complete)
+	}
+}
+
+func TestCompareRawStackEntriesCExactHasNoDepthCutoff(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser := &Parser{}
+	left := cExactCompareLeaf(2)
+	right := cExactCompareLeaf(3)
+	for i := 0; i < maxTreeWalkDepth+16; i++ {
+		left = cExactCompareParent(t, parser, arena, 10, left)
+		right = cExactCompareParent(t, parser, arena, 10, right)
+	}
+
+	cmp, complete := compareRawStackEntriesCExact(arena, left, right, 2*(maxTreeWalkDepth+16)+4)
+	if !complete || cmp != -1 {
+		t.Fatalf("deep C exact comparison = %d, complete=%t; want -1, true", cmp, complete)
+	}
+}
+
+func TestCompareRawStackEntriesCExactFailsClosedWithoutRawTopology(t *testing.T) {
+	child := &Node{symbol: 2, flags: nodeFlagNamed}
+	shared := &Node{symbol: 10, flags: nodeFlagNamed, children: []*Node{child}}
+	sharedLeft := newStackEntryNode(1, shared)
+	sharedRight := newStackEntryNode(9, shared)
+	if cmp, complete := compareRawStackEntriesCExact(nil, sharedLeft, sharedRight, 1); !complete || cmp != 0 {
+		t.Fatalf("shared shapeless comparison = %d, complete=%t; want 0, true", cmp, complete)
+	}
+
+	left := newStackEntryNode(1, &Node{symbol: 10, flags: nodeFlagNamed, children: []*Node{child}})
+	right := newStackEntryNode(1, &Node{symbol: 10, flags: nodeFlagNamed, children: []*Node{child}})
+	if cmp, complete := compareRawStackEntriesCExact(nil, left, right, 8); complete || cmp != 0 {
+		t.Fatalf("distinct shapeless comparison = %d, complete=%t; want 0, false", cmp, complete)
+	}
+
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser := &Parser{}
+	shaped := cExactCompareParent(t, parser, arena, 10, cExactCompareLeaf(2))
+	if cmp, complete := compareRawStackEntriesCExact(arena, shaped, right, 8); complete || cmp != 0 {
+		t.Fatalf("one-sided topology comparison = %d, complete=%t; want 0, false", cmp, complete)
+	}
+
+	invalid := &Node{symbol: 10, flags: nodeFlagNamed, rawShape: ^rawShapeRef(0)}
+	if cmp, complete := compareRawStackEntriesCExact(nil, newStackEntryNode(1, invalid), cExactCompareLeaf(10), 8); complete || cmp != 0 {
+		t.Fatalf("invalid-shape comparison = %d, complete=%t; want 0, false", cmp, complete)
+	}
+}
+
+func TestCompareRawStackEntriesCExactFailsClosedAtWorkLimit(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser := &Parser{}
+	left := cExactCompareParent(t, parser, arena, 10, cExactCompareLeaf(2), cExactCompareLeaf(3))
+	right := cExactCompareParent(t, parser, arena, 10, cExactCompareLeaf(2), cExactCompareLeaf(3))
+
+	cmp, complete := compareRawStackEntriesCExact(arena, left, right, 2)
+	if complete || cmp != 0 {
+		t.Fatalf("bounded C exact comparison = %d, complete=%t; want 0, false", cmp, complete)
+	}
+	cmp, complete = compareRawStackEntriesCExact(arena, left, right, 3)
+	if !complete || cmp != 0 {
+		t.Fatalf("exact-bound C comparison = %d, complete=%t; want 0, true", cmp, complete)
+	}
+}
+
+func TestCompareRawStackEntriesCExactRejectsForwardShapeReference(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser := &Parser{}
+	leftChild := cExactCompareParent(t, parser, arena, 9, cExactCompareLeaf(2))
+	left := cExactCompareParent(t, parser, arena, 10, leftChild)
+	rightChild := cExactCompareParent(t, parser, arena, 9, cExactCompareLeaf(2))
+	right := cExactCompareParent(t, parser, arena, 10, rightChild)
+
+	leftNode := stackEntryNode(left)
+	leftShape, ok := arena.rawShapeForRef(leftNode.rawShape)
+	if !ok {
+		t.Fatal("left root shape is unavailable")
+	}
+	children := arena.rawShapeChildren(leftShape)
+	if len(children) != 1 {
+		t.Fatalf("left root child count = %d, want 1", len(children))
+	}
+	children[0].packedEntry.state = StateID(leftNode.rawShape)
+
+	cmp, complete := compareRawStackEntriesCExact(arena, left, right, 8)
+	if complete || cmp != 0 {
+		t.Fatalf("forward-reference comparison = %d, complete=%t; want 0, false", cmp, complete)
+	}
+}
+
+func TestCompareRawStackEntriesCExactRejectsMalformedSharedSnapshot(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser := &Parser{}
+	shared := &Node{symbol: 9, flags: nodeFlagNamed, rawShape: ^rawShapeRef(0)}
+	left := cExactCompareParent(t, parser, arena, 10, newStackEntryNode(1, shared))
+	right := cExactCompareParent(t, parser, arena, 10, newStackEntryNode(1, shared))
+
+	cmp, complete := compareRawStackEntriesCExact(arena, left, right, 8)
+	if complete || cmp != 0 {
+		t.Fatalf("shared malformed snapshot comparison = %d, complete=%t; want 0, false", cmp, complete)
+	}
+}
+
+func TestCompareRawStackEntriesCExactRejectsMalformedChildRange(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser := &Parser{}
+	left := cExactCompareParent(t, parser, arena, 10, cExactCompareLeaf(2))
+	right := cExactCompareParent(t, parser, arena, 10, cExactCompareLeaf(2))
+	leftShape, ok := arena.rawShapeForRef(stackEntryNode(left).rawShape)
+	if !ok {
+		t.Fatal("left root shape is unavailable")
+	}
+	leftShape.childRange = rawShapeChildRange((uint64(1) << 48) | (uint64(^uint32(0)) << 16) | 1)
+
+	cmp, complete := compareRawStackEntriesCExact(arena, left, right, 8)
+	if complete || cmp != 0 {
+		t.Fatalf("malformed child-range comparison = %d, complete=%t; want 0, false", cmp, complete)
+	}
+}
+
+func TestCompareRawStackEntriesCExactRejectsCapturedZeroForSharedNonLeaf(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser := &Parser{}
+	shared := &Node{
+		symbol:   9,
+		flags:    nodeFlagNamed,
+		children: []*Node{{symbol: 2, flags: nodeFlagNamed}},
+	}
+	left := cExactCompareParent(t, parser, arena, 10, newStackEntryNode(1, shared))
+	right := cExactCompareParent(t, parser, arena, 10, newStackEntryNode(1, shared))
+
+	cmp, complete := compareRawStackEntriesCExact(arena, left, right, 8)
+	if complete || cmp != 0 {
+		t.Fatalf("captured-zero shared non-leaf comparison = %d, complete=%t; want 0, false", cmp, complete)
+	}
+}
+
+func TestCompareRawStackEntriesCExactRejectsUnsupportedSharedPayload(t *testing.T) {
+	entry := cExactCompareLeaf(7)
+	entry.kind = ^uint32(0)
+	cmp, complete := compareRawStackEntriesCExact(nil, entry, entry, 1)
+	if complete || cmp != 0 {
+		t.Fatalf("unsupported shared payload comparison = %d, complete=%t; want 0, false", cmp, complete)
+	}
+
+	left := cExactCompareLeaf(7)
+	right := cExactCompareLeaf(7)
+	left.kind = ^uint32(0)
+	right.kind = ^uint32(0)
+	cmp, complete = compareRawStackEntriesCExact(nil, left, right, 1)
+	if complete || cmp != 0 {
+		t.Fatalf("unsupported distinct payload comparison = %d, complete=%t; want 0, false", cmp, complete)
+	}
+}
+
 func TestFastVisibleReduceFromGSSDeclinesMultiLinkSpan(t *testing.T) {
 	old := glrFaithfulCapOneMerge
 	glrFaithfulCapOneMerge = true


### PR DESCRIPTION
## Summary

- Compare raw subtrees by symbol, child count, and preorder children.
- Preserve captured edge snapshots as authoritative topology.
- Decline on missing, malformed, unsupported, or over-budget topology.

## Compatibility

- Keep the primitive dormant until the complete selection path is certified.
- Ignore spans, production identifiers, repeat status, and hashes.
- Preserve the existing comparator for ordinary routes.

## Verification

- Focused Docker unit, race, and checkptr tests pass.
- A focused 32-bit malformed-range test passes.
- The rebased wave-scheduler combination compiles and passes focused tests.