### PR TITLE
Avoid header copies in compact dispatch

### DIFF
--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -6477,7 +6477,8 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 	raggedRelexNoActionHeads := 0
 	var raggedRelexWitness Token // the first ragged-end relex this pass, for the decline detail
 	raggedRelexHeaderIndex := 0  // that same relex's own header index, for the decline receipt
-	for index, header := range s.headers {
+	for index := range s.headers {
+		header := &s.headers[index]
 		if header.shifted || header.accepted {
 			continue
 		}
@@ -6602,7 +6603,6 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				}
 				s.headers[index].head = newHead
 				s.headers[index].s3Region = nil
-				header = s.headers[index]
 			case resumeToken.Symbol == 0:
 				// EOF while a region is open: cRecoverEOFAccept's whole-file
 				// wrap is out of S3 scope (s3TryOpenErrorRegion's doc


### PR DESCRIPTION
## Summary

- Read active scheduler headers through slice pointers.
- Remove the redundant reload after an in-place recovery update.
- Preserve the dispatch order and all recovery decisions.

## Performance

The Erlang issue 984 benchmark improved from 36.60 microseconds to 34.90 microseconds.
This is a 4.65 percent improvement with p=0.011 across 20 interleaved pairs.
Bytes and allocation counts did not change.

The required 20-seed primary benchmark trio showed no significant change.
The single-byte edit result had p=0.324.
The no-edit result had p=0.683.
The full-parse result had p=0.947.

## Correctness

- The focused compact dispatch and recovery tests pass in Docker.
- The full default root suite passes in Docker in 155.6 seconds.
- Erlang parity passes 25 of 25 cases for all three parity levels.
- The focused race and checkptr runs pass in Docker.
- The default vet path passes.

No run timed out or exceeded its memory limit.