### PR TITLE
compact: give parser versions independent lexer state

### DIFF
--- a/admission_census.go
+++ b/admission_census.go
@@ -518,7 +518,7 @@ func admissionCensusStopDecline(scheduler *diagnosticParserCoreGenericScheduler)
 			if scheduler.headers[index].isRecoveryLineage() {
 				marked++
 			}
-			if scheduler.headers[index].s3Region != nil {
+			if scheduler.headers[index].recoveryRegion() != nil {
 				openRegions++
 			}
 		}

--- a/cgo_harness/parity_compact_per_version_lexer_scala_test.go
+++ b/cgo_harness/parity_compact_per_version_lexer_scala_test.go
@@ -1,0 +1,151 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package cgoharness
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const (
+	compactPerVersionLexerScalaSource         = "(y)->"
+	compactPerVersionLexerScalaSourceSHA256   = "59b8f8c8f7f235973d07ac90f3089939e92da41ee23dcb496bc5c880f9577068"
+	compactPerVersionLexerScalaCDigest        = "81dc569b1ad3d567ed158aea75fd30a388ec1f4d3e1cbdd08c29a6535bd456d3"
+	compactPerVersionLexerScalaTree           = "(compilation_unit (postfix_expression (parenthesized_expression (identifier)) (operator_identifier)))"
+	compactPerVersionLexerScalaGrammarCommit  = "97aead18d97708190a51d4f551ea9b05b60641c9"
+	compactPerVersionLexerScalaGrammarRepo    = "https://github.com/tree-sitter/tree-sitter-scala"
+	compactPerVersionLexerScalaArtifactSHA256 = "c981583f2f5fa3acc4973b79ea7c43caa46e861179fe1323f12608bff5a21459"
+	compactPerVersionLexerScalaRuntimeVersion = "0.25.1"
+	compactPerVersionLexerScalaRuntimeCommit  = "f5afe475deb7c0bae6407fb776c76824f717bb61"
+)
+
+// TestCompactPerVersionLexerScalaCOracle is the stage-one oracle receipt.
+// Exhaustive enumeration found no shorter accepted witness over the tested
+// punctuation alphabet. The owned requests consume widths two and one.
+func TestCompactPerVersionLexerScalaCOracle(t *testing.T) {
+	source := []byte(compactPerVersionLexerScalaSource)
+	if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != compactPerVersionLexerScalaSourceSHA256 {
+		t.Fatalf("stage-one source SHA-256=%s, want %s", got, compactPerVersionLexerScalaSourceSHA256)
+	}
+
+	identity, err := COracleIdentity("scala")
+	if err != nil {
+		t.Fatalf("load locked Scala C identity: %v", err)
+	}
+	assertCompactPerVersionLexerScalaIdentity(t, identity)
+
+	cLanguage, err := ParityCLanguage("scala")
+	if err != nil {
+		t.Fatalf("load locked Scala C parser: %v", err)
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatalf("set locked Scala C language: %v", err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("locked C parser returned no root")
+	}
+	t.Cleanup(cTree.Close)
+	cRoot := cTree.RootNode()
+	assertCompactPerVersionLexerScalaCRoot(t, cRoot, len(source))
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatalf("inspect locked Scala C tree: %v", err)
+	}
+	if cDigest != compactPerVersionLexerScalaCDigest {
+		t.Fatalf("locked Scala C digest=%s, want %s", cDigest, compactPerVersionLexerScalaCDigest)
+	}
+	if got := formatCNodeSExpr(cRoot); got != compactPerVersionLexerScalaTree {
+		t.Fatalf("locked Scala C tree=%q, want %q", got, compactPerVersionLexerScalaTree)
+	}
+
+	entry := grammars.DetectLanguageByName("scala")
+	if entry == nil || entry.Language() == nil {
+		t.Fatal("Scala Go grammar is unavailable")
+	}
+	goLanguage := entry.Language()
+	gotreesitter.EnableRecoveryRuntimeTelemetry(true)
+	t.Cleanup(func() { gotreesitter.EnableRecoveryRuntimeTelemetry(false) })
+	beforeRouted, beforeFallback := gotreesitter.AdmissionCandidateCounters()
+	goParser := gotreesitter.NewParser(goLanguage)
+	goParser.SetAdmissionCandidateRoute(true)
+	goTree, err := goParser.Parse(source)
+	if err != nil {
+		t.Fatalf("compact candidate parse: %v", err)
+	}
+	if goTree == nil || goTree.RootNode() == nil {
+		t.Fatal("compact candidate returned no root")
+	}
+	t.Cleanup(goTree.Release)
+	routed, fallback := gotreesitter.AdmissionCandidateCounters()
+	if routed-beforeRouted != 1 || fallback-beforeFallback != 0 {
+		t.Fatalf("compact candidate counters=%d/%d, want 1/0; reason=%q",
+			routed-beforeRouted, fallback-beforeFallback, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+	if goTree.ParseStoppedEarly() {
+		t.Fatal("compact Scala parse stopped early")
+	}
+	goRoot := goTree.RootNode()
+	if goRoot.Type(goLanguage) != "compilation_unit" || goRoot.StartByte() != 0 || goRoot.EndByte() != uint32(len(source)) || goRoot.HasError() {
+		t.Fatalf("compact Scala root type/range/error=%q/%d..%d/%t, want compilation_unit/0..%d/false",
+			goRoot.Type(goLanguage), goRoot.StartByte(), goRoot.EndByte(), goRoot.HasError(), len(source))
+	}
+	if got := goRoot.SExpr(goLanguage); got != compactPerVersionLexerScalaTree {
+		t.Fatalf("compact Scala tree=%q, want %q", got, compactPerVersionLexerScalaTree)
+	}
+	if diff := FirstDivergenceDumpV1(goRoot, goLanguage, cRoot); diff != nil {
+		t.Fatalf("compact Scala tree diverges from locked C: %+v", *diff)
+	}
+	inspection, err := benchfixtures.InspectGoTree(goRoot, goLanguage)
+	if err != nil {
+		t.Fatalf("inspect compact Scala tree: %v", err)
+	}
+	if inspection.SHA256 != cDigest {
+		t.Fatalf("compact Scala digest=%s, want locked C %s", inspection.SHA256, cDigest)
+	}
+}
+
+func assertCompactPerVersionLexerScalaCRoot(t *testing.T, root *sitter.Node, sourceLength int) {
+	t.Helper()
+	if root.Kind() != "compilation_unit" || root.StartByte() != 0 || root.EndByte() != uint(sourceLength) || root.HasError() {
+		t.Fatalf("locked Scala C root type/range/error=%q/%d..%d/%t, want compilation_unit/0..%d/false",
+			root.Kind(), root.StartByte(), root.EndByte(), root.HasError(), sourceLength)
+	}
+}
+
+func assertCompactPerVersionLexerScalaIdentity(t *testing.T, identity COracleBuildIdentity) {
+	t.Helper()
+	checks := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"contract", identity.Contract, COracleContractVersion},
+		{"transport", identity.Transport, "cgo_parity_binding"},
+		{"binding module", identity.BindingModule, COracleBindingModule},
+		{"binding version", identity.BindingVersion, COracleBindingVersion},
+		{"binding commit", identity.BindingCommit, COracleBindingCommit},
+		{"runtime version", identity.RuntimeVersion, compactPerVersionLexerScalaRuntimeVersion},
+		{"runtime commit", identity.RuntimeCommit, compactPerVersionLexerScalaRuntimeCommit},
+		{"runtime linkage", identity.RuntimeLinkage, "static_cgo_test_binary"},
+		{"language", identity.Language, "scala"},
+		{"grammar repository", identity.GrammarRepo, compactPerVersionLexerScalaGrammarRepo},
+		{"grammar commit", identity.GrammarCommit, compactPerVersionLexerScalaGrammarCommit},
+		{"grammar linkage", identity.GrammarLinkage, "shared_dlopen"},
+		{"grammar compile flags", identity.GrammarCompileFlags, COracleGrammarCFlags},
+		{"grammar artifact SHA-256", identity.GrammarArtifactSHA256, compactPerVersionLexerScalaArtifactSHA256},
+	}
+	for _, check := range checks {
+		if check.got != check.want {
+			t.Fatalf("locked Scala C %s=%q, want %q", check.name, check.got, check.want)
+		}
+	}
+}

--- a/internal/parsercorephase0/checkpoint_interner.go
+++ b/internal/parsercorephase0/checkpoint_interner.go
@@ -113,6 +113,33 @@ func (i *checkpointInterner) receipt(id CheckpointID) (uint32, [32]byte, bool) {
 	return record.length, record.digest, true
 }
 
+// copyBytes copies one exact serialized checkpoint into dst. It reuses dst's
+// backing array when its capacity is sufficient and never exposes i.bytes.
+// Checkpoint zero is the valid empty checkpoint; every other ID must resolve
+// to a complete retained record.
+func (i *checkpointInterner) copyBytes(id CheckpointID, dst []byte) ([]byte, bool) {
+	if id == 0 {
+		return dst[:0], true
+	}
+	record, ok := i.record(id)
+	if !ok {
+		return nil, false
+	}
+	start := uint64(record.offset)
+	end := start + uint64(record.length)
+	if end < start || end > uint64(len(i.bytes)) {
+		return nil, false
+	}
+	length := int(record.length)
+	if cap(dst) < length {
+		dst = make([]byte, length)
+	} else {
+		dst = dst[:length]
+	}
+	copy(dst, i.bytes[int(start):int(end)])
+	return dst, true
+}
+
 func (i *checkpointInterner) stats() CheckpointInternerStats {
 	return CheckpointInternerStats{Unique: uint32(len(i.records)), SerializedBytes: uint64(len(i.bytes)), DigestCollisions: i.collisions}
 }

--- a/internal/parsercorephase0/checkpoint_interner_test.go
+++ b/internal/parsercorephase0/checkpoint_interner_test.go
@@ -1,6 +1,7 @@
 package parsercorephase0
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"errors"
 	"runtime"
@@ -63,6 +64,97 @@ func TestEmptyCheckpointReceiptIsConstantAndAllocationFree(t *testing.T) {
 		}
 	}); allocs != 0 {
 		t.Fatalf("empty checkpoint receipt allocations=%v, want 0", allocs)
+	}
+}
+
+func TestCheckpointInternerCopyBytesExactAndReusesCapacity(t *testing.T) {
+	interner := newCheckpointInterner(4, 64)
+	want := []byte{1, 2, 3, 4}
+	id, err := interner.intern(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	destination := make([]byte, 0, 8)
+	backing := &destination[:cap(destination)][0]
+	got, ok := interner.copyBytes(id, destination)
+	if !ok || !bytes.Equal(got, want) {
+		t.Fatalf("copied checkpoint=(%v,%t), want %v", got, ok, want)
+	}
+	if cap(got) != cap(destination) || &got[:cap(got)][0] != backing {
+		t.Fatalf("copy did not reuse destination capacity: cap=%d/%d", cap(got), cap(destination))
+	}
+
+	got[0] = 9
+	repeated, ok := interner.copyBytes(id, got[:0])
+	if !ok || !bytes.Equal(repeated, want) {
+		t.Fatalf("retained checkpoint changed through copied bytes=(%v,%t), want %v", repeated, ok, want)
+	}
+
+	emptyDestination := make([]byte, 3, 8)
+	empty, ok := interner.copyBytes(0, emptyDestination)
+	if !ok || len(empty) != 0 || cap(empty) != cap(emptyDestination) {
+		t.Fatalf("empty checkpoint copy=(%v,%t), cap=%d, want empty with cap=%d", empty, ok, cap(empty), cap(emptyDestination))
+	}
+
+	sentinel := []byte{7, 8, 9}
+	before := append([]byte(nil), sentinel...)
+	if copied, ok := interner.copyBytes(CheckpointID(99), sentinel); ok || copied != nil {
+		t.Fatalf("invalid checkpoint copy=(%v,%t), want (nil,false)", copied, ok)
+	}
+	if !bytes.Equal(sentinel, before) {
+		t.Fatalf("invalid checkpoint copy mutated destination=%v, want %v", sentinel, before)
+	}
+}
+
+func TestCoreCheckpointByteCopyMatchesReceiptAndOwnerContract(t *testing.T) {
+	compact, err := New(&fakeTable{}, Limits{MaxCheckpoints: 4, MaxCheckpointBytes: 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{4, 5, 6}
+	id := mustInternCheckpoint(t, compact, want)
+	destination := make([]byte, 0, 8)
+
+	length, digest, receiptOK := compact.CheckpointReceipt(id)
+	if !receiptOK || length != uint32(len(want)) || digest != sha256.Sum256(want) {
+		t.Fatalf("checkpoint receipt=(%d,%x,%t)", length, digest, receiptOK)
+	}
+	got, copyOK := compact.CopyCheckpointBytes(id, destination)
+	if !copyOK || !bytes.Equal(got, want) {
+		t.Fatalf("checkpoint copy=(%v,%t), want %v", got, copyOK, want)
+	}
+
+	if err := compact.ApplyAtomic(func() error {
+		inside, ok := compact.CopyCheckpointBytes(id, got[:0])
+		if !ok || !bytes.Equal(inside, want) {
+			t.Fatalf("transaction checkpoint copy=(%v,%t), want %v", inside, ok, want)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if copied, ok := compact.CopyCheckpointBytesOwned(SchedulerTransactionToken{}, id, destination); ok || copied != nil {
+		t.Fatalf("unowned checkpoint copy=(%v,%t), want (nil,false)", copied, ok)
+	}
+	var owner SchedulerTransactionToken
+	if err := compact.ApplySchedulerAtomic(func(token SchedulerTransactionToken) error {
+		owner = token
+		inside, ok := compact.CopyCheckpointBytesOwned(token, id, destination)
+		if !ok || !bytes.Equal(inside, want) {
+			t.Fatalf("owned checkpoint copy=(%v,%t), want %v", inside, ok, want)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if copied, ok := compact.CopyCheckpointBytesOwned(owner, id, destination); ok || copied != nil {
+		t.Fatalf("stale-owner checkpoint copy=(%v,%t), want (nil,false)", copied, ok)
+	}
+
+	if copied, ok := compact.CopyCheckpointBytes(CheckpointID(99), destination); ok || copied != nil {
+		t.Fatalf("invalid core checkpoint copy=(%v,%t), want (nil,false)", copied, ok)
 	}
 }
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -2053,6 +2053,15 @@ func (c *Core) AuthenticationGeneration() uint64 {
 	return c.classificationPhase
 }
 
+// PhaseScannerCheckpoints returns the current scanner checkpoint binding.
+// The exact flag is true only when start and end authenticate one token.
+func (c *Core) PhaseScannerCheckpoints() (checkpoint, start, end CheckpointID, exact bool) {
+	if c == nil {
+		return 0, 0, 0, false
+	}
+	return c.checkpoint, c.externalTokenScannerStart, c.externalTokenScannerEnd, c.externalTokenScannerExact
+}
+
 // ResetGeneration identifies the current retained Core arena lifetime. It
 // changes only when Reset clears the arena, not when a frontier or checkpoint
 // advances its authentication phase.
@@ -2248,16 +2257,31 @@ func (c *Core) SetPhaseCheckpoint(checkpoint CheckpointID) error {
 }
 
 // SetPhaseExternalTokenScannerCheckpoints binds one election to its exact
-// scanner states. It leaves no exact token proof when either identity fails.
+// scanner states. Validation is atomic. A changed pair advances boundary
+// authentication even when its end checkpoint is unchanged.
 func (c *Core) SetPhaseExternalTokenScannerCheckpoints(start, end CheckpointID) error {
-	if err := c.SetPhaseCheckpoint(end); err != nil {
-		return err
+	if len(c.transactions) != 0 {
+		return errors.New("parser-core phase zero: set checkpoint during active transaction")
+	}
+	if end != 0 {
+		if _, ok := c.checkpoints.record(end); !ok {
+			return errors.New("parser-core phase zero: unknown checkpoint identity")
+		}
 	}
 	if start != 0 {
 		if _, ok := c.checkpoints.record(start); !ok {
 			return errors.New("parser-core phase zero: unknown external token start checkpoint identity")
 		}
 	}
+	if c.checkpoint == end && c.externalTokenScannerExact &&
+		c.externalTokenScannerStart == start && c.externalTokenScannerEnd == end {
+		return nil
+	}
+	if c.classificationPhase == math.MaxUint64 {
+		return errors.New("parser-core phase zero: classification phase overflow")
+	}
+	c.classificationPhase++
+	c.checkpoint = end
 	c.externalTokenScannerStart = start
 	c.externalTokenScannerEnd = end
 	c.externalTokenScannerExact = true

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -2359,6 +2359,25 @@ func (c *Core) CheckpointReceiptOwned(owner SchedulerTransactionToken, id Checkp
 	return c.checkpoints.receipt(id)
 }
 
+// CopyCheckpointBytes copies one exact serialized checkpoint into dst. It
+// allows reads during transactions, reuses dst capacity, and returns no
+// retained interner storage to the caller.
+func (c *Core) CopyCheckpointBytes(id CheckpointID, dst []byte) ([]byte, bool) {
+	if c == nil {
+		return nil, false
+	}
+	return c.checkpoints.copyBytes(id, dst)
+}
+
+// CopyCheckpointBytesOwned copies one checkpoint under the active scheduler
+// owner. It follows CheckpointReceiptOwned's stale-owner failure contract.
+func (c *Core) CopyCheckpointBytesOwned(owner SchedulerTransactionToken, id CheckpointID, dst []byte) ([]byte, bool) {
+	if c == nil || c.validateSchedulerTransaction(owner) != nil {
+		return nil, false
+	}
+	return c.checkpoints.copyBytes(id, dst)
+}
+
 // CheckpointInternerStats reports bounded logical scanner-state retention.
 func (c *Core) CheckpointInternerStats() CheckpointInternerStats {
 	if c == nil {

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1277,17 +1277,20 @@ type Core struct {
 	reductionSourceOwner           uint32
 	transactions                   []uint64
 	nextTransaction                uint64
-	classificationPhase            uint64
-	work                           Work
-	popScratch                     popEnumerationScratch
-	reductionScratch               reductionOutputScratch
-	historicalNodeScratch          []NodeID
-	cohortHeadScratch              []Head
-	factorLinkScratch              []linkRecord
-	selectedBuild                  selectedStoreBuildScratch
-	selectedPoolMu                 sync.Mutex
-	selectedPool                   selectedStoreBacking
-	schedulerFrame                 schedulerTransactionFrame
+	// resetGeneration identifies the retained arena lifetime. It changes only
+	// when Reset clears the core, so phase checkpoints can advance independently.
+	resetGeneration       uint64
+	classificationPhase   uint64
+	work                  Work
+	popScratch            popEnumerationScratch
+	reductionScratch      reductionOutputScratch
+	historicalNodeScratch []NodeID
+	cohortHeadScratch     []Head
+	factorLinkScratch     []linkRecord
+	selectedBuild         selectedStoreBuildScratch
+	selectedPoolMu        sync.Mutex
+	selectedPool          selectedStoreBacking
+	schedulerFrame        schedulerTransactionFrame
 	// metadataConstructionAuthenticated remains true only while every compact
 	// subtree was published through the authenticated shift/reduction seams.
 	// Diagnostic generic publication clears it monotonically until Reset.
@@ -2011,6 +2014,7 @@ func New(tables TableView, limits Limits) (*Core, error) {
 	core := &Core{
 		tables: tables, limits: limits, frontier: 1, boundaries: boundaries,
 		checkpoints:                       newCheckpointInterner(limits.MaxCheckpoints, limits.MaxCheckpointBytes),
+		resetGeneration:                   1,
 		classificationPhase:               1,
 		dropCohortOwner:                   owner,
 		dropCohortEpoch:                   1,
@@ -2049,6 +2053,16 @@ func (c *Core) AuthenticationGeneration() uint64 {
 	return c.classificationPhase
 }
 
+// ResetGeneration identifies the current retained Core arena lifetime. It
+// changes only when Reset clears the arena, not when a frontier or checkpoint
+// advances its authentication phase.
+func (c *Core) ResetGeneration() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.resetGeneration
+}
+
 // Reset returns the compact core to the same empty frontier created by New
 // while retaining its authenticated tables, limits, diagnostic policy, and
 // arena capacities. Reset is deliberately unavailable during an active
@@ -2066,6 +2080,9 @@ func (c *Core) Reset() error {
 	if c.classificationPhase == math.MaxUint64 {
 		return errors.New("parser-core phase zero: classification phase overflow")
 	}
+	if c.resetGeneration == math.MaxUint64 {
+		return errors.New("parser-core phase zero: reset generation overflow")
+	}
 	if c.dropCohortEpoch == math.MaxUint64 {
 		return errors.New("parser-core phase zero: drop-cohort epoch overflow")
 	}
@@ -2073,6 +2090,7 @@ func (c *Core) Reset() error {
 		return err
 	}
 	c.classificationPhase++
+	c.resetGeneration++
 	if err := c.advanceDropCohortEpoch(); err != nil {
 		return err
 	}

--- a/internal/parsercorephase0/recursive_insert_test.go
+++ b/internal/parsercorephase0/recursive_insert_test.go
@@ -778,11 +778,20 @@ func TestExternalTokenScannerCheckpointValidation(t *testing.T) {
 	if !core.externalTokenScannerExact {
 		t.Fatal("exact token checkpoint pair was not retained")
 	}
+	phase := core.classificationPhase
 	if err := core.SetPhaseExternalTokenScannerCheckpoints(known, CheckpointID(99)); err == nil {
 		t.Fatal("unknown end checkpoint was accepted after exact proof")
 	}
-	if core.externalTokenScannerExact {
-		t.Fatal("rejected token checkpoint pair retained stale exact proof")
+	if !core.externalTokenScannerExact || core.externalTokenScannerStart != known ||
+		core.externalTokenScannerEnd != known || core.classificationPhase != phase {
+		t.Fatal("rejected token checkpoint pair changed the prior exact proof")
+	}
+	if err := core.SetPhaseExternalTokenScannerCheckpoints(CheckpointID(99), known); err == nil {
+		t.Fatal("unknown start checkpoint was accepted after exact proof")
+	}
+	if !core.externalTokenScannerExact || core.externalTokenScannerStart != known ||
+		core.externalTokenScannerEnd != known || core.classificationPhase != phase {
+		t.Fatal("rejected token start checkpoint changed the prior exact proof")
 	}
 	if err := core.SetPhaseExternalTokenScannerCheckpoints(known, known); err != nil {
 		t.Fatal(err)
@@ -798,6 +807,38 @@ func TestExternalTokenScannerCheckpointValidation(t *testing.T) {
 	}
 	if core.externalTokenScannerExact {
 		t.Fatal("frontier advance retained a stale token checkpoint pair")
+	}
+}
+
+func TestExternalTokenScannerCheckpointStartChangeInvalidatesBoundary(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{})
+	firstStart := mustInternCheckpoint(t, core, []byte{1})
+	secondStart := mustInternCheckpoint(t, core, []byte{2})
+	end := mustInternCheckpoint(t, core, []byte{3})
+	if err := core.SetPhaseExternalTokenScannerCheckpoints(firstStart, end); err != nil {
+		t.Fatal(err)
+	}
+	head, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	classified, err := core.ClassifyBoundary(head, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	generation := core.AuthenticationGeneration()
+	if err := core.SetPhaseExternalTokenScannerCheckpoints(secondStart, end); err != nil {
+		t.Fatal(err)
+	}
+	if core.AuthenticationGeneration() <= generation {
+		t.Fatalf("scanner start change did not advance authentication: before=%d after=%d", generation, core.AuthenticationGeneration())
+	}
+	_, start, gotEnd, exact := core.PhaseScannerCheckpoints()
+	if !exact || start != secondStart || gotEnd != end {
+		t.Fatalf("scanner pair=(%d,%d,%t), want (%d,%d,true)", start, gotEnd, exact, secondStart, end)
+	}
+	if err := core.validateClassification(classified); err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("old boundary validation error=%v, want stale", err)
 	}
 }
 

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -2934,10 +2934,19 @@ func (d *dfaTokenSource) CanRelexFromTokenStart(tok Token) bool {
 }
 
 type dfaRelexSnapshot struct {
-	lexerPos      int
-	lexerRow      uint32
-	lexerCol      uint32
-	lexerRangeIdx int
+	lexerPos               int
+	lexerRow               uint32
+	lexerCol               uint32
+	lexerRangeIdx          int
+	externalScannerPresent bool
+
+	// Lexer.scan records the beginning of its most recent failed token
+	// attempt. NextWithErrorRuns uses these coordinates to delimit the next
+	// error run, so a rejected re-lex must restore them with the cursor.
+	failTokenStartPos      int
+	failTokenStartRow      uint32
+	failTokenStartCol      uint32
+	failTokenStartRangeIdx int
 
 	externalPayload []byte
 
@@ -2971,6 +2980,11 @@ func (d *dfaTokenSource) snapshotRelexStateWithExternalBuffer(buf []byte) (dfaRe
 		lexerRow:                    d.lexer.row,
 		lexerCol:                    d.lexer.col,
 		lexerRangeIdx:               d.lexer.includedRangeIdx,
+		externalScannerPresent:      d.hasExternalScanner,
+		failTokenStartPos:           d.lexer.failTokenStartPos,
+		failTokenStartRow:           d.lexer.failTokenStartRow,
+		failTokenStartCol:           d.lexer.failTokenStartCol,
+		failTokenStartRangeIdx:      d.lexer.failTokenStartRangeIdx,
 		lastExternalTokenStartByte:  d.lastExternalTokenStartByte,
 		lastExternalTokenEndByte:    d.lastExternalTokenEndByte,
 		lastExternalTokenValid:      d.lastExternalTokenValid,
@@ -3009,6 +3023,10 @@ func (s dfaRelexSnapshot) restore(d *dfaTokenSource) {
 	d.lexer.row = s.lexerRow
 	d.lexer.col = s.lexerCol
 	d.lexer.includedRangeIdx = s.lexerRangeIdx
+	d.lexer.failTokenStartPos = s.failTokenStartPos
+	d.lexer.failTokenStartRow = s.failTokenStartRow
+	d.lexer.failTokenStartCol = s.failTokenStartCol
+	d.lexer.failTokenStartRangeIdx = s.failTokenStartRangeIdx
 	if d.hasExternalScanner && d.language != nil && d.language.ExternalScanner != nil {
 		d.language.ExternalScanner.Deserialize(d.externalPayload, s.externalPayload)
 	}

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -2969,9 +2969,126 @@ type dfaRelexSnapshot struct {
 	zeroWidthCount int
 }
 
+// dfaRelexSnapshotScratch owns the mutable slice backing for one transient
+// snapshot. A caller can reuse it only after the prior snapshot is dead.
+// Published parser-version snapshots must still deep-copy these slices.
+type dfaRelexSnapshotScratch struct {
+	externalPayload    []byte
+	externalTokenStart []byte
+	externalTokenEnd   []byte
+	extZeroTried       []bool
+}
+
 func (d *dfaTokenSource) snapshotRelexState() dfaRelexSnapshot {
 	snapshot, _ := d.snapshotRelexStateWithExternalBuffer(nil)
 	return snapshot
+}
+
+// snapshotRelexStateWithScratch captures the same state as
+// snapshotRelexState while reusing one caller-owned backing store. The
+// returned snapshot aliases scratch and remains valid only until the next
+// call with that scratch.
+func (d *dfaTokenSource) snapshotRelexStateWithScratch(scratch *dfaRelexSnapshotScratch) dfaRelexSnapshot {
+	if scratch == nil {
+		return d.snapshotRelexState()
+	}
+	s := d.snapshotRelexStateIntoScratch(scratch)
+	if d.hasExternalScanner && d.language != nil && d.language.ExternalScanner != nil {
+		buf := prepareDFARelexExternalPayloadScratch(scratch)
+		if n := d.language.ExternalScanner.Serialize(d.externalPayload, buf); n > 0 {
+			s.externalPayload = buf[:n]
+			scratch.externalPayload = buf[:n]
+		} else {
+			scratch.externalPayload = buf[:0]
+		}
+	} else {
+		clearDFARelexExternalPayloadScratch(scratch)
+	}
+	return s
+}
+
+// snapshotRelexStateWithScratchFromExternalPayload captures one snapshot
+// from scanner bytes that the caller already serialized at this cursor.
+// This avoids a second Serialize call during a parser election.
+func (d *dfaTokenSource) snapshotRelexStateWithScratchFromExternalPayload(
+	scratch *dfaRelexSnapshotScratch,
+	externalPayload []byte,
+) dfaRelexSnapshot {
+	if scratch == nil {
+		scratch = &dfaRelexSnapshotScratch{}
+	}
+	s := d.snapshotRelexStateIntoScratch(scratch)
+	if d.hasExternalScanner && d.language != nil && d.language.ExternalScanner != nil {
+		buf := prepareDFARelexExternalPayloadScratch(scratch)
+		if n := copy(buf, externalPayload); n > 0 {
+			s.externalPayload = buf[:n]
+			scratch.externalPayload = buf[:n]
+		} else {
+			scratch.externalPayload = buf[:0]
+		}
+	} else {
+		clearDFARelexExternalPayloadScratch(scratch)
+	}
+	return s
+}
+
+func (d *dfaTokenSource) snapshotRelexStateIntoScratch(scratch *dfaRelexSnapshotScratch) dfaRelexSnapshot {
+	s := dfaRelexSnapshot{
+		lexerPos:                    d.lexer.pos,
+		lexerRow:                    d.lexer.row,
+		lexerCol:                    d.lexer.col,
+		lexerRangeIdx:               d.lexer.includedRangeIdx,
+		externalScannerPresent:      d.hasExternalScanner,
+		failTokenStartPos:           d.lexer.failTokenStartPos,
+		failTokenStartRow:           d.lexer.failTokenStartRow,
+		failTokenStartCol:           d.lexer.failTokenStartCol,
+		failTokenStartRangeIdx:      d.lexer.failTokenStartRangeIdx,
+		lastExternalTokenStartByte:  d.lastExternalTokenStartByte,
+		lastExternalTokenEndByte:    d.lastExternalTokenEndByte,
+		lastExternalTokenValid:      d.lastExternalTokenValid,
+		lastExternalTokenWasExtra:   d.lastExternalTokenWasExtra,
+		externalTokenEndSameAsStart: d.externalTokenEndSameAsStart,
+		lastTokenStartByte:          d.lastTokenStartByte,
+		lastTokenEndByte:            d.lastTokenEndByte,
+		lastTokenValid:              d.lastTokenValid,
+		extZeroPos:                  d.extZeroPos,
+		extZeroState:                d.extZeroState,
+		zeroWidthPos:                d.zeroWidthPos,
+		zeroWidthCount:              d.zeroWidthCount,
+	}
+	scratch.externalTokenStart = append(scratch.externalTokenStart[:0], d.externalTokenStart...)
+	if len(d.externalTokenStart) != 0 {
+		s.externalTokenStart = scratch.externalTokenStart
+	}
+	scratch.externalTokenEnd = append(scratch.externalTokenEnd[:0], d.externalTokenEnd...)
+	if len(d.externalTokenEnd) != 0 {
+		s.externalTokenEnd = scratch.externalTokenEnd
+	}
+	scratch.extZeroTried = append(scratch.extZeroTried[:0], d.extZeroTried...)
+	if len(d.extZeroTried) != 0 {
+		s.extZeroTried = scratch.extZeroTried
+	}
+	return s
+}
+
+func prepareDFARelexExternalPayloadScratch(scratch *dfaRelexSnapshotScratch) []byte {
+	if cap(scratch.externalPayload) != externalScannerSerializationBufferSize {
+		if cap(scratch.externalPayload) > 0 {
+			clear(scratch.externalPayload[:cap(scratch.externalPayload)])
+		}
+		scratch.externalPayload = make([]byte, externalScannerSerializationBufferSize)
+	} else {
+		scratch.externalPayload = scratch.externalPayload[:externalScannerSerializationBufferSize]
+		clear(scratch.externalPayload)
+	}
+	return scratch.externalPayload
+}
+
+func clearDFARelexExternalPayloadScratch(scratch *dfaRelexSnapshotScratch) {
+	if cap(scratch.externalPayload) != 0 {
+		clear(scratch.externalPayload[:cap(scratch.externalPayload)])
+		scratch.externalPayload = scratch.externalPayload[:0]
+	}
 }
 
 func (d *dfaTokenSource) snapshotRelexStateWithExternalBuffer(buf []byte) (dfaRelexSnapshot, []byte) {

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -3,6 +3,7 @@ package gotreesitter
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2967,6 +2968,30 @@ type dfaRelexSnapshot struct {
 
 	zeroWidthPos   int
 	zeroWidthCount int
+}
+
+func (s dfaRelexSnapshot) equal(other dfaRelexSnapshot) bool {
+	return s.lexerPos == other.lexerPos && s.lexerRow == other.lexerRow &&
+		s.lexerCol == other.lexerCol && s.lexerRangeIdx == other.lexerRangeIdx &&
+		s.externalScannerPresent == other.externalScannerPresent &&
+		s.failTokenStartPos == other.failTokenStartPos &&
+		s.failTokenStartRow == other.failTokenStartRow &&
+		s.failTokenStartCol == other.failTokenStartCol &&
+		s.failTokenStartRangeIdx == other.failTokenStartRangeIdx &&
+		bytes.Equal(s.externalPayload, other.externalPayload) &&
+		s.lastExternalTokenStartByte == other.lastExternalTokenStartByte &&
+		s.lastExternalTokenEndByte == other.lastExternalTokenEndByte &&
+		s.lastExternalTokenValid == other.lastExternalTokenValid &&
+		s.lastExternalTokenWasExtra == other.lastExternalTokenWasExtra &&
+		s.externalTokenEndSameAsStart == other.externalTokenEndSameAsStart &&
+		s.lastTokenStartByte == other.lastTokenStartByte &&
+		s.lastTokenEndByte == other.lastTokenEndByte &&
+		s.lastTokenValid == other.lastTokenValid &&
+		bytes.Equal(s.externalTokenStart, other.externalTokenStart) &&
+		bytes.Equal(s.externalTokenEnd, other.externalTokenEnd) &&
+		s.extZeroPos == other.extZeroPos && s.extZeroState == other.extZeroState &&
+		slices.Equal(s.extZeroTried, other.extZeroTried) &&
+		s.zeroWidthPos == other.zeroWidthPos && s.zeroWidthCount == other.zeroWidthCount
 }
 
 // dfaRelexSnapshotScratch owns the mutable slice backing for one transient

--- a/parsercore_c4_vm.go
+++ b/parsercore_c4_vm.go
@@ -98,7 +98,7 @@ func (s *diagnosticParserCoreGenericScheduler) corridorEligible() bool {
 		return false
 	}
 	header := &s.headers[0]
-	if header.accepted || header.paused || header.s3Region != nil || header.shifted {
+	if header.accepted || header.paused || header.recoveryRegion() != nil || header.shifted {
 		return false
 	}
 	// Checkpoint continuity: the header must sit on the election's own

--- a/parsercore_phase0_canonical_scratch_internal_test.go
+++ b/parsercore_phase0_canonical_scratch_internal_test.go
@@ -434,7 +434,7 @@ func TestDiagnosticParserCoreCheckpointCompactLayoutsAMD64(t *testing.T) {
 	if got := unsafe.Sizeof(diagnosticParserCoreHeader{}); got != 224 {
 		t.Fatalf("scheduler header size=%d, want 224", got)
 	}
-	if got := unsafe.Sizeof(diagnosticParserCorePhaseHead{}); got != 12 {
-		t.Fatalf("canonical phase key size=%d, want 12", got)
+	if got := unsafe.Sizeof(diagnosticParserCorePhaseHead{}); got != 24 {
+		t.Fatalf("canonical phase key size=%d, want 24", got)
 	}
 }

--- a/parsercore_phase0_d2_span_unlocked_relex_test.go
+++ b/parsercore_phase0_d2_span_unlocked_relex_test.go
@@ -12,13 +12,12 @@ import (
 	"github.com/odvcencio/gotreesitter/grammars"
 )
 
-// D2-1 slice: span-unlocked per-header relex with fail-closed ragged-end
-// decline. relexTokenForState used to reject any per-header relex whose
+// D2-1 slice: span-unlocked per-header relex. relexTokenForState used to
+// reject any per-header relex whose
 // span (StartByte and EndByte) did not exactly match the shared election's
 // span. This slice unlocks EndByte: a same-start relex may now return a
-// wider or narrower token than the shared election, and dispatchPassActive
-// declines that shape fail-closed instead of shifting it (see
-// diagnosticParserCoreRaggedRelexDeclineDetail's doc comment).
+// wider or narrower token than the shared election. The scheduler now
+// activates owned per-header lexer requests for that shape.
 //
 // bashRaggedEndWitnessSource ("A(1%") is a real, minimal witness found by
 // targeted fuzzing of FuzzAdmissionRouteEquality's own bash lane (not
@@ -28,20 +27,19 @@ import (
 // deterministically via RelexTokenForStateForTest below. This witness's
 // own no-action head is drop-eligible on every recurrence during a full
 // scheduler run (a sibling header keeps advancing the same pass), so it
-// does not reach the scheduler-level ragged-end decline itself; see
+// does not reach the scheduler-level ownership activation itself; see
 // swiftRaggedEndWitnessSource below for that.
 var bashRaggedEndWitnessSource = []byte("A(1%")
 
-// swiftRaggedEndWitnessSource ("a<A<#-") is the scheduler-level, real
-// witness for the D2-1 ragged-end (different-span) decline (F1): at byte
+// swiftRaggedEndWitnessSource ("a<A<#-") is the scheduler-level witness
+// for D2-1 different-span ownership activation (F1). At byte
 // 3, swift's shared election is a 2-byte external-scanner token (symbol
 // 217, span 3..5, the "<#" raw-string-literal opener); a sibling header's
 // own state (47) relexes the same start byte to a narrower 1-byte token
 // (symbol 35, span 3..4, a plain "<" operator). Unlike
 // bashRaggedEndWitnessSource, every live header here is a no-action head
 // and at least one is ragged, so this shape is not drop-eligible: the
-// terminal Stop for this witness is the ragged-end decline itself (see
-// TestD2SpanUnlockedSchedulerDeclinesRaggedEndRelex).
+// scheduler activates owned lexer requests before a sibling can reduce.
 var swiftRaggedEndWitnessSource = []byte("a<A<#-")
 
 // TestD2SpanUnlockedRelexTokenForStateFindsRaggedEndOnRealBashWitness pins
@@ -99,10 +97,8 @@ func TestD2SpanUnlockedRelexTokenForStateFindsRaggedEndOnRealBashWitness(t *test
 	}
 }
 
-// TestD2SpanUnlockedRaggedRelexDeclineDetailCarriesWiderTokenSpan pins
-// the decline detail's exact format (Phase 1 item 4: receipts must record
-// the wider token's own symbol and span) against the same real witness's
-// exact values.
+// TestD2SpanUnlockedRaggedRelexDeclineDetailCarriesWiderTokenSpan pins the
+// legacy detail format for telemetry migrations.
 func TestD2SpanUnlockedRaggedRelexDeclineDetailCarriesWiderTokenSpan(t *testing.T) {
 	shared := gts.Token{Symbol: 160, StartByte: 2, EndByte: 3}
 	relexed := gts.Token{Symbol: 1, StartByte: 2, EndByte: 4}
@@ -121,29 +117,9 @@ func TestD2SpanUnlockedRaggedRelexDeclineDetailCarriesWiderTokenSpan(t *testing.
 	}
 }
 
-// TestD2SpanUnlockedSchedulerDeclinesRaggedEndRelex is the scheduler-level
-// fail-closed proof (Phase 2 item 1a, F1) for swiftRaggedEndWitnessSource:
-// the terminal Stop for the whole parse is the D2-1 ragged-end decline
-// itself (boundary recovery, detail prefixed by
-// diagnosticParserCoreRaggedRelexDeclineDetail's own text), not the
-// ordinary genuinely-empty-row boundary. Earlier evidence for this slice
-// (bashRaggedEndWitnessSource) claimed that branch was unreachable unless
-// every live header in a pass were simultaneously ragged; that claim was
-// wrong. The true condition is only that every live header is a no-action
-// head and at least one of them is ragged -- a shape swiftRaggedEndWitnessSource
-// exercises directly, and one this test's own mutation-verify step
-// (recorded in the D2-1 report) confirms kills a reverted decline.
-//
-// The primary assertion is the terminal Stop's boundary and detail (F2):
-// asserting there directly proves dispatchPassActive's own fail-closed
-// branch ran. The secondary NoActionDrops loop below is kept only as a
-// weaker check and cannot, on its own, detect a span leak: a
-// DiagnosticParserCoreGenericNoActionDrop's Token is the shared election's
-// own token by construction (a cell can never carry a different EndByte --
-// dispatchPassActive declines that shape before a cell is built), so a
-// leaked shift would remove the drop record entirely rather than change
-// its span.
-func TestD2SpanUnlockedSchedulerDeclinesRaggedEndRelex(t *testing.T) {
+// TestD2SpanUnlockedSchedulerActivatesOwnedLexerRequests proves that the
+// Swift witness preempts the shared pass and publishes both lexer views.
+func TestD2SpanUnlockedSchedulerActivatesOwnedLexerRequests(t *testing.T) {
 	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
 	entry := grammars.DetectLanguageByName("swift")
 	if entry == nil {
@@ -156,25 +132,38 @@ func TestD2SpanUnlockedSchedulerDeclinesRaggedEndRelex(t *testing.T) {
 		t.Fatalf("compact scheduler: %v", err)
 	}
 	if receipt.Acceptance != nil {
-		t.Fatal("compact scheduler unexpectedly accepted the ragged-end witness")
+		t.Fatal("compact scheduler unexpectedly accepted the ownership witness")
 	}
-	if receipt.Stop.Boundary != gts.DiagnosticParserCoreRecovery {
-		t.Fatalf("terminal Stop.Boundary = %q, want %q", receipt.Stop.Boundary, gts.DiagnosticParserCoreRecovery)
+	if receipt.Stop.Boundary != gts.DiagnosticParserCoreRoute {
+		t.Fatalf("terminal Stop.Boundary = %q, want %q", receipt.Stop.Boundary, gts.DiagnosticParserCoreRoute)
 	}
-	wantPrefix := gts.DiagnosticParserCoreRaggedRelexDeclineDetailForTest()
+	wantPrefix := gts.DiagnosticParserCoreOwnedDispatchPendingDetailForTest()
 	if !strings.HasPrefix(receipt.Stop.Detail, wantPrefix) {
 		t.Fatalf("terminal Stop.Detail = %q, want prefix %q", receipt.Stop.Detail, wantPrefix)
 	}
-
-	// Secondary, weaker check (see doc comment above): no no-action drop
-	// ever carries the narrower relexed token in place of the shared
-	// election's own token.
-	for _, drop := range receipt.NoActionDrops {
-		if drop.Token.StartByte != 3 {
-			continue
+	if receipt.PerVersionLexRequests != 2 || receipt.PerVersionLexRestores != 2 ||
+		receipt.PerVersionLexPublications != 6 || receipt.PerVersionLexAcceptedRaggedSpans != 0 {
+		t.Fatalf("owned lexer counters=%d/%d/%d/%d, want 2/2/6/0",
+			receipt.PerVersionLexRequests, receipt.PerVersionLexRestores,
+			receipt.PerVersionLexPublications, receipt.PerVersionLexAcceptedRaggedSpans)
+	}
+	want := map[gts.StateID]struct {
+		symbol  gts.Symbol
+		endByte uint32
+	}{
+		47:  {symbol: 35, endByte: 4},
+		524: {symbol: 217, endByte: 5},
+	}
+	if len(receipt.VersionLexerRequests) != len(want) {
+		t.Fatalf("owned lexer requests=%d, want %d", len(receipt.VersionLexerRequests), len(want))
+	}
+	for _, request := range receipt.VersionLexerRequests {
+		expect, ok := want[request.State]
+		if !ok {
+			t.Fatalf("unexpected owned lexer state=%d", request.State)
 		}
-		if drop.Token.EndByte != 5 || drop.Token.Symbol != 217 {
-			t.Fatalf("no-action drop at byte 3 = %+v, want the shared election's own token (symbol=217, end=5), never the relexed one", drop.Token)
+		if request.Token.Symbol != expect.symbol || request.Token.StartByte != 3 || request.Token.EndByte != expect.endByte {
+			t.Fatalf("state %d token=%+v, want symbol=%d span=3..%d", request.State, request.Token, expect.symbol, expect.endByte)
 		}
 	}
 }
@@ -305,9 +294,9 @@ func TestD2SpanUnlockedSameSpanRelexStillShiftsRealBashInstallWitness(t *testing
 // TestD2SpanUnlockedDisableOptionMatchesLegacyBehavior is the D2-1 Phase 2
 // item 1c anchor (F4): DisablePerHeaderSpanUnlockedRelex restores the
 // pre-D2-1 span-locked probe exactly, using swiftRaggedEndWitnessSource
-// (the same witness TestD2SpanUnlockedSchedulerDeclinesRaggedEndRelex
+// (the same witness TestD2SpanUnlockedSchedulerActivatesOwnedLexerRequests
 // pins) so the two routes are provably different, not just superficially
-// identical: enabled produces the D2-1 ragged-end decline's own detail;
+// identical: enabled activates owned per-header requests;
 // disabled produces exactly diagnosticParserCoreNoTableActionDetail, the
 // origin/main behavior for this witness (relexTokenForState never returns
 // a different-span token at all when disabled, so the no-action head takes
@@ -335,13 +324,14 @@ func TestD2SpanUnlockedDisableOptionMatchesLegacyBehavior(t *testing.T) {
 	if enabled.Acceptance != nil || disabled.Acceptance != nil {
 		t.Fatal("compact scheduler unexpectedly accepted the ragged-end witness")
 	}
-	if enabled.Stop.Boundary != gts.DiagnosticParserCoreRecovery || disabled.Stop.Boundary != gts.DiagnosticParserCoreRecovery {
-		t.Fatalf("enabled/disabled boundaries = %q/%q, want both %q",
-			enabled.Stop.Boundary, disabled.Stop.Boundary, gts.DiagnosticParserCoreRecovery)
+	if enabled.Stop.Boundary != gts.DiagnosticParserCoreRoute || disabled.Stop.Boundary != gts.DiagnosticParserCoreRecovery {
+		t.Fatalf("enabled/disabled boundaries = %q/%q, want %q/%q",
+			enabled.Stop.Boundary, disabled.Stop.Boundary,
+			gts.DiagnosticParserCoreRoute, gts.DiagnosticParserCoreRecovery)
 	}
-	wantEnabledPrefix := gts.DiagnosticParserCoreRaggedRelexDeclineDetailForTest()
+	wantEnabledPrefix := gts.DiagnosticParserCoreOwnedDispatchPendingDetailForTest()
 	if !strings.HasPrefix(enabled.Stop.Detail, wantEnabledPrefix) {
-		t.Fatalf("enabled detail = %q, want prefix %q (the D2-1 ragged-end decline)", enabled.Stop.Detail, wantEnabledPrefix)
+		t.Fatalf("enabled detail = %q, want prefix %q", enabled.Stop.Detail, wantEnabledPrefix)
 	}
 	wantDisabledDetail := gts.DiagnosticParserCoreNoTableActionDetailForTest()
 	if disabled.Stop.Detail != wantDisabledDetail {

--- a/parsercore_phase0_d2_span_unlocked_relex_test.go
+++ b/parsercore_phase0_d2_span_unlocked_relex_test.go
@@ -31,16 +31,16 @@ import (
 // swiftRaggedEndWitnessSource below for that.
 var bashRaggedEndWitnessSource = []byte("A(1%")
 
-// swiftRaggedEndWitnessSource ("a<A<#-") is the scheduler-level witness
+// swiftRaggedEndWitnessSource is the scheduler-level witness
 // for D2-1 different-span ownership activation (F1). At byte
-// 3, swift's shared election is a 2-byte external-scanner token (symbol
-// 217, span 3..5, the "<#" raw-string-literal opener); a sibling header's
+// 4, swift's shared election is a 2-byte external-scanner token (symbol
+// 217, span 4..6, the "<#" raw-string-literal opener); a sibling header's
 // own state (47) relexes the same start byte to a narrower 1-byte token
-// (symbol 35, span 3..4, a plain "<" operator). Unlike
+// (symbol 35, span 4..5, a plain "<" operator). Unlike
 // bashRaggedEndWitnessSource, every live header here is a no-action head
 // and at least one is ragged, so this shape is not drop-eligible: the
 // scheduler activates owned lexer requests before a sibling can reduce.
-var swiftRaggedEndWitnessSource = []byte("a<A<#-")
+var swiftRaggedEndWitnessSource = []byte("a<(A<#/x/#)")
 
 // TestD2SpanUnlockedRelexTokenForStateFindsRaggedEndOnRealBashWitness pins
 // the probe's own contract (Phase 1 item 2) against the real witness above.
@@ -131,39 +131,34 @@ func TestD2SpanUnlockedSchedulerActivatesOwnedLexerRequests(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compact scheduler: %v", err)
 	}
-	if receipt.Acceptance != nil {
-		t.Fatal("compact scheduler unexpectedly accepted the ownership witness")
+	if receipt.Acceptance == nil {
+		t.Fatalf("compact scheduler did not accept the ownership witness: stop=%+v", receipt.Stop)
 	}
-	if receipt.Stop.Boundary != gts.DiagnosticParserCoreRoute {
-		t.Fatalf("terminal Stop.Boundary = %q, want %q", receipt.Stop.Boundary, gts.DiagnosticParserCoreRoute)
-	}
-	wantPrefix := gts.DiagnosticParserCoreOwnedDispatchPendingDetailForTest()
-	if !strings.HasPrefix(receipt.Stop.Detail, wantPrefix) {
-		t.Fatalf("terminal Stop.Detail = %q, want prefix %q", receipt.Stop.Detail, wantPrefix)
-	}
-	if receipt.PerVersionLexRequests != 2 || receipt.PerVersionLexRestores != 2 ||
-		receipt.PerVersionLexPublications != 6 || receipt.PerVersionLexAcceptedRaggedSpans != 0 {
-		t.Fatalf("owned lexer counters=%d/%d/%d/%d, want 2/2/6/0",
+	if receipt.PerVersionLexRequests != 4 || receipt.PerVersionLexRestores != 4 ||
+		receipt.PerVersionLexPublications != 14 || receipt.PerVersionLexAcceptedRaggedSpans != 3 ||
+		receipt.PerVersionLexViabilityDrops != 1 {
+		t.Fatalf("owned lexer counters=%d/%d/%d/%d/%d, want 4/4/14/3/1",
 			receipt.PerVersionLexRequests, receipt.PerVersionLexRestores,
-			receipt.PerVersionLexPublications, receipt.PerVersionLexAcceptedRaggedSpans)
+			receipt.PerVersionLexPublications, receipt.PerVersionLexAcceptedRaggedSpans,
+			receipt.PerVersionLexViabilityDrops)
 	}
 	want := map[gts.StateID]struct {
 		symbol  gts.Symbol
 		endByte uint32
 	}{
-		47:  {symbol: 35, endByte: 4},
-		524: {symbol: 217, endByte: 5},
+		441:  {symbol: 35, endByte: 5},
+		1554: {symbol: 35, endByte: 5},
 	}
-	if len(receipt.VersionLexerRequests) != len(want) {
-		t.Fatalf("owned lexer requests=%d, want %d", len(receipt.VersionLexerRequests), len(want))
+	if len(receipt.VersionLexerRequests) < len(want) {
+		t.Fatalf("owned lexer requests=%d, want at least %d", len(receipt.VersionLexerRequests), len(want))
 	}
 	for _, request := range receipt.VersionLexerRequests {
 		expect, ok := want[request.State]
 		if !ok {
-			t.Fatalf("unexpected owned lexer state=%d", request.State)
+			continue
 		}
-		if request.Token.Symbol != expect.symbol || request.Token.StartByte != 3 || request.Token.EndByte != expect.endByte {
-			t.Fatalf("state %d token=%+v, want symbol=%d span=3..%d", request.State, request.Token, expect.symbol, expect.endByte)
+		if request.Token.Symbol != expect.symbol || request.Token.StartByte != 4 || request.Token.EndByte != expect.endByte {
+			t.Fatalf("state %d token=%+v, want symbol=%d span=4..%d", request.State, request.Token, expect.symbol, expect.endByte)
 		}
 	}
 }
@@ -321,17 +316,11 @@ func TestD2SpanUnlockedDisableOptionMatchesLegacyBehavior(t *testing.T) {
 		t.Fatalf("disabled: compact scheduler: %v", err)
 	}
 
-	if enabled.Acceptance != nil || disabled.Acceptance != nil {
-		t.Fatal("compact scheduler unexpectedly accepted the ragged-end witness")
+	if enabled.Acceptance == nil || disabled.Acceptance != nil {
+		t.Fatalf("enabled/disabled acceptance=%t/%t, want true/false", enabled.Acceptance != nil, disabled.Acceptance != nil)
 	}
-	if enabled.Stop.Boundary != gts.DiagnosticParserCoreRoute || disabled.Stop.Boundary != gts.DiagnosticParserCoreRecovery {
-		t.Fatalf("enabled/disabled boundaries = %q/%q, want %q/%q",
-			enabled.Stop.Boundary, disabled.Stop.Boundary,
-			gts.DiagnosticParserCoreRoute, gts.DiagnosticParserCoreRecovery)
-	}
-	wantEnabledPrefix := gts.DiagnosticParserCoreOwnedDispatchPendingDetailForTest()
-	if !strings.HasPrefix(enabled.Stop.Detail, wantEnabledPrefix) {
-		t.Fatalf("enabled detail = %q, want prefix %q", enabled.Stop.Detail, wantEnabledPrefix)
+	if enabled.Stop.Detail != "" || disabled.Stop.Boundary != gts.DiagnosticParserCoreRecovery {
+		t.Fatalf("enabled stop=%+v disabled boundary=%q, want accepted/recovery", enabled.Stop, disabled.Stop.Boundary)
 	}
 	wantDisabledDetail := gts.DiagnosticParserCoreNoTableActionDetailForTest()
 	if disabled.Stop.Detail != wantDisabledDetail {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -321,6 +321,20 @@ type DiagnosticParserCoreElection struct {
 	CurrentCheckpointBytes [2]uint32
 }
 
+// DiagnosticParserCoreVersionLexerRequest records one full owned lexer
+// request. The pair is the scanner state before and after the token, not a
+// cursor-only approximation. Full receipts retain these records so a caller
+// can audit straddled token spans and their authenticated checkpoints.
+type DiagnosticParserCoreVersionLexerRequest struct {
+	ElectionIndex     int
+	HeaderCreationSeq uint64
+	State             StateID
+	Token             Token
+	InternalDFAToken  bool
+	ScannerBefore     DiagnosticParserCoreScannerCheckpoint
+	ScannerAfter      DiagnosticParserCoreScannerCheckpoint
+}
+
 type DiagnosticParserCoreHeaderReceipt struct {
 	CreationSeq uint64
 	State       StateID
@@ -430,9 +444,23 @@ type DiagnosticParserCoreGenericWork struct {
 	ReductionPauses        uint64
 	NoActionDrops          uint64
 	Elections              uint64
-	Canonicalizations      uint64
-	PeakHeaders            uint64
-	Overflow               bool
+	// PerVersionLexRequests counts lexer calls issued for an owned parser
+	// version. The shared lexer election does not contribute to this counter.
+	PerVersionLexRequests uint64
+	// PerVersionLexRestores counts exact DFA and scanner snapshot restores
+	// before an owned request or a state-dependent re-request.
+	PerVersionLexRestores uint64
+	// PerVersionLexPublications counts immutable snapshots published to a
+	// parser header or its scheduler sidecar.
+	PerVersionLexPublications uint64
+	// PerVersionLexAcceptedRaggedSpans counts different-width token views that
+	// the owned scheduler accepted instead of declining at a shared cursor.
+	PerVersionLexAcceptedRaggedSpans uint64
+	// PeakLiveVersions records the largest live owned-header frontier.
+	PeakLiveVersions  uint64
+	Canonicalizations uint64
+	PeakHeaders       uint64
+	Overflow          bool
 }
 
 func (w *DiagnosticParserCoreGenericWork) add(counter *uint64, delta uint64) {
@@ -554,22 +582,28 @@ type DiagnosticParserCoreGenericCompletion struct {
 // DiagnosticParserCoreGenericScheduler records one committed compact scheduler
 // run from the sole authenticated seed lifecycle before its first election.
 type DiagnosticParserCoreGenericScheduler struct {
-	ReceiptMode       DiagnosticParserCoreReceiptMode
-	StartCheckpoint   DiagnosticParserCoreScannerCheckpoint
-	StartHeaders      []DiagnosticParserCoreHeaderPathReceipt
-	Rounds            []DiagnosticParserCoreDispatchRound
-	Conflicts         []DiagnosticParserCoreGenericConflict
-	ExternalShifts    []DiagnosticParserCoreGenericExternalShift
-	Elections         []DiagnosticParserCoreElection
-	NoActionDrops     []DiagnosticParserCoreGenericNoActionDrop
-	Completion        *DiagnosticParserCoreGenericCompletion
-	Acceptance        *DiagnosticParserCoreGenericAcceptance
-	acceptanceBacking DiagnosticParserCoreGenericAcceptance
-	Stop              DiagnosticParserCoreGenericStop
-	Tokens            uint64
-	Dispatches        uint64
-	GlobalBranchOrder uint64
-	NextCreationSeq   uint64
+	ReceiptMode                      DiagnosticParserCoreReceiptMode
+	StartCheckpoint                  DiagnosticParserCoreScannerCheckpoint
+	StartHeaders                     []DiagnosticParserCoreHeaderPathReceipt
+	Rounds                           []DiagnosticParserCoreDispatchRound
+	Conflicts                        []DiagnosticParserCoreGenericConflict
+	ExternalShifts                   []DiagnosticParserCoreGenericExternalShift
+	Elections                        []DiagnosticParserCoreElection
+	VersionLexerRequests             []DiagnosticParserCoreVersionLexerRequest
+	NoActionDrops                    []DiagnosticParserCoreGenericNoActionDrop
+	Completion                       *DiagnosticParserCoreGenericCompletion
+	Acceptance                       *DiagnosticParserCoreGenericAcceptance
+	acceptanceBacking                DiagnosticParserCoreGenericAcceptance
+	Stop                             DiagnosticParserCoreGenericStop
+	Tokens                           uint64
+	Dispatches                       uint64
+	GlobalBranchOrder                uint64
+	NextCreationSeq                  uint64
+	PerVersionLexRequests            uint64
+	PerVersionLexRestores            uint64
+	PerVersionLexPublications        uint64
+	PerVersionLexAcceptedRaggedSpans uint64
+	PeakLiveVersions                 uint64
 }
 
 type DiagnosticParserCorePrefixResult struct {
@@ -2501,19 +2535,41 @@ type diagnosticParserCoreTokenCell struct {
 	valid            bool
 }
 
+// diagnosticParserCoreVersionLexerRequest owns one header's current
+// lookahead. The scheduler keeps this sidecar outside the pinned header so a
+// different token width never changes the compact cell layout.
+type diagnosticParserCoreVersionLexerRequest struct {
+	electionIndex     int
+	headerCreationSeq uint64
+	state             StateID
+	token             Token
+	before            *diagnosticParserCoreVersionLexerSnapshot
+	after             *diagnosticParserCoreVersionLexerSnapshot
+	beforeCheckpoint  DiagnosticParserCoreScannerCheckpoint
+	afterCheckpoint   DiagnosticParserCoreScannerCheckpoint
+	beforeID          core.CheckpointID
+	afterID           core.CheckpointID
+	valid             bool
+}
+
 type diagnosticParserCoreGenericScheduler struct {
-	compact            *core.Core
-	tokenSource        *dfaTokenSource
-	scannerScratch     *[]byte
-	headers            []diagnosticParserCoreHeader
-	token              Token
-	checkpoint         DiagnosticParserCoreScannerCheckpoint
-	checkpointBeforeID core.CheckpointID
-	checkpointID       core.CheckpointID
-	currentElection    DiagnosticParserCoreElection
-	tokenCell          diagnosticParserCoreTokenCell
-	electionIndex      int
-	noLookaheadSteps   uint8
+	compact                      *core.Core
+	tokenSource                  *dfaTokenSource
+	scannerScratch               *[]byte
+	headers                      []diagnosticParserCoreHeader
+	token                        Token
+	checkpoint                   DiagnosticParserCoreScannerCheckpoint
+	checkpointBeforeID           core.CheckpointID
+	checkpointID                 core.CheckpointID
+	currentElection              DiagnosticParserCoreElection
+	tokenCell                    diagnosticParserCoreTokenCell
+	versionLexerBefore           dfaRelexSnapshot
+	versionLexerBeforeValid      bool
+	versionLexerBeforeElection   int
+	versionLexerBeforeCheckpoint core.CheckpointID
+	versionLexerRequests         []diagnosticParserCoreVersionLexerRequest
+	electionIndex                int
+	noLookaheadSteps             uint8
 	// recoveryIsolation becomes true only after S4 or S5 publishes two versions.
 	// Clean parses retain the canonical scheduler fast path.
 	recoveryIsolation bool
@@ -3963,6 +4019,13 @@ func clearDiagnosticParserCoreGenericSchedulerVersionState(scheduler *diagnostic
 	clearDiagnosticParserCorePhaseHeadBacking(scheduler.canonicalScratch.keys)
 	clearDiagnosticParserCorePhaseHeadBacking(scheduler.canonicalScratch.inlineKeys[:])
 	clear(scheduler.canonicalScratch.groups)
+	if cap(scheduler.versionLexerRequests) != 0 {
+		clear(scheduler.versionLexerRequests[:cap(scheduler.versionLexerRequests)])
+	}
+	scheduler.versionLexerBefore = dfaRelexSnapshot{}
+	scheduler.versionLexerBeforeValid = false
+	scheduler.versionLexerBeforeElection = 0
+	scheduler.versionLexerBeforeCheckpoint = 0
 }
 
 func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGenericScheduler) error {
@@ -3987,6 +4050,7 @@ func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGe
 	electStates := resetDiagnosticParserCoreRetainedSlice(scheduler.electStates)
 	electGLRStates := resetDiagnosticParserCoreRetainedSlice(scheduler.electGLRStates)
 	acceptedPayloads := resetDiagnosticParserCoreRetainedSlice(scheduler.acceptedPayloads)
+	versionLexerRequests := resetDiagnosticParserCoreRetainedSlice(scheduler.versionLexerRequests)
 	*scheduler = diagnosticParserCoreGenericScheduler{
 		summaryHeaderScratch: summaryHeaders,
 		dispatchScratch: diagnosticParserCoreDispatchScratch{
@@ -4005,6 +4069,7 @@ func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGe
 		electStates:           electStates,
 		electGLRStates:        electGLRStates,
 		acceptedPayloads:      acceptedPayloads,
+		versionLexerRequests:  versionLexerRequests,
 	}
 	return nil
 }
@@ -4456,6 +4521,245 @@ func (s *diagnosticParserCoreGenericScheduler) relexTokenForState(state StateID,
 		return tok, false
 	}
 	return relexed, true
+}
+
+// withVersionLexerOwner runs one snapshot publication under the scheduler's
+// authenticated owner. Fresh sessions already hold the owner; ordinary
+// diagnostic calls acquire one short transaction for the publication only.
+func (s *diagnosticParserCoreGenericScheduler) withVersionLexerOwner(fn func(core.SchedulerTransactionToken) error) error {
+	if s == nil || s.compact == nil || fn == nil {
+		return errors.New("parser-core phase zero: version lexer owner is unavailable")
+	}
+	if s.freshSessionOwner != nil {
+		return fn(*s.freshSessionOwner)
+	}
+	return s.compact.ApplySchedulerAtomic(fn)
+}
+
+func (s *diagnosticParserCoreGenericScheduler) versionLexerSnapshotForHeader(index int) *diagnosticParserCoreVersionLexerSnapshot {
+	if s == nil || index < 0 || index >= len(s.headers) {
+		return nil
+	}
+	return s.headers[index].versionLexerSnapshot()
+}
+
+func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestForHeader(index int) *diagnosticParserCoreVersionLexerRequest {
+	if s == nil || index < 0 || index >= len(s.headers) {
+		return nil
+	}
+	sequence := s.headers[index].creationSeq
+	state, _, err := s.compact.Boundary(s.headers[index].head)
+	if err != nil {
+		return nil
+	}
+	base := s.versionLexerSnapshotForHeader(index)
+	for requestIndex := range s.versionLexerRequests {
+		request := &s.versionLexerRequests[requestIndex]
+		if request.valid && request.electionIndex == s.electionIndex && request.headerCreationSeq == sequence && request.state == StateID(state) && request.before == base {
+			return request
+		}
+	}
+	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) clearVersionLexerRequests() {
+	if s == nil {
+		return
+	}
+	// Every append extends from a reset or a prior logical clear. No pointer can
+	// exist beyond len here. The scheduler reset performs the capacity sweep.
+	clear(s.versionLexerRequests)
+	s.versionLexerRequests = s.versionLexerRequests[:0]
+}
+
+// publishVersionLexerSnapshotOwned installs one immutable cursor snapshot on
+// a header. The wrapper remains copy-on-write, so a header update never
+// changes a by-value rollback copy or a sibling version.
+func (s *diagnosticParserCoreGenericScheduler) publishVersionLexerSnapshotOwned(
+	owner core.SchedulerTransactionToken,
+	index int,
+	snapshot *diagnosticParserCoreVersionLexerSnapshot,
+) error {
+	if s == nil || index < 0 || index >= len(s.headers) {
+		return errors.New("parser-core phase zero: version lexer header index is out of range")
+	}
+	if err := snapshot.validateDestination(s.compact, s.tokenSource.language); err != nil {
+		return err
+	}
+	if _, _, ok := s.compact.CheckpointReceiptOwned(owner, snapshot.beforeCheckpoint); !ok {
+		return errDiagnosticParserCoreUnknownCheckpointIdentity
+	}
+	if _, _, ok := s.compact.CheckpointReceiptOwned(owner, snapshot.afterCheckpoint); !ok {
+		return errDiagnosticParserCoreUnknownCheckpointIdentity
+	}
+	if err := s.headers[index].publishOwnedVersionLexerSnapshot(s.compact, s.tokenSource.language, snapshot); err != nil {
+		return err
+	}
+	s.work.add(&s.work.PerVersionLexPublications, 1)
+	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) newVersionLexerSnapshot(
+	owner core.SchedulerTransactionToken,
+	dfa dfaRelexSnapshot,
+	beforeID core.CheckpointID,
+	afterID core.CheckpointID,
+) (*diagnosticParserCoreVersionLexerSnapshot, error) {
+	if s == nil || s.compact == nil || s.tokenSource == nil || s.tokenSource.language == nil {
+		return nil, errors.New("parser-core phase zero: version lexer snapshot context is incomplete")
+	}
+	return newDiagnosticParserCoreVersionLexerSnapshot(
+		s.compact, s.tokenSource.language, owner, dfa, beforeID, afterID,
+	)
+}
+
+// seedVersionLexerOwnership creates a private cursor at the current shared
+// election start. It runs only when a ragged token activates ownership; clean
+// parses retain the zero-overhead shared path.
+func (s *diagnosticParserCoreGenericScheduler) seedVersionLexerOwnership() error {
+	if s == nil || !s.versionLexerBeforeValid || s.tokenSource == nil || s.tokenSource.language == nil {
+		return errors.New("parser-core phase zero: version lexer seed lacks an election snapshot")
+	}
+	if s.versionLexerBeforeElection != s.electionIndex || s.versionLexerBeforeCheckpoint != s.checkpointBeforeID {
+		return errors.New("parser-core phase zero: version lexer seed snapshot belongs to another election")
+	}
+	var seed *diagnosticParserCoreVersionLexerSnapshot
+	err := s.withVersionLexerOwner(func(owner core.SchedulerTransactionToken) error {
+		var seedErr error
+		seed, seedErr = s.newVersionLexerSnapshot(owner, s.versionLexerBefore, s.checkpointBeforeID, s.checkpointBeforeID)
+		return seedErr
+	})
+	if err != nil {
+		return err
+	}
+	if err := seed.validateDestination(s.compact, s.tokenSource.language); err != nil {
+		return err
+	}
+	states := make(map[*diagnosticParserCoreS3Region]*diagnosticParserCoreVersionState)
+	for index := range s.headers {
+		region := s.headers[index].recoveryRegion()
+		state := states[region]
+		if state == nil {
+			state = &diagnosticParserCoreVersionState{s3Region: region, relexSnapshot: seed}
+			states[region] = state
+		}
+		s.headers[index].versionState = state
+		s.work.add(&s.work.PerVersionLexPublications, 1)
+	}
+	if uint64(len(s.headers)) > s.work.PeakLiveVersions {
+		s.work.PeakLiveVersions = uint64(len(s.headers))
+	}
+	return nil
+}
+
+// requestVersionLexerHeader restores one exact owned cursor, sets its parser
+// state, and performs exactly one lexer request. Interner writes occur before
+// the short publication transaction on ordinary scheduler calls.
+func (s *diagnosticParserCoreGenericScheduler) requestVersionLexerHeader(index int) error {
+	if s == nil || s.tokenSource == nil || s.tokenSource.language == nil || index < 0 || index >= len(s.headers) {
+		return errors.New("parser-core phase zero: version lexer request context is incomplete")
+	}
+	if existing := s.versionLexerRequestForHeader(index); existing != nil {
+		return nil
+	}
+	header := &s.headers[index]
+	base := header.versionLexerSnapshot()
+	if base == nil {
+		return errors.New("parser-core phase zero: version lexer header has no owned cursor snapshot")
+	}
+	// A request is a speculative read. Restore the shared source on every exit,
+	// including snapshot validation, checkpoint, and publication failures.
+	// Keep parser state and GLR state with the DFA cursor: the next shared
+	// election must observe exactly the state that preceded this request.
+	priorDFA := s.tokenSource.snapshotRelexState()
+	priorState := s.tokenSource.state
+	priorGLRStates := s.tokenSource.glrStates
+	defer func() {
+		priorDFA.restore(s.tokenSource)
+		s.tokenSource.SetParserState(priorState)
+		s.tokenSource.SetGLRStates(priorGLRStates)
+	}()
+	if err := base.restore(s.compact, s.tokenSource); err != nil {
+		return err
+	}
+	s.work.add(&s.work.PerVersionLexRestores, 1)
+	state, _, err := s.compact.Boundary(header.head)
+	if err != nil {
+		return err
+	}
+	s.tokenSource.SetParserState(StateID(state))
+	s.tokenSource.SetGLRStates(nil)
+	beforeDFA := s.tokenSource.snapshotRelexState()
+	beforeID := base.afterCheckpoint
+	token := s.tokenSource.Next()
+	afterDFA := s.tokenSource.snapshotRelexState()
+	afterBytes := s.tokenSource.captureExternalScannerStateInto(s.scannerScratch)
+	afterID, _, err := diagnosticParserCoreInternCheckpoint(s.compact, afterBytes)
+	if err != nil {
+		return err
+	}
+	var beforeSnapshot, afterSnapshot *diagnosticParserCoreVersionLexerSnapshot
+	if err := s.withVersionLexerOwner(func(owner core.SchedulerTransactionToken) error {
+		var snapshotErr error
+		beforeSnapshot, snapshotErr = s.newVersionLexerSnapshot(owner, beforeDFA, beforeID, beforeID)
+		if snapshotErr != nil {
+			return snapshotErr
+		}
+		afterSnapshot, snapshotErr = s.newVersionLexerSnapshot(owner, afterDFA, afterID, afterID)
+		if snapshotErr != nil {
+			return snapshotErr
+		}
+		return s.publishVersionLexerSnapshotOwned(owner, index, beforeSnapshot)
+	}); err != nil {
+		return err
+	}
+	s.work.add(&s.work.PerVersionLexPublications, 1) // the after snapshot is a sidecar publication
+	request := diagnosticParserCoreVersionLexerRequest{
+		electionIndex:     s.electionIndex,
+		headerCreationSeq: header.creationSeq,
+		state:             StateID(state),
+		token:             token,
+		before:            beforeSnapshot,
+		after:             afterSnapshot,
+		beforeCheckpoint:  beforeSnapshot.afterCheckpointInfo,
+		afterCheckpoint:   afterSnapshot.afterCheckpointInfo,
+		beforeID:          beforeID,
+		afterID:           afterID,
+		valid:             true,
+	}
+	s.versionLexerRequests = append(s.versionLexerRequests, request)
+	s.work.add(&s.work.PerVersionLexRequests, 1)
+	if uint64(len(s.headers)) > s.work.PeakLiveVersions {
+		s.work.PeakLiveVersions = uint64(len(s.headers))
+	}
+	if s.fullReceipts() {
+		s.receipt.VersionLexerRequests = append(s.receipt.VersionLexerRequests, DiagnosticParserCoreVersionLexerRequest{
+			ElectionIndex: s.electionIndex, HeaderCreationSeq: request.headerCreationSeq,
+			State: request.state, Token: request.token, InternalDFAToken: request.token.lexerInternalDFALexed,
+			ScannerBefore: request.beforeCheckpoint, ScannerAfter: request.afterCheckpoint,
+		})
+	}
+	return nil
+}
+
+// requestHeaderLexerToken names the scheduler-owned one-request operation.
+// Keep requestVersionLexerHeader as the implementation name for callers that
+// describe the operation by its target header rather than its lexer result.
+func (s *diagnosticParserCoreGenericScheduler) requestHeaderLexerToken(index int) error {
+	return s.requestVersionLexerHeader(index)
+}
+
+// captureSharedElectionSnapshot records the scanner state around the legacy
+// shared election. It does not change the shared path or publish a version.
+func (s *diagnosticParserCoreGenericScheduler) captureSharedElectionSnapshot() error {
+	if s == nil || s.tokenSource == nil {
+		return errors.New("parser-core phase zero: shared lexer snapshot source is unavailable")
+	}
+	s.versionLexerBefore = s.tokenSource.snapshotRelexState()
+	s.versionLexerBeforeValid = true
+	s.versionLexerBeforeElection = s.electionIndex + 1
+	s.versionLexerBeforeCheckpoint = s.checkpointID
+	return nil
 }
 
 type diagnosticParserCoreDispatchScratch struct {
@@ -6312,6 +6616,41 @@ func appendDiagnosticParserCoreCanonicalScratchFootprintRefs(
 	return refs
 }
 
+func appendDiagnosticParserCoreVersionLexerRequestFootprintRefs(
+	refs []diagnosticParserCoreFootprintRef,
+	requests []diagnosticParserCoreVersionLexerRequest,
+) []diagnosticParserCoreFootprintRef {
+	for index := range requests {
+		refs = appendDiagnosticParserCoreFootprintRef(refs, diagnosticParserCoreFootprintSnapshot, unsafe.Pointer(requests[index].before))
+		refs = appendDiagnosticParserCoreFootprintRef(refs, diagnosticParserCoreFootprintSnapshot, unsafe.Pointer(requests[index].after))
+	}
+	return refs
+}
+
+func diagnosticParserCoreDFARelexSnapshotRetainedBytes(snapshot dfaRelexSnapshot) uint64 {
+	total := uint64(0)
+	add := func(count int, size uintptr) {
+		if count <= 0 || size == 0 || total == math.MaxUint64 {
+			return
+		}
+		if uint64(count) > math.MaxUint64/uint64(size) {
+			total = math.MaxUint64
+			return
+		}
+		bytes := uint64(count) * uint64(size)
+		if math.MaxUint64-total < bytes {
+			total = math.MaxUint64
+			return
+		}
+		total += bytes
+	}
+	add(cap(snapshot.externalPayload), 1)
+	add(cap(snapshot.externalTokenStart), 1)
+	add(cap(snapshot.externalTokenEnd), 1)
+	add(cap(snapshot.extZeroTried), unsafe.Sizeof(bool(false)))
+	return total
+}
+
 func compareDiagnosticParserCoreFootprintRefs(
 	left, right diagnosticParserCoreFootprintRef,
 ) int {
@@ -6380,6 +6719,7 @@ func diagnosticParserCoreSchedulerFootprintBytes(s *diagnosticParserCoreGenericS
 	refs = appendDiagnosticParserCoreHeaderFootprintRefs(refs, s.reductionReplacements)
 	refs = appendDiagnosticParserCoreHeaderFootprintRefs(refs, s.seedHeaders[:])
 	refs = appendDiagnosticParserCoreCanonicalScratchFootprintRefs(refs, &s.canonicalScratch)
+	refs = appendDiagnosticParserCoreVersionLexerRequestFootprintRefs(refs, s.versionLexerRequests)
 	slices.SortFunc(refs, compareDiagnosticParserCoreFootprintRefs)
 	for index := 0; index < len(refs); {
 		ref := refs[index]
@@ -6433,6 +6773,8 @@ func diagnosticParserCoreSchedulerFootprintBytes(s *diagnosticParserCoreGenericS
 	add(cap(s.electStates), unsafe.Sizeof(StateID(0)))
 	add(cap(s.electGLRStates), unsafe.Sizeof(StateID(0)))
 	add(cap(s.acceptedPayloads), unsafe.Sizeof(core.SubtreeID(0)))
+	add(cap(s.versionLexerRequests), unsafe.Sizeof(diagnosticParserCoreVersionLexerRequest{}))
+	addBytes(diagnosticParserCoreDFARelexSnapshotRetainedBytes(s.versionLexerBefore))
 	add(len(s.seedHeaders), unsafe.Sizeof(diagnosticParserCoreHeader{}))
 	add(len(s.corridorCells), unsafe.Sizeof(diagnosticParserCoreGenericCell{}))
 	add(1, unsafe.Sizeof(s.tokenCell))
@@ -10875,6 +11217,11 @@ func (s *diagnosticParserCoreGenericScheduler) publishTotals() {
 	s.receipt.Dispatches = s.dispatches
 	s.receipt.GlobalBranchOrder = s.branchOrder
 	s.receipt.NextCreationSeq = s.nextSeq
+	s.receipt.PerVersionLexRequests = s.work.PerVersionLexRequests
+	s.receipt.PerVersionLexRestores = s.work.PerVersionLexRestores
+	s.receipt.PerVersionLexPublications = s.work.PerVersionLexPublications
+	s.receipt.PerVersionLexAcceptedRaggedSpans = s.work.PerVersionLexAcceptedRaggedSpans
+	s.receipt.PeakLiveVersions = s.work.PeakLiveVersions
 }
 
 func authenticatedParserCoreGoLanguage(scanner ExternalScanner) (*Language, error) {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -62,8 +62,8 @@ type DiagnosticParserCorePrefixOptions struct {
 	// DisablePerHeaderSpanUnlockedRelex restores relexTokenForState's
 	// pre-D2-1 span-locked probe (only an exact-span relex is eligible; a
 	// relex whose EndByte differs from the shared election is declined the
-	// same way a scan failure is, never routed through the ragged-end
-	// decline). The zero value keeps the span-unlocked probe on. This is a
+	// same way a scan failure is, never routed through owned lexer
+	// activation). The zero value keeps the span-unlocked probe on. This is a
 	// test-and-diagnostic lever only: no production caller sets it, and it
 	// has no operator-facing surface (config flag, CLI flag, or similar).
 	DisablePerHeaderSpanUnlockedRelex bool
@@ -1552,7 +1552,11 @@ func (s *diagnosticParserCoreGenericScheduler) persistHeaderLineageOwned(
 			header.head,
 			uint32(header.creationSeq)+1,
 		); err != nil {
-			return err
+			return fmt.Errorf(
+				"parser-core phase zero: persist header %d head=%d owner=%d lexer_owned=%t recovery_region=%t: %w",
+				index, header.head.Node, header.creationSeq+1,
+				header.versionLexerSnapshot() != nil, header.recoveryRegion() != nil, err,
+			)
 		}
 		if !header.convergedReductionSplit && header.dropCohortRefs.Empty() &&
 			!header.dropCohortRefs.Overflowed() && !header.dropCohortRefs.Blended() {
@@ -2125,6 +2129,11 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeWithMutation(
 	if s == nil {
 		return nil, 0, errors.New("parser-core phase zero: nil canonicalization scratch")
 	}
+	if s.groups != nil {
+		clear(s.groups)
+	}
+	clear(s.keys)
+	s.keys = s.keys[:0]
 	target := int(s.nextBuffer & 1)
 	if len(headers) != 0 && cap(s.headerBuffers[target]) != 0 && &headers[0] == &s.headerBuffers[target][:1][0] {
 		target ^= 1
@@ -2183,9 +2192,15 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeWithMutation(
 		if canonical, ok := compact.CanonicalBoundary(state, byteOffset, header.shifted, header.checkpoint); ok {
 			header.head = canonical
 		}
+		versionState := header.versionState
+		if header.versionLexerSnapshot() == nil {
+			// Preserve the pre-ownership canonical key. Recovery isolation keeps
+			// region-bearing versions separate when that distinction matters.
+			versionState = nil
+		}
 		key := diagnosticParserCorePhaseHead{
 			head: header.head, shifted: header.shifted, accepted: header.accepted,
-			checkpoint: header.checkpoint, versionState: header.versionState,
+			checkpoint: header.checkpoint, versionState: versionState,
 		}
 		s.keys[index] = key
 	}
@@ -2203,6 +2218,9 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeWithMutation(
 	if err != nil {
 		clear(normalized)
 		clear(s.keys)
+		if s.groups != nil {
+			clear(s.groups)
+		}
 		s.headerBuffers[target] = normalized[:0]
 		s.keys = s.keys[:0]
 		return nil, 0, err
@@ -2228,6 +2246,11 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeRecoveryWithMutation(
 	if s == nil || compact == nil {
 		return nil, 0, errors.New("parser-core phase zero: recovery canonicalization requires scratch and core")
 	}
+	if s.groups != nil {
+		clear(s.groups)
+	}
+	clear(s.keys)
+	s.keys = s.keys[:0]
 	target := int(s.nextBuffer & 1)
 	if len(headers) != 0 && cap(s.headerBuffers[target]) != 0 && &headers[0] == &s.headerBuffers[target][:1][0] {
 		target ^= 1
@@ -2564,12 +2587,18 @@ type diagnosticParserCoreGenericScheduler struct {
 	currentElection              DiagnosticParserCoreElection
 	tokenCell                    diagnosticParserCoreTokenCell
 	versionLexerBefore           dfaRelexSnapshot
+	versionLexerBeforeScratch    dfaRelexSnapshotScratch
 	versionLexerBeforeValid      bool
 	versionLexerBeforeElection   int
 	versionLexerBeforeCheckpoint core.CheckpointID
 	versionLexerRequests         []diagnosticParserCoreVersionLexerRequest
-	electionIndex                int
-	noLookaheadSteps             uint8
+	// versionLexerOwnershipActive marks the ragged election that switched this
+	// scheduler from its shared-token fast path to owned per-header cursors.
+	// The current slice only records the activation and declines before action
+	// execution; later slices will consume the pending requests.
+	versionLexerOwnershipActive bool
+	electionIndex               int
+	noLookaheadSteps            uint8
 	// recoveryIsolation becomes true only after S4 or S5 publishes two versions.
 	// Clean parses retain the canonical scheduler fast path.
 	recoveryIsolation bool
@@ -3981,6 +4010,33 @@ func resetDiagnosticParserCoreRetainedSlice[T any](items []T) []T {
 	return items[:0]
 }
 
+func resetDiagnosticParserCoreRetainedScannerBytes(items []byte) []byte {
+	if cap(items) == 0 {
+		return nil
+	}
+	if cap(items) > externalScannerSerializationBufferSize {
+		return nil
+	}
+	clear(items[:cap(items)])
+	return items[:0]
+}
+
+func resetDiagnosticParserCoreDFARelexSnapshotScratch(scratch dfaRelexSnapshotScratch) dfaRelexSnapshotScratch {
+	if cap(scratch.externalPayload) == externalScannerSerializationBufferSize {
+		clear(scratch.externalPayload[:cap(scratch.externalPayload)])
+		scratch.externalPayload = scratch.externalPayload[:0]
+	} else {
+		if cap(scratch.externalPayload) != 0 {
+			clear(scratch.externalPayload[:cap(scratch.externalPayload)])
+		}
+		scratch.externalPayload = nil
+	}
+	scratch.externalTokenStart = resetDiagnosticParserCoreRetainedScannerBytes(scratch.externalTokenStart)
+	scratch.externalTokenEnd = resetDiagnosticParserCoreRetainedScannerBytes(scratch.externalTokenEnd)
+	scratch.extZeroTried = resetDiagnosticParserCoreRetainedSlice(scratch.extZeroTried)
+	return scratch
+}
+
 func clearDiagnosticParserCoreHeaderBacking(headers []diagnosticParserCoreHeader) {
 	if cap(headers) == 0 {
 		return
@@ -4026,6 +4082,7 @@ func clearDiagnosticParserCoreGenericSchedulerVersionState(scheduler *diagnostic
 	scheduler.versionLexerBeforeValid = false
 	scheduler.versionLexerBeforeElection = 0
 	scheduler.versionLexerBeforeCheckpoint = 0
+	scheduler.versionLexerOwnershipActive = false
 }
 
 func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGenericScheduler) error {
@@ -4051,6 +4108,7 @@ func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGe
 	electGLRStates := resetDiagnosticParserCoreRetainedSlice(scheduler.electGLRStates)
 	acceptedPayloads := resetDiagnosticParserCoreRetainedSlice(scheduler.acceptedPayloads)
 	versionLexerRequests := resetDiagnosticParserCoreRetainedSlice(scheduler.versionLexerRequests)
+	versionLexerBeforeScratch := resetDiagnosticParserCoreDFARelexSnapshotScratch(scheduler.versionLexerBeforeScratch)
 	*scheduler = diagnosticParserCoreGenericScheduler{
 		summaryHeaderScratch: summaryHeaders,
 		dispatchScratch: diagnosticParserCoreDispatchScratch{
@@ -4061,15 +4119,16 @@ func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGe
 			outputs: conflictOutputs, armRanges: conflictArmRanges, adopted: conflictAdopted,
 			headerAssembly: conflictHeaderAssembly,
 		},
-		reductionOutputs:      reductionOutputs,
-		reductionReplacements: reductionReplacements,
-		footprintRefs:         footprintRefs,
-		classifiedBoundaries:  classifiedBoundaries,
-		condenseCandidates:    condenseCandidates,
-		electStates:           electStates,
-		electGLRStates:        electGLRStates,
-		acceptedPayloads:      acceptedPayloads,
-		versionLexerRequests:  versionLexerRequests,
+		reductionOutputs:          reductionOutputs,
+		reductionReplacements:     reductionReplacements,
+		footprintRefs:             footprintRefs,
+		classifiedBoundaries:      classifiedBoundaries,
+		condenseCandidates:        condenseCandidates,
+		electStates:               electStates,
+		electGLRStates:            electGLRStates,
+		acceptedPayloads:          acceptedPayloads,
+		versionLexerBeforeScratch: versionLexerBeforeScratch,
+		versionLexerRequests:      versionLexerRequests,
 	}
 	return nil
 }
@@ -4347,8 +4406,8 @@ func dropCohortSelectionClass(selected diagnosticParserCoreCellSelection) core.D
 // the external-scanner/isKeyword bits, which are provenance of the shared
 // token's own lex path, not of tokenization identity). Every other field
 // must already match the shared token exactly; this checks that assumption
-// instead of trusting it. A different EndByte never reaches this function --
-// dispatchPassActive routes that shape to the ragged-end decline instead.
+// instead of trusting it. A different EndByte never reaches this function.
+// dispatchPassActive activates owned per-header lexer requests for that shape.
 func diagnosticParserCoreSameSpanRelex(shared, relexed Token) (Token, bool) {
 	if relexed.Symbol == 0 || relexed.Symbol == shared.Symbol {
 		return Token{}, false
@@ -4455,10 +4514,9 @@ func diagnosticParserCoreConflictPolicyOrdinal(
 // shared election's tokenization. The probe accepts any genuine internal-
 // DFA token that starts where the shared election started; it may differ
 // in Symbol and/or EndByte/EndPoint from the shared token. The caller alone
-// decides what to do with a different EndByte (dispatchPassActive declines
-// that shape fail-closed instead of shifting it -- see the ragged-end
-// handling there); this probe only decides whether a same-start token
-// exists at all.
+// decides what to do with a different EndByte. dispatchPassActive switches
+// that shape to owned per-header requests before any shared action executes.
+// This probe only decides whether a same-start token exists at all.
 //
 // DisablePerHeaderSpanUnlockedRelex restores the pre-D2-1 span-locked
 // probe: only an exact-span (same StartByte and EndByte) relex is eligible.
@@ -4749,17 +4807,98 @@ func (s *diagnosticParserCoreGenericScheduler) requestHeaderLexerToken(index int
 	return s.requestVersionLexerHeader(index)
 }
 
-// captureSharedElectionSnapshot records the scanner state around the legacy
-// shared election. It does not change the shared path or publish a version.
+// captureSharedElectionSnapshot records the scanner state around the shared
+// election. It does not change the shared path or publish a version.
 func (s *diagnosticParserCoreGenericScheduler) captureSharedElectionSnapshot() error {
 	if s == nil || s.tokenSource == nil {
 		return errors.New("parser-core phase zero: shared lexer snapshot source is unavailable")
 	}
-	s.versionLexerBefore = s.tokenSource.snapshotRelexState()
+	s.versionLexerBefore = s.tokenSource.snapshotRelexStateWithScratch(&s.versionLexerBeforeScratch)
+	return s.finishSharedElectionSnapshotCapture()
+}
+
+// captureSharedElectionSnapshotFromExternalPayload uses checkpoint bytes that
+// the election already serialized. This keeps one Serialize call per election.
+func (s *diagnosticParserCoreGenericScheduler) captureSharedElectionSnapshotFromExternalPayload(externalPayload []byte) error {
+	if s == nil || s.tokenSource == nil {
+		return errors.New("parser-core phase zero: shared lexer snapshot source is unavailable")
+	}
+	s.versionLexerBefore = s.tokenSource.snapshotRelexStateWithScratchFromExternalPayload(
+		&s.versionLexerBeforeScratch,
+		externalPayload,
+	)
+	return s.finishSharedElectionSnapshotCapture()
+}
+
+func (s *diagnosticParserCoreGenericScheduler) finishSharedElectionSnapshotCapture() error {
 	s.versionLexerBeforeValid = true
 	s.versionLexerBeforeElection = s.electionIndex + 1
 	s.versionLexerBeforeCheckpoint = s.checkpointID
 	return nil
+}
+
+// activateVersionLexerOwnershipAtRagged starts the owned-cursor tranche at
+// the first different-span relex. Keep this activation separate from action
+// execution: the shared pass must not reduce a sibling after another header
+// proves that its lexer view has a different width.
+//
+// The current tranche records the complete request set and then declines with
+// an explicit pending-action boundary. A later tranche will dispatch those
+// requests under their own scanner phases.
+const diagnosticParserCoreOwnedDispatchPendingDetail = "generic scheduler owned dispatch pending"
+
+// DiagnosticParserCoreOwnedDispatchPendingDetailForTest exposes the stable
+// activation prefix without exposing scheduler internals.
+func DiagnosticParserCoreOwnedDispatchPendingDetailForTest() string {
+	return diagnosticParserCoreOwnedDispatchPendingDetail
+}
+
+func (s *diagnosticParserCoreGenericScheduler) activateVersionLexerOwnershipAtRagged(
+	raggedHeaderIndex int,
+	witness Token,
+) (*diagnosticParserCoreGenericUnsupported, error) {
+	if s == nil || raggedHeaderIndex < 0 || raggedHeaderIndex >= len(s.headers) {
+		return nil, errors.New("parser-core phase zero: ragged lexer ownership header index is out of range")
+	}
+	if s.versionLexerOwnershipActive {
+		return &diagnosticParserCoreGenericUnsupported{
+			boundary:    DiagnosticParserCoreRoute,
+			detail:      diagnosticParserCoreOwnedDispatchPendingDetail + ": ownership is already active",
+			headerIndex: raggedHeaderIndex,
+		}, nil
+	}
+	// A shifted header already consumed the shared token and therefore cannot
+	// be seeded at this election's token start. Keep this activation slice
+	// fail-closed until the scheduler owns that mixed frontier explicitly.
+	for index, header := range s.headers {
+		if header.shifted && !header.accepted {
+			return &diagnosticParserCoreGenericUnsupported{
+				boundary:    DiagnosticParserCoreRoute,
+				detail:      diagnosticParserCoreOwnedDispatchPendingDetail + ": ragged ownership has a shifted sibling",
+				headerIndex: index,
+			}, nil
+		}
+	}
+	if err := s.seedVersionLexerOwnership(); err != nil {
+		return nil, err
+	}
+	for index := range s.headers {
+		if s.headers[index].accepted {
+			continue
+		}
+		if err := s.requestHeaderLexerToken(index); err != nil {
+			return nil, err
+		}
+	}
+	s.versionLexerOwnershipActive = true
+	return &diagnosticParserCoreGenericUnsupported{
+		boundary: DiagnosticParserCoreRoute,
+		detail: fmt.Sprintf(
+			diagnosticParserCoreOwnedDispatchPendingDetail+": per-header lexer ownership activated at header %d for ragged token symbol=%d span=%d..%d",
+			raggedHeaderIndex, witness.Symbol, witness.StartByte, witness.EndByte,
+		),
+		headerIndex: raggedHeaderIndex,
+	}, nil
 }
 
 type diagnosticParserCoreDispatchScratch struct {
@@ -6651,6 +6790,51 @@ func diagnosticParserCoreDFARelexSnapshotRetainedBytes(snapshot dfaRelexSnapshot
 	return total
 }
 
+func diagnosticParserCoreDFARelexSnapshotAndScratchRetainedBytes(
+	snapshot dfaRelexSnapshot,
+	scratch dfaRelexSnapshotScratch,
+) uint64 {
+	total := uint64(0)
+	addPair := func(left, right unsafe.Pointer, leftCap, rightCap int, size uintptr) {
+		if size == 0 || total == math.MaxUint64 {
+			return
+		}
+		count := leftCap + rightCap
+		if left != nil && left == right {
+			count = max(leftCap, rightCap)
+		}
+		if count <= 0 || uint64(count) > math.MaxUint64/uint64(size) {
+			if count > 0 {
+				total = math.MaxUint64
+			}
+			return
+		}
+		bytes := uint64(count) * uint64(size)
+		if math.MaxUint64-total < bytes {
+			total = math.MaxUint64
+			return
+		}
+		total += bytes
+	}
+	bytePointer := func(items []byte) unsafe.Pointer {
+		if cap(items) == 0 {
+			return nil
+		}
+		return unsafe.Pointer(&items[:cap(items)][0])
+	}
+	boolPointer := func(items []bool) unsafe.Pointer {
+		if cap(items) == 0 {
+			return nil
+		}
+		return unsafe.Pointer(&items[:cap(items)][0])
+	}
+	addPair(bytePointer(snapshot.externalPayload), bytePointer(scratch.externalPayload), cap(snapshot.externalPayload), cap(scratch.externalPayload), 1)
+	addPair(bytePointer(snapshot.externalTokenStart), bytePointer(scratch.externalTokenStart), cap(snapshot.externalTokenStart), cap(scratch.externalTokenStart), 1)
+	addPair(bytePointer(snapshot.externalTokenEnd), bytePointer(scratch.externalTokenEnd), cap(snapshot.externalTokenEnd), cap(scratch.externalTokenEnd), 1)
+	addPair(boolPointer(snapshot.extZeroTried), boolPointer(scratch.extZeroTried), cap(snapshot.extZeroTried), cap(scratch.extZeroTried), unsafe.Sizeof(bool(false)))
+	return total
+}
+
 func compareDiagnosticParserCoreFootprintRefs(
 	left, right diagnosticParserCoreFootprintRef,
 ) int {
@@ -6774,7 +6958,9 @@ func diagnosticParserCoreSchedulerFootprintBytes(s *diagnosticParserCoreGenericS
 	add(cap(s.electGLRStates), unsafe.Sizeof(StateID(0)))
 	add(cap(s.acceptedPayloads), unsafe.Sizeof(core.SubtreeID(0)))
 	add(cap(s.versionLexerRequests), unsafe.Sizeof(diagnosticParserCoreVersionLexerRequest{}))
-	addBytes(diagnosticParserCoreDFARelexSnapshotRetainedBytes(s.versionLexerBefore))
+	addBytes(diagnosticParserCoreDFARelexSnapshotAndScratchRetainedBytes(
+		s.versionLexerBefore, s.versionLexerBeforeScratch,
+	))
 	add(len(s.seedHeaders), unsafe.Sizeof(diagnosticParserCoreHeader{}))
 	add(len(s.corridorCells), unsafe.Sizeof(diagnosticParserCoreGenericCell{}))
 	add(1, unsafe.Sizeof(s.tokenCell))
@@ -6915,7 +7101,13 @@ func (s *diagnosticParserCoreGenericScheduler) observeCapPressure() error {
 	return nil
 }
 
+var errDiagnosticParserCoreTerminalSchedulerResume = errors.New("parser-core phase zero: terminal scheduler cannot resume")
+
 func (s *diagnosticParserCoreGenericScheduler) run() error {
+	if s != nil && s.receipt != nil &&
+		(s.receipt.Acceptance != nil || s.receipt.Completion != nil || s.receipt.Stop.Detail != "") {
+		return errDiagnosticParserCoreTerminalSchedulerResume
+	}
 	if err := s.pollStopControl(); err != nil {
 		return err
 	}
@@ -7009,10 +7201,8 @@ const diagnosticParserCoreNoTableActionDetail = "generic scheduler has no table 
 
 // DiagnosticParserCoreNoTableActionDetailForTest exposes
 // diagnosticParserCoreNoTableActionDetail so the external test package can
-// assert on the genuinely-empty-row decline's exact detail -- for example,
-// to prove DisablePerHeaderSpanUnlockedRelex restores this legacy detail
-// exactly in place of the D2-1 ragged-end decline's own detail -- without
-// duplicating the literal string.
+// assert on the genuinely-empty-row decline's exact detail. This proves that
+// DisablePerHeaderSpanUnlockedRelex restores the legacy route.
 func DiagnosticParserCoreNoTableActionDetailForTest() string {
 	return diagnosticParserCoreNoTableActionDetail
 }
@@ -7033,7 +7223,18 @@ func DiagnosticParserCoreContextualCloseAngleDeferralDetailForTest() string {
 	return diagnosticParserCoreContextualCloseAngleDeferralDetail
 }
 
-// diagnosticParserCoreRaggedRelexDeclineDetail is the decline detail prefix
+// diagnosticParserCoreRaggedRelexDeclineDetail is the former shared-cursor
+// decline detail prefix. Keep it for telemetry migrations and regression
+// tests that must distinguish the pre-ownership fallback from activation.
+// It describes a no-action head whose own-mode relex found a different end.
+//
+// The active scheduler now preempts the shared pass and publishes owned lexer
+// requests at the first such witness. It does not emit this detail there.
+//
+// The different-span shape starts where the shared election started but ends
+// at another byte. It can be wider or narrower.
+//
+// Historical detail format:
 // for a no-action head whose own-mode per-header relex (relexTokenForState)
 // found a genuine internal-DFA token starting where the shared election
 // started but ending at a different byte (D2-1's different-span shape,
@@ -7041,8 +7242,7 @@ func DiagnosticParserCoreContextualCloseAngleDeferralDetailForTest() string {
 // still used in a few surrounding identifiers and comments). This
 // scheduler shares one token source's byte cursor across every header in a
 // pass; shifting one header onto a wider or narrower span than every other
-// header sees would desynchronize that shared cursor, so this shape always
-// declines fail-closed instead of shifting -- never a guess. Kept distinct
+// header sees would desynchronize that shared cursor. Kept distinct
 // from diagnosticParserCoreNoTableActionDetail and
 // diagnosticParserCoreContextualCloseAngleDeferralDetail so census,
 // receipts, and tests can tell the three shapes apart even though all three
@@ -7363,20 +7563,21 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				relexed, ok := s.relexTokenForState(state, s.token)
 				if ok {
 					if relexed.EndByte != s.token.EndByte {
-						// A different span (D2-1): this header's own lex mode found a
-						// genuine internal-DFA token starting where the shared
-						// election started but ending at a different byte.
-						// Every header in this pass shares one token source's
-						// byte cursor; shifting only this header onto a wider
-						// or narrower span would desynchronize that cursor for
-						// every other header. Decline fail-closed instead of
-						// guessing -- excluded from the genuinely-empty-row
-						// classification and from s3TryOpenErrorRegion below,
-						// the same way a contextual close-angle deferral is.
 						if raggedRelexNoActionHeads == 0 {
 							raggedRelexWitness = relexed
 							raggedRelexHeaderIndex = index
+							raggedRelexNoActionHeads++
+							// A different span proves that this election cannot
+							// continue on the shared cursor. Discard every cell
+							// classified earlier in this pass before ownership
+							// publishes its per-header requests.
+							s.dispatchScratch.cells = s.dispatchScratch.cells[:0]
+							s.dispatchScratch.noActionIndices = s.dispatchScratch.noActionIndices[:0]
+							return s.activateVersionLexerOwnershipAtRagged(index, relexed)
 						}
+						// A second witness cannot occur in this activation pass,
+						// but keep the legacy accounting if a future caller
+						// continues after the first owned request.
 						raggedRelexNoActionHeads++
 						s.dispatchScratch.noActionIndices = append(s.dispatchScratch.noActionIndices, index)
 						continue
@@ -7502,17 +7703,17 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			return nil, s.dropGenericNoActionHeads(noActionIndices)
 		}
 		if len(noActionIndices) != 0 {
-			// pausedNoActionHeads == 0 && deferredNoActionHeads == 0 &&
-			// raggedRelexNoActionHeads == 0 means every no-action head
+			// pausedNoActionHeads == 0, deferredNoActionHeads == 0, and
+			// raggedRelexNoActionHeads == 0 mean every no-action head
 			// reached this point through a genuinely empty action row (no
 			// table action for the elected token), not through the
 			// unrelated group-election pause tracked by header.paused
 			// above, not through the issue #983 contextual close-angle
 			// deferral tracked by deferredNoActionHeads above, and not
-			// through the D2-1 ragged-end decline tracked by
+			// through the legacy ragged-span fallback tracked by
 			// raggedRelexNoActionHeads above. The close-angle deferral has a
 			// real, non-empty action row the header must not take this pass.
-			// The ragged-end decline's own action row is empty too (that
+			// The legacy ragged-span row is empty too. That
 			// emptiness is what triggers the per-header relex in the first
 			// place), but a live C stack in this exact state may relex its
 			// own version and shift that token instead of entering recovery
@@ -7570,7 +7771,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			}
 			if pausedNoActionHeads == 0 && deferredNoActionHeads == 0 {
 				// raggedRelexNoActionHeads > 0: at least one no-action head
-				// reached this point through the D2-1 ragged-end decline
+				// reached this dormant legacy path
 				// (relexTokenForState found a genuine, same-start relex
 				// whose EndByte differs from the shared election), not a
 				// genuinely empty action row and not the close-angle
@@ -7579,7 +7780,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				// 1, and a ragged relex needs len(s.headers) > 1 (the guard
 				// above), so the two conditions cannot both hold today. The
 				// exclusion documents intent and stays safe if either guard
-				// changes later, instead of silently letting a ragged-end
+				// changes later, instead of silently letting a ragged-span
 				// header reach the S3 resume path, which re-reads the raw
 				// table without this decline's own reasoning and could
 				// bounce forever. Keep the boundary class Recovery so routing is unchanged;
@@ -8608,6 +8809,11 @@ func (s *diagnosticParserCoreGenericScheduler) collapseToRecoveryWinner(winner i
 		if cap(buffer) != 0 {
 			clear(buffer)
 		}
+	}
+	clear(s.canonicalScratch.keys)
+	s.canonicalScratch.keys = s.canonicalScratch.keys[:0]
+	if s.canonicalScratch.groups != nil {
+		clear(s.canonicalScratch.groups)
 	}
 	s.headers = s.headers[:1]
 	s.headers[0] = winnerHeader
@@ -9919,29 +10125,31 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		outputDropCohortRefs := output.DropCohortRefs
 		switch output.Freshness {
 		case core.ReductionUnchanged:
-			if convergedHistory || resurrectionUnproved {
-				adopted, err := s.adoptUpdatedReductionSiblingOwned(
-					owner,
-					cell.headerIndex,
-					output.Head,
-					rank,
-					lineage,
-					outputSet,
-					outputSetBlended,
-					outputDropCohortRefs,
-					convergedHistory,
-					resurrectionUnproved,
-					core.DropCohortProducerSiblingAdoption,
-				)
-				if err != nil {
-					return err
+			// An unchanged output already names a live physical head. Reuse its
+			// existing scheduler slot only when the complete immutable version
+			// identity matches. Distinct owned cursors remain fail-closed until
+			// the physical-head merge package.
+			adopted, err := s.adoptUpdatedReductionSiblingOwned(
+				owner,
+				cell.headerIndex,
+				output.Head,
+				rank,
+				lineage,
+				outputSet,
+				outputSetBlended,
+				outputDropCohortRefs,
+				convergedHistory,
+				resurrectionUnproved,
+				core.DropCohortProducerSiblingAdoption,
+			)
+			if err != nil {
+				return err
+			}
+			if adopted {
+				if reductionFrontierSequence != 0 {
+					s.attachDiagnosticParserCoreFrontierToHead(output.Head, reductionFrontierSequence)
 				}
-				if adopted {
-					if reductionFrontierSequence != 0 {
-						s.attachDiagnosticParserCoreFrontierToHead(output.Head, reductionFrontierSequence)
-					}
-					continue
-				}
+				continue
 			}
 		case core.ReductionNew, core.ReductionUpdated:
 		default:
@@ -10156,8 +10364,8 @@ func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(
 		}
 		header := s.headers[index]
 		if header.versionState != sourceVersionState {
-			// A canonical head does not prove equal lexer history. Keep forks
-			// with different immutable scanner state as separate versions.
+			// A canonical head does not prove equal version history. Keep forks
+			// with distinct immutable state as separate versions.
 			continue
 		}
 		state, byteOffset, err := s.compact.Boundary(header.head)
@@ -11044,6 +11252,13 @@ func (s *diagnosticParserCoreGenericScheduler) elect(first bool) error {
 		s.tokenSource.SetGLRStates(glr)
 	}
 	beforeBytes := s.tokenSource.captureExternalScannerStateInto(s.scannerScratch)
+	// Retain the exact DFA and scanner state at this election's token start.
+	// A ragged per-header relex may activate ownership before any shared cell
+	// executes. Reuse the checkpoint serialization instead of serializing the
+	// scanner twice at the same cursor.
+	if err := s.captureSharedElectionSnapshotFromExternalPayload(beforeBytes); err != nil {
+		return err
+	}
 	beforeID, before, err := diagnosticParserCoreInternCheckpoint(s.compact, beforeBytes)
 	if err != nil {
 		return err

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1212,7 +1212,7 @@ type diagnosticParserCoreHeader struct {
 	lastPersistedBlended bool
 	// recoveryCompetitor marks a header that a native recovery mechanism
 	// created or advanced, and so may compete at acceptance. It sits before
-	// s3Region so it lands in the one padding byte the header already had
+	// versionState so it lands in the one padding byte the header already had
 	// (offset 215); placed after the pointer it would grow every header from
 	// 224 to 232 bytes, which two size ratchets pin.
 	//
@@ -1222,21 +1222,53 @@ type diagnosticParserCoreHeader struct {
 	//
 	// The open-recovery segment count is deliberately NOT stored beside this.
 	// It is derived from live header state at pricing time -- see
-	// recoveryOpenSegments -- because paused and s3Region are mutated by the
-	// ordinary reduce and pause paths, and a stored copy would go stale
-	// without them noticing.
+	// recoveryOpenSegments. Ordinary paths write paused, while region paths
+	// publish versionState. A stored copy could drift from either value.
 	recoveryCompetitor bool
-	// s3Region marks a header carrying an open native strategy-2 recovery
-	// region (campaign v7 tranche B3 stage S3: error-region absorb and
-	// condense-resume). nil for every header outside recovery, mirroring
-	// glrStack.cRec's nil-for-clean-stacks discipline (glr.go) -- the S3
-	// zero-cost clean-path gate (design section 8, G2). Never mutated in
-	// place: s3AdvanceErrorRegion and s3TryOpenErrorRegion always publish a
-	// fresh *diagnosticParserCoreS3Region and reassign this field, so a
-	// header snapshot taken by diagnosticParserCoreHeaderRollbackScratch
-	// (a plain by-value struct copy) restores a correct, independent region
-	// state on rollback without aliasing the live one.
+	// versionState carries optional state owned by this parser version. It is
+	// nil on the single-version fast path. The pointed-to state is immutable.
+	// Accessors publish a fresh wrapper or clear the pointer. A by-value header
+	// snapshot can therefore restore its prior state on rollback.
+	versionState *diagnosticParserCoreVersionState
+}
+
+// diagnosticParserCoreVersionState holds immutable state for one header.
+// Keep it separate from the fixed-size header so lexer ownership can grow
+// without changing the header layout.
+type diagnosticParserCoreVersionState struct {
 	s3Region *diagnosticParserCoreS3Region
+}
+
+// recoveryRegion returns the optional open strategy-2 region.
+func (h diagnosticParserCoreHeader) recoveryRegion() *diagnosticParserCoreS3Region {
+	if h.versionState == nil {
+		return nil
+	}
+	return h.versionState.s3Region
+}
+
+// openRecoveryRegion publishes an open strategy-2 region for this header.
+func (h *diagnosticParserCoreHeader) openRecoveryRegion(region *diagnosticParserCoreS3Region) {
+	h.setRecoveryRegion(region)
+}
+
+// setRecoveryRegion publishes a fresh immutable wrapper for the region.
+func (h *diagnosticParserCoreHeader) setRecoveryRegion(region *diagnosticParserCoreS3Region) {
+	if h == nil {
+		return
+	}
+	if region == nil {
+		h.closeRecoveryRegion()
+		return
+	}
+	h.versionState = &diagnosticParserCoreVersionState{s3Region: region}
+}
+
+// closeRecoveryRegion clears the header's open strategy-2 region.
+func (h *diagnosticParserCoreHeader) closeRecoveryRegion() {
+	if h != nil {
+		h.versionState = nil
+	}
 }
 
 // isRecoveryLineage reports whether this header may compete at acceptance.
@@ -1286,7 +1318,7 @@ func (s *diagnosticParserCoreGenericScheduler) retireTrailingRecoveryNoActionLin
 	survivor := &s.headers[0]
 	loser := &s.headers[1]
 	if !survivor.shifted || survivor.accepted || survivor.paused || loser.shifted || loser.accepted || loser.paused ||
-		survivor.s3Region != nil || loser.s3Region != nil || survivor.creationSeq >= loser.creationSeq ||
+		survivor.recoveryRegion() != nil || loser.recoveryRegion() != nil || survivor.creationSeq >= loser.creationSeq ||
 		survivor.checkpoint != loser.checkpoint || survivor.checkpoint != s.checkpointID ||
 		s.token.Symbol == 0 || s.token.EndByte <= s.token.StartByte {
 		return false, nil
@@ -1322,7 +1354,7 @@ func (s *diagnosticParserCoreGenericScheduler) retireTrailingRecoveryNoActionLin
 //
 // Deriving rather than storing is the point. paused is written by the
 // ordinary reduce and pause paths (they set it false on a fresh reduction and
-// true on a reduction pause) and s3Region is replaced wholesale by the region
+// true on a reduction pause) and versionState is replaced wholesale by the region
 // advance, none of which would update a stored count. A stale count
 // mis-prices the lineage by 500, which is ten times the margin this
 // arbitration turns on.
@@ -1330,7 +1362,8 @@ func (s *diagnosticParserCoreGenericScheduler) retireTrailingRecoveryNoActionLin
 // C's extraRecoveries term has no compact analogue yet: stage S3 does not
 // track unlexable-run re-pauses. When it does, add it here.
 func (h *diagnosticParserCoreHeader) recoveryOpenSegments() int {
-	if h.paused || (h.s3Region != nil && len(h.s3Region.children) == 0) {
+	region := h.recoveryRegion()
+	if h.paused || (region != nil && len(region.children) == 0) {
 		return 1
 	}
 	return 0
@@ -3225,7 +3258,7 @@ func (s *diagnosticParserCoreGenericScheduler) produceCompactEOFRecoveryAdmissio
 		return receipt, nil
 	}
 	for _, header := range s.headers {
-		if header.s3Region != nil {
+		if header.recoveryRegion() != nil {
 			compactEOFRecoveryAdmissionInvalidate(&receipt, "EOF recovery admission rejects an open strategy-three region")
 			return receipt, nil
 		}
@@ -6495,8 +6528,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			pausedNoActionHeads++
 			continue
 		}
-		if header.s3Region != nil {
-			region := header.s3Region
+		if region := header.recoveryRegion(); region != nil {
 			// A header sitting on an open region is the compact analogue of
 			// a live C stack in ERROR_STATE, which lexes with a completely
 			// different (most-permissive, LexModes[0]) mode than the
@@ -6610,7 +6642,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 					return nil, resumeErr
 				}
 				s.headers[index].head = newHead
-				s.headers[index].s3Region = nil
+				s.headers[index].closeRecoveryRegion()
 			case resumeToken.Symbol == 0:
 				// EOF while a region is open: cRecoverEOFAccept's whole-file
 				// wrap is out of S3 scope (s3TryOpenErrorRegion's doc
@@ -6640,9 +6672,9 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				grown := make([]core.SubtreeID, len(region.children)+1)
 				copy(grown, region.children)
 				grown[len(region.children)] = leafID
-				s.headers[index].s3Region = &diagnosticParserCoreS3Region{
+				s.headers[index].setRecoveryRegion(&diagnosticParserCoreS3Region{
 					state: region.state, startByte: region.startByte, endByte: resumeToken.EndByte, children: grown,
-				}
+				})
 				s.headers[index].shifted = true
 				if resumeToken.EndByte != s.token.EndByte {
 					// The error-mode relex consumed a different span than
@@ -7403,7 +7435,7 @@ func (s *diagnosticParserCoreGenericScheduler) s4TryStackSummaryRecovery(index i
 		return false, nil
 	}
 	original := s.headers[index]
-	if original.s3Region != nil || s.token.Missing || s.token.NoLookahead ||
+	if original.recoveryRegion() != nil || s.token.Missing || s.token.NoLookahead ||
 		s.token.Symbol == 0 || s.token.Symbol == errorSymbol {
 		return false, nil
 	}
@@ -7490,7 +7522,7 @@ func (s *diagnosticParserCoreGenericScheduler) s4TryStackSummaryRecovery(index i
 		restore()
 		return false, absorbErr
 	}
-	if !absorbed || s.headers[index].s3Region == nil || !s.headers[index].shifted {
+	if !absorbed || s.headers[index].recoveryRegion() == nil || !s.headers[index].shifted {
 		restore()
 		return false, nil
 	}
@@ -7511,7 +7543,7 @@ func (s *diagnosticParserCoreGenericScheduler) s4TryStackSummaryRecovery(index i
 		return false, err
 	}
 	recoveredHeader.head = recoveredHead
-	recoveredHeader.s3Region = nil
+	recoveredHeader.closeRecoveryRegion()
 	recoveredHeader.shifted = false
 	s.headers[index].markRecoveryLineage()
 	recoveredHeader.markRecoveryLineage()
@@ -7536,7 +7568,7 @@ func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertion(index 
 		return false, nil
 	}
 	original := s.headers[index]
-	if original.s3Region != nil || s.token.Missing || s.token.NoLookahead ||
+	if original.recoveryRegion() != nil || s.token.Missing || s.token.NoLookahead ||
 		s.token.Symbol == errorSymbol || s.s5MissingInsertions >= maxDiagnosticParserCoreMissingInsertions {
 		return false, nil
 	}
@@ -7664,7 +7696,7 @@ func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertion(index 
 		restore()
 		return false, absorbErr
 	}
-	if !absorbed || s.headers[index].s3Region == nil || !s.headers[index].shifted {
+	if !absorbed || s.headers[index].recoveryRegion() == nil || !s.headers[index].shifted {
 		restore()
 		return false, nil
 	}
@@ -7705,7 +7737,7 @@ func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegionWithAlternati
 		return false, nil
 	}
 	header := &s.headers[index]
-	if header.s3Region != nil {
+	if header.recoveryRegion() != nil {
 		// Already owned by the per-header advance hook (dispatchPassActive's
 		// s3Region branch); that hook declined to widen absorption to EOF.
 		// Fall through to the existing decline unchanged.
@@ -7833,12 +7865,12 @@ func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegionWithAlternati
 	if leafErr != nil {
 		return false, leafErr
 	}
-	header.s3Region = &diagnosticParserCoreS3Region{
+	header.openRecoveryRegion(&diagnosticParserCoreS3Region{
 		state:     state,
 		startByte: s.token.StartByte,
 		endByte:   s.token.EndByte,
 		children:  []core.SubtreeID{leafID},
-	}
+	})
 	s.s3RegionOpened = true
 	header.shifted = true
 	return true, nil

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -456,6 +456,10 @@ type DiagnosticParserCoreGenericWork struct {
 	// PerVersionLexAcceptedRaggedSpans counts different-width token views that
 	// the owned scheduler accepted instead of declining at a shared cursor.
 	PerVersionLexAcceptedRaggedSpans uint64
+	// PerVersionLexViabilityDrops counts owned versions removed only after
+	// their own tokens exhausted reductions without an action and a sibling's
+	// token shifted from the same byte. These are not grammar-ambiguity drops.
+	PerVersionLexViabilityDrops uint64
 	// PeakLiveVersions records the largest live owned-header frontier.
 	PeakLiveVersions  uint64
 	Canonicalizations uint64
@@ -603,6 +607,7 @@ type DiagnosticParserCoreGenericScheduler struct {
 	PerVersionLexRestores            uint64
 	PerVersionLexPublications        uint64
 	PerVersionLexAcceptedRaggedSpans uint64
+	PerVersionLexViabilityDrops      uint64
 	PeakLiveVersions                 uint64
 }
 
@@ -1273,6 +1278,10 @@ type diagnosticParserCoreHeader struct {
 type diagnosticParserCoreVersionState struct {
 	s3Region      *diagnosticParserCoreS3Region
 	relexSnapshot *diagnosticParserCoreVersionLexerSnapshot
+	// lexerRequest is a one-based scheduler sidecar reference. Reductions
+	// preserve it because they do not consume lookahead. Shifts clear it when
+	// they publish the request's after snapshot.
+	lexerRequest uint32
 }
 
 // recoveryRegion returns the optional open strategy-2 region.
@@ -1292,6 +1301,13 @@ func (h diagnosticParserCoreHeader) versionLexerSnapshot() *diagnosticParserCore
 	return h.versionState.relexSnapshot
 }
 
+func (h diagnosticParserCoreHeader) versionLexerRequestReference() uint32 {
+	if h.versionState == nil {
+		return 0
+	}
+	return h.versionState.lexerRequest
+}
+
 // openRecoveryRegion publishes an open strategy-2 region for this header.
 func (h *diagnosticParserCoreHeader) openRecoveryRegion(region *diagnosticParserCoreS3Region) {
 	h.setRecoveryRegion(region)
@@ -1309,6 +1325,7 @@ func (h *diagnosticParserCoreHeader) setRecoveryRegion(region *diagnosticParserC
 	h.versionState = &diagnosticParserCoreVersionState{
 		s3Region:      cloneDiagnosticParserCoreS3Region(region),
 		relexSnapshot: h.versionLexerSnapshot(),
+		lexerRequest:  h.versionLexerRequestReference(),
 	}
 }
 
@@ -1316,7 +1333,10 @@ func (h *diagnosticParserCoreHeader) setRecoveryRegion(region *diagnosticParserC
 func (h *diagnosticParserCoreHeader) closeRecoveryRegion() {
 	if h != nil {
 		if snapshot := h.versionLexerSnapshot(); snapshot != nil {
-			h.versionState = &diagnosticParserCoreVersionState{relexSnapshot: snapshot}
+			h.versionState = &diagnosticParserCoreVersionState{
+				relexSnapshot: snapshot,
+				lexerRequest:  h.versionLexerRequestReference(),
+			}
 		} else {
 			h.versionState = nil
 		}
@@ -2572,7 +2592,11 @@ type diagnosticParserCoreVersionLexerRequest struct {
 	afterCheckpoint   DiagnosticParserCoreScannerCheckpoint
 	beforeID          core.CheckpointID
 	afterID           core.CheckpointID
-	valid             bool
+	// raggedSpan marks the activation request whose token ends at a
+	// different byte than the shared election. Count it only after the
+	// owning header shifts it.
+	raggedSpan bool
+	valid      bool
 }
 
 type diagnosticParserCoreGenericScheduler struct {
@@ -2594,11 +2618,15 @@ type diagnosticParserCoreGenericScheduler struct {
 	versionLexerRequests         []diagnosticParserCoreVersionLexerRequest
 	// versionLexerOwnershipActive marks the ragged election that switched this
 	// scheduler from its shared-token fast path to owned per-header cursors.
-	// The current slice only records the activation and declines before action
-	// execution; later slices will consume the pending requests.
+	// versionLexerOwnershipActive keeps each live header on its own DFA and
+	// scanner cursor until one version remains and rejoins shared election.
 	versionLexerOwnershipActive bool
-	electionIndex               int
-	noLookaheadSteps            uint8
+	// versionLexerNoActionProof is true only during one exact C-style drop:
+	// owned versions shared a token start, at least one shifted, and the
+	// remaining versions exhausted reductions without an action.
+	versionLexerNoActionProof bool
+	electionIndex             int
+	noLookaheadSteps          uint8
 	// recoveryIsolation becomes true only after S4 or S5 publishes two versions.
 	// Clean parses retain the canonical scheduler fast path.
 	recoveryIsolation bool
@@ -4083,6 +4111,7 @@ func clearDiagnosticParserCoreGenericSchedulerVersionState(scheduler *diagnostic
 	scheduler.versionLexerBeforeElection = 0
 	scheduler.versionLexerBeforeCheckpoint = 0
 	scheduler.versionLexerOwnershipActive = false
+	scheduler.versionLexerNoActionProof = false
 }
 
 func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGenericScheduler) error {
@@ -4321,6 +4350,9 @@ type diagnosticParserCoreGenericCell struct {
 	headerIndex     int
 	boundary        core.ClassifiedBoundary
 	selectedOrdinal int
+	// versionLexerRequest is a one-based index into the scheduler's request
+	// sidecar. Zero keeps the shared-election fast path.
+	versionLexerRequest uint32
 	// relexedSymbol is the symbol a same-span per-header relex
 	// (diagnosticParserCoreSameSpanRelex) found for this header, or 0 when
 	// this header dispatches the shared election unchanged. Kept as just
@@ -4605,19 +4637,67 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestForHeader(inde
 	if s == nil || index < 0 || index >= len(s.headers) {
 		return nil
 	}
-	sequence := s.headers[index].creationSeq
-	state, _, err := s.compact.Boundary(s.headers[index].head)
+	header := &s.headers[index]
+	reference := header.versionLexerRequestReference()
+	if reference == 0 || int(reference) > len(s.versionLexerRequests) {
+		return nil
+	}
+	_, byteOffset, err := s.compact.Boundary(header.head)
 	if err != nil {
 		return nil
 	}
-	base := s.versionLexerSnapshotForHeader(index)
-	for requestIndex := range s.versionLexerRequests {
-		request := &s.versionLexerRequests[requestIndex]
-		if request.valid && request.electionIndex == s.electionIndex && request.headerCreationSeq == sequence && request.state == StateID(state) && request.before == base {
-			return request
-		}
+	base := header.versionLexerSnapshot()
+	request := &s.versionLexerRequests[reference-1]
+	if request.valid && request.electionIndex == s.electionIndex &&
+		request.token.StartByte == byteOffset && request.before == base {
+		return request
 	}
 	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestReferenceForHeader(index int) uint32 {
+	if s == nil || index < 0 || index >= len(s.headers) {
+		return 0
+	}
+	header := &s.headers[index]
+	reference := header.versionLexerRequestReference()
+	if reference == 0 || int(reference) > len(s.versionLexerRequests) {
+		return 0
+	}
+	_, byteOffset, err := s.compact.Boundary(header.head)
+	if err != nil {
+		return 0
+	}
+	request := &s.versionLexerRequests[reference-1]
+	if request.valid && request.electionIndex == s.electionIndex &&
+		request.token.StartByte == byteOffset && request.before == header.versionLexerSnapshot() {
+		return reference
+	}
+	return 0
+}
+
+func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestForCell(
+	cell diagnosticParserCoreGenericCell,
+) (*diagnosticParserCoreVersionLexerRequest, error) {
+	if cell.versionLexerRequest == 0 {
+		return nil, nil
+	}
+	requestIndex := int(cell.versionLexerRequest - 1)
+	if s == nil || requestIndex < 0 || requestIndex >= len(s.versionLexerRequests) {
+		return nil, errors.New("parser-core phase zero: version lexer cell request is out of range")
+	}
+	if cell.headerIndex < 0 || cell.headerIndex >= len(s.headers) {
+		return nil, errors.New("parser-core phase zero: version lexer cell header is out of range")
+	}
+	request := &s.versionLexerRequests[requestIndex]
+	header := &s.headers[cell.headerIndex]
+	if !request.valid || request.electionIndex != s.electionIndex ||
+		cell.versionLexerRequest != header.versionLexerRequestReference() ||
+		request.token.StartByte != cell.boundary.ByteOffset() || cell.boundary.Head() != header.head ||
+		request.before != header.versionLexerSnapshot() {
+		return nil, errors.New("parser-core phase zero: version lexer cell request is stale")
+	}
+	return request, nil
 }
 
 func (s *diagnosticParserCoreGenericScheduler) clearVersionLexerRequests() {
@@ -4650,10 +4730,104 @@ func (s *diagnosticParserCoreGenericScheduler) publishVersionLexerSnapshotOwned(
 	if _, _, ok := s.compact.CheckpointReceiptOwned(owner, snapshot.afterCheckpoint); !ok {
 		return errDiagnosticParserCoreUnknownCheckpointIdentity
 	}
-	if err := s.headers[index].publishOwnedVersionLexerSnapshot(s.compact, s.tokenSource.language, snapshot); err != nil {
+	if err := s.installEquivalentVersionLexerState(&s.headers[index], snapshot, 0, nil); err != nil {
 		return err
 	}
 	s.work.add(&s.work.PerVersionLexPublications, 1)
+	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) publishVersionLexerRequestOwned(
+	owner core.SchedulerTransactionToken,
+	index int,
+	snapshot *diagnosticParserCoreVersionLexerSnapshot,
+	requestReference uint32,
+) error {
+	if s == nil || index < 0 || index >= len(s.headers) || requestReference == 0 ||
+		int(requestReference) > len(s.versionLexerRequests) {
+		return errors.New("parser-core phase zero: version lexer request publication is out of range")
+	}
+	if err := snapshot.validateDestination(s.compact, s.tokenSource.language); err != nil {
+		return err
+	}
+	if _, _, ok := s.compact.CheckpointReceiptOwned(owner, snapshot.beforeCheckpoint); !ok {
+		return errDiagnosticParserCoreUnknownCheckpointIdentity
+	}
+	if _, _, ok := s.compact.CheckpointReceiptOwned(owner, snapshot.afterCheckpoint); !ok {
+		return errDiagnosticParserCoreUnknownCheckpointIdentity
+	}
+	if err := s.installEquivalentVersionLexerState(
+		&s.headers[index], snapshot, requestReference, nil,
+	); err != nil {
+		return err
+	}
+	s.work.add(&s.work.PerVersionLexPublications, 1)
+	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) installEquivalentVersionLexerState(
+	header *diagnosticParserCoreHeader,
+	snapshot *diagnosticParserCoreVersionLexerSnapshot,
+	requestReference uint32,
+	extra []diagnosticParserCoreHeader,
+) error {
+	if s == nil || header == nil {
+		return errors.New("parser-core phase zero: version lexer state publication is incomplete")
+	}
+	region := header.recoveryRegion()
+	for index := range s.headers {
+		state := s.headers[index].versionState
+		if state != nil && state.s3Region == region && state.relexSnapshot == snapshot &&
+			state.lexerRequest == requestReference {
+			header.versionState = state
+			return nil
+		}
+	}
+	for index := range extra {
+		state := extra[index].versionState
+		if state != nil && state.s3Region == region && state.relexSnapshot == snapshot &&
+			state.lexerRequest == requestReference {
+			header.versionState = state
+			return nil
+		}
+	}
+	if snapshot != nil {
+		if err := snapshot.validateDestination(s.compact, s.tokenSource.language); err != nil {
+			return err
+		}
+	}
+	header.versionState = &diagnosticParserCoreVersionState{
+		s3Region: region, relexSnapshot: snapshot, lexerRequest: requestReference,
+	}
+	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) equivalentVersionLexerSnapshot(
+	dfa dfaRelexSnapshot,
+	beforeID core.CheckpointID,
+	afterID core.CheckpointID,
+) *diagnosticParserCoreVersionLexerSnapshot {
+	if s == nil {
+		return nil
+	}
+	matches := func(snapshot *diagnosticParserCoreVersionLexerSnapshot) bool {
+		return snapshot != nil && snapshot.beforeCheckpoint == beforeID &&
+			snapshot.afterCheckpoint == afterID && snapshot.dfa.equal(dfa)
+	}
+	for index := range s.headers {
+		if snapshot := s.headers[index].versionLexerSnapshot(); matches(snapshot) {
+			return snapshot
+		}
+	}
+	for index := range s.versionLexerRequests {
+		request := &s.versionLexerRequests[index]
+		if matches(request.before) {
+			return request.before
+		}
+		if matches(request.after) {
+			return request.after
+		}
+	}
 	return nil
 }
 
@@ -4747,7 +4921,6 @@ func (s *diagnosticParserCoreGenericScheduler) requestVersionLexerHeader(index i
 	}
 	s.tokenSource.SetParserState(StateID(state))
 	s.tokenSource.SetGLRStates(nil)
-	beforeDFA := s.tokenSource.snapshotRelexState()
 	beforeID := base.afterCheckpoint
 	token := s.tokenSource.Next()
 	afterDFA := s.tokenSource.snapshotRelexState()
@@ -4756,22 +4929,20 @@ func (s *diagnosticParserCoreGenericScheduler) requestVersionLexerHeader(index i
 	if err != nil {
 		return err
 	}
-	var beforeSnapshot, afterSnapshot *diagnosticParserCoreVersionLexerSnapshot
+	beforeSnapshot := base
+	afterSnapshot := s.equivalentVersionLexerSnapshot(afterDFA, afterID, afterID)
 	if err := s.withVersionLexerOwner(func(owner core.SchedulerTransactionToken) error {
-		var snapshotErr error
-		beforeSnapshot, snapshotErr = s.newVersionLexerSnapshot(owner, beforeDFA, beforeID, beforeID)
-		if snapshotErr != nil {
-			return snapshotErr
+		if afterSnapshot == nil {
+			var snapshotErr error
+			afterSnapshot, snapshotErr = s.newVersionLexerSnapshot(owner, afterDFA, afterID, afterID)
+			if snapshotErr != nil {
+				return snapshotErr
+			}
 		}
-		afterSnapshot, snapshotErr = s.newVersionLexerSnapshot(owner, afterDFA, afterID, afterID)
-		if snapshotErr != nil {
-			return snapshotErr
-		}
-		return s.publishVersionLexerSnapshotOwned(owner, index, beforeSnapshot)
+		return nil
 	}); err != nil {
 		return err
 	}
-	s.work.add(&s.work.PerVersionLexPublications, 1) // the after snapshot is a sidecar publication
 	request := diagnosticParserCoreVersionLexerRequest{
 		electionIndex:     s.electionIndex,
 		headerCreationSeq: header.creationSeq,
@@ -4783,9 +4954,22 @@ func (s *diagnosticParserCoreGenericScheduler) requestVersionLexerHeader(index i
 		afterCheckpoint:   afterSnapshot.afterCheckpointInfo,
 		beforeID:          beforeID,
 		afterID:           afterID,
+		raggedSpan:        s.electionIndex == s.versionLexerBeforeElection && token.StartByte == s.token.StartByte && token.EndByte != s.token.EndByte,
 		valid:             true,
 	}
 	s.versionLexerRequests = append(s.versionLexerRequests, request)
+	requestReference := uint32(len(s.versionLexerRequests))
+	if err := s.withVersionLexerOwner(func(owner core.SchedulerTransactionToken) error {
+		return s.publishVersionLexerRequestOwned(owner, index, beforeSnapshot, requestReference)
+	}); err != nil {
+		clear(s.versionLexerRequests[len(s.versionLexerRequests)-1:])
+		s.versionLexerRequests = s.versionLexerRequests[:len(s.versionLexerRequests)-1]
+		return err
+	}
+	// Header checkpoint identity follows the classified election's current
+	// scanner phase. The request retains the separate before cursor.
+	header.checkpoint = afterID
+	s.work.add(&s.work.PerVersionLexPublications, 1) // the after snapshot is a sidecar publication
 	s.work.add(&s.work.PerVersionLexRequests, 1)
 	if uint64(len(s.headers)) > s.work.PeakLiveVersions {
 		s.work.PeakLiveVersions = uint64(len(s.headers))
@@ -4838,13 +5022,10 @@ func (s *diagnosticParserCoreGenericScheduler) finishSharedElectionSnapshotCaptu
 }
 
 // activateVersionLexerOwnershipAtRagged starts the owned-cursor tranche at
-// the first different-span relex. Keep this activation separate from action
+// the first different-span relex. Keep activation separate from action
 // execution: the shared pass must not reduce a sibling after another header
-// proves that its lexer view has a different width.
-//
-// The current tranche records the complete request set and then declines with
-// an explicit pending-action boundary. A later tranche will dispatch those
-// requests under their own scanner phases.
+// proves that its lexer view has a different width. The next scheduler pass
+// dispatches the complete owned request set.
 const diagnosticParserCoreOwnedDispatchPendingDetail = "generic scheduler owned dispatch pending"
 
 // DiagnosticParserCoreOwnedDispatchPendingDetailForTest exposes the stable
@@ -4855,8 +5036,7 @@ func DiagnosticParserCoreOwnedDispatchPendingDetailForTest() string {
 
 func (s *diagnosticParserCoreGenericScheduler) activateVersionLexerOwnershipAtRagged(
 	raggedHeaderIndex int,
-	witness Token,
-) (*diagnosticParserCoreGenericUnsupported, error) {
+) (stop *diagnosticParserCoreGenericUnsupported, err error) {
 	if s == nil || raggedHeaderIndex < 0 || raggedHeaderIndex >= len(s.headers) {
 		return nil, errors.New("parser-core phase zero: ragged lexer ownership header index is out of range")
 	}
@@ -4879,26 +5059,251 @@ func (s *diagnosticParserCoreGenericScheduler) activateVersionLexerOwnershipAtRa
 			}, nil
 		}
 	}
-	if err := s.seedVersionLexerOwnership(); err != nil {
+	if err = s.headerRollbackScratch.begin(s.headers); err != nil {
+		return nil, err
+	}
+	requestsBefore := len(s.versionLexerRequests)
+	receiptRequestsBefore := 0
+	if s.receipt != nil {
+		receiptRequestsBefore = len(s.receipt.VersionLexerRequests)
+	}
+	workBefore := s.work
+	defer func() {
+		s.headerRollbackScratch.finish(&s.headers, err != nil)
+		if err == nil {
+			return
+		}
+		clear(s.versionLexerRequests[requestsBefore:])
+		s.versionLexerRequests = s.versionLexerRequests[:requestsBefore]
+		if s.receipt != nil {
+			s.receipt.VersionLexerRequests = s.receipt.VersionLexerRequests[:receiptRequestsBefore]
+		}
+		s.work = workBefore
+		s.versionLexerOwnershipActive = false
+	}()
+	if err = s.seedVersionLexerOwnership(); err != nil {
 		return nil, err
 	}
 	for index := range s.headers {
 		if s.headers[index].accepted {
 			continue
 		}
-		if err := s.requestHeaderLexerToken(index); err != nil {
+		if err = s.requestHeaderLexerToken(index); err != nil {
 			return nil, err
 		}
 	}
 	s.versionLexerOwnershipActive = true
-	return &diagnosticParserCoreGenericUnsupported{
-		boundary: DiagnosticParserCoreRoute,
-		detail: fmt.Sprintf(
-			diagnosticParserCoreOwnedDispatchPendingDetail+": per-header lexer ownership activated at header %d for ragged token symbol=%d span=%d..%d",
-			raggedHeaderIndex, witness.Symbol, witness.StartByte, witness.EndByte,
-		),
-		headerIndex: raggedHeaderIndex,
-	}, nil
+	return nil, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) bindVersionLexerRequest(
+	request *diagnosticParserCoreVersionLexerRequest,
+) error {
+	if s == nil || request == nil || !request.valid || request.electionIndex != s.electionIndex {
+		return errors.New("parser-core phase zero: cannot bind an invalid version lexer request")
+	}
+	if _, _, ok := s.compact.CheckpointReceipt(request.beforeID); !ok {
+		return errDiagnosticParserCoreUnknownCheckpointIdentity
+	}
+	if _, _, ok := s.compact.CheckpointReceipt(request.afterID); !ok {
+		return errDiagnosticParserCoreUnknownCheckpointIdentity
+	}
+	if err := s.compact.SetPhaseExternalTokenScannerCheckpoints(request.beforeID, request.afterID); err != nil {
+		return err
+	}
+	s.token = request.token
+	s.checkpointBeforeID = request.beforeID
+	s.checkpointID = request.afterID
+	s.checkpoint = request.afterCheckpoint
+	s.currentElection = DiagnosticParserCoreElection{
+		Token:                  request.token,
+		ScannerBefore:          request.beforeCheckpoint,
+		ScannerAfter:           request.afterCheckpoint,
+		CurrentCheckpointValid: true,
+		CurrentCheckpointStart: request.beforeCheckpoint,
+		CurrentCheckpointEnd:   request.afterCheckpoint,
+		CurrentCheckpointBytes: [2]uint32{request.token.StartByte, request.token.EndByte},
+	}
+	s.tokenCell = diagnosticParserCoreTokenCell{
+		token: request.token, state: request.state, byteOffset: request.token.StartByte,
+		beforeCheckpoint: request.beforeID, afterCheckpoint: request.afterID, valid: true,
+	}
+	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) withVersionLexerRequest(
+	cell diagnosticParserCoreGenericCell,
+	fn func() error,
+) error {
+	request, err := s.versionLexerRequestForCell(cell)
+	if err != nil {
+		return err
+	}
+	if request == nil {
+		return fn()
+	}
+	tokenBefore := s.token
+	checkpointBefore := s.checkpoint
+	checkpointStartBefore, checkpointEndBefore := s.checkpointBeforeID, s.checkpointID
+	electionBefore := s.currentElection
+	tokenCellBefore := s.tokenCell
+	phaseCheckpointBefore, phaseStartBefore, phaseEndBefore, phaseExactBefore := s.compact.PhaseScannerCheckpoints()
+	restore := func() error {
+		s.token = tokenBefore
+		s.checkpoint = checkpointBefore
+		s.checkpointBeforeID, s.checkpointID = checkpointStartBefore, checkpointEndBefore
+		s.currentElection = electionBefore
+		s.tokenCell = tokenCellBefore
+		if phaseExactBefore {
+			return s.compact.SetPhaseExternalTokenScannerCheckpoints(phaseStartBefore, phaseEndBefore)
+		}
+		return s.compact.SetPhaseCheckpoint(phaseCheckpointBefore)
+	}
+	if err := s.bindVersionLexerRequest(request); err != nil {
+		return err
+	}
+	runErr := fn()
+	restoreErr := restore()
+	if runErr != nil {
+		return runErr
+	}
+	return restoreErr
+}
+
+func (s *diagnosticParserCoreGenericScheduler) publishVersionLexerShiftOnHeaderOwned(
+	owner core.SchedulerTransactionToken,
+	header *diagnosticParserCoreHeader,
+	request *diagnosticParserCoreVersionLexerRequest,
+) error {
+	if s == nil || header == nil || request == nil || request.after == nil {
+		return errors.New("parser-core phase zero: version lexer shift publication is incomplete")
+	}
+	if err := request.after.validateDestination(s.compact, s.tokenSource.language); err != nil {
+		return err
+	}
+	if _, _, ok := s.compact.CheckpointReceiptOwned(owner, request.after.beforeCheckpoint); !ok {
+		return errDiagnosticParserCoreUnknownCheckpointIdentity
+	}
+	if _, _, ok := s.compact.CheckpointReceiptOwned(owner, request.after.afterCheckpoint); !ok {
+		return errDiagnosticParserCoreUnknownCheckpointIdentity
+	}
+	if err := s.installEquivalentVersionLexerState(header, request.after, 0, nil); err != nil {
+		return err
+	}
+	header.checkpoint = request.afterID
+	s.work.add(&s.work.PerVersionLexPublications, 1)
+	if request.raggedSpan {
+		s.work.add(&s.work.PerVersionLexAcceptedRaggedSpans, 1)
+	}
+	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) beginNextVersionLexerElection() error {
+	if s == nil || !s.versionLexerOwnershipActive || len(s.headers) < 2 {
+		return errors.New("parser-core phase zero: next version lexer election requires multiple owned headers")
+	}
+	for index := range s.headers {
+		header := s.headers[index]
+		if header.accepted || !header.shifted || header.versionLexerSnapshot() == nil {
+			return errors.New("parser-core phase zero: next version lexer election requires a closed owned frontier")
+		}
+		if err := header.versionLexerSnapshot().validateDestination(s.compact, s.tokenSource.language); err != nil {
+			return err
+		}
+	}
+	if err := s.headerRollbackScratch.begin(s.headers); err != nil {
+		return err
+	}
+	requestsBefore := len(s.versionLexerRequests)
+	receiptRequestsBefore := 0
+	if s.receipt != nil {
+		receiptRequestsBefore = len(s.receipt.VersionLexerRequests)
+	}
+	electionBefore := s.electionIndex
+	workBefore := s.work
+	s.electionIndex++
+	rollback := true
+	defer func() {
+		s.headerRollbackScratch.finish(&s.headers, rollback)
+		if !rollback {
+			return
+		}
+		clear(s.versionLexerRequests[requestsBefore:])
+		s.versionLexerRequests = s.versionLexerRequests[:requestsBefore]
+		if s.receipt != nil {
+			s.receipt.VersionLexerRequests = s.receipt.VersionLexerRequests[:receiptRequestsBefore]
+		}
+		s.electionIndex = electionBefore
+		s.work = workBefore
+	}()
+	for index := range s.headers {
+		header := &s.headers[index]
+		header.shifted = false
+		header.paused = false
+		header.frontierSequence = 0
+		if err := s.requestHeaderLexerToken(index); err != nil {
+			return err
+		}
+	}
+	for index := range s.headers {
+		reference := s.headers[index].versionLexerRequestReference()
+		if int(reference) <= requestsBefore || s.versionLexerRequestForHeader(index) == nil {
+			return errors.New("parser-core phase zero: next version lexer request was not authenticated")
+		}
+	}
+	// Build every owned request before advancing the compact frontier. A
+	// request failure can then restore the scheduler without leaving the Core
+	// in a new authentication generation.
+	if err := s.compact.BeginFrontier(); err != nil {
+		return err
+	}
+	newRequestCount := len(s.versionLexerRequests) - requestsBefore
+	copy(s.versionLexerRequests, s.versionLexerRequests[requestsBefore:])
+	clear(s.versionLexerRequests[newRequestCount:])
+	s.versionLexerRequests = s.versionLexerRequests[:newRequestCount]
+	for index := range s.headers {
+		header := &s.headers[index]
+		reference := header.versionLexerRequestReference()
+		header.versionState = &diagnosticParserCoreVersionState{
+			s3Region:      header.recoveryRegion(),
+			relexSnapshot: header.versionLexerSnapshot(),
+			lexerRequest:  reference - uint32(requestsBefore),
+		}
+	}
+	s.epochProgress = false
+	rollback = false
+	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) rejoinSharedLexerFromOwnedHeader() error {
+	if s == nil || !s.versionLexerOwnershipActive || len(s.headers) != 1 {
+		return errors.New("parser-core phase zero: shared lexer rejoin requires one owned header")
+	}
+	header := &s.headers[0]
+	snapshot := header.versionLexerSnapshot()
+	if !header.shifted || header.accepted || snapshot == nil {
+		return errors.New("parser-core phase zero: shared lexer rejoin requires one shifted owned header")
+	}
+	if err := snapshot.restore(s.compact, s.tokenSource); err != nil {
+		return err
+	}
+	state, _, err := s.compact.Boundary(header.head)
+	if err != nil {
+		return err
+	}
+	s.tokenSource.SetParserState(StateID(state))
+	s.tokenSource.SetGLRStates(nil)
+	if err := s.compact.SetPhaseExternalTokenScannerCheckpoints(snapshot.beforeCheckpoint, snapshot.afterCheckpoint); err != nil {
+		return err
+	}
+	s.checkpointBeforeID = snapshot.beforeCheckpoint
+	s.checkpointID = snapshot.afterCheckpoint
+	s.checkpoint = snapshot.afterCheckpointInfo
+	header.checkpoint = snapshot.afterCheckpoint
+	header.clearVersionLexerSnapshot()
+	s.clearVersionLexerRequests()
+	s.versionLexerOwnershipActive = false
+	return nil
 }
 
 type diagnosticParserCoreDispatchScratch struct {
@@ -7141,6 +7546,25 @@ func (s *diagnosticParserCoreGenericScheduler) run() error {
 			}
 		}
 		if allClosed {
+			if s.versionLexerOwnershipActive && accepted == 0 {
+				if len(s.headers) == 1 {
+					if err := s.rejoinSharedLexerFromOwnedHeader(); err != nil {
+						return err
+					}
+					if err := s.elect(false); err != nil {
+						return err
+					}
+					if s.stoppedAfterElection {
+						s.publishTotals()
+						return nil
+					}
+					continue
+				}
+				if err := s.beginNextVersionLexerElection(); err != nil {
+					return err
+				}
+				continue
+			}
 			if accepted != 0 {
 				if shifted != 0 || accepted != len(s.headers) {
 					return s.finish(DiagnosticParserCoreRoute, "generic scheduler cannot mix accepted and shifted heads", 0)
@@ -7292,7 +7716,269 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPass() (*diagnosticParser
 	return s.dispatchPassActive()
 }
 
+func (s *diagnosticParserCoreGenericScheduler) classifyVersionLexerCell(
+	index int,
+	recordWork bool,
+) (diagnosticParserCoreGenericCell, bool, *diagnosticParserCoreGenericUnsupported, error) {
+	if s == nil || index < 0 || index >= len(s.headers) {
+		return diagnosticParserCoreGenericCell{}, false, nil, errors.New("parser-core phase zero: version lexer classification index is out of range")
+	}
+	header := &s.headers[index]
+	if header.shifted || header.accepted || header.paused {
+		return diagnosticParserCoreGenericCell{}, false, nil, nil
+	}
+	if header.recoveryRegion() != nil {
+		return diagnosticParserCoreGenericCell{}, false, &diagnosticParserCoreGenericUnsupported{
+			boundary: DiagnosticParserCoreRoute, detail: "generic scheduler owned lexer dispatch reached an open recovery region", headerIndex: index,
+		}, nil
+	}
+	if err := s.requestHeaderLexerToken(index); err != nil {
+		return diagnosticParserCoreGenericCell{}, false, nil, err
+	}
+	requestReference := s.versionLexerRequestReferenceForHeader(index)
+	if requestReference == 0 {
+		return diagnosticParserCoreGenericCell{}, false, nil, errors.New("parser-core phase zero: version lexer request was not published")
+	}
+	request := &s.versionLexerRequests[requestReference-1]
+	if err := s.bindVersionLexerRequest(request); err != nil {
+		return diagnosticParserCoreGenericCell{}, false, nil, err
+	}
+	if unsupported := diagnosticParserCoreGenericUnsupportedToken(request.token); unsupported != nil {
+		unsupported.headerIndex = index
+		return diagnosticParserCoreGenericCell{}, false, unsupported, nil
+	}
+	boundary, err := s.compact.ClassifyBoundary(header.head, core.Symbol(request.token.Symbol))
+	if err != nil {
+		return diagnosticParserCoreGenericCell{}, false, nil, err
+	}
+	if recordWork {
+		s.work.ActionLookups++
+	}
+	actions := boundary.Actions()
+	if recordWork {
+		workCountRecordResolvedActionCell(actions.Len())
+	}
+	if actions.Len() == 0 {
+		return diagnosticParserCoreGenericCell{}, true, nil, nil
+	}
+	cell := diagnosticParserCoreGenericCell{
+		headerIndex: index, boundary: boundary, versionLexerRequest: requestReference,
+	}
+	if ordinal, ok := diagnosticParserCoreConflictPolicyOrdinal(
+		s.tokenSource.language,
+		request.token,
+		boundary.State(),
+		actions,
+		len(s.headers),
+	); ok {
+		cell.selectedOrdinal = ordinal
+		cell.selectedBy = diagnosticParserCoreCellSelectionConflictPolicy
+	}
+	if cell.selectedBy == diagnosticParserCoreCellSelectionNone &&
+		actions.Descriptor().Kind() == core.ActionRowUnsupported {
+		if ordinal, ok := diagnosticParserCoreRepetitionFoldOrdinal(s.tokenSource.language, actions); ok {
+			cell.selectedOrdinal = ordinal
+			cell.selectedBy = diagnosticParserCoreCellSelectionRepetitionFold
+		} else if _, ok := diagnosticParserCoreSingleReduceRepetitionShiftOrdinal(actions); ok &&
+			cRepetitionSkipOptOut[s.tokenSource.language.Name] {
+			cell.selectedBy = diagnosticParserCoreCellSelectionRepetitionFork
+		}
+	}
+	if cell.selectedBy == diagnosticParserCoreCellSelectionNone && !cell.descriptor().DispatchSupported() {
+		if unsupported := diagnosticParserCoreGenericUnsupportedCellDescriptor(index, request.token, actions, cell.descriptor()); unsupported != nil {
+			return diagnosticParserCoreGenericCell{}, false, unsupported, nil
+		}
+	}
+	return cell, false, nil, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) versionLexerNoActionDropEligible(indices []int) bool {
+	if s == nil || !s.versionLexerOwnershipActive || s.recoveryIsolation ||
+		!diagnosticParserCoreGenericNoActionDropEligible(s.headers, indices, s.epochProgress) {
+		return false
+	}
+	drop := 0
+	sharedStart := uint32(0)
+	startSet := false
+	for index := range s.headers {
+		isDrop := drop < len(indices) && indices[drop] == index
+		if isDrop {
+			drop++
+			request := s.versionLexerRequestForHeader(index)
+			if request == nil || s.headers[index].shifted || s.headers[index].accepted || s.headers[index].paused {
+				return false
+			}
+			if !startSet {
+				sharedStart, startSet = request.token.StartByte, true
+			} else if request.token.StartByte != sharedStart {
+				return false
+			}
+			continue
+		}
+		header := &s.headers[index]
+		if !header.shifted || header.accepted || header.paused ||
+			header.versionLexerRequestReference() != 0 {
+			return false
+		}
+		matchedShift := false
+		for requestIndex := range s.versionLexerRequests {
+			request := &s.versionLexerRequests[requestIndex]
+			if !request.valid || request.electionIndex != s.electionIndex ||
+				request.after != header.versionLexerSnapshot() {
+				continue
+			}
+			if !startSet {
+				sharedStart, startSet = request.token.StartByte, true
+			} else if request.token.StartByte != sharedStart {
+				return false
+			}
+			matchedShift = true
+			break
+		}
+		if !matchedShift {
+			return false
+		}
+	}
+	return startSet && drop == len(indices)
+}
+
+func (s *diagnosticParserCoreGenericScheduler) dispatchVersionLexerPassActive() (*diagnosticParserCoreGenericUnsupported, error) {
+	s.work.Passes++
+	var before []DiagnosticParserCoreHeaderReceipt
+	if s.fullReceipts() {
+		var err error
+		before, err = s.headerReceipts(s.headers)
+		if err != nil {
+			return nil, err
+		}
+	}
+	cells := s.dispatchScratch.cells[:0]
+	noActionIndices := s.dispatchScratch.noActionIndices[:0]
+	acceptCell, extraCell, reductionCell, conflictCell, shiftCell := -1, -1, -1, -1, -1
+	for index := range s.headers {
+		cell, noAction, unsupported, err := s.classifyVersionLexerCell(index, true)
+		if err != nil || unsupported != nil {
+			return unsupported, err
+		}
+		if noAction {
+			noActionIndices = append(noActionIndices, index)
+			continue
+		}
+		if s.headers[index].shifted || s.headers[index].accepted || s.headers[index].paused {
+			continue
+		}
+		cellIndex := len(cells)
+		cells = append(cells, cell)
+		switch cell.kind() {
+		case core.ActionRowAccept:
+			if acceptCell < 0 {
+				acceptCell = cellIndex
+			}
+		case core.ActionRowExtraShift:
+			if extraCell < 0 {
+				extraCell = cellIndex
+			}
+		case core.ActionRowReduce:
+			if reductionCell < 0 {
+				reductionCell = cellIndex
+			}
+		case core.ActionRowConflict:
+			if cell.descriptor().HasReduce() && reductionCell < 0 {
+				reductionCell = cellIndex
+			}
+			if conflictCell < 0 {
+				conflictCell = cellIndex
+			}
+		case core.ActionRowShift:
+			if shiftCell < 0 {
+				shiftCell = cellIndex
+			}
+		}
+	}
+	s.dispatchScratch.cells = cells
+	s.dispatchScratch.noActionIndices = noActionIndices
+	if len(cells) == 0 {
+		if s.versionLexerNoActionDropEligible(noActionIndices) {
+			s.versionLexerNoActionProof = true
+			defer func() { s.versionLexerNoActionProof = false }()
+			if s.options.recordDropCohortFrontiers {
+				if err := s.publishDropCohortFrontierOwned(noActionIndices); err != nil {
+					return nil, err
+				}
+			}
+			if err := s.consumeDropCohortFrontierOwned(noActionIndices); err != nil {
+				return nil, err
+			}
+			return nil, s.dropGenericNoActionHeads(noActionIndices)
+		}
+		if len(noActionIndices) != 0 {
+			return &diagnosticParserCoreGenericUnsupported{
+				boundary: DiagnosticParserCoreRecovery, detail: diagnosticParserCoreNoTableActionDetail, headerIndex: noActionIndices[0],
+			}, nil
+		}
+		return &diagnosticParserCoreGenericUnsupported{
+			boundary: DiagnosticParserCoreRoute, detail: "generic scheduler owned lexer dispatch has no runnable head",
+		}, nil
+	}
+	selected := -1
+	operation := core.ActionRowEmpty
+	switch {
+	case acceptCell >= 0:
+		if len(s.headers) != 1 || len(cells) != 1 || len(noActionIndices) != 0 {
+			return &diagnosticParserCoreGenericUnsupported{
+				boundary: DiagnosticParserCoreAccept, detail: "generic scheduler owned lexer accept requires one live version", headerIndex: cells[acceptCell].headerIndex,
+			}, nil
+		}
+		selected, operation = acceptCell, core.ActionRowAccept
+	case extraCell >= 0:
+		selected, operation = extraCell, core.ActionRowExtraShift
+	case reductionCell >= 0:
+		selected = reductionCell
+		if cells[selected].kind() == core.ActionRowConflict {
+			operation = core.ActionRowConflict
+		} else {
+			operation = core.ActionRowReduce
+		}
+	case conflictCell >= 0:
+		selected, operation = conflictCell, core.ActionRowConflict
+	case shiftCell >= 0:
+		selected, operation = shiftCell, core.ActionRowShift
+	default:
+		return &diagnosticParserCoreGenericUnsupported{
+			boundary: DiagnosticParserCoreRoute, detail: "generic scheduler owned lexer dispatch found no supported action",
+		}, nil
+	}
+	selectedHeader := cells[selected].headerIndex
+	cell, noAction, unsupported, err := s.classifyVersionLexerCell(selectedHeader, false)
+	if err != nil || unsupported != nil {
+		return unsupported, err
+	}
+	if noAction {
+		return nil, errors.New("parser-core phase zero: version lexer action changed before dispatch")
+	}
+	err = s.withVersionLexerRequest(cell, func() error {
+		switch operation {
+		case core.ActionRowAccept:
+			return s.applyGenericAccept(before, cell)
+		case core.ActionRowExtraShift:
+			return s.applyGenericExtraShifts(before, []diagnosticParserCoreGenericCell{cell})
+		case core.ActionRowReduce:
+			return s.applyGenericReduction(before, cell)
+		case core.ActionRowConflict:
+			return s.applyGenericConflict(before, cell)
+		case core.ActionRowShift:
+			return s.applyGenericShifts(before, []diagnosticParserCoreGenericCell{cell})
+		default:
+			return errors.New("parser-core phase zero: invalid version lexer dispatch operation")
+		}
+	})
+	return nil, err
+}
+
 func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnosticParserCoreGenericUnsupported, error) {
+	if s.versionLexerOwnershipActive {
+		return s.dispatchVersionLexerPassActive()
+	}
 	s.work.Passes++
 	// R6 pass-mix counter. A single-header pass is exactly the shape the C4
 	// bytecode corridor is eligible for, so this count makes corridor coverage
@@ -7573,7 +8259,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 							// publishes its per-header requests.
 							s.dispatchScratch.cells = s.dispatchScratch.cells[:0]
 							s.dispatchScratch.noActionIndices = s.dispatchScratch.noActionIndices[:0]
-							return s.activateVersionLexerOwnershipAtRagged(index, relexed)
+							return s.activateVersionLexerOwnershipAtRagged(index)
 						}
 						// A second witness cannot occur in this activation pass,
 						// but keep the legacy accounting if a future caller
@@ -9701,6 +10387,7 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 		return errors.New("parser-core phase zero: sibling-backed no-action drop removed the complete frontier")
 	}
 	metadataDrop := s.compactEOFRecoveryAdmissionDropMatches(indices)
+	versionLexerDrop := s.versionLexerNoActionProof
 	// F4 disposition (spec.b4b-alternative-set.v2 section 5): a resurrection
 	// descended from a HistoricalBoundaryUnproved dead-node import carries no
 	// recorded provenance to prove, so it fails closed independently of the
@@ -9728,8 +10415,8 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 	// differing-tree cases, the Kotlin witness declines under v2, stage 1's
 	// gates re-passed); erlang's own class-3 probe re-proof miss is scoped
 	// to its stage 3 certificate precondition, not this gate.
-	convergedCoverageDrops, proved := uint64(0), metadataDrop
-	if !metadataDrop {
+	convergedCoverageDrops, proved := uint64(0), metadataDrop || versionLexerDrop
+	if !metadataDrop && !versionLexerDrop {
 		if frontierProofVerified {
 			convergedCoverageDrops = s.frontierProofConvergedDropCount(indices)
 			proved = true
@@ -9760,15 +10447,21 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 			if index < 0 || index >= len(pathReceipts) {
 				return errors.New("parser-core phase zero: no-action drop index is out of range")
 			}
+			token := s.token
+			if request := s.versionLexerRequestForHeader(index); request != nil {
+				token = request.token
+			}
 			s.receipt.NoActionDrops = append(s.receipt.NoActionDrops, DiagnosticParserCoreGenericNoActionDrop{
-				ElectionIndex: s.electionIndex, Token: s.token, Header: pathReceipts[index],
+				ElectionIndex: s.electionIndex, Token: token, Header: pathReceipts[index],
 			})
 		}
 	}
 	var convergedReductionSplitDrops uint64
-	for _, index := range indices {
-		if index >= 0 && index < len(s.headers) && s.headers[index].convergedReductionSplit {
-			convergedReductionSplitDrops++
+	if !versionLexerDrop {
+		for _, index := range indices {
+			if index >= 0 && index < len(s.headers) && s.headers[index].convergedReductionSplit {
+				convergedReductionSplitDrops++
+			}
 		}
 	}
 	s.invalidateVerifierHeaderBinding()
@@ -9790,6 +10483,9 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 	clear(s.headers[write:])
 	s.headers = s.headers[:write]
 	s.work.NoActionDrops += uint64(len(indices))
+	if versionLexerDrop {
+		s.work.add(&s.work.PerVersionLexViabilityDrops, uint64(len(indices)))
+	}
 	s.work.add(&s.work.ConvergedReductionSplitDrops, convergedReductionSplitDrops)
 	s.work.add(&s.work.ConvergedCoverageDrops, convergedCoverageDrops)
 	return nil
@@ -10556,6 +11252,13 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflict(before []Dia
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner core.SchedulerTransactionToken, before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) (err error) {
 	branchOrderBefore, nextSeqBefore := s.branchOrder, s.nextSeq
+	var versionLexerRequest *diagnosticParserCoreVersionLexerRequest
+	if cell.versionLexerRequest != 0 {
+		versionLexerRequest, err = s.versionLexerRequestForCell(cell)
+		if err != nil {
+			return err
+		}
+	}
 	if err = s.reserveDispatches(1); err != nil {
 		return err
 	}
@@ -10672,6 +11375,18 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	s.work.Dispatches++
 	if err := s.canonicalizeOwned(owner); err != nil {
 		return err
+	}
+	if cell.versionLexerRequest != 0 {
+		for index := range s.headers {
+			header := &s.headers[index]
+			if !header.shifted || header.versionLexerRequestReference() != cell.versionLexerRequest ||
+				header.versionLexerSnapshot() != versionLexerRequest.before {
+				continue
+			}
+			if err := s.publishVersionLexerShiftOnHeaderOwned(owner, header, versionLexerRequest); err != nil {
+				return err
+			}
+		}
 	}
 	if err := s.persistHeaderLineageOwned(owner); err != nil {
 		return err
@@ -10798,6 +11513,13 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 	} else {
 		for index := range cells {
 			cell := &cells[index]
+			var versionLexerRequest *diagnosticParserCoreVersionLexerRequest
+			if cell.versionLexerRequest != 0 {
+				versionLexerRequest, err = s.versionLexerRequestForCell(*cell)
+				if err != nil {
+					return err
+				}
+			}
 			ordinal := cell.selectedActionOrdinal()
 			action := cell.actions().At(ordinal)
 			if action.Type != core.ActionShift || action.Extra {
@@ -10818,6 +11540,11 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 			s.headers[cell.headerIndex].head = head
 			s.headers[cell.headerIndex].shifted = true
 			markDiagnosticParserCoreExternalLineage(&s.headers[cell.headerIndex], token)
+			if versionLexerRequest != nil {
+				if err := s.publishVersionLexerShiftOnHeaderOwned(owner, &s.headers[cell.headerIndex], versionLexerRequest); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	s.epochProgress = true
@@ -10892,6 +11619,13 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 		if isolatedRecovery {
 			for index := range cells {
 				cell := &cells[index]
+				var versionLexerRequest *diagnosticParserCoreVersionLexerRequest
+				if cell.versionLexerRequest != 0 {
+					versionLexerRequest, err = s.versionLexerRequestForCell(*cell)
+					if err != nil {
+						return err
+					}
+				}
 				head, shiftErr := s.compact.ShiftClassifiedWithLiveCondenseCandidatesOwned(
 					owner, s.collectCondenseCandidates(cell.headerIndex), cell.boundary, 0,
 					core.Token{
@@ -10907,6 +11641,11 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 				s.headers[cell.headerIndex].head = head
 				s.headers[cell.headerIndex].shifted = true
 				markDiagnosticParserCoreExternalLineage(&s.headers[cell.headerIndex], token)
+				if versionLexerRequest != nil {
+					if err := s.publishVersionLexerShiftOnHeaderOwned(owner, &s.headers[cell.headerIndex], versionLexerRequest); err != nil {
+						return err
+					}
+				}
 			}
 		} else {
 			s.classifiedBoundaries = s.classifiedBoundaries[:0]
@@ -10923,9 +11662,21 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 			}
 			for index := range cells {
 				cell := &cells[index]
+				var versionLexerRequest *diagnosticParserCoreVersionLexerRequest
+				if cell.versionLexerRequest != 0 {
+					versionLexerRequest, err = s.versionLexerRequestForCell(*cell)
+					if err != nil {
+						return err
+					}
+				}
 				s.headers[cell.headerIndex].head = heads[index]
 				s.headers[cell.headerIndex].shifted = true
 				markDiagnosticParserCoreExternalLineage(&s.headers[cell.headerIndex], token)
+				if versionLexerRequest != nil {
+					if err := s.publishVersionLexerShiftOnHeaderOwned(owner, &s.headers[cell.headerIndex], versionLexerRequest); err != nil {
+						return err
+					}
+				}
 			}
 		}
 		if s.extraPostExecutionFault != nil {
@@ -11436,6 +12187,7 @@ func (s *diagnosticParserCoreGenericScheduler) publishTotals() {
 	s.receipt.PerVersionLexRestores = s.work.PerVersionLexRestores
 	s.receipt.PerVersionLexPublications = s.work.PerVersionLexPublications
 	s.receipt.PerVersionLexAcceptedRaggedSpans = s.work.PerVersionLexAcceptedRaggedSpans
+	s.receipt.PerVersionLexViabilityDrops = s.work.PerVersionLexViabilityDrops
 	s.receipt.PeakLiveVersions = s.work.PeakLiveVersions
 }
 

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -5352,6 +5352,9 @@ func (s *diagnosticParserCoreGenericScheduler) rejoinSharedLexerFromOwnedHeader(
 	if s == nil || !s.versionLexerOwnershipActive || len(s.headers) != 1 {
 		return errors.New("parser-core phase zero: shared lexer rejoin requires one owned header")
 	}
+	if s.tokenSource == nil || s.tokenSource.lexer == nil {
+		return errors.New("parser-core phase zero: shared lexer rejoin token source is unavailable")
+	}
 	header := &s.headers[0]
 	snapshot := header.versionLexerSnapshot()
 	if !header.shifted || header.accepted || snapshot == nil {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1234,9 +1234,11 @@ type diagnosticParserCoreHeader struct {
 
 // diagnosticParserCoreVersionState holds immutable state for one header.
 // Keep it separate from the fixed-size header so lexer ownership can grow
-// without changing the header layout.
+// without changing the header layout. Region updates publish a new wrapper
+// while preserving the lexer snapshot, and snapshot updates do the reverse.
 type diagnosticParserCoreVersionState struct {
-	s3Region *diagnosticParserCoreS3Region
+	s3Region      *diagnosticParserCoreS3Region
+	relexSnapshot *diagnosticParserCoreVersionLexerSnapshot
 }
 
 // recoveryRegion returns the optional open strategy-2 region.
@@ -1245,6 +1247,15 @@ func (h diagnosticParserCoreHeader) recoveryRegion() *diagnosticParserCoreS3Regi
 		return nil
 	}
 	return h.versionState.s3Region
+}
+
+// versionLexerSnapshot returns the immutable DFA/scanner state owned by this
+// parser version. The nil value is the single-version fast-path state.
+func (h diagnosticParserCoreHeader) versionLexerSnapshot() *diagnosticParserCoreVersionLexerSnapshot {
+	if h.versionState == nil {
+		return nil
+	}
+	return h.versionState.relexSnapshot
 }
 
 // openRecoveryRegion publishes an open strategy-2 region for this header.
@@ -1261,13 +1272,20 @@ func (h *diagnosticParserCoreHeader) setRecoveryRegion(region *diagnosticParserC
 		h.closeRecoveryRegion()
 		return
 	}
-	h.versionState = &diagnosticParserCoreVersionState{s3Region: region}
+	h.versionState = &diagnosticParserCoreVersionState{
+		s3Region:      cloneDiagnosticParserCoreS3Region(region),
+		relexSnapshot: h.versionLexerSnapshot(),
+	}
 }
 
 // closeRecoveryRegion clears the header's open strategy-2 region.
 func (h *diagnosticParserCoreHeader) closeRecoveryRegion() {
 	if h != nil {
-		h.versionState = nil
+		if snapshot := h.versionLexerSnapshot(); snapshot != nil {
+			h.versionState = &diagnosticParserCoreVersionState{relexSnapshot: snapshot}
+		} else {
+			h.versionState = nil
+		}
 	}
 }
 
@@ -1297,6 +1315,16 @@ func (s *diagnosticParserCoreGenericScheduler) competingRecoveryFrontier() bool 
 		}
 	}
 	return true
+}
+
+// invalidateVerifierHeaderBinding drops the test-only pointer whenever a
+// frontier mutation can replace or compact its backing array.
+func (s *diagnosticParserCoreGenericScheduler) invalidateVerifierHeaderBinding() {
+	if s == nil {
+		return
+	}
+	s.verifierHeaderPtr = nil
+	s.verifierBound = 0
 }
 
 // retireTrailingRecoveryNoActionLineage ports one exact C condense-tail
@@ -1336,6 +1364,7 @@ func (s *diagnosticParserCoreGenericScheduler) retireTrailingRecoveryNoActionLin
 	}
 
 	survivor.clearRecoveryLineage()
+	s.invalidateVerifierHeaderBinding()
 	clear(s.headers[1:])
 	s.headers = s.headers[:1]
 	s.recoveryIsolation = false
@@ -1380,6 +1409,20 @@ type diagnosticParserCoreS3Region struct {
 	startByte uint32
 	endByte   uint32
 	children  []core.SubtreeID
+}
+
+// cloneDiagnosticParserCoreS3Region makes the header's recovery region
+// independent from the caller's region and child backing array.
+func cloneDiagnosticParserCoreS3Region(region *diagnosticParserCoreS3Region) *diagnosticParserCoreS3Region {
+	if region == nil {
+		return nil
+	}
+	owned := *region
+	if region.children != nil {
+		owned.children = make([]core.SubtreeID, len(region.children))
+		copy(owned.children, region.children)
+	}
+	return &owned
 }
 
 func nextDiagnosticParserCoreCleanPathLineage(next *uint16) (uint16, error) {
@@ -1885,10 +1928,23 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 }
 
 type diagnosticParserCorePhaseHead struct {
-	head       core.Head
-	checkpoint core.CheckpointID
-	shifted    bool
-	accepted   bool
+	head         core.Head
+	checkpoint   core.CheckpointID
+	shifted      bool
+	accepted     bool
+	versionState *diagnosticParserCoreVersionState
+}
+
+// clearDiagnosticParserCoreHeaderSuffix clears header values that no longer
+// belong to a logical slice. Keep the range bounded by the prior length.
+func clearDiagnosticParserCoreHeaderSuffix(headers []diagnosticParserCoreHeader, keep int) {
+	if keep < 0 {
+		keep = 0
+	}
+	if keep >= len(headers) {
+		return
+	}
+	clear(headers[keep:])
 }
 
 type diagnosticParserCoreCanonicalScratch struct {
@@ -2007,6 +2063,23 @@ func diagnosticParserCoreCanonicalGroupFlags(header *diagnosticParserCoreHeader)
 
 const diagnosticParserCoreLinearCanonicalLimit = 8
 
+func (s *diagnosticParserCoreCanonicalScratch) headerBufferFor(target, length int) []diagnosticParserCoreHeader {
+	previous := s.headerBuffers[target]
+	if length < len(previous) {
+		clearDiagnosticParserCoreHeaderSuffix(previous, length)
+	}
+	if cap(previous) < length {
+		// The previous logical contents become unreachable from this buffer when
+		// it grows into a different backing array.
+		clear(previous)
+		if length <= len(s.inlineHeaders[target]) {
+			return s.inlineHeaders[target][:length]
+		}
+		return make([]diagnosticParserCoreHeader, length)
+	}
+	return previous[:length]
+}
+
 func (s *diagnosticParserCoreCanonicalScratch) canonicalize(compact *core.Core, headers []diagnosticParserCoreHeader) ([]diagnosticParserCoreHeader, error) {
 	out, _, err := s.canonicalizeWithMutation(compact, headers)
 	return out, err
@@ -2022,16 +2095,7 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeWithMutation(
 	if len(headers) != 0 && cap(s.headerBuffers[target]) != 0 && &headers[0] == &s.headerBuffers[target][:1][0] {
 		target ^= 1
 	}
-	normalized := s.headerBuffers[target]
-	if cap(normalized) < len(headers) {
-		if len(headers) <= len(s.inlineHeaders[target]) {
-			normalized = s.inlineHeaders[target][:len(headers)]
-		} else {
-			normalized = make([]diagnosticParserCoreHeader, len(headers))
-		}
-	} else {
-		normalized = normalized[:len(headers)]
-	}
+	normalized := s.headerBufferFor(target, len(headers))
 	copy(normalized, headers)
 	s.headerBuffers[target] = normalized
 	// Single-head frontiers never reach canonicalizeLinear/canonicalizeMapped,
@@ -2042,9 +2106,13 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeWithMutation(
 	// copy above still runs unchanged, since the aliasing check above and on
 	// the next call depends on the returned slice living in s.headerBuffers.
 	if len(normalized) == 1 {
+		clear(s.keys)
+		s.keys = s.keys[:0]
 		header := &normalized[0]
 		state, byteOffset, err := compact.Boundary(header.head)
 		if err != nil {
+			clear(normalized)
+			s.headerBuffers[target] = normalized[:0]
 			return nil, 0, err
 		}
 		if canonical, ok := compact.CanonicalBoundary(state, byteOffset, header.shifted, header.checkpoint); ok {
@@ -2054,25 +2122,37 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeWithMutation(
 		s.nextBuffer = uint8(target ^ 1)
 		return normalized, 0, nil
 	}
+	previousKeys := s.keys
 	if cap(s.keys) < len(headers) {
+		clear(previousKeys)
 		if len(headers) <= len(s.inlineKeys) {
 			s.keys = s.inlineKeys[:len(headers)]
 		} else {
 			s.keys = make([]diagnosticParserCorePhaseHead, len(headers))
 		}
 	} else {
+		if len(previousKeys) > len(headers) {
+			clear(previousKeys[len(headers):])
+		}
 		s.keys = s.keys[:len(headers)]
 	}
 	for index := range normalized {
 		header := &normalized[index]
 		state, byteOffset, err := compact.Boundary(header.head)
 		if err != nil {
+			clear(normalized)
+			clear(s.keys)
+			s.headerBuffers[target] = normalized[:0]
+			s.keys = s.keys[:0]
 			return nil, 0, err
 		}
 		if canonical, ok := compact.CanonicalBoundary(state, byteOffset, header.shifted, header.checkpoint); ok {
 			header.head = canonical
 		}
-		key := diagnosticParserCorePhaseHead{head: header.head, shifted: header.shifted, accepted: header.accepted, checkpoint: header.checkpoint}
+		key := diagnosticParserCorePhaseHead{
+			head: header.head, shifted: header.shifted, accepted: header.accepted,
+			checkpoint: header.checkpoint, versionState: header.versionState,
+		}
 		s.keys[index] = key
 	}
 	var out []diagnosticParserCoreHeader
@@ -2087,6 +2167,10 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeWithMutation(
 		out, mutation, err = s.canonicalizeMappedCheckedWithMutation(compact, normalized)
 	}
 	if err != nil {
+		clear(normalized)
+		clear(s.keys)
+		s.headerBuffers[target] = normalized[:0]
+		s.keys = s.keys[:0]
 		return nil, 0, err
 	}
 	s.headerBuffers[target] = out
@@ -2114,19 +2198,12 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeRecoveryWithMutation(
 	if len(headers) != 0 && cap(s.headerBuffers[target]) != 0 && &headers[0] == &s.headerBuffers[target][:1][0] {
 		target ^= 1
 	}
-	normalized := s.headerBuffers[target]
-	if cap(normalized) < len(headers) {
-		if len(headers) <= len(s.inlineHeaders[target]) {
-			normalized = s.inlineHeaders[target][:len(headers)]
-		} else {
-			normalized = make([]diagnosticParserCoreHeader, len(headers))
-		}
-	} else {
-		normalized = normalized[:len(headers)]
-	}
+	normalized := s.headerBufferFor(target, len(headers))
 	copy(normalized, headers)
 	for index := range normalized {
 		if _, _, err := compact.Boundary(normalized[index].head); err != nil {
+			clear(normalized)
+			s.headerBuffers[target] = normalized[:0]
 			return nil, 0, err
 		}
 		normalized[index].freshness = 0
@@ -2236,6 +2313,11 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinearCheckedWithMuta
 			break
 		}
 	}
+	clearDiagnosticParserCoreHeaderSuffix(normalized, write)
+	if write < len(s.keys) {
+		clear(s.keys[write:])
+	}
+	s.keys = s.keys[:write]
 	var mutation core.DropCohortProducerMutation
 	if merged {
 		mutation = core.DropCohortProducerLinearCanonicalization
@@ -2322,6 +2404,11 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMappedCheckedWithMuta
 		}
 		write++
 	}
+	clearDiagnosticParserCoreHeaderSuffix(normalized, write)
+	if write < len(s.keys) {
+		clear(s.keys[write:])
+	}
+	s.keys = s.keys[:write]
 	var mutation core.DropCohortProducerMutation
 	if merged {
 		mutation = core.DropCohortProducerMappedCanonicalization
@@ -2444,18 +2531,21 @@ type diagnosticParserCoreGenericScheduler struct {
 	selectedRecoveryAbsorbLineage bool
 	// s5MissingInsertions counts recovery forks created by S5. The counter
 	// bounds zero-width progress across one parse.
-	s5MissingInsertions        uint32
-	tokens                     uint64
-	dispatches                 uint64
-	branchOrder                uint64
-	nextSeq                    uint64
-	nextCleanPathLineage       uint16
-	options                    DiagnosticParserCorePrefixOptions
-	receiptBacking             DiagnosticParserCoreGenericScheduler
-	receipt                    *DiagnosticParserCoreGenericScheduler
-	summaryHeaderScratch       []DiagnosticParserCoreHeaderReceipt
-	headerRollbackScratch      diagnosticParserCoreHeaderRollbackScratch
-	canonicalScratch           diagnosticParserCoreCanonicalScratch
+	s5MissingInsertions   uint32
+	tokens                uint64
+	dispatches            uint64
+	branchOrder           uint64
+	nextSeq               uint64
+	nextCleanPathLineage  uint16
+	options               DiagnosticParserCorePrefixOptions
+	receiptBacking        DiagnosticParserCoreGenericScheduler
+	receipt               *DiagnosticParserCoreGenericScheduler
+	summaryHeaderScratch  []DiagnosticParserCoreHeaderReceipt
+	headerRollbackScratch diagnosticParserCoreHeaderRollbackScratch
+	canonicalScratch      diagnosticParserCoreCanonicalScratch
+	// footprintRefs is reusable poll scratch. It is cleared after every
+	// footprint calculation so the retained backing array owns no state.
+	footprintRefs              []diagnosticParserCoreFootprintRef
 	dispatchScratch            diagnosticParserCoreDispatchScratch
 	conflictScratch            diagnosticParserCoreConflictScratch
 	reductionOutputs           []core.ReductionOutput
@@ -3548,10 +3638,17 @@ func (s *diagnosticParserCoreGenericScheduler) applyCompactEOFRecoveryAdmission(
 	noActionDropsBefore := s.receipt.NoActionDrops
 	receiptBefore := s.eofRecoveryAdmission
 	rollback := func(cause error) (bool, error) {
-		if cap(s.headers) >= len(headersBefore) {
-			s.headers = s.headers[:len(headersBefore)]
-			copy(s.headers, headersBefore[:])
+		s.invalidateVerifierHeaderBinding()
+		current := s.headers
+		if cap(current) < len(headersBefore) {
+			clear(current)
+			current = make([]diagnosticParserCoreHeader, len(headersBefore))
+		} else {
+			clearDiagnosticParserCoreHeaderSuffix(current, len(headersBefore))
+			current = current[:len(headersBefore)]
 		}
+		copy(current, headersBefore[:])
+		s.headers = current
 		s.dispatches, s.work = dispatchesBefore, workBefore
 		s.epochProgress = epochProgressBefore
 		s.acceptedHead = acceptedHeadBefore
@@ -3828,10 +3925,51 @@ func resetDiagnosticParserCoreRetainedSlice[T any](items []T) []T {
 	return items[:0]
 }
 
+func clearDiagnosticParserCoreHeaderBacking(headers []diagnosticParserCoreHeader) {
+	if cap(headers) == 0 {
+		return
+	}
+	clear(headers[:cap(headers)])
+}
+
+func clearDiagnosticParserCorePhaseHeadBacking(heads []diagnosticParserCorePhaseHead) {
+	if cap(heads) == 0 {
+		return
+	}
+	clear(heads[:cap(heads)])
+}
+
+// clearDiagnosticParserCoreGenericSchedulerVersionState drops every retained
+// header and phase-key reference before the scheduler struct is replaced.
+// Callers can retain aliases to these backing arrays, so dropping the fields
+// alone does not release the immutable per-version state they point to.
+func clearDiagnosticParserCoreGenericSchedulerVersionState(scheduler *diagnosticParserCoreGenericScheduler) {
+	if scheduler == nil {
+		return
+	}
+	clearDiagnosticParserCoreHeaderBacking(scheduler.headers)
+	clearDiagnosticParserCoreHeaderBacking(scheduler.seedHeaders[:])
+	clearDiagnosticParserCoreHeaderBacking(scheduler.headerRollbackScratch.headers)
+	clearDiagnosticParserCoreHeaderBacking(scheduler.headerRollbackScratch.inline[:])
+	for _, headers := range scheduler.canonicalScratch.headerBuffers {
+		clearDiagnosticParserCoreHeaderBacking(headers)
+	}
+	for index := range scheduler.canonicalScratch.inlineHeaders {
+		clearDiagnosticParserCoreHeaderBacking(scheduler.canonicalScratch.inlineHeaders[index][:])
+	}
+	clearDiagnosticParserCoreHeaderBacking(scheduler.conflictScratch.outputs)
+	clearDiagnosticParserCoreHeaderBacking(scheduler.conflictScratch.headerAssembly)
+	clearDiagnosticParserCoreHeaderBacking(scheduler.reductionReplacements)
+	clearDiagnosticParserCorePhaseHeadBacking(scheduler.canonicalScratch.keys)
+	clearDiagnosticParserCorePhaseHeadBacking(scheduler.canonicalScratch.inlineKeys[:])
+	clear(scheduler.canonicalScratch.groups)
+}
+
 func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGenericScheduler) error {
 	if scheduler.dispatchScratch.busy || scheduler.conflictScratch.busy {
 		return errors.New("parser-core phase zero: seed scheduler scratch is active")
 	}
+	clearDiagnosticParserCoreGenericSchedulerVersionState(scheduler)
 	summaryHeaders := resetDiagnosticParserCoreRetainedSlice(scheduler.summaryHeaderScratch)
 	dispatchCells := resetDiagnosticParserCoreRetainedSlice(scheduler.dispatchScratch.cells)
 	noActionIndices := resetDiagnosticParserCoreRetainedSlice(scheduler.dispatchScratch.noActionIndices)
@@ -3843,6 +3981,7 @@ func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGe
 	conflictHeaderAssembly := resetDiagnosticParserCoreRetainedSlice(scheduler.conflictScratch.headerAssembly)
 	reductionOutputs := resetDiagnosticParserCoreRetainedSlice(scheduler.reductionOutputs)
 	reductionReplacements := resetDiagnosticParserCoreRetainedSlice(scheduler.reductionReplacements)
+	footprintRefs := resetDiagnosticParserCoreRetainedSlice(scheduler.footprintRefs)
 	classifiedBoundaries := resetDiagnosticParserCoreRetainedSlice(scheduler.classifiedBoundaries)
 	condenseCandidates := resetDiagnosticParserCoreRetainedSlice(scheduler.condenseCandidates)
 	electStates := resetDiagnosticParserCoreRetainedSlice(scheduler.electStates)
@@ -3860,6 +3999,7 @@ func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGe
 		},
 		reductionOutputs:      reductionOutputs,
 		reductionReplacements: reductionReplacements,
+		footprintRefs:         footprintRefs,
 		classifiedBoundaries:  classifiedBoundaries,
 		condenseCandidates:    condenseCandidates,
 		electStates:           electStates,
@@ -4331,9 +4471,8 @@ type diagnosticParserCoreDispatchScratch struct {
 // The inline buffer covers the common one-to-eight-header frontier. Wider
 // frontiers retain the existing heap-backed growth path.
 //
-// diagnosticParserCoreHeader is pointer-free today. reset nevertheless clears
-// the retained capacity at the end of the scheduler lifecycle so adding a
-// pointer-bearing field later cannot make this scratch retain parse state.
+// Header values can own immutable per-version state. Clear the populated
+// snapshot range when the scratch operation finishes.
 type diagnosticParserCoreHeaderRollbackScratch struct {
 	inline  [8]diagnosticParserCoreHeader
 	busy    bool
@@ -4366,16 +4505,23 @@ func (scratch *diagnosticParserCoreHeaderRollbackScratch) finish(headers *[]diag
 	if scratch == nil || !scratch.busy {
 		return
 	}
+	snapshot := scratch.headers
 	if rollback && headers != nil {
 		restored := *headers
-		if cap(restored) < len(scratch.headers) {
+		aliasesSnapshot := len(restored) != 0 && len(snapshot) != 0 && &restored[0] == &snapshot[0]
+		if cap(restored) < len(snapshot) {
+			if !aliasesSnapshot {
+				clear(restored)
+			}
 			restored = make([]diagnosticParserCoreHeader, len(scratch.headers))
 		} else {
+			clearDiagnosticParserCoreHeaderSuffix(restored, len(scratch.headers))
 			restored = restored[:len(scratch.headers)]
 		}
 		copy(restored, scratch.headers)
 		*headers = restored
 	}
+	clear(snapshot)
 	scratch.headers = scratch.headers[:0]
 	scratch.busy = false
 }
@@ -4384,7 +4530,7 @@ func (scratch *diagnosticParserCoreHeaderRollbackScratch) reset() {
 	if scratch == nil {
 		return
 	}
-	clear(scratch.headers[:cap(scratch.headers)])
+	clear(scratch.headers)
 	scratch.headers = nil
 	scratch.busy = false
 }
@@ -6106,22 +6252,152 @@ func diagnosticParserCoreSliceAliases[T any](items []T, inline []T) bool {
 	return unsafe.Pointer(&items[:cap(items)][0]) == unsafe.Pointer(&inline[0])
 }
 
+type diagnosticParserCoreFootprintRef struct {
+	pointer unsafe.Pointer
+	kind    uint8
+}
+
+const (
+	diagnosticParserCoreFootprintState uint8 = iota + 1
+	diagnosticParserCoreFootprintRegion
+	diagnosticParserCoreFootprintSnapshot
+)
+
+func appendDiagnosticParserCoreFootprintRef(
+	refs []diagnosticParserCoreFootprintRef,
+	kind uint8,
+	pointer unsafe.Pointer,
+) []diagnosticParserCoreFootprintRef {
+	if pointer == nil {
+		return refs
+	}
+	return append(refs, diagnosticParserCoreFootprintRef{pointer: pointer, kind: kind})
+}
+
+func appendDiagnosticParserCoreVersionFootprintRefs(
+	refs []diagnosticParserCoreFootprintRef,
+	state *diagnosticParserCoreVersionState,
+) []diagnosticParserCoreFootprintRef {
+	if state == nil {
+		return refs
+	}
+	refs = appendDiagnosticParserCoreFootprintRef(refs, diagnosticParserCoreFootprintState, unsafe.Pointer(state))
+	refs = appendDiagnosticParserCoreFootprintRef(refs, diagnosticParserCoreFootprintRegion, unsafe.Pointer(state.s3Region))
+	return appendDiagnosticParserCoreFootprintRef(refs, diagnosticParserCoreFootprintSnapshot, unsafe.Pointer(state.relexSnapshot))
+}
+
+func appendDiagnosticParserCoreHeaderFootprintRefs(
+	refs []diagnosticParserCoreFootprintRef,
+	headers []diagnosticParserCoreHeader,
+) []diagnosticParserCoreFootprintRef {
+	for index := 0; index < cap(headers); index++ {
+		refs = appendDiagnosticParserCoreVersionFootprintRefs(refs, headers[:cap(headers)][index].versionState)
+	}
+	return refs
+}
+
+func appendDiagnosticParserCoreCanonicalScratchFootprintRefs(
+	refs []diagnosticParserCoreFootprintRef,
+	scratch *diagnosticParserCoreCanonicalScratch,
+) []diagnosticParserCoreFootprintRef {
+	if scratch == nil {
+		return refs
+	}
+	for _, key := range scratch.keys {
+		refs = appendDiagnosticParserCoreVersionFootprintRefs(refs, key.versionState)
+	}
+	for key := range scratch.groups {
+		refs = appendDiagnosticParserCoreVersionFootprintRefs(refs, key.versionState)
+	}
+	return refs
+}
+
+func compareDiagnosticParserCoreFootprintRefs(
+	left, right diagnosticParserCoreFootprintRef,
+) int {
+	if left.kind < right.kind {
+		return -1
+	}
+	if left.kind > right.kind {
+		return 1
+	}
+	leftPointer, rightPointer := uintptr(left.pointer), uintptr(right.pointer)
+	if leftPointer < rightPointer {
+		return -1
+	}
+	if leftPointer > rightPointer {
+		return 1
+	}
+	return 0
+}
+
 func diagnosticParserCoreSchedulerFootprintBytes(s *diagnosticParserCoreGenericScheduler) uint64 {
 	if s == nil {
 		return 0
 	}
 	total := uint64(0)
-	add := func(count int, size uintptr) {
-		if count <= 0 {
+	addBytes := func(bytes uint64) {
+		if total == math.MaxUint64 || bytes == 0 {
 			return
 		}
-		bytes := uint64(count) * uint64(size)
 		if math.MaxUint64-total < bytes {
 			total = math.MaxUint64
 			return
 		}
 		total += bytes
 	}
+	add := func(count int, size uintptr) {
+		if count <= 0 || size == 0 || total == math.MaxUint64 {
+			return
+		}
+		countBytes := uint64(count)
+		sizeBytes := uint64(size)
+		if countBytes > math.MaxUint64/sizeBytes {
+			total = math.MaxUint64
+			return
+		}
+		addBytes(countBytes * sizeBytes)
+	}
+	// Header copies share immutable version-state pointers. Count each owned
+	// wrapper, region, and lexer snapshot once across the active frontier,
+	// canonical keys/groups, and retained header scratch. The scheduler-owned
+	// buffer keeps repeated polls allocation-free while growing exactly for a
+	// wider frontier.
+	refs := s.footprintRefs[:0]
+	defer func() {
+		clear(refs)
+		s.footprintRefs = refs[:0]
+	}()
+	refs = appendDiagnosticParserCoreHeaderFootprintRefs(refs, s.headers)
+	refs = appendDiagnosticParserCoreHeaderFootprintRefs(refs, s.headerRollbackScratch.headers)
+	refs = appendDiagnosticParserCoreHeaderFootprintRefs(refs, s.headerRollbackScratch.inline[:])
+	for index := range s.canonicalScratch.inlineHeaders {
+		refs = appendDiagnosticParserCoreHeaderFootprintRefs(refs, s.canonicalScratch.inlineHeaders[index][:])
+		refs = appendDiagnosticParserCoreHeaderFootprintRefs(refs, s.canonicalScratch.headerBuffers[index])
+	}
+	refs = appendDiagnosticParserCoreHeaderFootprintRefs(refs, s.conflictScratch.outputs)
+	refs = appendDiagnosticParserCoreHeaderFootprintRefs(refs, s.conflictScratch.headerAssembly)
+	refs = appendDiagnosticParserCoreHeaderFootprintRefs(refs, s.reductionReplacements)
+	refs = appendDiagnosticParserCoreHeaderFootprintRefs(refs, s.seedHeaders[:])
+	refs = appendDiagnosticParserCoreCanonicalScratchFootprintRefs(refs, &s.canonicalScratch)
+	slices.SortFunc(refs, compareDiagnosticParserCoreFootprintRefs)
+	for index := 0; index < len(refs); {
+		ref := refs[index]
+		next := index + 1
+		for next < len(refs) && compareDiagnosticParserCoreFootprintRefs(ref, refs[next]) == 0 {
+			next++
+		}
+		switch ref.kind {
+		case diagnosticParserCoreFootprintState:
+			addBytes(uint64(unsafe.Sizeof(diagnosticParserCoreVersionState{})))
+		case diagnosticParserCoreFootprintRegion:
+			addBytes(diagnosticParserCoreVersionS3RegionFootprintBytes((*diagnosticParserCoreS3Region)(ref.pointer)))
+		case diagnosticParserCoreFootprintSnapshot:
+			addBytes(diagnosticParserCoreVersionLexerSnapshotFootprintBytes((*diagnosticParserCoreVersionLexerSnapshot)(ref.pointer)))
+		}
+		index = next
+	}
+	add(cap(refs), unsafe.Sizeof(diagnosticParserCoreFootprintRef{}))
 	add(cap(s.headers), unsafe.Sizeof(diagnosticParserCoreHeader{}))
 	add(cap(s.summaryHeaderScratch), unsafe.Sizeof(DiagnosticParserCoreHeaderReceipt{}))
 	add(len(s.headerRollbackScratch.inline), unsafe.Sizeof(diagnosticParserCoreHeader{}))
@@ -6141,13 +6417,6 @@ func diagnosticParserCoreSchedulerFootprintBytes(s *diagnosticParserCoreGenericS
 		add(cap(s.canonicalScratch.keys), unsafe.Sizeof(diagnosticParserCorePhaseHead{}))
 	}
 	add(len(s.canonicalScratch.inlineKeys), unsafe.Sizeof(diagnosticParserCorePhaseHead{}))
-	addBytes := func(bytes uint64) {
-		if math.MaxUint64-total < bytes {
-			total = math.MaxUint64
-			return
-		}
-		total += bytes
-	}
 	addBytes(s.canonicalScratch.groupsRetainedBytes)
 	add(cap(s.dispatchScratch.cells), unsafe.Sizeof(diagnosticParserCoreGenericCell{}))
 	add(cap(s.dispatchScratch.noActionIndices), unsafe.Sizeof(int(0)))
@@ -6216,7 +6485,14 @@ func (s *diagnosticParserCoreGenericScheduler) stopControlMemoryBudgetReason() P
 			footprint = diagnosticParserCoreSchedulerFootprintBytes(s)
 			haveFootprint = true
 		}
-		return footprint*stopControlFootprintChurnRatio >= uint64(bytes)
+		ratio := uint64(stopControlFootprintChurnRatio)
+		scaled := footprint
+		if ratio != 0 && footprint > math.MaxUint64/ratio {
+			scaled = math.MaxUint64
+		} else {
+			scaled = footprint * ratio
+		}
+		return scaled >= uint64(bytes)
 	}
 	if footprintAtLeast(s.options.stopControlMemoryBudgetBytes) {
 		return ParseStopMemoryBudget
@@ -7508,10 +7784,12 @@ func (s *diagnosticParserCoreGenericScheduler) s4TryStackSummaryRecovery(index i
 	absorbHeader.head = scanHead
 	absorbHeader.paused = false
 	absorbHeader.shifted = false
+	s.invalidateVerifierHeaderBinding()
 	s.headers[index] = absorbHeader
 	recoveredHeader := absorbHeader
 	recoveredHeader.creationSeq = s.nextSeq
 	restore := func() {
+		s.invalidateVerifierHeaderBinding()
 		clear(s.headers)
 		s.headers = s.headers[:1]
 		s.headers[0] = original
@@ -7547,6 +7825,7 @@ func (s *diagnosticParserCoreGenericScheduler) s4TryStackSummaryRecovery(index i
 	recoveredHeader.shifted = false
 	s.headers[index].markRecoveryLineage()
 	recoveredHeader.markRecoveryLineage()
+	s.invalidateVerifierHeaderBinding()
 	s.headers = append(s.headers, recoveredHeader)
 	s.recoveryIsolation = true
 	s.nextSeq++
@@ -7684,8 +7963,10 @@ func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertion(index 
 	missingHeader := absorbHeader
 	missingHeader.creationSeq = s.nextSeq
 	replacements := [...]diagnosticParserCoreHeader{absorbHeader, missingHeader}
+	s.invalidateVerifierHeaderBinding()
 	s.headers = replaceDiagnosticParserCoreHeader(s.headers, index, replacements[:])
 	restore := func() {
+		s.invalidateVerifierHeaderBinding()
 		clear(s.headers)
 		s.headers = s.headers[:1]
 		s.headers[0] = original
@@ -7978,11 +8259,12 @@ func (s *diagnosticParserCoreGenericScheduler) collapseToRecoveryWinner(winner i
 		s.headers[0].creationSeq < s.headers[1].creationSeq
 	winnerHeader := s.headers[winner]
 	winnerHeader.clearRecoveryLineage()
-	clear(s.headers[:cap(s.headers)])
+	s.invalidateVerifierHeaderBinding()
+	clear(s.headers)
 	for target := range s.canonicalScratch.headerBuffers {
 		buffer := s.canonicalScratch.headerBuffers[target]
 		if cap(buffer) != 0 {
-			clear(buffer[:cap(buffer)])
+			clear(buffer)
 		}
 	}
 	s.headers = s.headers[:1]
@@ -8941,6 +9223,7 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 			convergedReductionSplitDrops++
 		}
 	}
+	s.invalidateVerifierHeaderBinding()
 	write := 0
 	next := 0
 	for read := range s.headers {
@@ -9241,7 +9524,14 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		}
 	}
 	s.reductionOutputs = outputs
-	s.reductionReplacements = s.reductionReplacements[:0]
+	s.invalidateVerifierHeaderBinding()
+	previousReplacements := s.reductionReplacements
+	clear(previousReplacements)
+	s.reductionReplacements = previousReplacements[:0]
+	defer func() {
+		clear(s.reductionReplacements)
+		s.reductionReplacements = s.reductionReplacements[:0]
+	}()
 	replacements := s.reductionReplacements
 	madeFreshProgress := false
 	for outputIndex, output := range outputs {
@@ -9288,7 +9578,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		switch output.Freshness {
 		case core.ReductionUnchanged:
 			if convergedHistory || resurrectionUnproved {
-				if _, err := s.adoptUpdatedReductionSiblingOwned(
+				adopted, err := s.adoptUpdatedReductionSiblingOwned(
 					owner,
 					cell.headerIndex,
 					output.Head,
@@ -9300,19 +9590,24 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 					convergedHistory,
 					resurrectionUnproved,
 					core.DropCohortProducerSiblingAdoption,
-				); err != nil {
+				)
+				if err != nil {
 					return err
 				}
-				if reductionFrontierSequence != 0 {
-					s.attachDiagnosticParserCoreFrontierToHead(output.Head, reductionFrontierSequence)
+				if adopted {
+					if reductionFrontierSequence != 0 {
+						s.attachDiagnosticParserCoreFrontierToHead(output.Head, reductionFrontierSequence)
+					}
+					continue
 				}
 			}
-			continue
 		case core.ReductionNew, core.ReductionUpdated:
 		default:
 			return errors.New("parser-core phase zero: reduction returned invalid freshness")
 		}
-		madeFreshProgress = true
+		if output.Freshness != core.ReductionUnchanged {
+			madeFreshProgress = true
+		}
 		if output.Freshness == core.ReductionUpdated {
 			adopted, err := s.adoptUpdatedReductionSiblingOwned(
 				owner,
@@ -9478,6 +9773,7 @@ func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(
 		return false, errors.New("parser-core phase zero: sibling adoption source is out of range")
 	}
 	sourceFrontier := s.headers[source].frontierSequence
+	sourceVersionState := s.headers[source].versionState
 	var dropCohortRefs core.DropCohortRefSet
 	var convergedReductionSplit, resurrectionUnproved bool
 	switch len(compat) {
@@ -9517,6 +9813,11 @@ func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(
 			continue
 		}
 		header := s.headers[index]
+		if header.versionState != sourceVersionState {
+			// A canonical head does not prove equal lexer history. Keep forks
+			// with different immutable scanner state as separate versions.
+			continue
+		}
 		state, byteOffset, err := s.compact.Boundary(header.head)
 		if err != nil {
 			return false, err
@@ -9652,12 +9953,6 @@ func (s *diagnosticParserCoreGenericScheduler) reconcileGenericConflictOutputs(f
 			}
 			if ok {
 				adopted++
-				continue
-			}
-			if output.freshness == core.ReductionUnchanged {
-				if err := s.compact.RecordDropCohortProducerMutation(owner, core.DropCohortProducerConflictReconciliation); err != nil {
-					return nil, 0, err
-				}
 				continue
 			}
 		}
@@ -9808,6 +10103,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 		headers = append(headers, suffix...)
 	}
 	s.conflictScratch.headerAssembly = headers
+	s.invalidateVerifierHeaderBinding()
 	s.headers = headers
 	s.branchOrder, s.nextSeq = execution.branchOrder, execution.nextSeq
 	adoptedCount := 0
@@ -10285,6 +10581,9 @@ func replaceDiagnosticParserCoreHeader(headers []diagnosticParserCoreHeader, ind
 		headers = headers[:newLen]
 		copy(headers[index+len(replacements):], headers[index+1:oldLen])
 		copy(headers[index:index+len(replacements)], replacements)
+		// A shrink leaves the old tail inside the retained backing array. Clear
+		// only the previously populated tail because headers can own snapshots.
+		clearDiagnosticParserCoreHeaderSuffix(headers[:oldLen], newLen)
 		return headers
 	}
 	out := make([]diagnosticParserCoreHeader, newLen, max(newLen, 2*cap(headers)))
@@ -10325,6 +10624,7 @@ func (s *diagnosticParserCoreGenericScheduler) canonicalizeOwnedWithMutation(own
 			return err
 		}
 	}
+	s.invalidateVerifierHeaderBinding()
 	s.headers = headers
 	s.work.Canonicalizations++
 	if uint64(len(headers)) > s.work.PeakHeaders {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -5068,9 +5068,10 @@ func (s *diagnosticParserCoreGenericScheduler) activateVersionLexerOwnershipAtRa
 		receiptRequestsBefore = len(s.receipt.VersionLexerRequests)
 	}
 	workBefore := s.work
+	rollback := true
 	defer func() {
-		s.headerRollbackScratch.finish(&s.headers, err != nil)
-		if err == nil {
+		s.headerRollbackScratch.finish(&s.headers, rollback)
+		if !rollback {
 			return
 		}
 		clear(s.versionLexerRequests[requestsBefore:])
@@ -5093,6 +5094,7 @@ func (s *diagnosticParserCoreGenericScheduler) activateVersionLexerOwnershipAtRa
 		}
 	}
 	s.versionLexerOwnershipActive = true
+	rollback = false
 	return nil, nil
 }
 
@@ -5134,7 +5136,7 @@ func (s *diagnosticParserCoreGenericScheduler) bindVersionLexerRequest(
 func (s *diagnosticParserCoreGenericScheduler) withVersionLexerRequest(
 	cell diagnosticParserCoreGenericCell,
 	fn func() error,
-) error {
+) (err error) {
 	request, err := s.versionLexerRequestForCell(cell)
 	if err != nil {
 		return err
@@ -5159,15 +5161,33 @@ func (s *diagnosticParserCoreGenericScheduler) withVersionLexerRequest(
 		}
 		return s.compact.SetPhaseCheckpoint(phaseCheckpointBefore)
 	}
-	if err := s.bindVersionLexerRequest(request); err != nil {
+	if err = s.bindVersionLexerRequest(request); err != nil {
 		return err
 	}
-	runErr := fn()
-	restoreErr := restore()
-	if runErr != nil {
-		return runErr
-	}
-	return restoreErr
+	defer func() {
+		panicValue := recover()
+		restoreErr := restore()
+		if panicValue != nil {
+			if restoreErr != nil {
+				panic(fmt.Errorf(
+					"parser-core phase zero: version lexer callback panic=%v; restore: %w",
+					panicValue,
+					restoreErr,
+				))
+			}
+			panic(panicValue)
+		}
+		if restoreErr != nil {
+			wrapped := fmt.Errorf("parser-core phase zero: restore version lexer request: %w", restoreErr)
+			if err != nil {
+				err = errors.Join(err, wrapped)
+			} else {
+				err = wrapped
+			}
+		}
+	}()
+	err = fn()
+	return err
 }
 
 func (s *diagnosticParserCoreGenericScheduler) publishVersionLexerShiftOnHeaderOwned(
@@ -5221,6 +5241,8 @@ func (s *diagnosticParserCoreGenericScheduler) beginNextVersionLexerElection() e
 	}
 	electionBefore := s.electionIndex
 	workBefore := s.work
+	noLookaheadStepsBefore := s.noLookaheadSteps
+	requireEOFBefore := s.requireEOFPostNoLookaheadRoot
 	s.electionIndex++
 	rollback := true
 	defer func() {
@@ -5235,6 +5257,8 @@ func (s *diagnosticParserCoreGenericScheduler) beginNextVersionLexerElection() e
 		}
 		s.electionIndex = electionBefore
 		s.work = workBefore
+		s.noLookaheadSteps = noLookaheadStepsBefore
+		s.requireEOFPostNoLookaheadRoot = requireEOFBefore
 	}()
 	for index := range s.headers {
 		header := &s.headers[index]
@@ -5245,11 +5269,57 @@ func (s *diagnosticParserCoreGenericScheduler) beginNextVersionLexerElection() e
 			return err
 		}
 	}
+	requestNoLookahead := false
+	requestNoLookaheadSet := false
 	for index := range s.headers {
 		reference := s.headers[index].versionLexerRequestReference()
-		if int(reference) <= requestsBefore || s.versionLexerRequestForHeader(index) == nil {
+		request := s.versionLexerRequestForHeader(index)
+		if int(reference) <= requestsBefore || request == nil {
 			return errors.New("parser-core phase zero: next version lexer request was not authenticated")
 		}
+		if !requestNoLookaheadSet {
+			requestNoLookahead = request.token.NoLookahead
+			requestNoLookaheadSet = true
+		} else if request.token.NoLookahead != requestNoLookahead {
+			return &diagnosticParserCoreDecline{
+				boundary: DiagnosticParserCoreRoute,
+				detail:   "generic scheduler owned lexer election mixed no-lookahead and ordinary tokens",
+			}
+		}
+		if request.token.NoLookahead &&
+			(request.token.Symbol != 0 || request.token.StartByte != request.token.EndByte ||
+				request.token.Missing || request.token.ExternalScannerToken ||
+				request.beforeCheckpoint != request.afterCheckpoint) {
+			return &diagnosticParserCoreDecline{
+				boundary: DiagnosticParserCoreRoute,
+				detail:   "generic scheduler owned lexer no-lookahead token is not authenticated synthetic EOF",
+			}
+		}
+		if requireEOFBefore &&
+			(request.token.Symbol != 0 || request.token.StartByte != request.token.EndByte ||
+				request.token.Missing || request.token.NoLookahead || request.token.ExternalScannerToken) {
+			return &diagnosticParserCoreDecline{
+				boundary: DiagnosticParserCoreRoute,
+				detail:   "generic scheduler root reduction on no-lookahead was not followed by authenticated EOF",
+			}
+		}
+	}
+	if requestNoLookahead {
+		if s.noLookaheadSteps == math.MaxUint8 {
+			return &diagnosticParserCoreDecline{
+				boundary: DiagnosticParserCoreCap,
+				detail:   "generic scheduler no-lookahead re-election cap",
+			}
+		}
+		s.noLookaheadSteps++
+		if s.noLookaheadSteps > maxDiagnosticParserCoreNoLookaheadSteps {
+			return &diagnosticParserCoreDecline{
+				boundary: DiagnosticParserCoreCap,
+				detail:   "generic scheduler no-lookahead re-election cap",
+			}
+		}
+	} else {
+		s.noLookaheadSteps = 0
 	}
 	// Build every owned request before advancing the compact frontier. A
 	// request failure can then restore the scheduler without leaving the Core
@@ -5271,6 +5341,9 @@ func (s *diagnosticParserCoreGenericScheduler) beginNextVersionLexerElection() e
 		}
 	}
 	s.epochProgress = false
+	if requireEOFBefore {
+		s.requireEOFPostNoLookaheadRoot = false
+	}
 	rollback = false
 	return nil
 }
@@ -5284,11 +5357,26 @@ func (s *diagnosticParserCoreGenericScheduler) rejoinSharedLexerFromOwnedHeader(
 	if !header.shifted || header.accepted || snapshot == nil {
 		return errors.New("parser-core phase zero: shared lexer rejoin requires one shifted owned header")
 	}
-	if err := snapshot.restore(s.compact, s.tokenSource); err != nil {
+	if err := snapshot.validate(); err != nil {
 		return err
 	}
 	state, _, err := s.compact.Boundary(header.head)
 	if err != nil {
+		return err
+	}
+	priorDFA := s.tokenSource.snapshotRelexState()
+	priorState := s.tokenSource.state
+	priorGLRStates := s.tokenSource.glrStates
+	committed := false
+	defer func() {
+		if committed {
+			return
+		}
+		priorDFA.restore(s.tokenSource)
+		s.tokenSource.SetParserState(priorState)
+		s.tokenSource.SetGLRStates(priorGLRStates)
+	}()
+	if err := snapshot.restore(s.compact, s.tokenSource); err != nil {
 		return err
 	}
 	s.tokenSource.SetParserState(StateID(state))
@@ -5296,6 +5384,9 @@ func (s *diagnosticParserCoreGenericScheduler) rejoinSharedLexerFromOwnedHeader(
 	if err := s.compact.SetPhaseExternalTokenScannerCheckpoints(snapshot.beforeCheckpoint, snapshot.afterCheckpoint); err != nil {
 		return err
 	}
+	// Every remaining operation is an assignment or a bounded slice clear.
+	// Commit the token source after the last operation that can return an error.
+	committed = true
 	s.checkpointBeforeID = snapshot.beforeCheckpoint
 	s.checkpointID = snapshot.afterCheckpoint
 	s.checkpoint = snapshot.afterCheckpointInfo
@@ -7805,7 +7896,7 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerNoActionDropEligible(
 		if isDrop {
 			drop++
 			request := s.versionLexerRequestForHeader(index)
-			if request == nil || s.headers[index].shifted || s.headers[index].accepted || s.headers[index].paused {
+			if request == nil || s.headers[index].shifted || s.headers[index].accepted {
 				return false
 			}
 			if !startSet {
@@ -7856,6 +7947,18 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchVersionLexerPassActive() 
 	noActionIndices := s.dispatchScratch.noActionIndices[:0]
 	acceptCell, extraCell, reductionCell, conflictCell, shiftCell := -1, -1, -1, -1, -1
 	for index := range s.headers {
+		if s.headers[index].paused {
+			if s.headers[index].shifted || s.headers[index].accepted ||
+				s.versionLexerRequestForHeader(index) == nil {
+				return &diagnosticParserCoreGenericUnsupported{
+					boundary:    DiagnosticParserCoreRoute,
+					detail:      "generic scheduler owned lexer paused head is not authenticated",
+					headerIndex: index,
+				}, nil
+			}
+			noActionIndices = append(noActionIndices, index)
+			continue
+		}
 		cell, noAction, unsupported, err := s.classifyVersionLexerCell(index, true)
 		if err != nil || unsupported != nil {
 			return unsupported, err
@@ -7955,6 +8058,19 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchVersionLexerPassActive() 
 	}
 	if noAction {
 		return nil, errors.New("parser-core phase zero: version lexer action changed before dispatch")
+	}
+	if unsupported := s.validateGenericNoLookaheadReduction(
+		[]diagnosticParserCoreGenericCell{cell},
+		noActionIndices,
+	); unsupported != nil {
+		return unsupported, nil
+	}
+	if operation == core.ActionRowExtraShift {
+		if unsupported := s.zeroWidthExtraShiftWithoutProgress(
+			[]diagnosticParserCoreGenericCell{cell},
+		); unsupported != nil {
+			return unsupported, nil
+		}
 	}
 	err = s.withVersionLexerRequest(cell, func() error {
 		switch operation {
@@ -11252,6 +11368,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflict(before []Dia
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner core.SchedulerTransactionToken, before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) (err error) {
 	branchOrderBefore, nextSeqBefore := s.branchOrder, s.nextSeq
+	token := cell.dispatchToken(s.token)
+	scannerBefore, scannerAfter := s.currentElection.ScannerBefore, s.currentElection.ScannerAfter
+	affectedHead := cell.boundary.Head()
 	var versionLexerRequest *diagnosticParserCoreVersionLexerRequest
 	if cell.versionLexerRequest != 0 {
 		versionLexerRequest, err = s.versionLexerRequestForCell(cell)
@@ -11265,7 +11384,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	if err = s.reindexCondenseCandidatesOwned(owner, cell.headerIndex); err != nil {
 		return err
 	}
-	externalStatsBefore, err := s.genericExternalStats()
+	externalStatsBefore, err := s.genericExternalStats(affectedHead, token)
 	if err != nil {
 		return err
 	}
@@ -11275,7 +11394,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	}
 	defer s.conflictScratch.finish()
 	execution, err := executeDiagnosticParserCoreGenericConflictDetailed(
-		s.compact, owner, s.headers[cell.headerIndex], cell.headerIndex, cell.dispatchToken(s.token), cell.boundary,
+		s.compact, owner, s.headers[cell.headerIndex], cell.headerIndex, token, cell.boundary,
 		s.branchOrder, &s.nextCleanPathLineage,
 		s.options.captureLexerSkippedPrefixProvenance,
 		cell.selectedBy == diagnosticParserCoreCellSelectionRepetitionFork,
@@ -11283,6 +11402,17 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	)
 	if err != nil {
 		return err
+	}
+	for ordinal := range execution.armRanges {
+		for _, output := range execution.arm(ordinal) {
+			if output.shifted {
+				affectedHead = output.head
+				break
+			}
+		}
+		if affectedHead != cell.boundary.Head() {
+			break
+		}
 	}
 	if s.conflictPostExecutionFault != nil {
 		if err := s.conflictPostExecutionFault(); err != nil {
@@ -11429,7 +11559,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 		roundIndex = round.Index
 		s.receipt.Rounds = append(s.receipt.Rounds, round)
 		conflict := DiagnosticParserCoreGenericConflict{
-			ElectionIndex: s.electionIndex, Token: cell.dispatchToken(s.token), HeaderIndex: cell.headerIndex,
+			ElectionIndex: s.electionIndex, Token: token, HeaderIndex: cell.headerIndex,
 			BranchOrderBefore: branchOrderBefore, BranchOrderAfter: s.branchOrder,
 			NextCreationSeqBefore: nextSeqBefore, NextCreationSeqAfter: s.nextSeq,
 			Round: round, Prefix: prefixReceipts,
@@ -11443,7 +11573,14 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 		}
 		s.receipt.Conflicts = append(s.receipt.Conflicts, conflict)
 	}
-	return s.recordGenericExternalShift(externalStatsBefore, roundIndex)
+	return s.recordGenericExternalShift(
+		externalStatsBefore,
+		roundIndex,
+		token,
+		scannerBefore,
+		scannerAfter,
+		affectedHead,
+	)
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericShifts(before []DiagnosticParserCoreHeaderReceipt, cells []diagnosticParserCoreGenericCell) (err error) {
@@ -11472,10 +11609,23 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShifts(before []Diagn
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner core.SchedulerTransactionToken, before []DiagnosticParserCoreHeaderReceipt, cells []diagnosticParserCoreGenericCell) error {
+	if len(cells) == 0 {
+		return errors.New("parser-core phase zero: empty ordinary shift cohort")
+	}
 	if err := s.reserveDispatches(uint64(len(cells))); err != nil {
 		return err
 	}
-	externalStatsBefore, err := s.genericExternalStats()
+	telemetryCell := 0
+	for index := range cells {
+		if cells[index].dispatchToken(s.token).ExternalScannerToken {
+			telemetryCell = index
+			break
+		}
+	}
+	telemetryToken := cells[telemetryCell].dispatchToken(s.token)
+	scannerBefore, scannerAfter := s.currentElection.ScannerBefore, s.currentElection.ScannerAfter
+	affectedHead := cells[telemetryCell].boundary.Head()
+	externalStatsBefore, err := s.genericExternalStats(affectedHead, telemetryToken)
 	if err != nil {
 		return err
 	}
@@ -11503,6 +11653,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 		if err != nil {
 			return err
 		}
+		affectedHead = heads[telemetryCell]
 		for index := range cells {
 			cell := &cells[index]
 			s.headers[cell.headerIndex].head = heads[index]
@@ -11536,6 +11687,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 			)
 			if err != nil {
 				return err
+			}
+			if index == telemetryCell {
+				affectedHead = head
 			}
 			s.headers[cell.headerIndex].head = head
 			s.headers[cell.headerIndex].shifted = true
@@ -11577,7 +11731,14 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 		roundIndex = round.Index
 		s.receipt.Rounds = append(s.receipt.Rounds, round)
 	}
-	return s.recordGenericExternalShift(externalStatsBefore, roundIndex)
+	return s.recordGenericExternalShift(
+		externalStatsBefore,
+		roundIndex,
+		telemetryToken,
+		scannerBefore,
+		scannerAfter,
+		affectedHead,
+	)
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []DiagnosticParserCoreHeaderReceipt, cells []diagnosticParserCoreGenericCell) (err error) {
@@ -11610,11 +11771,21 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 		if err := s.reserveDispatches(uint64(len(cells))); err != nil {
 			return err
 		}
-		externalStatsBefore, err := s.genericExternalStats()
+		token := cells[0].dispatchToken(s.token)
+		telemetryCell := 0
+		for index := range cells {
+			if cells[index].dispatchToken(s.token).ExternalScannerToken {
+				telemetryCell = index
+				break
+			}
+		}
+		telemetryToken := cells[telemetryCell].dispatchToken(s.token)
+		scannerBefore, scannerAfter := s.currentElection.ScannerBefore, s.currentElection.ScannerAfter
+		affectedHead := cells[telemetryCell].boundary.Head()
+		externalStatsBefore, err := s.genericExternalStats(affectedHead, telemetryToken)
 		if err != nil {
 			return err
 		}
-		token := cells[0].dispatchToken(s.token)
 		isolatedRecovery := s.recoveryIsolation
 		if isolatedRecovery {
 			for index := range cells {
@@ -11638,6 +11809,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 				if shiftErr != nil {
 					return shiftErr
 				}
+				if index == telemetryCell {
+					affectedHead = head
+				}
 				s.headers[cell.headerIndex].head = head
 				s.headers[cell.headerIndex].shifted = true
 				markDiagnosticParserCoreExternalLineage(&s.headers[cell.headerIndex], token)
@@ -11660,6 +11834,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 			if shiftErr != nil {
 				return shiftErr
 			}
+			affectedHead = heads[telemetryCell]
 			for index := range cells {
 				cell := &cells[index]
 				var versionLexerRequest *diagnosticParserCoreVersionLexerRequest
@@ -11716,34 +11891,45 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 			roundIndex = round.Index
 			s.receipt.Rounds = append(s.receipt.Rounds, round)
 		}
-		return s.recordGenericExternalShift(externalStatsBefore, roundIndex)
+		return s.recordGenericExternalShift(
+			externalStatsBefore,
+			roundIndex,
+			telemetryToken,
+			scannerBefore,
+			scannerAfter,
+			affectedHead,
+		)
 	})
 }
 
-func (s *diagnosticParserCoreGenericScheduler) genericExternalStats() (core.Stats, error) {
-	if !s.fullReceipts() || !s.token.ExternalScannerToken {
+func (s *diagnosticParserCoreGenericScheduler) genericExternalStats(
+	head core.Head,
+	token Token,
+) (core.Stats, error) {
+	if !s.fullReceipts() || !token.ExternalScannerToken {
 		return core.Stats{}, nil
 	}
-	if len(s.headers) == 0 {
-		return core.Stats{}, errors.New("parser-core phase zero: external shift receipt requires a scheduler head")
-	}
-	return s.compact.Stats(s.headers[0].head)
+	return s.compact.Stats(head)
 }
 
-func (s *diagnosticParserCoreGenericScheduler) recordGenericExternalShift(before core.Stats, roundIndex int) error {
-	if !s.fullReceipts() || !s.token.ExternalScannerToken {
+func (s *diagnosticParserCoreGenericScheduler) recordGenericExternalShift(
+	before core.Stats,
+	roundIndex int,
+	token Token,
+	scannerBefore DiagnosticParserCoreScannerCheckpoint,
+	scannerAfter DiagnosticParserCoreScannerCheckpoint,
+	affectedHead core.Head,
+) error {
+	if !s.fullReceipts() || !token.ExternalScannerToken {
 		return nil
 	}
-	if len(s.headers) == 0 {
-		return errors.New("parser-core phase zero: external shift receipt requires a scheduler head")
-	}
-	after, err := s.compact.Stats(s.headers[0].head)
+	after, err := s.compact.Stats(affectedHead)
 	if err != nil {
 		return err
 	}
 	external := DiagnosticParserCoreGenericExternalShift{
-		ElectionIndex: s.electionIndex, Token: s.token,
-		ScannerBefore: s.currentElection.ScannerBefore, ScannerAfter: s.currentElection.ScannerAfter,
+		ElectionIndex: s.electionIndex, Token: token,
+		ScannerBefore: scannerBefore, ScannerAfter: scannerAfter,
 		RoundIndex: roundIndex,
 	}
 	for id := before.Subtrees + 1; id <= after.Subtrees; id++ {

--- a/parsercore_phase0_driver_ownership_internal_test.go
+++ b/parsercore_phase0_driver_ownership_internal_test.go
@@ -3,18 +3,21 @@
 package gotreesitter
 
 import (
+	"strings"
 	"testing"
 	"unsafe"
 
 	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
 )
 
-func TestDiagnosticParserCoreCanonicalVersionStateIdentity(t *testing.T) {
+func TestDiagnosticParserCoreCanonicalVersionLexerSnapshotIdentity(t *testing.T) {
 	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
 	for _, count := range []int{2, diagnosticParserCoreLinearCanonicalLimit + 1} {
 		t.Run("frontier_"+string(rune('0'+count)), func(t *testing.T) {
-			first := &diagnosticParserCoreVersionState{}
-			second := &diagnosticParserCoreVersionState{}
+			firstSnapshot := &diagnosticParserCoreVersionLexerSnapshot{}
+			secondSnapshot := &diagnosticParserCoreVersionLexerSnapshot{}
+			first := &diagnosticParserCoreVersionState{relexSnapshot: firstSnapshot}
+			second := &diagnosticParserCoreVersionState{relexSnapshot: secondSnapshot}
 			headers := make([]diagnosticParserCoreHeader, count)
 			for index := range headers {
 				headers[index] = diagnosticParserCoreHeader{head: head, versionState: first}
@@ -26,7 +29,7 @@ func TestDiagnosticParserCoreCanonicalVersionStateIdentity(t *testing.T) {
 				t.Fatal(err)
 			}
 			if len(out) != 2 {
-				t.Fatalf("divergent version states merged: len=%d output=%+v", len(out), out)
+				t.Fatalf("divergent lexer snapshots merged: len=%d output=%+v", len(out), out)
 			}
 			seenFirst, seenSecond := false, false
 			for _, header := range out {
@@ -34,7 +37,7 @@ func TestDiagnosticParserCoreCanonicalVersionStateIdentity(t *testing.T) {
 				seenSecond = seenSecond || header.versionState == second
 			}
 			if !seenFirst || !seenSecond {
-				t.Fatalf("canonical output lost a version identity: %+v", out)
+				t.Fatalf("canonical output lost a lexer snapshot identity: %+v", out)
 			}
 
 			shared := make([]diagnosticParserCoreHeader, count)
@@ -46,16 +49,29 @@ func TestDiagnosticParserCoreCanonicalVersionStateIdentity(t *testing.T) {
 				t.Fatal(err)
 			}
 			if len(out) != 1 || out[0].versionState != first {
-				t.Fatalf("equal fork states did not merge: len=%d output=%+v", len(out), out)
+				t.Fatalf("equal lexer snapshots did not merge: len=%d output=%+v", len(out), out)
+			}
+
+			shared[count-1].versionState = &diagnosticParserCoreVersionState{
+				s3Region: &diagnosticParserCoreS3Region{}, relexSnapshot: firstSnapshot,
+			}
+			out, err = scratch.canonicalize(compact, shared)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(out) != 2 {
+				t.Fatalf("distinct recovery region merged through equal lexer snapshots: len=%d output=%+v", len(out), out)
 			}
 		})
 	}
 }
 
-func TestDiagnosticParserCoreReductionSiblingAdoptionRequiresVersionStateIdentity(t *testing.T) {
+func TestDiagnosticParserCoreReductionSiblingAdoptionRequiresVersionLexerSnapshotIdentity(t *testing.T) {
 	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
-	first := &diagnosticParserCoreVersionState{}
-	second := &diagnosticParserCoreVersionState{}
+	firstSnapshot := &diagnosticParserCoreVersionLexerSnapshot{}
+	secondSnapshot := &diagnosticParserCoreVersionLexerSnapshot{}
+	first := &diagnosticParserCoreVersionState{relexSnapshot: firstSnapshot}
+	second := &diagnosticParserCoreVersionState{relexSnapshot: secondSnapshot}
 	scheduler := &diagnosticParserCoreGenericScheduler{
 		compact: compact,
 		headers: []diagnosticParserCoreHeader{
@@ -70,25 +86,37 @@ func TestDiagnosticParserCoreReductionSiblingAdoptionRequiresVersionStateIdentit
 		t.Fatal(err)
 	}
 	if adopted {
-		t.Fatal("sibling adoption merged divergent version states")
+		t.Fatal("sibling adoption merged divergent lexer snapshots")
 	}
 	if scheduler.headers[1].versionState != second || !scheduler.headers[1].paused {
 		t.Fatalf("divergent sibling changed: %+v", scheduler.headers[1])
 	}
 
+	scheduler.headers[1].versionState = &diagnosticParserCoreVersionState{
+		s3Region: &diagnosticParserCoreS3Region{}, relexSnapshot: firstSnapshot,
+	}
+	adopted, err = scheduler.adoptUpdatedReductionSibling(
+		0, head, core.CleanPathRankUnknown, 0, core.AlternativeSet{}, false, false, false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adopted {
+		t.Fatal("sibling adoption merged a distinct recovery region")
+	}
 	scheduler.headers[1].versionState = first
 	adopted, err = scheduler.adoptUpdatedReductionSibling(
 		0, head, core.CleanPathRankUnknown, 0, core.AlternativeSet{}, false, false, false,
 	)
 	if err != nil || !adopted {
-		t.Fatalf("equal version states were not adopted: adopted=%t err=%v", adopted, err)
+		t.Fatalf("equal immutable version state was not adopted: adopted=%t err=%v", adopted, err)
 	}
 }
 
-func TestDiagnosticParserCoreReductionUnchangedDistinctStateIsRetained(t *testing.T) {
+func TestDiagnosticParserCoreReductionUnchangedDistinctLexerSnapshotIsRetained(t *testing.T) {
 	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
-	first := &diagnosticParserCoreVersionState{}
-	second := &diagnosticParserCoreVersionState{}
+	first := &diagnosticParserCoreVersionState{relexSnapshot: &diagnosticParserCoreVersionLexerSnapshot{}}
+	second := &diagnosticParserCoreVersionState{relexSnapshot: &diagnosticParserCoreVersionLexerSnapshot{}}
 	scheduler := &diagnosticParserCoreGenericScheduler{
 		compact: compact,
 		headers: []diagnosticParserCoreHeader{
@@ -107,7 +135,7 @@ func TestDiagnosticParserCoreReductionUnchangedDistinctStateIsRetained(t *testin
 	}
 }
 
-func TestDiagnosticParserCoreGenericReductionUnchangedDistinctStateIsRetained(t *testing.T) {
+func TestDiagnosticParserCoreGenericReductionUnchangedDistinctLexerSnapshotFailsClosedBeforePhysicalMerge(t *testing.T) {
 	table := &genericConflictTable{
 		cells: map[genericConflictCell][]core.Action{
 			{state: 1, symbol: 8}: {{Type: core.ActionShift, State: 3}},
@@ -120,13 +148,73 @@ func TestDiagnosticParserCoreGenericReductionUnchangedDistinctStateIsRetained(t 
 	if err != nil || len(initial) != 1 {
 		t.Fatalf("initial reduction outputs=%+v err=%v", initial, err)
 	}
-	first := &diagnosticParserCoreVersionState{}
-	second := &diagnosticParserCoreVersionState{}
+	if initial[0].Freshness != core.ReductionNew {
+		t.Fatalf("initial reduction freshness=%v, want new prepopulation", initial[0].Freshness)
+	}
+	first := &diagnosticParserCoreVersionState{relexSnapshot: &diagnosticParserCoreVersionLexerSnapshot{}}
+	second := &diagnosticParserCoreVersionState{relexSnapshot: &diagnosticParserCoreVersionLexerSnapshot{}}
 	scheduler := &diagnosticParserCoreGenericScheduler{
 		compact: compact,
 		headers: []diagnosticParserCoreHeader{
-			{head: source, versionState: first},
-			{head: initial[0].Head, versionState: second},
+			{head: source, creationSeq: 6, versionState: first},
+			{head: initial[0].Head, creationSeq: 7, versionState: second},
+		},
+		token: Token{Symbol: 9, StartByte: 1, EndByte: 2},
+		options: DiagnosticParserCorePrefixOptions{
+			MaxDispatches: 20,
+			ReceiptMode:   DiagnosticParserCoreReceiptSummary,
+		},
+		receipt: &DiagnosticParserCoreGenericScheduler{},
+	}
+	before, err := diagnosticParserCoreHeaderReceipts(compact, scheduler.headers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cell := mustDiagnosticParserCoreGenericCell(t, compact, 0, scheduler.headers[0], 9)
+	err = scheduler.applyGenericReduction(before, cell)
+	if err == nil || !strings.Contains(err.Error(), "compact head has multiple scheduler owners") {
+		t.Fatalf("distinct-snapshot physical alias error=%v, want explicit owner conflict", err)
+	}
+	if len(scheduler.reductionOutputs) != 1 || scheduler.reductionOutputs[0].Freshness != core.ReductionUnchanged {
+		t.Fatalf("repeated reduction outputs=%+v, want one unchanged output", scheduler.reductionOutputs)
+	}
+	if len(scheduler.headers) != 2 {
+		t.Fatalf("distinct unchanged reduction output changed the frontier before failing closed: headers=%+v", scheduler.headers)
+	}
+	seenFirst, seenSecond := false, false
+	for _, header := range scheduler.headers {
+		seenFirst = seenFirst || header.versionState == first
+		seenSecond = seenSecond || header.versionState == second
+	}
+	if !seenFirst || !seenSecond {
+		t.Fatalf("reduction retained the wrong version identities: %+v", scheduler.headers)
+	}
+	if scheduler.headers[0].head != source || scheduler.headers[1].head != initial[0].Head {
+		t.Fatalf("owner-conflict rollback did not restore the original physical heads: headers=%+v", scheduler.headers)
+	}
+}
+
+func TestDiagnosticParserCoreGenericReductionUnchangedEqualSnapshotDoesNotDuplicatePhysicalHead(t *testing.T) {
+	table := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 8}: {{Type: core.ActionShift, State: 3}},
+			{state: 3, symbol: 9}: {{Type: core.ActionReduce, Symbol: 2, ChildCount: 1}},
+		},
+		gotos: map[genericConflictCell]core.StateID{{state: 1, symbol: 2}: 4},
+	}
+	compact, source := newGenericFreshnessSource(t, table)
+	initial, err := compact.ReduceOutputs(source, 9, 0, core.ForkOrder{})
+	if err != nil || len(initial) != 1 {
+		t.Fatalf("initial reduction outputs=%+v err=%v", initial, err)
+	}
+	if initial[0].Freshness != core.ReductionNew {
+		t.Fatalf("initial reduction freshness=%v, want new prepopulation", initial[0].Freshness)
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		headers: []diagnosticParserCoreHeader{
+			{head: source, creationSeq: 6},
+			{head: initial[0].Head, creationSeq: 7},
 		},
 		token: Token{Symbol: 9, StartByte: 1, EndByte: 2},
 		options: DiagnosticParserCorePrefixOptions{
@@ -143,16 +231,25 @@ func TestDiagnosticParserCoreGenericReductionUnchangedDistinctStateIsRetained(t 
 	if err := scheduler.applyGenericReduction(before, cell); err != nil {
 		t.Fatal(err)
 	}
-	if len(scheduler.headers) != 2 {
-		t.Fatalf("distinct unchanged reduction output was dropped: headers=%+v", scheduler.headers)
+	if len(scheduler.reductionOutputs) != 1 || scheduler.reductionOutputs[0].Freshness != core.ReductionUnchanged {
+		t.Fatalf("repeated reduction outputs=%+v, want one unchanged output", scheduler.reductionOutputs)
 	}
-	seenFirst, seenSecond := false, false
-	for _, header := range scheduler.headers {
-		seenFirst = seenFirst || header.versionState == first
-		seenSecond = seenSecond || header.versionState == second
+	if len(scheduler.headers) != 2 || scheduler.headers[0].head != source || !scheduler.headers[0].paused ||
+		scheduler.headers[1].head != initial[0].Head || scheduler.headers[1].paused {
+		t.Fatalf("equal-snapshot unchanged output duplicated its physical sibling: %+v", scheduler.headers)
 	}
-	if !seenFirst || !seenSecond {
-		t.Fatalf("reduction retained the wrong version identities: %+v", scheduler.headers)
+	if scheduler.headers[0].head.Node == scheduler.headers[1].head.Node {
+		t.Fatalf("equal-snapshot unchanged output retained duplicate physical node %d", scheduler.headers[0].head.Node)
+	}
+	if err := compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		return compact.RecordHeadOwnerOwned(owner, scheduler.headers[1].head, 9)
+	}); err == nil || !strings.Contains(err.Error(), "multiple scheduler owners") {
+		t.Fatalf("scheduler persistence did not bind the surviving physical head to owner 8: %v", err)
+	}
+	if err := compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		return compact.RecordHeadOwnerOwned(owner, scheduler.headers[1].head, 8)
+	}); err != nil {
+		t.Fatalf("surviving physical head rejected its persisted scheduler owner 8: %v", err)
 	}
 }
 
@@ -288,6 +385,12 @@ func TestDiagnosticParserCoreRecoveryCollapseClearsDiscardedVersionStateTail(t *
 		headers: active,
 		canonicalScratch: diagnosticParserCoreCanonicalScratch{
 			headerBuffers: [2][]diagnosticParserCoreHeader{canonical, canonical},
+			keys: []diagnosticParserCorePhaseHead{
+				{versionState: discarded},
+			},
+			groups: map[diagnosticParserCorePhaseHead]diagnosticParserCoreCanonicalGroup{
+				{versionState: discarded}: {},
+			},
 		},
 	}
 	scheduler.collapseToRecoveryWinner(0)
@@ -301,6 +404,34 @@ func TestDiagnosticParserCoreRecoveryCollapseClearsDiscardedVersionStateTail(t *
 		if buffer[:cap(buffer)][0].versionState != nil || buffer[:cap(buffer)][1].versionState != nil {
 			t.Fatalf("recovery collapse retained canonical buffer %d state", index)
 		}
+	}
+	if len(scheduler.canonicalScratch.keys) != 0 || len(scheduler.canonicalScratch.groups) != 0 {
+		t.Fatalf("recovery collapse retained canonical keys/groups=%d/%d",
+			len(scheduler.canonicalScratch.keys), len(scheduler.canonicalScratch.groups))
+	}
+}
+
+func TestDiagnosticParserCoreMappedCanonicalErrorReleasesVersionStateKeys(t *testing.T) {
+	compact, _, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	headers := make([]diagnosticParserCoreHeader, 0, diagnosticParserCoreLinearCanonicalLimit+2)
+	for index := 0; index <= diagnosticParserCoreLinearCanonicalLimit; index++ {
+		head, err := compact.Seed(core.StateID(index+10), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		headers = append(headers, diagnosticParserCoreHeader{
+			head: head, versionState: &diagnosticParserCoreVersionState{},
+		})
+	}
+	malformed := headers[0]
+	malformed.dropCohortRefs = core.DropCohortRefSet{Count: 3}
+	headers = append(headers, malformed)
+	var scratch diagnosticParserCoreCanonicalScratch
+	if _, err := scratch.canonicalize(compact, headers); err == nil {
+		t.Fatal("mapped canonicalization accepted an invalid reference set")
+	}
+	if len(scratch.keys) != 0 || len(scratch.groups) != 0 {
+		t.Fatalf("mapped canonical error retained keys/groups=%d/%d", len(scratch.keys), len(scratch.groups))
 	}
 }
 
@@ -356,12 +487,18 @@ func TestDiagnosticParserCoreSchedulerFootprintCountsWideSharedVersionStates(t *
 	}
 }
 
-func TestDiagnosticParserCoreCanonicalKeyAndGroupStatesAreAccounted(t *testing.T) {
+func TestDiagnosticParserCoreCanonicalKeyAndGroupSnapshotsAreAccounted(t *testing.T) {
 	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
-	keyState := &diagnosticParserCoreVersionState{}
-	groupState := &diagnosticParserCoreVersionState{}
-	key := diagnosticParserCorePhaseHead{head: head, versionState: keyState}
-	groupKey := diagnosticParserCorePhaseHead{head: head, versionState: groupState}
+	keySnapshot := &diagnosticParserCoreVersionLexerSnapshot{}
+	groupSnapshot := &diagnosticParserCoreVersionLexerSnapshot{}
+	keyRegion := &diagnosticParserCoreS3Region{children: make([]core.SubtreeID, 1, 3)}
+	groupRegion := &diagnosticParserCoreS3Region{children: make([]core.SubtreeID, 1, 4)}
+	key := diagnosticParserCorePhaseHead{head: head, versionState: &diagnosticParserCoreVersionState{
+		s3Region: keyRegion, relexSnapshot: keySnapshot,
+	}}
+	groupKey := diagnosticParserCorePhaseHead{head: head, versionState: &diagnosticParserCoreVersionState{
+		s3Region: groupRegion, relexSnapshot: groupSnapshot,
+	}}
 	scheduler := &diagnosticParserCoreGenericScheduler{
 		compact: compact,
 		canonicalScratch: diagnosticParserCoreCanonicalScratch{
@@ -371,11 +508,53 @@ func TestDiagnosticParserCoreCanonicalKeyAndGroupStatesAreAccounted(t *testing.T
 	}
 	base := diagnosticParserCoreSchedulerFootprintBytes(&diagnosticParserCoreGenericScheduler{compact: compact})
 	got := diagnosticParserCoreSchedulerFootprintBytes(scheduler) - base
-	minimum := uint64(2) * uint64(unsafe.Sizeof(diagnosticParserCoreVersionState{}))
+	minimum := uint64(2)*uint64(unsafe.Sizeof(diagnosticParserCoreVersionLexerSnapshot{})) +
+		uint64(2)*uint64(unsafe.Sizeof(diagnosticParserCoreVersionState{})) +
+		diagnosticParserCoreVersionS3RegionFootprintBytes(keyRegion) +
+		diagnosticParserCoreVersionS3RegionFootprintBytes(groupRegion)
 	if got < minimum {
-		t.Fatalf("canonical key/group states were not accounted: delta=%d minimum=%d", got, minimum)
+		t.Fatalf("canonical key/group version state was not accounted: delta=%d minimum=%d", got, minimum)
 	}
 	if len(scheduler.footprintRefs) != 0 {
 		t.Fatalf("footprint refs retained logical entries: len=%d", len(scheduler.footprintRefs))
+	}
+}
+
+func TestDiagnosticParserCoreCanonicalGroupsReleaseSnapshotKeysOnNarrowPaths(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	wide := make([]diagnosticParserCoreHeader, diagnosticParserCoreLinearCanonicalLimit+1)
+	for index := range wide {
+		wide[index] = diagnosticParserCoreHeader{
+			head: head,
+			versionState: &diagnosticParserCoreVersionState{
+				relexSnapshot: &diagnosticParserCoreVersionLexerSnapshot{},
+			},
+		}
+	}
+	var scratch diagnosticParserCoreCanonicalScratch
+	out, err := scratch.canonicalize(compact, wide)
+	if err != nil || len(out) != len(wide) || len(scratch.groups) != len(wide) {
+		t.Fatalf("mapped canonicalization output/groups=%d/%d err=%v, want %d/%d", len(out), len(scratch.groups), err, len(wide), len(wide))
+	}
+	if _, err := scratch.canonicalize(compact, wide[:1]); err != nil {
+		t.Fatal(err)
+	}
+	if len(scratch.groups) != 0 {
+		t.Fatalf("single-header canonicalization retained %d snapshot keys", len(scratch.groups))
+	}
+	if _, err := scratch.canonicalize(compact, wide); err != nil {
+		t.Fatal(err)
+	}
+	if len(scratch.groups) != len(wide) {
+		t.Fatalf("mapped canonicalization repopulated %d groups, want %d", len(scratch.groups), len(wide))
+	}
+	if _, err := scratch.canonicalizeRecovery(compact, wide[:2]); err != nil {
+		t.Fatal(err)
+	}
+	if len(scratch.groups) != 0 {
+		t.Fatalf("recovery canonicalization retained %d snapshot keys", len(scratch.groups))
+	}
+	if len(scratch.keys) != 0 {
+		t.Fatalf("recovery canonicalization retained %d stale phase keys", len(scratch.keys))
 	}
 }

--- a/parsercore_phase0_driver_ownership_internal_test.go
+++ b/parsercore_phase0_driver_ownership_internal_test.go
@@ -1,0 +1,381 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+	"unsafe"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func TestDiagnosticParserCoreCanonicalVersionStateIdentity(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	for _, count := range []int{2, diagnosticParserCoreLinearCanonicalLimit + 1} {
+		t.Run("frontier_"+string(rune('0'+count)), func(t *testing.T) {
+			first := &diagnosticParserCoreVersionState{}
+			second := &diagnosticParserCoreVersionState{}
+			headers := make([]diagnosticParserCoreHeader, count)
+			for index := range headers {
+				headers[index] = diagnosticParserCoreHeader{head: head, versionState: first}
+			}
+			headers[count-1].versionState = second
+			var scratch diagnosticParserCoreCanonicalScratch
+			out, err := scratch.canonicalize(compact, headers)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(out) != 2 {
+				t.Fatalf("divergent version states merged: len=%d output=%+v", len(out), out)
+			}
+			seenFirst, seenSecond := false, false
+			for _, header := range out {
+				seenFirst = seenFirst || header.versionState == first
+				seenSecond = seenSecond || header.versionState == second
+			}
+			if !seenFirst || !seenSecond {
+				t.Fatalf("canonical output lost a version identity: %+v", out)
+			}
+
+			shared := make([]diagnosticParserCoreHeader, count)
+			for index := range shared {
+				shared[index] = diagnosticParserCoreHeader{head: head, versionState: first}
+			}
+			out, err = scratch.canonicalize(compact, shared)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(out) != 1 || out[0].versionState != first {
+				t.Fatalf("equal fork states did not merge: len=%d output=%+v", len(out), out)
+			}
+		})
+	}
+}
+
+func TestDiagnosticParserCoreReductionSiblingAdoptionRequiresVersionStateIdentity(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	first := &diagnosticParserCoreVersionState{}
+	second := &diagnosticParserCoreVersionState{}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		headers: []diagnosticParserCoreHeader{
+			{head: head, versionState: first},
+			{head: head, versionState: second, paused: true},
+		},
+	}
+	adopted, err := scheduler.adoptUpdatedReductionSibling(
+		0, head, core.CleanPathRankUnknown, 0, core.AlternativeSet{}, false, false, false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adopted {
+		t.Fatal("sibling adoption merged divergent version states")
+	}
+	if scheduler.headers[1].versionState != second || !scheduler.headers[1].paused {
+		t.Fatalf("divergent sibling changed: %+v", scheduler.headers[1])
+	}
+
+	scheduler.headers[1].versionState = first
+	adopted, err = scheduler.adoptUpdatedReductionSibling(
+		0, head, core.CleanPathRankUnknown, 0, core.AlternativeSet{}, false, false, false,
+	)
+	if err != nil || !adopted {
+		t.Fatalf("equal version states were not adopted: adopted=%t err=%v", adopted, err)
+	}
+}
+
+func TestDiagnosticParserCoreReductionUnchangedDistinctStateIsRetained(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	first := &diagnosticParserCoreVersionState{}
+	second := &diagnosticParserCoreVersionState{}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		headers: []diagnosticParserCoreHeader{
+			{head: head, versionState: first},
+			{head: head, versionState: second},
+		},
+	}
+	kept, adopted, err := scheduler.reconcileGenericConflictOutputs(0, []diagnosticParserCoreHeader{
+		{head: head, versionState: second, freshness: core.ReductionUnchanged},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adopted != 0 || len(kept) != 1 || kept[0].versionState != second || kept[0].freshness != core.ReductionUnchanged {
+		t.Fatalf("distinct unchanged output was dropped: kept=%+v adopted=%d", kept, adopted)
+	}
+}
+
+func TestDiagnosticParserCoreGenericReductionUnchangedDistinctStateIsRetained(t *testing.T) {
+	table := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 8}: {{Type: core.ActionShift, State: 3}},
+			{state: 3, symbol: 9}: {{Type: core.ActionReduce, Symbol: 2, ChildCount: 1}},
+		},
+		gotos: map[genericConflictCell]core.StateID{{state: 1, symbol: 2}: 4},
+	}
+	compact, source := newGenericFreshnessSource(t, table)
+	initial, err := compact.ReduceOutputs(source, 9, 0, core.ForkOrder{})
+	if err != nil || len(initial) != 1 {
+		t.Fatalf("initial reduction outputs=%+v err=%v", initial, err)
+	}
+	first := &diagnosticParserCoreVersionState{}
+	second := &diagnosticParserCoreVersionState{}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		headers: []diagnosticParserCoreHeader{
+			{head: source, versionState: first},
+			{head: initial[0].Head, versionState: second},
+		},
+		token: Token{Symbol: 9, StartByte: 1, EndByte: 2},
+		options: DiagnosticParserCorePrefixOptions{
+			MaxDispatches: 20,
+			ReceiptMode:   DiagnosticParserCoreReceiptSummary,
+		},
+		receipt: &DiagnosticParserCoreGenericScheduler{},
+	}
+	before, err := diagnosticParserCoreHeaderReceipts(compact, scheduler.headers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cell := mustDiagnosticParserCoreGenericCell(t, compact, 0, scheduler.headers[0], 9)
+	if err := scheduler.applyGenericReduction(before, cell); err != nil {
+		t.Fatal(err)
+	}
+	if len(scheduler.headers) != 2 {
+		t.Fatalf("distinct unchanged reduction output was dropped: headers=%+v", scheduler.headers)
+	}
+	seenFirst, seenSecond := false, false
+	for _, header := range scheduler.headers {
+		seenFirst = seenFirst || header.versionState == first
+		seenSecond = seenSecond || header.versionState == second
+	}
+	if !seenFirst || !seenSecond {
+		t.Fatalf("reduction retained the wrong version identities: %+v", scheduler.headers)
+	}
+}
+
+func TestDiagnosticParserCoreCanonicalClearsDiscardedVersionStateTail(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	state := &diagnosticParserCoreVersionState{}
+	input := make([]diagnosticParserCoreHeader, 3, 4)
+	for index := range input {
+		input[index] = diagnosticParserCoreHeader{head: head, versionState: state}
+	}
+	var scratch diagnosticParserCoreCanonicalScratch
+	out, err := scratch.canonicalize(compact, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || cap(out) <= len(out) {
+		t.Fatalf("canonical output len/cap=%d/%d, want a retained tail", len(out), cap(out))
+	}
+	for index, header := range out[:cap(out)][len(out):] {
+		if header.versionState != nil {
+			t.Fatalf("canonical discarded slot %d retained version state", index+len(out))
+		}
+	}
+}
+
+func TestDiagnosticParserCoreRollbackClearsDiscardedVersionStateTail(t *testing.T) {
+	keep := &diagnosticParserCoreVersionState{}
+	discarded := &diagnosticParserCoreVersionState{}
+	headers := make([]diagnosticParserCoreHeader, 1, 4)
+	headers[0].versionState = keep
+	var scratch diagnosticParserCoreHeaderRollbackScratch
+	if err := scratch.begin(headers); err != nil {
+		t.Fatal(err)
+	}
+	headers = append(headers, diagnosticParserCoreHeader{versionState: discarded})
+	scratch.finish(&headers, true)
+	if len(headers) != 1 || headers[0].versionState != keep {
+		t.Fatalf("rollback did not restore the original header: %+v", headers)
+	}
+	if headers[:cap(headers)][1].versionState != nil {
+		t.Fatal("rollback retained a discarded header state beyond len")
+	}
+	if scratch.inline[0].versionState != nil {
+		t.Fatal("rollback scratch retained its snapshot state")
+	}
+}
+
+func TestDiagnosticParserCoreConflictScratchClearsDiscardedVersionStateTail(t *testing.T) {
+	state := &diagnosticParserCoreVersionState{}
+	scratch := diagnosticParserCoreConflictScratch{
+		outputs:        make([]diagnosticParserCoreHeader, 3, 5),
+		headerAssembly: make([]diagnosticParserCoreHeader, 3, 5),
+	}
+	for index := range scratch.outputs {
+		scratch.outputs[index].versionState = state
+		scratch.headerAssembly[index].versionState = state
+	}
+	if err := scratch.begin(1); err != nil {
+		t.Fatal(err)
+	}
+	for name, headers := range map[string][]diagnosticParserCoreHeader{
+		"outputs":  scratch.outputs,
+		"assembly": scratch.headerAssembly,
+	} {
+		if len(headers) != 0 || cap(headers) <= len(headers) {
+			t.Fatalf("%s len/cap=%d/%d, want an empty retained buffer", name, len(headers), cap(headers))
+		}
+		for index, header := range headers[:cap(headers)] {
+			if header.versionState != nil {
+				t.Fatalf("%s discarded slot %d retained version state", name, index)
+			}
+		}
+	}
+	scratch.finish()
+}
+
+func TestDiagnosticParserCoreReductionReplacementResetClearsStaleTail(t *testing.T) {
+	state := &diagnosticParserCoreVersionState{}
+	replacements := make([]diagnosticParserCoreHeader, 1, 4)
+	replacements[0].versionState = state
+	replacements[:cap(replacements)][1].versionState = state
+	scheduler := diagnosticParserCoreGenericScheduler{reductionReplacements: replacements}
+	if err := resetDiagnosticParserCoreGenericScheduler(&scheduler); err != nil {
+		t.Fatal(err)
+	}
+	if replacements[:cap(replacements)][0].versionState != nil || replacements[:cap(replacements)][1].versionState != nil {
+		t.Fatal("reduction replacement reset retained version state")
+	}
+}
+
+func TestDiagnosticParserCoreNoActionClearsDiscardedVersionStateTail(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	keep := &diagnosticParserCoreVersionState{}
+	discarded := &diagnosticParserCoreVersionState{}
+	headers := make([]diagnosticParserCoreHeader, 2, 4)
+	headers[0] = diagnosticParserCoreHeader{head: head, shifted: true, versionState: keep}
+	headers[1] = diagnosticParserCoreHeader{head: head, paused: true, versionState: discarded}
+	scheduler := diagnosticParserCoreGenericScheduler{
+		compact:           compact,
+		headers:           headers,
+		epochProgress:     true,
+		verifierBound:     len(headers),
+		verifierHeaderPtr: &headers[0],
+		options: DiagnosticParserCorePrefixOptions{
+			ReceiptMode:                     DiagnosticParserCoreReceiptSummary,
+			allowConvergedSplitDropArtifact: true,
+		},
+	}
+	if err := scheduler.dropGenericNoActionHeads([]int{1}); err != nil {
+		t.Fatal(err)
+	}
+	if len(scheduler.headers) != 1 || scheduler.headers[0].versionState != keep {
+		t.Fatalf("no-action drop changed the survivor: %+v", scheduler.headers)
+	}
+	if headers[:cap(headers)][1].versionState != nil {
+		t.Fatal("no-action drop retained the discarded header state")
+	}
+	if scheduler.verifierHeaderPtr != nil || scheduler.verifierBound != 0 {
+		t.Fatal("no-action drop retained a stale verifier binding")
+	}
+}
+
+func TestDiagnosticParserCoreRecoveryCollapseClearsDiscardedVersionStateTail(t *testing.T) {
+	keep := &diagnosticParserCoreVersionState{}
+	discarded := &diagnosticParserCoreVersionState{}
+	active := make([]diagnosticParserCoreHeader, 2, 4)
+	active[0].versionState = keep
+	active[1].versionState = discarded
+	canonical := make([]diagnosticParserCoreHeader, 2, 4)
+	canonical[0].versionState = keep
+	canonical[1].versionState = discarded
+	scheduler := diagnosticParserCoreGenericScheduler{
+		headers: active,
+		canonicalScratch: diagnosticParserCoreCanonicalScratch{
+			headerBuffers: [2][]diagnosticParserCoreHeader{canonical, canonical},
+		},
+	}
+	scheduler.collapseToRecoveryWinner(0)
+	if len(scheduler.headers) != 1 || scheduler.headers[0].versionState != keep {
+		t.Fatalf("recovery collapse changed the winner: %+v", scheduler.headers)
+	}
+	if active[:cap(active)][1].versionState != nil {
+		t.Fatal("recovery collapse retained a discarded active state")
+	}
+	for index, buffer := range scheduler.canonicalScratch.headerBuffers {
+		if buffer[:cap(buffer)][0].versionState != nil || buffer[:cap(buffer)][1].versionState != nil {
+			t.Fatalf("recovery collapse retained canonical buffer %d state", index)
+		}
+	}
+}
+
+func TestDiagnosticParserCoreReplacementClearsDiscardedVersionStateTail(t *testing.T) {
+	state := &diagnosticParserCoreVersionState{}
+	headers := make([]diagnosticParserCoreHeader, 3, 5)
+	for index := range headers {
+		headers[index].versionState = state
+	}
+	replacements := []diagnosticParserCoreHeader{}
+	got := replaceDiagnosticParserCoreHeader(headers, 1, replacements)
+	if len(got) != 2 || cap(got) != cap(headers) {
+		t.Fatalf("replacement unexpectedly changed storage: len/cap=%d/%d", len(got), cap(got))
+	}
+	if got[:cap(got)][2].versionState != nil {
+		t.Fatal("replacement retained its discarded tail state")
+	}
+}
+
+func TestDiagnosticParserCoreSchedulerFootprintCountsWideSharedVersionStates(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	const totalHeaders = 300
+	const uniqueStates = 257
+	states := make([]*diagnosticParserCoreVersionState, uniqueStates)
+	for index := range states {
+		states[index] = &diagnosticParserCoreVersionState{}
+	}
+	headers := make([]diagnosticParserCoreHeader, totalHeaders)
+	for index := range headers {
+		stateIndex := index
+		if stateIndex >= uniqueStates {
+			stateIndex = uniqueStates - 1
+		}
+		headers[index] = diagnosticParserCoreHeader{head: head, versionState: states[stateIndex]}
+	}
+	base := diagnosticParserCoreSchedulerFootprintBytes(&diagnosticParserCoreGenericScheduler{compact: compact})
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		headers: headers,
+	}
+	got := diagnosticParserCoreSchedulerFootprintBytes(scheduler) - base
+	want := uint64(totalHeaders)*uint64(unsafe.Sizeof(diagnosticParserCoreHeader{})) +
+		uint64(uniqueStates)*uint64(unsafe.Sizeof(diagnosticParserCoreVersionState{})) +
+		uint64(cap(scheduler.footprintRefs))*uint64(unsafe.Sizeof(diagnosticParserCoreFootprintRef{}))
+	if got != want {
+		t.Fatalf("wide shared-state footprint=%d, want exact %d", got, want)
+	}
+	var gotAgain uint64
+	if allocs := testing.AllocsPerRun(100, func() {
+		gotAgain = diagnosticParserCoreSchedulerFootprintBytes(scheduler)
+	}); allocs != 0 || gotAgain != diagnosticParserCoreSchedulerFootprintBytes(scheduler) {
+		t.Fatalf("wide footprint steady state allocs=%v got=%d", allocs, gotAgain)
+	}
+}
+
+func TestDiagnosticParserCoreCanonicalKeyAndGroupStatesAreAccounted(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	keyState := &diagnosticParserCoreVersionState{}
+	groupState := &diagnosticParserCoreVersionState{}
+	key := diagnosticParserCorePhaseHead{head: head, versionState: keyState}
+	groupKey := diagnosticParserCorePhaseHead{head: head, versionState: groupState}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		canonicalScratch: diagnosticParserCoreCanonicalScratch{
+			keys:   []diagnosticParserCorePhaseHead{key},
+			groups: map[diagnosticParserCorePhaseHead]diagnosticParserCoreCanonicalGroup{groupKey: {}},
+		},
+	}
+	base := diagnosticParserCoreSchedulerFootprintBytes(&diagnosticParserCoreGenericScheduler{compact: compact})
+	got := diagnosticParserCoreSchedulerFootprintBytes(scheduler) - base
+	minimum := uint64(2) * uint64(unsafe.Sizeof(diagnosticParserCoreVersionState{}))
+	if got < minimum {
+		t.Fatalf("canonical key/group states were not accounted: delta=%d minimum=%d", got, minimum)
+	}
+	if len(scheduler.footprintRefs) != 0 {
+		t.Fatalf("footprint refs retained logical entries: len=%d", len(scheduler.footprintRefs))
+	}
+}

--- a/parsercore_phase0_eof_recovery_metadata_contract_test.go
+++ b/parsercore_phase0_eof_recovery_metadata_contract_test.go
@@ -357,9 +357,9 @@ func newG4EOFFixture(t *testing.T, spec g4EOFFixtureSpec) *g4EOFFixture {
 	scheduler.options.materializationSource = spec.source
 	scheduler.options.materializationContextSet = true
 	if spec.openS3Region {
-		scheduler.headers[1].s3Region = &diagnosticParserCoreS3Region{
+		scheduler.headers[1].openRecoveryRegion(&diagnosticParserCoreS3Region{
 			state: recoveryFinalState, startByte: 0, endByte: sourceLength,
-		}
+		})
 	}
 	parser := NewParser(language)
 	runner := &parserCoreFreshFullRunner{

--- a/parsercore_phase0_generic_scheduler_test.go
+++ b/parsercore_phase0_generic_scheduler_test.go
@@ -501,7 +501,7 @@ func TestDiagnosticParserCoreSummaryReceiptPreservesExactRewrite(t *testing.T) {
 				ConflictActionArmsAdmitted: 328, CausalConflictForks: 168,
 				Reductions: 1259, OrdinaryShifts: 1238, OrdinaryCohorts: 215,
 				ExtraShifts: 27, ExtraCohorts: 1, Accepts: 1,
-				ReductionPauses: 31, NoActionDrops: 166, ConvergedReductionSplitDrops: 164, ConvergedCoverageDrops: 0, Elections: 1036,
+				ReductionPauses: 30, NoActionDrops: 165, ConvergedReductionSplitDrops: 163, ConvergedCoverageDrops: 0, Elections: 1036,
 				Canonicalizations: 2446, PeakHeaders: 4,
 			}) {
 			result.MaterializedTree.Release()

--- a/parsercore_phase0_generic_scheduler_test.go
+++ b/parsercore_phase0_generic_scheduler_test.go
@@ -501,7 +501,7 @@ func TestDiagnosticParserCoreSummaryReceiptPreservesExactRewrite(t *testing.T) {
 				ConflictActionArmsAdmitted: 328, CausalConflictForks: 168,
 				Reductions: 1259, OrdinaryShifts: 1238, OrdinaryCohorts: 215,
 				ExtraShifts: 27, ExtraCohorts: 1, Accepts: 1,
-				ReductionPauses: 30, NoActionDrops: 165, ConvergedReductionSplitDrops: 163, ConvergedCoverageDrops: 0, Elections: 1036,
+				ReductionPauses: 31, NoActionDrops: 166, ConvergedReductionSplitDrops: 164, ConvergedCoverageDrops: 0, Elections: 1036,
 				Canonicalizations: 2446, PeakHeaders: 4,
 			}) {
 			result.MaterializedTree.Release()

--- a/parsercore_phase0_per_version_lexer_activation_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_activation_internal_test.go
@@ -1,0 +1,49 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"fmt"
+)
+
+// DiagnosticParserCoreVersionLexerProductionActivationForTest runs the
+// production fresh-full scheduler and returns its activation receipt. The
+// external test package supplies the Swift language through the public grammar
+// registry, so the test enters the same runner used by Parser.Parse.
+func DiagnosticParserCoreVersionLexerProductionActivationForTest(
+	lang *Language,
+	source []byte,
+) (DiagnosticParserCoreGenericScheduler, error) {
+	if lang == nil {
+		return DiagnosticParserCoreGenericScheduler{}, fmt.Errorf("swift language is unavailable")
+	}
+	parser := NewParser(lang)
+	runner, err := newAdmissionCandidateRunner(parser)
+	if err != nil {
+		return DiagnosticParserCoreGenericScheduler{}, err
+	}
+	runner.options.ReceiptMode = DiagnosticParserCoreReceiptFull
+	if err := runner.compact.Reset(); err != nil {
+		return DiagnosticParserCoreGenericScheduler{}, err
+	}
+	tokenSource := parser.acquireParserDFATokenSource(source)
+	if tokenSource == nil {
+		return DiagnosticParserCoreGenericScheduler{}, fmt.Errorf("acquire parser DFA token source returned nil")
+	}
+	defer tokenSource.Close()
+	scheduler, err := executeDiagnosticParserCoreGenericSchedulerFromSeedInto(
+		&runner.scheduler, runner.compact, tokenSource, &runner.scannerScratch,
+		lang.InitialState, runner.options, diagnosticParserCoreSeedObserver{},
+	)
+	if err != nil {
+		return DiagnosticParserCoreGenericScheduler{}, err
+	}
+	if scheduler == nil || scheduler.receipt == nil {
+		return DiagnosticParserCoreGenericScheduler{}, fmt.Errorf("production scheduler returned no receipt")
+	}
+	if resumeErr := scheduler.run(); !errors.Is(resumeErr, errDiagnosticParserCoreTerminalSchedulerResume) {
+		return DiagnosticParserCoreGenericScheduler{}, fmt.Errorf("terminal activation resumed: %v", resumeErr)
+	}
+	return *scheduler.receipt, nil
+}

--- a/parsercore_phase0_per_version_lexer_activation_test.go
+++ b/parsercore_phase0_per_version_lexer_activation_test.go
@@ -1,0 +1,149 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestDiagnosticParserCoreVersionLexerProductionActivation proves the
+// production fresh-full scheduler preempts the shared ragged pass before the
+// wide-token sibling reduces, while recording both owned lexer requests.
+func TestDiagnosticParserCoreVersionLexerProductionActivation(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	entry := grammars.DetectLanguageByName("swift")
+	if entry == nil || entry.Language() == nil {
+		t.Fatal("swift grammar is unavailable")
+	}
+	receipt, err := gts.DiagnosticParserCoreVersionLexerProductionActivationForTest(
+		entry.Language(), []byte("a<A<#"),
+	)
+	if err != nil {
+		t.Fatalf("production scheduler: %v", err)
+	}
+	if !strings.HasPrefix(receipt.Stop.Detail, gts.DiagnosticParserCoreOwnedDispatchPendingDetailForTest()) {
+		t.Fatalf("scheduler stop detail=%q, want owned-dispatch-pending activation", receipt.Stop.Detail)
+	}
+	if receipt.PerVersionLexRequests != 2 || receipt.PerVersionLexRestores != 2 ||
+		receipt.PerVersionLexPublications != 6 || receipt.PerVersionLexAcceptedRaggedSpans != 0 {
+		t.Fatalf("published lexer counters=%d/%d/%d/%d, want 2/2/6/0",
+			receipt.PerVersionLexRequests, receipt.PerVersionLexRestores,
+			receipt.PerVersionLexPublications, receipt.PerVersionLexAcceptedRaggedSpans)
+	}
+	if receipt.Stop.Work.PerVersionLexRequests != 2 || receipt.Stop.Work.PerVersionLexRestores != 2 ||
+		receipt.Stop.Work.PerVersionLexPublications != 6 || receipt.Stop.Work.PerVersionLexAcceptedRaggedSpans != 0 {
+		t.Fatalf("stop lexer counters=%d/%d/%d/%d, want 2/2/6/0",
+			receipt.Stop.Work.PerVersionLexRequests, receipt.Stop.Work.PerVersionLexRestores,
+			receipt.Stop.Work.PerVersionLexPublications, receipt.Stop.Work.PerVersionLexAcceptedRaggedSpans)
+	}
+	if receipt.PeakLiveVersions != 2 || receipt.Stop.Work.PeakLiveVersions != 2 {
+		t.Fatalf("peak live versions=%d/%d, want 2/2", receipt.PeakLiveVersions, receipt.Stop.Work.PeakLiveVersions)
+	}
+	if got := receipt.Stop.Work.Reductions; got != 2 {
+		t.Fatalf("shared reductions=%d, want 2 before state-524 reduction", got)
+	}
+	if receipt.Stop.ElectionIndex < 0 || receipt.Stop.ElectionIndex >= len(receipt.Elections) {
+		t.Fatalf("stop election index=%d outside %d elections", receipt.Stop.ElectionIndex, len(receipt.Elections))
+	}
+	election := receipt.Elections[receipt.Stop.ElectionIndex]
+	// Elections record the parser states at token-election start. The shared
+	// state 10 reduces later in this same election into headers 47 and 524.
+	if len(election.States) != 1 || election.States[0] != 10 {
+		t.Fatalf("activation election index=%d states=%v, want initial state [10]", receipt.Stop.ElectionIndex, election.States)
+	}
+	if election.Token.Symbol != 217 || election.Token.StartByte != 3 || election.Token.EndByte != 5 || !election.Token.ExternalScannerToken {
+		t.Fatalf("activation election token=%+v, want external 217 over bytes 3..5", election.Token)
+	}
+	if receipt.Stop.Token != election.Token || receipt.Stop.ElectionIndex != electionIndexForRequests(receipt.VersionLexerRequests) {
+		t.Fatalf("stop/election identity: stop=(election=%d token=%+v), election token=%+v, request election=%d",
+			receipt.Stop.ElectionIndex, receipt.Stop.Token, election.Token, electionIndexForRequests(receipt.VersionLexerRequests))
+	}
+	assertNineByteCheckpoint := func(label string, checkpoint gts.DiagnosticParserCoreScannerCheckpoint) {
+		t.Helper()
+		if checkpoint.Length != 9 {
+			t.Fatalf("%s checkpoint length=%d, want exact Swift length 9", label, checkpoint.Length)
+		}
+		if checkpoint.SHA256 == [32]byte{} {
+			t.Fatalf("%s checkpoint has an empty digest", label)
+		}
+	}
+	assertNineByteCheckpoint("election scanner-before", election.ScannerBefore)
+	assertNineByteCheckpoint("election scanner-after", election.ScannerAfter)
+	if !election.CurrentCheckpointValid || election.CurrentCheckpointStart != election.ScannerBefore || election.CurrentCheckpointEnd != election.ScannerAfter {
+		t.Fatalf("activation election lost scanner checkpoint identity: %+v", election)
+	}
+	if election.CurrentCheckpointBytes != [2]uint32{3, 5} {
+		t.Fatalf("activation election checkpoint bytes=%v, want [3 5]", election.CurrentCheckpointBytes)
+	}
+	want := map[gts.StateID]struct {
+		symbol   gts.Symbol
+		endByte  uint32
+		external bool
+		internal bool
+	}{
+		47:  {symbol: 35, endByte: 4, internal: true},
+		524: {symbol: 217, endByte: 5, external: true},
+	}
+	if len(receipt.VersionLexerRequests) != len(want) {
+		t.Fatalf("owned lexer requests=%d, want %d", len(receipt.VersionLexerRequests), len(want))
+	}
+	requestByState := make(map[gts.StateID]gts.DiagnosticParserCoreVersionLexerRequest, len(want))
+	for _, request := range receipt.VersionLexerRequests {
+		expect, ok := want[request.State]
+		if !ok {
+			t.Fatalf("unexpected owned request state=%d", request.State)
+		}
+		if request.Token.Symbol != expect.symbol || request.Token.StartByte != 3 || request.Token.EndByte != expect.endByte {
+			t.Fatalf("state %d token=%+v, want symbol=%d span=3..%d", request.State, request.Token, expect.symbol, expect.endByte)
+		}
+		if request.Token.ExternalScannerToken != expect.external || request.InternalDFAToken != expect.internal {
+			t.Fatalf("state %d provenance external=%t/internal=%t, want external=%t/internal=%t", request.State, request.Token.ExternalScannerToken, request.InternalDFAToken, expect.external, expect.internal)
+		}
+		if request.ElectionIndex != receipt.Stop.ElectionIndex {
+			t.Fatalf("state %d request election=%d, want activation election %d", request.State, request.ElectionIndex, receipt.Stop.ElectionIndex)
+		}
+		assertNineByteCheckpoint(fmt.Sprintf("state %d scanner-before", request.State), request.ScannerBefore)
+		assertNineByteCheckpoint(fmt.Sprintf("state %d scanner-after", request.State), request.ScannerAfter)
+		if request.ScannerBefore != election.ScannerBefore {
+			t.Fatalf("state %d scanner-before=%+v, want shared election-before=%+v", request.State, request.ScannerBefore, election.ScannerBefore)
+		}
+		requestByState[request.State] = request
+	}
+	if len(requestByState) != len(want) {
+		t.Fatalf("owned request state identities=%v, want states 47 and 524", requestByState)
+	}
+	if len(receipt.Stop.Headers) != 2 {
+		t.Fatalf("stop headers=%d, want 2 activation headers", len(receipt.Stop.Headers))
+	}
+	for index, path := range receipt.Stop.Headers {
+		header := path.Header
+		request, ok := requestByState[header.State]
+		if !ok {
+			t.Fatalf("stop header %d state=%d has no matching owned request", index, header.State)
+		}
+		if header.CreationSeq != request.HeaderCreationSeq || header.ByteOffset != 3 {
+			t.Fatalf("stop header %d identity=%+v, want request seq=%d at byte 3", index, header, request.HeaderCreationSeq)
+		}
+		if header.Checkpoint != election.ScannerAfter.SHA256 {
+			t.Fatalf("stop header %d checkpoint=%x, want shared election-after=%x", index, header.Checkpoint, election.ScannerAfter.SHA256)
+		}
+	}
+}
+
+func electionIndexForRequests(requests []gts.DiagnosticParserCoreVersionLexerRequest) int {
+	if len(requests) == 0 {
+		return -1
+	}
+	index := requests[0].ElectionIndex
+	for _, request := range requests[1:] {
+		if request.ElectionIndex != index {
+			return -1
+		}
+	}
+	return index
+}

--- a/parsercore_phase0_per_version_lexer_activation_test.go
+++ b/parsercore_phase0_per_version_lexer_activation_test.go
@@ -4,16 +4,18 @@ package gotreesitter_test
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	gts "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
 
-// TestDiagnosticParserCoreVersionLexerProductionActivation proves the
-// production fresh-full scheduler preempts the shared ragged pass before the
-// wide-token sibling reduces, while recording both owned lexer requests.
+const versionLexerProductionSource = "a<(A<#/x/#)"
+
+// TestDiagnosticParserCoreVersionLexerProductionActivation proves that the
+// fresh-full scheduler owns each lexer cursor after a width disagreement. The
+// shared pass consumes '<#' at byte 4. Both retained versions consume '<' from
+// their own cursors. One lineage then shifts '#' and reaches EOF acceptance.
 func TestDiagnosticParserCoreVersionLexerProductionActivation(t *testing.T) {
 	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
 	entry := grammars.DetectLanguageByName("swift")
@@ -21,129 +23,105 @@ func TestDiagnosticParserCoreVersionLexerProductionActivation(t *testing.T) {
 		t.Fatal("swift grammar is unavailable")
 	}
 	receipt, err := gts.DiagnosticParserCoreVersionLexerProductionActivationForTest(
-		entry.Language(), []byte("a<A<#"),
+		entry.Language(), []byte(versionLexerProductionSource),
 	)
 	if err != nil {
 		t.Fatalf("production scheduler: %v", err)
 	}
-	if !strings.HasPrefix(receipt.Stop.Detail, gts.DiagnosticParserCoreOwnedDispatchPendingDetailForTest()) {
-		t.Fatalf("scheduler stop detail=%q, want owned-dispatch-pending activation", receipt.Stop.Detail)
+	if receipt.Acceptance == nil {
+		t.Fatalf("owned lexer route did not accept: stop=%+v", receipt.Stop)
 	}
-	if receipt.PerVersionLexRequests != 2 || receipt.PerVersionLexRestores != 2 ||
-		receipt.PerVersionLexPublications != 6 || receipt.PerVersionLexAcceptedRaggedSpans != 0 {
-		t.Fatalf("published lexer counters=%d/%d/%d/%d, want 2/2/6/0",
+	if receipt.Stop.Detail != "" {
+		t.Fatalf("accepted scheduler retained stop detail %q", receipt.Stop.Detail)
+	}
+	work := receipt.Acceptance.Work
+	if receipt.PerVersionLexRequests != 4 || receipt.PerVersionLexRestores != 4 ||
+		receipt.PerVersionLexPublications != 14 || receipt.PerVersionLexAcceptedRaggedSpans != 3 ||
+		receipt.PerVersionLexViabilityDrops != 1 {
+		t.Fatalf("published lexer counters=%d/%d/%d/%d/%d, want 4/4/14/3/1",
 			receipt.PerVersionLexRequests, receipt.PerVersionLexRestores,
-			receipt.PerVersionLexPublications, receipt.PerVersionLexAcceptedRaggedSpans)
+			receipt.PerVersionLexPublications, receipt.PerVersionLexAcceptedRaggedSpans,
+			receipt.PerVersionLexViabilityDrops)
 	}
-	if receipt.Stop.Work.PerVersionLexRequests != 2 || receipt.Stop.Work.PerVersionLexRestores != 2 ||
-		receipt.Stop.Work.PerVersionLexPublications != 6 || receipt.Stop.Work.PerVersionLexAcceptedRaggedSpans != 0 {
-		t.Fatalf("stop lexer counters=%d/%d/%d/%d, want 2/2/6/0",
-			receipt.Stop.Work.PerVersionLexRequests, receipt.Stop.Work.PerVersionLexRestores,
-			receipt.Stop.Work.PerVersionLexPublications, receipt.Stop.Work.PerVersionLexAcceptedRaggedSpans)
+	if work.PerVersionLexRequests != 4 || work.PerVersionLexRestores != 4 ||
+		work.PerVersionLexPublications != 14 || work.PerVersionLexAcceptedRaggedSpans != 3 ||
+		work.PerVersionLexViabilityDrops != 1 {
+		t.Fatalf("acceptance lexer counters=%d/%d/%d/%d/%d, want 4/4/14/3/1",
+			work.PerVersionLexRequests, work.PerVersionLexRestores,
+			work.PerVersionLexPublications, work.PerVersionLexAcceptedRaggedSpans,
+			work.PerVersionLexViabilityDrops)
 	}
-	if receipt.PeakLiveVersions != 2 || receipt.Stop.Work.PeakLiveVersions != 2 {
-		t.Fatalf("peak live versions=%d/%d, want 2/2", receipt.PeakLiveVersions, receipt.Stop.Work.PeakLiveVersions)
+	if receipt.PeakLiveVersions != 2 || work.PeakLiveVersions != 2 {
+		t.Fatalf("peak live versions=%d/%d, want 2/2", receipt.PeakLiveVersions, work.PeakLiveVersions)
 	}
-	if got := receipt.Stop.Work.Reductions; got != 2 {
-		t.Fatalf("shared reductions=%d, want 2 before state-524 reduction", got)
+	if work.NoActionDrops != 1 || work.ConvergedReductionSplitDrops != 0 || work.ConvergedCoverageDrops != 0 {
+		t.Fatalf("drop classes=%d/%d/%d, want viability-only 1/0/0",
+			work.NoActionDrops, work.ConvergedReductionSplitDrops, work.ConvergedCoverageDrops)
 	}
-	if receipt.Stop.ElectionIndex < 0 || receipt.Stop.ElectionIndex >= len(receipt.Elections) {
-		t.Fatalf("stop election index=%d outside %d elections", receipt.Stop.ElectionIndex, len(receipt.Elections))
+
+	if len(receipt.Elections) < 5 {
+		t.Fatalf("elections=%d, want activation election", len(receipt.Elections))
 	}
-	election := receipt.Elections[receipt.Stop.ElectionIndex]
-	// Elections record the parser states at token-election start. The shared
-	// state 10 reduces later in this same election into headers 47 and 524.
-	if len(election.States) != 1 || election.States[0] != 10 {
-		t.Fatalf("activation election index=%d states=%v, want initial state [10]", receipt.Stop.ElectionIndex, election.States)
+	activation := receipt.Elections[4]
+	if len(activation.States) != 1 || activation.States[0] != 10 {
+		t.Fatalf("activation states=%v, want [10]", activation.States)
 	}
-	if election.Token.Symbol != 217 || election.Token.StartByte != 3 || election.Token.EndByte != 5 || !election.Token.ExternalScannerToken {
-		t.Fatalf("activation election token=%+v, want external 217 over bytes 3..5", election.Token)
-	}
-	if receipt.Stop.Token != election.Token || receipt.Stop.ElectionIndex != electionIndexForRequests(receipt.VersionLexerRequests) {
-		t.Fatalf("stop/election identity: stop=(election=%d token=%+v), election token=%+v, request election=%d",
-			receipt.Stop.ElectionIndex, receipt.Stop.Token, election.Token, electionIndexForRequests(receipt.VersionLexerRequests))
+	if activation.Token.Symbol != 217 || activation.Token.StartByte != 4 ||
+		activation.Token.EndByte != 6 || !activation.Token.ExternalScannerToken {
+		t.Fatalf("activation token=%+v, want external 217 over bytes 4..6", activation.Token)
 	}
 	assertNineByteCheckpoint := func(label string, checkpoint gts.DiagnosticParserCoreScannerCheckpoint) {
 		t.Helper()
-		if checkpoint.Length != 9 {
-			t.Fatalf("%s checkpoint length=%d, want exact Swift length 9", label, checkpoint.Length)
-		}
-		if checkpoint.SHA256 == [32]byte{} {
-			t.Fatalf("%s checkpoint has an empty digest", label)
+		if checkpoint.Length != 9 || checkpoint.SHA256 == [32]byte{} {
+			t.Fatalf("%s checkpoint=%+v, want authenticated Swift state", label, checkpoint)
 		}
 	}
-	assertNineByteCheckpoint("election scanner-before", election.ScannerBefore)
-	assertNineByteCheckpoint("election scanner-after", election.ScannerAfter)
-	if !election.CurrentCheckpointValid || election.CurrentCheckpointStart != election.ScannerBefore || election.CurrentCheckpointEnd != election.ScannerAfter {
-		t.Fatalf("activation election lost scanner checkpoint identity: %+v", election)
-	}
-	if election.CurrentCheckpointBytes != [2]uint32{3, 5} {
-		t.Fatalf("activation election checkpoint bytes=%v, want [3 5]", election.CurrentCheckpointBytes)
-	}
+	assertNineByteCheckpoint("activation before", activation.ScannerBefore)
+	assertNineByteCheckpoint("activation after", activation.ScannerAfter)
+
 	want := map[gts.StateID]struct {
-		symbol   gts.Symbol
-		endByte  uint32
-		external bool
-		internal bool
+		election      int
+		symbol        gts.Symbol
+		start, end    uint32
+		external, dfa bool
 	}{
-		47:  {symbol: 35, endByte: 4, internal: true},
-		524: {symbol: 217, endByte: 5, external: true},
+		441:  {election: 4, symbol: 35, start: 4, end: 5, dfa: true},
+		1554: {election: 4, symbol: 35, start: 4, end: 5, dfa: true},
+		295:  {election: 5, symbol: 217, start: 5, end: 6, external: true},
+		402:  {election: 5, symbol: gts.Symbol(65535), start: 5, end: 6},
 	}
 	if len(receipt.VersionLexerRequests) != len(want) {
 		t.Fatalf("owned lexer requests=%d, want %d", len(receipt.VersionLexerRequests), len(want))
 	}
-	requestByState := make(map[gts.StateID]gts.DiagnosticParserCoreVersionLexerRequest, len(want))
 	for _, request := range receipt.VersionLexerRequests {
 		expect, ok := want[request.State]
 		if !ok {
-			t.Fatalf("unexpected owned request state=%d", request.State)
+			t.Fatalf("unexpected owned request state=%d: requests=%+v", request.State, receipt.VersionLexerRequests)
 		}
-		if request.Token.Symbol != expect.symbol || request.Token.StartByte != 3 || request.Token.EndByte != expect.endByte {
-			t.Fatalf("state %d token=%+v, want symbol=%d span=3..%d", request.State, request.Token, expect.symbol, expect.endByte)
+		if request.ElectionIndex != expect.election || request.Token.Symbol != expect.symbol ||
+			request.Token.StartByte != expect.start || request.Token.EndByte != expect.end ||
+			request.Token.ExternalScannerToken != expect.external || request.InternalDFAToken != expect.dfa {
+			t.Fatalf("state %d request=%+v, want election=%d symbol=%d span=%d..%d external=%t dfa=%t",
+				request.State, request, expect.election, expect.symbol, expect.start, expect.end,
+				expect.external, expect.dfa)
 		}
-		if request.Token.ExternalScannerToken != expect.external || request.InternalDFAToken != expect.internal {
-			t.Fatalf("state %d provenance external=%t/internal=%t, want external=%t/internal=%t", request.State, request.Token.ExternalScannerToken, request.InternalDFAToken, expect.external, expect.internal)
-		}
-		if request.ElectionIndex != receipt.Stop.ElectionIndex {
-			t.Fatalf("state %d request election=%d, want activation election %d", request.State, request.ElectionIndex, receipt.Stop.ElectionIndex)
-		}
-		assertNineByteCheckpoint(fmt.Sprintf("state %d scanner-before", request.State), request.ScannerBefore)
-		assertNineByteCheckpoint(fmt.Sprintf("state %d scanner-after", request.State), request.ScannerAfter)
-		if request.ScannerBefore != election.ScannerBefore {
-			t.Fatalf("state %d scanner-before=%+v, want shared election-before=%+v", request.State, request.ScannerBefore, election.ScannerBefore)
-		}
-		requestByState[request.State] = request
+		assertNineByteCheckpoint(fmt.Sprintf("state %d before", request.State), request.ScannerBefore)
+		assertNineByteCheckpoint(fmt.Sprintf("state %d after", request.State), request.ScannerAfter)
 	}
-	if len(requestByState) != len(want) {
-		t.Fatalf("owned request state identities=%v, want states 47 and 524", requestByState)
+	if len(receipt.NoActionDrops) != 1 {
+		t.Fatalf("owned viability drops=%d, want 1", len(receipt.NoActionDrops))
 	}
-	if len(receipt.Stop.Headers) != 2 {
-		t.Fatalf("stop headers=%d, want 2 activation headers", len(receipt.Stop.Headers))
+	if got := receipt.NoActionDrops[0].Token; got.Symbol != gts.Symbol(65535) || got.StartByte != 5 || got.EndByte != 6 {
+		t.Fatalf("viability drop token=%+v, want error symbol at 5..6", got)
 	}
-	for index, path := range receipt.Stop.Headers {
-		header := path.Header
-		request, ok := requestByState[header.State]
-		if !ok {
-			t.Fatalf("stop header %d state=%d has no matching owned request", index, header.State)
-		}
-		if header.CreationSeq != request.HeaderCreationSeq || header.ByteOffset != 3 {
-			t.Fatalf("stop header %d identity=%+v, want request seq=%d at byte 3", index, header, request.HeaderCreationSeq)
-		}
-		if header.Checkpoint != election.ScannerAfter.SHA256 {
-			t.Fatalf("stop header %d checkpoint=%x, want shared election-after=%x", index, header.Checkpoint, election.ScannerAfter.SHA256)
-		}
-	}
-}
 
-func electionIndexForRequests(requests []gts.DiagnosticParserCoreVersionLexerRequest) int {
-	if len(requests) == 0 {
-		return -1
+	acceptance := receipt.Acceptance
+	wantEOF := uint32(len(versionLexerProductionSource))
+	if acceptance.Token.Symbol != 0 || acceptance.Token.StartByte != wantEOF || acceptance.Token.EndByte != wantEOF {
+		t.Fatalf("accepted token=%+v, want EOF at byte %d", acceptance.Token, wantEOF)
 	}
-	index := requests[0].ElectionIndex
-	for _, request := range requests[1:] {
-		if request.ElectionIndex != index {
-			return -1
-		}
+	if !acceptance.Header.Header.Accepted || acceptance.Header.Header.ByteOffset != wantEOF ||
+		acceptance.Header.Header.Shifted || acceptance.Header.Header.Paused {
+		t.Fatalf("accepted header=%+v, want sole closed EOF header", acceptance.Header.Header)
 	}
-	return index
 }

--- a/parsercore_phase0_per_version_lexer_adversarial_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_adversarial_internal_test.go
@@ -1,0 +1,344 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// phase0PerVersionLexerSwiftWidthSource is the smallest checked-in Swift lexer
+// witness for two parser versions that disagree about token width.
+//
+// At byte 3, parser state 524 consumes _hash_symbol_custom (217) over "<#".
+// Parser state 47 consumes the one-byte '<' operator (35). C keeps both lexer
+// views on their owning versions before it chooses a tree.
+const phase0PerVersionLexerSwiftWidthSource = "a<A<#/x/#"
+
+// phase0PerVersionLexerSwiftOracleSource adds one tuple wrapper. The wrapper
+// removes an unrelated comparison-associativity difference from the generated
+// Go table. It keeps the production width disagreement and owned dispatch.
+const phase0PerVersionLexerSwiftOracleSource = "a<(A<#/x/#)"
+
+// TestPhase0PerVersionLexerVersionsOwnWidths is the stage-1
+// falsifier. The direct probe pins both exact token widths. The scheduler
+// assertion then requires the two parser versions to continue independently
+// instead of declining because one shared cursor cannot represent both ends.
+//
+// The locked C comparison remains in the cgo_harness package. The root
+// internal test package cannot call it.
+// Incremental edits belong to the stage-5 integration gate and stay out of
+// this stage-1 lexer-ownership falsifier.
+func TestPhase0PerVersionLexerVersionsOwnWidths(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	entry := grammars.DetectLanguageByName("swift")
+	if entry == nil {
+		t.Fatal("swift is absent from the language registry")
+	}
+	lang := entry.Language()
+	widthSource := []byte(phase0PerVersionLexerSwiftWidthSource)
+
+	shared := gts.Token{
+		Symbol:                   217,
+		StartByte:                3,
+		EndByte:                  5,
+		StartPoint:               gts.Point{Column: 3},
+		EndPoint:                 gts.Point{Column: 5},
+		ExternalScannerToken:     true,
+		ExternalScannerStartByte: 3,
+	}
+	const narrowState = gts.StateID(47)
+	narrow, ok := gts.RelexTokenForStateForTest(
+		lang,
+		widthSource,
+		1,
+		gts.DiagnosticParserCorePrefixOptions{},
+		narrowState,
+		shared,
+	)
+	if !ok {
+		t.Fatal("narrow parser version did not produce its own DFA token")
+	}
+	if narrow.Symbol != 35 || narrow.StartByte != 3 || narrow.EndByte != 4 {
+		t.Fatalf("narrow parser-version token=%+v, want symbol 35 over bytes 3..4", narrow)
+	}
+	if narrow.StartPoint != (gts.Point{Column: 3}) || narrow.EndPoint != (gts.Point{Column: 4}) || narrow.ExternalScannerToken {
+		t.Fatalf("narrow parser-version token=%+v, want DFA token points 3..4", narrow)
+	}
+	widthReceipt, err := gts.RunStateDependentRelexSchedulerForTest(lang, widthSource)
+	if err != nil {
+		t.Fatalf("width scheduler: %v", err)
+	}
+	var narrowRequest, wideRequest *gts.DiagnosticParserCoreVersionLexerRequest
+	for index := range widthReceipt.VersionLexerRequests {
+		request := &widthReceipt.VersionLexerRequests[index]
+		switch request.State {
+		case 47:
+			narrowRequest = request
+		case 524:
+			wideRequest = request
+		}
+	}
+	if narrowRequest == nil || wideRequest == nil {
+		t.Fatalf("width requests=%+v, want states 47 and 524", widthReceipt.VersionLexerRequests)
+	}
+	if narrowRequest.Token.Symbol != 35 || narrowRequest.Token.StartByte != 3 || narrowRequest.Token.EndByte != 4 || !narrowRequest.InternalDFAToken {
+		t.Fatalf("narrow request=%+v, want DFA symbol 35 over bytes 3..4", *narrowRequest)
+	}
+	if wideRequest.Token.Symbol != 217 || wideRequest.Token.StartByte != 3 || wideRequest.Token.EndByte != 5 || !wideRequest.Token.ExternalScannerToken {
+		t.Fatalf("wide request=%+v, want external symbol 217 over bytes 3..5", *wideRequest)
+	}
+	if wideRequest.Token.EndByte-wideRequest.Token.StartByte != 2 || narrowRequest.Token.EndByte-narrowRequest.Token.StartByte != 1 {
+		t.Fatalf("version token widths=wide:%d narrow:%d, want 2:1", wideRequest.Token.EndByte-wideRequest.Token.StartByte, narrowRequest.Token.EndByte-narrowRequest.Token.StartByte)
+	}
+
+	source := []byte(phase0PerVersionLexerSwiftOracleSource)
+	receipt, err := gts.RunStateDependentRelexSchedulerForTest(lang, source)
+	if err != nil {
+		t.Fatalf("compact scheduler: %v", err)
+	}
+	if receipt.Tokens == 0 || len(receipt.Elections) == 0 {
+		t.Fatalf("scheduler telemetry did not prove an executed path: tokens=%d elections=%d", receipt.Tokens, len(receipt.Elections))
+	}
+	if strings.HasPrefix(receipt.Stop.Detail, gts.DiagnosticParserCoreOwnedDispatchPendingDetailForTest()) {
+		t.Fatalf("owned lexer requests activated but did not dispatch: stop=%+v", receipt.Stop)
+	}
+	assertPhase0PerVersionLexerReceipt(t, receipt, source)
+	peakHeaders := receipt.Stop.Work.PeakHeaders
+	if receipt.Acceptance != nil && receipt.Acceptance.Work.PeakHeaders > peakHeaders {
+		peakHeaders = receipt.Acceptance.Work.PeakHeaders
+	}
+	if peakHeaders < 2 {
+		t.Fatalf("scheduler telemetry did not prove two live parser versions: peak_headers=%d, want at least 2", peakHeaders)
+	}
+	hasMultiVersionElection := false
+	for _, election := range receipt.Elections {
+		if len(election.States) >= 2 {
+			hasMultiVersionElection = true
+			break
+		}
+	}
+	if !hasMultiVersionElection {
+		t.Fatalf("scheduler telemetry did not prove a multi-version election: elections=%+v", receipt.Elections)
+	}
+	wantRaggedDetail := gts.DiagnosticParserCoreRaggedRelexDeclineDetailFormatForTest(
+		gts.Token{Symbol: 35, StartByte: 4, EndByte: 5},
+		gts.Token{Symbol: 217, StartByte: 4, EndByte: 6},
+	)
+	if receipt.Stop.Detail == wantRaggedDetail || strings.HasPrefix(receipt.Stop.Detail, gts.DiagnosticParserCoreRaggedRelexDeclineDetailForTest()) {
+		t.Fatalf("shared-cursor decline prevented C-equivalent parser-version selection: stop boundary=%q detail=%q; C views are symbol 217 bytes 4..6 and symbol 35 bytes 4..5", receipt.Stop.Boundary, receipt.Stop.Detail)
+	}
+	if receipt.Acceptance == nil {
+		t.Fatalf("per-version lexer route did not select an accepted C-equivalent tree: stop=%+v", receipt.Stop)
+	}
+	if receipt.Acceptance.Work.PerVersionLexViabilityDrops != 1 ||
+		receipt.Acceptance.Work.PerVersionLexAcceptedRaggedSpans != 3 {
+		t.Fatalf("owned path telemetry=%d/%d, want 1 viability drop and 3 ragged shifts",
+			receipt.Acceptance.Work.PerVersionLexViabilityDrops,
+			receipt.Acceptance.Work.PerVersionLexAcceptedRaggedSpans)
+	}
+}
+
+// TestPhase0PerVersionLexerScalaOracleWitness pins the smallest clean witness
+// used by the locked C comparison. Both owned requests start at byte 3. One
+// consumes "->" and the other consumes "-". The compact route must accept.
+func TestPhase0PerVersionLexerScalaOracleWitness(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	entry := grammars.DetectLanguageByName("scala")
+	if entry == nil || entry.Language() == nil {
+		t.Fatal("scala grammar is unavailable")
+	}
+	const source = "(y)->"
+	receipt, err := gts.RunStateDependentRelexSchedulerForTest(entry.Language(), []byte(source))
+	if err != nil {
+		t.Fatalf("compact scheduler: %v", err)
+	}
+	if receipt.Acceptance == nil || receipt.Stop.Detail != "" {
+		t.Fatalf("owned lexer route did not accept cleanly: stop=%+v", receipt.Stop)
+	}
+	if receipt.PeakLiveVersions != 2 || receipt.PerVersionLexRequests != 2 || receipt.PerVersionLexViabilityDrops != 1 {
+		t.Fatalf("owned path telemetry peak/requests/drops=%d/%d/%d, want 2/2/1",
+			receipt.PeakLiveVersions, receipt.PerVersionLexRequests, receipt.PerVersionLexViabilityDrops)
+	}
+	want := map[gts.StateID]struct {
+		symbol     gts.Symbol
+		start, end uint32
+	}{
+		8195:  {symbol: 79, start: 3, end: 5},
+		18766: {symbol: 23, start: 3, end: 4},
+	}
+	if len(receipt.VersionLexerRequests) != len(want) {
+		t.Fatalf("owned requests=%+v, want two width competitors", receipt.VersionLexerRequests)
+	}
+	for _, request := range receipt.VersionLexerRequests {
+		expect, ok := want[request.State]
+		if !ok {
+			t.Fatalf("unexpected owned request=%+v; all=%+v", request, receipt.VersionLexerRequests)
+		}
+		if request.ElectionIndex != 3 || request.Token.Symbol != expect.symbol ||
+			request.Token.StartByte != expect.start || request.Token.EndByte != expect.end {
+			t.Fatalf("state %d request=%+v, want election 3 symbol %d span %d..%d",
+				request.State, request, expect.symbol, expect.start, expect.end)
+		}
+	}
+	if got := receipt.Acceptance.Header.Header.ByteOffset; got != uint32(len(source)) {
+		t.Fatalf("accepted byte offset=%d, want %d", got, len(source))
+	}
+}
+
+// assertPhase0PerVersionLexerReceipt checks the exact shared and owned lexer
+// evidence that the generic scheduler publishes for this witness.
+func assertPhase0PerVersionLexerReceipt(t *testing.T, receipt gts.DiagnosticParserCoreGenericScheduler, source []byte) {
+	t.Helper()
+	if receipt.StartCheckpoint != receipt.Elections[0].ScannerBefore {
+		t.Fatalf("start checkpoint=%+v, want first election's scanner-before=%+v", receipt.StartCheckpoint, receipt.Elections[0].ScannerBefore)
+	}
+
+	widthTokens := make([]gts.Token, 0, 7)
+	cursor := uint32(0)
+	var widthElection gts.DiagnosticParserCoreElection
+	foundWidthElection := false
+	for index, election := range receipt.Elections {
+		token := election.Token
+		if token.StartByte > token.EndByte || token.EndByte > uint32(len(source)) {
+			t.Fatalf("election %d token span=%d..%d escapes source length %d", index, token.StartByte, token.EndByte, len(source))
+		}
+		if election.ScannerBefore.Length != 9 || election.ScannerAfter.Length != 9 {
+			t.Fatalf("election %d scanner checkpoint lengths=%d/%d, want Swift's exact nine-byte contract", index, election.ScannerBefore.Length, election.ScannerAfter.Length)
+		}
+		if token.Symbol == 0 {
+			if election.CurrentCheckpointValid {
+				t.Fatalf("EOF election %d retained external-token checkpoint geometry: %+v", index, election)
+			}
+		} else {
+			if !election.CurrentCheckpointValid || election.CurrentCheckpointStart != election.ScannerBefore || election.CurrentCheckpointEnd != election.ScannerAfter {
+				t.Fatalf("election %d lost its scanner checkpoint sidecar: %+v", index, election)
+			}
+			if election.CurrentCheckpointBytes != [2]uint32{token.StartByte, token.EndByte} {
+				t.Fatalf("election %d checkpoint bytes=%v, want token span [%d %d]", index, election.CurrentCheckpointBytes, token.StartByte, token.EndByte)
+			}
+		}
+		if index > 0 && election.ScannerBefore != receipt.Elections[index-1].ScannerAfter {
+			t.Fatalf("election %d scanner-before=%+v does not follow election %d scanner-after=%+v", index, election.ScannerBefore, index-1, receipt.Elections[index-1].ScannerAfter)
+		}
+		if token.EndByte == token.StartByte {
+			if token.Symbol != 0 || token.StartByte != cursor {
+				t.Fatalf("zero-width non-EOF or cursor-discontinuous token at election %d: %+v cursor=%d", index, token, cursor)
+			}
+			continue
+		}
+		if token.StartByte != cursor {
+			t.Fatalf("lexer cursor gap or overlap at election %d: token=%d..%d cursor=%d", index, token.StartByte, token.EndByte, cursor)
+		}
+		cursor = token.EndByte
+		widthTokens = append(widthTokens, token)
+		if token.Symbol == 217 && token.StartByte == 4 && token.EndByte == 6 && token.ExternalScannerToken {
+			widthElection = election
+			foundWidthElection = true
+		}
+	}
+	if cursor != uint32(len(source)) {
+		t.Fatalf("lexer cursor ended at %d, want source length %d", cursor, len(source))
+	}
+	wantTokens := []struct {
+		symbol     gts.Symbol
+		start, end uint32
+		external   bool
+	}{
+		{symbol: 160, start: 0, end: 1},
+		{symbol: 35, start: 1, end: 2},
+		{symbol: 19, start: 2, end: 3},
+		{symbol: 160, start: 3, end: 4},
+		{symbol: 217, start: 4, end: 6, external: true},
+		{symbol: 164, start: 6, end: 10},
+		{symbol: 15, start: 10, end: 11},
+	}
+	if len(widthTokens) != len(wantTokens) {
+		t.Fatalf("scheduler emitted %d non-zero-width tokens=%+v, want the exact seven-token witness", len(widthTokens), widthTokens)
+	}
+	for index, want := range wantTokens {
+		got := widthTokens[index]
+		if got.Symbol != want.symbol || got.StartByte != want.start || got.EndByte != want.end || got.ExternalScannerToken != want.external {
+			t.Fatalf("scheduler token %d=%+v, want symbol=%d span=%d..%d external=%t", index, got, want.symbol, want.start, want.end, want.external)
+		}
+	}
+	if !foundWidthElection {
+		t.Fatal("scheduler telemetry did not retain the two-byte external token election")
+	}
+
+	// Keep two distinct headers alive at the shared-token boundary. A receipt
+	// that merges them before this point cannot represent the narrower re-lex.
+	hasTwoVersionsAtWidthStart := false
+	for _, round := range receipt.Rounds {
+		if len(round.Before) < 2 {
+			continue
+		}
+		distinctStates := false
+		firstState := round.Before[0].State
+		allAtWidthStart := true
+		for _, header := range round.Before {
+			if header.ByteOffset != 4 || header.Checkpoint != widthElection.ScannerBefore.SHA256 {
+				allAtWidthStart = false
+				break
+			}
+			if header.State != firstState {
+				distinctStates = true
+			}
+		}
+		if allAtWidthStart && distinctStates {
+			hasTwoVersionsAtWidthStart = true
+			break
+		}
+	}
+	if !hasTwoVersionsAtWidthStart {
+		t.Fatalf("scheduler telemetry did not retain two distinct parser versions at byte 4 before the wide token: rounds=%+v", receipt.Rounds)
+	}
+
+	if receipt.Acceptance == nil {
+		return
+	}
+	acceptance := receipt.Acceptance
+	if acceptance.Token.Symbol != 0 || acceptance.Token.StartByte != uint32(len(source)) || acceptance.Token.EndByte != uint32(len(source)) {
+		t.Fatalf("accepted token=%+v, want zero-width EOF at byte %d", acceptance.Token, len(source))
+	}
+	if acceptance.Header.Header.ByteOffset != uint32(len(source)) || !acceptance.Header.Header.Accepted || acceptance.Header.Header.Shifted || acceptance.Header.Header.Paused {
+		t.Fatalf("accepted header=%+v, want one unshifted accepted EOF header at byte %d", acceptance.Header.Header, len(source))
+	}
+	foundEOF := false
+	for _, election := range receipt.Elections {
+		if election.Token.Symbol == 0 && election.Token.StartByte == uint32(len(source)) && election.Token.EndByte == uint32(len(source)) {
+			if acceptance.Header.Header.Checkpoint != election.ScannerAfter.SHA256 {
+				t.Fatalf("accepted header checkpoint=%x, want EOF scanner-after=%x", acceptance.Header.Header.Checkpoint, election.ScannerAfter.SHA256)
+			}
+			foundEOF = true
+		}
+	}
+	if !foundEOF {
+		t.Fatal("scheduler reported acceptance without an authenticated EOF election")
+	}
+
+	foundExternalShift := false
+	for _, shift := range receipt.ExternalShifts {
+		if shift.Token.StartByte == 4 && shift.Token.EndByte == 6 {
+			t.Fatalf("wide shared token shifted, want its owned version dropped: %+v", shift)
+		}
+		if shift.Token.StartByte != 5 || shift.Token.EndByte != 6 {
+			continue
+		}
+		if shift.Token.Symbol != 217 || !shift.Token.ExternalScannerToken ||
+			shift.ScannerBefore.Length != 9 || shift.ScannerAfter.Length != 9 {
+			t.Fatalf("selected external shift lost its owning scanner contract: %+v", shift)
+		}
+		for _, payload := range shift.Payloads {
+			if payload.Symbol == 217 && payload.StartByte == 5 && payload.EndByte == 6 && payload.External && payload.Terminal {
+				foundExternalShift = true
+			}
+		}
+	}
+	if !foundExternalShift {
+		t.Fatal("accepted scheduler receipt has no scanner-owned terminal for the selected '#' token")
+	}
+}

--- a/parsercore_phase0_per_version_lexer_lifecycle_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_lifecycle_internal_test.go
@@ -1,0 +1,569 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+type diagnosticParserCoreOwnedLexerPanicRestoreScanner struct{}
+
+func (diagnosticParserCoreOwnedLexerPanicRestoreScanner) Create() any { return new(byte) }
+func (diagnosticParserCoreOwnedLexerPanicRestoreScanner) Destroy(any) {}
+func (diagnosticParserCoreOwnedLexerPanicRestoreScanner) Serialize(any, []byte) int {
+	return 1
+}
+func (diagnosticParserCoreOwnedLexerPanicRestoreScanner) Deserialize(any, []byte) {
+	panic("owned scanner restore panic")
+}
+func (diagnosticParserCoreOwnedLexerPanicRestoreScanner) Scan(any, *ExternalLexer, []bool) bool {
+	return false
+}
+
+func newDiagnosticParserCoreOwnedLexerSnapshot(
+	t *testing.T,
+	compact *core.Core,
+	language *Language,
+	lexerPosition int,
+) *diagnosticParserCoreVersionLexerSnapshot {
+	t.Helper()
+	var snapshot *diagnosticParserCoreVersionLexerSnapshot
+	err := compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		var snapshotErr error
+		snapshot, snapshotErr = newDiagnosticParserCoreVersionLexerSnapshot(
+			compact,
+			language,
+			owner,
+			dfaRelexSnapshot{lexerPos: lexerPosition},
+			0,
+			0,
+		)
+		return snapshotErr
+	})
+	if err != nil {
+		t.Fatalf("construct owned lexer snapshot: %v", err)
+	}
+	return snapshot
+}
+
+func newDiagnosticParserCoreOwnedLexerRequest(
+	electionIndex int,
+	state StateID,
+	token Token,
+	before *diagnosticParserCoreVersionLexerSnapshot,
+	after *diagnosticParserCoreVersionLexerSnapshot,
+) diagnosticParserCoreVersionLexerRequest {
+	return diagnosticParserCoreVersionLexerRequest{
+		electionIndex: electionIndex,
+		state:         state,
+		token:         token,
+		before:        before,
+		after:         after,
+		valid:         true,
+	}
+}
+
+func TestDiagnosticParserCoreOwnedLexerBindingRestoresAfterErrorAndPanic(t *testing.T) {
+	table := &genericConflictTable{cells: map[genericConflictCell][]core.Action{
+		{state: 1, symbol: 9}: {{Type: core.ActionShift, State: 2}},
+	}}
+	compact, err := core.New(table, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	language := &Language{Name: "owned-lexer-binding-test"}
+	before := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 0)
+	after := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 1)
+	token := Token{Symbol: 9, StartByte: 0, EndByte: 1}
+	request := newDiagnosticParserCoreOwnedLexerRequest(4, 1, token, before, after)
+	header := diagnosticParserCoreHeader{
+		head: head,
+		versionState: &diagnosticParserCoreVersionState{
+			relexSnapshot: before,
+			lexerRequest:  1,
+		},
+	}
+	boundary, err := compact.ClassifyBoundary(head, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	priorToken := Token{Symbol: 7, StartByte: 3, EndByte: 4}
+	priorElection := DiagnosticParserCoreElection{Token: priorToken}
+	priorCell := diagnosticParserCoreTokenCell{token: priorToken, state: 7, valid: true}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		tokenSource: &dfaTokenSource{
+			lexer:    &Lexer{source: []byte("x")},
+			language: language,
+		},
+		headers:              []diagnosticParserCoreHeader{header},
+		token:                priorToken,
+		currentElection:      priorElection,
+		tokenCell:            priorCell,
+		electionIndex:        4,
+		versionLexerRequests: []diagnosticParserCoreVersionLexerRequest{request},
+	}
+	cell := diagnosticParserCoreGenericCell{headerIndex: 0, boundary: boundary, versionLexerRequest: 1}
+	callbackErr := errors.New("owned callback failed")
+	if err := scheduler.withVersionLexerRequest(cell, func() error {
+		if scheduler.token != token || scheduler.currentElection.Token != token {
+			t.Fatalf("owned request was not bound: token=%+v election=%+v", scheduler.token, scheduler.currentElection)
+		}
+		return callbackErr
+	}); !errors.Is(err, callbackErr) {
+		t.Fatalf("callback error=%v, want %v", err, callbackErr)
+	}
+	assertRestored := func() {
+		t.Helper()
+		if scheduler.token != priorToken || !reflect.DeepEqual(scheduler.currentElection, priorElection) || scheduler.tokenCell != priorCell {
+			t.Fatalf("request binding leaked scheduler state: token=%+v election=%+v cell=%+v", scheduler.token, scheduler.currentElection, scheduler.tokenCell)
+		}
+		_, start, end, exact := compact.PhaseScannerCheckpoints()
+		if start != 0 || end != 0 || exact {
+			t.Fatalf("request binding leaked scanner phase: start=%d end=%d exact=%t", start, end, exact)
+		}
+	}
+	assertRestored()
+
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != "owned callback panic" {
+				t.Fatalf("panic=%v, want original callback panic", recovered)
+			}
+		}()
+		_ = scheduler.withVersionLexerRequest(cell, func() error {
+			panic("owned callback panic")
+		})
+	}()
+	assertRestored()
+}
+
+func TestDiagnosticParserCoreOwnedLexerRejoinRestoresTokenSourceOnPhaseFailure(t *testing.T) {
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	language := &Language{Name: "owned-lexer-rejoin-test"}
+	snapshot := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 1)
+	tokenSource := &dfaTokenSource{
+		lexer:     &Lexer{source: []byte("12345678"), pos: 7, row: 2, col: 3},
+		language:  language,
+		state:     9,
+		glrStates: []StateID{9, 10},
+	}
+	priorDFA := tokenSource.snapshotRelexState()
+	priorGLRStates := append([]StateID(nil), tokenSource.glrStates...)
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact:     compact,
+		tokenSource: tokenSource,
+		headers: []diagnosticParserCoreHeader{{
+			head:    head,
+			shifted: true,
+			versionState: &diagnosticParserCoreVersionState{
+				relexSnapshot: snapshot,
+			},
+		}},
+		versionLexerOwnershipActive: true,
+	}
+	err = compact.ApplySchedulerAtomic(func(core.SchedulerTransactionToken) error {
+		return scheduler.rejoinSharedLexerFromOwnedHeader()
+	})
+	if err == nil || !strings.Contains(err.Error(), "set checkpoint during active transaction") {
+		t.Fatalf("rejoin phase error=%v", err)
+	}
+	if got := tokenSource.snapshotRelexState(); !got.equal(priorDFA) || tokenSource.state != 9 ||
+		!reflect.DeepEqual(tokenSource.glrStates, priorGLRStates) {
+		t.Fatalf("rejoin failure leaked token source: dfa=%+v state=%d glr=%v", got, tokenSource.state, tokenSource.glrStates)
+	}
+	if len(scheduler.headers) != 1 || scheduler.headers[0].versionLexerSnapshot() != snapshot ||
+		!scheduler.versionLexerOwnershipActive {
+		t.Fatalf("rejoin failure mutated owned frontier: headers=%+v active=%t", scheduler.headers, scheduler.versionLexerOwnershipActive)
+	}
+}
+
+func TestDiagnosticParserCoreOwnedLexerActivationRollsBackAfterPanic(t *testing.T) {
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkpoint, err := compact.InternCheckpoint([]byte{1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.SetPhaseCheckpoint(checkpoint); err != nil {
+		t.Fatal(err)
+	}
+	firstHead, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondHead, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanner := diagnosticParserCoreOwnedLexerPanicRestoreScanner{}
+	language := &Language{Name: "owned-lexer-activation-panic-test", ExternalScanner: scanner}
+	tokenSource := &dfaTokenSource{
+		lexer:              &Lexer{},
+		language:           language,
+		hasExternalScanner: true,
+		externalPayload:    scanner.Create(),
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact:     compact,
+		tokenSource: tokenSource,
+		headers: []diagnosticParserCoreHeader{
+			{head: firstHead},
+			{head: secondHead},
+		},
+		checkpointBeforeID:           checkpoint,
+		electionIndex:                5,
+		versionLexerBefore:           dfaRelexSnapshot{externalScannerPresent: true, externalPayload: []byte{1}},
+		versionLexerBeforeValid:      true,
+		versionLexerBeforeElection:   5,
+		versionLexerBeforeCheckpoint: checkpoint,
+		receipt:                      &DiagnosticParserCoreGenericScheduler{},
+	}
+	beforeHeaders := append([]diagnosticParserCoreHeader(nil), scheduler.headers...)
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != "owned scanner restore panic" {
+				t.Fatalf("activation panic=%v", recovered)
+			}
+		}()
+		_, _ = scheduler.activateVersionLexerOwnershipAtRagged(0)
+	}()
+	if !reflect.DeepEqual(scheduler.headers, beforeHeaders) || len(scheduler.versionLexerRequests) != 0 ||
+		len(scheduler.receipt.VersionLexerRequests) != 0 || scheduler.versionLexerOwnershipActive ||
+		scheduler.headerRollbackScratch.busy || scheduler.work != (DiagnosticParserCoreGenericWork{}) {
+		t.Fatalf("activation panic rollback drifted: headers=%+v requests=%d receiptRequests=%d active=%t scratchBusy=%t work=%+v",
+			scheduler.headers,
+			len(scheduler.versionLexerRequests),
+			len(scheduler.receipt.VersionLexerRequests),
+			scheduler.versionLexerOwnershipActive,
+			scheduler.headerRollbackScratch.busy,
+			scheduler.work,
+		)
+	}
+}
+
+func TestDiagnosticParserCoreOwnedLexerDropsAuthenticatedPausedVersion(t *testing.T) {
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pausedHead, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	shiftedHead, err := compact.Seed(2, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	language := &Language{Name: "owned-lexer-paused-drop-test"}
+	pausedSnapshot := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 0)
+	shiftedSnapshot := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 1)
+	token := Token{Symbol: 9, StartByte: 0, EndByte: 1}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		tokenSource: &dfaTokenSource{
+			lexer:    &Lexer{source: []byte("x")},
+			language: language,
+		},
+		headers: []diagnosticParserCoreHeader{
+			{
+				head:   pausedHead,
+				paused: true,
+				versionState: &diagnosticParserCoreVersionState{
+					relexSnapshot: pausedSnapshot,
+					lexerRequest:  1,
+				},
+			},
+			{
+				head:    shiftedHead,
+				shifted: true,
+				versionState: &diagnosticParserCoreVersionState{
+					relexSnapshot: shiftedSnapshot,
+				},
+			},
+		},
+		token:                       token,
+		electionIndex:               6,
+		epochProgress:               true,
+		versionLexerOwnershipActive: true,
+		versionLexerRequests: []diagnosticParserCoreVersionLexerRequest{
+			newDiagnosticParserCoreOwnedLexerRequest(6, 1, token, pausedSnapshot, pausedSnapshot),
+			newDiagnosticParserCoreOwnedLexerRequest(6, 2, token, pausedSnapshot, shiftedSnapshot),
+		},
+		options: DiagnosticParserCorePrefixOptions{
+			ReceiptMode:   DiagnosticParserCoreReceiptSummary,
+			MaxDispatches: 10,
+		},
+		receipt: &DiagnosticParserCoreGenericScheduler{},
+	}
+	stop, err := scheduler.dispatchPass()
+	if err != nil || stop != nil {
+		t.Fatalf("paused owned drop stop=%+v err=%v", stop, err)
+	}
+	if len(scheduler.headers) != 1 || scheduler.headers[0].head != shiftedHead || !scheduler.headers[0].shifted {
+		t.Fatalf("paused owned drop frontier=%+v, want shifted survivor", scheduler.headers)
+	}
+	if scheduler.work.NoActionDrops != 1 || scheduler.work.PerVersionLexViabilityDrops != 1 {
+		t.Fatalf("paused owned drop work=%+v", scheduler.work)
+	}
+}
+
+func TestDiagnosticParserCoreOwnedLexerNoLookaheadRequiresOneRunnableHead(t *testing.T) {
+	table := &genericConflictTable{cells: map[genericConflictCell][]core.Action{
+		{state: 1, symbol: 0}: {{Type: core.ActionReduce, Symbol: 3}},
+		{state: 2, symbol: 0}: {{Type: core.ActionReduce, Symbol: 3}},
+	}}
+	compact, err := core.New(table, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstHead, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondHead, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	language := &Language{Name: "owned-lexer-no-lookahead-test"}
+	firstSnapshot := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 0)
+	secondSnapshot := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 0)
+	token := Token{NoLookahead: true}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		tokenSource: &dfaTokenSource{
+			lexer:    &Lexer{},
+			language: language,
+		},
+		headers: []diagnosticParserCoreHeader{
+			{head: firstHead, versionState: &diagnosticParserCoreVersionState{relexSnapshot: firstSnapshot, lexerRequest: 1}},
+			{head: secondHead, versionState: &diagnosticParserCoreVersionState{relexSnapshot: secondSnapshot, lexerRequest: 2}},
+		},
+		token:                       token,
+		electionIndex:               2,
+		versionLexerOwnershipActive: true,
+		versionLexerRequests: []diagnosticParserCoreVersionLexerRequest{
+			newDiagnosticParserCoreOwnedLexerRequest(2, 1, token, firstSnapshot, firstSnapshot),
+			newDiagnosticParserCoreOwnedLexerRequest(2, 2, token, secondSnapshot, secondSnapshot),
+		},
+		options: DiagnosticParserCorePrefixOptions{
+			ReceiptMode:              DiagnosticParserCoreReceiptSummary,
+			MaxDispatches:            10,
+			hasNoLookaheadRootSymbol: true,
+			noLookaheadRootSymbol:    3,
+		},
+		receipt: &DiagnosticParserCoreGenericScheduler{},
+	}
+	stop, err := scheduler.dispatchPass()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stop == nil || stop.boundary != DiagnosticParserCoreRoute ||
+		!strings.Contains(stop.detail, "requires one runnable head") {
+		t.Fatalf("owned no-lookahead stop=%+v", stop)
+	}
+	if scheduler.dispatches != 0 || scheduler.work.Reductions != 0 {
+		t.Fatalf("owned no-lookahead mutated scheduler: dispatches=%d work=%+v", scheduler.dispatches, scheduler.work)
+	}
+}
+
+func TestDiagnosticParserCoreOwnedLexerElectionEnforcesPostReductionEOF(t *testing.T) {
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstHead, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondHead, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	language := &Language{
+		Name: "owned-lexer-post-reduction-eof-test",
+		LexModes: []LexMode{
+			{LexState: 0},
+			{LexState: 0},
+			{LexState: 0},
+		},
+		LexStates: []LexState{
+			{
+				Default: -1,
+				EOF:     -1,
+				Transitions: []LexTransition{
+					{Lo: 'x', Hi: 'x', NextState: 1},
+				},
+			},
+			{AcceptToken: 9, Default: -1, EOF: -1},
+		},
+	}
+	firstSnapshot := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 0)
+	secondSnapshot := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 0)
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		tokenSource: &dfaTokenSource{
+			lexer:    NewLexer(language.LexStates, []byte("x")),
+			language: language,
+		},
+		headers: []diagnosticParserCoreHeader{
+			{head: firstHead, shifted: true, versionState: &diagnosticParserCoreVersionState{relexSnapshot: firstSnapshot}},
+			{head: secondHead, shifted: true, versionState: &diagnosticParserCoreVersionState{relexSnapshot: secondSnapshot}},
+		},
+		electionIndex:                 7,
+		versionLexerOwnershipActive:   true,
+		requireEOFPostNoLookaheadRoot: true,
+		receipt:                       &DiagnosticParserCoreGenericScheduler{},
+	}
+	beforeHeaders := append([]diagnosticParserCoreHeader(nil), scheduler.headers...)
+	err = scheduler.beginNextVersionLexerElection()
+	var decline *diagnosticParserCoreDecline
+	if !errors.As(err, &decline) || decline.boundary != DiagnosticParserCoreRoute ||
+		!strings.Contains(decline.detail, "not followed by authenticated EOF") {
+		t.Fatalf("post-reduction EOF error=%v", err)
+	}
+	if scheduler.electionIndex != 7 || !scheduler.requireEOFPostNoLookaheadRoot ||
+		len(scheduler.versionLexerRequests) != 0 || !reflect.DeepEqual(scheduler.headers, beforeHeaders) {
+		t.Fatalf("post-reduction EOF rollback drifted: election=%d requireEOF=%t requests=%d headers=%+v",
+			scheduler.electionIndex,
+			scheduler.requireEOFPostNoLookaheadRoot,
+			len(scheduler.versionLexerRequests),
+			scheduler.headers,
+		)
+	}
+}
+
+func TestDiagnosticParserCoreOwnedLexerElectionEnforcesNoLookaheadCap(t *testing.T) {
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstHead, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondHead, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	language := &Language{
+		Name: "owned-lexer-no-lookahead-cap-test",
+		LexModes: []LexMode{
+			{LexStateID: noLookaheadLexState},
+			{LexStateID: noLookaheadLexState},
+			{LexStateID: noLookaheadLexState},
+		},
+	}
+	firstSnapshot := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 0)
+	secondSnapshot := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 0)
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		tokenSource: &dfaTokenSource{
+			lexer:    NewLexer(nil, nil),
+			language: language,
+		},
+		headers: []diagnosticParserCoreHeader{
+			{head: firstHead, shifted: true, versionState: &diagnosticParserCoreVersionState{relexSnapshot: firstSnapshot}},
+			{head: secondHead, shifted: true, versionState: &diagnosticParserCoreVersionState{relexSnapshot: secondSnapshot}},
+		},
+		electionIndex:               11,
+		noLookaheadSteps:            maxDiagnosticParserCoreNoLookaheadSteps,
+		versionLexerOwnershipActive: true,
+		receipt:                     &DiagnosticParserCoreGenericScheduler{},
+	}
+	beforeHeaders := append([]diagnosticParserCoreHeader(nil), scheduler.headers...)
+	err = scheduler.beginNextVersionLexerElection()
+	var decline *diagnosticParserCoreDecline
+	if !errors.As(err, &decline) || decline.boundary != DiagnosticParserCoreCap ||
+		!strings.Contains(decline.detail, "no-lookahead re-election cap") {
+		t.Fatalf("no-lookahead cap error=%v", err)
+	}
+	if scheduler.electionIndex != 11 || scheduler.noLookaheadSteps != maxDiagnosticParserCoreNoLookaheadSteps ||
+		len(scheduler.versionLexerRequests) != 0 || !reflect.DeepEqual(scheduler.headers, beforeHeaders) {
+		t.Fatalf("no-lookahead cap rollback drifted: election=%d steps=%d requests=%d headers=%+v",
+			scheduler.electionIndex,
+			scheduler.noLookaheadSteps,
+			len(scheduler.versionLexerRequests),
+			scheduler.headers,
+		)
+	}
+}
+
+func TestDiagnosticParserCoreOwnedLexerZeroWidthExtraRequiresProgress(t *testing.T) {
+	table := &genericConflictTable{cells: map[genericConflictCell][]core.Action{
+		{state: 5, symbol: 9}: {{Type: core.ActionShift, Extra: true}},
+	}}
+	compact, err := core.New(table, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(5, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeStats, err := compact.Stats(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	language := &Language{Name: "owned-lexer-zero-width-extra-test"}
+	snapshot := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 10)
+	token := Token{Symbol: 9, StartByte: 10, EndByte: 10, ExternalScannerToken: true}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		tokenSource: &dfaTokenSource{
+			lexer:    &Lexer{},
+			language: language,
+		},
+		headers: []diagnosticParserCoreHeader{{
+			head: head,
+			versionState: &diagnosticParserCoreVersionState{
+				relexSnapshot: snapshot,
+				lexerRequest:  1,
+			},
+		}},
+		token:                       token,
+		electionIndex:               3,
+		versionLexerOwnershipActive: true,
+		versionLexerRequests: []diagnosticParserCoreVersionLexerRequest{
+			newDiagnosticParserCoreOwnedLexerRequest(3, 5, token, snapshot, snapshot),
+		},
+		options: DiagnosticParserCorePrefixOptions{
+			ReceiptMode:   DiagnosticParserCoreReceiptSummary,
+			MaxDispatches: 10,
+		},
+		receipt: &DiagnosticParserCoreGenericScheduler{},
+	}
+	stop, err := scheduler.dispatchPass()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stop == nil || stop.boundary != DiagnosticParserCoreRoute ||
+		stop.detail != "generic scheduler zero-width extra shift has no scanner or parser-state progress" {
+		t.Fatalf("owned zero-width extra stop=%+v", stop)
+	}
+	afterStats, err := compact.Stats(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(afterStats, beforeStats) || scheduler.dispatches != 0 {
+		t.Fatalf("owned zero-width extra mutated state: before=%+v after=%+v dispatches=%d", beforeStats, afterStats, scheduler.dispatches)
+	}
+}

--- a/parsercore_phase0_per_version_lexer_lifecycle_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_lifecycle_internal_test.go
@@ -194,6 +194,22 @@ func TestDiagnosticParserCoreOwnedLexerRejoinRestoresTokenSourceOnPhaseFailure(t
 	}
 }
 
+func TestDiagnosticParserCoreOwnedLexerRejoinRejectsMissingTokenSource(t *testing.T) {
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		headers:                     []diagnosticParserCoreHeader{{shifted: true}},
+		versionLexerOwnershipActive: true,
+	}
+	if err := scheduler.rejoinSharedLexerFromOwnedHeader(); err == nil ||
+		!strings.Contains(err.Error(), "token source is unavailable") {
+		t.Fatalf("missing token source error=%v", err)
+	}
+	scheduler.tokenSource = &dfaTokenSource{}
+	if err := scheduler.rejoinSharedLexerFromOwnedHeader(); err == nil ||
+		!strings.Contains(err.Error(), "token source is unavailable") {
+		t.Fatalf("missing lexer error=%v", err)
+	}
+}
+
 func TestDiagnosticParserCoreOwnedLexerActivationRollsBackAfterPanic(t *testing.T) {
 	compact, err := core.New(&genericConflictTable{}, core.Limits{})
 	if err != nil {

--- a/parsercore_phase0_per_version_lexer_scheduler_helper_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_scheduler_helper_internal_test.go
@@ -11,6 +11,31 @@ import (
 	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
 )
 
+type diagnosticParserCoreZeroSnapshotScanner struct{ stateless bool }
+
+func (diagnosticParserCoreZeroSnapshotScanner) Create() any                           { return nil }
+func (diagnosticParserCoreZeroSnapshotScanner) Destroy(any)                           {}
+func (diagnosticParserCoreZeroSnapshotScanner) Serialize(any, []byte) int             { return 0 }
+func (diagnosticParserCoreZeroSnapshotScanner) Deserialize(any, []byte)               {}
+func (diagnosticParserCoreZeroSnapshotScanner) Scan(any, *ExternalLexer, []bool) bool { return false }
+func (s diagnosticParserCoreZeroSnapshotScanner) ExternalScannerIsStateless() bool {
+	return s.stateless
+}
+
+type diagnosticParserCoreCountingSnapshotScanner struct{ serializeCalls *int }
+
+func (diagnosticParserCoreCountingSnapshotScanner) Create() any { return nil }
+func (diagnosticParserCoreCountingSnapshotScanner) Destroy(any) {}
+func (s diagnosticParserCoreCountingSnapshotScanner) Serialize(_ any, buffer []byte) int {
+	(*s.serializeCalls)++
+	buffer[0] = 0x7b
+	return 1
+}
+func (diagnosticParserCoreCountingSnapshotScanner) Deserialize(any, []byte) {}
+func (diagnosticParserCoreCountingSnapshotScanner) Scan(any, *ExternalLexer, []bool) bool {
+	return false
+}
+
 // DiagnosticParserCoreVersionLexerRequestWitnessForTest advances a scheduler
 // to the Swift ragged-token frontier and exercises its private cursor requests.
 // The helper stays in an internal test file so production callers cannot arm it.
@@ -184,6 +209,173 @@ func DiagnosticParserCoreVersionLexerRequestWitnessForTest(
 	return scheduler.receipt.VersionLexerRequests, nil
 }
 
+func TestDiagnosticParserCoreVersionLexerElectionCaptureReusesScratch(t *testing.T) {
+	scanner := byteStateExternalScanner{}
+	payload := scanner.Create()
+	*payload.(*byte) = 0x5a
+	tokenSource := &dfaTokenSource{
+		lexer: &Lexer{
+			source:                 []byte("abc"),
+			pos:                    2,
+			row:                    3,
+			col:                    4,
+			includedRangeIdx:       1,
+			failTokenStartPos:      1,
+			failTokenStartRow:      2,
+			failTokenStartCol:      3,
+			failTokenStartRangeIdx: 1,
+		},
+		language:                    &Language{Name: "version-lexer-scratch-test", ExternalScanner: scanner},
+		hasExternalScanner:          true,
+		externalPayload:             payload,
+		lastExternalTokenStartByte:  5,
+		lastExternalTokenEndByte:    8,
+		lastExternalTokenValid:      true,
+		lastExternalTokenWasExtra:   true,
+		externalTokenEndSameAsStart: true,
+		lastTokenStartByte:          4,
+		lastTokenEndByte:            8,
+		lastTokenValid:              true,
+		externalTokenStart:          []byte{0x11, 0x12},
+		externalTokenEnd:            []byte{0x21, 0x22},
+		extZeroPos:                  7,
+		extZeroState:                23,
+		extZeroTried:                []bool{true, false, true},
+		zeroWidthPos:                8,
+		zeroWidthCount:              2,
+	}
+	scheduler := diagnosticParserCoreGenericScheduler{
+		tokenSource:   tokenSource,
+		electionIndex: 4,
+		checkpointID:  7,
+	}
+	if err := scheduler.captureSharedElectionSnapshot(); err != nil {
+		t.Fatal(err)
+	}
+	payloadPointer := unsafe.Pointer(&scheduler.versionLexerBeforeScratch.externalPayload[:cap(scheduler.versionLexerBeforeScratch.externalPayload)][0])
+	startPointer := unsafe.Pointer(&scheduler.versionLexerBeforeScratch.externalTokenStart[:cap(scheduler.versionLexerBeforeScratch.externalTokenStart)][0])
+	endPointer := unsafe.Pointer(&scheduler.versionLexerBeforeScratch.externalTokenEnd[:cap(scheduler.versionLexerBeforeScratch.externalTokenEnd)][0])
+	triedPointer := unsafe.Pointer(&scheduler.versionLexerBeforeScratch.extZeroTried[:cap(scheduler.versionLexerBeforeScratch.extZeroTried)][0])
+	var captureErr error
+	if allocs := testing.AllocsPerRun(100, func() {
+		captureErr = scheduler.captureSharedElectionSnapshot()
+	}); allocs != 0 {
+		t.Fatalf("warm election snapshot allocations=%v, want 0", allocs)
+	}
+	if captureErr != nil {
+		t.Fatal(captureErr)
+	}
+	if payloadPointer != unsafe.Pointer(&scheduler.versionLexerBeforeScratch.externalPayload[:cap(scheduler.versionLexerBeforeScratch.externalPayload)][0]) ||
+		startPointer != unsafe.Pointer(&scheduler.versionLexerBeforeScratch.externalTokenStart[:cap(scheduler.versionLexerBeforeScratch.externalTokenStart)][0]) ||
+		endPointer != unsafe.Pointer(&scheduler.versionLexerBeforeScratch.externalTokenEnd[:cap(scheduler.versionLexerBeforeScratch.externalTokenEnd)][0]) ||
+		triedPointer != unsafe.Pointer(&scheduler.versionLexerBeforeScratch.extZeroTried[:cap(scheduler.versionLexerBeforeScratch.extZeroTried)][0]) {
+		t.Fatal("warm election capture replaced reusable backing storage")
+	}
+	got := scheduler.versionLexerBefore
+	if got.lexerPos != 2 || got.lexerRow != 3 || got.lexerCol != 4 || got.lexerRangeIdx != 1 ||
+		got.failTokenStartPos != 1 || got.failTokenStartRow != 2 || got.failTokenStartCol != 3 || got.failTokenStartRangeIdx != 1 ||
+		!reflect.DeepEqual(got.externalPayload, []byte{0x5a}) || !reflect.DeepEqual(got.externalTokenStart, []byte{0x11, 0x12}) ||
+		!reflect.DeepEqual(got.externalTokenEnd, []byte{0x21, 0x22}) || !reflect.DeepEqual(got.extZeroTried, []bool{true, false, true}) {
+		t.Fatalf("reused election snapshot lost state: %+v", got)
+	}
+	tokenSource.externalTokenStart[0] = 0xff
+	tokenSource.externalTokenEnd[0] = 0xee
+	tokenSource.extZeroTried[0] = false
+	*payload.(*byte) = 0xdd
+	tokenSource.lexer.pos = 99
+	tokenSource.lexer.row = 98
+	tokenSource.lexer.col = 97
+	tokenSource.lexer.includedRangeIdx = 96
+	tokenSource.lexer.failTokenStartPos = 95
+	tokenSource.lexer.failTokenStartRow = 94
+	tokenSource.lexer.failTokenStartCol = 93
+	tokenSource.lexer.failTokenStartRangeIdx = 92
+	tokenSource.lastExternalTokenStartByte = 91
+	tokenSource.lastExternalTokenEndByte = 90
+	tokenSource.lastExternalTokenValid = false
+	tokenSource.lastExternalTokenWasExtra = false
+	tokenSource.externalTokenEndSameAsStart = false
+	tokenSource.lastTokenStartByte = 89
+	tokenSource.lastTokenEndByte = 88
+	tokenSource.lastTokenValid = false
+	tokenSource.extZeroPos = 87
+	tokenSource.extZeroState = 86
+	tokenSource.zeroWidthPos = 85
+	tokenSource.zeroWidthCount = 84
+	if !reflect.DeepEqual(got.externalPayload, []byte{0x5a}) || !reflect.DeepEqual(got.externalTokenStart, []byte{0x11, 0x12}) ||
+		!reflect.DeepEqual(got.externalTokenEnd, []byte{0x21, 0x22}) || !reflect.DeepEqual(got.extZeroTried, []bool{true, false, true}) {
+		t.Fatalf("live token source mutated the captured election state: %+v", got)
+	}
+	got.restore(tokenSource)
+	if restored := tokenSource.snapshotRelexState(); !reflect.DeepEqual(restored, got) {
+		t.Fatalf("reused election snapshot restore=%+v, want %+v", restored, got)
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerElectionReusesCheckpointSerialization(t *testing.T) {
+	serializeCalls := 0
+	scanner := diagnosticParserCoreCountingSnapshotScanner{serializeCalls: &serializeCalls}
+	tokenSource := &dfaTokenSource{
+		lexer:              &Lexer{source: []byte("abc"), pos: 2},
+		language:           &Language{Name: "version-lexer-serialization-test", ExternalScanner: scanner},
+		hasExternalScanner: true,
+	}
+	scheduler := diagnosticParserCoreGenericScheduler{
+		tokenSource:   tokenSource,
+		electionIndex: 4,
+		checkpointID:  7,
+	}
+	var checkpointScratch []byte
+	payload := tokenSource.captureExternalScannerStateInto(&checkpointScratch)
+	if serializeCalls != 1 {
+		t.Fatalf("checkpoint Serialize calls=%d, want 1", serializeCalls)
+	}
+	if err := scheduler.captureSharedElectionSnapshotFromExternalPayload(payload); err != nil {
+		t.Fatal(err)
+	}
+	if serializeCalls != 1 {
+		t.Fatalf("election snapshot Serialize calls=%d, want no second call", serializeCalls)
+	}
+	if !reflect.DeepEqual(scheduler.versionLexerBefore.externalPayload, []byte{0x7b}) {
+		t.Fatalf("election payload=%v, want [123]", scheduler.versionLexerBefore.externalPayload)
+	}
+	checkpointScratch[0] = 0xff
+	if !reflect.DeepEqual(scheduler.versionLexerBefore.externalPayload, []byte{0x7b}) {
+		t.Fatalf("checkpoint scratch mutated election payload=%v", scheduler.versionLexerBefore.externalPayload)
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerElectionScratchPreservesZeroPayload(t *testing.T) {
+	for _, stateless := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stateless_%t", stateless), func(t *testing.T) {
+			scanner := diagnosticParserCoreZeroSnapshotScanner{stateless: stateless}
+			tokenSource := &dfaTokenSource{
+				lexer:              &Lexer{source: []byte("x")},
+				language:           &Language{Name: "zero-snapshot-test", ExternalScanner: scanner},
+				hasExternalScanner: true,
+			}
+			want := tokenSource.snapshotRelexState()
+			var scratch dfaRelexSnapshotScratch
+			got := tokenSource.snapshotRelexStateWithScratch(&scratch)
+			if !reflect.DeepEqual(got, want) || got.externalPayload != nil {
+				t.Fatalf("zero-payload scratch snapshot=%+v, want %+v", got, want)
+			}
+			if len(scratch.externalPayload) != 0 || cap(scratch.externalPayload) != externalScannerSerializationBufferSize {
+				t.Fatalf("zero-payload scratch len/cap=%d/%d, want 0/%d", len(scratch.externalPayload), cap(scratch.externalPayload), externalScannerSerializationBufferSize)
+			}
+			var next dfaRelexSnapshot
+			if allocs := testing.AllocsPerRun(100, func() {
+				next = tokenSource.snapshotRelexStateWithScratch(&scratch)
+			}); allocs != 0 {
+				t.Fatalf("warm zero-payload snapshot allocations=%v, want 0", allocs)
+			}
+			if !reflect.DeepEqual(next, want) || next.externalPayload != nil {
+				t.Fatalf("warm zero-payload scratch snapshot=%+v, want %+v", next, want)
+			}
+		})
+	}
+}
+
 func TestDiagnosticParserCoreVersionLexerSidecarFootprintAndReset(t *testing.T) {
 	compact, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
 	requests := make([]diagnosticParserCoreVersionLexerRequest, 1, 3)
@@ -219,5 +411,88 @@ func TestDiagnosticParserCoreVersionLexerSidecarFootprintAndReset(t *testing.T) 
 		scheduler.versionLexerBefore.externalTokenStart != nil || scheduler.versionLexerBefore.externalTokenEnd != nil ||
 		scheduler.versionLexerBefore.extZeroTried != nil {
 		t.Fatalf("reset retained the shared election snapshot: %+v", scheduler.versionLexerBefore)
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerElectionScratchFootprintAndReset(t *testing.T) {
+	payload := make([]byte, 1, externalScannerSerializationBufferSize)
+	payload[0] = 0x11
+	start := make([]byte, 2, externalScannerSerializationBufferSize)
+	copy(start, []byte{0x21, 0x22})
+	end := make([]byte, 2, externalScannerSerializationBufferSize)
+	copy(end, []byte{0x31, 0x32})
+	tried := make([]bool, 3, 6)
+	copy(tried, []bool{true, false, true})
+	scratch := dfaRelexSnapshotScratch{
+		externalPayload: payload, externalTokenStart: start,
+		externalTokenEnd: end, extZeroTried: tried,
+	}
+	scheduler := diagnosticParserCoreGenericScheduler{
+		versionLexerBefore: dfaRelexSnapshot{
+			externalPayload: payload, externalTokenStart: start,
+			externalTokenEnd: end, extZeroTried: tried,
+		},
+		versionLexerBeforeScratch: scratch,
+		versionLexerBeforeValid:   true,
+	}
+	base := diagnosticParserCoreSchedulerFootprintBytes(&diagnosticParserCoreGenericScheduler{})
+	delta := diagnosticParserCoreSchedulerFootprintBytes(&scheduler) - base
+	want := uint64(cap(payload) + cap(start) + cap(end) + cap(tried))
+	if delta != want {
+		t.Fatalf("aliased election snapshot/scratch footprint=%d, want exact %d", delta, want)
+	}
+	if err := resetDiagnosticParserCoreGenericScheduler(&scheduler); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(scheduler.versionLexerBefore, dfaRelexSnapshot{}) || scheduler.versionLexerBeforeValid {
+		t.Fatalf("reset retained an active election snapshot: %+v", scheduler.versionLexerBefore)
+	}
+	retained := scheduler.versionLexerBeforeScratch
+	if len(retained.externalPayload) != 0 || cap(retained.externalPayload) != externalScannerSerializationBufferSize ||
+		len(retained.externalTokenStart) != 0 || cap(retained.externalTokenStart) != cap(start) ||
+		len(retained.externalTokenEnd) != 0 || cap(retained.externalTokenEnd) != cap(end) ||
+		len(retained.extZeroTried) != 0 || cap(retained.extZeroTried) != cap(tried) {
+		t.Fatalf("reset election scratch capacities=%+v", retained)
+	}
+	for index, value := range retained.externalPayload[:cap(retained.externalPayload)] {
+		if value != 0 {
+			t.Fatalf("reset payload scratch byte %d=%d, want 0", index, value)
+		}
+	}
+	for name, values := range map[string][]byte{
+		"start": retained.externalTokenStart[:cap(retained.externalTokenStart)],
+		"end":   retained.externalTokenEnd[:cap(retained.externalTokenEnd)],
+	} {
+		for index, value := range values {
+			if value != 0 {
+				t.Fatalf("reset %s scratch byte %d=%d, want 0", name, index, value)
+			}
+		}
+	}
+	for index, value := range retained.extZeroTried[:cap(retained.extZeroTried)] {
+		if value {
+			t.Fatalf("reset zero-width scratch bit %d=true, want false", index)
+		}
+	}
+	scanner := byteStateExternalScanner{}
+	scannerPayload := scanner.Create()
+	*scannerPayload.(*byte) = 0x41
+	scheduler.tokenSource = &dfaTokenSource{
+		lexer:              &Lexer{source: []byte("abc")},
+		language:           &Language{Name: "version-lexer-reset-scratch-test", ExternalScanner: scanner},
+		hasExternalScanner: true,
+		externalPayload:    scannerPayload,
+		externalTokenStart: []byte{0x51, 0x52},
+		externalTokenEnd:   []byte{0x61, 0x62},
+		extZeroTried:       []bool{true, false, true},
+	}
+	var captureErr error
+	if allocs := testing.AllocsPerRun(100, func() {
+		captureErr = scheduler.captureSharedElectionSnapshot()
+	}); allocs != 0 {
+		t.Fatalf("post-reset warm election snapshot allocations=%v, want 0", allocs)
+	}
+	if captureErr != nil {
+		t.Fatal(captureErr)
 	}
 }

--- a/parsercore_phase0_per_version_lexer_scheduler_helper_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_scheduler_helper_internal_test.go
@@ -1,0 +1,223 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// DiagnosticParserCoreVersionLexerRequestWitnessForTest advances a scheduler
+// to the Swift ragged-token frontier and exercises its private cursor requests.
+// The helper stays in an internal test file so production callers cannot arm it.
+func DiagnosticParserCoreVersionLexerRequestWitnessForTest(
+	lang *Language,
+	source []byte,
+) ([]DiagnosticParserCoreVersionLexerRequest, error) {
+	if lang == nil {
+		return nil, fmt.Errorf("version lexer witness requires a language")
+	}
+	parser := NewParser(lang)
+	runner, err := newAdmissionCandidateRunner(parser)
+	if err != nil {
+		return nil, err
+	}
+	runner.options.ReceiptMode = DiagnosticParserCoreReceiptFull
+	tokenSource := parser.acquireParserDFATokenSource(source)
+	if tokenSource == nil {
+		return nil, fmt.Errorf("acquire parser DFA token source returned nil")
+	}
+	defer tokenSource.Close()
+
+	tokenSource.SetParserState(lang.InitialState)
+	tokenSource.SetGLRStates(nil)
+	var scannerScratch []byte
+	initialBytes := tokenSource.captureExternalScannerStateInto(&scannerScratch)
+	initialID, initialInfo, err := diagnosticParserCoreInternCheckpoint(runner.compact, initialBytes)
+	if err != nil {
+		return nil, fmt.Errorf("intern initial scanner checkpoint: %w", err)
+	}
+	if err := runner.compact.SetPhaseCheckpoint(initialID); err != nil {
+		return nil, fmt.Errorf("set initial scanner checkpoint phase: %w", err)
+	}
+	seed, err := runner.compact.Seed(core.StateID(lang.InitialState), 0)
+	if err != nil {
+		return nil, fmt.Errorf("seed compact parser core: %w", err)
+	}
+	scheduler, err := newDiagnosticParserCoreGenericScheduler(
+		runner.compact, tokenSource, &scannerScratch, seed, initialID, initialInfo,
+		diagnosticParserCoreSeedObserver{}, runner.options,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("new generic scheduler: %w", err)
+	}
+	if err := scheduler.captureSharedElectionSnapshot(); err != nil {
+		return nil, fmt.Errorf("capture initial lexer election: %w", err)
+	}
+	if err := scheduler.elect(true); err != nil {
+		return nil, fmt.Errorf("initial election: %w", err)
+	}
+	foundWitness := false
+	for step := 0; step < 32; step++ {
+		stop, dispatchErr := scheduler.dispatchPass()
+		if dispatchErr != nil {
+			return nil, fmt.Errorf("dispatch step %d: %w", step, dispatchErr)
+		}
+		if stop != nil {
+			return nil, fmt.Errorf("scheduler stopped before the ragged witness: %+v", stop)
+		}
+		if len(scheduler.headers) == 2 && scheduler.token.StartByte == 3 && scheduler.token.EndByte == 5 {
+			states := make([]StateID, len(scheduler.headers))
+			for index, header := range scheduler.headers {
+				state, byteOffset, boundaryErr := scheduler.compact.Boundary(header.head)
+				if boundaryErr != nil {
+					return nil, fmt.Errorf("read witness header %d boundary: %w", index, boundaryErr)
+				}
+				if byteOffset != 3 {
+					return nil, fmt.Errorf("witness header %d byte offset=%d, want 3", index, byteOffset)
+				}
+				states[index] = StateID(state)
+			}
+			if states[0] == StateID(47) && states[1] == StateID(524) {
+				foundWitness = true
+				break
+			}
+		}
+		allClosed := true
+		for _, header := range scheduler.headers {
+			if !header.shifted && !header.accepted {
+				allClosed = false
+				break
+			}
+		}
+		if allClosed {
+			if err := scheduler.captureSharedElectionSnapshot(); err != nil {
+				return nil, fmt.Errorf("capture lexer election after dispatch step %d: %w", step, err)
+			}
+			if err := scheduler.elect(false); err != nil {
+				return nil, fmt.Errorf("next election after dispatch step %d: %w", step, err)
+			}
+		}
+	}
+	if !foundWitness {
+		return nil, fmt.Errorf("did not reach two-header byte-3 witness")
+	}
+	capturedElection := scheduler.versionLexerBeforeElection
+	scheduler.versionLexerBeforeElection--
+	if err := scheduler.seedVersionLexerOwnership(); err == nil {
+		return nil, fmt.Errorf("stale lexer election snapshot was accepted")
+	}
+	scheduler.versionLexerBeforeElection = capturedElection
+	if err := scheduler.seedVersionLexerOwnership(); err != nil {
+		return nil, fmt.Errorf("seed per-header lexer ownership: %w", err)
+	}
+	if scheduler.headers[0].versionState != scheduler.headers[1].versionState {
+		return nil, fmt.Errorf("equal lexer cursors did not share one version identity")
+	}
+
+	for index := range scheduler.headers {
+		priorDFA := tokenSource.snapshotRelexState()
+		priorState := tokenSource.state
+		priorGLRStates := append([]StateID(nil), tokenSource.glrStates...)
+		if err := scheduler.requestHeaderLexerToken(index); err != nil {
+			return nil, fmt.Errorf("request header lexer token %d: %w", index, err)
+		}
+		if got := tokenSource.snapshotRelexState(); !reflect.DeepEqual(got, priorDFA) {
+			return nil, fmt.Errorf("request %d changed the shared DFA cursor: got=%+v want=%+v", index, got, priorDFA)
+		}
+		if tokenSource.state != priorState {
+			return nil, fmt.Errorf("request %d changed the shared parser state: got=%d want=%d", index, tokenSource.state, priorState)
+		}
+		if !reflect.DeepEqual(tokenSource.glrStates, priorGLRStates) {
+			return nil, fmt.Errorf("request %d changed the shared GLR states: got=%v want=%v", index, tokenSource.glrStates, priorGLRStates)
+		}
+	}
+
+	if len(scheduler.versionLexerRequests) != 2 {
+		return nil, fmt.Errorf("owned lexer requests=%d, want 2", len(scheduler.versionLexerRequests))
+	}
+	scheduler.electionIndex++
+	if request := scheduler.versionLexerRequestForHeader(0); request != nil {
+		return nil, fmt.Errorf("owned lexer request survived its election")
+	}
+	scheduler.electionIndex--
+	if scheduler.work.PerVersionLexRequests != 2 || scheduler.work.PerVersionLexRestores != 2 ||
+		scheduler.work.PerVersionLexPublications != 6 || scheduler.work.PeakLiveVersions != 2 {
+		return nil, fmt.Errorf("owned lexer work counters=%+v", scheduler.work)
+	}
+	scheduler.publishTotals()
+	if scheduler.receipt.PerVersionLexRequests != 2 || scheduler.receipt.PerVersionLexRestores != 2 ||
+		scheduler.receipt.PerVersionLexPublications != 6 || scheduler.receipt.PeakLiveVersions != 2 {
+		return nil, fmt.Errorf("owned lexer receipt totals=%+v", scheduler.receipt)
+	}
+	want := map[StateID]struct {
+		symbol      Symbol
+		endByte     uint32
+		external    bool
+		internalDFA bool
+	}{
+		47:  {symbol: 35, endByte: 4, internalDFA: true},
+		524: {symbol: 217, endByte: 5, external: true},
+	}
+	for _, request := range scheduler.versionLexerRequests {
+		expect, ok := want[request.state]
+		if !ok {
+			return nil, fmt.Errorf("unexpected owned request state=%d", request.state)
+		}
+		if request.token.Symbol != expect.symbol || request.token.StartByte != 3 || request.token.EndByte != expect.endByte {
+			return nil, fmt.Errorf("state %d token=%+v, want symbol=%d span=3..%d", request.state, request.token, expect.symbol, expect.endByte)
+		}
+		if request.token.ExternalScannerToken != expect.external || request.token.lexerInternalDFALexed != expect.internalDFA {
+			return nil, fmt.Errorf("state %d token provenance external=%t internalDFA=%t, want external=%t internalDFA=%t", request.state, request.token.ExternalScannerToken, request.token.lexerInternalDFALexed, expect.external, expect.internalDFA)
+		}
+		if request.before == nil || request.after == nil || request.beforeCheckpoint.Length != 9 || request.afterCheckpoint.Length != 9 {
+			return nil, fmt.Errorf("state %d request lost owned scanner checkpoints: %+v", request.state, request)
+		}
+		if request.before.dfa.lexerPos != 3 || request.after.dfa.lexerPos != int(expect.endByte) {
+			return nil, fmt.Errorf("state %d cursor positions=%d..%d, want 3..%d", request.state, request.before.dfa.lexerPos, request.after.dfa.lexerPos, expect.endByte)
+		}
+	}
+	return scheduler.receipt.VersionLexerRequests, nil
+}
+
+func TestDiagnosticParserCoreVersionLexerSidecarFootprintAndReset(t *testing.T) {
+	compact, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
+	requests := make([]diagnosticParserCoreVersionLexerRequest, 1, 3)
+	requests[0] = diagnosticParserCoreVersionLexerRequest{before: snapshot, after: snapshot, valid: true}
+	requests[:cap(requests)][2] = diagnosticParserCoreVersionLexerRequest{before: snapshot, after: snapshot, valid: true}
+	scheduler := diagnosticParserCoreGenericScheduler{
+		compact:                      compact,
+		versionLexerBefore:           cloneDiagnosticParserCoreDFARelexSnapshot(snapshot.dfa),
+		versionLexerBeforeValid:      true,
+		versionLexerBeforeElection:   7,
+		versionLexerBeforeCheckpoint: snapshot.beforeCheckpoint,
+		versionLexerRequests:         requests,
+	}
+	base := diagnosticParserCoreSchedulerFootprintBytes(&diagnosticParserCoreGenericScheduler{compact: compact})
+	delta := diagnosticParserCoreSchedulerFootprintBytes(&scheduler) - base
+	want := uint64(cap(requests))*uint64(unsafe.Sizeof(diagnosticParserCoreVersionLexerRequest{})) +
+		diagnosticParserCoreVersionLexerSnapshotFootprintBytes(snapshot) +
+		diagnosticParserCoreDFARelexSnapshotRetainedBytes(scheduler.versionLexerBefore) +
+		uint64(cap(scheduler.footprintRefs))*uint64(unsafe.Sizeof(diagnosticParserCoreFootprintRef{}))
+	if delta != want {
+		t.Fatalf("version lexer sidecar footprint=%d, want %d", delta, want)
+	}
+	if err := resetDiagnosticParserCoreGenericScheduler(&scheduler); err != nil {
+		t.Fatalf("reset scheduler: %v", err)
+	}
+	for index, request := range requests[:cap(requests)] {
+		if request.before != nil || request.after != nil || request.valid {
+			t.Fatalf("request backing slot %d retained a snapshot: %+v", index, request)
+		}
+	}
+	if scheduler.versionLexerBeforeValid || scheduler.versionLexerBeforeElection != 0 || scheduler.versionLexerBeforeCheckpoint != 0 ||
+		scheduler.versionLexerBefore.externalPayload != nil ||
+		scheduler.versionLexerBefore.externalTokenStart != nil || scheduler.versionLexerBefore.externalTokenEnd != nil ||
+		scheduler.versionLexerBefore.extZeroTried != nil {
+		t.Fatalf("reset retained the shared election snapshot: %+v", scheduler.versionLexerBefore)
+	}
+}

--- a/parsercore_phase0_per_version_lexer_scheduler_test.go
+++ b/parsercore_phase0_per_version_lexer_scheduler_test.go
@@ -1,0 +1,54 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestDiagnosticParserCoreVersionLexerRequestsOwnRaggedSpans(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	entry := grammars.DetectLanguageByName("swift")
+	if entry == nil || entry.Language() == nil {
+		t.Fatal("swift grammar is unavailable")
+	}
+	requests, err := gts.DiagnosticParserCoreVersionLexerRequestWitnessForTest(
+		entry.Language(), []byte("a<A<#"),
+	)
+	if err != nil {
+		t.Fatalf("version lexer request witness: %v", err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("version lexer requests=%d, want 2", len(requests))
+	}
+	want := map[gts.StateID]struct {
+		symbol   gts.Symbol
+		endByte  uint32
+		external bool
+		internal bool
+	}{
+		47:  {symbol: 35, endByte: 4, internal: true},
+		524: {symbol: 217, endByte: 5, external: true},
+	}
+	for _, request := range requests {
+		expect, ok := want[request.State]
+		if !ok {
+			t.Fatalf("unexpected request state=%d", request.State)
+		}
+		if request.Token.Symbol != expect.symbol || request.Token.StartByte != 3 || request.Token.EndByte != expect.endByte {
+			t.Fatalf("state %d token=%+v, want symbol=%d span=3..%d", request.State, request.Token, expect.symbol, expect.endByte)
+		}
+		if request.Token.ExternalScannerToken != expect.external {
+			t.Fatalf("state %d external=%t, want %t", request.State, request.Token.ExternalScannerToken, expect.external)
+		}
+		if request.InternalDFAToken != expect.internal {
+			t.Fatalf("state %d internal DFA=%t, want %t", request.State, request.InternalDFAToken, expect.internal)
+		}
+		if request.ScannerBefore.Length != 9 || request.ScannerAfter.Length != 9 {
+			t.Fatalf("state %d lost scanner checkpoint pair: before=%+v after=%+v", request.State, request.ScannerBefore, request.ScannerAfter)
+		}
+	}
+}

--- a/parsercore_phase0_per_version_lexer_snapshot_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_snapshot_internal_test.go
@@ -1,0 +1,716 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func diagnosticParserCoreVersionLexerTestDFA() dfaRelexSnapshot {
+	return dfaRelexSnapshot{
+		lexerPos:                    17,
+		lexerRow:                    3,
+		lexerCol:                    9,
+		lexerRangeIdx:               2,
+		failTokenStartPos:           13,
+		failTokenStartRow:           2,
+		failTokenStartCol:           8,
+		failTokenStartRangeIdx:      1,
+		externalPayload:             []byte{0x11, 0x22},
+		lastExternalTokenStartByte:  12,
+		lastExternalTokenEndByte:    17,
+		lastExternalTokenValid:      true,
+		lastExternalTokenWasExtra:   true,
+		externalTokenEndSameAsStart: true,
+		lastTokenStartByte:          12,
+		lastTokenEndByte:            17,
+		lastTokenValid:              true,
+		externalTokenStart:          []byte{0x31, 0x32},
+		externalTokenEnd:            []byte{0x41, 0x42},
+		extZeroPos:                  17,
+		extZeroState:                23,
+		extZeroTried:                []bool{true, false, true},
+		zeroWidthPos:                17,
+		zeroWidthCount:              2,
+	}
+}
+
+func newDiagnosticParserCoreVersionLexerTestCore(t *testing.T) (*core.Core, core.CheckpointID, core.CheckpointID) {
+	t.Helper()
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := compact.InternCheckpoint([]byte{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+	})
+	if err != nil {
+		t.Fatalf("intern before checkpoint: %v", err)
+	}
+	after, err := compact.InternCheckpoint([]byte{
+		0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
+	})
+	if err != nil {
+		t.Fatalf("intern after checkpoint: %v", err)
+	}
+	return compact, before, after
+}
+
+func newDiagnosticParserCoreVersionLexerTestSnapshot(t *testing.T) (*core.Core, *diagnosticParserCoreVersionLexerSnapshot) {
+	t.Helper()
+	compact, before, after := newDiagnosticParserCoreVersionLexerTestCore(t)
+	dfa := diagnosticParserCoreVersionLexerTestDFA()
+	dfa.externalScannerPresent = true
+	language := &Language{Name: "snapshot-test", ExternalScanner: byteStateExternalScanner{}}
+	var snapshot *diagnosticParserCoreVersionLexerSnapshot
+	err := compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		var err error
+		snapshot, err = newDiagnosticParserCoreVersionLexerSnapshot(compact, language, owner, dfa, before, after)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("construct owned lexer snapshot: %v", err)
+	}
+	return compact, snapshot
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotCopiesAllMutableState(t *testing.T) {
+	compact, before, after := newDiagnosticParserCoreVersionLexerTestCore(t)
+	dfa := diagnosticParserCoreVersionLexerTestDFA()
+	dfa.externalScannerPresent = true
+	language := &Language{Name: "snapshot-test", ExternalScanner: byteStateExternalScanner{}}
+	var snapshot *diagnosticParserCoreVersionLexerSnapshot
+	err := compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		var err error
+		snapshot, err = newDiagnosticParserCoreVersionLexerSnapshot(compact, language, owner, dfa, before, after)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("construct owned lexer snapshot: %v", err)
+	}
+	if snapshot == nil {
+		t.Fatal("constructor returned a nil snapshot")
+	}
+	if snapshot.compact != compact || snapshot.coreGeneration != compact.ResetGeneration() || snapshot.coreGeneration == 0 {
+		t.Fatalf("snapshot core binding=%p generation=%d, want core=%p generation=%d", snapshot.compact, snapshot.coreGeneration, compact, compact.ResetGeneration())
+	}
+	if snapshot.beforeCheckpoint != before || snapshot.afterCheckpoint != after {
+		t.Fatalf("checkpoint IDs=%d/%d, want %d/%d", snapshot.beforeCheckpoint, snapshot.afterCheckpoint, before, after)
+	}
+	if snapshot.beforeCheckpointInfo != parserCoreCheckpoint(snapshot.beforeCheckpointBytes) ||
+		snapshot.afterCheckpointInfo != parserCoreCheckpoint(snapshot.afterCheckpointBytes) {
+		t.Fatalf("checkpoint metadata does not describe owned bytes: before=%+v after=%+v", snapshot.beforeCheckpointInfo, snapshot.afterCheckpointInfo)
+	}
+
+	dfa.externalPayload[0] = 0xff
+	dfa.externalTokenStart[0] = 0xff
+	dfa.externalTokenEnd[0] = 0xff
+	dfa.extZeroTried[0] = false
+	dfa.lexerPos = 99
+	if !bytes.Equal(snapshot.dfa.externalPayload, []byte{0x11, 0x22}) ||
+		!bytes.Equal(snapshot.dfa.externalTokenStart, []byte{0x31, 0x32}) ||
+		!bytes.Equal(snapshot.dfa.externalTokenEnd, []byte{0x41, 0x42}) ||
+		len(snapshot.dfa.extZeroTried) != 3 || !snapshot.dfa.extZeroTried[0] || snapshot.dfa.lexerPos != 17 ||
+		snapshot.dfa.lexerRow != 3 || snapshot.dfa.lexerCol != 9 || snapshot.dfa.lexerRangeIdx != 2 ||
+		snapshot.dfa.failTokenStartPos != 13 || snapshot.dfa.failTokenStartRow != 2 ||
+		snapshot.dfa.failTokenStartCol != 8 || snapshot.dfa.failTokenStartRangeIdx != 1 ||
+		snapshot.dfa.lastExternalTokenStartByte != 12 || snapshot.dfa.lastExternalTokenEndByte != 17 ||
+		!snapshot.dfa.lastExternalTokenValid || !snapshot.dfa.lastExternalTokenWasExtra ||
+		!snapshot.dfa.externalTokenEndSameAsStart || snapshot.dfa.lastTokenStartByte != 12 ||
+		snapshot.dfa.lastTokenEndByte != 17 || !snapshot.dfa.lastTokenValid || snapshot.dfa.extZeroPos != 17 ||
+		snapshot.dfa.extZeroState != 23 || snapshot.dfa.zeroWidthPos != 17 || snapshot.dfa.zeroWidthCount != 2 {
+		t.Fatalf("snapshot aliases or lost source DFA state: %+v", snapshot.dfa)
+	}
+	if &snapshot.beforeCheckpointBytes[0] == &snapshot.afterCheckpointBytes[0] {
+		t.Fatal("checkpoint copies unexpectedly alias each other")
+	}
+	if !bytes.Equal(snapshot.beforeCheckpointBytes, []byte{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+	}) || !bytes.Equal(snapshot.afterCheckpointBytes, []byte{
+		0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
+	}) {
+		t.Fatalf("owned checkpoint bytes changed: before=%v after=%v", snapshot.beforeCheckpointBytes, snapshot.afterCheckpointBytes)
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotPublicationCopiesPublishedState(t *testing.T) {
+	compact, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
+	var header diagnosticParserCoreHeader
+	if err := header.publishVersionLexerSnapshot(compact, snapshot.language, snapshot); err != nil {
+		t.Fatalf("publish lexer snapshot: %v", err)
+	}
+	published := header.versionLexerSnapshot()
+	if published == nil || published == snapshot {
+		t.Fatal("publication did not create a distinct snapshot")
+	}
+
+	// Mutating the constructor result must not mutate the header-owned copy.
+	snapshot.dfa.externalPayload[0] = 0xff
+	snapshot.dfa.externalTokenStart[0] = 0xff
+	snapshot.dfa.extZeroTried[0] = false
+	snapshot.dfa.failTokenStartPos = 99
+	snapshot.beforeCheckpointBytes[0] = 0xff
+	if published.dfa.externalPayload[0] != 0x11 || published.dfa.externalTokenStart[0] != 0x31 ||
+		!published.dfa.extZeroTried[0] || published.dfa.failTokenStartPos != 13 ||
+		published.beforeCheckpointBytes[0] != 0x01 {
+		t.Fatal("published snapshot aliases the constructor result")
+	}
+
+	// Mutating the published copy must not mutate the constructor result either.
+	published.dfa.externalTokenEnd[0] = 0xee
+	published.dfa.failTokenStartRow = 88
+	published.afterCheckpointBytes[0] = 0xee
+	if snapshot.dfa.externalTokenEnd[0] != 0x41 || snapshot.dfa.failTokenStartRow != 2 ||
+		snapshot.afterCheckpointBytes[0] != 0x11 {
+		t.Fatal("constructor snapshot aliases the published copy")
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotCloneDoesNotAlias(t *testing.T) {
+	_, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
+	clone := snapshot.clone()
+	if clone == nil || clone == snapshot {
+		t.Fatal("clone did not create a distinct snapshot")
+	}
+	clone.dfa.externalPayload[0] = 0xff
+	clone.dfa.externalTokenStart[0] = 0xff
+	clone.dfa.externalTokenEnd[0] = 0xff
+	clone.dfa.extZeroTried[0] = false
+	clone.beforeCheckpointBytes[0] = 0xff
+	clone.afterCheckpointBytes[0] = 0xff
+	if snapshot.dfa.externalPayload[0] != 0x11 || snapshot.dfa.externalTokenStart[0] != 0x31 ||
+		snapshot.dfa.externalTokenEnd[0] != 0x41 || !snapshot.dfa.extZeroTried[0] ||
+		snapshot.beforeCheckpointBytes[0] != 0x01 || snapshot.afterCheckpointBytes[0] != 0x11 {
+		t.Fatal("snapshot clone aliases mutable state")
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotInterleavedErrorRunRestoration(t *testing.T) {
+	states := []LexState{
+		{
+			Default: -1,
+			EOF:     -1,
+			Transitions: []LexTransition{
+				{Lo: 'a', Hi: 'a', NextState: 2},
+			},
+		},
+		{
+			Default: -1,
+			EOF:     -1,
+			Transitions: []LexTransition{
+				{Lo: 'a', Hi: 'a', NextState: 2},
+			},
+		},
+		{AcceptToken: 1, Default: -1, EOF: -1},
+	}
+	d := &dfaTokenSource{lexer: &Lexer{
+		states:                 states,
+		source:                 []byte("xax"),
+		failTokenStartPos:      77,
+		failTokenStartRow:      8,
+		failTokenStartCol:      9,
+		failTokenStartRangeIdx: 6,
+	}, language: &Language{LexStates: states}}
+	d.lexer.errorRunLexState = 1
+	d.lexer.hasErrorRunLexState = true
+
+	first := d.snapshotRelexState()
+	if tok := d.lexer.NextWithErrorRuns(0); tok.Symbol != errorSymbol || tok.StartByte != 0 || tok.EndByte != 1 {
+		t.Fatalf("first error run = %+v, want [0,1)", tok)
+	}
+	second := d.snapshotRelexState()
+	if tok := d.lexer.NextWithErrorRuns(0); tok.Symbol != 1 || tok.StartByte != 1 || tok.EndByte != 2 {
+		t.Fatalf("delimiter token = %+v, want [1,2)", tok)
+	}
+	if tok := d.lexer.NextWithErrorRuns(0); tok.Symbol != errorSymbol || tok.StartByte != 2 || tok.EndByte != 3 {
+		t.Fatalf("second error run = %+v, want [2,3)", tok)
+	}
+	if d.lexer.failTokenStartPos != 2 || d.lexer.failTokenStartCol != 2 {
+		t.Fatalf("second failure origin = %d/%d, want 2/2", d.lexer.failTokenStartPos, d.lexer.failTokenStartCol)
+	}
+
+	first.restore(d)
+	if d.lexer.pos != first.lexerPos || d.lexer.row != first.lexerRow || d.lexer.col != first.lexerCol ||
+		d.lexer.includedRangeIdx != first.lexerRangeIdx || d.lexer.failTokenStartPos != 77 ||
+		d.lexer.failTokenStartRow != 8 || d.lexer.failTokenStartCol != 9 || d.lexer.failTokenStartRangeIdx != 6 {
+		t.Fatalf("first interleaved restore lost lexer failure state: %+v", *d.lexer)
+	}
+	if tok := d.lexer.NextWithErrorRuns(0); tok.Symbol != errorSymbol || tok.StartByte != 0 || tok.EndByte != 1 {
+		t.Fatalf("replayed first error run = %+v, want [0,1)", tok)
+	}
+	second.restore(d)
+	if d.lexer.pos != second.lexerPos || d.lexer.row != second.lexerRow || d.lexer.col != second.lexerCol ||
+		d.lexer.includedRangeIdx != second.lexerRangeIdx || d.lexer.failTokenStartPos != second.failTokenStartPos ||
+		d.lexer.failTokenStartRow != second.failTokenStartRow || d.lexer.failTokenStartCol != second.failTokenStartCol ||
+		d.lexer.failTokenStartRangeIdx != second.failTokenStartRangeIdx {
+		t.Fatalf("second interleaved restore lost lexer failure state: %+v", *d.lexer)
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotAcceptsEmptyCheckpointIDs(t *testing.T) {
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dfa := diagnosticParserCoreVersionLexerTestDFA()
+	dfa.externalPayload = nil
+	language := &Language{Name: "snapshot-empty-test"}
+	var snapshot *diagnosticParserCoreVersionLexerSnapshot
+	err = compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		var err error
+		snapshot, err = newDiagnosticParserCoreVersionLexerSnapshot(compact, language, owner, dfa, 0, 0)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("construct empty-checkpoint snapshot: %v", err)
+	}
+	if snapshot.beforeCheckpoint != 0 || snapshot.afterCheckpoint != 0 || snapshot.beforeCheckpointBytes != nil || snapshot.afterCheckpointBytes != nil ||
+		snapshot.beforeCheckpointInfo != parserCoreEmptyCheckpoint || snapshot.afterCheckpointInfo != parserCoreEmptyCheckpoint {
+		t.Fatalf("empty checkpoint state=%+v, want zero IDs and empty receipts", snapshot)
+	}
+	if err := snapshot.validate(); err != nil {
+		t.Fatalf("validate empty-checkpoint snapshot: %v", err)
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotSurvivesPhaseChangesAndRejectsReset(t *testing.T) {
+	compact, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
+	lang := snapshot.language
+	payload := lang.ExternalScanner.Create()
+	ts := &dfaTokenSource{
+		lexer:              &Lexer{source: []byte("abc"), pos: 4, row: 5, col: 6},
+		language:           lang,
+		hasExternalScanner: true,
+		externalPayload:    payload,
+	}
+	before := *ts.lexer
+	resetGeneration := compact.ResetGeneration()
+	if err := compact.BeginFrontier(); err != nil {
+		t.Fatalf("advance core frontier: %v", err)
+	}
+	if compact.ResetGeneration() != resetGeneration {
+		t.Fatalf("frontier advanced reset generation to %d, want %d", compact.ResetGeneration(), resetGeneration)
+	}
+	if err := compact.SetPhaseCheckpoint(snapshot.afterCheckpoint); err != nil {
+		t.Fatalf("advance checkpoint phase: %v", err)
+	}
+	if compact.ResetGeneration() != resetGeneration {
+		t.Fatalf("checkpoint advanced reset generation to %d, want %d", compact.ResetGeneration(), resetGeneration)
+	}
+	if err := snapshot.restore(compact, ts); err != nil {
+		t.Fatalf("restore rejected a snapshot across phase changes: %v", err)
+	}
+	if ts.lexer.pos != snapshot.dfa.lexerPos || ts.lexer.row != snapshot.dfa.lexerRow || ts.lexer.col != snapshot.dfa.lexerCol ||
+		ts.lexer.includedRangeIdx != snapshot.dfa.lexerRangeIdx || ts.lexer.failTokenStartPos != snapshot.dfa.failTokenStartPos ||
+		ts.lexer.failTokenStartRow != snapshot.dfa.failTokenStartRow || ts.lexer.failTokenStartCol != snapshot.dfa.failTokenStartCol ||
+		ts.lexer.failTokenStartRangeIdx != snapshot.dfa.failTokenStartRangeIdx {
+		t.Fatalf("phase-change restore lost lexer state: got=%+v want=%+v", *ts.lexer, snapshot.dfa)
+	}
+	if err := compact.Reset(); err != nil {
+		t.Fatalf("reset compact core: %v", err)
+	}
+	if compact.ResetGeneration() == resetGeneration {
+		t.Fatalf("reset did not advance reset generation: %d", resetGeneration)
+	}
+	before = *ts.lexer
+	if err := snapshot.restore(compact, ts); err == nil {
+		t.Fatal("restore accepted a snapshot from an older reset generation")
+	}
+	if ts.lexer.pos != before.pos || ts.lexer.row != before.row || ts.lexer.col != before.col ||
+		ts.lexer.includedRangeIdx != before.includedRangeIdx || ts.lexer.failTokenStartPos != before.failTokenStartPos ||
+		ts.lexer.failTokenStartRow != before.failTokenStartRow || ts.lexer.failTokenStartCol != before.failTokenStartCol ||
+		ts.lexer.failTokenStartRangeIdx != before.failTokenStartRangeIdx {
+		t.Fatalf("reset-mismatch restore mutated lexer: got=%+v want=%+v", *ts.lexer, before)
+	}
+	var header diagnosticParserCoreHeader
+	if err := header.publishVersionLexerSnapshot(compact, lang, snapshot); err == nil {
+		t.Fatal("publication accepted a snapshot from an older reset generation")
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotPublicationPreservesRecoveryRegion(t *testing.T) {
+	compact, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
+	firstRegion := &diagnosticParserCoreS3Region{state: 7, startByte: 2, endByte: 5, children: []core.SubtreeID{11, 12}}
+	secondRegion := &diagnosticParserCoreS3Region{state: 9, startByte: 5, endByte: 8, children: []core.SubtreeID{21, 22}}
+	var header diagnosticParserCoreHeader
+	header.openRecoveryRegion(firstRegion)
+	if err := header.publishVersionLexerSnapshot(compact, snapshot.language, snapshot); err != nil {
+		t.Fatalf("publish lexer snapshot: %v", err)
+	}
+	publishedState := header.versionState
+	publishedSnapshot := header.versionLexerSnapshot()
+	if publishedState == nil || publishedSnapshot == nil || publishedSnapshot == snapshot {
+		t.Fatal("snapshot publication did not create an immutable wrapper copy")
+	}
+	publishedFirstRegion := header.recoveryRegion()
+	if publishedFirstRegion == firstRegion || publishedFirstRegion.state != 7 || publishedFirstRegion.startByte != 2 ||
+		publishedFirstRegion.endByte != 5 || len(publishedFirstRegion.children) != 2 ||
+		publishedFirstRegion.children[0] != 11 || publishedFirstRegion.children[1] != 12 {
+		t.Fatalf("published recovery region=%+v, want an owned copy", publishedFirstRegion)
+	}
+	firstRegion.state = 70
+	firstRegion.startByte = 20
+	firstRegion.children[0] = 110
+	if publishedFirstRegion.state != 7 || publishedFirstRegion.startByte != 2 || publishedFirstRegion.children[0] != 11 {
+		t.Fatal("published recovery region aliases the caller's region or children")
+	}
+
+	header.setRecoveryRegion(secondRegion)
+	publishedSecondRegion := header.recoveryRegion()
+	if publishedSecondRegion == secondRegion || publishedSecondRegion.state != 9 || publishedSecondRegion.startByte != 5 ||
+		publishedSecondRegion.endByte != 8 || len(publishedSecondRegion.children) != 2 ||
+		publishedSecondRegion.children[0] != 21 || publishedSecondRegion.children[1] != 22 ||
+		header.versionLexerSnapshot() != publishedSnapshot {
+		t.Fatal("region update did not preserve the published lexer snapshot")
+	}
+	secondRegion.endByte = 80
+	secondRegion.children[1] = 220
+	if publishedSecondRegion.endByte != 8 || publishedSecondRegion.children[1] != 22 {
+		t.Fatal("updated recovery region aliases the caller's region or children")
+	}
+	copyOfHeader := header
+	header.closeRecoveryRegion()
+	if header.recoveryRegion() != nil || header.versionLexerSnapshot() != publishedSnapshot {
+		t.Fatal("region closure dropped the lexer snapshot")
+	}
+	if copyOfHeader.recoveryRegion() != publishedSecondRegion || copyOfHeader.versionLexerSnapshot() != publishedSnapshot {
+		t.Fatal("header copy changed after region closure")
+	}
+	header.clearVersionLexerSnapshot()
+	if header.versionState != nil {
+		t.Fatal("clearing the only version state left a wrapper")
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotRollbackRestoresImmutablePointer(t *testing.T) {
+	compact, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
+	first := &diagnosticParserCoreS3Region{state: 1}
+	second := &diagnosticParserCoreS3Region{state: 2}
+	headers := []diagnosticParserCoreHeader{{}}
+	headers[0].openRecoveryRegion(first)
+	if err := headers[0].publishVersionLexerSnapshot(compact, snapshot.language, snapshot); err != nil {
+		t.Fatalf("publish lexer snapshot: %v", err)
+	}
+	originalState := headers[0].versionState
+	originalSnapshot := headers[0].versionLexerSnapshot()
+	var scratch diagnosticParserCoreHeaderRollbackScratch
+	if err := scratch.begin(headers); err != nil {
+		t.Fatalf("begin rollback: %v", err)
+	}
+	ownedFirst := headers[0].recoveryRegion()
+	if ownedFirst == nil || ownedFirst == first || ownedFirst.state != first.state {
+		t.Fatalf("published recovery region=%+v, want an owned copy of %+v", ownedFirst, first)
+	}
+	headers[0].setRecoveryRegion(second)
+	headers[0].clearVersionLexerSnapshot()
+	scratch.finish(&headers, true)
+	restoredRegion := headers[0].recoveryRegion()
+	if headers[0].versionState != originalState || headers[0].versionLexerSnapshot() != originalSnapshot || restoredRegion != ownedFirst || restoredRegion.state != first.state {
+		t.Fatal("rollback did not restore the complete immutable version state")
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotRestoreRestoresScannerAndGuards(t *testing.T) {
+	compact, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
+	lang := snapshot.language
+	payload := lang.ExternalScanner.Create()
+	ts := &dfaTokenSource{
+		lexer:              &Lexer{source: []byte("abc")},
+		language:           lang,
+		hasExternalScanner: true,
+		externalPayload:    payload,
+	}
+	if err := snapshot.restore(compact, ts); err != nil {
+		t.Fatalf("restore snapshot: %v", err)
+	}
+	if got := *payload.(*byte); got != 0x11 {
+		t.Fatalf("scanner payload=%d, want 17", got)
+	}
+	if ts.lexer.pos != 17 || ts.lexer.row != 3 || ts.lexer.col != 9 || ts.lexer.includedRangeIdx != 2 {
+		t.Fatalf("lexer cursor=%d/%d/%d range=%d, want 17/3/9/2", ts.lexer.pos, ts.lexer.row, ts.lexer.col, ts.lexer.includedRangeIdx)
+	}
+	if !bytes.Equal(ts.externalTokenStart, []byte{0x31, 0x32}) || !bytes.Equal(ts.externalTokenEnd, []byte{0x41, 0x42}) ||
+		ts.extZeroPos != 17 || ts.extZeroState != 23 || len(ts.extZeroTried) != 3 || !ts.extZeroTried[0] ||
+		ts.zeroWidthPos != 17 || ts.zeroWidthCount != 2 {
+		t.Fatalf("scanner bookkeeping was not restored: %+v", ts)
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotRequiresOwnedCheckpointAccess(t *testing.T) {
+	compact, before, after := newDiagnosticParserCoreVersionLexerTestCore(t)
+	dfa := diagnosticParserCoreVersionLexerTestDFA()
+	dfa.externalScannerPresent = true
+	language := &Language{Name: "snapshot-owner-test", ExternalScanner: byteStateExternalScanner{}}
+	if _, err := newDiagnosticParserCoreVersionLexerSnapshot(compact, language, core.SchedulerTransactionToken{}, dfa, before, after); err == nil {
+		t.Fatal("snapshot constructor accepted an unauthenticated owner")
+	}
+	var stale core.SchedulerTransactionToken
+	if err := compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		stale = owner
+		return nil
+	}); err != nil {
+		t.Fatalf("finish owner session: %v", err)
+	}
+	if _, err := newDiagnosticParserCoreVersionLexerSnapshot(compact, language, stale, dfa, before, after); err == nil {
+		t.Fatal("snapshot constructor accepted a stale owner")
+	}
+	if err := compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		if _, err := newDiagnosticParserCoreVersionLexerSnapshot(compact, language, owner, dfa, core.CheckpointID(99), after); err == nil {
+			t.Fatal("snapshot constructor accepted a missing checkpoint")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("finish missing-checkpoint owner session: %v", err)
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotFootprintDeduplicatesHeaderCopies(t *testing.T) {
+	compact, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
+	region := &diagnosticParserCoreS3Region{children: make([]core.SubtreeID, 1, 3)}
+	state := &diagnosticParserCoreVersionState{s3Region: region, relexSnapshot: snapshot}
+	baseScheduler := diagnosticParserCoreGenericScheduler{compact: compact}
+	base := diagnosticParserCoreSchedulerFootprintBytes(&baseScheduler)
+	headers := make([]diagnosticParserCoreHeader, 2, 2)
+	headers[0].versionState = state
+	headers[1] = headers[0]
+	scheduler := diagnosticParserCoreGenericScheduler{compact: compact, headers: headers}
+	delta := diagnosticParserCoreSchedulerFootprintBytes(&scheduler) - base
+	want := uint64(2)*uint64(unsafe.Sizeof(diagnosticParserCoreHeader{})) +
+		diagnosticParserCoreVersionStateFootprintBytes(state) +
+		uint64(cap(scheduler.footprintRefs))*uint64(unsafe.Sizeof(diagnosticParserCoreFootprintRef{}))
+	if delta != want {
+		t.Fatalf("shared version-state footprint delta=%d, want %d", delta, want)
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotResetClearsRetainedHeaderBuffers(t *testing.T) {
+	_, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
+	state := &diagnosticParserCoreVersionState{relexSnapshot: snapshot}
+	active := make([]diagnosticParserCoreHeader, 1, 2)
+	active[0].versionState = state
+	rollback := make([]diagnosticParserCoreHeader, 1, 2)
+	rollback[0].versionState = state
+	canonical := make([]diagnosticParserCoreHeader, 1, 2)
+	canonical[0].versionState = state
+	conflictOutputs := make([]diagnosticParserCoreHeader, 1, 2)
+	conflictOutputs[0].versionState = state
+	conflictAssembly := make([]diagnosticParserCoreHeader, 1, 2)
+	conflictAssembly[0].versionState = state
+	reductions := make([]diagnosticParserCoreHeader, 1, 2)
+	reductions[0].versionState = state
+	scheduler := diagnosticParserCoreGenericScheduler{
+		headers: active,
+		canonicalScratch: diagnosticParserCoreCanonicalScratch{
+			headerBuffers: [2][]diagnosticParserCoreHeader{canonical, canonical},
+		},
+		conflictScratch: diagnosticParserCoreConflictScratch{
+			outputs:        conflictOutputs,
+			headerAssembly: conflictAssembly,
+		},
+		reductionReplacements: reductions,
+	}
+	scheduler.headerRollbackScratch.headers = rollback
+	scheduler.headerRollbackScratch.inline[0].versionState = state
+	scheduler.canonicalScratch.inlineHeaders[0][0].versionState = state
+	before := diagnosticParserCoreSchedulerFootprintBytes(&scheduler)
+	if err := resetDiagnosticParserCoreGenericScheduler(&scheduler); err != nil {
+		t.Fatalf("reset scheduler: %v", err)
+	}
+	for name, headers := range map[string][]diagnosticParserCoreHeader{
+		"active": active, "rollback": rollback, "canonical": canonical,
+		"conflict outputs": conflictOutputs, "conflict assembly": conflictAssembly,
+		"reductions": reductions,
+	} {
+		for index, header := range headers[:cap(headers)] {
+			if header.versionState != nil {
+				t.Fatalf("%s header slot %d retained version state", name, index)
+			}
+		}
+	}
+	if scheduler.headerRollbackScratch.inline[0].versionState != nil || scheduler.canonicalScratch.inlineHeaders[0][0].versionState != nil {
+		t.Fatal("inline header scratch retained version state after reset")
+	}
+	if after := diagnosticParserCoreSchedulerFootprintBytes(&scheduler); after >= before {
+		t.Fatalf("reset footprint=%d, want below pre-reset %d", after, before)
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotRetirementClearsLoser(t *testing.T) {
+	compact, err := core.New(&genericConflictTable{
+		actions: []core.Action{{Type: core.ActionShift, State: 2}},
+	}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	survivor, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	survivor, err = compact.Shift(survivor, 9, 0, core.Token{
+		Symbol: 9, StartByte: 0, EndByte: 1,
+	}, core.ForkOrder{})
+	if err != nil {
+		t.Fatalf("shift survivor: %v", err)
+	}
+	loser, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
+	state := &diagnosticParserCoreVersionState{relexSnapshot: snapshot}
+	headers := make([]diagnosticParserCoreHeader, 2, 2)
+	headers[0] = diagnosticParserCoreHeader{head: survivor, checkpoint: 0, creationSeq: 1, shifted: true, versionState: state}
+	headers[1] = diagnosticParserCoreHeader{head: loser, checkpoint: 0, creationSeq: 2, versionState: state}
+	headers[0].markRecoveryLineage()
+	headers[1].markRecoveryLineage()
+	scheduler := diagnosticParserCoreGenericScheduler{
+		compact:           compact,
+		headers:           headers,
+		checkpointID:      0,
+		recoveryIsolation: true,
+		epochProgress:     true,
+		token:             Token{Symbol: 9, StartByte: 0, EndByte: 1},
+		options: DiagnosticParserCorePrefixOptions{
+			allowCompactRecoveryLineageSelection:          true,
+			allowCompactRecoveryTrailingLineageRetirement: true,
+		},
+	}
+	retired, err := scheduler.retireTrailingRecoveryNoActionLineage([]int{1})
+	if err != nil || !retired {
+		t.Fatalf("retirement=%t err=%v, want true/nil", retired, err)
+	}
+	if len(scheduler.headers) != 1 || scheduler.headers[0].versionState != state {
+		t.Fatalf("survivor state changed during retirement: headers=%+v", scheduler.headers)
+	}
+	if headers[1].versionState != nil {
+		t.Fatal("retired loser retained its immutable version state")
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotRejectsCrossCoreDestination(t *testing.T) {
+	compact, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
+	other, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := &dfaTokenSource{
+		lexer:              &Lexer{source: []byte("abc"), pos: 4, row: 5, col: 6},
+		language:           snapshot.language,
+		hasExternalScanner: true,
+		externalPayload:    snapshot.language.ExternalScanner.Create(),
+	}
+	before := *target.lexer
+	if err := snapshot.restore(other, target); err == nil {
+		t.Fatal("restore accepted a snapshot for a different Core")
+	}
+	if !reflect.DeepEqual(*target.lexer, before) {
+		t.Fatalf("cross-Core restore mutated the target lexer: got=%+v want=%+v", *target.lexer, before)
+	}
+	var header diagnosticParserCoreHeader
+	if err := header.publishVersionLexerSnapshot(other, snapshot.language, snapshot); err == nil {
+		t.Fatal("publication accepted a snapshot for a different Core")
+	}
+	if header.versionState != nil {
+		t.Fatal("failed cross-Core publication installed version state")
+	}
+	if compact == other {
+		t.Fatal("test Cores unexpectedly alias")
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotRejectsCrossLanguageDestination(t *testing.T) {
+	compact, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
+	otherLanguage := &Language{Name: "other-snapshot-test", ExternalScanner: byteStateExternalScanner{}}
+	target := &dfaTokenSource{
+		lexer:              &Lexer{source: []byte("abc"), pos: 4, row: 5, col: 6},
+		language:           otherLanguage,
+		hasExternalScanner: true,
+		externalPayload:    otherLanguage.ExternalScanner.Create(),
+	}
+	before := *target.lexer
+	if err := snapshot.restore(compact, target); err == nil {
+		t.Fatal("restore accepted a snapshot for a different Language")
+	}
+	if !reflect.DeepEqual(*target.lexer, before) {
+		t.Fatalf("cross-Language restore mutated the target lexer: got=%+v want=%+v", *target.lexer, before)
+	}
+	var header diagnosticParserCoreHeader
+	if err := header.publishVersionLexerSnapshot(compact, otherLanguage, snapshot); err == nil {
+		t.Fatal("publication accepted a snapshot for a different Language")
+	}
+	if header.versionState != nil {
+		t.Fatal("failed cross-Language publication installed version state")
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotRejectsScannerReplacement(t *testing.T) {
+	compact, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
+	language := snapshot.language
+	originalScanner := language.ExternalScanner
+	language.ExternalScanner = checkpointByteExternalScanner{}
+	defer func() { language.ExternalScanner = originalScanner }()
+	target := &dfaTokenSource{
+		lexer:              &Lexer{source: []byte("abc"), pos: 4, row: 5, col: 6},
+		language:           language,
+		hasExternalScanner: true,
+		externalPayload:    language.ExternalScanner.Create(),
+	}
+	before := *target.lexer
+	if err := snapshot.restore(compact, target); err == nil {
+		t.Fatal("restore accepted a replacement scanner contract")
+	}
+	if !reflect.DeepEqual(*target.lexer, before) {
+		t.Fatalf("scanner-mismatch restore mutated the target lexer: got=%+v want=%+v", *target.lexer, before)
+	}
+	var header diagnosticParserCoreHeader
+	if err := header.publishVersionLexerSnapshot(compact, language, snapshot); err == nil {
+		t.Fatal("publication accepted a replacement scanner contract")
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotRejectsUnrepresentableScannerState(t *testing.T) {
+	compact, before, after := newDiagnosticParserCoreVersionLexerTestCore(t)
+	dfa := diagnosticParserCoreVersionLexerTestDFA()
+	dfa.externalPayload = nil
+	dfa.externalScannerPresent = true
+	language := &Language{Name: "unrepresentable-snapshot-test", ExternalScanner: byteStateExternalScanner{}}
+	err := compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		_, err := newDiagnosticParserCoreVersionLexerSnapshot(compact, language, owner, dfa, before, after)
+		return err
+	})
+	if err == nil {
+		t.Fatal("constructor accepted an unrepresentable external scanner state")
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotAcceptsSameContractIDZero(t *testing.T) {
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	language := &Language{Name: "empty-contract-snapshot-test"}
+	dfa := diagnosticParserCoreVersionLexerTestDFA()
+	dfa.externalPayload = nil
+	var snapshot *diagnosticParserCoreVersionLexerSnapshot
+	err = compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		var err error
+		snapshot, err = newDiagnosticParserCoreVersionLexerSnapshot(compact, language, owner, dfa, 0, 0)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("construct ID-zero snapshot: %v", err)
+	}
+	target := &dfaTokenSource{lexer: &Lexer{source: []byte("abc")}, language: language}
+	if err := snapshot.restore(compact, target); err != nil {
+		t.Fatalf("same-contract ID-zero restore failed: %v", err)
+	}
+	var header diagnosticParserCoreHeader
+	if err := header.publishVersionLexerSnapshot(compact, language, snapshot); err != nil {
+		t.Fatalf("same-contract ID-zero publication failed: %v", err)
+	}
+}

--- a/parsercore_phase0_per_version_lexer_state.go
+++ b/parsercore_phase0_per_version_lexer_state.go
@@ -1,0 +1,477 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"unsafe"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// diagnosticParserCoreVersionLexerSnapshot is an owned, immutable copy of
+// the DFA token-source state needed to retry the next lexer election for one
+// parser version. The parser's shared token source remains mutable; this
+// value gives one version an independent rollback point.
+//
+// The checkpoint IDs identify the compact-core records. The byte copies are
+// owned here as well, so a reset, scratch reuse, or interner growth cannot
+// change a published version's scanner state.
+type diagnosticParserCoreVersionLexerSnapshot struct {
+	// compact and coreGeneration bind this snapshot to the compact core arena
+	// lifetime that authenticated its checkpoint identities. A reset invalidates
+	// the snapshot, while frontier and checkpoint phases may advance safely.
+	compact        *core.Core
+	coreGeneration uint64
+	language       *Language
+	scanner        diagnosticParserCoreVersionLexerScannerContract
+	dfa            dfaRelexSnapshot
+
+	beforeCheckpoint      core.CheckpointID
+	afterCheckpoint       core.CheckpointID
+	beforeCheckpointBytes []byte
+	afterCheckpointBytes  []byte
+	beforeCheckpointInfo  DiagnosticParserCoreScannerCheckpoint
+	afterCheckpointInfo   DiagnosticParserCoreScannerCheckpoint
+}
+
+// diagnosticParserCoreVersionLexerScannerContract is comparable and remains
+// valid while a token source is returned to and acquired from its pool. The
+// language pointer binds the grammar, while the scanner type and fingerprint
+// reject a scanner replacement on the same Language value.
+type diagnosticParserCoreVersionLexerScannerContract struct {
+	present         bool
+	typeID          reflect.Type
+	fingerprint     [32]byte
+	usesCheckpoints bool
+	stateless       bool
+}
+
+func diagnosticParserCoreVersionLexerScannerFingerprint(scanner ExternalScanner) [32]byte {
+	if scanner == nil {
+		return [32]byte{}
+	}
+	typeID := reflect.TypeOf(scanner)
+	// Pointer scanners carry their identity in the pointer. Avoid hashing their
+	// mutable pointee, because scanner state belongs in Create's payload.
+	if value := reflect.ValueOf(scanner); value.IsValid() && value.Kind() == reflect.Pointer {
+		return sha256.Sum256([]byte(fmt.Sprintf("%s@%x", typeID, value.Pointer())))
+	}
+	return sha256.Sum256([]byte(fmt.Sprintf("%T:%#v", scanner, scanner)))
+}
+
+func diagnosticParserCoreVersionLexerScannerContractForLanguage(language *Language) (diagnosticParserCoreVersionLexerScannerContract, error) {
+	if language == nil {
+		return diagnosticParserCoreVersionLexerScannerContract{}, errors.New("parser-core phase zero: version lexer snapshot requires a language")
+	}
+	contract := diagnosticParserCoreVersionLexerScannerContract{}
+	if language.ExternalScanner == nil {
+		return contract, nil
+	}
+	scanner := language.ExternalScanner
+	value := reflect.ValueOf(scanner)
+	if value.IsValid() && value.Kind() == reflect.Pointer && value.IsNil() {
+		return diagnosticParserCoreVersionLexerScannerContract{}, errors.New("parser-core phase zero: version lexer snapshot rejects a nil external scanner")
+	}
+	contract.present = true
+	contract.typeID = reflect.TypeOf(scanner)
+	contract.fingerprint = diagnosticParserCoreVersionLexerScannerFingerprint(scanner)
+	contract.usesCheckpoints = languageUsesExternalScannerCheckpoints(language)
+	if stateless, ok := scanner.(StatelessExternalScanner); ok {
+		contract.stateless = stateless.ExternalScannerIsStateless()
+	}
+	return contract, nil
+}
+
+func (s diagnosticParserCoreVersionLexerScannerContract) equal(other diagnosticParserCoreVersionLexerScannerContract) bool {
+	return s == other
+}
+
+// cloneBytesForDiagnosticParserCoreVersion copies a byte slice while
+// retaining nil as nil. Published version state never aliases lexer scratch.
+func cloneBytesForDiagnosticParserCoreVersion(src []byte) []byte {
+	if src == nil {
+		return nil
+	}
+	out := make([]byte, len(src))
+	copy(out, src)
+	return out
+}
+
+func cloneBoolsForDiagnosticParserCoreVersion(src []bool) []bool {
+	if src == nil {
+		return nil
+	}
+	out := make([]bool, len(src))
+	copy(out, src)
+	return out
+}
+
+// cloneDiagnosticParserCoreDFARelexSnapshot makes every mutable slice in a
+// DFA snapshot independent. Cursor, failure-origin, and zero-width scalars
+// copy with the value assignment.
+func cloneDiagnosticParserCoreDFARelexSnapshot(src dfaRelexSnapshot) dfaRelexSnapshot {
+	src.externalPayload = cloneBytesForDiagnosticParserCoreVersion(src.externalPayload)
+	src.externalTokenStart = cloneBytesForDiagnosticParserCoreVersion(src.externalTokenStart)
+	src.externalTokenEnd = cloneBytesForDiagnosticParserCoreVersion(src.externalTokenEnd)
+	src.extZeroTried = cloneBoolsForDiagnosticParserCoreVersion(src.extZeroTried)
+	return src
+}
+
+func (s *diagnosticParserCoreVersionLexerSnapshot) clone() *diagnosticParserCoreVersionLexerSnapshot {
+	if s == nil {
+		return nil
+	}
+	return &diagnosticParserCoreVersionLexerSnapshot{
+		compact:               s.compact,
+		coreGeneration:        s.coreGeneration,
+		language:              s.language,
+		scanner:               s.scanner,
+		dfa:                   cloneDiagnosticParserCoreDFARelexSnapshot(s.dfa),
+		beforeCheckpoint:      s.beforeCheckpoint,
+		afterCheckpoint:       s.afterCheckpoint,
+		beforeCheckpointBytes: cloneBytesForDiagnosticParserCoreVersion(s.beforeCheckpointBytes),
+		afterCheckpointBytes:  cloneBytesForDiagnosticParserCoreVersion(s.afterCheckpointBytes),
+		beforeCheckpointInfo:  s.beforeCheckpointInfo,
+		afterCheckpointInfo:   s.afterCheckpointInfo,
+	}
+}
+
+// copyDiagnosticParserCoreVersionCheckpoint obtains a complete private copy
+// of one compact checkpoint and verifies its length and digest metadata.
+func copyDiagnosticParserCoreVersionCheckpoint(
+	compact *core.Core,
+	owner core.SchedulerTransactionToken,
+	id core.CheckpointID,
+) ([]byte, DiagnosticParserCoreScannerCheckpoint, error) {
+	if compact == nil {
+		return nil, DiagnosticParserCoreScannerCheckpoint{}, errors.New("parser-core phase zero: version lexer checkpoint requires a core")
+	}
+	if id == 0 {
+		// Checkpoint ID zero means that the scanner has no serialized state.
+		// Authenticate the owner even when no bytes need copying. Keep its
+		// metadata explicit so callers can distinguish it from a missing
+		// non-zero checkpoint identity.
+		if _, _, ok := compact.CheckpointReceiptOwned(owner, id); !ok {
+			return nil, DiagnosticParserCoreScannerCheckpoint{}, errDiagnosticParserCoreUnknownCheckpointIdentity
+		}
+		return nil, parserCoreEmptyCheckpoint, nil
+	}
+	length, digest, ok := compact.CheckpointReceiptOwned(owner, id)
+	if !ok {
+		return nil, DiagnosticParserCoreScannerCheckpoint{}, errDiagnosticParserCoreUnknownCheckpointIdentity
+	}
+	bytes, ok := compact.CopyCheckpointBytesOwned(owner, id, nil)
+	if !ok || uint64(len(bytes)) != uint64(length) {
+		return nil, DiagnosticParserCoreScannerCheckpoint{}, errors.New("parser-core phase zero: version lexer checkpoint bytes are unavailable")
+	}
+	if sha256.Sum256(bytes) != digest {
+		return nil, DiagnosticParserCoreScannerCheckpoint{}, errors.New("parser-core phase zero: version lexer checkpoint digest does not match its bytes")
+	}
+	return bytes, DiagnosticParserCoreScannerCheckpoint{Length: int(length), SHA256: digest}, nil
+}
+
+// newDiagnosticParserCoreVersionLexerSnapshot creates an owned snapshot from
+// a live DFA snapshot and two compact checkpoint identities. It is safe to
+// call before or during a compact transaction because CopyCheckpointBytes is
+// read-only and explicitly supports transactions.
+func newDiagnosticParserCoreVersionLexerSnapshot(
+	compact *core.Core,
+	language *Language,
+	owner core.SchedulerTransactionToken,
+	dfa dfaRelexSnapshot,
+	beforeCheckpoint core.CheckpointID,
+	afterCheckpoint core.CheckpointID,
+) (*diagnosticParserCoreVersionLexerSnapshot, error) {
+	scanner, err := diagnosticParserCoreVersionLexerScannerContractForLanguage(language)
+	if err != nil {
+		return nil, err
+	}
+	if dfa.externalScannerPresent != scanner.present {
+		return nil, errors.New("parser-core phase zero: version lexer snapshot external scanner presence changed")
+	}
+	if scanner.present && len(dfa.externalPayload) == 0 && !scanner.stateless {
+		return nil, errors.New("parser-core phase zero: version lexer snapshot cannot represent external scanner state")
+	}
+	beforeBytes, beforeInfo, err := copyDiagnosticParserCoreVersionCheckpoint(compact, owner, beforeCheckpoint)
+	if err != nil {
+		return nil, err
+	}
+	afterBytes, afterInfo, err := copyDiagnosticParserCoreVersionCheckpoint(compact, owner, afterCheckpoint)
+	if err != nil {
+		return nil, err
+	}
+	generation := compact.ResetGeneration()
+	if generation == 0 {
+		return nil, errors.New("parser-core phase zero: version lexer snapshot requires an authenticated reset generation")
+	}
+	return &diagnosticParserCoreVersionLexerSnapshot{
+		compact:               compact,
+		coreGeneration:        generation,
+		language:              language,
+		scanner:               scanner,
+		dfa:                   cloneDiagnosticParserCoreDFARelexSnapshot(dfa),
+		beforeCheckpoint:      beforeCheckpoint,
+		afterCheckpoint:       afterCheckpoint,
+		beforeCheckpointBytes: beforeBytes,
+		afterCheckpointBytes:  afterBytes,
+		beforeCheckpointInfo:  beforeInfo,
+		afterCheckpointInfo:   afterInfo,
+	}, nil
+}
+
+func (s *diagnosticParserCoreVersionLexerSnapshot) validateGeneration() error {
+	if s == nil || s.compact == nil || s.coreGeneration == 0 {
+		return errors.New("parser-core phase zero: version lexer snapshot has no authenticated reset generation")
+	}
+	if s.compact.ResetGeneration() != s.coreGeneration {
+		return errors.New("parser-core phase zero: version lexer snapshot Core reset generation changed")
+	}
+	return nil
+}
+
+func (s *diagnosticParserCoreVersionLexerSnapshot) validateDestination(compact *core.Core, language *Language) error {
+	if s == nil || compact == nil || language == nil {
+		return errors.New("parser-core phase zero: version lexer snapshot destination identity is unavailable")
+	}
+	if s.compact != compact {
+		return errors.New("parser-core phase zero: version lexer snapshot belongs to a different Core")
+	}
+	if s.language != language {
+		return errors.New("parser-core phase zero: version lexer snapshot belongs to a different Language")
+	}
+	scanner, err := diagnosticParserCoreVersionLexerScannerContractForLanguage(language)
+	if err != nil {
+		return err
+	}
+	if !s.scanner.equal(scanner) {
+		return errors.New("parser-core phase zero: version lexer snapshot scanner contract changed")
+	}
+	if err := s.validateGeneration(); err != nil {
+		return err
+	}
+	if s.dfa.externalScannerPresent != scanner.present {
+		return errors.New("parser-core phase zero: version lexer snapshot external scanner presence changed")
+	}
+	if scanner.present && len(s.dfa.externalPayload) == 0 && !scanner.stateless {
+		return errors.New("parser-core phase zero: version lexer snapshot cannot represent external scanner state")
+	}
+	return nil
+}
+
+func validateDiagnosticParserCoreVersionLexerCheckpoint(
+	compact *core.Core,
+	id core.CheckpointID,
+	bytes []byte,
+	info DiagnosticParserCoreScannerCheckpoint,
+) error {
+	if id == 0 {
+		if len(bytes) != 0 || info != parserCoreEmptyCheckpoint {
+			return errors.New("parser-core phase zero: version lexer empty checkpoint metadata changed")
+		}
+		return nil
+	}
+	if compact == nil {
+		return errors.New("parser-core phase zero: version lexer checkpoint has no core")
+	}
+	if info != parserCoreCheckpoint(bytes) {
+		return errors.New("parser-core phase zero: version lexer checkpoint metadata does not match its bytes")
+	}
+	length, digest, ok := compact.CheckpointReceipt(id)
+	if !ok || uint64(len(bytes)) != uint64(length) || digest != info.SHA256 {
+		return errDiagnosticParserCoreUnknownCheckpointIdentity
+	}
+	return nil
+}
+
+// validate confirms the compact-core generation and the immutable checkpoint
+// copies before a version can publish or restore its lexer state.
+func (s *diagnosticParserCoreVersionLexerSnapshot) validate() error {
+	if s == nil {
+		return errors.New("parser-core phase zero: version lexer snapshot is nil")
+	}
+	if err := s.validateDestination(s.compact, s.language); err != nil {
+		return err
+	}
+	if err := validateDiagnosticParserCoreVersionLexerCheckpoint(s.compact, s.beforeCheckpoint, s.beforeCheckpointBytes, s.beforeCheckpointInfo); err != nil {
+		return err
+	}
+	return validateDiagnosticParserCoreVersionLexerCheckpoint(s.compact, s.afterCheckpoint, s.afterCheckpointBytes, s.afterCheckpointInfo)
+}
+
+func (h *diagnosticParserCoreHeader) installVersionLexerSnapshot(snapshot *diagnosticParserCoreVersionLexerSnapshot) {
+	if h == nil {
+		return
+	}
+	region := h.recoveryRegion()
+	if snapshot == nil && region == nil {
+		h.versionState = nil
+		return
+	}
+	h.versionState = &diagnosticParserCoreVersionState{
+		s3Region:      region,
+		relexSnapshot: snapshot,
+	}
+}
+
+// publishVersionLexerSnapshot installs a private copy of an owned snapshot
+// while preserving any open recovery region on the same parser version.
+func (h *diagnosticParserCoreHeader) publishVersionLexerSnapshot(
+	compact *core.Core,
+	language *Language,
+	snapshot *diagnosticParserCoreVersionLexerSnapshot,
+) error {
+	if snapshot != nil {
+		if err := snapshot.validateDestination(compact, language); err != nil {
+			return err
+		}
+		snapshot = snapshot.clone()
+	}
+	h.installVersionLexerSnapshot(snapshot)
+	return nil
+}
+
+// publishOwnedVersionLexerSnapshot transfers an already-owned snapshot into
+// the header. The constructor creates all of its copies, so no second clone is
+// needed on this publication path.
+func (h *diagnosticParserCoreHeader) publishOwnedVersionLexerSnapshot(
+	compact *core.Core,
+	language *Language,
+	snapshot *diagnosticParserCoreVersionLexerSnapshot,
+) error {
+	if snapshot != nil {
+		if err := snapshot.validateDestination(compact, language); err != nil {
+			return err
+		}
+	}
+	h.installVersionLexerSnapshot(snapshot)
+	return nil
+}
+
+// publishDFARelexSnapshot copies the live token-source state and checkpoint
+// identities into this header's immutable version state.
+func (h *diagnosticParserCoreHeader) publishDFARelexSnapshot(
+	compact *core.Core,
+	language *Language,
+	owner core.SchedulerTransactionToken,
+	dfa dfaRelexSnapshot,
+	beforeCheckpoint core.CheckpointID,
+	afterCheckpoint core.CheckpointID,
+) error {
+	snapshot, err := newDiagnosticParserCoreVersionLexerSnapshot(compact, language, owner, dfa, beforeCheckpoint, afterCheckpoint)
+	if err != nil {
+		return err
+	}
+	return h.publishOwnedVersionLexerSnapshot(compact, language, snapshot)
+}
+
+// clearVersionLexerSnapshot removes only the owned lexer state. An open
+// recovery region remains attached to the header until its own close path.
+func (h *diagnosticParserCoreHeader) clearVersionLexerSnapshot() {
+	if h == nil {
+		return
+	}
+	region := h.recoveryRegion()
+	if region == nil {
+		h.versionState = nil
+		return
+	}
+	h.versionState = &diagnosticParserCoreVersionState{s3Region: region}
+}
+
+// restore applies the owned DFA state to a token source. The caller restores
+// parser-state and frontier checkpoint fields separately.
+func (s *diagnosticParserCoreVersionLexerSnapshot) restore(compact *core.Core, d *dfaTokenSource) error {
+	if s == nil || d == nil || d.lexer == nil {
+		return errors.New("parser-core phase zero: cannot restore a nil version lexer snapshot")
+	}
+	if err := s.validateDestination(compact, d.language); err != nil {
+		return err
+	}
+	if d.hasExternalScanner != s.dfa.externalScannerPresent {
+		return errors.New("parser-core phase zero: version lexer snapshot target scanner presence changed")
+	}
+	if d.hasExternalScanner && len(s.dfa.externalPayload) == 0 && !s.scanner.stateless {
+		return errors.New("parser-core phase zero: version lexer snapshot target scanner state is unrepresentable")
+	}
+	if len(s.dfa.externalPayload) > externalScannerSerializationBufferSize {
+		return errors.New("parser-core phase zero: version lexer snapshot target scanner state exceeds its bound")
+	}
+	if err := validateDiagnosticParserCoreVersionLexerCheckpoint(s.compact, s.beforeCheckpoint, s.beforeCheckpointBytes, s.beforeCheckpointInfo); err != nil {
+		return err
+	}
+	if err := validateDiagnosticParserCoreVersionLexerCheckpoint(s.compact, s.afterCheckpoint, s.afterCheckpointBytes, s.afterCheckpointInfo); err != nil {
+		return err
+	}
+	s.dfa.restore(d)
+	return nil
+}
+
+func diagnosticParserCoreVersionS3RegionFootprintBytes(region *diagnosticParserCoreS3Region) uint64 {
+	if region == nil {
+		return 0
+	}
+	total := uint64(unsafe.Sizeof(*region))
+	size := uint64(unsafe.Sizeof(core.SubtreeID(0)))
+	if uint64(cap(region.children)) > math.MaxUint64/size {
+		return math.MaxUint64
+	}
+	bytes := uint64(cap(region.children)) * size
+	if math.MaxUint64-total < bytes {
+		return math.MaxUint64
+	}
+	total += bytes
+	return total
+}
+
+func diagnosticParserCoreVersionLexerSnapshotFootprintBytes(snapshot *diagnosticParserCoreVersionLexerSnapshot) uint64 {
+	if snapshot == nil {
+		return 0
+	}
+	// dfa is embedded in the snapshot record, so sizeof(snapshot) already
+	// includes its scalar fields and slice headers.
+	total := uint64(unsafe.Sizeof(*snapshot))
+	add := func(count int, size uintptr) {
+		if count <= 0 || size == 0 || total == math.MaxUint64 {
+			return
+		}
+		if uint64(count) > math.MaxUint64/uint64(size) {
+			total = math.MaxUint64
+			return
+		}
+		bytes := uint64(count) * uint64(size)
+		if math.MaxUint64-total < bytes {
+			total = math.MaxUint64
+			return
+		}
+		total += bytes
+	}
+	add(cap(snapshot.dfa.externalPayload), 1)
+	add(cap(snapshot.dfa.externalTokenStart), 1)
+	add(cap(snapshot.dfa.externalTokenEnd), 1)
+	add(cap(snapshot.dfa.extZeroTried), unsafe.Sizeof(bool(false)))
+	add(cap(snapshot.beforeCheckpointBytes), 1)
+	add(cap(snapshot.afterCheckpointBytes), 1)
+	return total
+}
+
+func diagnosticParserCoreVersionStateFootprintBytes(state *diagnosticParserCoreVersionState) uint64 {
+	if state == nil {
+		return 0
+	}
+	total := uint64(unsafe.Sizeof(*state))
+	regionBytes := diagnosticParserCoreVersionS3RegionFootprintBytes(state.s3Region)
+	snapshotBytes := diagnosticParserCoreVersionLexerSnapshotFootprintBytes(state.relexSnapshot)
+	if math.MaxUint64-total < regionBytes {
+		return math.MaxUint64
+	}
+	total += regionBytes
+	if math.MaxUint64-total < snapshotBytes {
+		return math.MaxUint64
+	}
+	return total + snapshotBytes
+}

--- a/parsercore_phase0_per_version_lexer_state_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_state_internal_test.go
@@ -3,6 +3,7 @@
 package gotreesitter
 
 import (
+	"reflect"
 	"testing"
 	"unsafe"
 
@@ -28,11 +29,11 @@ func TestDiagnosticParserCorePerVersionStatePublishesImmutableCopies(t *testing.
 	if header.versionState == initialState {
 		t.Fatal("setRecoveryRegion reused the previous immutable wrapper")
 	}
-	if got := header.recoveryRegion(); got != second {
-		t.Fatalf("updated region=%p, want %p", got, second)
+	if got := header.recoveryRegion(); got == second || !reflect.DeepEqual(got, second) {
+		t.Fatalf("updated region=%+v, want an independent copy of %+v", got, second)
 	}
-	if got := copyOfHeader.recoveryRegion(); got != first {
-		t.Fatalf("copied header region=%p, want original %p", got, first)
+	if got := copyOfHeader.recoveryRegion(); got == first || !reflect.DeepEqual(got, first) {
+		t.Fatalf("copied header region=%+v, want an independent copy of %+v", got, first)
 	}
 	if copyOfHeader.versionState != initialState {
 		t.Fatal("updating the live header changed the copied header state")
@@ -50,10 +51,10 @@ func TestDiagnosticParserCorePerVersionStateCloseDoesNotMutateSnapshot(t *testin
 	if header.versionState != nil || header.recoveryRegion() != nil {
 		t.Fatal("closeRecoveryRegion left recovery state live")
 	}
-	if snapshot.versionState == nil || snapshot.recoveryRegion() != region {
+	if snapshot.versionState == nil || snapshot.recoveryRegion() == region || !reflect.DeepEqual(snapshot.recoveryRegion(), region) {
 		t.Fatal("closing the live header changed its copied recovery state")
 	}
-	if snapshot.versionState.s3Region != region {
+	if snapshot.versionState.s3Region != snapshot.recoveryRegion() {
 		t.Fatal("closing the live header mutated the immutable wrapper")
 	}
 }
@@ -71,8 +72,8 @@ func TestDiagnosticParserCorePerVersionStateRollbackRestoresCopy(t *testing.T) {
 	headers[0].setRecoveryRegion(second)
 	scratch.finish(&headers, true)
 
-	if got := headers[0].recoveryRegion(); got != first {
-		t.Fatalf("rolled-back region=%p, want %p", got, first)
+	if got := headers[0].recoveryRegion(); got == first || !reflect.DeepEqual(got, first) {
+		t.Fatalf("rolled-back region=%+v, want an independent copy of %+v", got, first)
 	}
 	if headers[0].versionState != originalState {
 		t.Fatal("rollback did not restore the original immutable wrapper")

--- a/parsercore_phase0_per_version_lexer_state_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_state_internal_test.go
@@ -1,0 +1,92 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+	"unsafe"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func TestDiagnosticParserCorePerVersionStateKeepsHeaderSize(t *testing.T) {
+	if got := unsafe.Sizeof(diagnosticParserCoreHeader{}); got != 224 {
+		t.Fatalf("diagnostic parser core header is %d bytes, want 224", got)
+	}
+}
+
+func TestDiagnosticParserCorePerVersionStatePublishesImmutableCopies(t *testing.T) {
+	first := &diagnosticParserCoreS3Region{state: 7, startByte: 2, endByte: 4}
+	second := &diagnosticParserCoreS3Region{state: 9, startByte: 4, endByte: 6}
+	var header diagnosticParserCoreHeader
+	header.openRecoveryRegion(first)
+	copyOfHeader := header
+	initialState := header.versionState
+
+	header.setRecoveryRegion(second)
+
+	if header.versionState == initialState {
+		t.Fatal("setRecoveryRegion reused the previous immutable wrapper")
+	}
+	if got := header.recoveryRegion(); got != second {
+		t.Fatalf("updated region=%p, want %p", got, second)
+	}
+	if got := copyOfHeader.recoveryRegion(); got != first {
+		t.Fatalf("copied header region=%p, want original %p", got, first)
+	}
+	if copyOfHeader.versionState != initialState {
+		t.Fatal("updating the live header changed the copied header state")
+	}
+}
+
+func TestDiagnosticParserCorePerVersionStateCloseDoesNotMutateSnapshot(t *testing.T) {
+	region := &diagnosticParserCoreS3Region{state: 3, children: []core.SubtreeID{11}}
+	var header diagnosticParserCoreHeader
+	header.openRecoveryRegion(region)
+	snapshot := header
+
+	header.closeRecoveryRegion()
+
+	if header.versionState != nil || header.recoveryRegion() != nil {
+		t.Fatal("closeRecoveryRegion left recovery state live")
+	}
+	if snapshot.versionState == nil || snapshot.recoveryRegion() != region {
+		t.Fatal("closing the live header changed its copied recovery state")
+	}
+	if snapshot.versionState.s3Region != region {
+		t.Fatal("closing the live header mutated the immutable wrapper")
+	}
+}
+
+func TestDiagnosticParserCorePerVersionStateRollbackRestoresCopy(t *testing.T) {
+	first := &diagnosticParserCoreS3Region{state: 1, startByte: 5, endByte: 7}
+	second := &diagnosticParserCoreS3Region{state: 2, startByte: 7, endByte: 9}
+	headers := []diagnosticParserCoreHeader{{}}
+	headers[0].openRecoveryRegion(first)
+	originalState := headers[0].versionState
+	var scratch diagnosticParserCoreHeaderRollbackScratch
+	if err := scratch.begin(headers); err != nil {
+		t.Fatalf("begin rollback snapshot: %v", err)
+	}
+	headers[0].setRecoveryRegion(second)
+	scratch.finish(&headers, true)
+
+	if got := headers[0].recoveryRegion(); got != first {
+		t.Fatalf("rolled-back region=%p, want %p", got, first)
+	}
+	if headers[0].versionState != originalState {
+		t.Fatal("rollback did not restore the original immutable wrapper")
+	}
+	if scratch.busy || len(scratch.headers) != 0 {
+		t.Fatal("rollback scratch remained active after finish")
+	}
+}
+
+func TestDiagnosticParserCorePerVersionStateSetNilCloses(t *testing.T) {
+	var header diagnosticParserCoreHeader
+	header.openRecoveryRegion(&diagnosticParserCoreS3Region{state: 4})
+	header.setRecoveryRegion(nil)
+	if header.versionState != nil || header.recoveryRegion() != nil {
+		t.Fatal("setRecoveryRegion(nil) did not close recovery state")
+	}
+}

--- a/parsercore_phase0_recovery_lineage_fork_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_fork_internal_test.go
@@ -86,10 +86,10 @@ func TestS5MissingInsertionForkPublishesBothRecoveryLineages(t *testing.T) {
 	if !scheduler.recoveryIsolation {
 		t.Fatal("the fork did not activate recovery isolation")
 	}
-	if scheduler.headers[1].shifted || scheduler.headers[1].s3Region != nil {
+	if scheduler.headers[1].shifted || scheduler.headers[1].recoveryRegion() != nil {
 		t.Fatalf("missing lineage consumed the real token: %+v", scheduler.headers[1])
 	}
-	if !scheduler.headers[0].shifted || scheduler.headers[0].s3Region == nil {
+	if !scheduler.headers[0].shifted || scheduler.headers[0].recoveryRegion() == nil {
 		t.Fatalf("absorb lineage did not consume the real token: %+v", scheduler.headers[0])
 	}
 	if scheduler.headers[0].creationSeq != 3 || scheduler.headers[1].creationSeq != 10 || scheduler.nextSeq != 11 {
@@ -118,7 +118,7 @@ func TestS5MissingInsertionForkPublishesBothRecoveryLineages(t *testing.T) {
 		t.Fatalf("missing payload=%+v, want symbol 2 at byte 1", missing)
 	}
 
-	region := scheduler.headers[0].s3Region
+	region := scheduler.headers[0].recoveryRegion()
 	if len(region.children) != 1 || region.startByte != 1 || region.endByte != 2 {
 		t.Fatalf("absorb region=%+v, want one child over bytes 1..2", region)
 	}
@@ -167,8 +167,8 @@ func TestS3RegionMarkerAllowsClosureOnlyRedispatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("s3TryOpenErrorRegion: %v", err)
 	}
-	if !handled || scheduler.headers[0].s3Region != nil {
-		t.Fatalf("closure-only redispatch handled=%t region=%+v", handled, scheduler.headers[0].s3Region)
+	if !handled || scheduler.headers[0].recoveryRegion() != nil {
+		t.Fatalf("closure-only redispatch handled=%t region=%+v", handled, scheduler.headers[0].recoveryRegion())
 	}
 	state, _, err := scheduler.compact.Boundary(scheduler.headers[0].head)
 	if err != nil {

--- a/parsercore_phase0_recovery_lineage_selection_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_selection_internal_test.go
@@ -233,13 +233,13 @@ func TestRecoveryOpenSegmentsDerivesFromLiveState(t *testing.T) {
 	}
 	header.paused = false
 
-	header.s3Region = &diagnosticParserCoreS3Region{}
+	header.openRecoveryRegion(&diagnosticParserCoreS3Region{})
 	if got := header.recoveryOpenSegments(); got != 1 {
 		t.Fatalf("an opened-but-empty error region reported %d open segments, want 1", got)
 	}
 	// Once the region holds absorbed content, its cost lives in the published
 	// subtrees and the open term must stop applying.
-	header.s3Region = &diagnosticParserCoreS3Region{children: []core.SubtreeID{1}}
+	header.setRecoveryRegion(&diagnosticParserCoreS3Region{children: []core.SubtreeID{1}})
 	if got := header.recoveryOpenSegments(); got != 0 {
 		t.Fatalf("a region with absorbed content reported %d open segments, want 0", got)
 	}
@@ -253,13 +253,13 @@ func TestCollapseToRecoveryWinnerSeatsTheWinnerAndClearsLosers(t *testing.T) {
 	scheduler := newLineageSelectionScheduler(t, true)
 	scheduler.headers = append(scheduler.headers, diagnosticParserCoreHeader{})
 	scheduler.headers[2].markRecoveryLineage()
-	scheduler.headers[2].s3Region = &diagnosticParserCoreS3Region{}
+	scheduler.headers[2].openRecoveryRegion(&diagnosticParserCoreS3Region{})
 	scheduler.recoveryIsolation = true
 	retainedRegion := &diagnosticParserCoreS3Region{}
 	for target := range scheduler.canonicalScratch.headerBuffers {
 		buffer := make([]diagnosticParserCoreHeader, 2, 4)
 		buffer[1].markRecoveryLineage()
-		buffer[1].s3Region = retainedRegion
+		buffer[1].openRecoveryRegion(retainedRegion)
 		scheduler.canonicalScratch.headerBuffers[target] = buffer
 	}
 	want := scheduler.headers[1]
@@ -282,13 +282,13 @@ func TestCollapseToRecoveryWinnerSeatsTheWinnerAndClearsLosers(t *testing.T) {
 	// error region for the scheduler's lifetime otherwise.
 	tail := scheduler.headers[:cap(scheduler.headers)][1:3]
 	for index := range tail {
-		if tail[index].s3Region != nil || tail[index].isRecoveryLineage() {
+		if tail[index].recoveryRegion() != nil || tail[index].isRecoveryLineage() {
 			t.Fatalf("dropped header %d is still live in the backing array", index+1)
 		}
 	}
 	for target, buffer := range scheduler.canonicalScratch.headerBuffers {
 		for index, header := range buffer[:cap(buffer)] {
-			if header.s3Region == retainedRegion || header.isRecoveryLineage() {
+			if header.recoveryRegion() == retainedRegion || header.isRecoveryLineage() {
 				t.Fatalf("canonical buffer %d retained loser %d", target, index)
 			}
 		}

--- a/parsercore_phase0_stack_summary_recovery_internal_test.go
+++ b/parsercore_phase0_stack_summary_recovery_internal_test.go
@@ -87,10 +87,10 @@ func TestS4StackSummaryRecoveryForkPublishesBothLineages(t *testing.T) {
 	if !scheduler.recoveryIsolation {
 		t.Fatal("the fork did not activate recovery isolation")
 	}
-	if !scheduler.headers[0].shifted || scheduler.headers[0].s3Region == nil {
+	if !scheduler.headers[0].shifted || scheduler.headers[0].recoveryRegion() == nil {
 		t.Fatalf("absorb lineage did not consume the real token: %+v", scheduler.headers[0])
 	}
-	if scheduler.headers[1].shifted || scheduler.headers[1].s3Region != nil {
+	if scheduler.headers[1].shifted || scheduler.headers[1].recoveryRegion() != nil {
 		t.Fatalf("recovered lineage consumed the real token: %+v", scheduler.headers[1])
 	}
 	if scheduler.headers[0].creationSeq != 3 || scheduler.headers[1].creationSeq != 10 || scheduler.nextSeq != 11 {


### PR DESCRIPTION
Stage 1 of the compact-parser graduation funnel.

Scope:

- Give each live parser version an exact lexer and scanner cursor.
- Dispatch each version against its own token width.
- Preserve checkpoint continuity and shared-source isolation.
- Keep later graduation packages out of this PR.

C-oracle witness:

- Grammar: Scala.
- Source: `(y)->`, five bytes.
- Source SHA-256: `59b8f8c8f7f235973d07ac90f3089939e92da41ee23dcb496bc5c880f9577068`.
- Owned state 8195 consumes symbol 79 over bytes 3 through 5.
- Owned state 18766 consumes symbol 23 over bytes 3 through 4.
- Go and the locked C oracle produce the same clean `compilation_unit` tree.
- Both deep digests equal `81dc569b1ad3d567ed158aea75fd30a388ec1f4d3e1cbdd08c29a6535bd456d3`.
- Restricted enumeration found no shorter accepted witness in 1,776 tested strings.

Implementation:

- Store immutable deterministic finite automaton and scanner snapshots behind the fixed-size header.
- Carry one-based request references through reductions and ambiguity forks.
- Bind each dispatch cell to its exact request and classified boundary.
- Publish the after snapshot only when the owning version shifts.
- Advance multi-version elections without exposing a partial frontier.
- Rejoin the shared lexer only after one shifted owned version remains.
- Separate proven lexer-viability drops from grammar-ambiguity drops.
- Validate exact scanner checkpoint pairs before mutation.
- Retire paused owned lineages through the no-action path.
- Enforce no-lookahead progress, post-root end-of-file, and step-cap rules.
- Roll back request, activation, and rejoin state on errors and panics.
- Reject shared-lexer rejoin when the token source or lexer is unavailable.
- Attribute external-token telemetry to the selected head and its checkpoints.
- Clear discarded pointer-bearing state on rollback, collapse, and reuse.

Proof:

- The locked Scala C tree, ranges, flags, S-expression, and deep digest match.
- The compact route records one routed parse and zero fallbacks.
- The Swift scanner witness records 4 requests, 4 restores, 14 publications, 3 ragged shifts, and 1 viability drop.
- The peak live-version count is 2.
- The header remains 224 bytes.
- Snapshot, rollback, cleanup, ownership, footprint, and disabled-tag checks pass.
- Focused lifecycle tests cover paused retirement, no-lookahead rules, callback panics, rollback, and nil rejoin inputs.
- The focused owned-lexer race test passes.
- The required compact admission ratchet passes.
- Final Docker receipt: `harness_out/docker/20260901T113050Z`. It had no out-of-memory or timeout event.
- Focused race receipt: `harness_out/docker/20260901T113445Z`. It had no out-of-memory or timeout event.

This PR excludes physical graph-head merging, ambiguity recovery, end-of-file recovery, incremental integration, grammar certification, and performance work.
