### PR TITLE
Add the gated C eight-link stack policy

### DIFF
--- a/glr.go
+++ b/glr.go
@@ -4399,6 +4399,17 @@ func gssMainCanAddLinkSeen(n *gssNode, prev *gssNode, entry stackEntry, seen map
 	return newGSSMainPreflight(seen).canAddLink(n, prev, entry)
 }
 
+func compactCMainLinkPolicyEnabled(scratch *glrMergeScratch) bool {
+	return scratch != nil && scratch.language != nil && scratch.language.CompactPackedGSSVersionOrderCertified
+}
+
+func gssMainLinkLimitForScratch(scratch *glrMergeScratch) int {
+	if compactCMainLinkPolicyEnabled(scratch) {
+		return maxCMainLinkCount
+	}
+	return maxMainLinkCount
+}
+
 func (p *gssMainPreflight) canAddLink(n *gssNode, prev *gssNode, entry stackEntry) bool {
 	if n == nil {
 		return false
@@ -4418,7 +4429,13 @@ func (p *gssMainPreflight) canAddLink(n *gssNode, prev *gssNode, entry stackEntr
 			return p.canMergeNodes(existingPrev, prev)
 		}
 	}
-	if p.linkCount(n) >= maxMainLinkCount {
+	if p.linkCount(n) >= gssMainLinkLimitForScratch(p.scratch) {
+		// stack_node_add_link is void in C. Once all eight slots are full, it
+		// drops a new distinct link and still completes the enclosing merge.
+		// Do not stage a virtual link, because the mutate phase also drops it.
+		if compactCMainLinkPolicyEnabled(p.scratch) {
+			return true
+		}
 		return p.canReplaceWorstEquivalentLinkIfBetter(n, prev, entry)
 	}
 	p.addVirtualLink(n, prev, entry)
@@ -4476,7 +4493,12 @@ func gssMainAddLinkSeenMutate(scratch *glrMergeScratch, n *gssNode, prev *gssNod
 			return merged
 		}
 	}
-	if n.linkCount() >= maxMainLinkCount {
+	if n.linkCount() >= gssMainLinkLimitForScratch(scratch) {
+		// Match C's fixed eight-link node: keep the incumbent links, drop this
+		// distinct late link, and let the enclosing merge retire its source.
+		if compactCMainLinkPolicyEnabled(scratch) {
+			return true
+		}
 		if gssMainReplaceWorstEquivalentLinkIfBetterMutate(scratch, n, prev, entry, seen) {
 			n.hash = 0
 			return true
@@ -4487,7 +4509,11 @@ func gssMainAddLinkSeenMutate(scratch *glrMergeScratch, n *gssNode, prev *gssNod
 	if scratch != nil {
 		owner = scratch.gssOwner
 	}
-	n.appendExtraLinkWithOwner(gssMainLink{prev: prev, entry: entry}, owner)
+	n.appendExtraLinkWithLimitAndOwner(
+		gssMainLink{prev: prev, entry: entry},
+		gssMainLinkLimitForScratch(scratch),
+		owner,
+	)
 	n.hash = 0
 	return true
 }

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -96,12 +96,24 @@ type gssMainLink struct {
 	entry stackEntry
 }
 
-const maxMainLinkCount = maxStacksPerMergeKey
+const (
+	// maxMainLinkCount is the ordinary Go merge-policy limit. Keep it separate
+	// from the backing-array limit so uncertified grammars retain the current
+	// six-link behavior.
+	maxMainLinkCount = maxStacksPerMergeKey
+
+	// maxCMainLinkCount matches tree-sitter C's MAX_LINK_COUNT (stack.c). The
+	// compact C-order capability can use all eight physical link slots.
+	maxCMainLinkCount = 8
+)
 
 // extraLinkCount/extraLinkCap are uint8; the compacted layout is only valid
 // while every possible link count fits. This conversion fails to compile if
-// maxMainLinkCount ever grows past what uint8 can carry.
-const _ = uint8(maxMainLinkCount - 1)
+// maxCMainLinkCount ever grows past what uint8 can carry.
+const _ = uint8(maxCMainLinkCount - 1)
+
+// The physical backing limit must contain the ordinary policy limit.
+const _ = uint8(maxCMainLinkCount - maxMainLinkCount)
 
 func (n *gssNode) linkCount() int {
 	if n == nil {
@@ -136,14 +148,22 @@ func (n *gssNode) setExtraLink(i int, link gssMainLink) {
 }
 
 func (n *gssNode) appendExtraLink(link gssMainLink) {
-	n.appendExtraLinkWithOwner(link, nil)
+	n.appendExtraLinkWithLimitAndOwner(link, maxMainLinkCount, nil)
 }
 
-// appendExtraLinkWithOwner bills current packed-link capacity to the scratch
-// that owns n. Standalone callers pass nil because they do not own a parser
-// scratch budget.
-func (n *gssNode) appendExtraLinkWithOwner(link gssMainLink, owner *gssScratch) {
-	if n == nil || int(n.extraLinkCount) >= maxMainLinkCount-1 {
+// appendExtraLinkWithLimit keeps the ordinary six-link allocation shape while
+// the certified C policy can use the full eight-link backing limit.
+func (n *gssNode) appendExtraLinkWithLimit(link gssMainLink, linkLimit int) {
+	n.appendExtraLinkWithLimitAndOwner(link, linkLimit, nil)
+}
+
+// appendExtraLinkWithLimitAndOwner applies one limit to storage and billing.
+func (n *gssNode) appendExtraLinkWithLimitAndOwner(link gssMainLink, linkLimit int, owner *gssScratch) {
+	if linkLimit < 1 || linkLimit > maxCMainLinkCount {
+		panic("gssNode.appendExtraLinkWithLimit: invalid link limit")
+	}
+	maxExtraLinks := linkLimit - 1
+	if n == nil || int(n.extraLinkCount) >= maxExtraLinks {
 		panic("gssNode.appendExtraLink: link limit exceeded")
 	}
 	n.cleanZeroState = gssCleanZeroUnknown
@@ -161,8 +181,8 @@ func (n *gssNode) appendExtraLinkWithOwner(link gssMainLink, owner *gssScratch) 
 	if capacity > 0 {
 		newCapacity = capacity * 2
 	}
-	if max := maxMainLinkCount - 1; newCapacity > max {
-		newCapacity = max
+	if newCapacity > maxExtraLinks {
+		newCapacity = maxExtraLinks
 	}
 	links := make([]gssMainLink, newCapacity)
 	if count > 0 {

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -85,6 +85,38 @@ func TestGSSPackedLinkCapacityIsTrackedAndReleasedOnRecycle(t *testing.T) {
 	}
 }
 
+func TestGSSPackedLinkCertifiedPolicyBillsSevenSlotCapacity(t *testing.T) {
+	var owner gssScratch
+	prevs := make([]*gssNode, maxCMainLinkCount)
+	for i := range prevs {
+		prevs[i] = owner.allocNode(stackEntry{state: StateID(10 + i)}, nil, 1)
+	}
+	head := owner.allocNode(newStackEntryNode(2, &Node{symbol: 1}), prevs[0], 2)
+	baseline := owner.allocatedBytes
+	merge := glrMergeScratch{
+		language: &Language{CompactPackedGSSVersionOrderCertified: true},
+		gssOwner: &owner,
+	}
+
+	for i := 1; i < maxCMainLinkCount; i++ {
+		entry := newStackEntryNode(2, &Node{symbol: Symbol(10 + i)})
+		if !gssMainAddLinkSeenMutate(&merge, head, prevs[i], entry, make(map[gssMergePair]bool)) {
+			t.Fatalf("append certified packed link %d failed", i)
+		}
+	}
+
+	wantBytes := gssMainLinkBytesForCap(maxCMainLinkCount - 1)
+	if got := int(head.extraLinkCap); got != maxCMainLinkCount-1 {
+		t.Fatalf("certified packed link capacity = %d, want %d", got, maxCMainLinkCount-1)
+	}
+	if got := owner.packedLinkBytes; got != wantBytes {
+		t.Fatalf("certified packed link bytes = %d, want %d", got, wantBytes)
+	}
+	if got := owner.allocatedBytes; got != baseline+wantBytes {
+		t.Fatalf("certified allocated bytes = %d, want %d", got, baseline+wantBytes)
+	}
+}
+
 func TestGSSPackedLinkRecycleRepairsCounterUnderflow(t *testing.T) {
 	var owner gssScratch
 	base := owner.allocNode(stackEntry{state: 1}, nil, 1)
@@ -765,6 +797,9 @@ func TestGSSMainAddLinkAtCapRejectsUnsafeEquivalentReplacement(t *testing.T) {
 	if got := head.linkCount(); got != maxMainLinkCount {
 		t.Fatalf("head link count = %d, want cap %d", got, maxMainLinkCount)
 	}
+	if got := int(head.extraLinkCap); got != maxMainLinkCount-1 {
+		t.Fatalf("ordinary extra-link capacity = %d, want %d", got, maxMainLinkCount-1)
+	}
 
 	latePrev := &gssNode{entry: stackEntry{state: 200}, depth: 1}
 	lateEntry := newStackEntryNode(10, &Node{symbol: 20, startByte: 1, endByte: 2, flags: nodeFlagNamed, dynamicPrecedence: 99})
@@ -823,6 +858,152 @@ func TestGSSMainAddLinkAtCapReplacesEquivalentSamePredecessorWithHigherDynamic(t
 	}
 	if got := stackEntryDynamicPrecedence(entry); got != 99 {
 		t.Fatalf("dynamic precedence = %d, want 99", got)
+	}
+}
+
+func TestGSSMainCLinkPolicyUsesEightSlotsThenDropsDistinctLink(t *testing.T) {
+	entry := func(sym Symbol, dynamic int32) stackEntry {
+		return newStackEntryNode(10, &Node{
+			symbol:            sym,
+			startByte:         1,
+			endByte:           2,
+			flags:             nodeFlagNamed,
+			dynamicPrecedence: dynamic,
+		})
+	}
+	prev := func(state StateID) *gssNode {
+		return &gssNode{entry: stackEntry{state: state}, depth: 1}
+	}
+
+	head := &gssNode{entry: entry(20, 1), prev: prev(100), depth: 2}
+	scratch := glrMergeScratch{language: &Language{CompactPackedGSSVersionOrderCertified: true}}
+	for i := 1; i < maxCMainLinkCount; i++ {
+		if !gssMainAddLinkSeenMutate(
+			&scratch,
+			head,
+			prev(StateID(100+i)),
+			entry(Symbol(20+i), int32(i+1)),
+			make(map[gssMergePair]bool),
+		) {
+			t.Fatalf("add link %d was rejected", i)
+		}
+	}
+	if got := head.linkCount(); got != maxCMainLinkCount {
+		t.Fatalf("head link count = %d, want C cap %d", got, maxCMainLinkCount)
+	}
+	if got := int(head.extraLinkCap); got != maxCMainLinkCount-1 {
+		t.Fatalf("C extra-link capacity = %d, want %d", got, maxCMainLinkCount-1)
+	}
+	if head.linkCount() <= maxMainLinkCount {
+		t.Fatalf("C link policy did not exceed ordinary cap %d", maxMainLinkCount)
+	}
+
+	before := snapshotGSSMainLinks(head)
+	latePrev := prev(999)
+	lateEntry := entry(20, 99)
+	preflight := acquirePreflightForScratch(&scratch)
+	if !preflight.canAddLink(head, latePrev, lateEntry) {
+		t.Fatal("C preflight rejected a distinct link that C drops at capacity")
+	}
+	if got := preflight.linkCount(head); got != maxCMainLinkCount {
+		t.Fatalf("preflight link count = %d, want unchanged C cap %d", got, maxCMainLinkCount)
+	}
+	if !gssMainAddLinkSeenMutate(&scratch, head, latePrev, lateEntry, make(map[gssMergePair]bool)) {
+		t.Fatal("C mutate phase rejected a distinct link that C drops at capacity")
+	}
+	assertGSSMainLinksEqual(t, head, before)
+}
+
+func TestGSSMainCLinkPolicyStillUpdatesSamePredecessorAtCap(t *testing.T) {
+	entry := func(sym Symbol, dynamic int32) stackEntry {
+		return newStackEntryNode(10, &Node{
+			symbol:            sym,
+			startByte:         1,
+			endByte:           2,
+			flags:             nodeFlagNamed,
+			dynamicPrecedence: dynamic,
+		})
+	}
+	sharedPrev := &gssNode{entry: stackEntry{state: 100}, depth: 1}
+	head := &gssNode{entry: entry(20, 1), prev: sharedPrev, depth: 2}
+	for i := 1; i < maxCMainLinkCount; i++ {
+		head.appendExtraLinkWithLimit(gssMainLink{
+			prev:  &gssNode{entry: stackEntry{state: StateID(100 + i)}, depth: 1},
+			entry: entry(Symbol(20+i), int32(i+1)),
+		}, maxCMainLinkCount)
+	}
+
+	scratch := glrMergeScratch{language: &Language{CompactPackedGSSVersionOrderCertified: true}}
+	if !gssMainAddLinkSeenMutate(&scratch, head, sharedPrev, entry(20, 99), make(map[gssMergePair]bool)) {
+		t.Fatal("same-predecessor update was rejected at the C link cap")
+	}
+	if got := head.linkCount(); got != maxCMainLinkCount {
+		t.Fatalf("head link count = %d, want %d", got, maxCMainLinkCount)
+	}
+	gotPrev, gotEntry := head.link(0)
+	if gotPrev != sharedPrev || stackEntryDynamicPrecedence(gotEntry) != 99 {
+		t.Fatal("same-predecessor update did not retain C's higher dynamic precedence")
+	}
+}
+
+func TestGSSMainCLinkPolicyPreflightMatchesMultiLinkMutationAtLimit(t *testing.T) {
+	entry := func(sym Symbol) stackEntry {
+		return newStackEntryNode(10, &Node{
+			symbol:    sym,
+			startByte: 1,
+			endByte:   2,
+			flags:     nodeFlagNamed,
+		})
+	}
+	prev := func(state StateID) *gssNode {
+		return &gssNode{entry: stackEntry{state: state}, depth: 1}
+	}
+
+	destination := &gssNode{entry: entry(20), prev: prev(100), depth: 2}
+	for i := 1; i < maxMainLinkCount; i++ {
+		destination.appendExtraLink(gssMainLink{
+			prev:  prev(StateID(100 + i)),
+			entry: entry(Symbol(20 + i)),
+		})
+	}
+	sourcePrevs := []*gssNode{prev(200), prev(201), prev(202)}
+	source := &gssNode{entry: entry(50), prev: sourcePrevs[0], depth: 2}
+	for i := 1; i < len(sourcePrevs); i++ {
+		source.appendExtraLink(gssMainLink{
+			prev:  sourcePrevs[i],
+			entry: entry(Symbol(50 + i)),
+		})
+	}
+
+	scratch := glrMergeScratch{language: &Language{CompactPackedGSSVersionOrderCertified: true}}
+	preflight := acquirePreflightForScratch(&scratch)
+	if !preflight.canMergeNodes(destination, source) {
+		t.Fatal("C preflight rejected a merge that can fill and then drop links")
+	}
+	if got := preflight.linkCount(destination); got != maxCMainLinkCount {
+		t.Fatalf("preflight destination links = %d, want %d", got, maxCMainLinkCount)
+	}
+	if got := len(preflight.virtualLink[destination]); got != maxCMainLinkCount-maxMainLinkCount {
+		t.Fatalf("preflight staged links = %d, want %d", got, maxCMainLinkCount-maxMainLinkCount)
+	}
+	if !gssMainMergeNodesSeenMutate(&scratch, destination, source, make(map[gssMergePair]bool)) {
+		t.Fatal("C mutation rejected a merge that its preflight accepted")
+	}
+	if got := destination.linkCount(); got != maxCMainLinkCount {
+		t.Fatalf("mutated destination links = %d, want %d", got, maxCMainLinkCount)
+	}
+	for i, sourcePrev := range sourcePrevs {
+		found := false
+		for linkIndex := 0; linkIndex < destination.linkCount(); linkIndex++ {
+			gotPrev, _ := destination.link(linkIndex)
+			if gotPrev == sourcePrev {
+				found = true
+				break
+			}
+		}
+		if want := i < maxCMainLinkCount-maxMainLinkCount; found != want {
+			t.Fatalf("source link %d retained = %v, want %v", i, found, want)
+		}
 	}
 }
 

--- a/glr_test.go
+++ b/glr_test.go
@@ -4344,7 +4344,7 @@ func TestGSSMainMergePreservesCandidateBeyondUnsafeCLinkCap(t *testing.T) {
 		t.Fatalf("setup link count = %d, want %d", got, maxMainLinkCount)
 	}
 
-	var scratch glrMergeScratch
+	scratch := glrMergeScratch{language: &Language{}}
 	scratch.perKeyCap = 1
 	scratch.beginEquivEpoch()
 
@@ -4355,6 +4355,37 @@ func TestGSSMainMergePreservesCandidateBeyondUnsafeCLinkCap(t *testing.T) {
 	if got := result[0].gss.head.linkCount(); got != maxMainLinkCount {
 		t.Fatalf("link count after capped merge = %d, want %d", got, maxMainLinkCount)
 	}
+}
+
+func TestGSSMainMergeCLinkPolicyRetiresCandidateAtEightLinkCap(t *testing.T) {
+	var gssScratch gssScratch
+	buildStack := func(sym Symbol) glrStack {
+		node := NewLeafNode(sym, true, 0, 5, Point{}, Point{Column: 5})
+		entries := []stackEntry{{state: 1}, newStackEntryNode(7, node)}
+		return glrStack{
+			gss:        buildGSSStack(entries, &gssScratch),
+			byteOffset: stackByteOffset(entries),
+		}
+	}
+
+	incumbent := buildStack(20)
+	for i := 1; i < maxCMainLinkCount; i++ {
+		extraNode := NewLeafNode(Symbol(20+i), true, 0, 5, Point{}, Point{Column: 5})
+		incumbent.gss.head.appendExtraLinkWithLimit(gssMainLink{
+			prev:  incumbent.gss.head.prev,
+			entry: newStackEntryNode(StateID(7+i), extraNode),
+		}, maxCMainLinkCount)
+	}
+	before := snapshotGSSMainLinks(incumbent.gss.head)
+	candidate := buildStack(99)
+	scratch := glrMergeScratch{language: &Language{CompactPackedGSSVersionOrderCertified: true}}
+	if !gssMainCanMergeWithScratch(&scratch, &incumbent, &candidate) {
+		t.Fatal("certified C link policy rejected the merge eligibility gate")
+	}
+	if !gssMainMergeWithScratch(&scratch, &incumbent, &candidate) {
+		t.Fatal("certified C link policy retained a candidate that C retires")
+	}
+	assertGSSMainLinksEqual(t, incumbent.gss.head, before)
 }
 
 func TestMergeStacksGeneralFaithfulGSSPreservesCandidateBeyondUnsafeCLinkCap(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add the eight-link Graph-Structured Stack limit used by the C runtime.
- Gate this behavior with CompactPackedGSSVersionOrderCertified.
- Keep the ordinary six-link policy and five-slot allocation.
- Drop a ninth distinct link after equivalent-link merging.
- Keep preflight and mutation decisions aligned.

## Reason

The C runtime stores eight physical links in each stack node.
The compact route must match this limit and its drop order.
Uncertified grammars must retain their existing behavior and allocation shape.

## Verification

- Focused unit gate: harness_out/docker/20260831T044120Z
- Focused race gate: harness_out/docker/20260831T044139Z
- Focused Go pointer gate: harness_out/docker/20260831T044210Z
- Post-rebase unit gate: harness_out/docker/20260831T044555Z

The post-rebase gate covered ordinary allocation, C fill and drop behavior, transaction agreement, and candidate retirement.

## Follow-up

Combine this limit with owner-aware link accounting before any profile enables the capability.