### PR TITLE
ci: authenticate compact-route campaign lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,6 +547,7 @@ jobs:
       - merge-event-census-cgo
       - parity-cgo-exhaustive
       - freshness
+      - compact-route-lifecycle-history
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -570,6 +571,7 @@ jobs:
           MERGE_EVENT_CENSUS_CGO_RESULT: ${{ needs.merge-event-census-cgo.result }}
           EXHAUSTIVE_PARITY_RESULT: ${{ needs.parity-cgo-exhaustive.result }}
           FRESHNESS_RESULT: ${{ needs.freshness.result }}
+          COMPACT_ROUTE_LIFECYCLE_HISTORY_RESULT: ${{ needs.compact-route-lifecycle-history.result }}
         run: |
           set -euo pipefail
           failed=0
@@ -599,6 +601,7 @@ jobs:
           fi
 
           require_success "freshness" "$FRESHNESS_RESULT"
+          require_success "compact-route-lifecycle-history" "$COMPACT_ROUTE_LIFECYCLE_HISTORY_RESULT"
           require_success "compile" "$COMPILE_RESULT"
           require_success "selected_store_admission" "$SELECTED_STORE_ADMISSION_RESULT"
           require_success "compact_admission_ratchet" "$COMPACT_ADMISSION_RATCHET_RESULT"
@@ -759,6 +762,25 @@ jobs:
             echo "::error::Count mismatch — lock: $lock_count, blobs: $blob_count, gen: $gen_count"
             exit 1
           fi
+
+  compact-route-lifecycle-history:
+    needs: exhaustive_parity_scope
+    if: needs.exhaustive_parity_scope.outputs.run_code_ci == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Validate compact route campaign lifecycle history
+        env:
+          GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF: "1"
+        run: go test . -run '^TestCompactRouteCampaignLifecycleRegistry$' -count=1
 
   # apidiff compares the public API of package `gotreesitter` (the module
   # root only, not the full module) between the last released tag and this

