### PR TITLE
Add the compact S4 stack-summary recovery fork

### DIFF
--- a/admission_census.go
+++ b/admission_census.go
@@ -511,6 +511,22 @@ func admissionCensusStopDecline(scheduler *diagnosticParserCoreGenericScheduler)
 			detail += "]"
 		}
 	}
+	if scheduler.work.StackSummaryRecoveryForks != 0 {
+		marked := 0
+		openRegions := 0
+		for index := range scheduler.headers {
+			if scheduler.headers[index].isRecoveryLineage() {
+				marked++
+			}
+			if scheduler.headers[index].s3Region != nil {
+				openRegions++
+			}
+		}
+		detail += fmt.Sprintf(
+			" [compact-s4-forks=%d headers=%d marked=%d open_regions=%d stop_header=%d]",
+			scheduler.work.StackSummaryRecoveryForks, len(scheduler.headers), marked, openRegions, stop.HeaderIndex,
+		)
+	}
 	return &diagnosticParserCoreDecline{
 		boundary: stop.Boundary,
 		detail:   detail,

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -62,13 +62,14 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		allowCompactAcceptanceStructuralElection: p.language.CompactAcceptanceStructuralElectionCertified,
 		allowConvergedSplitDropArtifact:          p.language.CompactConvergedReductionSplitDropsCertified,
 		captureLexerSkippedPrefixProvenance:      p.language.CompactLexerSkippedPrefixTilingCertified,
-		// Recovery admits the certified S3 base mechanism. S5 also needs the
-		// insertion gate and the lineage-selection gate.
+		// Recovery admits the certified S3 base mechanism. S4 and S5 also need
+		// their fork gate and the lineage-selection gate.
 		Recovery:                          p.language.CompactStrategy2ErrorRegionCertified,
 		allowCompactStrategy2ErrorRegion:  p.language.CompactStrategy2ErrorRegionCertified,
+		allowCompactStackSummaryRecovery:  p.language.CompactStackSummaryRecoveryCertified,
 		allowCompactMissingTokenInsertion: p.language.CompactMissingTokenInsertionCertified,
 		allowCompactRecoveryLineageSelection: p.language.CompactStrategy2ErrorRegionCertified &&
-			p.language.CompactMissingTokenInsertionCertified,
+			(p.language.CompactStackSummaryRecoveryCertified || p.language.CompactMissingTokenInsertionCertified),
 		allowCompactRecoveryTrailingLineageRetirement: p.language.CompactRecoveryTrailingLineageRetirementCertified,
 		allowCompactRecoveryErrorModeKeywordCapture:   p.language.CompactRecoveryErrorModeKeywordCaptureCertified,
 		noLookaheadRootSymbol:                         p.rootSymbol,

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -29,6 +29,7 @@ type builtinLanguageRuntimeProfile struct {
 	exactStackNodeEquivalence           bool
 	compactPackedGSSVersionOrder        bool
 	compactStrategy2ErrorRegion         bool
+	compactStackSummaryRecovery         bool
 	compactMissingTokenInsertion        bool
 	compactRecoveryTrailingRetirement   bool
 	compactRecoveryErrorModeKeyword     bool
@@ -729,6 +730,10 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	}
 	if profile.compactStrategy2ErrorRegion && !lang.CompactStrategy2ErrorRegionCertified {
 		lang.CompactStrategy2ErrorRegionCertified = true
+		changed = true
+	}
+	if profile.compactStackSummaryRecovery && !lang.CompactStackSummaryRecoveryCertified {
+		lang.CompactStackSummaryRecoveryCertified = true
 		changed = true
 	}
 	if profile.compactMissingTokenInsertion && !lang.CompactMissingTokenInsertionCertified {

--- a/internal/parsercorephase0/ancestor_recovery.go
+++ b/internal/parsercorephase0/ancestor_recovery.go
@@ -13,6 +13,12 @@ const StackSummaryMaxDepth = 16
 
 const stackSummaryMaxVisitedNodes = 4096
 
+var (
+	errAncestorRecoveryCandidateAmbiguous = errors.New("parser-core phase zero: ancestor recovery candidate has ambiguous pop paths")
+	errAncestorRecoveryCandidateNoPath    = errors.New("parser-core phase zero: stack-summary candidate has no exact pop path")
+	errAncestorRecoveryCandidateLinkDepth = errors.New("parser-core phase zero: stale stack-summary candidate link depth")
+)
+
 // StackSummaryCandidate authenticates one ordered predecessor summary entry.
 // Depth counts non-extra payloads, exactly like tree-sitter's stack summary.
 // The scheduler performs cost comparison before it looks up an action.
@@ -212,6 +218,26 @@ func (c *Core) RecoverToAncestorStateOwned(owner SchedulerTransactionToken, cand
 	return out, c.finishSchedulerOwned(owner, err)
 }
 
+// StackSummaryCandidateRecoverable reports whether one authenticated summary
+// entry identifies exactly one mutable pop path. Summary deduplication can
+// retain an observational entry that is not safe to mutate.
+func (c *Core) StackSummaryCandidateRecoverable(candidate StackSummaryCandidate) (bool, error) {
+	if c == nil || candidate.owner != c || candidate.generation == 0 ||
+		candidate.generation != c.classificationPhase || candidate.source == 0 {
+		return false, nil
+	}
+	_, _, err := c.uniqueAncestorRecoveryPath(candidate)
+	if errors.Is(err, errAncestorRecoveryCandidateAmbiguous) ||
+		errors.Is(err, errAncestorRecoveryCandidateNoPath) ||
+		errors.Is(err, errAncestorRecoveryCandidateLinkDepth) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandidate) (Head, error) {
 	if candidate.owner != c {
 		return Head{}, errors.New("parser-core phase zero: stack-summary candidate belongs to a different core")
@@ -337,7 +363,7 @@ func (c *Core) uniqueAncestorRecoveryPath(candidate StackSummaryCandidate) ([]li
 			if len(route) != 0 && node.state == candidate.state {
 				matches++
 				if matches > 1 {
-					return errors.New("parser-core phase zero: ancestor recovery candidate has ambiguous pop paths")
+					return errAncestorRecoveryCandidateAmbiguous
 				}
 				if node.byteOffset != candidate.byteOffset {
 					return errors.New("parser-core phase zero: stale stack-summary candidate position")
@@ -385,10 +411,10 @@ func (c *Core) uniqueAncestorRecoveryPath(candidate StackSummaryCandidate) ([]li
 		return nil, 0, err
 	}
 	if matches == 0 {
-		return nil, 0, errors.New("parser-core phase zero: stack-summary candidate has no exact pop path")
+		return nil, 0, errAncestorRecoveryCandidateNoPath
 	}
 	if selectedTarget == 0 || len(selected) != int(candidate.linkDepth) {
-		return nil, 0, errors.New("parser-core phase zero: stale stack-summary candidate link depth")
+		return nil, 0, errAncestorRecoveryCandidateLinkDepth
 	}
 	return selected, selectedTarget, nil
 }

--- a/internal/parsercorephase0/ancestor_recovery_test.go
+++ b/internal/parsercorephase0/ancestor_recovery_test.go
@@ -345,6 +345,10 @@ func TestRecoverToAncestorStateRejectsAmbiguousDeduplicatedCandidate(t *testing.
 	if err != nil || len(candidates) != 1 {
 		t.Fatalf("deduplicated candidates=%+v err=%v, want one", candidates, err)
 	}
+	recoverable, err := compact.StackSummaryCandidateRecoverable(candidates[0])
+	if err != nil || recoverable {
+		t.Fatalf("ambiguous candidate recoverable=%t err=%v, want false nil", recoverable, err)
+	}
 
 	before := captureSchedulerTransactionState(compact)
 	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {

--- a/language.go
+++ b/language.go
@@ -822,6 +822,17 @@ type Language struct {
 	// no-action point exactly as before this stage landed.
 	CompactStrategy2ErrorRegionCertified bool
 
+	// CompactStackSummaryRecoveryCertified permits the compact fresh-full
+	// route to scan C's bounded stack summary at a no-action point. A
+	// successful scan forks the head into an ancestor-recovered lineage and
+	// an error-absorb lineage.
+	//
+	// The fork also requires CompactStrategy2ErrorRegionCertified. Both
+	// lineages continue to acceptance, where C-compatible error pricing selects
+	// the result. Exact built-in profiles must certify the complete competition.
+	// Custom and adapted languages retain the false default.
+	CompactStackSummaryRecoveryCertified bool
+
 	// CompactMissingTokenInsertionCertified permits the compact fresh-full
 	// route to scan for C's missing-token recovery candidate. A successful
 	// scan forks the head into missing and error-absorb lineages.

--- a/parser_derived_tables_internal_test.go
+++ b/parser_derived_tables_internal_test.go
@@ -180,6 +180,7 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 	derived := lang.acquireParserDerivedTables()
 
 	restoreErrorRegion := lang.CompactStrategy2ErrorRegionCertified
+	restoreStackSummary := lang.CompactStackSummaryRecoveryCertified
 	restoreStructuralElection := lang.CompactAcceptanceStructuralElectionCertified
 	restoreLexerSkippedPrefix := lang.CompactLexerSkippedPrefixTilingCertified
 	restoreMissingInsertion := lang.CompactMissingTokenInsertionCertified
@@ -188,6 +189,7 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 	restoreScanner := lang.ExternalScanner
 	t.Cleanup(func() {
 		lang.CompactStrategy2ErrorRegionCertified = restoreErrorRegion
+		lang.CompactStackSummaryRecoveryCertified = restoreStackSummary
 		lang.CompactAcceptanceStructuralElectionCertified = restoreStructuralElection
 		lang.CompactLexerSkippedPrefixTilingCertified = restoreLexerSkippedPrefix
 		lang.CompactMissingTokenInsertionCertified = restoreMissingInsertion
@@ -196,6 +198,7 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 		lang.ExternalScanner = restoreScanner
 	})
 	lang.CompactStrategy2ErrorRegionCertified = !restoreErrorRegion
+	lang.CompactStackSummaryRecoveryCertified = !restoreStackSummary
 	lang.CompactAcceptanceStructuralElectionCertified = !restoreStructuralElection
 	lang.CompactLexerSkippedPrefixTilingCertified = !restoreLexerSkippedPrefix
 	lang.CompactMissingTokenInsertionCertified = !restoreMissingInsertion

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -102,6 +102,10 @@ type DiagnosticParserCorePrefixOptions struct {
 	// name-keyed -- design section 7). Recovery must also be true: this
 	// option alone does not admit the fresh-full runner's recovery guard.
 	allowCompactStrategy2ErrorRegion bool
+	// allowCompactStackSummaryRecovery permits the scheduler to fork one
+	// no-action head into ancestor-recovered and error-absorb lineages.
+	// Language.CompactStackSummaryRecoveryCertified is its artifact gate.
+	allowCompactStackSummaryRecovery bool
 	// allowCompactMissingTokenInsertion permits the scheduler to fork one
 	// no-action head into missing-token and error-absorb recovery lineages.
 	// Language.CompactMissingTokenInsertionCertified is its artifact gate.
@@ -116,8 +120,9 @@ type DiagnosticParserCorePrefixOptions struct {
 	// (ts_parser__select_tree). A compact route that requires a sole accepted
 	// head cannot express that outcome at all.
 	//
-	// The admission route sets this only when one artifact certifies both
-	// recovery mechanisms. Other parses retain the conservative false default.
+	// The admission route sets this only when one artifact certifies strategy 2
+	// and at least one competing recovery mechanism. Other parses retain the
+	// conservative false default.
 	allowCompactRecoveryLineageSelection bool
 	// allowCompactRecoveryTrailingLineageRetirement permits C's condense-tail
 	// removal for one exact two-version S5 frontier. The admission route sets
@@ -374,6 +379,9 @@ type DiagnosticParserCoreHeaderPathReceipt struct {
 // from the compact core's physical arena storage.
 type DiagnosticParserCoreGenericWork struct {
 	Passes uint64
+	// StackSummaryRecoveryForks counts S4 forks that retain both the
+	// ancestor-recovered lineage and the error-absorb lineage.
+	StackSummaryRecoveryForks uint64
 	// RecoveryLineageSelections counts accepting frontiers resolved by pricing
 	// competing recovery lineages instead of declining. Every other
 	// head-removal site in this scheduler accounts for itself; without this
@@ -2386,7 +2394,7 @@ type diagnosticParserCoreGenericScheduler struct {
 	tokenCell          diagnosticParserCoreTokenCell
 	electionIndex      int
 	noLookaheadSteps   uint8
-	// recoveryIsolation becomes true only after S5 publishes its two versions.
+	// recoveryIsolation becomes true only after S4 or S5 publishes two versions.
 	// Clean parses retain the canonical scheduler fast path.
 	recoveryIsolation bool
 	// s3RegionOpened records one S3 recovery episode across this parse. A later
@@ -6612,12 +6620,9 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				// s3TryOpenErrorRegion bails (s3Region already set) and the
 				// existing decline applies -- fail-closed, not a guess.
 			case deeperResumeExists:
-				// A stack entry above depth 0 would accept resumeToken: C's
-				// own election could pick that deeper resume instead of
-				// continuing to absorb (strategy 1, out of S3 scope). Keeping
-				// this region growing here would risk swallowing bytes C's
-				// oracle would instead have left outside the ERROR container
-				// entirely -- decline rather than guess which one C picks.
+				// A stack entry above depth 0 would accept resumeToken. C can
+				// recover there instead of continuing to absorb. This S4 unit
+				// owns only the first no-action fork, so decline here.
 				return &diagnosticParserCoreGenericUnsupported{
 					boundary:    DiagnosticParserCoreRoute,
 					detail:      "generic scheduler s3 error region found a deeper stack-summary resume opportunity outside single-path depth-0 scope",
@@ -6881,13 +6886,20 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				if retired {
 					return nil, nil
 				}
-				// Try the certified S5 competition before standalone S3.
-				// Both routes own only the sole-header, sole-no-action shape.
+				// Try each certified recovery competition before standalone S3.
+				// This foundation owns only the sole-header, sole-no-action shape.
 				// Unmodeled ambiguity falls through to the existing decline.
 				if len(s.headers) == 1 && len(noActionIndices) == 1 {
 					handled, s5Err := s.s5TryMissingTokenInsertion(noActionIndices[0])
 					if s5Err != nil {
 						return nil, s5Err
+					}
+					if handled {
+						return nil, nil
+					}
+					handled, s4Err := s.s4TryStackSummaryRecovery(noActionIndices[0])
+					if s4Err != nil {
+						return nil, s4Err
 					}
 					if handled {
 						return nil, nil
@@ -7372,6 +7384,144 @@ func (s *diagnosticParserCoreGenericScheduler) s5MissingTokenAdmitted() bool {
 		s.options.allowCompactRecoveryLineageSelection
 }
 
+// s4StackSummaryRecoveryAdmitted reports whether the complete ancestor-
+// recovery competition is available. S4 needs the summary, absorb, and
+// acceptance capabilities.
+func (s *diagnosticParserCoreGenericScheduler) s4StackSummaryRecoveryAdmitted() bool {
+	return s.options.Recovery &&
+		s.options.allowCompactStackSummaryRecovery &&
+		s.options.allowCompactStrategy2ErrorRegion &&
+		s.options.allowCompactRecoveryLineageSelection
+}
+
+// s4TryStackSummaryRecovery forks one no-action head into two versions. The
+// original version absorbs the real token through S3. Its copied sibling
+// recovers to the first actionable stack-summary entry. This order matches
+// C's version list: strategy 1 appends its fork after the absorbing version.
+func (s *diagnosticParserCoreGenericScheduler) s4TryStackSummaryRecovery(index int) (handled bool, err error) {
+	if !s.s4StackSummaryRecoveryAdmitted() || len(s.headers) != 1 || index != 0 {
+		return false, nil
+	}
+	original := s.headers[index]
+	if original.s3Region != nil || s.token.Missing || s.token.NoLookahead ||
+		s.token.Symbol == 0 || s.token.Symbol == errorSymbol {
+		return false, nil
+	}
+	if s.nextSeq == math.MaxUint64 {
+		return false, errors.New("parser-core phase zero: recovery fork creation sequence overflow")
+	}
+
+	// C closes productions before it records and scans the stack summary.
+	// Keep the original header unchanged unless the complete fork succeeds.
+	closedHead, closedChanged, closeOK, closeErr := s.s3CloseInProgressProductions(original.head)
+	if closeErr != nil {
+		return false, closeErr
+	}
+	if !closeOK {
+		return false, nil
+	}
+	scanHead := original.head
+	if closedChanged {
+		scanHead = closedHead
+	}
+	_, position, boundaryErr := s.compact.Boundary(scanHead)
+	if boundaryErr != nil {
+		return false, boundaryErr
+	}
+
+	electionSymbol := s.token.Symbol
+	if relexed, relexOK := s.s3ErrorModeRelex(s.token.StartByte); relexOK && relexed.Symbol != errorSymbol {
+		electionSymbol = relexed.Symbol
+	}
+	candidates, summaryErr := s.compact.StackSummaryCandidates(scanHead, cRecoverMaxSummaryDepth)
+	if summaryErr != nil {
+		return false, summaryErr
+	}
+	var elected core.StackSummaryCandidate
+	found := false
+	for candidateIndex, candidate := range candidates {
+		if candidateIndex&63 == 0 {
+			if pollErr := s.pollStopControl(); pollErr != nil {
+				return false, pollErr
+			}
+		}
+		// C skips summary entries at the current group position. This first-fork
+		// unit has no older competing version to apply C's better-version gate to.
+		if candidate.ByteOffset() == position || candidate.ByteOffset() > position {
+			continue
+		}
+		recoverable, recoverableErr := s.compact.StackSummaryCandidateRecoverable(candidate)
+		if recoverableErr != nil {
+			return false, recoverableErr
+		}
+		if !recoverable {
+			continue
+		}
+		row, rowErr := s.compact.Actions(candidate.State(), core.Symbol(electionSymbol))
+		if rowErr != nil {
+			return false, rowErr
+		}
+		if row.Len() == 0 {
+			continue
+		}
+		elected = candidate
+		found = true
+		break
+	}
+	if !found {
+		return false, nil
+	}
+
+	absorbHeader := original
+	absorbHeader.head = scanHead
+	absorbHeader.paused = false
+	absorbHeader.shifted = false
+	s.headers[index] = absorbHeader
+	recoveredHeader := absorbHeader
+	recoveredHeader.creationSeq = s.nextSeq
+	restore := func() {
+		clear(s.headers)
+		s.headers = s.headers[:1]
+		s.headers[0] = original
+	}
+
+	absorbed, absorbErr := s.s3TryOpenErrorRegionWithAlternatives(index, true)
+	if absorbErr != nil {
+		restore()
+		return false, absorbErr
+	}
+	if !absorbed || s.headers[index].s3Region == nil || !s.headers[index].shifted {
+		restore()
+		return false, nil
+	}
+
+	var recoveredHead core.Head
+	recover := func(owner core.SchedulerTransactionToken) error {
+		var recoverErr error
+		recoveredHead, recoverErr = s.compact.RecoverToAncestorStateOwned(owner, elected)
+		return recoverErr
+	}
+	if s.freshSessionOwner != nil {
+		err = recover(*s.freshSessionOwner)
+	} else {
+		err = s.compact.ApplySchedulerAtomic(recover)
+	}
+	if err != nil {
+		restore()
+		return false, err
+	}
+	recoveredHeader.head = recoveredHead
+	recoveredHeader.s3Region = nil
+	recoveredHeader.shifted = false
+	s.headers[index].markRecoveryLineage()
+	recoveredHeader.markRecoveryLineage()
+	s.headers = append(s.headers, recoveredHeader)
+	s.recoveryIsolation = true
+	s.nextSeq++
+	s.work.add(&s.work.StackSummaryRecoveryForks, 1)
+	return true, nil
+}
+
 const (
 	s5MissingTokenMaxSpineDepth  = 4096
 	s5MissingTokenMaxSimulations = 256
@@ -7509,7 +7659,7 @@ func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertion(index 
 		s.headers[0] = original
 	}
 
-	absorbed, absorbErr := s.s3TryOpenErrorRegionWithMissingFork(index, true)
+	absorbed, absorbErr := s.s3TryOpenErrorRegionWithAlternatives(index, true)
 	if absorbErr != nil {
 		restore()
 		return false, absorbErr
@@ -7543,13 +7693,14 @@ func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertion(index 
 // unchanged: recovery is not admitted, the shape is not a single deterministic
 // path, or absorbing would require the EOF wrap S3 does not own.
 func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegion(index int) (handled bool, err error) {
-	return s.s3TryOpenErrorRegionWithMissingFork(index, false)
+	return s.s3TryOpenErrorRegionWithAlternatives(index, false)
 }
 
-// s3TryOpenErrorRegionWithMissingFork opens the absorb side of an S5 fork
-// when pairedMissing is true. The paired missing lineage replaces S3's normal
-// reason to decline a missing-token opportunity.
-func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegionWithMissingFork(index int, pairedMissing bool) (handled bool, err error) {
+// s3TryOpenErrorRegionWithAlternatives opens an absorb lineage after S4 and
+// S5 have either preserved or precisely rejected their alternatives. When
+// alternativesResolved is false, standalone S3 keeps its conservative
+// missing-token and deeper-summary decline guards.
+func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegionWithAlternatives(index int, alternativesResolved bool) (handled bool, err error) {
 	if !s.s3ErrorRegionAdmitted() {
 		return false, nil
 	}
@@ -7651,7 +7802,7 @@ func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegionWithMissingFo
 	// html_log_7 (a dangling start_tag whose next real token is a valid "</"
 	// it cannot use) needs a MISSING ">" here; absorbing "</" as an ordinary
 	// error-region token instead produced a confirmed wrong tree.
-	if !pairedMissing {
+	if !alternativesResolved {
 		missingOpportunity, missingErr := s.s3MissingTokenOpportunityExists(state)
 		if missingErr != nil {
 			return false, missingErr
@@ -7665,7 +7816,7 @@ func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegionWithMissingFo
 	// retains the strategy-2 version because C keeps that version beside its
 	// recovery forks. The artifact gate must prove that the carried versions
 	// produce C's selected result.
-	if !pairedMissing {
+	if !alternativesResolved {
 		deeperResumeExists, deeperErr := s.compact.AncestorStateWithActionExists(header.head, core.Symbol(s.token.Symbol), cRecoverMaxSummaryDepth)
 		if deeperErr != nil {
 			return false, deeperErr

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -452,6 +452,7 @@ func (r *parserCoreFreshFullRunner) parseWithObserverAndErrorRuns(
 ) (*Tree, error) {
 	savedRecovery := r.options.Recovery
 	savedErrorRegion := r.options.allowCompactStrategy2ErrorRegion
+	savedStackSummary := r.options.allowCompactStackSummaryRecovery
 	savedMissingInsertion := r.options.allowCompactMissingTokenInsertion
 	savedLineageSelection := r.options.allowCompactRecoveryLineageSelection
 	savedTrailingRetirement := r.options.allowCompactRecoveryTrailingLineageRetirement
@@ -459,6 +460,7 @@ func (r *parserCoreFreshFullRunner) parseWithObserverAndErrorRuns(
 	if !recoveryEnabled {
 		r.options.Recovery = false
 		r.options.allowCompactStrategy2ErrorRegion = false
+		r.options.allowCompactStackSummaryRecovery = false
 		r.options.allowCompactMissingTokenInsertion = false
 		r.options.allowCompactRecoveryLineageSelection = false
 		r.options.allowCompactRecoveryTrailingLineageRetirement = false
@@ -467,6 +469,7 @@ func (r *parserCoreFreshFullRunner) parseWithObserverAndErrorRuns(
 	defer func() {
 		r.options.Recovery = savedRecovery
 		r.options.allowCompactStrategy2ErrorRegion = savedErrorRegion
+		r.options.allowCompactStackSummaryRecovery = savedStackSummary
 		r.options.allowCompactMissingTokenInsertion = savedMissingInsertion
 		r.options.allowCompactRecoveryLineageSelection = savedLineageSelection
 		r.options.allowCompactRecoveryTrailingLineageRetirement = savedTrailingRetirement

--- a/parsercore_phase0_recovery_lineage_fork_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_fork_internal_test.go
@@ -136,9 +136,9 @@ func TestS3SecondIndependentErrorRegionDeclines(t *testing.T) {
 	scheduler.s3RegionOpened = true
 	original := scheduler.headers[0]
 
-	handled, err := scheduler.s3TryOpenErrorRegionWithMissingFork(0, true)
+	handled, err := scheduler.s3TryOpenErrorRegionWithAlternatives(0, true)
 	if err == nil || !strings.Contains(err.Error(), "one error region per parse") {
-		t.Fatalf("s3TryOpenErrorRegionWithMissingFork error=%v, want typed single-region decline", err)
+		t.Fatalf("s3TryOpenErrorRegionWithAlternatives error=%v, want typed single-region decline", err)
 	}
 	if handled || scheduler.headers[0] != original {
 		t.Fatalf("second region changed the frontier: handled=%t header=%+v", handled, scheduler.headers[0])

--- a/parsercore_phase0_stack_summary_recovery_internal_test.go
+++ b/parsercore_phase0_stack_summary_recovery_internal_test.go
@@ -1,0 +1,159 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+type stackSummaryRecoveryForkTable struct{}
+
+func (stackSummaryRecoveryForkTable) Actions(state core.StateID, symbol core.Symbol) (core.ActionRow, error) {
+	var actions []core.Action
+	switch {
+	case state == 1 && symbol == 2:
+		actions = []core.Action{{Type: core.ActionShift, State: 2}}
+	case state == 1 && symbol == 4:
+		actions = []core.Action{{Type: core.ActionShift, State: 4}}
+	case state == 1 && symbol == 5:
+		actions = []core.Action{{Type: core.ActionShift, State: 5}}
+	}
+	return core.NewActionRow(actions, false), nil
+}
+
+func (stackSummaryRecoveryForkTable) Goto(core.StateID, core.Symbol) (core.StateID, error) {
+	return 0, nil
+}
+
+func (stackSummaryRecoveryForkTable) ProductionFields(uint16, int) ([]core.FieldMapEntry, error) {
+	return nil, nil
+}
+
+func (stackSummaryRecoveryForkTable) ProductionAliases(uint16, int) ([]core.Symbol, error) {
+	return nil, nil
+}
+
+func newStackSummaryRecoveryForkScheduler(t *testing.T, armed bool) *diagnosticParserCoreGenericScheduler {
+	t.Helper()
+	compact, err := core.New(stackSummaryRecoveryForkTable{}, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(core.StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	head, err := compact.Shift(seed, core.Symbol(2), 0, core.Token{
+		Symbol: 2, StartByte: 0, EndByte: 1,
+	}, core.ForkOrder{})
+	if err != nil {
+		t.Fatalf("Shift: %v", err)
+	}
+	return &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		tokenSource: &dfaTokenSource{
+			language: &Language{TokenCount: 5},
+			lexer:    &Lexer{source: []byte("a?")},
+		},
+		headers: []diagnosticParserCoreHeader{{head: head, creationSeq: 3}},
+		token:   Token{Symbol: 4, StartByte: 1, EndByte: 2},
+		nextSeq: 10,
+		options: DiagnosticParserCorePrefixOptions{
+			Recovery:                             true,
+			allowCompactStrategy2ErrorRegion:     true,
+			allowCompactStackSummaryRecovery:     armed,
+			allowCompactRecoveryLineageSelection: true,
+		},
+	}
+}
+
+func TestS4StackSummaryRecoveryForkPublishesBothLineages(t *testing.T) {
+	scheduler := newStackSummaryRecoveryForkScheduler(t, true)
+	handled, err := scheduler.s4TryStackSummaryRecovery(0)
+	if err != nil {
+		t.Fatalf("s4TryStackSummaryRecovery: %v", err)
+	}
+	if !handled {
+		t.Fatal("the actionable ancestor did not fork")
+	}
+	if len(scheduler.headers) != 2 {
+		t.Fatalf("headers=%d, want two recovery lineages", len(scheduler.headers))
+	}
+	if !scheduler.headers[0].isRecoveryLineage() || !scheduler.headers[1].isRecoveryLineage() {
+		t.Fatal("the fork did not mark both recovery lineages")
+	}
+	if !scheduler.recoveryIsolation {
+		t.Fatal("the fork did not activate recovery isolation")
+	}
+	if !scheduler.headers[0].shifted || scheduler.headers[0].s3Region == nil {
+		t.Fatalf("absorb lineage did not consume the real token: %+v", scheduler.headers[0])
+	}
+	if scheduler.headers[1].shifted || scheduler.headers[1].s3Region != nil {
+		t.Fatalf("recovered lineage consumed the real token: %+v", scheduler.headers[1])
+	}
+	if scheduler.headers[0].creationSeq != 3 || scheduler.headers[1].creationSeq != 10 || scheduler.nextSeq != 11 {
+		t.Fatalf("creation sequence=%d/%d next=%d, want 3/10 next 11",
+			scheduler.headers[0].creationSeq, scheduler.headers[1].creationSeq, scheduler.nextSeq)
+	}
+	if scheduler.work.StackSummaryRecoveryForks != 1 {
+		t.Fatalf("stack-summary forks=%d, want 1", scheduler.work.StackSummaryRecoveryForks)
+	}
+
+	state, byteOffset, err := scheduler.compact.Boundary(scheduler.headers[1].head)
+	if err != nil {
+		t.Fatalf("recovered boundary: %v", err)
+	}
+	if state != 1 || byteOffset != 1 {
+		t.Fatalf("recovered boundary=%d@%d, want 1@1", state, byteOffset)
+	}
+	derivations, err := scheduler.compact.Derivations(scheduler.headers[1].head)
+	if err != nil {
+		t.Fatalf("recovered derivation: %v", err)
+	}
+	if len(derivations) != 1 || len(derivations[0].Payloads) != 1 {
+		t.Fatalf("recovered derivations=%+v, want one ERROR payload", derivations)
+	}
+	recovered, err := scheduler.compact.MaterializationView(derivations[0].Payloads[0])
+	if err != nil {
+		t.Fatalf("recovered payload: %v", err)
+	}
+	if recovered.Symbol != core.Symbol(errorSymbol) || recovered.StartByte != 0 || recovered.EndByte != 1 || len(recovered.Children) != 1 {
+		t.Fatalf("recovered payload=%+v, want ERROR over bytes 0..1", recovered)
+	}
+}
+
+func TestS4StackSummaryRecoveryForkRequiresArtifactGate(t *testing.T) {
+	scheduler := newStackSummaryRecoveryForkScheduler(t, false)
+	original := scheduler.headers[0]
+	handled, err := scheduler.s4TryStackSummaryRecovery(0)
+	if err != nil {
+		t.Fatalf("s4TryStackSummaryRecovery: %v", err)
+	}
+	if handled || len(scheduler.headers) != 1 || scheduler.headers[0] != original {
+		t.Fatalf("unarmed S4 changed the frontier: handled=%t headers=%+v", handled, scheduler.headers)
+	}
+	if scheduler.work.StackSummaryRecoveryForks != 0 || scheduler.nextSeq != 10 || scheduler.recoveryIsolation {
+		t.Fatalf("unarmed S4 changed state: forks=%d next=%d isolated=%t",
+			scheduler.work.StackSummaryRecoveryForks, scheduler.nextSeq, scheduler.recoveryIsolation)
+	}
+}
+
+func TestS4StackSummaryRecoveryForkRequiresSoleHeader(t *testing.T) {
+	scheduler := newStackSummaryRecoveryForkScheduler(t, true)
+	original := scheduler.headers[0]
+	scheduler.headers = append(scheduler.headers, original)
+
+	handled, err := scheduler.s4TryStackSummaryRecovery(1)
+	if err != nil {
+		t.Fatalf("s4TryStackSummaryRecovery: %v", err)
+	}
+	if handled || len(scheduler.headers) != 2 || scheduler.headers[0] != original || scheduler.headers[1] != original {
+		t.Fatalf("multi-header S4 changed the frontier: handled=%t headers=%+v", handled, scheduler.headers)
+	}
+	if scheduler.work.StackSummaryRecoveryForks != 0 || scheduler.recoveryIsolation {
+		t.Fatalf("multi-header S4 changed state: forks=%d isolated=%t",
+			scheduler.work.StackSummaryRecoveryForks, scheduler.recoveryIsolation)
+	}
+}


### PR DESCRIPTION
## Summary

Add the first fail-closed S4 recovery fork to the compact scheduler.

Keep the absorbing version and the ancestor-recovered version in C creation order.

Reject ambiguous stack-summary candidates before they mutate a parser head.

Keep the new capability disabled for all runtime profiles.

## Validation

- Run focused S4, S3, S5, and core tests in Docker.
- Run the full root and internal core packages in Docker.
- Compile the disabled-core build tag in Docker.
- Match all 25 HTML parity cases across three checks.
- Match all 25 JavaScript parity cases across three checks.
- Confirm the parser header remains 224 bytes.

## Scope

This change does not certify a runtime grammar.

A later change will add the exact six-version recovery condense before broader recovery routing.