### PR TITLE
parsercorephase0: merge equivalent physical graph heads

### DIFF
--- a/cgo_harness/c_topology_receipt_test.go
+++ b/cgo_harness/c_topology_receipt_test.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"testing"
 
+	gotreesitter "github.com/odvcencio/gotreesitter"
 	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
@@ -90,6 +91,12 @@ func TestCTopologyReceiptErlangOneBytePhysicalMerge(t *testing.T) {
 	if receipt.Truncated || receipt.ArithmeticOverflow || receipt.IdentityCollision || receipt.IdentityIncomplete || receipt.EventsDropped != 0 {
 		t.Fatalf("incomplete one-byte C topology receipt: %+v", receipt)
 	}
+	if receipt.EventsSeen != uint64(len(receipt.Events)) || receipt.EventsRetained != uint32(len(receipt.Events)) {
+		t.Fatalf(
+			"one-byte event accounting seen=%d retained=%d dropped=%d len=%d",
+			receipt.EventsSeen, receipt.EventsRetained, receipt.EventsDropped, len(receipt.Events),
+		)
+	}
 	if len(receipt.Events) != cTopologyErlangOneByteEventCount || cTopologyReceiptSHA256(receipt) != cTopologyErlangOneByteSHA256 {
 		t.Fatalf("one-byte C topology events=%d sha256=%s", len(receipt.Events), cTopologyReceiptSHA256(receipt))
 	}
@@ -135,6 +142,36 @@ func TestCTopologyReceiptErlangOneBytePhysicalMerge(t *testing.T) {
 		row.Accepts != 3 || row.ExplicitRecovers != 0 || row.LinkUnionAttempts != 4 ||
 		row.LinkUnionDuplicate != 1 || row.LinkUnionAppended != 3 || row.GraphLinkAdditions != 31 || row.Overflow {
 		t.Fatalf("one-byte C work receipt=%+v", row)
+	}
+
+	entry, ok := parityEntriesByName["erlang"]
+	if !ok {
+		t.Fatal("Erlang Go grammar is not registered")
+	}
+	goLanguage := entry.Language()
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	goParser := gotreesitter.NewParser(goLanguage)
+	goParser.SetAdmissionCandidateRoute(true)
+	goTree, err := goParser.Parse(source)
+	if err != nil {
+		t.Fatalf("one-byte routed Go parse: %v", err)
+	}
+	if goTree == nil || goTree.RootNode() == nil {
+		t.Fatal("one-byte routed Go parser returned no tree")
+	}
+	t.Cleanup(func() { goTree.Release() })
+	if diff := FirstDivergenceDumpV1(goTree.RootNode(), goLanguage, root); diff != nil {
+		t.Fatalf("one-byte routed Go tree diverges from C: %+v", diff)
+	}
+	if diff := firstLockedCTreeFlagDivergence(goTree.RootNode(), goLanguage, root, "/source_file"); diff != nil {
+		t.Fatalf("one-byte routed Go flags diverge from C: %v", diff)
+	}
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter != routedBefore || fallbackAfter != fallbackBefore+1 {
+		t.Fatalf(
+			"one-byte route delta=%d/%d, want 0/1 before recovery-through-ambiguity graduation",
+			routedAfter-routedBefore, fallbackAfter-fallbackBefore,
+		)
 	}
 }
 

--- a/cgo_harness/c_topology_receipt_test.go
+++ b/cgo_harness/c_topology_receipt_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 const (
@@ -34,7 +36,107 @@ const (
 
 	cTopologyErlangIssue984EventCount = 280
 	cTopologyErlangIssue984SHA256     = "f90b82a19bd52475a0b61376a631fe53b69ac827c89bec6802940e8302d77754"
+	cTopologyErlangOneByteEventCount  = 219
+	cTopologyErlangOneByteSHA256      = "eea03c73787e2353366ec29a90e0b051ca0e1c53db05625ef84ff3abc9c11f3e"
 )
+
+// TestCTopologyReceiptErlangOneBytePhysicalMerge locks the smallest C source
+// that performs a physical stack-version merge. It pins both the merge count
+// and the complete topology receipt before the compact implementation changes.
+func TestCTopologyReceiptErlangOneBytePhysicalMerge(t *testing.T) {
+	oracle := mergeCensusOracleForTest(t)
+	source := []byte("(")
+	if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != "32ebb1abcc1c601ceb9c4e3c4faba0caa5b85bb98c4f1e6612c40faa528a91c9" {
+		t.Fatalf("source SHA-256=%s", got)
+	}
+	cLanguage, err := COracleLanguage("erlang")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil {
+		t.Fatal("one-byte C parse returned a nil tree")
+	}
+	t.Cleanup(cTree.Close)
+	root := cTree.RootNode()
+	if root.Kind() != "source_file" || !root.IsNamed() || root.StartByte() != 0 || root.EndByte() != 1 || root.ChildCount() != 1 || !root.HasError() {
+		t.Fatalf("one-byte C root:\n%s", dumpCTree(root, 0))
+	}
+	errorNode := root.Child(0)
+	if errorNode.Kind() != "ERROR" || !errorNode.IsNamed() || errorNode.StartByte() != 0 || errorNode.EndByte() != 1 || errorNode.ChildCount() != 1 || !errorNode.IsError() {
+		t.Fatalf("one-byte C error node:\n%s", dumpCTree(root, 0))
+	}
+	token := errorNode.Child(0)
+	if token.Kind() != "(" || token.IsNamed() || token.StartByte() != 0 || token.EndByte() != 1 || token.ChildCount() != 0 {
+		t.Fatalf("one-byte C token:\n%s", dumpCTree(root, 0))
+	}
+	topology, err := mergeCensusRunCTopology(oracle, "erlang", a3CertificationSweepSource{
+		Name:   "one_byte_open_paren",
+		Source: source,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if topology.Status != "ok" || topology.SourceBytes != 1 || topology.RootEndByte != 1 ||
+		topology.RootChildCount != 1 || !topology.RootHasError {
+		t.Fatalf("one-byte C tree receipt=%+v", topology)
+	}
+	receipt := topology.Receipt
+	if receipt.Truncated || receipt.ArithmeticOverflow || receipt.IdentityCollision || receipt.IdentityIncomplete || receipt.EventsDropped != 0 {
+		t.Fatalf("incomplete one-byte C topology receipt: %+v", receipt)
+	}
+	if len(receipt.Events) != cTopologyErlangOneByteEventCount || cTopologyReceiptSHA256(receipt) != cTopologyErlangOneByteSHA256 {
+		t.Fatalf("one-byte C topology events=%d sha256=%s", len(receipt.Events), cTopologyReceiptSHA256(receipt))
+	}
+	var successfulMergeIDs []uint64
+	kindCounts := make(map[uint64]int)
+	for _, event := range receipt.Events {
+		kindCounts[event.Kind]++
+		if event.Kind == cTopologyEventMerge && event.Flags&cTopologyFlagSelected != 0 {
+			successfulMergeIDs = append(successfulMergeIDs, event.EventID)
+		}
+	}
+	if got, want := fmt.Sprint(successfulMergeIDs), "[47 173 181 188]"; got != want {
+		t.Fatalf("successful C merge events=%s, want %s", got, want)
+	}
+	wantKinds := map[uint64]int{
+		cTopologyEventAction: 17, cTopologyEventVersionAdd: 20,
+		cTopologyEventVersionCopy: 2, cTopologyEventVersionRenumber: 39,
+		cTopologyEventMerge: 82, cTopologyEventLinkInsert: 31,
+		cTopologyEventPopPath: 22, cTopologyEventAcceptElection: 6,
+	}
+	if len(kindCounts) != len(wantKinds) {
+		t.Fatalf("one-byte C topology kind counts=%v, want %v", kindCounts, wantKinds)
+	}
+	for kind, want := range wantKinds {
+		if kindCounts[kind] != want {
+			t.Fatalf("one-byte C topology kind %d=%d, want %d", kind, kindCounts[kind], want)
+		}
+	}
+
+	counts, err := mergeCensusRunC(oracle, "erlang", []a3CertificationSweepSource{{
+		Name:   "one_byte_open_paren",
+		Source: source,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(counts) != 1 {
+		t.Fatalf("one-byte C count rows=%d, want 1", len(counts))
+	}
+	row := counts[0]
+	if row.Status != "ok" || row.MergeAttempts != 82 || row.MergeSuccesses != 4 ||
+		row.VersionCreations != 23 || row.Shifts != 1 || row.Reductions != 15 ||
+		row.Accepts != 3 || row.ExplicitRecovers != 0 || row.LinkUnionAttempts != 4 ||
+		row.LinkUnionDuplicate != 1 || row.LinkUnionAppended != 3 || row.GraphLinkAdditions != 31 || row.Overflow {
+		t.Fatalf("one-byte C work receipt=%+v", row)
+	}
+}
 
 func TestCTopologyReceiptErlangIssue984(t *testing.T) {
 	oracle := mergeCensusOracleForTest(t)

--- a/cgo_harness/merge_event_census.go
+++ b/cgo_harness/merge_event_census.go
@@ -628,6 +628,9 @@ func runMergeEventCensusRow(
 		row.Go.CompactLinkUnionRecursiveChanged = compact.CompactLinkUnionRecursiveChanged
 		row.Go.CompactLinkUnionAlternateAppended = compact.CompactLinkUnionAlternateAppended
 		row.Go.CompactLinkUnionRejected = compact.CompactLinkUnionRejected
+		row.Go.CompactPhysicalHeadMergeAttempts = compact.CompactPhysicalHeadMergeAttempts
+		row.Go.CompactPhysicalHeadMergeSuccesses = compact.CompactPhysicalHeadMergeSuccesses
+		row.Go.CompactPhysicalHeadMergeInputLinks = compact.CompactPhysicalHeadMergeInputLinks
 		row.Go.CompactAcceptancesObserved = compact.CompactAcceptancesObserved
 	}
 	return row
@@ -669,11 +672,14 @@ type mergeCensusTotals struct {
 	LinkPayloadDeepWouldAccept    uint64
 	LinkPayloadPending            uint64
 
-	CompactAccepted     int
-	CompactUnionAttempt uint64
-	CompactUnionAppend  uint64
-	CompactUnionDup     uint64
-	CompactUnionReject  uint64
+	CompactAccepted           int
+	CompactUnionAttempt       uint64
+	CompactUnionAppend        uint64
+	CompactUnionDup           uint64
+	CompactUnionReject        uint64
+	CompactPhysicalAttempts   uint64
+	CompactPhysicalSuccesses  uint64
+	CompactPhysicalInputLinks uint64
 
 	// SourcesWhereGoOverMerges is the stop-the-line class of gate G6: a source
 	// where production collapses MORE versions than the reference runtime.
@@ -725,6 +731,9 @@ func (t *mergeCensusTotals) add(row mergeCensusRow) {
 		t.CompactUnionAppend += row.Go.CompactLinkUnionAlternateAppended
 		t.CompactUnionDup += row.Go.CompactLinkUnionDuplicateNoop
 		t.CompactUnionReject += row.Go.CompactLinkUnionRejected
+		t.CompactPhysicalAttempts += row.Go.CompactPhysicalHeadMergeAttempts
+		t.CompactPhysicalSuccesses += row.Go.CompactPhysicalHeadMergeSuccesses
+		t.CompactPhysicalInputLinks += row.Go.CompactPhysicalHeadMergeInputLinks
 	}
 
 	if row.Go.Successes > row.C.MergeSuccesses {

--- a/cgo_harness/merge_event_census_test.go
+++ b/cgo_harness/merge_event_census_test.go
@@ -32,6 +32,32 @@ import (
 // test binary run.
 var mergeCensusOracleCache *mergeCensusCOracle
 
+func TestMergeCensusTotalsAggregatesPhysicalHeadMergeTelemetry(t *testing.T) {
+	totals := &mergeCensusTotals{}
+	totals.add(mergeCensusRow{
+		CompactAccepted: true,
+		Go: gotreesitter.MergeEventCensusCounts{
+			CompactPhysicalHeadMergeAttempts:   3,
+			CompactPhysicalHeadMergeSuccesses:  2,
+			CompactPhysicalHeadMergeInputLinks: 5,
+		},
+	})
+	totals.add(mergeCensusRow{
+		CompactAccepted: true,
+		Go: gotreesitter.MergeEventCensusCounts{
+			CompactPhysicalHeadMergeAttempts:   7,
+			CompactPhysicalHeadMergeSuccesses:  4,
+			CompactPhysicalHeadMergeInputLinks: 9,
+		},
+	})
+	if totals.CompactPhysicalAttempts != 10 || totals.CompactPhysicalSuccesses != 6 ||
+		totals.CompactPhysicalInputLinks != 14 {
+		t.Fatalf("physical merge totals=%d/%d/%d, want 10/6/14",
+			totals.CompactPhysicalAttempts, totals.CompactPhysicalSuccesses, totals.CompactPhysicalInputLinks,
+		)
+	}
+}
+
 func mergeCensusOracleForTest(t *testing.T) *mergeCensusCOracle {
 	t.Helper()
 	if mergeCensusOracleCache != nil {
@@ -234,15 +260,23 @@ func TestMergeEventCensusBaseline(t *testing.T) {
 			grand.SourcesWhereGoOverMerges,
 		)
 	}
+	if grand.CompactPhysicalAttempts != 0 || grand.CompactPhysicalSuccesses != 0 ||
+		grand.CompactPhysicalInputLinks != 0 {
+		t.Errorf(
+			"accepted corpus physical merges changed: attempts=%d successes=%d input-links=%d, want all zero",
+			grand.CompactPhysicalAttempts, grand.CompactPhysicalSuccesses, grand.CompactPhysicalInputLinks,
+		)
+	}
 }
 
 func mergeCensusFormatTotals(label string, t *mergeCensusTotals) string {
 	return fmt.Sprintf(
-		"%-22s sources=%3d M_c=%6d M_p=%6d ratio=%-8s c-attempts=%7d go-attempts=%7d over-merge-sources=%d c-merges-go-does-not=%d | refusals: %s | tier2: %s | compact: accepted=%d union-attempts=%d union-appends=%d",
+		"%-22s sources=%3d M_c=%6d M_p=%6d ratio=%-8s c-attempts=%7d go-attempts=%7d over-merge-sources=%d c-merges-go-does-not=%d | refusals: %s | tier2: %s | compact: accepted=%d union-attempts=%d union-appends=%d physical-attempts=%d physical-successes=%d physical-input-links=%d",
 		label, t.Sources, t.CMergeSuccesses, t.GoSuccesses, t.ratioText(),
 		t.CMergeAttempts, t.GoAttempts, t.SourcesWhereGoOverMerges, t.SourcesWhereCMergesAndGoDoesNot,
 		t.refusalLine(), t.linkPayloadLine(),
 		t.CompactAccepted, t.CompactUnionAttempt, t.CompactUnionAppend,
+		t.CompactPhysicalAttempts, t.CompactPhysicalSuccesses, t.CompactPhysicalInputLinks,
 	)
 }
 
@@ -256,13 +290,16 @@ func mergeCensusLogRow(t *testing.T, row mergeCensusRow) {
 		ratio = fmt.Sprintf("%.4f", value)
 	}
 	t.Logf(
-		"%s/%s: M_c=%d M_p=%d ratio=%s c-status=%s c-link-union(att=%d dup=%d prec=%d rec=%d app=%d rej=%d) go-refusals(score=%d shapes=%d clean=%d state=%d cost=%d) tier2-shallow-would-accept=%d",
+		"%s/%s: M_c=%d M_p=%d ratio=%s c-status=%s c-link-union(att=%d dup=%d prec=%d rec=%d app=%d rej=%d) go-refusals(score=%d shapes=%d clean=%d state=%d cost=%d) tier2-shallow-would-accept=%d compact-physical(att=%d ok=%d links=%d)",
 		row.Language, row.Name, row.C.MergeSuccesses, row.Go.Successes, ratio, row.C.Status,
 		row.C.LinkUnionAttempts, row.C.LinkUnionDuplicate, row.C.LinkUnionPrecedence,
 		row.C.LinkUnionRecursive, row.C.LinkUnionAppended, row.C.LinkUnionRejected,
 		row.Go.RefuseScoreOrShifted, row.Go.RefuseDistinctShapes, row.Go.RefuseCleanZero,
 		row.Go.RefuseStateOrOffset, row.Go.RefuseErrorCost,
 		row.Go.LinkPayloadShallowWouldAccept,
+		row.Go.CompactPhysicalHeadMergeAttempts,
+		row.Go.CompactPhysicalHeadMergeSuccesses,
+		row.Go.CompactPhysicalHeadMergeInputLinks,
 	)
 }
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1079,9 +1079,13 @@ type Head struct {
 // output can merge into. The scheduler excludes the source version.
 type CondenseCandidate struct {
 	Head           Head
-	DropCohortRefs DropCohortRefSet
-	Shifted        bool
 	Checkpoint     CheckpointID
+	DropCohortRefs DropCohortRefSet
+	// ErrorCost is zero for the clean Stage 2 merge route. Recovery versions
+	// stay separate until a later stage can compare their complete C costs.
+	ErrorCost     uint32
+	MergeIdentity uint16
+	Shifted       bool
 }
 
 // Derivation is one retained exact root-to-head path after local shallow-link
@@ -1166,6 +1170,9 @@ type Work struct {
 	ReductionPopRequests                   uint64
 	EmittedPopPaths                        uint64
 	EmittedPopPayloads                     uint64
+	PhysicalHeadMergeAttempts              uint64
+	PhysicalHeadMergeSuccesses             uint64
+	PhysicalHeadMergeInputLinks            uint64
 	PredecessorLinkUnionAttempts           uint64
 	PredecessorLinkUnionDuplicateNoop      uint64
 	PredecessorLinkUnionPrecedenceReplaced uint64
@@ -2202,6 +2209,7 @@ func (c *Core) ResetReleasingRetention() error {
 	if err := c.Reset(); err != nil {
 		return err
 	}
+	c.condenseCandidates = nil
 	c.releaseRecordArenaReserve()
 	c.releaseOversizedRetention()
 	return nil
@@ -3905,6 +3913,9 @@ func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int, folde
 		changed = changed || inserted
 	}
 	if len(links) == 0 && !changed {
+		if err := c.mergeNodeLineageMetadata(leftID, rightID, leftID); err != nil {
+			return 0, false, err
+		}
 		return leftID, false, nil
 	}
 	// C updates the containing node's maximum even when the incoming edge is
@@ -3918,10 +3929,16 @@ func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int, folde
 		changed = true
 	}
 	if !changed {
+		if err := c.mergeNodeLineageMetadata(leftID, rightID, leftID); err != nil {
+			return 0, false, err
+		}
 		return leftID, false, nil
 	}
 	merged, err := c.appendAdjacencyNodeAtWithPrecedence(left.state, left.byteOffset, leftCheckpoint, links, *folded)
 	if err != nil {
+		return 0, false, err
+	}
+	if err := c.mergeNodeLineageMetadata(leftID, rightID, merged); err != nil {
 		return 0, false, err
 	}
 	return merged, true, nil

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1081,8 +1081,10 @@ type CondenseCandidate struct {
 	Head           Head
 	Checkpoint     CheckpointID
 	DropCohortRefs DropCohortRefSet
-	// ErrorCost is zero for the clean Stage 2 merge route. Recovery versions
-	// stay separate until a later stage can compare their complete C costs.
+	// ErrorCost is zero for the clean Stage 2 merge route. The production
+	// driver preserves a permanent recovery-costed marker and excludes those
+	// headers. Recovery versions stay separate until a later stage can compare
+	// their complete C costs.
 	ErrorCost     uint32
 	MergeIdentity uint16
 	Shifted       bool

--- a/internal/parsercorephase0/physical_head_merge_stage2_test.go
+++ b/internal/parsercorephase0/physical_head_merge_stage2_test.go
@@ -1,0 +1,708 @@
+//go:build gts_parsercorephase0
+
+package parsercorephase0
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// newStage2PhysicalHeadPair creates two immutable graph heads at one boundary.
+// Each head owns a different predecessor path, so a merge must retain both.
+func newStage2PhysicalHeadPair(t *testing.T) (*Core, Head, Head, uint32, uint32) {
+	t.Helper()
+	compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	leftRoot, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightRoot, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftPayload, err := compact.appendSubtree(subtreeRecord{
+		symbol: 10, startByte: 0, endByte: 1, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightPayload, err := compact.appendSubtree(subtreeRecord{
+		symbol: 11, startByte: 0, endByte: 1, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftLink := compact.appendGraphLink(linkRecord{prev: leftRoot.Node, payload: leftPayload})
+	leftNode, err := compact.appendNode(nodeRecord{
+		state: 3, byteOffset: 1, firstLink: uint32(leftLink), linkCount: 1, pathCount: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightLink := compact.appendGraphLink(linkRecord{prev: rightRoot.Node, payload: rightPayload})
+	rightNode, err := compact.appendNode(nodeRecord{
+		state: 3, byteOffset: 1, firstLink: uint32(rightLink), linkCount: 1, pathCount: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return compact, Head{Node: leftNode}, Head{Node: rightNode}, uint32(leftPayload), uint32(rightPayload)
+}
+
+func TestStage2PhysicalHeadMergeUnionsEquivalentDistinctNodes(t *testing.T) {
+	compact, left, right, leftPayload, rightPayload := newStage2PhysicalHeadPair(t)
+	candidates := []CondenseCandidate{
+		{Head: left, Shifted: false, Checkpoint: 0},
+		{Head: right, Shifted: false, Checkpoint: 0},
+	}
+	before := compact.Work()
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.ReindexCondenseCandidatesOwned(owner, candidates)
+	})
+	if err != nil {
+		t.Fatalf("ReindexCondenseCandidatesOwned: %v", err)
+	}
+	canonical, ok := compact.CanonicalBoundary(3, 1, false, 0)
+	if !ok {
+		t.Fatal("physical-head merge did not publish a canonical boundary")
+	}
+	if canonical == left || canonical == right {
+		t.Fatalf("physical-head merge reused one input node: canonical=%+v left=%+v right=%+v", canonical, left, right)
+	}
+	stats, err := compact.Stats(canonical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.CurrentExactPaths != 2 {
+		t.Fatalf("merged physical head paths=%d, want 2", stats.CurrentExactPaths)
+	}
+	derivations, err := compact.Derivations(canonical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(derivations) != 2 {
+		t.Fatalf("merged physical head derivations=%+v, want two", derivations)
+	}
+	seenLeft, seenRight := false, false
+	for _, derivation := range derivations {
+		if len(derivation.Payloads) != 1 {
+			t.Fatalf("merged derivation=%+v, want one payload", derivation)
+		}
+		seenLeft = seenLeft || uint32(derivation.Payloads[0]) == leftPayload
+		seenRight = seenRight || uint32(derivation.Payloads[0]) == rightPayload
+	}
+	if !seenLeft || !seenRight {
+		t.Fatalf("merged derivations lost one predecessor payload: %+v", derivations)
+	}
+	after := compact.Work()
+	if after.PhysicalHeadMergeAttempts-before.PhysicalHeadMergeAttempts != 1 ||
+		after.PhysicalHeadMergeSuccesses-before.PhysicalHeadMergeSuccesses != 1 ||
+		after.PhysicalHeadMergeInputLinks-before.PhysicalHeadMergeInputLinks != 1 {
+		t.Fatalf("physical-head merge telemetry=%+v before=%+v", after, before)
+	}
+}
+
+func TestStage2PhysicalHeadMergeAtSixVersionBoundaryRetainsEveryPath(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 16, MaxPopPaths: 16})
+	headCount := 6
+	candidates := make([]CondenseCandidate, 0, headCount)
+	wantPayloads := make(map[SubtreeID]bool, headCount)
+	for index := 0; index < headCount; index++ {
+		root, err := compact.Seed(StateID(index+1), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload, err := compact.appendSubtree(subtreeRecord{
+			symbol: Symbol(index + 10), startByte: 0, endByte: 1, terminal: true,
+		}, nil, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		link := compact.appendGraphLink(linkRecord{prev: root.Node, payload: payload})
+		node, err := compact.appendNode(nodeRecord{
+			state: 7, byteOffset: 1, firstLink: uint32(link), linkCount: 1, pathCount: 1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		head := Head{Node: node}
+		candidates = append(candidates, CondenseCandidate{Head: head})
+		wantPayloads[payload] = true
+	}
+
+	before := compact.Work()
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.ReindexCondenseCandidatesOwned(owner, candidates)
+	})
+	if err != nil {
+		t.Fatalf("ReindexCondenseCandidatesOwned: %v", err)
+	}
+	canonical, ok := compact.CanonicalBoundary(7, 1, false, 0)
+	if !ok {
+		t.Fatal("six-version condense did not publish a canonical boundary")
+	}
+	stats, err := compact.Stats(canonical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.CurrentExactPaths != uint64(headCount) {
+		t.Fatalf("six-version physical head paths=%d, want %d", stats.CurrentExactPaths, headCount)
+	}
+	derivations, err := compact.Derivations(canonical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(derivations) != headCount {
+		t.Fatalf("six-version derivations=%d, want %d", len(derivations), headCount)
+	}
+	for _, derivation := range derivations {
+		if len(derivation.Payloads) != 1 || !wantPayloads[derivation.Payloads[0]] {
+			t.Fatalf("six-version derivation=%+v lost a path", derivation)
+		}
+		delete(wantPayloads, derivation.Payloads[0])
+	}
+	if len(wantPayloads) != 0 {
+		t.Fatalf("six-version merge lost payloads=%v", wantPayloads)
+	}
+	after := compact.Work()
+	if after.PhysicalHeadMergeAttempts-before.PhysicalHeadMergeAttempts != uint64(headCount-1) ||
+		after.PhysicalHeadMergeSuccesses-before.PhysicalHeadMergeSuccesses != uint64(headCount-1) ||
+		after.PhysicalHeadMergeInputLinks-before.PhysicalHeadMergeInputLinks != uint64(headCount-1) {
+		t.Fatalf("six-version merge telemetry=%+v before=%+v", after, before)
+	}
+}
+
+func TestStage2PhysicalHeadMergeKeepsScannerCheckpointIdentity(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	leftCheckpoint := mustInternCheckpoint(t, compact, []byte("scanner-left"))
+	rightCheckpoint := mustInternCheckpoint(t, compact, []byte("scanner-right"))
+	if err := compact.SetPhaseCheckpoint(leftCheckpoint); err != nil {
+		t.Fatal(err)
+	}
+	leftRoot, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftPayload, err := compact.appendSubtree(subtreeRecord{
+		symbol: 10, startByte: 0, endByte: 1, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftNode, err := compact.appendAdjacencyNodeAt(7, 1, leftCheckpoint, []linkRecord{{prev: leftRoot.Node, payload: leftPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.SetPhaseCheckpoint(rightCheckpoint); err != nil {
+		t.Fatal(err)
+	}
+	rightRoot, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightPayload, err := compact.appendSubtree(subtreeRecord{
+		symbol: 11, startByte: 0, endByte: 1, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightNode, err := compact.appendAdjacencyNodeAt(7, 1, rightCheckpoint, []linkRecord{{prev: rightRoot.Node, payload: rightPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidates := []CondenseCandidate{
+		{Head: Head{Node: leftNode}, Checkpoint: leftCheckpoint},
+		{Head: Head{Node: rightNode}, Checkpoint: rightCheckpoint},
+	}
+	before := compact.Work()
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.ReindexCondenseCandidatesOwned(owner, candidates)
+	})
+	if err != nil {
+		t.Fatalf("ReindexCondenseCandidatesOwned: %v", err)
+	}
+	leftCanonical, leftOK := compact.CanonicalBoundary(7, 1, false, leftCheckpoint)
+	rightCanonical, rightOK := compact.CanonicalBoundary(7, 1, false, rightCheckpoint)
+	if !leftOK || !rightOK || leftCanonical.Node != leftNode || rightCanonical.Node != rightNode {
+		t.Fatalf("scanner checkpoint merge changed identities: left=%+v/%t right=%+v/%t", leftCanonical, leftOK, rightCanonical, rightOK)
+	}
+	if leftCanonical == rightCanonical {
+		t.Fatalf("distinct scanner checkpoints shared one physical head: left=%+v right=%+v", leftCanonical, rightCanonical)
+	}
+	after := compact.Work()
+	if after.PhysicalHeadMergeAttempts != before.PhysicalHeadMergeAttempts ||
+		after.PhysicalHeadMergeSuccesses != before.PhysicalHeadMergeSuccesses ||
+		after.PhysicalHeadMergeInputLinks != before.PhysicalHeadMergeInputLinks {
+		t.Fatalf("checkpoint guard entered physical merge path: before=%+v after=%+v", before, after)
+	}
+}
+
+func TestStage2PhysicalHeadMergeSeparatesLookaheadAndNodeCheckpoints(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	nodeCheckpoint := mustInternCheckpoint(t, compact, []byte("last-consumed"))
+	lookaheadCheckpoint := mustInternCheckpoint(t, compact, []byte("current-lookahead"))
+	if err := compact.SetPhaseCheckpoint(nodeCheckpoint); err != nil {
+		t.Fatal(err)
+	}
+	leftRoot, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightRoot, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftPayload, err := compact.appendSubtree(subtreeRecord{symbol: 10, endByte: 1, terminal: true}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightPayload, err := compact.appendSubtree(subtreeRecord{symbol: 11, endByte: 1, terminal: true}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftNode, err := compact.appendAdjacencyNodeAt(7, 1, nodeCheckpoint, []linkRecord{{prev: leftRoot.Node, payload: leftPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightNode, err := compact.appendAdjacencyNodeAt(7, 1, nodeCheckpoint, []linkRecord{{prev: rightRoot.Node, payload: rightPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.ReindexCondenseCandidatesOwned(owner, []CondenseCandidate{
+			{Head: Head{Node: leftNode}, Checkpoint: lookaheadCheckpoint},
+			{Head: Head{Node: rightNode}, Checkpoint: lookaheadCheckpoint},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	merged, ok := compact.CanonicalBoundary(7, 1, false, lookaheadCheckpoint)
+	if !ok {
+		t.Fatal("lookahead boundary is unavailable")
+	}
+	gotCheckpoint, exact := compact.nodeScannerCheckpoint(merged.Node)
+	if !exact || gotCheckpoint != nodeCheckpoint {
+		t.Fatalf("merged node checkpoint=%d/%t, want %d", gotCheckpoint, exact, nodeCheckpoint)
+	}
+}
+
+func TestStage2PhysicalHeadMergeFailsClosedOnDifferentNodeCheckpoints(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	leftCheckpoint := mustInternCheckpoint(t, compact, []byte("left-node"))
+	rightCheckpoint := mustInternCheckpoint(t, compact, []byte("right-node"))
+	lookaheadCheckpoint := mustInternCheckpoint(t, compact, []byte("shared-lookahead"))
+	leftRoot, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightRoot, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftPayload, err := compact.appendSubtree(subtreeRecord{symbol: 10, endByte: 1, terminal: true}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightPayload, err := compact.appendSubtree(subtreeRecord{symbol: 11, endByte: 1, terminal: true}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftNode, err := compact.appendAdjacencyNodeAt(7, 1, leftCheckpoint, []linkRecord{{prev: leftRoot.Node, payload: leftPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightNode, err := compact.appendAdjacencyNodeAt(7, 1, rightCheckpoint, []linkRecord{{prev: rightRoot.Node, payload: rightPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := compact.Work()
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.ReindexCondenseCandidatesOwned(owner, []CondenseCandidate{
+			{Head: Head{Node: leftNode}, Checkpoint: lookaheadCheckpoint},
+			{Head: Head{Node: rightNode}, Checkpoint: lookaheadCheckpoint},
+		})
+	})
+	if err == nil || err.Error() != "parser-core phase zero: physical heads have different scanner provenance" {
+		t.Fatalf("different node checkpoint error=%v", err)
+	}
+	if compact.Work() != before {
+		t.Fatalf("different node checkpoints entered merge telemetry: before=%+v after=%+v", before, compact.Work())
+	}
+}
+
+func TestStage2PhysicalHeadMergeNormalizesLiveScope(t *testing.T) {
+	compact, left, right, _, _ := newStage2PhysicalHeadPair(t)
+	candidates := []CondenseCandidate{{Head: left}, {Head: right}}
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.RunSchedulerOwned(owner, func() error {
+			return compact.runLiveCondenseCandidates(candidates, func() error {
+				if len(compact.condenseCandidates) != 1 {
+					t.Fatalf("live physical heads=%d, want 1", len(compact.condenseCandidates))
+				}
+				stats, err := compact.Stats(compact.condenseCandidates[0].Head)
+				if err != nil {
+					return err
+				}
+				if stats.CurrentExactPaths != 2 {
+					t.Fatalf("live physical-head paths=%d, want 2", stats.CurrentExactPaths)
+				}
+				return nil
+			})
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compact.condenseScopeActive || len(compact.condenseCandidates) != 0 {
+		t.Fatalf("live physical-head scope leaked: active=%t candidates=%+v", compact.condenseScopeActive, compact.condenseCandidates)
+	}
+}
+
+func TestStage2PhysicalHeadMergeRollsBackCapacityFailure(t *testing.T) {
+	compact, left, right, _, _ := newStage2PhysicalHeadPair(t)
+	compact.limits.MaxLinksPerBoundary = 1
+	beforeNodes, beforeLinks := len(compact.nodes), len(compact.links)
+	beforeBoundaries := compact.BoundaryIndexStats()
+	beforeWork := compact.Work()
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.ReindexCondenseCandidatesOwned(owner, []CondenseCandidate{{Head: left}, {Head: right}})
+	})
+	var capacityErr *LiveLinkCapacityError
+	if !errors.As(err, &capacityErr) {
+		t.Fatalf("physical-head merge error=%v, want LiveLinkCapacityError", err)
+	}
+	if len(compact.nodes) != beforeNodes || len(compact.links) != beforeLinks || compact.BoundaryIndexStats() != beforeBoundaries {
+		t.Fatalf("failed physical-head merge changed storage: nodes=%d/%d links=%d/%d boundaries=%+v/%+v",
+			len(compact.nodes), beforeNodes, len(compact.links), beforeLinks, compact.BoundaryIndexStats(), beforeBoundaries)
+	}
+	if after := compact.Work(); after != beforeWork {
+		t.Fatalf("failed physical-head merge changed telemetry: before=%+v after=%+v", beforeWork, after)
+	}
+}
+
+func TestStage2PhysicalHeadMergeRejectsRecoveryCost(t *testing.T) {
+	compact, left, right, _, _ := newStage2PhysicalHeadPair(t)
+	beforeNodes, beforeLinks := len(compact.nodes), len(compact.links)
+	beforeBoundaries := compact.BoundaryIndexStats()
+	beforeWork := compact.Work()
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.ReindexCondenseCandidatesOwned(owner, []CondenseCandidate{
+			{Head: left, ErrorCost: 610}, {Head: right, ErrorCost: 610},
+		})
+	})
+	if err == nil || err.Error() != "parser-core phase zero: physical head merge requires zero error cost" {
+		t.Fatalf("recovery-cost merge error=%v", err)
+	}
+	if len(compact.nodes) != beforeNodes || len(compact.links) != beforeLinks ||
+		compact.BoundaryIndexStats() != beforeBoundaries || compact.Work() != beforeWork {
+		t.Fatal("recovery-cost rejection changed compact state")
+	}
+}
+
+func TestStage2PhysicalHeadMergePreservesCandidateOwnership(t *testing.T) {
+	compact, left, right, _, _ := newStage2PhysicalHeadPair(t)
+	candidates := []CondenseCandidate{{Head: left}, {Head: right}}
+	want := append([]CondenseCandidate(nil), candidates...)
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.RunSchedulerOwned(owner, func() error {
+			return compact.runLiveCondenseCandidates(candidates, func() error { return nil })
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(candidates, want) {
+		t.Fatalf("caller candidates changed: got=%+v want=%+v", candidates, want)
+	}
+}
+
+func TestStage2PhysicalHeadMergeRequiresSchedulerTransaction(t *testing.T) {
+	compact, left, right, _, _ := newStage2PhysicalHeadPair(t)
+	beforeNodes, beforeLinks := len(compact.nodes), len(compact.links)
+	beforeBoundaries := compact.BoundaryIndexStats()
+	beforeWork := compact.Work()
+	err := compact.enterLiveCondenseCandidates([]CondenseCandidate{{Head: left}, {Head: right}})
+	if err == nil || err.Error() != "parser-core phase zero: live condense candidate scope requires a scheduler transaction" {
+		t.Fatalf("unowned live merge error=%v", err)
+	}
+	if len(compact.nodes) != beforeNodes || len(compact.links) != beforeLinks ||
+		compact.BoundaryIndexStats() != beforeBoundaries || compact.Work() != beforeWork ||
+		compact.condenseScopeActive || len(compact.condenseCandidates) != 0 {
+		t.Fatal("unowned live merge changed compact state")
+	}
+}
+
+func TestStage2PhysicalHeadMergeSkipsUnrelatedLiveBoundary(t *testing.T) {
+	compact, left, right, _, _ := newStage2PhysicalHeadPair(t)
+	unrelatedRoot, err := compact.Seed(9, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unrelatedPayload, err := compact.appendSubtree(subtreeRecord{
+		symbol: 19, startByte: 0, endByte: 1, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unrelatedNode, err := compact.appendAdjacencyNode(3, 1, []linkRecord{{prev: unrelatedRoot.Node, payload: unrelatedPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := compact.boundaryKey(3, 1)
+	probe, _ := compact.boundaries.probe(boundaryIdentityFromKey(key))
+	if err := compact.publishBoundary(probe, unrelatedNode); err != nil {
+		t.Fatal(err)
+	}
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.RunSchedulerOwned(owner, func() error {
+			return compact.runLiveCondenseCandidates(
+				[]CondenseCandidate{{Head: left}, {Head: right}},
+				func() error {
+					if len(compact.condenseCandidates) != 2 {
+						t.Fatalf("unrelated boundary merged live candidates: %+v", compact.condenseCandidates)
+					}
+					return nil
+				},
+			)
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, ok := compact.CanonicalBoundary(3, 1, false, 0)
+	if !ok || canonical.Node != unrelatedNode {
+		t.Fatalf("unrelated canonical changed: got=%+v/%t want node=%d", canonical, ok, unrelatedNode)
+	}
+}
+
+func TestStage2PhysicalHeadMergePreservesLineageMetadata(t *testing.T) {
+	compact, left, right, _, _ := newStage2PhysicalHeadPair(t)
+	leftSet := NewAlternativeSetMember(11, 1)
+	rightSet := NewAlternativeSetMember(12, 2)
+	leftRefs := g18RefSetFrom(t, compact, g18Ref(1, 1, 1, 0))
+	rightRefs := g18RefSetFrom(t, compact, g18Ref(2, 1, 1, 0))
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if err := compact.RecordHeadOwnerOwned(owner, left, 101); err != nil {
+			return err
+		}
+		if err := compact.RecordHeadOwnerOwned(owner, right, 202); err != nil {
+			return err
+		}
+		if err := compact.RecordHeadLineageOwned(owner, left, CleanPathRankSelected, 11, leftSet, false, true, leftRefs); err != nil {
+			return err
+		}
+		if err := compact.RecordHeadLineageOwned(owner, right, CleanPathRankUnselected, 12, rightSet, false, true, rightRefs); err != nil {
+			return err
+		}
+		return compact.ReindexCondenseCandidatesOwned(owner, []CondenseCandidate{{Head: left}, {Head: right}})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	merged, ok := compact.CanonicalBoundary(3, 1, false, 0)
+	if !ok {
+		t.Fatal("merged lineage boundary is unavailable")
+	}
+	record, err := compact.nodeLineage(merged.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.owner != 0 {
+		t.Fatalf("new merged node owner=%d, want canonicalization ownership", record.owner)
+	}
+	if !record.converged || record.rank != CleanPathRankUnknown || record.lineage != 0 || !record.blended {
+		t.Fatalf("merged scalar lineage=%+v", *record)
+	}
+	members, ok := compact.AlternativeSetMembers(record.set)
+	if !ok || len(members) != 2 {
+		t.Fatalf("merged alternative set=%v/%t", members, ok)
+	}
+	refs := g18Members(t, compact, record.dropCohortRefs)
+	if len(refs) != 2 || refs[0] != g18Ref(1, 1, 1, 0) || refs[1] != g18Ref(2, 1, 1, 0) {
+		t.Fatalf("merged drop-cohort refs=%v", refs)
+	}
+}
+
+func TestStage2PhysicalHeadMergePersistsCandidateDropCohortReferences(t *testing.T) {
+	compact, left, right, _, _ := newStage2PhysicalHeadPair(t)
+	leftRef := g18Ref(1, 1, 1, 0)
+	rightRef := g18Ref(2, 1, 1, 0)
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.ReindexCondenseCandidatesOwned(owner, []CondenseCandidate{
+			{Head: left, DropCohortRefs: g18RefSetFrom(t, compact, leftRef)},
+			{Head: right, DropCohortRefs: g18RefSetFrom(t, compact, rightRef)},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	merged, ok := compact.CanonicalBoundary(3, 1, false, 0)
+	if !ok {
+		t.Fatal("candidate reference boundary is unavailable")
+	}
+	record, err := compact.nodeLineage(merged.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := g18Members(t, compact, record.dropCohortRefs)
+	if len(refs) != 2 || refs[0] != leftRef || refs[1] != rightRef {
+		t.Fatalf("candidate references=%v", refs)
+	}
+}
+
+func TestStage2PhysicalHeadMergeAppliesHigherPrecedenceReplacement(t *testing.T) {
+	compact, root := newDiagnosticShallowFoldCore(t, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	incumbentPayload := appendShallowPayload(t, compact, shallowPayloadSpec{
+		symbol: 20, productionID: 1, startByte: 12, endByte: 17, childSymbols: []Symbol{30},
+	})
+	incomingPayload := appendShallowPayload(t, compact, shallowPayloadSpec{
+		symbol: 20, productionID: 2, startByte: 12, endByte: 17, childSymbols: []Symbol{31},
+	})
+	leftID, err := compact.appendAdjacencyNode(3, 17, []linkRecord{{prev: root.Node, payload: incumbentPayload, scoreDelta: 2}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightID, err := compact.appendAdjacencyNode(3, 17, []linkRecord{{prev: root.Node, payload: incomingPayload, scoreDelta: 3}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := compact.Work()
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.ReindexCondenseCandidatesOwned(owner, []CondenseCandidate{
+			{Head: Head{Node: leftID}}, {Head: Head{Node: rightID}},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	merged, ok := compact.CanonicalBoundary(3, 17, false, 0)
+	if !ok {
+		t.Fatal("precedence boundary is unavailable")
+	}
+	links, err := compact.nodeLinks(*mustNode(t, compact, merged.Node))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 1 || links[0].payload != incomingPayload || links[0].scoreDelta != 3 {
+		t.Fatalf("precedence replacement links=%+v", links)
+	}
+	after := compact.Work()
+	if after.PredecessorLinkUnionPrecedenceReplaced-before.PredecessorLinkUnionPrecedenceReplaced != 1 {
+		t.Fatalf("precedence replacement telemetry before=%+v after=%+v", before, after)
+	}
+}
+
+func TestStage2PhysicalHeadMergePreservesRecursivePrecedenceMaximum(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	leftRoot, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightRoot, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftPayload := appendShallowPayload(t, compact, shallowPayloadSpec{symbol: 20, endByte: 1, childSymbols: []Symbol{22}})
+	rightPayload := appendShallowPayload(t, compact, shallowPayloadSpec{symbol: 21, endByte: 1, childSymbols: []Symbol{23}})
+	leftPrev, err := compact.appendAdjacencyNode(3, 1, []linkRecord{{prev: leftRoot.Node, payload: leftPayload, scoreDelta: 2}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightPrev, err := compact.appendAdjacencyNode(3, 1, []linkRecord{{prev: rightRoot.Node, payload: rightPayload, scoreDelta: 7}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	topPayload := appendShallowPayload(t, compact, shallowPayloadSpec{symbol: 30, startByte: 1, endByte: 2})
+	leftTop, err := compact.appendAdjacencyNode(4, 2, []linkRecord{{prev: leftPrev, payload: topPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightTop, err := compact.appendAdjacencyNode(4, 2, []linkRecord{{prev: rightPrev, payload: topPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.ReindexCondenseCandidatesOwned(owner, []CondenseCandidate{
+			{Head: Head{Node: leftTop}}, {Head: Head{Node: rightTop}},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	merged, ok := compact.CanonicalBoundary(4, 2, false, 0)
+	if !ok {
+		t.Fatal("recursive precedence boundary is unavailable")
+	}
+	maximum, err := compact.nodePrecedenceMaximum(merged.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if maximum.value != 7 {
+		t.Fatalf("recursive precedence maximum=%d, want 7", maximum.value)
+	}
+	if compact.Work().PredecessorLinkUnionRecursiveChanged == 0 {
+		t.Fatalf("recursive precedence path did not execute: %+v", compact.Work())
+	}
+}
+
+func TestStage2PhysicalHeadMergePreservesRecursiveDuplicateLineage(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	root, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := appendShallowPayload(t, compact, shallowPayloadSpec{symbol: 20, endByte: 1})
+	leftID, err := compact.appendAdjacencyNode(3, 1, []linkRecord{{prev: root.Node, payload: payload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightID, err := compact.appendAdjacencyNode(3, 1, []linkRecord{{prev: root.Node, payload: payload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	left := Head{Node: leftID}
+	right := Head{Node: rightID}
+	leftSet := NewAlternativeSetMember(21, 1)
+	rightSet := NewAlternativeSetMember(22, 2)
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if err := compact.RecordHeadLineageOwned(owner, left, CleanPathRankSelected, 21, leftSet, false, true); err != nil {
+			return err
+		}
+		if err := compact.RecordHeadLineageOwned(owner, right, CleanPathRankUnselected, 22, rightSet, false, true); err != nil {
+			return err
+		}
+		merged, changed, err := compact.mergePredecessorsBounded(
+			leftID, rightID, 0, &precedenceMaximumWitness{},
+		)
+		if err != nil {
+			return err
+		}
+		if changed || merged != leftID {
+			t.Fatalf("duplicate recursive topology merged=%d changed=%t", merged, changed)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := compact.nodeLineage(leftID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	members, ok := compact.AlternativeSetMembers(record.set)
+	if !ok || len(members) != 2 || record.rank != CleanPathRankUnknown ||
+		record.lineage != 0 || !record.converged || !record.blended {
+		t.Fatalf("recursive duplicate lineage=%+v members=%v/%t", *record, members, ok)
+	}
+}
+
+func mustNode(t *testing.T, compact *Core, id NodeID) *nodeRecord {
+	t.Helper()
+	node, err := compact.node(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return node
+}

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -294,42 +294,105 @@ func (c *Core) recordNodeLineageMember(head Head, event, branch uint16) error {
 	return nil
 }
 
-// enterLiveCondenseCandidates installs the live condense-candidate scope:
-// reject nesting, reject two candidates that would collide on one boundary,
-// then publish the scope fields (condenseCandidates, condenseNewNode,
-// condenseScopeActive) that condenseNodeIsLive reads during the dispatch that
-// follows. It is the non-closure setup half of runLiveCondenseCandidates,
-// factored out so the hot shift/reduce/cohort dispatch paths below can call
-// it directly instead of threading a fn func() error parameter through two
-// extra wrapper layers.
+// enterLiveCondenseCandidates installs the live condense-candidate scope. It
+// first merges clean, scheduler-proved equivalents that occupy one boundary.
+// The normalized scope then contains one immutable physical head per boundary.
+// It is the non-closure setup half of runLiveCondenseCandidates, factored out
+// so the hot shift/reduce/cohort dispatch paths can call it directly.
 func (c *Core) enterLiveCondenseCandidates(candidates []CondenseCandidate) error {
 	if c.condenseScopeActive {
 		return errors.New("parser-core phase zero: nested live condense candidate scope")
 	}
-	for index, candidate := range candidates {
+	if !c.schedulerFrame.active {
+		return errors.New("parser-core phase zero: live condense candidate scope requires a scheduler transaction")
+	}
+	owned := append(c.condenseCandidates[:0], candidates...)
+	normalized, err := c.mergeLiveCondenseCandidatesUncheckpointed(owned)
+	if err != nil {
+		clear(c.condenseCandidates)
+		c.condenseCandidates = c.condenseCandidates[:0]
+		return err
+	}
+	c.condenseCandidates = normalized
+	c.condenseNewNode = NodeID(len(c.nodes) + 1)
+	c.condenseScopeActive = true
+	return nil
+}
+
+func (c *Core) mergeLiveCondenseCandidatesUncheckpointed(candidates []CondenseCandidate) ([]CondenseCandidate, error) {
+	write := 0
+	for _, candidate := range candidates {
+		if candidate.ErrorCost != 0 {
+			return nil, errors.New("parser-core phase zero: physical head merge requires zero error cost")
+		}
+		if err := c.recordNodeLineageRefs(candidate.Head, candidate.DropCohortRefs); err != nil {
+			return nil, err
+		}
 		node, err := c.node(candidate.Head.Node)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		for prior := 0; prior < index; prior++ {
+		match := -1
+		for prior := 0; prior < write; prior++ {
 			other := candidates[prior]
 			otherNode, err := c.node(other.Head.Node)
 			if err != nil {
-				return err
+				return nil, err
 			}
+			candidateNodeCheckpoint, candidateNodeExact := c.nodeScannerCheckpoint(candidate.Head.Node)
+			otherNodeCheckpoint, otherNodeExact := c.nodeScannerCheckpoint(other.Head.Node)
 			if node.state == otherNode.state &&
 				node.byteOffset == otherNode.byteOffset &&
 				candidate.Shifted == other.Shifted &&
 				candidate.Checkpoint == other.Checkpoint &&
-				candidate.Head.Node != other.Head.Node {
-				return errors.New("parser-core phase zero: distinct condense candidates share one boundary")
+				candidate.MergeIdentity == other.MergeIdentity &&
+				candidateNodeExact && otherNodeExact &&
+				candidateNodeCheckpoint == otherNodeCheckpoint {
+				match = prior
+				break
 			}
 		}
+		if match < 0 {
+			candidates[write] = candidate
+			write++
+			continue
+		}
+		group := &candidates[match]
+		if group.Head != candidate.Head {
+			key := boundaryKey{
+				frontier: c.frontier, state: node.state, byteOffset: node.byteOffset,
+				shifted: candidate.Shifted, checkpoint: candidate.Checkpoint,
+			}
+			probe, existing := c.boundaries.probe(boundaryIdentityFromKey(key))
+			switch {
+			case !probe.found:
+				if err := c.publishBoundary(probe, group.Head.Node); err != nil {
+					return nil, err
+				}
+			case existing == candidate.Head.Node:
+				if err := c.publishBoundary(probe, group.Head.Node); err != nil {
+					return nil, err
+				}
+			case existing != group.Head.Node:
+				// A live scope can observe an older entry from the same parser
+				// frontier. Keep both current candidates separate. The next
+				// authenticated reindex establishes a fresh boundary generation.
+				candidates[write] = candidate
+				write++
+				continue
+			}
+			merged, err := c.mergeEquivalentHeadsAtBoundaryUncheckpointed(key, group.Head, candidate.Head)
+			if err != nil {
+				return nil, err
+			}
+			group.Head = merged
+		}
+		if _, err := c.dropCohortRefUnion(&group.DropCohortRefs, candidate.DropCohortRefs); err != nil {
+			return nil, err
+		}
 	}
-	c.condenseCandidates = candidates
-	c.condenseNewNode = NodeID(len(c.nodes) + 1)
-	c.condenseScopeActive = true
-	return nil
+	clear(candidates[write:])
+	return candidates[:write], nil
 }
 
 // runLiveCondenseCandidates keeps the closure-taking shape used directly by
@@ -352,17 +415,46 @@ func (c *Core) clearLiveCondenseCandidates() {
 	if c == nil {
 		return
 	}
-	c.condenseCandidates = nil
+	clear(c.condenseCandidates)
+	c.condenseCandidates = c.condenseCandidates[:0]
 	c.condenseNewNode = 0
 	c.condenseScopeActive = false
 }
 
 func (c *Core) reindexCondenseCandidatesUncheckpointed(candidates []CondenseCandidate) error {
 	c.boundaries.advanceGeneration()
-	for _, candidate := range candidates {
+	for index, candidate := range candidates {
+		if candidate.ErrorCost != 0 {
+			return errors.New("parser-core phase zero: physical head merge requires zero error cost")
+		}
+		if err := c.recordNodeLineageRefs(candidate.Head, candidate.DropCohortRefs); err != nil {
+			return err
+		}
 		node, err := c.node(candidate.Head.Node)
 		if err != nil {
 			return err
+		}
+		candidateNodeCheckpoint, candidateNodeExact := c.nodeScannerCheckpoint(candidate.Head.Node)
+		if !candidateNodeExact {
+			return errors.New("parser-core phase zero: physical head merge has inexact scanner provenance")
+		}
+		for prior := 0; prior < index; prior++ {
+			other := candidates[prior]
+			otherNode, err := c.node(other.Head.Node)
+			if err != nil {
+				return err
+			}
+			if node.state != otherNode.state || node.byteOffset != otherNode.byteOffset ||
+				candidate.Shifted != other.Shifted || candidate.Checkpoint != other.Checkpoint {
+				continue
+			}
+			if candidate.MergeIdentity != other.MergeIdentity {
+				return errors.New("parser-core phase zero: physical heads have different lexer ownership")
+			}
+			otherNodeCheckpoint, otherNodeExact := c.nodeScannerCheckpoint(other.Head.Node)
+			if !otherNodeExact || candidateNodeCheckpoint != otherNodeCheckpoint {
+				return errors.New("parser-core phase zero: physical heads have different scanner provenance")
+			}
 		}
 		key := boundaryKey{
 			frontier: c.frontier, state: node.state, byteOffset: node.byteOffset,
@@ -371,7 +463,11 @@ func (c *Core) reindexCondenseCandidatesUncheckpointed(candidates []CondenseCand
 		probe, existing := c.boundaries.probe(boundaryIdentityFromKey(key))
 		if probe.found {
 			if existing != candidate.Head.Node {
-				return errors.New("parser-core phase zero: distinct condense candidates share one boundary")
+				if _, err := c.mergeEquivalentHeadsAtBoundaryUncheckpointed(
+					key, Head{Node: existing}, candidate.Head,
+				); err != nil {
+					return err
+				}
 			}
 			continue
 		}
@@ -380,6 +476,180 @@ func (c *Core) reindexCondenseCandidatesUncheckpointed(candidates []CondenseCand
 		}
 	}
 	return nil
+}
+
+// mergeEquivalentHeadsAtBoundaryUncheckpointed ports ts_stack_merge for two
+// clean scheduler versions. It keeps the incumbent adjacency first, applies
+// C's bounded link insertion rules to the incoming adjacency, then publishes
+// one immutable replacement at the same authenticated boundary. Capacity
+// rejection rolls back the merge. C removes the incoming version after that
+// rejection, but this bounded route fails closed to preserve its memory limit.
+//
+// Header-owned recovery state and lexer ownership are outside Core. The
+// scheduler must prove those identities before it supplies candidates here.
+func (c *Core) mergeEquivalentHeadsAtBoundaryUncheckpointed(
+	key boundaryKey,
+	incumbent Head,
+	incoming Head,
+) (Head, error) {
+	if key.frontier != c.frontier {
+		return Head{}, errors.New("parser-core phase zero: physical head merge frontier mismatch")
+	}
+	if incumbent == incoming {
+		return incumbent, nil
+	}
+	left, err := c.node(incumbent.Node)
+	if err != nil {
+		return Head{}, err
+	}
+	right, err := c.node(incoming.Node)
+	if err != nil {
+		return Head{}, err
+	}
+	if left.state != key.state || right.state != key.state ||
+		left.byteOffset != key.byteOffset || right.byteOffset != key.byteOffset {
+		return Head{}, errors.New("parser-core phase zero: physical heads are not boundary-equivalent")
+	}
+	leftCheckpoint, leftExact := c.nodeScannerCheckpoint(incumbent.Node)
+	rightCheckpoint, rightExact := c.nodeScannerCheckpoint(incoming.Node)
+	if !leftExact || !rightExact || leftCheckpoint != rightCheckpoint {
+		return Head{}, errors.New("parser-core phase zero: physical heads have different scanner provenance")
+	}
+	related, err := c.nodesAncestryRelated(incumbent.Node, incoming.Node)
+	if err != nil {
+		return Head{}, err
+	}
+	if related {
+		return Head{}, errors.New("parser-core phase zero: physical heads are ancestry-related")
+	}
+
+	var leftInline [inlineAdjacencyCapacity]linkRecord
+	links, err := c.publishedNodeLinksInto(leftInline[:0], *left)
+	if err != nil {
+		return Head{}, err
+	}
+	var rightInline [inlineAdjacencyCapacity]linkRecord
+	incomingLinks, err := c.publishedNodeLinksInto(rightInline[:0], *right)
+	if err != nil {
+		return Head{}, err
+	}
+	// Count only pairs that pass the clean boundary and scanner predicates.
+	// C's wider attempt counter also includes pairs that fail those predicates.
+	c.addWork(&c.work.PhysicalHeadMergeAttempts, 1)
+	c.addWork(&c.work.PhysicalHeadMergeInputLinks, uint64(len(incomingLinks)))
+	leftMaximum, err := c.nodePrecedenceMaximum(incumbent.Node)
+	if err != nil {
+		return Head{}, err
+	}
+	folded := precedenceMaximumWitness{seed: leftMaximum.value, hasSeed: true}
+	changed := false
+	for _, link := range incomingLinks {
+		var inserted bool
+		links, inserted, err = c.insertLinkBounded(key.state, key.byteOffset, links, link, 0, &folded)
+		if err != nil {
+			return Head{}, err
+		}
+		changed = changed || inserted
+	}
+	maximum, err := c.computePrecedenceMaximum(links, folded)
+	if err != nil {
+		return Head{}, err
+	}
+	if !changed && maximum.value <= leftMaximum.value {
+		if err := c.mergeNodeLineageMetadata(incumbent.Node, incoming.Node, incumbent.Node); err != nil {
+			return Head{}, err
+		}
+		c.addWork(&c.work.PhysicalHeadMergeSuccesses, 1)
+		return incumbent, nil
+	}
+	// key.checkpoint authenticates the current lookahead boundary. The graph
+	// node checkpoint authenticates the last consumed external scanner state.
+	// Keep the source node checkpoint when those two identities differ.
+	merged, err := c.appendAdjacencyNodeAtWithPrecedence(
+		key.state, key.byteOffset, leftCheckpoint, links, folded,
+	)
+	if err != nil {
+		return Head{}, err
+	}
+	if err := c.mergeNodeLineageMetadata(incumbent.Node, incoming.Node, merged); err != nil {
+		return Head{}, err
+	}
+	probe, existing := c.boundaries.probe(boundaryIdentityFromKey(key))
+	if !probe.found || existing != incumbent.Node {
+		return Head{}, errors.New("parser-core phase zero: physical head merge lost its incumbent boundary")
+	}
+	if err := c.publishBoundary(probe, merged); err != nil {
+		return Head{}, err
+	}
+	c.addWork(&c.work.PhysicalHeadMergeSuccesses, 1)
+	return Head{Node: merged}, nil
+}
+
+// mergeNodeLineageMetadata preserves the histories represented by a physical
+// graph merge. A new merged node has no scheduler owner until canonicalization
+// elects its surviving header. An unchanged incumbent keeps its current owner.
+func (c *Core) mergeNodeLineageMetadata(leftID, rightID, targetID NodeID) error {
+	left, err := c.nodeLineage(leftID)
+	if err != nil {
+		return err
+	}
+	right, err := c.nodeLineage(rightID)
+	if err != nil {
+		return err
+	}
+	target, err := c.nodeLineage(targetID)
+	if err != nil {
+		return err
+	}
+	before := *target
+	merged := nodeLineageRecord{}
+	if targetID == leftID {
+		merged.owner = left.owner
+	}
+	merged.dropCohortRefs = left.dropCohortRefs
+	if _, err := c.dropCohortRefUnion(&merged.dropCohortRefs, right.dropCohortRefs); err != nil {
+		return err
+	}
+	merged.set = left.set
+	merged.blended = left.blended || right.blended || c.AlternativeSetIncomparable(left.set, right.set)
+	c.alternativeSetUnion(&merged.set, right.set)
+	merged.rank, merged.lineage = mergeNodeLineageScalars(
+		left.rank, left.lineage, right.rank, right.lineage,
+	)
+	merged.converged = left.converged || right.converged
+	if *target == merged {
+		return nil
+	}
+	if targetID == leftID && len(c.transactions) != 0 {
+		c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
+			node: targetID, owner: before.owner, dropCohortRefs: before.dropCohortRefs,
+			setCount: before.set.count, setFlags: before.set.flags, setSpillRef: before.set.spillRef,
+			lineage: before.lineage, rank: before.rank, converged: before.converged, blended: before.blended,
+		})
+	}
+	*target = merged
+	return nil
+}
+
+func mergeNodeLineageScalars(
+	leftRank CleanPathRankSelection,
+	leftLineage uint16,
+	rightRank CleanPathRankSelection,
+	rightLineage uint16,
+) (CleanPathRankSelection, uint16) {
+	if leftRank == CleanPathRankUnknown || rightRank == CleanPathRankUnknown {
+		return CleanPathRankUnknown, 0
+	}
+	if leftRank == CleanPathRankNotApplicable || leftLineage == 0 {
+		return rightRank, rightLineage
+	}
+	if rightRank == CleanPathRankNotApplicable || rightLineage == 0 {
+		return leftRank, leftLineage
+	}
+	if leftLineage != rightLineage {
+		return CleanPathRankUnknown, 0
+	}
+	return mergeCleanPathRank(leftRank, rightRank), leftLineage
 }
 
 // ShiftClassifiedOwned authenticates the scheduler owner, then delegates to

--- a/merge_event_census.go
+++ b/merge_event_census.go
@@ -129,6 +129,9 @@ type MergeEventCensusCounts struct {
 	CompactLinkUnionRecursiveChanged   uint64
 	CompactLinkUnionAlternateAppended  uint64
 	CompactLinkUnionRejected           uint64
+	CompactPhysicalHeadMergeAttempts   uint64
+	CompactPhysicalHeadMergeSuccesses  uint64
+	CompactPhysicalHeadMergeInputLinks uint64
 	CompactAcceptancesObserved         uint64
 }
 
@@ -297,7 +300,10 @@ func mergeCensusShallowEquivalent(a, b stackEntry) bool {
 // always-on link-union counters at a compact acceptance. The compact core
 // keeps cumulative per-parse totals, so the census stores the last observed
 // values rather than summing them.
-func mergeCensusRecordCompactLinkUnion(attempts, duplicate, precedence, recursive, alternate, rejected uint64) {
+func mergeCensusRecordCompactLinkUnion(
+	attempts, duplicate, precedence, recursive, alternate, rejected uint64,
+	physicalAttempts, physicalSuccesses, physicalInputLinks uint64,
+) {
 	mergeCensusState.mu.Lock()
 	counts := &mergeCensusState.counts
 	counts.CompactAcceptancesObserved++
@@ -307,5 +313,8 @@ func mergeCensusRecordCompactLinkUnion(attempts, duplicate, precedence, recursiv
 	counts.CompactLinkUnionRecursiveChanged = recursive
 	counts.CompactLinkUnionAlternateAppended = alternate
 	counts.CompactLinkUnionRejected = rejected
+	counts.CompactPhysicalHeadMergeAttempts = physicalAttempts
+	counts.CompactPhysicalHeadMergeSuccesses = physicalSuccesses
+	counts.CompactPhysicalHeadMergeInputLinks = physicalInputLinks
 	mergeCensusState.mu.Unlock()
 }

--- a/merge_event_census_disabled.go
+++ b/merge_event_census_disabled.go
@@ -21,13 +21,17 @@ const mergeCensusEnabled = false
 // census. The shipped build never does.
 func MergeEventCensusBuilt() bool { return false }
 
-func mergeCensusRecordAttempt()                                                        {}
-func mergeCensusRecordSuccess()                                                        {}
-func mergeCensusRecordMergeFailed()                                                    {}
-func mergeCensusRecordDistinctShapes()                                                 {}
-func mergeCensusRecordErrorCost()                                                      {}
-func mergeCensusRecordScorePreflight()                                                 {}
-func mergeCensusAttributeForParserRefusal(*Parser, *glrStack, *glrStack)               {}
-func mergeCensusRecordGateRefusal(*glrMergeScratch, *glrStack, *glrStack)              {}
-func mergeCensusRecordLinkPayload(stackEntry, stackEntry, bool)                        {}
-func mergeCensusRecordCompactLinkUnion(uint64, uint64, uint64, uint64, uint64, uint64) {}
+func mergeCensusRecordAttempt()                                           {}
+func mergeCensusRecordSuccess()                                           {}
+func mergeCensusRecordMergeFailed()                                       {}
+func mergeCensusRecordDistinctShapes()                                    {}
+func mergeCensusRecordErrorCost()                                         {}
+func mergeCensusRecordScorePreflight()                                    {}
+func mergeCensusAttributeForParserRefusal(*Parser, *glrStack, *glrStack)  {}
+func mergeCensusRecordGateRefusal(*glrMergeScratch, *glrStack, *glrStack) {}
+func mergeCensusRecordLinkPayload(stackEntry, stackEntry, bool)           {}
+func mergeCensusRecordCompactLinkUnion(
+	uint64, uint64, uint64, uint64, uint64, uint64,
+	uint64, uint64, uint64,
+) {
+}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1249,11 +1249,9 @@ type diagnosticParserCoreHeader struct {
 	// witness (section 5).
 	blended              bool
 	lastPersistedBlended bool
-	// recoveryCompetitor marks a header that a native recovery mechanism
-	// created or advanced, and so may compete at acceptance. It sits before
-	// versionState so it lands in the one padding byte the header already had
-	// (offset 215); placed after the pointer it would grow every header from
-	// 224 to 232 bytes, which two size ratchets pin.
+	// recoveryFlags records recovery competition and permanent cost provenance.
+	// It sits before versionState in the padding byte at offset 215. Placing it
+	// after the pointer would grow each header from 224 to 232 bytes.
 	//
 	// A frontier that merely forked on ordinary grammar ambiguity must NOT be
 	// marked. Error cost answers "which recovery is cheaper", which is not the
@@ -1263,7 +1261,7 @@ type diagnosticParserCoreHeader struct {
 	// It is derived from live header state at pricing time -- see
 	// recoveryOpenSegments. Ordinary paths write paused, while region paths
 	// publish versionState. A stored copy could drift from either value.
-	recoveryCompetitor bool
+	recoveryFlags diagnosticParserCoreRecoveryFlags
 	// versionState carries optional state owned by this parser version. It is
 	// nil on the single-version fast path. The pointed-to state is immutable.
 	// Accessors publish a fresh wrapper or clear the pointer. A by-value header
@@ -1283,6 +1281,13 @@ type diagnosticParserCoreVersionState struct {
 	// they publish the request's after snapshot.
 	lexerRequest uint32
 }
+
+type diagnosticParserCoreRecoveryFlags uint8
+
+const (
+	diagnosticParserCoreRecoveryCompetitorFlag diagnosticParserCoreRecoveryFlags = 1 << iota
+	diagnosticParserCoreRecoveryCostedFlag
+)
 
 // recoveryRegion returns the optional open strategy-2 region.
 func (h diagnosticParserCoreHeader) recoveryRegion() *diagnosticParserCoreS3Region {
@@ -1306,6 +1311,10 @@ func (h diagnosticParserCoreHeader) versionLexerRequestReference() uint32 {
 		return 0
 	}
 	return h.versionState.lexerRequest
+}
+
+func (h diagnosticParserCoreHeader) isRecoveryCosted() bool {
+	return h.recoveryFlags&diagnosticParserCoreRecoveryCostedFlag != 0
 }
 
 // openRecoveryRegion publishes an open strategy-2 region for this header.
@@ -1344,10 +1353,24 @@ func (h *diagnosticParserCoreHeader) closeRecoveryRegion() {
 }
 
 // isRecoveryLineage reports whether this header may compete at acceptance.
-func (h *diagnosticParserCoreHeader) isRecoveryLineage() bool { return h.recoveryCompetitor }
+func (h *diagnosticParserCoreHeader) isRecoveryLineage() bool {
+	return h != nil && h.recoveryFlags&diagnosticParserCoreRecoveryCompetitorFlag != 0
+}
 
-// markRecoveryLineage marks this header as a competing recovery lineage.
-func (h *diagnosticParserCoreHeader) markRecoveryLineage() { h.recoveryCompetitor = true }
+// markRecoveryLineage marks a competing recovery lineage with cost provenance.
+func (h *diagnosticParserCoreHeader) markRecoveryLineage() {
+	if h == nil {
+		return
+	}
+	h.recoveryFlags |= diagnosticParserCoreRecoveryCompetitorFlag | diagnosticParserCoreRecoveryCostedFlag
+}
+
+// markRecoveryCosted records recovery work without creating a competition.
+func (h *diagnosticParserCoreHeader) markRecoveryCosted() {
+	if h != nil {
+		h.recoveryFlags |= diagnosticParserCoreRecoveryCostedFlag
+	}
+}
 
 // clearRecoveryLineage demotes this header out of the competition.
 //
@@ -1355,7 +1378,11 @@ func (h *diagnosticParserCoreHeader) markRecoveryLineage() { h.recoveryCompetito
 // head produces marked children. A fork on ORDINARY grammar ambiguity must
 // call this on its replacements, or acceptance would decide that frontier by
 // error cost -- a different decision procedure than the one C applies to it.
-func (h *diagnosticParserCoreHeader) clearRecoveryLineage() { h.recoveryCompetitor = false }
+func (h *diagnosticParserCoreHeader) clearRecoveryLineage() {
+	if h != nil {
+		h.recoveryFlags &^= diagnosticParserCoreRecoveryCompetitorFlag
+	}
+}
 
 // competingRecoveryFrontier reports whether every live version belongs to
 // one recovery competition. Such versions can accept independently at EOF.
@@ -9500,6 +9527,7 @@ func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegionWithAlternati
 		endByte:   s.token.EndByte,
 		children:  []core.SubtreeID{leafID},
 	})
+	header.markRecoveryCosted()
 	s.s3RegionOpened = true
 	header.shifted = true
 	return true, nil
@@ -9866,6 +9894,9 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() (err error) 
 			compactWork.PredecessorLinkUnionRecursiveChanged,
 			compactWork.PredecessorLinkUnionAlternateAppended,
 			compactWork.PredecessorLinkUnionRejected,
+			compactWork.PhysicalHeadMergeAttempts,
+			compactWork.PhysicalHeadMergeSuccesses,
+			compactWork.PhysicalHeadMergeInputLinks,
 		)
 	}
 	s.publishTotals()
@@ -11084,6 +11115,8 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 
 // reindexCondenseCandidatesOwned retains only active sibling versions.
 // Tree-sitter C does not merge a new reduction into its source version.
+// Stage 2 also requires a never-recovered lineage. This makes every supplied
+// ErrorCost zero an authenticated fact instead of a struct default.
 func (s *diagnosticParserCoreGenericScheduler) reindexCondenseCandidatesOwned(owner core.SchedulerTransactionToken, source int) error {
 	return s.compact.ReindexCondenseCandidatesOwned(owner, s.collectCondenseCandidates(source))
 }
@@ -11093,7 +11126,8 @@ func (s *diagnosticParserCoreGenericScheduler) collectCondenseCandidates(source 
 	if source >= 0 && source < len(s.headers) {
 		sourceHeader := &s.headers[source]
 		if sourceHeader.accepted || sourceHeader.paused ||
-			sourceHeader.isRecoveryLineage() || sourceHeader.recoveryRegion() != nil {
+			sourceHeader.isRecoveryLineage() || sourceHeader.recoveryRegion() != nil ||
+			sourceHeader.isRecoveryCosted() {
 			s.condenseCandidates = candidates
 			return candidates
 		}
@@ -11101,12 +11135,13 @@ func (s *diagnosticParserCoreGenericScheduler) collectCondenseCandidates(source 
 	if !s.recoveryIsolation {
 		for index, header := range s.headers {
 			if index == source || header.accepted || header.paused ||
-				header.isRecoveryLineage() || header.recoveryRegion() != nil {
+				header.isRecoveryLineage() || header.recoveryRegion() != nil ||
+				header.isRecoveryCosted() {
 				continue
 			}
 			candidates = append(candidates, core.CondenseCandidate{
 				Head: header.head, DropCohortRefs: header.dropCohortRefs,
-				Shifted: header.shifted, Checkpoint: header.checkpoint,
+				Shifted: header.shifted, Checkpoint: header.checkpoint, ErrorCost: 0,
 				MergeIdentity: s.condenseCandidateMergeIdentity(index),
 			})
 		}
@@ -11119,12 +11154,12 @@ func (s *diagnosticParserCoreGenericScheduler) collectCondenseCandidates(source 
 		}
 		// Marked recovery versions must remain separate until acceptance can
 		// price them. Ordinary unmarked versions retain normal condensation.
-		if header.isRecoveryLineage() || header.recoveryRegion() != nil {
+		if header.isRecoveryLineage() || header.recoveryRegion() != nil || header.isRecoveryCosted() {
 			continue
 		}
 		candidates = append(candidates, core.CondenseCandidate{
 			Head: header.head, DropCohortRefs: header.dropCohortRefs,
-			Shifted: header.shifted, Checkpoint: header.checkpoint,
+			Shifted: header.shifted, Checkpoint: header.checkpoint, ErrorCost: 0,
 			MergeIdentity: s.condenseCandidateMergeIdentity(index),
 		})
 	}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -11090,36 +11090,64 @@ func (s *diagnosticParserCoreGenericScheduler) reindexCondenseCandidatesOwned(ow
 
 func (s *diagnosticParserCoreGenericScheduler) collectCondenseCandidates(source int) []core.CondenseCandidate {
 	candidates := s.condenseCandidates[:0]
+	if source >= 0 && source < len(s.headers) {
+		sourceHeader := &s.headers[source]
+		if sourceHeader.accepted || sourceHeader.paused ||
+			sourceHeader.isRecoveryLineage() || sourceHeader.recoveryRegion() != nil {
+			s.condenseCandidates = candidates
+			return candidates
+		}
+	}
 	if !s.recoveryIsolation {
 		for index, header := range s.headers {
-			if index == source || header.accepted || header.paused {
+			if index == source || header.accepted || header.paused ||
+				header.isRecoveryLineage() || header.recoveryRegion() != nil {
 				continue
 			}
 			candidates = append(candidates, core.CondenseCandidate{
 				Head: header.head, DropCohortRefs: header.dropCohortRefs,
 				Shifted: header.shifted, Checkpoint: header.checkpoint,
+				MergeIdentity: s.condenseCandidateMergeIdentity(index),
 			})
 		}
 		s.condenseCandidates = candidates
 		return candidates
 	}
-	sourceRecovery := source >= 0 && source < len(s.headers) && s.headers[source].isRecoveryLineage()
 	for index, header := range s.headers {
 		if index == source || header.accepted || header.paused {
 			continue
 		}
 		// Marked recovery versions must remain separate until acceptance can
 		// price them. Ordinary unmarked versions retain normal condensation.
-		if sourceRecovery || header.isRecoveryLineage() {
+		if header.isRecoveryLineage() || header.recoveryRegion() != nil {
 			continue
 		}
 		candidates = append(candidates, core.CondenseCandidate{
 			Head: header.head, DropCohortRefs: header.dropCohortRefs,
 			Shifted: header.shifted, Checkpoint: header.checkpoint,
+			MergeIdentity: s.condenseCandidateMergeIdentity(index),
 		})
 	}
 	s.condenseCandidates = candidates
 	return candidates
+}
+
+// condenseCandidateMergeIdentity partitions exact immutable lexer ownership
+// without removing a candidate from reduction freshness classification.
+func (s *diagnosticParserCoreGenericScheduler) condenseCandidateMergeIdentity(index int) uint16 {
+	if s == nil || index < 0 || index >= len(s.headers) {
+		return 0
+	}
+	state := s.headers[index].versionState
+	if state == nil {
+		return 0
+	}
+	for prior := 0; prior < index; prior++ {
+		if s.headers[prior].versionState == state {
+			return uint16(prior + 1)
+		}
+	}
+	return uint16(index + 1)
 }
 
 // adoptUpdatedReductionSibling updates an already-active canonical sibling in

--- a/parsercore_phase0_physical_head_merge_stage2_internal_test.go
+++ b/parsercore_phase0_physical_head_merge_stage2_internal_test.go
@@ -60,8 +60,8 @@ func TestStage2PhysicalHeadMergePreservesDistinctErrorRegions(t *testing.T) {
 		},
 	}
 	headers := []diagnosticParserCoreHeader{
-		{head: left, shifted: true, versionState: leftState, recoveryCompetitor: true},
-		{head: right, shifted: true, versionState: rightState, recoveryCompetitor: true},
+		{head: left, shifted: true, versionState: leftState, recoveryFlags: diagnosticParserCoreRecoveryCompetitorFlag},
+		{head: right, shifted: true, versionState: rightState, recoveryFlags: diagnosticParserCoreRecoveryCompetitorFlag},
 	}
 	var scratch diagnosticParserCoreCanonicalScratch
 	out, err := scratch.canonicalizeRecovery(compact, headers)
@@ -80,8 +80,8 @@ func TestStage2PhysicalHeadMergePreservesDistinctErrorRegions(t *testing.T) {
 func TestStage2PhysicalHeadMergePreservesRecoveryLineage(t *testing.T) {
 	compact, left, right, _, _ := newStage2RecoveryHeadPair(t)
 	headers := []diagnosticParserCoreHeader{
-		{head: left, shifted: true, recoveryCompetitor: true},
-		{head: right, shifted: true, recoveryCompetitor: true},
+		{head: left, shifted: true, recoveryFlags: diagnosticParserCoreRecoveryCompetitorFlag},
+		{head: right, shifted: true, recoveryFlags: diagnosticParserCoreRecoveryCompetitorFlag},
 	}
 	var scratch diagnosticParserCoreCanonicalScratch
 	out, err := scratch.canonicalizeRecovery(compact, headers)
@@ -198,6 +198,104 @@ func TestStage2PhysicalHeadMergeCanonicalizationUnionsLineage(t *testing.T) {
 	}
 }
 
+func TestStage2PhysicalHeadMergeRunsThroughGenericReductionDispatch(t *testing.T) {
+	table := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 3}: {{Type: core.ActionShift, State: 2}},
+			{state: 1, symbol: 4}: {{Type: core.ActionShift, State: 2}},
+			{state: 1, symbol: 5}: {{Type: core.ActionShift, State: 3}},
+			{state: 3, symbol: 9}: {{Type: core.ActionReduce, Symbol: 6, ChildCount: 1}},
+		},
+		gotos: map[genericConflictCell]core.StateID{{state: 1, symbol: 6}: 7},
+	}
+	compact, err := core.New(table, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftSeed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := compact.Shift(leftSeed, 3, 0, core.Token{Symbol: 3, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.BeginFrontier(); err != nil {
+		t.Fatal(err)
+	}
+	rightSeed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := compact.Shift(rightSeed, 4, 0, core.Token{Symbol: 4, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceSeed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := compact.Shift(sourceSeed, 5, 0, core.Token{Symbol: 5, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if left == right {
+		t.Fatal("fixture did not create two physical sibling heads")
+	}
+
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		headers: []diagnosticParserCoreHeader{
+			{head: source, creationSeq: 1},
+			{head: left, creationSeq: 2},
+			{head: right, creationSeq: 3},
+		},
+		token: Token{Symbol: 9, StartByte: 1, EndByte: 2},
+		options: DiagnosticParserCorePrefixOptions{
+			MaxDispatches: 20,
+			ReceiptMode:   DiagnosticParserCoreReceiptSummary,
+		},
+		receipt: &DiagnosticParserCoreGenericScheduler{},
+	}
+	before, err := diagnosticParserCoreHeaderReceipts(compact, scheduler.headers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cell := mustDiagnosticParserCoreGenericCell(t, compact, 0, scheduler.headers[0], 9)
+	workBefore := compact.Work()
+	if err := scheduler.applyGenericReduction(before, cell); err != nil {
+		t.Fatal(err)
+	}
+	workAfter := compact.Work()
+	if workAfter.PhysicalHeadMergeAttempts-workBefore.PhysicalHeadMergeAttempts != 1 ||
+		workAfter.PhysicalHeadMergeSuccesses-workBefore.PhysicalHeadMergeSuccesses != 1 ||
+		workAfter.PhysicalHeadMergeInputLinks-workBefore.PhysicalHeadMergeInputLinks != 1 {
+		t.Fatalf("generic reduction physical-merge telemetry before=%+v after=%+v", workBefore, workAfter)
+	}
+	canonical, ok := compact.CanonicalBoundary(2, 1, false, 0)
+	if !ok {
+		t.Fatal("generic reduction did not publish the merged sibling boundary")
+	}
+	derivations, err := compact.Derivations(canonical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(derivations) != 2 || len(derivations[0].Payloads) != 1 || len(derivations[1].Payloads) != 1 {
+		t.Fatalf("generic reduction merged derivations=%+v", derivations)
+	}
+	first, err := compact.Subtree(derivations[0].Payloads[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := compact.Subtree(derivations[1].Payloads[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Symbol != 3 || second.Symbol != 4 {
+		t.Fatalf("generic reduction changed stable sibling order: first=%+v second=%+v", first, second)
+	}
+}
+
 func TestStage2PhysicalHeadMergeCandidatesPreserveDistinctLexerVersionsForClassification(t *testing.T) {
 	compact, first, second := newDiagnosticParserCoreCanonicalTestCore(t)
 	sharedSnapshot := &diagnosticParserCoreVersionLexerSnapshot{}
@@ -207,13 +305,40 @@ func TestStage2PhysicalHeadMergeCandidatesPreserveDistinctLexerVersionsForClassi
 		{head: first, versionState: sharedState},
 		{head: second, versionState: sharedState},
 		{head: second, versionState: distinctState},
-		{head: second, versionState: sharedState, recoveryCompetitor: true},
+		{head: second, versionState: sharedState, recoveryFlags: diagnosticParserCoreRecoveryCompetitorFlag},
 		{head: second, versionState: sharedState, paused: true},
 		{head: second, versionState: sharedState, accepted: true},
 	}}
 	candidates := scheduler.collectCondenseCandidates(0)
 	if len(candidates) != 2 || candidates[0].Head != second || candidates[1].Head != second {
 		t.Fatalf("classification candidates=%+v, want both clean lexer versions", candidates)
+	}
+}
+
+func TestStage2PhysicalHeadMergeRejectsClearedRecoveryCostedLineage(t *testing.T) {
+	compact, first, second := newDiagnosticParserCoreCanonicalTestCore(t)
+	recovered := diagnosticParserCoreHeader{head: second}
+	recovered.markRecoveryLineage()
+	recovered.openRecoveryRegion(&diagnosticParserCoreS3Region{state: 2, startByte: 0, endByte: 1})
+	recovered.closeRecoveryRegion()
+	recovered.clearRecoveryLineage()
+	recovered.clearVersionLexerSnapshot()
+	if recovered.isRecoveryLineage() || !recovered.isRecoveryCosted() || recovered.versionState != nil {
+		t.Fatalf("cleared recovery header lost its permanent cost marker: %+v", recovered)
+	}
+
+	scheduler := diagnosticParserCoreGenericScheduler{compact: compact, headers: []diagnosticParserCoreHeader{
+		{head: first}, recovered,
+	}}
+	if candidates := scheduler.collectCondenseCandidates(0); len(candidates) != 0 {
+		t.Fatalf("recovery-costed candidate entered clean physical merge: %+v", candidates)
+	}
+	scheduler.headers[0], scheduler.headers[1] = scheduler.headers[1], scheduler.headers[0]
+	if candidates := scheduler.collectCondenseCandidates(0); len(candidates) != 0 {
+		t.Fatalf("recovery-costed source entered clean physical merge: %+v", candidates)
+	}
+	if work := compact.Work(); work.PhysicalHeadMergeAttempts != 0 || work.PhysicalHeadMergeSuccesses != 0 {
+		t.Fatalf("recovery-cost guard entered physical merge: %+v", work)
 	}
 }
 

--- a/parsercore_phase0_physical_head_merge_stage2_internal_test.go
+++ b/parsercore_phase0_physical_head_merge_stage2_internal_test.go
@@ -1,0 +1,267 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func newStage2RecoveryHeadPair(t *testing.T) (*core.Core, core.Head, core.Head, core.SubtreeID, core.SubtreeID) {
+	t.Helper()
+	compact, err := core.New(&genericConflictTable{}, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftSeed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftChild, err := compact.ErrorRegionLeaf(3, 0, 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := compact.ErrorRegionResume(leftSeed, 2, 0, 1, []core.SubtreeID{leftChild})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.BeginFrontier(); err != nil {
+		t.Fatal(err)
+	}
+	rightSeed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightChild, err := compact.ErrorRegionLeaf(4, 0, 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := compact.ErrorRegionResume(rightSeed, 2, 0, 1, []core.SubtreeID{rightChild})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if left == right {
+		t.Fatal("frontier generations reused one physical recovery head")
+	}
+	return compact, left, right, leftChild, rightChild
+}
+
+func TestStage2PhysicalHeadMergePreservesDistinctErrorRegions(t *testing.T) {
+	compact, left, right, leftChild, rightChild := newStage2RecoveryHeadPair(t)
+	leftState := &diagnosticParserCoreVersionState{
+		s3Region: &diagnosticParserCoreS3Region{
+			state: 2, startByte: 0, endByte: 1, children: []core.SubtreeID{leftChild},
+		},
+	}
+	rightState := &diagnosticParserCoreVersionState{
+		s3Region: &diagnosticParserCoreS3Region{
+			state: 2, startByte: 0, endByte: 1, children: []core.SubtreeID{rightChild},
+		},
+	}
+	headers := []diagnosticParserCoreHeader{
+		{head: left, shifted: true, versionState: leftState, recoveryCompetitor: true},
+		{head: right, shifted: true, versionState: rightState, recoveryCompetitor: true},
+	}
+	var scratch diagnosticParserCoreCanonicalScratch
+	out, err := scratch.canonicalizeRecovery(compact, headers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 2 || out[0].head == out[1].head {
+		t.Fatalf("distinct error regions were physically merged: %+v", out)
+	}
+	if out[0].recoveryRegion() == nil || out[1].recoveryRegion() == nil ||
+		out[0].recoveryRegion().children[0] != leftChild || out[1].recoveryRegion().children[0] != rightChild {
+		t.Fatalf("error-region children changed during canonicalization: %+v", out)
+	}
+}
+
+func TestStage2PhysicalHeadMergePreservesRecoveryLineage(t *testing.T) {
+	compact, left, right, _, _ := newStage2RecoveryHeadPair(t)
+	headers := []diagnosticParserCoreHeader{
+		{head: left, shifted: true, recoveryCompetitor: true},
+		{head: right, shifted: true, recoveryCompetitor: true},
+	}
+	var scratch diagnosticParserCoreCanonicalScratch
+	out, err := scratch.canonicalizeRecovery(compact, headers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 2 || out[0].head == out[1].head {
+		t.Fatalf("recovery lineage heads were physically merged: %+v", out)
+	}
+	for index, header := range out {
+		if !header.isRecoveryLineage() {
+			t.Fatalf("header %d lost recovery lineage marker: %+v", index, out)
+		}
+	}
+}
+
+func TestStage2PhysicalHeadMergePreservesDistinctLexerSnapshots(t *testing.T) {
+	compact, left, right, _, _ := newStage2RecoveryHeadPair(t)
+	leftSnapshot := &diagnosticParserCoreVersionLexerSnapshot{}
+	rightSnapshot := &diagnosticParserCoreVersionLexerSnapshot{}
+	headers := []diagnosticParserCoreHeader{
+		{head: left, shifted: true, versionState: &diagnosticParserCoreVersionState{relexSnapshot: leftSnapshot}},
+		{head: right, shifted: true, versionState: &diagnosticParserCoreVersionState{relexSnapshot: rightSnapshot}},
+	}
+	before := compact.Work()
+	var scratch diagnosticParserCoreCanonicalScratch
+	out, err := scratch.canonicalize(compact, headers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("distinct lexer snapshots were merged: %+v", out)
+	}
+	seenLeft, seenRight := false, false
+	for _, header := range out {
+		seenLeft = seenLeft || header.versionLexerSnapshot() == leftSnapshot
+		seenRight = seenRight || header.versionLexerSnapshot() == rightSnapshot
+	}
+	if !seenLeft || !seenRight {
+		t.Fatalf("lexer snapshot identity was lost: %+v", out)
+	}
+	if after := compact.Work(); after != before {
+		t.Fatalf("lexer snapshot guard entered physical merge path: before=%+v after=%+v", before, after)
+	}
+}
+
+func TestStage2PhysicalHeadMergeCanonicalizationUnionsLineage(t *testing.T) {
+	table := &genericConflictTable{cells: map[genericConflictCell][]core.Action{
+		{state: 1, symbol: 3}: {{Type: core.ActionShift, State: 2}},
+		{state: 1, symbol: 4}: {{Type: core.ActionShift, State: 2}},
+	}}
+	compact, err := core.New(table, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := compact.Shift(seed, 3, 0, core.Token{Symbol: 3, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.BeginFrontier(); err != nil {
+		t.Fatal(err)
+	}
+	seed, err = compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := compact.Shift(seed, 4, 0, core.Token{Symbol: 4, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := compact.Seed(9, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftSet := core.NewAlternativeSetMember(11, 1)
+	rightSet := core.NewAlternativeSetMember(12, 2)
+	scheduler := diagnosticParserCoreGenericScheduler{compact: compact, headers: []diagnosticParserCoreHeader{
+		{head: source, creationSeq: 1},
+		{head: left, creationSeq: 3, altSet: leftSet, cleanPathRank: core.CleanPathRankSelected, cleanPathLineage: 11},
+		{head: right, creationSeq: 5, altSet: rightSet, cleanPathRank: core.CleanPathRankUnselected, cleanPathLineage: 12},
+	}}
+	err = compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		if err := scheduler.reindexCondenseCandidatesOwned(owner, 0); err != nil {
+			return err
+		}
+		if err := scheduler.canonicalizeOwned(owner); err != nil {
+			return err
+		}
+		return scheduler.persistHeaderLineageOwned(owner)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(scheduler.headers) != 2 {
+		t.Fatalf("physical heads did not canonicalize: %+v", scheduler.headers)
+	}
+	merged := scheduler.headers[1]
+	members, ok := compact.AlternativeSetMembers(merged.altSet)
+	if !ok || len(members) != 2 ||
+		core.AlternativeSetMemberEvent(members[0]) != 11 ||
+		core.AlternativeSetMemberEvent(members[1]) != 12 {
+		t.Fatalf("physical-head lineage union=%v/%t", members, ok)
+	}
+	if merged.cleanPathRank != core.CleanPathRankUnknown || merged.cleanPathLineage != 0 {
+		t.Fatalf("physical-head scalar lineage did not fail closed: %+v", merged)
+	}
+	work := compact.Work()
+	if work.PhysicalHeadMergeAttempts != 1 || work.PhysicalHeadMergeSuccesses != 1 || work.PhysicalHeadMergeInputLinks != 1 {
+		t.Fatalf("physical-head scheduler telemetry=%+v", work)
+	}
+}
+
+func TestStage2PhysicalHeadMergeCandidatesPreserveDistinctLexerVersionsForClassification(t *testing.T) {
+	compact, first, second := newDiagnosticParserCoreCanonicalTestCore(t)
+	sharedSnapshot := &diagnosticParserCoreVersionLexerSnapshot{}
+	sharedState := &diagnosticParserCoreVersionState{relexSnapshot: sharedSnapshot}
+	distinctState := &diagnosticParserCoreVersionState{relexSnapshot: &diagnosticParserCoreVersionLexerSnapshot{}}
+	scheduler := diagnosticParserCoreGenericScheduler{compact: compact, headers: []diagnosticParserCoreHeader{
+		{head: first, versionState: sharedState},
+		{head: second, versionState: sharedState},
+		{head: second, versionState: distinctState},
+		{head: second, versionState: sharedState, recoveryCompetitor: true},
+		{head: second, versionState: sharedState, paused: true},
+		{head: second, versionState: sharedState, accepted: true},
+	}}
+	candidates := scheduler.collectCondenseCandidates(0)
+	if len(candidates) != 2 || candidates[0].Head != second || candidates[1].Head != second {
+		t.Fatalf("classification candidates=%+v, want both clean lexer versions", candidates)
+	}
+}
+
+func TestStage2PhysicalHeadMergeFailsClosedAcrossDistinctLexerOwnership(t *testing.T) {
+	table := &genericConflictTable{cells: map[genericConflictCell][]core.Action{
+		{state: 1, symbol: 3}: {{Type: core.ActionShift, State: 2}},
+		{state: 1, symbol: 4}: {{Type: core.ActionShift, State: 2}},
+	}}
+	compact, err := core.New(table, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := compact.Shift(seed, 3, 0, core.Token{Symbol: 3, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.BeginFrontier(); err != nil {
+		t.Fatal(err)
+	}
+	seed, err = compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := compact.Shift(seed, 4, 0, core.Token{Symbol: 4, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := compact.Seed(9, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := diagnosticParserCoreGenericScheduler{compact: compact, headers: []diagnosticParserCoreHeader{
+		{head: source},
+		{head: left, versionState: &diagnosticParserCoreVersionState{relexSnapshot: &diagnosticParserCoreVersionLexerSnapshot{}}},
+		{head: right, versionState: &diagnosticParserCoreVersionState{relexSnapshot: &diagnosticParserCoreVersionLexerSnapshot{}}},
+	}}
+	before := compact.Work()
+	err = compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		return scheduler.reindexCondenseCandidatesOwned(owner, 0)
+	})
+	if err == nil || err.Error() != "parser-core phase zero: physical heads have different lexer ownership" {
+		t.Fatalf("distinct lexer ownership error=%v", err)
+	}
+	if compact.Work() != before {
+		t.Fatalf("distinct lexer ownership entered physical merge: before=%+v after=%+v", before, compact.Work())
+	}
+}

--- a/parsercore_phase0_recovery_lineage_fork_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_fork_internal_test.go
@@ -83,6 +83,9 @@ func TestS5MissingInsertionForkPublishesBothRecoveryLineages(t *testing.T) {
 	if !scheduler.headers[0].isRecoveryLineage() || !scheduler.headers[1].isRecoveryLineage() {
 		t.Fatal("the fork did not mark both recovery lineages")
 	}
+	if !scheduler.headers[0].isRecoveryCosted() || !scheduler.headers[1].isRecoveryCosted() {
+		t.Fatal("the fork did not preserve recovery cost provenance")
+	}
 	if !scheduler.recoveryIsolation {
 		t.Fatal("the fork did not activate recovery isolation")
 	}
@@ -176,6 +179,49 @@ func TestS3RegionMarkerAllowsClosureOnlyRedispatch(t *testing.T) {
 	}
 	if state != 3 || !scheduler.s3RegionOpened {
 		t.Fatalf("closure-only state=%d marker=%t, want 3/true", state, scheduler.s3RegionOpened)
+	}
+	if scheduler.headers[0].isRecoveryCosted() {
+		t.Fatal("closure-only redispatch gained recovery cost provenance")
+	}
+}
+
+func TestS3AbsorbCostProvenanceSurvivesResumeAndRegionClose(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	clean := scheduler.headers[0]
+
+	handled, err := scheduler.s3TryOpenErrorRegionWithAlternatives(0, true)
+	if err != nil {
+		t.Fatalf("s3TryOpenErrorRegionWithAlternatives: %v", err)
+	}
+	if !handled {
+		t.Fatal("standalone S3 absorb did not open a region")
+	}
+	recovered := &scheduler.headers[0]
+	region := recovered.recoveryRegion()
+	if region == nil || !recovered.isRecoveryCosted() || recovered.isRecoveryLineage() {
+		t.Fatalf("opened standalone S3 header=%+v region=%+v", *recovered, region)
+	}
+
+	resumed, err := scheduler.compact.ErrorRegionResume(
+		recovered.head, region.state, region.startByte, region.endByte, region.children,
+	)
+	if err != nil {
+		t.Fatalf("ErrorRegionResume: %v", err)
+	}
+	recovered.head = resumed
+	recovered.closeRecoveryRegion()
+	if recovered.recoveryRegion() != nil || recovered.versionState != nil || !recovered.isRecoveryCosted() {
+		t.Fatalf("closed standalone S3 header lost cost provenance: %+v", *recovered)
+	}
+
+	recoveredHeader := *recovered
+	scheduler.headers = []diagnosticParserCoreHeader{clean, recoveredHeader}
+	if candidates := scheduler.collectCondenseCandidates(0); len(candidates) != 0 {
+		t.Fatalf("recovery-costed candidate entered clean physical merge: %+v", candidates)
+	}
+	scheduler.headers[0], scheduler.headers[1] = scheduler.headers[1], scheduler.headers[0]
+	if candidates := scheduler.collectCondenseCandidates(0); len(candidates) != 0 {
+		t.Fatalf("recovery-costed source entered clean physical merge: %+v", candidates)
 	}
 }
 

--- a/parsercore_phase0_recovery_lineage_selection_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_selection_internal_test.go
@@ -193,11 +193,8 @@ func TestSelectCompetingRecoveryLineageDeclinesSingleHead(t *testing.T) {
 	}
 }
 
-// TestRecoveryLineageMarkerDoesNotGrowTheHeader pins the reason the marker is
-// a single field placed before s3Region. Two fields, or one placed after the
-// pointer, take the header from 224 to 232 bytes -- measured -- and two
-// separate size ratchets pin 224. Asserting it here means a reader who splits
-// the field finds out from this test rather than from an unrelated ratchet.
+// TestRecoveryLineageMarkerDoesNotGrowTheHeader pins one byte of recovery
+// flags before versionState. A second field grows the header to 232 bytes.
 func TestRecoveryLineageMarkerDoesNotGrowTheHeader(t *testing.T) {
 	if got := unsafe.Sizeof(diagnosticParserCoreHeader{}); got != 224 {
 		t.Fatalf("scheduler header is %d bytes, want 224", got)
@@ -207,12 +204,12 @@ func TestRecoveryLineageMarkerDoesNotGrowTheHeader(t *testing.T) {
 		t.Fatal("a zero header reported itself as a recovery lineage")
 	}
 	header.markRecoveryLineage()
-	if !header.isRecoveryLineage() {
+	if !header.isRecoveryLineage() || !header.isRecoveryCosted() {
 		t.Fatal("marking did not take")
 	}
 	header.clearRecoveryLineage()
-	if header.isRecoveryLineage() {
-		t.Fatal("clearing did not demote the header")
+	if header.isRecoveryLineage() || !header.isRecoveryCosted() {
+		t.Fatal("lineage clearing changed permanent cost provenance")
 	}
 }
 


### PR DESCRIPTION
## Scope

This pull request completes graduation funnel Stage 2: physical graph-head merging.

- Merge clean, equivalent heads at one authenticated boundary.
- Preserve every node, link, lineage, checkpoint, and drop-cohort reference.
- Keep recovery-costed headers and distinct lexer owners separate.
- Add transactional path telemetry and retention cleanup.
- Keep all unrelated performance work out of this pull request.

## C oracle

- Grammar: Erlang at commit `1d78195c4fbb1fc027eb3e4220427f1eb8bfc89e`.
- Source: one opening parenthesis byte.
- Source SHA-256: `32ebb1abcc1c601ceb9c4faba0caa5b85bb98c4f1e6612c40faa528a91c9`.
- Exact tree: `source_file [0,1)`, `ERROR [0,1)`, and `"(" [0,1)`.
- Receipt: 219 retained events and zero dropped events.
- Receipt SHA-256: `eea03c73787e2353366ec29a90e0b051ca0e1c53db05625ef84ff3abc9c11f3e`.
- C merge results: 82 attempts and four successes at events 47, 173, 181, and 188.
- The routed Go tree and all missing and error flags match C exactly.
- The route records one expected fallback before Stage 3 graduates recovery through ambiguity.

## Correctness proof

- A generic reduction dispatch records one physical attempt, one success, and one input link.
- Six equivalent versions retain six distinct paths in stable order.
- Different lexer ownership fails closed before a physical merge.
- Different scanner provenance fails closed before a physical merge.
- Distinct error regions and recovery lineages remain separate.
- Standalone S3 absorption keeps permanent cost provenance after resume and region close.
- Closure-only S3 redispatch remains uncosted.
- Ordinary ambiguity clears only competition status and keeps cost provenance.
- Capacity failure rolls back the graph, boundary, and telemetry state.
- Header size stays 224 bytes. `CondenseCandidate` stays 88 bytes.
- Three independent Luna max reviews found no P1 or P2 issue.

## Certification evidence

- The focused Docker race suite passes for Stage 2, S3 provenance, and lexer-state retirement.
- Erlang parity passes 25 of 25 sources for exact S-expression and deep comparison.
- The Erlang run reaches 1,223,880 KB maximum resident memory without an out-of-memory event.
- The 104-source merge census keeps `M_c=191` and `M_p=11`.
- The census records zero physical attempts, successes, and input links on accepted corpus routes.
- A separate unit test proves that nonzero physical telemetry aggregates correctly.

## Performance evidence

The comparison uses 20 shuffled seeds, one process, and a 750 millisecond benchmark duration.

- Full parse time increases 4.25 percent.
- Full parse bytes increase 3.70 percent. Allocation count stays at five.
- Incremental single-byte edit time increases 2.77 percent.
- Incremental edit bytes and allocations stay at zero.
- Incremental no-edit time, bytes, and allocations have no significant change.
- Candidate fallback stays zero.
- Time geomean increases 3.50 percent.
- Bytes geomean increases 0.32 percent. Allocation geomean does not change.

The run also measures 4 to 8 percent slowdowns in unrelated benchmarks. This pull request records the result and defers optimization.

Baseline SHA-256: `c085440b923c3042ec20a653e4eb3c49311d80e87891ae9aa2f4c673cd926ed7`.

Candidate SHA-256: `c4753d81152da8f07de018e1fec1504b199940c61b232445b75067e572c77da4`.

## Safety boundary

- Stage 2 accepts only clean candidates with authenticated zero error cost.
- Recovery-costed merging remains in Stage 3.
- Capacity rejection fails closed instead of discarding the incoming version.
- Distinct lexer ownership remains available for freshness classification.
- The compact route does not become the default in this pull request.

## Funnel

Start Stage 3, recovery through ambiguity, only after this pull request merges.
