### PR TITLE
add(compact): Certify end-of-file recovery

### DIFF
--- a/admission_census_recovery_shape_test.go
+++ b/admission_census_recovery_shape_test.go
@@ -52,6 +52,9 @@ type admissionCensusRecoveryShapeWitness struct {
 	source   string
 	// mechanism is the c-mechanism value the census must report.
 	mechanism string
+	// admitted marks the first live recover_eof witness. It now serves through
+	// the certified compact route, so it has no decline classification.
+	admitted bool
 	// candidates, when non-zero, additionally pins the reported
 	// missing-token candidate population. It is asserted only where the
 	// count is a structural claim worth pinning (exactly one candidate
@@ -87,7 +90,7 @@ func admissionCensusRecoveryShapeWitnesses() []admissionCensusRecoveryShapeWitne
 		// C ts_parser__recover recover_eof: the elected token is
 		// authenticated end-of-file and no earlier mechanism applies, so C
 		// wraps the remaining stack in one ERROR root.
-		{language: "yaml", source: "a: [1\n", mechanism: "recover-eof-wrap"},
+		{language: "yaml", source: "[\n", mechanism: "recover-eof-wrap", admitted: true},
 	}
 }
 
@@ -142,6 +145,12 @@ func TestAdmissionCensusRecoveryShapeClassification(t *testing.T) {
 	for _, witness := range admissionCensusRecoveryShapeWitnesses() {
 		t.Run(witness.language+"/"+witness.mechanism, func(t *testing.T) {
 			reason := admissionCensusDeclineReason(t, witness.language, witness.source)
+			if witness.admitted {
+				if reason != "" {
+					t.Fatalf("certified compact route declined %q: %s", witness.source, reason)
+				}
+				return
+			}
 			if reason == "" {
 				t.Fatalf("compact route admitted %q; expected a recovery decline", witness.source)
 			}
@@ -170,6 +179,16 @@ func TestAdmissionCensusRecoveryShapeIsDiagnosticOnly(t *testing.T) {
 				disableAdmissionCensus(t)
 				return admissionCensusDeclineReason(t, witness.language, witness.source)
 			}()
+			if witness.admitted {
+				if off != "" {
+					t.Fatalf("certified compact route declined %q with the census disabled: %s", witness.source, off)
+				}
+				enableAdmissionCensus(t)
+				if on := admissionCensusDeclineReason(t, witness.language, witness.source); on != "" {
+					t.Fatalf("certified compact route declined %q with the census enabled: %s", witness.source, on)
+				}
+				return
+			}
 			if off == "" {
 				t.Fatalf("compact route admitted %q with the census disabled", witness.source)
 			}
@@ -228,6 +247,9 @@ func TestAdmissionCensusRecoveryShapeVocabulary(t *testing.T) {
 		t.Fatalf("census exposes %d recovery shapes, want the 4 documented ones", len(known))
 	}
 	for _, witness := range admissionCensusRecoveryShapeWitnesses() {
+		if witness.admitted {
+			continue
+		}
 		if !known[witness.mechanism] {
 			t.Fatalf("witness pins mechanism %q outside the documented vocabulary", witness.mechanism)
 		}
@@ -262,6 +284,9 @@ func TestAdmissionCensusRecoveryShapeNeedsItsOwnOptIn(t *testing.T) {
 	t.Cleanup(gts.ResetAdmissionCensusEnabledForTest)
 
 	for _, witness := range admissionCensusRecoveryShapeWitnesses() {
+		if witness.admitted {
+			continue
+		}
 		reason := admissionCensusDeclineReason(t, witness.language, witness.source)
 		if reason == "" {
 			t.Fatalf("compact route admitted %q", witness.source)

--- a/admission_recover_eof_admission_test.go
+++ b/admission_recover_eof_admission_test.go
@@ -1,0 +1,229 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestAdmissionRecoverEOFSingletonAdmissionAndPriorityFree(t *testing.T) {
+	lang := grammars.YamlLanguage()
+	tree, ok, reason := gts.TryCompactFullParseRouteForTest(gts.NewParser(lang), []byte("[\n"))
+	if tree != nil {
+		defer tree.Release()
+	}
+	if !ok || reason != "" {
+		t.Fatalf("singleton recover_eof route ok=%t reason=%q", ok, reason)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("singleton recover_eof route returned no tree")
+	}
+	root := tree.RootNode()
+	if !root.IsError() || !root.HasError() || root.IsExtra() || root.IsMissing() ||
+		root.StartByte() != 0 || root.EndByte() != 1 || root.ChildCount() != 1 {
+		t.Fatalf("singleton recover_eof root type=%s error=%t/%t extra=%t missing=%t span=%d..%d children=%d",
+			root.Type(lang), root.IsError(), root.HasError(), root.IsExtra(), root.IsMissing(),
+			root.StartByte(), root.EndByte(), root.ChildCount())
+	}
+	child := root.Child(0)
+	if child == nil || child.StartByte() != 0 || child.EndByte() != 1 || child.Type(lang) != "[" {
+		t.Fatalf("singleton recover_eof child=%v, want [ at 0..1", child)
+	}
+}
+
+func TestAdmissionRecoverEOFLiveTelemetry(t *testing.T) {
+	lang := grammars.YamlLanguage()
+	tree, telemetry, ok, reason := gts.TryCompactRecoverEOFAcceptTelemetryForTest(
+		gts.NewParser(lang), []byte("[\n"),
+	)
+	if tree != nil {
+		defer tree.Release()
+	}
+	if !ok || reason != "" || tree == nil {
+		t.Fatalf("live recover_eof route ok=%t reason=%q tree=%v", ok, reason, tree != nil)
+	}
+	if telemetry.RecoverEOFAccepts != 1 {
+		t.Fatalf("RecoverEOFAccepts=%d, want exactly one", telemetry.RecoverEOFAccepts)
+	}
+	runtime := telemetry.Runtime
+	if runtime.StopReason != gts.ParseStopAccepted || !runtime.LastTokenWasEOF ||
+		runtime.LastTokenEndByte != 2 || runtime.ExpectedEOFByte != 2 || runtime.RootEndByte != 1 {
+		t.Fatalf("recover_eof runtime=%+v, want accepted EOF at 2 with root end 1", runtime)
+	}
+}
+
+func TestAdmissionRecoverEOFArtifactReceiptTamperingDeclines(t *testing.T) {
+	lang := grammars.YamlLanguage()
+	want := lang.CompactRecoverEOFArtifactReceipt
+	tamper := []struct {
+		name string
+		edit func(*gts.CompactRecoverEOFArtifactReceipt)
+	}{
+		{name: "blob", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.BlobSHA256[0] ^= 1 }},
+		{name: "terminal", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.TerminalSymbol++ }},
+		{name: "state", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.EOFState++ }},
+		{name: "offset", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.EOFByteOffset++ }},
+		{name: "passes", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.Passes++ }},
+		{name: "elections", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.Elections++ }},
+		{name: "lookups", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.ActionLookups++ }},
+		{name: "dispatches", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.Dispatches++ }},
+		{name: "ordinary_shifts", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.OrdinaryShifts++ }},
+		{name: "ordinary_cohorts", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.OrdinaryCohorts++ }},
+		{name: "extra_shifts", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.ExtraShifts++ }},
+		{name: "extra_cohorts", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.ExtraCohorts++ }},
+		{name: "reductions", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.Reductions++ }},
+		{name: "conflicts", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.Conflicts++ }},
+		{name: "conflict_actions", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.ConflictActions++ }},
+		{name: "forks", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.Forks++ }},
+		{name: "repetition_folds", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.RepetitionFolds++ }},
+		{name: "recovery_work", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.RecoveryWork++ }},
+		{name: "no_action_drops", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.NoActionDrops++ }},
+		{name: "reduction_pauses", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.ReductionPauses++ }},
+		{name: "accepts", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.Accepts++ }},
+		{name: "canonicalizations", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.Canonicalizations++ }},
+		{name: "peak_headers", edit: func(receipt *gts.CompactRecoverEOFArtifactReceipt) { receipt.PeakHeaders++ }},
+	}
+	for _, tt := range tamper {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := want
+			tt.edit(&candidate)
+			lang.CompactRecoverEOFArtifactReceipt = candidate
+			defer func() { lang.CompactRecoverEOFArtifactReceipt = want }()
+			tree, telemetry, ok, reason := gts.TryCompactRecoverEOFAcceptTelemetryForTest(
+				gts.NewParser(lang), []byte("[\n"),
+			)
+			if tree != nil {
+				tree.Release()
+			}
+			if ok || reason == "" || telemetry.RecoverEOFAccepts != 0 {
+				t.Fatalf("tampered receipt routed: ok=%t reason=%q telemetry=%+v", ok, reason, telemetry)
+			}
+		})
+	}
+}
+
+func TestAdmissionRecoverEOFPayloadCountFallsBackForUnfinishedYAML(t *testing.T) {
+	lang := grammars.YamlLanguage()
+	for _, source := range []string{"a: [1\n", "\"a\": [\"x\"\n"} {
+		t.Run(source, func(t *testing.T) {
+			tree, ok, reason := gts.TryCompactFullParseRouteForTest(gts.NewParser(lang), []byte(source))
+			if tree != nil {
+				tree.Release()
+			}
+			if ok || reason == "" {
+				t.Fatalf("unfinished YAML route ok=%t reason=%q, want fail-closed fallback", ok, reason)
+			}
+
+			production := gts.NewParser(lang)
+			production.SetAdmissionCandidateRoute(false)
+			want, err := production.Parse([]byte(source))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer want.Release()
+
+			candidate := gts.NewParser(lang)
+			candidate.SetAdmissionCandidateRoute(true)
+			got, err := candidate.Parse([]byte(source))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer got.Release()
+			if got.RootNode().SExpr(lang) != want.RootNode().SExpr(lang) {
+				t.Fatalf("unfinished YAML fallback tree=%s want=%s", got.RootNode().SExpr(lang), want.RootNode().SExpr(lang))
+			}
+		})
+	}
+}
+
+func TestAdmissionRecoverEOFIncrementalMarkerForcesFreshTree(t *testing.T) {
+	lang := grammars.YamlLanguage()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	oldSource := []byte("[\n")
+	oldTree, err := parser.Parse(oldSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldTree == nil || oldTree.RootNode() == nil || !oldTree.RootNode().IsError() {
+		if oldTree != nil {
+			oldTree.Release()
+		}
+		t.Fatal("recover_eof source did not produce its ERROR root")
+	}
+	defer oldTree.Release()
+	oldTree.Edit(gts.InputEdit{
+		StartByte:   0,
+		OldEndByte:  1,
+		NewEndByte:  1,
+		StartPoint:  gts.Point{},
+		OldEndPoint: gts.Point{Column: 1},
+		NewEndPoint: gts.Point{Column: 1},
+	})
+	newSource := []byte("]\n")
+	got, profile, err := parser.ParseIncrementalProfiled(newSource, oldTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.RootNode() == nil {
+		if got != nil {
+			got.Release()
+		}
+		t.Fatal("incremental marker fallback returned no tree")
+	}
+	defer got.Release()
+	freshParser := gts.NewParser(lang)
+	freshParser.SetAdmissionCandidateRoute(false)
+	want, err := freshParser.Parse(newSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer want.Release()
+	if got.RootNode().SExpr(lang) != want.RootNode().SExpr(lang) {
+		t.Fatalf("incremental marker tree=%s want fresh=%s", got.RootNode().SExpr(lang), want.RootNode().SExpr(lang))
+	}
+	if profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 ||
+		!profile.ReuseUnsupported || !strings.Contains(profile.ReuseUnsupportedReason, "compact") {
+		t.Fatalf("recover_eof marker reused old tree: %+v", profile)
+	}
+}
+
+func TestAdmissionRecoverEOFUnfinishedYAMLIncrementalFallsBackCorrectly(t *testing.T) {
+	lang := grammars.YamlLanguage()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	oldSource := []byte("\"a\": [\"x\"\n")
+	oldTree, err := parser.Parse(oldSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oldTree.Release()
+	oldTree.Edit(gts.InputEdit{
+		StartByte:   7,
+		OldEndByte:  8,
+		NewEndByte:  8,
+		StartPoint:  gts.Point{Column: 7},
+		OldEndPoint: gts.Point{Column: 8},
+		NewEndPoint: gts.Point{Column: 8},
+	})
+	newSource := []byte("\"a\": [\"y\"\n")
+	got, _, err := parser.ParseIncrementalProfiled(newSource, oldTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer got.Release()
+	freshParser := gts.NewParser(lang)
+	freshParser.SetAdmissionCandidateRoute(false)
+	want, err := freshParser.Parse(newSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer want.Release()
+	if got.RootNode().SExpr(lang) != want.RootNode().SExpr(lang) {
+		t.Fatalf("unfinished YAML incremental tree=%s want fresh=%s", got.RootNode().SExpr(lang), want.RootNode().SExpr(lang))
+	}
+}

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -46,6 +46,7 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 	if p == nil || p.language == nil {
 		return nil, errors.New("admission candidate route: parser has no language")
 	}
+	allowRecoverEOF := compactRecoverEOFArtifactConfigured(p.language)
 	options := DiagnosticParserCorePrefixOptions{
 		ReceiptMode:                    DiagnosticParserCoreReceiptSummary,
 		MaxTokens:                      1 << 24,
@@ -62,10 +63,12 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		allowCompactAcceptanceStructuralElection: p.language.CompactAcceptanceStructuralElectionCertified,
 		allowConvergedSplitDropArtifact:          p.language.CompactConvergedReductionSplitDropsCertified,
 		captureLexerSkippedPrefixProvenance:      p.language.CompactLexerSkippedPrefixTilingCertified,
-		// Recovery admits the certified S3 base mechanism. S4 and S5 also need
-		// their fork gate and the lineage-selection gate.
-		Recovery:                          p.language.CompactStrategy2ErrorRegionCertified,
+		// Recovery admits either the certified S3 base mechanism or the
+		// dedicated recover_eof root route. The latter does not enable S3, S4,
+		// or S5.
+		Recovery:                          p.language.CompactStrategy2ErrorRegionCertified || allowRecoverEOF,
 		allowCompactStrategy2ErrorRegion:  p.language.CompactStrategy2ErrorRegionCertified,
+		allowCompactRecoverEOF:            allowRecoverEOF,
 		allowCompactStackSummaryRecovery:  p.language.CompactStackSummaryRecoveryCertified,
 		allowCompactMissingTokenInsertion: p.language.CompactMissingTokenInsertionCertified,
 		allowCompactRecoveryLineageSelection: p.language.CompactStrategy2ErrorRegionCertified &&
@@ -303,6 +306,9 @@ func (p *Parser) tryCompactFullParseRoute(source []byte) (*Tree, bool, string) {
 //     claim; see docs/compat-tail-elision.md.
 func (p *Parser) finalizeCompactReturnedTreeForParse(tree *Tree, source []byte) {
 	if !shouldNormalizeReturnedTree(tree) {
+		return
+	}
+	if compactRecoverEOFRootSpanPreserved(tree) {
 		return
 	}
 	if tree.hasDeferredResultCompatibility() {

--- a/cgo_harness/compact_t3_oracle_adjudication_test.go
+++ b/cgo_harness/compact_t3_oracle_adjudication_test.go
@@ -815,8 +815,8 @@ func assertCompactT3Outcome(t *testing.T, witness compactT3Witness, route string
 // compactT3StructuralDivergence is one node-level structural mismatch found
 // while walking a Go tree against the pinned C oracle tree in lockstep. The
 // compared axes are exactly the B3 stage S1 obligation: deep-tree shape
-// (type, child count), byte and point spans, the Missing flag, HasError, and
-// child field names.
+// (type, child count), byte and point spans, named and extra flags, the
+// Missing flag, direct and propagated error flags, and child field names.
 type compactT3StructuralDivergence struct {
 	Path     string
 	Category string
@@ -862,6 +862,18 @@ func compactT3WalkStructuralDivergences(goNode *gotreesitter.Node, goLang *gotre
 		*out = append(*out, compactT3StructuralDivergence{
 			Path: path, Category: "named",
 			GoValue: fmt.Sprintf("%v", goNode.IsNamed()), CValue: fmt.Sprintf("%v", cNode.IsNamed()),
+		})
+	}
+	if goNode.IsExtra() != cNode.IsExtra() {
+		*out = append(*out, compactT3StructuralDivergence{
+			Path: path, Category: "extra",
+			GoValue: fmt.Sprintf("%v", goNode.IsExtra()), CValue: fmt.Sprintf("%v", cNode.IsExtra()),
+		})
+	}
+	if goNode.IsError() != cNode.IsError() {
+		*out = append(*out, compactT3StructuralDivergence{
+			Path: path, Category: "error",
+			GoValue: fmt.Sprintf("%v", goNode.IsError()), CValue: fmt.Sprintf("%v", cNode.IsError()),
 		})
 	}
 	if goNode.IsMissing() != cNode.IsMissing() {

--- a/cgo_harness/yaml_eof_recovery_compact_regression_test.go
+++ b/cgo_harness/yaml_eof_recovery_compact_regression_test.go
@@ -1,0 +1,188 @@
+//go:build cgo && treesitter_c_parity && !gts_no_parsercorephase0
+
+package cgoharness
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestYAMLEOFRecoverWrapCompactRoute keeps the compact route aligned with the
+// locked C recover_eof root for this certified YAML boundary.
+func TestYAMLEOFRecoverWrapCompactRoute(t *testing.T) {
+	source := []byte("[\n")
+	cLanguage, err := ParityCLanguage("yaml")
+	if err != nil {
+		t.Fatalf("load YAML C oracle: %v", err)
+	}
+	cTree := compactT3ParseC(t, cLanguage, source)
+	defer cTree.Close()
+	cRoot := cTree.RootNode()
+	if cRoot == nil {
+		t.Fatal("YAML C oracle returned no root")
+	}
+	if cRoot.Kind() != "ERROR" || cRoot.IsExtra() || !cRoot.IsError() || !cRoot.HasError() {
+		t.Fatalf("C root kind=%q extra=%t is_error=%t has_error=%t, want non-extra ERROR with both error flags", cRoot.Kind(), cRoot.IsExtra(), cRoot.IsError(), cRoot.HasError())
+	}
+	if cRoot.StartByte() != 0 || cRoot.EndByte() != 1 {
+		t.Fatalf("C root span=%d..%d, want 0..1", cRoot.StartByte(), cRoot.EndByte())
+	}
+
+	wantChildren := []struct {
+		kind       string
+		start, end uint64
+	}{
+		{kind: "[", start: 0, end: 1},
+	}
+	if got := int(cRoot.ChildCount()); got != len(wantChildren) {
+		t.Fatalf("C root child count=%d, want %d", got, len(wantChildren))
+	}
+	for i, want := range wantChildren {
+		child := cRoot.Child(uint(i))
+		if child == nil {
+			t.Fatalf("C root child[%d] is nil", i)
+		}
+		if child.Kind() != want.kind || uint64(child.StartByte()) != want.start || uint64(child.EndByte()) != want.end {
+			t.Fatalf("C root child[%d]=%q[%d..%d], want %q[%d..%d]", i, child.Kind(), child.StartByte(), child.EndByte(), want.kind, want.start, want.end)
+		}
+	}
+
+	goLanguage := grammars.YamlLanguage()
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	compactTree := compactT3ParseGo(t, goLanguage, source, true)
+	defer compactTree.Release()
+	goRoot := compactTree.RootNode()
+	if goRoot == nil {
+		t.Fatal("compact Go route returned no root")
+	}
+	if goRoot.Type(goLanguage) != "ERROR" || goRoot.IsExtra() || !goRoot.IsError() || !goRoot.HasError() ||
+		goRoot.StartByte() != 0 || goRoot.EndByte() != 1 {
+		t.Fatalf("compact Go root kind=%q span=%d..%d extra=%t is_error=%t has_error=%t, want non-extra ERROR 0..1 with both error flags", goRoot.Type(goLanguage), goRoot.StartByte(), goRoot.EndByte(), goRoot.IsExtra(), goRoot.IsError(), goRoot.HasError())
+	}
+	if divergences := compactT3StructuralDivergences(goRoot, goLanguage, cRoot); len(divergences) != 0 {
+		formatted := make([]string, len(divergences))
+		for index, divergence := range divergences {
+			formatted[index] = compactT3FormatDivergence(divergence)
+		}
+		t.Fatalf("compact Go/C YAML recover_eof tree diverged:\n%s\nGo: %s\n%s\nC: %s\n%s", strings.Join(formatted, "\n"), goRoot.SExpr(goLanguage), dumpGoTree(goRoot, goLanguage, 0), cRoot.ToSexp(), dumpCTree(cRoot, 0))
+	}
+	if got := goRoot.ChildCount(); got != len(wantChildren) {
+		t.Fatalf("compact Go root child count=%d, want %d", got, len(wantChildren))
+	}
+	for i := 0; i < goRoot.ChildCount(); i++ {
+		child := goRoot.Child(i)
+		want := wantChildren[i]
+		if child == nil || uint64(child.StartByte()) != want.start || uint64(child.EndByte()) != want.end || child.IsExtra() || child.IsError() || child.Parent() != goRoot {
+			t.Fatalf("compact Go root child[%d] invalid: child=%v, want span=%d..%d non-extra non-error", i, child, want.start, want.end)
+		}
+	}
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter-routedBefore != 1 || fallbackAfter-fallbackBefore != 0 {
+		t.Fatalf("compact route counters=%d/%d, want publication 1/0; reason=%q", routedAfter-routedBefore, fallbackAfter-fallbackBefore, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+}
+
+func TestYAMLEOFRecoverWrapUnfinishedMappingDeclinesCompact(t *testing.T) {
+	source := []byte("a: [1\n")
+	cLanguage, err := ParityCLanguage("yaml")
+	if err != nil {
+		t.Fatalf("load YAML C oracle: %v", err)
+	}
+	cTree := compactT3ParseC(t, cLanguage, source)
+	defer cTree.Close()
+	cRoot := cTree.RootNode()
+	if cRoot == nil {
+		t.Fatal("YAML C oracle returned no root")
+	}
+	if cRoot.Kind() != "ERROR" || cRoot.IsExtra() || !cRoot.IsError() || !cRoot.HasError() ||
+		cRoot.StartByte() != 0 || cRoot.EndByte() != 5 || cRoot.ChildCount() != 4 {
+		t.Fatalf("C root=%q[%d..%d] extra=%t is_error=%t has_error=%t children=%d, want non-extra ERROR 0..5 with four children", cRoot.Kind(), cRoot.StartByte(), cRoot.EndByte(), cRoot.IsExtra(), cRoot.IsError(), cRoot.HasError(), cRoot.ChildCount())
+	}
+	wantChildren := []struct {
+		kind                  string
+		start, end            uint
+		named, missing, extra bool
+	}{
+		{kind: "flow_node", start: 0, end: 1, named: true},
+		{kind: ":", start: 1, end: 2},
+		{kind: "[", start: 3, end: 4},
+		{kind: "flow_node", start: 4, end: 5, named: true},
+	}
+	for index, want := range wantChildren {
+		child := cRoot.Child(uint(index))
+		if child == nil || child.Kind() != want.kind || child.StartByte() != want.start || child.EndByte() != want.end ||
+			child.IsNamed() != want.named || child.IsMissing() != want.missing || child.IsExtra() != want.extra || child.IsError() || child.HasError() {
+			t.Fatalf("C root child[%d]=%v, want %q[%d..%d] named=%t ordinary", index, child, want.kind, want.start, want.end, want.named)
+		}
+	}
+	goLanguage := grammars.YamlLanguage()
+	goParser := gotreesitter.NewParser(goLanguage)
+	goParser.SetAdmissionCandidateRoute(true)
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	goTree, err := goParser.Parse(source)
+	if err != nil {
+		t.Fatalf("unfinished mapping admission parse: %v", err)
+	}
+	defer goTree.Release()
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter-routedBefore != 0 || fallbackAfter-fallbackBefore != 1 ||
+		gotreesitter.AdmissionCandidateLastFallbackReason() == "" {
+		t.Fatalf("unfinished mapping compact direct admission routed=%d fallback=%d reason=%q, want 0/1 decline", routedAfter-routedBefore, fallbackAfter-fallbackBefore, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+}
+
+func TestYAMLOneBytePrintableEOFAdmissionMatchesLockedC(t *testing.T) {
+	cLanguage, err := ParityCLanguage("yaml")
+	if err != nil {
+		t.Fatalf("load YAML C oracle: %v", err)
+	}
+	goLanguage := grammars.YamlLanguage()
+	for value := byte(0x21); value <= 0x7e; value++ {
+		value := value
+		t.Run(fmt.Sprintf("byte_%02x", value), func(t *testing.T) {
+			source := []byte{value, '\n'}
+			cTree := compactT3ParseC(t, cLanguage, source)
+			defer cTree.Close()
+			cRoot := cTree.RootNode()
+			if cRoot == nil {
+				t.Fatal("YAML C oracle returned no root")
+			}
+
+			goParser := gotreesitter.NewParser(goLanguage)
+			goParser.SetAdmissionCandidateRoute(true)
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			goTree, err := goParser.Parse(source)
+			if err != nil {
+				t.Fatalf("one-byte YAML admission parse: %v", err)
+			}
+			defer goTree.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			routedDelta := routedAfter - routedBefore
+			fallbackDelta := fallbackAfter - fallbackBefore
+			if routedDelta == 0 {
+				if fallbackDelta != 1 {
+					t.Fatalf("declined one-byte YAML route counters=%d/%d, want 0/1", routedDelta, fallbackDelta)
+				}
+				return
+			}
+			if routedDelta != 1 || fallbackDelta != 0 {
+				t.Fatalf("admitted one-byte YAML route counters=%d/%d, want 1/0", routedDelta, fallbackDelta)
+			}
+			goRoot := goTree.RootNode()
+			if goRoot == nil {
+				t.Fatal("admitted one-byte YAML route returned no root")
+			}
+			if divergences := compactT3StructuralDivergences(goRoot, goLanguage, cRoot); len(divergences) != 0 {
+				formatted := make([]string, len(divergences))
+				for index, divergence := range divergences {
+					formatted[index] = compactT3FormatDivergence(divergence)
+				}
+				t.Fatalf("admitted one-byte YAML Go/C tree diverged:\n%s\nGo: %s\n%s\nC: %s\n%s", strings.Join(formatted, "\n"), goRoot.SExpr(goLanguage), dumpGoTree(goRoot, goLanguage, 0), cRoot.ToSexp(), dumpCTree(cRoot, 0))
+			}
+		})
+	}
+}

--- a/export_recover_eof_test.go
+++ b/export_recover_eof_test.go
@@ -1,0 +1,32 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+// CompactRecoverEOFAcceptTelemetryForTest captures the private runner receipt
+// and public runtime for one direct compact recover_eof test route.
+//
+// This test-only seam keeps the scheduler work counter out of the production
+// API while allowing external grammar tests to verify live publication.
+type CompactRecoverEOFAcceptTelemetryForTest struct {
+	RecoverEOFAccepts uint64
+	Runtime           ParseRuntime
+}
+
+// TryCompactRecoverEOFAcceptTelemetryForTest runs the direct compact candidate
+// route and returns its scheduler recover_eof count and tree runtime.
+func TryCompactRecoverEOFAcceptTelemetryForTest(
+	p *Parser,
+	source []byte,
+) (tree *Tree, telemetry CompactRecoverEOFAcceptTelemetryForTest, ok bool, reason string) {
+	if p == nil {
+		return nil, telemetry, false, "parser is nil"
+	}
+	tree, ok, reason = p.tryCompactFullParseRoute(source)
+	if runner, err := p.acquireAdmissionCandidateRunner(); err == nil && runner != nil {
+		telemetry.RecoverEOFAccepts = runner.scheduler.work.RecoverEOFAccepts
+	}
+	if tree != nil {
+		telemetry.Runtime = tree.ParseRuntime()
+	}
+	return tree, telemetry, ok, reason
+}

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -29,6 +29,7 @@ type builtinLanguageRuntimeProfile struct {
 	exactStackNodeEquivalence           bool
 	compactPackedGSSVersionOrder        bool
 	compactStrategy2ErrorRegion         bool
+	compactRecoverEOFArtifact           gotreesitter.CompactRecoverEOFArtifactReceipt
 	compactStackSummaryRecovery         bool
 	compactMissingTokenInsertion        bool
 	compactRecoveryTrailingRetirement   bool
@@ -67,6 +68,37 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	"go": {
 		blobSHA256:                 mustRuntimeProfileSHA256("9cf914d26d962d1a62e7954f8b20b302337a44cb7d4a07218eec482c45a57a08"),
 		compactConvergedSplitDrops: true,
+	},
+	// YAML's irreducible flow opener has one direct no-action EOF lineage whose
+	// C result is the recover_eof ERROR root. Keep this gate independent from
+	// S3, S4, and S5.
+	"yaml": {
+		blobSHA256: mustRuntimeProfileSHA256("9ac37a326be7a4f4297efa6e43ba00317c5959e7b4909c9262043d408f284b30"),
+		compactRecoverEOFArtifact: gotreesitter.CompactRecoverEOFArtifactReceipt{
+			BlobSHA256:        mustRuntimeProfileSHA256("9ac37a326be7a4f4297efa6e43ba00317c5959e7b4909c9262043d408f284b30"),
+			TerminalSymbol:    26,
+			EOFState:          189,
+			EOFByteOffset:     1,
+			Passes:            2,
+			Elections:         2,
+			ActionLookups:     2,
+			Dispatches:        1,
+			OrdinaryShifts:    1,
+			OrdinaryCohorts:   0,
+			ExtraShifts:       0,
+			ExtraCohorts:      0,
+			Reductions:        0,
+			Conflicts:         0,
+			ConflictActions:   0,
+			Forks:             0,
+			RepetitionFolds:   0,
+			RecoveryWork:      0,
+			NoActionDrops:     0,
+			ReductionPauses:   0,
+			Accepts:           0,
+			Canonicalizations: 1,
+			PeakHeaders:       1,
+		},
 	},
 	"erlang": {
 		blobSHA256:                   mustRuntimeProfileSHA256("355deb34ae4b9d8e0bf649c1c36096929d5e403107fa3c8b9c2ee82b138dfdc5"),
@@ -731,6 +763,16 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	if profile.compactStrategy2ErrorRegion && !lang.CompactStrategy2ErrorRegionCertified {
 		lang.CompactStrategy2ErrorRegionCertified = true
 		changed = true
+	}
+	if profile.compactRecoverEOFArtifact.BlobSHA256 != ([32]byte{}) {
+		if lang.CompactRecoverEOFArtifactReceipt != profile.compactRecoverEOFArtifact {
+			lang.CompactRecoverEOFArtifactReceipt = profile.compactRecoverEOFArtifact
+			changed = true
+		}
+		if !lang.CompactRecoverEOFCertified {
+			lang.CompactRecoverEOFCertified = true
+			changed = true
+		}
 	}
 	if profile.compactStackSummaryRecovery && !lang.CompactStackSummaryRecoveryCertified {
 		lang.CompactStackSummaryRecoveryCertified = true

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -71,6 +71,57 @@ func TestHTMLProfileCertifiesCompleteCompactRecovery(t *testing.T) {
 	}
 }
 
+func TestYAMLProfileCertifiesOnlyExactRecoverEOFArtifact(t *testing.T) {
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+	lang := YamlLanguage()
+	if !lang.CompactRecoverEOFCertified {
+		t.Fatal("the YAML profile did not attach recover_eof certification")
+	}
+	wantArtifact := gotreesitter.CompactRecoverEOFArtifactReceipt{
+		BlobSHA256:        mustRuntimeProfileSHA256("9ac37a326be7a4f4297efa6e43ba00317c5959e7b4909c9262043d408f284b30"),
+		TerminalSymbol:    26,
+		EOFState:          189,
+		EOFByteOffset:     1,
+		Passes:            2,
+		Elections:         2,
+		ActionLookups:     2,
+		Dispatches:        1,
+		OrdinaryShifts:    1,
+		OrdinaryCohorts:   0,
+		ExtraShifts:       0,
+		ExtraCohorts:      0,
+		Reductions:        0,
+		Conflicts:         0,
+		ConflictActions:   0,
+		Forks:             0,
+		RepetitionFolds:   0,
+		RecoveryWork:      0,
+		NoActionDrops:     0,
+		ReductionPauses:   0,
+		Accepts:           0,
+		Canonicalizations: 1,
+		PeakHeaders:       1,
+	}
+	if lang.CompactRecoverEOFArtifactReceipt != wantArtifact {
+		t.Fatalf("YAML recover_eof artifact receipt=%+v, want %+v", lang.CompactRecoverEOFArtifactReceipt, wantArtifact)
+	}
+	if lang.CompactStrategy2ErrorRegionCertified || lang.CompactStackSummaryRecoveryCertified ||
+		lang.CompactMissingTokenInsertionCertified {
+		t.Fatal("the YAML recover_eof profile enabled another recovery mechanism")
+	}
+	stale := &gotreesitter.Language{}
+	if attachBuiltinLanguageRuntimeProfile("yaml", sha256.Sum256([]byte("stale yaml blob")), stale) ||
+		stale.CompactRecoverEOFCertified {
+		t.Fatal("a stale YAML blob received recover_eof certification")
+	}
+	exact := &gotreesitter.Language{}
+	blob := BlobByName("yaml")
+	if len(blob) == 0 || !attachBuiltinLanguageRuntimeProfile("yaml", sha256.Sum256(blob), exact) ||
+		!exact.CompactRecoverEOFCertified || exact.CompactRecoverEOFArtifactReceipt != wantArtifact {
+		t.Fatal("the exact YAML blob did not receive recover_eof certification")
+	}
+}
+
 func TestJavaScriptProfileCertifiesCompactRecoveryFrontier(t *testing.T) {
 	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
 	lang := JavascriptLanguage()
@@ -140,7 +191,8 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	// skipped-prefix evidence for compact reduce tiling.
 	// 50 = the prior 49 plus the Markdown inline entry. It certifies four exact
 	// compact conflict rows while production parsing ignores them.
-	if got, want := len(builtinLanguageRuntimeProfiles), 50; got != want {
+	// 51 = the prior 50 plus the irreducible YAML recover_eof EOF-root entry.
+	if got, want := len(builtinLanguageRuntimeProfiles), 51; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -176,6 +228,9 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	}
 	if lang.CompactPackedGSSVersionOrderCertified {
 		t.Fatal("unknown runtime profile enabled packed GSS version ordering")
+	}
+	if lang.CompactRecoverEOFCertified {
+		t.Fatal("unknown runtime profile enabled recover_eof acceptance")
 	}
 	if lang.CompactRecoveryPlainFirstCertified {
 		t.Fatal("unknown runtime profile enabled compact plain-first recovery")

--- a/incremental_leaf_fastpath.go
+++ b/incremental_leaf_fastpath.go
@@ -6,6 +6,9 @@ func (p *Parser) tryTokenInvariantLeafEdit(source []byte, oldTree *Tree, ts Toke
 	if p == nil || oldTree == nil || oldTree.RootNode() == nil || oldTree.language != p.language {
 		return nil, false
 	}
+	if compactRecoverEOFTreeMarked(oldTree) {
+		return nil, false
+	}
 	if len(oldTree.edits) != 1 {
 		return nil, false
 	}
@@ -795,6 +798,9 @@ func asciiLower(b byte) byte {
 
 func (p *Parser) tokenInvariantLeafEditCandidate(source []byte, oldTree *Tree) (*Node, InputEdit, bool) {
 	if p == nil || oldTree == nil || oldTree.RootNode() == nil || oldTree.language != p.language {
+		return nil, InputEdit{}, false
+	}
+	if compactRecoverEOFTreeMarked(oldTree) {
 		return nil, InputEdit{}, false
 	}
 	if len(oldTree.edits) != 1 {

--- a/incremental_leaf_fastpath_test.go
+++ b/incremental_leaf_fastpath_test.go
@@ -14,6 +14,40 @@ func TestSnapshotTokenSourceStateUnsupportedType(t *testing.T) {
 	}
 }
 
+func TestTokenInvariantLeafEditRejectsMarkedCompactRecoverEOF(t *testing.T) {
+	lang := &Language{
+		Name:                       "yaml",
+		CompactRecoverEOFCertified: true,
+		SymbolNames:                []string{"ERROR", "string_scalar"},
+	}
+	child := &Node{symbol: 1, startByte: 0, endByte: 1}
+	root := &Node{
+		symbol:    errorSymbol,
+		startByte: 0,
+		endByte:   1,
+		children:  []*Node{child},
+		flags:     nodeFlagHasError | nodeFlagCompactRecoverEOF,
+	}
+	child.parent = root
+	oldTree := &Tree{
+		root:                root,
+		source:              []byte("a\n"),
+		language:            lang,
+		lastEditedLeaf:      child,
+		compactMaterialized: true,
+		edits: []InputEdit{{
+			StartByte: 0, OldEndByte: 1, NewEndByte: 1,
+		}},
+	}
+	p := &Parser{language: lang}
+	if reused, ok := p.tryTokenInvariantLeafEdit([]byte("b\n"), oldTree, nil, nil); ok || reused != nil {
+		if reused != nil {
+			reused.Release()
+		}
+		t.Fatal("marked compact recover_eof tree entered token-invariant reuse")
+	}
+}
+
 func TestYAMLPlainScalarKind(t *testing.T) {
 	for _, tc := range []struct {
 		text string

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1228,12 +1228,16 @@ type Core struct {
 	children             []SubtreeID
 	fields               []FieldMapEntry
 	aliases              []Symbol
-	frontier             uint64
-	checkpoint           CheckpointID
-	checkpoints          checkpointInterner
-	boundaries           boundaryIndex
-	boundaryJournal      []boundaryMutation
-	nodeLineageJournal   []nodeLineageMutation
+	// eofRecoveryRoots records synthetic non-extra ERROR roots published by
+	// RecoverEOFAcceptOwned. Keep this provenance outside subtreeRecord: that
+	// record is size-pinned at 44 bytes for every compact payload.
+	eofRecoveryRoots   []SubtreeID
+	frontier           uint64
+	checkpoint         CheckpointID
+	checkpoints        checkpointInterner
+	boundaries         boundaryIndex
+	boundaryJournal    []boundaryMutation
+	nodeLineageJournal []nodeLineageMutation
 	// alternativeSpillArena backs every AlternativeSet beyond
 	// alternativeSetInlineCapacity members, shared by nodeLineages and every
 	// diagnosticParserCoreHeader.altSet (parsercore_phase0_driver.go). It
@@ -1399,6 +1403,7 @@ type checkpoint struct {
 	nodes, nodeLineages, nodeCheckpoints, links, subtrees, externalProvenance int
 	lexerSkippedPrefixes                                                      int
 	children, fields, aliases                                                 int
+	eofRecoveryRoots                                                          int
 	dropCohortLinkRefIndexes                                                  int
 	dropCohortLinkRefJournal                                                  int
 	frontier                                                                  uint64
@@ -1517,6 +1522,7 @@ func (c *Core) markInto(mark *checkpoint) {
 		externalProvenance:   len(c.externalProvenance),
 		lexerSkippedPrefixes: len(c.lexerSkippedPrefixes),
 		children:             len(c.children), fields: len(c.fields), aliases: len(c.aliases),
+		eofRecoveryRoots: len(c.eofRecoveryRoots),
 
 		dropCohortLinkRefIndexes: len(c.dropCohortLinkRefIndexes),
 		dropCohortLinkRefJournal: len(c.dropCohortLinkRefJournal),
@@ -1623,6 +1629,7 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 	c.nodeCheckpoints = c.nodeCheckpoints[:mark.nodeCheckpoints]
 	c.links = c.links[:mark.links]
 	c.subtrees = c.subtrees[:mark.subtrees]
+	c.eofRecoveryRoots = c.eofRecoveryRoots[:mark.eofRecoveryRoots]
 	c.externalProvenance = c.externalProvenance[:mark.externalProvenance]
 	c.lexerSkippedPrefixes = c.lexerSkippedPrefixes[:mark.lexerSkippedPrefixes]
 	c.children = c.children[:mark.children]
@@ -2120,6 +2127,7 @@ func (c *Core) Reset() error {
 	clear(c.dropCohortLinkRefIndexes)
 	c.dropCohortLinkRefIndexes = c.dropCohortLinkRefIndexes[:0]
 	c.subtrees = c.subtrees[:0]
+	c.eofRecoveryRoots = c.eofRecoveryRoots[:0]
 	c.externalProvenance = c.externalProvenance[:0]
 	c.lexerSkippedPrefixes = c.lexerSkippedPrefixes[:0]
 	c.children = c.children[:0]
@@ -5502,6 +5510,13 @@ func (c *Core) validateMaterializationMetadata(id SubtreeID, record subtreeRecor
 	// materialization adds no evidence. The flag is Core-scoped so subtreeRecord
 	// remains byte-for-byte unchanged on the scheduler's hot equality/copy path.
 	if c.metadataConstructionAuthenticated {
+		return nil
+	}
+	if c.isRecoverEOFAcceptRoot(id) {
+		if record.symbol != ErrorRegionSymbol || record.extra || record.terminal ||
+			record.fieldCount != 0 || record.aliasCount != 0 {
+			return errors.New("parser-core phase zero: malformed recover_eof root provenance")
+		}
 		return nil
 	}
 	return c.validateGenericMaterializationMetadata(id, record)

--- a/internal/parsercorephase0/eof_recovery_live.go
+++ b/internal/parsercorephase0/eof_recovery_live.go
@@ -1,0 +1,152 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+)
+
+// RecoverEOFAcceptOwned replaces one authenticated, exact singleton stack
+// path with the non-extra ERROR root that tree-sitter publishes from
+// recover_eof. originalPayloads authenticate the exact path and become the
+// children of the new root. The caller must keep the returned head and root
+// together.
+//
+// The mutation runs through the scheduler-owner seam. A caller that needs a
+// rollback must place this operation inside ApplySchedulerAtomic; a fresh
+// scheduler session rolls back the complete Core when its owner returns an
+// error. The root provenance sidecar lets generic materialization authenticate
+// this synthetic production without growing subtreeRecord.
+func (c *Core) RecoverEOFAcceptOwned(
+	owner SchedulerTransactionToken,
+	head Head,
+	payloads []SubtreeID,
+	startByte uint32,
+	endByte uint32,
+) (out Head, root SubtreeID, err error) {
+	if c == nil {
+		return Head{}, 0, errors.New("parser-core phase zero: recover_eof accept on nil core")
+	}
+	err = c.RunSchedulerOwned(owner, func() error {
+		var operationErr error
+		out, root, operationErr = c.recoverEOFAcceptUncheckpointed(
+			head, payloads, startByte, endByte,
+		)
+		return operationErr
+	})
+	if err != nil {
+		return Head{}, 0, err
+	}
+	return out, root, nil
+}
+
+func (c *Core) recoverEOFAcceptUncheckpointed(
+	head Head,
+	payloads []SubtreeID,
+	startByte uint32,
+	endByte uint32,
+) (Head, SubtreeID, error) {
+	if head.Node == 0 {
+		return Head{}, 0, errors.New("parser-core phase zero: recover_eof accept requires a head")
+	}
+	if len(payloads) == 0 || len(payloads) > EOFAdmissionMaxTopPayloads {
+		return Head{}, 0, fmt.Errorf(
+			"parser-core phase zero: recover_eof accept payload count %d is outside 1..%d",
+			len(payloads), EOFAdmissionMaxTopPayloads,
+		)
+	}
+	if startByte > endByte {
+		return Head{}, 0, errors.New("parser-core phase zero: recover_eof accept span is reversed")
+	}
+	if _, err := c.node(head.Node); err != nil {
+		return Head{}, 0, err
+	}
+	paths, err := c.Derivations(head)
+	if err != nil {
+		return Head{}, 0, err
+	}
+	if len(paths) != 1 || !slices.Equal(paths[0].Payloads, payloads) {
+		return Head{}, 0, errors.New("parser-core phase zero: recover_eof accept requires one exact singleton path")
+	}
+	if err := c.validateRecoverEOFAcceptPayloads(payloads, startByte, endByte); err != nil {
+		return Head{}, 0, err
+	}
+
+	root, err := c.appendSubtree(subtreeRecord{
+		symbol:    ErrorRegionSymbol,
+		startByte: startByte,
+		endByte:   endByte,
+	}, payloads, nil, nil)
+	if err != nil {
+		return Head{}, 0, err
+	}
+	// Mark the synthetic root only after its record is complete. The marker is
+	// length-journaled by Core checkpoints and therefore rolls back with it.
+	c.eofRecoveryRoots = append(c.eofRecoveryRoots, root)
+
+	// The recovered root replaces the old stack path. Build a private empty
+	// predecessor so the new head has exactly one payload and no old siblings.
+	base, err := c.appendNodeAt(nodeRecord{
+		state: 1, byteOffset: endByte, pathCount: 1,
+	}, c.checkpoint)
+	if err != nil {
+		return Head{}, 0, err
+	}
+	linkID := c.appendGraphLink(linkRecord{prev: base, payload: root})
+	c.addWork(&c.work.GraphLinkAdditionsProxy, 1)
+	newNode, err := c.appendNodeAt(nodeRecord{
+		state: 1, byteOffset: endByte,
+		firstLink: uint32(linkID), linkCount: 1, pathCount: 1,
+	}, c.checkpoint)
+	if err != nil {
+		return Head{}, 0, err
+	}
+	return Head{Node: newNode}, root, nil
+}
+
+func (c *Core) validateRecoverEOFAcceptPayloads(payloads []SubtreeID, startByte, endByte uint32) error {
+	previousEnd := startByte
+	for index, payload := range payloads {
+		record, err := c.subtree(payload)
+		if err != nil {
+			return err
+		}
+		if record.extra {
+			return fmt.Errorf("parser-core phase zero: recover_eof accept payload %d is trailing extra", index)
+		}
+		if record.missing {
+			return fmt.Errorf("parser-core phase zero: recover_eof accept payload %d is missing", index)
+		}
+		_, exact, provenanceErr := c.subtreeExternalProvenance(payload)
+		if provenanceErr != nil {
+			return provenanceErr
+		}
+		if !exact {
+			return fmt.Errorf("parser-core phase zero: recover_eof accept payload %d has inexact external provenance", index)
+		}
+		if record.startByte > record.endByte || record.startByte < startByte || record.endByte > endByte {
+			return fmt.Errorf("parser-core phase zero: recover_eof accept payload %d is outside root span", index)
+		}
+		if index != 0 && record.startByte < previousEnd {
+			return fmt.Errorf("parser-core phase zero: recover_eof accept payload %d overlaps its predecessor", index)
+		}
+		previousEnd = record.endByte
+	}
+	return nil
+}
+
+func (c *Core) isRecoverEOFAcceptRoot(id SubtreeID) bool {
+	for _, root := range c.eofRecoveryRoots {
+		if root == id {
+			return true
+		}
+	}
+	return false
+}
+
+// IsRecoverEOFAcceptRoot reports whether id is the synthetic root published
+// by RecoverEOFAcceptOwned. The marker is provenance, not a grammar symbol:
+// ordinary ERROR subtrees must retain normal materialization checks.
+func (c *Core) IsRecoverEOFAcceptRoot(id SubtreeID) bool {
+	return c != nil && c.isRecoverEOFAcceptRoot(id)
+}

--- a/internal/parsercorephase0/eof_recovery_live_test.go
+++ b/internal/parsercorephase0/eof_recovery_live_test.go
@@ -1,0 +1,237 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type recoverEOFAcceptFixture struct {
+	core    *Core
+	head    Head
+	payload []SubtreeID
+}
+
+func newRecoverEOFAcceptFixture(t *testing.T) recoverEOFAcceptFixture {
+	t.Helper()
+	compact, err := New(&fakeTable{}, (Limits{}).withDefaults())
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact.CertifyExternalPayloadsQuiescent()
+	head, err := compact.Seed(7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payloads []SubtreeID
+	for index, symbol := range []Symbol{11, 12} {
+		payload, err := compact.appendSubtree(subtreeRecord{
+			symbol: symbol, startByte: uint32(index), endByte: uint32(index + 1), terminal: true,
+		}, nil, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payloads = append(payloads, payload)
+		head, err = compact.appendPrivate(8+StateID(index), uint32(index+1), linkInput{
+			prev: head.Node, payload: payload,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return recoverEOFAcceptFixture{core: compact, head: head, payload: payloads}
+}
+
+func TestRecoverEOFAcceptOwnedPublishesExactNonExtraRoot(t *testing.T) {
+	fixture := newRecoverEOFAcceptFixture(t)
+	storageBefore, footprintBefore := fixture.core.StorageBytes(), fixture.core.FootprintBytes()
+	var recovered Head
+	var root SubtreeID
+	if err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		var err error
+		recovered, root, err = fixture.core.RecoverEOFAcceptOwned(
+			owner, fixture.head, fixture.payload, 0, 2,
+		)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	view, err := fixture.core.Subtree(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.Symbol != ErrorRegionSymbol || view.Extra || view.Terminal || view.StartByte != 0 || view.EndByte != 2 {
+		t.Fatalf("recover_eof root=%+v, want non-extra non-terminal ERROR 0..2", view)
+	}
+	if !reflect.DeepEqual(view.Children, fixture.payload) {
+		t.Fatalf("recover_eof children=%v, want %v", view.Children, fixture.payload)
+	}
+	paths, err := fixture.core.Derivations(recovered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) != 1 || !reflect.DeepEqual(paths[0].Payloads, []SubtreeID{root}) {
+		t.Fatalf("recovered derivations=%+v, want one root payload %d", paths, root)
+	}
+	var visited []SubtreeID
+	if err := fixture.core.VisitMaterializationPostorder([]SubtreeID{root}, nil, func(id SubtreeID, _ MaterializationSubtreeView) error {
+		visited = append(visited, id)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	wantVisited := []SubtreeID{fixture.payload[0], fixture.payload[1], root}
+	if !reflect.DeepEqual(visited, wantVisited) {
+		t.Fatalf("materialization order=%v, want %v", visited, wantVisited)
+	}
+	wantStorageDelta := coreSubtreeRecordBytes + uint64(len(fixture.payload))*coreChildRecordBytes +
+		2*coreNodeRecordBytes + coreLinkRecordBytes + coreSubtreeIDBytes
+	if got := fixture.core.StorageBytes() - storageBefore; got != wantStorageDelta {
+		t.Fatalf("recover_eof storage delta=%d, want %d", got, wantStorageDelta)
+	}
+	if got := fixture.core.FootprintBytes(); got < footprintBefore+wantStorageDelta || got < fixture.core.StorageBytes() {
+		t.Fatalf("recover_eof footprint=%d before=%d storage=%d", got, footprintBefore, fixture.core.StorageBytes())
+	}
+	if err := fixture.core.ResetReleasingRetention(); err != nil {
+		t.Fatal(err)
+	}
+	if cap(fixture.core.eofRecoveryRoots) != 0 {
+		t.Fatalf("recover_eof reset retained root sidecar capacity %d", cap(fixture.core.eofRecoveryRoots))
+	}
+}
+
+func TestRecoverEOFAcceptOwnedRejectsForeignOwnerWithoutMutation(t *testing.T) {
+	fixture := newRecoverEOFAcceptFixture(t)
+	foreign := newRecoverEOFAcceptFixture(t)
+	before, err := fixture.core.Stats(fixture.head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ownerErr error
+	if err := foreign.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, _, ownerErr = fixture.core.RecoverEOFAcceptOwned(owner, fixture.head, fixture.payload, 0, 2)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if ownerErr == nil {
+		t.Fatal("foreign scheduler owner unexpectedly published recover_eof root")
+	}
+	after, err := fixture.core.Stats(fixture.head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != before {
+		t.Fatalf("foreign-owner mutation changed stats from %+v to %+v", before, after)
+	}
+}
+
+func TestRecoverEOFAcceptOwnedRollsBackPartialPublication(t *testing.T) {
+	fixture := newRecoverEOFAcceptFixture(t)
+	before, err := fixture.core.Stats(fixture.head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeSubtrees := fixture.core.SubtreeArenaLen()
+	fixture.core.limits.MaxNodes = uint32(len(fixture.core.nodes))
+	err = fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, _, operationErr := fixture.core.RecoverEOFAcceptOwned(owner, fixture.head, fixture.payload, 0, 2)
+		if operationErr == nil {
+			return errors.New("recover_eof operation unexpectedly succeeded at node cap")
+		}
+		return operationErr
+	})
+	if err == nil {
+		t.Fatal("node-cap recover_eof operation unexpectedly committed")
+	}
+	after, err := fixture.core.Stats(fixture.head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != before || fixture.core.SubtreeArenaLen() != beforeSubtrees || len(fixture.core.eofRecoveryRoots) != 0 {
+		t.Fatalf("rollback retained recover_eof state: before=%+v after=%+v subtrees=%d roots=%d", before, after, fixture.core.SubtreeArenaLen(), len(fixture.core.eofRecoveryRoots))
+	}
+}
+
+func TestRecoverEOFAcceptOwnedPreservesExternalPayloadFlag(t *testing.T) {
+	compact, err := New(&fakeTable{}, (Limits{}).withDefaults())
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact.CertifyExternalPayloadsQuiescent()
+	head, err := compact.Seed(7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	external, err := compact.appendSubtree(subtreeRecord{
+		symbol: 13, startByte: 0, endByte: 1, terminal: true, external: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err = compact.appendPrivate(9, 1, linkInput{prev: head.Node, payload: external})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root SubtreeID
+	if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		var operationErr error
+		_, root, operationErr = compact.RecoverEOFAcceptOwned(
+			owner, head, []SubtreeID{external}, 0, 1,
+		)
+		return operationErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	view, err := compact.Subtree(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := compact.Subtree(view.Children[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !child.External {
+		t.Fatalf("recover_eof external payload flag was cleared: child=%+v", child)
+	}
+}
+
+func TestRecoverEOFAcceptOwnedRejectsInexactExternalPayload(t *testing.T) {
+	compact, err := New(&fakeTable{}, (Limits{}).withDefaults())
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	external, err := compact.appendSubtree(subtreeRecord{
+		symbol: 13, startByte: 0, endByte: 1, terminal: true, external: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err = compact.appendPrivate(9, 1, linkInput{prev: head.Node, payload: external})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := compact.Stats(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeSubtrees := compact.SubtreeArenaLen()
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, _, operationErr := compact.RecoverEOFAcceptOwned(owner, head, []SubtreeID{external}, 0, 1)
+		return operationErr
+	})
+	if err == nil {
+		t.Fatal("inexact external payload unexpectedly published recover_eof root")
+	}
+	after, statsErr := compact.Stats(head)
+	if statsErr != nil {
+		t.Fatal(statsErr)
+	}
+	if after != before || compact.SubtreeArenaLen() != beforeSubtrees || len(compact.eofRecoveryRoots) != 0 {
+		t.Fatalf("inexact external rejection mutated Core: before=%+v after=%+v subtrees=%d roots=%d", before, after, compact.SubtreeArenaLen(), len(compact.eofRecoveryRoots))
+	}
+}

--- a/internal/parsercorephase0/eof_recovery_shadow.go
+++ b/internal/parsercorephase0/eof_recovery_shadow.go
@@ -189,6 +189,7 @@ func ForkDiagnosticEOFRecovery(
 	if err != nil {
 		return nil, 0, receipt, err
 	}
+	shadow.eofRecoveryRoots = append(shadow.eofRecoveryRoots, root)
 	receipt.Steps = 1
 	receipt.SubtreesAfter = uint32(len(shadow.subtrees))
 	receipt.ChildrenAfter = uint32(len(shadow.children))
@@ -291,6 +292,7 @@ func planDiagnosticEOFRecoveryClone(live *Core, payloads []SubtreeID, providerWr
 		{len(live.nodeCheckpoints), coreCheckpointIDBytes},
 		{len(live.links), coreLinkRecordBytes},
 		{len(live.subtrees), coreSubtreeRecordBytes},
+		{len(live.eofRecoveryRoots), coreSubtreeIDBytes},
 		{len(live.externalProvenance), coreExternalProvenanceBytes},
 		{len(live.lexerSkippedPrefixes), coreLexerSkippedPrefixBytes},
 		{len(live.children), coreChildRecordBytes},
@@ -314,6 +316,9 @@ func planDiagnosticEOFRecoveryClone(live *Core, payloads []SubtreeID, providerWr
 	}
 	if !diagnosticEOFRecoveryAdd(&plan.appendReserveBytes, coreSubtreeRecordBytes) {
 		return plan, errors.New("parser-core phase zero: EOF recovery subtree reserve overflow")
+	}
+	if !diagnosticEOFRecoveryAdd(&plan.appendReserveBytes, coreSubtreeIDBytes) {
+		return plan, errors.New("parser-core phase zero: EOF recovery root marker reserve overflow")
 	}
 	childReserve, ok := diagnosticEOFRecoveryMul(uint64(len(payloads)), coreChildRecordBytes)
 	if !ok || !diagnosticEOFRecoveryAdd(&plan.appendReserveBytes, childReserve) {
@@ -452,6 +457,7 @@ func cloneDiagnosticEOFRecoveryCore(
 	shadow.nodeCheckpoints = cloneDiagnosticSlice(live.nodeCheckpoints, 0)
 	shadow.links = cloneDiagnosticSlice(live.links, 0)
 	shadow.subtrees = cloneDiagnosticSlice(live.subtrees, 1)
+	shadow.eofRecoveryRoots = cloneDiagnosticSlice(live.eofRecoveryRoots, 1)
 	shadow.externalProvenance = cloneDiagnosticSlice(live.externalProvenance, 0)
 	shadow.lexerSkippedPrefixes = cloneDiagnosticSlice(live.lexerSkippedPrefixes, 0)
 	shadow.children = cloneDiagnosticSlice(live.children, payloadCount)
@@ -468,6 +474,21 @@ func cloneDiagnosticEOFRecoveryCore(
 	shadow.dropCohortMembers = cloneDiagnosticSlice(live.dropCohortMembers, 0)
 	shadow.dropCohortDerivations = cloneDiagnosticSlice(live.dropCohortDerivations, 0)
 	shadow.dropCohortDerivationBytes = cloneDiagnosticSlice(live.dropCohortDerivationBytes, 0)
+
+	// The EOF recovery append path does not read or mutate these drop-cohort
+	// families. Clear them after the shallow Core copy so no omitted sidecar,
+	// nested reservation header, or map can alias live mutable state.
+	shadow.dropCohortLinkRefIndexes = nil
+	shadow.dropCohortLinkRefJournal = nil
+	shadow.dropCohortDerivationIntern = nil
+	shadow.dropCohortCertificateRefs = nil
+	shadow.dropCohortMapStore = nil
+	shadow.dropCohortJournalStore = nil
+	shadow.dropCohortFrontiers = nil
+	shadow.dropCohortFrontierParticipants = nil
+	shadow.dropCohortFrontierMembers = nil
+	shadow.dropCohortFrontierJournal = nil
+	shadow.dropCohortReservations = nil
 
 	// One append does not use live journals, schedulers, or retained builders.
 	shadow.boundaryJournal = nil
@@ -520,7 +541,9 @@ func cloneDiagnosticSlice[T any](source []T, extraCapacity int) []T {
 }
 
 func diagnosticEOFRecoveryCopiedArenasEqual(live, shadow *Core) bool {
-	if live == nil || shadow == nil || len(shadow.subtrees) < len(live.subtrees) || len(shadow.children) < len(live.children) {
+	if live == nil || shadow == nil || len(shadow.subtrees) < len(live.subtrees) ||
+		len(shadow.eofRecoveryRoots) < len(live.eofRecoveryRoots) ||
+		len(shadow.children) < len(live.children) {
 		return false
 	}
 	return equalDiagnosticSlice(live.nodes, shadow.nodes) &&
@@ -528,6 +551,7 @@ func diagnosticEOFRecoveryCopiedArenasEqual(live, shadow *Core) bool {
 		equalDiagnosticSlice(live.nodeCheckpoints, shadow.nodeCheckpoints) &&
 		equalDiagnosticSlice(live.links, shadow.links) &&
 		equalDiagnosticSlice(live.subtrees, shadow.subtrees[:len(live.subtrees)]) &&
+		equalDiagnosticSlice(live.eofRecoveryRoots, shadow.eofRecoveryRoots[:len(live.eofRecoveryRoots)]) &&
 		equalDiagnosticSlice(live.externalProvenance, shadow.externalProvenance) &&
 		equalDiagnosticSlice(live.lexerSkippedPrefixes, shadow.lexerSkippedPrefixes) &&
 		equalDiagnosticSlice(live.children, shadow.children[:len(live.children)]) &&
@@ -582,6 +606,7 @@ func diagnosticEOFRecoveryStorageDisjoint(live, shadow *Core) bool {
 		disjointDiagnosticSlice(live.nodeCheckpoints, shadow.nodeCheckpoints) &&
 		disjointDiagnosticSlice(live.links, shadow.links) &&
 		disjointDiagnosticSlice(live.subtrees, shadow.subtrees) &&
+		disjointDiagnosticSlice(live.eofRecoveryRoots, shadow.eofRecoveryRoots) &&
 		disjointDiagnosticSlice(live.externalProvenance, shadow.externalProvenance) &&
 		disjointDiagnosticSlice(live.lexerSkippedPrefixes, shadow.lexerSkippedPrefixes) &&
 		disjointDiagnosticSlice(live.children, shadow.children) &&

--- a/internal/parsercorephase0/eof_recovery_shadow_test.go
+++ b/internal/parsercorephase0/eof_recovery_shadow_test.go
@@ -18,6 +18,7 @@ func TestDiagnosticEOFRecoveryClonePlanAccountsEveryRequestedByte(t *testing.T) 
 		nodeCheckpoints:                   make([]CheckpointID, 2),
 		links:                             make([]linkRecord, 3),
 		subtrees:                          make([]subtreeRecord, 4),
+		eofRecoveryRoots:                  []SubtreeID{2},
 		externalProvenance:                make([]externalPayloadProvenance, 1),
 		lexerSkippedPrefixes:              make([]lexerSkippedPrefixProvenance, 2),
 		children:                          make([]SubtreeID, 5),
@@ -46,6 +47,7 @@ func TestDiagnosticEOFRecoveryClonePlanAccountsEveryRequestedByte(t *testing.T) 
 		uint64(2)*coreCheckpointIDBytes +
 		uint64(3)*coreLinkRecordBytes +
 		uint64(4)*coreSubtreeRecordBytes +
+		coreSubtreeIDBytes +
 		coreExternalProvenanceBytes +
 		uint64(2)*coreLexerSkippedPrefixBytes +
 		uint64(5)*coreChildRecordBytes +
@@ -55,7 +57,7 @@ func TestDiagnosticEOFRecoveryClonePlanAccountsEveryRequestedByte(t *testing.T) 
 		9 +
 		uint64(8)*coreBoundarySlotBytes +
 		uint64(10)*coreUint32Bytes
-	wantAppend := coreSubtreeRecordBytes + uint64(len(payloads))*coreChildRecordBytes
+	wantAppend := coreSubtreeRecordBytes + uint64(len(payloads))*coreChildRecordBytes + coreSubtreeIDBytes
 	wantTemporary := uint64(len(payloads)) * coreUint16Bytes
 	wantPeak := uint64(unsafe.Sizeof(Core{})) + wantCopied + wantAppend + wantTemporary + providerWrapperBytes
 	if plan.coreHeaderBytes != uint64(unsafe.Sizeof(Core{})) ||
@@ -81,6 +83,66 @@ func TestDiagnosticEOFRecoveryClonePlanRejectsRetainedState(t *testing.T) {
 	live.checkpoints.buckets = nil
 	if _, err := planDiagnosticEOFRecoveryClone(live, []SubtreeID{1}, 0); err == nil || !strings.Contains(err.Error(), "provider wrapper storage") {
 		t.Fatalf("unaccounted provider wrapper error=%v", err)
+	}
+}
+
+func TestDiagnosticEOFRecoveryCopiedArenasEqualRejectsPartialRootSidecar(t *testing.T) {
+	live := &Core{eofRecoveryRoots: []SubtreeID{1, 2}}
+	shadow := &Core{eofRecoveryRoots: []SubtreeID{1}}
+	if diagnosticEOFRecoveryCopiedArenasEqual(live, shadow) {
+		t.Fatal("partial EOF recovery root sidecar was accepted")
+	}
+}
+
+func TestDiagnosticEOFRecoveryCloneClearsUnaccountedMutableDropCohortState(t *testing.T) {
+	live := &Core{
+		checkpoints: checkpointInterner{
+			buckets: map[[32]byte]CheckpointID{{1}: 1},
+		},
+		reductionScratch: reductionOutputScratch{
+			boundaryByKey: map[boundaryKey]int{{state: 1}: 1},
+		},
+		dropCohortLinkRefIndexes:       []uint32{1},
+		dropCohortLinkRefJournal:       []dropCohortLinkRefMutation{{}},
+		dropCohortDerivationIntern:     []dropCohortDerivationInternEntry{{}},
+		dropCohortCertificateRefs:      []DropCohortRef{{}},
+		dropCohortMapStore:             []dropCohortMapEntry{{}},
+		dropCohortJournalStore:         []dropCohortJournalStoreEntry{{}},
+		dropCohortFrontiers:            []dropCohortFrontierRecord{{}},
+		dropCohortFrontierParticipants: []dropCohortFrontierParticipant{{}},
+		dropCohortFrontierMembers:      []dropCohortFrontierMember{{}},
+		dropCohortFrontierJournal:      []dropCohortFrontierMutation{{}},
+		dropCohortDerivationScratch:    []byte{1},
+		dropCohortPathScratch:          []dropCohortPathStep{{}},
+		dropCohortJournal:              []dropCohortMutation{{}},
+		dropCohortReservations:         []dropCohortReservation{{actionsHeader: []dropCohortActionIdentity{{}}}},
+	}
+	shadow := cloneDiagnosticEOFRecoveryCore(live, 1, diagnosticEOFRecoveryValidationDemand{})
+	if shadow.checkpoints.buckets != nil || shadow.reductionScratch.boundaryByKey != nil {
+		t.Fatal("clone retained mutable map state")
+	}
+	for name, length := range map[string]int{
+		"link ref indexes":      len(shadow.dropCohortLinkRefIndexes),
+		"link ref journal":      len(shadow.dropCohortLinkRefJournal),
+		"derivation interner":   len(shadow.dropCohortDerivationIntern),
+		"certificate refs":      len(shadow.dropCohortCertificateRefs),
+		"map store":             len(shadow.dropCohortMapStore),
+		"journal store":         len(shadow.dropCohortJournalStore),
+		"frontiers":             len(shadow.dropCohortFrontiers),
+		"frontier participants": len(shadow.dropCohortFrontierParticipants),
+		"frontier members":      len(shadow.dropCohortFrontierMembers),
+		"frontier journal":      len(shadow.dropCohortFrontierJournal),
+		"derivation scratch":    len(shadow.dropCohortDerivationScratch),
+		"path scratch":          len(shadow.dropCohortPathScratch),
+		"journal":               len(shadow.dropCohortJournal),
+		"reservations":          len(shadow.dropCohortReservations),
+	} {
+		if length != 0 {
+			t.Fatalf("clone retained %s length %d", name, length)
+		}
+	}
+	if !diagnosticEOFRecoveryStorageDisjoint(live, shadow) {
+		t.Fatal("clone storage was not disjoint after clearing unused state")
 	}
 }
 

--- a/internal/parsercorephase0/storage_bytes.go
+++ b/internal/parsercorephase0/storage_bytes.go
@@ -63,6 +63,7 @@ func (c *Core) StorageBytes() uint64 {
 		uint64(len(c.links))*coreLinkRecordBytes +
 		uint64(len(c.dropCohortLinkRefIndexes))*coreUint32Bytes +
 		uint64(len(c.subtrees))*coreSubtreeRecordBytes +
+		uint64(len(c.eofRecoveryRoots))*coreSubtreeIDBytes +
 		uint64(len(c.children))*coreChildRecordBytes +
 		uint64(len(c.fields))*coreFieldRecordBytes +
 		uint64(len(c.aliases))*coreAliasRecordBytes +
@@ -150,6 +151,7 @@ func (c *Core) FootprintBytes() uint64 {
 	total := uint64(cap(c.nodes))*coreNodeRecordBytes +
 		uint64(cap(c.links))*coreLinkRecordBytes +
 		uint64(cap(c.subtrees))*coreSubtreeRecordBytes +
+		uint64(cap(c.eofRecoveryRoots))*coreSubtreeIDBytes +
 		uint64(cap(c.children))*coreChildRecordBytes +
 		uint64(cap(c.fields))*coreFieldRecordBytes +
 		uint64(cap(c.aliases))*coreAliasRecordBytes
@@ -313,6 +315,7 @@ func (c *Core) releaseRecordArenaReserve() {
 	c.dropCohortLinkRefIndexes = nil
 	c.dropCohortLinkRefJournal = nil
 	c.subtrees = nil
+	c.eofRecoveryRoots = nil
 	c.children = nil
 	c.dropCohortRefSpill = nil
 	c.dropCohortActions = nil
@@ -344,6 +347,7 @@ func (c *Core) releaseOversizedRetention() {
 	c.dropCohortLinkRefIndexes = nil
 	c.dropCohortLinkRefJournal = nil
 	c.subtrees = nil
+	c.eofRecoveryRoots = nil
 	c.externalProvenance = nil
 	c.lexerSkippedPrefixes = nil
 	c.children = nil

--- a/language.go
+++ b/language.go
@@ -472,6 +472,40 @@ const (
 	ResultCompatibilityNativeRecoveredStructure ResultCompatibilityCapability = 1 << 6
 )
 
+// CompactRecoverEOFArtifactReceipt is the locked-C certification data for one
+// compact recover_eof boundary. A zero BlobSHA256 disables this route. The
+// receipt binds the exact grammar artifact to the terminal, parser boundary,
+// and compact scheduler facts for the locked-C-certified witness.
+//
+// The work fields are intentionally explicit. They prevent a Boolean grant
+// from admitting a parse after an unmodeled shift, reduction, conflict, fork,
+// or recovery operation changes the pre-EOF lineage.
+type CompactRecoverEOFArtifactReceipt struct {
+	BlobSHA256        [32]byte
+	TerminalSymbol    Symbol
+	EOFState          StateID
+	EOFByteOffset     uint32
+	Passes            uint64
+	Elections         uint64
+	ActionLookups     uint64
+	Dispatches        uint64
+	OrdinaryShifts    uint64
+	OrdinaryCohorts   uint64
+	ExtraShifts       uint64
+	ExtraCohorts      uint64
+	Reductions        uint64
+	Conflicts         uint64
+	ConflictActions   uint64
+	Forks             uint64
+	RepetitionFolds   uint64
+	RecoveryWork      uint64
+	NoActionDrops     uint64
+	ReductionPauses   uint64
+	Accepts           uint64
+	Canonicalizations uint64
+	PeakHeaders       uint64
+}
+
 // Language holds all data needed to parse a specific language.
 // It mirrors tree-sitter's TSLanguage C struct, translated into
 // idiomatic Go types with slice-based tables instead of raw pointers.
@@ -822,6 +856,18 @@ type Language struct {
 	// no-action point exactly as before this stage landed.
 	CompactStrategy2ErrorRegionCertified bool
 
+	// CompactRecoverEOFCertified permits one exact EOF no-action lineage to
+	// publish tree-sitter's non-extra ERROR root from recover_eof. It is a
+	// compatibility marker. The compact route also requires the explicit,
+	// artifact-bound CompactRecoverEOFArtifactReceipt below.
+	CompactRecoverEOFCertified bool
+
+	// CompactRecoverEOFArtifactReceipt carries locked-C boundary and scheduler
+	// facts for the one recover_eof route certified on this language artifact.
+	// Its zero value disables the route, including when the compatibility marker
+	// above is set by an older caller.
+	CompactRecoverEOFArtifactReceipt CompactRecoverEOFArtifactReceipt
+
 	// CompactStackSummaryRecoveryCertified permits the compact fresh-full
 	// route to scan C's bounded stack summary at a no-action point. A
 	// successful scan forks the head into an ancestor-recovered lineage and
@@ -1124,6 +1170,18 @@ func (l *Language) GrammarBlobSHA256() ([32]byte, bool) {
 		return [32]byte{}, false
 	}
 	return l.grammarBlobSHA256, true
+}
+
+func compactRecoverEOFArtifactConfigured(l *Language) bool {
+	if l == nil || !l.CompactRecoverEOFCertified {
+		return false
+	}
+	receipt := l.CompactRecoverEOFArtifactReceipt
+	if receipt.BlobSHA256 == ([32]byte{}) {
+		return false
+	}
+	blob, ok := l.GrammarBlobSHA256()
+	return ok && blob == receipt.BlobSHA256
 }
 
 var nextCompactTableIdentity atomic.Uint64

--- a/parser.go
+++ b/parser.go
@@ -3188,7 +3188,7 @@ func (p *Parser) parseIncrementalInternalWithMergePerKeyOverride(source []byte, 
 		if timing != nil {
 			timing.reuseUnsupported = true
 			timing.reuseUnsupportedReason = incrementalReuseUnsupportedReasonForTree(oldTree)
-			if oldTree != nil && oldTree.compactMaterialized {
+			if oldTree != nil && oldTree.compactMaterialized && !compactRecoverEOFTreeMarked(oldTree) {
 				if reason := incrementalReuseUnavailableReason(ts); reason != "" {
 					timing.reuseUnsupportedReason = reason
 				}

--- a/parser_api.go
+++ b/parser_api.go
@@ -101,6 +101,9 @@ func (p *Parser) normalizeReturnedIncrementalTree(tree, oldTree *Tree, source []
 	if !shouldNormalizeIncrementalReturnedTree(tree, oldTree) {
 		return
 	}
+	if compactRecoverEOFRootSpanPreserved(tree) {
+		return
+	}
 	if tree.hasDeferredResultCompatibility() {
 		finalizeDeferredReturnedTreeTruncation(tree, source)
 		return
@@ -134,6 +137,9 @@ func shouldNormalizeReturnedTree(tree *Tree) bool {
 
 func (p *Parser) normalizeReturnedTreeForParse(tree *Tree, source []byte) {
 	if !shouldNormalizeReturnedTree(tree) {
+		return
+	}
+	if compactRecoverEOFRootSpanPreserved(tree) {
 		return
 	}
 	if tree.hasDeferredResultCompatibility() {
@@ -176,17 +182,30 @@ func finalizeDeferredReturnedTreeTruncation(tree *Tree, _ []byte) {
 }
 
 const (
-	forestIncrementalReuseUnsupportedReason  = "old tree was built by GSS forest fast path"
-	compactIncrementalReuseUnsupportedReason = "old tree was compact-materialized without a scanner-quiescence proof"
+	forestIncrementalReuseUnsupportedReason            = "old tree was built by GSS forest fast path"
+	compactIncrementalReuseUnsupportedReason           = "old tree was compact-materialized without a scanner-quiescence proof"
+	compactRecoverEOFIncrementalReuseUnsupportedReason = "old tree carried a compact recover_eof EOF runtime"
 )
 
 const forestRecoveryFallbackReuseReason = "forest_recovery_fallback"
 
 func oldTreeDisablesIncrementalReuse(oldTree *Tree) bool {
-	return oldTree != nil && oldTree.incrementalReuseDisabled
+	return oldTree != nil && (oldTree.incrementalReuseDisabled || compactRecoverEOFTreeMarked(oldTree))
+}
+
+// compactRecoverEOFTreeMarked identifies the one compact tree whose root
+// carries raw recover_eof framing. Its scanner runtime describes the old
+// source's end-of-file boundary, so incremental reuse must not trust it after
+// an edit until a fresh parse rebuilds that runtime.
+func compactRecoverEOFTreeMarked(tree *Tree) bool {
+	return tree != nil && tree.compactMaterialized && tree.root != nil &&
+		tree.root.hasFlag(nodeFlagCompactRecoverEOF)
 }
 
 func incrementalReuseUnsupportedReasonForTree(oldTree *Tree) string {
+	if compactRecoverEOFTreeMarked(oldTree) {
+		return compactRecoverEOFIncrementalReuseUnsupportedReason
+	}
 	if oldTree != nil && oldTree.compactMaterialized {
 		return compactIncrementalReuseUnsupportedReason
 	}
@@ -408,6 +427,9 @@ func finalizeReturnedTreeRootSpan(tree *Tree, source []byte) {
 	if tree == nil {
 		return
 	}
+	if compactRecoverEOFRootSpanPreserved(tree) {
+		return
+	}
 	root := rawRootOrNil(tree)
 	if root == nil {
 		return
@@ -428,6 +450,23 @@ func finalizeReturnedTreeRootSpan(tree *Tree, source []byte) {
 	}
 	markTruncatedTreeHasError(rt, root)
 	tree.setParseRuntime(rt)
+}
+
+// compactRecoverEOFRootSpanPreserved identifies the one compact result whose
+// raw C root intentionally ends before a clean source tail. The shape is
+// deliberately exact: ordinary compact ERROR roots and edited trees do not
+// bypass the normal root-span finalizer.
+func compactRecoverEOFRootSpanPreserved(tree *Tree) bool {
+	if tree == nil || !tree.compactMaterialized || tree.language == nil ||
+		!tree.language.CompactRecoverEOFCertified || tree.root == nil ||
+		!tree.root.IsError() || !tree.root.HasError() ||
+		!tree.root.hasFlag(nodeFlagCompactRecoverEOF) {
+		return false
+	}
+	rt := tree.parseRuntime
+	return rt.StopReason == ParseStopAccepted && rt.LastTokenWasEOF &&
+		rt.ExpectedEOFByte > rt.RootEndByte &&
+		rt.LastTokenEndByte == rt.ExpectedEOFByte
 }
 
 // markTruncatedTreeHasError repairs the wave2b SILENT-TRUNCATION contract: a

--- a/parser_derived_tables_internal_test.go
+++ b/parser_derived_tables_internal_test.go
@@ -180,6 +180,8 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 	derived := lang.acquireParserDerivedTables()
 
 	restoreErrorRegion := lang.CompactStrategy2ErrorRegionCertified
+	restoreRecoverEOF := lang.CompactRecoverEOFCertified
+	restoreRecoverEOFReceipt := lang.CompactRecoverEOFArtifactReceipt
 	restoreStackSummary := lang.CompactStackSummaryRecoveryCertified
 	restoreStructuralElection := lang.CompactAcceptanceStructuralElectionCertified
 	restoreLexerSkippedPrefix := lang.CompactLexerSkippedPrefixTilingCertified
@@ -189,6 +191,8 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 	restoreScanner := lang.ExternalScanner
 	t.Cleanup(func() {
 		lang.CompactStrategy2ErrorRegionCertified = restoreErrorRegion
+		lang.CompactRecoverEOFCertified = restoreRecoverEOF
+		lang.CompactRecoverEOFArtifactReceipt = restoreRecoverEOFReceipt
 		lang.CompactStackSummaryRecoveryCertified = restoreStackSummary
 		lang.CompactAcceptanceStructuralElectionCertified = restoreStructuralElection
 		lang.CompactLexerSkippedPrefixTilingCertified = restoreLexerSkippedPrefix
@@ -198,6 +202,8 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 		lang.ExternalScanner = restoreScanner
 	})
 	lang.CompactStrategy2ErrorRegionCertified = !restoreErrorRegion
+	lang.CompactRecoverEOFCertified = !restoreRecoverEOF
+	lang.CompactRecoverEOFArtifactReceipt.EOFByteOffset++
 	lang.CompactStackSummaryRecoveryCertified = !restoreStackSummary
 	lang.CompactAcceptanceStructuralElectionCertified = !restoreStructuralElection
 	lang.CompactLexerSkippedPrefixTilingCertified = !restoreLexerSkippedPrefix

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -1158,6 +1158,37 @@ func (b *resultRootBuild) finishTree(root *Node, wireParentLinks, extendTrailing
 	return tree
 }
 
+// finishRecoverEOFTree publishes the selected C recover_eof root without the
+// language result-compatibility or root-span rewrites used by ordinary trees.
+// The compact scheduler has already authenticated this synthetic ERROR root;
+// only parent links and the error summary remain materialization work.
+func (b *resultRootBuild) finishRecoverEOFTree(root *Node, wireParentLinks bool) *Tree {
+	if root == nil {
+		return nil
+	}
+	root.setFlag(nodeFlagCompactRecoverEOF, true)
+	errorSummary := resultErrorSummaryUnknown
+	if wireParentLinks {
+		if !wireParentLinksWithScratchUntil(root, b.linkScratch, b.parser, &errorSummary) && root.ownerArena != nil {
+			root.ownerArena.deferParentLinks(root)
+		}
+	} else if root.IsError() || root.hasError() {
+		errorSummary = resultErrorSummaryPresent
+	} else {
+		errorSummary = resultErrorSummaryClean
+	}
+	borrowed := b.borrowedArenas()
+	if b.parser != nil {
+		borrowed = append(borrowed, b.parser.takeCompatibilityBorrowedArenas()...)
+	}
+	tree := newTreeWithArenas(root, b.source, b.lang, b.arena, borrowed)
+	tree.resultErrorSummary = errorSummary
+	// The root is already the locked-C result. Mark compatibility complete so
+	// later public accessors do not normalize it into a grammar-root tree.
+	tree.resultCompatibilityApplied = true
+	return tree
+}
+
 func (b *resultRootBuild) finalizeRoot(root *Node, wireParentLinks, extendTrailing bool) (resultErrorSummary, bool) {
 	return b.parser.finalizeResultRoot(root, b.source, b.linkScratch, wireParentLinks, extendTrailing, b.incrementalResultCompatibilityRanges(root))
 }

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -102,6 +102,10 @@ type DiagnosticParserCorePrefixOptions struct {
 	// name-keyed -- design section 7). Recovery must also be true: this
 	// option alone does not admit the fresh-full runner's recovery guard.
 	allowCompactStrategy2ErrorRegion bool
+	// allowCompactRecoverEOF permits one exact, authenticated EOF no-action
+	// lineage to publish the locked-C recover_eof ERROR root. It is separate
+	// from strategy-2 recovery and never enables S3, S4, or S5.
+	allowCompactRecoverEOF bool
 	// allowCompactStackSummaryRecovery permits the scheduler to fork one
 	// no-action head into ancestor-recovered and error-absorb lineages.
 	// Language.CompactStackSummaryRecoveryCertified is its artifact gate.
@@ -449,9 +453,12 @@ type DiagnosticParserCoreGenericWork struct {
 	ExtraShifts            uint64
 	ExtraCohorts           uint64
 	Accepts                uint64
-	ReductionPauses        uint64
-	NoActionDrops          uint64
-	Elections              uint64
+	// RecoverEOFAccepts counts one certified live publication of C's
+	// recover_eof ERROR root. It is distinct from ordinary ActionAccept work.
+	RecoverEOFAccepts uint64
+	ReductionPauses   uint64
+	NoActionDrops     uint64
+	Elections         uint64
 	// PerVersionLexRequests counts lexer calls issued for an owned parser
 	// version. The shared lexer election does not contribute to this counter.
 	PerVersionLexRequests uint64
@@ -2771,15 +2778,18 @@ type diagnosticParserCoreGenericScheduler struct {
 	epochProgress                bool
 	acceptedHead                 core.Head
 	acceptedPayloads             []core.SubtreeID
-	eofRecoveryAdmission         compactEOFRecoveryAdmissionReceipt
-	conflictPostExecutionFault   func() error
-	extraPostExecutionFault      func() error
-	freshSessionOwner            *core.SchedulerTransactionToken
-	verifierHeads                [32]core.Head
-	verifierRefs                 [32]core.DropCohortRef
-	verifierBound                int
-	verifierHeaderPtr            *diagnosticParserCoreHeader
-	verifierInvocation           uint64
+	// acceptedRootFinalization is a scheduler sidecar. Keeping it outside the
+	// fixed header preserves the 224-byte scheduler-header contract.
+	acceptedRootFinalization   diagnosticParserCoreRootFinalization
+	eofRecoveryAdmission       compactEOFRecoveryAdmissionReceipt
+	conflictPostExecutionFault func() error
+	extraPostExecutionFault    func() error
+	freshSessionOwner          *core.SchedulerTransactionToken
+	verifierHeads              [32]core.Head
+	verifierRefs               [32]core.DropCohortRef
+	verifierBound              int
+	verifierHeaderPtr          *diagnosticParserCoreHeader
+	verifierInvocation         uint64
 	// frontierProofVerified binds one successful D6b proof to the immediately
 	// following no-action drop. The state is reset with the scheduler and is
 	// consumed by dropGenericNoActionHeads.
@@ -3892,12 +3902,22 @@ func (s *diagnosticParserCoreGenericScheduler) applyCompactEOFRecoveryAdmission(
 	); validateErr != nil {
 		return rollback(validateErr)
 	}
+	siblings := make([]int, 0, len(s.headers)-1)
+	for index := range s.headers {
+		if index != cell.headerIndex {
+			siblings = append(siblings, index)
+		}
+	}
 	if transitionErr := compactEOFRecoveryAdmissionTransition(
 		&s.eofRecoveryAdmission,
 		compactEOFRecoveryAdmissionPreApplyValidated,
 	); transitionErr != nil {
 		return rollback(transitionErr)
 	}
+	// Census the complete frontier at the safe pre-apply point. Applying the
+	// accept can mutate the compact head and retire its sibling, so later reads
+	// cannot reconstruct this admission history without observing live state.
+	s.censusEOFAcceptHistoryFrontier(cell.headerIndex, siblings)
 	if applyErr := s.applyGenericAccept(before, cell); applyErr != nil {
 		return rollback(applyErr)
 	}
@@ -6996,7 +7016,8 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 			// in isolation from a genuine drop. The exemption stays limited to the
 			// grammar root. Every internal reduce still passes the ordinary tiling
 			// check before materialization can publish it.
-			isDerivationRootReduce := parser.hasRootSymbol && Symbol(view.Symbol) == parser.rootSymbol
+			isDerivationRootReduce := rootFinalization == diagnosticParserCoreFinalizeDefault &&
+				parser.hasRootSymbol && Symbol(view.Symbol) == parser.rootSymbol
 			if allowLexerSkippedPrefix {
 				acceptedLeaves.propagateLeadingLexerSkippedPrefix(id, view.StartByte, view.Children, nodesByID)
 			}
@@ -7139,9 +7160,13 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 	// the leading-gap decline below, which compares this pre-normalization
 	// value instead.
 	acceptedRootSpanStart := nodes[0].startByte
+	acceptedRootSpanEnd := nodes[0].endByte
 	for _, n := range nodes[1:] {
 		if n.startByte < acceptedRootSpanStart {
 			acceptedRootSpanStart = n.startByte
+		}
+		if n.endByte > acceptedRootSpanEnd {
+			acceptedRootSpanEnd = n.endByte
 		}
 	}
 	if err := poll(); err != nil {
@@ -7167,9 +7192,10 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 			return nil, errors.New("parser-core phase zero: recover_eof finalization requires one ERROR payload")
 		}
 		// C publishes the ERROR parent pushed by recover_eof before accept.
-		// Do not apply the generic Go single-error grammar-root framing rule.
+		// Do not apply the generic Go single-error grammar-root framing rule or
+		// any language result-compatibility rewrite.
 		builder := newResultRootBuild(parser, source, arena, nil, nil, linkScratch)
-		tree = builder.finishTree(nodes[0], builder.shouldWireParentLinks, true)
+		tree = builder.finishRecoverEOFTree(nodes[0], builder.shouldWireParentLinks)
 	} else {
 		tree = parser.buildResultFromNodes(nodes, source, arena, nil, nil, linkScratch)
 	}
@@ -7207,11 +7233,15 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 	root := tree.root
 	if rootFinalization == diagnosticParserCoreFinalizeRecoverEOF {
 		expectedStart := firstNonTriviaByteStart(source)
+		tailClean := root.endByte <= sourceLen && parserTailAllowsCleanAcceptance(
+			source, root.endByte, sourceLen, nil, parser.lineContinuationEscapeByte(),
+		)
 		if !allowErrorRoot || !root.IsError() || !root.HasError() ||
-			root.startByte != expectedStart || root.endByte != sourceLen {
+			root.startByte != expectedStart || root.startByte != acceptedRootSpanStart ||
+			root.endByte != acceptedRootSpanEnd || !tailClean {
 			return rejectTree(fmt.Errorf(
-				"parser-core phase zero: recover_eof root is not exact: span=%d..%d expected=%d..%d error=%t has-error=%t",
-				root.startByte, root.endByte, expectedStart, sourceLen, root.IsError(), root.HasError(),
+				"parser-core phase zero: recover_eof root is not exact: span=%d..%d expected=%d..%d source-tail-clean=%t error=%t has-error=%t",
+				root.startByte, root.endByte, expectedStart, acceptedRootSpanEnd, tailClean, root.IsError(), root.HasError(),
 			))
 		}
 	} else {
@@ -7244,7 +7274,9 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 			),
 		})
 	}
-	tree.incrementalReuseDisabled = !incrementalReuseProven
+	// A recover_eof result carries an EOF runtime for the original source.
+	// Never let an edited copy enter incremental reuse with that stale boundary.
+	tree.incrementalReuseDisabled = rootFinalization == diagnosticParserCoreFinalizeRecoverEOF || !incrementalReuseProven
 	tree.compactMaterialized = true
 	tree.setParseRuntime(ParseRuntime{
 		StopReason: ParseStopAccepted, SourceLen: sourceLen, ExpectedEOFByte: sourceLen,
@@ -8698,6 +8730,13 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 					if handled {
 						return nil, nil
 					}
+					handled, eofErr := s.tryRecoverEOFAccept(noActionIndices[0])
+					if eofErr != nil {
+						return nil, eofErr
+					}
+					if handled {
+						return nil, nil
+					}
 					handled, s3Err := s.s3TryOpenErrorRegion(noActionIndices[0])
 					if s3Err != nil {
 						return nil, s3Err
@@ -8882,6 +8921,318 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 // compact-recovery-ownership.v1 section 4 and internal/parsercorephase0/
 // error_region.go's file doc comment for the mechanism this ports.
 // ---------------------------------------------------------------------------
+
+// recoverEOFAcceptAdmitted reports whether this scheduler may attempt the
+// dedicated recover_eof route. It never follows from the S3 capability.
+func (s *diagnosticParserCoreGenericScheduler) recoverEOFAcceptAdmitted() bool {
+	return s != nil && s.options.Recovery && s.options.allowCompactRecoverEOF &&
+		s.tokenSource != nil && compactRecoverEOFArtifactConfigured(s.tokenSource.language)
+}
+
+// recoverEOFAcceptHeaderTopologyEligible keeps the direct EOF package
+// separate from every ambiguity and recovery-lineage path.
+func recoverEOFAcceptHeaderTopologyEligible(header diagnosticParserCoreHeader) bool {
+	return !header.accepted && !header.shifted && !header.paused &&
+		header.recoveryRegion() == nil && !header.isRecoveryLineage() &&
+		header.altSet.Len() == 0 && !header.convergedReductionSplit &&
+		!header.resurrectionUnproved && !header.blended
+}
+
+// recoverEOFAcceptPayloadShapeEligible admits only a materializable terminal
+// for the first direct recover_eof package. Fragile reductions stay closed.
+func recoverEOFAcceptPayloadShapeEligible(compact *core.Core, payload core.SubtreeID) (core.SubtreeView, bool, error) {
+	if compact == nil {
+		return core.SubtreeView{}, false, nil
+	}
+	view, err := compact.Subtree(payload)
+	if err != nil {
+		return core.SubtreeView{}, false, err
+	}
+	if view.Extra || view.Missing || !view.Terminal || view.StartByte > view.EndByte {
+		return view, false, nil
+	}
+	materializationView, err := compact.MaterializationView(payload)
+	if err != nil {
+		return core.SubtreeView{}, false, err
+	}
+	if materializationView.Fragile {
+		return view, false, nil
+	}
+	return view, true, nil
+}
+
+// recoverEOFAcceptPriorityFree proves that the direct EOF package does not
+// shadow an earlier C recovery mechanism. The probes are read-only; Core
+// mutation starts only after this function returns true.
+func (s *diagnosticParserCoreGenericScheduler) recoverEOFAcceptPriorityFree(head core.Head) (bool, error) {
+	if s == nil || s.compact == nil || s.tokenSource == nil || s.tokenSource.language == nil {
+		return false, nil
+	}
+	state, position, err := s.compact.Boundary(head)
+	if err != nil {
+		return false, err
+	}
+	tokenCount := Symbol(s.tokenSource.language.TokenCount)
+	for symbol := Symbol(0); symbol < tokenCount; symbol++ {
+		row, rowErr := s.compact.Actions(state, core.Symbol(symbol))
+		if rowErr != nil {
+			return false, rowErr
+		}
+		for ordinal := 0; ordinal < row.Len(); ordinal++ {
+			if row.At(ordinal).Type == core.ActionReduce {
+				return false, nil
+			}
+		}
+	}
+	missingOpportunity, missingErr := s.s3MissingTokenOpportunityExists(state)
+	if missingErr != nil {
+		return false, missingErr
+	}
+	if missingOpportunity {
+		return false, nil
+	}
+	candidates, summaryErr := s.compact.StackSummaryCandidates(head, cRecoverMaxSummaryDepth)
+	if summaryErr != nil {
+		return false, summaryErr
+	}
+	for _, candidate := range candidates {
+		if candidate.ByteOffset() >= position {
+			continue
+		}
+		recoverable, recoverableErr := s.compact.StackSummaryCandidateRecoverable(candidate)
+		if recoverableErr != nil {
+			return false, recoverableErr
+		}
+		if !recoverable {
+			continue
+		}
+		row, rowErr := s.compact.Actions(candidate.State(), core.Symbol(0))
+		if rowErr != nil {
+			return false, rowErr
+		}
+		if row.Len() != 0 {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func compactRecoverEOFRecoveryWork(s *diagnosticParserCoreGenericScheduler) uint64 {
+	if s == nil {
+		return math.MaxUint64
+	}
+	values := [...]uint64{
+		s.work.StackSummaryRecoveryForks,
+		s.work.RecoveryLineageSelections,
+		s.work.RecoveryLineageRetirements,
+		s.work.RecoveryAmbiguityForks,
+		s.work.RecoveryCondensePasses,
+		s.work.RecoveryVersionCapDrops,
+		s.work.ReductionPauses,
+		s.work.NoActionDrops,
+		s.work.PerVersionLexRequests,
+		s.work.PerVersionLexRestores,
+		s.work.PerVersionLexPublications,
+		s.work.PerVersionLexAcceptedRaggedSpans,
+		s.work.PerVersionLexViabilityDrops,
+		uint64(s.s5MissingInsertions),
+		uint64(s.s3ResumeCount),
+	}
+	var total uint64
+	for _, value := range values {
+		if math.MaxUint64-total < value {
+			return math.MaxUint64
+		}
+		total += value
+	}
+	for _, active := range []bool{
+		s.s3RegionOpened,
+		s.recoveryIsolation,
+		s.selectedRecoveryAbsorbLineage,
+	} {
+		if active {
+			if total == math.MaxUint64 {
+				return total
+			}
+			total++
+		}
+	}
+	return total
+}
+
+func (s *diagnosticParserCoreGenericScheduler) recoverEOFAcceptArtifactEligible(
+	header diagnosticParserCoreHeader,
+	view core.SubtreeView,
+) (bool, error) {
+	if s == nil || s.compact == nil || s.tokenSource == nil || s.tokenSource.language == nil {
+		return false, nil
+	}
+	language := s.tokenSource.language
+	receipt := language.CompactRecoverEOFArtifactReceipt
+	blob, blobOK := language.GrammarBlobSHA256()
+	if !blobOK || receipt.BlobSHA256 == ([32]byte{}) || receipt.BlobSHA256 != blob ||
+		!compactRecoverEOFArtifactConfigured(language) || !s.compact.TableIdentityMatches() {
+		return false, nil
+	}
+	state, offset, err := s.compact.Boundary(header.head)
+	if err != nil {
+		return false, err
+	}
+	if StateID(state) != receipt.EOFState || offset != receipt.EOFByteOffset ||
+		Symbol(view.Symbol) != receipt.TerminalSymbol {
+		return false, nil
+	}
+	work := s.work
+	if work.Passes != receipt.Passes || work.Elections != receipt.Elections ||
+		work.ActionLookups != receipt.ActionLookups || work.Dispatches != receipt.Dispatches ||
+		work.OrdinaryShifts != receipt.OrdinaryShifts ||
+		work.OrdinaryCohorts != receipt.OrdinaryCohorts || work.ExtraShifts != receipt.ExtraShifts ||
+		work.ExtraCohorts != receipt.ExtraCohorts || work.Reductions != receipt.Reductions ||
+		work.Conflicts != receipt.Conflicts || work.ConflictActions != receipt.ConflictActions ||
+		work.Forks != receipt.Forks || work.RepetitionFolds != receipt.RepetitionFolds ||
+		compactRecoverEOFRecoveryWork(s) != receipt.RecoveryWork ||
+		work.NoActionDrops != receipt.NoActionDrops || work.ReductionPauses != receipt.ReductionPauses ||
+		work.Accepts != receipt.Accepts || work.Canonicalizations != receipt.Canonicalizations ||
+		work.PeakHeaders != receipt.PeakHeaders || work.Overflow {
+		return false, nil
+	}
+	return true, nil
+}
+
+// recoverEOFAcceptPayloads validates the sole no-action path before it is
+// replaced by a synthetic ERROR root. Keep extra and missing nodes out of
+// this focused package. Core receives the original path payloads because EOF
+// admission does not reconstruct reductions that the parser did not perform.
+func (s *diagnosticParserCoreGenericScheduler) recoverEOFAcceptPayloads(
+	index int,
+) (core.Head, []core.SubtreeID, uint32, uint32, bool, error) {
+	if s == nil || index < 0 || index >= len(s.headers) || len(s.headers) != 1 ||
+		s.tokenSource == nil || s.tokenSource.language == nil ||
+		s.options.materializationParser == nil || !s.options.materializationContextSet {
+		return core.Head{}, nil, 0, 0, false, nil
+	}
+	if s.token.Symbol != 0 || s.token.StartByte != s.token.EndByte ||
+		s.token.Missing || s.token.NoLookahead || s.token.ExternalScannerToken {
+		return core.Head{}, nil, 0, 0, false, nil
+	}
+	header := s.headers[index]
+	// Recover-eof admission owns one deterministic derivation only. Any
+	// alternative-set, split, resurrection, or blended provenance means the
+	// head came through a condensation or ambiguity path that this route does
+	// not reproduce. Decline before reading or mutating the compact graph.
+	if !recoverEOFAcceptHeaderTopologyEligible(header) {
+		return core.Head{}, nil, 0, 0, false, nil
+	}
+	paths, err := compactDerivationsForAcceptance(s.compact, header.head)
+	if err != nil {
+		return core.Head{}, nil, 0, 0, false, nil
+	}
+	if len(paths) != 1 || len(paths[0].Payloads) == 0 ||
+		len(paths[0].Payloads) > compactEOFRecoveryAdmissionMaxTopPayloads {
+		return core.Head{}, nil, 0, 0, false, nil
+	}
+	payloads := paths[0].Payloads
+	if len(payloads) != 1 {
+		return core.Head{}, nil, 0, 0, false, nil
+	}
+	priorityFree, priorityErr := s.recoverEOFAcceptPriorityFree(header.head)
+	if priorityErr != nil {
+		return core.Head{}, nil, 0, 0, false, priorityErr
+	}
+	if !priorityFree {
+		return core.Head{}, nil, 0, 0, false, nil
+	}
+	var firstStart, lastEnd uint32
+	var terminalView core.SubtreeView
+	for payloadIndex, payload := range payloads {
+		view, shapeEligible, viewErr := recoverEOFAcceptPayloadShapeEligible(s.compact, payload)
+		if viewErr != nil {
+			return core.Head{}, nil, 0, 0, false, viewErr
+		}
+		terminalView = view
+		if !shapeEligible {
+			return core.Head{}, nil, 0, 0, false, nil
+		}
+		if payloadIndex == 0 {
+			firstStart = view.StartByte
+		} else {
+			previous, previousErr := s.compact.Subtree(payloads[payloadIndex-1])
+			if previousErr != nil {
+				return core.Head{}, nil, 0, 0, false, previousErr
+			}
+			if view.StartByte < previous.EndByte {
+				return core.Head{}, nil, 0, 0, false, nil
+			}
+		}
+		lastEnd = view.EndByte
+	}
+	source := s.options.materializationSource
+	if s.token.StartByte != uint32(len(source)) ||
+		uint64(len(source)) > uint64(^uint32(0)) || firstStart > uint32(len(source)) ||
+		lastEnd > uint32(len(source)) || firstStart != firstNonTriviaByteStart(source) ||
+		lastEnd < firstStart ||
+		!parserTailAllowsCleanAcceptance(source, lastEnd, uint32(len(source)), nil,
+			s.options.materializationParser.lineContinuationEscapeByte()) {
+		return core.Head{}, nil, 0, 0, false, nil
+	}
+	artifactEligible, artifactErr := s.recoverEOFAcceptArtifactEligible(header, terminalView)
+	if artifactErr != nil {
+		return core.Head{}, nil, 0, 0, false, artifactErr
+	}
+	if !artifactEligible {
+		return core.Head{}, nil, 0, 0, false, nil
+	}
+	return header.head, payloads, firstStart, lastEnd, true, nil
+}
+
+// tryRecoverEOFAccept publishes one exact recover_eof ERROR root. The Core
+// mutation and scheduler counters commit together; unsupported topologies
+// return false so the existing S3 and final-decline ladder remains intact.
+func (s *diagnosticParserCoreGenericScheduler) tryRecoverEOFAccept(index int) (bool, error) {
+	if !s.recoverEOFAcceptAdmitted() {
+		return false, nil
+	}
+	selectedHead, payloads, startByte, endByte, eligible, err := s.recoverEOFAcceptPayloads(index)
+	if err != nil || !eligible {
+		return false, err
+	}
+	dispatchesBefore, workBefore, epochProgressBefore := s.dispatches, s.work, s.epochProgress
+	if err := s.reserveDispatches(1); err != nil {
+		return false, err
+	}
+	var recovered core.Head
+	var root core.SubtreeID
+	apply := func(owner core.SchedulerTransactionToken) error {
+		var applyErr error
+		recovered, root, applyErr = s.compact.RecoverEOFAcceptOwned(
+			owner, selectedHead, payloads, startByte, endByte,
+		)
+		return applyErr
+	}
+	var applyErr error
+	if s.freshSessionOwner != nil {
+		applyErr = apply(*s.freshSessionOwner)
+	} else {
+		applyErr = s.compact.ApplySchedulerAtomic(apply)
+	}
+	if applyErr != nil {
+		s.dispatches, s.work, s.epochProgress = dispatchesBefore, workBefore, epochProgressBefore
+		return false, applyErr
+	}
+	header := &s.headers[index]
+	header.head = recovered
+	header.accepted = true
+	header.shifted = false
+	header.paused = false
+	s.acceptedHead = recovered
+	s.acceptedPayloads = append(s.acceptedPayloads[:0], root)
+	s.acceptedRootFinalization = diagnosticParserCoreFinalizeRecoverEOF
+	s.epochProgress = true
+	s.work.add(&s.work.Accepts, 1)
+	s.work.add(&s.work.RecoverEOFAccepts, 1)
+	s.work.add(&s.work.Dispatches, 1)
+	return true, nil
+}
 
 // s3ErrorRegionAdmitted reports whether native S3 recovery may attempt to
 // own a true no-action point for the current parse instead of declining.

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -59,9 +59,9 @@ type parserCoreFreshFullRunner struct {
 }
 
 func newParserCoreFreshFullRunner(scanner ExternalScanner, options DiagnosticParserCorePrefixOptions) (*parserCoreFreshFullRunner, error) {
-	// S3 supplies the base recovery mechanism. S5 separately requires its
-	// insertion and acceptance-selection gates.
-	if (options.Recovery && !options.allowCompactStrategy2ErrorRegion) ||
+	// S3 supplies the base recovery mechanism. A dedicated recover_eof route
+	// has its own artifact gate and does not imply S3, S4, or S5.
+	if (options.Recovery && !options.allowCompactStrategy2ErrorRegion && !options.allowCompactRecoverEOF) ||
 		options.Retry || options.Incremental || options.IncludedRanges || options.GenericStopAtClosedByte != nil {
 		return nil, &diagnosticParserCoreDecline{
 			boundary: DiagnosticParserCoreRoute,
@@ -303,6 +303,14 @@ func (r *parserCoreFreshFullRunner) s3AllowErrorRoot() bool {
 	return r != nil && r.options.Recovery && r.options.allowCompactStrategy2ErrorRegion
 }
 
+func (r *parserCoreFreshFullRunner) recoverEOFFinalizationAdmitted(
+	scheduler *diagnosticParserCoreGenericScheduler,
+) bool {
+	return r != nil && scheduler != nil && r.options.Recovery &&
+		r.options.allowCompactRecoverEOF &&
+		scheduler.acceptedRootFinalization == diagnosticParserCoreFinalizeRecoverEOF
+}
+
 func (r *parserCoreFreshFullRunner) compactRecoveryTerminalAliasSymbol(
 	scheduler *diagnosticParserCoreGenericScheduler,
 ) (Symbol, bool) {
@@ -354,7 +362,13 @@ func (r *parserCoreFreshFullRunner) materializeSelection(source []byte, compact 
 	}
 	r.scratch.recoveryTerminalAliasSymbol, r.scratch.recoveryTerminalAliasCertified =
 		r.compactRecoveryTerminalAliasSymbol(scheduler)
-	tree, err := materializeDiagnosticParserCoreAcceptedSelection(
+	rootFinalization := diagnosticParserCoreFinalizeDefault
+	allowErrorRoot := r.s3AllowErrorRoot()
+	if r.recoverEOFFinalizationAdmitted(scheduler) {
+		rootFinalization = diagnosticParserCoreFinalizeRecoverEOF
+		allowErrorRoot = true
+	}
+	tree, err := materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(
 		compact,
 		scheduler.acceptedHead,
 		scheduler.acceptedPayloads,
@@ -362,7 +376,8 @@ func (r *parserCoreFreshFullRunner) materializeSelection(source []byte, compact 
 		source,
 		&r.scratch,
 		r.replayParseStates,
-		r.s3AllowErrorRoot(),
+		allowErrorRoot,
+		rootFinalization,
 	)
 	if err != nil && gated {
 		scheduler.failCompactEOFRecoveryConstruction(err)
@@ -378,6 +393,9 @@ func (r *parserCoreFreshFullRunner) materializeSelectedStoreSelection(
 ) (*core.SelectedStore, error) {
 	if r == nil || compact == nil || scheduler == nil {
 		return nil, errors.New("parser-core fresh-full selected-store construction is incomplete")
+	}
+	if scheduler.acceptedRootFinalization == diagnosticParserCoreFinalizeRecoverEOF {
+		return nil, errors.New("parser-core fresh-full selected-store does not support recover_eof roots")
 	}
 	gated, err := scheduler.beginCompactEOFRecoveryConstruction(
 		source,
@@ -430,7 +448,8 @@ func (r *parserCoreFreshFullRunner) parseWithObserver(
 			err = errors.Join(err, fmt.Errorf("parser-core fresh-full runner: reset after decline: %w", resetErr))
 		}
 	}()
-	recoveryEnabled := r.options.Recovery && r.options.allowCompactStrategy2ErrorRegion
+	recoveryEnabled := r.options.Recovery &&
+		(r.options.allowCompactStrategy2ErrorRegion || r.options.allowCompactRecoverEOF)
 	if r.recoveryPlainFirst && recoveryEnabled {
 		tree, err = r.parseWithObserverAndErrorRuns(source, observer, false, false)
 		if err == nil {
@@ -441,7 +460,8 @@ func (r *parserCoreFreshFullRunner) parseWithObserver(
 		}
 		return r.parseWithObserverAndErrorRuns(source, observer, true, true)
 	}
-	return r.parseWithObserverAndErrorRuns(source, observer, recoveryEnabled, recoveryEnabled)
+	forceErrorRuns := recoveryEnabled && r.options.allowCompactStrategy2ErrorRegion
+	return r.parseWithObserverAndErrorRuns(source, observer, recoveryEnabled, forceErrorRuns)
 }
 
 func (r *parserCoreFreshFullRunner) parseWithObserverAndErrorRuns(
@@ -452,6 +472,7 @@ func (r *parserCoreFreshFullRunner) parseWithObserverAndErrorRuns(
 ) (*Tree, error) {
 	savedRecovery := r.options.Recovery
 	savedErrorRegion := r.options.allowCompactStrategy2ErrorRegion
+	savedRecoverEOF := r.options.allowCompactRecoverEOF
 	savedStackSummary := r.options.allowCompactStackSummaryRecovery
 	savedMissingInsertion := r.options.allowCompactMissingTokenInsertion
 	savedLineageSelection := r.options.allowCompactRecoveryLineageSelection
@@ -460,6 +481,7 @@ func (r *parserCoreFreshFullRunner) parseWithObserverAndErrorRuns(
 	if !recoveryEnabled {
 		r.options.Recovery = false
 		r.options.allowCompactStrategy2ErrorRegion = false
+		r.options.allowCompactRecoverEOF = false
 		r.options.allowCompactStackSummaryRecovery = false
 		r.options.allowCompactMissingTokenInsertion = false
 		r.options.allowCompactRecoveryLineageSelection = false
@@ -469,6 +491,7 @@ func (r *parserCoreFreshFullRunner) parseWithObserverAndErrorRuns(
 	defer func() {
 		r.options.Recovery = savedRecovery
 		r.options.allowCompactStrategy2ErrorRegion = savedErrorRegion
+		r.options.allowCompactRecoverEOF = savedRecoverEOF
 		r.options.allowCompactStackSummaryRecovery = savedStackSummary
 		r.options.allowCompactMissingTokenInsertion = savedMissingInsertion
 		r.options.allowCompactRecoveryLineageSelection = savedLineageSelection

--- a/parsercore_phase0_fresh_full_runner_internal_test.go
+++ b/parsercore_phase0_fresh_full_runner_internal_test.go
@@ -120,12 +120,13 @@ func TestResetDiagnosticParserCoreGenericSchedulerRejectsActiveScratch(t *testin
 
 func TestResetDiagnosticParserCoreGenericSchedulerClearsRecoveryState(t *testing.T) {
 	scheduler := diagnosticParserCoreGenericScheduler{
-		s5MissingInsertions: 7,
-		s3RegionOpened:      true,
-		s3ResumeState:       11,
-		s3ResumeSymbol:      12,
-		s3ResumeCount:       1,
-		recoveryIsolation:   true,
+		s5MissingInsertions:      7,
+		s3RegionOpened:           true,
+		s3ResumeState:            11,
+		s3ResumeSymbol:           12,
+		s3ResumeCount:            1,
+		recoveryIsolation:        true,
+		acceptedRootFinalization: diagnosticParserCoreFinalizeRecoverEOF,
 	}
 	if err := resetDiagnosticParserCoreGenericScheduler(&scheduler); err != nil {
 		t.Fatal(err)
@@ -142,6 +143,35 @@ func TestResetDiagnosticParserCoreGenericSchedulerClearsRecoveryState(t *testing
 	}
 	if scheduler.recoveryIsolation {
 		t.Fatal("recovery isolation remained active after reset")
+	}
+	if scheduler.acceptedRootFinalization != diagnosticParserCoreFinalizeDefault {
+		t.Fatalf("accepted root finalization=%v, want default after reset", scheduler.acceptedRootFinalization)
+	}
+}
+
+func TestParserCoreFreshFullRunnerClearsRecoverEOFFinalizationBeforeOrdinaryAcceptance(t *testing.T) {
+	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runner.scheduler.acceptedRootFinalization = diagnosticParserCoreFinalizeRecoverEOF
+	ordinary, err := runner.parse([]byte("package p\n"))
+	if err != nil {
+		t.Fatalf("ordinary parse after stale recover-eof finalization: %v", err)
+	}
+	if ordinary == nil || ordinary.RootNode() == nil {
+		if ordinary != nil {
+			ordinary.Release()
+		}
+		t.Fatal("ordinary parse returned no root")
+	}
+	defer ordinary.Release()
+	if ordinary.RootNode().IsError() || ordinary.RootNode().HasError() {
+		t.Fatalf("ordinary parse retained stale error state: type=%s", ordinary.RootNode().Type(runner.lang))
+	}
+	if runner.scheduler.acceptedRootFinalization != diagnosticParserCoreFinalizeDefault {
+		t.Fatalf("ordinary finalization=%v, want default", runner.scheduler.acceptedRootFinalization)
 	}
 }
 

--- a/parsercore_phase0_generic_conflict_internal_test.go
+++ b/parsercore_phase0_generic_conflict_internal_test.go
@@ -522,6 +522,175 @@ func (*genericConflictTable) ProductionAliases(uint16, int) ([]core.Symbol, erro
 	return nil, nil
 }
 
+func TestDiagnosticParserCoreRecoverEOFAcceptHeaderTopologyRejectsUnsupportedProvenance(t *testing.T) {
+	base := diagnosticParserCoreHeader{}
+	if !recoverEOFAcceptHeaderTopologyEligible(base) {
+		t.Fatal("plain singleton header was rejected")
+	}
+	tests := []struct {
+		name   string
+		mutate func(*diagnosticParserCoreHeader)
+	}{
+		{name: "accepted", mutate: func(header *diagnosticParserCoreHeader) { header.accepted = true }},
+		{name: "shifted", mutate: func(header *diagnosticParserCoreHeader) { header.shifted = true }},
+		{name: "paused", mutate: func(header *diagnosticParserCoreHeader) { header.paused = true }},
+		{name: "alternative-set", mutate: func(header *diagnosticParserCoreHeader) { header.altSet = core.NewAlternativeSetMember(7, 0) }},
+		{name: "converged-split", mutate: func(header *diagnosticParserCoreHeader) { header.convergedReductionSplit = true }},
+		{name: "resurrection-unproved", mutate: func(header *diagnosticParserCoreHeader) { header.resurrectionUnproved = true }},
+		{name: "blended", mutate: func(header *diagnosticParserCoreHeader) { header.blended = true }},
+		{name: "recovery-lineage", mutate: func(header *diagnosticParserCoreHeader) { header.markRecoveryLineage() }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			header := base
+			test.mutate(&header)
+			if recoverEOFAcceptHeaderTopologyEligible(header) {
+				t.Fatalf("unsupported header topology was admitted: %+v", header)
+			}
+		})
+	}
+}
+
+func TestDiagnosticParserCoreRecoverEOFAcceptPayloadShapeAdmitsSingletonAndRejectsFragile(t *testing.T) {
+	plainTable := &genericConflictTable{cells: map[genericConflictCell][]core.Action{
+		{state: 1, symbol: 1}: {{Type: core.ActionShift, State: 2}},
+	}}
+	plain, err := core.New(plainTable, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := plain.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plainHead, err := plain.Shift(seed, 1, 0, core.Token{Symbol: 1, StartByte: 0, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plainPaths, err := plain.Derivations(plainHead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plainPaths) != 1 || len(plainPaths[0].Payloads) != 1 {
+		t.Fatalf("plain singleton derivations=%+v", plainPaths)
+	}
+	if _, ok, err := recoverEOFAcceptPayloadShapeEligible(plain, plainPaths[0].Payloads[0]); err != nil || !ok {
+		t.Fatalf("plain singleton shape eligible=%t err=%v", ok, err)
+	}
+
+	fragileTable := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 1}: {{Type: core.ActionShift, State: 2}},
+			{state: 2, symbol: 2}: {{Type: core.ActionShift, State: 3}},
+			{state: 3, symbol: 9}: {{Type: core.ActionReduce, Symbol: 4, ChildCount: 2, ProductionID: 1}},
+		},
+		gotos: map[genericConflictCell]core.StateID{{state: 1, symbol: 4}: 4},
+	}
+	fragile, err := core.New(fragileTable, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fragileSeed, err := fragile.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fragileHead, err := fragile.Shift(fragileSeed, 1, 0, core.Token{Symbol: 1, StartByte: 0, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fragileHead, err = fragile.Shift(fragileHead, 2, 0, core.Token{Symbol: 2, StartByte: 1, EndByte: 2}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fragile.SetReduceConflictContext(true)
+	fragileFrontier, err := fragile.Reduce(fragileHead, 9, 0, core.ForkOrder{})
+	fragile.SetReduceConflictContext(false)
+	if err != nil || len(fragileFrontier) != 1 {
+		t.Fatalf("fragile reduction frontier=%v err=%v", fragileFrontier, err)
+	}
+	fragilePaths, err := fragile.Derivations(fragileFrontier[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fragilePaths) != 1 || len(fragilePaths[0].Payloads) != 1 {
+		t.Fatalf("fragile derivations=%+v", fragilePaths)
+	}
+	fragileView, err := fragile.MaterializationView(fragilePaths[0].Payloads[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fragileView.Fragile {
+		t.Fatalf("fixture reduction was not fragile: %+v", fragileView)
+	}
+	if _, ok, err := recoverEOFAcceptPayloadShapeEligible(fragile, fragilePaths[0].Payloads[0]); err != nil || ok {
+		t.Fatalf("fragile payload shape eligible=%t err=%v", ok, err)
+	}
+}
+
+func TestDiagnosticParserCoreRecoverEOFAcceptPriorityFreeProbesAreReadOnly(t *testing.T) {
+	tests := []struct {
+		name      string
+		cells     map[genericConflictCell][]core.Action
+		gotos     map[genericConflictCell]core.StateID
+		shiftHead bool
+		wantAdmit bool
+	}{
+		{name: "no-earlier-mechanism", wantAdmit: true},
+		{name: "any-lookahead-reduction", cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 2}: {{Type: core.ActionReduce, Symbol: 4, ChildCount: 1}},
+		}},
+		{name: "missing-token-opportunity", cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 2}: {{Type: core.ActionShift, State: 3}},
+			{state: 3, symbol: 9}: {{Type: core.ActionReduce, Symbol: 4, ChildCount: 1}},
+		}},
+		{name: "ancestor-eof-action", cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 0}: {{Type: core.ActionShift, State: 4}},
+			{state: 1, symbol: 1}: {{Type: core.ActionShift, State: 2}},
+		}, shiftHead: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			compact, err := core.New(&genericConflictTable{cells: test.cells, gotos: test.gotos}, core.Limits{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			head, err := compact.Seed(1, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.shiftHead {
+				head, err = compact.Shift(head, 1, 0, core.Token{Symbol: 1, StartByte: 0, EndByte: 1}, core.ForkOrder{})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			before, err := compact.Stats(head)
+			if err != nil {
+				t.Fatal(err)
+			}
+			scheduler := &diagnosticParserCoreGenericScheduler{
+				compact:     compact,
+				tokenSource: &dfaTokenSource{language: &Language{TokenCount: 4}},
+				token:       Token{Symbol: 9, StartByte: 1, EndByte: 1},
+			}
+			got, err := scheduler.recoverEOFAcceptPriorityFree(head)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.wantAdmit {
+				t.Fatalf("priority-free=%t, want %t", got, test.wantAdmit)
+			}
+			after, err := compact.Stats(head)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if after != before {
+				t.Fatalf("priority probes mutated Core: before=%+v after=%+v", before, after)
+			}
+		})
+	}
+}
+
 func TestDiagnosticParserCoreGenericConflictArbitraryNOrdering(t *testing.T) {
 	actions := []core.Action{
 		{Type: core.ActionShift, State: 2},

--- a/tree.go
+++ b/tree.go
@@ -91,6 +91,10 @@ const (
 	// survive materialization.
 	nodeFlagFragileLeft
 	nodeFlagFragileRight
+	// nodeFlagCompactRecoverEOF marks the one compact recover_eof root whose
+	// raw C span must survive public result finalization. It is runtime-only
+	// provenance and fits the existing uint16 flag budget.
+	nodeFlagCompactRecoverEOF
 )
 
 func (n *Node) hasFlag(flag nodeFlags) bool {


### PR DESCRIPTION
## Summary

- Add an owned compact `recover_eof` primitive for one exact YAML witness.
- Publish the same non-extra `ERROR` root as the locked C oracle.
- Bind admission to the grammar blob, table identity, boundary, and scheduler receipt.
- Reject unsupported payloads before mutation.
- Preserve rollback, memory accounting, and shadow-clone isolation.
- Block incremental reuse for the marked end-of-file runtime.
- Add telemetry for successful compact end-of-file recovery.

## Correctness proof

The smallest witness is `[\n`.

The compact result matches C exactly:

- root symbol and error flags;
- raw span `0..1`;
- one `[` child;
- child range and flags;
- zero extra or missing nodes.

The route declines for unfinished YAML with multiple payloads. Production fallback then matches C.

Every receipt field has a tamper test. Each mutation causes a closed admission and zero recovery accepts.

The printable one-byte differential matches C for every admitted byte.

## Verification

- Focused root and parser-core tests pass.
- Focused Docker race tests pass.
- The YAML Cgo differential passes.
- The YAML one-grammar Docker parity run passes.
- Both parser build modes compile.
- Header size stays 224 bytes.
- Subtree records stay 44 bytes.
- `git diff --check` passes.
- The adversarial review found no blocker.

Artifacts:

- Receipt and Cgo gates: `harness_out/docker/20260901T220014Z`
- YAML parity: `harness_out/docker/20260901T210753Z-diag-yaml`
- Focused race: `harness_out/docker/20260901T220615Z`

## Performance

The standard 20-seed randomized loop compared this commit with `9f9e9039`.

The primary benchmark trio has no significant regression:

- Full parse: 12.20 ms to 12.72 ms, `p=0.414`.
- Incremental edit: 983.7 ns to 1013.0 ns, `p=0.764`.
- Incremental no-edit: 2.964 ns to 3.185 ns, `p=0.136`.
- Allocation counts remain unchanged for all three.

The change adds one 24-byte slice header to each compact Core. The memory accounting includes that header and any contents.

Three secondary timings moved significantly:

- warm materialization: +9.81%;
- selected-store language: +6.62%;
- fact-program parsing: +11.55%.

Fact-program bytes increased 4.18%. Allocation counts did not change.

These secondary signals do not block this correctness package. Stage 7 will remeasure and optimize them separately.

## Scope

This pull request contains no later incremental, certification, or release package.