--- a/cgo_harness/parity_gate_ratchet_test.go
+++ b/cgo_harness/parity_gate_ratchet_test.go
@@ -96,9 +96,26 @@ func assertRequiredBuildFreshness(t *testing.T) {
 		"      - freshness",
 		"          FRESHNESS_RESULT: ${{ needs.freshness.result }}",
 		`          require_success "freshness" "$FRESHNESS_RESULT"`,
+		"      - compact-route-lifecycle-history",
+		"          COMPACT_ROUTE_LIFECYCLE_HISTORY_RESULT: ${{ needs.compact-route-lifecycle-history.result }}",
+		`          require_success "compact-route-lifecycle-history" "$COMPACT_ROUTE_LIFECYCLE_HISTORY_RESULT"`,
 	} {
 		if !strings.Contains(build, required) {
-			t.Errorf("CI build aggregate is missing freshness contract %q", required)
+			t.Errorf("CI build aggregate is missing required gate contract %q", required)
+		}
+	}
+
+	history := workflowJobBlock(string(workflow), "compact-route-lifecycle-history")
+	if history == "" {
+		t.Fatal("CI workflow is missing the compact-route-lifecycle-history job")
+	}
+	for _, required := range []string{
+		"          fetch-depth: 0",
+		"          GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF: \"1\"",
+		"go test . -run '^TestCompactRouteCampaignLifecycleRegistry$' -count=1",
+	} {
+		if !strings.Contains(history, required) {
+			t.Errorf("CI historical lifecycle job is missing contract %q", required)
 		}
 	}
 }

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -1,0 +1,1766 @@
+package gotreesitter
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const (
+	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
+	compactRouteLifecycleSourceRevision               = "72afa041e9ec2f02872724bbdce17694d89955d8"
+	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
+	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
+	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
+	compactRouteLifecycleReceiptPolicyOptional        = "optional"
+)
+
+type compactRouteLifecycleHistoricalProofMode struct {
+	Strict       bool
+	Shallow      bool
+	GitAvailable bool
+}
+
+var (
+	compactRouteLifecycleCommitPattern   = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	compactRouteLifecycleSHA256Pattern   = regexp.MustCompile(`^[0-9a-f]{64}$`)
+	compactRouteLifecycleEnvPattern      = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+	compactRouteLifecycleBuildTagPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
+	compactRouteLifecyclePRRefPattern    = regexp.MustCompile(`^pr:#([0-9]+)$`)
+)
+
+var compactRouteLifecycleKnownProofRevisions = map[string]string{
+	"pr:#1016": "8bb49959d95fce0cf8bea5468d86e30978ccf393",
+	"cgo_harness/parity_compact_per_version_lexer_scala_test.go#TestCompactPerVersionLexerScalaCOracle": "8bb49959d95fce0cf8bea5468d86e30978ccf393",
+	"pr:#1017": "865d03b07ffd74ee44163a4cfa2f7ddc057134e6",
+	"internal/parsercorephase0/physical_head_merge_stage2_test.go#TestStage2PhysicalHeadMergeAtSixVersionBoundaryRetainsEveryPath": "865d03b07ffd74ee44163a4cfa2f7ddc057134e6",
+	"pr:#1018": "9f9e903940655da46fb8c976fa2e08139153df0f",
+	"parsercore_phase0_recovery_lineage_fork_internal_test.go#TestS5MissingInsertionForkPublishesBothRecoveryLineages": "9f9e903940655da46fb8c976fa2e08139153df0f",
+	"pr:#1019": "0beb95d399655d200e687e0912d3265b1c9562e9",
+	"cgo_harness/eof_recovery_admission_oracle_test.go#TestEOFRecoveryAdmissionUsesLockedCEventsAndPublishedTree": "2ebeb6c64632163622691786a71ac6da76a14929",
+	"incremental_invariant_gate_test.go#TestIncrementalInvariantGatePython":                                       "bf7ab0567122e863ef831e8aa56dbee93127ad93",
+	"w5_editor_latency_gate_test.go#TestW5EditorLatencyGate":                                                      "e734c93543654818082e8d3ae3721cdb6fe9e4a5",
+	"testdata/incremental_allowlist.json":                                                                         "95a1d13156b82e2221415342c9ac8048f2caf644",
+	"docs/compact-route-real-corpus-matrix.md#Current compact-graduation matrix":                                  "41af6afa6da47c9f8b55b3156fd88fb56686373f",
+	"docs/compact-route-coverage-census.md":                                                                       "38d86d417fc6209228b8b175bc2aa7bb9700b8d3",
+	"docs/a8-derivation-divergence-certificate-v1.md":                                                             "acccb81d20128e337a35ee274a2e3e3631b73b1a",
+}
+
+var compactRouteLifecycleKnownCorpusTreeSHA256 = map[string]string{
+	"scala-owned-width": "81dc569b1ad3d567ed158aea75fd30a388ec1f4d3e1cbdd08c29a6535bd456d3",
+}
+
+type compactRouteLifecycleRegistry struct {
+	Schema               string                          `json:"schema"`
+	SourceRevision       string                          `json:"source_revision"`
+	Scope                string                          `json:"scope"`
+	Authority            []string                        `json:"authority"`
+	CampaignIdentifiers  []string                        `json:"campaign_identifiers"`
+	Funnel               compactRouteLifecycleFunnel     `json:"funnel"`
+	CorePRGate           compactRouteLifecycleCorePRGate `json:"core_pr_gate"`
+	GraduationDefinition []string                        `json:"graduation_definition"`
+	HistoryPolicy        compactRouteLifecycleHistory    `json:"history_policy"`
+	Vocabularies         compactRouteLifecycleVocab      `json:"vocabularies"`
+	Controls             []compactRouteLifecycleControl  `json:"controls"`
+	Entries              []compactRouteLifecycleEntry    `json:"entries"`
+}
+
+type compactRouteLifecycleFunnel struct {
+	OrderedStages                  []int    `json:"ordered_stages"`
+	ActiveCoreStage                int      `json:"active_core_stage"`
+	CoreRule                       string   `json:"core_rule"`
+	ParallelLanes                  []string `json:"parallel_lanes"`
+	CorrectnessPrecedesPerformance bool     `json:"correctness_precedes_performance"`
+}
+
+type compactRouteLifecycleCorePRGate struct {
+	RequiredFields  []string `json:"required_fields"`
+	PerformanceRule string   `json:"performance_rule"`
+}
+
+type compactRouteLifecycleHistory struct {
+	PreserveEntries     bool                             `json:"preserve_entries"`
+	PreserveReceiptRefs bool                             `json:"preserve_receipt_refs"`
+	PreservePlanRefs    bool                             `json:"preserve_plan_refs"`
+	RetirementRule      string                           `json:"retirement_rule"`
+	StaleRule           string                           `json:"stale_rule"`
+	StatePolicy         compactRouteLifecycleStatePolicy `json:"state_policy"`
+}
+
+type compactRouteLifecycleStatePolicy struct {
+	CurrentReceiptRequired []string `json:"current_receipt_required"`
+	HistoricalOnly         []string `json:"historical_only"`
+	ReceiptsOptional       []string `json:"receipts_optional"`
+}
+
+type compactRouteLifecycleVocab struct {
+	Owners          []string `json:"owners"`
+	Statuses        []string `json:"statuses"`
+	ReceiptStatuses []string `json:"receipt_statuses"`
+	PlanStatuses    []string `json:"plan_statuses"`
+	Retention       []string `json:"retention"`
+	Lanes           []string `json:"lanes"`
+	ControlKinds    []string `json:"control_kinds"`
+	PathRoles       []string `json:"path_roles"`
+}
+
+type compactRouteLifecycleControl struct {
+	ID         string                          `json:"id"`
+	Kind       string                          `json:"kind"`
+	Expression string                          `json:"expression"`
+	Scope      string                          `json:"scope"`
+	Name       string                          `json:"name"`
+	Default    string                          `json:"default"`
+	ReadSites  []compactRouteLifecycleReadSite `json:"read_sites"`
+}
+
+type compactRouteLifecycleReadSite struct {
+	Path   string `json:"path"`
+	Symbol string `json:"symbol"`
+	Line   int    `json:"line"`
+}
+
+type compactRouteLifecycleEntry struct {
+	ID                string                         `json:"id"`
+	Stage             int                            `json:"stage"`
+	Lane              string                         `json:"lane"`
+	Status            string                         `json:"status"`
+	Owner             string                         `json:"owner"`
+	Campaigns         []string                       `json:"campaigns"`
+	Purpose           string                         `json:"purpose"`
+	BuildExpressions  []string                       `json:"build_expressions"`
+	ControlIDs        []string                       `json:"control_ids"`
+	Paths             []compactRouteLifecyclePath    `json:"paths"`
+	TestCommands      []compactRouteLifecycleCommand `json:"test_commands"`
+	Corpus            []compactRouteLifecycleCorpus  `json:"corpus"`
+	Gates             []string                       `json:"gates"`
+	Telemetry         []string                       `json:"telemetry"`
+	PlanRefs          []compactRouteLifecyclePlan    `json:"plan_refs"`
+	ProofReceipts     []compactRouteLifecycleReceipt `json:"proof_receipts"`
+	DeletionCondition string                         `json:"deletion_condition"`
+	Retention         string                         `json:"retention"`
+	HistoryPreserved  bool                           `json:"history_preserved"`
+}
+
+type compactRouteLifecyclePath struct {
+	Path            string `json:"path"`
+	Role            string `json:"role"`
+	BuildExpression string `json:"build_expression"`
+	Symbol          string `json:"symbol"`
+}
+
+type compactRouteLifecycleCommand struct {
+	Name       string `json:"name"`
+	Command    string `json:"command"`
+	WorkingDir string `json:"working_dir"`
+	Isolation  string `json:"isolation"`
+}
+
+type compactRouteLifecycleCorpus struct {
+	ID           string `json:"id"`
+	Kind         string `json:"kind"`
+	Path         string `json:"path"`
+	Source       string `json:"source"`
+	SourceSHA256 string `json:"source_sha256"`
+	TreeSHA256   string `json:"tree_sha256"`
+	Availability string `json:"availability"`
+	LockStatus   string `json:"lock_status"`
+	Plan         string `json:"plan"`
+	LockOrDigest string `json:"lock_or_digest"`
+}
+
+type compactRouteLifecyclePlan struct {
+	Ref            string `json:"ref"`
+	Kind           string `json:"kind"`
+	SourceRevision string `json:"source_revision"`
+	Status         string `json:"status"`
+}
+
+type compactRouteLifecycleReceipt struct {
+	Ref            string `json:"ref"`
+	Kind           string `json:"kind"`
+	SourceRevision string `json:"source_revision"`
+	Status         string `json:"status"`
+}
+
+func TestCompactRouteCampaignLifecycleRegistry(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+
+	if registry.Schema != "gotreesitter/compact-route-campaign-lifecycle/v1" {
+		t.Fatalf("schema = %q", registry.Schema)
+	}
+	if registry.SourceRevision != compactRouteLifecycleSourceRevision {
+		t.Fatalf("source_revision = %q, want %q", registry.SourceRevision, compactRouteLifecycleSourceRevision)
+	}
+	if !compactRouteLifecycleCommitPattern.MatchString(registry.SourceRevision) {
+		t.Fatalf("source_revision is not a commit hash: %q", registry.SourceRevision)
+	}
+	if strings.TrimSpace(registry.Scope) == "" {
+		t.Fatal("scope is empty")
+	}
+	if len(registry.Authority) == 0 || len(registry.CampaignIdentifiers) == 0 {
+		t.Fatal("authority and campaign_identifiers are required")
+	}
+	validateStringVocabulary(t, "authority", registry.Authority, nil)
+	validateStringVocabulary(t, "campaign_identifiers", registry.CampaignIdentifiers, nil)
+	root, err := compactRouteLifecycleRepositoryRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	historicalProofMode, err := compactRouteLifecycleHistoricalProofModeForRepository(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compactRouteLifecycleValidateRegistryBase(root, registry.SourceRevision, historicalProofMode); err != nil {
+		t.Fatal(err)
+	}
+
+	validateCompactRouteLifecycleFunnel(t, registry)
+	validateCompactRouteLifecycleGate(t, registry)
+	validateCompactRouteLifecycleHistory(t, registry)
+	validateCompactRouteLifecycleVocabularies(t, registry)
+
+	campaigns := compactRouteLifecycleSet(t, "campaign_identifiers", registry.CampaignIdentifiers)
+	for _, authority := range registry.Authority {
+		if !campaigns[authority] {
+			t.Errorf("authority %q is not a campaign identifier", authority)
+		}
+	}
+
+	controls := validateCompactRouteLifecycleControls(t, registry, root)
+	validateCompactRouteLifecycleEntries(t, registry, campaigns, controls, root, historicalProofMode)
+}
+
+func TestCompactRouteLifecycleRejectsFabricatedProofReceipt(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+	receipt := registry.Entries[0].ProofReceipts[0]
+	receipt.SourceRevision = strings.Repeat("0", 40)
+	if err := compactRouteLifecycleProofReceiptError(receipt); err == nil {
+		t.Fatal("fabricated proof receipt was accepted")
+	}
+}
+
+func TestCompactRouteLifecycleDefaultAllowsMissingHistoricalProofInShallowMode(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+	root, err := compactRouteLifecycleRepositoryRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mode, err := compactRouteLifecycleDecideHistoricalProofMode(false, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := registry.Entries[0].ProofReceipts[0]
+	receipt.SourceRevision = strings.Repeat("0", 40)
+	if err := compactRouteLifecycleProofRepositoryErrorAtMode(root, registry.SourceRevision, receipt, mode); err != nil {
+		t.Fatalf("default shallow mode rejected an unavailable historical object: %v", err)
+	}
+}
+
+func TestCompactRouteLifecycleShallowModeStillRequiresAllowlistEquality(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+	root, err := compactRouteLifecycleRepositoryRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mode, err := compactRouteLifecycleDecideHistoricalProofMode(false, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := registry.Entries[0].ProofReceipts[0]
+	receipt.SourceRevision = strings.Repeat("0", 40)
+	receipt.Ref = "pr:#9999"
+	if err := compactRouteLifecycleProofReceiptErrorAtMode(root, registry.SourceRevision, receipt, mode); err == nil {
+		t.Fatal("shallow mode accepted a proof receipt outside the immutable allowlist")
+	}
+}
+
+func TestCompactRouteLifecycleShallowModeChecksAvailableHistoricalProof(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+	root, err := compactRouteLifecycleRepositoryRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mode, err := compactRouteLifecycleDecideHistoricalProofMode(false, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := registry.Entries[0].ProofReceipts[1]
+	receipt.Ref += "#fabricatedLifecycleAnchor"
+	if err := compactRouteLifecycleProofReceiptErrorAtMode(root, registry.SourceRevision, receipt, mode); err == nil {
+		t.Fatal("shallow mode accepted an invalid anchor for available historical objects")
+	}
+}
+
+func TestCompactRouteLifecycleRejectsPRReceiptWithWrongCommitMessage(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+	root, err := compactRouteLifecycleRepositoryRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := registry.Entries[0].ProofReceipts[0]
+	receipt.Ref = "pr:#1017"
+	strictMode := compactRouteLifecycleHistoricalProofMode{Strict: true, GitAvailable: true}
+	if err := compactRouteLifecycleProofRepositoryErrorAtMode(root, registry.SourceRevision, receipt, strictMode); err == nil {
+		t.Fatal("a real ancestor with a different pull-request number was accepted")
+	}
+}
+
+func TestCompactRouteLifecycleStrictModeRejectsShallowRepository(t *testing.T) {
+	if _, err := compactRouteLifecycleDecideHistoricalProofMode(true, true, true); err == nil {
+		t.Fatal("strict historical proof mode accepted a shallow repository")
+	}
+}
+
+func TestCompactRouteLifecycleStrictModeRequiresGitRepository(t *testing.T) {
+	if _, err := compactRouteLifecycleDecideHistoricalProofMode(true, false, false); err == nil {
+		t.Fatal("strict historical proof mode accepted an unavailable repository")
+	}
+}
+
+func TestCompactRouteLifecycleHistoricalProofEnvironmentContract(t *testing.T) {
+	t.Setenv(compactRouteLifecycleHistoricalProofEnv, "1")
+	strictMode, err := compactRouteLifecycleDecideHistoricalProofMode(os.Getenv(compactRouteLifecycleHistoricalProofEnv) == "1", true, true)
+	if err == nil || !strictMode.Strict || !strictMode.Shallow {
+		t.Fatalf("strict environment contract produced mode=%+v err=%v", strictMode, err)
+	}
+	t.Setenv(compactRouteLifecycleHistoricalProofEnv, "0")
+	defaultMode, err := compactRouteLifecycleDecideHistoricalProofMode(os.Getenv(compactRouteLifecycleHistoricalProofEnv) == "1", true, true)
+	if err != nil || defaultMode.Strict || !defaultMode.Shallow {
+		t.Fatalf("non-strict environment value produced mode=%+v err=%v", defaultMode, err)
+	}
+}
+
+func TestCompactRouteLifecycleRejectsFabricatedProofCommit(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+	root, err := compactRouteLifecycleRepositoryRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := registry.Entries[0].ProofReceipts[0]
+	receipt.SourceRevision = strings.Repeat("0", 40)
+	if err := compactRouteLifecycleProofReceiptErrorAt(root, registry.SourceRevision, receipt); err == nil {
+		t.Fatal("fabricated proof commit was accepted")
+	}
+}
+
+func TestCompactRouteLifecycleRejectsFabricatedProofPath(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+	root, err := compactRouteLifecycleRepositoryRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := registry.Entries[0].ProofReceipts[1]
+	receipt.Ref = "compact_route_campaign_lifecycle_test.go#TestCompactRouteCampaignLifecycleRegistry"
+	if err := compactRouteLifecycleProofReceiptErrorAt(root, registry.SourceRevision, receipt); err == nil {
+		t.Fatal("fabricated proof path was accepted")
+	}
+}
+
+func TestCompactRouteLifecycleRejectsFabricatedProofAnchor(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+	root, err := compactRouteLifecycleRepositoryRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := registry.Entries[0].ProofReceipts[1]
+	receipt.Ref += "#fabricatedLifecycleAnchor"
+	if err := compactRouteLifecycleProofReceiptErrorAt(root, registry.SourceRevision, receipt); err == nil {
+		t.Fatal("fabricated proof anchor was accepted")
+	}
+}
+
+func TestCompactRouteLifecycleRejectsEmbeddedCorpusHashMismatch(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+	corpus := registry.Entries[3].Corpus[0]
+	corpus.Source = "[\\n"
+	if err := compactRouteLifecycleEmbeddedCorpusHashError(corpus); err == nil {
+		t.Fatal("embedded corpus hash mismatch was accepted")
+	}
+}
+
+func TestCompactRouteLifecycleRejectsFileBackedCorpusHashMismatch(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+	root, err := compactRouteLifecycleRepositoryRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	corpus := registry.Entries[4].Corpus[len(registry.Entries[4].Corpus)-1]
+	corpus.SourceSHA256 = strings.Repeat("0", 64)
+	if err := compactRouteLifecycleCorpusHashError(root, corpus); err == nil {
+		t.Fatal("file-backed corpus hash mismatch was accepted")
+	}
+}
+
+func TestCompactRouteLifecycleRejectsKnownCorpusTreeHashMismatch(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+	root, err := compactRouteLifecycleRepositoryRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	corpus := registry.Entries[0].Corpus[0]
+	corpus.TreeSHA256 = strings.Repeat("0", 64)
+	if err := compactRouteLifecycleCorpusHashError(root, corpus); err == nil {
+		t.Fatal("known corpus tree hash mismatch was accepted")
+	}
+}
+
+func TestCompactRouteLifecycleRejectsCurrentReceiptForHistoricalStates(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+	receipt := registry.Entries[0].ProofReceipts[0]
+	for _, status := range []string{"retired", "superseded"} {
+		policy := compactRouteLifecycleReceiptPolicyForStatus(registry.HistoryPolicy.StatePolicy, status)
+		if err := compactRouteLifecycleReceiptStateError(status, []compactRouteLifecycleReceipt{receipt}, policy); err == nil {
+			t.Errorf("%s entry accepted a current receipt", status)
+		}
+		for _, receiptStatus := range []string{"stale", "historical"} {
+			retained := receipt
+			retained.Status = receiptStatus
+			if err := compactRouteLifecycleReceiptStateError(status, []compactRouteLifecycleReceipt{retained}, policy); err != nil {
+				t.Errorf("%s entry rejected a %s receipt: %v", status, receiptStatus, err)
+			}
+		}
+	}
+}
+
+func TestCompactRouteLifecycleRejectsStaleReadSite(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+	root, err := compactRouteLifecycleRepositoryRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	site := registry.Controls[0].ReadSites[0]
+	t.Run("stale line", func(t *testing.T) {
+		stale := site
+		stale.Line = 1
+		if err := compactRouteLifecycleReadSiteError(root, "negative", stale); err == nil {
+			t.Fatal("stale read-site line was accepted")
+		}
+	})
+	t.Run("stale symbol", func(t *testing.T) {
+		stale := site
+		stale.Symbol = "fabricatedLifecycleSymbol"
+		if err := compactRouteLifecycleReadSiteError(root, "negative", stale); err == nil {
+			t.Fatal("stale read-site symbol was accepted")
+		}
+	})
+}
+
+func TestCompactRouteLifecycleRejectsIncompleteBuildExpression(t *testing.T) {
+	if err := parseCompactRouteLifecycleBuildExpression("gts_parsercorephase0 &&"); err == nil {
+		t.Fatal("incomplete build expression was accepted")
+	}
+}
+
+func TestCompactRouteLifecycleRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	link := filepath.Join(root, "escape")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink setup is unavailable: %v", err)
+	}
+	if _, err := compactRouteLifecycleResolvePath(root, "escape", true); err == nil {
+		t.Fatal("symlink escape was accepted")
+	}
+}
+
+func TestCompactRouteLifecycleRejectsUnsafeCommandDestinations(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{name: "absolute output flag", command: "go test . --output /tmp/x"},
+		{name: "absolute receipt assignment", command: "RECEIPT=/tmp/x go test ."},
+		{name: "parent traversal", command: "go test . --output ../outside"},
+		{name: "home expansion", command: "go test . --output ~/x"},
+		{name: "unresolved variable", command: "go test . --output ${DEST}"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := compactRouteLifecycleCommandDestinationError(test.command); err == nil {
+				t.Fatalf("unsafe command destination was accepted: %s", test.command)
+			}
+		})
+	}
+	if err := compactRouteLifecycleCommandDestinationError("go test . --output harness_out/result.json"); err != nil {
+		t.Fatalf("repository-relative harness_out destination was rejected: %v", err)
+	}
+}
+
+func TestCompactRouteLifecycleRejectsDuplicateJSONKeys(t *testing.T) {
+	_, err := decodeCompactRouteLifecycleRegistry([]byte(`{"schema":"one","schema":"two"}`))
+	if err == nil || !strings.Contains(err.Error(), "duplicate JSON key") {
+		t.Fatalf("duplicate JSON keys were accepted: %v", err)
+	}
+}
+
+func TestCompactRouteLifecycleRejectsPlannedReceiptLabel(t *testing.T) {
+	registry := loadCompactRouteLifecycleRegistry(t)
+	plan := registry.Entries[5].PlanRefs[0]
+	mislabelled := compactRouteLifecycleReceipt{
+		Ref:            plan.Ref,
+		Kind:           plan.Kind,
+		SourceRevision: plan.SourceRevision,
+		Status:         "current",
+	}
+	if err := compactRouteLifecycleProofReceiptError(mislabelled); err == nil {
+		t.Fatal("planned reference was accepted as a proof receipt")
+	}
+}
+
+func loadCompactRouteLifecycleRegistry(t *testing.T) compactRouteLifecycleRegistry {
+	t.Helper()
+	data, err := os.ReadFile(compactRouteLifecycleRegistryPath)
+	if err != nil {
+		t.Fatalf("open %s: %v", compactRouteLifecycleRegistryPath, err)
+	}
+	registry, err := decodeCompactRouteLifecycleRegistry(data)
+	if err != nil {
+		t.Fatalf("decode %s: %v", compactRouteLifecycleRegistryPath, err)
+	}
+	return registry
+}
+
+func decodeCompactRouteLifecycleRegistry(data []byte) (compactRouteLifecycleRegistry, error) {
+	if err := rejectCompactRouteLifecycleDuplicateKeys(data); err != nil {
+		return compactRouteLifecycleRegistry{}, err
+	}
+	var registry compactRouteLifecycleRegistry
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&registry); err != nil {
+		return compactRouteLifecycleRegistry{}, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return compactRouteLifecycleRegistry{}, fmt.Errorf("trailing JSON data: %v", err)
+	}
+	return registry, nil
+}
+
+func rejectCompactRouteLifecycleDuplicateKeys(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := consumeCompactRouteLifecycleJSONValue(decoder, "$"); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return fmt.Errorf("trailing JSON data: %v", err)
+	}
+	return nil
+}
+
+func consumeCompactRouteLifecycleJSONValue(decoder *json.Decoder, path string) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := make(map[string]bool)
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return fmt.Errorf("object key at %s is not a string", path)
+			}
+			if seen[key] {
+				return fmt.Errorf("duplicate JSON key %q at %s", key, path)
+			}
+			seen[key] = true
+			if err := consumeCompactRouteLifecycleJSONValue(decoder, path+"."+key); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil || end != json.Delim('}') {
+			return fmt.Errorf("object at %s is not closed", path)
+		}
+	case '[':
+		index := 0
+		for decoder.More() {
+			if err := consumeCompactRouteLifecycleJSONValue(decoder, fmt.Sprintf("%s[%d]", path, index)); err != nil {
+				return err
+			}
+			index++
+		}
+		end, err := decoder.Token()
+		if err != nil || end != json.Delim(']') {
+			return fmt.Errorf("array at %s is not closed", path)
+		}
+	default:
+		return fmt.Errorf("unexpected JSON delimiter %q at %s", delim, path)
+	}
+	return nil
+}
+
+func validateCompactRouteLifecycleFunnel(t *testing.T, registry compactRouteLifecycleRegistry) {
+	t.Helper()
+	wantStages := []int{1, 2, 3, 4, 5, 6, 7}
+	if !equalCompactRouteLifecycleInts(registry.Funnel.OrderedStages, wantStages) {
+		t.Errorf("ordered_stages = %v, want %v", registry.Funnel.OrderedStages, wantStages)
+	}
+	if registry.Funnel.ActiveCoreStage != 5 {
+		t.Errorf("active_core_stage = %d, want 5", registry.Funnel.ActiveCoreStage)
+	}
+	if strings.TrimSpace(registry.Funnel.CoreRule) == "" {
+		t.Error("funnel core_rule is empty")
+	}
+	if !registry.Funnel.CorrectnessPrecedesPerformance {
+		t.Error("funnel must require correctness before performance")
+	}
+	validateStringVocabulary(t, "parallel_lanes", registry.Funnel.ParallelLanes, []string{"adversarial", "certification", "performance"})
+}
+
+func validateCompactRouteLifecycleGate(t *testing.T, registry compactRouteLifecycleRegistry) {
+	t.Helper()
+	want := []string{
+		"smallest_c_oracle_falsifier",
+		"focused_implementation",
+		"one_core_implementation_stage_active",
+		"exact_tree_range_error_assertions",
+		"one_grammar_docker_parity",
+		"cleanup_and_ownership_checks",
+		"intended_path_telemetry",
+		"no_unrelated_performance_work",
+	}
+	if !equalCompactRouteLifecycleStrings(registry.CorePRGate.RequiredFields, want) {
+		t.Errorf("core_pr_gate.required_fields = %v, want %v", registry.CorePRGate.RequiredFields, want)
+	}
+	if strings.TrimSpace(registry.CorePRGate.PerformanceRule) == "" {
+		t.Error("core_pr_gate.performance_rule is empty")
+	}
+	if len(registry.GraduationDefinition) < 6 {
+		t.Errorf("graduation_definition has %d items, want at least 6", len(registry.GraduationDefinition))
+	}
+	for index, item := range registry.GraduationDefinition {
+		if strings.TrimSpace(item) == "" {
+			t.Errorf("graduation_definition[%d] is empty", index)
+		}
+	}
+}
+
+func validateCompactRouteLifecycleHistory(t *testing.T, registry compactRouteLifecycleRegistry) {
+	t.Helper()
+	if !registry.HistoryPolicy.PreserveEntries || !registry.HistoryPolicy.PreserveReceiptRefs || !registry.HistoryPolicy.PreservePlanRefs {
+		t.Error("history policy must preserve entries, proof receipts, and plans")
+	}
+	if strings.TrimSpace(registry.HistoryPolicy.RetirementRule) == "" || strings.TrimSpace(registry.HistoryPolicy.StaleRule) == "" {
+		t.Error("history policy requires retirement and stale rules")
+	}
+	validateCompactRouteLifecycleStatePolicy(t, registry)
+}
+
+func validateCompactRouteLifecycleStatePolicy(t *testing.T, registry compactRouteLifecycleRegistry) {
+	t.Helper()
+	policy := registry.HistoryPolicy.StatePolicy
+	validateStringVocabulary(t, "state_policy.current_receipt_required", policy.CurrentReceiptRequired, []string{"active", "graduated"})
+	validateStringVocabulary(t, "state_policy.historical_only", policy.HistoricalOnly, []string{"retired", "superseded"})
+	validateStringVocabulary(t, "state_policy.receipts_optional", policy.ReceiptsOptional, []string{"planned"})
+	sets := map[string][]string{
+		compactRouteLifecycleReceiptPolicyCurrentRequired: policy.CurrentReceiptRequired,
+		compactRouteLifecycleReceiptPolicyHistoricalOnly:  policy.HistoricalOnly,
+		compactRouteLifecycleReceiptPolicyOptional:        policy.ReceiptsOptional,
+	}
+	seen := make(map[string]string)
+	for policyName, statuses := range sets {
+		for _, status := range statuses {
+			if previous, ok := seen[status]; ok {
+				t.Errorf("lifecycle state %q appears in state policies %q and %q", status, previous, policyName)
+			}
+			seen[status] = policyName
+		}
+	}
+	for _, status := range registry.Vocabularies.Statuses {
+		if _, ok := seen[status]; !ok {
+			t.Errorf("lifecycle state %q has no state policy", status)
+		}
+	}
+	for status := range seen {
+		if !containsCompactRouteLifecycleString(registry.Vocabularies.Statuses, status) {
+			t.Errorf("state policy names unknown lifecycle state %q", status)
+		}
+	}
+}
+
+func compactRouteLifecycleReceiptPolicyForStatus(policy compactRouteLifecycleStatePolicy, status string) string {
+	if containsCompactRouteLifecycleString(policy.CurrentReceiptRequired, status) {
+		return compactRouteLifecycleReceiptPolicyCurrentRequired
+	}
+	if containsCompactRouteLifecycleString(policy.HistoricalOnly, status) {
+		return compactRouteLifecycleReceiptPolicyHistoricalOnly
+	}
+	if containsCompactRouteLifecycleString(policy.ReceiptsOptional, status) {
+		return compactRouteLifecycleReceiptPolicyOptional
+	}
+	return ""
+}
+
+func validateCompactRouteLifecycleVocabularies(t *testing.T, registry compactRouteLifecycleRegistry) {
+	t.Helper()
+	validateStringVocabulary(t, "owners", registry.Vocabularies.Owners, nil)
+	validateStringVocabulary(t, "statuses", registry.Vocabularies.Statuses, nil)
+	validateStringVocabulary(t, "receipt_statuses", registry.Vocabularies.ReceiptStatuses, []string{"current", "stale", "historical"})
+	validateStringVocabulary(t, "plan_statuses", registry.Vocabularies.PlanStatuses, []string{"active", "planned", "stale", "historical"})
+	validateStringVocabulary(t, "retention", registry.Vocabularies.Retention, nil)
+	validateStringVocabulary(t, "lanes", registry.Vocabularies.Lanes, []string{"core", "adversarial", "certification", "performance"})
+	validateStringVocabulary(t, "control_kinds", registry.Vocabularies.ControlKinds, []string{"build_expression", "environment"})
+	validateStringVocabulary(t, "path_roles", registry.Vocabularies.PathRoles, nil)
+}
+
+func validateStringVocabulary(t *testing.T, name string, values, required []string) {
+	t.Helper()
+	if len(values) == 0 {
+		t.Errorf("%s is empty", name)
+		return
+	}
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			t.Errorf("%s contains an empty value", name)
+		}
+		if seen[value] {
+			t.Errorf("%s contains duplicate value %q", name, value)
+		}
+		seen[value] = true
+	}
+	for _, value := range required {
+		if !seen[value] {
+			t.Errorf("%s does not contain required value %q", name, value)
+		}
+	}
+}
+
+func validateCompactRouteLifecycleControls(t *testing.T, registry compactRouteLifecycleRegistry, root string) map[string]compactRouteLifecycleControl {
+	t.Helper()
+	allowedScopes := map[string]bool{"production": true, "test": true, "harness": true}
+	allowedKinds := compactRouteLifecycleSet(t, "control_kinds", registry.Vocabularies.ControlKinds)
+	controls := make(map[string]compactRouteLifecycleControl, len(registry.Controls))
+	environmentNames := make(map[string]bool)
+	for _, control := range registry.Controls {
+		if strings.TrimSpace(control.ID) == "" || controls[control.ID].ID != "" {
+			t.Errorf("control IDs must be unique and non-empty: %q", control.ID)
+			continue
+		}
+		if !allowedKinds[control.Kind] {
+			t.Errorf("control %q has unsupported kind %q", control.ID, control.Kind)
+		}
+		if !allowedScopes[control.Scope] {
+			t.Errorf("control %q has an unsupported scope %q", control.ID, control.Scope)
+		}
+		if control.Kind == "build_expression" && strings.TrimSpace(control.Expression) == "" {
+			t.Errorf("build control %q has no expression", control.ID)
+		} else if control.Kind == "build_expression" {
+			if err := parseCompactRouteLifecycleBuildExpression(control.Expression); err != nil {
+				t.Errorf("build control %q: %v", control.ID, err)
+			}
+		}
+		if control.Kind == "environment" {
+			if !compactRouteLifecycleEnvPattern.MatchString(control.Name) {
+				t.Errorf("control %q has invalid environment name %q", control.ID, control.Name)
+			}
+			if control.ID != "env."+control.Name {
+				t.Errorf("environment control %q does not match name %q", control.ID, control.Name)
+			}
+			if environmentNames[control.Name] {
+				t.Errorf("environment name %q is duplicated", control.Name)
+			}
+			environmentNames[control.Name] = true
+			if strings.TrimSpace(control.Default) == "" {
+				t.Errorf("environment control %q has no default", control.ID)
+			}
+		}
+		if len(control.ReadSites) == 0 {
+			t.Errorf("control %q has no read sites", control.ID)
+		}
+		for _, site := range control.ReadSites {
+			validateCompactRouteLifecycleReadSite(t, root, control.ID, site)
+		}
+		controls[control.ID] = control
+	}
+	return controls
+}
+
+func validateCompactRouteLifecycleReadSite(t *testing.T, root, owner string, site compactRouteLifecycleReadSite) {
+	t.Helper()
+	if err := compactRouteLifecycleReadSiteError(root, owner, site); err != nil {
+		t.Error(err)
+	}
+}
+
+func compactRouteLifecycleReadSiteError(root, owner string, site compactRouteLifecycleReadSite) error {
+	if strings.TrimSpace(site.Path) == "" || strings.TrimSpace(site.Symbol) == "" || site.Line < 1 {
+		return fmt.Errorf("%s read site has an empty path, symbol, or invalid line", owner)
+	}
+	resolved, err := compactRouteLifecycleResolvePath(root, site.Path, true)
+	if err != nil {
+		return fmt.Errorf("%s read site %s: %v", owner, site.Path, err)
+	}
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return fmt.Errorf("%s read site %s: %v", owner, site.Path, err)
+	}
+	lines := strings.Split(string(data), "\n")
+	if site.Line > len(lines) {
+		return fmt.Errorf("%s read site %s:%d exceeds %d lines", owner, site.Path, site.Line, len(lines))
+	}
+	lo := site.Line - 12
+	if lo < 1 {
+		lo = 1
+	}
+	hi := site.Line + 12
+	if hi > len(lines) {
+		hi = len(lines)
+	}
+	for _, line := range lines[lo-1 : hi] {
+		if strings.Contains(line, site.Symbol) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s read site %s:%d does not contain symbol %q nearby", owner, site.Path, site.Line, site.Symbol)
+}
+
+func validateCompactRouteLifecycleEntries(t *testing.T, registry compactRouteLifecycleRegistry, campaigns map[string]bool, controls map[string]compactRouteLifecycleControl, root string, historicalProofMode compactRouteLifecycleHistoricalProofMode) {
+	t.Helper()
+	allowedStatuses := compactRouteLifecycleSet(t, "statuses", registry.Vocabularies.Statuses)
+	allowedOwners := compactRouteLifecycleSet(t, "owners", registry.Vocabularies.Owners)
+	allowedLanes := compactRouteLifecycleSet(t, "lanes", registry.Vocabularies.Lanes)
+	allowedRoles := compactRouteLifecycleSet(t, "path_roles", registry.Vocabularies.PathRoles)
+	allowedRetention := compactRouteLifecycleSet(t, "retention", registry.Vocabularies.Retention)
+	allowedReceiptStatuses := compactRouteLifecycleSet(t, "receipt_statuses", registry.Vocabularies.ReceiptStatuses)
+	allowedPlanStatuses := compactRouteLifecycleSet(t, "plan_statuses", registry.Vocabularies.PlanStatuses)
+
+	want := map[int]struct {
+		id        string
+		status    string
+		owner     string
+		retention string
+	}{
+		1: {"stage-1-per-version-lexer", "graduated", "scanner_checkpoint_state", "preserve_receipt"},
+		2: {"stage-2-physical-graph-head-merge", "graduated", "graph_head_lifecycle", "preserve_receipt"},
+		3: {"stage-3-recovery-through-ambiguity", "graduated", "derivation_election_selection", "preserve_receipt"},
+		4: {"stage-4-end-of-file-recovery", "graduated", "scheduler_action_semantics", "preserve_receipt"},
+		5: {"stage-5-incremental-integration", "active", "incremental_edit_reuse", "keep_stable_telemetry"},
+		6: {"stage-6-grammar-certification", "planned", "oracle_certification", "preserve_receipt"},
+		7: {"stage-7-performance-and-release", "planned", "performance_release", "keep_emergency_fallback"},
+	}
+	seenStages := make(map[int]bool)
+	seenIDs := make(map[string]bool)
+	seenProofRefs := make(map[string]int, len(compactRouteLifecycleKnownProofRevisions))
+	activeCoreStages := 0
+	for _, entry := range registry.Entries {
+		if strings.TrimSpace(entry.ID) == "" {
+			t.Error("entry ID is empty")
+			continue
+		}
+		spec, ok := want[entry.Stage]
+		if !ok {
+			t.Errorf("entry %q has unsupported stage %d", entry.ID, entry.Stage)
+			continue
+		}
+		if seenIDs[entry.ID] {
+			t.Errorf("entry IDs must be unique: %q", entry.ID)
+		}
+		seenIDs[entry.ID] = true
+		if entry.ID == spec.id {
+			if seenStages[entry.Stage] {
+				t.Errorf("canonical stage %d is duplicated", entry.Stage)
+			}
+			seenStages[entry.Stage] = true
+		}
+		if entry.ID == spec.id && (entry.Status != spec.status || entry.Owner != spec.owner || entry.Retention != spec.retention) {
+			t.Errorf("stage %d identity = %q/%q/%q/%q, want %q/%q/%q/%q", entry.Stage, entry.ID, entry.Status, entry.Owner, entry.Retention, spec.id, spec.status, spec.owner, spec.retention)
+		}
+		if entry.Lane != "core" || !allowedLanes[entry.Lane] {
+			t.Errorf("stage %d lane = %q, want core", entry.Stage, entry.Lane)
+		}
+		if !allowedStatuses[entry.Status] || !allowedOwners[entry.Owner] || !allowedRetention[entry.Retention] {
+			t.Errorf("stage %d uses a vocabulary value outside the registry", entry.Stage)
+		}
+		if strings.TrimSpace(entry.Purpose) == "" || strings.TrimSpace(entry.DeletionCondition) == "" || !entry.HistoryPreserved {
+			t.Errorf("stage %d requires purpose, deletion condition, and history preservation", entry.Stage)
+		}
+		if len(entry.Campaigns) == 0 || len(entry.BuildExpressions) == 0 || len(entry.ControlIDs) == 0 || len(entry.Paths) == 0 || len(entry.TestCommands) == 0 || len(entry.Corpus) == 0 || len(entry.Gates) == 0 || len(entry.Telemetry) == 0 {
+			t.Errorf("stage %d is missing a lifecycle section", entry.Stage)
+		}
+		receiptPolicy := compactRouteLifecycleReceiptPolicyForStatus(registry.HistoryPolicy.StatePolicy, entry.Status)
+		if receiptPolicy == "" {
+			t.Errorf("stage %d status %q has no receipt policy", entry.Stage, entry.Status)
+		}
+		if entry.Status == "planned" && len(entry.PlanRefs) == 0 {
+			t.Errorf("planned stage %d has no plan references", entry.Stage)
+		}
+		if receiptPolicy == compactRouteLifecycleReceiptPolicyCurrentRequired && len(entry.ProofReceipts) == 0 {
+			t.Errorf("stage %d status %q has no proof receipts", entry.Stage, entry.Status)
+		}
+		if entry.Status == "active" && entry.Lane == "core" {
+			activeCoreStages++
+		}
+		validateCompactRouteLifecycleCampaigns(t, entry, campaigns)
+		validateCompactRouteLifecycleBuildExpressions(t, entry)
+		for _, controlID := range entry.ControlIDs {
+			if _, ok := controls[controlID]; !ok {
+				t.Errorf("stage %d references unknown control %q", entry.Stage, controlID)
+			}
+		}
+		for _, path := range entry.Paths {
+			if !allowedRoles[path.Role] {
+				t.Errorf("stage %d path %q has unsupported role %q", entry.Stage, path.Path, path.Role)
+			}
+			if !containsCompactRouteLifecycleString(entry.BuildExpressions, path.BuildExpression) {
+				t.Errorf("stage %d path %q uses unlisted build expression %q", entry.Stage, path.Path, path.BuildExpression)
+			}
+			validateCompactRouteLifecyclePath(t, root, entry.Stage, path)
+		}
+		validateCompactRouteLifecycleCommands(t, root, entry)
+		validateCompactRouteLifecycleCorpus(t, root, entry)
+		staleReceipts := validateCompactRouteLifecycleReceipts(t, root, registry.SourceRevision, entry, allowedReceiptStatuses, receiptPolicy, historicalProofMode)
+		for _, receipt := range entry.ProofReceipts {
+			if previousStage, ok := seenProofRefs[receipt.Ref]; ok {
+				t.Errorf("proof receipt %q is duplicated in stages %d and %d", receipt.Ref, previousStage, entry.Stage)
+			}
+			seenProofRefs[receipt.Ref] = entry.Stage
+		}
+		validateCompactRouteLifecyclePlans(t, root, entry, allowedPlanStatuses)
+		if receiptPolicy == compactRouteLifecycleReceiptPolicyOptional && staleReceipts == 0 && len(entry.ProofReceipts) > 0 {
+			t.Errorf("planned stage %d must preserve stale proof evidence", entry.Stage)
+		}
+	}
+	for stage := 1; stage <= 7; stage++ {
+		if !seenStages[stage] {
+			t.Errorf("stage %d is missing", stage)
+		}
+	}
+	if activeCoreStages != 1 {
+		t.Errorf("active core stages = %d, want 1", activeCoreStages)
+	}
+	for ref := range compactRouteLifecycleKnownProofRevisions {
+		if _, ok := seenProofRefs[ref]; !ok {
+			t.Errorf("immutable proof allowlist entry %q is missing from the registry", ref)
+		}
+	}
+	if len(seenProofRefs) != len(compactRouteLifecycleKnownProofRevisions) {
+		t.Errorf("proof receipt set has %d entries, want immutable allowlist size %d", len(seenProofRefs), len(compactRouteLifecycleKnownProofRevisions))
+	}
+}
+
+func validateCompactRouteLifecycleCampaigns(t *testing.T, entry compactRouteLifecycleEntry, campaigns map[string]bool) {
+	t.Helper()
+	seen := make(map[string]bool, len(entry.Campaigns))
+	for _, campaign := range entry.Campaigns {
+		if !campaigns[campaign] {
+			t.Errorf("stage %d references unknown campaign %q", entry.Stage, campaign)
+		}
+		if seen[campaign] {
+			t.Errorf("stage %d repeats campaign %q", entry.Stage, campaign)
+		}
+		seen[campaign] = true
+	}
+}
+
+func validateCompactRouteLifecycleBuildExpressions(t *testing.T, entry compactRouteLifecycleEntry) {
+	t.Helper()
+	seen := make(map[string]bool, len(entry.BuildExpressions))
+	for _, expression := range entry.BuildExpressions {
+		if strings.TrimSpace(expression) == "" || seen[expression] {
+			t.Errorf("stage %d has an empty or duplicate build expression %q", entry.Stage, expression)
+		} else if err := parseCompactRouteLifecycleBuildExpression(expression); err != nil {
+			t.Errorf("stage %d build expression %q: %v", entry.Stage, expression, err)
+		}
+		seen[expression] = true
+	}
+}
+
+func validateCompactRouteLifecycleCommands(t *testing.T, root string, entry compactRouteLifecycleEntry) {
+	t.Helper()
+	allowedIsolation := map[string]bool{"local": true, "docker": true, "quiet_host": true, "spot_vm_optional": true}
+	hasDocker := false
+	for _, command := range entry.TestCommands {
+		if strings.TrimSpace(command.Name) == "" || strings.TrimSpace(command.Command) == "" || !allowedIsolation[command.Isolation] {
+			t.Errorf("stage %d has an incomplete test command %q", entry.Stage, command.Name)
+		}
+		if command.Isolation == "docker" {
+			hasDocker = true
+		}
+		if err := compactRouteLifecycleCommandDestinationError(command.Command); err != nil {
+			t.Errorf("stage %d command %q: %v", entry.Stage, command.Name, err)
+		}
+		if !validateCompactRouteLifecyclePathName(t, root, fmt.Sprintf("stage %d command", entry.Stage), command.WorkingDir, true) {
+			continue
+		}
+	}
+	if !hasDocker {
+		t.Errorf("stage %d has no isolated Docker command", entry.Stage)
+	}
+}
+
+func compactRouteLifecycleCommandDestinationError(command string) error {
+	tokens, err := compactRouteLifecycleCommandTokens(command)
+	if err != nil {
+		return err
+	}
+	for index := 0; index < len(tokens); index++ {
+		token := tokens[index]
+		if name, value, ok := compactRouteLifecycleAssignmentToken(token); ok {
+			if compactRouteLifecycleDestinationVariable(name) {
+				if err := compactRouteLifecycleDestinationPathError(value); err != nil {
+					return fmt.Errorf("environment destination %s: %v", name, err)
+				}
+			}
+			continue
+		}
+		flag, value, takesValue, ok := compactRouteLifecycleDestinationFlag(token)
+		if !ok {
+			continue
+		}
+		if !takesValue {
+			if index+1 >= len(tokens) {
+				return fmt.Errorf("destination flag %s has no value", flag)
+			}
+			index++
+			value = tokens[index]
+		}
+		if err := compactRouteLifecycleDestinationPathError(value); err != nil {
+			return fmt.Errorf("destination flag %s: %v", flag, err)
+		}
+	}
+	return nil
+}
+
+func compactRouteLifecycleAssignmentToken(token string) (name, value string, ok bool) {
+	separator := strings.IndexByte(token, '=')
+	if separator <= 0 {
+		return "", "", false
+	}
+	name = token[:separator]
+	if !compactRouteLifecycleEnvPattern.MatchString(name) {
+		return "", "", false
+	}
+	return name, token[separator+1:], true
+}
+
+func compactRouteLifecycleDestinationVariable(name string) bool {
+	name = strings.ToUpper(name)
+	return name == "RECEIPT" || strings.Contains(name, "RECEIPT") ||
+		name == "OUTPUT" || strings.Contains(name, "OUTPUT") ||
+		name == "OUT" || strings.HasSuffix(name, "_OUT") || strings.HasSuffix(name, "_DIR")
+}
+
+func compactRouteLifecycleDestinationFlag(token string) (flag, value string, takesValue, ok bool) {
+	if !strings.HasPrefix(token, "-") {
+		return "", "", false, false
+	}
+	separator := strings.IndexByte(token, '=')
+	flag = token
+	if separator >= 0 {
+		flag = token[:separator]
+		value = token[separator+1:]
+		takesValue = true
+	}
+	name := strings.ToLower(strings.TrimLeft(flag, "-"))
+	if name == "" || (!strings.Contains(name, "output") && !strings.Contains(name, "receipt") && name != "out" && !strings.HasPrefix(name, "out-") && !strings.HasSuffix(name, "-dir")) {
+		return "", "", false, false
+	}
+	return flag, value, takesValue, true
+}
+
+func compactRouteLifecycleDestinationPathError(destination string) error {
+	if destination == "" || strings.TrimSpace(destination) != destination {
+		return fmt.Errorf("destination %q is empty or contains whitespace", destination)
+	}
+	if strings.ContainsAny(destination, "\x00$%`'\";|&<>()") {
+		return fmt.Errorf("destination %q contains unsupported shell syntax or an unresolved variable", destination)
+	}
+	if strings.HasPrefix(destination, "~") {
+		return fmt.Errorf("destination %q uses home expansion", destination)
+	}
+	if strings.Contains(destination, "\\") {
+		return fmt.Errorf("destination %q uses unsupported backslash path syntax", destination)
+	}
+	if len(destination) >= 3 && ((destination[0] >= 'A' && destination[0] <= 'Z') || (destination[0] >= 'a' && destination[0] <= 'z')) && destination[1] == ':' && destination[2] == '/' {
+		return fmt.Errorf("destination %q is an absolute Windows path", destination)
+	}
+	if strings.HasPrefix(destination, "//") {
+		return fmt.Errorf("destination %q is an absolute network path", destination)
+	}
+	if strings.Contains(destination, "=") {
+		return fmt.Errorf("destination %q is not a plain path", destination)
+	}
+	if strings.HasPrefix(destination, "-") {
+		return fmt.Errorf("destination %q is another command flag", destination)
+	}
+	if err := compactRouteLifecyclePathSyntaxError(destination); err != nil {
+		return err
+	}
+	return nil
+}
+
+func compactRouteLifecycleCommandTokens(command string) ([]string, error) {
+	var tokens []string
+	var token strings.Builder
+	inSingle, inDouble, escaped, started := false, false, false, false
+	flush := func() {
+		if started {
+			tokens = append(tokens, token.String())
+			token.Reset()
+			started = false
+		}
+	}
+	for _, character := range command {
+		if escaped {
+			token.WriteRune(character)
+			started = true
+			escaped = false
+			continue
+		}
+		if character == '\\' && !inSingle {
+			escaped = true
+			started = true
+			continue
+		}
+		if character == '\'' && !inDouble {
+			inSingle = !inSingle
+			started = true
+			continue
+		}
+		if character == '"' && !inSingle {
+			inDouble = !inDouble
+			started = true
+			continue
+		}
+		if (character == ' ' || character == '\t' || character == '\n' || character == '\r') && !inSingle && !inDouble {
+			flush()
+			continue
+		}
+		token.WriteRune(character)
+		started = true
+	}
+	if escaped || inSingle || inDouble {
+		return nil, fmt.Errorf("command has an incomplete quoted or escaped token")
+	}
+	flush()
+	return tokens, nil
+}
+
+func validateCompactRouteLifecycleCorpus(t *testing.T, root string, entry compactRouteLifecycleEntry) {
+	t.Helper()
+	seen := make(map[string]bool, len(entry.Corpus))
+	for _, corpus := range entry.Corpus {
+		if strings.TrimSpace(corpus.ID) == "" || seen[corpus.ID] {
+			t.Errorf("stage %d corpus IDs must be unique and non-empty: %q", entry.Stage, corpus.ID)
+		}
+		seen[corpus.ID] = true
+		if strings.TrimSpace(corpus.Kind) == "" || strings.TrimSpace(corpus.Path) == "" {
+			t.Errorf("stage %d corpus %q needs kind and path", entry.Stage, corpus.ID)
+		}
+		unavailable := corpus.Availability == "unavailable"
+		if unavailable {
+			if corpus.LockStatus != "unlocked" || strings.TrimSpace(corpus.Plan) == "" || corpus.LockOrDigest != "" || corpus.SourceSHA256 != "" || corpus.TreeSHA256 != "" {
+				t.Errorf("stage %d unavailable corpus %q needs unlocked plan metadata without digests", entry.Stage, corpus.ID)
+			}
+			validateCompactRouteLifecyclePathName(t, root, fmt.Sprintf("stage %d unavailable corpus", entry.Stage), corpus.Path, false)
+		} else {
+			if corpus.LockStatus != "" && corpus.LockStatus != "locked" {
+				t.Errorf("stage %d corpus %q has unsupported lock_status %q", entry.Stage, corpus.ID, corpus.LockStatus)
+			}
+			if strings.TrimSpace(corpus.LockOrDigest) == "" {
+				t.Errorf("stage %d locked corpus %q needs lock_or_digest", entry.Stage, corpus.ID)
+			}
+			validateCompactRouteLifecyclePathName(t, root, fmt.Sprintf("stage %d corpus", entry.Stage), corpus.Path, true)
+		}
+		if corpus.SourceSHA256 != "" && !compactRouteLifecycleSHA256Pattern.MatchString(corpus.SourceSHA256) {
+			t.Errorf("stage %d corpus %q has invalid source_sha256", entry.Stage, corpus.ID)
+		}
+		if err := compactRouteLifecycleCorpusHashError(root, corpus); err != nil {
+			t.Errorf("stage %d: %v", entry.Stage, err)
+		}
+		if corpus.TreeSHA256 != "" && !compactRouteLifecycleSHA256Pattern.MatchString(corpus.TreeSHA256) {
+			t.Errorf("stage %d corpus %q has invalid tree_sha256", entry.Stage, corpus.ID)
+		}
+	}
+}
+
+func compactRouteLifecycleEmbeddedCorpusHashError(corpus compactRouteLifecycleCorpus) error {
+	if corpus.SourceSHA256 == "" {
+		return nil
+	}
+	if corpus.Source == "" {
+		return nil
+	}
+	if !compactRouteLifecycleSHA256Pattern.MatchString(corpus.SourceSHA256) {
+		return fmt.Errorf("corpus %q has invalid source_sha256", corpus.ID)
+	}
+	got := fmt.Sprintf("%x", sha256.Sum256([]byte(corpus.Source)))
+	if got != corpus.SourceSHA256 {
+		return fmt.Errorf("corpus %q source_sha256 = %s, want %s for the embedded source bytes", corpus.ID, corpus.SourceSHA256, got)
+	}
+	return nil
+}
+
+func compactRouteLifecycleCorpusHashError(root string, corpus compactRouteLifecycleCorpus) error {
+	if err := compactRouteLifecycleEmbeddedCorpusHashError(corpus); err != nil {
+		return err
+	}
+	if corpus.SourceSHA256 != "" && corpus.Source == "" {
+		resolved, err := compactRouteLifecycleResolvePath(root, corpus.Path, true)
+		if err != nil {
+			return fmt.Errorf("corpus %q source hash path: %v", corpus.ID, err)
+		}
+		data, err := os.ReadFile(resolved)
+		if err != nil {
+			return fmt.Errorf("corpus %q source hash path %q: %v", corpus.ID, corpus.Path, err)
+		}
+		got := fmt.Sprintf("%x", sha256.Sum256(data))
+		if got != corpus.SourceSHA256 {
+			return fmt.Errorf("corpus %q source_sha256 = %s, want %s for %s", corpus.ID, corpus.SourceSHA256, got, corpus.Path)
+		}
+	}
+	if corpus.TreeSHA256 != "" {
+		want, ok := compactRouteLifecycleKnownCorpusTreeSHA256[corpus.ID]
+		if !ok {
+			return fmt.Errorf("corpus %q has no authenticated tree_sha256", corpus.ID)
+		}
+		if corpus.TreeSHA256 != want {
+			return fmt.Errorf("corpus %q tree_sha256 = %s, want authenticated %s", corpus.ID, corpus.TreeSHA256, want)
+		}
+	}
+	return nil
+}
+
+func validateCompactRouteLifecyclePath(t *testing.T, root string, stage int, path compactRouteLifecyclePath) {
+	t.Helper()
+	if !validateCompactRouteLifecyclePathName(t, root, fmt.Sprintf("stage %d path", stage), path.Path, true) {
+		return
+	}
+	resolved, err := compactRouteLifecycleResolvePath(root, path.Path, true)
+	if err != nil {
+		t.Errorf("stage %d path %q: %v", stage, path.Path, err)
+		return
+	}
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		t.Errorf("stage %d path %q: %v", stage, path.Path, err)
+		return
+	}
+	if strings.TrimSpace(path.Symbol) == "" || !strings.Contains(string(data), path.Symbol) {
+		t.Errorf("stage %d path %q does not contain symbol %q", stage, path.Path, path.Symbol)
+	}
+	actual := compactRouteLifecycleFileBuildExpression(data)
+	if actual != path.BuildExpression {
+		t.Errorf("stage %d path %q build expression = %q, want %q", stage, path.Path, path.BuildExpression, actual)
+	}
+}
+
+func validateCompactRouteLifecyclePlans(t *testing.T, root string, entry compactRouteLifecycleEntry, allowedStatuses map[string]bool) {
+	t.Helper()
+	seen := make(map[string]bool, len(entry.PlanRefs))
+	allowedKinds := map[string]bool{"plan": true, "runbook": true}
+	for _, plan := range entry.PlanRefs {
+		if strings.TrimSpace(plan.Ref) == "" || seen[plan.Ref] {
+			t.Errorf("stage %d plan refs must be unique and non-empty: %q", entry.Stage, plan.Ref)
+		}
+		seen[plan.Ref] = true
+		if !allowedKinds[plan.Kind] || !allowedStatuses[plan.Status] || !compactRouteLifecycleCommitPattern.MatchString(plan.SourceRevision) {
+			t.Errorf("stage %d plan %q has an invalid kind, status, or source revision", entry.Stage, plan.Ref)
+		}
+		if plan.Status == "active" && strings.HasPrefix(plan.Ref, "pr:") {
+			t.Errorf("active stage %d cannot claim an unverified active PR", entry.Stage)
+		}
+		if !validateCompactRouteLifecycleReferencePath(t, root, fmt.Sprintf("stage %d plan", entry.Stage), plan.Ref) {
+			continue
+		}
+	}
+}
+
+func validateCompactRouteLifecycleReceipts(t *testing.T, root, registrySourceRevision string, entry compactRouteLifecycleEntry, allowedStatuses map[string]bool, receiptPolicy string, historicalProofMode compactRouteLifecycleHistoricalProofMode) int {
+	t.Helper()
+	allowedKinds := map[string]bool{"merge": true, "test": true, "document": true, "policy": true}
+	seen := make(map[string]bool, len(entry.ProofReceipts))
+	stale := 0
+	for _, receipt := range entry.ProofReceipts {
+		if strings.TrimSpace(receipt.Ref) == "" || seen[receipt.Ref] {
+			t.Errorf("stage %d proof receipts must be unique and non-empty: %q", entry.Stage, receipt.Ref)
+		}
+		seen[receipt.Ref] = true
+		if !allowedKinds[receipt.Kind] || !allowedStatuses[receipt.Status] || !compactRouteLifecycleCommitPattern.MatchString(receipt.SourceRevision) {
+			t.Errorf("stage %d proof receipt %q has an invalid kind, status, or source revision", entry.Stage, receipt.Ref)
+		}
+		if err := compactRouteLifecycleProofReceiptErrorAtMode(root, registrySourceRevision, receipt, historicalProofMode); err != nil {
+			t.Errorf("stage %d: %v", entry.Stage, err)
+		}
+		if entry.Status == "active" && strings.HasPrefix(receipt.Ref, "pr:") {
+			t.Errorf("active stage %d cannot claim an unverified active PR", entry.Stage)
+		}
+		switch receipt.Status {
+		case "stale":
+			stale++
+			if receipt.SourceRevision == registrySourceRevision {
+				t.Errorf("stage %d stale proof receipt %q points at the registry revision", entry.Stage, receipt.Ref)
+			}
+		}
+	}
+	if err := compactRouteLifecycleReceiptStateError(entry.Status, entry.ProofReceipts, receiptPolicy); err != nil {
+		t.Errorf("stage %d: %v", entry.Stage, err)
+	}
+	return stale
+}
+
+func compactRouteLifecycleReceiptStateError(status string, receipts []compactRouteLifecycleReceipt, receiptPolicy string) error {
+	current := 0
+	for _, receipt := range receipts {
+		if receipt.Status == "current" {
+			current++
+		}
+	}
+	switch receiptPolicy {
+	case compactRouteLifecycleReceiptPolicyCurrentRequired:
+		if current == 0 {
+			return fmt.Errorf("status %q requires at least one current proof receipt", status)
+		}
+	case compactRouteLifecycleReceiptPolicyHistoricalOnly:
+		for _, receipt := range receipts {
+			if receipt.Status != "stale" && receipt.Status != "historical" {
+				return fmt.Errorf("status %q may retain only stale or historical proof receipts, got %q for %q", status, receipt.Status, receipt.Ref)
+			}
+		}
+	case compactRouteLifecycleReceiptPolicyOptional:
+		return nil
+	default:
+		return fmt.Errorf("status %q has unknown receipt policy %q", status, receiptPolicy)
+	}
+	return nil
+}
+
+func compactRouteLifecycleProofReceiptError(receipt compactRouteLifecycleReceipt) error {
+	root, err := compactRouteLifecycleRepositoryRoot()
+	if err != nil {
+		return err
+	}
+	return compactRouteLifecycleProofReceiptErrorAt(root, compactRouteLifecycleSourceRevision, receipt)
+}
+
+func compactRouteLifecycleProofReceiptErrorAt(root, registrySourceRevision string, receipt compactRouteLifecycleReceipt) error {
+	historicalProofMode, err := compactRouteLifecycleHistoricalProofModeForRepository(root)
+	if err != nil {
+		return err
+	}
+	return compactRouteLifecycleProofReceiptErrorAtMode(root, registrySourceRevision, receipt, historicalProofMode)
+}
+
+func compactRouteLifecycleProofReceiptErrorAtMode(root, registrySourceRevision string, receipt compactRouteLifecycleReceipt, historicalProofMode compactRouteLifecycleHistoricalProofMode) error {
+	switch receipt.Kind {
+	case "merge", "test", "document", "policy":
+	default:
+		return fmt.Errorf("proof receipt %q has non-proof kind %q", receipt.Ref, receipt.Kind)
+	}
+	if !compactRouteLifecycleCommitPattern.MatchString(receipt.SourceRevision) {
+		return fmt.Errorf("proof receipt %q has invalid source revision", receipt.Ref)
+	}
+	if err := compactRouteLifecycleProofRepositoryErrorAtMode(root, registrySourceRevision, receipt, historicalProofMode); err != nil {
+		return err
+	}
+	want, ok := compactRouteLifecycleKnownProofRevisions[receipt.Ref]
+	if !ok {
+		return fmt.Errorf("proof receipt %q is not an authenticated registry receipt", receipt.Ref)
+	}
+	if want != receipt.SourceRevision {
+		return fmt.Errorf("proof receipt %q has revision %q, want authenticated %q", receipt.Ref, receipt.SourceRevision, want)
+	}
+	return nil
+}
+
+func compactRouteLifecycleProofRepositoryError(root, registrySourceRevision string, receipt compactRouteLifecycleReceipt) error {
+	historicalProofMode, err := compactRouteLifecycleHistoricalProofModeForRepository(root)
+	if err != nil {
+		return err
+	}
+	return compactRouteLifecycleProofRepositoryErrorAtMode(root, registrySourceRevision, receipt, historicalProofMode)
+}
+
+func compactRouteLifecycleProofRepositoryErrorAtMode(root, registrySourceRevision string, receipt compactRouteLifecycleReceipt, historicalProofMode compactRouteLifecycleHistoricalProofMode) error {
+	if !historicalProofMode.GitAvailable {
+		if historicalProofMode.Strict {
+			return fmt.Errorf("%s=1 requires a non-shallow Git repository", compactRouteLifecycleHistoricalProofEnv)
+		}
+		return nil
+	}
+	if historicalProofMode.Strict && historicalProofMode.Shallow {
+		return fmt.Errorf("%s=1 requires a non-shallow Git repository", compactRouteLifecycleHistoricalProofEnv)
+	}
+	if historicalProofMode.Strict {
+		if err := compactRouteLifecycleRequireCommit(root, registrySourceRevision, "registry source revision"); err != nil {
+			return err
+		}
+		if err := compactRouteLifecycleRequireCommit(root, receipt.SourceRevision, fmt.Sprintf("proof receipt %q", receipt.Ref)); err != nil {
+			return err
+		}
+		if _, err := compactRouteLifecycleGitOutput(root, "merge-base", "--is-ancestor", receipt.SourceRevision, registrySourceRevision); err != nil {
+			return fmt.Errorf("proof receipt %q revision %s is not an ancestor of registry source %s: %w", receipt.Ref, receipt.SourceRevision, registrySourceRevision, err)
+		}
+	} else {
+		if !compactRouteLifecycleCommitObjectAvailable(root, receipt.SourceRevision) {
+			return nil
+		}
+		if compactRouteLifecycleCommitObjectAvailable(root, registrySourceRevision) {
+			if _, err := compactRouteLifecycleGitOutput(root, "merge-base", "--is-ancestor", receipt.SourceRevision, registrySourceRevision); err != nil {
+				return fmt.Errorf("proof receipt %q revision %s is not an ancestor of registry source %s: %w", receipt.Ref, receipt.SourceRevision, registrySourceRevision, err)
+			}
+		}
+	}
+
+	if strings.HasPrefix(receipt.Ref, "pr:") {
+		prNumber, err := compactRouteLifecyclePullRequestNumber(receipt.Ref)
+		if err != nil {
+			return fmt.Errorf("proof receipt %q: %v", receipt.Ref, err)
+		}
+		if err := compactRouteLifecyclePullRequestCommitMessageError(root, receipt.SourceRevision, prNumber); err != nil {
+			return fmt.Errorf("proof receipt %q: %v", receipt.Ref, err)
+		}
+		// A pull-request receipt has no local path or blob anchor. Its immutable
+		// allowlist entry still requires the referenced merge commit and message.
+		return nil
+	}
+	parts := strings.SplitN(receipt.Ref, "#", 2)
+	blob, err := compactRouteLifecycleHistoricalBlob(root, receipt.SourceRevision, receipt.Ref)
+	if err != nil {
+		return err
+	}
+	if len(parts) == 2 {
+		if strings.TrimSpace(parts[1]) == "" {
+			return fmt.Errorf("proof receipt %q has an empty historical blob anchor", receipt.Ref)
+		}
+		if !bytes.Contains(blob, []byte(parts[1])) {
+			return fmt.Errorf("proof receipt %q has no anchor %q in the historical blob at %s", receipt.Ref, parts[1], receipt.SourceRevision)
+		}
+	}
+	return nil
+}
+
+func compactRouteLifecyclePullRequestNumber(reference string) (string, error) {
+	match := compactRouteLifecyclePRRefPattern.FindStringSubmatch(reference)
+	if len(match) != 2 {
+		return "", fmt.Errorf("pull-request receipt must use the pr:#N form")
+	}
+	return match[1], nil
+}
+
+func compactRouteLifecyclePullRequestCommitMessageError(root, revision, number string) error {
+	message, err := compactRouteLifecycleGitOutput(root, "show", "-s", "--format=%s%n%b", revision)
+	if err != nil {
+		return fmt.Errorf("cannot read the pull-request commit message at %s: %w", revision, err)
+	}
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)(^|[^0-9])(?:merge[[:space:]]+)?pull[[:space:]]+request[[:space:]]*#` + regexp.QuoteMeta(number) + `([^0-9]|$)`),
+		regexp.MustCompile(`(?i)(^|[^0-9])\(#` + regexp.QuoteMeta(number) + `\)([^0-9]|$)`),
+	}
+	for _, pattern := range patterns {
+		if pattern.Match(message) {
+			return nil
+		}
+	}
+	return fmt.Errorf("commit message at %s does not identify pull request #%s", revision, number)
+}
+
+func compactRouteLifecycleValidateRegistryBase(root, revision string, historicalProofMode compactRouteLifecycleHistoricalProofMode) error {
+	if !historicalProofMode.GitAvailable {
+		if historicalProofMode.Strict {
+			return fmt.Errorf("%s=1 requires a non-shallow Git repository", compactRouteLifecycleHistoricalProofEnv)
+		}
+		return nil
+	}
+	if historicalProofMode.Strict && historicalProofMode.Shallow {
+		return fmt.Errorf("%s=1 requires a non-shallow Git repository", compactRouteLifecycleHistoricalProofEnv)
+	}
+	if err := compactRouteLifecycleRequireCommit(root, revision, "registry source revision"); err != nil && historicalProofMode.Strict {
+		return err
+	}
+	return nil
+}
+
+func compactRouteLifecycleCommitObjectAvailable(root, revision string) bool {
+	if !compactRouteLifecycleCommitPattern.MatchString(revision) {
+		return false
+	}
+	_, err := compactRouteLifecycleGitOutput(root, "cat-file", "-e", revision+"^{commit}")
+	return err == nil
+}
+
+func compactRouteLifecycleHistoricalProofModeForRepository(root string) (compactRouteLifecycleHistoricalProofMode, error) {
+	strict := os.Getenv(compactRouteLifecycleHistoricalProofEnv) == "1"
+	output, err := compactRouteLifecycleGitOutput(root, "rev-parse", "--is-shallow-repository")
+	if err != nil {
+		return compactRouteLifecycleDecideHistoricalProofMode(strict, false, false)
+	}
+	var shallow bool
+	switch strings.TrimSpace(string(output)) {
+	case "true":
+		shallow = true
+	case "false":
+	default:
+		if strict {
+			return compactRouteLifecycleHistoricalProofMode{}, fmt.Errorf("%s=1 requires Git shallow-repository detection", compactRouteLifecycleHistoricalProofEnv)
+		}
+		return compactRouteLifecycleDecideHistoricalProofMode(false, false, false)
+	}
+	return compactRouteLifecycleDecideHistoricalProofMode(strict, shallow, true)
+}
+
+func compactRouteLifecycleDecideHistoricalProofMode(strict, shallow, gitAvailable bool) (compactRouteLifecycleHistoricalProofMode, error) {
+	mode := compactRouteLifecycleHistoricalProofMode{Strict: strict, Shallow: shallow, GitAvailable: gitAvailable}
+	if strict && (!gitAvailable || shallow) {
+		return mode, fmt.Errorf("%s=1 requires a non-shallow Git repository", compactRouteLifecycleHistoricalProofEnv)
+	}
+	return mode, nil
+}
+
+func compactRouteLifecycleRequireCommit(root, revision, owner string) error {
+	if !compactRouteLifecycleCommitPattern.MatchString(revision) {
+		return fmt.Errorf("%s has invalid commit revision %q", owner, revision)
+	}
+	if _, err := compactRouteLifecycleGitOutput(root, "cat-file", "-e", revision+"^{commit}"); err != nil {
+		return fmt.Errorf("%s %s does not exist as a commit: %w", owner, revision, err)
+	}
+	return nil
+}
+
+func compactRouteLifecycleHistoricalBlob(root, revision, reference string) ([]byte, error) {
+	parts := strings.SplitN(reference, "#", 2)
+	refPath := parts[0]
+	if err := compactRouteLifecyclePathSyntaxError(refPath); err != nil {
+		return nil, fmt.Errorf("proof receipt %q: %v", reference, err)
+	}
+	object := revision + ":" + refPath
+	typ, err := compactRouteLifecycleGitOutput(root, "cat-file", "-t", object)
+	if err != nil {
+		return nil, fmt.Errorf("proof receipt %q path %q is absent at %s: %w", reference, refPath, revision, err)
+	}
+	if strings.TrimSpace(string(typ)) != "blob" {
+		return nil, fmt.Errorf("proof receipt %q path %q at %s is %q, want blob", reference, refPath, revision, strings.TrimSpace(string(typ)))
+	}
+	blob, err := compactRouteLifecycleGitOutput(root, "show", object)
+	if err != nil {
+		return nil, fmt.Errorf("read proof receipt %q historical blob at %s: %w", reference, revision, err)
+	}
+	return blob, nil
+}
+
+func compactRouteLifecycleGitOutput(root string, args ...string) ([]byte, error) {
+	commandArgs := append([]string{"-C", root}, args...)
+	command := exec.Command("git", commandArgs...)
+	command.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_OPTIONAL_LOCKS=0")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+	}
+	return output, nil
+}
+
+func validateCompactRouteLifecycleReferencePath(t *testing.T, root, owner, reference string) bool {
+	t.Helper()
+	parts := strings.SplitN(reference, "#", 2)
+	path := parts[0]
+	if strings.HasPrefix(path, "pr:") {
+		if _, err := compactRouteLifecyclePullRequestNumber(reference); err != nil {
+			t.Errorf("%s reference %q: %v", owner, reference, err)
+			return false
+		}
+		return true
+	}
+	if !validateCompactRouteLifecyclePathName(t, root, owner, path, true) {
+		return false
+	}
+	resolved, err := compactRouteLifecycleResolvePath(root, path, true)
+	if err != nil {
+		t.Errorf("%s reference %q: %v", owner, reference, err)
+		return false
+	}
+	if _, err := os.Stat(resolved); err != nil {
+		t.Errorf("%s reference %q: %v", owner, reference, err)
+		return false
+	}
+	if len(parts) == 2 {
+		data, err := os.ReadFile(resolved)
+		if err != nil || !strings.Contains(string(data), parts[1]) {
+			t.Errorf("%s reference %q has no matching anchor", owner, reference)
+			return false
+		}
+	}
+	return true
+}
+
+func validateCompactRouteLifecyclePathName(t *testing.T, root, owner, name string, mustExist bool) bool {
+	t.Helper()
+	if err := compactRouteLifecyclePathSyntaxError(name); err != nil {
+		t.Errorf("%s: %v", owner, err)
+		return false
+	}
+	if _, err := compactRouteLifecycleResolvePath(root, name, mustExist); err != nil {
+		t.Errorf("%s path %q: %v", owner, name, err)
+		return false
+	}
+	return true
+}
+
+func compactRouteLifecyclePathSyntaxError(name string) error {
+	if strings.TrimSpace(name) == "" || strings.ContainsRune(name, 0) || strings.HasPrefix(name, "external:") || filepath.IsAbs(name) {
+		return fmt.Errorf("path %q is absolute, external, empty, or contains a NUL", name)
+	}
+	clean := filepath.Clean(name)
+	if clean != name || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || clean == ".." {
+		return fmt.Errorf("path %q is non-local", name)
+	}
+	return nil
+}
+
+func compactRouteLifecycleRepositoryRoot() (string, error) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("get lifecycle registry working directory: %w", err)
+	}
+	return filepath.EvalSymlinks(workingDir)
+}
+
+func compactRouteLifecycleResolvePath(root, name string, mustExist bool) (string, error) {
+	if strings.TrimSpace(name) == "" || strings.HasPrefix(name, "external:") || filepath.IsAbs(name) {
+		return "", fmt.Errorf("path is absolute or external")
+	}
+	clean := filepath.Clean(name)
+	if clean != name || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes the repository")
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve repository root: %w", err)
+	}
+	candidate := filepath.Join(resolvedRoot, clean)
+	if mustExist {
+		resolved, err := filepath.EvalSymlinks(candidate)
+		if err != nil {
+			return "", err
+		}
+		if !compactRouteLifecycleWithinRoot(resolvedRoot, resolved) {
+			return "", fmt.Errorf("resolved path escapes the repository")
+		}
+		return resolved, nil
+	}
+	ancestor := candidate
+	for {
+		if _, err := os.Lstat(ancestor); err == nil {
+			resolved, err := filepath.EvalSymlinks(ancestor)
+			if err != nil {
+				return "", err
+			}
+			if !compactRouteLifecycleWithinRoot(resolvedRoot, resolved) {
+				return "", fmt.Errorf("resolved path escapes the repository")
+			}
+			return candidate, nil
+		}
+		parent := filepath.Dir(ancestor)
+		if parent == ancestor {
+			return "", fmt.Errorf("path has no repository ancestor")
+		}
+		ancestor = parent
+	}
+}
+
+func compactRouteLifecycleWithinRoot(root, path string) bool {
+	relative, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func parseCompactRouteLifecycleBuildExpression(expression string) error {
+	expression = strings.TrimSpace(expression)
+	if expression == "default" {
+		return nil
+	}
+	if expression == "" {
+		return fmt.Errorf("empty build expression")
+	}
+	parts := strings.Split(expression, "&&")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return fmt.Errorf("incomplete build expression %q", expression)
+		}
+		part = strings.TrimPrefix(part, "!")
+		if !compactRouteLifecycleBuildTagPattern.MatchString(part) {
+			return fmt.Errorf("unsupported build atom %q", part)
+		}
+	}
+	return nil
+}
+
+func compactRouteLifecycleFileBuildExpression(data []byte) string {
+	for _, line := range strings.Split(string(data), "\n")[:minCompactRouteLifecycleLines(20, 1+bytes.Count(data, []byte("\n")))] {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "//go:build ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "//go:build "))
+		}
+	}
+	return "default"
+}
+
+func minCompactRouteLifecycleLines(left, right int) int {
+	if left < right {
+		return left
+	}
+	return right
+}
+
+func compactRouteLifecycleSet(t *testing.T, name string, values []string) map[string]bool {
+	t.Helper()
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		seen[value] = true
+	}
+	return seen
+}
+
+func containsCompactRouteLifecycleString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func equalCompactRouteLifecycleInts(left, right []int) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalCompactRouteLifecycleStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,0 +1,1087 @@
+{
+  "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
+  "source_revision": "72afa041e9ec2f02872724bbdce17694d89955d8",
+  "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
+  "authority": [
+    "spec.parser-graduation.v1#8.1",
+    "spec.campaign.v7",
+    "spec.campaign.v6.7",
+    "spec.campaign.oedit"
+  ],
+  "campaign_identifiers": [
+    "spec.parser-graduation.v1#8.1",
+    "spec.campaign.v7",
+    "spec.campaign.v6.7",
+    "spec.campaign.oedit",
+    "spec.campaign.post-admission-frontier",
+    "spec.compact-recovery-ownership.v1",
+    "spec.b4b-alternative-set.v1",
+    "spec.b4b-alternative-set.v2",
+    "spec.c4-bytecode-isa.v1",
+    "spec.derivation-set-equivalence.v1",
+    "spec.merge-time-election.v1",
+    "spec.forest-coalescer-dedup-generalization.v1",
+    "spec.recovery-strategy1-linearization-v2",
+    "spec.a2-election-table-parity",
+    "spec.outline-api.v1"
+  ],
+  "funnel": {
+    "ordered_stages": [1, 2, 3, 4, 5, 6, 7],
+    "active_core_stage": 5,
+    "core_rule": "Keep one core implementation stage active. Run the other lanes around it.",
+    "parallel_lanes": ["adversarial", "certification", "performance"],
+    "correctness_precedes_performance": true
+  },
+  "core_pr_gate": {
+      "required_fields": [
+        "smallest_c_oracle_falsifier",
+        "focused_implementation",
+        "one_core_implementation_stage_active",
+        "exact_tree_range_error_assertions",
+      "one_grammar_docker_parity",
+      "cleanup_and_ownership_checks",
+      "intended_path_telemetry",
+      "no_unrelated_performance_work"
+    ],
+    "performance_rule": "Run randomized performance after correctness evidence passes."
+  },
+  "graduation_definition": [
+    "Supported grammars match the locked C tree output.",
+    "Recovery and ambiguity match C.",
+    "Incremental edits preserve parity and reuse.",
+    "Memory, race, fallback, and retention gates pass.",
+    "Performance evidence meets release safety requirements.",
+    "The compact route can become the default without hidden exceptions."
+  ],
+  "history_policy": {
+    "preserve_entries": true,
+    "preserve_receipt_refs": true,
+    "preserve_plan_refs": true,
+    "retirement_rule": "Keep retired and superseded entries with their source revisions and receipts.",
+    "stale_rule": "Mark stale evidence before replacement. Do not delete it from the registry.",
+    "state_policy": {
+      "current_receipt_required": ["active", "graduated"],
+      "historical_only": ["retired", "superseded"],
+      "receipts_optional": ["planned", "experimental", "diagnostic", "blocked", "retirement_pending", "emergency_fallback", "stale_evidence"]
+    }
+  },
+  "vocabularies": {
+    "owners": [
+      "scheduler_action_semantics",
+      "derivation_election_selection",
+      "materialization",
+      "scanner_checkpoint_state",
+      "incremental_edit_reuse",
+      "public_compatibility",
+      "graph_head_lifecycle",
+      "oracle_certification",
+      "performance_release",
+      "release_safety"
+    ],
+    "statuses": [
+      "planned",
+      "active",
+      "experimental",
+      "diagnostic",
+      "blocked",
+      "graduated",
+      "superseded",
+      "retirement_pending",
+      "emergency_fallback",
+      "stale_evidence",
+      "retired"
+    ],
+    "receipt_statuses": ["current", "stale", "historical"],
+    "plan_statuses": ["active", "planned", "stale", "historical"],
+    "retention": [
+      "preserve_receipt",
+      "keep_stable_telemetry",
+      "delete_after_receipt",
+      "keep_emergency_fallback"
+    ],
+    "lanes": ["core", "adversarial", "certification", "performance"],
+    "control_kinds": ["build_expression", "environment"],
+    "path_roles": [
+      "implementation",
+      "proof",
+      "adversarial_test",
+      "c_oracle",
+      "incremental_test",
+      "certification",
+      "performance",
+      "runbook",
+      "corpus_policy"
+    ]
+  },
+  "controls": [
+    {
+      "id": "build.default",
+      "kind": "build_expression",
+      "expression": "default",
+      "scope": "production",
+      "read_sites": [
+        {"path": "incremental.go", "symbol": "tryReuseSubtree", "line": 612},
+        {"path": "incremental_invariant_gate_test.go", "symbol": "TestIncrementalInvariantGate", "line": 192}
+      ]
+    },
+    {
+      "id": "build.compact.default",
+      "kind": "build_expression",
+      "expression": "!gts_no_parsercorephase0",
+      "scope": "production",
+      "read_sites": [
+        {"path": "admission_switch_candidate.go", "symbol": "tryCompactFullParseRoute", "line": 204},
+        {"path": "parsercore_phase0_driver.go", "symbol": "DiagnosticParserCoreGenericScheduler", "line": 603},
+        {"path": "parsercore_phase0_fresh_full_runner.go", "symbol": "parserCoreFreshFullRunner", "line": 27}
+      ]
+    },
+    {
+      "id": "build.compact.proof",
+      "kind": "build_expression",
+      "expression": "gts_parsercorephase0 && !gts_no_parsercorephase0",
+      "scope": "test",
+      "read_sites": [
+        {"path": "parsercore_phase0_per_version_lexer_adversarial_internal_test.go", "symbol": "TestPhase0PerVersionLexerVersionsOwnWidths", "line": 35}
+      ]
+    },
+    {
+      "id": "build.compact.emergency",
+      "kind": "build_expression",
+      "expression": "gts_no_parsercorephase0",
+      "scope": "production",
+      "read_sites": [
+        {"path": "admission_switch_stub.go", "symbol": "tryCompactFullParseRoute", "line": 12}
+      ]
+    },
+    {
+      "id": "build.compact.emergency.proof",
+      "kind": "build_expression",
+      "expression": "gts_no_parsercorephase0 && !gts_workcount",
+      "scope": "test",
+      "read_sites": [
+        {"path": "parsercore_phase0_compileout_test.go", "symbol": "TestParserCorePhaseZeroDriverCompilesOutOfEmergencyBuild", "line": 15}
+      ]
+    },
+    {
+      "id": "build.phase0.internal",
+      "kind": "build_expression",
+      "expression": "gts_parsercorephase0",
+      "scope": "test",
+      "read_sites": [
+        {"path": "parsercore_phase0_physical_head_merge_stage2_internal_test.go", "symbol": "TestStage2PhysicalHeadMergePreservesDistinctErrorRegions", "line": 50},
+        {"path": "parsercore_phase0_recovery_condense_stage3_internal_test.go", "symbol": "TestStage3RecoveryCondenseOrdersBeforeSixVersionCap", "line": 73}
+      ]
+    },
+    {
+      "id": "build.merge.census",
+      "kind": "build_expression",
+      "expression": "gts_merge_census",
+      "scope": "test",
+      "read_sites": [
+        {"path": "merge_event_census.go", "symbol": "MergeEventCensusSnapshot", "line": 157}
+      ]
+    },
+    {
+      "id": "build.merge.cgo",
+      "kind": "build_expression",
+      "expression": "cgo && treesitter_c_parity && gts_merge_census",
+      "scope": "harness",
+      "read_sites": [
+        {"path": "cgo_harness/merge_event_census_test.go", "symbol": "TestMergeEventCensusBaseline", "line": 146}
+      ]
+    },
+    {
+      "id": "build.derivation.census",
+      "kind": "build_expression",
+      "expression": "!gts_no_parsercorephase0 && gts_derivation_set_census",
+      "scope": "test",
+      "read_sites": [
+        {"path": "parsercore_phase0_derivation_set_census.go", "symbol": "DerivationSetCensusSnapshot", "line": 132},
+        {"path": "cgo_harness/derivation_set_differential_test.go", "symbol": "TestDerivationSetDifferentialWitnessReproduction", "line": 42}
+      ]
+    },
+    {
+      "id": "build.eof.metadata",
+      "kind": "build_expression",
+      "expression": "!gts_no_parsercorephase0 && gts_eof_recovery_admission_contract",
+      "scope": "test",
+      "read_sites": [
+        {"path": "parsercore_phase0_eof_recovery_admission_contract.go", "symbol": "EOFRecoveryAdmissionCensusSnapshot", "line": 75},
+        {"path": "parsercore_phase0_eof_recovery_metadata_contract_test.go", "symbol": "TestCompactEOFRecoveryMetadataProducerDerivesEventsWithoutMutation", "line": 481}
+      ]
+    },
+    {
+      "id": "build.eof.history",
+      "kind": "build_expression",
+      "expression": "!gts_no_parsercorephase0 && gts_eof_history_census",
+      "scope": "test",
+      "read_sites": [
+        {"path": "parsercore_phase0_eof_history_census.go", "symbol": "EOFAcceptHistoryCensusSnapshot", "line": 138},
+        {"path": "cgo_harness/eof_history_differential_test.go", "symbol": "TestEOFAcceptHistoryDifferential", "line": 20}
+      ]
+    },
+    {
+      "id": "build.eof.shadow",
+      "kind": "build_expression",
+      "expression": "!gts_no_parsercorephase0 && gts_eof_history_census && gts_eof_recovery_shadow",
+      "scope": "test",
+      "read_sites": [
+        {"path": "parsercore_phase0_eof_recovery_shadow.go", "symbol": "censusEOFRecoveryShadow", "line": 50},
+        {"path": "internal/parsercorephase0/eof_recovery_shadow.go", "symbol": "ForkDiagnosticEOFRecovery", "line": 106}
+      ]
+    },
+    {
+      "id": "build.eof.cgo.admission",
+      "kind": "build_expression",
+      "expression": "cgo && treesitter_c_parity && gts_derivation_set_census && gts_eof_history_census && gts_eof_recovery_shadow && gts_eof_recovery_admission_contract",
+      "scope": "harness",
+      "read_sites": [
+        {"path": "cgo_harness/eof_recovery_admission_oracle_test.go", "symbol": "TestEOFRecoveryAdmissionUsesLockedCEventsAndPublishedTree", "line": 14}
+      ]
+    },
+    {
+      "id": "build.eof.cgo.regression",
+      "kind": "build_expression",
+      "expression": "cgo && treesitter_c_parity && !gts_no_parsercorephase0",
+      "scope": "harness",
+      "read_sites": [
+        {"path": "cgo_harness/yaml_eof_recovery_compact_regression_test.go", "symbol": "TestYAMLEOFRecoverWrapCompactRoute", "line": 16}
+      ]
+    },
+    {
+      "id": "build.incremental.phase0",
+      "kind": "build_expression",
+      "expression": "gts_parsercorephase0",
+      "scope": "test",
+      "read_sites": [
+        {"path": "parsestate_replay_compact_diff_test.go", "symbol": "TestParseStateReplayCompactDifferential", "line": 23}
+      ]
+    },
+    {
+      "id": "build.parity.cgo",
+      "kind": "build_expression",
+      "expression": "cgo && treesitter_c_parity",
+      "scope": "harness",
+      "read_sites": [
+        {"path": "cgo_harness/parity_cgo_test.go", "symbol": "TestParityFreshParse", "line": 814}
+      ]
+    },
+    {
+      "id": "build.parity.perf",
+      "kind": "build_expression",
+      "expression": "cgo && treesitter_c_parity && treesitter_c_perfscan",
+      "scope": "harness",
+      "read_sites": [
+        {"path": "cgo_harness/work_count_board_test.go", "symbol": "TestAuthenticatedFourFixtureWorkCountBoard", "line": 284}
+      ]
+    },
+    {
+      "id": "build.recovery.telemetry",
+      "kind": "build_expression",
+      "expression": "gts_recovery_telemetry",
+      "scope": "test",
+      "read_sites": [
+        {"path": "recovery_runtime_detailed_enabled.go", "symbol": "detailedRecoveryRuntimeState", "line": 10}
+      ]
+    },
+    {
+      "id": "build.selectedstore.onepass",
+      "kind": "build_expression",
+      "expression": "gts_parsercorephase0_selectedstore_onepass",
+      "scope": "test",
+      "read_sites": [
+        {"path": "internal/parsercorephase0/selected_store_builder_onepass.go", "symbol": "BuildSelectedStore", "line": 16}
+      ]
+    },
+    {
+      "id": "env.GTS_ADMISSION_CANDIDATE",
+      "kind": "environment",
+      "name": "GTS_ADMISSION_CANDIDATE",
+      "scope": "production",
+      "default": "enabled unless explicitly set to 0, false, off, or no",
+      "read_sites": [
+        {"path": "admission_switch.go", "symbol": "admissionCandidateEnvEnabled", "line": 82}
+      ]
+    },
+    {
+      "id": "env.GTS_ADMISSION_CENSUS",
+      "kind": "environment",
+      "name": "GTS_ADMISSION_CENSUS",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "admission_census.go", "symbol": "admissionCensusEnabled", "line": 189}
+      ]
+    },
+    {
+      "id": "env.GTS_ADMISSION_CENSUS_RECOVERY_SHAPE",
+      "kind": "environment",
+      "name": "GTS_ADMISSION_CENSUS_RECOVERY_SHAPE",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "admission_census.go", "symbol": "admissionCensusRecoveryShapeEnabled", "line": 175}
+      ]
+    },
+    {
+      "id": "env.GTS_B4B_SHADOW_CENSUS",
+      "kind": "environment",
+      "name": "GTS_B4B_SHADOW_CENSUS",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "parsercore_phase0_alternative_set_census.go", "symbol": "diagnosticParserCoreShadowCensusEnabled", "line": 329},
+        {"path": "internal/parsercorephase0/core.go", "symbol": "cleanPathRankWalkEnabled", "line": 671}
+      ]
+    },
+    {
+      "id": "env.GTS_C4_CORRIDOR",
+      "kind": "environment",
+      "name": "GTS_C4_CORRIDOR",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "parsercore_c4_vm.go", "symbol": "parserCoreCorridorEnabled", "line": 48}
+      ]
+    },
+    {
+      "id": "env.GTS_C4_REDUCE_CHAIN",
+      "kind": "environment",
+      "name": "GTS_C4_REDUCE_CHAIN",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "parsercore_c4_program.go", "symbol": "corridorReduceChainEnabled", "line": 203}
+      ]
+    },
+    {
+      "id": "env.GTS_C4_REDUCE_SHIFT",
+      "kind": "environment",
+      "name": "GTS_C4_REDUCE_SHIFT",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "parsercore_c4_program.go", "symbol": "corridorReduceShiftEnabled", "line": 214}
+      ]
+    },
+    {
+      "id": "env.GTS_REPLAY_PARSESTATE",
+      "kind": "environment",
+      "name": "GTS_REPLAY_PARSESTATE",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "parsestate_replay_compact.go", "symbol": "parserCoreReplayParseStatesEnabled", "line": 26}
+      ]
+    },
+    {
+      "id": "env.GOT_PARSE_PROGRESS",
+      "kind": "environment",
+      "name": "GOT_PARSE_PROGRESS",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "admission_switch.go", "symbol": "hasActiveParseObservability", "line": 247},
+        {"path": "parse_progress_telemetry.go", "symbol": "newParseProgressTelemetry", "line": 25}
+      ]
+    },
+    {
+      "id": "env.GTS_DISPATCHER_CENSUS",
+      "kind": "environment",
+      "name": "GTS_DISPATCHER_CENSUS",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "parser_result_compat.go", "symbol": "dispatcherCensusEnabled", "line": 325}
+      ]
+    },
+    {
+      "id": "env.GTS_DISPATCHER_TRANSCRIPT",
+      "kind": "environment",
+      "name": "GTS_DISPATCHER_TRANSCRIPT",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "parser_result_dispatcher_transcript.go", "symbol": "dispatcherTranscriptEnabled", "line": 69}
+      ]
+    },
+    {
+      "id": "env.GTS_DISPATCHER_TRANSCRIPT_OUT",
+      "kind": "environment",
+      "name": "GTS_DISPATCHER_TRANSCRIPT_OUT",
+      "scope": "production",
+      "default": "unset",
+      "read_sites": [
+        {"path": "parser_result_dispatcher_transcript.go", "symbol": "dispatcherTranscriptOutputPath", "line": 81}
+      ]
+    },
+    {
+      "id": "env.GOT_GLR_FOREST",
+      "kind": "environment",
+      "name": "GOT_GLR_FOREST",
+      "scope": "production",
+      "default": "enabled unless set to 0",
+      "read_sites": [
+        {"path": "glr_forest.go", "symbol": "glrForestEnabled", "line": 45}
+      ]
+    },
+    {
+      "id": "env.GOT_GLR_FOREST_RECOVER",
+      "kind": "environment",
+      "name": "GOT_GLR_FOREST_RECOVER",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "glr_forest.go", "symbol": "glrForestRecover", "line": 99}
+      ]
+    },
+    {
+      "id": "env.GOT_GLR_MAX_STACKS",
+      "kind": "environment",
+      "name": "GOT_GLR_MAX_STACKS",
+      "scope": "production",
+      "default": "compiled stack cap",
+      "read_sites": [
+        {"path": "parser_config.go", "symbol": "parseMaxGLRStacksValue", "line": 108}
+      ]
+    },
+    {
+      "id": "env.GOT_GLR_MAX_MERGE_PER_KEY",
+      "kind": "environment",
+      "name": "GOT_GLR_MAX_MERGE_PER_KEY",
+      "scope": "production",
+      "default": "compiled merge cap",
+      "read_sites": [
+        {"path": "parser_config.go", "symbol": "parseMaxMergePerKeyValue", "line": 124}
+      ]
+    },
+    {
+      "id": "env.GOT_PARSE_NODE_LIMIT_SCALE",
+      "kind": "environment",
+      "name": "GOT_PARSE_NODE_LIMIT_SCALE",
+      "scope": "production",
+      "default": "1",
+      "read_sites": [
+        {"path": "parser_config.go", "symbol": "parseNodeLimitScaleFactor", "line": 87}
+      ]
+    },
+    {
+      "id": "env.GOT_PARSE_MEMORY_BUDGET_MB",
+      "kind": "environment",
+      "name": "GOT_PARSE_MEMORY_BUDGET_MB",
+      "scope": "production",
+      "default": "512",
+      "read_sites": [
+        {"path": "parser_config.go", "symbol": "parseMemoryBudgetMB", "line": 333}
+      ]
+    },
+    {
+      "id": "env.GOT_PARSE_MEMORY_HARD_CEILING_MB",
+      "kind": "environment",
+      "name": "GOT_PARSE_MEMORY_HARD_CEILING_MB",
+      "scope": "production",
+      "default": "2048",
+      "read_sites": [
+        {"path": "parser_config.go", "symbol": "parseMemoryHardCeilingMB", "line": 357}
+      ]
+    },
+    {
+      "id": "env.GOT_C_RECOVERY",
+      "kind": "environment",
+      "name": "GOT_C_RECOVERY",
+      "scope": "production",
+      "default": "language profile policy",
+      "read_sites": [
+        {"path": "parser_recover_c.go", "symbol": "errorCostCompetitionLanguage", "line": 234},
+        {"path": "parser_recover_c.go", "symbol": "cRecoveryGateReason", "line": 282},
+        {"path": "parser_recover_c.go", "symbol": "cRecoveryGateReason", "line": 289}
+      ]
+    },
+    {
+      "id": "env.GOT_PARSE_PHASE_TIMING",
+      "kind": "environment",
+      "name": "GOT_PARSE_PHASE_TIMING",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "parser_config.go", "symbol": "parsePhaseTimingEnabled", "line": 215}
+      ]
+    },
+    {
+      "id": "env.GOT_PARSE_REDUCE_TIMING",
+      "kind": "environment",
+      "name": "GOT_PARSE_REDUCE_TIMING",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "parser_config.go", "symbol": "parseReduceTimingEnabled", "line": 223}
+      ]
+    },
+    {
+      "id": "env.GOT_PARSE_ACTION_TIMING",
+      "kind": "environment",
+      "name": "GOT_PARSE_ACTION_TIMING",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "parser_config.go", "symbol": "parseActionTimingEnabled", "line": 231}
+      ]
+    },
+    {
+      "id": "env.GOT_GLR_RAW_SHAPE_DIAG",
+      "kind": "environment",
+      "name": "GOT_GLR_RAW_SHAPE_DIAG",
+      "scope": "production",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "raw_shape_diag.go", "symbol": "rawShapeDiagEnabled", "line": 13}
+      ]
+    },
+    {
+      "id": "env.GOT_GLR_RAW_SHAPE_DIAG_CHILD_LIMIT",
+      "kind": "environment",
+      "name": "GOT_GLR_RAW_SHAPE_DIAG_CHILD_LIMIT",
+      "scope": "production",
+      "default": "40",
+      "read_sites": [
+        {"path": "raw_shape_diag.go", "symbol": "rawShapeDiagChildLimit", "line": 18}
+      ]
+    },
+    {
+      "id": "env.GOT_GLR_RAW_SHAPE_DIAG_DEPTH",
+      "kind": "environment",
+      "name": "GOT_GLR_RAW_SHAPE_DIAG_DEPTH",
+      "scope": "production",
+      "default": "3",
+      "read_sites": [
+        {"path": "raw_shape_diag.go", "symbol": "rawShapeDiagDepthLimit", "line": 28}
+      ]
+    },
+    {
+      "id": "env.GTS_ADMISSION_SCORECARD",
+      "kind": "environment",
+      "name": "GTS_ADMISSION_SCORECARD",
+      "scope": "test",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "admission_scorecard_test.go", "symbol": "TestAdmissionCandidateScorecard206", "line": 105}
+      ]
+    },
+    {
+      "id": "env.GTS_ADMISSION_SCORECARD_STRICT",
+      "kind": "environment",
+      "name": "GTS_ADMISSION_SCORECARD_STRICT",
+      "scope": "test",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "admission_scorecard_test.go", "symbol": "GTS_ADMISSION_SCORECARD_STRICT", "line": 139}
+      ]
+    },
+    {
+      "id": "env.GTS_ADMISSION_SCORECARD_RATCHET",
+      "kind": "environment",
+      "name": "GTS_ADMISSION_SCORECARD_RATCHET",
+      "scope": "test",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "admission_scorecard_test.go", "symbol": "GTS_ADMISSION_SCORECARD_RATCHET", "line": 144}
+      ]
+    },
+    {
+      "id": "env.GTS_ADMISSION_REAL_CORPUS",
+      "kind": "environment",
+      "name": "GTS_ADMISSION_REAL_CORPUS",
+      "scope": "test",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "admission_real_corpus_matrix_test.go", "symbol": "TestAdmissionCandidateRealCorpusMatrix", "line": 37}
+      ]
+    },
+    {
+      "id": "env.GTS_ADMISSION_REAL_CORPUS_MANIFEST",
+      "kind": "environment",
+      "name": "GTS_ADMISSION_REAL_CORPUS_MANIFEST",
+      "scope": "test",
+      "default": "cgo_harness/corpus_real/manifest.json",
+      "read_sites": [
+        {"path": "admission_real_corpus_matrix_test.go", "symbol": "TestAdmissionCandidateRealCorpusMatrix", "line": 42}
+      ]
+    },
+    {
+      "id": "env.GTS_ADMISSION_REAL_CORPUS_LANGS",
+      "kind": "environment",
+      "name": "GTS_ADMISSION_REAL_CORPUS_LANGS",
+      "scope": "test",
+      "default": "all",
+      "read_sites": [
+        {"path": "admission_real_corpus_matrix_test.go", "symbol": "admissionRealCorpusFilter", "line": 59}
+      ]
+    },
+    {
+      "id": "env.GTS_ADMISSION_REAL_CORPUS_EXCLUDE_LANGS",
+      "kind": "environment",
+      "name": "GTS_ADMISSION_REAL_CORPUS_EXCLUDE_LANGS",
+      "scope": "test",
+      "default": "none",
+      "read_sites": [
+        {"path": "admission_real_corpus_matrix_test.go", "symbol": "admissionRealCorpusFilter", "line": 60}
+      ]
+    },
+    {
+      "id": "env.GTS_ADMISSION_REAL_CORPUS_BUCKETS",
+      "kind": "environment",
+      "name": "GTS_ADMISSION_REAL_CORPUS_BUCKETS",
+      "scope": "test",
+      "default": "all",
+      "read_sites": [
+        {"path": "admission_real_corpus_matrix_test.go", "symbol": "admissionRealCorpusFilter", "line": 61}
+      ]
+    },
+    {
+      "id": "env.GTS_ADMISSION_REAL_CORPUS_MAX_BYTES",
+      "kind": "environment",
+      "name": "GTS_ADMISSION_REAL_CORPUS_MAX_BYTES",
+      "scope": "test",
+      "default": "unbounded",
+      "read_sites": [
+        {"path": "admission_real_corpus_matrix_test.go", "symbol": "GTS_ADMISSION_REAL_CORPUS_MAX_BYTES", "line": 63}
+      ]
+    },
+    {
+      "id": "env.GTS_ADMISSION_REAL_CORPUS_RATCHET",
+      "kind": "environment",
+      "name": "GTS_ADMISSION_REAL_CORPUS_RATCHET",
+      "scope": "test",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "admission_real_corpus_matrix_test.go", "symbol": "GTS_ADMISSION_REAL_CORPUS_RATCHET", "line": 211}
+      ]
+    },
+    {
+      "id": "env.GTS_CANONICAL_GO_INCREMENTAL",
+      "kind": "environment",
+      "name": "GTS_CANONICAL_GO_INCREMENTAL",
+      "scope": "harness",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "cgo_harness/benchmark_go_canonical_incremental_test.go", "symbol": "TestCanonicalGoIncrementalParity", "line": 182}
+      ]
+    },
+    {
+      "id": "env.GTS_CANONICAL_INCREMENTAL_RECEIPT_OUT",
+      "kind": "environment",
+      "name": "GTS_CANONICAL_INCREMENTAL_RECEIPT_OUT",
+      "scope": "harness",
+      "default": "unset",
+      "read_sites": [
+        {"path": "cgo_harness/benchmark_go_canonical_incremental_test.go", "symbol": "prepareCanonicalIncrementalReceiptOutput", "line": 796}
+      ]
+    },
+    {
+      "id": "env.GTS_PARITY_MODE",
+      "kind": "environment",
+      "name": "GTS_PARITY_MODE",
+      "scope": "harness",
+      "default": "smoke",
+      "read_sites": [
+        {"path": "cgo_harness/parity_cgo_test.go", "symbol": "parityMode", "line": 193}
+      ]
+    },
+    {
+      "id": "env.GTS_PARITY_ALLOW_HOST",
+      "kind": "environment",
+      "name": "GTS_PARITY_ALLOW_HOST",
+      "scope": "harness",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "cgo_harness/testmain_cgo_test.go", "symbol": "TestMain", "line": 19}
+      ]
+    },
+    {
+      "id": "env.GTS_PARITY_REPO_CACHE",
+      "kind": "environment",
+      "name": "GTS_PARITY_REPO_CACHE",
+      "scope": "harness",
+      "default": "unset",
+      "read_sites": [
+        {"path": "cgo_harness/parity_c_loader_cgo.go", "symbol": "parityRepoCacheDir", "line": 746}
+      ]
+    },
+    {
+      "id": "env.GTS_PARITY_REPO_ROOT",
+      "kind": "environment",
+      "name": "GTS_PARITY_REPO_ROOT",
+      "scope": "harness",
+      "default": "unset",
+      "read_sites": [
+        {"path": "cgo_harness/parity_c_loader_cgo.go", "symbol": "parityLocalRepoDir", "line": 613}
+      ]
+    },
+    {
+      "id": "env.GTS_PARITY_C_REF_BUILD_CACHE",
+      "kind": "environment",
+      "name": "GTS_PARITY_C_REF_BUILD_CACHE",
+      "scope": "harness",
+      "default": "automatic cache path",
+      "read_sites": [
+        {"path": "cgo_harness/parity_c_loader_cgo.go", "symbol": "parityDefaultCBuildCacheDir", "line": 459}
+      ]
+    },
+    {
+      "id": "env.GTS_PARITY_C_REF_BUILD_JOBS",
+      "kind": "environment",
+      "name": "GTS_PARITY_C_REF_BUILD_JOBS",
+      "scope": "harness",
+      "default": "1",
+      "read_sites": [
+        {"path": "cgo_harness/parity_c_loader_cgo.go", "symbol": "parityCBuildJobs", "line": 447}
+      ]
+    },
+    {
+      "id": "env.GTS_WORK_COUNT_BOARD",
+      "kind": "environment",
+      "name": "GTS_WORK_COUNT_BOARD",
+      "scope": "harness",
+      "default": "disabled",
+      "read_sites": [
+        {"path": "cgo_harness/work_count_board_test.go", "symbol": "TestAuthenticatedFourFixtureWorkCountBoard", "line": 285}
+      ]
+    },
+    {
+      "id": "env.GTS_WORK_COUNT_BOARD_RECEIPT",
+      "kind": "environment",
+      "name": "GTS_WORK_COUNT_BOARD_RECEIPT",
+      "scope": "harness",
+      "default": "unset",
+      "read_sites": [
+        {"path": "cgo_harness/work_count_security_test.go", "symbol": "workCountPrepareBoardReceiptPath", "line": 316}
+      ]
+    },
+    {
+      "id": "env.GOT_CORPUS_SOURCES_ROOT",
+      "kind": "environment",
+      "name": "GOT_CORPUS_SOURCES_ROOT",
+      "scope": "production",
+      "default": "sibling gotreesitter-corpora checkout",
+      "read_sites": [
+        {"path": "grammars/outline_census.go", "symbol": "outlineResolveRealCorpusRoot", "line": 114}
+      ]
+    },
+    {
+      "id": "env.GTS_OUTLINE_CENSUS_OUT",
+      "kind": "environment",
+      "name": "GTS_OUTLINE_CENSUS_OUT",
+      "scope": "test",
+      "default": "unset",
+      "read_sites": [
+        {"path": "grammars/outline_census_test.go", "symbol": "GTS_OUTLINE_CENSUS_OUT", "line": 97}
+      ]
+    },
+    {
+      "id": "env.GOTREESITTER_GRAMMARGEN_BLOB_DIR",
+      "kind": "environment",
+      "name": "GOTREESITTER_GRAMMARGEN_BLOB_DIR",
+      "scope": "production",
+      "default": "unset",
+      "read_sites": [
+        {"path": "grammars/grammargen_blob_override.go", "symbol": "preferredLanguageOverridePath", "line": 75}
+      ]
+    }
+  ],
+  "entries": [
+    {
+      "id": "stage-1-per-version-lexer",
+      "stage": 1,
+      "lane": "core",
+      "status": "graduated",
+      "owner": "scanner_checkpoint_state",
+      "campaigns": ["spec.parser-graduation.v1#8.1", "spec.campaign.v7"],
+      "purpose": "Give each parser version its own lexer cursor, width, scanner checkpoint, and rollback state.",
+      "build_expressions": [
+        "!gts_no_parsercorephase0",
+        "gts_parsercorephase0 && !gts_no_parsercorephase0",
+        "cgo && treesitter_c_parity && gts_parsercorephase0 && !gts_no_parsercorephase0"
+      ],
+      "control_ids": [
+        "build.compact.default",
+        "build.compact.proof",
+        "build.parity.cgo",
+        "env.GTS_ADMISSION_CANDIDATE",
+        "env.GOT_PARSE_PROGRESS"
+      ],
+      "paths": [
+        {"path": "parsercore_phase0_per_version_lexer_state.go", "role": "implementation", "build_expression": "!gts_no_parsercorephase0", "symbol": "diagnosticParserCoreVersionLexerSnapshot"},
+        {"path": "parsercore_phase0_per_version_lexer_adversarial_internal_test.go", "role": "adversarial_test", "build_expression": "gts_parsercorephase0 && !gts_no_parsercorephase0", "symbol": "TestPhase0PerVersionLexerVersionsOwnWidths"},
+        {"path": "parsercore_phase0_per_version_lexer_scheduler_test.go", "role": "proof", "build_expression": "gts_parsercorephase0 && !gts_no_parsercorephase0", "symbol": "TestDiagnosticParserCoreVersionLexerRequestsOwnRaggedSpans"},
+        {"path": "cgo_harness/parity_compact_per_version_lexer_scala_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0 && !gts_no_parsercorephase0", "symbol": "TestCompactPerVersionLexerScalaCOracle"}
+      ],
+      "test_commands": [
+        {"name": "owned-width witness", "command": "go test -tags 'gts_parsercorephase0' -run '^TestPhase0PerVersionLexerVersionsOwnWidths$' -count=1 .", "working_dir": ".", "isolation": "local"},
+        {"name": "Scala locked-C oracle", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestCompactPerVersionLexerScalaCOracle$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+      ],
+      "corpus": [
+        {"id": "scala-owned-width", "kind": "locked_fixture", "path": "cgo_harness/parity_compact_per_version_lexer_scala_test.go", "source": "(y)->", "source_sha256": "59b8f8c8f7f235973d07ac90f3089939e92da41ee23dcb496bc5c880f9577068", "tree_sha256": "81dc569b1ad3d567ed158aea75fd30a388ec1f4d3e1cbdd08c29a6535bd456d3", "lock_or_digest": "grammar 97aead18d97708190a51d4f551ea9b05b60641c9; runtime f5afe475deb7c0bae6407fb776c76824f717bb61; artifact c981583f2f5fa3acc4973b79ea7c43caa46e861179fe1323f12608bff5a21459"}
+      ],
+      "gates": ["different token widths select the C-equivalent tree", "exact root range and zero error flags", "owned lexer telemetry records two versions and accepted ragged spans", "no shared-cursor decline"],
+      "telemetry": ["PerVersionLexRequests", "PerVersionLexAcceptedRaggedSpans", "PerVersionLexViabilityDrops", "accepted C-equivalent tree"],
+      "plan_refs": [],
+      "proof_receipts": [
+        {"ref": "pr:#1016", "kind": "merge", "source_revision": "8bb49959d95fce0cf8bea5468d86e30978ccf393", "status": "current"},
+        {"ref": "cgo_harness/parity_compact_per_version_lexer_scala_test.go#TestCompactPerVersionLexerScalaCOracle", "kind": "test", "source_revision": "8bb49959d95fce0cf8bea5468d86e30978ccf393", "status": "current"}
+      ],
+      "deletion_condition": "Delete the tagged lexer census only after all registered width witnesses pass exact tree, range, error, checkpoint, and incremental receipts.",
+      "retention": "preserve_receipt",
+      "history_preserved": true
+    },
+    {
+      "id": "stage-2-physical-graph-head-merge",
+      "stage": 2,
+      "lane": "core",
+      "status": "graduated",
+      "owner": "graph_head_lifecycle",
+      "campaigns": ["spec.parser-graduation.v1#8.1", "spec.merge-time-election.v1", "spec.compact-recovery-ownership.v1"],
+      "purpose": "Merge equivalent physical heads while retaining graph nodes, errors, recovery lineage, scanner checkpoints, and ownership.",
+      "build_expressions": ["default", "gts_parsercorephase0", "gts_merge_census", "cgo && treesitter_c_parity && gts_merge_census"],
+      "control_ids": ["build.phase0.internal", "build.merge.census", "build.merge.cgo", "build.parity.cgo", "env.GOT_GLR_MAX_MERGE_PER_KEY", "env.GTS_B4B_SHADOW_CENSUS"],
+      "paths": [
+        {"path": "internal/parsercorephase0/core.go", "role": "implementation", "build_expression": "default", "symbol": "condenseWithOutcome"},
+        {"path": "internal/parsercorephase0/physical_head_merge_stage2_test.go", "role": "proof", "build_expression": "gts_parsercorephase0", "symbol": "TestStage2PhysicalHeadMergeUnionsEquivalentDistinctNodes"},
+        {"path": "parsercore_phase0_physical_head_merge_stage2_internal_test.go", "role": "adversarial_test", "build_expression": "gts_parsercorephase0", "symbol": "TestStage2PhysicalHeadMergePreservesDistinctErrorRegions"},
+        {"path": "merge_event_census.go", "role": "proof", "build_expression": "gts_merge_census", "symbol": "MergeEventCensusSnapshot"},
+        {"path": "cgo_harness/merge_event_census_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity && gts_merge_census", "symbol": "TestMergeEventCensusBaseline"}
+      ],
+      "test_commands": [
+        {"name": "physical-head proofs", "command": "go test -tags 'gts_parsercorephase0' -run '^TestStage2PhysicalHeadMerge' -count=1 . ./internal/parsercorephase0", "working_dir": ".", "isolation": "local"},
+        {"name": "merge census parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_merge_census' -run '^TestMergeEventCensus(Baseline|TotalsAggregatesPhysicalHeadMergeTelemetry)$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+      ],
+      "corpus": [
+        {"id": "six-version-head-boundary", "kind": "synthetic_fixture", "path": "internal/parsercorephase0/physical_head_merge_stage2_test.go", "source": "six distinct physical paths at one boundary", "lock_or_digest": "test source and expected path census at merge revision"}
+      ],
+      "gates": ["equivalent heads union every distinct node path", "different error regions remain separate", "lineage and candidate ownership survive", "scanner and node checkpoints remain distinct", "capacity failure rolls back"],
+      "telemetry": ["MergeEventCensusCounts.Attempts", "MergeEventCensusCounts.Successes", "refusal causes", "current exact paths and derivation count"],
+      "plan_refs": [],
+      "proof_receipts": [
+        {"ref": "pr:#1017", "kind": "merge", "source_revision": "865d03b07ffd74ee44163a4cfa2f7ddc057134e6", "status": "current"},
+        {"ref": "internal/parsercorephase0/physical_head_merge_stage2_test.go#TestStage2PhysicalHeadMergeAtSixVersionBoundaryRetainsEveryPath", "kind": "test", "source_revision": "865d03b07ffd74ee44163a4cfa2f7ddc057134e6", "status": "current"}
+      ],
+      "deletion_condition": "Delete merge-only census code after a locked-C topology receipt proves node, error, lineage, checkpoint, and rollback equivalence.",
+      "retention": "preserve_receipt",
+      "history_preserved": true
+    },
+    {
+      "id": "stage-3-recovery-through-ambiguity",
+      "stage": 3,
+      "lane": "core",
+      "status": "graduated",
+      "owner": "derivation_election_selection",
+      "campaigns": ["spec.parser-graduation.v1#8.1", "spec.campaign.v7", "spec.b4b-alternative-set.v1", "spec.b4b-alternative-set.v2", "spec.compact-recovery-ownership.v1"],
+      "purpose": "Keep ordinary ambiguity grammar-driven while pricing and selecting competing recovery lineages by C error cost.",
+      "build_expressions": ["!gts_no_parsercorephase0", "gts_parsercorephase0", "gts_parsercorephase0 && !gts_no_parsercorephase0"],
+      "control_ids": ["build.compact.default", "build.phase0.internal", "build.derivation.census", "build.recovery.telemetry", "env.GTS_ADMISSION_CENSUS", "env.GTS_ADMISSION_CENSUS_RECOVERY_SHAPE", "env.GTS_B4B_SHADOW_CENSUS", "env.GOT_C_RECOVERY"],
+      "paths": [
+        {"path": "parsercore_phase0_recovery_condense.go", "role": "implementation", "build_expression": "!gts_no_parsercorephase0", "symbol": "condenseRecoveryVersions"},
+        {"path": "parsercore_phase0_recovery_condense_stage3_internal_test.go", "role": "proof", "build_expression": "gts_parsercorephase0", "symbol": "TestStage3RecoveryCondenseOrdersBeforeSixVersionCap"},
+        {"path": "parsercore_phase0_recovery_lineage_fork_internal_test.go", "role": "adversarial_test", "build_expression": "!gts_no_parsercorephase0", "symbol": "TestS5MissingInsertionForkPublishesBothRecoveryLineages"},
+        {"path": "parsercore_phase0_recovery_lineage_selection_internal_test.go", "role": "proof", "build_expression": "!gts_no_parsercorephase0", "symbol": "TestCompleteAcceptancePricesRecoveryFrontierBeforeCollapse"},
+        {"path": "parsercore_phase0_generic_conflict_internal_test.go", "role": "proof", "build_expression": "gts_parsercorephase0", "symbol": "TestDiagnosticParserCoreGenericConflictArbitraryNOrdering"}
+      ],
+      "test_commands": [
+        {"name": "six-version recovery cap", "command": "go test -tags 'gts_parsercorephase0' -run '^TestStage3RecoveryCondense' -count=1 .", "working_dir": ".", "isolation": "local"},
+        {"name": "recovery lineage competition", "command": "go test -tags 'gts_parsercorephase0' -run '^(TestS5MissingInsertionFork|TestSelectCompetingRecoveryLineage|TestCompleteAcceptancePricesRecoveryFrontier)' -count=1 .", "working_dir": ".", "isolation": "local"},
+        {"name": "derivation-set C differential", "command": "go test . -tags 'cgo treesitter_c_parity gts_derivation_set_census' -run '^TestDerivationSetDifferential' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+      ],
+      "corpus": [
+        {"id": "recovery-six-version-cap", "kind": "synthetic_fixture", "path": "parsercore_phase0_recovery_condense_stage3_internal_test.go", "source": "seven recovery versions with six retained keys", "lock_or_digest": "expected C cost order and recovery version cap"},
+        {"id": "recovery-fork-ambiguity", "kind": "synthetic_fixture", "path": "parsercore_phase0_recovery_lineage_fork_internal_test.go", "source": "missing insertion plus error absorption", "lock_or_digest": "both marked lineages and ordinary ambiguity isolation"}
+      ],
+      "gates": ["condense before the six-version cap", "recoveries retain cost provenance", "missing and absorb lineages compete", "ordinary ambiguity does not use recovery cost", "selection resolves before collapse and clears losers"],
+      "telemetry": ["RecoveryCondensePasses", "RecoveryVersionCapDrops", "recovery lineage markers", "selected and declined recovery reasons"],
+      "plan_refs": [],
+      "proof_receipts": [
+        {"ref": "pr:#1018", "kind": "merge", "source_revision": "9f9e903940655da46fb8c976fa2e08139153df0f", "status": "current"},
+        {"ref": "parsercore_phase0_recovery_lineage_fork_internal_test.go#TestS5MissingInsertionForkPublishesBothRecoveryLineages", "kind": "test", "source_revision": "9f9e903940655da46fb8c976fa2e08139153df0f", "status": "current"}
+      ],
+      "deletion_condition": "Delete recovery-condense diagnostics only after ordinary ambiguity and recovery competition match C across exact tree and error receipts.",
+      "retention": "preserve_receipt",
+      "history_preserved": true
+    },
+    {
+      "id": "stage-4-end-of-file-recovery",
+      "stage": 4,
+      "lane": "core",
+      "status": "graduated",
+      "owner": "scheduler_action_semantics",
+      "campaigns": ["spec.parser-graduation.v1#8.1", "spec.campaign.v7", "spec.recovery-strategy1-linearization-v2", "spec.compact-recovery-ownership.v1"],
+      "purpose": "Match C end-of-file recovery for missing insertions, unfinished reductions, error tails, and authenticated root publication.",
+      "build_expressions": [
+        "default",
+        "!gts_no_parsercorephase0",
+        "!gts_no_parsercorephase0 && gts_eof_recovery_admission_contract",
+        "!gts_no_parsercorephase0 && gts_eof_history_census && gts_eof_recovery_shadow",
+        "gts_eof_recovery_shadow",
+        "cgo && treesitter_c_parity && gts_derivation_set_census && gts_eof_history_census && gts_eof_recovery_shadow && gts_eof_recovery_admission_contract",
+        "cgo && treesitter_c_parity && !gts_no_parsercorephase0"
+      ],
+      "control_ids": ["build.compact.default", "build.eof.metadata", "build.eof.history", "build.eof.shadow", "build.eof.cgo.admission", "build.eof.cgo.regression", "env.GTS_ADMISSION_CANDIDATE", "env.GOT_GLR_FOREST"],
+      "paths": [
+        {"path": "internal/parsercorephase0/eof_recovery_live.go", "role": "implementation", "build_expression": "default", "symbol": "RecoverEOFAcceptOwned"},
+        {"path": "parsercore_phase0_eof_recovery_admission_contract.go", "role": "proof", "build_expression": "!gts_no_parsercorephase0 && gts_eof_recovery_admission_contract", "symbol": "EOFRecoveryAdmissionCensusSnapshot"},
+        {"path": "parsercore_phase0_eof_recovery_metadata_contract_test.go", "role": "proof", "build_expression": "!gts_no_parsercorephase0 && gts_eof_recovery_admission_contract", "symbol": "TestCompactEOFRecoveryMetadataUsesRealSchedulerAndConstructionPaths"},
+        {"path": "internal/parsercorephase0/eof_recovery_live_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestRecoverEOFAcceptOwnedRollsBackPartialPublication"},
+        {"path": "internal/parsercorephase0/eof_recovery_shadow.go", "role": "proof", "build_expression": "gts_eof_recovery_shadow", "symbol": "ForkDiagnosticEOFRecovery"},
+        {"path": "cgo_harness/eof_recovery_admission_oracle_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity && gts_derivation_set_census && gts_eof_history_census && gts_eof_recovery_shadow && gts_eof_recovery_admission_contract", "symbol": "TestEOFRecoveryAdmissionUsesLockedCEventsAndPublishedTree"},
+        {"path": "cgo_harness/yaml_eof_recovery_compact_regression_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity && !gts_no_parsercorephase0", "symbol": "TestYAMLEOFRecoverWrapCompactRoute"}
+      ],
+      "test_commands": [
+        {"name": "EOF metadata contract", "command": "go test -tags 'gts_eof_recovery_admission_contract' -run '^TestCompactEOFRecoveryMetadata' -count=1 .", "working_dir": ".", "isolation": "local"},
+        {"name": "YAML EOF C regression", "command": "go test . -tags 'cgo treesitter_c_parity' -run '^TestYAMLEOFRecoverWrapCompactRoute$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"},
+        {"name": "EOF admission oracle", "command": "go test . -tags 'cgo treesitter_c_parity gts_derivation_set_census gts_eof_history_census gts_eof_recovery_shadow gts_eof_recovery_admission_contract' -run '^TestEOFRecoveryAdmissionUsesLockedCEventsAndPublishedTree$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+      ],
+      "corpus": [
+        {"id": "yaml-open-sequence", "kind": "locked_fixture", "path": "cgo_harness/yaml_eof_recovery_compact_regression_test.go", "source": "[\n", "source_sha256": "95d2b1934931691669cc35a87619518015336213dda0a60fe1b09f9b8e3e993d", "lock_or_digest": "locked C root shape and exact 0..1 range in TestYAMLEOFRecoverWrapCompactRoute"},
+        {"id": "yaml-unfinished-mapping", "kind": "locked_fixture", "path": "cgo_harness/yaml_eof_recovery_compact_regression_test.go", "source": "a: [1\n", "source_sha256": "18b06c413ddca5348d118edfbc58a2b8be7ce796bdf53479f8a0063ed92f4f02", "lock_or_digest": "fail-closed compact admission and production/C tree equality"}
+      ],
+      "gates": ["one exact EOF derivation", "missing insertion publishes the C root", "unfinished reductions fall back safely", "root range, child ranges, error flags, and release lifecycle match", "shadow storage is disjoint and bounded"],
+      "telemetry": ["EOFRecoveryAdmissionReceipt", "EOF accept-history frontier", "recover_eof accepted event", "publication and fallback counters"],
+      "plan_refs": [],
+      "proof_receipts": [
+        {"ref": "pr:#1019", "kind": "merge", "source_revision": "0beb95d399655d200e687e0912d3265b1c9562e9", "status": "current"},
+        {"ref": "cgo_harness/eof_recovery_admission_oracle_test.go#TestEOFRecoveryAdmissionUsesLockedCEventsAndPublishedTree", "kind": "test", "source_revision": "2ebeb6c64632163622691786a71ac6da76a14929", "status": "current"}
+      ],
+      "deletion_condition": "Delete EOF shadow and admission diagnostics only after every supported EOF shape has exact C tree, range, error, incremental, and retention receipts.",
+      "retention": "preserve_receipt",
+      "history_preserved": true
+    },
+    {
+      "id": "stage-5-incremental-integration",
+      "stage": 5,
+      "lane": "core",
+      "status": "active",
+      "owner": "incremental_edit_reuse",
+      "campaigns": ["spec.campaign.oedit", "spec.campaign.post-admission-frontier", "spec.parser-graduation.v1#8.1"],
+      "purpose": "Invalidate the correct version state after edits while preserving exact trees, scanner safety, reuse, and deterministic counters.",
+      "build_expressions": ["default", "!gts_no_parsercorephase0", "gts_parsercorephase0", "cgo && treesitter_c_parity"],
+      "control_ids": ["build.default", "build.compact.default", "build.incremental.phase0", "build.selectedstore.onepass", "build.parity.cgo", "env.GTS_CANONICAL_GO_INCREMENTAL", "env.GTS_CANONICAL_INCREMENTAL_RECEIPT_OUT", "env.GOT_PARSE_MEMORY_BUDGET_MB", "env.GOT_PARSE_PROGRESS"],
+      "paths": [
+        {"path": "incremental.go", "role": "implementation", "build_expression": "default", "symbol": "tryReuseSubtree"},
+        {"path": "parser_result_incremental_range.go", "role": "implementation", "build_expression": "default", "symbol": "incrementalReparsedTopLevelRanges"},
+        {"path": "incremental_invariant_gate_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestIncrementalInvariantGatePython"},
+        {"path": "w1_block_splice_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW1BlockSpliceOracleEquality"},
+        {"path": "w1_leading_splice_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestLeadingSpliceOracleEqualityMiddleBottom"},
+        {"path": "w1b_reduce_settle_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW1BSettleUnlocksGoTopLevelSiblingSplice"},
+        {"path": "parser_go_scanner_quiescence_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestGoScannerQuiescenceOracleSweep"},
+        {"path": "w5_editor_latency_gate_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW5EditorLatencyGate"},
+        {"path": "parsestate_replay_compact_diff_test.go", "role": "proof", "build_expression": "gts_parsercorephase0", "symbol": "TestParseStateReplayCompactDifferential"}
+      ],
+      "test_commands": [
+        {"name": "incremental invariant gate", "command": "go test -run '^TestIncrementalInvariantGate(Python|JavaScript|JSON|Go|Rust|CSS|C)$' -count=1 .", "working_dir": ".", "isolation": "local"},
+        {"name": "O(edit) splice proofs", "command": "go test -run '^(TestW1|TestW1B|TestLeadingSplice|TestGoScannerQuiescenceOracleSweep|TestW5)' -count=1 .", "working_dir": ".", "isolation": "local"},
+        {"name": "compact ParseState replay", "command": "go test -tags 'gts_parsercorephase0' -run '^TestParseStateReplayCompactDifferential$' -count=1 .", "working_dir": ".", "isolation": "local"},
+        {"name": "locked four-way incremental parity", "command": "go test . -tags 'cgo treesitter_c_parity' -run '^TestCanonicalGoIncrementalParity$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+      ],
+      "corpus": [
+        {"id": "python", "kind": "incremental_fixture", "path": "testdata/incremental_gate/python_setup.py", "lock_or_digest": "source tree at 72afa041e9ec2f02872724bbdce17694d89955d8"},
+        {"id": "python-large-indent", "kind": "incremental_fixture", "path": "testdata/incremental_gate/python_large_indent.py", "lock_or_digest": "source tree at 72afa041e9ec2f02872724bbdce17694d89955d8"},
+        {"id": "javascript", "kind": "incremental_fixture", "path": "testdata/incremental_gate/javascript_grammar.js", "lock_or_digest": "source tree at 72afa041e9ec2f02872724bbdce17694d89955d8"},
+        {"id": "json", "kind": "incremental_fixture", "path": "testdata/incremental_gate/json_contract.json", "lock_or_digest": "source tree at 72afa041e9ec2f02872724bbdce17694d89955d8"},
+        {"id": "go", "kind": "incremental_fixture", "path": "testdata/incremental_gate/go_print.go", "lock_or_digest": "source tree at 72afa041e9ec2f02872724bbdce17694d89955d8"},
+        {"id": "rust", "kind": "incremental_fixture", "path": "testdata/incremental_gate/rust_ast.rs", "lock_or_digest": "source tree at 72afa041e9ec2f02872724bbdce17694d89955d8"},
+        {"id": "css", "kind": "incremental_fixture", "path": "testdata/incremental_gate/css_stylesheet.css", "lock_or_digest": "source tree at 72afa041e9ec2f02872724bbdce17694d89955d8"},
+        {"id": "c", "kind": "incremental_fixture", "path": "testdata/incremental_gate/c_repeated_functions.c", "lock_or_digest": "source tree at 72afa041e9ec2f02872724bbdce17694d89955d8"},
+        {"id": "incremental-allowlist", "kind": "policy_lock", "path": "testdata/incremental_allowlist.json", "source_sha256": "58e96c69a23675b1b666789306e93fe3ce3756b2976cfb32fea9fc544229b810", "lock_or_digest": "ratchet entries must reproduce or be removed after confirmed fixes"}
+      ],
+      "gates": ["fresh and incremental trees are structurally identical", "edits invalidate the correct version state", "scanner boundaries remain quiescent or fail closed", "reuse counters remain deterministic and nonzero where expected", "incremental memory and fallback budgets pass"],
+      "telemetry": ["IncrementalParseProfile.ReusedBytes", "NewNodesAllocated", "ReuseRejectRootNonLeafChanged", "ReuseRejectScannerUnquiescent", "BlockSpliceSteps", "ParseState replay receipt"],
+      "plan_refs": [],
+      "proof_receipts": [
+        {"ref": "incremental_invariant_gate_test.go#TestIncrementalInvariantGatePython", "kind": "test", "source_revision": "bf7ab0567122e863ef831e8aa56dbee93127ad93", "status": "current"},
+        {"ref": "w5_editor_latency_gate_test.go#TestW5EditorLatencyGate", "kind": "test", "source_revision": "e734c93543654818082e8d3ae3721cdb6fe9e4a5", "status": "current"},
+        {"ref": "testdata/incremental_allowlist.json", "kind": "policy", "source_revision": "95a1d13156b82e2221415342c9ac8048f2caf644", "status": "current"}
+      ],
+      "deletion_condition": "Delete temporary O(edit) experiments only after canonical C parity, edit invalidation, exact tree, reuse, race, and memory receipts pass.",
+      "retention": "keep_stable_telemetry",
+      "history_preserved": true
+    },
+    {
+      "id": "stage-6-grammar-certification",
+      "stage": 6,
+      "lane": "core",
+      "status": "planned",
+      "owner": "oracle_certification",
+      "campaigns": ["spec.parser-graduation.v1#8.1", "spec.campaign.v7", "spec.derivation-set-equivalence.v1", "spec.outline-api.v1"],
+      "purpose": "Certify exact trees, ranges, errors, and incremental results against the locked C baseline, one grammar at a time.",
+      "build_expressions": ["default", "gts_parsercorephase0", "cgo && treesitter_c_parity", "cgo && treesitter_c_parity && gts_derivation_set_census", "!gts_no_parsercorephase0 && gts_derivation_set_census"],
+      "control_ids": ["build.phase0.internal", "build.parity.cgo", "build.derivation.census", "env.GTS_ADMISSION_SCORECARD", "env.GTS_ADMISSION_SCORECARD_STRICT", "env.GTS_ADMISSION_SCORECARD_RATCHET", "env.GTS_ADMISSION_REAL_CORPUS", "env.GTS_ADMISSION_REAL_CORPUS_MANIFEST", "env.GTS_ADMISSION_REAL_CORPUS_LANGS", "env.GTS_ADMISSION_REAL_CORPUS_EXCLUDE_LANGS", "env.GTS_ADMISSION_REAL_CORPUS_BUCKETS", "env.GTS_ADMISSION_REAL_CORPUS_MAX_BYTES", "env.GTS_ADMISSION_REAL_CORPUS_RATCHET", "env.GTS_PARITY_MODE", "env.GTS_PARITY_ALLOW_HOST", "env.GOT_CORPUS_SOURCES_ROOT", "env.GTS_OUTLINE_CENSUS_OUT"],
+      "paths": [
+        {"path": "admission_scorecard_test.go", "role": "certification", "build_expression": "gts_parsercorephase0", "symbol": "TestAdmissionCandidateScorecard206"},
+        {"path": "admission_real_corpus_matrix_test.go", "role": "certification", "build_expression": "gts_parsercorephase0", "symbol": "TestAdmissionCandidateRealCorpusMatrix"},
+        {"path": "cgo_harness/parity_cgo_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity", "symbol": "TestParityFreshParse"},
+        {"path": "cgo_harness/derivation_set_differential_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity && gts_derivation_set_census", "symbol": "TestDerivationSetDifferentialBaselineCensus"},
+        {"path": "cgo_harness/docker/run_single_grammar_parity.sh", "role": "certification", "build_expression": "default", "symbol": "run_single_grammar_parity.sh"},
+        {"path": "cgo_harness/docker/run_grammargen_focus_targets.sh", "role": "certification", "build_expression": "default", "symbol": "run_grammargen_focus_targets.sh"},
+        {"path": "docs/compact-route-real-corpus-matrix.md", "role": "corpus_policy", "build_expression": "default", "symbol": "Current compact-graduation matrix"}
+      ],
+      "test_commands": [
+        {"name": "206-language scorecard", "command": "GTS_ADMISSION_SCORECARD=1 go test -tags 'gts_parsercorephase0' -run '^TestAdmissionCandidateScorecard206$' -count=1 -v .", "working_dir": ".", "isolation": "docker"},
+        {"name": "one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh typescript", "working_dir": ".", "isolation": "docker"},
+        {"name": "real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs typescript", "working_dir": ".", "isolation": "docker"},
+        {"name": "C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs typescript", "working_dir": ".", "isolation": "docker"}
+      ],
+      "corpus": [
+        {"id": "real-corpus-matrix", "kind": "authenticated_external_manifest", "path": "cgo_harness/corpus_real/manifest.json", "source": "External manifest is not present in this worktree.", "availability": "unavailable", "lock_status": "unlocked", "plan": "Acquire the authenticated manifest in an isolated certification run before Stage 6.", "lock_or_digest": ""},
+        {"id": "grammar-lock", "kind": "grammar_lock", "path": "grammars/languages.lock", "lock_or_digest": "grammar lock file is tracked; verify each source and generated artifact identity"}
+      ],
+      "gates": ["exact tree shape and node fields", "exact ranges and error or missing flags", "exact C and Go grammar identities", "incremental result parity", "one grammar per isolated Docker run", "zero silent divergence and explicit fallback accounting"],
+      "telemetry": ["PASS/FALLBACK/DIVERGE/SKIP/ERROR scorecard rows", "deep-tree digest", "exact mismatch path and field", "fallback reason", "derivation-set receipt"],
+      "plan_refs": [
+        {"ref": "cgo_harness/parity_cgo_test.go", "kind": "plan", "source_revision": "72afa041e9ec2f02872724bbdce17694d89955d8", "status": "active"}
+      ],
+      "proof_receipts": [
+        {"ref": "docs/compact-route-real-corpus-matrix.md#Current compact-graduation matrix", "kind": "document", "source_revision": "41af6afa6da47c9f8b55b3156fd88fb56686373f", "status": "stale"},
+        {"ref": "docs/compact-route-coverage-census.md", "kind": "document", "source_revision": "38d86d417fc6209228b8b175bc2aa7bb9700b8d3", "status": "stale"},
+        {"ref": "docs/a8-derivation-divergence-certificate-v1.md", "kind": "document", "source_revision": "acccb81d20128e337a35ee274a2e3e3631b73b1a", "status": "stale"}
+      ],
+      "deletion_condition": "Delete certification scaffolding only after every supported grammar has a current locked-C receipt for trees, fields, ranges, errors, and incremental edits.",
+      "retention": "preserve_receipt",
+      "history_preserved": true
+    },
+    {
+      "id": "stage-7-performance-and-release",
+      "stage": 7,
+      "lane": "core",
+      "status": "planned",
+      "owner": "performance_release",
+      "campaigns": ["spec.parser-graduation.v1#8.1", "spec.campaign.v6.7", "spec.campaign.v7"],
+      "purpose": "Pass memory, race, fallback, benchmark, and release safety gates before making compact parsing the default without exceptions.",
+      "build_expressions": ["default", "gts_parsercorephase0", "gts_no_parsercorephase0", "gts_no_parsercorephase0 && !gts_workcount", "cgo && treesitter_c_parity && treesitter_c_perfscan", "gts_recovery_telemetry"],
+      "control_ids": ["build.incremental.phase0", "build.parity.perf", "build.recovery.telemetry", "build.compact.emergency", "build.compact.emergency.proof", "env.GTS_ADMISSION_CANDIDATE", "env.GOT_PARSE_MEMORY_BUDGET_MB", "env.GOT_PARSE_MEMORY_HARD_CEILING_MB", "env.GTS_WORK_COUNT_BOARD", "env.GTS_WORK_COUNT_BOARD_RECEIPT", "env.GTS_PARITY_C_REF_BUILD_CACHE", "env.GTS_PARITY_C_REF_BUILD_JOBS"],
+      "paths": [
+        {"path": "scripts/run_randomized_benchmarks.sh", "role": "performance", "build_expression": "default", "symbol": "run_randomized_benchmarks.sh"},
+        {"path": "cgo_harness/work_count_board_test.go", "role": "performance", "build_expression": "cgo && treesitter_c_parity && treesitter_c_perfscan", "symbol": "TestAuthenticatedFourFixtureWorkCountBoard"},
+        {"path": "docs/v10-gcp-fleet-measurement-runbook.md", "role": "runbook", "build_expression": "default", "symbol": "runbook.v10-gcp-fleet-measurement"},
+        {"path": "docs/releasing.md", "role": "runbook", "build_expression": "default", "symbol": "Release checklist"}
+      ],
+      "test_commands": [
+        {"name": "randomized benchmark loop", "command": "bash scripts/run_randomized_benchmarks.sh --output harness_out/randomized-bench.txt", "working_dir": ".", "isolation": "quiet_host"},
+        {"name": "authenticated work-count board", "command": "GTS_WORK_COUNT_BOARD=1 GTS_WORK_COUNT_BOARD_RECEIPT=harness_out/work-count-board.json go test . -tags 'treesitter_c_parity treesitter_c_perfscan' -run '^TestAuthenticatedFourFixtureWorkCountBoard$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+      ],
+      "corpus": [
+        {"id": "canonical-four-fixture-board", "kind": "locked_fixture_set", "path": "cgo_harness/work_count/reference_atlas_event_schema_v1.json", "source": "rewrite, query_compile, language, grammargen_lr", "lock_or_digest": "reference runtime tree-sitter-c 0.25.1 at f5afe475deb7c0bae6407fb776c76824f717bb61"},
+        {"id": "full-fleet-source-lock", "kind": "authenticated_external_lock", "path": "cgo_harness/corpus_real/corpus_sources.lock", "source": "External source lock is not present in this worktree.", "availability": "unavailable", "lock_status": "unlocked", "plan": "Provision the authenticated 206-language source lock on the isolated performance worker before Stage 7.", "lock_or_digest": ""}
+      ],
+      "gates": ["no crash, out-of-memory, or runaway retention", "memory-budget contracts remain intact", "race suite passes in an isolated container", "fallback telemetry stays within the agreed limit", "benchmark trio meets release safety targets", "clean source and reproducible receipt identity"],
+      "telemetry": ["ns/op", "B/op", "allocs/op", "maximum resident set size", "fallback count and reason", "work-count completeness and audit", "race and timeout outcome"],
+      "plan_refs": [
+        {"ref": "scripts/run_randomized_benchmarks.sh", "kind": "plan", "source_revision": "72afa041e9ec2f02872724bbdce17694d89955d8", "status": "active"},
+        {"ref": "cgo_harness/work_count_board_test.go#TestAuthenticatedFourFixtureWorkCountBoard", "kind": "plan", "source_revision": "4f281e3cbc1bfcefa94145710dd49858fa38faa3", "status": "active"},
+        {"ref": "docs/v10-gcp-fleet-measurement-runbook.md#Provision the VM", "kind": "runbook", "source_revision": "33a7101948ffd30efba0256ebf6928347f5a10d1", "status": "active"},
+        {"ref": "docs/v10-gcp-fleet-measurement-runbook.md#Stage the authenticated corpus", "kind": "runbook", "source_revision": "33a7101948ffd30efba0256ebf6928347f5a10d1", "status": "active"},
+        {"ref": "docs/phase3-admission-timing-runbook.md", "kind": "runbook", "source_revision": "98323ffb1af20c7db40f7de589814f0293589224", "status": "stale"}
+      ],
+      "proof_receipts": [],
+      "deletion_condition": "Delete temporary benchmark and VM artifacts after a complete release receipt. Retain scripts, stable telemetry, and the emergency fallback path.",
+      "retention": "keep_emergency_fallback",
+      "history_preserved": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add one versioned compact-route campaign lifecycle registry.
- Record each stage, owner, gate, proof receipt, corpus, and deletion condition.
- Validate receipt commits, ancestry, historical paths, anchors, and pull-request identity.
- Validate corpus hashes, command destinations, build expressions, and lifecycle policies.
- Add a required full-history CI job for strict receipt authentication.

## Proof

- Default focused lifecycle tests pass.
- Strict full-history lifecycle validation passes.
- The no-parser build-tag tests pass.
- Five shuffled focused runs pass.
- The focused Docker race test passes.
- The Docker workflow contract test passes.
- `actionlint` passes.
- JSON validation and `git diff --check` pass.

## Scope

This is a campaign enablement package. It does not change parser decisions or tree construction.