### PR TITLE
Add C topology receipt parity gate for GLR stack merges

### DIFF
--- a/cgo_harness/c_topology_receipt_test.go
+++ b/cgo_harness/c_topology_receipt_test.go
@@ -1,0 +1,288 @@
+//go:build cgo && treesitter_c_parity && gts_merge_census
+
+package cgoharness
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"testing"
+)
+
+const (
+	cTopologyEventAction          = 1
+	cTopologyEventVersionAdd      = 2
+	cTopologyEventVersionCopy     = 3
+	cTopologyEventVersionRenumber = 4
+	cTopologyEventMerge           = 5
+	cTopologyEventLinkInsert      = 6
+	cTopologyEventPopPath         = 7
+	cTopologyEventChildElection   = 8
+	cTopologyEventAcceptElection  = 9
+
+	cTopologyFlagSelected       = 1 << 0
+	cTopologyFlagPrimaryLink    = 1 << 1
+	cTopologyFlagInitialVersion = 1 << 2
+	cTopologyFlagTargetReplaced = 1 << 3
+	cTopologyFlagNoIncumbent    = 1 << 4
+	cTopologyFlagActionContext  = 1 << 5
+	cTopologyKnownFlags         = (1 << 6) - 1
+
+	cTopologyActionReduce  = 1
+	cTopologyActionUnknown = 255
+
+	cTopologyErlangIssue984EventCount = 280
+	cTopologyErlangIssue984SHA256     = "f90b82a19bd52475a0b61376a631fe53b69ac827c89bec6802940e8302d77754"
+)
+
+func TestCTopologyReceiptErlangIssue984(t *testing.T) {
+	oracle := mergeCensusOracleForTest(t)
+	source := []byte("000\"0A!A \"A\"=0:A0!)A\"0%0000")
+	if len(source) != 27 {
+		t.Fatalf("source bytes=%d, want 27", len(source))
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != "ad9482f4aabfc3f348a20f6071a2732dcf0473d87b61fa8df4f960e84d4b1ab4" {
+		t.Fatalf("source SHA-256=%s", got)
+	}
+	row, err := mergeCensusRunCTopology(oracle, "erlang", a3CertificationSweepSource{
+		Name:   "erlang_issue984_no_newline",
+		Source: source,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.Status != "ok" || row.SourceBytes != 27 || row.RootEndByte != 27 {
+		t.Fatalf("row status=%q source=%d root_end=%d", row.Status, row.SourceBytes, row.RootEndByte)
+	}
+	if row.RootHasError || row.RootChildCount != 6 {
+		t.Fatalf("root has_error=%v child_count=%d", row.RootHasError, row.RootChildCount)
+	}
+
+	receipt := row.Receipt
+	if receipt.Capacity != cTopologyEventCapacity {
+		t.Fatalf("capacity=%d, want %d", receipt.Capacity, cTopologyEventCapacity)
+	}
+	if receipt.Truncated || receipt.ArithmeticOverflow || receipt.IdentityCollision || receipt.IdentityIncomplete {
+		t.Fatalf("incomplete receipt: %+v", receipt)
+	}
+	if receipt.EventsDropped != 0 || receipt.EventsSeen != uint64(len(receipt.Events)) || receipt.EventsRetained != uint32(len(receipt.Events)) {
+		t.Fatalf(
+			"event accounting seen=%d retained=%d dropped=%d len=%d",
+			receipt.EventsSeen, receipt.EventsRetained, receipt.EventsDropped, len(receipt.Events),
+		)
+	}
+	if len(receipt.Events) == 0 {
+		t.Fatal("empty C topology receipt")
+	}
+	receiptSHA256 := cTopologyReceiptSHA256(receipt)
+	if len(receipt.Events) != cTopologyErlangIssue984EventCount || receiptSHA256 != cTopologyErlangIssue984SHA256 {
+		t.Fatalf(
+			"C topology receipt: events=%d sha256=%s, want events=%d sha256=%s",
+			len(receipt.Events), receiptSHA256,
+			cTopologyErlangIssue984EventCount, cTopologyErlangIssue984SHA256,
+		)
+	}
+	t.Logf(
+		"C topology receipt: events=%d sha256=%s",
+		len(receipt.Events), receiptSHA256,
+	)
+
+	kinds := make(map[uint64]int)
+	nextVersionID := uint64(1)
+	nextLinkID := uint64(1)
+	nextElectionID := uint64(1)
+	lastActionID := uint64(0)
+	lastPopID := uint64(0)
+	lastPathOrdinal := uint64(0)
+	acceptPayloads := make([]int, 0, 4)
+	for index, event := range receipt.Events {
+		if event.EventID != uint64(index+1) {
+			t.Fatalf("event[%d] id=%d", index, event.EventID)
+		}
+		if event.Kind < cTopologyEventAction || event.Kind > cTopologyEventAcceptElection {
+			t.Fatalf("event[%d] kind=%d", index, event.Kind)
+		}
+		if event.Flags & ^uint64(cTopologyKnownFlags) != 0 {
+			t.Fatalf("event[%d] reserved flags=%#x", index, event.Flags)
+		}
+		if event.Flags&cTopologyFlagActionContext != 0 {
+			if event.ActionID == 0 || event.ActionType > 3 || event.ActionOrdinal < -1 {
+				t.Fatalf("event[%d] invalid action context: %+v", index, event)
+			}
+		} else if event.ActionID != 0 || event.ActionOrdinal != -1 || event.ActionType != cTopologyActionUnknown {
+			t.Fatalf("event[%d] leaked action context: %+v", index, event)
+		}
+		kinds[event.Kind]++
+
+		switch event.Kind {
+		case cTopologyEventAction:
+			if event.ActionID <= lastActionID {
+				t.Fatalf("action id=%d after %d", event.ActionID, lastActionID)
+			}
+			lastActionID = event.ActionID
+		case cTopologyEventVersionAdd, cTopologyEventVersionCopy:
+			if event.VersionID != nextVersionID || event.NodeID == 0 {
+				t.Fatalf("version allocation id=%d node=%d, want id=%d", event.VersionID, event.NodeID, nextVersionID)
+			}
+			nextVersionID++
+		case cTopologyEventVersionRenumber:
+			if event.VersionID == 0 || event.SourceVersionID != event.VersionID || event.TargetVersionID == 0 ||
+				event.VersionIndex != event.TargetIndex || event.SourceIndex <= event.TargetIndex || event.NodeID == 0 ||
+				event.Flags&cTopologyFlagTargetReplaced == 0 {
+				t.Fatalf("invalid renumber event: %+v", event)
+			}
+		case cTopologyEventMerge:
+			if event.SurvivorVersionID == 0 || event.RemovedVersionID == 0 || event.SurvivorVersionID != event.SourceVersionID || event.RemovedVersionID != event.TargetVersionID {
+				t.Fatalf("invalid merge orientation: %+v", event)
+			}
+		case cTopologyEventLinkInsert:
+			if event.LinkID != nextLinkID || event.NodeID == 0 || event.PredecessorNodeID == 0 || event.LinkOrdinal >= 8 {
+				t.Fatalf("link insert=%+v, want link id=%d", event, nextLinkID)
+			}
+			nextLinkID++
+		case cTopologyEventPopPath:
+			if event.PopID == 0 || event.VersionID == 0 || event.SourceVersionID == 0 || event.NodeID == 0 || event.PopToNodeID == 0 {
+				t.Fatalf("invalid pop path: %+v", event)
+			}
+			if event.PopID == lastPopID {
+				if event.PathOrdinal != lastPathOrdinal+1 {
+					t.Fatalf("pop %d path ordinal=%d after %d", event.PopID, event.PathOrdinal, lastPathOrdinal)
+				}
+			} else {
+				if event.PopID <= lastPopID || event.PathOrdinal != 0 {
+					t.Fatalf("new pop id=%d path ordinal=%d after pop=%d", event.PopID, event.PathOrdinal, lastPopID)
+				}
+			}
+			lastPopID = event.PopID
+			lastPathOrdinal = event.PathOrdinal
+		case cTopologyEventChildElection, cTopologyEventAcceptElection:
+			if event.ElectionID != nextElectionID || event.CandidateID == 0 || event.SelectedID == 0 {
+				t.Fatalf("election=%+v, want election id=%d", event, nextElectionID)
+			}
+			if event.Flags&cTopologyFlagNoIncumbent == 0 && event.IncumbentID == 0 {
+				t.Fatalf("election has no incumbent identity: %+v", event)
+			}
+			nextElectionID++
+			if event.Kind == cTopologyEventAcceptElection {
+				acceptPayloads = append(acceptPayloads, int(event.PayloadCount))
+			}
+		}
+	}
+
+	for _, kind := range []uint64{
+		cTopologyEventAction,
+		cTopologyEventVersionAdd,
+		cTopologyEventVersionRenumber,
+		cTopologyEventMerge,
+		cTopologyEventLinkInsert,
+		cTopologyEventPopPath,
+		cTopologyEventChildElection,
+		cTopologyEventAcceptElection,
+	} {
+		if kinds[kind] == 0 {
+			t.Errorf("event kind %d is absent", kind)
+		}
+	}
+	if kinds[cTopologyEventVersionCopy] != 0 {
+		t.Errorf("version-copy events=%d, want zero for the locked-C witness", kinds[cTopologyEventVersionCopy])
+	}
+	sort.Ints(acceptPayloads)
+	wantAcceptPayloads := []int{3}
+	if fmt.Sprint(acceptPayloads) != fmt.Sprint(wantAcceptPayloads) {
+		t.Errorf("accept election payload counts=%v, want %v", acceptPayloads, wantAcceptPayloads)
+	}
+
+	assertCTopologyReduceAnchor(t, receipt.Events, 320, 130, 10, 1)
+	assertCTopologyReduceAnchor(t, receipt.Events, 274, 133, 11, 1)
+}
+
+func cTopologyReceiptSHA256(receipt cTopologyReceipt) string {
+	digest := sha256.New()
+	_, _ = digest.Write([]byte("gts-topology-receipt/v1\x00"))
+	writeUint64 := func(value uint64) {
+		var encoded [8]byte
+		binary.LittleEndian.PutUint64(encoded[:], value)
+		_, _ = digest.Write(encoded[:])
+	}
+	writeBool := func(value bool) {
+		if value {
+			writeUint64(1)
+		} else {
+			writeUint64(0)
+		}
+	}
+
+	writeUint64(uint64(receipt.Capacity))
+	writeUint64(receipt.EventsSeen)
+	writeUint64(uint64(receipt.EventsRetained))
+	writeUint64(receipt.EventsDropped)
+	writeBool(receipt.Truncated)
+	writeBool(receipt.ArithmeticOverflow)
+	writeBool(receipt.IdentityCollision)
+	writeBool(receipt.IdentityIncomplete)
+	for _, event := range receipt.Events {
+		writeUint64(event.EventID)
+		writeUint64(event.Kind)
+		writeUint64(event.ActionID)
+		writeUint64(uint64(event.ActionOrdinal))
+		writeUint64(event.ActionType)
+		writeUint64(event.State)
+		writeUint64(event.LookaheadSymbol)
+		writeUint64(event.ByteOffset)
+		writeUint64(event.VersionID)
+		writeUint64(event.VersionIndex)
+		writeUint64(event.SourceVersionID)
+		writeUint64(event.SourceIndex)
+		writeUint64(event.TargetVersionID)
+		writeUint64(event.TargetIndex)
+		writeUint64(event.SurvivorVersionID)
+		writeUint64(event.RemovedVersionID)
+		writeUint64(event.NodeID)
+		writeUint64(event.PredecessorNodeID)
+		writeUint64(event.LinkID)
+		writeUint64(event.LinkOrdinal)
+		writeUint64(event.PopID)
+		writeUint64(event.PathOrdinal)
+		writeUint64(event.PopToNodeID)
+		writeUint64(event.ElectionID)
+		writeUint64(event.IncumbentID)
+		writeUint64(event.CandidateID)
+		writeUint64(event.SelectedID)
+		writeUint64(event.PayloadCount)
+		writeUint64(event.Flags)
+	}
+	return fmt.Sprintf("%x", digest.Sum(nil))
+}
+
+func assertCTopologyReduceAnchor(
+	t *testing.T,
+	events []cTopologyEvent,
+	state uint64,
+	lookahead uint64,
+	byteOffset uint64,
+	wantVersions int,
+) {
+	t.Helper()
+	ordinalsByVersion := make(map[uint64][]int64)
+	for _, event := range events {
+		if event.Kind != cTopologyEventAction || event.State != state || event.LookaheadSymbol != lookahead || event.ByteOffset != byteOffset {
+			continue
+		}
+		if event.ActionType != cTopologyActionReduce {
+			t.Fatalf("anchor state=%d lookahead=%d byte=%d has action type=%d", state, lookahead, byteOffset, event.ActionType)
+		}
+		ordinalsByVersion[event.VersionID] = append(ordinalsByVersion[event.VersionID], event.ActionOrdinal)
+	}
+	if len(ordinalsByVersion) != wantVersions {
+		t.Fatalf(
+			"anchor state=%d lookahead=%d byte=%d versions=%d, want %d: %v",
+			state, lookahead, byteOffset, len(ordinalsByVersion), wantVersions, ordinalsByVersion,
+		)
+	}
+	for versionID, ordinals := range ordinalsByVersion {
+		if fmt.Sprint(ordinals) != "[0 1]" {
+			t.Errorf("anchor version=%d ordinals=%v, want [0 1]", versionID, ordinals)
+		}
+	}
+}

--- a/cgo_harness/merge_event_census.go
+++ b/cgo_harness/merge_event_census.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -68,8 +69,67 @@ import (
 const (
 	mergeCensusRuntimeModule  = "github.com/tree-sitter/go-tree-sitter"
 	mergeCensusDriverSchema   = "gts-merge-census-c/v1"
+	cTopologyDriverSchema     = "gts-topology-receipt-c/v1"
+	cTopologyReceiptSchema    = "gts-topology-receipt/v1"
+	cTopologyEventCapacity    = 4096
 	mergeCensusParseTimeoutUS = "30000000"
 )
+
+type cTopologyEvent struct {
+	EventID           uint64 `json:"event_id"`
+	Kind              uint64 `json:"kind"`
+	ActionID          uint64 `json:"action_id"`
+	ActionOrdinal     int64  `json:"action_ordinal"`
+	ActionType        uint64 `json:"action_type"`
+	State             uint64 `json:"state"`
+	LookaheadSymbol   uint64 `json:"lookahead_symbol"`
+	ByteOffset        uint64 `json:"byte_offset"`
+	VersionID         uint64 `json:"version_id"`
+	VersionIndex      uint64 `json:"version_index"`
+	SourceVersionID   uint64 `json:"source_version_id"`
+	SourceIndex       uint64 `json:"source_index"`
+	TargetVersionID   uint64 `json:"target_version_id"`
+	TargetIndex       uint64 `json:"target_index"`
+	SurvivorVersionID uint64 `json:"survivor_version_id"`
+	RemovedVersionID  uint64 `json:"removed_version_id"`
+	NodeID            uint64 `json:"node_id"`
+	PredecessorNodeID uint64 `json:"predecessor_node_id"`
+	LinkID            uint64 `json:"link_id"`
+	LinkOrdinal       uint64 `json:"link_ordinal"`
+	PopID             uint64 `json:"pop_id"`
+	PathOrdinal       uint64 `json:"path_ordinal"`
+	PopToNodeID       uint64 `json:"pop_to_node_id"`
+	ElectionID        uint64 `json:"election_id"`
+	IncumbentID       uint64 `json:"incumbent_id"`
+	CandidateID       uint64 `json:"candidate_id"`
+	SelectedID        uint64 `json:"selected_id"`
+	PayloadCount      uint64 `json:"payload_count"`
+	Flags             uint64 `json:"flags"`
+}
+
+type cTopologyReceipt struct {
+	Schema             string           `json:"schema"`
+	Capacity           uint32           `json:"capacity"`
+	EventsSeen         uint64           `json:"events_seen"`
+	EventsRetained     uint32           `json:"events_retained"`
+	EventsDropped      uint64           `json:"events_dropped"`
+	Truncated          bool             `json:"truncated"`
+	ArithmeticOverflow bool             `json:"arithmetic_overflow"`
+	IdentityCollision  bool             `json:"identity_collision"`
+	IdentityIncomplete bool             `json:"identity_incomplete"`
+	Events             []cTopologyEvent `json:"events"`
+}
+
+type cTopologyRow struct {
+	Schema         string           `json:"schema"`
+	Path           string           `json:"path"`
+	Status         string           `json:"status"`
+	SourceBytes    uint32           `json:"source_bytes"`
+	RootEndByte    uint32           `json:"root_end_byte"`
+	RootChildCount uint32           `json:"root_child_count"`
+	RootHasError   bool             `json:"root_has_error"`
+	Receipt        cTopologyReceipt `json:"receipt"`
+}
 
 // mergeCensusCRow is one reference-runtime measurement, decoded from the
 // driver's per-source JSON line.
@@ -430,6 +490,76 @@ func mergeCensusRunC(oracle *mergeCensusCOracle, language string, sources []a3Ce
 		rows[index] = row
 	}
 	return rows, nil
+}
+
+func mergeCensusRunCTopology(
+	oracle *mergeCensusCOracle,
+	language string,
+	source a3CertificationSweepSource,
+) (cTopologyRow, error) {
+	identity, err := COracleIdentity(language)
+	if err != nil {
+		return cTopologyRow{}, fmt.Errorf("resolve %s C oracle identity: %w", language, err)
+	}
+	symbols, err := mergeCensusCSymbols(language)
+	if err != nil {
+		return cTopologyRow{}, err
+	}
+
+	batchRoot, err := os.MkdirTemp("", "gts-c-topology-receipt-*")
+	if err != nil {
+		return cTopologyRow{}, fmt.Errorf("create C topology receipt root: %w", err)
+	}
+	defer os.RemoveAll(batchRoot)
+	sourcePath := filepath.Join(batchRoot, "000000.src")
+	if err := os.WriteFile(sourcePath, source.Source, 0o644); err != nil {
+		return cTopologyRow{}, fmt.Errorf("write C topology source: %w", err)
+	}
+	manifestPath := filepath.Join(batchRoot, "manifest.txt")
+	if err := os.WriteFile(manifestPath, []byte(sourcePath+"\n"), 0o644); err != nil {
+		return cTopologyRow{}, fmt.Errorf("write C topology manifest: %w", err)
+	}
+
+	command := exec.Command(
+		oracle.Binary, "--topology", identity.GrammarArtifactPath,
+		strings.Join(symbols, ","), manifestPath, mergeCensusParseTimeoutUS,
+	)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		return cTopologyRow{}, fmt.Errorf(
+			"run C topology receipt for %s/%s: %w: %s",
+			language, source.Name, err, bytes.TrimSpace(stderr.Bytes()),
+		)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(stdout.Bytes()))
+	decoder.DisallowUnknownFields()
+	var row cTopologyRow
+	if err := decoder.Decode(&row); err != nil {
+		return cTopologyRow{}, fmt.Errorf("decode C topology receipt: %w", err)
+	}
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return cTopologyRow{}, fmt.Errorf("decode C topology receipt: trailing JSON value")
+		}
+		return cTopologyRow{}, fmt.Errorf("decode C topology receipt trailer: %w", err)
+	}
+	if row.Schema != cTopologyDriverSchema {
+		return cTopologyRow{}, fmt.Errorf("C topology row schema %q, want %q", row.Schema, cTopologyDriverSchema)
+	}
+	if row.Receipt.Schema != cTopologyReceiptSchema {
+		return cTopologyRow{}, fmt.Errorf(
+			"C topology receipt schema %q, want %q",
+			row.Receipt.Schema, cTopologyReceiptSchema,
+		)
+	}
+	if row.Path != sourcePath {
+		return cTopologyRow{}, fmt.Errorf("C topology row path %q, want %q", row.Path, sourcePath)
+	}
+	return row, nil
 }
 
 // mergeCensusRow is one source's full accounting: the reference runtime's

--- a/cgo_harness/pure_c/merge_census_oracle.c
+++ b/cgo_harness/pure_c/merge_census_oracle.c
@@ -112,6 +112,78 @@ static void print_row(const char *path, const char *status, GTSWorkCount c,
   printf(",\"overflow\":%s}\n", c.overflow ? "true" : "false");
 }
 
