### PR TITLE
Preserve recovery competition through ambiguity

### DIFF
--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1122,9 +1122,9 @@ type SubtreeView struct {
 }
 
 // MaterializationSubtreeView is a callback-scoped borrowed view of one compact
-// subtree. Children aliases compact arena storage and must not be retained or
-// mutated by the visitor. The copying Subtree diagnostic API remains the
-// stable inspection surface.
+// subtree. Children and Aliases reference compact arena storage. A visitor
+// must not retain or mutate them. The copying Subtree diagnostic API remains
+// the stable inspection surface.
 type MaterializationSubtreeView struct {
 	Symbol            Symbol
 	ProductionID      uint16
@@ -1132,6 +1132,7 @@ type MaterializationSubtreeView struct {
 	StartByte         uint32
 	EndByte           uint32
 	Children          []SubtreeID
+	Aliases           []Symbol
 	Extra             bool
 	External          bool
 	Terminal          bool
@@ -5460,8 +5461,8 @@ func (c *Core) VisitMaterializationPostorder(
 // subtree id. It is the random-access companion to VisitMaterializationPostorder
 // used by ParseState-by-table-replay (Phase-3 Lane 2): the driver walks the
 // derivation top-down to reconstruct per-node parser states before the
-// postorder pass materializes public nodes. The returned Children slice
-// aliases compact arena storage and must not be retained or mutated.
+// postorder pass materializes public nodes. The returned Children and Aliases
+// slices reference compact arena storage and must not be retained or mutated.
 func (c *Core) MaterializationView(id SubtreeID) (MaterializationSubtreeView, error) {
 	record, err := c.subtree(id)
 	if err != nil {
@@ -5474,6 +5475,7 @@ func (c *Core) MaterializationView(id SubtreeID) (MaterializationSubtreeView, er
 		StartByte:         record.startByte,
 		EndByte:           record.endByte,
 		Children:          c.children[record.firstChild : record.firstChild+record.childCount],
+		Aliases:           c.aliases[record.firstAlias : record.firstAlias+record.aliasCount],
 		Extra:             record.extra,
 		External:          record.external,
 		Terminal:          record.terminal,

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -156,6 +156,13 @@ func TestPinnedGoConflictAndReductionMetadata(t *testing.T) {
 	if !slices.Equal(view.Aliases, []Symbol{229}) {
 		t.Fatalf("aliases = %#v, want pinned [229]", view.Aliases)
 	}
+	borrowed, err := core.MaterializationView(paths[0].Payloads[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(borrowed.Aliases, []Symbol{229}) {
+		t.Fatalf("borrowed aliases = %#v, want pinned [229]", borrowed.Aliases)
+	}
 
 	// ParseActions[106].Actions[0] is the pinned real Go production-zero
 	// reduction from the conflict cell above. Production zero has no alias

--- a/internal/parsercorephase0/recovery_cost.go
+++ b/internal/parsercorephase0/recovery_cost.go
@@ -3,6 +3,7 @@ package parsercorephase0
 import (
 	"errors"
 	"fmt"
+	"math"
 )
 
 // ---------------------------------------------------------------------------
@@ -63,6 +64,10 @@ const recoveryMaxCostDifference = 18 * RecoveryCostPerSkippedTree
 // constant (parser_api.go:997).
 const RecoveryErrorSymbol Symbol = 65535
 
+// RecoveryErrorRepeatSymbol is tree-sitter's hidden ERROR_REPEAT symbol. C
+// counts this intermediate node as progress even though it is not visible.
+const RecoveryErrorRepeatSymbol Symbol = RecoveryErrorSymbol - 1
+
 // RecoveryCostNode is the immutable, per-subtree view the cost model reads.
 // See the file doc comment above for why it carries two fields SubtreeView
 // does not.
@@ -75,6 +80,9 @@ type RecoveryCostNode struct {
 	StartRow  uint32
 	EndRow    uint32
 	Children  []SubtreeID
+	// Aliases is empty or has one symbol per child. A non-zero alias makes a
+	// non-extra child occurrence visible in C's cached descendant count.
+	Aliases []Symbol
 }
 
 // RecoveryCostSource resolves a SubtreeID to its cost-model view. Compact
@@ -120,8 +128,14 @@ func recoveryVisibleChildCount(symbols []SelectedSymbolPolicy, src RecoveryCostS
 	if err != nil {
 		return 0, fmt.Errorf("parser-core phase zero: recovery cost node %d: %w", id, err)
 	}
+	if len(node.Aliases) != 0 && len(node.Aliases) != len(node.Children) {
+		return 0, fmt.Errorf(
+			"parser-core phase zero: recovery cost node %d has %d aliases for %d children",
+			id, len(node.Aliases), len(node.Children),
+		)
+	}
 	count := 0
-	for _, childID := range node.Children {
+	for index, childID := range node.Children {
 		if childID == 0 {
 			continue
 		}
@@ -129,7 +143,8 @@ func recoveryVisibleChildCount(symbols []SelectedSymbolPolicy, src RecoveryCostS
 		if err != nil {
 			return 0, fmt.Errorf("parser-core phase zero: recovery cost node %d: %w", childID, err)
 		}
-		if RecoverySymbolVisible(symbols, child.Symbol) {
+		hasAlias := len(node.Aliases) != 0 && node.Aliases[index] != 0
+		if hasAlias && !child.Extra || RecoverySymbolVisible(symbols, child.Symbol) {
 			count++
 		} else if len(child.Children) > 0 {
 			sub, err := recoveryVisibleChildCount(symbols, src, childID)
@@ -138,6 +153,58 @@ func recoveryVisibleChildCount(symbols []SelectedSymbolPolicy, src RecoveryCostS
 			}
 			count += sub
 		}
+	}
+	return count, nil
+}
+
+// RecoveryNodeVisibleSubtreeCount is the compact equivalent of
+// stack__subtree_node_count. It counts each visible node in one subtree.
+// Production aliases relabel a child before C stores and counts that child.
+// The result uses C's uint32 node-count domain and fails closed on overflow.
+func RecoveryNodeVisibleSubtreeCount(symbols []SelectedSymbolPolicy, src RecoveryCostSource, id SubtreeID) (uint32, error) {
+	return recoveryNodeVisibleSubtreeCount(symbols, src, id, false, true)
+}
+
+func recoveryNodeVisibleSubtreeCount(
+	symbols []SelectedSymbolPolicy,
+	src RecoveryCostSource,
+	id SubtreeID,
+	hasAlias bool,
+	countErrorRepeat bool,
+) (uint32, error) {
+	if id == 0 {
+		return 0, nil
+	}
+	node, err := src.RecoveryCostNode(id)
+	if err != nil {
+		return 0, fmt.Errorf("parser-core phase zero: recovery cost node %d: %w", id, err)
+	}
+	if len(node.Aliases) != 0 && len(node.Aliases) != len(node.Children) {
+		return 0, fmt.Errorf(
+			"parser-core phase zero: recovery cost node %d has %d aliases for %d children",
+			id, len(node.Aliases), len(node.Children),
+		)
+	}
+	count := uint32(0)
+	if hasAlias && !node.Extra || RecoverySymbolVisible(symbols, node.Symbol) ||
+		countErrorRepeat && node.Symbol == RecoveryErrorRepeatSymbol {
+		count++
+	}
+	for index, childID := range node.Children {
+		childAlias := Symbol(0)
+		if len(node.Aliases) != 0 {
+			childAlias = node.Aliases[index]
+		}
+		childCount, childErr := recoveryNodeVisibleSubtreeCount(
+			symbols, src, childID, childAlias != 0, false,
+		)
+		if childErr != nil {
+			return 0, childErr
+		}
+		if math.MaxUint32-count < childCount {
+			return 0, errors.New("parser-core phase zero: recovery visible-node count overflow")
+		}
+		count += childCount
 	}
 	return count, nil
 }
@@ -225,6 +292,26 @@ func RecoveryNodeErrorCostMemo(symbols []SelectedSymbolPolicy, src RecoveryCostS
 	return recoveryNodeErrorCost(symbols, src, memo, id)
 }
 
+// RecoveryErrorRegionCost prices an open ERROR node that the scheduler owns
+// outside the compact arena. Its children are published subtree identifiers.
+// This is the live equivalent of RecoveryNodeErrorCost on an ERROR record.
+func RecoveryErrorRegionCost(
+	symbols []SelectedSymbolPolicy,
+	src RecoveryCostSource,
+	memo *RecoveryCostMemo,
+	startByte, startRow, endByte, endRow uint32,
+	children []SubtreeID,
+) (uint32, error) {
+	return recoveryCostNodeErrorCost(symbols, src, memo, RecoveryCostNode{
+		Symbol:    RecoveryErrorSymbol,
+		StartByte: startByte,
+		EndByte:   endByte,
+		StartRow:  startRow,
+		EndRow:    endRow,
+		Children:  children,
+	})
+}
+
 func recoveryNodeErrorCost(symbols []SelectedSymbolPolicy, src RecoveryCostSource, memo *RecoveryCostMemo, id SubtreeID) (uint32, error) {
 	if id == 0 {
 		return 0, nil
@@ -238,12 +325,24 @@ func recoveryNodeErrorCost(symbols []SelectedSymbolPolicy, src RecoveryCostSourc
 	if err != nil {
 		return 0, fmt.Errorf("parser-core phase zero: recovery cost node %d: %w", id, err)
 	}
+	cost, err := recoveryCostNodeErrorCost(symbols, src, memo, node)
+	if err != nil {
+		return 0, err
+	}
+	if memo != nil {
+		memo.store(id, cost)
+	}
+	return cost, nil
+}
+
+func recoveryCostNodeErrorCost(
+	symbols []SelectedSymbolPolicy,
+	src RecoveryCostSource,
+	memo *RecoveryCostMemo,
+	node RecoveryCostNode,
+) (uint32, error) {
 	if node.Missing && len(node.Children) == 0 {
-		cost := uint32(RecoveryCostPerMissingTree + RecoveryCostPerRecovery)
-		if memo != nil {
-			memo.store(id, cost)
-		}
-		return cost, nil
+		return uint32(RecoveryCostPerMissingTree + RecoveryCostPerRecovery), nil
 	}
 	var cost uint32
 	for _, childID := range node.Children {
@@ -266,6 +365,12 @@ func recoveryNodeErrorCost(symbols []SelectedSymbolPolicy, src RecoveryCostSourc
 		cost += childCost
 	}
 	if node.Symbol == RecoveryErrorSymbol {
+		if len(node.Aliases) != 0 && len(node.Aliases) != len(node.Children) {
+			return 0, fmt.Errorf(
+				"parser-core phase zero: recovery cost node has %d aliases for %d children",
+				len(node.Aliases), len(node.Children),
+			)
+		}
 		for _, childID := range node.Children {
 			if childID == 0 {
 				continue
@@ -297,9 +402,6 @@ func recoveryNodeErrorCost(symbols []SelectedSymbolPolicy, src RecoveryCostSourc
 		}
 		cost += RecoveryCostPerRecovery + RecoveryCostPerSkippedChar*spanBytes + RecoveryCostPerSkippedLine*spanRows
 	}
-	if memo != nil {
-		memo.store(id, cost)
-	}
 	return cost, nil
 }
 
@@ -318,12 +420,10 @@ type RecoveryErrorStatus struct {
 // The scheduler supplies paused state, node count, precedence, and open
 // recovery state. subtreeCost is the accumulated subtree cost for one head.
 //
-// cNodeVisibleSubtreeCount and cNodeCountSinceError
-// (parser_recover_c.go:1178-1214,2155-2166) are deliberately not ported
-// here: they accumulate a visible-node count across a live GLR stack since
-// an error baseline, which is per-head bookkeeping, not a property of one
-// compact subtree. The scheduler owns that bookkeeping, so NodeCount remains
-// an explicit input.
+// RecoveryNodeVisibleSubtreeCount prices one immutable subtree. The scheduler
+// sums those counts across one live graph path and subtracts its per-version
+// error baseline. NodeCount remains an explicit input because the baseline is
+// header state, not a subtree property.
 func RecoveryVersionStatus(subtreeCost uint32, paused bool, nodeCount int, dynPrec int, hasOpenRecovery bool) RecoveryErrorStatus {
 	cost := subtreeCost
 	if paused {

--- a/internal/parsercorephase0/recovery_cost_test.go
+++ b/internal/parsercorephase0/recovery_cost_test.go
@@ -31,6 +31,7 @@ type recoveryCostSpec struct {
 	end      uint32
 	startRow uint32
 	endRow   uint32
+	aliases  []Symbol
 	children []*recoveryCostSpec
 }
 
@@ -50,6 +51,7 @@ func publishRecoveryCostSpec(src fakeRecoveryCostSource, next *SubtreeID, spec *
 		StartRow:  spec.startRow,
 		EndRow:    spec.endRow,
 		Children:  children,
+		Aliases:   append([]Symbol(nil), spec.aliases...),
 	}
 	return id
 }
@@ -85,6 +87,97 @@ func TestRecoveryNodeErrorCostCleanTreeIsZero(t *testing.T) {
 	}
 	if got != 0 {
 		t.Fatalf("clean tree cost = %d, want 0", got)
+	}
+}
+
+func TestRecoveryNodeVisibleSubtreeCountIncludesVisibleDescendants(t *testing.T) {
+	src, root := newRecoveryCostFixture(&recoveryCostSpec{
+		symbol: ordinarySymbol,
+		children: []*recoveryCostSpec{
+			{symbol: ordinarySymbol},
+			{symbol: 6, children: []*recoveryCostSpec{{symbol: ordinarySymbol}}},
+			{symbol: RecoveryErrorSymbol},
+		},
+	})
+	got, err := RecoveryNodeVisibleSubtreeCount(visibleSymbols(), src, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 4 {
+		t.Fatalf("visible subtree count=%d, want root, two ordinary nodes, and ERROR", got)
+	}
+}
+
+func TestRecoveryNodeVisibleSubtreeCountAppliesProductionAliases(t *testing.T) {
+	symbols := visibleSymbols()
+	src, root := newRecoveryCostFixture(&recoveryCostSpec{
+		symbol:  ordinarySymbol,
+		aliases: []Symbol{7, 0},
+		children: []*recoveryCostSpec{
+			{symbol: 6},
+			{symbol: 6},
+		},
+	})
+	got, err := RecoveryNodeVisibleSubtreeCount(symbols, src, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 2 {
+		t.Fatalf("alias-aware visible subtree count=%d, want visible root and aliased first child", got)
+	}
+}
+
+func TestRecoveryNodeVisibleSubtreeCountIgnoresAliasOnExtraChild(t *testing.T) {
+	src, root := newRecoveryCostFixture(&recoveryCostSpec{
+		symbol:   6,
+		aliases:  []Symbol{7},
+		children: []*recoveryCostSpec{{symbol: 6, extra: true}},
+	})
+	got, err := RecoveryNodeVisibleSubtreeCount(visibleSymbols(), src, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 0 {
+		t.Fatalf("extra-child alias visible count=%d, want 0", got)
+	}
+}
+
+func TestRecoveryNodeVisibleSubtreeCountIncludesHiddenErrorRepeat(t *testing.T) {
+	src, root := newRecoveryCostFixture(&recoveryCostSpec{symbol: RecoveryErrorRepeatSymbol})
+	got, err := RecoveryNodeVisibleSubtreeCount(visibleSymbols(), src, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 1 {
+		t.Fatalf("ERROR_REPEAT visible count=%d, want progress count 1", got)
+	}
+}
+
+func TestRecoveryNodeVisibleSubtreeCountDoesNotCountNestedErrorRepeatWrapper(t *testing.T) {
+	src, root := newRecoveryCostFixture(&recoveryCostSpec{
+		symbol: ordinarySymbol,
+		children: []*recoveryCostSpec{{
+			symbol:   RecoveryErrorRepeatSymbol,
+			children: []*recoveryCostSpec{{symbol: ordinarySymbol}},
+		}},
+	})
+	got, err := RecoveryNodeVisibleSubtreeCount(visibleSymbols(), src, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 2 {
+		t.Fatalf("nested ERROR_REPEAT visible count=%d, want visible root and descendant", got)
+	}
+}
+
+func TestRecoveryNodeVisibleSubtreeCountRejectsMalformedAliasRow(t *testing.T) {
+	src, root := newRecoveryCostFixture(&recoveryCostSpec{
+		symbol:   ordinarySymbol,
+		aliases:  []Symbol{7, 6},
+		children: []*recoveryCostSpec{{symbol: ordinarySymbol}},
+	})
+	if _, err := RecoveryNodeVisibleSubtreeCount(visibleSymbols(), src, root); err == nil {
+		t.Fatal("malformed recovery alias row unexpectedly passed")
 	}
 }
 
@@ -172,6 +265,46 @@ func TestRecoveryNodeErrorCostErrorNodeSkippedChildren(t *testing.T) {
 		RecoveryCostPerRecovery + RecoveryCostPerSkippedChar*6 + RecoveryCostPerSkippedLine*2)
 	if got != want {
 		t.Fatalf("ERROR node cost = %d, want %d", got, want)
+	}
+}
+
+func TestRecoveryNodeErrorCostUsesAliasedGrandchildVisibility(t *testing.T) {
+	symbols := visibleSymbols()
+	src, root := newRecoveryCostFixture(&recoveryCostSpec{
+		symbol: RecoveryErrorSymbol,
+		children: []*recoveryCostSpec{{
+			symbol:   6,
+			aliases:  []Symbol{7},
+			children: []*recoveryCostSpec{{symbol: 6}},
+		}},
+	})
+	got, err := RecoveryNodeErrorCost(symbols, src, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := uint32(RecoveryCostPerSkippedTree + RecoveryCostPerRecovery)
+	if got != want {
+		t.Fatalf("alias-aware ERROR cost=%d, want %d", got, want)
+	}
+}
+
+func TestRecoveryErrorRegionCostPricesUnpublishedOpenNode(t *testing.T) {
+	symbols := visibleSymbols()
+	src, child := newRecoveryCostFixture(&recoveryCostSpec{
+		symbol: ordinarySymbol, start: 2, end: 9, startRow: 1, endRow: 3,
+	})
+	got, err := RecoveryErrorRegionCost(
+		symbols, src, nil,
+		2, 1, 9, 3,
+		[]SubtreeID{child},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := uint32(RecoveryCostPerSkippedTree + RecoveryCostPerRecovery +
+		RecoveryCostPerSkippedChar*7 + RecoveryCostPerSkippedLine*2)
+	if got != want {
+		t.Fatalf("open ERROR region cost=%d, want %d", got, want)
 	}
 }
 

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -406,6 +406,14 @@ type DiagnosticParserCoreGenericWork struct {
 	// RecoveryLineageRetirements counts C-condense-tail transitions that remove
 	// one trailing no-action recovery version after an earlier version shifts.
 	RecoveryLineageRetirements uint64
+	// RecoveryAmbiguityForks counts ordinary grammar forks whose source already
+	// belongs to a recovery competition. The outputs retain recovery cost.
+	RecoveryAmbiguityForks uint64
+	// RecoveryCondensePasses counts completed C-style recovery condensations.
+	RecoveryCondensePasses uint64
+	// RecoveryVersionCapDrops counts histories removed because their distinct
+	// C merge key ranked after the six-version recovery limit.
+	RecoveryVersionCapDrops uint64
 	// SingleHeaderPasses counts dispatch passes executed against a
 	// single-header frontier (spec.c4-bytecode-isa.v1 section 5, obligation
 	// R6). It is count-only and published on the gts_workcount board so
@@ -1280,6 +1288,14 @@ type diagnosticParserCoreVersionState struct {
 	// preserve it because they do not consume lookahead. Shifts clear it when
 	// they publish the request's after snapshot.
 	lexerRequest uint32
+	// recoveryGroup identifies one live C error-state group. missingGroup ties
+	// a missing-token version to that group for C's S5 ordering rule.
+	recoveryGroup uint64
+	missingGroup  uint64
+	// recoveryNodeBaseline is C's cumulative visible-node count at the last
+	// error entry. Current counts come from the live graph during condensation.
+	recoveryNodeBaseline    uint32
+	recoveryNodeBaselineSet bool
 }
 
 type diagnosticParserCoreRecoveryFlags uint8
@@ -1313,6 +1329,64 @@ func (h diagnosticParserCoreHeader) versionLexerRequestReference() uint32 {
 	return h.versionState.lexerRequest
 }
 
+func (h diagnosticParserCoreHeader) recoveryGroupIdentity() uint64 {
+	if h.versionState == nil {
+		return 0
+	}
+	return h.versionState.recoveryGroup
+}
+
+func (h diagnosticParserCoreHeader) recoveryMissingGroupIdentity() uint64 {
+	if h.versionState == nil {
+		return 0
+	}
+	return h.versionState.missingGroup
+}
+
+func (h diagnosticParserCoreHeader) recoveryNodeBaseline() (uint32, bool) {
+	if h.versionState == nil {
+		return 0, false
+	}
+	return h.versionState.recoveryNodeBaseline, h.versionState.recoveryNodeBaselineSet
+}
+
+func (h *diagnosticParserCoreHeader) publishVersionState(
+	region *diagnosticParserCoreS3Region,
+	snapshot *diagnosticParserCoreVersionLexerSnapshot,
+	request uint32,
+	recoveryGroup, missingGroup uint64,
+	nodeBaseline uint32,
+	nodeBaselineSet bool,
+) {
+	if h == nil {
+		return
+	}
+	if region == nil && snapshot == nil && request == 0 && recoveryGroup == 0 &&
+		missingGroup == 0 && !nodeBaselineSet {
+		h.versionState = nil
+		return
+	}
+	h.versionState = &diagnosticParserCoreVersionState{
+		s3Region: region, relexSnapshot: snapshot, lexerRequest: request,
+		recoveryGroup: recoveryGroup, missingGroup: missingGroup,
+		recoveryNodeBaseline: nodeBaseline, recoveryNodeBaselineSet: nodeBaselineSet,
+	}
+}
+
+func (h *diagnosticParserCoreHeader) publishRecoveryCondenseState(
+	recoveryGroup, missingGroup uint64,
+	nodeBaseline uint32,
+	nodeBaselineSet bool,
+) {
+	if h == nil {
+		return
+	}
+	h.publishVersionState(
+		h.recoveryRegion(), h.versionLexerSnapshot(), h.versionLexerRequestReference(),
+		recoveryGroup, missingGroup, nodeBaseline, nodeBaselineSet,
+	)
+}
+
 func (h diagnosticParserCoreHeader) isRecoveryCosted() bool {
 	return h.recoveryFlags&diagnosticParserCoreRecoveryCostedFlag != 0
 }
@@ -1331,24 +1405,25 @@ func (h *diagnosticParserCoreHeader) setRecoveryRegion(region *diagnosticParserC
 		h.closeRecoveryRegion()
 		return
 	}
-	h.versionState = &diagnosticParserCoreVersionState{
-		s3Region:      cloneDiagnosticParserCoreS3Region(region),
-		relexSnapshot: h.versionLexerSnapshot(),
-		lexerRequest:  h.versionLexerRequestReference(),
-	}
+	baseline, baselineSet := h.recoveryNodeBaseline()
+	h.publishVersionState(
+		cloneDiagnosticParserCoreS3Region(region), h.versionLexerSnapshot(),
+		h.versionLexerRequestReference(), h.recoveryGroupIdentity(),
+		h.recoveryMissingGroupIdentity(), baseline, baselineSet,
+	)
 }
 
 // closeRecoveryRegion clears the header's open strategy-2 region.
 func (h *diagnosticParserCoreHeader) closeRecoveryRegion() {
 	if h != nil {
-		if snapshot := h.versionLexerSnapshot(); snapshot != nil {
-			h.versionState = &diagnosticParserCoreVersionState{
-				relexSnapshot: snapshot,
-				lexerRequest:  h.versionLexerRequestReference(),
-			}
-		} else {
-			h.versionState = nil
+		baseline, baselineSet := h.recoveryNodeBaseline()
+		if !h.isRecoveryLineage() {
+			baseline, baselineSet = 0, false
 		}
+		h.publishVersionState(
+			nil, h.versionLexerSnapshot(), h.versionLexerRequestReference(),
+			0, h.recoveryMissingGroupIdentity(), baseline, baselineSet,
+		)
 	}
 }
 
@@ -1363,6 +1438,11 @@ func (h *diagnosticParserCoreHeader) markRecoveryLineage() {
 		return
 	}
 	h.recoveryFlags |= diagnosticParserCoreRecoveryCompetitorFlag | diagnosticParserCoreRecoveryCostedFlag
+	if _, set := h.recoveryNodeBaseline(); !set {
+		h.publishRecoveryCondenseState(
+			h.recoveryGroupIdentity(), h.recoveryMissingGroupIdentity(), 0, true,
+		)
+	}
 }
 
 // markRecoveryCosted records recovery work without creating a competition.
@@ -1372,16 +1452,17 @@ func (h *diagnosticParserCoreHeader) markRecoveryCosted() {
 	}
 }
 
-// clearRecoveryLineage demotes this header out of the competition.
+// clearRecoveryLineage removes this header from a finished competition.
 //
-// Every header-rewrite path copies the whole struct, so a fork of a marked
-// head produces marked children. A fork on ORDINARY grammar ambiguity must
-// call this on its replacements, or acceptance would decide that frontier by
-// error cost -- a different decision procedure than the one C applies to it.
+// Do not call it at an ordinary ambiguity fork. C copies the complete stack
+// head there, including its recovery cost. Each ambiguity arm must therefore
+// retain the competitor flag until C's cost and precedence election runs.
 func (h *diagnosticParserCoreHeader) clearRecoveryLineage() {
-	if h != nil {
-		h.recoveryFlags &^= diagnosticParserCoreRecoveryCompetitorFlag
+	if h == nil || !h.isRecoveryLineage() {
+		return
 	}
+	h.recoveryFlags &^= diagnosticParserCoreRecoveryCompetitorFlag
+	h.publishRecoveryCondenseState(0, 0, 0, false)
 }
 
 // competingRecoveryFrontier reports whether every live version belongs to
@@ -1893,7 +1974,6 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 		return diagnosticParserCoreConflictExecution{}, errors.New("parser-core phase zero: conflict branch order overflow")
 	}
 	trialOrder := branchOrder
-	recoveryAmbiguity := incoming.isRecoveryLineage()
 	var receipts []DiagnosticParserCoreRoundAction
 	err := compact.RunSchedulerOwned(owner, func() error {
 		for ordinal := 1; ordinal < actions.Len(); ordinal++ {
@@ -1911,11 +1991,6 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 			start := len(scratch.outputs)
 			for _, output := range scratch.actionOutputs {
 				secondary := incoming
-				// A table conflict is ordinary grammar ambiguity. Recovery cost
-				// must not select among its arms.
-				if recoveryAmbiguity {
-					secondary.clearRecoveryLineage()
-				}
 				secondary.head = output.head
 				secondary.shifted = action.Type == core.ActionShift
 				secondary.freshness = output.freshness
@@ -1964,10 +2039,6 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 		start := len(scratch.outputs)
 		for _, output := range scratch.actionOutputs {
 			primary := incoming
-			// Clear the marker on every arm, including the primary arm.
-			if recoveryAmbiguity {
-				primary.clearRecoveryLineage()
-			}
 			primary.head = output.head
 			primary.shifted = primaryAction.Type == core.ActionShift
 			primary.freshness = output.freshness
@@ -2685,28 +2756,30 @@ type diagnosticParserCoreGenericScheduler struct {
 	canonicalScratch      diagnosticParserCoreCanonicalScratch
 	// footprintRefs is reusable poll scratch. It is cleared after every
 	// footprint calculation so the retained backing array owns no state.
-	footprintRefs              []diagnosticParserCoreFootprintRef
-	dispatchScratch            diagnosticParserCoreDispatchScratch
-	conflictScratch            diagnosticParserCoreConflictScratch
-	reductionOutputs           []core.ReductionOutput
-	reductionReplacements      []diagnosticParserCoreHeader
-	classifiedBoundaries       []core.ClassifiedBoundary
-	condenseCandidates         []core.CondenseCandidate
-	electStates                []StateID
-	electGLRStates             []StateID
-	work                       DiagnosticParserCoreGenericWork
-	epochProgress              bool
-	acceptedHead               core.Head
-	acceptedPayloads           []core.SubtreeID
-	eofRecoveryAdmission       compactEOFRecoveryAdmissionReceipt
-	conflictPostExecutionFault func() error
-	extraPostExecutionFault    func() error
-	freshSessionOwner          *core.SchedulerTransactionToken
-	verifierHeads              [32]core.Head
-	verifierRefs               [32]core.DropCohortRef
-	verifierBound              int
-	verifierHeaderPtr          *diagnosticParserCoreHeader
-	verifierInvocation         uint64
+	footprintRefs                []diagnosticParserCoreFootprintRef
+	dispatchScratch              diagnosticParserCoreDispatchScratch
+	conflictScratch              diagnosticParserCoreConflictScratch
+	reductionOutputs             []core.ReductionOutput
+	reductionReplacements        []diagnosticParserCoreHeader
+	recoveryCondenseScratch      []diagnosticParserCoreRecoveryCondenseEntry
+	recoveryCondenseOrderScratch []int
+	classifiedBoundaries         []core.ClassifiedBoundary
+	condenseCandidates           []core.CondenseCandidate
+	electStates                  []StateID
+	electGLRStates               []StateID
+	work                         DiagnosticParserCoreGenericWork
+	epochProgress                bool
+	acceptedHead                 core.Head
+	acceptedPayloads             []core.SubtreeID
+	eofRecoveryAdmission         compactEOFRecoveryAdmissionReceipt
+	conflictPostExecutionFault   func() error
+	extraPostExecutionFault      func() error
+	freshSessionOwner            *core.SchedulerTransactionToken
+	verifierHeads                [32]core.Head
+	verifierRefs                 [32]core.DropCohortRef
+	verifierBound                int
+	verifierHeaderPtr            *diagnosticParserCoreHeader
+	verifierInvocation           uint64
 	// frontierProofVerified binds one successful D6b proof to the immediately
 	// following no-action drop. The state is reset with the scheduler and is
 	// consumed by dropGenericNoActionHeads.
@@ -4127,6 +4200,12 @@ func clearDiagnosticParserCoreGenericSchedulerVersionState(scheduler *diagnostic
 	clearDiagnosticParserCoreHeaderBacking(scheduler.conflictScratch.outputs)
 	clearDiagnosticParserCoreHeaderBacking(scheduler.conflictScratch.headerAssembly)
 	clearDiagnosticParserCoreHeaderBacking(scheduler.reductionReplacements)
+	if cap(scheduler.recoveryCondenseScratch) != 0 {
+		clear(scheduler.recoveryCondenseScratch[:cap(scheduler.recoveryCondenseScratch)])
+	}
+	if cap(scheduler.recoveryCondenseOrderScratch) != 0 {
+		clear(scheduler.recoveryCondenseOrderScratch[:cap(scheduler.recoveryCondenseOrderScratch)])
+	}
 	clearDiagnosticParserCorePhaseHeadBacking(scheduler.canonicalScratch.keys)
 	clearDiagnosticParserCorePhaseHeadBacking(scheduler.canonicalScratch.inlineKeys[:])
 	clear(scheduler.canonicalScratch.groups)
@@ -4157,6 +4236,8 @@ func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGe
 	conflictHeaderAssembly := resetDiagnosticParserCoreRetainedSlice(scheduler.conflictScratch.headerAssembly)
 	reductionOutputs := resetDiagnosticParserCoreRetainedSlice(scheduler.reductionOutputs)
 	reductionReplacements := resetDiagnosticParserCoreRetainedSlice(scheduler.reductionReplacements)
+	recoveryCondenseScratch := resetDiagnosticParserCoreRetainedSlice(scheduler.recoveryCondenseScratch)
+	recoveryCondenseOrderScratch := resetDiagnosticParserCoreRetainedSlice(scheduler.recoveryCondenseOrderScratch)
 	footprintRefs := resetDiagnosticParserCoreRetainedSlice(scheduler.footprintRefs)
 	classifiedBoundaries := resetDiagnosticParserCoreRetainedSlice(scheduler.classifiedBoundaries)
 	condenseCandidates := resetDiagnosticParserCoreRetainedSlice(scheduler.condenseCandidates)
@@ -4175,16 +4256,18 @@ func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGe
 			outputs: conflictOutputs, armRanges: conflictArmRanges, adopted: conflictAdopted,
 			headerAssembly: conflictHeaderAssembly,
 		},
-		reductionOutputs:          reductionOutputs,
-		reductionReplacements:     reductionReplacements,
-		footprintRefs:             footprintRefs,
-		classifiedBoundaries:      classifiedBoundaries,
-		condenseCandidates:        condenseCandidates,
-		electStates:               electStates,
-		electGLRStates:            electGLRStates,
-		acceptedPayloads:          acceptedPayloads,
-		versionLexerBeforeScratch: versionLexerBeforeScratch,
-		versionLexerRequests:      versionLexerRequests,
+		reductionOutputs:             reductionOutputs,
+		reductionReplacements:        reductionReplacements,
+		recoveryCondenseScratch:      recoveryCondenseScratch,
+		recoveryCondenseOrderScratch: recoveryCondenseOrderScratch,
+		footprintRefs:                footprintRefs,
+		classifiedBoundaries:         classifiedBoundaries,
+		condenseCandidates:           condenseCandidates,
+		electStates:                  electStates,
+		electGLRStates:               electGLRStates,
+		acceptedPayloads:             acceptedPayloads,
+		versionLexerBeforeScratch:    versionLexerBeforeScratch,
+		versionLexerRequests:         versionLexerRequests,
 	}
 	return nil
 }
@@ -4802,18 +4885,25 @@ func (s *diagnosticParserCoreGenericScheduler) installEquivalentVersionLexerStat
 		return errors.New("parser-core phase zero: version lexer state publication is incomplete")
 	}
 	region := header.recoveryRegion()
+	recoveryGroup := header.recoveryGroupIdentity()
+	missingGroup := header.recoveryMissingGroupIdentity()
+	baseline, baselineSet := header.recoveryNodeBaseline()
+	matches := func(state *diagnosticParserCoreVersionState) bool {
+		return state != nil && state.s3Region == region && state.relexSnapshot == snapshot &&
+			state.lexerRequest == requestReference && state.recoveryGroup == recoveryGroup &&
+			state.missingGroup == missingGroup && state.recoveryNodeBaseline == baseline &&
+			state.recoveryNodeBaselineSet == baselineSet
+	}
 	for index := range s.headers {
 		state := s.headers[index].versionState
-		if state != nil && state.s3Region == region && state.relexSnapshot == snapshot &&
-			state.lexerRequest == requestReference {
+		if matches(state) {
 			header.versionState = state
 			return nil
 		}
 	}
 	for index := range extra {
 		state := extra[index].versionState
-		if state != nil && state.s3Region == region && state.relexSnapshot == snapshot &&
-			state.lexerRequest == requestReference {
+		if matches(state) {
 			header.versionState = state
 			return nil
 		}
@@ -4823,9 +4913,10 @@ func (s *diagnosticParserCoreGenericScheduler) installEquivalentVersionLexerStat
 			return err
 		}
 	}
-	header.versionState = &diagnosticParserCoreVersionState{
-		s3Region: region, relexSnapshot: snapshot, lexerRequest: requestReference,
-	}
+	header.publishVersionState(
+		region, snapshot, requestReference, recoveryGroup, missingGroup,
+		baseline, baselineSet,
+	)
 	return nil
 }
 
@@ -4894,15 +4985,32 @@ func (s *diagnosticParserCoreGenericScheduler) seedVersionLexerOwnership() error
 	if err := seed.validateDestination(s.compact, s.tokenSource.language); err != nil {
 		return err
 	}
-	states := make(map[*diagnosticParserCoreS3Region]*diagnosticParserCoreVersionState)
+	type seedStateKey struct {
+		region                  *diagnosticParserCoreS3Region
+		recoveryGroup           uint64
+		missingGroup            uint64
+		recoveryNodeBaseline    uint32
+		recoveryNodeBaselineSet bool
+	}
+	states := make(map[seedStateKey]*diagnosticParserCoreVersionState)
 	for index := range s.headers {
-		region := s.headers[index].recoveryRegion()
-		state := states[region]
-		if state == nil {
-			state = &diagnosticParserCoreVersionState{s3Region: region, relexSnapshot: seed}
-			states[region] = state
+		header := &s.headers[index]
+		baseline, baselineSet := header.recoveryNodeBaseline()
+		key := seedStateKey{
+			region: header.recoveryRegion(), recoveryGroup: header.recoveryGroupIdentity(),
+			missingGroup:         header.recoveryMissingGroupIdentity(),
+			recoveryNodeBaseline: baseline, recoveryNodeBaselineSet: baselineSet,
 		}
-		s.headers[index].versionState = state
+		state := states[key]
+		if state == nil {
+			header.publishVersionState(
+				key.region, seed, 0, key.recoveryGroup, key.missingGroup,
+				key.recoveryNodeBaseline, key.recoveryNodeBaselineSet,
+			)
+			state = header.versionState
+			states[key] = state
+		}
+		header.versionState = state
 		s.work.add(&s.work.PerVersionLexPublications, 1)
 	}
 	if uint64(len(s.headers)) > s.work.PeakLiveVersions {
@@ -5361,11 +5469,12 @@ func (s *diagnosticParserCoreGenericScheduler) beginNextVersionLexerElection() e
 	for index := range s.headers {
 		header := &s.headers[index]
 		reference := header.versionLexerRequestReference()
-		header.versionState = &diagnosticParserCoreVersionState{
-			s3Region:      header.recoveryRegion(),
-			relexSnapshot: header.versionLexerSnapshot(),
-			lexerRequest:  reference - uint32(requestsBefore),
-		}
+		baseline, baselineSet := header.recoveryNodeBaseline()
+		header.publishVersionState(
+			header.recoveryRegion(), header.versionLexerSnapshot(),
+			reference-uint32(requestsBefore), header.recoveryGroupIdentity(),
+			header.recoveryMissingGroupIdentity(), baseline, baselineSet,
+		)
 	}
 	s.epochProgress = false
 	if requireEOFBefore {
@@ -7478,6 +7587,8 @@ func diagnosticParserCoreSchedulerFootprintBytes(s *diagnosticParserCoreGenericS
 	add(cap(s.conflictScratch.headerAssembly), unsafe.Sizeof(diagnosticParserCoreHeader{}))
 	add(cap(s.reductionOutputs), unsafe.Sizeof(core.ReductionOutput{}))
 	add(cap(s.reductionReplacements), unsafe.Sizeof(diagnosticParserCoreHeader{}))
+	add(cap(s.recoveryCondenseScratch), unsafe.Sizeof(diagnosticParserCoreRecoveryCondenseEntry{}))
+	add(cap(s.recoveryCondenseOrderScratch), unsafe.Sizeof(int(0)))
 	add(cap(s.classifiedBoundaries), unsafe.Sizeof(core.ClassifiedBoundary{}))
 	add(cap(s.condenseCandidates), unsafe.Sizeof(core.CondenseCandidate{}))
 	add(cap(s.electStates), unsafe.Sizeof(StateID(0)))
@@ -9154,6 +9265,14 @@ func (s *diagnosticParserCoreGenericScheduler) s4TryStackSummaryRecovery(index i
 	if !found {
 		return false, nil
 	}
+	recoveryBaseline, baselineOK, baselineErr := s.recoveryNodeBaselineForHead(scanHead)
+	if baselineErr != nil {
+		return false, baselineErr
+	}
+	if !baselineOK {
+		return false, nil
+	}
+	recoveryGroup := s.nextSeq
 
 	absorbHeader := original
 	absorbHeader.head = scanHead
@@ -9198,6 +9317,8 @@ func (s *diagnosticParserCoreGenericScheduler) s4TryStackSummaryRecovery(index i
 	recoveredHeader.head = recoveredHead
 	recoveredHeader.closeRecoveryRegion()
 	recoveredHeader.shifted = false
+	s.headers[index].publishRecoveryCondenseState(recoveryGroup, 0, recoveryBaseline, true)
+	recoveredHeader.publishRecoveryCondenseState(0, 0, recoveryBaseline, true)
 	s.headers[index].markRecoveryLineage()
 	recoveredHeader.markRecoveryLineage()
 	s.invalidateVerifierHeaderBinding()
@@ -9328,6 +9449,22 @@ func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertion(index 
 	if s.nextSeq == math.MaxUint64 {
 		return false, errors.New("parser-core phase zero: recovery fork creation sequence overflow")
 	}
+	recoveryBaseline, baselineOK, baselineErr := s.recoveryNodeBaselineForHead(scanHead)
+	if baselineErr != nil {
+		return false, baselineErr
+	}
+	if !baselineOK {
+		return false, nil
+	}
+	missingBaseline, missingBaselineSet := original.recoveryNodeBaseline()
+	if !missingBaselineSet {
+		missingBaseline = 0
+		missingBaselineSet = true
+	} else if missingBaseline > recoveryBaseline {
+		// C clamps the copied stack head before it forks the missing version.
+		missingBaseline = recoveryBaseline
+	}
+	recoveryGroup := s.nextSeq
 
 	// Replace the sole head temporarily. This lets the existing S3 primitive
 	// build the absorb lineage without duplicating its fail-closed checks.
@@ -9363,6 +9500,10 @@ func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertion(index 
 		return false, insertErr
 	}
 	s.headers[index+1].head = missingHead
+	s.headers[index].publishRecoveryCondenseState(recoveryGroup, 0, recoveryBaseline, true)
+	s.headers[index+1].publishRecoveryCondenseState(
+		0, recoveryGroup, missingBaseline, missingBaselineSet,
+	)
 	s.headers[index].markRecoveryLineage()
 	s.headers[index+1].markRecoveryLineage()
 	s.recoveryIsolation = true
@@ -9517,6 +9658,13 @@ func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegionWithAlternati
 	if extraErr != nil {
 		return false, extraErr
 	}
+	recoveryBaseline, baselineOK, baselineErr := s.recoveryNodeBaselineForHead(header.head)
+	if baselineErr != nil {
+		return false, baselineErr
+	}
+	if !baselineOK {
+		return false, nil
+	}
 	leafID, leafErr := s.compact.ErrorRegionLeaf(core.Symbol(s.token.Symbol), s.token.StartByte, s.token.EndByte, tokenExtra)
 	if leafErr != nil {
 		return false, leafErr
@@ -9527,6 +9675,10 @@ func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegionWithAlternati
 		endByte:   s.token.EndByte,
 		children:  []core.SubtreeID{leafID},
 	})
+	header.publishRecoveryCondenseState(
+		header.recoveryGroupIdentity(), header.recoveryMissingGroupIdentity(),
+		recoveryBaseline, true,
+	)
 	header.markRecoveryCosted()
 	s.s3RegionOpened = true
 	header.shifted = true
@@ -9630,9 +9782,10 @@ func (s *diagnosticParserCoreGenericScheduler) collapseToRecoveryWinner(winner i
 		return
 	}
 	s.work.RecoveryLineageSelections++
-	s.selectedRecoveryAbsorbLineage = len(s.headers) == 2 && winner == 0 &&
-		s.s5MissingInsertions == 1 &&
-		s.headers[0].creationSeq < s.headers[1].creationSeq
+	other := 1 - winner
+	s.selectedRecoveryAbsorbLineage = len(s.headers) == 2 &&
+		s.s5MissingInsertions == 1 && other >= 0 && other < len(s.headers) &&
+		s.headers[winner].creationSeq < s.headers[other].creationSeq
 	winnerHeader := s.headers[winner]
 	winnerHeader.clearRecoveryLineage()
 	s.invalidateVerifierHeaderBinding()
@@ -10785,6 +10938,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReduction(before []Di
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner core.SchedulerTransactionToken, before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) error {
+	recoveryAmbiguitySource := s.headers[cell.headerIndex].isRecoveryLineage()
 	if err := s.reserveDispatches(1); err != nil {
 		return err
 	}
@@ -11060,17 +11214,20 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		replacements = append(replacements, replacement)
 	}
 	s.reductionReplacements = replacements
-	if s.recoveryIsolation && len(replacements) > 1 {
-		// Multiple pop-path outputs form ordinary grammar ambiguity. A marked
-		// recovery lineage can continue only through one exact reduction path.
-		for index := range replacements {
-			replacements[index].clearRecoveryLineage()
-		}
-	}
 	if len(replacements) == 0 {
 		// The canonical outputs already exist and have been processed in this
 		// election. Keep this version paused until a sibling makes real progress;
 		// the ordinary no-action drop then removes it under the same safety rule.
+		supported, baselineErr := s.resetRecoveryNodeBaseline(&s.headers[cell.headerIndex])
+		if baselineErr != nil {
+			return baselineErr
+		}
+		if !supported && s.headers[cell.headerIndex].isRecoveryLineage() {
+			return &diagnosticParserCoreDecline{
+				boundary: DiagnosticParserCoreRecovery,
+				detail:   "recovery pause has an ambiguous visible-node count",
+			}
+		}
 		s.headers[cell.headerIndex].paused = true
 		s.work.ReductionPauses++
 	} else if len(replacements) == 1 {
@@ -11083,6 +11240,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 	}
 	if cell.selectsConflictReduction() {
 		s.work.add(&s.work.RepetitionFolds, 1)
+	}
+	if recoveryAmbiguitySource && len(replacements) > 1 {
+		s.work.add(&s.work.RecoveryAmbiguityForks, 1)
 	}
 	s.work.Reductions++
 	s.work.Dispatches++
@@ -11434,6 +11594,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflict(before []Dia
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner core.SchedulerTransactionToken, before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) (err error) {
 	branchOrderBefore, nextSeqBefore := s.branchOrder, s.nextSeq
+	recoveryAmbiguitySource := s.headers[cell.headerIndex].isRecoveryLineage()
 	token := cell.dispatchToken(s.token)
 	scannerBefore, scannerAfter := s.currentElection.ScannerBefore, s.currentElection.ScannerAfter
 	affectedHead := cell.boundary.Head()
@@ -11546,6 +11707,16 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	}
 	if outputCount == 0 {
 		paused := s.headers[cell.headerIndex]
+		supported, baselineErr := s.resetRecoveryNodeBaseline(&paused)
+		if baselineErr != nil {
+			return baselineErr
+		}
+		if !supported && paused.isRecoveryLineage() {
+			return &diagnosticParserCoreDecline{
+				boundary: DiagnosticParserCoreRecovery,
+				detail:   "recovery conflict pause has an ambiguous visible-node count",
+			}
+		}
 		paused.paused = true
 		headers = headers[:len(prefix)]
 		headers = append(headers, paused)
@@ -11568,6 +11739,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	s.work.add(&s.work.ConflictActionArmsAdmitted, uint64(actions.Len()))
 	s.work.add(&s.work.CausalConflictForks, uint64(actions.Len()-1))
 	s.work.ConflictHeads += uint64(outputCount)
+	if recoveryAmbiguitySource && outputCount > 1 {
+		s.work.add(&s.work.RecoveryAmbiguityForks, 1)
+	}
 	s.work.Dispatches++
 	if err := s.canonicalizeOwned(owner); err != nil {
 		return err
@@ -12168,6 +12342,21 @@ func (s *diagnosticParserCoreGenericScheduler) canonicalizeOwnedWithMutation(own
 	}
 	if err != nil {
 		return err
+	}
+	if s.recoveryIsolation {
+		var drops uint64
+		var applied bool
+		headers, drops, applied, err = s.condenseRecoveryVersions(headers)
+		if err != nil {
+			// The recovery canonicalizer copied header-owned pointers into its
+			// alternate buffer. Release that failed frontier before rollback.
+			clear(headers)
+			return err
+		}
+		if applied {
+			s.work.add(&s.work.RecoveryCondensePasses, 1)
+			s.work.add(&s.work.RecoveryVersionCapDrops, drops)
+		}
 	}
 	if expected != 0 && mutation != expected {
 		return fmt.Errorf("parser-core phase zero: canonicalizer mutation class mismatch: got %d want %d", mutation, expected)

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -12356,6 +12356,13 @@ func (s *diagnosticParserCoreGenericScheduler) canonicalizeOwnedWithMutation(own
 		if applied {
 			s.work.add(&s.work.RecoveryCondensePasses, 1)
 			s.work.add(&s.work.RecoveryVersionCapDrops, drops)
+			// C ends recovery competition when pairwise condensation leaves
+			// one active version. Clear the compact marker before the next
+			// dispatch, or the sole winner rejects itself as mixed ambiguity.
+			if len(headers) == 1 && !headers[0].accepted {
+				headers[0].clearRecoveryLineage()
+				s.recoveryIsolation = false
+			}
 		}
 	}
 	if expected != 0 && mutation != expected {

--- a/parsercore_phase0_generic_conflict_internal_test.go
+++ b/parsercore_phase0_generic_conflict_internal_test.go
@@ -584,14 +584,18 @@ func TestDiagnosticParserCoreGenericConflictArbitraryNOrdering(t *testing.T) {
 		t.Fatalf("physical conflict order states=%v sequences=%v", states, sequences)
 	}
 	for index := range scheduler.headers {
-		if scheduler.headers[index].isRecoveryLineage() {
-			t.Fatalf("ordinary conflict output %d retained the recovery marker", index)
+		wantRecovery := index == 1 || index == 3 || index == 4
+		if scheduler.headers[index].isRecoveryLineage() != wantRecovery {
+			t.Fatalf("conflict output %d recovery marker=%t, want %t", index, scheduler.headers[index].isRecoveryLineage(), wantRecovery)
+		}
+		if wantRecovery && !scheduler.headers[index].isRecoveryCosted() {
+			t.Fatalf("conflict output %d lost recovery cost provenance", index)
 		}
 	}
 	if scheduler.branchOrder != 9 || scheduler.nextSeq != 12 || scheduler.dispatches != 1 || scheduler.work != (DiagnosticParserCoreGenericWork{
 		Dispatches: 1, Conflicts: 1, ConflictActions: 3, Forks: 2, ConflictHeads: 3,
 		ConflictActionArmsAdmitted: 3, CausalConflictForks: 2,
-		Canonicalizations: 1, PeakHeaders: 5,
+		RecoveryAmbiguityForks: 1, Canonicalizations: 1, PeakHeaders: 5,
 	}) {
 		t.Fatalf("scheduler allocation/work drift: order=%d seq=%d dispatches=%d work=%+v", scheduler.branchOrder, scheduler.nextSeq, scheduler.dispatches, scheduler.work)
 	}

--- a/parsercore_phase0_generic_freshness_internal_test.go
+++ b/parsercore_phase0_generic_freshness_internal_test.go
@@ -46,7 +46,16 @@ func TestDiagnosticParserCoreGenericReductionPauseIsFinite(t *testing.T) {
 		compact: compact,
 		headers: []diagnosticParserCoreHeader{{head: source, creationSeq: 3}, {head: outputs[0].Head, creationSeq: 7}},
 		token:   Token{Symbol: 9, StartByte: 1, EndByte: 2},
-		options: DiagnosticParserCorePrefixOptions{MaxDispatches: 20},
+		tokenSource: &dfaTokenSource{language: &Language{
+			SymbolCount: 10,
+			SymbolMetadata: []SymbolMetadata{
+				8: {Visible: true, Named: true},
+			},
+		}},
+		options: DiagnosticParserCorePrefixOptions{
+			MaxDispatches:         20,
+			materializationSource: []byte("a?"),
+		},
 		receipt: &DiagnosticParserCoreGenericScheduler{},
 	}
 	before, err := diagnosticParserCoreHeaderReceipts(compact, scheduler.headers)
@@ -59,6 +68,9 @@ func TestDiagnosticParserCoreGenericReductionPauseIsFinite(t *testing.T) {
 	}
 	if !scheduler.headers[0].paused || scheduler.epochProgress || scheduler.work.ReductionPauses != 1 {
 		t.Fatalf("unchanged reduction did not pause: headers=%+v work=%+v progress=%t", scheduler.headers, scheduler.work, scheduler.epochProgress)
+	}
+	if baseline, set := scheduler.headers[0].recoveryNodeBaseline(); !set || baseline != 1 {
+		t.Fatalf("reduction pause baseline=%d/%t, want one visible shifted node", baseline, set)
 	}
 	if stop, err := scheduler.dispatchPass(); err != nil || stop != nil {
 		t.Fatalf("sibling shift pass stop=%+v err=%v", stop, err)
@@ -131,7 +143,7 @@ func TestDiagnosticParserCoreGenericReductionSequenceOverflowRollsBack(t *testin
 	}
 }
 
-func TestDiagnosticParserCoreRecoveryReductionForkClearsMarkers(t *testing.T) {
+func TestDiagnosticParserCoreRecoveryReductionForkPreservesMarkers(t *testing.T) {
 	table := &genericConflictTable{
 		cells: map[genericConflictCell][]core.Action{
 			{state: 1, symbol: 8}: {{Type: core.ActionShift, State: 3}},
@@ -168,8 +180,11 @@ func TestDiagnosticParserCoreRecoveryReductionForkClearsMarkers(t *testing.T) {
 		token:                Token{Symbol: 9, StartByte: 1, EndByte: 2},
 		nextSeq:              10,
 		nextCleanPathLineage: 1,
-		options:              DiagnosticParserCorePrefixOptions{MaxDispatches: 20},
-		receipt:              &DiagnosticParserCoreGenericScheduler{},
+		options: DiagnosticParserCorePrefixOptions{
+			MaxDispatches:                        20,
+			allowCompactRecoveryLineageSelection: true,
+		},
+		receipt: &DiagnosticParserCoreGenericScheduler{},
 	}
 	scheduler.headers[0].markRecoveryLineage()
 	scheduler.recoveryIsolation = true
@@ -185,19 +200,18 @@ func TestDiagnosticParserCoreRecoveryReductionForkClearsMarkers(t *testing.T) {
 		t.Fatalf("reduction produced %d heads, want 2", len(scheduler.headers))
 	}
 	for index := range scheduler.headers {
-		if scheduler.headers[index].isRecoveryLineage() {
-			t.Fatalf("ordinary reduction output %d retained the recovery marker", index)
+		if !scheduler.headers[index].isRecoveryLineage() || !scheduler.headers[index].isRecoveryCosted() {
+			t.Fatalf("reduction output %d lost recovery competition provenance", index)
 		}
 	}
 	if !scheduler.recoveryIsolation {
-		t.Fatal("ordinary reduction disabled the fail-closed recovery guard")
+		t.Fatal("ordinary reduction disabled recovery competition")
 	}
-	unsupported, err := scheduler.dispatchPass()
-	if err != nil {
-		t.Fatalf("dispatchPass: %v", err)
+	if !scheduler.competingRecoveryFrontier() {
+		t.Fatal("ordinary reduction stopped the marked outputs from competing")
 	}
-	if unsupported == nil || unsupported.boundary != DiagnosticParserCoreRecovery {
-		t.Fatalf("unsupported=%+v, want recovery decline", unsupported)
+	if scheduler.work.RecoveryAmbiguityForks != 1 {
+		t.Fatalf("recovery ambiguity telemetry=%+v, want one reduction fork", scheduler.work)
 	}
 }
 

--- a/parsercore_phase0_per_version_lexer_snapshot_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_snapshot_internal_test.go
@@ -568,6 +568,7 @@ func TestDiagnosticParserCoreVersionLexerSnapshotRetirementClearsLoser(t *testin
 	headers[1] = diagnosticParserCoreHeader{head: loser, checkpoint: 0, creationSeq: 2, versionState: state}
 	headers[0].markRecoveryLineage()
 	headers[1].markRecoveryLineage()
+	survivorState := headers[0].versionState
 	scheduler := diagnosticParserCoreGenericScheduler{
 		compact:           compact,
 		headers:           headers,
@@ -584,8 +585,12 @@ func TestDiagnosticParserCoreVersionLexerSnapshotRetirementClearsLoser(t *testin
 	if err != nil || !retired {
 		t.Fatalf("retirement=%t err=%v, want true/nil", retired, err)
 	}
-	if len(scheduler.headers) != 1 || scheduler.headers[0].versionState != state {
-		t.Fatalf("survivor state changed during retirement: headers=%+v", scheduler.headers)
+	if len(scheduler.headers) != 1 || scheduler.headers[0].versionState == survivorState ||
+		scheduler.headers[0].versionLexerSnapshot() != snapshot || scheduler.headers[0].isRecoveryLineage() {
+		t.Fatalf("survivor state did not clear lineage while retaining lexer ownership: headers=%+v", scheduler.headers)
+	}
+	if baseline, set := scheduler.headers[0].recoveryNodeBaseline(); set || baseline != 0 {
+		t.Fatalf("retired survivor baseline=%d/%t, want cleared 0/false", baseline, set)
 	}
 	if headers[1].versionState != nil {
 		t.Fatal("retired loser retained its immutable version state")

--- a/parsercore_phase0_per_version_lexer_state.go
+++ b/parsercore_phase0_per_version_lexer_state.go
@@ -307,15 +307,12 @@ func (h *diagnosticParserCoreHeader) installVersionLexerSnapshot(snapshot *diagn
 	if h == nil {
 		return
 	}
-	region := h.recoveryRegion()
-	if snapshot == nil && region == nil {
-		h.versionState = nil
-		return
-	}
-	h.versionState = &diagnosticParserCoreVersionState{
-		s3Region:      region,
-		relexSnapshot: snapshot,
-	}
+	baseline, baselineSet := h.recoveryNodeBaseline()
+	h.publishVersionState(
+		h.recoveryRegion(), snapshot, 0,
+		h.recoveryGroupIdentity(), h.recoveryMissingGroupIdentity(),
+		baseline, baselineSet,
+	)
 }
 
 // publishVersionLexerSnapshot installs a private copy of an owned snapshot
@@ -375,12 +372,18 @@ func (h *diagnosticParserCoreHeader) clearVersionLexerSnapshot() {
 	if h == nil {
 		return
 	}
-	region := h.recoveryRegion()
-	if region == nil {
-		h.versionState = nil
-		return
+	baseline, baselineSet := h.recoveryNodeBaseline()
+	recoveryGroup := h.recoveryGroupIdentity()
+	missingGroup := h.recoveryMissingGroupIdentity()
+	if !h.isRecoveryLineage() && h.recoveryRegion() == nil {
+		recoveryGroup, missingGroup = 0, 0
+		baseline, baselineSet = 0, false
 	}
-	h.versionState = &diagnosticParserCoreVersionState{s3Region: region}
+	h.publishVersionState(
+		h.recoveryRegion(), nil, 0,
+		recoveryGroup, missingGroup,
+		baseline, baselineSet,
+	)
 }
 
 // restore applies the owned DFA state to a token source. The caller restores

--- a/parsercore_phase0_recovery_condense.go
+++ b/parsercore_phase0_recovery_condense.go
@@ -1,0 +1,419 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"math"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// Tree-sitter C retains at most six distinct live version keys after recovery
+// condensation. Histories with one retained key remain separate here because
+// the compact graph represents C's merged links as separate headers.
+const diagnosticParserCoreRecoveryVersionLimit = 6
+
+type diagnosticParserCoreRecoveryCondenseKey struct {
+	state         core.StateID
+	byteOffset    uint32
+	cost          uint32
+	checkpoint    core.CheckpointID
+	recoveryGroup uint64
+	missingGroup  uint64
+	shifted       bool
+	paused        bool
+}
+
+type diagnosticParserCoreRecoveryCondenseEntry struct {
+	header diagnosticParserCoreHeader
+	status core.RecoveryErrorStatus
+	key    diagnosticParserCoreRecoveryCondenseKey
+}
+
+func diagnosticParserCoreMergeEquivalentRecoveryStatus(
+	target *diagnosticParserCoreRecoveryCondenseEntry,
+	candidate diagnosticParserCoreRecoveryCondenseEntry,
+) {
+	if target == nil {
+		return
+	}
+	if candidate.status.NodeCount > target.status.NodeCount {
+		target.status.NodeCount = candidate.status.NodeCount
+	}
+	if candidate.status.DynPrec > target.status.DynPrec {
+		target.status.DynPrec = candidate.status.DynPrec
+	}
+}
+
+func diagnosticParserCoreRecoveryCondenseSameGroup(
+	left, right diagnosticParserCoreRecoveryCondenseEntry,
+) bool {
+	return left.key.recoveryGroup != 0 && left.key.recoveryGroup == right.key.recoveryGroup
+}
+
+func diagnosticParserCoreRecoveryCondenseShouldStayBefore(
+	left, right diagnosticParserCoreRecoveryCondenseEntry,
+) bool {
+	if left.header.paused || right.header.paused {
+		return false
+	}
+	return left.key.recoveryGroup != 0 && right.key.recoveryGroup == 0 &&
+		right.key.missingGroup == left.key.recoveryGroup
+}
+
+func diagnosticParserCoreRecoveryCondensePairwise(
+	entries []diagnosticParserCoreRecoveryCondenseEntry,
+	order []int,
+) []int {
+	for i := 1; i < len(order); i++ {
+		removedCurrent := false
+		for j := 0; j < i; j++ {
+			left := entries[order[j]]
+			right := entries[order[i]]
+			if diagnosticParserCoreRecoveryCondenseSameGroup(left, right) ||
+				diagnosticParserCoreRecoveryCondenseShouldStayBefore(left, right) {
+				continue
+			}
+			if diagnosticParserCoreRecoveryCondenseShouldStayBefore(right, left) {
+				order[i], order[j] = order[j], order[i]
+				continue
+			}
+			switch core.RecoveryCompareVersions(left.status, right.status) {
+			case core.RecoveryComparisonTakeLeft:
+				order = append(order[:i], order[i+1:]...)
+				i--
+				removedCurrent = true
+			case core.RecoveryComparisonPreferLeft, core.RecoveryComparisonNone:
+			case core.RecoveryComparisonPreferRight:
+				order[i], order[j] = order[j], order[i]
+			case core.RecoveryComparisonTakeRight:
+				order = append(order[:j], order[j+1:]...)
+				i--
+				j--
+			}
+			if removedCurrent || i < 1 {
+				break
+			}
+		}
+	}
+	return order
+}
+
+func diagnosticParserCoreDerivationVisibleNodeCount(
+	symbols []core.SelectedSymbolPolicy,
+	src *diagnosticParserCoreRecoveryCostSource,
+	derivation core.Derivation,
+) (uint32, error) {
+	var total uint32
+	for _, payload := range derivation.Payloads {
+		count, err := core.RecoveryNodeVisibleSubtreeCount(symbols, src, payload)
+		if err != nil {
+			return 0, err
+		}
+		if math.MaxUint32-total < count {
+			return 0, errors.New("parser-core phase zero: recovery visible-node count overflow")
+		}
+		total += count
+	}
+	return total, nil
+}
+
+func diagnosticParserCoreOpenRegionVisibleNodeCount(
+	symbols []core.SelectedSymbolPolicy,
+	src *diagnosticParserCoreRecoveryCostSource,
+	region *diagnosticParserCoreS3Region,
+) (uint32, error) {
+	if region == nil || len(region.children) == 0 {
+		return 0, nil
+	}
+	total := uint32(1)
+	for _, child := range region.children {
+		count, err := core.RecoveryNodeVisibleSubtreeCount(symbols, src, child)
+		if err != nil {
+			return 0, err
+		}
+		if math.MaxUint32-total < count {
+			return 0, errors.New("parser-core phase zero: recovery region visible-node count overflow")
+		}
+		total += count
+	}
+	return total, nil
+}
+
+func diagnosticParserCoreRecoveryCumulativeVisibleNodeCount(
+	derivation core.Derivation,
+	region *diagnosticParserCoreS3Region,
+	symbols []core.SelectedSymbolPolicy,
+	src *diagnosticParserCoreRecoveryCostSource,
+) (uint32, error) {
+	count, err := diagnosticParserCoreDerivationVisibleNodeCount(symbols, src, derivation)
+	if err != nil {
+		return 0, err
+	}
+	regionCount, err := diagnosticParserCoreOpenRegionVisibleNodeCount(symbols, src, region)
+	if err != nil {
+		return 0, err
+	}
+	if math.MaxUint32-count < regionCount {
+		return 0, errors.New("parser-core phase zero: recovery cumulative visible-node count overflow")
+	}
+	return count + regionCount, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) recoveryCumulativeVisibleNodeCount(
+	head core.Head,
+	region *diagnosticParserCoreS3Region,
+	symbols []core.SelectedSymbolPolicy,
+	src *diagnosticParserCoreRecoveryCostSource,
+) (uint32, bool, error) {
+	derivations, err := s.compact.Derivations(head)
+	if err != nil {
+		if errors.Is(err, core.ErrDerivationEnumerationCap) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	if len(derivations) != 1 {
+		return 0, false, nil
+	}
+	count, err := diagnosticParserCoreRecoveryCumulativeVisibleNodeCount(
+		derivations[0], region, symbols, src,
+	)
+	return count, true, err
+}
+
+func (s *diagnosticParserCoreGenericScheduler) recoveryNodeBaselineForHead(
+	head core.Head,
+) (uint32, bool, error) {
+	if s == nil || s.compact == nil || s.tokenSource == nil || s.tokenSource.language == nil {
+		return 0, false, nil
+	}
+	src, err := newDiagnosticParserCoreRecoveryCostSource(s.compact, s.options.materializationSource)
+	if err != nil {
+		return 0, false, err
+	}
+	return s.recoveryCumulativeVisibleNodeCount(
+		head, nil, diagnosticParserCoreRecoverySymbolPolicy(s.tokenSource.language), src,
+	)
+}
+
+// resetRecoveryNodeBaseline records C's current cumulative count after a
+// pause or ERROR-state entry. The caller decides whether an unsupported
+// ambiguous graph must decline the compact route.
+func (s *diagnosticParserCoreGenericScheduler) resetRecoveryNodeBaseline(
+	header *diagnosticParserCoreHeader,
+) (bool, error) {
+	if header == nil {
+		return false, nil
+	}
+	baseline, supported, err := s.recoveryNodeBaselineForHead(header.head)
+	if err != nil || !supported {
+		return supported, err
+	}
+	header.publishRecoveryCondenseState(
+		header.recoveryGroupIdentity(), header.recoveryMissingGroupIdentity(),
+		baseline, true,
+	)
+	return true, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) recoveryCondenseEntry(
+	header diagnosticParserCoreHeader,
+	symbols []core.SelectedSymbolPolicy,
+	src *diagnosticParserCoreRecoveryCostSource,
+	memo *core.RecoveryCostMemo,
+) (diagnosticParserCoreRecoveryCondenseEntry, bool, error) {
+	derivations, err := s.compact.Derivations(header.head)
+	if err != nil {
+		if errors.Is(err, core.ErrDerivationEnumerationCap) {
+			return diagnosticParserCoreRecoveryCondenseEntry{}, false, nil
+		}
+		return diagnosticParserCoreRecoveryCondenseEntry{}, false, err
+	}
+	if len(derivations) != 1 {
+		return diagnosticParserCoreRecoveryCondenseEntry{}, false, nil
+	}
+	derivation := derivations[0]
+	if int64(int(derivation.Score)) != derivation.Score {
+		return diagnosticParserCoreRecoveryCondenseEntry{}, false, nil
+	}
+	stackCost, err := diagnosticParserCoreDerivationErrorCost(symbols, src, memo, derivation)
+	if err != nil {
+		return diagnosticParserCoreRecoveryCondenseEntry{}, false, err
+	}
+	state, byteOffset, err := s.compact.Boundary(header.head)
+	if err != nil {
+		return diagnosticParserCoreRecoveryCondenseEntry{}, false, err
+	}
+	region := header.recoveryRegion()
+	if region != nil {
+		state = 0
+		byteOffset = region.endByte
+		if len(region.children) != 0 {
+			regionCost, regionErr := core.RecoveryErrorRegionCost(
+				symbols, src, memo,
+				region.startByte, src.rowAt(region.startByte),
+				region.endByte, src.rowAt(region.endByte),
+				region.children,
+			)
+			if regionErr != nil {
+				return diagnosticParserCoreRecoveryCondenseEntry{}, false, regionErr
+			}
+			stackCost += regionCost
+		}
+	}
+	openSegments := header.recoveryOpenSegments()
+	if openSegments < 0 {
+		return diagnosticParserCoreRecoveryCondenseEntry{}, false, errors.New("parser-core phase zero: negative recovery segment count")
+	}
+	stackCost += uint32(openSegments) * uint32(core.RecoveryCostPerRecovery)
+
+	currentCount, err := diagnosticParserCoreRecoveryCumulativeVisibleNodeCount(
+		derivation, region, symbols, src,
+	)
+	if err != nil {
+		return diagnosticParserCoreRecoveryCondenseEntry{}, false, err
+	}
+	baseline, baselineSet := header.recoveryNodeBaseline()
+	if !baselineSet {
+		return diagnosticParserCoreRecoveryCondenseEntry{}, false, nil
+	}
+	if baseline > currentCount {
+		baseline = currentCount
+		header.publishRecoveryCondenseState(
+			header.recoveryGroupIdentity(), header.recoveryMissingGroupIdentity(),
+			baseline, true,
+		)
+	}
+	nodeCount := currentCount - baseline
+	if uint64(nodeCount) > uint64(math.MaxInt) {
+		return diagnosticParserCoreRecoveryCondenseEntry{}, false, nil
+	}
+	return diagnosticParserCoreRecoveryCondenseEntry{
+		header: header,
+		status: core.RecoveryVersionStatus(
+			stackCost, header.paused, int(nodeCount), int(derivation.Score), region != nil,
+		),
+		key: diagnosticParserCoreRecoveryCondenseKey{
+			state: state, byteOffset: byteOffset, cost: stackCost,
+			checkpoint:    header.checkpoint,
+			recoveryGroup: header.recoveryGroupIdentity(),
+			missingGroup:  header.recoveryMissingGroupIdentity(),
+			shifted:       header.shifted, paused: header.paused,
+		},
+	}, true, nil
+}
+
+// condenseRecoveryVersions applies C's pairwise recovery competition before
+// it keeps the first six distinct merge keys. Accepted versions stay outside
+// the competition and retain their acceptance order.
+func (s *diagnosticParserCoreGenericScheduler) condenseRecoveryVersions(
+	headers []diagnosticParserCoreHeader,
+) ([]diagnosticParserCoreHeader, uint64, bool, error) {
+	if s == nil || s.compact == nil || !s.recoveryIsolation ||
+		!s.options.allowCompactRecoveryLineageSelection || len(headers) < 2 {
+		return headers, 0, false, nil
+	}
+	activeCount := 0
+	for index := range headers {
+		if !headers[index].isRecoveryLineage() {
+			return headers, 0, false, nil
+		}
+		if !headers[index].accepted {
+			activeCount++
+		}
+	}
+	if activeCount == 0 {
+		return headers, 0, false, nil
+	}
+	if s.tokenSource == nil || s.tokenSource.language == nil || len(s.options.materializationSource) == 0 {
+		return headers, 0, false, nil
+	}
+	src, err := newDiagnosticParserCoreRecoveryCostSource(s.compact, s.options.materializationSource)
+	if err != nil {
+		return headers, 0, false, nil
+	}
+	scratch := s.recoveryCondenseScratch[:0]
+	if cap(scratch) < len(headers) {
+		scratch = make([]diagnosticParserCoreRecoveryCondenseEntry, 0, len(headers))
+	}
+	order := s.recoveryCondenseOrderScratch[:0]
+	if cap(order) < activeCount {
+		order = make([]int, 0, activeCount)
+	}
+	clearScratch := func() {
+		clear(scratch)
+		s.recoveryCondenseScratch = scratch[:0]
+		clear(order)
+		s.recoveryCondenseOrderScratch = order[:0]
+	}
+	var memo core.RecoveryCostMemo
+	symbols := diagnosticParserCoreRecoverySymbolPolicy(s.tokenSource.language)
+	for index := range headers {
+		if headers[index].accepted {
+			continue
+		}
+		entry, supported, entryErr := s.recoveryCondenseEntry(headers[index], symbols, src, &memo)
+		if entryErr != nil {
+			clearScratch()
+			return headers, 0, false, entryErr
+		}
+		if !supported {
+			clearScratch()
+			return headers, 0, false, nil
+		}
+		scratch = append(scratch, entry)
+		representative := true
+		for prior := 0; prior < len(scratch)-1; prior++ {
+			if scratch[prior].key == entry.key {
+				representative = false
+				diagnosticParserCoreMergeEquivalentRecoveryStatus(&scratch[prior], entry)
+				break
+			}
+		}
+		if representative {
+			order = append(order, len(scratch)-1)
+		}
+	}
+	activeEntries := len(scratch)
+	for index := range headers {
+		if headers[index].accepted {
+			scratch = append(scratch, diagnosticParserCoreRecoveryCondenseEntry{header: headers[index]})
+		}
+	}
+	order = diagnosticParserCoreRecoveryCondensePairwise(scratch, order)
+
+	var drops uint64
+	if len(order) > diagnosticParserCoreRecoveryVersionLimit {
+		for _, droppedRepresentative := range order[diagnosticParserCoreRecoveryVersionLimit:] {
+			key := scratch[droppedRepresentative].key
+			for index := 0; index < activeEntries; index++ {
+				if scratch[index].key == key {
+					drops++
+				}
+			}
+		}
+		order = order[:diagnosticParserCoreRecoveryVersionLimit]
+	}
+
+	write := 0
+	for _, representative := range order {
+		key := scratch[representative].key
+		for index := 0; index < activeEntries; index++ {
+			if scratch[index].key != key {
+				continue
+			}
+			headers[write] = scratch[index].header
+			write++
+		}
+	}
+	for index := activeEntries; index < len(scratch); index++ {
+		headers[write] = scratch[index].header
+		write++
+	}
+	clearDiagnosticParserCoreHeaderSuffix(headers, write)
+	headers = headers[:write]
+	clearScratch()
+	return headers, drops, true, nil
+}

--- a/parsercore_phase0_recovery_condense_stage3_internal_test.go
+++ b/parsercore_phase0_recovery_condense_stage3_internal_test.go
@@ -1,0 +1,575 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func newStage3RecoveryCondenseScheduler(t *testing.T, regionEnds []uint32) *diagnosticParserCoreGenericScheduler {
+	t.Helper()
+	compact, err := core.New(&genericConflictTable{}, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	headers := make([]diagnosticParserCoreHeader, 0, len(regionEnds))
+	for index, endByte := range regionEnds {
+		head, seedErr := compact.Seed(core.StateID(index+1), 0)
+		if seedErr != nil {
+			t.Fatal(seedErr)
+		}
+		child, childErr := compact.ErrorRegionLeaf(2, 0, endByte, false)
+		if childErr != nil {
+			t.Fatal(childErr)
+		}
+		header := diagnosticParserCoreHeader{head: head, creationSeq: uint64(index + 1)}
+		header.openRecoveryRegion(&diagnosticParserCoreS3Region{
+			state: core.StateID(index + 1), startByte: 0, endByte: endByte,
+			children: []core.SubtreeID{child},
+		})
+		header.markRecoveryLineage()
+		headers = append(headers, header)
+	}
+	lang := &Language{SymbolMetadata: make([]SymbolMetadata, 16)}
+	for index := range lang.SymbolMetadata {
+		lang.SymbolMetadata[index] = SymbolMetadata{Visible: true, Named: true}
+	}
+	return &diagnosticParserCoreGenericScheduler{
+		compact: compact, headers: headers, recoveryIsolation: true,
+		tokenSource: &dfaTokenSource{language: lang},
+		options: DiagnosticParserCorePrefixOptions{
+			allowCompactRecoveryLineageSelection: true,
+			materializationSource:                []byte("abcdefgh"),
+		},
+	}
+}
+
+func runStage3RecoveryCondense(t *testing.T, scheduler *diagnosticParserCoreGenericScheduler) {
+	t.Helper()
+	if err := scheduler.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		return scheduler.canonicalizeOwned(owner)
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func stage3RecoveryCondenseStates(t *testing.T, scheduler *diagnosticParserCoreGenericScheduler) []StateID {
+	t.Helper()
+	states := make([]StateID, 0, len(scheduler.headers))
+	for index := range scheduler.headers {
+		state, _, err := scheduler.compact.Boundary(scheduler.headers[index].head)
+		if err != nil {
+			t.Fatal(err)
+		}
+		states = append(states, StateID(state))
+	}
+	return states
+}
+
+func TestStage3RecoveryCondenseOrdersBeforeSixVersionCap(t *testing.T) {
+	scheduler := newStage3RecoveryCondenseScheduler(t, []uint32{2, 3, 4, 5, 6, 7, 1})
+	runStage3RecoveryCondense(t, scheduler)
+
+	if got, want := stage3RecoveryCondenseStates(t, scheduler), []StateID{7, 1, 2, 3, 4, 5}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("recovery condense states=%v, want C cost order and six-version cap %v", got, want)
+	}
+	if scheduler.work.RecoveryCondensePasses != 1 || scheduler.work.RecoveryVersionCapDrops != 1 {
+		t.Fatalf("recovery condense telemetry=%+v, want one pass and one cap drop", scheduler.work)
+	}
+	for index := range scheduler.headers {
+		if !scheduler.headers[index].isRecoveryLineage() || !scheduler.headers[index].isRecoveryCosted() || scheduler.headers[index].recoveryRegion() == nil {
+			t.Fatalf("retained recovery header %d lost ownership: %+v", index, scheduler.headers[index])
+		}
+	}
+	for index := len(scheduler.headers); index < cap(scheduler.headers); index++ {
+		if scheduler.headers[:cap(scheduler.headers)][index].versionState != nil {
+			t.Fatalf("dropped recovery header %d retained version state", index)
+		}
+	}
+}
+
+func TestStage3RecoveryCondenseKeepsSixDistinctVersions(t *testing.T) {
+	scheduler := newStage3RecoveryCondenseScheduler(t, []uint32{6, 5, 4, 3, 2, 1})
+	runStage3RecoveryCondense(t, scheduler)
+
+	if got, want := stage3RecoveryCondenseStates(t, scheduler), []StateID{6, 5, 4, 3, 2, 1}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("six-version recovery order=%v, want %v", got, want)
+	}
+	if scheduler.work.RecoveryCondensePasses != 1 || scheduler.work.RecoveryVersionCapDrops != 0 {
+		t.Fatalf("six-version telemetry=%+v, want one pass and no drop", scheduler.work)
+	}
+}
+
+func TestStage3RecoveryCondensePairwiseDeletesClearlyWorseVersion(t *testing.T) {
+	clean := diagnosticParserCoreRecoveryCondenseEntry{
+		header: diagnosticParserCoreHeader{creationSeq: 1},
+		status: core.RecoveryErrorStatus{Cost: 100, IsInError: false},
+		key:    diagnosticParserCoreRecoveryCondenseKey{state: 1},
+	}
+	recovery := diagnosticParserCoreRecoveryCondenseEntry{
+		header: diagnosticParserCoreHeader{creationSeq: 2},
+		status: core.RecoveryErrorStatus{Cost: 2000, IsInError: true},
+		key:    diagnosticParserCoreRecoveryCondenseKey{state: 2},
+	}
+	for _, test := range []struct {
+		name    string
+		entries []diagnosticParserCoreRecoveryCondenseEntry
+		want    int
+	}{
+		{name: "take_left", entries: []diagnosticParserCoreRecoveryCondenseEntry{clean, recovery}, want: 0},
+		{name: "take_right", entries: []diagnosticParserCoreRecoveryCondenseEntry{recovery, clean}, want: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			order := diagnosticParserCoreRecoveryCondensePairwise(test.entries, []int{0, 1})
+			if len(order) != 1 || order[0] != test.want {
+				t.Fatalf("pairwise order=%v, want only input %d", order, test.want)
+			}
+		})
+	}
+}
+
+func TestStage3RecoveryCondenseEquivalentKeyUsesMergedNodeCountAndPrecedence(t *testing.T) {
+	key := diagnosticParserCoreRecoveryCondenseKey{state: 1, byteOffset: 4, cost: 100}
+	entries := []diagnosticParserCoreRecoveryCondenseEntry{
+		{key: key, status: core.RecoveryErrorStatus{Cost: 100, NodeCount: 0, DynPrec: 1}},
+		{key: key, status: core.RecoveryErrorStatus{Cost: 100, NodeCount: 20, DynPrec: 7}},
+		{
+			key:    diagnosticParserCoreRecoveryCondenseKey{state: 2, byteOffset: 4, cost: 200},
+			status: core.RecoveryErrorStatus{Cost: 200},
+		},
+	}
+	diagnosticParserCoreMergeEquivalentRecoveryStatus(&entries[0], entries[1])
+	if entries[0].status.NodeCount != 20 || entries[0].status.DynPrec != 7 {
+		t.Fatalf("merged equivalent status=%+v, want maximum node count and precedence", entries[0].status)
+	}
+	if got := diagnosticParserCoreRecoveryCondensePairwise(entries, []int{0, 2}); !reflect.DeepEqual(got, []int{0}) {
+		t.Fatalf("merged-node-count comparison order=%v, want lower-cost merged key to take competitor", got)
+	}
+}
+
+func TestStage3RecoveryCondenseKeyIgnoresDynamicPrecedence(t *testing.T) {
+	key := diagnosticParserCoreRecoveryCondenseKey{
+		state: 3, byteOffset: 4, cost: 500, checkpoint: 6,
+		shifted: true, paused: true,
+	}
+	left := diagnosticParserCoreRecoveryCondenseEntry{
+		key: key, status: core.RecoveryErrorStatus{Cost: 500, DynPrec: 1},
+	}
+	right := diagnosticParserCoreRecoveryCondenseEntry{
+		key: key, status: core.RecoveryErrorStatus{Cost: 500, DynPrec: 9},
+	}
+	if left.key != right.key {
+		t.Fatal("dynamic precedence split one C recovery merge key")
+	}
+	diagnosticParserCoreMergeEquivalentRecoveryStatus(&left, right)
+	if left.status.DynPrec != 9 {
+		t.Fatalf("merged dynamic precedence=%d, want 9", left.status.DynPrec)
+	}
+}
+
+func TestStage3RecoveryCondenseDifferentScoresShareOneVersionKey(t *testing.T) {
+	table := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 8}: {{Type: core.ActionShift, State: 2}},
+			{state: 2, symbol: 9}: {{
+				Type: core.ActionReduce, Symbol: 10, ChildCount: 1,
+				DynamicPrecedence: 7,
+			}},
+		},
+		gotos: map[genericConflictCell]core.StateID{{state: 1, symbol: 10}: 3},
+	}
+	compact, err := core.New(table, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	shifted, err := compact.Shift(seed, 8, 0, core.Token{Symbol: 8}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputs, err := compact.ReduceOutputs(shifted, 9, 0, core.ForkOrder{})
+	if err != nil || len(outputs) != 1 {
+		t.Fatalf("scored reduction outputs=%+v error=%v", outputs, err)
+	}
+
+	makeHeader := func(head core.Head, sequence uint64, endByte uint32) diagnosticParserCoreHeader {
+		child, childErr := compact.ErrorRegionLeaf(2, 0, endByte, false)
+		if childErr != nil {
+			t.Fatal(childErr)
+		}
+		header := diagnosticParserCoreHeader{head: head, creationSeq: sequence}
+		header.openRecoveryRegion(&diagnosticParserCoreS3Region{
+			state: 1, startByte: 0, endByte: endByte, children: []core.SubtreeID{child},
+		})
+		header.markRecoveryLineage()
+		return header
+	}
+	headers := []diagnosticParserCoreHeader{makeHeader(outputs[0].Head, 1, 1)}
+	for index, endByte := range []uint32{1, 2, 3, 4, 5, 6} {
+		head, seedErr := compact.Seed(core.StateID(index+4), 0)
+		if seedErr != nil {
+			t.Fatal(seedErr)
+		}
+		headers = append(headers, makeHeader(head, uint64(index+2), endByte))
+	}
+	lang := &Language{SymbolMetadata: make([]SymbolMetadata, 16)}
+	for index := range lang.SymbolMetadata {
+		lang.SymbolMetadata[index] = SymbolMetadata{Visible: true, Named: true}
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact, headers: headers, recoveryIsolation: true,
+		tokenSource: &dfaTokenSource{language: lang},
+		options: DiagnosticParserCorePrefixOptions{
+			allowCompactRecoveryLineageSelection: true,
+			materializationSource:                []byte("abcdef"),
+		},
+	}
+	runStage3RecoveryCondense(t, scheduler)
+	if len(scheduler.headers) != 7 || scheduler.work.RecoveryVersionCapDrops != 0 {
+		t.Fatalf("score-equivalent recovery keys left %d histories with %d cap drops, want 7 and 0",
+			len(scheduler.headers), scheduler.work.RecoveryVersionCapDrops)
+	}
+}
+
+func TestStage3RecoveryCondenseUsesLiveNodeCountForTakeDecision(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		ends []uint32
+		want StateID
+	}{
+		{name: "take_left", ends: []uint32{1, 1001}, want: 1},
+		{name: "take_right", ends: []uint32{1001, 1}, want: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			scheduler := newStage3RecoveryCondenseScheduler(t, test.ends)
+			runStage3RecoveryCondense(t, scheduler)
+			if got := stage3RecoveryCondenseStates(t, scheduler); !reflect.DeepEqual(got, []StateID{test.want}) {
+				t.Fatalf("node-count recovery decision=%v, want [%d]", got, test.want)
+			}
+			if cap(scheduler.headers) > len(scheduler.headers) &&
+				scheduler.headers[:cap(scheduler.headers)][len(scheduler.headers)].versionState != nil {
+				t.Fatal("pairwise recovery drop retained loser ownership")
+			}
+		})
+	}
+}
+
+func TestStage3OpenRegionVisibleNodeCountRequiresOneAbsorbedChild(t *testing.T) {
+	scheduler := newStage3RecoveryCondenseScheduler(t, []uint32{1})
+	src, err := newDiagnosticParserCoreRecoveryCostSource(
+		scheduler.compact, scheduler.options.materializationSource,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbols := diagnosticParserCoreRecoverySymbolPolicy(scheduler.tokenSource.language)
+	if got, err := diagnosticParserCoreOpenRegionVisibleNodeCount(
+		symbols, src, &diagnosticParserCoreS3Region{},
+	); err != nil || got != 0 {
+		t.Fatalf("empty open-region count=%d error=%v, want 0", got, err)
+	}
+	region := scheduler.headers[0].recoveryRegion()
+	if got, err := diagnosticParserCoreOpenRegionVisibleNodeCount(symbols, src, region); err != nil || got != 2 {
+		t.Fatalf("non-empty open-region count=%d error=%v, want hidden wrapper plus child", got, err)
+	}
+}
+
+func TestStage3RecoveryCondensePreservesAbsorbBeforeItsMissingSibling(t *testing.T) {
+	absorb := diagnosticParserCoreRecoveryCondenseEntry{
+		header: diagnosticParserCoreHeader{creationSeq: 1},
+		status: core.RecoveryErrorStatus{Cost: 2000, IsInError: true},
+		key: diagnosticParserCoreRecoveryCondenseKey{
+			state: 0, recoveryGroup: 9,
+		},
+	}
+	missing := diagnosticParserCoreRecoveryCondenseEntry{
+		header: diagnosticParserCoreHeader{creationSeq: 2},
+		status: core.RecoveryErrorStatus{Cost: 100, IsInError: false},
+		key: diagnosticParserCoreRecoveryCondenseKey{
+			state: 2, missingGroup: 9,
+		},
+	}
+	for _, test := range []struct {
+		name    string
+		entries []diagnosticParserCoreRecoveryCondenseEntry
+		want    []int
+	}{
+		{name: "already_ordered", entries: []diagnosticParserCoreRecoveryCondenseEntry{absorb, missing}, want: []int{0, 1}},
+		{name: "restore_order", entries: []diagnosticParserCoreRecoveryCondenseEntry{missing, absorb}, want: []int{1, 0}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			order := diagnosticParserCoreRecoveryCondensePairwise(test.entries, []int{0, 1})
+			if !reflect.DeepEqual(order, test.want) {
+				t.Fatalf("S5 group order=%v, want %v", order, test.want)
+			}
+		})
+	}
+}
+
+func TestStage3RecoveryCondenseSkipsCostCompetitionWithinRecoveryGroup(t *testing.T) {
+	entries := []diagnosticParserCoreRecoveryCondenseEntry{
+		{
+			header: diagnosticParserCoreHeader{creationSeq: 1},
+			status: core.RecoveryErrorStatus{Cost: 100, IsInError: true},
+			key:    diagnosticParserCoreRecoveryCondenseKey{state: 1, recoveryGroup: 7},
+		},
+		{
+			header: diagnosticParserCoreHeader{creationSeq: 2},
+			status: core.RecoveryErrorStatus{Cost: 4000, IsInError: true},
+			key:    diagnosticParserCoreRecoveryCondenseKey{state: 2, recoveryGroup: 7},
+		},
+	}
+	if got := diagnosticParserCoreRecoveryCondensePairwise(entries, []int{0, 1}); !reflect.DeepEqual(got, []int{0, 1}) {
+		t.Fatalf("same-group recovery order=%v, want both histories", got)
+	}
+}
+
+func TestStage3RecoveryCondenseClampsBaselineAfterGraphPop(t *testing.T) {
+	scheduler := newStage3RecoveryCondenseScheduler(t, []uint32{1, 2})
+	for index := range scheduler.headers {
+		header := &scheduler.headers[index]
+		header.closeRecoveryRegion()
+		header.publishRecoveryCondenseState(0, 0, 0, true)
+	}
+	scheduler.headers[0].publishRecoveryCondenseState(0, 0, 5, true)
+	runStage3RecoveryCondense(t, scheduler)
+
+	for index := range scheduler.headers {
+		state, _, err := scheduler.compact.Boundary(scheduler.headers[index].head)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if state != 1 {
+			continue
+		}
+		baseline, set := scheduler.headers[index].recoveryNodeBaseline()
+		if !set || baseline != 0 {
+			t.Fatalf("clamped baseline=%d/%t, want 0/true", baseline, set)
+		}
+		return
+	}
+	t.Fatal("clamped recovery header was removed")
+}
+
+func TestStage3RecoveryMetadataSurvivesLexerStateUpdates(t *testing.T) {
+	absorb := diagnosticParserCoreHeader{}
+	absorb.openRecoveryRegion(&diagnosticParserCoreS3Region{state: 2, startByte: 1, endByte: 2})
+	absorb.markRecoveryLineage()
+	absorb.publishRecoveryCondenseState(9, 0, 7, true)
+	snapshot := &diagnosticParserCoreVersionLexerSnapshot{}
+	absorb.installVersionLexerSnapshot(snapshot)
+	absorb.setRecoveryRegion(&diagnosticParserCoreS3Region{state: 2, startByte: 1, endByte: 3})
+	if absorb.versionLexerSnapshot() != snapshot || absorb.recoveryGroupIdentity() != 9 {
+		t.Fatalf("absorb lexer update lost recovery group: %+v", absorb.versionState)
+	}
+	if baseline, set := absorb.recoveryNodeBaseline(); !set || baseline != 7 {
+		t.Fatalf("absorb lexer update baseline=%d/%t, want 7/true", baseline, set)
+	}
+	absorb.closeRecoveryRegion()
+	if absorb.recoveryGroupIdentity() != 0 {
+		t.Fatalf("closed absorb retained recovery group %d", absorb.recoveryGroupIdentity())
+	}
+	if baseline, set := absorb.recoveryNodeBaseline(); !set || baseline != 7 {
+		t.Fatalf("closed absorb baseline=%d/%t, want 7/true", baseline, set)
+	}
+
+	missing := diagnosticParserCoreHeader{}
+	missing.markRecoveryLineage()
+	missing.publishRecoveryCondenseState(0, 9, 5, true)
+	missing.installVersionLexerSnapshot(snapshot)
+	missing.clearVersionLexerSnapshot()
+	if missing.recoveryMissingGroupIdentity() != 9 {
+		t.Fatalf("missing lexer update lost group %d", missing.recoveryMissingGroupIdentity())
+	}
+	if baseline, set := missing.recoveryNodeBaseline(); !set || baseline != 5 {
+		t.Fatalf("missing lexer update baseline=%d/%t, want 5/true", baseline, set)
+	}
+}
+
+func TestStage3RecoveryCondenseRetainsDuplicateHistoryOfKeptKey(t *testing.T) {
+	scheduler := newStage3RecoveryCondenseScheduler(t, []uint32{1, 2, 3, 4, 5, 6, 1})
+	firstChild := scheduler.headers[0].recoveryRegion().children[0]
+	duplicateChild := scheduler.headers[6].recoveryRegion().children[0]
+	runStage3RecoveryCondense(t, scheduler)
+
+	if got, want := stage3RecoveryCondenseStates(t, scheduler), []StateID{1, 7, 2, 3, 4, 5, 6}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("duplicate-key recovery order=%v, want retained C merge histories %v", got, want)
+	}
+	if scheduler.work.RecoveryVersionCapDrops != 0 || len(scheduler.headers) != 7 {
+		t.Fatalf("duplicate-key recovery frontier=%d telemetry=%+v, want seven histories across six keys", len(scheduler.headers), scheduler.work)
+	}
+	if firstChild == duplicateChild || scheduler.headers[0].recoveryRegion().children[0] != firstChild ||
+		scheduler.headers[1].recoveryRegion().children[0] != duplicateChild {
+		t.Fatalf("duplicate C key lost one recovery history: first=%d duplicate=%d headers=%+v", firstChild, duplicateChild, scheduler.headers)
+	}
+}
+
+func TestStage3RecoveryCondenseDropsOnlyExcessKeyAfterDuplicate(t *testing.T) {
+	scheduler := newStage3RecoveryCondenseScheduler(t, []uint32{1, 2, 3, 4, 5, 6, 1, 7})
+	runStage3RecoveryCondense(t, scheduler)
+
+	if got, want := stage3RecoveryCondenseStates(t, scheduler), []StateID{1, 7, 2, 3, 4, 5, 6}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("duplicate-before-excess order=%v, want %v", got, want)
+	}
+	if scheduler.work.RecoveryVersionCapDrops != 1 || len(scheduler.headers) != 7 {
+		t.Fatalf("duplicate-before-excess frontier=%d telemetry=%+v, want one excess-key drop", len(scheduler.headers), scheduler.work)
+	}
+}
+
+func TestStage3RecoveryCondenseUsesScannerCheckpointInsteadOfSnapshotPointer(t *testing.T) {
+	scheduler := newStage3RecoveryCondenseScheduler(t, []uint32{1, 1, 2, 3, 4, 5, 6, 7})
+	for index := 0; index < 2; index++ {
+		header := &scheduler.headers[index]
+		baseline, baselineSet := header.recoveryNodeBaseline()
+		header.publishVersionState(
+			header.recoveryRegion(), &diagnosticParserCoreVersionLexerSnapshot{}, 0,
+			header.recoveryGroupIdentity(), header.recoveryMissingGroupIdentity(),
+			baseline, baselineSet,
+		)
+	}
+	runStage3RecoveryCondense(t, scheduler)
+
+	if got, want := stage3RecoveryCondenseStates(t, scheduler), []StateID{1, 2, 3, 4, 5, 6, 7}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("equal scanner checkpoint with cloned snapshots=%v, want %v", got, want)
+	}
+	if scheduler.work.RecoveryVersionCapDrops != 1 || len(scheduler.headers) != 7 {
+		t.Fatalf("cloned-snapshot cap frontier=%d telemetry=%+v, want seven histories and one drop", len(scheduler.headers), scheduler.work)
+	}
+}
+
+func TestStage3RecoveryCondenseAppendsAcceptedVersionsAfterActivePool(t *testing.T) {
+	scheduler := newStage3RecoveryCondenseScheduler(t, []uint32{2, 1, 3})
+	scheduler.headers[0].accepted = true
+	runStage3RecoveryCondense(t, scheduler)
+
+	if got, want := stage3RecoveryCondenseStates(t, scheduler), []StateID{2, 3, 1}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("active and accepted recovery order=%v, want C pool order %v", got, want)
+	}
+	if scheduler.headers[0].accepted || scheduler.headers[1].accepted || !scheduler.headers[2].accepted {
+		t.Fatalf("accepted recovery version did not remain outside the active pool: %+v", scheduler.headers)
+	}
+}
+
+func TestStage3RecoveryCondenseErrorRollsBackConflictAndOwnership(t *testing.T) {
+	actions := []core.Action{
+		{Type: core.ActionShift, State: 2},
+		{Type: core.ActionShift, State: 3},
+		{Type: core.ActionShift, State: 4},
+	}
+	compact, err := core.New(&genericConflictTable{actions: actions}, core.Limits{MaxDerivations: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := diagnosticParserCoreHeader{head: head, creationSeq: 4}
+	header.openRecoveryRegion(&diagnosticParserCoreS3Region{
+		state: 1, startByte: 0, endByte: 1,
+		children: []core.SubtreeID{core.SubtreeID(^uint32(0))},
+	})
+	header.markRecoveryLineage()
+	headers := []diagnosticParserCoreHeader{header}
+	before, err := diagnosticParserCoreHeaderReceipts(compact, headers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lang := &Language{SymbolMetadata: make([]SymbolMetadata, 8)}
+	for index := range lang.SymbolMetadata {
+		lang.SymbolMetadata[index] = SymbolMetadata{Visible: true, Named: true}
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact, headers: append([]diagnosticParserCoreHeader(nil), headers...),
+		token:       Token{Symbol: 9, StartByte: 0, EndByte: 1},
+		branchOrder: 7, nextSeq: 10, recoveryIsolation: true,
+		tokenSource: &dfaTokenSource{language: lang},
+		options: DiagnosticParserCorePrefixOptions{
+			MaxDispatches:                        100,
+			allowCompactRecoveryLineageSelection: true,
+			materializationSource:                []byte("x"),
+		},
+		receipt: &DiagnosticParserCoreGenericScheduler{},
+	}
+	statsBefore, err := compact.Stats(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cell := mustDiagnosticParserCoreGenericCell(t, compact, 0, headers[0], 9)
+	if err := scheduler.applyGenericConflict(before, cell); err == nil {
+		t.Fatal("invalid open-region child unexpectedly passed recovery condensation")
+	}
+	statsAfter, err := compact.Stats(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statsAfter != statsBefore || !reflect.DeepEqual(scheduler.headers, headers) ||
+		scheduler.branchOrder != 7 || scheduler.nextSeq != 10 || scheduler.dispatches != 0 ||
+		scheduler.work != (DiagnosticParserCoreGenericWork{}) ||
+		!reflect.DeepEqual(scheduler.receipt, &DiagnosticParserCoreGenericScheduler{}) {
+		t.Fatalf("recovery condense rollback leaked: before=%+v after=%+v scheduler=%+v", statsBefore, statsAfter, scheduler)
+	}
+	if len(scheduler.recoveryCondenseScratch) != 0 {
+		t.Fatalf("recovery condense scratch length=%d after rollback", len(scheduler.recoveryCondenseScratch))
+	}
+	for index := range scheduler.recoveryCondenseScratch[:cap(scheduler.recoveryCondenseScratch)] {
+		if scheduler.recoveryCondenseScratch[:cap(scheduler.recoveryCondenseScratch)][index].header.versionState != nil {
+			t.Fatalf("recovery condense scratch entry %d retained version state", index)
+		}
+	}
+}
+
+func TestStage3RecoveryCondenseScratchIsCountedAndClearedOnReset(t *testing.T) {
+	scheduler := newStage3RecoveryCondenseScheduler(t, []uint32{1})
+	entry := diagnosticParserCoreRecoveryCondenseEntry{header: scheduler.headers[0]}
+	scheduler.recoveryCondenseScratch = append(
+		make([]diagnosticParserCoreRecoveryCondenseEntry, 0, 7), entry,
+	)
+	withScratch := diagnosticParserCoreSchedulerFootprintBytes(scheduler)
+	scheduler.recoveryCondenseScratch = nil
+	withoutScratch := diagnosticParserCoreSchedulerFootprintBytes(scheduler)
+	wantDelta := uint64(7 * unsafe.Sizeof(diagnosticParserCoreRecoveryCondenseEntry{}))
+	if withScratch-withoutScratch != wantDelta {
+		t.Fatalf("recovery scratch footprint delta=%d, want %d", withScratch-withoutScratch, wantDelta)
+	}
+	scheduler.recoveryCondenseOrderScratch = append(make([]int, 0, 5), 3)
+	withOrder := diagnosticParserCoreSchedulerFootprintBytes(scheduler)
+	scheduler.recoveryCondenseOrderScratch = nil
+	withoutOrder := diagnosticParserCoreSchedulerFootprintBytes(scheduler)
+	wantOrderDelta := uint64(5 * unsafe.Sizeof(int(0)))
+	if withOrder-withoutOrder != wantOrderDelta {
+		t.Fatalf("recovery order scratch footprint delta=%d, want %d", withOrder-withoutOrder, wantOrderDelta)
+	}
+
+	scheduler.recoveryCondenseScratch = append(
+		make([]diagnosticParserCoreRecoveryCondenseEntry, 0, 7), entry,
+	)
+	scheduler.recoveryCondenseOrderScratch = append(make([]int, 0, 5), 3)
+	if err := resetDiagnosticParserCoreGenericScheduler(scheduler); err != nil {
+		t.Fatal(err)
+	}
+	if len(scheduler.recoveryCondenseScratch) != 0 || cap(scheduler.recoveryCondenseScratch) != 7 {
+		t.Fatalf("reset recovery scratch len/cap=%d/%d, want 0/7", len(scheduler.recoveryCondenseScratch), cap(scheduler.recoveryCondenseScratch))
+	}
+	for index := range scheduler.recoveryCondenseScratch[:cap(scheduler.recoveryCondenseScratch)] {
+		if scheduler.recoveryCondenseScratch[:cap(scheduler.recoveryCondenseScratch)][index].header.versionState != nil {
+			t.Fatalf("reset recovery scratch entry %d retained version state", index)
+		}
+	}
+	if len(scheduler.recoveryCondenseOrderScratch) != 0 || cap(scheduler.recoveryCondenseOrderScratch) != 5 {
+		t.Fatalf("reset recovery order scratch len/cap=%d/%d, want 0/5",
+			len(scheduler.recoveryCondenseOrderScratch), cap(scheduler.recoveryCondenseOrderScratch))
+	}
+	for index, value := range scheduler.recoveryCondenseOrderScratch[:cap(scheduler.recoveryCondenseOrderScratch)] {
+		if value != 0 {
+			t.Fatalf("reset recovery order scratch entry %d=%d, want zero", index, value)
+		}
+	}
+}

--- a/parsercore_phase0_recovery_condense_stage3_internal_test.go
+++ b/parsercore_phase0_recovery_condense_stage3_internal_test.go
@@ -253,6 +253,18 @@ func TestStage3RecoveryCondenseUsesLiveNodeCountForTakeDecision(t *testing.T) {
 			if got := stage3RecoveryCondenseStates(t, scheduler); !reflect.DeepEqual(got, []StateID{test.want}) {
 				t.Fatalf("node-count recovery decision=%v, want [%d]", got, test.want)
 			}
+			if scheduler.recoveryIsolation || scheduler.headers[0].isRecoveryLineage() ||
+				!scheduler.headers[0].isRecoveryCosted() {
+				t.Fatalf("sole recovery winner retained active competition: isolation=%t header=%+v",
+					scheduler.recoveryIsolation, scheduler.headers[0])
+			}
+			if scheduler.headers[0].recoveryGroupIdentity() != 0 ||
+				scheduler.headers[0].recoveryMissingGroupIdentity() != 0 {
+				t.Fatalf("sole recovery winner retained group ownership: %+v", scheduler.headers[0].versionState)
+			}
+			if _, set := scheduler.headers[0].recoveryNodeBaseline(); set {
+				t.Fatalf("sole recovery winner retained its competition baseline: %+v", scheduler.headers[0].versionState)
+			}
 			if cap(scheduler.headers) > len(scheduler.headers) &&
 				scheduler.headers[:cap(scheduler.headers)][len(scheduler.headers)].versionState != nil {
 				t.Fatal("pairwise recovery drop retained loser ownership")

--- a/parsercore_phase0_recovery_cost_internal_test.go
+++ b/parsercore_phase0_recovery_cost_internal_test.go
@@ -167,6 +167,14 @@ func assertRecoveryCostNodeForNode(t *testing.T, trial int, lang *Language, symb
 	if gotMemo != want {
 		t.Fatalf("trial %d: compact memoized cost for id %d = %d, want %d (production)", trial, id, gotMemo, want)
 	}
+	gotVisible, err := core.RecoveryNodeVisibleSubtreeCount(symbols, fixture, id)
+	if err != nil {
+		t.Fatalf("trial %d: RecoveryNodeVisibleSubtreeCount(id=%d): %v", trial, id, err)
+	}
+	if wantVisible := cNodeVisibleSubtreeCountUncachedLang(lang, n); uint64(gotVisible) != uint64(wantVisible) {
+		t.Fatalf("trial %d: compact visible count for id %d = %d, want %d (production)",
+			trial, id, gotVisible, wantVisible)
+	}
 
 	for _, c := range n.children {
 		assertRecoveryCostNodeForNode(t, trial, lang, symbols, fixture, ids, c)
@@ -194,6 +202,65 @@ func TestRecoveryCostCompactMatchesProductionNodeForNode(t *testing.T) {
 
 		fixture, _, ids := compactifyRecoveryCostTree(root)
 		assertRecoveryCostNodeForNode(t, trial, lang, symbols, fixture, ids, root)
+	}
+}
+
+func TestRecoveryVisibleNodeCountMatchesProductionAliasRelabel(t *testing.T) {
+	lang := &Language{SymbolMetadata: make([]SymbolMetadata, 8)}
+	lang.SymbolMetadata[5] = SymbolMetadata{Visible: true, Named: true}
+	lang.SymbolMetadata[6] = SymbolMetadata{Visible: false}
+	lang.SymbolMetadata[7] = SymbolMetadata{Visible: true, Named: true}
+	symbols := make([]core.SelectedSymbolPolicy, len(lang.SymbolMetadata))
+	for index := range symbols {
+		symbols[index] = core.SelectedSymbolPolicy{
+			Visible: lang.SymbolMetadata[index].Visible,
+			Named:   lang.SymbolMetadata[index].Named,
+		}
+	}
+
+	production := NewParentNode(5, true, []*Node{
+		NewLeafNode(7, true, 0, 1, Point{}, Point{Column: 1}),
+	}, nil, 1)
+	fixture := compactRecoveryCostFixture{
+		1: {Symbol: 6, StartByte: 0, EndByte: 1},
+		2: {Symbol: 5, StartByte: 0, EndByte: 1, Children: []core.SubtreeID{1}, Aliases: []core.Symbol{7}},
+	}
+	got, err := core.RecoveryNodeVisibleSubtreeCount(symbols, fixture, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := cNodeVisibleSubtreeCountUncachedLang(lang, production)
+	if uint64(got) != uint64(want) {
+		t.Fatalf("alias-aware compact visible count=%d, want production count %d", got, want)
+	}
+}
+
+func TestRecoveryErrorRegionCostMatchesUnpublishedProductionNode(t *testing.T) {
+	const symbolCount = 8
+	lang := &Language{SymbolMetadata: make([]SymbolMetadata, symbolCount)}
+	symbols := make([]core.SelectedSymbolPolicy, symbolCount)
+	for index := range lang.SymbolMetadata {
+		lang.SymbolMetadata[index] = SymbolMetadata{Visible: true, Named: true}
+		symbols[index] = core.SelectedSymbolPolicy{Visible: true, Named: true}
+	}
+	children := []*Node{
+		NewLeafNode(2, true, 1, 3, Point{}, Point{}),
+		NewLeafNode(3, true, 3, 8, Point{}, Point{Row: 2}),
+	}
+	region := NewParentNode(errorSymbol, true, children, nil, 0)
+	fixture, _, ids := compactifyRecoveryCostTree(region)
+	childIDs := []core.SubtreeID{ids[children[0]], ids[children[1]]}
+	got, err := core.RecoveryErrorRegionCost(
+		symbols, fixture, nil,
+		region.startByte, region.startPoint.Row,
+		region.endByte, region.endPoint.Row,
+		childIDs,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := cNodeErrorCostLang(lang, region); got != want {
+		t.Fatalf("unpublished compact ERROR cost=%d, want production %d", got, want)
 	}
 }
 

--- a/parsercore_phase0_recovery_cost_source.go
+++ b/parsercore_phase0_recovery_cost_source.go
@@ -111,11 +111,9 @@ func (s *diagnosticParserCoreRecoveryCostSource) rowAt(byteOffset uint32) uint32
 
 // RecoveryCostNode implements core.RecoveryCostSource.
 //
-// Children are COPIED, not aliased. MaterializationView documents its
-// Children slice as borrowed arena storage that must not be retained, and the
-// cost model holds a node's children across recursive calls that re-enter this
-// method. Copying is the cheap, obviously-correct response; this path runs at
-// a recovery decision point, never on the clean hot path.
+// Children and aliases are COPIED, not retained. MaterializationView documents
+// both slices as borrowed arena storage. The cost model holds them across
+// recursive calls that re-enter this method.
 func (s *diagnosticParserCoreRecoveryCostSource) RecoveryCostNode(id core.SubtreeID) (core.RecoveryCostNode, error) {
 	if s == nil || s.compact == nil {
 		return core.RecoveryCostNode{}, errors.New("parser-core phase zero: recovery cost source has no compact core")
@@ -139,6 +137,9 @@ func (s *diagnosticParserCoreRecoveryCostSource) RecoveryCostNode(id core.Subtre
 	}
 	if len(view.Children) != 0 {
 		node.Children = append(make([]core.SubtreeID, 0, len(view.Children)), view.Children...)
+	}
+	if len(view.Aliases) != 0 {
+		node.Aliases = append(make([]core.Symbol, 0, len(view.Aliases)), view.Aliases...)
 	}
 	return node, nil
 }

--- a/parsercore_phase0_recovery_lineage_fork_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_fork_internal_test.go
@@ -49,7 +49,7 @@ func newRecoveryLineageForkScheduler(t *testing.T, armed bool) *diagnosticParser
 	if err != nil {
 		t.Fatalf("Seed: %v", err)
 	}
-	lang := &Language{TokenCount: 5}
+	lang := &Language{TokenCount: 5, SymbolCount: 5}
 	return &diagnosticParserCoreGenericScheduler{
 		compact: compact,
 		tokenSource: &dfaTokenSource{
@@ -99,6 +99,17 @@ func TestS5MissingInsertionForkPublishesBothRecoveryLineages(t *testing.T) {
 		t.Fatalf("creation sequence=%d/%d next=%d, want 3/10 next 11",
 			scheduler.headers[0].creationSeq, scheduler.headers[1].creationSeq, scheduler.nextSeq)
 	}
+	if scheduler.headers[0].recoveryGroupIdentity() != 10 ||
+		scheduler.headers[1].recoveryMissingGroupIdentity() != 10 {
+		t.Fatalf("S5 recovery groups=%d/%d, want absorb/missing group 10",
+			scheduler.headers[0].recoveryGroupIdentity(), scheduler.headers[1].recoveryMissingGroupIdentity())
+	}
+	if baseline, set := scheduler.headers[0].recoveryNodeBaseline(); !set || baseline != 0 {
+		t.Fatalf("S5 absorb baseline=%d/%t, want 0/true", baseline, set)
+	}
+	if baseline, set := scheduler.headers[1].recoveryNodeBaseline(); !set || baseline != 0 {
+		t.Fatalf("S5 missing baseline=%d/%t, want 0/true", baseline, set)
+	}
 	if scheduler.s5MissingInsertions != 1 {
 		t.Fatalf("missing insertion count=%d, want 1", scheduler.s5MissingInsertions)
 	}
@@ -131,6 +142,23 @@ func TestS5MissingInsertionForkPublishesBothRecoveryLineages(t *testing.T) {
 	}
 	if absorbed.Symbol != 4 || absorbed.StartByte != 1 || absorbed.EndByte != 2 {
 		t.Fatalf("absorbed payload=%+v, want symbol 4 over bytes 1..2", absorbed)
+	}
+}
+
+func TestS5MissingInsertionClampsInheritedBaselineBeforeFork(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	scheduler.headers[0].publishRecoveryCondenseState(0, 0, 9, true)
+	handled, err := scheduler.s5TryMissingTokenInsertion(0)
+	if err != nil {
+		t.Fatalf("s5TryMissingTokenInsertion: %v", err)
+	}
+	if !handled || len(scheduler.headers) != 2 {
+		t.Fatalf("S5 clamp fixture did not fork: handled=%t headers=%d", handled, len(scheduler.headers))
+	}
+	for index := range scheduler.headers {
+		if baseline, set := scheduler.headers[index].recoveryNodeBaseline(); !set || baseline != 0 {
+			t.Fatalf("S5 header %d baseline=%d/%t, want clamped 0/true", index, baseline, set)
+		}
 	}
 }
 

--- a/parsercore_phase0_recovery_lineage_selection_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_selection_internal_test.go
@@ -313,4 +313,18 @@ func TestCollapseToRecoveryWinnerRecordsOnlyTheOriginalS5AbsorbLineage(t *testin
 	if missing.selectedRecoveryAbsorbLineage {
 		t.Fatal("the later missing lineage was recorded as the absorb winner")
 	}
+
+	reorderedAbsorb := newScheduler()
+	reorderedAbsorb.headers[0], reorderedAbsorb.headers[1] = reorderedAbsorb.headers[1], reorderedAbsorb.headers[0]
+	reorderedAbsorb.collapseToRecoveryWinner(1)
+	if !reorderedAbsorb.selectedRecoveryAbsorbLineage {
+		t.Fatal("cost ordering hid the earlier original S5 absorb winner")
+	}
+
+	reorderedMissing := newScheduler()
+	reorderedMissing.headers[0], reorderedMissing.headers[1] = reorderedMissing.headers[1], reorderedMissing.headers[0]
+	reorderedMissing.collapseToRecoveryWinner(0)
+	if reorderedMissing.selectedRecoveryAbsorbLineage {
+		t.Fatal("cost ordering changed the later missing lineage into the absorb winner")
+	}
 }

--- a/parsercore_phase0_stack_summary_recovery_internal_test.go
+++ b/parsercore_phase0_stack_summary_recovery_internal_test.go
@@ -54,7 +54,7 @@ func newStackSummaryRecoveryForkScheduler(t *testing.T, armed bool) *diagnosticP
 	return &diagnosticParserCoreGenericScheduler{
 		compact: compact,
 		tokenSource: &dfaTokenSource{
-			language: &Language{TokenCount: 5},
+			language: &Language{TokenCount: 5, SymbolCount: 5},
 			lexer:    &Lexer{source: []byte("a?")},
 		},
 		headers: []diagnosticParserCoreHeader{{head: head, creationSeq: 3}},
@@ -97,6 +97,19 @@ func TestS4StackSummaryRecoveryForkPublishesBothLineages(t *testing.T) {
 		t.Fatalf("creation sequence=%d/%d next=%d, want 3/10 next 11",
 			scheduler.headers[0].creationSeq, scheduler.headers[1].creationSeq, scheduler.nextSeq)
 	}
+	if scheduler.headers[0].recoveryGroupIdentity() != 10 ||
+		scheduler.headers[1].recoveryGroupIdentity() != 0 ||
+		scheduler.headers[1].recoveryMissingGroupIdentity() != 0 {
+		t.Fatalf("S4 recovery groups absorb=%d recovered=%d/%d, want 10 and 0/0",
+			scheduler.headers[0].recoveryGroupIdentity(),
+			scheduler.headers[1].recoveryGroupIdentity(),
+			scheduler.headers[1].recoveryMissingGroupIdentity())
+	}
+	for index := range scheduler.headers {
+		if baseline, set := scheduler.headers[index].recoveryNodeBaseline(); !set || baseline != 1 {
+			t.Fatalf("S4 header %d baseline=%d/%t, want 1/true", index, baseline, set)
+		}
+	}
 	if scheduler.work.StackSummaryRecoveryForks != 1 {
 		t.Fatalf("stack-summary forks=%d, want 1", scheduler.work.StackSummaryRecoveryForks)
 	}
@@ -121,6 +134,20 @@ func TestS4StackSummaryRecoveryForkPublishesBothLineages(t *testing.T) {
 	}
 	if recovered.Symbol != core.Symbol(errorSymbol) || recovered.StartByte != 0 || recovered.EndByte != 1 || len(recovered.Children) != 1 {
 		t.Fatalf("recovered payload=%+v, want ERROR over bytes 0..1", recovered)
+	}
+}
+
+func TestS3ErrorEntryPublishesCurrentVisibleNodeBaseline(t *testing.T) {
+	scheduler := newStackSummaryRecoveryForkScheduler(t, true)
+	handled, err := scheduler.s3TryOpenErrorRegionWithAlternatives(0, true)
+	if err != nil {
+		t.Fatalf("s3TryOpenErrorRegionWithAlternatives: %v", err)
+	}
+	if !handled || scheduler.headers[0].recoveryRegion() == nil {
+		t.Fatal("standalone S3 did not open its error region")
+	}
+	if baseline, set := scheduler.headers[0].recoveryNodeBaseline(); !set || baseline != 1 {
+		t.Fatalf("S3 baseline=%d/%t, want one visible shifted node", baseline, set)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Preserve recovery costs through ordinary conflict and reduction forks.
- Condense recovery versions with C pairwise comparison and the six-key cap.
- Track per-version recovery groups and visible-node baselines.
- Count aliases, open error regions, and ERROR_REPEAT progress with C semantics.
- Add ownership cleanup and path telemetry.

## Proof

- Focused Stage 3 and lifecycle tests pass in both modified packages.
- The exact JavaScript recovery tree gate passes with one compact selection.
- HTML Docker parity passes 25 of 25 cases for every parity level.
- Both parser-core build modes compile.
- The 20-seed randomized benchmark loop completes without a crash or memory stop.
- Full parse averages 10.33 ms and five allocations across the 20 seeds.
- Both incremental probes remain allocation-free.

No certified grammar witness currently increments RecoveryAmbiguityForks. Synthetic C-semantic falsifiers cover the fork, comparison, ordering, ownership, and cleanup paths. The closest locked JavaScript witness conflicts before recovery and still matches C.

This pull request contains no unrelated performance changes.