+static void print_topology_event(GTSTopologyEvent event) {
+  printf("{");
+#define EVENT_U64(field) \
+  printf("\"" #field "\":%llu,", (unsigned long long)event.field)
+  EVENT_U64(event_id);
+  EVENT_U64(kind);
+  EVENT_U64(action_id);
+  printf("\"action_ordinal\":%lld,", (long long)event.action_ordinal);
+  EVENT_U64(action_type);
+  EVENT_U64(state);
+  EVENT_U64(lookahead_symbol);
+  EVENT_U64(byte_offset);
+  EVENT_U64(version_id);
+  EVENT_U64(version_index);
+  EVENT_U64(source_version_id);
+  EVENT_U64(source_index);
+  EVENT_U64(target_version_id);
+  EVENT_U64(target_index);
+  EVENT_U64(survivor_version_id);
+  EVENT_U64(removed_version_id);
+  EVENT_U64(node_id);
+  EVENT_U64(predecessor_node_id);
+  EVENT_U64(link_id);
+  EVENT_U64(link_ordinal);
+  EVENT_U64(pop_id);
+  EVENT_U64(path_ordinal);
+  EVENT_U64(pop_to_node_id);
+  EVENT_U64(election_id);
+  EVENT_U64(incumbent_id);
+  EVENT_U64(candidate_id);
+  EVENT_U64(selected_id);
+  EVENT_U64(payload_count);
+#undef EVENT_U64
+  printf("\"flags\":%llu}", (unsigned long long)event.flags);
+}
+
+static void print_topology_row(
+  const char *path,
+  const char *status,
+  const GTSTopologyReceipt *receipt,
+  uint32_t source_len,
+  uint32_t root_end_byte,
+  uint32_t root_child_count,
+  bool root_has_error
+) {
+  printf("{\"schema\":\"gts-topology-receipt-c/v1\",\"path\":\"");
+  print_escaped(path);
+  printf("\",\"status\":\"%s\"", status);
+  printf(",\"source_bytes\":%u,\"root_end_byte\":%u", source_len, root_end_byte);
+  printf(",\"root_child_count\":%u,\"root_has_error\":%s", root_child_count,
+         root_has_error ? "true" : "false");
+  printf(",\"receipt\":{");
+  printf("\"schema\":\"gts-topology-receipt/v1\"");
+  printf(",\"capacity\":%u", GTS_TOPOLOGY_EVENT_CAPACITY);
+  printf(",\"events_seen\":%llu", (unsigned long long)receipt->events_seen);
+  printf(",\"events_retained\":%u", receipt->events_retained);
+  printf(",\"events_dropped\":%llu", (unsigned long long)receipt->events_dropped);
+  printf(",\"truncated\":%s", receipt->truncated ? "true" : "false");
+  printf(",\"arithmetic_overflow\":%s",
+         receipt->arithmetic_overflow ? "true" : "false");
+  printf(",\"identity_collision\":%s",
+         receipt->identity_collision ? "true" : "false");
+  printf(",\"identity_incomplete\":%s",
+         receipt->identity_incomplete ? "true" : "false");
+  printf(",\"events\":[");
+  for (uint32_t i = 0; i < receipt->events_retained; i++) {
+    if (i > 0) fputc(',', stdout);
+    print_topology_event(receipt->events[i]);
+  }
+  printf("]}}\n");
+}
+
 static unsigned long long parse_u64(const char *raw) {
   char *end = NULL;
   unsigned long long value = strtoull(raw, &end, 10);
@@ -125,25 +197,29 @@ int main(int argc, char **argv) {
     // proves the counters it reads still behave as the patch's model states.
     bool passed = gts_work_count_validate_action_model() &&
                   gts_work_count_validate_link_union_model() &&
-                  gts_work_count_validate_raw_census_model();
+                  gts_work_count_validate_raw_census_model() &&
+                  gts_topology_validate_model() &&
+                  gts_topology_validate_stack_model();
     printf("{\"schema\":\"gts-merge-census-c-exact-model/v1\",\"passed\":%s}\n",
            passed ? "true" : "false");
     return passed ? 0 : 12;
   }
-  if (argc != 5) {
+  bool topology_mode = argc == 6 && strcmp(argv[1], "--topology") == 0;
+  int argument_offset = topology_mode ? 1 : 0;
+  if (argc != 5 + argument_offset) {
     fputs("status=c_protocol_error\n", stderr);
-    fprintf(stderr, "usage: %s <grammar-so> <symbol> <manifest> <timeout-us>\n",
+    fprintf(stderr, "usage: %s [--topology] <grammar-so> <symbol> <manifest> <timeout-us>\n",
             argv[0]);
     return 2;
   }
 
-  unsigned long long timeout_us = parse_u64(argv[4]);
+  unsigned long long timeout_us = parse_u64(argv[4 + argument_offset]);
   if (timeout_us == 0) {
     fputs("status=c_protocol_error\n", stderr);
     return 2;
   }
 
-  void *handle = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+  void *handle = dlopen(argv[1 + argument_offset], RTLD_NOW | RTLD_LOCAL);
   if (!handle) {
     fprintf(stderr, "status=c_dlopen_error %s\n", dlerror());
     return 3;
@@ -152,7 +228,7 @@ int main(int argc, char **argv) {
   // loader's parityLanguageSymbols: a grammar repository does not always name
   // its entry point after the lock row.
   gts_lang_fn lang_fn = NULL;
-  char *symbols = strdup(argv[2]);
+  char *symbols = strdup(argv[2 + argument_offset]);
   if (!symbols) {
     fputs("status=c_alloc_error\n", stderr);
     return 3;
@@ -168,7 +244,7 @@ int main(int argc, char **argv) {
   }
   free(symbols);
   if (!lang_fn) {
-    fprintf(stderr, "status=c_dlsym_error %s\n", argv[2]);
+    fprintf(stderr, "status=c_dlsym_error %s\n", argv[2 + argument_offset]);
     return 3;
   }
   const TSLanguage *language = lang_fn();
@@ -178,7 +254,7 @@ int main(int argc, char **argv) {
   }
 
   size_t manifest_len = 0;
-  char *manifest = read_file(argv[3], &manifest_len);
+  char *manifest = read_file(argv[3 + argument_offset], &manifest_len);
   if (!manifest) {
     fputs("status=c_manifest_error\n", stderr);
     return 4;
@@ -196,7 +272,12 @@ int main(int argc, char **argv) {
     char *source = read_file(path, &source_len);
     if (!source || source_len > UINT32_MAX) {
       free(source);
-      print_row(path, "source_error", (GTSWorkCount){0}, 0u, 0u, false);
+      if (topology_mode) {
+        GTSTopologyReceipt empty = {0};
+        print_topology_row(path, "source_error", &empty, 0u, 0u, 0u, false);
+      } else {
+        print_row(path, "source_error", (GTSWorkCount){0}, 0u, 0u, false);
+      }
       continue;
     }
 
@@ -204,25 +285,45 @@ int main(int argc, char **argv) {
     if (!parser || !ts_parser_set_language(parser, language)) {
       if (parser) ts_parser_delete(parser);
       free(source);
-      print_row(path, "parser_error", (GTSWorkCount){0}, (uint32_t)source_len,
-                0u, false);
+      if (topology_mode) {
+        GTSTopologyReceipt empty = {0};
+        print_topology_row(path, "parser_error", &empty, (uint32_t)source_len,
+                           0u, 0u, false);
+      } else {
+        print_row(path, "parser_error", (GTSWorkCount){0}, (uint32_t)source_len,
+                  0u, false);
+      }
       continue;
     }
     ts_parser_set_timeout_micros(parser, timeout_us);
 
     gts_work_count_reset();
+    gts_topology_enable(topology_mode);
     TSTree *tree =
         ts_parser_parse_string(parser, NULL, source, (uint32_t)source_len);
+    gts_topology_finish_parse();
     GTSWorkCount counts = gts_work_count_snapshot();
+    const GTSTopologyReceipt *receipt = gts_topology_snapshot();
     if (!tree) {
       ts_parser_delete(parser);
       free(source);
-      print_row(path, "timeout", counts, (uint32_t)source_len, 0u, false);
+      if (topology_mode) {
+        print_topology_row(path, "timeout", receipt, (uint32_t)source_len,
+                           0u, 0u, false);
+      } else {
+        print_row(path, "timeout", counts, (uint32_t)source_len, 0u, false);
+      }
       continue;
     }
     TSNode root = ts_tree_root_node(tree);
-    print_row(path, "ok", counts, (uint32_t)source_len, ts_node_end_byte(root),
-              ts_node_has_error(root));
+    if (topology_mode) {
+      print_topology_row(path, "ok", receipt, (uint32_t)source_len,
+                         ts_node_end_byte(root), ts_node_child_count(root),
+                         ts_node_has_error(root));
+    } else {
+      print_row(path, "ok", counts, (uint32_t)source_len, ts_node_end_byte(root),
+                ts_node_has_error(root));
+    }
     ts_tree_delete(tree);
     ts_parser_delete(parser);
     free(source);

--- a/cgo_harness/work_count/tree_sitter_v0_25_1.patch
+++ b/cgo_harness/work_count/tree_sitter_v0_25_1.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/src/language.c b/lib/src/language.c
-index b341a670..07ac8155 100644
+index b341a67..07ac815 100644
 --- a/lib/src/language.c
 +++ b/lib/src/language.c
 @@ -1,6 +1,7 @@
@@ -30,10 +30,10 @@ index b341a670..07ac8155 100644
 
  TSLexerMode ts_language_lex_mode_for_state(
 diff --git a/lib/src/parser.c b/lib/src/parser.c
-index 7aac259e..9032e98a 100644
+index 41a349d..c944b7a 100644
 --- a/lib/src/parser.c
 +++ b/lib/src/parser.c
-@@ -20,6 +20,83 @@
+@@ -20,6 +20,228 @@
  #include "./tree.h"
  #include "./ts_assert.h"
  #include "./wasm_store.h"
@@ -41,13 +41,158 @@ index 7aac259e..9032e98a 100644
 +#include <stddef.h>
 +
 +_Thread_local GTSWorkCount gts_work_count_current;
++_Thread_local GTSTopologyReceipt gts_topology_current;
++static _Thread_local uint64_t gts_topology_generation_counter;
 +
 +void gts_work_count_reset(void) {
 +  gts_work_count_current = (GTSWorkCount) {0};
++  gts_topology_current = (GTSTopologyReceipt) {
++    .current_action_ordinal = -1,
++    .current_action_type = GTSTopologyActionUnknown,
++  };
 +}
 +
 +GTSWorkCount gts_work_count_snapshot(void) {
 +  return gts_work_count_current;
++}
++
++void gts_topology_enable(bool enabled) {
++  if (enabled && !gts_topology_current.enabled) {
++    if (gts_topology_generation_counter == UINT64_MAX) {
++      gts_topology_current.arithmetic_overflow = true;
++      gts_topology_current.identity_incomplete = true;
++      return;
++    }
++    gts_topology_current.generation = ++gts_topology_generation_counter;
++  }
++  gts_topology_current.enabled = enabled;
++}
++
++void gts_topology_finish_parse(void) {
++  gts_topology_action_end();
++  gts_topology_current.enabled = false;
++}
++
++const GTSTopologyReceipt *gts_topology_snapshot(void) {
++  return &gts_topology_current;
++}
++
++static uint64_t gts_topology_next_id(uint64_t *slot) {
++  if (!gts_topology_current.enabled) return 0;
++  if (*slot == UINT64_MAX) {
++    gts_topology_current.arithmetic_overflow = true;
++    gts_topology_current.identity_incomplete = true;
++    return 0;
++  }
++  return ++*slot;
++}
++
++uint64_t gts_topology_next_action_id(void) {
++  return gts_topology_next_id(&gts_topology_current.next_action_id);
++}
++
++uint64_t gts_topology_next_version_id(void) {
++  return gts_topology_next_id(&gts_topology_current.next_version_id);
++}
++
++uint64_t gts_topology_next_node_id(void) {
++  return gts_topology_next_id(&gts_topology_current.next_node_id);
++}
++
++uint64_t gts_topology_next_link_id(void) {
++  return gts_topology_next_id(&gts_topology_current.next_link_id);
++}
++
++uint64_t gts_topology_next_pop_id(void) {
++  return gts_topology_next_id(&gts_topology_current.next_pop_id);
++}
++
++uint64_t gts_topology_next_election_id(void) {
++  return gts_topology_next_id(&gts_topology_current.next_election_id);
++}
++
++uint64_t gts_topology_next_candidate_id(void) {
++  return gts_topology_next_id(&gts_topology_current.next_candidate_id);
++}
++
++uint64_t gts_topology_generation(void) {
++  return gts_topology_current.enabled ? gts_topology_current.generation : 0;
++}
++
++void gts_topology_action_begin(uint64_t action_id, int64_t ordinal, uint64_t type) {
++  if (!gts_topology_current.enabled) return;
++  gts_topology_current.current_action_id = action_id;
++  gts_topology_current.current_action_ordinal = ordinal;
++  gts_topology_current.current_action_type = type;
++}
++
++void gts_topology_action_end(void) {
++  gts_topology_current.current_action_id = 0;
++  gts_topology_current.current_action_ordinal = -1;
++  gts_topology_current.current_action_type = GTSTopologyActionUnknown;
++}
++
++void gts_topology_record(GTSTopologyEvent event) {
++  if (!gts_topology_current.enabled) return;
++  if (gts_topology_current.events_seen == UINT64_MAX) {
++    gts_topology_current.arithmetic_overflow = true;
++    gts_topology_current.identity_incomplete = true;
++    return;
++  }
++  event.event_id = ++gts_topology_current.events_seen;
++  if (gts_topology_current.current_action_id != 0) {
++    event.action_id = gts_topology_current.current_action_id;
++    event.action_ordinal = gts_topology_current.current_action_ordinal;
++    event.action_type = gts_topology_current.current_action_type;
++    event.flags |= GTSTopologyFlagActionContextKnown;
++  } else {
++    event.action_ordinal = -1;
++    event.action_type = GTSTopologyActionUnknown;
++  }
++  if (gts_topology_current.events_retained < GTS_TOPOLOGY_EVENT_CAPACITY) {
++    gts_topology_current.events[gts_topology_current.events_retained++] = event;
++    return;
++  }
++  gts_topology_current.truncated = true;
++  if (gts_topology_current.events_dropped == UINT64_MAX) {
++    gts_topology_current.arithmetic_overflow = true;
++    return;
++  }
++  gts_topology_current.events_dropped++;
++}
++
++bool gts_topology_validate_model(void) {
++  gts_work_count_reset();
++  gts_topology_enable(true);
++  uint64_t action_id = gts_topology_next_action_id();
++  gts_topology_action_begin(action_id, 7, GTSTopologyActionReduce);
++  for (uint64_t i = 0; i <= GTS_TOPOLOGY_EVENT_CAPACITY; i++) {
++    gts_topology_record((GTSTopologyEvent) {
++      .kind = GTSTopologyEventAction,
++      .state = i,
++    });
++  }
++  gts_topology_action_end();
++  bool bounded = action_id == 1 &&
++    gts_topology_current.events_seen == GTS_TOPOLOGY_EVENT_CAPACITY + 1 &&
++    gts_topology_current.events_retained == GTS_TOPOLOGY_EVENT_CAPACITY &&
++    gts_topology_current.events_dropped == 1 &&
++    gts_topology_current.truncated &&
++    gts_topology_current.events[0].event_id == 1 &&
++    gts_topology_current.events[GTS_TOPOLOGY_EVENT_CAPACITY - 1].event_id == GTS_TOPOLOGY_EVENT_CAPACITY &&
++    gts_topology_current.events[0].action_id == action_id &&
++    gts_topology_current.events[0].action_ordinal == 7 &&
++    gts_topology_current.events[0].action_type == GTSTopologyActionReduce &&
++    gts_topology_current.events[0].flags == GTSTopologyFlagActionContextKnown &&
++    !gts_topology_current.arithmetic_overflow &&
++    !gts_topology_current.identity_collision &&
++    !gts_topology_current.identity_incomplete;
++  gts_topology_current.next_node_id = UINT64_MAX;
++  bool overflowed = gts_topology_next_node_id() == 0 &&
++    gts_topology_current.arithmetic_overflow &&
++    gts_topology_current.identity_incomplete;
++  gts_work_count_reset();
++  return bounded && overflowed;
 +}
 +
 +static void gts_work_count_raw_selected_subtree(Subtree subtree) {
@@ -117,7 +262,37 @@ index 7aac259e..9032e98a 100644
 
  #define LOG(...)                                                                            \
    if (self->lexer.logger.log || self->dot_graph_file) {                                     \
-@@ -345,6 +422,7 @@ static bool ts_parser__better_version_exists(
+@@ -119,6 +341,29 @@ struct TSParser {
+   bool has_error;
+ };
+
++static uint64_t gts_topology_begin_parser_action(
++  TSParser *self,
++  StackVersion version,
++  TSStateId state,
++  Subtree lookahead,
++  int64_t ordinal,
++  uint64_t type
++) {
++  uint64_t action_id = gts_topology_next_action_id();
++  gts_topology_action_begin(action_id, ordinal, type);
++  gts_topology_record((GTSTopologyEvent) {
++    .kind = GTSTopologyEventAction,
++    .state = state,
++    .lookahead_symbol = lookahead.ptr
++      ? ts_subtree_leaf_symbol(lookahead)
++      : ts_builtin_sym_end,
++    .byte_offset = ts_stack_position(self->stack, version).bytes,
++    .version_id = ts_stack_topology_version_id(self->stack, version),
++    .version_index = version,
++  });
++  return action_id;
++}
++
+ typedef struct {
+   unsigned cost;
+   unsigned node_count;
+@@ -345,6 +590,7 @@ static bool ts_parser__better_version_exists(
  }
 
  static bool ts_parser__call_main_lex_fn(TSParser *self, TSLexerMode lex_mode) {
@@ -125,7 +300,7 @@ index 7aac259e..9032e98a 100644
    if (ts_language_is_wasm(self->language)) {
      return ts_wasm_store_call_lex_main(self->wasm_store, lex_mode.lex_state);
    } else {
-@@ -509,6 +587,8 @@ static Subtree ts_parser__lex(
+@@ -509,6 +755,8 @@ static Subtree ts_parser__lex(
    StackVersion version,
    TSStateId parse_state
  ) {
@@ -134,7 +309,7 @@ index 7aac259e..9032e98a 100644
    TSLexerMode lex_mode = ts_language_lex_mode_for_state(self->language, parse_state);
    if (lex_mode.lex_state == (uint16_t)-1) {
      LOG("no_lookahead_after_non_terminal_extra");
-@@ -912,6 +992,7 @@ static void ts_parser__shift(
+@@ -912,6 +1160,7 @@ static void ts_parser__shift(
    Subtree lookahead,
    bool extra
  ) {
@@ -142,7 +317,7 @@ index 7aac259e..9032e98a 100644
    bool is_leaf = ts_subtree_child_count(lookahead) == 0;
    Subtree subtree_to_push = lookahead;
    if (extra != ts_subtree_extra(lookahead) && is_leaf) {
-@@ -938,6 +1019,7 @@ static StackVersion ts_parser__reduce(
+@@ -938,6 +1187,7 @@ static StackVersion ts_parser__reduce(
    bool is_fragile,
    bool end_of_non_terminal_extra
  ) {
@@ -150,7 +325,51 @@ index 7aac259e..9032e98a 100644
    uint32_t initial_version_count = ts_stack_version_count(self->stack);
 
    // Pop the given number of nodes from the given version of the parse stack.
-@@ -1048,6 +1130,7 @@ static void ts_parser__accept(
+@@ -977,6 +1227,7 @@ static StackVersion ts_parser__reduce(
+     MutableSubtree parent = ts_subtree_new_node(
+       symbol, &children, production_id, self->language
+     );
++    uint64_t parent_candidate_id = gts_topology_next_candidate_id();
+
+     // This pop operation may have caused multiple stack versions to collapse
+     // into one, because they all diverged from a common state. In that case,
+@@ -990,17 +1241,33 @@ static StackVersion ts_parser__reduce(
+       SubtreeArray next_slice_children = next_slice.subtrees;
+       ts_subtree_array_remove_trailing_extras(&next_slice_children, &self->trailing_extras2);
+
+-      if (ts_parser__select_children(
++      uint64_t candidate_id = gts_topology_next_candidate_id();
++      uint64_t election_id = gts_topology_next_election_id();
++      bool selected_candidate = ts_parser__select_children(
+         self,
+         ts_subtree_from_mut(parent),
+         &next_slice_children
+-      )) {
++      );
++      gts_topology_record((GTSTopologyEvent) {
++        .kind = GTSTopologyEventChildElection,
++        .state = symbol,
++        .version_id = ts_stack_topology_version_id(self->stack, slice_version),
++        .version_index = slice_version,
++        .election_id = election_id,
++        .incumbent_id = parent_candidate_id,
++        .candidate_id = candidate_id,
++        .selected_id = selected_candidate ? candidate_id : parent_candidate_id,
++        .payload_count = next_slice_children.size,
++        .flags = selected_candidate ? GTSTopologyFlagSuccessOrSelected : 0,
++      });
++      if (selected_candidate) {
+         ts_subtree_array_clear(&self->tree_pool, &self->trailing_extras);
+         ts_subtree_release(&self->tree_pool, ts_subtree_from_mut(parent));
+         array_swap(&self->trailing_extras, &self->trailing_extras2);
+         parent = ts_subtree_new_node(
+           symbol, &next_slice_children, production_id, self->language
+         );
++        parent_candidate_id = candidate_id;
+       } else {
+         array_clear(&self->trailing_extras2);
+         ts_subtree_array_delete(&self->tree_pool, &next_slice.subtrees);
+@@ -1048,6 +1315,7 @@ static void ts_parser__accept(
    StackVersion version,
    Subtree lookahead
  ) {
@@ -158,7 +377,68 @@ index 7aac259e..9032e98a 100644
    ts_assert(ts_subtree_is_eof(lookahead));
    ts_stack_push(self->stack, version, lookahead, false, 1);
 
-@@ -1616,13 +1699,19 @@ static bool ts_parser__advance(
+@@ -1079,16 +1347,43 @@ static void ts_parser__accept(
+
+     ts_assert(root.ptr);
+     self->accept_count++;
++    uint64_t candidate_id = gts_topology_next_candidate_id();
++    uint64_t election_id = gts_topology_next_election_id();
+
+     if (self->finished_tree.ptr) {
+-      if (ts_parser__select_tree(self, self->finished_tree, root)) {
++      uint64_t incumbent_id = gts_topology_current.finished_candidate_id;
++      bool selected_candidate = ts_parser__select_tree(self, self->finished_tree, root);
++      gts_topology_record((GTSTopologyEvent) {
++        .kind = GTSTopologyEventAcceptElection,
++        .version_id = ts_stack_topology_version_id(self->stack, version),
++        .version_index = version,
++        .election_id = election_id,
++        .incumbent_id = incumbent_id,
++        .candidate_id = candidate_id,
++        .selected_id = selected_candidate ? candidate_id : incumbent_id,
++        .payload_count = trees.size,
++        .flags = selected_candidate ? GTSTopologyFlagSuccessOrSelected : 0,
++      });
++      if (selected_candidate) {
+         ts_subtree_release(&self->tree_pool, self->finished_tree);
+         self->finished_tree = root;
++        gts_topology_current.finished_candidate_id = candidate_id;
+       } else {
+         ts_subtree_release(&self->tree_pool, root);
+       }
+     } else {
++      gts_topology_record((GTSTopologyEvent) {
++        .kind = GTSTopologyEventAcceptElection,
++        .version_id = ts_stack_topology_version_id(self->stack, version),
++        .version_index = version,
++        .election_id = election_id,
++        .candidate_id = candidate_id,
++        .selected_id = candidate_id,
++        .payload_count = trees.size,
++        .flags = GTSTopologyFlagSuccessOrSelected | GTSTopologyFlagNoIncumbent,
++      });
+       self->finished_tree = root;
++      gts_topology_current.finished_candidate_id = candidate_id;
+     }
+   }
+
+@@ -1160,11 +1455,15 @@ static bool ts_parser__do_all_potential_reductions(
+     for (uint32_t j = 0; j < self->reduce_actions.size; j++) {
+       ReduceAction action = self->reduce_actions.contents[j];
+
++      gts_topology_begin_parser_action(
++        self, version, state, NULL_SUBTREE, -1, GTSTopologyActionReduce
++      );
+       reduction_version = ts_parser__reduce(
+         self, version, action.symbol, action.count,
+         action.dynamic_precedence, action.production_id,
+         true, false
+       );
++      gts_topology_action_end();
+     }
+
+     if (has_shift_action) {
+@@ -1616,13 +1915,22 @@ static bool ts_parser__advance(
      // an ambiguous state. REDUCE actions always create a new stack
      // version, whereas SHIFT actions update the existing stack version
      // and terminate this loop.
@@ -174,35 +454,73 @@ index 7aac259e..9032e98a 100644
        switch (action.type) {
          case TSParseActionTypeShift: {
            if (action.shift.repetition) break;
++          gts_topology_begin_parser_action(
++            self, version, state, lookahead, i, GTSTopologyActionShift
++          );
 +          gts_work_count_admit_action_arm(&admitted_action_arms, table_entry.action_count);
            TSStateId next_state;
            if (action.shift.extra) {
              next_state = state;
-@@ -1643,6 +1732,7 @@ static bool ts_parser__advance(
+@@ -1639,10 +1947,15 @@ static bool ts_parser__advance(
+
+           ts_parser__shift(self, version, next_state, lookahead, action.shift.extra);
+           if (did_reuse) reusable_node_advance(&self->reusable_node);
++          gts_topology_action_end();
+           return true;
          }
 
          case TSParseActionTypeReduce: {
++          gts_topology_begin_parser_action(
++            self, version, state, lookahead, i, GTSTopologyActionReduce
++          );
 +          gts_work_count_admit_action_arm(&admitted_action_arms, table_entry.action_count);
            bool is_fragile = table_entry.action_count > 1;
            bool end_of_non_terminal_extra = lookahead.ptr == NULL;
            LOG("reduce sym:%s, child_count:%u", SYM_NAME(action.reduce.symbol), action.reduce.child_count);
-@@ -1658,12 +1748,15 @@ static bool ts_parser__advance(
+@@ -1654,22 +1967,34 @@ static bool ts_parser__advance(
+           if (reduction_version != STACK_VERSION_NONE) {
+             last_reduction_version = reduction_version;
+           }
++          gts_topology_action_end();
+           break;
          }
 
          case TSParseActionTypeAccept: {
++          gts_topology_begin_parser_action(
++            self, version, state, lookahead, i, GTSTopologyActionAccept
++          );
 +          gts_work_count_admit_action_arm(&admitted_action_arms, table_entry.action_count);
            LOG("accept");
            ts_parser__accept(self, version, lookahead);
++          gts_topology_action_end();
            return true;
          }
 
          case TSParseActionTypeRecover: {
++          gts_topology_begin_parser_action(
++            self, version, state, lookahead, i, GTSTopologyActionRecover
++          );
 +          gts_work_count_admit_action_arm(&admitted_action_arms, table_entry.action_count);
 +          gts_work_count_add(&gts_work_count_current.explicit_recover_actions, 1);
            if (ts_subtree_child_count(lookahead) > 0) {
              ts_parser__breakdown_lookahead(self, &lookahead, ERROR_STATE, &self->reusable_node);
            }
-@@ -2203,6 +2296,7 @@ balance:
+
+           ts_parser__recover(self, version, lookahead);
+           if (did_reuse) reusable_node_advance(&self->reusable_node);
++          gts_topology_action_end();
+           return true;
+         }
+       }
+@@ -2137,6 +2462,7 @@ TSTree *ts_parser_parse(
+   }
+
+   uint32_t position = 0, last_position = 0, version_count = 0;
++  ts_stack_topology_begin(self->stack);
+   do {
+     for (
+       StackVersion version = 0;
+@@ -2202,6 +2528,7 @@ balance:
    self->canceled_balancing = false;
    LOG("done");
    LOG_TREE(self->finished_tree);
@@ -210,8 +528,16 @@ index 7aac259e..9032e98a 100644
 
    result = ts_tree_new(
      self->finished_tree,
+@@ -2212,6 +2539,7 @@ balance:
+   self->finished_tree = NULL_SUBTREE;
+
+ exit:
++  gts_topology_finish_parse();
+   ts_parser_reset(self);
+   return result;
+ }
 diff --git a/lib/src/stack.c b/lib/src/stack.c
-index f0d57108..ddf0425d 100644
+index f0d5710..d5bf3b7 100644
 --- a/lib/src/stack.c
 +++ b/lib/src/stack.c
 @@ -4,6 +4,7 @@
@@ -222,15 +548,94 @@ index f0d57108..ddf0425d 100644
  #include <assert.h>
  #include <inttypes.h>
  #include <stdio.h>
-@@ -158,6 +159,7 @@ static StackNode *stack_node_new(
+@@ -24,6 +25,8 @@ typedef struct {
+   StackNode *node;
+   Subtree subtree;
+   bool is_pending;
++  uint64_t topology_generation;
++  uint64_t topology_id;
+ } StackLink;
+
+ struct StackNode {
+@@ -35,6 +38,8 @@ struct StackNode {
+   unsigned error_cost;
+   unsigned node_count;
+   int dynamic_precedence;
++  uint64_t topology_generation;
++  uint64_t topology_id;
+ };
+
+ typedef struct {
+@@ -59,6 +64,8 @@ typedef struct {
+   Subtree last_external_token;
+   Subtree lookahead_when_paused;
+   StackStatus status;
++  uint64_t topology_generation;
++  uint64_t topology_id;
+ } StackHead;
+
+ struct Stack {
+@@ -79,6 +86,34 @@ enum {
+
+ typedef StackAction (*StackCallback)(void *, const StackIterator *);
+
++static uint64_t stack_node_topology_id(StackNode *node) {
++  uint64_t generation = gts_topology_generation();
++  if (!node || generation == 0) return 0;
++  if (node->topology_generation != generation) {
++    node->topology_generation = generation;
++    node->topology_id = gts_topology_next_node_id();
++  }
++  return node->topology_id;
++}
++
++static void stack_record_link_insert(
++  StackNode *node,
++  StackNode *predecessor,
++  uint64_t link_id,
++  uint64_t link_ordinal,
++  bool primary
++) {
++  gts_topology_record((GTSTopologyEvent) {
++    .kind = GTSTopologyEventLinkInsert,
++    .state = node ? node->state : 0,
++    .node_id = stack_node_topology_id(node),
++    .predecessor_node_id = stack_node_topology_id(predecessor),
++    .link_id = link_id,
++    .link_ordinal = link_ordinal,
++    .flags = primary ? GTSTopologyFlagPrimaryLink : 0,
++  });
++}
++
+ static void stack_node_retain(StackNode *self) {
+   if (!self)
+     return;
+@@ -150,6 +185,7 @@ static StackNode *stack_node_new(
+     .link_count = 0,
+     .state = state
+   };
++  stack_node_topology_id(node);
+
+   if (previous_node) {
+     node->link_count = 1;
+@@ -158,6 +194,16 @@ static StackNode *stack_node_new(
        .subtree = subtree,
        .is_pending = is_pending,
      };
++    node->links[0].topology_generation = gts_topology_generation();
++    node->links[0].topology_id = gts_topology_next_link_id();
++    stack_record_link_insert(
++      node,
++      previous_node,
++      node->links[0].topology_id,
++      0,
++      true
++    );
 +    gts_work_count_add(&gts_work_count_current.graph_link_additions_proxy, 1);
 
      node->position = previous_node->position;
      node->error_cost = previous_node->error_cost;
-@@ -197,12 +199,29 @@ static bool stack__subtree_is_equivalent(Subtree left, Subtree right) {
+@@ -197,12 +243,29 @@ static bool stack__subtree_is_equivalent(Subtree left, Subtree right) {
    );
  }
 
@@ -262,7 +667,7 @@ index f0d57108..ddf0425d 100644
 
    for (int i = 0; i < self->link_count; i++) {
      StackLink *existing_link = &self->links[i];
-@@ -221,8 +240,15 @@ static void stack_node_add_link(
+@@ -221,8 +284,15 @@ static void stack_node_add_link(
            existing_link->subtree = link.subtree;
            self->dynamic_precedence =
              link.node->dynamic_precedence + ts_subtree_dynamic_precedence(link.subtree);
@@ -279,7 +684,7 @@ index f0d57108..ddf0425d 100644
        }
 
        // If the previous nodes are mergeable, merge them recursively.
-@@ -231,8 +257,17 @@ static void stack_node_add_link(
+@@ -231,8 +301,17 @@ static void stack_node_add_link(
          existing_link->node->position.bytes == link.node->position.bytes &&
          existing_link->node->error_cost == link.node->error_cost
        ) {
@@ -298,7 +703,7 @@ index f0d57108..ddf0425d 100644
          }
          int32_t dynamic_precedence = link.node->dynamic_precedence;
          if (link.subtree.ptr) {
-@@ -241,17 +276,38 @@ static void stack_node_add_link(
+@@ -241,17 +320,42 @@ static void stack_node_add_link(
          if (dynamic_precedence > self->dynamic_precedence) {
            self->dynamic_precedence = dynamic_precedence;
          }
@@ -330,7 +735,11 @@ index f0d57108..ddf0425d 100644
    stack_node_retain(link.node);
    unsigned node_count = link.node->node_count;
    int dynamic_precedence = link.node->dynamic_precedence;
++  uint64_t link_ordinal = self->link_count;
++  link.topology_generation = gts_topology_generation();
++  link.topology_id = gts_topology_next_link_id();
    self->links[self->link_count++] = link;
++  stack_record_link_insert(self, link.node, link.topology_id, link_ordinal, false);
 +  gts_work_count_add(&gts_work_count_current.graph_link_additions_proxy, 1);
 +  if (union_attempt) {
 +    gts_work_count_add(&gts_work_count_current.predecessor_link_union_alternate_appended, 1);
@@ -339,7 +748,7 @@ index f0d57108..ddf0425d 100644
 
    if (link.subtree.ptr) {
      ts_subtree_retain(link.subtree);
-@@ -261,6 +317,132 @@ static void stack_node_add_link(
+@@ -261,6 +365,132 @@ static void stack_node_add_link(
 
    if (node_count > self->node_count) self->node_count = node_count;
    if (dynamic_precedence > self->dynamic_precedence) self->dynamic_precedence = dynamic_precedence;
@@ -472,15 +881,153 @@ index f0d57108..ddf0425d 100644
  }
 
  static void stack_head_delete(
-@@ -296,6 +478,7 @@ static StackVersion ts_stack__add_version(
+@@ -296,12 +526,26 @@ static StackVersion ts_stack__add_version(
      .lookahead_when_paused = NULL_SUBTREE,
    };
    array_push(&self->heads, head);
 +  gts_work_count_add(&gts_work_count_current.stack_version_creations_proxy, 1);
++  StackVersion version = (StackVersion)(self->heads.size - 1);
++  StackHead *added = &self->heads.contents[version];
++  added->topology_generation = gts_topology_generation();
++  added->topology_id = gts_topology_next_version_id();
++  StackHead *source = &self->heads.contents[original_version];
++  gts_topology_record((GTSTopologyEvent) {
++    .kind = GTSTopologyEventVersionAdd,
++    .version_id = added->topology_id,
++    .version_index = version,
++    .source_version_id = source->topology_id,
++    .source_index = original_version,
++    .node_id = stack_node_topology_id(node),
++  });
    stack_node_retain(node);
    if (head.last_external_token.ptr) ts_subtree_retain(head.last_external_token);
-   return (StackVersion)(self->heads.size - 1);
-@@ -521,7 +704,16 @@ forceinline StackAction pop_count_callback(void *payload, const StackIterator *i
+-  return (StackVersion)(self->heads.size - 1);
++  return version;
+ }
+
+-static void ts_stack__add_slice(
++static StackVersion ts_stack__add_slice(
+   Stack *self,
+   StackVersion original_version,
+   StackNode *node,
+@@ -312,13 +556,14 @@ static void ts_stack__add_slice(
+     if (self->heads.contents[version].node == node) {
+       StackSlice slice = {*subtrees, version};
+       array_insert(&self->slices, i + 1, slice);
+-      return;
++      return version;
+     }
+   }
+
+   StackVersion version = ts_stack__add_version(self, original_version, node);
+   StackSlice slice = { *subtrees, version };
+   array_push(&self->slices, slice);
++  return version;
+ }
+
+ static StackSliceArray stack__iter(
+@@ -332,6 +577,9 @@ static StackSliceArray stack__iter(
+   array_clear(&self->iterators);
+
+   StackHead *head = array_get(&self->heads, version);
++  uint64_t source_version_id = head->topology_id;
++  uint64_t pop_id = goal_subtree_count >= 0 ? gts_topology_next_pop_id() : 0;
++  uint64_t path_ordinal = 0;
+   StackIterator new_iterator = {
+     .node = head->node,
+     .subtrees = array_new(),
+@@ -362,12 +610,25 @@ static StackSliceArray stack__iter(
+           ts_subtree_array_copy(subtrees, &subtrees);
+         }
+         ts_subtree_array_reverse(&subtrees);
+-        ts_stack__add_slice(
++        StackVersion pop_version = ts_stack__add_slice(
+           self,
+           version,
+           node,
+           &subtrees
+         );
++        StackHead *pop_head = &self->heads.contents[pop_version];
++        gts_topology_record((GTSTopologyEvent) {
++          .kind = GTSTopologyEventPopPath,
++          .version_id = pop_head->topology_id,
++          .version_index = pop_version,
++          .source_version_id = source_version_id,
++          .source_index = version,
++          .node_id = stack_node_topology_id(pop_head->node),
++          .pop_id = pop_id,
++          .path_ordinal = path_ordinal++,
++          .pop_to_node_id = stack_node_topology_id(node),
++          .payload_count = subtrees.size,
++        });
+       }
+
+       if (should_stop) {
+@@ -460,6 +721,63 @@ uint32_t ts_stack_version_count(const Stack *self) {
+   return self->heads.size;
+ }
+
++void ts_stack_topology_begin(Stack *self) {
++  uint64_t generation = gts_topology_generation();
++  if (generation == 0) return;
++  for (uint32_t i = 0; i < self->heads.size; i++) {
++    StackHead *head = &self->heads.contents[i];
++    head->topology_generation = generation;
++    head->topology_id = gts_topology_next_version_id();
++    gts_topology_record((GTSTopologyEvent) {
++      .kind = GTSTopologyEventVersionAdd,
++      .version_id = head->topology_id,
++      .version_index = i,
++      .node_id = stack_node_topology_id(head->node),
++      .flags = GTSTopologyFlagInitialVersion,
++    });
++  }
++}
++
++uint64_t ts_stack_topology_version_id(const Stack *self, StackVersion version) {
++  return array_get(&self->heads, version)->topology_id;
++}
++
++bool gts_topology_validate_stack_model(void) {
++  gts_work_count_reset();
++  gts_topology_enable(true);
++  SubtreePool pool = ts_subtree_pool_new(0);
++  Stack *stack = ts_stack_new(&pool);
++  ts_stack_topology_begin(stack);
++  ts_stack_copy_version(stack, 0);
++  ts_stack_copy_version(stack, 0);
++  ts_stack_copy_version(stack, 0);
++  ts_stack_remove_version(stack, 1);
++  ts_stack_copy_version(stack, 0);
++  ts_stack_copy_version(stack, 0);
++  ts_stack_renumber_version(stack, 3, 1);
++  const GTSTopologyReceipt *receipt = gts_topology_snapshot();
++  bool passed = receipt->events_seen == 10 && receipt->events_retained == 10 && receipt->events_dropped == 0 &&
++    receipt->events[0].kind == GTSTopologyEventVersionAdd && receipt->events[0].version_id == 1 && receipt->events[0].flags == GTSTopologyFlagInitialVersion &&
++    receipt->events[1].kind == GTSTopologyEventVersionCopy && receipt->events[1].version_id == 2 && receipt->events[2].version_id == 3 &&
++    receipt->events[3].version_id == 4 && receipt->events[6].version_id == 5 && receipt->events[7].version_id == 6 &&
++    receipt->events[4].kind == GTSTopologyEventVersionRenumber && receipt->events[4].version_id == 3 &&
++    receipt->events[4].source_index == 2 && receipt->events[4].target_index == 1 && receipt->events[4].target_version_id == 2 &&
++    receipt->events[5].kind == GTSTopologyEventVersionRenumber && receipt->events[5].version_id == 4 &&
++    receipt->events[5].source_index == 3 && receipt->events[5].target_index == 2 && receipt->events[5].target_version_id == 3 &&
++    receipt->events[8].kind == GTSTopologyEventVersionRenumber && receipt->events[8].version_id == 5 &&
++    receipt->events[8].source_index == 3 && receipt->events[8].target_index == 1 && receipt->events[8].target_version_id == 3 &&
++    receipt->events[9].kind == GTSTopologyEventVersionRenumber && receipt->events[9].version_id == 6 &&
++    receipt->events[9].source_index == 4 && receipt->events[9].target_index == 3 && receipt->events[9].target_version_id == 5 &&
++    receipt->events[4].flags == GTSTopologyFlagTargetReplaced && receipt->events[5].flags == GTSTopologyFlagTargetReplaced &&
++    receipt->events[8].flags == GTSTopologyFlagTargetReplaced && receipt->events[9].flags == GTSTopologyFlagTargetReplaced &&
++    !receipt->truncated && !receipt->arithmetic_overflow && !receipt->identity_collision && !receipt->identity_incomplete;
++  gts_topology_finish_parse();
++  ts_stack_delete(stack);
++  ts_subtree_pool_delete(&pool);
++  gts_work_count_reset();
++  return passed;
++}
++
+ TSStateId ts_stack_state(const Stack *self, StackVersion version) {
+   return array_get(&self->heads, version)->node->state;
+ }
+@@ -521,7 +839,16 @@ forceinline StackAction pop_count_callback(void *payload, const StackIterator *i
  }
 
  StackSliceArray ts_stack_pop_count(Stack *self, StackVersion version, uint32_t count) {
@@ -498,23 +1045,106 @@ index f0d57108..ddf0425d 100644
  }
 
  forceinline StackAction pop_pending_callback(void *payload, const StackIterator *iterator) {
-@@ -685,6 +877,7 @@ void ts_stack_swap_versions(Stack *self, StackVersion v1, StackVersion v2) {
+@@ -656,7 +983,28 @@ bool ts_stack_has_advanced_since_error(const Stack *self, StackVersion version) {
+   return false;
+ }
+
++static void ts_stack__record_version_shift(Stack *self, StackVersion source_index) {
++  if (gts_topology_generation() == 0) return;
++  ts_assert(source_index > 0 && source_index < self->heads.size);
++  StackHead *source_head = &self->heads.contents[source_index];
++  StackHead *target_head = &self->heads.contents[source_index - 1];
++  gts_topology_record((GTSTopologyEvent) {
++    .kind = GTSTopologyEventVersionRenumber,
++    .version_id = source_head->topology_id,
++    .version_index = source_index - 1,
++    .source_version_id = source_head->topology_id,
++    .source_index = source_index,
++    .target_version_id = target_head->topology_id,
++    .target_index = source_index - 1,
++    .node_id = stack_node_topology_id(source_head->node),
++    .flags = GTSTopologyFlagTargetReplaced,
++  });
++}
++
+ void ts_stack_remove_version(Stack *self, StackVersion version) {
++  for (StackVersion source = version + 1; source < self->heads.size; source++) {
++    ts_stack__record_version_shift(self, source);
++  }
+   stack_head_delete(array_get(&self->heads, version), &self->node_pool, self->subtree_pool);
+   array_erase(&self->heads, version);
+ }
+@@ -667,6 +1015,20 @@ void ts_stack_renumber_version(Stack *self, StackVersion v1, StackVersion v2) {
+   ts_assert((uint32_t)v1 < self->heads.size);
+   StackHead *source_head = &self->heads.contents[v1];
+   StackHead *target_head = &self->heads.contents[v2];
++  gts_topology_record((GTSTopologyEvent) {
++    .kind = GTSTopologyEventVersionRenumber,
++    .version_id = source_head->topology_id,
++    .version_index = v2,
++    .source_version_id = source_head->topology_id,
++    .source_index = v1,
++    .target_version_id = target_head->topology_id,
++    .target_index = v2,
++    .node_id = stack_node_topology_id(source_head->node),
++    .flags = GTSTopologyFlagTargetReplaced,
++  });
++  for (StackVersion source = v1 + 1; source < self->heads.size; source++) {
++    ts_stack__record_version_shift(self, source);
++  }
+   if (target_head->summary && !source_head->summary) {
+     source_head->summary = target_head->summary;
+     target_head->summary = NULL;
+@@ -685,17 +1047,46 @@ void ts_stack_swap_versions(Stack *self, StackVersion v1, StackVersion v2) {
  StackVersion ts_stack_copy_version(Stack *self, StackVersion version) {
    ts_assert(version < self->heads.size);
    array_push(&self->heads, self->heads.contents[version]);
 +  gts_work_count_add(&gts_work_count_current.stack_version_creations_proxy, 1);
    StackHead *head = array_back(&self->heads);
++  StackHead *source = &self->heads.contents[version];
++  StackVersion copy = self->heads.size - 1;
++  head->topology_generation = gts_topology_generation();
++  head->topology_id = gts_topology_next_version_id();
++  gts_topology_record((GTSTopologyEvent) {
++    .kind = GTSTopologyEventVersionCopy,
++    .version_id = head->topology_id,
++    .version_index = copy,
++    .source_version_id = source->topology_id,
++    .source_index = version,
++    .node_id = stack_node_topology_id(head->node),
++  });
    stack_node_retain(head->node);
    if (head->last_external_token.ptr) ts_subtree_retain(head->last_external_token);
-@@ -693,6 +886,7 @@ StackVersion ts_stack_copy_version(Stack *self, StackVersion version) {
+   head->summary = NULL;
+-  return self->heads.size - 1;
++  return copy;
  }
 
  bool ts_stack_merge(Stack *self, StackVersion version1, StackVersion version2) {
+-  if (!ts_stack_can_merge(self, version1, version2)) return false;
 +  gts_work_count_add(&gts_work_count_current.merge_attempts_proxy, 1);
-   if (!ts_stack_can_merge(self, version1, version2)) return false;
    StackHead *head1 = &self->heads.contents[version1];
    StackHead *head2 = &self->heads.contents[version2];
-@@ -703,6 +897,7 @@ bool ts_stack_merge(Stack *self, StackVersion version1, StackVersion version2) {
++  bool can_merge = ts_stack_can_merge(self, version1, version2);
++  gts_topology_record((GTSTopologyEvent) {
++    .kind = GTSTopologyEventMerge,
++    .version_id = head1->topology_id,
++    .version_index = version1,
++    .source_version_id = head1->topology_id,
++    .source_index = version1,
++    .target_version_id = head2->topology_id,
++    .target_index = version2,
++    .survivor_version_id = head1->topology_id,
++    .removed_version_id = head2->topology_id,
++    .node_id = stack_node_topology_id(head1->node),
++    .predecessor_node_id = stack_node_topology_id(head2->node),
++    .flags = can_merge ? GTSTopologyFlagSuccessOrSelected : 0,
++  });
++  if (!can_merge) return false;
+   for (uint32_t i = 0; i < head2->node->link_count; i++) {
+     stack_node_add_link(head1->node, head2->node->links[i], self->subtree_pool);
+   }
+@@ -703,6 +1094,7 @@ bool ts_stack_merge(Stack *self, StackVersion version1, StackVersion version2) {
      head1->node_count_at_last_error = head1->node->node_count;
    }
    ts_stack_remove_version(self, version2);
@@ -522,7 +1152,7 @@ index f0d57108..ddf0425d 100644
    return true;
  }
 
-@@ -762,6 +957,7 @@ void ts_stack_clear(Stack *self) {
+@@ -762,6 +1154,7 @@ void ts_stack_clear(Stack *self) {
      .last_external_token = NULL_SUBTREE,
      .lookahead_when_paused = NULL_SUBTREE,
    }));
@@ -530,8 +1160,23 @@ index f0d57108..ddf0425d 100644
  }
 
  bool ts_stack_print_dot_graph(Stack *self, const TSLanguage *language, FILE *f) {
+diff --git a/lib/src/stack.h b/lib/src/stack.h
+index ac32234..190f3ac 100644
+--- a/lib/src/stack.h
++++ b/lib/src/stack.h
+@@ -36,6 +36,10 @@ void ts_stack_delete(Stack *self);
+ // Get the stack's current number of versions.
+ uint32_t ts_stack_version_count(const Stack *self);
+
++void ts_stack_topology_begin(Stack *self);
++
++uint64_t ts_stack_topology_version_id(const Stack *self, StackVersion version);
++
+ // Get the state at the top of the given version of the stack. If the stack is
+ // empty, this returns the initial state, 0.
+ TSStateId ts_stack_state(const Stack *self, StackVersion version);
 diff --git a/lib/src/subtree.c b/lib/src/subtree.c
-index 42794de7..c814693e 100644
+index 42794de..c814693 100644
 --- a/lib/src/subtree.c
 +++ b/lib/src/subtree.c
 @@ -10,6 +10,7 @@
@@ -560,15 +1205,102 @@ index 42794de7..c814693e 100644
 
 diff --git a/lib/src/work_count.h b/lib/src/work_count.h
 new file mode 100644
-index 00000000..5e09ba6c
+index 0000000..e41e849
 --- /dev/null
 +++ b/lib/src/work_count.h
-@@ -0,0 +1,68 @@
+@@ -0,0 +1,172 @@
 +#ifndef TREE_SITTER_WORK_COUNT_H_
 +#define TREE_SITTER_WORK_COUNT_H_
 +
 +#include <stdbool.h>
 +#include <stdint.h>
++
++#define GTS_TOPOLOGY_EVENT_CAPACITY 4096u
++
++typedef enum {
++  GTSTopologyEventAction = 1,
++  GTSTopologyEventVersionAdd = 2,
++  GTSTopologyEventVersionCopy = 3,
++  GTSTopologyEventVersionRenumber = 4,
++  GTSTopologyEventMerge = 5,
++  GTSTopologyEventLinkInsert = 6,
++  GTSTopologyEventPopPath = 7,
++  GTSTopologyEventChildElection = 8,
++  GTSTopologyEventAcceptElection = 9,
++} GTSTopologyEventKind;
++
++enum {
++  GTSTopologyFlagSuccessOrSelected = 1u << 0,
++  GTSTopologyFlagPrimaryLink = 1u << 1,
++  GTSTopologyFlagInitialVersion = 1u << 2,
++  GTSTopologyFlagTargetReplaced = 1u << 3,
++  GTSTopologyFlagNoIncumbent = 1u << 4,
++  GTSTopologyFlagActionContextKnown = 1u << 5,
++};
++
++enum {
++  GTSTopologyActionShift = 0,
++  GTSTopologyActionReduce = 1,
++  GTSTopologyActionAccept = 2,
++  GTSTopologyActionRecover = 3,
++  GTSTopologyActionUnknown = 255,
++};
++
++typedef struct {
++  uint64_t event_id;
++  uint64_t kind;
++  uint64_t action_id;
++  int64_t action_ordinal;
++  uint64_t action_type;
++  uint64_t state;
++  uint64_t lookahead_symbol;
++  uint64_t byte_offset;
++  uint64_t version_id;
++  uint64_t version_index;
++  uint64_t source_version_id;
++  uint64_t source_index;
++  uint64_t target_version_id;
++  uint64_t target_index;
++  uint64_t survivor_version_id;
++  uint64_t removed_version_id;
++  uint64_t node_id;
++  uint64_t predecessor_node_id;
++  uint64_t link_id;
++  uint64_t link_ordinal;
++  uint64_t pop_id;
++  uint64_t path_ordinal;
++  uint64_t pop_to_node_id;
++  uint64_t election_id;
++  uint64_t incumbent_id;
++  uint64_t candidate_id;
++  uint64_t selected_id;
++  uint64_t payload_count;
++  uint64_t flags;
++} GTSTopologyEvent;
++
++typedef struct {
++  bool enabled;
++  bool truncated;
++  bool arithmetic_overflow;
++  bool identity_collision;
++  bool identity_incomplete;
++  uint32_t events_retained;
++  uint64_t generation;
++  uint64_t events_seen;
++  uint64_t events_dropped;
++  uint64_t next_action_id;
++  uint64_t next_version_id;
++  uint64_t next_node_id;
++  uint64_t next_link_id;
++  uint64_t next_pop_id;
++  uint64_t next_election_id;
++  uint64_t next_candidate_id;
++  uint64_t current_action_id;
++  int64_t current_action_ordinal;
++  uint64_t current_action_type;
++  uint64_t finished_candidate_id;
++  GTSTopologyEvent events[GTS_TOPOLOGY_EVENT_CAPACITY];
++} GTSTopologyReceipt;
 +
 +typedef struct {
 +  bool overflow;
@@ -614,12 +1346,29 @@ index 00000000..5e09ba6c
 +} GTSWorkCount;
 +
 +extern _Thread_local GTSWorkCount gts_work_count_current;
++extern _Thread_local GTSTopologyReceipt gts_topology_current;
 +
 +void gts_work_count_reset(void);
 +GTSWorkCount gts_work_count_snapshot(void);
 +bool gts_work_count_validate_action_model(void);
 +bool gts_work_count_validate_link_union_model(void);
 +bool gts_work_count_validate_raw_census_model(void);
++bool gts_topology_validate_model(void);
++bool gts_topology_validate_stack_model(void);
++void gts_topology_enable(bool enabled);
++void gts_topology_finish_parse(void);
++const GTSTopologyReceipt *gts_topology_snapshot(void);
++uint64_t gts_topology_next_action_id(void);
++uint64_t gts_topology_next_version_id(void);
++uint64_t gts_topology_next_node_id(void);
++uint64_t gts_topology_next_link_id(void);
++uint64_t gts_topology_next_pop_id(void);
++uint64_t gts_topology_next_election_id(void);
++uint64_t gts_topology_next_candidate_id(void);
++uint64_t gts_topology_generation(void);
++void gts_topology_action_begin(uint64_t action_id, int64_t ordinal, uint64_t type);
++void gts_topology_action_end(void);
++void gts_topology_record(GTSTopologyEvent event);
 +
 +static inline void gts_work_count_add(uint64_t *slot, uint64_t delta) {
 +  if (!slot || delta == 0) return;

--- a/glr.go
+++ b/glr.go
@@ -3446,7 +3446,12 @@ func tryGSSMainMergeForParser(p *Parser, a, b *glrStack) bool {
 	return merged
 }
 
-func tryGSSMainMergeForParserPhase(p *Parser, a, b *glrStack, phase string, recordDecision bool) bool {
+func tryGSSMainMergeForParserPhase(p *Parser, a, b *glrStack, phase string, recordDecision bool) (merged bool) {
+	if workCountInstrumentationEnabled && a != nil && b != nil {
+		defer func() {
+			workCountTopologyRecordMerge(a, b, merged) // work-count-assembly: topology parser-merge seam
+		}()
+	}
 	workCountRecordMergeAttempt()
 	if mergeCensusEnabled {
 		mergeCensusRecordAttempt()
@@ -3464,7 +3469,7 @@ func tryGSSMainMergeForParserPhase(p *Parser, a, b *glrStack, phase string, reco
 	if p != nil {
 		scratch = p.mergeScratch
 	}
-	merged := false
+	merged = false
 	if workCountInstrumentationEnabled {
 		merged = workCountMergeGSSObserved(p, scratch, phase, "GSS merge", a, b)
 	} else {
@@ -4661,6 +4666,11 @@ func tryGSSMainMergeResult(scratch *glrMergeScratch, result []glrStack, idx int,
 	}
 	if idx < 0 || idx >= len(result) || stack == nil {
 		return false, false
+	}
+	if workCountInstrumentationEnabled {
+		defer func() {
+			workCountTopologyRecordMerge(&result[idx], stack, merged) // work-count-assembly: topology boundary-merge seam
+		}()
 	}
 	if workCountInstrumentationEnabled {
 		workCountRecordPairCandidate(workCountParserFromMergeScratch(scratch), workCountConvergencePhaseBoundaryGSS, "boundary merge entered eligibility preflight", &result[idx], stack)

--- a/glr.go
+++ b/glr.go
@@ -4931,6 +4931,9 @@ func mergeStacksSmallForLanguage(alive []glrStack, scratch *glrMergeScratch, lan
 				}
 				cmp := stackCompareMergeSmallCapOne(scratch, &stack, &result[j])
 				if cmp > 0 {
+					if workCountInstrumentationEnabled {
+						workCountTopologyRenumberVersion(&stack, &result[j])
+					}
 					result[j] = stack
 					duplicateIndex = j
 					break
@@ -4955,6 +4958,9 @@ func mergeStacksSmallForLanguage(alive []glrStack, scratch *glrMergeScratch, lan
 		}
 		if stackCompareMerge(&stack, &result[duplicateIndex]) >= 0 {
 			traceCRecoverMergeDecision(scratch, "small", "replace-duplicate", &result[duplicateIndex], &stack)
+			if workCountInstrumentationEnabled {
+				workCountTopologyRenumberVersion(&stack, &result[duplicateIndex])
+			}
 			result[duplicateIndex] = stack
 		} else {
 			traceCRecoverMergeDecision(scratch, "small", "drop-duplicate", &result[duplicateIndex], &stack)
@@ -5008,6 +5014,9 @@ func mergeStacksSmallDeferExact(alive []glrStack, scratch *glrMergeScratch, lang
 				}
 				cmp := stackCompareMergeSmallCapOne(scratch, &stack, &result[j])
 				if cmp > 0 {
+					if workCountInstrumentationEnabled {
+						workCountTopologyRenumberVersion(&stack, &result[j])
+					}
 					result[j] = stack
 					duplicateIndex = j
 					break
@@ -5036,6 +5045,9 @@ func mergeStacksSmallDeferExact(alive []glrStack, scratch *glrMergeScratch, lang
 		}
 		if stackCompareMerge(&stack, &result[duplicateIndex]) >= 0 {
 			traceCRecoverMergeDecision(scratch, "small-defer", "replace-duplicate", &result[duplicateIndex], &stack)
+			if workCountInstrumentationEnabled {
+				workCountTopologyRenumberVersion(&stack, &result[duplicateIndex])
+			}
 			result[duplicateIndex] = stack
 		} else {
 			traceCRecoverMergeDecision(scratch, "small-defer", "drop-duplicate", &result[duplicateIndex], &stack)
@@ -5060,6 +5072,10 @@ func mergeStacksWithScratch(stacks []glrStack, scratch *glrMergeScratch) []glrSt
 		perfRecordMergeCall(len(stacks))
 	}
 
+	var topologyBeforeAlive []glrStack
+	if workCountInstrumentationEnabled {
+		topologyBeforeAlive = append(topologyBeforeAlive, stacks...)
+	}
 	// Remove dead stacks first. Most merge calls have no dead stacks; avoid
 	// copying the full live slice in that case.
 	alive := stacks
@@ -5085,6 +5101,9 @@ func mergeStacksWithScratch(stacks []glrStack, scratch *glrMergeScratch) []glrSt
 	if perfCountersEnabled {
 		perfRecordMergeAlive(len(alive), deadCount)
 	}
+	if workCountInstrumentationEnabled && deadCount > 0 {
+		workCountTopologyRetireMissingVersions(topologyBeforeAlive, alive)
+	}
 	if len(alive) <= 1 {
 		return alive
 	}
@@ -5094,7 +5113,14 @@ func mergeStacksWithScratch(stacks []glrStack, scratch *glrMergeScratch) []glrSt
 		scratch = &local
 	}
 	if limit := mergeAliveLimitForScratch(scratch, len(alive)); limit > 0 && len(alive) > limit {
+		var topologyBeforeCull []glrStack
+		if workCountInstrumentationEnabled {
+			topologyBeforeCull = append(topologyBeforeCull, alive...)
+		}
 		alive = retainTopStacksForLanguage(alive, limit, scratch.language)
+		if workCountInstrumentationEnabled {
+			workCountTopologyReconcileVersionSelection(topologyBeforeCull, alive)
+		}
 	}
 	if len(alive) <= 4 {
 		result := mergeStacksSmallForLanguage(alive, scratch, scratch.language)
@@ -5179,6 +5205,9 @@ func mergeStacksWithScratch(stacks []glrStack, scratch *glrMergeScratch) []glrSt
 			}
 			cmp := stackCompareMergeSmallCapOne(scratch, &stack, &result[idx])
 			if cmp > 0 {
+				if workCountInstrumentationEnabled {
+					workCountTopologyRenumberVersion(&stack, &result[idx])
+				}
 				result[idx] = stack
 				if pos := mergeSlotPositionForIndex(slot, idx); pos >= 0 {
 					mergeSlotSetHashAt(slot, pos, hash)
@@ -5234,6 +5263,9 @@ func mergeStacksWithScratch(stacks []glrStack, scratch *glrMergeScratch) []glrSt
 				continue
 			}
 			if stackCompareMerge(&stack, &result[duplicateIndex]) >= 0 {
+				if workCountInstrumentationEnabled {
+					workCountTopologyRenumberVersion(&stack, &result[duplicateIndex])
+				}
 				result[duplicateIndex] = stack
 				if pos := mergeSlotPositionForIndex(slot, duplicateIndex); pos >= 0 {
 					mergeSlotSetHashAt(slot, pos, hash)
@@ -5292,6 +5324,9 @@ func mergeStacksWithScratch(stacks []glrStack, scratch *glrMergeScratch) []glrSt
 			}
 			if perfCountersEnabled {
 				perfRecordMergeReplacement()
+			}
+			if workCountInstrumentationEnabled {
+				workCountTopologyRenumberVersion(&stack, &result[slot.worstIndex])
 			}
 			result[slot.worstIndex] = stack
 			if replacedSlot >= 0 {
@@ -5368,6 +5403,9 @@ func mergeStacksWithScratchDeferExact(alive []glrStack, scratch *glrMergeScratch
 			}
 			cmp := stackCompareMergeSmallCapOne(scratch, &stack, &result[idx])
 			if cmp > 0 {
+				if workCountInstrumentationEnabled {
+					workCountTopologyRenumberVersion(&stack, &result[idx])
+				}
 				result[idx] = stack
 				if pos := mergeSlotPositionForIndex(slot, idx); pos >= 0 {
 					mergeSlotSetHashAt(slot, pos, hash)
@@ -5420,6 +5458,9 @@ func mergeStacksWithScratchDeferExact(alive []glrStack, scratch *glrMergeScratch
 				continue
 			}
 			if stackCompareMerge(&stack, &result[duplicateIndex]) >= 0 {
+				if workCountInstrumentationEnabled {
+					workCountTopologyRenumberVersion(&stack, &result[duplicateIndex])
+				}
 				result[duplicateIndex] = stack
 				if pos := mergeSlotPositionForIndex(slot, duplicateIndex); pos >= 0 {
 					mergeSlotSetHashAt(slot, pos, hash)
@@ -5476,6 +5517,9 @@ func mergeStacksWithScratchDeferExact(alive []glrStack, scratch *glrMergeScratch
 			}
 			if perfCountersEnabled {
 				perfRecordMergeReplacement()
+			}
+			if workCountInstrumentationEnabled {
+				workCountTopologyRenumberVersion(&stack, &result[slot.worstIndex])
 			}
 			result[slot.worstIndex] = stack
 			if replacedSlot >= 0 {
@@ -5587,6 +5631,9 @@ func mergeStacksWithScratchLargeCap(alive []glrStack, scratch *glrMergeScratch, 
 			// branch by accident. Let later survivors replace ties so
 			// post-reduce reprocessing can keep the branch that stayed viable.
 			if stackCompareMerge(&stack, &result[duplicateIndex]) >= 0 {
+				if workCountInstrumentationEnabled {
+					workCountTopologyRenumberVersion(&stack, &result[duplicateIndex])
+				}
 				result[duplicateIndex] = stack
 				for j := 0; j < slot.count; j++ {
 					if slot.indices[j] == duplicateIndex {
@@ -5637,6 +5684,9 @@ func mergeStacksWithScratchLargeCap(alive []glrStack, scratch *glrMergeScratch, 
 			}
 			if perfCountersEnabled {
 				perfRecordMergeReplacement()
+			}
+			if workCountInstrumentationEnabled {
+				workCountTopologyRenumberVersion(&stack, &result[slot.worstIndex])
 			}
 			result[slot.worstIndex] = stack
 			if replacedSlot >= 0 {

--- a/glr.go
+++ b/glr.go
@@ -91,6 +91,11 @@ type glrStack struct {
 	// lockstep token loop uses this to avoid letting an already-advanced
 	// sibling suppress that group's Strategy 1 recovery.
 	cRecoverMissingGroup *cRecGroup
+	// diagnosticTopology carries a version identity only in gts_workcount
+	// builds. The production type is zero-sized, so it does not change the
+	// parser stack layout. Ordinary Go value copies preserve the identity;
+	// explicit parser forks replace it through the topology copy hooks.
+	diagnosticTopology diagnosticTopologyStackToken
 	// cEntryAgg* caches the recovery-cost and visible-node aggregates of this
 	// stack's contiguous entries representation. It lives on the stack value,
 	// not the shared cRecoverState pointer, so distinct materialized GSS paths
@@ -593,7 +598,13 @@ func (s *glrStack) ensureGSS(scratch *gssScratch) {
 	if s.gss.head != nil || len(s.entries) == 0 {
 		return
 	}
+	if workCountInstrumentationEnabled {
+		workCountTopologyPreparePromotion(s)
+	}
 	s.gss = buildGSSStack(s.entries, scratch)
+	if workCountInstrumentationEnabled {
+		workCountTopologyCommitPromotion(s)
+	}
 }
 
 // conflictForkBase promotes the live stack before it copies the fork base.
@@ -635,6 +646,7 @@ func (s *glrStack) clone() glrStack {
 			branchOrder:                s.branchOrder,
 			cRec:                       s.cRec.clone(),
 			cRecoverMissingGroup:       s.cRecoverMissingGroup,
+			diagnosticTopology:         s.diagnosticTopology,
 			cNodeBaseline:              s.cNodeBaseline,
 			cEntryAggGen:               s.cEntryAggGen,
 			cEntryAggCost:              s.cEntryAggCost,
@@ -654,6 +666,7 @@ func (s *glrStack) clone() glrStack {
 		branchOrder:                s.branchOrder,
 		cRec:                       s.cRec.clone(),
 		cRecoverMissingGroup:       s.cRecoverMissingGroup,
+		diagnosticTopology:         s.diagnosticTopology,
 		cNodeBaseline:              s.cNodeBaseline,
 		cEntryAggGen:               s.cEntryAggGen,
 		cEntryAggCost:              s.cEntryAggCost,
@@ -676,6 +689,7 @@ func (s *glrStack) cloneWithScratch(scratch *gssScratch) glrStack {
 		branchOrder:                s.branchOrder,
 		cRec:                       s.cRec.clone(),
 		cRecoverMissingGroup:       s.cRecoverMissingGroup,
+		diagnosticTopology:         s.diagnosticTopology,
 		cNodeBaseline:              s.cNodeBaseline,
 		cEntryAggGen:               s.cEntryAggGen,
 		cEntryAggCost:              s.cEntryAggCost,

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -153,6 +153,9 @@ func (n *gssNode) appendExtraLinkWithOwner(link gssMainLink, owner *gssScratch) 
 		unsafe.Slice(n.extraLinks, capacity)[count] = link
 		n.extraLinkCount++
 		workCountRecordGraphLinkAddition()
+		if workCountInstrumentationEnabled {
+			workCountTopologyRecordLinkInsert(n, link.prev, count+1, false) // work-count-assembly: topology alternate-link-reuse seam
+		}
 		workCountRecordAlternatePredecessorLinkAppended() // work-count-assembly: alternate predecessor append-reuse seam
 		workCountRecordGSSMutation()                      // work-count-assembly: GSS mutation append-reuse seam
 		return
@@ -178,6 +181,9 @@ func (n *gssNode) appendExtraLinkWithOwner(link gssMainLink, owner *gssScratch) 
 		owner.packedLinkBytes += delta
 	}
 	workCountRecordGraphLinkAddition()
+	if workCountInstrumentationEnabled {
+		workCountTopologyRecordLinkInsert(n, link.prev, count+1, false) // work-count-assembly: topology alternate-link-grow seam
+	}
 	workCountRecordAlternatePredecessorLinkAppended() // work-count-assembly: alternate predecessor append-grow seam
 	workCountRecordGSSMutation()                      // work-count-assembly: GSS mutation append-grow seam
 }
@@ -834,6 +840,12 @@ func (s *gssStack) pushEntry(entry stackEntry, scratch *gssScratch) {
 		depth = s.head.depth + 1
 	}
 	n := scratch.allocNode(entry, s.head, depth)
+	if workCountInstrumentationEnabled {
+		workCountTopologyRecordNodeAllocation(n)
+		if s.head != nil {
+			workCountTopologyRecordLinkInsert(n, s.head, 0, true) // work-count-assembly: topology primary-link seam
+		}
+	}
 	if s.head != nil {
 		workCountRecordGraphLinkAddition()
 	}

--- a/glr_test.go
+++ b/glr_test.go
@@ -22,8 +22,9 @@ func TestCRecoverStateSizeBudget(t *testing.T) {
 }
 
 func TestGLRStackSizeBudget(t *testing.T) {
-	if got := unsafe.Sizeof(glrStack{}); got != 104 {
-		t.Fatalf("glrStack size = %d, want 104", got)
+	want := uintptr(104) + diagnosticTopologyStackOverhead
+	if got := unsafe.Sizeof(glrStack{}); got != want {
+		t.Fatalf("glrStack size = %d, want %d", got, want)
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -2868,10 +2868,16 @@ func (p *Parser) tryAdvanceEOFOnSingleStack(s *glrStack, tok Token, expectedEOFB
 		}
 		switch act.Type {
 		case ParseActionReduce:
+			if workCountInstrumentationEnabled {
+				workCountTopologyRecordAction(s, tok, act, 0)
+			}
 			if semanticPhaseTraceActive() {
 				semanticPhaseTraceRecordActionExecution(p, s, tok, act, 0, "eof-prefix-reduce", false) // semantic-phase-assembly: EOF-prefix action-execution seam
 			}
 			p.applyAction(nil, s, act, tok, &anyReduced, nodeCount, arena, entryScratch, gssScratch, tmpEntries, false, nil)
+			if workCountInstrumentationEnabled {
+				workCountTopologyRecordActionResult(s)
+			}
 			if p.rejectUndrainedPendingForkStacks(s) {
 				return false
 			}
@@ -2879,10 +2885,16 @@ func (p *Parser) tryAdvanceEOFOnSingleStack(s *glrStack, tok Token, expectedEOFB
 				return false
 			}
 		case ParseActionAccept:
+			if workCountInstrumentationEnabled {
+				workCountTopologyRecordAction(s, tok, act, 0)
+			}
 			if semanticPhaseTraceActive() {
 				semanticPhaseTraceRecordActionExecution(p, s, tok, act, 0, "eof-prefix-accept", false)
 			}
 			s.accepted = true
+			if workCountInstrumentationEnabled {
+				workCountTopologyRecordActionResult(s)
+			}
 			return true
 		default:
 			return false
@@ -2985,6 +2997,9 @@ func (p *Parser) tryRecoverTrailingEOFSuffix(s *glrStack, tok Token, nodeCount *
 		}
 		for _, cut := range trailingEOFSuffixCuts(entries, firstDrop, node) {
 			prefix := s.cloneWithScratch(gssScratch)
+			if workCountInstrumentationEnabled {
+				workCountTopologyRecordVersionCopy(s, &prefix)
+			}
 			if !prefix.truncate(cut) {
 				continue
 			}
@@ -4705,6 +4720,9 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	arena.audit = nil
 	scratch.merge.arena = arena
 	scratch.merge.parser = p
+	if workCountInstrumentationEnabled {
+		workCountTopologySetParseContext(p, arena, trackChildErrors)
+	}
 	if scratch.audit.enabled || scratch.audit.equivEnabled {
 		scratch.merge.audit = &scratch.audit
 	}

--- a/parser.go
+++ b/parser.go
@@ -1312,6 +1312,9 @@ func (p *Parser) noteStopActionDiagnostic(phase string, s *glrStack, tok Token, 
 }
 
 func (p *Parser) noteStopActionResult(s *glrStack) {
+	if workCountInstrumentationEnabled {
+		workCountTopologyRecordActionResult(s) // work-count-assembly: topology action-result seam
+	}
 	if p == nil || p.stopActionDiag == nil || !p.stopActionDiag.captured || s == nil || s.depth() == 0 {
 		return
 	}
@@ -5297,6 +5300,9 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	}
 
 	stacks, maxStacksSeen = p.newInitialParseStacks(scratch, reuse, timing, len(source))
+	if workCountInstrumentationEnabled && len(stacks) != 0 {
+		workCountTopologyRecordInitialVersion(&stacks[0]) // work-count-assembly: topology initial-version seam
+	}
 	caps := p.configureParseCaps(source, reuse, arenaClass, scratch, maxStacksOverride, maxNodesOverride, maxMergePerKeyOverride)
 	workCountResolveParseAttempt(
 		workCountAttempt,
@@ -6574,6 +6580,9 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					fork.branchOrder = allocBranchOrder()
 					if actions[ai].Type != ParseActionShift || p.guardRealShiftGap(source, &fork, tok) {
 						if actions[ai].Type != ParseActionRecover || p.guardRealTokenAttachmentGap(source, &fork, tok, "recover") {
+							if workCountInstrumentationEnabled {
+								workCountTopologyPrepareVersionCopy(&base, &fork) // work-count-assembly: topology conflict-copy seam
+							}
 							setPendingTrace("conflict-fork", si, ai, len(actions), actions[ai])
 							p.noteStopActionDiagnostic("conflict-fork", &fork, tok, actions[ai], ai, len(actions), false, 0, 0, false)
 							actionBeforeState, actionBeforeByte, actionBeforeDepth := stackTraceState(&fork)

--- a/parser.go
+++ b/parser.go
@@ -2462,6 +2462,9 @@ func (p *Parser) rejectUndrainedPendingForkStacks(s *glrStack) bool {
 		return false
 	}
 	workCountRecordPendingTransition(p, &p.pendingForkStacks[0], len(p.pendingForkStacks), 0, workCountConvergenceOutcomePendingDiscarded, "undrained post-reduce candidates rejected")
+	if workCountInstrumentationEnabled {
+		workCountTopologyRetireVersionsIfActive(p.pendingForkStacks)
+	}
 	p.pendingForkStacks = p.pendingForkStacks[:0]
 	if s != nil {
 		s.dead = true
@@ -3001,11 +3004,17 @@ func (p *Parser) tryRecoverTrailingEOFSuffix(s *glrStack, tok Token, nodeCount *
 				workCountTopologyRecordVersionCopy(s, &prefix)
 			}
 			if !prefix.truncate(cut) {
+				if workCountInstrumentationEnabled {
+					workCountTopologyRetireVersionIfActive(&prefix)
+				}
 				continue
 			}
 			prefixEOF := eofTokenForTrailingCut(tok, entries, cut, node)
 			insertedMissing, advanced := p.advanceTrailingEOFPrefix(&prefix, prefixEOF, prefixEOF.EndByte, source, nodeCount, arena, entryScratch, gssScratch, tmpEntries)
 			if !advanced {
+				if workCountInstrumentationEnabled {
+					workCountTopologyRetireVersionIfActive(&prefix)
+				}
 				continue
 			}
 
@@ -3017,6 +3026,9 @@ func (p *Parser) tryRecoverTrailingEOFSuffix(s *glrStack, tok Token, nodeCount *
 				}
 			}
 			nodes, recovered := p.appendTrailingEOFRecoveryNodes(nodes, entries, cut, tok, arena, nodeCount)
+			if workCountInstrumentationEnabled {
+				workCountTopologyRetireVersionIfActive(&prefix)
+			}
 			if recovered || insertedMissing || cut > firstDrop {
 				return nodes, true
 			}
@@ -5244,6 +5256,10 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			parserLoopNanos = time.Since(parseStart).Nanoseconds()
 		}
 		workCountRecordFinalPendingDiscards(p, p.pendingForkStacks, p.pendingFrontierForkStacks)
+		if workCountInstrumentationEnabled {
+			workCountTopologyRetireVersionsIfActive(p.pendingForkStacks)
+			workCountTopologyRetireVersionsIfActive(p.pendingFrontierForkStacks)
+		}
 		if p.noTreeBenchmarkOnly {
 			rootEndByte := expectedEOFByte
 			if stopReason != ParseStopAccepted && stopReason != ParseStopNone {
@@ -6790,10 +6806,20 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 
 		postDispatchVersionCount := compactPackedGSSDispatchVersionCount(packedVersionOrder, numStacks, len(stacks))
 		if postDispatchVersionCount > 1 && retryPass && allParseStacksDead(stacks) {
+			var topologyBefore []glrStack
+			if workCountInstrumentationEnabled {
+				topologyBefore = append(topologyBefore, stacks...)
+			}
 			bestIdx := bestRetryRecoveryStack(stacks)
 			stacks[bestIdx].dead = false
+			if workCountInstrumentationEnabled && bestIdx != 0 {
+				workCountTopologyRenumberVersion(&stacks[bestIdx], &stacks[0])
+			}
 			stacks[0] = stacks[bestIdx]
 			stacks = stacks[:1]
+			if workCountInstrumentationEnabled {
+				workCountTopologyRetireMissingVersions(topologyBefore, stacks)
+			}
 			if p.glrTrace {
 				fmt.Printf("[GLR] ALL-DEAD RECOVERY: resurrect stack (was [%d]) st=%d dep=%d byte=%d\n",
 					bestIdx, stacks[0].top().state, stacks[0].depth(), stacks[0].byteOffset)
@@ -7481,6 +7507,10 @@ type parseStackPrepResult struct {
 
 func (p *Parser) prepareParseStacksForIteration(stacks []glrStack, scratch *parserScratch, arena *nodeArena, arenaClass arenaClass, maxStacks, maxStackCullTrigger int, phaseTiming bool, glrMergeNanos, glrCullNanos *int64) parseStackPrepResult {
 	result := parseStackPrepResult{stacks: stacks}
+	var topologyBefore []glrStack
+	if workCountInstrumentationEnabled && len(stacks) > 1 {
+		topologyBefore = append(topologyBefore, stacks...)
+	}
 	resetCRecoveryMergeScratch(&scratch.merge)
 	if len(stacks) == 1 {
 		if stacks[0].dead {
@@ -7543,6 +7573,9 @@ func (p *Parser) prepareParseStacksForIteration(stacks []glrStack, scratch *pars
 		p.promotePrimaryStack(result.stacks)
 	} else {
 		p.tryDemoteSingleLinearGSS(result.stacks, scratch)
+	}
+	if workCountInstrumentationEnabled {
+		workCountTopologyRetireMissingVersions(topologyBefore, result.stacks)
 	}
 	scratch.gss.setSingleStackMode(len(result.stacks) == 1)
 	clearParseStackEntryCaches(result.stacks)
@@ -7708,6 +7741,10 @@ func (p *Parser) cullParseStacksForIteration(stacks []glrStack, scratch *parserS
 		perfRecordGlobalCapCull(len(stacks), maxStacks)
 	}
 	cullIn := len(stacks)
+	var topologyBefore []glrStack
+	if workCountInstrumentationEnabled {
+		topologyBefore = append(topologyBefore, stacks...)
+	}
 	cullLang := stackCullLanguageForArena(p.language, arenaClass)
 	if phaseTiming && glrCullNanos != nil {
 		cullStart := time.Now()
@@ -7715,6 +7752,9 @@ func (p *Parser) cullParseStacksForIteration(stacks []glrStack, scratch *parserS
 		*glrCullNanos += time.Since(cullStart).Nanoseconds()
 	} else {
 		stacks = retainTopStacksForLanguageWithScratch(stacks, maxStacks, cullLang, &scratch.stackPick, &scratch.stackKeep, &scratch.stackCull)
+	}
+	if workCountInstrumentationEnabled {
+		workCountTopologyReconcileVersionSelection(topologyBefore, stacks)
 	}
 	scratch.audit.recordGlobalCull(cullIn, len(stacks))
 	workCountRecordBoundaryCull(p, cullIn, len(stacks))
@@ -8695,6 +8735,10 @@ func csharpCanShiftDeclarationListRepetitionToken(lang *Language, tok Token) boo
 }
 
 func compactAcceptedStacks(stacks []glrStack) []glrStack {
+	var topologyBefore []glrStack
+	if workCountInstrumentationEnabled {
+		topologyBefore = append(topologyBefore, stacks...)
+	}
 	acceptedCount := 0
 	for i := range stacks {
 		if stacks[i].accepted {
@@ -8702,7 +8746,11 @@ func compactAcceptedStacks(stacks []glrStack) []glrStack {
 			acceptedCount++
 		}
 	}
-	return stacks[:acceptedCount]
+	stacks = stacks[:acceptedCount]
+	if workCountInstrumentationEnabled {
+		workCountTopologyRetireMissingVersions(topologyBefore, stacks)
+	}
+	return stacks
 }
 
 func stackCullLanguageForArena(lang *Language, class arenaClass) *Language {
@@ -8768,6 +8816,9 @@ func (p *Parser) promotePrimaryStack(stacks []glrStack) {
 	}
 	if best != 0 {
 		stacks[0], stacks[best] = stacks[best], stacks[0]
+		if workCountInstrumentationEnabled {
+			workCountTopologySyncVersionOrder(stacks)
+		}
 	}
 }
 

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -3256,6 +3256,10 @@ func (p *Parser) cReductionCandidatesForActionInto(source []byte, start glrStack
 		return nil, false, reason
 	}
 	fork := start.cloneWithScratch(gssScratch)
+	if workCountInstrumentationEnabled {
+		workCountTopologyPrepareVersionCopy(&start, &fork)
+		workCountTopologyRecordAction(&fork, tok, act, -1)
+	}
 	var dummy bool
 	deferParentLinks := p.reduceScratch != nil && p.reduceScratch.transientParents != nil
 	var localTmpEntries []stackEntry
@@ -3265,6 +3269,9 @@ func (p *Parser) cReductionCandidatesForActionInto(source []byte, start glrStack
 	p.applyAction(source, &fork, act, tok, &dummy, nodeCount, arena, entryScratch, gssScratch, &localTmpEntries, deferParentLinks, trackChildErrors)
 	if dummy && anyReduced != nil {
 		*anyReduced = true
+	}
+	if workCountInstrumentationEnabled {
+		workCountTopologyRecordActionResult(&fork)
 	}
 	if tmpEntries != nil {
 		if localTmpEntries != nil {
@@ -3573,7 +3580,11 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	// Promote the error stack to the graph-structured stack before reductions.
 	// Recovery forks then share the immutable prefix instead of copying each deep linear stack.
 	var outerResultSeed [2]glrStack
-	versions, _, reason := p.cDoAllPotentialReductions(source, s.cloneWithScratch(gssScratch), 0, true, tok, nodeCount, arena, entryScratch, gssScratch, tmpEntries, trackChildErrors, outerResultSeed[:0])
+	reductionSeed := s.cloneWithScratch(gssScratch)
+	if workCountInstrumentationEnabled {
+		workCountTopologyRecordVersionCopy(s, &reductionSeed)
+	}
+	versions, _, reason := p.cDoAllPotentialReductions(source, reductionSeed, 0, true, tok, nodeCount, arena, entryScratch, gssScratch, tmpEntries, trackChildErrors, outerResultSeed[:0])
 	if reason != ParseStopNone {
 		return cRecHalted, false, reason
 	}
@@ -3621,6 +3632,9 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 					break missingTokenSearch
 				}
 				cand := versions[vi].cloneWithScratch(gssScratch)
+				if workCountInstrumentationEnabled {
+					workCountTopologyRecordVersionCopy(&versions[vi], &cand)
+				}
 				cand.cRec = nil
 				cand.cRecoverMissingGroup = nil
 				missingTok := Token{
@@ -4432,6 +4446,9 @@ func (p *Parser) cRecoverToState(v *glrStack, depth int, goal StateID, arena *no
 	}
 
 	fork := v.cloneWithScratch(gssScratch)
+	if workCountInstrumentationEnabled {
+		workCountTopologyRecordVersionCopy(v, &fork)
+	}
 	fork.cRec = nil
 	fork.cRecoverMissingGroup = nil
 	fork.dead = false

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -3058,6 +3058,9 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 		return ParseStopNone
 	}
 	if reason := checkStop(); reason != ParseStopNone {
+		if workCountInstrumentationEnabled {
+			workCountTopologyRetireVersionIfActive(&start)
+		}
 		return nil, false, reason
 	}
 
@@ -3069,6 +3072,9 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 	candidateAttempts := 0
 	for iter := 0; ; iter++ {
 		if reason := checkStop(); reason != ParseStopNone {
+			if workCountInstrumentationEnabled {
+				workCountTopologyRetireVersionsIfActive(versions)
+			}
 			return versions, canShift, reason
 		}
 		if v >= len(versions) {
@@ -3078,6 +3084,9 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 		merged := false
 		for j := 0; j < v; j++ {
 			if reason := checkStop(); reason != ParseStopNone {
+				if workCountInstrumentationEnabled {
+					workCountTopologyRetireVersionsIfActive(versions)
+				}
 				return versions, canShift, reason
 			}
 			if p.cTryMergeReductionVersion(&versions[j], &versions[v]) {
@@ -3094,6 +3103,9 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 		lastReduction := -1
 		for _, act := range reduces {
 			if reason := checkStop(); reason != ParseStopNone {
+				if workCountInstrumentationEnabled {
+					workCountTopologyRetireVersionsIfActive(versions)
+				}
 				return versions, canShift, reason
 			}
 			// cRecoverMaxReductionCandidateAttempts backstop (see its doc
@@ -3116,6 +3128,9 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 				gssScratch, tmpEntries, trackChildErrors, &singletonCandidate, nil,
 			)
 			if reason != ParseStopNone {
+				if workCountInstrumentationEnabled {
+					workCountTopologyRetireVersionsIfActive(versions)
+				}
 				return versions, canShift, reason
 			}
 			// C overwrites reduction_version for every reduce action, including
@@ -3138,6 +3153,9 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 			// C renumbers the LAST reduction version onto the current version
 			// (reduction_version is overwritten per reduce action) and
 			// reprocesses it in place.
+			if workCountInstrumentationEnabled {
+				workCountTopologyRenumberVersion(&versions[lastReduction], &versions[v])
+			}
 			var renumbered bool
 			versions, renumbered = cRenumberReductionVersion(versions, lastReduction, v)
 			if !renumbered {
@@ -3145,6 +3163,9 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 			}
 			continue
 		} else if !anyLookahead {
+			if workCountInstrumentationEnabled {
+				workCountTopologyRetireVersion(&versions[v])
+			}
 			versions, _ = cRemoveReductionVersion(versions, v)
 			continue
 		}
@@ -3247,8 +3268,14 @@ func (p *Parser) cAppendActionCellReductionVersions(source []byte, versions []gl
 }
 
 func (p *Parser) cReductionCandidatesForActionInto(source []byte, start glrStack, act ParseAction, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, tmpEntries *[]stackEntry, trackChildErrors *bool, singletonCandidate *glrStack, anyReduced *bool) ([]glrStack, bool, ParseStopReason) {
+	if workCountInstrumentationEnabled {
+		workCountTopologyRetireVersionsIfActive(p.pendingForkStacks)
+	}
 	p.pendingForkStacks = p.pendingForkStacks[:0]
 	defer func() {
+		if workCountInstrumentationEnabled {
+			workCountTopologyRetireVersionsIfActive(p.pendingForkStacks)
+		}
 		clear(p.pendingForkStacks)
 		p.pendingForkStacks = p.pendingForkStacks[:0]
 	}()
@@ -3281,10 +3308,16 @@ func (p *Parser) cReductionCandidatesForActionInto(source []byte, start glrStack
 		}
 	}
 	if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+		if workCountInstrumentationEnabled {
+			workCountTopologyRetireVersionIfActive(&fork)
+		}
 		return nil, false, reason
 	}
 	if len(p.pendingForkStacks) == 0 {
 		if fork.dead {
+			if workCountInstrumentationEnabled {
+				workCountTopologyRetireVersionIfActive(&fork)
+			}
 			return nil, false, ParseStopNone
 		}
 		// The caller consumes this value synchronously. The append helper copies
@@ -3295,17 +3328,26 @@ func (p *Parser) cReductionCandidatesForActionInto(source []byte, start glrStack
 	candidates := make([]glrStack, 0, 1+len(p.pendingForkStacks))
 	if !fork.dead {
 		candidates = append(candidates, fork)
+	} else if workCountInstrumentationEnabled {
+		workCountTopologyRetireVersionIfActive(&fork)
 	}
 	for i := range p.pendingForkStacks {
 		if i&15 == 0 {
 			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+				if workCountInstrumentationEnabled {
+					workCountTopologyRetireVersionIfActive(&fork)
+					workCountTopologyRetireVersionsIfActive(candidates)
+				}
 				return candidates, false, reason
 			}
 		}
 		if !p.pendingForkStacks[i].dead {
 			candidates = append(candidates, p.pendingForkStacks[i])
+		} else if workCountInstrumentationEnabled {
+			workCountTopologyRetireVersionIfActive(&p.pendingForkStacks[i])
 		}
 	}
+	p.pendingForkStacks = p.pendingForkStacks[:0]
 	return candidates, false, ParseStopNone
 }
 
@@ -3407,7 +3449,12 @@ func (p *Parser) cTryCollapseSamePopReductionVersion(target, candidate *glrStack
 		return false
 	}
 	if p.cSelectReplacementParentEntry(arena, targetParent.entry, candidateParent.entry) {
+		if workCountInstrumentationEnabled {
+			workCountTopologyRenumberVersion(candidate, target)
+		}
 		*target = *candidate
+	} else if workCountInstrumentationEnabled {
+		workCountTopologyRetireVersion(candidate)
 	}
 	return true
 }
@@ -3522,6 +3569,14 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 		return cRecHalted, false, reason
 	}
 	s := &(*stacks)[si]
+	var versions, missingVersions []glrStack
+	var reason ParseStopReason
+	defer func() {
+		if workCountInstrumentationEnabled {
+			workCountTopologyRetireUnpublishedVersions(versions, *stacks)
+			workCountTopologyRetireUnpublishedVersions(missingVersions, *stacks)
+		}
+	}()
 	s.cPaused = false
 	// Sticky per-stack wreckage bit: this lineage is entering C error handling.
 	// Unlike cRec/cPaused/cNodeBaseline (all of which a later recovery resets to
@@ -3584,7 +3639,7 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	if workCountInstrumentationEnabled {
 		workCountTopologyRecordVersionCopy(s, &reductionSeed)
 	}
-	versions, _, reason := p.cDoAllPotentialReductions(source, reductionSeed, 0, true, tok, nodeCount, arena, entryScratch, gssScratch, tmpEntries, trackChildErrors, outerResultSeed[:0])
+	versions, _, reason = p.cDoAllPotentialReductions(source, reductionSeed, 0, true, tok, nodeCount, arena, entryScratch, gssScratch, tmpEntries, trackChildErrors, outerResultSeed[:0])
 	if reason != ParseStopNone {
 		return cRecHalted, false, reason
 	}
@@ -3593,7 +3648,6 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	// 2. Missing-token insertion (once across the version set, in order).
 	// C keeps every version that survives do_all_potential_reductions on the
 	// lookahead (the copied version plus its reduction forks).
-	var missingVersions []glrStack
 	var missingProbeSeed [2]glrStack
 	if !p.isGraphQLRecoveryTripleQuote(tok.Symbol) {
 		missingTokenTrialAttempts := 0
@@ -3654,20 +3708,37 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 				var dummy bool
 				p.applyAction(source, &cand, shiftAct, missingTok, &dummy, nodeCount, arena, entryScratch, gssScratch, nil, false, trackChildErrors)
 				if reason := checkStop(); reason != ParseStopNone {
+					if workCountInstrumentationEnabled {
+						workCountTopologyRetireVersionIfActive(&cand)
+					}
 					return cRecHalted, false, reason
 				}
 				if p.rejectUndrainedPendingForkStacks(&cand) {
+					if workCountInstrumentationEnabled {
+						workCountTopologyRetireVersionIfActive(&cand)
+					}
 					continue
 				}
 				cand.shifted = false
 				if cand.dead {
+					if workCountInstrumentationEnabled {
+						workCountTopologyRetireVersionIfActive(&cand)
+					}
 					continue
 				}
 				reduced, canShift, reason := p.cDoAllPotentialReductions(source, cand, tok.Symbol, false, tok, nodeCount, arena, entryScratch, gssScratch, tmpEntries, trackChildErrors, missingProbeSeed[:0])
 				if reason != ParseStopNone {
+					if workCountInstrumentationEnabled {
+						workCountTopologyRetireVersionIfActive(&cand)
+						workCountTopologyRetireVersionsIfActive(reduced)
+					}
 					return cRecHalted, false, reason
 				}
 				if !canShift || len(reduced) == 0 {
+					if workCountInstrumentationEnabled {
+						workCountTopologyRetireVersionIfActive(&cand)
+						workCountTopologyRetireVersionsIfActive(reduced)
+					}
 					continue
 				}
 				missingVersions = reduced
@@ -3725,6 +3796,9 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	}
 
 	// The original stack becomes the first absorbing version.
+	if workCountInstrumentationEnabled {
+		workCountTopologyRenumberVersion(&versions[0], s)
+	}
 	*s = versions[0]
 	for vi := 1; vi < len(versions); vi++ {
 		if reason := checkStop(); reason != ParseStopNone {
@@ -4203,6 +4277,9 @@ func (p *Parser) cRecoverStrategy1Election(stacks *[]glrStack, group *cRecGroup,
 			}
 			if fork, ok := p.cRecoverToState(&(*stacks)[mi], depth, entry.state, arena, entryScratch, gssScratch, trackChildErrors); ok {
 				if reason := checkStop(); reason != ParseStopNone {
+					if workCountInstrumentationEnabled {
+						workCountTopologyRetireVersionIfActive(&fork)
+					}
 					return false, false, reason
 				}
 				fork.branchOrder = (*stacks)[mi].branchOrder
@@ -4296,6 +4373,7 @@ func (p *Parser) cRecoverEOFAccept(v *glrStack, tok Token, nodeCount *int, arena
 	}
 	v.accepted = true
 	v.shifted = true
+	workCountTopologyRetireVersion(v)
 }
 
 func cStackPosRow(s *glrStack) uint32 {
@@ -4462,6 +4540,9 @@ func (p *Parser) cRecoverToState(v *glrStack, depth int, goal StateID, arena *no
 	fork.cEverErrored = true
 	keepDepth := len(entries) - cut
 	if !fork.truncate(keepDepth) {
+		if workCountInstrumentationEnabled {
+			workCountTopologyRetireVersionIfActive(&fork)
+		}
 		return glrStack{}, false
 	}
 	// C also pops a directly-preceding closed ERROR subtree and splices its
@@ -4764,6 +4845,10 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, ts TokenSo
 	if !relevant {
 		return stacks, false, tok, ParseStopNone
 	}
+	var topologyBefore []glrStack
+	if workCountInstrumentationEnabled {
+		topologyBefore = append(topologyBefore, stacks...)
+	}
 	// Drop dead versions first (C removes halted versions in condense).
 	// Accepted versions have left the pool in C (ts_parser__accept stashes
 	// the tree and removes the version): they sit out the cost competition,
@@ -4785,6 +4870,10 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, ts TokenSo
 		alive = append(alive, stacks[i])
 	}
 	stacks = alive
+	if workCountInstrumentationEnabled {
+		workCountTopologyRetireMissingVersions(topologyBefore, stacks)
+		topologyBefore = append(topologyBefore[:0], stacks...)
+	}
 	// No stack payloads are inserted during the pairwise phase, so the sticky
 	// construction proof cannot change until the resume phase below.
 	subtreeCostRelevant := trackChildErrors == nil || *trackChildErrors
@@ -4809,6 +4898,9 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, ts TokenSo
 			}
 			if cRecoverVersionShouldStayBefore(stacks[i], stacks[j]) {
 				stacks[i], stacks[j] = stacks[j], stacks[i]
+				if workCountInstrumentationEnabled {
+					workCountTopologySyncVersionOrder(stacks)
+				}
 				statusI = p.cCondenseVersionStatus(&stacks[i], subtreeCostRelevant)
 				continue
 			}
@@ -4820,6 +4912,9 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, ts TokenSo
 						p.cVersionStatusForTrace(&stacks[i], statusI),
 						p.cVersionStatusForTrace(&stacks[j], statusJ))
 				}
+				if workCountInstrumentationEnabled {
+					workCountTopologyRetireVersion(&stacks[i])
+				}
 				stacks = append(stacks[:i], stacks[i+1:]...)
 				i--
 				j = i
@@ -4830,12 +4925,18 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, ts TokenSo
 						p.cVersionStatusForTrace(&stacks[j], statusJ))
 				}
 				stacks[i], stacks[j] = stacks[j], stacks[i]
+				if workCountInstrumentationEnabled {
+					workCountTopologySyncVersionOrder(stacks)
+				}
 				statusI = p.cCondenseVersionStatus(&stacks[i], subtreeCostRelevant)
 			case cErrorComparisonTakeRight:
 				if p.glrTrace {
 					p.traceCCondenseDrop("take-right", j, i, stacks[j], stacks[i],
 						p.cVersionStatusForTrace(&stacks[j], statusJ),
 						p.cVersionStatusForTrace(&stacks[i], statusI))
+				}
+				if workCountInstrumentationEnabled {
+					workCountTopologyRetireVersion(&stacks[j])
 				}
 				stacks = append(stacks[:j], stacks[j+1:]...)
 				i--
@@ -4888,9 +4989,16 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, ts TokenSo
 			if p.glrTrace {
 				p.traceCCondenseTrim(i, stacks[i])
 			}
+			if workCountInstrumentationEnabled {
+				workCountTopologyRetireVersion(&stacks[i])
+			}
 			stacks = append(stacks[:i], stacks[i+1:]...)
 			i--
 		}
+	}
+	if workCountInstrumentationEnabled {
+		workCountTopologyRetireMissingVersions(topologyBefore, stacks)
+		topologyBefore = append(topologyBefore[:0], stacks...)
 	}
 
 	// Resume the best paused version; remove the rest (C condense tail).
@@ -4960,8 +5068,14 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, ts TokenSo
 			hasUnpaused = true
 			continue
 		}
+		if workCountInstrumentationEnabled {
+			workCountTopologyRetireVersion(&stacks[i])
+		}
 		stacks = append(stacks[:i], stacks[i+1:]...)
 		i--
+	}
+	if workCountInstrumentationEnabled {
+		workCountTopologyRetireMissingVersions(topologyBefore, stacks)
 	}
 	stacks = append(stacks, acceptedStacks...)
 	return stacks, needsRedispatch, tok, ParseStopNone

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -801,9 +801,6 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 		currentReduceKey := makeReduceKey(reduce)
 		currentReduceEntry := frontier.entry(currentReduceKey, true)
 		appendTerminalFork := func(fork glrStack) {
-			if allocBranchOrder != nil {
-				fork.branchOrder = allocBranchOrder()
-			}
 			pendingBefore := len(p.pendingFrontierForkStacks)
 			p.pendingFrontierForkStacks = append(p.pendingFrontierForkStacks, fork)
 			workCountRecordPendingQueued(p, s, &fork, pendingBefore, len(p.pendingFrontierForkStacks), "conflict-frontier candidate queued")
@@ -819,6 +816,12 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 			case ParseActionShift:
 				fork := s.cloneWithScratch(gssScratch)
 				if p.guardRealShiftGap(source, &fork, tok) {
+					if allocBranchOrder != nil {
+						fork.branchOrder = allocBranchOrder()
+					}
+					if workCountInstrumentationEnabled {
+						workCountTopologyPrepareVersionCopy(s, &fork) // work-count-assembly: topology frontier-shift-copy seam
+					}
 					p.noteStopActionDiagnostic("conflict-frontier-fork-shift", &fork, tok, terminal, terminalOrdinal, len(actions), true, step, 0, false)
 					p.applyShiftAction(&fork, terminal, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
 					p.noteStopActionResult(&fork)
@@ -827,6 +830,12 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 				}
 			case ParseActionAccept:
 				fork := s.cloneWithScratch(gssScratch)
+				if allocBranchOrder != nil {
+					fork.branchOrder = allocBranchOrder()
+				}
+				if workCountInstrumentationEnabled {
+					workCountTopologyPrepareVersionCopy(s, &fork) // work-count-assembly: topology frontier-accept-copy seam
+				}
 				p.noteStopActionDiagnostic("conflict-frontier-fork-accept", &fork, tok, terminal, terminalOrdinal, len(actions), true, step, 0, false)
 				p.applyAcceptAction(&fork)
 				p.noteStopActionResult(&fork)
@@ -835,6 +844,12 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 			case ParseActionRecover:
 				fork := s.cloneWithScratch(gssScratch)
 				if p.guardRealTokenAttachmentGap(source, &fork, tok, "conflict-frontier-fork-recover") {
+					if allocBranchOrder != nil {
+						fork.branchOrder = allocBranchOrder()
+					}
+					if workCountInstrumentationEnabled {
+						workCountTopologyPrepareVersionCopy(s, &fork) // work-count-assembly: topology frontier-recover-copy seam
+					}
 					p.noteStopActionDiagnostic("conflict-frontier-fork-recover", &fork, tok, terminal, terminalOrdinal, len(actions), true, step, 0, false)
 					p.applyRecoverAction(&fork, terminal, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
 					fork.shifted = true
@@ -3571,6 +3586,7 @@ func (p *Parser) selectedReduceWindowsFromGSSWithBudget(arena *nodeArena, act Pa
 	revPath := revBuf[:0]
 	work := 0
 	capped := false
+	pathOrdinal := uint64(0)
 
 	addFork := func(fork reduceFork) {
 		keep := true
@@ -3580,7 +3596,11 @@ func (p *Parser) selectedReduceWindowsFromGSSWithBudget(arena *nodeArena, act Pa
 				i++
 				continue
 			}
-			switch p.reduceForkWindowPreference(arena, act, fork, forks[i]) {
+			preference := p.reduceForkWindowPreference(arena, act, fork, forks[i])
+			if workCountInstrumentationEnabled && preference != 0 {
+				workCountTopologyRecordChildElection(s, forks[i], fork, preference) // work-count-assembly: topology child-election seam
+			}
+			switch preference {
 			case -1:
 				if insertAt < 0 {
 					insertAt = i
@@ -3628,6 +3648,10 @@ func (p *Parser) selectedReduceWindowsFromGSSWithBudget(arena *nodeArena, act Pa
 						window[j] = revPath[pathLen-1-j]
 					}
 					workCountObservePopWindow(window) // work-count-assembly: payload-census seam
+					if workCountInstrumentationEnabled {
+						workCountTopologyRecordPopPath(s, window, prev, pathOrdinal) // work-count-assembly: topology pop-path seam
+					}
+					pathOrdinal++
 					addFork(reduceFork{
 						window:   window,
 						topState: prev.entry.state,
@@ -4285,8 +4309,14 @@ func (p *Parser) applyReduceActionForked(source []byte, s *glrStack, act ParseAc
 
 	for i := 1; i < len(forks); i++ {
 		clone := base.cloneWithScratch(gssScratch)
+		if workCountInstrumentationEnabled {
+			workCountTopologyRecordVersionCopy(s, &clone) // work-count-assembly: topology reduce-copy seam
+		}
 		applyForkToStack(&clone, forks[i])
 		clone.score = base.score + int(act.DynamicPrecedence)
+		if workCountInstrumentationEnabled {
+			workCountTopologyCommitVersion(&clone) // work-count-assembly: topology reduce-copy-result seam
+		}
 		if !p.disablePostReduceForkMerge {
 			finalizationRisk := p.postReduceForkMergeHasFinalizationRisk(&clone, tok)
 			if finalizationRisk {

--- a/parser_result.go
+++ b/parser_result.go
@@ -281,9 +281,6 @@ func (p *Parser) buildResultFromGLR(stacks []glrStack, source []byte, arena *nod
 		selectionStart = time.Now()
 	}
 	best := 0
-	if workCountInstrumentationEnabled {
-		workCountTopologyRecordAcceptElection(nil, &stacks[0], &stacks[0], true, true) // work-count-assembly: topology first-accept seam
-	}
 	for i := 1; i < len(stacks); i++ {
 		if i&63 == 0 {
 			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
@@ -293,13 +290,6 @@ func (p *Parser) buildResultFromGLR(stacks []glrStack, source []byte, arena *nod
 		cmp := stackCompareForResultSelection(p, arena, &stacks[i], &stacks[best], skipErrorRank)
 		if p.glrTrace && p.errorCostCompetitionEnabled() {
 			p.traceCResultSelectionCompare(i, best, cmp, &stacks[i], &stacks[best], arena)
-		}
-		if workCountInstrumentationEnabled {
-			selectedIndex := best
-			if cmp > 0 {
-				selectedIndex = i
-			}
-			workCountTopologyRecordAcceptElection(&stacks[best], &stacks[i], &stacks[selectedIndex], false, cmp > 0) // work-count-assembly: topology accept-election seam
 		}
 		if cmp > 0 {
 			best = i

--- a/parser_result.go
+++ b/parser_result.go
@@ -281,6 +281,9 @@ func (p *Parser) buildResultFromGLR(stacks []glrStack, source []byte, arena *nod
 		selectionStart = time.Now()
 	}
 	best := 0
+	if workCountInstrumentationEnabled {
+		workCountTopologyRecordAcceptElection(nil, &stacks[0], &stacks[0], true, true) // work-count-assembly: topology first-accept seam
+	}
 	for i := 1; i < len(stacks); i++ {
 		if i&63 == 0 {
 			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
@@ -290,6 +293,13 @@ func (p *Parser) buildResultFromGLR(stacks []glrStack, source []byte, arena *nod
 		cmp := stackCompareForResultSelection(p, arena, &stacks[i], &stacks[best], skipErrorRank)
 		if p.glrTrace && p.errorCostCompetitionEnabled() {
 			p.traceCResultSelectionCompare(i, best, cmp, &stacks[i], &stacks[best], arena)
+		}
+		if workCountInstrumentationEnabled {
+			selectedIndex := best
+			if cmp > 0 {
+				selectedIndex = i
+			}
+			workCountTopologyRecordAcceptElection(&stacks[best], &stacks[i], &stacks[selectedIndex], false, cmp > 0) // work-count-assembly: topology accept-election seam
 		}
 		if cmp > 0 {
 			best = i

--- a/work_count_diagnostic.go
+++ b/work_count_diagnostic.go
@@ -285,6 +285,7 @@ func workCountSetNextParseAttempt(logicalRung, operationCause string) {
 type workCountAttemptToken uint32
 
 func workCountBeginParseAttempt(maxStacks, maxNodes, maxMergePerKey int) workCountAttemptToken {
+	workCountTopologyBeginAttempt()
 	c := diagnosticAttemptLedger()
 	if c == nil {
 		return 0
@@ -485,6 +486,12 @@ func workCountRecordExplicitRecover() {
 // the point selectedReduceWindowsFromGSSWithBudget emits each concrete path.
 func workCountObserveReductionPop(s *glrStack, childCount int) {
 	if activeDiagnosticWorkCount == nil || s == nil || childCount < 0 {
+		if activeDiagnosticTopology == nil || s == nil || childCount < 0 {
+			return
+		}
+	}
+	workCountTopologyRecordDirectPop(s, childCount)
+	if activeDiagnosticWorkCount == nil {
 		return
 	}
 	if childCount == 0 {

--- a/work_count_hooks.go
+++ b/work_count_hooks.go
@@ -3,8 +3,10 @@
 package gotreesitter
 
 type workCountAttemptToken uint32
+type diagnosticTopologyStackToken struct{}
 
 const workCountInstrumentationEnabled = false
+const diagnosticTopologyStackOverhead = uintptr(0)
 
 func workCountAttemptTraceActive() bool { return false }
 
@@ -77,18 +79,20 @@ func workCountRecordBoundaryCull(*Parser, int, int)                             
 func workCountRecordFinalExpand(*Parser, *glrStack, int, bool, bool)                {}
 func workCountRecordFinalExpansions(*Parser, []glrStack)                            {}
 func workCountRecordFinalSelect(*Parser, []glrStack, *glrStack)                     {}
+func workCountTopologySetParseContext(*Parser, *nodeArena, *bool)                   {}
+func workCountTopologyRecordAction(*glrStack, Token, ParseAction, int)              {}
 func workCountTopologyRecordActionResult(*glrStack)                                 {}
 func workCountTopologyRecordInitialVersion(*glrStack)                               {}
 func workCountTopologyPrepareVersionCopy(*glrStack, *glrStack)                      {}
 func workCountTopologyRecordVersionCopy(*glrStack, *glrStack)                       {}
 func workCountTopologyCommitVersion(*glrStack)                                      {}
+func workCountTopologyPreparePromotion(*glrStack)                                   {}
+func workCountTopologyCommitPromotion(*glrStack)                                    {}
 func workCountTopologyRecordNodeAllocation(*gssNode)                                {}
 func workCountTopologyRecordLinkInsert(*gssNode, *gssNode, int, bool)               {}
 func workCountTopologyRecordPopPath(*glrStack, []stackEntry, *gssNode, uint64)      {}
 func workCountTopologyRecordChildElection(*glrStack, reduceFork, reduceFork, int)   {}
 func workCountTopologyRecordMerge(*glrStack, *glrStack, bool)                       {}
-func workCountTopologyRecordAcceptElection(*glrStack, *glrStack, *glrStack, bool, bool) {
-}
 func workCountTryPostReduceMergeObserved(p *Parser, _ string, _ string, target, candidate *glrStack) bool {
 	return tryMergePostReduceFork(p, target, candidate)
 }

--- a/work_count_hooks.go
+++ b/work_count_hooks.go
@@ -93,6 +93,14 @@ func workCountTopologyRecordLinkInsert(*gssNode, *gssNode, int, bool)           
 func workCountTopologyRecordPopPath(*glrStack, []stackEntry, *gssNode, uint64)      {}
 func workCountTopologyRecordChildElection(*glrStack, reduceFork, reduceFork, int)   {}
 func workCountTopologyRecordMerge(*glrStack, *glrStack, bool)                       {}
+func workCountTopologyRetireVersion(*glrStack)                                      {}
+func workCountTopologyRetireVersionIfActive(*glrStack)                              {}
+func workCountTopologyRetireVersionsIfActive([]glrStack)                            {}
+func workCountTopologyRetireUnpublishedVersions([]glrStack, []glrStack)             {}
+func workCountTopologyRenumberVersion(*glrStack, *glrStack)                         {}
+func workCountTopologyRetireMissingVersions([]glrStack, []glrStack)                 {}
+func workCountTopologyReconcileVersionSelection([]glrStack, []glrStack)             {}
+func workCountTopologySyncVersionOrder([]glrStack)                                  {}
 func workCountTryPostReduceMergeObserved(p *Parser, _ string, _ string, target, candidate *glrStack) bool {
 	return tryMergePostReduceFork(p, target, candidate)
 }

--- a/work_count_hooks.go
+++ b/work_count_hooks.go
@@ -77,6 +77,18 @@ func workCountRecordBoundaryCull(*Parser, int, int)                             
 func workCountRecordFinalExpand(*Parser, *glrStack, int, bool, bool)                {}
 func workCountRecordFinalExpansions(*Parser, []glrStack)                            {}
 func workCountRecordFinalSelect(*Parser, []glrStack, *glrStack)                     {}
+func workCountTopologyRecordActionResult(*glrStack)                                 {}
+func workCountTopologyRecordInitialVersion(*glrStack)                               {}
+func workCountTopologyPrepareVersionCopy(*glrStack, *glrStack)                      {}
+func workCountTopologyRecordVersionCopy(*glrStack, *glrStack)                       {}
+func workCountTopologyCommitVersion(*glrStack)                                      {}
+func workCountTopologyRecordNodeAllocation(*gssNode)                                {}
+func workCountTopologyRecordLinkInsert(*gssNode, *gssNode, int, bool)               {}
+func workCountTopologyRecordPopPath(*glrStack, []stackEntry, *gssNode, uint64)      {}
+func workCountTopologyRecordChildElection(*glrStack, reduceFork, reduceFork, int)   {}
+func workCountTopologyRecordMerge(*glrStack, *glrStack, bool)                       {}
+func workCountTopologyRecordAcceptElection(*glrStack, *glrStack, *glrStack, bool, bool) {
+}
 func workCountTryPostReduceMergeObserved(p *Parser, _ string, _ string, target, candidate *glrStack) bool {
 	return tryMergePostReduceFork(p, target, candidate)
 }

--- a/work_count_production_assembly_test.go
+++ b/work_count_production_assembly_test.go
@@ -37,8 +37,6 @@ const (
 	topologyChildElectionMarker            = "work-count-assembly: topology child-election seam"
 	topologyPopPathMarker                  = "work-count-assembly: topology pop-path seam"
 	topologyReduceCopyMarker               = "work-count-assembly: topology reduce-copy seam"
-	topologyFirstAcceptMarker              = "work-count-assembly: topology first-accept seam"
-	topologyAcceptElectionMarker           = "work-count-assembly: topology accept-election seam"
 	topologyNodeAllocationMarker           = "work-count-assembly: topology primary-link seam"
 	semanticPhaseActionCellMarker          = "semantic-phase-assembly: action-cell seam"
 	semanticPhaseActionExecutionMarker     = "semantic-phase-assembly: action-execution seam"
@@ -111,8 +109,6 @@ func TestWorkCountProductionAssemblyHasNoDiagnosticScaffolding(t *testing.T) {
 	assertNoDiagnosticAssembly(t, noteStopAssembly)
 	resultAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.\(\*Parser\)\.buildResultFromGLR`, testBinary)
 	assertNoAssemblyAtMarker(t, resultAssembly, "parser_result.go", convergenceFinalExpandMarker)
-	assertNoAssemblyAtMarker(t, resultAssembly, "parser_result.go", topologyFirstAcceptMarker)
-	assertNoAssemblyAtMarker(t, resultAssembly, "parser_result.go", topologyAcceptElectionMarker)
 	assertNoDiagnosticAssembly(t, resultAssembly)
 	gssAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.tryGSSMainMergeForParser`, testBinary)
 	assertNoAssemblyAtMarker(t, gssAssembly, "glr.go", convergenceGSSMarker)

--- a/work_count_production_assembly_test.go
+++ b/work_count_production_assembly_test.go
@@ -30,6 +30,16 @@ const (
 	gssAlternateAppendGrowMarker           = "work-count-assembly: alternate predecessor append-grow seam"
 	gssMutationAppendReuseMarker           = "work-count-assembly: GSS mutation append-reuse seam"
 	gssMutationAppendGrowMarker            = "work-count-assembly: GSS mutation append-grow seam"
+	topologyActionResultMarker             = "work-count-assembly: topology action-result seam"
+	topologyInitialVersionMarker           = "work-count-assembly: topology initial-version seam"
+	topologyConflictCopyMarker             = "work-count-assembly: topology conflict-copy seam"
+	topologyFrontierShiftCopyMarker        = "work-count-assembly: topology frontier-shift-copy seam"
+	topologyChildElectionMarker            = "work-count-assembly: topology child-election seam"
+	topologyPopPathMarker                  = "work-count-assembly: topology pop-path seam"
+	topologyReduceCopyMarker               = "work-count-assembly: topology reduce-copy seam"
+	topologyFirstAcceptMarker              = "work-count-assembly: topology first-accept seam"
+	topologyAcceptElectionMarker           = "work-count-assembly: topology accept-election seam"
+	topologyNodeAllocationMarker           = "work-count-assembly: topology primary-link seam"
 	semanticPhaseActionCellMarker          = "semantic-phase-assembly: action-cell seam"
 	semanticPhaseActionExecutionMarker     = "semantic-phase-assembly: action-execution seam"
 	semanticPhaseExtraShiftExecutionMarker = "semantic-phase-assembly: extra-shift-execution seam"
@@ -47,6 +57,9 @@ func TestWorkCountProductionAssemblyHasNoDiagnosticScaffolding(t *testing.T) {
 	}
 	if bytes.Contains(nm, []byte("github.com/odvcencio/gotreesitter.semanticPhaseTrace")) {
 		t.Fatal("untagged binary retains semantic-phase trace symbols")
+	}
+	if bytes.Contains(nm, []byte("github.com/odvcencio/gotreesitter.DiagnosticTopology")) {
+		t.Fatal("untagged binary retains diagnostic topology symbols")
 	}
 	for _, forbidden := range []string{
 		"gssMainCanMergeForParserPhase",
@@ -77,6 +90,8 @@ func TestWorkCountProductionAssemblyHasNoDiagnosticScaffolding(t *testing.T) {
 	assertNoAssemblyAtMarker(t, closures, "parser.go", convergenceIterationMarker)
 	parseInternalAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.\(\*Parser\)\.parseInternal$`, testBinary)
 	assertNoAssemblyAtMarker(t, parseInternalAssembly, "parser.go", resolvedActionCellMarker)
+	assertNoAssemblyAtMarker(t, parseInternalAssembly, "parser.go", topologyInitialVersionMarker)
+	assertNoAssemblyAtMarker(t, parseInternalAssembly, "parser.go", topologyConflictCopyMarker)
 	assertNoDiagnosticAssembly(t, parseInternalAssembly)
 	lexerScanAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.\(\*Lexer\)\.scan$`, testBinary)
 	assertNoAssemblyAtMarker(t, lexerScanAssembly, "lexer.go", rawMainLexerInvocationMarker)
@@ -90,11 +105,14 @@ func TestWorkCountProductionAssemblyHasNoDiagnosticScaffolding(t *testing.T) {
 	assertNoAssemblyAtMarker(t, eofAdvanceAssembly, "parser.go", semanticPhaseEOFActionCellMarker)
 	assertNoAssemblyAtMarker(t, eofAdvanceAssembly, "parser.go", semanticPhaseEOFActionExecutionMarker)
 	assertNoDiagnosticAssembly(t, eofAdvanceAssembly)
-	noteStopAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.\(\*Parser\)\.noteStopActionDiagnostic`, testBinary)
+	noteStopAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.\(\*Parser\)\.noteStopAction(?:Diagnostic|Result)`, testBinary)
 	assertNoAssemblyAtMarker(t, noteStopAssembly, "parser.go", semanticPhaseActionExecutionMarker)
+	assertNoAssemblyAtMarker(t, noteStopAssembly, "parser.go", topologyActionResultMarker)
 	assertNoDiagnosticAssembly(t, noteStopAssembly)
 	resultAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.\(\*Parser\)\.buildResultFromGLR`, testBinary)
 	assertNoAssemblyAtMarker(t, resultAssembly, "parser_result.go", convergenceFinalExpandMarker)
+	assertNoAssemblyAtMarker(t, resultAssembly, "parser_result.go", topologyFirstAcceptMarker)
+	assertNoAssemblyAtMarker(t, resultAssembly, "parser_result.go", topologyAcceptElectionMarker)
 	assertNoDiagnosticAssembly(t, resultAssembly)
 	gssAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.tryGSSMainMergeForParser`, testBinary)
 	assertNoAssemblyAtMarker(t, gssAssembly, "glr.go", convergenceGSSMarker)
@@ -108,7 +126,16 @@ func TestWorkCountProductionAssemblyHasNoDiagnosticScaffolding(t *testing.T) {
 	assertNoAssemblyAtMarker(t, gssMutationAssembly, "glr_gss.go", gssMutationAppendGrowMarker)
 	assertNoDiagnosticAssembly(t, gssMutationAssembly)
 	postReduceAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.(?:tryMergePostReduceFork|postReduceForkMergePreflight|\(\*Parser\)\.(?:applyReduceActionForked|applyReduceActionFromGSS))`, testBinary)
+	assertNoAssemblyAtMarker(t, postReduceAssembly, "parser_reduce.go", topologyReduceCopyMarker)
 	assertNoDiagnosticAssembly(t, postReduceAssembly)
+	frontierAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.\(\*Parser\)\.completeConflictReduceFrontier`, testBinary)
+	assertNoAssemblyAtMarker(t, frontierAssembly, "parser_reduce.go", topologyFrontierShiftCopyMarker)
+	assertNoDiagnosticAssembly(t, frontierAssembly)
+	assertNoAssemblyAtMarker(t, reduceAssembly, "parser_reduce.go", topologyChildElectionMarker)
+	assertNoAssemblyAtMarker(t, reduceAssembly, "parser_reduce.go", topologyPopPathMarker)
+	pushEntryAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.\(\*gssStack\)\.pushEntry`, testBinary)
+	assertNoAssemblyAtMarker(t, pushEntryAssembly, "glr_gss.go", topologyNodeAllocationMarker)
+	assertNoDiagnosticAssembly(t, pushEntryAssembly)
 	allSymbols := runGoTool(t, "nm", testBinary)
 	if bytes.Contains(allSymbols, []byte("uniqueActionOrdinal")) {
 		t.Fatalf("untagged binary retains action-ordinal reconstruction symbol:\n%s", allSymbols)
@@ -132,6 +159,8 @@ func assertNoDiagnosticAssembly(t *testing.T, assembly []byte) {
 		[]byte("work_count_hooks.go:"),
 		[]byte("semanticPhaseTrace"),
 		[]byte("work_count_semantic_phase_trace.go:"),
+		[]byte("DiagnosticTopology"),
+		[]byte("work_count_topology.go:"),
 	} {
 		if bytes.Contains(assembly, forbidden) {
 			t.Fatalf("untagged assembly retains diagnostic code %q:\n%s", forbidden, assembly)

--- a/work_count_semantic_phase_trace.go
+++ b/work_count_semantic_phase_trace.go
@@ -224,6 +224,12 @@ func semanticPhaseTraceRecordActionCell(p *Parser, stack *glrStack, state StateI
 }
 
 func semanticPhaseTraceRecordActionExecution(p *Parser, stack *glrStack, tok Token, action ParseAction, actionOrdinal int, phase string, cycle bool) {
+	// -2 is emitted only by the production deterministic-conflict seam. Keep
+	// uniqueness reconstruction entirely inside the diagnostic build.
+	if actionOrdinal == -2 && (activeDiagnosticTopology != nil || activeDiagnosticSemanticPhaseTrace != nil) && p != nil && stack != nil && stack.depth() != 0 {
+		actionOrdinal = semanticPhaseUniqueActionOrdinal(semanticPhaseActionsAt(p, stack.top().state, tok.Symbol), action)
+	}
+	workCountTopologyRecordAction(stack, tok, action, actionOrdinal)
 	if activeDiagnosticSemanticPhaseTrace == nil || p == nil || stack == nil || stack.depth() == 0 {
 		return
 	}
@@ -233,12 +239,6 @@ func semanticPhaseTraceRecordActionExecution(p *Parser, stack *glrStack, tok Tok
 	semanticPhaseAuditActionCell(actions, cellHash)
 	boundaryClass := semanticPhaseCoarseBoundaryClass(stack)
 	semanticPhaseAuditBoundary(stack, boundaryClass)
-	// -2 is emitted only by the production deterministic-conflict seam. Keep
-	// uniqueness reconstruction entirely inside the diagnostic build so an
-	// untagged parser executes no scan, call, or helper symbol for tracing.
-	if actionOrdinal == -2 {
-		actionOrdinal = semanticPhaseUniqueActionOrdinal(actions, action)
-	}
 	ordinal := int16(actionOrdinal)
 	if actionOrdinal < 0 {
 		ordinal = -1

--- a/work_count_topology.go
+++ b/work_count_topology.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"math"
+	"sync"
 )
 
 const (
@@ -172,18 +173,12 @@ type diagnosticTopologyLinkKey struct {
 
 type diagnosticTopologyVersion struct {
 	id            uint64
-	branchOrder   uint64
+	index         uint64
 	head          *gssNode
 	nodeID        uint64
 	entrySnapshot []stackEntry
 	entryNodeIDs  []uint64
 	emptyNodeID   uint64
-}
-
-type diagnosticTopologyStackBinding struct {
-	versionID uint64
-	head      *gssNode
-	branch    uint64
 }
 
 type diagnosticTopologyAction struct {
@@ -232,31 +227,34 @@ type diagnosticTopologyState struct {
 	nextElectionID  uint64
 	nextCandidateID uint64
 
-	nodeIDs        map[*gssNode]uint64
-	linkIDs        map[diagnosticTopologyLinkKey]uint64
-	linkPrevIDs    map[diagnosticTopologyLinkKey]uint64
-	versions       map[uint64]diagnosticTopologyVersion
-	stackVersions  map[*glrStack]diagnosticTopologyStackBinding
-	headVersions   map[*gssNode][]uint64
-	branchVersions map[uint64][]uint64
-	actions        map[*glrStack]diagnosticTopologyAction
-	pendingCopies  map[*glrStack]diagnosticTopologyPendingCopy
-	candidates     []diagnosticTopologyCandidate
-	currentAction  *diagnosticTopologyAction
-	promotion      diagnosticTopologyPromotion
-	parser         *Parser
-	arena          *nodeArena
-	trackErrors    *bool
-	acceptCurrent  diagnosticTopologyAcceptCandidate
-	acceptSet      bool
+	nodeIDs       map[*gssNode]uint64
+	linkIDs       map[diagnosticTopologyLinkKey]uint64
+	linkPrevIDs   map[diagnosticTopologyLinkKey]uint64
+	versions      map[uint64]diagnosticTopologyVersion
+	versionSlots  []uint64
+	actions       map[*glrStack]diagnosticTopologyAction
+	pendingCopies map[*glrStack]diagnosticTopologyPendingCopy
+	candidates    []diagnosticTopologyCandidate
+	currentAction *diagnosticTopologyAction
+	promotion     diagnosticTopologyPromotion
+	parser        *Parser
+	arena         *nodeArena
+	trackErrors   *bool
+	acceptCurrent diagnosticTopologyAcceptCandidate
+	acceptSet     bool
 }
 
+// diagnosticTopologyReceiptOwner gives one caller exclusive receipt ownership.
+// A concurrent caller waits until EndDiagnosticTopologyReceipt releases it.
+var diagnosticTopologyReceiptOwner sync.Mutex
 var activeDiagnosticTopology *diagnosticTopologyState
 
-// BeginDiagnosticTopologyReceipt starts one parse-local topology receipt.
+// BeginDiagnosticTopologyReceipt starts one exclusive topology receipt.
 // It is available only in gts_workcount builds.
 func BeginDiagnosticTopologyReceipt() {
+	diagnosticTopologyReceiptOwner.Lock()
 	if activeDiagnosticTopology != nil {
+		diagnosticTopologyReceiptOwner.Unlock()
 		panic("gotreesitter: diagnostic topology receipt already active")
 	}
 	activeDiagnosticTopology = &diagnosticTopologyState{
@@ -265,19 +263,16 @@ func BeginDiagnosticTopologyReceipt() {
 			Capacity: DiagnosticTopologyReceiptCapacity,
 			Events:   make([]DiagnosticTopologyEvent, 0, DiagnosticTopologyReceiptCapacity),
 		},
-		nodeIDs:        make(map[*gssNode]uint64),
-		linkIDs:        make(map[diagnosticTopologyLinkKey]uint64),
-		linkPrevIDs:    make(map[diagnosticTopologyLinkKey]uint64),
-		versions:       make(map[uint64]diagnosticTopologyVersion),
-		stackVersions:  make(map[*glrStack]diagnosticTopologyStackBinding),
-		headVersions:   make(map[*gssNode][]uint64),
-		branchVersions: make(map[uint64][]uint64),
-		actions:        make(map[*glrStack]diagnosticTopologyAction),
-		pendingCopies:  make(map[*glrStack]diagnosticTopologyPendingCopy),
+		nodeIDs:       make(map[*gssNode]uint64),
+		linkIDs:       make(map[diagnosticTopologyLinkKey]uint64),
+		linkPrevIDs:   make(map[diagnosticTopologyLinkKey]uint64),
+		versions:      make(map[uint64]diagnosticTopologyVersion),
+		actions:       make(map[*glrStack]diagnosticTopologyAction),
+		pendingCopies: make(map[*glrStack]diagnosticTopologyPendingCopy),
 	}
 }
 
-// EndDiagnosticTopologyReceipt returns the receipt and releases pointer maps.
+// EndDiagnosticTopologyReceipt returns the receipt and releases its owner.
 func EndDiagnosticTopologyReceipt() DiagnosticTopologyReceipt {
 	if activeDiagnosticTopology == nil {
 		panic("gotreesitter: diagnostic topology receipt is not active")
@@ -286,6 +281,7 @@ func EndDiagnosticTopologyReceipt() DiagnosticTopologyReceipt {
 	state.receipt.EventsRetained = uint64(len(state.receipt.Events))
 	out := state.receipt
 	activeDiagnosticTopology = nil
+	diagnosticTopologyReceiptOwner.Unlock()
 	return out
 }
 
@@ -351,9 +347,8 @@ func workCountTopologyBeginAttempt() {
 	if s == nil {
 		return
 	}
-	clear(s.stackVersions)
-	clear(s.headVersions)
-	clear(s.branchVersions)
+	clear(s.versions)
+	s.versionSlots = s.versionSlots[:0]
 	clear(s.actions)
 	clear(s.pendingCopies)
 	s.candidates = s.candidates[:0]
@@ -477,22 +472,365 @@ func diagnosticTopologyStackState(stack *glrStack) uint64 {
 	return uint64(stack.top().state)
 }
 
-func (s *diagnosticTopologyState) removeHeadVersion(head *gssNode, id uint64) {
-	if head == nil || id == 0 {
+func (s *diagnosticTopologyState) recordVersionShift(sourceIndex int) bool {
+	if sourceIndex <= 0 || sourceIndex >= len(s.versionSlots) {
+		s.receipt.IdentityIncomplete = true
+		return false
+	}
+	movedID := s.versionSlots[sourceIndex]
+	replacedID := s.versionSlots[sourceIndex-1]
+	moved, exists := s.versions[movedID]
+	_, targetExists := s.versions[replacedID]
+	// A direct lower-slot promotion leaves its source ID in the old source
+	// slot until the stable erase. The target ID can therefore have another
+	// authoritative index during the later-slot shift sequence.
+	if movedID != 0 && movedID == replacedID {
+		s.markIdentityCollision()
+		return false
+	}
+	if !exists || !targetExists || movedID == 0 || replacedID == 0 || moved.index != uint64(sourceIndex) {
+		s.receipt.IdentityIncomplete = true
+		return false
+	}
+	event := diagnosticTopologyEventBase()
+	event.Kind = DiagnosticTopologyEventVersionRenumber
+	event.VersionID = movedID
+	event.VersionIndex = uint64(sourceIndex - 1)
+	event.SourceVersionID = movedID
+	event.SourceIndex = uint64(sourceIndex)
+	event.TargetVersionID = replacedID
+	event.TargetIndex = uint64(sourceIndex - 1)
+	event.NodeID = s.versionNodeID(movedID, nil)
+	event.Flags = DiagnosticTopologyFlagTargetReplaced
+	if action := s.currentAction; action != nil {
+		s.applyActionContext(&event, action)
+	}
+	s.appendEvent(event)
+	moved.index = uint64(sourceIndex - 1)
+	s.versions[movedID] = moved
+	s.versionSlots[sourceIndex-1] = movedID
+	return true
+}
+
+func (s *diagnosticTopologyState) forgetVersion(id uint64) {
+	_, ok := s.versions[id]
+	if !ok || id == 0 {
 		return
 	}
-	ids := s.headVersions[head]
-	for i := range ids {
-		if ids[i] != id {
+	delete(s.versions, id)
+	for stack, action := range s.actions {
+		if action.versionID == id {
+			delete(s.actions, stack)
+		}
+	}
+	if s.currentAction != nil && s.currentAction.versionID == id {
+		s.currentAction = nil
+	}
+	for stack, copy := range s.pendingCopies {
+		if copy.targetVersionID == id {
+			delete(s.pendingCopies, stack)
+		}
+	}
+}
+
+func (s *diagnosticTopologyState) versionHasMutationBinding(ids ...uint64) bool {
+	contains := func(id uint64) bool {
+		for _, candidate := range ids {
+			if id != 0 && id == candidate {
+				return true
+			}
+		}
+		return false
+	}
+	for _, action := range s.actions {
+		if contains(action.versionID) {
+			return true
+		}
+	}
+	if s.currentAction != nil && contains(s.currentAction.versionID) {
+		return true
+	}
+	for _, copy := range s.pendingCopies {
+		if contains(copy.targetVersionID) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *diagnosticTopologyState) retireVersion(id uint64) {
+	version, ok := s.versions[id]
+	if !ok || id == 0 || version.index >= uint64(len(s.versionSlots)) || s.versionSlots[version.index] != id {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	removedIndex := int(version.index)
+	for sourceIndex := removedIndex + 1; sourceIndex < len(s.versionSlots); sourceIndex++ {
+		if !s.recordVersionShift(sourceIndex) {
+			return
+		}
+	}
+	s.versionSlots = s.versionSlots[:len(s.versionSlots)-1]
+	s.forgetVersion(id)
+}
+
+func workCountTopologyRenumberVersion(source, target *glrStack) {
+	s := activeDiagnosticTopology
+	if s == nil || source == nil || target == nil {
+		return
+	}
+	sourceID := source.diagnosticTopology.versionID
+	targetID := target.diagnosticTopology.versionID
+	if source.accepted || target.accepted {
+		return
+	}
+	if sourceID != 0 && sourceID == targetID {
+		return
+	}
+	if s.versionHasMutationBinding(sourceID, targetID) {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	sourceVersion, sourceOK := s.versions[sourceID]
+	targetVersion, targetOK := s.versions[targetID]
+	if !sourceOK || !targetOK || sourceID == 0 || targetID == 0 ||
+		sourceVersion.index <= targetVersion.index || sourceVersion.index >= uint64(len(s.versionSlots)) ||
+		s.versionSlots[sourceVersion.index] != sourceID || s.versionSlots[targetVersion.index] != targetID {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	sourceIndex := int(sourceVersion.index)
+	targetIndex := int(targetVersion.index)
+	event := diagnosticTopologyEventBase()
+	event.Kind = DiagnosticTopologyEventVersionRenumber
+	event.VersionID = sourceID
+	event.VersionIndex = uint64(targetIndex)
+	event.SourceVersionID = sourceID
+	event.SourceIndex = uint64(sourceIndex)
+	event.TargetVersionID = targetID
+	event.TargetIndex = uint64(targetIndex)
+	event.NodeID = s.versionNodeID(sourceID, source)
+	event.Flags = DiagnosticTopologyFlagTargetReplaced
+	if action := s.currentAction; action != nil {
+		s.applyActionContext(&event, action)
+	}
+	s.appendEvent(event)
+	sourceVersion.index = uint64(targetIndex)
+	s.versions[sourceID] = sourceVersion
+	s.versionSlots[targetIndex] = sourceID
+	for index := sourceIndex + 1; index < len(s.versionSlots); index++ {
+		if !s.recordVersionShift(index) {
+			return
+		}
+	}
+	s.versionSlots = s.versionSlots[:len(s.versionSlots)-1]
+	s.forgetVersion(targetID)
+	target.diagnosticTopology.versionID = 0
+}
+
+func workCountTopologyRetireVersion(stack *glrStack) {
+	s := activeDiagnosticTopology
+	if s == nil || stack == nil {
+		return
+	}
+	id := stack.diagnosticTopology.versionID
+	if id == 0 {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	if _, ok := s.versions[id]; !ok {
+		return
+	}
+	s.retireVersion(id)
+	stack.diagnosticTopology.versionID = 0
+}
+
+func workCountTopologyRetireVersionIfActive(stack *glrStack) {
+	s := activeDiagnosticTopology
+	if s == nil || stack == nil {
+		return
+	}
+	id := stack.diagnosticTopology.versionID
+	if id == 0 {
+		return
+	}
+	if _, ok := s.versions[id]; !ok {
+		stack.diagnosticTopology.versionID = 0
+		return
+	}
+	s.retireVersion(id)
+	stack.diagnosticTopology.versionID = 0
+}
+
+func workCountTopologyRetireVersionsIfActive(stacks []glrStack) {
+	for i := range stacks {
+		workCountTopologyRetireVersionIfActive(&stacks[i])
+	}
+}
+
+func workCountTopologyRetireUnpublishedVersions(owned, published []glrStack) {
+	for i := range owned {
+		id := owned[i].diagnosticTopology.versionID
+		if id == 0 {
 			continue
 		}
-		ids = append(ids[:i], ids[i+1:]...)
-		if len(ids) == 0 {
-			delete(s.headVersions, head)
-		} else {
-			s.headVersions[head] = ids
+		found := false
+		for j := range published {
+			if published[j].diagnosticTopology.versionID == id {
+				found = true
+				break
+			}
 		}
+		if !found {
+			workCountTopologyRetireVersionIfActive(&owned[i])
+		}
+	}
+}
+
+func workCountTopologyRetireMissingVersions(before, after []glrStack) {
+	s := activeDiagnosticTopology
+	if s == nil {
 		return
+	}
+	for i := range before {
+		id := before[i].diagnosticTopology.versionID
+		if id == 0 {
+			continue
+		}
+		retained := false
+		for j := range after {
+			if after[j].diagnosticTopology.versionID == id {
+				retained = true
+				break
+			}
+		}
+		if !retained {
+			if _, ok := s.versions[id]; ok {
+				s.retireVersion(id)
+			}
+		}
+	}
+	workCountTopologySyncVersionOrder(after)
+}
+
+// workCountTopologyReconcileVersionSelection records a swap-based survivor
+// selection. The selection moves survivors before it truncates the tail, so it
+// does not emit the stable-deletion renumbers used by array erasure.
+func workCountTopologyReconcileVersionSelection(before, after []glrStack) {
+	s := activeDiagnosticTopology
+	if s == nil {
+		return
+	}
+	beforeIDs := make(map[uint64]struct{}, len(before))
+	for i := range before {
+		if before[i].accepted {
+			continue
+		}
+		id := before[i].diagnosticTopology.versionID
+		if id == 0 {
+			s.receipt.IdentityIncomplete = true
+			return
+		}
+		if _, ok := s.versions[id]; !ok {
+			s.receipt.IdentityIncomplete = true
+			return
+		}
+		if _, duplicate := beforeIDs[id]; duplicate {
+			s.markIdentityCollision()
+			return
+		}
+		beforeIDs[id] = struct{}{}
+	}
+	if len(beforeIDs) != len(s.versionSlots) {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	ordered := make([]uint64, 0, len(s.versionSlots))
+	retained := make(map[uint64]struct{}, len(after))
+	for i := range after {
+		if after[i].accepted {
+			continue
+		}
+		id := after[i].diagnosticTopology.versionID
+		if id == 0 {
+			s.receipt.IdentityIncomplete = true
+			return
+		}
+		if _, ok := beforeIDs[id]; !ok {
+			s.receipt.IdentityIncomplete = true
+			return
+		}
+		if _, duplicate := retained[id]; duplicate {
+			s.markIdentityCollision()
+			return
+		}
+		retained[id] = struct{}{}
+		ordered = append(ordered, id)
+	}
+	removed := make([]uint64, 0, len(s.versionSlots)-len(ordered))
+	for _, id := range s.versionSlots {
+		if _, ok := retained[id]; !ok {
+			removed = append(removed, id)
+		}
+	}
+	ordered = append(ordered, removed...)
+	if len(ordered) != len(s.versionSlots) {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	copy(s.versionSlots, ordered)
+	for index, id := range s.versionSlots {
+		version, ok := s.versions[id]
+		if !ok {
+			s.receipt.IdentityIncomplete = true
+			return
+		}
+		version.index = uint64(index)
+		s.versions[id] = version
+	}
+	for _, id := range removed {
+		s.forgetVersion(id)
+	}
+	s.versionSlots = s.versionSlots[:len(retained)]
+}
+
+func workCountTopologySyncVersionOrder(stacks []glrStack) {
+	s := activeDiagnosticTopology
+	if s == nil {
+		return
+	}
+	seen := make(map[uint64]struct{}, len(stacks))
+	versionIndex := 0
+	for i := range stacks {
+		if stacks[i].accepted {
+			continue
+		}
+		id := stacks[i].diagnosticTopology.versionID
+		if id == 0 {
+			s.receipt.IdentityIncomplete = true
+			return
+		}
+		version, ok := s.versions[id]
+		if !ok {
+			s.receipt.IdentityIncomplete = true
+			return
+		}
+		if _, duplicate := seen[id]; duplicate {
+			s.markIdentityCollision()
+			return
+		}
+		seen[id] = struct{}{}
+		version.index = uint64(versionIndex)
+		s.versions[id] = version
+		if versionIndex >= len(s.versionSlots) {
+			s.receipt.IdentityIncomplete = true
+			return
+		}
+		s.versionSlots[versionIndex] = id
+		versionIndex++
+	}
+	if versionIndex != len(s.versionSlots) {
+		s.receipt.IdentityIncomplete = true
 	}
 }
 
@@ -507,14 +845,7 @@ func (s *diagnosticTopologyState) bindVersion(stack *glrStack, id uint64) {
 	}
 	stack.diagnosticTopology.versionID = id
 	newHead := stack.gss.head
-	if version.head != newHead {
-		s.removeHeadVersion(version.head, id)
-		if newHead != nil {
-			s.headVersions[newHead] = append(s.headVersions[newHead], id)
-		}
-	}
 	version.head = newHead
-	version.branchOrder = stack.branchOrder
 	if newHead != nil {
 		version.nodeID = s.nodeID(newHead)
 	}
@@ -522,7 +853,6 @@ func (s *diagnosticTopologyState) bindVersion(stack *glrStack, id uint64) {
 	if newHead == nil {
 		s.syncVersionEntries(id, stack)
 	}
-	s.stackVersions[stack] = diagnosticTopologyStackBinding{versionID: id, head: newHead, branch: stack.branchOrder}
 }
 
 func diagnosticTopologyCommonEntryPrefix(a, b []stackEntry) int {
@@ -574,14 +904,15 @@ func (s *diagnosticTopologyState) syncVersionEntries(id uint64, stack *glrStack)
 }
 
 func (s *diagnosticTopologyState) allocateVersion(stack *glrStack, sourceID uint64) uint64 {
-	if stack == nil || !s.identityAvailable(len(s.versions)) {
+	if stack == nil || s.nextVersionID >= diagnosticTopologyIdentityCapacity {
+		s.receipt.IdentityIncomplete = true
 		return 0
 	}
 	id := s.nextID(&s.nextVersionID)
 	if id == 0 {
 		return 0
 	}
-	version := diagnosticTopologyVersion{id: id, branchOrder: stack.branchOrder}
+	version := diagnosticTopologyVersion{id: id, index: uint64(len(s.versionSlots))}
 	if sourceID != 0 {
 		source, ok := s.versions[sourceID]
 		if !ok {
@@ -594,7 +925,7 @@ func (s *diagnosticTopologyState) allocateVersion(stack *glrStack, sourceID uint
 		}
 	}
 	s.versions[id] = version
-	s.branchVersions[stack.branchOrder] = append(s.branchVersions[stack.branchOrder], id)
+	s.versionSlots = append(s.versionSlots, id)
 	s.bindVersion(stack, id)
 	version = s.versions[id]
 	if version.nodeID == 0 {
@@ -632,48 +963,6 @@ func (s *diagnosticTopologyState) versionID(stack *glrStack) uint64 {
 		s.bindVersion(stack, id)
 		return id
 	}
-	if binding, ok := s.stackVersions[stack]; ok {
-		if binding.head == stack.gss.head && binding.branch == stack.branchOrder {
-			return binding.versionID
-		}
-		delete(s.stackVersions, stack)
-	}
-	if ids := s.branchVersions[stack.branchOrder]; len(ids) != 0 {
-		matched := uint64(0)
-		for _, id := range ids {
-			version := s.versions[id]
-			if version.head != stack.gss.head {
-				continue
-			}
-			if matched != 0 && matched != id {
-				s.markIdentityCollision()
-				return 0
-			}
-			matched = id
-		}
-		if matched != 0 {
-			s.bindVersion(stack, matched)
-			return matched
-		}
-		// A unique branch can move from its contiguous entries form to a GSS
-		// head without creating a new version. Bind that physical promotion to
-		// the existing lineage.
-		if len(ids) == 1 {
-			s.bindVersion(stack, ids[0])
-			return ids[0]
-		}
-	}
-	if stack.gss.head != nil {
-		ids := s.headVersions[stack.gss.head]
-		if len(ids) == 1 {
-			s.bindVersion(stack, ids[0])
-			return ids[0]
-		}
-		if len(ids) > 1 {
-			s.receipt.IdentityIncomplete = true
-			return 0
-		}
-	}
 	id := s.allocateVersion(stack, 0)
 	if id == 0 {
 		return 0
@@ -685,7 +974,7 @@ func (s *diagnosticTopologyState) versionID(stack *glrStack) uint64 {
 	event := diagnosticTopologyEventBase()
 	event.Kind = DiagnosticTopologyEventVersionAdd
 	event.VersionID = id
-	event.VersionIndex = stack.branchOrder
+	event.VersionIndex = s.versions[id].index
 	event.NodeID = s.versionNodeID(id, stack)
 	if action := s.currentAction; action != nil {
 		s.applyActionContext(&event, action)
@@ -721,7 +1010,7 @@ func workCountTopologyRecordInitialVersion(stack *glrStack) {
 	event := diagnosticTopologyEventBase()
 	event.Kind = DiagnosticTopologyEventVersionAdd
 	event.VersionID = id
-	event.VersionIndex = stack.branchOrder
+	event.VersionIndex = s.versions[id].index
 	event.NodeID = s.versionNodeID(id, stack)
 	event.Flags = DiagnosticTopologyFlagInitialVersion
 	s.appendEvent(event)
@@ -743,9 +1032,9 @@ func workCountTopologyPrepareVersionCopy(source, target *glrStack) {
 	}
 	s.pendingCopies[target] = diagnosticTopologyPendingCopy{
 		sourceVersionID: sourceID,
-		sourceIndex:     source.branchOrder,
+		sourceIndex:     s.versions[sourceID].index,
 		targetVersionID: targetID,
-		targetIndex:     target.branchOrder,
+		targetIndex:     s.versions[targetID].index,
 	}
 }
 
@@ -758,9 +1047,9 @@ func workCountTopologyRecordVersionCopy(source, target *glrStack) {
 	targetID := s.allocateVersion(target, sourceID)
 	s.recordVersionCopyEvent(target, diagnosticTopologyPendingCopy{
 		sourceVersionID: sourceID,
-		sourceIndex:     source.branchOrder,
+		sourceIndex:     s.versions[sourceID].index,
 		targetVersionID: targetID,
-		targetIndex:     target.branchOrder,
+		targetIndex:     s.versions[targetID].index,
 	}, s.currentAction)
 }
 
@@ -769,12 +1058,12 @@ func workCountTopologyCommitVersion(stack *glrStack) {
 	if s == nil || stack == nil {
 		return
 	}
-	binding, ok := s.stackVersions[stack]
-	if !ok || binding.versionID == 0 {
+	id := stack.diagnosticTopology.versionID
+	if id == 0 {
 		s.receipt.IdentityIncomplete = true
 		return
 	}
-	s.bindVersion(stack, binding.versionID)
+	s.bindVersion(stack, id)
 }
 
 func (s *diagnosticTopologyState) recordVersionCopyEvent(target *glrStack, copy diagnosticTopologyPendingCopy, action *diagnosticTopologyAction) {
@@ -812,7 +1101,7 @@ func workCountTopologyRecordAction(stack *glrStack, tok Token, action ParseActio
 		byte:      uint64(stack.byteOffset),
 		symbol:    uint64(action.Symbol),
 		versionID: versionID,
-		index:     stack.branchOrder,
+		index:     s.versions[versionID].index,
 	}
 	event := diagnosticTopologyEventBase()
 	event.Kind = DiagnosticTopologyEventAction
@@ -844,8 +1133,12 @@ func workCountTopologyRecordActionResult(stack *glrStack) {
 		return
 	}
 	s.bindVersion(stack, context.versionID)
-	if context.typeID == uint64(ParseActionAccept) && stack.accepted {
-		s.recordAcceptAction(stack, context)
+	if stack.accepted {
+		if context.typeID == uint64(ParseActionAccept) {
+			s.recordAcceptAction(stack, context)
+		}
+		s.retireVersion(context.versionID)
+		stack.diagnosticTopology.versionID = 0
 	}
 	delete(s.actions, stack)
 	if s.currentAction != nil && s.currentAction.id == context.id {
@@ -1128,14 +1421,20 @@ func workCountTopologyRecordMerge(target, candidate *glrStack, merged bool) {
 	}
 	targetID := s.versionID(target)
 	candidateID := s.versionID(candidate)
+	targetVersion, targetOK := s.versions[targetID]
+	candidateVersion, candidateOK := s.versions[candidateID]
+	if !targetOK || !candidateOK || targetID == 0 || candidateID == 0 || targetID == candidateID || targetVersion.index >= candidateVersion.index {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
 	event := diagnosticTopologyEventBase()
 	event.Kind = DiagnosticTopologyEventMerge
 	event.VersionID = targetID
-	event.VersionIndex = target.branchOrder
+	event.VersionIndex = targetVersion.index
 	event.SourceVersionID = targetID
-	event.SourceIndex = target.branchOrder
+	event.SourceIndex = targetVersion.index
 	event.TargetVersionID = candidateID
-	event.TargetIndex = candidate.branchOrder
+	event.TargetIndex = candidateVersion.index
 	event.SurvivorVersionID = targetID
 	event.RemovedVersionID = candidateID
 	event.NodeID = s.versionNodeID(targetID, target)
@@ -1148,6 +1447,9 @@ func workCountTopologyRecordMerge(target, candidate *glrStack, merged bool) {
 		s.applyActionContext(&event, action)
 	}
 	s.appendEvent(event)
+	if merged {
+		s.retireVersion(candidateID)
+	}
 }
 
 type diagnosticTopologyAcceptCandidate struct {

--- a/work_count_topology.go
+++ b/work_count_topology.go
@@ -40,6 +40,12 @@ const (
 
 const diagnosticTopologyNoActionType = uint64(255)
 
+type diagnosticTopologyStackToken struct {
+	versionID uint64
+}
+
+const diagnosticTopologyStackOverhead = uintptr(8)
+
 // DiagnosticTopologyEvent is one event in the shared topology contract.
 // Every field has a fixed uint64 framing position. ActionOrdinal uses -1 when
 // no exact table ordinal is available.
@@ -165,10 +171,13 @@ type diagnosticTopologyLinkKey struct {
 }
 
 type diagnosticTopologyVersion struct {
-	id          uint64
-	branchOrder uint64
-	head        *gssNode
-	nodeID      uint64
+	id            uint64
+	branchOrder   uint64
+	head          *gssNode
+	nodeID        uint64
+	entrySnapshot []stackEntry
+	entryNodeIDs  []uint64
+	emptyNodeID   uint64
 }
 
 type diagnosticTopologyStackBinding struct {
@@ -206,10 +215,10 @@ type diagnosticTopologyCandidate struct {
 	window   []stackEntry
 }
 
-type diagnosticTopologyAcceptKey struct {
+type diagnosticTopologyPromotion struct {
 	versionID uint64
-	head      *gssNode
-	branch    uint64
+	nodeIDs   []uint64
+	next      int
 }
 
 type diagnosticTopologyState struct {
@@ -225,6 +234,7 @@ type diagnosticTopologyState struct {
 
 	nodeIDs        map[*gssNode]uint64
 	linkIDs        map[diagnosticTopologyLinkKey]uint64
+	linkPrevIDs    map[diagnosticTopologyLinkKey]uint64
 	versions       map[uint64]diagnosticTopologyVersion
 	stackVersions  map[*glrStack]diagnosticTopologyStackBinding
 	headVersions   map[*gssNode][]uint64
@@ -232,8 +242,13 @@ type diagnosticTopologyState struct {
 	actions        map[*glrStack]diagnosticTopologyAction
 	pendingCopies  map[*glrStack]diagnosticTopologyPendingCopy
 	candidates     []diagnosticTopologyCandidate
-	acceptIDs      map[diagnosticTopologyAcceptKey]uint64
 	currentAction  *diagnosticTopologyAction
+	promotion      diagnosticTopologyPromotion
+	parser         *Parser
+	arena          *nodeArena
+	trackErrors    *bool
+	acceptCurrent  diagnosticTopologyAcceptCandidate
+	acceptSet      bool
 }
 
 var activeDiagnosticTopology *diagnosticTopologyState
@@ -252,13 +267,13 @@ func BeginDiagnosticTopologyReceipt() {
 		},
 		nodeIDs:        make(map[*gssNode]uint64),
 		linkIDs:        make(map[diagnosticTopologyLinkKey]uint64),
+		linkPrevIDs:    make(map[diagnosticTopologyLinkKey]uint64),
 		versions:       make(map[uint64]diagnosticTopologyVersion),
 		stackVersions:  make(map[*glrStack]diagnosticTopologyStackBinding),
 		headVersions:   make(map[*gssNode][]uint64),
 		branchVersions: make(map[uint64][]uint64),
 		actions:        make(map[*glrStack]diagnosticTopologyAction),
 		pendingCopies:  make(map[*glrStack]diagnosticTopologyPendingCopy),
-		acceptIDs:      make(map[diagnosticTopologyAcceptKey]uint64),
 	}
 }
 
@@ -315,6 +330,17 @@ func (s *diagnosticTopologyState) identityAvailable(size int) bool {
 	return false
 }
 
+func (s *diagnosticTopologyState) nextNodeIdentity() uint64 {
+	if s.nextNodeID == math.MaxUint64 {
+		return s.nextID(&s.nextNodeID)
+	}
+	if s.nextNodeID >= diagnosticTopologyIdentityCapacity {
+		s.receipt.IdentityIncomplete = true
+		return 0
+	}
+	return s.nextID(&s.nextNodeID)
+}
+
 func (s *diagnosticTopologyState) markIdentityCollision() {
 	s.receipt.IdentityCollision = true
 	s.receipt.IdentityIncomplete = true
@@ -330,9 +356,68 @@ func workCountTopologyBeginAttempt() {
 	clear(s.branchVersions)
 	clear(s.actions)
 	clear(s.pendingCopies)
-	clear(s.acceptIDs)
 	s.candidates = s.candidates[:0]
 	s.currentAction = nil
+	s.promotion = diagnosticTopologyPromotion{}
+	s.parser = nil
+	s.arena = nil
+	s.trackErrors = nil
+	s.acceptCurrent = diagnosticTopologyAcceptCandidate{}
+	s.acceptSet = false
+}
+
+func workCountTopologySetParseContext(p *Parser, arena *nodeArena, trackErrors *bool) {
+	s := activeDiagnosticTopology
+	if s == nil {
+		return
+	}
+	s.parser = p
+	s.arena = arena
+	s.trackErrors = trackErrors
+}
+
+func workCountTopologyPreparePromotion(stack *glrStack) {
+	s := activeDiagnosticTopology
+	if s == nil || stack == nil || stack.gss.head != nil || len(stack.entries) == 0 {
+		return
+	}
+	if s.promotion.versionID != 0 {
+		s.markIdentityCollision()
+		return
+	}
+	versionID := s.versionID(stack)
+	s.syncVersionEntries(versionID, stack)
+	version, ok := s.versions[versionID]
+	if !ok || len(version.entryNodeIDs) != len(stack.entries) {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	s.promotion = diagnosticTopologyPromotion{
+		versionID: versionID,
+		nodeIDs:   append([]uint64(nil), version.entryNodeIDs...),
+	}
+}
+
+func workCountTopologyCommitPromotion(stack *glrStack) {
+	s := activeDiagnosticTopology
+	if s == nil || stack == nil {
+		return
+	}
+	promotion := s.promotion
+	s.promotion = diagnosticTopologyPromotion{}
+	if promotion.versionID == 0 {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	if promotion.next != len(promotion.nodeIDs) || stack.gss.head == nil {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	if got, want := s.nodeID(stack.gss.head), promotion.nodeIDs[len(promotion.nodeIDs)-1]; got == 0 || got != want {
+		s.markIdentityCollision()
+		return
+	}
+	s.bindVersion(stack, promotion.versionID)
 }
 
 func workCountTopologyRecordNodeAllocation(node *gssNode) {
@@ -340,11 +425,25 @@ func workCountTopologyRecordNodeAllocation(node *gssNode) {
 	if s == nil || node == nil {
 		return
 	}
+	if s.promotion.versionID != 0 {
+		if s.promotion.next >= len(s.promotion.nodeIDs) {
+			s.receipt.IdentityIncomplete = true
+			return
+		}
+		id := s.promotion.nodeIDs[s.promotion.next]
+		s.promotion.next++
+		if id == 0 {
+			s.receipt.IdentityIncomplete = true
+			return
+		}
+		s.nodeIDs[node] = id
+		return
+	}
 	if !s.identityAvailable(len(s.nodeIDs)) {
 		delete(s.nodeIDs, node)
 		return
 	}
-	id := s.nextID(&s.nextNodeID)
+	id := s.nextNodeIdentity()
 	if id == 0 {
 		return
 	}
@@ -364,7 +463,7 @@ func (s *diagnosticTopologyState) nodeID(node *gssNode) uint64 {
 	if !s.identityAvailable(len(s.nodeIDs)) {
 		return 0
 	}
-	id := s.nextID(&s.nextNodeID)
+	id := s.nextNodeIdentity()
 	if id != 0 {
 		s.nodeIDs[node] = id
 	}
@@ -406,6 +505,7 @@ func (s *diagnosticTopologyState) bindVersion(stack *glrStack, id uint64) {
 		s.receipt.IdentityIncomplete = true
 		return
 	}
+	stack.diagnosticTopology.versionID = id
 	newHead := stack.gss.head
 	if version.head != newHead {
 		s.removeHeadVersion(version.head, id)
@@ -419,10 +519,61 @@ func (s *diagnosticTopologyState) bindVersion(stack *glrStack, id uint64) {
 		version.nodeID = s.nodeID(newHead)
 	}
 	s.versions[id] = version
+	if newHead == nil {
+		s.syncVersionEntries(id, stack)
+	}
 	s.stackVersions[stack] = diagnosticTopologyStackBinding{versionID: id, head: newHead, branch: stack.branchOrder}
 }
 
-func (s *diagnosticTopologyState) allocateVersion(stack *glrStack) uint64 {
+func diagnosticTopologyCommonEntryPrefix(a, b []stackEntry) int {
+	limit := len(a)
+	if len(b) < limit {
+		limit = len(b)
+	}
+	for i := 0; i < limit; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return limit
+}
+
+func (s *diagnosticTopologyState) syncVersionEntries(id uint64, stack *glrStack) {
+	if id == 0 || stack == nil || stack.gss.head != nil {
+		return
+	}
+	version, ok := s.versions[id]
+	if !ok {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	common := diagnosticTopologyCommonEntryPrefix(version.entrySnapshot, stack.entries)
+	if common < len(version.entryNodeIDs) {
+		version.entryNodeIDs = version.entryNodeIDs[:common]
+	}
+	for len(version.entryNodeIDs) < len(stack.entries) {
+		id := s.nextNodeIdentity()
+		if id == 0 {
+			break
+		}
+		version.entryNodeIDs = append(version.entryNodeIDs, id)
+	}
+	version.entrySnapshot = append(version.entrySnapshot[:0], stack.entries...)
+	if len(version.entryNodeIDs) == len(stack.entries) && len(version.entryNodeIDs) != 0 {
+		version.nodeID = version.entryNodeIDs[len(version.entryNodeIDs)-1]
+	} else if len(stack.entries) == 0 {
+		if version.emptyNodeID == 0 {
+			version.emptyNodeID = s.nextNodeIdentity()
+		}
+		version.nodeID = version.emptyNodeID
+	} else {
+		version.nodeID = 0
+		s.receipt.IdentityIncomplete = true
+	}
+	s.versions[id] = version
+}
+
+func (s *diagnosticTopologyState) allocateVersion(stack *glrStack, sourceID uint64) uint64 {
 	if stack == nil || !s.identityAvailable(len(s.versions)) {
 		return 0
 	}
@@ -430,12 +581,24 @@ func (s *diagnosticTopologyState) allocateVersion(stack *glrStack) uint64 {
 	if id == 0 {
 		return 0
 	}
-	s.versions[id] = diagnosticTopologyVersion{id: id, branchOrder: stack.branchOrder}
+	version := diagnosticTopologyVersion{id: id, branchOrder: stack.branchOrder}
+	if sourceID != 0 {
+		source, ok := s.versions[sourceID]
+		if !ok {
+			s.receipt.IdentityIncomplete = true
+		} else {
+			version.nodeID = source.nodeID
+			version.entrySnapshot = append([]stackEntry(nil), source.entrySnapshot...)
+			version.entryNodeIDs = append([]uint64(nil), source.entryNodeIDs...)
+			version.emptyNodeID = source.emptyNodeID
+		}
+	}
+	s.versions[id] = version
 	s.branchVersions[stack.branchOrder] = append(s.branchVersions[stack.branchOrder], id)
 	s.bindVersion(stack, id)
-	version := s.versions[id]
+	version = s.versions[id]
 	if version.nodeID == 0 {
-		version.nodeID = s.nextID(&s.nextNodeID)
+		version.nodeID = s.nextNodeIdentity()
 		s.versions[id] = version
 	}
 	return id
@@ -451,19 +614,23 @@ func (s *diagnosticTopologyState) versionNodeID(versionID uint64, stack *glrStac
 		return 0
 	}
 	if version.nodeID == 0 {
-		version.nodeID = s.nextID(&s.nextNodeID)
+		version.nodeID = s.nextNodeIdentity()
 		s.versions[versionID] = version
 	}
 	return version.nodeID
 }
 
-func (s *diagnosticTopologyState) syntheticNodeID() uint64 {
-	return s.nextID(&s.nextNodeID)
-}
-
 func (s *diagnosticTopologyState) versionID(stack *glrStack) uint64 {
 	if stack == nil {
 		return 0
+	}
+	if id := stack.diagnosticTopology.versionID; id != 0 {
+		if _, ok := s.versions[id]; !ok {
+			s.receipt.IdentityIncomplete = true
+			return 0
+		}
+		s.bindVersion(stack, id)
+		return id
 	}
 	if binding, ok := s.stackVersions[stack]; ok {
 		if binding.head == stack.gss.head && binding.branch == stack.branchOrder {
@@ -507,7 +674,24 @@ func (s *diagnosticTopologyState) versionID(stack *glrStack) uint64 {
 			return 0
 		}
 	}
-	return s.allocateVersion(stack)
+	id := s.allocateVersion(stack, 0)
+	if id == 0 {
+		return 0
+	}
+	// Every non-initial version must enter through an authenticated copy seam.
+	// Keep the event prefix readable, but fail the receipt closed when a seam is
+	// missing instead of presenting an invented lineage as complete evidence.
+	s.receipt.IdentityIncomplete = true
+	event := diagnosticTopologyEventBase()
+	event.Kind = DiagnosticTopologyEventVersionAdd
+	event.VersionID = id
+	event.VersionIndex = stack.branchOrder
+	event.NodeID = s.versionNodeID(id, stack)
+	if action := s.currentAction; action != nil {
+		s.applyActionContext(&event, action)
+	}
+	s.appendEvent(event)
+	return id
 }
 
 func diagnosticTopologyEventBase() DiagnosticTopologyEvent {
@@ -529,7 +713,11 @@ func workCountTopologyRecordInitialVersion(stack *glrStack) {
 	if s == nil || stack == nil {
 		return
 	}
-	id := s.versionID(stack)
+	id := s.allocateVersion(stack, 0)
+	if id == 0 {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
 	event := diagnosticTopologyEventBase()
 	event.Kind = DiagnosticTopologyEventVersionAdd
 	event.VersionID = id
@@ -545,7 +733,7 @@ func workCountTopologyPrepareVersionCopy(source, target *glrStack) {
 		return
 	}
 	sourceID := s.versionID(source)
-	targetID := s.allocateVersion(target)
+	targetID := s.allocateVersion(target, sourceID)
 	if sourceID == 0 || targetID == 0 {
 		s.receipt.IdentityIncomplete = true
 		return
@@ -567,7 +755,7 @@ func workCountTopologyRecordVersionCopy(source, target *glrStack) {
 		return
 	}
 	sourceID := s.versionID(source)
-	targetID := s.allocateVersion(target)
+	targetID := s.allocateVersion(target, sourceID)
 	s.recordVersionCopyEvent(target, diagnosticTopologyPendingCopy{
 		sourceVersionID: sourceID,
 		sourceIndex:     source.branchOrder,
@@ -612,6 +800,9 @@ func workCountTopologyRecordAction(stack *glrStack, tok Token, action ParseActio
 		ordinal = -1
 	}
 	versionID := s.versionID(stack)
+	if stack.gss.head == nil {
+		s.syncVersionEntries(versionID, stack)
+	}
 	context := diagnosticTopologyAction{
 		id:        s.nextID(&s.nextActionID),
 		ordinal:   ordinal,
@@ -653,6 +844,9 @@ func workCountTopologyRecordActionResult(stack *glrStack) {
 		return
 	}
 	s.bindVersion(stack, context.versionID)
+	if context.typeID == uint64(ParseActionAccept) && stack.accepted {
+		s.recordAcceptAction(stack, context)
+	}
 	delete(s.actions, stack)
 	if s.currentAction != nil && s.currentAction.id == context.id {
 		s.currentAction = nil
@@ -665,8 +859,15 @@ func workCountTopologyRecordLinkInsert(node, predecessor *gssNode, ordinal int, 
 		return
 	}
 	nodeID := s.nodeID(node)
+	predecessorID := s.nodeID(predecessor)
 	key := diagnosticTopologyLinkKey{nodeID: nodeID, ordinal: uint64(ordinal)}
 	linkID := s.linkIDs[key]
+	if linkID != 0 {
+		if s.linkPrevIDs[key] != predecessorID {
+			s.markIdentityCollision()
+		}
+		return
+	}
 	if linkID == 0 {
 		if !s.identityAvailable(len(s.linkIDs)) {
 			return
@@ -676,12 +877,13 @@ func workCountTopologyRecordLinkInsert(node, predecessor *gssNode, ordinal int, 
 			return
 		}
 		s.linkIDs[key] = linkID
+		s.linkPrevIDs[key] = predecessorID
 	}
 	event := diagnosticTopologyEventBase()
 	event.Kind = DiagnosticTopologyEventLinkInsert
 	event.State = uint64(node.entry.state)
 	event.NodeID = nodeID
-	event.PredecessorNodeID = s.nodeID(predecessor)
+	event.PredecessorNodeID = predecessorID
 	event.LinkID = linkID
 	event.LinkOrdinal = uint64(ordinal)
 	if primary {
@@ -707,6 +909,10 @@ func diagnosticTopologyPayloadCount(window []stackEntry) uint64 {
 }
 
 func workCountTopologyRecordPopPath(stack *glrStack, window []stackEntry, popTo *gssNode, pathOrdinal uint64) {
+	workCountTopologyRecordPopPathWithNodeID(stack, window, popTo, 0, pathOrdinal)
+}
+
+func workCountTopologyRecordPopPathWithNodeID(stack *glrStack, window []stackEntry, popTo *gssNode, popToNodeID, pathOrdinal uint64) {
 	s := activeDiagnosticTopology
 	if s == nil || stack == nil {
 		return
@@ -750,9 +956,12 @@ func workCountTopologyRecordPopPath(stack *glrStack, window []stackEntry, popTo 
 	event.NodeID = s.versionNodeID(action.versionID, stack)
 	event.PopID = action.popID
 	event.PathOrdinal = pathOrdinal
-	event.PopToNodeID = s.nodeID(popTo)
+	event.PopToNodeID = popToNodeID
 	if event.PopToNodeID == 0 {
-		event.PopToNodeID = s.syntheticNodeID()
+		event.PopToNodeID = s.nodeID(popTo)
+	}
+	if event.PopToNodeID == 0 {
+		s.receipt.IdentityIncomplete = true
 	}
 	event.PayloadCount = payloads
 	s.appendEvent(event)
@@ -763,10 +972,34 @@ func workCountTopologyRecordDirectPop(stack *glrStack, childCount int) {
 		return
 	}
 	if childCount == 0 {
+		if stack.entries != nil && stack.gss.head == nil {
+			action, ok := activeDiagnosticTopology.actions[stack]
+			if !ok {
+				activeDiagnosticTopology.receipt.IdentityIncomplete = true
+				return
+			}
+			version := activeDiagnosticTopology.versions[action.versionID]
+			if len(version.entryNodeIDs) != len(stack.entries) || len(version.entryNodeIDs) == 0 {
+				activeDiagnosticTopology.receipt.IdentityIncomplete = true
+				return
+			}
+			workCountTopologyRecordPopPathWithNodeID(stack, nil, nil, version.entryNodeIDs[len(version.entryNodeIDs)-1], 0)
+			return
+		}
 		workCountTopologyRecordPopPath(stack, nil, stack.gss.head, 0)
 		return
 	}
 	if stack.entries != nil {
+		action, ok := activeDiagnosticTopology.actions[stack]
+		if !ok {
+			activeDiagnosticTopology.receipt.IdentityIncomplete = true
+			return
+		}
+		version := activeDiagnosticTopology.versions[action.versionID]
+		if len(version.entryNodeIDs) != len(stack.entries) {
+			activeDiagnosticTopology.receipt.IdentityIncomplete = true
+			return
+		}
 		remaining := childCount
 		start := len(stack.entries)
 		for i := len(stack.entries) - 1; i >= 0; i-- {
@@ -778,7 +1011,11 @@ func workCountTopologyRecordDirectPop(stack *glrStack, childCount int) {
 			if !stackEntryNodeIsExtra(entry) {
 				remaining--
 				if remaining == 0 {
-					workCountTopologyRecordPopPath(stack, stack.entries[start:], nil, 0)
+					popToNodeID := version.emptyNodeID
+					if start > 0 {
+						popToNodeID = version.entryNodeIDs[start-1]
+					}
+					workCountTopologyRecordPopPathWithNodeID(stack, stack.entries[start:], nil, popToNodeID, 0)
 					return
 				}
 			}
@@ -913,34 +1150,91 @@ func workCountTopologyRecordMerge(target, candidate *glrStack, merged bool) {
 	s.appendEvent(event)
 }
 
-func (s *diagnosticTopologyState) acceptCandidateID(stack *glrStack) (uint64, uint64) {
-	versionID := s.versionID(stack)
-	key := diagnosticTopologyAcceptKey{versionID: versionID, head: stack.gss.head, branch: stack.branchOrder}
-	if id := s.acceptIDs[key]; id != 0 {
-		return id, versionID
-	}
-	if !s.identityAvailable(len(s.acceptIDs)) {
-		return 0, versionID
-	}
-	id := s.nextID(&s.nextCandidateID)
-	if id != 0 {
-		s.acceptIDs[key] = id
-	}
-	return id, versionID
+type diagnosticTopologyAcceptCandidate struct {
+	action       diagnosticTopologyAction
+	versionID    uint64
+	stack        glrStack
+	payloadCount uint64
+	candidateID  uint64
 }
 
-func workCountTopologyRecordAcceptElection(incumbent, candidate, selected *glrStack, noIncumbent, candidateSelected bool) {
-	s := activeDiagnosticTopology
-	if s == nil || candidate == nil || selected == nil {
+func diagnosticTopologySnapshotAcceptStack(stack glrStack) glrStack {
+	entries, _ := stack.entriesForRead(nil)
+	stack.entries = append([]stackEntry(nil), entries...)
+	stack.gss = gssStack{}
+	stack.cacheEntries = true
+	return stack
+}
+
+func diagnosticTopologyAcceptPayloadCount(stack *glrStack) uint64 {
+	if stack == nil {
+		return 0
+	}
+	entries, _ := stack.entriesForRead(nil)
+	payloads := 0
+	rootChildren := 0
+	rootFound := false
+	for i := len(entries) - 1; i >= 0; i-- {
+		entry := entries[i]
+		if !stackEntryHasNode(entry) {
+			continue
+		}
+		payloads++
+		if !rootFound && !stackEntryNodeIsExtra(entry) {
+			rootChildren = stackEntryNodeChildCount(entry)
+			rootFound = true
+		}
+	}
+	return uint64(payloads + rootChildren)
+}
+
+func (s *diagnosticTopologyState) recordAcceptAction(stack *glrStack, action diagnosticTopologyAction) {
+	if stack == nil || action.id == 0 || action.typeID != uint64(ParseActionAccept) || action.versionID == 0 {
+		s.receipt.IdentityIncomplete = true
 		return
 	}
-	incumbentID := uint64(0)
-	if incumbent != nil {
-		incumbentID, _ = s.acceptCandidateID(incumbent)
+	if _, ok := s.versions[action.versionID]; !ok {
+		s.receipt.IdentityIncomplete = true
+		return
 	}
-	candidateID, candidateVersionID := s.acceptCandidateID(candidate)
-	selectedID, _ := s.acceptCandidateID(selected)
-	if candidateID == 0 || selectedID == 0 || (!noIncumbent && incumbentID == 0) {
+	paths := expandPackedGSSResultPaths([]glrStack{*stack})
+	skipErrorRank := false
+	if s.trackErrors != nil {
+		skipErrorRank = !*s.trackErrors
+	}
+	for i := range paths {
+		snapshot := diagnosticTopologySnapshotAcceptStack(paths[i])
+		candidate := diagnosticTopologyAcceptCandidate{
+			action:       action,
+			versionID:    action.versionID,
+			stack:        snapshot,
+			payloadCount: diagnosticTopologyAcceptPayloadCount(&snapshot),
+			candidateID:  s.nextID(&s.nextCandidateID),
+		}
+		if candidate.candidateID == 0 {
+			return
+		}
+		selected := !s.acceptSet || stackCompareForResultSelection(
+			s.parser, s.arena, &candidate.stack, &s.acceptCurrent.stack, skipErrorRank,
+		) > 0
+		s.recordAcceptElection(candidate, selected)
+		if selected {
+			s.acceptCurrent = candidate
+			s.acceptSet = true
+		}
+	}
+}
+
+func (s *diagnosticTopologyState) recordAcceptElection(candidate diagnosticTopologyAcceptCandidate, candidateSelected bool) {
+	incumbentID := uint64(0)
+	if s.acceptSet {
+		incumbentID = s.acceptCurrent.candidateID
+	}
+	selectedID := incumbentID
+	if candidateSelected {
+		selectedID = candidate.candidateID
+	}
+	if candidate.candidateID == 0 || selectedID == 0 || (s.acceptSet && incumbentID == 0) {
 		s.receipt.IdentityIncomplete = true
 		return
 	}
@@ -950,14 +1244,15 @@ func workCountTopologyRecordAcceptElection(incumbent, candidate, selected *glrSt
 	}
 	event := diagnosticTopologyEventBase()
 	event.Kind = DiagnosticTopologyEventAcceptElection
-	event.VersionID = candidateVersionID
-	event.VersionIndex = candidate.branchOrder
+	s.applyActionContext(&event, &candidate.action)
+	event.VersionID = candidate.versionID
+	event.VersionIndex = candidate.action.index
 	event.ElectionID = electionID
 	event.IncumbentID = incumbentID
-	event.CandidateID = candidateID
+	event.CandidateID = candidate.candidateID
 	event.SelectedID = selectedID
-	event.PayloadCount = uint64(stackMaterializingResultEntryCount(candidate))
-	if noIncumbent {
+	event.PayloadCount = candidate.payloadCount
+	if !s.acceptSet {
 		event.Flags |= DiagnosticTopologyFlagNoIncumbent
 	}
 	if candidateSelected {

--- a/work_count_topology.go
+++ b/work_count_topology.go
@@ -1,0 +1,967 @@
+//go:build gts_workcount
+
+package gotreesitter
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"math"
+)
+
+const (
+	// DiagnosticTopologyReceiptSchema is the shared Go and locked-C event
+	// contract. The receipt retains a chronological prefix.
+	DiagnosticTopologyReceiptSchema    = "gts-topology-receipt/v1"
+	DiagnosticTopologyReceiptCapacity  = 4096
+	diagnosticTopologyIdentityCapacity = 64 * 1024
+)
+
+const (
+	DiagnosticTopologyEventAction uint64 = iota + 1
+	DiagnosticTopologyEventVersionAdd
+	DiagnosticTopologyEventVersionCopy
+	DiagnosticTopologyEventVersionRenumber
+	DiagnosticTopologyEventMerge
+	DiagnosticTopologyEventLinkInsert
+	DiagnosticTopologyEventPopPath
+	DiagnosticTopologyEventChildElection
+	DiagnosticTopologyEventAcceptElection
+)
+
+const (
+	DiagnosticTopologyFlagSuccessOrSelected uint64 = 1 << iota
+	DiagnosticTopologyFlagPrimaryLink
+	DiagnosticTopologyFlagInitialVersion
+	DiagnosticTopologyFlagTargetReplaced
+	DiagnosticTopologyFlagNoIncumbent
+	DiagnosticTopologyFlagActionContextKnown
+)
+
+const diagnosticTopologyNoActionType = uint64(255)
+
+// DiagnosticTopologyEvent is one event in the shared topology contract.
+// Every field has a fixed uint64 framing position. ActionOrdinal uses -1 when
+// no exact table ordinal is available.
+type DiagnosticTopologyEvent struct {
+	EventID           uint64 `json:"event_id"`
+	Kind              uint64 `json:"kind"`
+	ActionID          uint64 `json:"action_id"`
+	ActionOrdinal     int64  `json:"action_ordinal"`
+	ActionType        uint64 `json:"action_type"`
+	State             uint64 `json:"state"`
+	LookaheadSymbol   uint64 `json:"lookahead_symbol"`
+	ByteOffset        uint64 `json:"byte_offset"`
+	VersionID         uint64 `json:"version_id"`
+	VersionIndex      uint64 `json:"version_index"`
+	SourceVersionID   uint64 `json:"source_version_id"`
+	SourceIndex       uint64 `json:"source_index"`
+	TargetVersionID   uint64 `json:"target_version_id"`
+	TargetIndex       uint64 `json:"target_index"`
+	SurvivorVersionID uint64 `json:"survivor_version_id"`
+	RemovedVersionID  uint64 `json:"removed_version_id"`
+	NodeID            uint64 `json:"node_id"`
+	PredecessorNodeID uint64 `json:"predecessor_node_id"`
+	LinkID            uint64 `json:"link_id"`
+	LinkOrdinal       uint64 `json:"link_ordinal"`
+	PopID             uint64 `json:"pop_id"`
+	PathOrdinal       uint64 `json:"path_ordinal"`
+	PopToNodeID       uint64 `json:"pop_to_node_id"`
+	ElectionID        uint64 `json:"election_id"`
+	IncumbentID       uint64 `json:"incumbent_id"`
+	CandidateID       uint64 `json:"candidate_id"`
+	SelectedID        uint64 `json:"selected_id"`
+	PayloadCount      uint64 `json:"payload_count"`
+	Flags             uint64 `json:"flags"`
+}
+
+// DiagnosticTopologyReceipt is a bounded physical topology receipt. A
+// complete receipt has no truncation, overflow, collision, or incomplete ID.
+type DiagnosticTopologyReceipt struct {
+	Schema             string                    `json:"schema"`
+	Capacity           uint64                    `json:"capacity"`
+	EventsSeen         uint64                    `json:"events_seen"`
+	EventsRetained     uint64                    `json:"events_retained"`
+	EventsDropped      uint64                    `json:"events_dropped"`
+	Truncated          bool                      `json:"truncated"`
+	ArithmeticOverflow bool                      `json:"arithmetic_overflow"`
+	IdentityCollision  bool                      `json:"identity_collision"`
+	IdentityIncomplete bool                      `json:"identity_incomplete"`
+	Events             []DiagnosticTopologyEvent `json:"events"`
+}
+
+// Complete reports whether the receipt retained every event and every ID.
+func (r DiagnosticTopologyReceipt) Complete() bool {
+	return !r.Truncated && !r.ArithmeticOverflow && !r.IdentityCollision && !r.IdentityIncomplete
+}
+
+// SHA256 returns the shared little-endian u64 framing digest.
+func (r DiagnosticTopologyReceipt) SHA256() string {
+	h := sha256.New()
+	_, _ = h.Write([]byte(DiagnosticTopologyReceiptSchema))
+	_, _ = h.Write([]byte{0})
+	write := func(value uint64) {
+		var encoded [8]byte
+		binary.LittleEndian.PutUint64(encoded[:], value)
+		_, _ = h.Write(encoded[:])
+	}
+	write(r.Capacity)
+	write(r.EventsSeen)
+	write(r.EventsRetained)
+	write(r.EventsDropped)
+	write(diagnosticTopologyBool(r.Truncated))
+	write(diagnosticTopologyBool(r.ArithmeticOverflow))
+	write(diagnosticTopologyBool(r.IdentityCollision))
+	write(diagnosticTopologyBool(r.IdentityIncomplete))
+	for i := range r.Events {
+		event := r.Events[i]
+		for _, value := range [...]uint64{
+			event.EventID,
+			event.Kind,
+			event.ActionID,
+			uint64(event.ActionOrdinal),
+			event.ActionType,
+			event.State,
+			event.LookaheadSymbol,
+			event.ByteOffset,
+			event.VersionID,
+			event.VersionIndex,
+			event.SourceVersionID,
+			event.SourceIndex,
+			event.TargetVersionID,
+			event.TargetIndex,
+			event.SurvivorVersionID,
+			event.RemovedVersionID,
+			event.NodeID,
+			event.PredecessorNodeID,
+			event.LinkID,
+			event.LinkOrdinal,
+			event.PopID,
+			event.PathOrdinal,
+			event.PopToNodeID,
+			event.ElectionID,
+			event.IncumbentID,
+			event.CandidateID,
+			event.SelectedID,
+			event.PayloadCount,
+			event.Flags,
+		} {
+			write(value)
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func diagnosticTopologyBool(value bool) uint64 {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+type diagnosticTopologyLinkKey struct {
+	nodeID  uint64
+	ordinal uint64
+}
+
+type diagnosticTopologyVersion struct {
+	id          uint64
+	branchOrder uint64
+	head        *gssNode
+	nodeID      uint64
+}
+
+type diagnosticTopologyStackBinding struct {
+	versionID uint64
+	head      *gssNode
+	branch    uint64
+}
+
+type diagnosticTopologyAction struct {
+	id        uint64
+	ordinal   int64
+	typeID    uint64
+	state     uint64
+	lookahead uint64
+	byte      uint64
+	symbol    uint64
+	versionID uint64
+	index     uint64
+	popID     uint64
+}
+
+type diagnosticTopologyPendingCopy struct {
+	sourceVersionID uint64
+	sourceIndex     uint64
+	targetVersionID uint64
+	targetIndex     uint64
+}
+
+type diagnosticTopologyCandidate struct {
+	id       uint64
+	popID    uint64
+	ordinal  uint64
+	popTo    *gssNode
+	topState StateID
+	window   []stackEntry
+}
+
+type diagnosticTopologyAcceptKey struct {
+	versionID uint64
+	head      *gssNode
+	branch    uint64
+}
+
+type diagnosticTopologyState struct {
+	receipt DiagnosticTopologyReceipt
+
+	nextActionID    uint64
+	nextVersionID   uint64
+	nextNodeID      uint64
+	nextLinkID      uint64
+	nextPopID       uint64
+	nextElectionID  uint64
+	nextCandidateID uint64
+
+	nodeIDs        map[*gssNode]uint64
+	linkIDs        map[diagnosticTopologyLinkKey]uint64
+	versions       map[uint64]diagnosticTopologyVersion
+	stackVersions  map[*glrStack]diagnosticTopologyStackBinding
+	headVersions   map[*gssNode][]uint64
+	branchVersions map[uint64][]uint64
+	actions        map[*glrStack]diagnosticTopologyAction
+	pendingCopies  map[*glrStack]diagnosticTopologyPendingCopy
+	candidates     []diagnosticTopologyCandidate
+	acceptIDs      map[diagnosticTopologyAcceptKey]uint64
+	currentAction  *diagnosticTopologyAction
+}
+
+var activeDiagnosticTopology *diagnosticTopologyState
+
+// BeginDiagnosticTopologyReceipt starts one parse-local topology receipt.
+// It is available only in gts_workcount builds.
+func BeginDiagnosticTopologyReceipt() {
+	if activeDiagnosticTopology != nil {
+		panic("gotreesitter: diagnostic topology receipt already active")
+	}
+	activeDiagnosticTopology = &diagnosticTopologyState{
+		receipt: DiagnosticTopologyReceipt{
+			Schema:   DiagnosticTopologyReceiptSchema,
+			Capacity: DiagnosticTopologyReceiptCapacity,
+			Events:   make([]DiagnosticTopologyEvent, 0, DiagnosticTopologyReceiptCapacity),
+		},
+		nodeIDs:        make(map[*gssNode]uint64),
+		linkIDs:        make(map[diagnosticTopologyLinkKey]uint64),
+		versions:       make(map[uint64]diagnosticTopologyVersion),
+		stackVersions:  make(map[*glrStack]diagnosticTopologyStackBinding),
+		headVersions:   make(map[*gssNode][]uint64),
+		branchVersions: make(map[uint64][]uint64),
+		actions:        make(map[*glrStack]diagnosticTopologyAction),
+		pendingCopies:  make(map[*glrStack]diagnosticTopologyPendingCopy),
+		acceptIDs:      make(map[diagnosticTopologyAcceptKey]uint64),
+	}
+}
+
+// EndDiagnosticTopologyReceipt returns the receipt and releases pointer maps.
+func EndDiagnosticTopologyReceipt() DiagnosticTopologyReceipt {
+	if activeDiagnosticTopology == nil {
+		panic("gotreesitter: diagnostic topology receipt is not active")
+	}
+	state := activeDiagnosticTopology
+	state.receipt.EventsRetained = uint64(len(state.receipt.Events))
+	out := state.receipt
+	activeDiagnosticTopology = nil
+	return out
+}
+
+func (s *diagnosticTopologyState) nextID(slot *uint64) uint64 {
+	if *slot == math.MaxUint64 {
+		s.receipt.ArithmeticOverflow = true
+		s.receipt.IdentityIncomplete = true
+		return 0
+	}
+	*slot++
+	return *slot
+}
+
+func (s *diagnosticTopologyState) appendEvent(event DiagnosticTopologyEvent) {
+	if s == nil {
+		return
+	}
+	if s.receipt.EventsSeen == math.MaxUint64 {
+		s.receipt.ArithmeticOverflow = true
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	s.receipt.EventsSeen++
+	event.EventID = s.receipt.EventsSeen
+	if uint64(len(s.receipt.Events)) < s.receipt.Capacity {
+		s.receipt.Events = append(s.receipt.Events, event)
+		return
+	}
+	s.receipt.Truncated = true
+	if s.receipt.EventsDropped == math.MaxUint64 {
+		s.receipt.ArithmeticOverflow = true
+		return
+	}
+	s.receipt.EventsDropped++
+}
+
+func (s *diagnosticTopologyState) identityAvailable(size int) bool {
+	if size < diagnosticTopologyIdentityCapacity {
+		return true
+	}
+	s.receipt.IdentityIncomplete = true
+	return false
+}
+
+func (s *diagnosticTopologyState) markIdentityCollision() {
+	s.receipt.IdentityCollision = true
+	s.receipt.IdentityIncomplete = true
+}
+
+func workCountTopologyBeginAttempt() {
+	s := activeDiagnosticTopology
+	if s == nil {
+		return
+	}
+	clear(s.stackVersions)
+	clear(s.headVersions)
+	clear(s.branchVersions)
+	clear(s.actions)
+	clear(s.pendingCopies)
+	clear(s.acceptIDs)
+	s.candidates = s.candidates[:0]
+	s.currentAction = nil
+}
+
+func workCountTopologyRecordNodeAllocation(node *gssNode) {
+	s := activeDiagnosticTopology
+	if s == nil || node == nil {
+		return
+	}
+	if !s.identityAvailable(len(s.nodeIDs)) {
+		delete(s.nodeIDs, node)
+		return
+	}
+	id := s.nextID(&s.nextNodeID)
+	if id == 0 {
+		return
+	}
+	s.nodeIDs[node] = id
+}
+
+func (s *diagnosticTopologyState) nodeID(node *gssNode) uint64 {
+	if node == nil {
+		return 0
+	}
+	if id := s.nodeIDs[node]; id != 0 {
+		return id
+	}
+	// Production GSS nodes pass through allocNode. A missing allocation event
+	// means this pointer came from a synthetic or unsupported construction.
+	s.receipt.IdentityIncomplete = true
+	if !s.identityAvailable(len(s.nodeIDs)) {
+		return 0
+	}
+	id := s.nextID(&s.nextNodeID)
+	if id != 0 {
+		s.nodeIDs[node] = id
+	}
+	return id
+}
+
+func diagnosticTopologyStackState(stack *glrStack) uint64 {
+	if stack == nil || stack.depth() == 0 {
+		return 0
+	}
+	return uint64(stack.top().state)
+}
+
+func (s *diagnosticTopologyState) removeHeadVersion(head *gssNode, id uint64) {
+	if head == nil || id == 0 {
+		return
+	}
+	ids := s.headVersions[head]
+	for i := range ids {
+		if ids[i] != id {
+			continue
+		}
+		ids = append(ids[:i], ids[i+1:]...)
+		if len(ids) == 0 {
+			delete(s.headVersions, head)
+		} else {
+			s.headVersions[head] = ids
+		}
+		return
+	}
+}
+
+func (s *diagnosticTopologyState) bindVersion(stack *glrStack, id uint64) {
+	if stack == nil || id == 0 {
+		return
+	}
+	version, ok := s.versions[id]
+	if !ok {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	newHead := stack.gss.head
+	if version.head != newHead {
+		s.removeHeadVersion(version.head, id)
+		if newHead != nil {
+			s.headVersions[newHead] = append(s.headVersions[newHead], id)
+		}
+	}
+	version.head = newHead
+	version.branchOrder = stack.branchOrder
+	if newHead != nil {
+		version.nodeID = s.nodeID(newHead)
+	}
+	s.versions[id] = version
+	s.stackVersions[stack] = diagnosticTopologyStackBinding{versionID: id, head: newHead, branch: stack.branchOrder}
+}
+
+func (s *diagnosticTopologyState) allocateVersion(stack *glrStack) uint64 {
+	if stack == nil || !s.identityAvailable(len(s.versions)) {
+		return 0
+	}
+	id := s.nextID(&s.nextVersionID)
+	if id == 0 {
+		return 0
+	}
+	s.versions[id] = diagnosticTopologyVersion{id: id, branchOrder: stack.branchOrder}
+	s.branchVersions[stack.branchOrder] = append(s.branchVersions[stack.branchOrder], id)
+	s.bindVersion(stack, id)
+	version := s.versions[id]
+	if version.nodeID == 0 {
+		version.nodeID = s.nextID(&s.nextNodeID)
+		s.versions[id] = version
+	}
+	return id
+}
+
+func (s *diagnosticTopologyState) versionNodeID(versionID uint64, stack *glrStack) uint64 {
+	if stack != nil && stack.gss.head != nil {
+		return s.nodeID(stack.gss.head)
+	}
+	version, ok := s.versions[versionID]
+	if !ok || versionID == 0 {
+		s.receipt.IdentityIncomplete = true
+		return 0
+	}
+	if version.nodeID == 0 {
+		version.nodeID = s.nextID(&s.nextNodeID)
+		s.versions[versionID] = version
+	}
+	return version.nodeID
+}
+
+func (s *diagnosticTopologyState) syntheticNodeID() uint64 {
+	return s.nextID(&s.nextNodeID)
+}
+
+func (s *diagnosticTopologyState) versionID(stack *glrStack) uint64 {
+	if stack == nil {
+		return 0
+	}
+	if binding, ok := s.stackVersions[stack]; ok {
+		if binding.head == stack.gss.head && binding.branch == stack.branchOrder {
+			return binding.versionID
+		}
+		delete(s.stackVersions, stack)
+	}
+	if ids := s.branchVersions[stack.branchOrder]; len(ids) != 0 {
+		matched := uint64(0)
+		for _, id := range ids {
+			version := s.versions[id]
+			if version.head != stack.gss.head {
+				continue
+			}
+			if matched != 0 && matched != id {
+				s.markIdentityCollision()
+				return 0
+			}
+			matched = id
+		}
+		if matched != 0 {
+			s.bindVersion(stack, matched)
+			return matched
+		}
+		// A unique branch can move from its contiguous entries form to a GSS
+		// head without creating a new version. Bind that physical promotion to
+		// the existing lineage.
+		if len(ids) == 1 {
+			s.bindVersion(stack, ids[0])
+			return ids[0]
+		}
+	}
+	if stack.gss.head != nil {
+		ids := s.headVersions[stack.gss.head]
+		if len(ids) == 1 {
+			s.bindVersion(stack, ids[0])
+			return ids[0]
+		}
+		if len(ids) > 1 {
+			s.receipt.IdentityIncomplete = true
+			return 0
+		}
+	}
+	return s.allocateVersion(stack)
+}
+
+func diagnosticTopologyEventBase() DiagnosticTopologyEvent {
+	return DiagnosticTopologyEvent{ActionOrdinal: -1, ActionType: diagnosticTopologyNoActionType}
+}
+
+func (s *diagnosticTopologyState) applyActionContext(event *DiagnosticTopologyEvent, action *diagnosticTopologyAction) {
+	if event == nil || action == nil {
+		return
+	}
+	event.ActionID = action.id
+	event.ActionOrdinal = action.ordinal
+	event.ActionType = action.typeID
+	event.Flags |= DiagnosticTopologyFlagActionContextKnown
+}
+
+func workCountTopologyRecordInitialVersion(stack *glrStack) {
+	s := activeDiagnosticTopology
+	if s == nil || stack == nil {
+		return
+	}
+	id := s.versionID(stack)
+	event := diagnosticTopologyEventBase()
+	event.Kind = DiagnosticTopologyEventVersionAdd
+	event.VersionID = id
+	event.VersionIndex = stack.branchOrder
+	event.NodeID = s.versionNodeID(id, stack)
+	event.Flags = DiagnosticTopologyFlagInitialVersion
+	s.appendEvent(event)
+}
+
+func workCountTopologyPrepareVersionCopy(source, target *glrStack) {
+	s := activeDiagnosticTopology
+	if s == nil || source == nil || target == nil {
+		return
+	}
+	sourceID := s.versionID(source)
+	targetID := s.allocateVersion(target)
+	if sourceID == 0 || targetID == 0 {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	if previous, ok := s.pendingCopies[target]; ok && previous.targetVersionID != targetID {
+		s.markIdentityCollision()
+	}
+	s.pendingCopies[target] = diagnosticTopologyPendingCopy{
+		sourceVersionID: sourceID,
+		sourceIndex:     source.branchOrder,
+		targetVersionID: targetID,
+		targetIndex:     target.branchOrder,
+	}
+}
+
+func workCountTopologyRecordVersionCopy(source, target *glrStack) {
+	s := activeDiagnosticTopology
+	if s == nil || source == nil || target == nil {
+		return
+	}
+	sourceID := s.versionID(source)
+	targetID := s.allocateVersion(target)
+	s.recordVersionCopyEvent(target, diagnosticTopologyPendingCopy{
+		sourceVersionID: sourceID,
+		sourceIndex:     source.branchOrder,
+		targetVersionID: targetID,
+		targetIndex:     target.branchOrder,
+	}, s.currentAction)
+}
+
+func workCountTopologyCommitVersion(stack *glrStack) {
+	s := activeDiagnosticTopology
+	if s == nil || stack == nil {
+		return
+	}
+	binding, ok := s.stackVersions[stack]
+	if !ok || binding.versionID == 0 {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	s.bindVersion(stack, binding.versionID)
+}
+
+func (s *diagnosticTopologyState) recordVersionCopyEvent(target *glrStack, copy diagnosticTopologyPendingCopy, action *diagnosticTopologyAction) {
+	event := diagnosticTopologyEventBase()
+	event.Kind = DiagnosticTopologyEventVersionCopy
+	event.VersionID = copy.targetVersionID
+	event.VersionIndex = copy.targetIndex
+	event.SourceVersionID = copy.sourceVersionID
+	event.SourceIndex = copy.sourceIndex
+	event.NodeID = s.versionNodeID(copy.targetVersionID, target)
+	s.applyActionContext(&event, action)
+	s.appendEvent(event)
+}
+
+func workCountTopologyRecordAction(stack *glrStack, tok Token, action ParseAction, actionOrdinal int) {
+	s := activeDiagnosticTopology
+	if s == nil || stack == nil {
+		return
+	}
+	workCountTopologyRecordActionResult(stack)
+	ordinal := int64(actionOrdinal)
+	if actionOrdinal < 0 {
+		ordinal = -1
+	}
+	versionID := s.versionID(stack)
+	context := diagnosticTopologyAction{
+		id:        s.nextID(&s.nextActionID),
+		ordinal:   ordinal,
+		typeID:    uint64(action.Type),
+		state:     diagnosticTopologyStackState(stack),
+		lookahead: uint64(tok.Symbol),
+		byte:      uint64(stack.byteOffset),
+		symbol:    uint64(action.Symbol),
+		versionID: versionID,
+		index:     stack.branchOrder,
+	}
+	event := diagnosticTopologyEventBase()
+	event.Kind = DiagnosticTopologyEventAction
+	event.ActionID = context.id
+	event.ActionOrdinal = context.ordinal
+	event.ActionType = context.typeID
+	event.State = context.state
+	event.LookaheadSymbol = context.lookahead
+	event.ByteOffset = context.byte
+	event.VersionID = versionID
+	event.VersionIndex = context.index
+	event.Flags = DiagnosticTopologyFlagActionContextKnown
+	s.appendEvent(event)
+	s.actions[stack] = context
+	s.currentAction = &context
+	if copy, ok := s.pendingCopies[stack]; ok {
+		s.recordVersionCopyEvent(stack, copy, &context)
+		delete(s.pendingCopies, stack)
+	}
+}
+
+func workCountTopologyRecordActionResult(stack *glrStack) {
+	s := activeDiagnosticTopology
+	if s == nil || stack == nil {
+		return
+	}
+	context, ok := s.actions[stack]
+	if !ok {
+		return
+	}
+	s.bindVersion(stack, context.versionID)
+	delete(s.actions, stack)
+	if s.currentAction != nil && s.currentAction.id == context.id {
+		s.currentAction = nil
+	}
+}
+
+func workCountTopologyRecordLinkInsert(node, predecessor *gssNode, ordinal int, primary bool) {
+	s := activeDiagnosticTopology
+	if s == nil || node == nil || predecessor == nil || ordinal < 0 {
+		return
+	}
+	nodeID := s.nodeID(node)
+	key := diagnosticTopologyLinkKey{nodeID: nodeID, ordinal: uint64(ordinal)}
+	linkID := s.linkIDs[key]
+	if linkID == 0 {
+		if !s.identityAvailable(len(s.linkIDs)) {
+			return
+		}
+		linkID = s.nextID(&s.nextLinkID)
+		if linkID == 0 {
+			return
+		}
+		s.linkIDs[key] = linkID
+	}
+	event := diagnosticTopologyEventBase()
+	event.Kind = DiagnosticTopologyEventLinkInsert
+	event.State = uint64(node.entry.state)
+	event.NodeID = nodeID
+	event.PredecessorNodeID = s.nodeID(predecessor)
+	event.LinkID = linkID
+	event.LinkOrdinal = uint64(ordinal)
+	if primary {
+		event.Flags |= DiagnosticTopologyFlagPrimaryLink
+	}
+	if action := s.currentAction; action != nil {
+		s.applyActionContext(&event, action)
+	}
+	s.appendEvent(event)
+}
+
+func diagnosticTopologyPayloadCount(window []stackEntry) uint64 {
+	var payloads uint64
+	for i := range window {
+		if stackEntryHasNode(window[i]) {
+			if payloads == math.MaxUint64 {
+				return math.MaxUint64
+			}
+			payloads++
+		}
+	}
+	return payloads
+}
+
+func workCountTopologyRecordPopPath(stack *glrStack, window []stackEntry, popTo *gssNode, pathOrdinal uint64) {
+	s := activeDiagnosticTopology
+	if s == nil || stack == nil {
+		return
+	}
+	action, ok := s.actions[stack]
+	if !ok {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	if action.popID == 0 {
+		action.popID = s.nextID(&s.nextPopID)
+		s.actions[stack] = action
+		if s.currentAction != nil && s.currentAction.id == action.id {
+			s.currentAction = &action
+		}
+	}
+	if len(s.candidates) < diagnosticTopologyIdentityCapacity {
+		windowCopy := append([]stackEntry(nil), window...)
+		topState := StateID(0)
+		if popTo != nil {
+			topState = popTo.entry.state
+		}
+		s.candidates = append(s.candidates, diagnosticTopologyCandidate{
+			popID: action.popID, ordinal: pathOrdinal,
+			popTo: popTo, topState: topState, window: windowCopy,
+		})
+	} else {
+		s.receipt.IdentityIncomplete = true
+	}
+	payloads := diagnosticTopologyPayloadCount(window)
+	if payloads == math.MaxUint64 {
+		s.receipt.ArithmeticOverflow = true
+	}
+	event := diagnosticTopologyEventBase()
+	event.Kind = DiagnosticTopologyEventPopPath
+	s.applyActionContext(&event, &action)
+	event.VersionID = action.versionID
+	event.VersionIndex = action.index
+	event.SourceVersionID = action.versionID
+	event.SourceIndex = action.index
+	event.NodeID = s.versionNodeID(action.versionID, stack)
+	event.PopID = action.popID
+	event.PathOrdinal = pathOrdinal
+	event.PopToNodeID = s.nodeID(popTo)
+	if event.PopToNodeID == 0 {
+		event.PopToNodeID = s.syntheticNodeID()
+	}
+	event.PayloadCount = payloads
+	s.appendEvent(event)
+}
+
+func workCountTopologyRecordDirectPop(stack *glrStack, childCount int) {
+	if activeDiagnosticTopology == nil || stack == nil || childCount < 0 {
+		return
+	}
+	if childCount == 0 {
+		workCountTopologyRecordPopPath(stack, nil, stack.gss.head, 0)
+		return
+	}
+	if stack.entries != nil {
+		remaining := childCount
+		start := len(stack.entries)
+		for i := len(stack.entries) - 1; i >= 0; i-- {
+			entry := stack.entries[i]
+			if !stackEntryHasNode(entry) {
+				continue
+			}
+			start = i
+			if !stackEntryNodeIsExtra(entry) {
+				remaining--
+				if remaining == 0 {
+					workCountTopologyRecordPopPath(stack, stack.entries[start:], nil, 0)
+					return
+				}
+			}
+		}
+		return
+	}
+	if stack.gss.head == nil || !gssSpanIsLinear(stack.gss.head, childCount) {
+		return
+	}
+	remaining := childCount
+	window := make([]stackEntry, 0, childCount)
+	var popTo *gssNode
+	for node := stack.gss.head; node != nil; node = node.prev {
+		entry := node.entry
+		if !stackEntryHasNode(entry) {
+			continue
+		}
+		window = append(window, entry)
+		if !stackEntryNodeIsExtra(entry) {
+			remaining--
+			if remaining == 0 {
+				popTo = node.prev
+				break
+			}
+		}
+	}
+	if remaining == 0 {
+		for left, right := 0, len(window)-1; left < right; left, right = left+1, right-1 {
+			window[left], window[right] = window[right], window[left]
+		}
+		workCountTopologyRecordPopPath(stack, window, popTo, 0)
+	}
+}
+
+func diagnosticTopologyWindowsEqual(a, b []stackEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *diagnosticTopologyState) reduceCandidateID(fork reduceFork) uint64 {
+	for i := len(s.candidates) - 1; i >= 0; i-- {
+		candidate := &s.candidates[i]
+		if candidate.popTo == fork.popTo && candidate.topState == fork.topState &&
+			diagnosticTopologyWindowsEqual(candidate.window, fork.window) {
+			if candidate.id == 0 {
+				candidate.id = s.nextID(&s.nextCandidateID)
+			}
+			return candidate.id
+		}
+	}
+	s.receipt.IdentityIncomplete = true
+	return 0
+}
+
+func workCountTopologyRecordChildElection(stack *glrStack, incumbent, candidate reduceFork, preference int) {
+	s := activeDiagnosticTopology
+	if s == nil || stack == nil || (preference != -1 && preference != 1) {
+		return
+	}
+	action, ok := s.actions[stack]
+	if !ok {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	incumbentID := s.reduceCandidateID(incumbent)
+	candidateID := s.reduceCandidateID(candidate)
+	if incumbentID == 0 || candidateID == 0 {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	selectedID := uint64(0)
+	flags := uint64(0)
+	switch preference {
+	case -1:
+		selectedID = candidateID
+		flags = DiagnosticTopologyFlagSuccessOrSelected
+	case 1:
+		selectedID = incumbentID
+	}
+	electionID := s.nextID(&s.nextElectionID)
+	if electionID == 0 {
+		return
+	}
+	event := diagnosticTopologyEventBase()
+	event.Kind = DiagnosticTopologyEventChildElection
+	s.applyActionContext(&event, &action)
+	event.State = action.symbol
+	event.VersionID = action.versionID
+	event.VersionIndex = action.index
+	event.ElectionID = electionID
+	event.IncumbentID = incumbentID
+	event.CandidateID = candidateID
+	event.SelectedID = selectedID
+	event.PayloadCount = diagnosticTopologyPayloadCount(candidate.window)
+	event.Flags |= flags
+	s.appendEvent(event)
+}
+
+func workCountTopologyRecordMerge(target, candidate *glrStack, merged bool) {
+	s := activeDiagnosticTopology
+	if s == nil || target == nil || candidate == nil {
+		return
+	}
+	targetID := s.versionID(target)
+	candidateID := s.versionID(candidate)
+	event := diagnosticTopologyEventBase()
+	event.Kind = DiagnosticTopologyEventMerge
+	event.VersionID = targetID
+	event.VersionIndex = target.branchOrder
+	event.SourceVersionID = targetID
+	event.SourceIndex = target.branchOrder
+	event.TargetVersionID = candidateID
+	event.TargetIndex = candidate.branchOrder
+	event.SurvivorVersionID = targetID
+	event.RemovedVersionID = candidateID
+	event.NodeID = s.versionNodeID(targetID, target)
+	event.PredecessorNodeID = s.versionNodeID(candidateID, candidate)
+	if merged {
+		event.Flags |= DiagnosticTopologyFlagSuccessOrSelected
+		s.bindVersion(target, targetID)
+	}
+	if action := s.currentAction; action != nil {
+		s.applyActionContext(&event, action)
+	}
+	s.appendEvent(event)
+}
+
+func (s *diagnosticTopologyState) acceptCandidateID(stack *glrStack) (uint64, uint64) {
+	versionID := s.versionID(stack)
+	key := diagnosticTopologyAcceptKey{versionID: versionID, head: stack.gss.head, branch: stack.branchOrder}
+	if id := s.acceptIDs[key]; id != 0 {
+		return id, versionID
+	}
+	if !s.identityAvailable(len(s.acceptIDs)) {
+		return 0, versionID
+	}
+	id := s.nextID(&s.nextCandidateID)
+	if id != 0 {
+		s.acceptIDs[key] = id
+	}
+	return id, versionID
+}
+
+func workCountTopologyRecordAcceptElection(incumbent, candidate, selected *glrStack, noIncumbent, candidateSelected bool) {
+	s := activeDiagnosticTopology
+	if s == nil || candidate == nil || selected == nil {
+		return
+	}
+	incumbentID := uint64(0)
+	if incumbent != nil {
+		incumbentID, _ = s.acceptCandidateID(incumbent)
+	}
+	candidateID, candidateVersionID := s.acceptCandidateID(candidate)
+	selectedID, _ := s.acceptCandidateID(selected)
+	if candidateID == 0 || selectedID == 0 || (!noIncumbent && incumbentID == 0) {
+		s.receipt.IdentityIncomplete = true
+		return
+	}
+	electionID := s.nextID(&s.nextElectionID)
+	if electionID == 0 {
+		return
+	}
+	event := diagnosticTopologyEventBase()
+	event.Kind = DiagnosticTopologyEventAcceptElection
+	event.VersionID = candidateVersionID
+	event.VersionIndex = candidate.branchOrder
+	event.ElectionID = electionID
+	event.IncumbentID = incumbentID
+	event.CandidateID = candidateID
+	event.SelectedID = selectedID
+	event.PayloadCount = uint64(stackMaterializingResultEntryCount(candidate))
+	if noIncumbent {
+		event.Flags |= DiagnosticTopologyFlagNoIncumbent
+	}
+	if candidateSelected {
+		event.Flags |= DiagnosticTopologyFlagSuccessOrSelected
+	}
+	s.appendEvent(event)
+}

--- a/work_count_topology_internal_test.go
+++ b/work_count_topology_internal_test.go
@@ -2,7 +2,10 @@
 
 package gotreesitter
 
-import "testing"
+import (
+	"testing"
+	"unsafe"
+)
 
 func TestDiagnosticTopologyReceiptBoundsChronologicalPrefix(t *testing.T) {
 	BeginDiagnosticTopologyReceipt()
@@ -64,7 +67,7 @@ func TestDiagnosticTopologyReceiptPreservesEntriesPrefixAcrossPromotionAndCopy(t
 	clone := stack.cloneWithScratch(&scratch)
 	clone.branchOrder = 1
 	workCountTopologyRecordVersionCopy(&stack, &clone)
-	copyVersionID := activeDiagnosticTopology.stackVersions[&clone].versionID
+	copyVersionID := clone.diagnosticTopology.versionID
 	copyVersion := activeDiagnosticTopology.versions[copyVersionID]
 	if got := activeDiagnosticTopology.nodeID(stack.gss.head); got != initialNodeID {
 		t.Fatalf("promoted head ID = %d, want initial ID %d", got, initialNodeID)
@@ -95,6 +98,450 @@ func TestDiagnosticTopologyReceiptPreservesEntriesPrefixAcrossPromotionAndCopy(t
 	}
 }
 
+func TestDiagnosticTopologyReceiptSeparatesMutatedEntriesCopiesBeforePromotion(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	source := glrStack{entries: []stackEntry{{state: 1}, {state: 2}}, branchOrder: 41}
+	workCountTopologyRecordInitialVersion(&source)
+	first := source.clone()
+	first.branchOrder = 99
+	workCountTopologyRecordVersionCopy(&source, &first)
+	second := source.clone()
+	second.branchOrder = 7
+	workCountTopologyRecordVersionCopy(&source, &second)
+
+	first.entries[1].state = 3
+	workCountTopologyCommitVersion(&first)
+	firstID := first.diagnosticTopology.versionID
+	secondID := second.diagnosticTopology.versionID
+	firstPrefix := append([]uint64(nil), activeDiagnosticTopology.versions[firstID].entryNodeIDs...)
+	secondPrefix := append([]uint64(nil), activeDiagnosticTopology.versions[secondID].entryNodeIDs...)
+	if len(firstPrefix) != 2 || len(secondPrefix) != 2 || firstPrefix[0] != secondPrefix[0] || firstPrefix[1] == secondPrefix[1] {
+		t.Fatalf("copy prefix IDs = %v/%v, want one shared and one distinct slot", firstPrefix, secondPrefix)
+	}
+
+	var scratch gssScratch
+	first.ensureGSS(&scratch)
+	second.ensureGSS(&scratch)
+	if first.gss.head == nil || first.gss.head.prev == nil || second.gss.head == nil || second.gss.head.prev == nil {
+		t.Fatal("promoted copies have an incomplete graph stack")
+	}
+	if got := activeDiagnosticTopology.nodeID(first.gss.head.prev); got != firstPrefix[0] {
+		t.Fatalf("first shared prefix node ID = %d, want %d", got, firstPrefix[0])
+	}
+	if got := activeDiagnosticTopology.nodeID(second.gss.head.prev); got != secondPrefix[0] {
+		t.Fatalf("second shared prefix node ID = %d, want %d", got, secondPrefix[0])
+	}
+	if got := activeDiagnosticTopology.nodeID(first.gss.head); got != firstPrefix[1] {
+		t.Fatalf("first mutated head node ID = %d, want %d", got, firstPrefix[1])
+	}
+	if got := activeDiagnosticTopology.nodeID(second.gss.head); got != secondPrefix[1] {
+		t.Fatalf("second original head node ID = %d, want %d", got, secondPrefix[1])
+	}
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.Complete() {
+		t.Fatalf("two-copy promotion receipt is incomplete: %+v", receipt)
+	}
+}
+
+func TestDiagnosticTopologyReceiptRetiresMergedSlotAndRenumbersLaterVersions(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	source := glrStack{entries: []stackEntry{{state: 1}}, branchOrder: 41}
+	workCountTopologyRecordInitialVersion(&source)
+	removed := source.clone()
+	removed.branchOrder = 99
+	workCountTopologyRecordVersionCopy(&source, &removed)
+	later := source.clone()
+	later.branchOrder = 7
+	workCountTopologyRecordVersionCopy(&source, &later)
+	removedID := removed.diagnosticTopology.versionID
+	laterID := later.diagnosticTopology.versionID
+	workCountTopologyRecordMerge(&source, &removed, true)
+
+	if _, ok := activeDiagnosticTopology.versions[removedID]; ok {
+		t.Fatalf("merged version %d remains bound", removedID)
+	}
+	if got := activeDiagnosticTopology.versions[laterID].index; got != 1 {
+		t.Fatalf("later version index = %d, want 1", got)
+	}
+	if len(activeDiagnosticTopology.versionSlots) != 2 || activeDiagnosticTopology.versionSlots[0] != source.diagnosticTopology.versionID || activeDiagnosticTopology.versionSlots[1] != laterID {
+		t.Fatalf("physical version slots = %v", activeDiagnosticTopology.versionSlots)
+	}
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.Complete() {
+		t.Fatalf("merge retirement receipt is incomplete: %+v", receipt)
+	}
+	if len(receipt.Events) != 5 {
+		t.Fatalf("merge retirement events = %d, want 5: %+v", len(receipt.Events), receipt.Events)
+	}
+	merge := receipt.Events[3]
+	renumber := receipt.Events[4]
+	if merge.Kind != DiagnosticTopologyEventMerge || merge.SourceIndex != 0 || merge.TargetIndex != 1 || merge.RemovedVersionID != removedID {
+		t.Fatalf("merge event = %+v", merge)
+	}
+	if renumber.Kind != DiagnosticTopologyEventVersionRenumber || renumber.VersionID != laterID || renumber.SourceIndex != 2 || renumber.TargetIndex != 1 || renumber.TargetVersionID != removedID || renumber.Flags&DiagnosticTopologyFlagTargetReplaced == 0 {
+		t.Fatalf("renumber event = %+v", renumber)
+	}
+}
+
+func TestDiagnosticTopologyReceiptRenumbersLaterSourceOntoTargetSlot(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	initial := glrStack{entries: []stackEntry{{state: 1}}}
+	workCountTopologyRecordInitialVersion(&initial)
+	target := initial.clone()
+	workCountTopologyRecordVersionCopy(&initial, &target)
+	middle := initial.clone()
+	workCountTopologyRecordVersionCopy(&initial, &middle)
+	source := initial.clone()
+	workCountTopologyRecordVersionCopy(&initial, &source)
+	later := initial.clone()
+	workCountTopologyRecordVersionCopy(&initial, &later)
+	targetID := target.diagnosticTopology.versionID
+	middleID := middle.diagnosticTopology.versionID
+	sourceID := source.diagnosticTopology.versionID
+	laterID := later.diagnosticTopology.versionID
+
+	workCountTopologyRenumberVersion(&source, &target)
+	if _, ok := activeDiagnosticTopology.versions[targetID]; ok {
+		t.Fatalf("replaced target version %d remains bound", targetID)
+	}
+	wantSlots := []uint64{initial.diagnosticTopology.versionID, sourceID, middleID, laterID}
+	if len(activeDiagnosticTopology.versionSlots) != len(wantSlots) {
+		t.Fatalf("renumbered slots = %v, want %v", activeDiagnosticTopology.versionSlots, wantSlots)
+	}
+	for i := range wantSlots {
+		if activeDiagnosticTopology.versionSlots[i] != wantSlots[i] || activeDiagnosticTopology.versions[wantSlots[i]].index != uint64(i) {
+			t.Fatalf("renumbered slots = %v, want %v", activeDiagnosticTopology.versionSlots, wantSlots)
+		}
+	}
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.Complete() {
+		t.Fatalf("explicit renumber receipt is incomplete: %+v", receipt)
+	}
+	if len(receipt.Events) != 7 {
+		t.Fatalf("explicit renumber events = %d, want 7: %+v", len(receipt.Events), receipt.Events)
+	}
+	direct := receipt.Events[5]
+	shift := receipt.Events[6]
+	if direct.Kind != DiagnosticTopologyEventVersionRenumber || direct.VersionID != sourceID || direct.SourceIndex != 3 || direct.TargetIndex != 1 || direct.TargetVersionID != targetID {
+		t.Fatalf("direct renumber event = %+v", direct)
+	}
+	if shift.Kind != DiagnosticTopologyEventVersionRenumber || shift.VersionID != laterID || shift.SourceIndex != 4 || shift.TargetIndex != 3 || shift.TargetVersionID != sourceID {
+		t.Fatalf("source-slot shift event = %+v", shift)
+	}
+}
+
+func TestDiagnosticTopologyReceiptRenumberRejectsAliasedMutationBindings(t *testing.T) {
+	t.Run("action", func(t *testing.T) {
+		BeginDiagnosticTopologyReceipt()
+		initial := glrStack{entries: []stackEntry{{state: 1}}}
+		workCountTopologyRecordInitialVersion(&initial)
+		target := initial.clone()
+		workCountTopologyRecordVersionCopy(&initial, &target)
+		source := initial.clone()
+		workCountTopologyRecordVersionCopy(&initial, &source)
+		alias := source
+		workCountTopologyRecordAction(&alias, Token{Symbol: 1}, ParseAction{Type: ParseActionShift}, 0)
+		workCountTopologyRenumberVersion(&source, &target)
+		slotCount := len(activeDiagnosticTopology.versionSlots)
+		receipt := EndDiagnosticTopologyReceipt()
+		if !receipt.IdentityIncomplete || slotCount != 3 {
+			t.Fatalf("action-bound renumber state = %+v, slots=%d", receipt, slotCount)
+		}
+	})
+
+	t.Run("pending-copy", func(t *testing.T) {
+		BeginDiagnosticTopologyReceipt()
+		initial := glrStack{entries: []stackEntry{{state: 1}}}
+		workCountTopologyRecordInitialVersion(&initial)
+		target := initial.clone()
+		workCountTopologyRecordVersionCopy(&initial, &target)
+		pending := initial.clone()
+		workCountTopologyPrepareVersionCopy(&initial, &pending)
+		alias := pending
+		workCountTopologyRenumberVersion(&alias, &target)
+		slotCount := len(activeDiagnosticTopology.versionSlots)
+		receipt := EndDiagnosticTopologyReceipt()
+		if !receipt.IdentityIncomplete || slotCount != 3 {
+			t.Fatalf("copy-bound renumber state = %+v, slots=%d", receipt, slotCount)
+		}
+	})
+}
+
+func TestDiagnosticTopologyReceiptRetiresOnlyUnpublishedVersions(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	initial := glrStack{entries: []stackEntry{{state: 1}}}
+	workCountTopologyRecordInitialVersion(&initial)
+	omitted := initial.clone()
+	workCountTopologyRecordVersionCopy(&initial, &omitted)
+	published := initial.clone()
+	workCountTopologyRecordVersionCopy(&initial, &published)
+	omittedID := omitted.diagnosticTopology.versionID
+	publishedID := published.diagnosticTopology.versionID
+	workCountTopologyRetireUnpublishedVersions([]glrStack{omitted, published}, []glrStack{published})
+	if _, ok := activeDiagnosticTopology.versions[omittedID]; ok {
+		t.Fatalf("omitted version %d remains active", omittedID)
+	}
+	if slots := activeDiagnosticTopology.versionSlots; len(slots) != 2 || slots[1] != publishedID {
+		t.Fatalf("published slots = %v, want initial then %d", slots, publishedID)
+	}
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.Complete() {
+		t.Fatalf("unpublished-version receipt is incomplete: %+v", receipt)
+	}
+	last := receipt.Events[len(receipt.Events)-1]
+	if last.Kind != DiagnosticTopologyEventVersionRenumber || last.VersionID != publishedID || last.SourceIndex != 2 || last.TargetIndex != 1 || last.TargetVersionID != omittedID {
+		t.Fatalf("published-version shift = %+v", last)
+	}
+}
+
+func TestDiagnosticTopologyReceiptReplacementAndCullDoNotDoubleRenumber(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	incumbent := glrStack{entries: []stackEntry{{state: 1}}, score: 1}
+	workCountTopologyRecordInitialVersion(&incumbent)
+	candidate := incumbent.clone()
+	candidate.score = 2
+	workCountTopologyRecordVersionCopy(&incumbent, &candidate)
+	culled := incumbent.clone()
+	culled.entries[0].state = 2
+	culled.score = 0
+	workCountTopologyRecordVersionCopy(&incumbent, &culled)
+	workCountTopologyCommitVersion(&culled)
+	incumbentID := incumbent.diagnosticTopology.versionID
+	candidateID := candidate.diagnosticTopology.versionID
+	culledID := culled.diagnosticTopology.versionID
+	before := []glrStack{incumbent, candidate, culled}
+	topologyBefore := append([]glrStack(nil), before...)
+
+	var scratch glrMergeScratch
+	scratch.perKeyCap = 1
+	scratch.beginEquivEpoch()
+	merged := mergeStacksWithScratch(before, &scratch)
+	if len(merged) != 2 || merged[0].diagnosticTopology.versionID != candidateID {
+		t.Fatalf("replacement survivors = %+v, want candidate %d first", merged, candidateID)
+	}
+	kept := retainTopStacksForLanguage(merged, 1, nil)
+	workCountTopologyRetireMissingVersions(topologyBefore, kept)
+
+	if len(activeDiagnosticTopology.versionSlots) != 1 || activeDiagnosticTopology.versionSlots[0] != candidateID {
+		t.Fatalf("physical version slots = %v, want [%d]", activeDiagnosticTopology.versionSlots, candidateID)
+	}
+	if _, ok := activeDiagnosticTopology.versions[incumbentID]; ok {
+		t.Fatalf("replaced incumbent version %d remains bound", incumbentID)
+	}
+	if _, ok := activeDiagnosticTopology.versions[culledID]; ok {
+		t.Fatalf("culled version %d remains bound", culledID)
+	}
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.Complete() {
+		t.Fatalf("replacement/cull receipt is incomplete: %+v", receipt)
+	}
+	var renumbers []DiagnosticTopologyEvent
+	for _, event := range receipt.Events {
+		if event.Kind == DiagnosticTopologyEventVersionRenumber {
+			renumbers = append(renumbers, event)
+		}
+	}
+	if len(renumbers) != 2 {
+		t.Fatalf("replacement/cull renumbers = %d, want 2: %+v", len(renumbers), renumbers)
+	}
+	direct := renumbers[0]
+	if direct.SourceVersionID != candidateID || direct.SourceIndex != 1 || direct.TargetVersionID != incumbentID || direct.TargetIndex != 0 {
+		t.Fatalf("replacement renumber = %+v", direct)
+	}
+	shift := renumbers[1]
+	if shift.SourceVersionID != culledID || shift.SourceIndex != 2 || shift.TargetVersionID != candidateID || shift.TargetIndex != 1 {
+		t.Fatalf("replacement tail shift = %+v", shift)
+	}
+}
+
+func TestDiagnosticTopologyReceiptReconcilesDeadRemovalBeforeReplacement(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	dead := glrStack{entries: []stackEntry{{state: 1}}, dead: true}
+	workCountTopologyRecordInitialVersion(&dead)
+	incumbent := dead.clone()
+	incumbent.dead = false
+	incumbent.score = 1
+	workCountTopologyRecordVersionCopy(&dead, &incumbent)
+	candidate := incumbent.clone()
+	candidate.score = 2
+	workCountTopologyRecordVersionCopy(&incumbent, &candidate)
+	deadID := dead.diagnosticTopology.versionID
+	incumbentID := incumbent.diagnosticTopology.versionID
+	candidateID := candidate.diagnosticTopology.versionID
+	before := []glrStack{dead, incumbent, candidate}
+	topologyBefore := append([]glrStack(nil), before...)
+
+	var scratch glrMergeScratch
+	scratch.perKeyCap = 1
+	scratch.beginEquivEpoch()
+	result := mergeStacksWithScratch(before, &scratch)
+	workCountTopologyRetireMissingVersions(topologyBefore, result)
+	if len(result) != 1 || result[0].diagnosticTopology.versionID != candidateID {
+		t.Fatalf("dead/replacement survivor = %+v, want candidate %d", result, candidateID)
+	}
+	if len(activeDiagnosticTopology.versionSlots) != 1 || activeDiagnosticTopology.versionSlots[0] != candidateID {
+		t.Fatalf("dead/replacement slots = %v, want [%d]", activeDiagnosticTopology.versionSlots, candidateID)
+	}
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.Complete() {
+		t.Fatalf("dead/replacement receipt is incomplete: %+v", receipt)
+	}
+	var renumbers []DiagnosticTopologyEvent
+	for _, event := range receipt.Events {
+		if event.Kind == DiagnosticTopologyEventVersionRenumber {
+			renumbers = append(renumbers, event)
+		}
+	}
+	if len(renumbers) != 3 {
+		t.Fatalf("dead/replacement renumbers = %d, want 3: %+v", len(renumbers), renumbers)
+	}
+	if event := renumbers[0]; event.SourceVersionID != incumbentID || event.SourceIndex != 1 || event.TargetVersionID != deadID || event.TargetIndex != 0 {
+		t.Fatalf("first dead-removal shift = %+v", event)
+	}
+	if event := renumbers[1]; event.SourceVersionID != candidateID || event.SourceIndex != 2 || event.TargetVersionID != incumbentID || event.TargetIndex != 1 {
+		t.Fatalf("second dead-removal shift = %+v", event)
+	}
+	if event := renumbers[2]; event.SourceVersionID != candidateID || event.SourceIndex != 1 || event.TargetVersionID != incumbentID || event.TargetIndex != 0 {
+		t.Fatalf("replacement renumber = %+v", event)
+	}
+}
+
+func TestDiagnosticTopologyReceiptReconcilesBudgetCullBeforeReplacement(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	incumbent := glrStack{entries: []stackEntry{{state: 1}}, score: 1}
+	workCountTopologyRecordInitialVersion(&incumbent)
+	candidate := incumbent.clone()
+	workCountTopologyRecordVersionCopy(&incumbent, &candidate)
+	otherBest := incumbent.clone()
+	otherBest.entries[0].state = 2
+	otherBest.score = 2
+	workCountTopologyRecordVersionCopy(&incumbent, &otherBest)
+	workCountTopologyCommitVersion(&otherBest)
+	otherLoser := otherBest.clone()
+	otherLoser.score = 0
+	workCountTopologyRecordVersionCopy(&otherBest, &otherLoser)
+	incumbentID := incumbent.diagnosticTopology.versionID
+	candidateID := candidate.diagnosticTopology.versionID
+	otherBestID := otherBest.diagnosticTopology.versionID
+	otherLoserID := otherLoser.diagnosticTopology.versionID
+	before := []glrStack{incumbent, candidate, otherBest, otherLoser}
+	topologyBefore := append([]glrStack(nil), before...)
+
+	perStack := int64(unsafe.Sizeof(glrStack{}) + unsafe.Sizeof(glrMergeSlot{}))
+	var scratch glrMergeScratch
+	scratch.budgetBytes = 3 * perStack
+	scratch.beginEquivEpoch()
+	if limit := mergeAliveLimitForScratch(&scratch, len(before)); limit != 3 {
+		t.Fatalf("merge alive limit = %d, want 3", limit)
+	}
+	result := mergeStacksWithScratch(before, &scratch)
+	workCountTopologyRetireMissingVersions(topologyBefore, result)
+	if len(result) != 2 || result[0].diagnosticTopology.versionID != otherBestID || result[1].diagnosticTopology.versionID != candidateID {
+		t.Fatalf("budget-cull survivors = %+v, want versions [%d %d]", result, otherBestID, candidateID)
+	}
+	if _, ok := activeDiagnosticTopology.versions[incumbentID]; ok {
+		t.Fatalf("replaced incumbent version %d remains bound", incumbentID)
+	}
+	if _, ok := activeDiagnosticTopology.versions[otherLoserID]; ok {
+		t.Fatalf("budget-culled version %d remains bound", otherLoserID)
+	}
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.Complete() {
+		t.Fatalf("budget-cull receipt is incomplete: %+v", receipt)
+	}
+	var renumbers []DiagnosticTopologyEvent
+	for _, event := range receipt.Events {
+		if event.Kind == DiagnosticTopologyEventVersionRenumber {
+			renumbers = append(renumbers, event)
+		}
+	}
+	if len(renumbers) != 1 {
+		t.Fatalf("budget-cull renumbers = %d, want 1: %+v", len(renumbers), renumbers)
+	}
+	if event := renumbers[0]; event.SourceVersionID != candidateID || event.SourceIndex != 2 || event.TargetVersionID != incumbentID || event.TargetIndex != 1 {
+		t.Fatalf("post-cull replacement renumber = %+v", event)
+	}
+}
+
+func TestDiagnosticTopologyReceiptIgnoresRetiredAcceptedCopiesDuringSync(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	live := glrStack{entries: []stackEntry{{state: 1}}}
+	workCountTopologyRecordInitialVersion(&live)
+	accepted := live.clone()
+	workCountTopologyRecordVersionCopy(&live, &accepted)
+	accepted.accepted = true
+	staleAccepted := accepted
+	workCountTopologyRetireVersion(&accepted)
+	workCountTopologySyncVersionOrder([]glrStack{staleAccepted, live})
+	if len(activeDiagnosticTopology.versionSlots) != 1 || activeDiagnosticTopology.versionSlots[0] != live.diagnosticTopology.versionID {
+		t.Fatalf("accepted/live slots = %v, want live version %d", activeDiagnosticTopology.versionSlots, live.diagnosticTopology.versionID)
+	}
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.Complete() {
+		t.Fatalf("accepted/live receipt is incomplete: %+v", receipt)
+	}
+}
+
+func TestDiagnosticTopologyReceiptRetiresSamePopReductionLosers(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	low := NewLeafNode(7, true, 0, 1, Point{}, Point{Column: 1})
+	low.dynamicPrecedence = 1
+	target := glrStack{
+		entries:    []stackEntry{{state: 1}, newStackEntryNode(2, low)},
+		byteOffset: 1,
+	}
+	workCountTopologyRecordInitialVersion(&target)
+	var scratch gssScratch
+	target.ensureGSS(&scratch)
+	target.entries = nil
+	better := target.cloneWithScratch(&scratch)
+	workCountTopologyRecordVersionCopy(&target, &better)
+	high := NewLeafNode(7, true, 0, 1, Point{}, Point{Column: 1})
+	high.dynamicPrecedence = 2
+	better.gss = gssStack{head: target.gss.head.prev}
+	better.gss.push(2, high, &scratch)
+	workCountTopologyCommitVersion(&better)
+	betterID := better.diagnosticTopology.versionID
+	parser := &Parser{}
+	if !parser.cTryCollapseSamePopReductionVersion(&target, &better, nil) {
+		t.Fatal("better same-pop candidate did not collapse")
+	}
+	if target.diagnosticTopology.versionID != betterID {
+		t.Fatalf("same-pop survivor version = %d, want %d", target.diagnosticTopology.versionID, betterID)
+	}
+
+	worse := target.cloneWithScratch(&scratch)
+	workCountTopologyRecordVersionCopy(&target, &worse)
+	worseNode := NewLeafNode(7, true, 0, 1, Point{}, Point{Column: 1})
+	worseNode.dynamicPrecedence = 0
+	worse.gss = gssStack{head: target.gss.head.prev}
+	worse.gss.push(2, worseNode, &scratch)
+	workCountTopologyCommitVersion(&worse)
+	worseID := worse.diagnosticTopology.versionID
+	if !parser.cTryCollapseSamePopReductionVersion(&target, &worse, nil) {
+		t.Fatal("worse same-pop candidate did not collapse")
+	}
+	if _, ok := activeDiagnosticTopology.versions[worseID]; ok {
+		t.Fatalf("same-pop loser version %d remains bound", worseID)
+	}
+	if len(activeDiagnosticTopology.versionSlots) != 1 || activeDiagnosticTopology.versionSlots[0] != betterID {
+		t.Fatalf("same-pop slots = %v, want [%d]", activeDiagnosticTopology.versionSlots, betterID)
+	}
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.Complete() {
+		t.Fatalf("same-pop receipt is incomplete: %+v", receipt)
+	}
+	var renumbers []DiagnosticTopologyEvent
+	for _, event := range receipt.Events {
+		if event.Kind == DiagnosticTopologyEventVersionRenumber {
+			renumbers = append(renumbers, event)
+		}
+	}
+	if len(renumbers) != 1 || renumbers[0].SourceVersionID != betterID || renumbers[0].SourceIndex != 1 || renumbers[0].TargetIndex != 0 {
+		t.Fatalf("same-pop renumbers = %+v", renumbers)
+	}
+}
+
 func TestDiagnosticTopologyReceiptReusesEntriesPopTargetIdentity(t *testing.T) {
 	BeginDiagnosticTopologyReceipt()
 	stack := glrStack{entries: []stackEntry{{state: 1}}, branchOrder: 0}
@@ -119,21 +566,78 @@ func TestDiagnosticTopologyReceiptReusesEntriesPopTargetIdentity(t *testing.T) {
 	}
 }
 
-func TestDiagnosticTopologyReceiptDoesNotCallFinalFallbackAnAcceptElection(t *testing.T) {
+func TestDiagnosticTopologyReceiptRetiresRecoverAcceptedVersionWithoutAcceptElection(t *testing.T) {
 	BeginDiagnosticTopologyReceipt()
 	stack := glrStack{entries: []stackEntry{{state: 1}}, branchOrder: 0}
 	workCountTopologyRecordInitialVersion(&stack)
+	initialID := stack.diagnosticTopology.versionID
+	later := stack.clone()
+	workCountTopologyRecordVersionCopy(&stack, &later)
+	laterID := later.diagnosticTopology.versionID
 	workCountTopologyRecordAction(&stack, Token{Symbol: 0}, ParseAction{Type: ParseActionRecover}, 0)
 	stack.accepted = true
 	workCountTopologyRecordActionResult(&stack)
+	if stack.diagnosticTopology.versionID != 0 {
+		t.Fatalf("accepted recovery version token = %d, want zero", stack.diagnosticTopology.versionID)
+	}
+	if slots := activeDiagnosticTopology.versionSlots; len(slots) != 1 || slots[0] != laterID {
+		t.Fatalf("accepted recovery slots = %v, want [%d]", slots, laterID)
+	}
 	receipt := EndDiagnosticTopologyReceipt()
 	if !receipt.Complete() {
-		t.Fatalf("unaccepted-final receipt is incomplete: %+v", receipt)
+		t.Fatalf("recovery-accept receipt is incomplete: %+v", receipt)
 	}
+	renumbers := 0
 	for _, event := range receipt.Events {
 		if event.Kind == DiagnosticTopologyEventAcceptElection {
-			t.Fatalf("unaccepted final stack emitted an accept election: %+v", event)
+			t.Fatalf("recovery accepted stack emitted an accept election: %+v", event)
 		}
+		if event.Kind == DiagnosticTopologyEventVersionRenumber {
+			renumbers++
+			if event.VersionID != laterID || event.SourceIndex != 1 || event.TargetIndex != 0 || event.TargetVersionID != initialID {
+				t.Fatalf("recovery-accept shift = %+v", event)
+			}
+		}
+	}
+	if renumbers != 1 {
+		t.Fatalf("recovery-accept renumbers = %d, want 1", renumbers)
+	}
+}
+
+func TestDiagnosticTopologyReceiptRetiresCRecoverEOFAccept(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	stack := glrStack{entries: []stackEntry{{state: 1}}}
+	workCountTopologyRecordInitialVersion(&stack)
+	initialID := stack.diagnosticTopology.versionID
+	later := stack.clone()
+	workCountTopologyRecordVersionCopy(&stack, &later)
+	laterID := later.diagnosticTopology.versionID
+	parser := &Parser{}
+	parser.cRecoverEOFAccept(&stack, Token{}, nil, nil, nil, nil, nil)
+	if !stack.accepted || stack.diagnosticTopology.versionID != 0 {
+		t.Fatalf("C EOF recovery accepted/token = %v/%d", stack.accepted, stack.diagnosticTopology.versionID)
+	}
+	if slots := activeDiagnosticTopology.versionSlots; len(slots) != 1 || slots[0] != laterID {
+		t.Fatalf("C EOF recovery slots = %v, want [%d]", slots, laterID)
+	}
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.Complete() {
+		t.Fatalf("C EOF recovery receipt is incomplete: %+v", receipt)
+	}
+	renumbers := 0
+	for _, event := range receipt.Events {
+		if event.Kind == DiagnosticTopologyEventAcceptElection {
+			t.Fatalf("C EOF recovery emitted an accept election: %+v", event)
+		}
+		if event.Kind == DiagnosticTopologyEventVersionRenumber {
+			renumbers++
+			if event.VersionID != laterID || event.SourceIndex != 1 || event.TargetIndex != 0 || event.TargetVersionID != initialID {
+				t.Fatalf("C EOF recovery shift = %+v", event)
+			}
+		}
+	}
+	if renumbers != 1 {
+		t.Fatalf("C EOF recovery renumbers = %d, want 1", renumbers)
 	}
 }
 

--- a/work_count_topology_internal_test.go
+++ b/work_count_topology_internal_test.go
@@ -1,0 +1,131 @@
+//go:build gts_workcount
+
+package gotreesitter
+
+import "testing"
+
+func TestDiagnosticTopologyReceiptBoundsChronologicalPrefix(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	for i := 0; i < DiagnosticTopologyReceiptCapacity+3; i++ {
+		event := diagnosticTopologyEventBase()
+		event.Kind = DiagnosticTopologyEventAction
+		event.State = uint64(i)
+		activeDiagnosticTopology.appendEvent(event)
+	}
+	receipt := EndDiagnosticTopologyReceipt()
+	if receipt.EventsSeen != DiagnosticTopologyReceiptCapacity+3 ||
+		receipt.EventsRetained != DiagnosticTopologyReceiptCapacity ||
+		receipt.EventsDropped != 3 || !receipt.Truncated || receipt.Complete() {
+		t.Fatalf("bounded receipt = %+v", receipt)
+	}
+	if first, last := receipt.Events[0], receipt.Events[len(receipt.Events)-1]; first.EventID != 1 || first.State != 0 || last.EventID != DiagnosticTopologyReceiptCapacity || last.State != DiagnosticTopologyReceiptCapacity-1 {
+		t.Fatalf("retained prefix endpoints = %+v / %+v", first, last)
+	}
+	firstDigest, secondDigest := receipt.SHA256(), receipt.SHA256()
+	if firstDigest == "" || firstDigest != secondDigest {
+		t.Fatal("receipt digest is empty or unstable")
+	}
+}
+
+func TestDiagnosticTopologyReceiptNodeAllocationRefreshesReusedPointer(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	predecessor := &gssNode{}
+	workCountTopologyRecordNodeAllocation(predecessor)
+	node := &gssNode{}
+	workCountTopologyRecordNodeAllocation(node)
+	first := activeDiagnosticTopology.nodeID(node)
+	workCountTopologyRecordLinkInsert(node, predecessor, 0, true)
+	workCountTopologyRecordNodeAllocation(node)
+	second := activeDiagnosticTopology.nodeID(node)
+	workCountTopologyRecordLinkInsert(node, predecessor, 0, true)
+	receipt := EndDiagnosticTopologyReceipt()
+	if first == 0 || second == 0 || first == second {
+		t.Fatalf("node IDs = %d/%d, want distinct nonzero IDs", first, second)
+	}
+	if receipt.IdentityCollision || receipt.IdentityIncomplete || receipt.ArithmeticOverflow {
+		t.Fatalf("explicit pointer reuse invalidated receipt: %+v", receipt)
+	}
+	if len(receipt.Events) != 2 || receipt.Events[0].LinkID == 0 || receipt.Events[1].LinkID == 0 || receipt.Events[0].LinkID == receipt.Events[1].LinkID {
+		t.Fatalf("reused-node link events = %+v", receipt.Events)
+	}
+}
+
+func TestDiagnosticTopologyReceiptStopsAtEventCounterOverflow(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	activeDiagnosticTopology.receipt.EventsSeen = ^uint64(0)
+	activeDiagnosticTopology.appendEvent(diagnosticTopologyEventBase())
+	receipt := EndDiagnosticTopologyReceipt()
+	if receipt.EventsSeen != ^uint64(0) || receipt.EventsRetained != 0 || len(receipt.Events) != 0 {
+		t.Fatalf("overflow receipt recorded an event: %+v", receipt)
+	}
+	if !receipt.ArithmeticOverflow || !receipt.IdentityIncomplete || receipt.Complete() {
+		t.Fatalf("overflow flags = %+v", receipt)
+	}
+}
+
+func TestDiagnosticTopologyReceiptRecordsChildElection(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	stack := glrStack{
+		entries:     []stackEntry{{state: 1}},
+		branchOrder: 7,
+	}
+	workCountTopologyRecordInitialVersion(&stack)
+	workCountTopologyRecordAction(&stack, Token{Symbol: 13}, ParseAction{Type: ParseActionReduce}, 2)
+	incumbentWindow := []stackEntry{{state: 21}}
+	candidateWindow := []stackEntry{{state: 22}}
+	workCountTopologyRecordPopPath(&stack, incumbentWindow, nil, 0)
+	workCountTopologyRecordPopPath(&stack, candidateWindow, nil, 1)
+	workCountTopologyRecordChildElection(
+		&stack,
+		reduceFork{window: incumbentWindow},
+		reduceFork{window: candidateWindow},
+		-1,
+	)
+	workCountTopologyRecordChildElection(
+		&stack,
+		reduceFork{window: incumbentWindow},
+		reduceFork{window: candidateWindow},
+		0,
+	)
+	workCountTopologyRecordActionResult(&stack)
+	receipt := EndDiagnosticTopologyReceipt()
+
+	var pops []DiagnosticTopologyEvent
+	var election DiagnosticTopologyEvent
+	for _, event := range receipt.Events {
+		switch event.Kind {
+		case DiagnosticTopologyEventPopPath:
+			pops = append(pops, event)
+		case DiagnosticTopologyEventChildElection:
+			election = event
+		}
+	}
+	if len(pops) != 2 || pops[0].PathOrdinal != 0 || pops[1].PathOrdinal != 1 || pops[0].PopID == 0 || pops[0].PopID != pops[1].PopID {
+		t.Fatalf("pop events = %+v", pops)
+	}
+	if election.ElectionID != 1 || election.PopID != 0 || election.IncumbentID != 1 || election.CandidateID != 2 || election.SelectedID != 2 {
+		t.Fatalf("child election = %+v, pops = %+v", election, pops)
+	}
+	if election.Flags&(DiagnosticTopologyFlagSuccessOrSelected|DiagnosticTopologyFlagActionContextKnown) != DiagnosticTopologyFlagSuccessOrSelected|DiagnosticTopologyFlagActionContextKnown {
+		t.Fatalf("child election flags = %#x", election.Flags)
+	}
+	if !receipt.Complete() {
+		t.Fatalf("child-election receipt is incomplete: %+v", receipt)
+	}
+}
+
+func TestDiagnosticTopologyReceiptMarksIdentityCollisionAndOverflow(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	source := glrStack{entries: []stackEntry{{state: 1}}, branchOrder: 0}
+	target := source
+	target.branchOrder = 1
+	workCountTopologyRecordInitialVersion(&source)
+	workCountTopologyPrepareVersionCopy(&source, &target)
+	workCountTopologyPrepareVersionCopy(&source, &target)
+	activeDiagnosticTopology.nextNodeID = ^uint64(0)
+	workCountTopologyRecordNodeAllocation(&gssNode{})
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.IdentityCollision || !receipt.IdentityIncomplete || !receipt.ArithmeticOverflow || receipt.Complete() {
+		t.Fatalf("collision and overflow flags = %+v", receipt)
+	}
+}

--- a/work_count_topology_internal_test.go
+++ b/work_count_topology_internal_test.go
@@ -50,6 +50,142 @@ func TestDiagnosticTopologyReceiptNodeAllocationRefreshesReusedPointer(t *testin
 	}
 }
 
+func TestDiagnosticTopologyReceiptPreservesEntriesPrefixAcrossPromotionAndCopy(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	stack := glrStack{
+		entries:     []stackEntry{{state: 1}, {state: 2}},
+		branchOrder: 0,
+	}
+	workCountTopologyRecordInitialVersion(&stack)
+	initialNodeID := activeDiagnosticTopology.versions[1].nodeID
+	initialPrefixIDs := append([]uint64(nil), activeDiagnosticTopology.versions[1].entryNodeIDs...)
+
+	var scratch gssScratch
+	clone := stack.cloneWithScratch(&scratch)
+	clone.branchOrder = 1
+	workCountTopologyRecordVersionCopy(&stack, &clone)
+	copyVersionID := activeDiagnosticTopology.stackVersions[&clone].versionID
+	copyVersion := activeDiagnosticTopology.versions[copyVersionID]
+	if got := activeDiagnosticTopology.nodeID(stack.gss.head); got != initialNodeID {
+		t.Fatalf("promoted head ID = %d, want initial ID %d", got, initialNodeID)
+	}
+	if copyVersion.nodeID != initialNodeID {
+		t.Fatalf("copied head ID = %d, want shared ID %d", copyVersion.nodeID, initialNodeID)
+	}
+	if len(copyVersion.entryNodeIDs) != len(initialPrefixIDs) {
+		t.Fatalf("copied prefix IDs = %v, want %v", copyVersion.entryNodeIDs, initialPrefixIDs)
+	}
+	for i := range initialPrefixIDs {
+		if copyVersion.entryNodeIDs[i] != initialPrefixIDs[i] {
+			t.Fatalf("copied prefix IDs = %v, want %v", copyVersion.entryNodeIDs, initialPrefixIDs)
+		}
+	}
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.Complete() {
+		t.Fatalf("promotion/copy receipt is incomplete: %+v", receipt)
+	}
+	var copyEvent DiagnosticTopologyEvent
+	for _, event := range receipt.Events {
+		if event.Kind == DiagnosticTopologyEventVersionCopy {
+			copyEvent = event
+		}
+	}
+	if copyEvent.VersionID != copyVersionID || copyEvent.NodeID != initialNodeID {
+		t.Fatalf("copy event = %+v, want version/head %d/%d", copyEvent, copyVersionID, initialNodeID)
+	}
+}
+
+func TestDiagnosticTopologyReceiptReusesEntriesPopTargetIdentity(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	stack := glrStack{entries: []stackEntry{{state: 1}}, branchOrder: 0}
+	workCountTopologyRecordInitialVersion(&stack)
+	for ordinal := 0; ordinal < 2; ordinal++ {
+		workCountTopologyRecordAction(&stack, Token{Symbol: 9}, ParseAction{Type: ParseActionReduce}, ordinal)
+		workCountTopologyRecordDirectPop(&stack, 0)
+		workCountTopologyRecordActionResult(&stack)
+	}
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.Complete() {
+		t.Fatalf("entries-pop receipt is incomplete: %+v", receipt)
+	}
+	var popTargets []uint64
+	for _, event := range receipt.Events {
+		if event.Kind == DiagnosticTopologyEventPopPath {
+			popTargets = append(popTargets, event.PopToNodeID)
+		}
+	}
+	if len(popTargets) != 2 || popTargets[0] == 0 || popTargets[0] != popTargets[1] {
+		t.Fatalf("pop target IDs = %v, want two equal nonzero IDs", popTargets)
+	}
+}
+
+func TestDiagnosticTopologyReceiptDoesNotCallFinalFallbackAnAcceptElection(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	stack := glrStack{entries: []stackEntry{{state: 1}}, branchOrder: 0}
+	workCountTopologyRecordInitialVersion(&stack)
+	workCountTopologyRecordAction(&stack, Token{Symbol: 0}, ParseAction{Type: ParseActionRecover}, 0)
+	stack.accepted = true
+	workCountTopologyRecordActionResult(&stack)
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.Complete() {
+		t.Fatalf("unaccepted-final receipt is incomplete: %+v", receipt)
+	}
+	for _, event := range receipt.Events {
+		if event.Kind == DiagnosticTopologyEventAcceptElection {
+			t.Fatalf("unaccepted final stack emitted an accept election: %+v", event)
+		}
+	}
+}
+
+func TestDiagnosticTopologyReceiptKeepsEachCandidateFromOneAcceptAction(t *testing.T) {
+	BeginDiagnosticTopologyReceipt()
+	stack := glrStack{entries: []stackEntry{{state: 1}, {state: 2}}, branchOrder: 0}
+	workCountTopologyRecordInitialVersion(&stack)
+	var scratch gssScratch
+	stack.ensureGSS(&scratch)
+	stack.entries = nil
+	stack.cacheEntries = false
+	stack.gss.head.appendExtraLink(gssMainLink{
+		prev:  stack.gss.head.prev,
+		entry: stackEntry{state: 3},
+	})
+	workCountTopologyRecordLinkInsert(stack.gss.head, stack.gss.head.prev, 1, false)
+	if got := len(expandPackedGSSResultPaths([]glrStack{stack})); got != 2 {
+		t.Fatalf("expanded packed paths = %d, want two; links=%d", got, stack.gss.head.linkCount())
+	}
+	workCountTopologyRecordAction(&stack, Token{Symbol: 0}, ParseAction{Type: ParseActionAccept}, 0)
+	stack.accepted = true
+	workCountTopologyRecordActionResult(&stack)
+	receipt := EndDiagnosticTopologyReceipt()
+	if !receipt.Complete() {
+		t.Fatalf("multi-candidate accept receipt is incomplete: %+v", receipt)
+	}
+	var elections []DiagnosticTopologyEvent
+	var acceptAction DiagnosticTopologyEvent
+	for _, event := range receipt.Events {
+		if event.Kind == DiagnosticTopologyEventAction && event.ActionType == uint64(ParseActionAccept) {
+			acceptAction = event
+		}
+		if event.Kind == DiagnosticTopologyEventAcceptElection {
+			elections = append(elections, event)
+		}
+	}
+	if len(elections) != 2 {
+		t.Fatalf("accept elections = %d, want two", len(elections))
+	}
+	if elections[0].ActionID == 0 || elections[0].ActionID != elections[1].ActionID ||
+		elections[0].CandidateID == 0 || elections[0].CandidateID == elections[1].CandidateID {
+		t.Fatalf("accept elections do not preserve the shared action and distinct candidates: %+v", elections)
+	}
+	if elections[0].Flags&DiagnosticTopologyFlagNoIncumbent == 0 ||
+		elections[1].IncumbentID != elections[0].CandidateID {
+		t.Fatalf("accept election chain = %+v, want the first candidate as the second incumbent", elections)
+	}
+	if acceptAction.EventID == 0 || elections[0].EventID != acceptAction.EventID+1 || elections[1].EventID != elections[0].EventID+1 {
+		t.Fatalf("accept elections are not inside the ACCEPT action: %+v", elections)
+	}
+}
+
 func TestDiagnosticTopologyReceiptStopsAtEventCounterOverflow(t *testing.T) {
 	BeginDiagnosticTopologyReceipt()
 	activeDiagnosticTopology.receipt.EventsSeen = ^uint64(0)
@@ -73,8 +209,9 @@ func TestDiagnosticTopologyReceiptRecordsChildElection(t *testing.T) {
 	workCountTopologyRecordAction(&stack, Token{Symbol: 13}, ParseAction{Type: ParseActionReduce}, 2)
 	incumbentWindow := []stackEntry{{state: 21}}
 	candidateWindow := []stackEntry{{state: 22}}
-	workCountTopologyRecordPopPath(&stack, incumbentWindow, nil, 0)
-	workCountTopologyRecordPopPath(&stack, candidateWindow, nil, 1)
+	popToNodeID := activeDiagnosticTopology.versions[1].entryNodeIDs[0]
+	workCountTopologyRecordPopPathWithNodeID(&stack, incumbentWindow, nil, popToNodeID, 0)
+	workCountTopologyRecordPopPathWithNodeID(&stack, candidateWindow, nil, popToNodeID, 1)
 	workCountTopologyRecordChildElection(
 		&stack,
 		reduceFork{window: incumbentWindow},

--- a/work_count_topology_test.go
+++ b/work_count_topology_test.go
@@ -1,0 +1,226 @@
+//go:build gts_workcount
+
+package gotreesitter_test
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+const erlangIssue984Source = "000\"0A!A \"A\"=0:A0!)A\"0%0000"
+
+func captureErlangIssue984Topology(t *testing.T) (string, gts.DiagnosticTopologyReceipt) {
+	t.Helper()
+	if got := len(erlangIssue984Source); got != 27 {
+		t.Fatalf("Erlang issue 984 witness length = %d, want 27", got)
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256([]byte(erlangIssue984Source))); got != "ad9482f4aabfc3f348a20f6071a2732dcf0473d87b61fa8df4f960e84d4b1ab4" {
+		t.Fatalf("Erlang issue 984 witness SHA-256 = %s", got)
+	}
+	parser := gts.NewParser(grammars.ErlangLanguage())
+	parser.SetAdmissionCandidateRoute(false)
+	gts.BeginDiagnosticTopologyReceipt()
+	tree, err := parser.Parse([]byte(erlangIssue984Source))
+	receipt := gts.EndDiagnosticTopologyReceipt()
+	if err != nil {
+		t.Fatalf("parse the Erlang issue 984 witness: %v", err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		if tree != nil {
+			tree.Release()
+		}
+		t.Fatal("parse the Erlang issue 984 witness: no root")
+	}
+	defer tree.Release()
+	if tree.RootNode().HasError() {
+		t.Fatalf("Erlang issue 984 witness has an error root: %s", tree.RootNode().SExpr(grammars.ErlangLanguage()))
+	}
+	return tree.RootNode().SExpr(grammars.ErlangLanguage()), receipt
+}
+
+func assertDiagnosticTopologyEventInvariants(t *testing.T, receipt gts.DiagnosticTopologyReceipt) {
+	t.Helper()
+	const allowedFlags = uint64(1<<6) - 1
+	nextVersionID := uint64(1)
+	nextLinkID := uint64(1)
+	nextElectionID := uint64(1)
+	lastActionID := uint64(0)
+	lastPopID := uint64(0)
+	lastPathOrdinal := uint64(0)
+	for i, event := range receipt.Events {
+		if event.EventID != uint64(i+1) {
+			t.Fatalf("event %d has ID %d", i, event.EventID)
+		}
+		if event.Kind < gts.DiagnosticTopologyEventAction || event.Kind > gts.DiagnosticTopologyEventAcceptElection {
+			t.Fatalf("event %d has kind %d", event.EventID, event.Kind)
+		}
+		if event.Flags&^allowedFlags != 0 {
+			t.Fatalf("event %d has reserved flags %#x", event.EventID, event.Flags)
+		}
+		hasAction := event.Flags&gts.DiagnosticTopologyFlagActionContextKnown != 0
+		if hasAction && (event.ActionID == 0 || event.ActionType > uint64(gts.ParseActionRecover) || event.ActionOrdinal < -1) {
+			t.Fatalf("event %d has invalid action context: %+v", event.EventID, event)
+		}
+		if !hasAction && (event.ActionID != 0 || event.ActionOrdinal != -1 || event.ActionType != 255) {
+			t.Fatalf("event %d has invalid absent action context: %+v", event.EventID, event)
+		}
+		switch event.Kind {
+		case gts.DiagnosticTopologyEventAction:
+			if event.ActionID <= lastActionID {
+				t.Fatalf("action ID %d follows %d", event.ActionID, lastActionID)
+			}
+			lastActionID = event.ActionID
+		case gts.DiagnosticTopologyEventVersionAdd, gts.DiagnosticTopologyEventVersionCopy:
+			if event.VersionID != nextVersionID || event.NodeID == 0 {
+				t.Fatalf("version event %d has ID/node %d/%d, want ID %d", event.EventID, event.VersionID, event.NodeID, nextVersionID)
+			}
+			nextVersionID++
+		case gts.DiagnosticTopologyEventVersionRenumber:
+			if event.VersionID == 0 || event.SourceVersionID != event.VersionID || event.TargetVersionID == 0 || event.Flags&gts.DiagnosticTopologyFlagTargetReplaced == 0 {
+				t.Fatalf("invalid renumber event %d: %+v", event.EventID, event)
+			}
+		case gts.DiagnosticTopologyEventMerge:
+			if event.SurvivorVersionID == 0 || event.RemovedVersionID == 0 || event.SurvivorVersionID != event.SourceVersionID || event.RemovedVersionID != event.TargetVersionID {
+				t.Fatalf("invalid merge event %d: %+v", event.EventID, event)
+			}
+		case gts.DiagnosticTopologyEventLinkInsert:
+			if event.NodeID == 0 || event.PredecessorNodeID == 0 || event.LinkID != nextLinkID || event.LinkOrdinal >= 8 {
+				t.Fatalf("link event %d has an incomplete identity: %+v", event.EventID, event)
+			}
+			nextLinkID++
+		case gts.DiagnosticTopologyEventPopPath:
+			if event.PopID == 0 || event.VersionID == 0 || event.SourceVersionID == 0 || event.NodeID == 0 || event.PopToNodeID == 0 {
+				t.Fatalf("pop event %d has an incomplete identity: %+v", event.EventID, event)
+			}
+			if event.PopID == lastPopID {
+				if event.PathOrdinal != lastPathOrdinal+1 {
+					t.Fatalf("pop %d path ordinal %d follows %d", event.PopID, event.PathOrdinal, lastPathOrdinal)
+				}
+			} else if event.PopID <= lastPopID || event.PathOrdinal != 0 {
+				t.Fatalf("new pop %d path ordinal %d follows pop %d", event.PopID, event.PathOrdinal, lastPopID)
+			}
+			lastPopID = event.PopID
+			lastPathOrdinal = event.PathOrdinal
+		case gts.DiagnosticTopologyEventChildElection, gts.DiagnosticTopologyEventAcceptElection:
+			if event.ElectionID != nextElectionID || event.CandidateID == 0 || event.SelectedID == 0 {
+				t.Fatalf("election event %d has an incomplete identity: %+v", event.EventID, event)
+			}
+			if event.Flags&gts.DiagnosticTopologyFlagNoIncumbent == 0 && event.IncumbentID == 0 {
+				t.Fatalf("election event %d has no incumbent: %+v", event.EventID, event)
+			}
+			nextElectionID++
+		}
+	}
+}
+
+func TestDiagnosticTopologyReceiptErlangIssue984(t *testing.T) {
+	sexpr, receipt := captureErlangIssue984Topology(t)
+	if want := `(source_file (integer) (concatables (string) (var) (string)) (integer) (comment))`; sexpr != want {
+		t.Fatalf("production witness tree = %s, want %s", sexpr, want)
+	}
+	if receipt.Schema != gts.DiagnosticTopologyReceiptSchema || receipt.Capacity != gts.DiagnosticTopologyReceiptCapacity {
+		t.Fatalf("receipt identity = %q/%d", receipt.Schema, receipt.Capacity)
+	}
+	if !receipt.Complete() || receipt.EventsRetained != receipt.EventsSeen || receipt.EventsDropped != 0 {
+		t.Fatalf("receipt is incomplete: %+v", receipt)
+	}
+	assertDiagnosticTopologyEventInvariants(t, receipt)
+
+	counts := make(map[uint64]int)
+	anchors := make(map[[4]uint64]bool)
+	type actionSliceEntry struct {
+		state, actionType uint64
+		ordinal           int64
+		branch            uint64
+	}
+	var state320Slice []actionSliceEntry
+	state320Started := false
+	var acceptEvents []gts.DiagnosticTopologyEvent
+	for _, event := range receipt.Events {
+		counts[event.Kind]++
+		if event.Kind == gts.DiagnosticTopologyEventAction {
+			if event.State == 320 && event.ByteOffset == 10 {
+				state320Started = true
+			}
+			if state320Started && event.ByteOffset == 10 {
+				state320Slice = append(state320Slice, actionSliceEntry{event.State, event.ActionType, event.ActionOrdinal, event.VersionIndex})
+			}
+		}
+		if event.Kind == gts.DiagnosticTopologyEventAction && event.ActionType == uint64(gts.ParseActionReduce) {
+			anchors[[4]uint64{event.State, event.LookaheadSymbol, event.ByteOffset, uint64(event.ActionOrdinal)}] = true
+			if (event.State == 320 && event.LookaheadSymbol == 130 && event.ByteOffset == 10) ||
+				(event.State == 274 && event.LookaheadSymbol == 133 && event.ByteOffset == 11) {
+				t.Logf("anchor event=%d state=%d lookahead=%d byte=%d ordinal=%d version=%d branch=%d", event.EventID, event.State, event.LookaheadSymbol, event.ByteOffset, event.ActionOrdinal, event.VersionID, event.VersionIndex)
+			}
+		}
+		if event.Kind == gts.DiagnosticTopologyEventAcceptElection {
+			acceptEvents = append(acceptEvents, event)
+		}
+	}
+	for _, anchor := range [][4]uint64{
+		{320, 130, 10, 0},
+		{320, 130, 10, 1},
+		{274, 133, 11, 0},
+		{274, 133, 11, 1},
+	} {
+		if !anchors[anchor] {
+			t.Errorf("missing all-REDUCE anchor state/lookahead/byte/ordinal %v", anchor)
+		}
+	}
+	wantState320Slice := []actionSliceEntry{
+		{320, uint64(gts.ParseActionReduce), 1, 1},
+		{830, uint64(gts.ParseActionShift), 0, 1},
+		{320, uint64(gts.ParseActionReduce), 0, 0},
+		{295, uint64(gts.ParseActionReduce), 0, 0},
+		{264, uint64(gts.ParseActionReduce), 0, 0},
+		{50, uint64(gts.ParseActionShift), 1, 2},
+		{50, uint64(gts.ParseActionReduce), 0, 0},
+		{44, uint64(gts.ParseActionShift), 0, 0},
+	}
+	state320Matches := len(state320Slice) == len(wantState320Slice)
+	for i := 0; state320Matches && i < len(state320Slice); i++ {
+		state320Matches = state320Slice[i] == wantState320Slice[i]
+	}
+	if !state320Matches {
+		t.Fatalf("state-320 frontier slice = %v, want %v", state320Slice, wantState320Slice)
+	}
+	for _, kind := range []uint64{
+		gts.DiagnosticTopologyEventAction,
+		gts.DiagnosticTopologyEventVersionAdd,
+		gts.DiagnosticTopologyEventVersionCopy,
+		gts.DiagnosticTopologyEventMerge,
+		gts.DiagnosticTopologyEventLinkInsert,
+		gts.DiagnosticTopologyEventPopPath,
+		gts.DiagnosticTopologyEventAcceptElection,
+	} {
+		if counts[kind] == 0 {
+			t.Errorf("receipt has no event kind %d", kind)
+		}
+	}
+	if len(acceptEvents) != 4 {
+		t.Fatalf("accept elections = %d, want four accepted candidates", len(acceptEvents))
+	}
+	wantAcceptPayloads := []uint64{1, 1, 1, 1}
+	for i := range acceptEvents {
+		if acceptEvents[i].PayloadCount != wantAcceptPayloads[i] {
+			t.Fatalf("accept payloads = [%d %d %d %d], want %v", acceptEvents[0].PayloadCount, acceptEvents[1].PayloadCount, acceptEvents[2].PayloadCount, acceptEvents[3].PayloadCount, wantAcceptPayloads)
+		}
+	}
+	last := acceptEvents[len(acceptEvents)-1]
+	if acceptEvents[0].VersionIndex != 1 || last.SelectedID != acceptEvents[0].CandidateID || last.Flags&gts.DiagnosticTopologyFlagSuccessOrSelected != 0 {
+		t.Fatalf("final production selection = %+v, want first branch 1 candidate %d to remain selected", last, acceptEvents[0].CandidateID)
+	}
+	if receipt.EventsSeen != 387 || receipt.SHA256() != "283e0a0a8405d8f6059787ac441779d234fae30e4a19ca8fb383fc5baa3e89e3" {
+		t.Fatalf("canonical receipt = %d/%s", receipt.EventsSeen, receipt.SHA256())
+	}
+	t.Logf("receipt sha256=%s events=%d kinds=%v selected_candidate=%d", receipt.SHA256(), receipt.EventsSeen, counts, last.SelectedID)
+
+	secondSExpr, second := captureErlangIssue984Topology(t)
+	if secondSExpr != sexpr || second.SHA256() != receipt.SHA256() {
+		t.Fatalf("receipt is not deterministic: first=%s/%s second=%s/%s", sexpr, receipt.SHA256(), secondSExpr, second.SHA256())
+	}
+}

--- a/work_count_topology_test.go
+++ b/work_count_topology_test.go
@@ -68,6 +68,9 @@ func assertDiagnosticTopologyEventInvariants(t *testing.T, receipt gts.Diagnosti
 		if !hasAction && (event.ActionID != 0 || event.ActionOrdinal != -1 || event.ActionType != 255) {
 			t.Fatalf("event %d has invalid absent action context: %+v", event.EventID, event)
 		}
+		if event.Kind != gts.DiagnosticTopologyEventAction && hasAction && event.ActionID != lastActionID {
+			t.Fatalf("event %d is outside action %d: latest action is %d", event.EventID, event.ActionID, lastActionID)
+		}
 		switch event.Kind {
 		case gts.DiagnosticTopologyEventAction:
 			if event.ActionID <= lastActionID {
@@ -204,17 +207,21 @@ func TestDiagnosticTopologyReceiptErlangIssue984(t *testing.T) {
 	if len(acceptEvents) != 4 {
 		t.Fatalf("accept elections = %d, want four accepted candidates", len(acceptEvents))
 	}
-	wantAcceptPayloads := []uint64{1, 1, 1, 1}
+	wantAcceptPayloads := []uint64{5, 7, 6, 7}
 	for i := range acceptEvents {
 		if acceptEvents[i].PayloadCount != wantAcceptPayloads[i] {
 			t.Fatalf("accept payloads = [%d %d %d %d], want %v", acceptEvents[0].PayloadCount, acceptEvents[1].PayloadCount, acceptEvents[2].PayloadCount, acceptEvents[3].PayloadCount, wantAcceptPayloads)
+		}
+		if acceptEvents[i].Flags&gts.DiagnosticTopologyFlagActionContextKnown == 0 ||
+			acceptEvents[i].ActionID == 0 || acceptEvents[i].ActionType != uint64(gts.ParseActionAccept) {
+			t.Fatalf("accept election lacks ACCEPT action context: %+v", acceptEvents[i])
 		}
 	}
 	last := acceptEvents[len(acceptEvents)-1]
 	if acceptEvents[0].VersionIndex != 1 || last.SelectedID != acceptEvents[0].CandidateID || last.Flags&gts.DiagnosticTopologyFlagSuccessOrSelected != 0 {
 		t.Fatalf("final production selection = %+v, want first branch 1 candidate %d to remain selected", last, acceptEvents[0].CandidateID)
 	}
-	if receipt.EventsSeen != 387 || receipt.SHA256() != "283e0a0a8405d8f6059787ac441779d234fae30e4a19ca8fb383fc5baa3e89e3" {
+	if receipt.EventsSeen != 386 || receipt.SHA256() != "afd1958220f13ad6aae1a91595576518e61c7ea0b3e86e6fe271bb3291c2158e" {
 		t.Fatalf("canonical receipt = %d/%s", receipt.EventsSeen, receipt.SHA256())
 	}
 	t.Logf("receipt sha256=%s events=%d kinds=%v selected_candidate=%d", receipt.SHA256(), receipt.EventsSeen, counts, last.SelectedID)
@@ -222,5 +229,47 @@ func TestDiagnosticTopologyReceiptErlangIssue984(t *testing.T) {
 	secondSExpr, second := captureErlangIssue984Topology(t)
 	if secondSExpr != sexpr || second.SHA256() != receipt.SHA256() {
 		t.Fatalf("receipt is not deterministic: first=%s/%s second=%s/%s", sexpr, receipt.SHA256(), secondSExpr, second.SHA256())
+	}
+}
+
+func TestDiagnosticTopologyReceiptRecoveryDoesNotForgeAcceptContext(t *testing.T) {
+	parser := gts.NewParser(grammars.ErlangLanguage())
+	parser.SetAdmissionCandidateRoute(false)
+	gts.BeginDiagnosticTopologyReceipt()
+	tree, err := parser.Parse([]byte("f() -> ."))
+	receipt := gts.EndDiagnosticTopologyReceipt()
+	if err != nil {
+		t.Fatalf("parse recovery witness: %v", err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		if tree != nil {
+			tree.Release()
+		}
+		t.Fatal("parse recovery witness: no root")
+	}
+	defer tree.Release()
+	if !tree.RootNode().HasError() {
+		t.Fatalf("recovery witness has no error: %s", tree.RootNode().SExpr(grammars.ErlangLanguage()))
+	}
+	if !receipt.Complete() {
+		t.Fatalf("recovery receipt is incomplete: %+v", receipt)
+	}
+	foundPotentialReduction := false
+	for _, event := range receipt.Events {
+		if event.Kind == gts.DiagnosticTopologyEventAction &&
+			event.ActionType == uint64(gts.ParseActionReduce) &&
+			event.ActionOrdinal == -1 && event.State == 414 && event.ByteOffset == 6 {
+			if event.LookaheadSymbol != 2 {
+				t.Fatalf("recovery reduction lookahead = %d, want 2: %+v", event.LookaheadSymbol, event)
+			}
+			foundPotentialReduction = true
+		}
+		if event.Kind == gts.DiagnosticTopologyEventAcceptElection &&
+			(event.Flags&gts.DiagnosticTopologyFlagActionContextKnown == 0 || event.ActionType != uint64(gts.ParseActionAccept)) {
+			t.Fatalf("recovery forged an ACCEPT election: %+v", event)
+		}
+	}
+	if !foundPotentialReduction {
+		t.Fatal("recovery receipt has no state-414 potential reduction at byte 6")
 	}
 }

--- a/work_count_topology_test.go
+++ b/work_count_topology_test.go
@@ -5,6 +5,7 @@ package gotreesitter_test
 import (
 	"crypto/sha256"
 	"fmt"
+	"sync"
 	"testing"
 
 	gts "github.com/odvcencio/gotreesitter"
@@ -12,6 +13,81 @@ import (
 )
 
 const erlangIssue984Source = "000\"0A!A \"A\"=0:A0!)A\"0%0000"
+
+type diagnosticTopologyCapture struct {
+	sexpr  string
+	digest string
+	events uint64
+}
+
+func captureErlangTopology(source string) (diagnosticTopologyCapture, error) {
+	parser := gts.NewParser(grammars.ErlangLanguage())
+	parser.SetAdmissionCandidateRoute(false)
+	gts.BeginDiagnosticTopologyReceipt()
+	tree, parseErr := parser.Parse([]byte(source))
+	receipt := gts.EndDiagnosticTopologyReceipt()
+	if parseErr != nil {
+		return diagnosticTopologyCapture{}, parseErr
+	}
+	if tree == nil || tree.RootNode() == nil {
+		if tree != nil {
+			tree.Release()
+		}
+		return diagnosticTopologyCapture{}, fmt.Errorf("parse returned no root")
+	}
+	defer tree.Release()
+	if !receipt.Complete() {
+		return diagnosticTopologyCapture{}, fmt.Errorf("receipt is incomplete: %+v", receipt)
+	}
+	return diagnosticTopologyCapture{
+		sexpr:  tree.RootNode().SExpr(grammars.ErlangLanguage()),
+		digest: receipt.SHA256(),
+		events: receipt.EventsSeen,
+	}, nil
+}
+
+func TestDiagnosticTopologyReceiptSerializesConcurrentOwners(t *testing.T) {
+	sources := [...]string{erlangIssue984Source, "f() -> ."}
+	var want [len(sources)]diagnosticTopologyCapture
+	for i := range sources {
+		capture, err := captureErlangTopology(sources[i])
+		if err != nil {
+			t.Fatalf("capture baseline %d: %v", i, err)
+		}
+		want[i] = capture
+	}
+
+	const workerCount = 8
+	type result struct {
+		worker  int
+		capture diagnosticTopologyCapture
+		err     error
+	}
+	start := make(chan struct{})
+	results := make(chan result, workerCount)
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for worker := 0; worker < workerCount; worker++ {
+		go func(worker int) {
+			defer workers.Done()
+			<-start
+			capture, err := captureErlangTopology(sources[worker%len(sources)])
+			results <- result{worker: worker, capture: capture, err: err}
+		}(worker)
+	}
+	close(start)
+	workers.Wait()
+	close(results)
+	for got := range results {
+		if got.err != nil {
+			t.Errorf("worker %d: %v", got.worker, got.err)
+			continue
+		}
+		if expected := want[got.worker%len(sources)]; got.capture != expected {
+			t.Errorf("worker %d capture = %+v, want %+v", got.worker, got.capture, expected)
+		}
+	}
+}
 
 func captureErlangIssue984Topology(t *testing.T) (string, gts.DiagnosticTopologyReceipt) {
 	t.Helper()
@@ -81,13 +157,19 @@ func assertDiagnosticTopologyEventInvariants(t *testing.T, receipt gts.Diagnosti
 			if event.VersionID != nextVersionID || event.NodeID == 0 {
 				t.Fatalf("version event %d has ID/node %d/%d, want ID %d", event.EventID, event.VersionID, event.NodeID, nextVersionID)
 			}
+			if event.Kind == gts.DiagnosticTopologyEventVersionCopy && event.SourceVersionID == 0 {
+				t.Fatalf("version copy event %d has no source: %+v", event.EventID, event)
+			}
 			nextVersionID++
 		case gts.DiagnosticTopologyEventVersionRenumber:
-			if event.VersionID == 0 || event.SourceVersionID != event.VersionID || event.TargetVersionID == 0 || event.Flags&gts.DiagnosticTopologyFlagTargetReplaced == 0 {
+			if event.VersionID == 0 || event.SourceVersionID != event.VersionID || event.TargetVersionID == 0 ||
+				event.VersionIndex != event.TargetIndex || event.SourceIndex <= event.TargetIndex || event.NodeID == 0 ||
+				event.Flags&gts.DiagnosticTopologyFlagTargetReplaced == 0 {
 				t.Fatalf("invalid renumber event %d: %+v", event.EventID, event)
 			}
 		case gts.DiagnosticTopologyEventMerge:
-			if event.SurvivorVersionID == 0 || event.RemovedVersionID == 0 || event.SurvivorVersionID != event.SourceVersionID || event.RemovedVersionID != event.TargetVersionID {
+			if event.SurvivorVersionID == 0 || event.RemovedVersionID == 0 || event.SurvivorVersionID != event.SourceVersionID ||
+				event.RemovedVersionID != event.TargetVersionID || event.SourceIndex >= event.TargetIndex {
 				t.Fatalf("invalid merge event %d: %+v", event.EventID, event)
 			}
 		case gts.DiagnosticTopologyEventLinkInsert:
@@ -138,7 +220,7 @@ func TestDiagnosticTopologyReceiptErlangIssue984(t *testing.T) {
 	type actionSliceEntry struct {
 		state, actionType uint64
 		ordinal           int64
-		branch            uint64
+		versionIndex      uint64
 	}
 	var state320Slice []actionSliceEntry
 	state320Started := false
@@ -157,7 +239,7 @@ func TestDiagnosticTopologyReceiptErlangIssue984(t *testing.T) {
 			anchors[[4]uint64{event.State, event.LookaheadSymbol, event.ByteOffset, uint64(event.ActionOrdinal)}] = true
 			if (event.State == 320 && event.LookaheadSymbol == 130 && event.ByteOffset == 10) ||
 				(event.State == 274 && event.LookaheadSymbol == 133 && event.ByteOffset == 11) {
-				t.Logf("anchor event=%d state=%d lookahead=%d byte=%d ordinal=%d version=%d branch=%d", event.EventID, event.State, event.LookaheadSymbol, event.ByteOffset, event.ActionOrdinal, event.VersionID, event.VersionIndex)
+				t.Logf("anchor event=%d state=%d lookahead=%d byte=%d ordinal=%d version=%d index=%d", event.EventID, event.State, event.LookaheadSymbol, event.ByteOffset, event.ActionOrdinal, event.VersionID, event.VersionIndex)
 			}
 		}
 		if event.Kind == gts.DiagnosticTopologyEventAcceptElection {
@@ -195,6 +277,7 @@ func TestDiagnosticTopologyReceiptErlangIssue984(t *testing.T) {
 		gts.DiagnosticTopologyEventAction,
 		gts.DiagnosticTopologyEventVersionAdd,
 		gts.DiagnosticTopologyEventVersionCopy,
+		gts.DiagnosticTopologyEventVersionRenumber,
 		gts.DiagnosticTopologyEventMerge,
 		gts.DiagnosticTopologyEventLinkInsert,
 		gts.DiagnosticTopologyEventPopPath,
@@ -218,13 +301,13 @@ func TestDiagnosticTopologyReceiptErlangIssue984(t *testing.T) {
 		}
 	}
 	last := acceptEvents[len(acceptEvents)-1]
-	if acceptEvents[0].VersionIndex != 1 || last.SelectedID != acceptEvents[0].CandidateID || last.Flags&gts.DiagnosticTopologyFlagSuccessOrSelected != 0 {
-		t.Fatalf("final production selection = %+v, want first branch 1 candidate %d to remain selected", last, acceptEvents[0].CandidateID)
-	}
-	if receipt.EventsSeen != 386 || receipt.SHA256() != "afd1958220f13ad6aae1a91595576518e61c7ea0b3e86e6fe271bb3291c2158e" {
-		t.Fatalf("canonical receipt = %d/%s", receipt.EventsSeen, receipt.SHA256())
+	if acceptEvents[0].VersionIndex != 0 || last.SelectedID != acceptEvents[0].CandidateID || last.Flags&gts.DiagnosticTopologyFlagSuccessOrSelected != 0 {
+		t.Fatalf("final production selection = %+v, want physical slot 0 candidate %d to remain selected; elections=%+v", last, acceptEvents[0].CandidateID, acceptEvents)
 	}
 	t.Logf("receipt sha256=%s events=%d kinds=%v selected_candidate=%d", receipt.SHA256(), receipt.EventsSeen, counts, last.SelectedID)
+	if receipt.EventsSeen != 399 || receipt.SHA256() != "492192644602d6cc85bee6fe05301e6a9067088f8c24125dda470edb896b45a2" {
+		t.Fatalf("canonical receipt = %d/%s", receipt.EventsSeen, receipt.SHA256())
+	}
 
 	secondSExpr, second := captureErlangIssue984Topology(t)
 	if secondSExpr != sexpr || second.SHA256() != receipt.SHA256() {


### PR DESCRIPTION
## Summary

- Add a bounded topology receipt for tagged Go parser runs.
- Instrument the locked C runtime with the same 29-field event schema.
- Track stable identities through copies, merges, removals, links, pops, and elections.
- Lock deterministic Go and C receipts for the Erlang issue 984 witness.

## Contract

- Retain the first 4,096 events in chronological order.
- Mark receipts incomplete after truncation, overflow, collision, or missing identity.
- Record every survivor shift after a stable version deletion.
- Keep recovery acceptance separate from production accept elections.

## Verification

- The tagged Go receipt witness passed.
- Go artifact: harness_out/docker/20260831T050258Z-topology-rebase-go-receipt
- The tagged C receipt witness passed.
- C artifact: harness_out/docker/20260831T050322Z-topology-rebase-c-receipt