### PR TITLE
update(incremental): Certify Python compact scanner reuse

### DIFF
--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -93,7 +93,7 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 	if err != nil {
 		return nil, err
 	}
-	certifyParserCoreExternalPayloadQuiescence(compact, p.language)
+	configureParserCoreScannerProvenance(compact, p.language)
 	return &parserCoreFreshFullRunner{
 		lang: p.language, parser: p, tables: tables, compact: compact, options: options,
 		// Incremental reuse is admitted only when materialization can attach the

--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -1170,7 +1170,7 @@ func TestParityPythonIncrementalDedentCheckpointFallback(t *testing.T) {
 	}
 }
 
-func TestParityPythonDerivedScannerFallback(t *testing.T) {
+func TestParityPythonDerivedScannerIncremental(t *testing.T) {
 	cases := []struct {
 		name   string
 		lang   func() *gotreesitter.Language
@@ -1211,7 +1211,11 @@ func TestParityPythonDerivedScannerFallback(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer releaseGoTree(goTree)
-			if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" ||
+			if tc.name == "python" {
+				if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" {
+					t.Fatalf("%s authenticated scanner reuse declined: %+v", tc.name, profile)
+				}
+			} else if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" ||
 				profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
 				t.Fatalf("%s scanner fallback profile is not fail-closed: %+v", tc.name, profile)
 			}

--- a/cgo_harness/python_dispatch_blocker_receipt_test.go
+++ b/cgo_harness/python_dispatch_blocker_receipt_test.go
@@ -52,8 +52,8 @@ func TestPythonDispatchBlockerReceiptRoutes(t *testing.T) {
 	if language.ExternalScanner == nil {
 		t.Fatal("Python language has no registered external scanner")
 	}
-	if reusable, ok := language.ExternalScanner.(gotreesitter.IncrementalReuseExternalScanner); ok && reusable.SupportsIncrementalReuse() {
-		t.Fatal("Python external scanner unexpectedly supports incremental reuse")
+	if reusable, ok := language.ExternalScanner.(gotreesitter.IncrementalReuseExternalScanner); !ok || !reusable.SupportsIncrementalReuse() {
+		t.Fatal("Python external scanner does not expose authenticated incremental reuse")
 	}
 	cLanguage, err := COracleLanguage("python")
 	if err != nil {
@@ -242,8 +242,8 @@ func TestPythonDispatchBlockerReceiptRoutes(t *testing.T) {
 			pythonDispatchCheckDivergence(t, "incremental", incrementalDiff, witness.wantRouteDiff)
 			pythonDispatchCheckPass(t, "incremental", incremental, witness.wantIncremental)
 			pythonDispatchCheckNativeAuthority(t, "incremental", incremental)
-			if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
-				t.Fatalf("incremental reuse changed: unsupported=%t reason=%q old_tree=%t subtrees=%d bytes=%d", profile.ReuseUnsupported, profile.ReuseUnsupportedReason, profile.OldTreeReuseRoute, profile.ReusedSubtrees, profile.ReusedBytes)
+			if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" {
+				t.Fatalf("incremental authenticated scanner reuse declined: unsupported=%t reason=%q old_tree=%t subtrees=%d bytes=%d", profile.ReuseUnsupported, profile.ReuseUnsupportedReason, profile.OldTreeReuseRoute, profile.ReusedSubtrees, profile.ReusedBytes)
 			}
 
 			t.Logf("route-summary compact=%s raw=%s production=%s forest=%s incremental=%s reuse=%t unsupported=%t reason=%q", compactMode, pythonDispatchPassSummary(raw), pythonDispatchPassSummary(production), pythonDispatchPassSummary(forest), pythonDispatchPassSummary(incremental), profile.OldTreeReuseRoute, profile.ReuseUnsupported, profile.ReuseUnsupportedReason)

--- a/cgo_harness/stage5_compact_incremental_test.go
+++ b/cgo_harness/stage5_compact_incremental_test.go
@@ -1,0 +1,688 @@
+//go:build cgo && treesitter_c_parity && !gts_no_parsercorephase0
+
+package cgoharness
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// TestStage5CompactPythonScannerCheckpointReuse proves the first Stage 5
+// package with the smallest locked-C indentation edit. The edit changes four
+// spaces before the second top-level function's final return into eight
+// spaces, so the return moves inside the if statement. The compact tree must
+// retain scanner checkpoints, reject stale boundaries, and preserve reuse on
+// unaffected leaves in both directions.
+func TestStage5CompactPythonScannerCheckpointReuse(t *testing.T) {
+	source, err := os.ReadFile("testdata/canonical_incremental_python_scanner.py")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source = append(source, []byte("\n\ndef classify_again(value):\n    if value:\n        return \"present\"\n    return \"missing\"\n")...)
+	const marker = "\n    return \"missing\"\n"
+	offset := bytes.LastIndex(source, []byte(marker)) + 1
+	if offset <= 0 {
+		t.Fatalf("locked Python scanner witness has no second return marker %q", marker)
+	}
+	const inserted = "    "
+	if source[offset] != ' ' {
+		t.Fatalf("locked Python scanner witness changed at byte %d: got %q", offset, source[offset])
+	}
+	offsetByte := uint32(offset)
+	insertedBytes := uint32(len(inserted))
+	edited := make([]byte, 0, len(source)+len(inserted))
+	edited = append(edited, source[:offset]...)
+	edited = append(edited, inserted...)
+	edited = append(edited, source[offset:]...)
+	forwardEdit := gotreesitter.InputEdit{
+		StartByte:   offsetByte,
+		OldEndByte:  offsetByte,
+		NewEndByte:  offsetByte + insertedBytes,
+		StartPoint:  pointAtOffset(source, offset),
+		OldEndPoint: pointAtOffset(source, offset),
+		NewEndPoint: pointAtOffset(edited, offset+len(inserted)),
+	}
+	backEdit := gotreesitter.InputEdit{
+		StartByte:   offsetByte,
+		OldEndByte:  offsetByte + insertedBytes,
+		NewEndByte:  offsetByte,
+		StartPoint:  pointAtOffset(edited, offset),
+		OldEndPoint: pointAtOffset(edited, offset+len(inserted)),
+		NewEndPoint: pointAtOffset(source, offset),
+	}
+
+	goLang := grammars.PythonLanguage()
+	cLang, err := ParityCLanguage("python")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatal(err)
+	}
+	cInitial := cParser.Parse(source, nil)
+	if cInitial == nil || cInitial.RootNode() == nil {
+		t.Fatal("locked C parser returned no initial tree")
+	}
+	t.Cleanup(cInitial.Close)
+	cEditedFresh := cParser.Parse(edited, nil)
+	if cEditedFresh == nil || cEditedFresh.RootNode() == nil {
+		t.Fatal("locked C parser returned no edited tree")
+	}
+	t.Cleanup(cEditedFresh.Close)
+	cOld := cParser.Parse(source, nil)
+	if cOld == nil {
+		t.Fatal("locked C parser returned no incremental base tree")
+	}
+	cOldEdit := realCorpusCInputEdit(forwardEdit)
+	cOld.Edit(&cOldEdit)
+	cEditedIncremental := cParser.Parse(edited, cOld)
+	cOld.Close()
+	if cEditedIncremental == nil || cEditedIncremental.RootNode() == nil {
+		t.Fatal("locked C parser returned no forward incremental tree")
+	}
+	t.Cleanup(cEditedIncremental.Close)
+	cReverseOld := cParser.Parse(edited, nil)
+	if cReverseOld == nil || cReverseOld.RootNode() == nil {
+		t.Fatal("locked C parser returned no reverse incremental base tree")
+	}
+	cReverseOldEdit := realCorpusCInputEdit(backEdit)
+	cReverseOld.Edit(&cReverseOldEdit)
+	cReverseIncremental := cParser.Parse(source, cReverseOld)
+	cReverseOld.Close()
+	if cReverseIncremental == nil || cReverseIncremental.RootNode() == nil {
+		t.Fatal("locked C parser returned no reverse incremental tree")
+	}
+	t.Cleanup(cReverseIncremental.Close)
+
+	routedBefore, fallbacksBefore := gotreesitter.AdmissionCandidateCounters()
+	parser := gotreesitter.NewParser(goLang)
+	parser.SetAdmissionCandidateRoute(true)
+	base, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("compact base parse: %v", err)
+	}
+	t.Cleanup(base.Release)
+	routedAfter, fallbacksAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter-routedBefore != 1 || fallbacksAfter-fallbacksBefore != 0 {
+		t.Fatalf("compact base route counter delta=%d/%d, want 1/0; reason=%q", routedAfter-routedBefore, fallbacksAfter-fallbacksBefore, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+	assertStage5PythonGoCParity(t, base, goLang, cInitial.RootNode(), "compact initial")
+	baseRuntime := base.ParseRuntime()
+	if baseRuntime.ExternalScannerCheckpointRecords == 0 ||
+		baseRuntime.ExternalScannerCheckpointLeafNodes == 0 ||
+		baseRuntime.ExternalScannerSnapshotBytesAllocated == 0 ||
+		!baseRuntime.CompactExternalScannerCheckpointTransferProven {
+		t.Fatalf("compact base did not publish scanner checkpoint accounting: %+v", baseRuntime)
+	}
+
+	untouched := base.Copy()
+	if untouched == nil {
+		t.Fatal("compact base copy returned nil")
+	}
+	t.Cleanup(untouched.Release)
+	untouchedRuntime := untouched.ParseRuntime()
+	if untouchedRuntime.ExternalScannerCheckpointRecords != baseRuntime.ExternalScannerCheckpointRecords ||
+		untouchedRuntime.ExternalScannerCheckpointSlotsAllocated != baseRuntime.ExternalScannerCheckpointSlotsAllocated ||
+		untouchedRuntime.ExternalScannerCheckpointBytesAllocated != baseRuntime.ExternalScannerCheckpointBytesAllocated ||
+		untouchedRuntime.ExternalScannerCheckpointLeafNodes != baseRuntime.ExternalScannerCheckpointLeafNodes ||
+		untouchedRuntime.ExternalScannerSnapshotBytesAllocated != baseRuntime.ExternalScannerSnapshotBytesAllocated {
+		t.Fatalf("compact copy changed checkpoint accounting: base=%+v copy=%+v", baseRuntime, untouchedRuntime)
+	}
+
+	forwardBase := base.Copy()
+	if forwardBase == nil {
+		t.Fatal("compact forward copy returned nil")
+	}
+	t.Cleanup(forwardBase.Release)
+	forwardBase.Edit(forwardEdit)
+	forward, profile, err := parser.ParseIncrementalProfiled(edited, forwardBase)
+	if err != nil {
+		t.Fatalf("compact forward incremental parse: %v", err)
+	}
+	if forward != forwardBase {
+		t.Cleanup(forward.Release)
+	}
+	if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" || !profile.OldTreeReuseRoute {
+		t.Fatalf("compact forward reuse was not admitted: %+v", profile)
+	}
+	if profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("compact forward lost all reuse: %+v", profile)
+	}
+	if profile.ReuseRejectScannerUnquiescent == 0 {
+		t.Fatalf("compact forward did not report invalidated scanner boundaries: %+v", profile)
+	}
+	assertStage5PythonGoCParity(t, forward, goLang, cEditedFresh.RootNode(), "compact forward fresh C")
+	assertStage5PythonGoCParity(t, forward, goLang, cEditedIncremental.RootNode(), "compact forward incremental C")
+	forwardRuntime := forward.ParseRuntime()
+	if forwardRuntime.StopReason != gotreesitter.ParseStopAccepted ||
+		forwardRuntime.Truncated || forwardRuntime.TokenSourceEOFEarly ||
+		forwardRuntime.ExpectedEOFByte != uint32(len(edited)) ||
+		forwardRuntime.RootEndByte != uint32(len(edited)) ||
+		!forwardRuntime.IncrementalOldTreeReuseRoute {
+		t.Fatalf("compact forward runtime is incomplete: %+v", forwardRuntime)
+	}
+	if forwardRuntime.ExternalScannerCheckpointRecords == 0 ||
+		forwardRuntime.ExternalScannerCheckpointSlotsAllocated == 0 ||
+		forwardRuntime.ExternalScannerCheckpointBytesAllocated == 0 ||
+		forwardRuntime.ExternalScannerCheckpointLeafNodes == 0 ||
+		forwardRuntime.ExternalScannerSnapshotBytesAllocated == 0 {
+		t.Fatalf("compact forward lost scanner checkpoint accounting: %+v", forwardRuntime)
+	}
+
+	// Tree.Copy must isolate the source branch. The untouched copy remains the
+	// original tree while the forward branch edits and reparses independently.
+	assertStage5PythonGoCParity(t, untouched, goLang, cInitial.RootNode(), "untouched copy")
+	if got := untouched.ParseRuntime().ExternalScannerCheckpointRecords; got != untouchedRuntime.ExternalScannerCheckpointRecords {
+		t.Fatalf("untouched copy checkpoint records changed: before=%d after=%d", untouchedRuntime.ExternalScannerCheckpointRecords, got)
+	}
+	if got := untouched.ParseRuntime().ExternalScannerCheckpointSlotsAllocated; got != untouchedRuntime.ExternalScannerCheckpointSlotsAllocated {
+		t.Fatalf("untouched copy checkpoint slots changed: before=%d after=%d", untouchedRuntime.ExternalScannerCheckpointSlotsAllocated, got)
+	}
+	if got := untouched.ParseRuntime().ExternalScannerCheckpointBytesAllocated; got != untouchedRuntime.ExternalScannerCheckpointBytesAllocated {
+		t.Fatalf("untouched copy checkpoint bytes changed: before=%d after=%d", untouchedRuntime.ExternalScannerCheckpointBytesAllocated, got)
+	}
+	if got := untouched.ParseRuntime().ExternalScannerSnapshotBytesAllocated; got != untouchedRuntime.ExternalScannerSnapshotBytesAllocated {
+		t.Fatalf("untouched copy snapshot bytes changed: before=%d after=%d", untouchedRuntime.ExternalScannerSnapshotBytesAllocated, got)
+	}
+	if got := base.ParseRuntime().ExternalScannerCheckpointRecords; got != baseRuntime.ExternalScannerCheckpointRecords {
+		t.Fatalf("compact base checkpoint records changed through copy: before=%d after=%d", baseRuntime.ExternalScannerCheckpointRecords, got)
+	}
+
+	if forward == nil {
+		t.Fatal("compact forward tree is nil")
+	}
+	forward.Edit(backEdit)
+	reverse, reverseProfile, err := parser.ParseIncrementalProfiled(source, forward)
+	if err != nil {
+		t.Fatalf("compact reverse incremental parse: %v", err)
+	}
+	if reverse != forward {
+		t.Cleanup(reverse.Release)
+	}
+	if reverseProfile.ReuseUnsupported || reverseProfile.ReuseUnsupportedReason != "" || !reverseProfile.OldTreeReuseRoute ||
+		reverseProfile.ReusedSubtrees == 0 || reverseProfile.ReusedBytes == 0 {
+		t.Fatalf("compact reverse did not preserve later-child checkpoint reuse: %+v", reverseProfile)
+	}
+	assertStage5PythonGoCParity(t, reverse, goLang, cInitial.RootNode(), "compact reverse fresh C")
+	assertStage5PythonGoCParity(t, reverse, goLang, cReverseIncremental.RootNode(), "compact reverse incremental C")
+	reverseRuntime := reverse.ParseRuntime()
+	if reverseRuntime.StopReason != gotreesitter.ParseStopAccepted ||
+		reverseRuntime.Truncated || reverseRuntime.TokenSourceEOFEarly ||
+		reverseRuntime.ExpectedEOFByte != uint32(len(source)) ||
+		reverseRuntime.RootEndByte != uint32(len(source)) ||
+		!reverseRuntime.IncrementalOldTreeReuseRoute {
+		t.Fatalf("compact reverse runtime is incomplete: %+v", reverseRuntime)
+	}
+	if reverseRuntime.ExternalScannerCheckpointRecords == 0 ||
+		reverseRuntime.ExternalScannerCheckpointSlotsAllocated == 0 ||
+		reverseRuntime.ExternalScannerCheckpointBytesAllocated == 0 ||
+		reverseRuntime.ExternalScannerCheckpointLeafNodes == 0 ||
+		reverseRuntime.ExternalScannerSnapshotBytesAllocated == 0 {
+		t.Fatalf("compact reverse lost scanner checkpoint accounting: %+v", reverseRuntime)
+	}
+	t.Logf("stage5 python checkpoint witness: forward reuse=%d/%d reject_scanner=%d; reverse reuse=%d/%d reject_scanner=%d; checkpoints=%d/%d leaves=%d/%d", profile.ReusedSubtrees, profile.ReusedBytes, profile.ReuseRejectScannerUnquiescent, reverseProfile.ReusedSubtrees, reverseProfile.ReusedBytes, reverseProfile.ReuseRejectScannerUnquiescent, forwardRuntime.ExternalScannerCheckpointRecords, reverseRuntime.ExternalScannerCheckpointRecords, forwardRuntime.ExternalScannerCheckpointLeafNodes, reverseRuntime.ExternalScannerCheckpointLeafNodes)
+}
+
+// TestStage5PythonSameLengthScannerDelimiterParity proves the conservative
+// same-length scanner-state lane against both C fresh and C incremental trees.
+// It changes a regular string with literal braces into a real f-string
+// interpolation without changing the byte span, then checks the following
+// top-level child.
+func TestStage5PythonSameLengthScannerDelimiterParity(t *testing.T) {
+	source := []byte("def first(value):\n    return u\"{x}\"\n\ndef second(value):\n    return \"unchanged\"\n")
+	oldText := []byte("u\"{x}\"")
+	replacement := []byte("f'{x}'")
+	offset := bytes.Index(source, oldText)
+	if offset < 0 || len(oldText) != len(replacement) {
+		t.Fatalf("same-length delimiter witness is malformed: offset=%d old=%d new=%d", offset, len(oldText), len(replacement))
+	}
+	edited := make([]byte, 0, len(source))
+	edited = append(edited, source[:offset]...)
+	edited = append(edited, replacement...)
+	edited = append(edited, source[offset+len(oldText):]...)
+	edit := gotreesitter.InputEdit{
+		StartByte:   uint32(offset),
+		OldEndByte:  uint32(offset + len(oldText)),
+		NewEndByte:  uint32(offset + len(replacement)),
+		StartPoint:  pointAtOffset(source, offset),
+		OldEndPoint: pointAtOffset(source, offset+len(oldText)),
+		NewEndPoint: pointAtOffset(edited, offset+len(replacement)),
+	}
+
+	goLang := grammars.PythonLanguage()
+	goParser := gotreesitter.NewParser(goLang)
+	goParser.SetAdmissionCandidateRoute(false)
+	goOld, err := goParser.Parse(source)
+	if err != nil {
+		t.Fatalf("Go same-length old parse: %v", err)
+	}
+	t.Cleanup(goOld.Release)
+	goOld.Edit(edit)
+	goIncremental, profile, err := goParser.ParseIncrementalProfiled(edited, goOld)
+	if err != nil {
+		t.Fatalf("Go same-length incremental parse: %v", err)
+	}
+	if goIncremental != goOld {
+		t.Cleanup(goIncremental.Release)
+	}
+	goFreshParser := gotreesitter.NewParser(goLang)
+	goFreshParser.SetAdmissionCandidateRoute(false)
+	goFresh, err := goFreshParser.Parse(edited)
+	if err != nil {
+		t.Fatalf("Go same-length fresh parse: %v", err)
+	}
+	t.Cleanup(goFresh.Release)
+	var goFreshDiff []string
+	compareGoNodes(goIncremental.RootNode(), goLang, goFresh.RootNode(), "root", &goFreshDiff)
+	if len(goFreshDiff) > 0 {
+		t.Fatalf("Go same-length incremental differs from fresh: %s", goFreshDiff[0])
+	}
+	if goIncremental.RootNode().HasError() != goFresh.RootNode().HasError() {
+		t.Fatalf("Go same-length error state differs from fresh: incremental=%t fresh=%t", goIncremental.RootNode().HasError(), goFresh.RootNode().HasError())
+	}
+	if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" || !profile.OldTreeReuseRoute ||
+		profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("Go same-length scanner-state edit did not use authenticated reuse: %+v", profile)
+	}
+
+	cLang, err := ParityCLanguage("python")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatal(err)
+	}
+	cFresh := cParser.Parse(edited, nil)
+	if cFresh == nil || cFresh.RootNode() == nil {
+		t.Fatal("C same-length fresh parse returned no root")
+	}
+	t.Cleanup(cFresh.Close)
+	cOld := cParser.Parse(source, nil)
+	if cOld == nil || cOld.RootNode() == nil {
+		t.Fatal("C same-length old parse returned no root")
+	}
+	cEdit := realCorpusCInputEdit(edit)
+	cOld.Edit(&cEdit)
+	cIncremental := cParser.Parse(edited, cOld)
+	cOld.Close()
+	if cIncremental == nil || cIncremental.RootNode() == nil {
+		t.Fatal("C same-length incremental parse returned no root")
+	}
+	t.Cleanup(cIncremental.Close)
+	if diff := FirstDivergenceDumpV1(goIncremental.RootNode(), goLang, cFresh.RootNode()); diff != nil {
+		t.Fatalf("Go same-length incremental differs from C fresh: %+v", *diff)
+	}
+	if diff := FirstDivergenceDumpV1(goIncremental.RootNode(), goLang, cIncremental.RootNode()); diff != nil {
+		t.Fatalf("Go same-length incremental differs from C incremental: %+v", *diff)
+	}
+	if goIncremental.RootNode().HasError() != cFresh.RootNode().HasError() || goIncremental.RootNode().HasError() != cIncremental.RootNode().HasError() {
+		t.Fatalf("same-length error state differs across Go/C: go=%t c_fresh=%t c_incremental=%t", goIncremental.RootNode().HasError(), cFresh.RootNode().HasError(), cIncremental.RootNode().HasError())
+	}
+	t.Logf("same-length scanner delimiter parity: reuse=%t unsupported=%t reason=%q reused=%d bytes=%d", profile.OldTreeReuseRoute, profile.ReuseUnsupported, profile.ReuseUnsupportedReason, profile.ReusedSubtrees, profile.ReusedBytes)
+}
+
+// TestStage5PythonWideIndentBoundaryParity proves the uint16 indentation
+// counter used by the locked Python commit 26855eab. Each bounded case
+// compares fresh, forward-incremental, and reverse-incremental Go trees with
+// the locked C trees, including ranges and error state.
+func TestStage5PythonWideIndentBoundaryParity(t *testing.T) {
+	for _, width := range []int{65535, 65536, 131072} {
+		width := width
+		t.Run(fmt.Sprintf("spaces_%d", width), func(t *testing.T) {
+			source := stage5PythonWideIndentSource(width)
+			const oldReturn = "return 2"
+			offset := bytes.LastIndex(source, []byte(oldReturn))
+			if offset < 0 {
+				t.Fatalf("wide-indent fixture has no second return marker")
+			}
+			edited := append([]byte(nil), source...)
+			edited[offset+len(oldReturn)-1] = '3'
+			edit := gotreesitter.InputEdit{
+				StartByte:   uint32(offset + len(oldReturn) - 1),
+				OldEndByte:  uint32(offset + len(oldReturn)),
+				NewEndByte:  uint32(offset + len(oldReturn)),
+				StartPoint:  pointAtOffset(source, offset+len(oldReturn)-1),
+				OldEndPoint: pointAtOffset(source, offset+len(oldReturn)),
+				NewEndPoint: pointAtOffset(edited, offset+len(oldReturn)),
+			}
+			reverseEdit := gotreesitter.InputEdit{
+				StartByte:   edit.StartByte,
+				OldEndByte:  edit.OldEndByte,
+				NewEndByte:  edit.NewEndByte,
+				StartPoint:  edit.StartPoint,
+				OldEndPoint: edit.NewEndPoint,
+				NewEndPoint: edit.OldEndPoint,
+			}
+
+			goLang := grammars.PythonLanguage()
+			goParser := gotreesitter.NewParser(goLang)
+			goParser.SetAdmissionCandidateRoute(false)
+			goBase, err := goParser.Parse(source)
+			if err != nil {
+				t.Fatalf("Go wide-indent fresh parse: %v", err)
+			}
+			t.Cleanup(goBase.Release)
+			goBaseRuntime := goBase.ParseRuntime()
+			if goBaseRuntime.Truncated || goBaseRuntime.RootEndByte != uint32(len(source)) {
+				t.Fatalf("Go wide-indent fresh parse incomplete: %+v", goBaseRuntime)
+			}
+
+			cLang, err := ParityCLanguage("python")
+			if err != nil {
+				t.Fatal(err)
+			}
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatal(err)
+			}
+			cBase := cParser.Parse(source, nil)
+			if cBase == nil || cBase.RootNode() == nil {
+				t.Fatal("locked C wide-indent fresh parse returned no root")
+			}
+			t.Cleanup(cBase.Close)
+			assertStage5PythonGoCParity(t, goBase, goLang, cBase.RootNode(), "wide-indent fresh")
+			assertStage5PythonRootRange(t, goBase, cBase.RootNode(), "wide-indent fresh")
+
+			cForwardFresh := cParser.Parse(edited, nil)
+			if cForwardFresh == nil || cForwardFresh.RootNode() == nil {
+				t.Fatal("locked C wide-indent forward fresh parse returned no root")
+			}
+			t.Cleanup(cForwardFresh.Close)
+			cForwardOld := cParser.Parse(source, nil)
+			if cForwardOld == nil {
+				t.Fatal("locked C wide-indent forward base parse returned no tree")
+			}
+			cForwardOldEdit := realCorpusCInputEdit(edit)
+			cForwardOld.Edit(&cForwardOldEdit)
+			cForward := cParser.Parse(edited, cForwardOld)
+			cForwardOld.Close()
+			if cForward == nil || cForward.RootNode() == nil {
+				t.Fatal("locked C wide-indent forward incremental parse returned no root")
+			}
+			t.Cleanup(cForward.Close)
+
+			goForwardBase := goBase.Copy()
+			if goForwardBase == nil {
+				t.Fatal("Go wide-indent forward base copy returned nil")
+			}
+			t.Cleanup(goForwardBase.Release)
+			goForwardBase.Edit(edit)
+			goForward, forwardProfile, err := goParser.ParseIncrementalProfiled(edited, goForwardBase)
+			if err != nil {
+				t.Fatalf("Go wide-indent forward incremental parse: %v", err)
+			}
+			if goForward != goForwardBase {
+				t.Cleanup(goForward.Release)
+			}
+			assertStage5PythonGoCParity(t, goForward, goLang, cForwardFresh.RootNode(), "wide-indent forward fresh C")
+			assertStage5PythonGoCParity(t, goForward, goLang, cForward.RootNode(), "wide-indent forward incremental C")
+			assertStage5PythonRootRange(t, goForward, cForward.RootNode(), "wide-indent forward")
+
+			cReverseOld := cParser.Parse(edited, nil)
+			if cReverseOld == nil {
+				t.Fatal("locked C wide-indent reverse base parse returned no tree")
+			}
+			cReverseOldEdit := realCorpusCInputEdit(reverseEdit)
+			cReverseOld.Edit(&cReverseOldEdit)
+			cReverse := cParser.Parse(source, cReverseOld)
+			cReverseOld.Close()
+			if cReverse == nil || cReverse.RootNode() == nil {
+				t.Fatal("locked C wide-indent reverse incremental parse returned no root")
+			}
+			t.Cleanup(cReverse.Close)
+
+			goForward.Edit(reverseEdit)
+			goReverse, reverseProfile, err := goParser.ParseIncrementalProfiled(source, goForward)
+			if err != nil {
+				t.Fatalf("Go wide-indent reverse incremental parse: %v", err)
+			}
+			if goReverse != goForward {
+				t.Cleanup(goReverse.Release)
+			}
+			assertStage5PythonGoCParity(t, goReverse, goLang, cBase.RootNode(), "wide-indent reverse fresh C")
+			assertStage5PythonGoCParity(t, goReverse, goLang, cReverse.RootNode(), "wide-indent reverse incremental C")
+			assertStage5PythonRootRange(t, goReverse, cReverse.RootNode(), "wide-indent reverse")
+			t.Logf("wide-indent spaces=%d source=%d base_stop=%s base_end=%d forward_profile=%+v reverse_profile=%+v", width, len(source), goBaseRuntime.StopReason, goBaseRuntime.RootEndByte, forwardProfile, reverseProfile)
+		})
+	}
+}
+
+// TestStage5PythonWideIndentTransitionParity proves edits across the locked
+// uint16 indentation boundary. The cases use bounded source sizes and compare
+// fresh and incremental trees in both directions.
+func TestStage5PythonWideIndentTransitionParity(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		oldWidth, newWidth int
+	}{
+		{name: "65535_to_65536", oldWidth: 65535, newWidth: 65536},
+		{name: "65536_to_131072", oldWidth: 65536, newWidth: 131072},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			source, edited, edit, reverseEdit := stage5PythonWideIndentTransition(tc.oldWidth, tc.newWidth)
+
+			goLang := grammars.PythonLanguage()
+			goParser := gotreesitter.NewParser(goLang)
+			goParser.SetAdmissionCandidateRoute(false)
+			goOld, err := goParser.Parse(source)
+			if err != nil {
+				t.Fatalf("Go wide-indent transition old fresh parse: %v", err)
+			}
+			t.Cleanup(goOld.Release)
+			goOldRuntime := goOld.ParseRuntime()
+			if goOldRuntime.Truncated || goOldRuntime.RootEndByte != uint32(len(source)) {
+				t.Fatalf("Go wide-indent transition old fresh parse incomplete: %+v", goOldRuntime)
+			}
+
+			goFreshParser := gotreesitter.NewParser(goLang)
+			goFreshParser.SetAdmissionCandidateRoute(false)
+			goNewFresh, err := goFreshParser.Parse(edited)
+			if err != nil {
+				t.Fatalf("Go wide-indent transition new fresh parse: %v", err)
+			}
+			t.Cleanup(goNewFresh.Release)
+			goNewRuntime := goNewFresh.ParseRuntime()
+			if goNewRuntime.Truncated || goNewRuntime.RootEndByte != uint32(len(edited)) {
+				t.Fatalf("Go wide-indent transition new fresh parse incomplete: %+v", goNewRuntime)
+			}
+
+			cLang, err := ParityCLanguage("python")
+			if err != nil {
+				t.Fatal(err)
+			}
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatal(err)
+			}
+			cOldFresh := cParser.Parse(source, nil)
+			if cOldFresh == nil || cOldFresh.RootNode() == nil {
+				t.Fatal("locked C wide-indent transition old fresh parse returned no root")
+			}
+			t.Cleanup(cOldFresh.Close)
+			cNewFresh := cParser.Parse(edited, nil)
+			if cNewFresh == nil || cNewFresh.RootNode() == nil {
+				t.Fatal("locked C wide-indent transition new fresh parse returned no root")
+			}
+			t.Cleanup(cNewFresh.Close)
+
+			assertStage5PythonGoCParity(t, goOld, goLang, cOldFresh.RootNode(), "wide-indent transition old fresh")
+			assertStage5PythonRootRange(t, goOld, cOldFresh.RootNode(), "wide-indent transition old fresh")
+			assertStage5PythonGoCParity(t, goNewFresh, goLang, cNewFresh.RootNode(), "wide-indent transition new fresh")
+			assertStage5PythonRootRange(t, goNewFresh, cNewFresh.RootNode(), "wide-indent transition new fresh")
+
+			cForwardOld := cParser.Parse(source, nil)
+			if cForwardOld == nil {
+				t.Fatal("locked C wide-indent transition forward base parse returned no tree")
+			}
+			cForwardEdit := realCorpusCInputEdit(edit)
+			cForwardOld.Edit(&cForwardEdit)
+			cForward := cParser.Parse(edited, cForwardOld)
+			cForwardOld.Close()
+			if cForward == nil || cForward.RootNode() == nil {
+				t.Fatal("locked C wide-indent transition forward incremental parse returned no root")
+			}
+			t.Cleanup(cForward.Close)
+
+			goForwardBase := goOld.Copy()
+			if goForwardBase == nil {
+				t.Fatal("Go wide-indent transition forward base copy returned nil")
+			}
+			t.Cleanup(goForwardBase.Release)
+			goForwardBase.Edit(edit)
+			goForward, forwardProfile, err := goParser.ParseIncrementalProfiled(edited, goForwardBase)
+			if err != nil {
+				t.Fatalf("Go wide-indent transition forward incremental parse: %v", err)
+			}
+			if goForward != goForwardBase {
+				t.Cleanup(goForward.Release)
+			}
+			assertStage5PythonPrefixFallback(t, forwardProfile, "wide-indent transition forward")
+			assertStage5PythonGoCParity(t, goForward, goLang, cNewFresh.RootNode(), "wide-indent transition forward fresh C")
+			assertStage5PythonGoCParity(t, goForward, goLang, cForward.RootNode(), "wide-indent transition forward incremental C")
+			assertStage5PythonRootRange(t, goForward, cForward.RootNode(), "wide-indent transition forward")
+
+			cReverseOld := cParser.Parse(edited, nil)
+			if cReverseOld == nil {
+				t.Fatal("locked C wide-indent transition reverse base parse returned no tree")
+			}
+			cReverseEdit := realCorpusCInputEdit(reverseEdit)
+			cReverseOld.Edit(&cReverseEdit)
+			cReverse := cParser.Parse(source, cReverseOld)
+			cReverseOld.Close()
+			if cReverse == nil || cReverse.RootNode() == nil {
+				t.Fatal("locked C wide-indent transition reverse incremental parse returned no root")
+			}
+			t.Cleanup(cReverse.Close)
+
+			goForward.Edit(reverseEdit)
+			goReverse, reverseProfile, err := goParser.ParseIncrementalProfiled(source, goForward)
+			if err != nil {
+				t.Fatalf("Go wide-indent transition reverse incremental parse: %v", err)
+			}
+			if goReverse != goForward {
+				t.Cleanup(goReverse.Release)
+			}
+			assertStage5PythonPrefixFallback(t, reverseProfile, "wide-indent transition reverse")
+			assertStage5PythonGoCParity(t, goReverse, goLang, cOldFresh.RootNode(), "wide-indent transition reverse fresh C")
+			assertStage5PythonGoCParity(t, goReverse, goLang, cReverse.RootNode(), "wide-indent transition reverse incremental C")
+			assertStage5PythonRootRange(t, goReverse, cReverse.RootNode(), "wide-indent transition reverse")
+			t.Logf("wide-indent transition %d->%d old=%d new=%d forward_nodes=%d reverse_nodes=%d", tc.oldWidth, tc.newWidth, len(source), len(edited), forwardProfile.NewNodesAllocated, reverseProfile.NewNodesAllocated)
+		})
+	}
+}
+
+func stage5PythonWideIndentSource(width int) []byte {
+	source := make([]byte, 0, width+96)
+	source = append(source, "def first():\n"...)
+	source = append(source, bytes.Repeat([]byte{' '}, width)...)
+	source = append(source, "return 1\n\n"...)
+	source = append(source, "def second():\n    return 2\n"...)
+	return source
+}
+
+func stage5PythonWideIndentTransition(oldWidth, newWidth int) ([]byte, []byte, gotreesitter.InputEdit, gotreesitter.InputEdit) {
+	source := stage5PythonWideIndentSource(oldWidth)
+	edited := stage5PythonWideIndentSource(newWidth)
+	const indentStart = len("def first():\n")
+	forward := gotreesitter.InputEdit{
+		StartByte:   uint32(indentStart),
+		OldEndByte:  uint32(indentStart + oldWidth),
+		NewEndByte:  uint32(indentStart + newWidth),
+		StartPoint:  pointAtOffset(source, indentStart),
+		OldEndPoint: pointAtOffset(source, indentStart+oldWidth),
+		NewEndPoint: pointAtOffset(edited, indentStart+newWidth),
+	}
+	reverse := gotreesitter.InputEdit{
+		StartByte:   forward.StartByte,
+		OldEndByte:  forward.NewEndByte,
+		NewEndByte:  forward.OldEndByte,
+		StartPoint:  forward.StartPoint,
+		OldEndPoint: forward.NewEndPoint,
+		NewEndPoint: forward.OldEndPoint,
+	}
+	return source, edited, forward, reverse
+}
+
+func assertStage5PythonRootRange(t *testing.T, tree *gotreesitter.Tree, cRoot *sitter.Node, label string) {
+	t.Helper()
+	if tree == nil || tree.RootNode() == nil || cRoot == nil {
+		t.Fatalf("%s has no root", label)
+	}
+	goRange := tree.RootNode().Range()
+	cStart := cRoot.StartPosition()
+	cEnd := cRoot.EndPosition()
+	if goRange.StartByte != uint32(cRoot.StartByte()) || goRange.EndByte != uint32(cRoot.EndByte()) ||
+		goRange.StartPoint.Row != uint32(cStart.Row) || goRange.StartPoint.Column != uint32(cStart.Column) ||
+		goRange.EndPoint.Row != uint32(cEnd.Row) || goRange.EndPoint.Column != uint32(cEnd.Column) {
+		t.Fatalf("%s root range differs: Go=%+v C=[%d,%d) (%d,%d)..(%d,%d)", label, goRange, cRoot.StartByte(), cRoot.EndByte(), cStart.Row, cStart.Column, cEnd.Row, cEnd.Column)
+	}
+}
+
+func assertStage5PythonGoCParity(t *testing.T, tree *gotreesitter.Tree, lang *gotreesitter.Language, cRoot *sitter.Node, label string) {
+	t.Helper()
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatalf("%s returned no Go root", label)
+	}
+	if cRoot == nil {
+		t.Fatalf("%s received no C root", label)
+	}
+	if diff := FirstDivergenceDumpV1(tree.RootNode(), lang, cRoot); diff != nil {
+		t.Fatalf("%s differs from locked C: %+v", label, *diff)
+	}
+	if got, want := stage5PythonGoErrorCount(tree.RootNode()), stage5PythonCErrorCount(cRoot); got != want {
+		t.Fatalf("%s error-node count=%d, want %d", label, got, want)
+	}
+	if got, want := tree.RootNode().HasError(), cRoot.HasError(); got != want {
+		t.Fatalf("%s root HasError=%t, want %t", label, got, want)
+	}
+}
+
+func assertStage5PythonPrefixFallback(t *testing.T, profile gotreesitter.IncrementalParseProfile, label string) {
+	t.Helper()
+	if profile.ReuseUnsupportedReason != "external_scanner_prefix_frontier_unproven" ||
+		!profile.ReuseUnsupported || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 ||
+		profile.ReusedBytes != 0 || profile.ReuseCursorNanos != 0 {
+		t.Fatalf("%s did not fail closed before candidate scanning: %+v", label, profile)
+	}
+}
+
+func stage5PythonGoErrorCount(node *gotreesitter.Node) uint64 {
+	if node == nil {
+		return 0
+	}
+	count := uint64(0)
+	if node.IsError() {
+		count++
+	}
+	for index := 0; index < node.ChildCount(); index++ {
+		count += stage5PythonGoErrorCount(node.Child(index))
+	}
+	return count
+}
+
+func stage5PythonCErrorCount(node *sitter.Node) uint64 {
+	if node == nil {
+		return 0
+	}
+	count := uint64(0)
+	if node.IsError() {
+		count++
+	}
+	for index := uint(0); index < node.ChildCount(); index++ {
+		count += stage5PythonCErrorCount(node.Child(index))
+	}
+	return count
+}

--- a/cgo_harness/stage5_compact_incremental_test.go
+++ b/cgo_harness/stage5_compact_incremental_test.go
@@ -233,38 +233,38 @@ func TestStage5CompactPythonScannerCheckpointReuse(t *testing.T) {
 
 // TestStage5PythonSameLengthScannerDelimiterParity proves the conservative
 // same-length scanner-state lane against both C fresh and C incremental trees.
-// It changes a regular string with literal braces into a real f-string
-// interpolation without changing the byte span. The changed token cannot use
-// the one-leaf authentication path, so the prefix guard must parse fresh.
+// It changes only the u prefix to f. Both scans produce the same string_start
+// token and span, but only the f prefix enables interpolation. The checkpoint
+// end state must reject leaf reuse and send the compact route to a fresh parse.
 func TestStage5PythonSameLengthScannerDelimiterParity(t *testing.T) {
 	source := []byte("def first(value):\n    return u\"{x}\"\n\ndef second(value):\n    return \"unchanged\"\n")
-	oldText := []byte("u\"{x}\"")
-	replacement := []byte("f'{x}'")
-	offset := bytes.Index(source, oldText)
-	if offset < 0 || len(oldText) != len(replacement) {
-		t.Fatalf("same-length delimiter witness is malformed: offset=%d old=%d new=%d", offset, len(oldText), len(replacement))
+	marker := []byte("u\"{x}\"")
+	offset := bytes.Index(source, marker)
+	if offset < 0 {
+		t.Fatalf("same-length delimiter witness is malformed: offset=%d", offset)
 	}
-	edited := make([]byte, 0, len(source))
-	edited = append(edited, source[:offset]...)
-	edited = append(edited, replacement...)
-	edited = append(edited, source[offset+len(oldText):]...)
+	edited := append([]byte(nil), source...)
+	edited[offset] = 'f'
 	edit := gotreesitter.InputEdit{
 		StartByte:   uint32(offset),
-		OldEndByte:  uint32(offset + len(oldText)),
-		NewEndByte:  uint32(offset + len(replacement)),
+		OldEndByte:  uint32(offset + 1),
+		NewEndByte:  uint32(offset + 1),
 		StartPoint:  pointAtOffset(source, offset),
-		OldEndPoint: pointAtOffset(source, offset+len(oldText)),
-		NewEndPoint: pointAtOffset(edited, offset+len(replacement)),
+		OldEndPoint: pointAtOffset(source, offset+1),
+		NewEndPoint: pointAtOffset(edited, offset+1),
 	}
 
 	goLang := grammars.PythonLanguage()
 	goParser := gotreesitter.NewParser(goLang)
-	goParser.SetAdmissionCandidateRoute(false)
+	goParser.SetAdmissionCandidateRoute(true)
 	goOld, err := goParser.Parse(source)
 	if err != nil {
 		t.Fatalf("Go same-length old parse: %v", err)
 	}
 	t.Cleanup(goOld.Release)
+	if !goOld.ParseRuntime().CompactExternalScannerCheckpointTransferProven {
+		t.Fatalf("Go same-length old parse did not use the compact checkpoint route: %+v", goOld.ParseRuntime())
+	}
 	goOld.Edit(edit)
 	goIncremental, profile, err := goParser.ParseIncrementalProfiled(edited, goOld)
 	if err != nil {

--- a/cgo_harness/stage5_compact_incremental_test.go
+++ b/cgo_harness/stage5_compact_incremental_test.go
@@ -234,8 +234,8 @@ func TestStage5CompactPythonScannerCheckpointReuse(t *testing.T) {
 // TestStage5PythonSameLengthScannerDelimiterParity proves the conservative
 // same-length scanner-state lane against both C fresh and C incremental trees.
 // It changes a regular string with literal braces into a real f-string
-// interpolation without changing the byte span, then checks the following
-// top-level child.
+// interpolation without changing the byte span. The changed token cannot use
+// the one-leaf authentication path, so the prefix guard must parse fresh.
 func TestStage5PythonSameLengthScannerDelimiterParity(t *testing.T) {
 	source := []byte("def first(value):\n    return u\"{x}\"\n\ndef second(value):\n    return \"unchanged\"\n")
 	oldText := []byte("u\"{x}\"")
@@ -288,10 +288,7 @@ func TestStage5PythonSameLengthScannerDelimiterParity(t *testing.T) {
 	if goIncremental.RootNode().HasError() != goFresh.RootNode().HasError() {
 		t.Fatalf("Go same-length error state differs from fresh: incremental=%t fresh=%t", goIncremental.RootNode().HasError(), goFresh.RootNode().HasError())
 	}
-	if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" || !profile.OldTreeReuseRoute ||
-		profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
-		t.Fatalf("Go same-length scanner-state edit did not use authenticated reuse: %+v", profile)
-	}
+	assertStage5PythonPrefixFallback(t, profile, "same-length scanner delimiter")
 
 	cLang, err := ParityCLanguage("python")
 	if err != nil {
@@ -331,6 +328,82 @@ func TestStage5PythonSameLengthScannerDelimiterParity(t *testing.T) {
 	t.Logf("same-length scanner delimiter parity: reuse=%t unsupported=%t reason=%q reused=%d bytes=%d", profile.OldTreeReuseRoute, profile.ReuseUnsupported, profile.ReuseUnsupportedReason, profile.ReusedSubtrees, profile.ReusedBytes)
 }
 
+// TestStage5PythonPrefixFrontierAdversarialParity proves that byte-width
+// equality and leading extras cannot move the first structural frontier.
+func TestStage5PythonPrefixFrontierAdversarialParity(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		source      []byte
+		needle      []byte
+		replacement []byte
+	}{
+		{
+			name:        "same_length_indentation_state",
+			source:      []byte("def first():\n        value = 1\n        return value\n\ndef second():\n    return 2\n"),
+			needle:      []byte("        return value"),
+			replacement: []byte("\t       return value"),
+		},
+		{
+			name:        "leading_comment_extra",
+			source:      []byte("# leading extra\n\ndef first():\n    return 1\n\ndef second():\n    return 2\n"),
+			needle:      []byte("return 1"),
+			replacement: []byte("return 19"),
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			edited, edit := stage5PythonReplace(t, tc.source, tc.needle, tc.replacement)
+			goLang := grammars.PythonLanguage()
+			goParser := gotreesitter.NewParser(goLang)
+			goParser.SetAdmissionCandidateRoute(false)
+			goOld, err := goParser.Parse(tc.source)
+			if err != nil {
+				t.Fatalf("Go old parse: %v", err)
+			}
+			t.Cleanup(goOld.Release)
+			goOld.Edit(edit)
+			goIncremental, profile, err := goParser.ParseIncrementalProfiled(edited, goOld)
+			if err != nil {
+				t.Fatalf("Go incremental parse: %v", err)
+			}
+			if goIncremental != goOld {
+				t.Cleanup(goIncremental.Release)
+			}
+			assertStage5PythonPrefixFallback(t, profile, tc.name)
+
+			cLang, err := ParityCLanguage("python")
+			if err != nil {
+				t.Fatal(err)
+			}
+			cParser := sitter.NewParser()
+			t.Cleanup(cParser.Close)
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatal(err)
+			}
+			cFresh := cParser.Parse(edited, nil)
+			if cFresh == nil || cFresh.RootNode() == nil {
+				t.Fatal("locked C fresh parse returned no root")
+			}
+			t.Cleanup(cFresh.Close)
+			cOld := cParser.Parse(tc.source, nil)
+			if cOld == nil || cOld.RootNode() == nil {
+				t.Fatal("locked C old parse returned no root")
+			}
+			cEdit := realCorpusCInputEdit(edit)
+			cOld.Edit(&cEdit)
+			cIncremental := cParser.Parse(edited, cOld)
+			cOld.Close()
+			if cIncremental == nil || cIncremental.RootNode() == nil {
+				t.Fatal("locked C incremental parse returned no root")
+			}
+			t.Cleanup(cIncremental.Close)
+			assertStage5PythonGoCParity(t, goIncremental, goLang, cFresh.RootNode(), tc.name+" fresh C")
+			assertStage5PythonGoCParity(t, goIncremental, goLang, cIncremental.RootNode(), tc.name+" incremental C")
+			assertStage5PythonRootRange(t, goIncremental, cIncremental.RootNode(), tc.name)
+		})
+	}
+}
+
 // TestStage5PythonWideIndentBoundaryParity proves the uint16 indentation
 // counter used by the locked Python commit 26855eab. Each bounded case
 // compares fresh, forward-incremental, and reverse-incremental Go trees with
@@ -341,19 +414,22 @@ func TestStage5PythonWideIndentBoundaryParity(t *testing.T) {
 		t.Run(fmt.Sprintf("spaces_%d", width), func(t *testing.T) {
 			source := stage5PythonWideIndentSource(width)
 			const oldReturn = "return 2"
+			const newReturn = "return 20"
 			offset := bytes.LastIndex(source, []byte(oldReturn))
 			if offset < 0 {
 				t.Fatalf("wide-indent fixture has no second return marker")
 			}
-			edited := append([]byte(nil), source...)
-			edited[offset+len(oldReturn)-1] = '3'
+			edited := make([]byte, 0, len(source)+len(newReturn)-len(oldReturn))
+			edited = append(edited, source[:offset]...)
+			edited = append(edited, newReturn...)
+			edited = append(edited, source[offset+len(oldReturn):]...)
 			edit := gotreesitter.InputEdit{
-				StartByte:   uint32(offset + len(oldReturn) - 1),
+				StartByte:   uint32(offset),
 				OldEndByte:  uint32(offset + len(oldReturn)),
-				NewEndByte:  uint32(offset + len(oldReturn)),
-				StartPoint:  pointAtOffset(source, offset+len(oldReturn)-1),
+				NewEndByte:  uint32(offset + len(newReturn)),
+				StartPoint:  pointAtOffset(source, offset),
 				OldEndPoint: pointAtOffset(source, offset+len(oldReturn)),
-				NewEndPoint: pointAtOffset(edited, offset+len(oldReturn)),
+				NewEndPoint: pointAtOffset(edited, offset+len(newReturn)),
 			}
 			reverseEdit := gotreesitter.InputEdit{
 				StartByte:   edit.StartByte,
@@ -428,6 +504,7 @@ func TestStage5PythonWideIndentBoundaryParity(t *testing.T) {
 			assertStage5PythonGoCParity(t, goForward, goLang, cForwardFresh.RootNode(), "wide-indent forward fresh C")
 			assertStage5PythonGoCParity(t, goForward, goLang, cForward.RootNode(), "wide-indent forward incremental C")
 			assertStage5PythonRootRange(t, goForward, cForward.RootNode(), "wide-indent forward")
+			assertStage5PythonReuseRoute(t, forwardProfile, "wide-indent forward")
 
 			cReverseOld := cParser.Parse(edited, nil)
 			if cReverseOld == nil {
@@ -453,6 +530,7 @@ func TestStage5PythonWideIndentBoundaryParity(t *testing.T) {
 			assertStage5PythonGoCParity(t, goReverse, goLang, cBase.RootNode(), "wide-indent reverse fresh C")
 			assertStage5PythonGoCParity(t, goReverse, goLang, cReverse.RootNode(), "wide-indent reverse incremental C")
 			assertStage5PythonRootRange(t, goReverse, cReverse.RootNode(), "wide-indent reverse")
+			assertStage5PythonReuseRoute(t, reverseProfile, "wide-indent reverse")
 			t.Logf("wide-indent spaces=%d source=%d base_stop=%s base_end=%d forward_profile=%+v reverse_profile=%+v", width, len(source), goBaseRuntime.StopReason, goBaseRuntime.RootEndByte, forwardProfile, reverseProfile)
 		})
 	}
@@ -616,6 +694,27 @@ func stage5PythonWideIndentTransition(oldWidth, newWidth int) ([]byte, []byte, g
 	return source, edited, forward, reverse
 }
 
+func stage5PythonReplace(t *testing.T, source, needle, replacement []byte) ([]byte, gotreesitter.InputEdit) {
+	t.Helper()
+	offset := bytes.Index(source, needle)
+	if offset < 0 {
+		t.Fatalf("Python edit fixture has no marker %q", needle)
+	}
+	oldEnd := offset + len(needle)
+	edited := make([]byte, 0, len(source)-len(needle)+len(replacement))
+	edited = append(edited, source[:offset]...)
+	edited = append(edited, replacement...)
+	edited = append(edited, source[oldEnd:]...)
+	return edited, gotreesitter.InputEdit{
+		StartByte:   uint32(offset),
+		OldEndByte:  uint32(oldEnd),
+		NewEndByte:  uint32(offset + len(replacement)),
+		StartPoint:  pointAtOffset(source, offset),
+		OldEndPoint: pointAtOffset(source, oldEnd),
+		NewEndPoint: pointAtOffset(edited, offset+len(replacement)),
+	}
+}
+
 func assertStage5PythonRootRange(t *testing.T, tree *gotreesitter.Tree, cRoot *sitter.Node, label string) {
 	t.Helper()
 	if tree == nil || tree.RootNode() == nil || cRoot == nil {
@@ -656,6 +755,15 @@ func assertStage5PythonPrefixFallback(t *testing.T, profile gotreesitter.Increme
 		!profile.ReuseUnsupported || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 ||
 		profile.ReusedBytes != 0 || profile.ReuseCursorNanos != 0 {
 		t.Fatalf("%s did not fail closed before candidate scanning: %+v", label, profile)
+	}
+}
+
+func assertStage5PythonReuseRoute(t *testing.T, profile gotreesitter.IncrementalParseProfile, label string) {
+	t.Helper()
+	if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" || !profile.OldTreeReuseRoute ||
+		profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 || profile.NewNodesAllocated == 0 ||
+		profile.TokensConsumed == 0 {
+		t.Fatalf("%s did not use the scanner-aware old-tree route: %+v", label, profile)
 	}
 }
 

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "425ffdc2eb919b82b38484a0b3a2107d5c7341f1"
+	compactRouteLifecycleSourceRevision               = "0d6683a465c6d20477c6a16b6b1f70ac2a90e87b"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -56,10 +56,11 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack":                         "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonSameLengthScannerDelimiterParity":                   "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
 	"incremental_leaf_fastpath_test.go#TestIncludedRangeCheckpointLeafProbeRestoresTokenProvenance":                     "425ffdc2eb919b82b38484a0b3a2107d5c7341f1",
-	"testdata/incremental_allowlist.json":                                                                               "95a1d13156b82e2221415342c9ac8048f2caf644",
-	"docs/compact-route-real-corpus-matrix.md#Current compact-graduation matrix":                                        "41af6afa6da47c9f8b55b3156fd88fb56686373f",
-	"docs/compact-route-coverage-census.md":                                                                             "38d86d417fc6209228b8b175bc2aa7bb9700b8d3",
-	"docs/a8-derivation-divergence-certificate-v1.md":                                                                   "acccb81d20128e337a35ee274a2e3e3631b73b1a",
+	"internal/parsercorephase0/recursive_insert_test.go#TestAuthenticatedTerminalScannerProvenanceCoversOrdinaryLeaf":   "0d6683a465c6d20477c6a16b6b1f70ac2a90e87b",
+	"testdata/incremental_allowlist.json":                                        "95a1d13156b82e2221415342c9ac8048f2caf644",
+	"docs/compact-route-real-corpus-matrix.md#Current compact-graduation matrix": "41af6afa6da47c9f8b55b3156fd88fb56686373f",
+	"docs/compact-route-coverage-census.md":                                      "38d86d417fc6209228b8b175bc2aa7bb9700b8d3",
+	"docs/a8-derivation-divergence-certificate-v1.md":                            "acccb81d20128e337a35ee274a2e3e3631b73b1a",
 }
 
 var compactRouteLifecycleKnownCorpusTreeSHA256 = map[string]string{

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "9bd3e9a971b323e2cdeed302aa045af174ffe53c"
+	compactRouteLifecycleSourceRevision               = "425ffdc2eb919b82b38484a0b3a2107d5c7341f1"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -55,6 +55,7 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity":                    "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack":                         "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonSameLengthScannerDelimiterParity":                   "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
+	"incremental_leaf_fastpath_test.go#TestIncludedRangeCheckpointLeafProbeRestoresTokenProvenance":                     "425ffdc2eb919b82b38484a0b3a2107d5c7341f1",
 	"testdata/incremental_allowlist.json":                                                                               "95a1d13156b82e2221415342c9ac8048f2caf644",
 	"docs/compact-route-real-corpus-matrix.md#Current compact-graduation matrix":                                        "41af6afa6da47c9f8b55b3156fd88fb56686373f",
 	"docs/compact-route-coverage-census.md":                                                                             "38d86d417fc6209228b8b175bc2aa7bb9700b8d3",

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "e1de4484b5655ab11057f70d9dc7b1245972d03f"
+	compactRouteLifecycleSourceRevision               = "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -51,6 +51,8 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5CompactPythonScannerCheckpointReuse":                      "5070ffd4594a819e8ebe78fa2bf651c197cbdce4",
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonWideIndentTransitionParity":                         "5070ffd4594a819e8ebe78fa2bf651c197cbdce4",
 	"parser_external_scanner_prefix_frontier_test.go#TestCheckpointedScannerWithoutPrefixFrontierRequirementKeepsReuse": "e1de4484b5655ab11057f70d9dc7b1245972d03f",
+	"external_scanner_checkpoints_test.go#TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots":            "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
+	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity":                    "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"testdata/incremental_allowlist.json":                                                                               "95a1d13156b82e2221415342c9ac8048f2caf644",
 	"docs/compact-route-real-corpus-matrix.md#Current compact-graduation matrix":                                        "41af6afa6da47c9f8b55b3156fd88fb56686373f",
 	"docs/compact-route-coverage-census.md":                                                                             "38d86d417fc6209228b8b175bc2aa7bb9700b8d3",

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "72afa041e9ec2f02872724bbdce17694d89955d8"
+	compactRouteLifecycleSourceRevision               = "5070ffd4594a819e8ebe78fa2bf651c197cbdce4"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -48,6 +48,8 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"cgo_harness/eof_recovery_admission_oracle_test.go#TestEOFRecoveryAdmissionUsesLockedCEventsAndPublishedTree": "2ebeb6c64632163622691786a71ac6da76a14929",
 	"incremental_invariant_gate_test.go#TestIncrementalInvariantGatePython":                                       "bf7ab0567122e863ef831e8aa56dbee93127ad93",
 	"w5_editor_latency_gate_test.go#TestW5EditorLatencyGate":                                                      "e734c93543654818082e8d3ae3721cdb6fe9e4a5",
+	"cgo_harness/stage5_compact_incremental_test.go#TestStage5CompactPythonScannerCheckpointReuse":                "5070ffd4594a819e8ebe78fa2bf651c197cbdce4",
+	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonWideIndentTransitionParity":                   "5070ffd4594a819e8ebe78fa2bf651c197cbdce4",
 	"testdata/incremental_allowlist.json":                                                                         "95a1d13156b82e2221415342c9ac8048f2caf644",
 	"docs/compact-route-real-corpus-matrix.md#Current compact-graduation matrix":                                  "41af6afa6da47c9f8b55b3156fd88fb56686373f",
 	"docs/compact-route-coverage-census.md":                                                                       "38d86d417fc6209228b8b175bc2aa7bb9700b8d3",

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a"
+	compactRouteLifecycleSourceRevision               = "9bd3e9a971b323e2cdeed302aa045af174ffe53c"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -53,6 +53,8 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"parser_external_scanner_prefix_frontier_test.go#TestCheckpointedScannerWithoutPrefixFrontierRequirementKeepsReuse": "e1de4484b5655ab11057f70d9dc7b1245972d03f",
 	"external_scanner_checkpoints_test.go#TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots":            "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity":                    "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
+	"parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack":                         "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
+	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonSameLengthScannerDelimiterParity":                   "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
 	"testdata/incremental_allowlist.json":                                                                               "95a1d13156b82e2221415342c9ac8048f2caf644",
 	"docs/compact-route-real-corpus-matrix.md#Current compact-graduation matrix":                                        "41af6afa6da47c9f8b55b3156fd88fb56686373f",
 	"docs/compact-route-coverage-census.md":                                                                             "38d86d417fc6209228b8b175bc2aa7bb9700b8d3",

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "5070ffd4594a819e8ebe78fa2bf651c197cbdce4"
+	compactRouteLifecycleSourceRevision               = "e1de4484b5655ab11057f70d9dc7b1245972d03f"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -45,15 +45,16 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"pr:#1018": "9f9e903940655da46fb8c976fa2e08139153df0f",
 	"parsercore_phase0_recovery_lineage_fork_internal_test.go#TestS5MissingInsertionForkPublishesBothRecoveryLineages": "9f9e903940655da46fb8c976fa2e08139153df0f",
 	"pr:#1019": "0beb95d399655d200e687e0912d3265b1c9562e9",
-	"cgo_harness/eof_recovery_admission_oracle_test.go#TestEOFRecoveryAdmissionUsesLockedCEventsAndPublishedTree": "2ebeb6c64632163622691786a71ac6da76a14929",
-	"incremental_invariant_gate_test.go#TestIncrementalInvariantGatePython":                                       "bf7ab0567122e863ef831e8aa56dbee93127ad93",
-	"w5_editor_latency_gate_test.go#TestW5EditorLatencyGate":                                                      "e734c93543654818082e8d3ae3721cdb6fe9e4a5",
-	"cgo_harness/stage5_compact_incremental_test.go#TestStage5CompactPythonScannerCheckpointReuse":                "5070ffd4594a819e8ebe78fa2bf651c197cbdce4",
-	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonWideIndentTransitionParity":                   "5070ffd4594a819e8ebe78fa2bf651c197cbdce4",
-	"testdata/incremental_allowlist.json":                                                                         "95a1d13156b82e2221415342c9ac8048f2caf644",
-	"docs/compact-route-real-corpus-matrix.md#Current compact-graduation matrix":                                  "41af6afa6da47c9f8b55b3156fd88fb56686373f",
-	"docs/compact-route-coverage-census.md":                                                                       "38d86d417fc6209228b8b175bc2aa7bb9700b8d3",
-	"docs/a8-derivation-divergence-certificate-v1.md":                                                             "acccb81d20128e337a35ee274a2e3e3631b73b1a",
+	"cgo_harness/eof_recovery_admission_oracle_test.go#TestEOFRecoveryAdmissionUsesLockedCEventsAndPublishedTree":       "2ebeb6c64632163622691786a71ac6da76a14929",
+	"incremental_invariant_gate_test.go#TestIncrementalInvariantGatePython":                                             "bf7ab0567122e863ef831e8aa56dbee93127ad93",
+	"w5_editor_latency_gate_test.go#TestW5EditorLatencyGate":                                                            "e734c93543654818082e8d3ae3721cdb6fe9e4a5",
+	"cgo_harness/stage5_compact_incremental_test.go#TestStage5CompactPythonScannerCheckpointReuse":                      "5070ffd4594a819e8ebe78fa2bf651c197cbdce4",
+	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonWideIndentTransitionParity":                         "5070ffd4594a819e8ebe78fa2bf651c197cbdce4",
+	"parser_external_scanner_prefix_frontier_test.go#TestCheckpointedScannerWithoutPrefixFrontierRequirementKeepsReuse": "e1de4484b5655ab11057f70d9dc7b1245972d03f",
+	"testdata/incremental_allowlist.json":                                                                               "95a1d13156b82e2221415342c9ac8048f2caf644",
+	"docs/compact-route-real-corpus-matrix.md#Current compact-graduation matrix":                                        "41af6afa6da47c9f8b55b3156fd88fb56686373f",
+	"docs/compact-route-coverage-census.md":                                                                             "38d86d417fc6209228b8b175bc2aa7bb9700b8d3",
+	"docs/a8-derivation-divergence-certificate-v1.md":                                                                   "acccb81d20128e337a35ee274a2e3e3631b73b1a",
 }
 
 var compactRouteLifecycleKnownCorpusTreeSHA256 = map[string]string{

--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -305,7 +305,8 @@ numbering, use the public remapper:
   declare true only if reusing subtrees across edits is safe for your
   state. Stateless scanners: yes. Returning false is an explicit opt-out;
   not implementing the interface is also treated as uncertified and fails
-  closed. Python, Mojo, and Starlark currently return false.
+  closed. Python returns true after complete checkpoint restoration; Mojo and
+  Starlark still return false.
 - `CheckpointedExternalScanner` (`UsesExternalScannerCheckpoints() bool`):
   declare true only when every non-empty `Serialize` result is a complete,
   collision-free encoding of the payload values that can affect a later scan.
@@ -313,11 +314,16 @@ numbering, use the public remapper:
   zero means "checkpoint absent" and reuse fails closed at that boundary. The
   empty payload itself must have a non-empty encoding so it is distinguishable
   from absence. Reuse compares the live start state and restores the recorded
-  end state. SQL, CMake, and HTML use this route; Python, Mojo, and Starlark
+  end state. SQL, CMake, HTML, and Python use this route; Mojo and Starlark
   record checkpoints but still opt out of reuse. The shared HTML-family tag
   encoding is exact and fails closed when depth, custom-name length, or buffer
   capacity cannot represent the complete state; Svelte still opts out pending
   certification of its additional raw-text and expression-block behavior.
+  Python counts indentation with the `uint16` counter used by the locked
+  `tree-sitter-python` commit `26855eabccb19c6abf499fbc5b8dc7cc9ab8bc64`.
+  Its checkpoint bytes are ephemeral snapshots; compact materialization copies
+  them into tree sidecars before the parser-core store is released. Do not
+  retain checkpoint IDs or buffer pointers across that boundary.
 - `ErrorTreeIncrementalReuseExternalScanner`
   (`SupportsIncrementalReuseFromErrorTree() bool`): an optional narrower gate
   for a scanner whose clean-tree checkpoints are certified but whose recovery
@@ -369,8 +375,8 @@ The token-invariant leaf exception is intentionally narrow: on a production
 tree, a same-length edit that independently reauthenticates the same leaf
 token may return before the scanner gate. That is not certification for
 general scanner-dependent subtree reuse. Likewise, scanner checkpoints do
-not certify a scanner by themselves: CMake, SQL, and HTML opt in, while Python,
-Mojo, Starlark, and Svelte explicitly opt out. Custom
+not certify a scanner by themselves: CMake, SQL, HTML, and Python opt in,
+while Mojo, Starlark, and Svelte explicitly opt out. Custom
 `TokenSource` implementations have their own
 `IncrementalReuseTokenSource` contract and are outside this registry matrix.
 The Markdown scanner is certified for incremental reuse. The Markdown Inline
@@ -557,7 +563,7 @@ silently widening HTML admission.
 | `properties` | fallback (uncertified) |
 | `pug` | fallback (uncertified) |
 | `purescript` | fallback (uncertified) |
-| `python` | fallback (explicit opt-out) |
+| `python` | certified reuse |
 | `r` | fallback (uncertified) |
 | `racket` | certified reuse |
 | `rescript` | fallback (uncertified) |

--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -324,6 +324,12 @@ numbering, use the public remapper:
   Its checkpoint bytes are ephemeral snapshots; compact materialization copies
   them into tree sidecars before the parser-core store is released. Do not
   retain checkpoint IDs or buffer pointers across that boundary.
+- `IncrementalPrefixFrontierExternalScanner`
+  (`RequiresIncrementalPrefixFrontierProof() bool`): require a fresh parse
+  after a changed-length or changed-point edit before the second top-level
+  sibling. Use this only when scanner state depends on the old reduction
+  frontier. Python enables it for indentation ownership. Other certified
+  checkpoint scanners keep their existing reuse contracts.
 - `ErrorTreeIncrementalReuseExternalScanner`
   (`SupportsIncrementalReuseFromErrorTree() bool`): an optional narrower gate
   for a scanner whose clean-tree checkpoints are certified but whose recovery

--- a/external_scanner_adapter.go
+++ b/external_scanner_adapter.go
@@ -73,6 +73,11 @@ func (a *externalScannerOrderAdapter) UsesExternalScannerCheckpoints() bool {
 	return ok && checkpointed.UsesExternalScannerCheckpoints()
 }
 
+func (a *externalScannerOrderAdapter) RequiresIncrementalPrefixFrontierProof() bool {
+	prefixSensitive, ok := a.optionalInner().(IncrementalPrefixFrontierExternalScanner)
+	return ok && prefixSensitive.RequiresIncrementalPrefixFrontierProof()
+}
+
 func (a *externalScannerOrderAdapter) AllowsIncrementalReuseWithoutCheckpoint() bool {
 	checkpointless, ok := a.optionalInner().(CheckpointlessExternalScannerReuse)
 	return ok && checkpointless.AllowsIncrementalReuseWithoutCheckpoint()

--- a/external_scanner_adapter_test.go
+++ b/external_scanner_adapter_test.go
@@ -39,6 +39,9 @@ func (*capabilityExternalScanner) SupportsIncrementalReuse() bool { return true 
 func (*capabilityExternalScanner) UsesExternalScannerCheckpoints() bool {
 	return true
 }
+func (*capabilityExternalScanner) RequiresIncrementalPrefixFrontierProof() bool {
+	return true
+}
 func (*capabilityExternalScanner) AllowsIncrementalReuseWithoutCheckpoint() bool {
 	return true
 }
@@ -71,6 +74,9 @@ func TestExternalScannerOrderAdapterPreservesOptionalCapabilities(t *testing.T) 
 	}
 	if checkpointed, ok := adapted.(CheckpointedExternalScanner); !ok || !checkpointed.UsesExternalScannerCheckpoints() {
 		t.Fatal("checkpoint capability was not preserved")
+	}
+	if prefixSensitive, ok := adapted.(IncrementalPrefixFrontierExternalScanner); !ok || !prefixSensitive.RequiresIncrementalPrefixFrontierProof() {
+		t.Fatal("incremental prefix-frontier capability was not preserved")
 	}
 	if checkpointless, ok := adapted.(CheckpointlessExternalScannerReuse); !ok || !checkpointless.AllowsIncrementalReuseWithoutCheckpoint() {
 		t.Fatal("checkpointless capability was not preserved")

--- a/external_scanner_checkpoints.go
+++ b/external_scanner_checkpoints.go
@@ -39,6 +39,14 @@ func languageUsesExternalScannerCheckpoints(lang *Language) bool {
 	return ok && checkpointed.UsesExternalScannerCheckpoints()
 }
 
+func languageRequiresExternalScannerPrefixFrontierProof(lang *Language) bool {
+	if lang == nil || lang.ExternalScanner == nil {
+		return false
+	}
+	prefixSensitive, ok := lang.ExternalScanner.(IncrementalPrefixFrontierExternalScanner)
+	return ok && prefixSensitive.RequiresIncrementalPrefixFrontierProof()
+}
+
 func languageAllowsCheckpointlessExternalReuse(lang *Language) bool {
 	if lang == nil || lang.ExternalScanner == nil {
 		return false

--- a/external_scanner_checkpoints.go
+++ b/external_scanner_checkpoints.go
@@ -86,7 +86,6 @@ func (a *nodeArena) recordExternalScannerCompactCheckpoint(start, end []byte) ex
 	if !bytes.Equal(start, end) {
 		endRef = a.copyExternalScannerSnapshotRef(end)
 	}
-	a.externalScannerCheckpointRecords++
 	return externalScannerCheckpointRef{
 		start: startRef,
 		end:   endRef,

--- a/external_scanner_checkpoints.go
+++ b/external_scanner_checkpoints.go
@@ -144,7 +144,9 @@ func externalScannerCheckpointRefForNode(node *Node) (externalScannerCheckpointR
 		return externalScannerCheckpointRef{}, false
 	}
 	cp, ok := set.lookup(idx)
-	if !ok || !externalScannerCheckpointRefComplete(cp) {
+	if !ok || !externalScannerCheckpointRefComplete(cp) ||
+		!node.ownerArena.externalScannerSnapshotRefValid(cp.start) ||
+		!node.ownerArena.externalScannerSnapshotRefValid(cp.end) {
 		return externalScannerCheckpointRef{}, false
 	}
 	return cp, true
@@ -240,26 +242,29 @@ func rebuildExternalScannerCheckpointForNode(n *Node) (externalScannerCheckpoint
 	if n == nil || n.ownerArena == nil {
 		return externalScannerCheckpointRef{}, false
 	}
+	if cp, ok := externalScannerCheckpointRefForNode(n); ok {
+		return cp, true
+	}
 	childCount := nodeChildCountNoMaterialize(n)
 	if childCount == 0 {
-		return externalScannerCheckpointRefForNode(n)
+		return externalScannerCheckpointRef{}, false
 	}
-	var startRef externalScannerSnapshotRef
-	var endRef externalScannerSnapshotRef
+	var startBytes []byte
+	var endBytes []byte
 	startOK := false
 	endOK := false
 	for i := 0; i < childCount; i++ {
-		cp, ok := externalScannerCheckpointRefForChild(n, i)
+		cp, ok := externalScannerCheckpointForChild(n, i)
 		if ok {
-			startRef = cp.start
+			startBytes = cp.start
 			startOK = true
 			break
 		}
 	}
 	for i := childCount - 1; i >= 0; i-- {
-		cp, ok := externalScannerCheckpointRefForChild(n, i)
+		cp, ok := externalScannerCheckpointForChild(n, i)
 		if ok {
-			endRef = cp.end
+			endBytes = cp.end
 			endOK = true
 			break
 		}
@@ -267,74 +272,96 @@ func rebuildExternalScannerCheckpointForNode(n *Node) (externalScannerCheckpoint
 	if !startOK || !endOK {
 		return externalScannerCheckpointRef{}, false
 	}
+	startRef := n.ownerArena.copyExternalScannerSnapshotRef(startBytes)
+	endRef := startRef
+	if !bytes.Equal(startBytes, endBytes) {
+		endRef = n.ownerArena.copyExternalScannerSnapshotRef(endBytes)
+	}
 	cp := externalScannerCheckpointRef{start: startRef, end: endRef}
-	n.ownerArena.setExternalScannerCheckpoint(n, cp)
+	if !externalScannerCheckpointRefComplete(cp) ||
+		!n.ownerArena.externalScannerSnapshotRefValid(cp.start) ||
+		!n.ownerArena.externalScannerSnapshotRefValid(cp.end) ||
+		!n.ownerArena.setExternalScannerCheckpoint(n, cp) {
+		return externalScannerCheckpointRef{}, false
+	}
+	n.ownerArena.externalScannerCheckpointRecords++
 	return cp, true
 }
 
-func externalScannerCheckpointRefForChild(parent *Node, childIndex int) (externalScannerCheckpointRef, bool) {
+func externalScannerCheckpointForChild(parent *Node, childIndex int) (externalScannerCheckpoint, bool) {
 	if parent == nil || parent.ownerArena == nil {
-		return externalScannerCheckpointRef{}, false
+		return externalScannerCheckpoint{}, false
 	}
 	entry, ok := nodeChildEntryAtNoMaterialize(parent, childIndex)
 	if !ok {
 		child := nodeChildAtForReason(parent, childIndex, materializeForCheckpointRebuild)
-		return rebuildExternalScannerCheckpointForNode(child)
+		if _, ok := rebuildExternalScannerCheckpointForNode(child); !ok {
+			return externalScannerCheckpoint{}, false
+		}
+		return externalScannerCheckpointForNode(child)
 	}
-	return externalScannerCheckpointRefForStackEntry(parent.ownerArena, entry)
+	return externalScannerCheckpointForStackEntry(parent.ownerArena, entry)
 }
 
-func externalScannerCheckpointRefForStackEntry(arena *nodeArena, entry stackEntry) (externalScannerCheckpointRef, bool) {
+func externalScannerCheckpointForStackEntry(arena *nodeArena, entry stackEntry) (externalScannerCheckpoint, bool) {
 	if !stackEntryHasNode(entry) {
-		return externalScannerCheckpointRef{}, false
+		return externalScannerCheckpoint{}, false
 	}
 	if node := stackEntryNode(entry); node != nil {
-		return rebuildExternalScannerCheckpointForNode(node)
+		if _, ok := rebuildExternalScannerCheckpointForNode(node); !ok {
+			return externalScannerCheckpoint{}, false
+		}
+		return externalScannerCheckpointForNode(node)
 	}
 	if leaf := stackEntryCompactFullLeaf(entry); leaf != nil {
-		if !leaf.hasCheckpoint {
-			return externalScannerCheckpointRef{}, false
+		if !leaf.hasCheckpoint || arena == nil ||
+			!arena.externalScannerSnapshotRefValid(leaf.checkpoint.start) ||
+			!arena.externalScannerSnapshotRefValid(leaf.checkpoint.end) {
+			return externalScannerCheckpoint{}, false
 		}
-		return leaf.checkpoint, true
+		return externalScannerCheckpoint{
+			start: arena.externalScannerSnapshotBytes(leaf.checkpoint.start),
+			end:   arena.externalScannerSnapshotBytes(leaf.checkpoint.end),
+		}, true
 	}
 	if parent := stackEntryPendingParent(entry); parent != nil {
-		return externalScannerCheckpointRefForPendingParent(arena, parent)
+		return externalScannerCheckpointForPendingParent(arena, parent)
 	}
-	return externalScannerCheckpointRef{}, false
+	return externalScannerCheckpoint{}, false
 }
 
-func externalScannerCheckpointRefForPendingParent(arena *nodeArena, parent *pendingParent) (externalScannerCheckpointRef, bool) {
+func externalScannerCheckpointForPendingParent(arena *nodeArena, parent *pendingParent) (externalScannerCheckpoint, bool) {
 	if arena == nil || parent == nil {
-		return externalScannerCheckpointRef{}, false
+		return externalScannerCheckpoint{}, false
 	}
 	childCount := parent.childEntryCount()
 	if childCount == 0 {
-		return externalScannerCheckpointRef{}, false
+		return externalScannerCheckpoint{}, false
 	}
-	var startRef externalScannerSnapshotRef
-	var endRef externalScannerSnapshotRef
+	var startBytes []byte
+	var endBytes []byte
 	startOK := false
 	endOK := false
 	for i := 0; i < childCount; i++ {
-		cp, ok := externalScannerCheckpointRefForStackEntry(arena, parent.childEntry(arena, i))
+		cp, ok := externalScannerCheckpointForStackEntry(arena, parent.childEntry(arena, i))
 		if ok {
-			startRef = cp.start
+			startBytes = cp.start
 			startOK = true
 			break
 		}
 	}
 	for i := childCount - 1; i >= 0; i-- {
-		cp, ok := externalScannerCheckpointRefForStackEntry(arena, parent.childEntry(arena, i))
+		cp, ok := externalScannerCheckpointForStackEntry(arena, parent.childEntry(arena, i))
 		if ok {
-			endRef = cp.end
+			endBytes = cp.end
 			endOK = true
 			break
 		}
 	}
 	if !startOK || !endOK {
-		return externalScannerCheckpointRef{}, false
+		return externalScannerCheckpoint{}, false
 	}
-	return externalScannerCheckpointRef{start: startRef, end: endRef}, true
+	return externalScannerCheckpoint{start: startBytes, end: endBytes}, true
 }
 
 func rebuildExternalScannerCheckpointForMaterializedParent(n *Node, reason materializeReason) {

--- a/external_scanner_checkpoints_test.go
+++ b/external_scanner_checkpoints_test.go
@@ -275,6 +275,45 @@ func TestExternalScannerCheckpointSurvivesShapingCloneAndParent(t *testing.T) {
 	}
 }
 
+func TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots(t *testing.T) {
+	sourceArena := acquireNodeArena(arenaClassFull)
+	defer sourceArena.Release()
+	targetArena := acquireNodeArena(arenaClassIncremental)
+	defer targetArena.Release()
+
+	left := newLeafNodeInArena(sourceArena, 1, true, 0, 1, Point{}, Point{Column: 1})
+	sourceArena.recordExternalScannerLeafCheckpoint(left, []byte{1}, []byte{2})
+	right := newLeafNodeInArena(sourceArena, 1, true, 1, 2, Point{Column: 1}, Point{Column: 2})
+	sourceArena.recordExternalScannerLeafCheckpoint(right, []byte{3}, []byte{4})
+
+	// Occupy the same destination offsets with unrelated bytes. A borrowed
+	// reference stored without copying would silently resolve to these values.
+	targetArena.recordExternalScannerCompactCheckpoint([]byte{9}, []byte{8})
+	parent := targetArena.allocNode()
+	parent.ownerArena = targetArena
+	parent.children = []*Node{left, right}
+
+	recordsBefore := targetArena.externalScannerCheckpointRecords
+	rebuildExternalScannerCheckpoints(parent, &Language{Name: "arbitrary", ExternalScanner: checkpointTestScanner{}})
+	got, ok := externalScannerCheckpointForNode(parent)
+	if !ok || !bytes.Equal(got.start, []byte{1}) || !bytes.Equal(got.end, []byte{4}) {
+		t.Fatalf("rebuilt borrowed checkpoint = (%v, %v, %v), want ([1], [4], true)", got.start, got.end, ok)
+	}
+	if gotRecords := targetArena.externalScannerCheckpointRecords - recordsBefore; gotRecords != 1 {
+		t.Fatalf("rebuilt checkpoint records = %d, want 1", gotRecords)
+	}
+
+	payloadAfter := targetArena.externalScannerSnapshotPayloadBytes
+	recordsAfter := targetArena.externalScannerCheckpointRecords
+	rebuildExternalScannerCheckpoints(parent, &Language{Name: "arbitrary", ExternalScanner: checkpointTestScanner{}})
+	if targetArena.externalScannerCheckpointRecords != recordsAfter {
+		t.Fatalf("repeat rebuild changed checkpoint records: got %d, want %d", targetArena.externalScannerCheckpointRecords, recordsAfter)
+	}
+	if targetArena.externalScannerSnapshotPayloadBytes != payloadAfter {
+		t.Fatalf("repeat rebuild changed snapshot payload: got %d, want %d", targetArena.externalScannerSnapshotPayloadBytes, payloadAfter)
+	}
+}
+
 func TestRebuildExternalScannerCheckpointsUsesLazyFinalChildRefs(t *testing.T) {
 	arena := newNodeArena(arenaClassFull)
 	arena.finalChildRefs = true

--- a/external_scanner_checkpoints_test.go
+++ b/external_scanner_checkpoints_test.go
@@ -13,6 +13,12 @@ type checkpointlessTestScanner struct{ checkpointTestScanner }
 
 func (checkpointlessTestScanner) AllowsIncrementalReuseWithoutCheckpoint() bool { return true }
 
+type prefixFrontierCheckpointTestScanner struct{ checkpointTestScanner }
+
+func (prefixFrontierCheckpointTestScanner) RequiresIncrementalPrefixFrontierProof() bool {
+	return true
+}
+
 func TestExternalScannerCheckpointCapabilitiesAreBehaviorBased(t *testing.T) {
 	if languageUsesExternalScannerCheckpoints(&Language{Name: "python", ExternalScanner: parserTestSafeExternalScanner{}}) {
 		t.Fatal("language name enabled checkpoints without a capability")
@@ -25,6 +31,12 @@ func TestExternalScannerCheckpointCapabilitiesAreBehaviorBased(t *testing.T) {
 	}
 	if !languageAllowsCheckpointlessExternalReuse(&Language{Name: "not-an-allowlisted-name", ExternalScanner: checkpointlessTestScanner{}}) {
 		t.Fatal("checkpointless capability was ignored for an arbitrary language name")
+	}
+	if languageRequiresExternalScannerPrefixFrontierProof(&Language{Name: "python", ExternalScanner: checkpointTestScanner{}}) {
+		t.Fatal("language name enabled prefix-frontier proof without a capability")
+	}
+	if !languageRequiresExternalScannerPrefixFrontierProof(&Language{Name: "not-an-allowlisted-name", ExternalScanner: prefixFrontierCheckpointTestScanner{}}) {
+		t.Fatal("prefix-frontier capability was ignored for an arbitrary language name")
 	}
 }
 

--- a/grammars/python_parse_regression_test.go
+++ b/grammars/python_parse_regression_test.go
@@ -151,28 +151,108 @@ func TestPythonScannerSerializationRecomputesInterpolatedStringState(t *testing.
 	scanner := PythonExternalScanner{}
 	buf := make([]byte, 256)
 
-	plain := &pythonScannerState{
-		indents:                  []uint16{0},
-		delimiters:               []pyDelimiter{pyDelimDoubleQuote},
-		insideInterpolatedString: true,
-	}
-	n := scanner.Serialize(plain, buf)
-	var restoredPlain pythonScannerState
-	scanner.Deserialize(&restoredPlain, buf[:n])
-	if restoredPlain.insideInterpolatedString {
-		t.Fatal("plain string checkpoint restored insideInterpolatedString=true, want false")
-	}
-
 	formatted := &pythonScannerState{
 		indents:                  []uint16{0},
 		delimiters:               []pyDelimiter{pyDelimDoubleQuote | pyDelimFormat},
 		insideInterpolatedString: false,
 	}
-	n = scanner.Serialize(formatted, buf)
+	n := scanner.Serialize(formatted, buf)
 	var restoredFormatted pythonScannerState
 	scanner.Deserialize(&restoredFormatted, buf[:n])
 	if !restoredFormatted.insideInterpolatedString {
 		t.Fatal("f-string checkpoint restored insideInterpolatedString=false, want true")
+	}
+
+	// Reuse the same buffer after a formatted checkpoint. A false flag must
+	// overwrite the old byte, or later reuse gates see a stale f-string state.
+	plain := &pythonScannerState{
+		indents:                  []uint16{0},
+		delimiters:               []pyDelimiter{pyDelimDoubleQuote},
+		insideInterpolatedString: true,
+	}
+	n = scanner.Serialize(plain, buf)
+	if n == 0 || buf[0] != 0 {
+		t.Fatalf("plain checkpoint flag=%d, want 0 after formatted serialization", buf[0])
+	}
+	var restoredPlain pythonScannerState
+	scanner.Deserialize(&restoredPlain, buf[:n])
+	if restoredPlain.insideInterpolatedString {
+		t.Fatal("plain string checkpoint restored insideInterpolatedString=true, want false")
+	}
+}
+
+func TestPythonScannerSerializationFailsClosed(t *testing.T) {
+	scanner := PythonExternalScanner{}
+
+	state := &pythonScannerState{
+		indents:    []uint16{0, 4, 8, 12},
+		delimiters: []pyDelimiter{pyDelimSingleQuote | pyDelimFormat},
+	}
+	full := make([]byte, 256)
+	n := scanner.Serialize(state, full)
+	if n == 0 {
+		t.Fatal("representable scanner state did not serialize")
+	}
+	if got, want := n, 4+1+3*2; got != want {
+		t.Fatalf("serialized checkpoint length=%d, want %d", got, want)
+	}
+
+	short := make([]byte, n-1)
+	for i := range short {
+		short[i] = 0xA5
+	}
+	if got := scanner.Serialize(state, short); got != 0 {
+		t.Fatalf("undersized checkpoint serialized %d bytes, want 0", got)
+	}
+	for i, b := range short {
+		if b != 0xA5 {
+			t.Fatalf("undersized checkpoint wrote byte %d before rejecting", i)
+		}
+	}
+
+	var partial pythonScannerState
+	partial.delimiters = []pyDelimiter{pyDelimDoubleQuote}
+	partial.indents = []uint16{0, 20}
+	scanner.Deserialize(&partial, full[:n-1])
+	if len(partial.delimiters) != 0 || len(partial.indents) != 1 || partial.indents[0] != 0 || partial.insideInterpolatedString {
+		t.Fatalf("partial checkpoint restored scanner state: %+v", partial)
+	}
+
+	malformedFlag := append([]byte(nil), full[:n]...)
+	malformedFlag[0] = 0
+	var inconsistent pythonScannerState
+	scanner.Deserialize(&inconsistent, malformedFlag)
+	if len(inconsistent.delimiters) != 0 || len(inconsistent.indents) != 1 || inconsistent.indents[0] != 0 || inconsistent.insideInterpolatedString {
+		t.Fatalf("inconsistent checkpoint restored scanner state: %+v", inconsistent)
+	}
+
+	malformedTrailing := append(append([]byte(nil), full[:n]...), 0x00)
+	var trailing pythonScannerState
+	scanner.Deserialize(&trailing, malformedTrailing)
+	if len(trailing.delimiters) != 0 || len(trailing.indents) != 1 || trailing.indents[0] != 0 || trailing.insideInterpolatedString {
+		t.Fatalf("trailing checkpoint bytes restored scanner state: %+v", trailing)
+	}
+
+	// Checkpoint bytes are ephemeral and version-local. Reject the former
+	// delimiter-only shape instead of treating it as a complete state.
+	legacyShape := []byte{1, 1, byte(pyDelimSingleQuote | pyDelimFormat)}
+	var legacy pythonScannerState
+	scanner.Deserialize(&legacy, legacyShape)
+	if len(legacy.delimiters) != 0 || len(legacy.indents) != 1 || legacy.indents[0] != 0 || legacy.insideInterpolatedString {
+		t.Fatalf("legacy checkpoint shape restored scanner state: %+v", legacy)
+	}
+
+	tooManyDelimiters := &pythonScannerState{delimiters: make([]pyDelimiter, maxPythonScannerDelimiterCount+1)}
+	if got := scanner.Serialize(tooManyDelimiters, make([]byte, 4096)); got != 0 {
+		t.Fatalf("unrepresentable delimiter stack serialized %d bytes, want 0", got)
+	}
+
+	// A deeply nested indentation stack needs more than the runtime checkpoint
+	// buffer. The serializer must reject the complete state rather than publish
+	// a prefix that could restore a shallower stack.
+	deep := &pythonScannerState{indents: make([]uint16, 3000)}
+	if got := scanner.Serialize(deep, make([]byte, 4096)); got != 0 {
+		t.Fatalf("deep indentation stack serialized %d bytes, want fail-closed 0", got)
 	}
 }
 

--- a/grammars/python_scanner.go
+++ b/grammars/python_scanner.go
@@ -114,6 +114,10 @@ func (PythonExternalScanner) SupportsIncrementalReuse() bool { return true }
 
 func (PythonExternalScanner) UsesExternalScannerCheckpoints() bool { return true }
 
+// RequiresIncrementalPrefixFrontierProof prevents a changed indentation
+// prefix from transferring a reduction that belongs to the old source.
+func (PythonExternalScanner) RequiresIncrementalPrefixFrontierProof() bool { return true }
+
 func (PythonExternalScanner) PreservesStateOnScanFailure() bool { return true }
 
 func (p PythonExternalScanner) symbolTable() *[pyTokenCount]gotreesitter.Symbol {

--- a/grammars/python_scanner.go
+++ b/grammars/python_scanner.go
@@ -106,11 +106,11 @@ func (PythonExternalScanner) Deserialize(payload any, buf []byte) {
 	deserializePythonScannerState(payload.(*pythonScannerState), buf)
 }
 
-// SupportsIncrementalReuse remains disabled until checkpoint restoration can
-// prove that indentation stacks preserve every class-closing DEDENT. The
-// token-invariant leaf fast path is validated before this capability check and
-// remains available for edits that do not depend on scanner state.
-func (PythonExternalScanner) SupportsIncrementalReuse() bool { return false }
+// SupportsIncrementalReuse enables checkpoint-authenticated subtree reuse.
+// Python serializes its complete indentation and string-delimiter state, so a
+// reused boundary is accepted only after the live scanner matches its start
+// checkpoint and restores its end checkpoint.
+func (PythonExternalScanner) SupportsIncrementalReuse() bool { return true }
 
 func (PythonExternalScanner) UsesExternalScannerCheckpoints() bool { return true }
 

--- a/grammars/python_scanner_shared.go
+++ b/grammars/python_scanner_shared.go
@@ -51,48 +51,82 @@ func (s *pythonScannerState) syncInsideInterpolatedString() {
 	}
 }
 
+// Python scanner checkpoints use a compact, self-delimiting wire format:
+// one flag byte, one delimiter-count byte, the delimiter stack, one
+// little-endian indent-count word, and the indent stack as little-endian
+// words. Keep the delimiter count byte as part of the current prefix shape,
+// but treat the payload as ephemeral and version-local, not backward-compatible.
+const (
+	pythonScannerCheckpointHeaderBytes = 1 + 1 + 2
+	maxPythonScannerDelimiterCount     = int(^uint8(0))
+	maxPythonScannerIndentCount        = int(^uint16(0))
+)
+
+func pythonScannerCheckpointSize(delimiterCount, indentCount int) (int, bool) {
+	if delimiterCount < 0 || delimiterCount > maxPythonScannerDelimiterCount ||
+		indentCount < 0 || indentCount > maxPythonScannerIndentCount {
+		return 0, false
+	}
+	size := pythonScannerCheckpointHeaderBytes + delimiterCount
+	maxInt := int(^uint(0) >> 1)
+	if indentCount > (maxInt-size)/2 {
+		return 0, false
+	}
+	return size + indentCount*2, true
+}
+
 func serializePythonScannerState(s *pythonScannerState, buf []byte) int {
-	if len(buf) == 0 {
+	if s == nil {
 		return 0
 	}
 	s.syncInsideInterpolatedString()
 
-	size := 0
+	indentCount := 0
+	if len(s.indents) > 0 {
+		// indents[0] is the scanner's root sentinel and is not serialized.
+		indentCount = len(s.indents) - 1
+	}
+	size, ok := pythonScannerCheckpointSize(len(s.delimiters), indentCount)
+	if !ok || len(buf) < size {
+		// Never publish a prefix. A zero return tells the parser that this
+		// boundary has no usable checkpoint and forces the safe fallback.
+		return 0
+	}
+
+	write := 0
+	// Always write the flag. Scanner checkpoint buffers are reused between
+	// tokens, so leaving a false flag untouched would leak a prior f-string
+	// state into the next checkpoint.
+	buf[write] = 0
 	if s.insideInterpolatedString {
-		buf[size] = 1
+		buf[write] = 1
 	}
-	size++
-	if size >= len(buf) {
-		return size
+	write++
+	buf[write] = byte(len(s.delimiters))
+	write++
+	for _, delimiter := range s.delimiters {
+		buf[write] = byte(delimiter)
+		write++
 	}
-
-	delimCount := len(s.delimiters)
-	if delimCount > 255 {
-		delimCount = 255
-	}
-	buf[size] = byte(delimCount)
-	size++
-	if size >= len(buf) {
-		return size
-	}
-
-	for i := 0; i < delimCount && size < len(buf); i++ {
-		buf[size] = byte(s.delimiters[i])
-		size++
-	}
+	buf[write] = byte(indentCount)
+	buf[write+1] = byte(indentCount >> 8)
+	write += 2
 
 	// Skip indents[0] (sentinel), serialize from index 1.
-	for i := 1; i < len(s.indents) && size+1 < len(buf); i++ {
+	for i := 1; i < len(s.indents); i++ {
 		v := s.indents[i]
-		buf[size] = byte(v & 0xFF)
-		buf[size+1] = byte((v >> 8) & 0xFF)
-		size += 2
+		buf[write] = byte(v)
+		buf[write+1] = byte(v >> 8)
+		write += 2
 	}
 
-	return size
+	return write
 }
 
 func deserializePythonScannerState(s *pythonScannerState, buf []byte) {
+	if s == nil {
+		return
+	}
 	s.delimiters = s.delimiters[:0]
 	s.indents = s.indents[:0]
 	s.indents = append(s.indents, 0)
@@ -101,25 +135,41 @@ func deserializePythonScannerState(s *pythonScannerState, buf []byte) {
 	if len(buf) == 0 {
 		return
 	}
-
-	size := 0
-	s.insideInterpolatedString = buf[size] != 0
-	size++
-	if size >= len(buf) {
+	if len(buf) < pythonScannerCheckpointHeaderBytes {
 		return
 	}
 
-	delimCount := int(buf[size])
-	size++
-	for i := 0; i < delimCount && size < len(buf); i++ {
-		s.delimiters = append(s.delimiters, pyDelimiter(buf[size]))
-		size++
+	encodedInside := buf[0] != 0
+	delimCount := int(buf[1])
+	indentCountOffset := 2 + delimCount
+	if indentCountOffset+2 > len(buf) {
+		return
 	}
-	s.syncInsideInterpolatedString()
+	indentCount := int(buf[indentCountOffset]) | int(buf[indentCountOffset+1])<<8
+	required, ok := pythonScannerCheckpointSize(delimCount, indentCount)
+	if !ok || len(buf) != required {
+		// Reject both truncated and trailing data. Leave the reset sentinel in
+		// place so a malformed checkpoint cannot partially restore scanner state.
+		return
+	}
 
-	for size+1 < len(buf) {
+	inside := false
+	for i := 0; i < delimCount; i++ {
+		delimiter := pyDelimiter(buf[2+i])
+		s.delimiters = append(s.delimiters, delimiter)
+		inside = inside || delimiter.isFormat()
+	}
+	if encodedInside != inside {
+		// The flag is redundant, but an inconsistent checkpoint is not a
+		// complete state representation. Fail closed instead of guessing.
+		s.delimiters = s.delimiters[:0]
+		return
+	}
+	size := indentCountOffset + 2
+	for i := 0; i < indentCount; i++ {
 		v := uint16(buf[size]) | uint16(buf[size+1])<<8
 		s.indents = append(s.indents, v)
 		size += 2
 	}
+	s.insideInterpolatedString = inside
 }

--- a/grammars/swift_ternary_retirement_test.go
+++ b/grammars/swift_ternary_retirement_test.go
@@ -128,7 +128,11 @@ func TestSwiftTernaryRetirementRoutes(t *testing.T) {
 				t.Fatalf("incremental parse: %v", err)
 			}
 			t.Cleanup(incremental.Release)
-			if !profile.OldTreeReuseRoute && (!profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported") {
+			reuseClassified := profile.OldTreeReuseRoute && !profile.ReuseUnsupported
+			fallbackClassified := !profile.OldTreeReuseRoute && profile.ReuseUnsupported &&
+				(profile.ReuseUnsupportedReason == "external_scanner_unsupported" ||
+					profile.ReuseUnsupportedReason == "external_scanner_prefix_frontier_unproven")
+			if !reuseClassified && !fallbackClassified {
 				t.Fatalf("incremental route receipt is not classified: %+v", profile)
 			}
 			if got := requireSwiftTernaryRetirementTree(t, "incremental", incremental, language, source); got != wantDigest {

--- a/grammars/swift_ternary_retirement_test.go
+++ b/grammars/swift_ternary_retirement_test.go
@@ -128,11 +128,7 @@ func TestSwiftTernaryRetirementRoutes(t *testing.T) {
 				t.Fatalf("incremental parse: %v", err)
 			}
 			t.Cleanup(incremental.Release)
-			reuseClassified := profile.OldTreeReuseRoute && !profile.ReuseUnsupported
-			fallbackClassified := !profile.OldTreeReuseRoute && profile.ReuseUnsupported &&
-				(profile.ReuseUnsupportedReason == "external_scanner_unsupported" ||
-					profile.ReuseUnsupportedReason == "external_scanner_prefix_frontier_unproven")
-			if !reuseClassified && !fallbackClassified {
+			if !profile.OldTreeReuseRoute && (!profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported") {
 				t.Fatalf("incremental route receipt is not classified: %+v", profile)
 			}
 			if got := requireSwiftTernaryRetirementTree(t, "incremental", incremental, language, source); got != wantDigest {

--- a/incremental.go
+++ b/incremental.go
@@ -83,7 +83,7 @@ type reuseCursor struct {
 	// candidates that have exact scanner bytes but no proof that the recorded
 	// reduction owned the live parser frontier. Leaves use their independent
 	// shift and checkpoint checks; non-leaves stay barred until that proof exists.
-	rejectFrontierProofUnavailable uint64
+	rejectFrontierProofUnavailable uint32
 	forestFastPath                 bool
 	// compactMaterialized marks old trees whose node states came from compact
 	// replay. Checkpoint snapshots authenticate scanner state, but they do not

--- a/incremental.go
+++ b/incremental.go
@@ -79,9 +79,21 @@ type reuseCursor struct {
 	// for certified stateless-scanner languages, whose every boundary is
 	// proven quiescent. See the Parser.ReuseRejectScannerUnquiescent field.
 	rejectScannerUnquiescent uint64
-	forestFastPath           bool
-	languageName             string // cached for language-specific reuse safety policies
-	strictTopLevelOwnership  bool   // forest trees and certified stateless scanners require the recorded normal-dispatch frontier
+	// rejectFrontierProofUnavailable counts compact-materialized non-leaf
+	// candidates that have exact scanner bytes but no proof that the recorded
+	// reduction owned the live parser frontier. Leaves use their independent
+	// shift and checkpoint checks; non-leaves stay barred until that proof exists.
+	rejectFrontierProofUnavailable uint64
+	forestFastPath                 bool
+	// compactMaterialized marks old trees whose node states came from compact
+	// replay. Checkpoint snapshots authenticate scanner state, but they do not
+	// prove the parser frontier after a non-leaf reduction. Keep compact
+	// checkpoint reuse at independently revalidated leaves until that ownership
+	// proof exists.
+	compactMaterialized        bool
+	compactCheckpointedScanner bool
+	languageName               string // cached for language-specific reuse safety policies
+	strictTopLevelOwnership    bool   // forest trees and certified stateless scanners require the recorded normal-dispatch frontier
 }
 
 // reuseScratch holds reusable buffers for incremental reuse traversal.
@@ -129,7 +141,10 @@ func (c *reuseCursor) reset(oldTree *Tree, source []byte, scratch *reuseScratch)
 	c.rejectStaleNonLeafBoundary = 0
 	c.rejectFragileNonLeaf = 0
 	c.rejectScannerUnquiescent = 0
+	c.rejectFrontierProofUnavailable = 0
 	c.forestFastPath = oldTree.forestFastPath
+	c.compactMaterialized = oldTree.compactMaterialized
+	c.compactCheckpointedScanner = c.compactMaterialized && languageUsesExternalScannerCheckpoints(oldTree.language)
 	c.languageName = ""
 	// Every forest node records the GSS state that owned its original reduce.
 	// A compatible goto alone cannot transfer that ownership after an edit, so
@@ -223,6 +238,8 @@ func (c *reuseCursor) releaseNodeRefs() {
 	c.newSource = nil
 	c.edits = nil
 	c.forestFastPath = false
+	c.compactMaterialized = false
+	c.compactCheckpointedScanner = false
 	c.languageName = ""
 	if cap(c.stack) > 0 {
 		clear(c.stack[:cap(c.stack)])
@@ -354,6 +371,13 @@ func (c *reuseCursor) collectTopLevelCandidates(start uint32) bool {
 			}
 			n := nodeChildAtForReason(c.topLevelParent, c.topLevelIndex-1, materializeForEdit)
 			if n != nil {
+				if c.compactCheckpointedScanner && n.ChildCount() > 0 {
+					// A clean compact sibling may carry exact scanner bytes while
+					// its reduction frontier remains unproven. Leave it for the
+					// parser and keep scanning later siblings on the next request.
+					c.rejectFrontierProofUnavailable++
+					continue
+				}
 				c.cached = append(c.cached, n)
 			}
 		}
@@ -622,6 +646,10 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 	state := s.top().state
 	for _, n := range candidates {
 		if n.ChildCount() > 0 {
+			if idx.compactCheckpointedScanner {
+				idx.rejectFrontierProofUnavailable++
+				continue
+			}
 			// Preserve full-root reuse on undo when bytes are identical.
 			fullRootUndo := n.startByte == 0 &&
 				n.endByte == idx.sourceLen &&
@@ -676,6 +704,16 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 	const maxNonLeafReuseSpan = 1 << 20
 	for _, n := range candidates {
 		if n == nil || n.ChildCount() == 0 || n.parent == nil {
+			continue
+		}
+		// Compact replay records exact scanner snapshots, but a checkpoint at a
+		// reduction boundary does not identify the parser state for the next
+		// token. A length-changing indentation edit can keep that snapshot equal
+		// while changing whether the next statement belongs to the reduction.
+		// Reuse leaves, whose shift state and token span are independently checked;
+		// reparse compact non-leaf reductions until frontier ownership is recorded.
+		if idx.compactCheckpointedScanner {
+			idx.rejectFrontierProofUnavailable++
 			continue
 		}
 		span := n.EndByte() - n.StartByte()

--- a/incremental_leaf_fastpath.go
+++ b/incremental_leaf_fastpath.go
@@ -1037,16 +1037,21 @@ func scanDFALeafTokenWithExternalCheckpoint(dts *dfaTokenSource, leaf *Node) (To
 }
 
 type dfaLeafScanSnapshot struct {
-	state                  StateID
-	glrStates              []StateID
-	lexer                  Lexer
-	lastExternalTokenStart uint32
-	lastExternalTokenEnd   uint32
-	lastExternalTokenValid bool
-	extZeroPos             int
-	extZeroState           StateID
-	zeroWidthPos           int
-	zeroWidthCount         int
+	state                       StateID
+	glrStates                   []StateID
+	lexer                       Lexer
+	lastExternalTokenStart      uint32
+	lastExternalTokenEnd        uint32
+	lastExternalTokenValid      bool
+	lastExternalTokenWasExtra   bool
+	externalTokenEndSameAsStart bool
+	lastTokenStart              uint32
+	lastTokenEnd                uint32
+	lastTokenValid              bool
+	extZeroPos                  int
+	extZeroState                StateID
+	zeroWidthPos                int
+	zeroWidthCount              int
 }
 
 func prepareDFALeafScan(dts *dfaTokenSource, leaf *Node) (dfaLeafScanSnapshot, bool) {
@@ -1057,16 +1062,21 @@ func prepareDFALeafScan(dts *dfaTokenSource, leaf *Node) (dfaLeafScanSnapshot, b
 		return dfaLeafScanSnapshot{}, false
 	}
 	snapshot := dfaLeafScanSnapshot{
-		state:                  dts.state,
-		glrStates:              dts.glrStates,
-		lexer:                  *dts.lexer,
-		lastExternalTokenStart: dts.lastExternalTokenStartByte,
-		lastExternalTokenEnd:   dts.lastExternalTokenEndByte,
-		lastExternalTokenValid: dts.lastExternalTokenValid,
-		extZeroPos:             dts.extZeroPos,
-		extZeroState:           dts.extZeroState,
-		zeroWidthPos:           dts.zeroWidthPos,
-		zeroWidthCount:         dts.zeroWidthCount,
+		state:                       dts.state,
+		glrStates:                   dts.glrStates,
+		lexer:                       *dts.lexer,
+		lastExternalTokenStart:      dts.lastExternalTokenStartByte,
+		lastExternalTokenEnd:        dts.lastExternalTokenEndByte,
+		lastExternalTokenValid:      dts.lastExternalTokenValid,
+		lastExternalTokenWasExtra:   dts.lastExternalTokenWasExtra,
+		externalTokenEndSameAsStart: dts.externalTokenEndSameAsStart,
+		lastTokenStart:              dts.lastTokenStartByte,
+		lastTokenEnd:                dts.lastTokenEndByte,
+		lastTokenValid:              dts.lastTokenValid,
+		extZeroPos:                  dts.extZeroPos,
+		extZeroState:                dts.extZeroState,
+		zeroWidthPos:                dts.zeroWidthPos,
+		zeroWidthCount:              dts.zeroWidthCount,
 	}
 	dts.state = leaf.preGotoState
 	dts.glrStates = nil
@@ -1080,6 +1090,11 @@ func restoreDFALeafScan(dts *dfaTokenSource, snapshot dfaLeafScanSnapshot) {
 	dts.lastExternalTokenStartByte = snapshot.lastExternalTokenStart
 	dts.lastExternalTokenEndByte = snapshot.lastExternalTokenEnd
 	dts.lastExternalTokenValid = snapshot.lastExternalTokenValid
+	dts.lastExternalTokenWasExtra = snapshot.lastExternalTokenWasExtra
+	dts.externalTokenEndSameAsStart = snapshot.externalTokenEndSameAsStart
+	dts.lastTokenStartByte = snapshot.lastTokenStart
+	dts.lastTokenEndByte = snapshot.lastTokenEnd
+	dts.lastTokenValid = snapshot.lastTokenValid
 	dts.extZeroPos = snapshot.extZeroPos
 	dts.extZeroState = snapshot.extZeroState
 	dts.zeroWidthPos = snapshot.zeroWidthPos
@@ -1087,27 +1102,32 @@ func restoreDFALeafScan(dts *dfaTokenSource, snapshot dfaLeafScanSnapshot) {
 }
 
 type dfaTokenSourceStateSnapshot struct {
-	state                  StateID
-	glrStates              []StateID
-	lexer                  Lexer
-	hasLexer               bool
-	externalValid          []bool
-	extZeroTried           []bool
-	externalTokenStart     []byte
-	externalTokenEnd       []byte
-	externalSnapshot       []byte
-	externalRetrySnap      []byte
-	externalCompare        []byte
-	externalScannerState   []byte
-	externalLexer          ExternalLexer
-	externalRetryLexer     ExternalLexer
-	lastExternalTokenStart uint32
-	lastExternalTokenEnd   uint32
-	lastExternalTokenValid bool
-	extZeroPos             int
-	extZeroState           StateID
-	zeroWidthPos           int
-	zeroWidthCount         int
+	state                       StateID
+	glrStates                   []StateID
+	lexer                       Lexer
+	hasLexer                    bool
+	externalValid               []bool
+	extZeroTried                []bool
+	externalTokenStart          []byte
+	externalTokenEnd            []byte
+	externalSnapshot            []byte
+	externalRetrySnap           []byte
+	externalCompare             []byte
+	externalScannerState        []byte
+	externalLexer               ExternalLexer
+	externalRetryLexer          ExternalLexer
+	lastExternalTokenStart      uint32
+	lastExternalTokenEnd        uint32
+	lastExternalTokenValid      bool
+	lastExternalTokenWasExtra   bool
+	externalTokenEndSameAsStart bool
+	lastTokenStart              uint32
+	lastTokenEnd                uint32
+	lastTokenValid              bool
+	extZeroPos                  int
+	extZeroState                StateID
+	zeroWidthPos                int
+	zeroWidthCount              int
 }
 
 func snapshotTokenSourceState(ts TokenSource) (func(), bool) {
@@ -1140,24 +1160,29 @@ func snapshotDFATokenSourceState(dts *dfaTokenSource) (dfaTokenSourceStateSnapsh
 		return dfaTokenSourceStateSnapshot{}, false
 	}
 	state := dfaTokenSourceStateSnapshot{
-		state:                  dts.state,
-		glrStates:              append([]StateID(nil), dts.glrStates...),
-		externalValid:          append([]bool(nil), dts.externalValid...),
-		extZeroTried:           append([]bool(nil), dts.extZeroTried...),
-		externalTokenStart:     append([]byte(nil), dts.externalTokenStart...),
-		externalTokenEnd:       append([]byte(nil), dts.externalTokenEnd...),
-		externalSnapshot:       append([]byte(nil), dts.externalSnapshot...),
-		externalRetrySnap:      append([]byte(nil), dts.externalRetrySnap...),
-		externalCompare:        append([]byte(nil), dts.externalCompare...),
-		externalLexer:          dts.externalLexer,
-		externalRetryLexer:     dts.externalRetryLexer,
-		lastExternalTokenStart: dts.lastExternalTokenStartByte,
-		lastExternalTokenEnd:   dts.lastExternalTokenEndByte,
-		lastExternalTokenValid: dts.lastExternalTokenValid,
-		extZeroPos:             dts.extZeroPos,
-		extZeroState:           dts.extZeroState,
-		zeroWidthPos:           dts.zeroWidthPos,
-		zeroWidthCount:         dts.zeroWidthCount,
+		state:                       dts.state,
+		glrStates:                   append([]StateID(nil), dts.glrStates...),
+		externalValid:               append([]bool(nil), dts.externalValid...),
+		extZeroTried:                append([]bool(nil), dts.extZeroTried...),
+		externalTokenStart:          append([]byte(nil), dts.externalTokenStart...),
+		externalTokenEnd:            append([]byte(nil), dts.externalTokenEnd...),
+		externalSnapshot:            append([]byte(nil), dts.externalSnapshot...),
+		externalRetrySnap:           append([]byte(nil), dts.externalRetrySnap...),
+		externalCompare:             append([]byte(nil), dts.externalCompare...),
+		externalLexer:               dts.externalLexer,
+		externalRetryLexer:          dts.externalRetryLexer,
+		lastExternalTokenStart:      dts.lastExternalTokenStartByte,
+		lastExternalTokenEnd:        dts.lastExternalTokenEndByte,
+		lastExternalTokenValid:      dts.lastExternalTokenValid,
+		lastExternalTokenWasExtra:   dts.lastExternalTokenWasExtra,
+		externalTokenEndSameAsStart: dts.externalTokenEndSameAsStart,
+		lastTokenStart:              dts.lastTokenStartByte,
+		lastTokenEnd:                dts.lastTokenEndByte,
+		lastTokenValid:              dts.lastTokenValid,
+		extZeroPos:                  dts.extZeroPos,
+		extZeroState:                dts.extZeroState,
+		zeroWidthPos:                dts.zeroWidthPos,
+		zeroWidthCount:              dts.zeroWidthCount,
 	}
 	if dts.language != nil && dts.language.ExternalScanner != nil {
 		buf := make([]byte, 0, externalScannerSerializationBufferSize)
@@ -1196,6 +1221,11 @@ func restoreDFATokenSourceState(dts *dfaTokenSource, state dfaTokenSourceStateSn
 	dts.lastExternalTokenStartByte = state.lastExternalTokenStart
 	dts.lastExternalTokenEndByte = state.lastExternalTokenEnd
 	dts.lastExternalTokenValid = state.lastExternalTokenValid
+	dts.lastExternalTokenWasExtra = state.lastExternalTokenWasExtra
+	dts.externalTokenEndSameAsStart = state.externalTokenEndSameAsStart
+	dts.lastTokenStartByte = state.lastTokenStart
+	dts.lastTokenEndByte = state.lastTokenEnd
+	dts.lastTokenValid = state.lastTokenValid
 	dts.extZeroPos = state.extZeroPos
 	dts.extZeroState = state.extZeroState
 	dts.zeroWidthPos = state.zeroWidthPos

--- a/incremental_leaf_fastpath.go
+++ b/incremental_leaf_fastpath.go
@@ -832,6 +832,12 @@ func (p *Parser) scanTokenInvariantEditedLeaf(source []byte, ts TokenSource, lea
 	if ok {
 		return tok, true
 	}
+	if p != nil && languageUsesExternalScannerCheckpoints(p.language) {
+		// The checkpoint scan authenticates both scanner boundary states. A
+		// fresh scanner can reproduce the token symbol and span while ending in
+		// different state. Do not replace a failed checkpoint proof with it.
+		return Token{}, false
+	}
 	if tok, ok = p.scanLeafTokenWithFreshSource(source, leaf, tokenSourceHasDFABase(ts)); ok {
 		return tok, true
 	}
@@ -942,6 +948,9 @@ func scanLeafTokenWithoutMutatingSource(ts TokenSource, leaf *Node) (Token, bool
 		if !ok {
 			return Token{}, false
 		}
+		if languageUsesExternalScannerCheckpoints(base.language) {
+			return scanIncludedRangeLeafTokenWithExternalCheckpoint(typed, base, leaf)
+		}
 		snapshot, ok := prepareDFALeafScan(base, leaf)
 		if !ok {
 			return Token{}, false
@@ -954,6 +963,37 @@ func scanLeafTokenWithoutMutatingSource(ts TokenSource, leaf *Node) (Token, bool
 	default:
 		return Token{}, false
 	}
+}
+
+func scanIncludedRangeLeafTokenWithExternalCheckpoint(ts *includedRangeTokenSource, dts *dfaTokenSource, leaf *Node) (Token, bool) {
+	if ts == nil || dts == nil || dts.lexer == nil || leaf == nil {
+		return Token{}, false
+	}
+	cp, ok := externalScannerCheckpointForNode(leaf)
+	if !ok {
+		return Token{}, false
+	}
+	snapshot, ok := snapshotDFATokenSourceState(dts)
+	if !ok {
+		return Token{}, false
+	}
+	idx := ts.idx
+	defer func() {
+		restoreDFATokenSourceState(dts, snapshot)
+		ts.idx = idx
+	}()
+
+	dts.state = leaf.preGotoState
+	dts.glrStates = nil
+	dts.restoreExternalScannerState(cp.start)
+	tok := ts.SkipToByteWithPoint(leaf.startByte, leaf.startPoint)
+	if tok.Symbol != leaf.symbol || tok.StartByte != leaf.startByte || tok.EndByte != leaf.endByte {
+		return Token{}, false
+	}
+	if !dts.externalScannerStateMatches(cp.end) {
+		return Token{}, false
+	}
+	return tok, true
 }
 
 func scanDFALeafTokenWithoutMutatingSource(dts *dfaTokenSource, leaf *Node) (Token, bool) {

--- a/incremental_leaf_fastpath_test.go
+++ b/incremental_leaf_fastpath_test.go
@@ -702,6 +702,113 @@ func TestScanLeafTokenWithoutMutatingRejectsExternalScanner(t *testing.T) {
 	}
 }
 
+func TestIncludedRangeCheckpointLeafProbeRestoresTokenProvenance(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		corruptEnd  bool
+		wantSuccess bool
+	}{
+		{name: "success", wantSuccess: true},
+		{name: "failed_end_state", corruptEnd: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lang := *buildArithmeticLanguage()
+			lang.ExternalScanner = checkpointByteExternalScanner{}
+			parser := NewParser(&lang)
+			oldSource := []byte("1+2")
+			newSource := []byte("1+3")
+			tree := mustParse(t, parser, oldSource)
+			defer tree.Release()
+			tree.Edit(InputEdit{
+				StartByte:   2,
+				OldEndByte:  3,
+				NewEndByte:  3,
+				StartPoint:  Point{Row: 0, Column: 2},
+				OldEndPoint: Point{Row: 0, Column: 3},
+				NewEndPoint: Point{Row: 0, Column: 3},
+			})
+			leaf := tree.lastEditedLeaf
+			if leaf == nil {
+				t.Fatal("expected edited leaf to be tracked")
+			}
+			if leaf.ownerArena == nil || !leaf.ownerArena.recordExternalScannerLeafCheckpoint(leaf, []byte{0}, []byte{0}) {
+				t.Fatal("failed to attach the scanner checkpoint")
+			}
+			checkpoint, ok := externalScannerCheckpointForNode(leaf)
+			if !ok {
+				t.Fatal("expected edited leaf to retain a scanner checkpoint")
+			}
+			if tc.corruptEnd && !leaf.ownerArena.recordExternalScannerLeafCheckpoint(leaf, checkpoint.start, []byte{9}) {
+				t.Fatal("failed to replace the scanner end checkpoint")
+			}
+
+			base := newDFATokenSourceDirect(NewLexer(lang.LexStates, newSource), &lang, parser.lookupActionIndex, parser.hasKeywordState, parser.externalValidByState, parser.externalValidMaskByState)
+			defer base.Close()
+			wrapped := &includedRangeTokenSource{
+				base: base,
+				ranges: []Range{{
+					StartByte: 0,
+					EndByte:   uint32(len(newSource)),
+					EndPoint:  Point{Row: 0, Column: uint32(len(newSource))},
+				}},
+			}
+			base.lastExternalTokenWasExtra = true
+			base.externalTokenEndSameAsStart = true
+			base.lastTokenStartByte = 91
+			base.lastTokenEndByte = 97
+			base.lastTokenValid = true
+			beforeSnapshot, ok := snapshotDFATokenSourceState(base)
+			if !ok {
+				t.Fatal("failed to snapshot the token source")
+			}
+			beforeProvenance := struct {
+				lastExternalTokenWasExtra   bool
+				externalTokenEndSameAsStart bool
+				lastTokenStartByte          uint32
+				lastTokenEndByte            uint32
+				lastTokenValid              bool
+			}{
+				lastExternalTokenWasExtra:   base.lastExternalTokenWasExtra,
+				externalTokenEndSameAsStart: base.externalTokenEndSameAsStart,
+				lastTokenStartByte:          base.lastTokenStartByte,
+				lastTokenEndByte:            base.lastTokenEndByte,
+				lastTokenValid:              base.lastTokenValid,
+			}
+
+			tok, success := scanIncludedRangeLeafTokenWithExternalCheckpoint(wrapped, base, leaf)
+			if success != tc.wantSuccess {
+				t.Fatalf("checkpoint leaf probe success=%t, want %t; token=%+v", success, tc.wantSuccess, tok)
+			}
+			if wrapped.idx != 0 {
+				t.Fatalf("included range index=%d, want 0", wrapped.idx)
+			}
+			afterSnapshot, ok := snapshotDFATokenSourceState(base)
+			if !ok {
+				t.Fatal("failed to snapshot the restored token source")
+			}
+			if !reflect.DeepEqual(afterSnapshot, beforeSnapshot) {
+				t.Fatalf("checkpoint leaf probe changed captured token-source state:\n before=%+v\n after=%+v", beforeSnapshot, afterSnapshot)
+			}
+			afterProvenance := struct {
+				lastExternalTokenWasExtra   bool
+				externalTokenEndSameAsStart bool
+				lastTokenStartByte          uint32
+				lastTokenEndByte            uint32
+				lastTokenValid              bool
+			}{
+				lastExternalTokenWasExtra:   base.lastExternalTokenWasExtra,
+				externalTokenEndSameAsStart: base.externalTokenEndSameAsStart,
+				lastTokenStartByte:          base.lastTokenStartByte,
+				lastTokenEndByte:            base.lastTokenEndByte,
+				lastTokenValid:              base.lastTokenValid,
+			}
+			if afterProvenance != beforeProvenance {
+				t.Fatalf("checkpoint leaf probe changed token provenance: before=%+v after=%+v", beforeProvenance, afterProvenance)
+			}
+		})
+	}
+}
+
 func TestScanLeafTokenWithoutMutatingRejectsSyntheticExternalSymbols(t *testing.T) {
 	lang := *buildArithmeticLanguage()
 	lang.ExternalSymbols = []Symbol{1}

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1000,8 +1000,10 @@ type subtreeRecord struct {
 	fragile bool
 }
 
-// externalPayloadProvenance stores the exact scanner states for one external
-// terminal. Sparse storage preserves the compact subtree record size.
+// externalPayloadProvenance stores the exact scanner states for one
+// authenticated terminal. External-token identity and compact leaf
+// reauthentication share this sparse sidecar so subtree records stay small.
+// The historical type name remains internal.
 type externalPayloadProvenance struct {
 	payload SubtreeID
 	start   CheckpointID
@@ -1137,9 +1139,9 @@ type MaterializationSubtreeView struct {
 	External          bool
 	Terminal          bool
 	// ExternalScannerCheckpointStart and ExternalScannerCheckpointEnd identify
-	// the serialized scanner states before and after this external terminal.
-	// They are zero when the subtree has no authenticated external-token
-	// provenance. The materializer copies the bytes into its own arena.
+	// the serialized scanner states before and after this terminal. They are
+	// zero when the subtree has no authenticated scanner provenance. The
+	// materializer copies the bytes into its own arena.
 	ExternalScannerCheckpointStart CheckpointID
 	ExternalScannerCheckpointEnd   CheckpointID
 	ExternalScannerCheckpointExact bool
@@ -1343,9 +1345,14 @@ type Core struct {
 	// certifies that external payload identity does not depend on scanner state.
 	// Reset retains it because the property is stable for this core's tables.
 	externalPayloadsQuiescent bool
+	// terminalScannerCheckpointProvenance is a one-way language capability.
+	// It records the scanner pair for every shifted terminal, including a DFA
+	// terminal. Compact materialization needs both states to reauthenticate an
+	// edited leaf without trusting a fresh scanner payload.
+	terminalScannerCheckpointProvenance bool
 	// externalTokenScannerStart and externalTokenScannerEnd authenticate one
-	// elected token. Only an authenticated external shift copies this pair into
-	// its immutable terminal payload.
+	// elected token. A checkpoint-capable language copies this pair into each
+	// immutable terminal payload.
 	externalTokenScannerStart CheckpointID
 	externalTokenScannerEnd   CheckpointID
 	externalTokenScannerExact bool
@@ -1395,6 +1402,19 @@ func (c *Core) CertifyExternalPayloadsQuiescent() {
 		return
 	}
 	c.externalPayloadsQuiescent = true
+}
+
+// EnableTerminalScannerCheckpointProvenance records the exact scanner pair on
+// every authenticated terminal. Call this only for a language that declares
+// complete external-scanner checkpoints.
+//
+// The capability is permanent for the Core. Reset retains it because Reset
+// also retains the authenticated language tables.
+func (c *Core) EnableTerminalScannerCheckpointProvenance() {
+	if c == nil {
+		return
+	}
+	c.terminalScannerCheckpointProvenance = true
 }
 
 // inlineAdjacencyCapacity covers the production default without forcing a
@@ -5497,7 +5517,7 @@ func (c *Core) MaterializationView(id SubtreeID) (MaterializationSubtreeView, er
 		Fragile:           record.fragile,
 		Missing:           record.missing,
 	}
-	if record.external && record.terminal {
+	if record.terminal {
 		if provenance, ok := c.externalPayloadScannerProvenance(id); ok {
 			view.ExternalScannerCheckpointStart = provenance.start
 			view.ExternalScannerCheckpointEnd = provenance.end
@@ -5759,13 +5779,13 @@ func (c *Core) appendAuthenticatedTerminal(
 	if err != nil {
 		return 0, err
 	}
-	if r.external && c.externalTokenScannerExact {
+	if (r.external || c.terminalScannerCheckpointProvenance) && c.externalTokenScannerExact {
 		c.externalProvenance = append(c.externalProvenance, externalPayloadProvenance{
 			payload: payload,
 			start:   c.externalTokenScannerStart,
 			end:     c.externalTokenScannerEnd,
 		})
-		if !c.externalPayloadsQuiescent {
+		if r.external && !c.externalPayloadsQuiescent {
 			c.subtrees[payload-1].externalProvenanceState = subtreeExternalProvenanceExactHasExternal
 		}
 	}

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1136,6 +1136,13 @@ type MaterializationSubtreeView struct {
 	Extra             bool
 	External          bool
 	Terminal          bool
+	// ExternalScannerCheckpointStart and ExternalScannerCheckpointEnd identify
+	// the serialized scanner states before and after this external terminal.
+	// They are zero when the subtree has no authenticated external-token
+	// provenance. The materializer copies the bytes into its own arena.
+	ExternalScannerCheckpointStart CheckpointID
+	ExternalScannerCheckpointEnd   CheckpointID
+	ExternalScannerCheckpointExact bool
 	// Fragile mirrors subtreeRecord.fragile: the record was produced by a
 	// reduce/conflict-arm decision that ran under ambiguity (multiPop or an
 	// authenticated >=2-action conflict). Threaded to the public materializer so
@@ -5489,6 +5496,13 @@ func (c *Core) MaterializationView(id SubtreeID) (MaterializationSubtreeView, er
 		Terminal:          record.terminal,
 		Fragile:           record.fragile,
 		Missing:           record.missing,
+	}
+	if record.external && record.terminal {
+		if provenance, ok := c.externalPayloadScannerProvenance(id); ok {
+			view.ExternalScannerCheckpointStart = provenance.start
+			view.ExternalScannerCheckpointEnd = provenance.end
+			view.ExternalScannerCheckpointExact = true
+		}
 	}
 	view.LexerSkippedPrefixStart, view.LexerSkippedPrefix = c.lexerSkippedPrefix(id)
 	return view, nil

--- a/internal/parsercorephase0/eof_recovery_shadow.go
+++ b/internal/parsercorephase0/eof_recovery_shadow.go
@@ -583,6 +583,7 @@ func diagnosticEOFRecoveryCopiedHeadersEqual(live, shadow *Core) bool {
 		live.reduceConflictContext == shadow.reduceConflictContext &&
 		live.reduceNoLookaheadContext == shadow.reduceNoLookaheadContext &&
 		live.externalPayloadsQuiescent == shadow.externalPayloadsQuiescent &&
+		live.terminalScannerCheckpointProvenance == shadow.terminalScannerCheckpointProvenance &&
 		live.externalTokenScannerStart == shadow.externalTokenScannerStart &&
 		live.externalTokenScannerEnd == shadow.externalTokenScannerEnd &&
 		live.externalTokenScannerExact == shadow.externalTokenScannerExact

--- a/internal/parsercorephase0/materialization_postorder_scratch.go
+++ b/internal/parsercorephase0/materialization_postorder_scratch.go
@@ -134,7 +134,7 @@ func (c *Core) VisitMaterializationPostorderWithScratch(
 				Extra:    record.extra, External: record.external, Terminal: record.terminal,
 				Fragile: record.fragile, Missing: record.missing,
 			}
-			if record.external && record.terminal {
+			if record.terminal {
 				if provenance, ok := c.externalPayloadScannerProvenance(top.id); ok {
 					view.ExternalScannerCheckpointStart = provenance.start
 					view.ExternalScannerCheckpointEnd = provenance.end

--- a/internal/parsercorephase0/materialization_postorder_scratch.go
+++ b/internal/parsercorephase0/materialization_postorder_scratch.go
@@ -134,6 +134,13 @@ func (c *Core) VisitMaterializationPostorderWithScratch(
 				Extra:    record.extra, External: record.external, Terminal: record.terminal,
 				Fragile: record.fragile, Missing: record.missing,
 			}
+			if record.external && record.terminal {
+				if provenance, ok := c.externalPayloadScannerProvenance(top.id); ok {
+					view.ExternalScannerCheckpointStart = provenance.start
+					view.ExternalScannerCheckpointEnd = provenance.end
+					view.ExternalScannerCheckpointExact = true
+				}
+			}
 			view.LexerSkippedPrefixStart, view.LexerSkippedPrefix = c.lexerSkippedPrefix(top.id)
 			if err := visit(top.id, view); err != nil {
 				return err

--- a/internal/parsercorephase0/recursive_insert_test.go
+++ b/internal/parsercorephase0/recursive_insert_test.go
@@ -707,6 +707,63 @@ func TestSubtreeExternalProvenanceUsesPackedCache(t *testing.T) {
 	}
 }
 
+func TestAuthenticatedTerminalScannerProvenanceCoversOrdinaryLeaf(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{})
+	start := mustInternCheckpoint(t, compact, []byte{1})
+	end := mustInternCheckpoint(t, compact, []byte{2})
+	if err := compact.SetPhaseExternalTokenScannerCheckpoints(start, end); err != nil {
+		t.Fatal(err)
+	}
+
+	withoutCapability, err := compact.appendAuthenticatedTerminal(subtreeRecord{
+		symbol: 10, terminal: true,
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := compact.externalPayloadScannerProvenance(withoutCapability); ok {
+		t.Fatal("ordinary terminal retained scanner checkpoints without the language capability")
+	}
+
+	compact.EnableTerminalScannerCheckpointProvenance()
+	ordinary, err := compact.appendAuthenticatedTerminal(subtreeRecord{
+		symbol: 11, terminal: true,
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := compact.subtrees[ordinary-1].externalProvenanceState; got != subtreeExternalProvenanceExactNoExternal {
+		t.Fatalf("ordinary terminal changed external provenance state: %d", got)
+	}
+	provenance, ok := compact.externalPayloadScannerProvenance(ordinary)
+	if !ok || provenance.start != start || provenance.end != end {
+		t.Fatalf("ordinary terminal scanner provenance = %+v, %t", provenance, ok)
+	}
+
+	view, err := compact.MaterializationView(ordinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !view.ExternalScannerCheckpointExact || view.ExternalScannerCheckpointStart != start || view.ExternalScannerCheckpointEnd != end {
+		t.Fatalf("ordinary terminal materialization checkpoint = %+v", view)
+	}
+
+	var visited MaterializationSubtreeView
+	var scratch MaterializationPostorderScratch
+	if err := compact.VisitMaterializationPostorderWithScratch(
+		[]SubtreeID{ordinary}, nil, &scratch,
+		func(_ SubtreeID, got MaterializationSubtreeView) error {
+			visited = got
+			return nil
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if !visited.ExternalScannerCheckpointExact || visited.ExternalScannerCheckpointStart != start || visited.ExternalScannerCheckpointEnd != end {
+		t.Fatalf("ordinary terminal postorder checkpoint = %+v", visited)
+	}
+}
+
 func TestRecursiveInsertKeepsScannerCheckpointMismatchSeparate(t *testing.T) {
 	core := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxPopPaths: 8})
 	start := mustInternCheckpoint(t, core, []byte{1})

--- a/issue728_incremental_reuse_regression_test.go
+++ b/issue728_incremental_reuse_regression_test.go
@@ -28,7 +28,7 @@ func TestIssue728IncrementalReuseMeasurement(t *testing.T) {
 		{name: "tsx", lang: grammars.TsxLanguage, source: issue728TypeScriptSource, marker: []byte("export function f"), insert: 'f', wantReuse: true},
 		{name: "toml", lang: grammars.TomlLanguage, source: issue728TOMLSource, marker: []byte("key"), insert: 'k', wantReuse: true},
 		{name: "cmake", lang: grammars.CmakeLanguage, source: issue728CMakeSource, marker: []byte("VAR"), insert: 'X', wantReuse: true},
-		{name: "sql", lang: grammars.SqlLanguage, source: issue728SQLSource, marker: []byte("AS value_"), insert: 'x', wantReuse: false},
+		{name: "sql", lang: grammars.SqlLanguage, source: issue728SQLSource, marker: []byte("AS value_"), insert: 'x', wantReuse: true},
 		{name: "ini", lang: grammars.IniLanguage, source: issue728INISource, marker: []byte("key"), insert: 'x', wantReuse: true},
 		{name: "go", lang: grammars.GoLanguage, source: issue728GoSource, marker: []byte("func f"), insert: 'f', wantReuse: true},
 	}

--- a/language.go
+++ b/language.go
@@ -234,6 +234,16 @@ type CheckpointedExternalScanner interface {
 	UsesExternalScannerCheckpoints() bool
 }
 
+// IncrementalPrefixFrontierExternalScanner is an optional refinement for a
+// checkpointed scanner whose state can depend on reductions before the next
+// top-level sibling. A changed-length or changed-point edit before that
+// sibling must take the fresh-parse fallback unless the parser can prove the
+// old reduction frontier. Python uses this gate for indentation ownership.
+type IncrementalPrefixFrontierExternalScanner interface {
+	ExternalScanner
+	RequiresIncrementalPrefixFrontierProof() bool
+}
+
 // CheckpointlessExternalScannerReuse is implemented by checkpointed scanners
 // that can additionally prove subtree reuse safe when a candidate node has no
 // scanner checkpoint. Most stateful scanners must not implement this: absence

--- a/no_tree_node.go
+++ b/no_tree_node.go
@@ -643,9 +643,10 @@ func materializeStackEntryCompactFullLeafEntry(arena *nodeArena, entry stackEntr
 	node.productionID = leaf.productionID
 	node.rawShape = leaf.rawShape
 	node.dynamicPrecedence = leaf.dynamicPrecedence
-	if leaf.hasCheckpoint && arena != nil {
+	if leaf.hasCheckpoint && arena != nil && externalScannerCheckpointRefComplete(leaf.checkpoint) {
 		if arena.setExternalScannerCheckpoint(node, leaf.checkpoint) {
 			arena.externalScannerCheckpointLeafNodes++
+			arena.externalScannerCheckpointRecords++
 			if arena.checkpointLeafFullNodesAvoided > 0 {
 				arena.checkpointLeafFullNodesAvoided--
 			}

--- a/parser.go
+++ b/parser.go
@@ -3265,7 +3265,7 @@ func (p *Parser) parseIncrementalInternalWithMergePerKeyOverride(source []byte, 
 			timing.reuseRejectStaleNonLeafBoundary += reuse.rejectStaleNonLeafBoundary
 			timing.reuseRejectFragileNonLeaf += reuse.rejectFragileNonLeaf
 			timing.reuseRejectScannerUnquiescent += reuse.rejectScannerUnquiescent
-			timing.reuseRejectFrontierProofUnavailable += reuse.rejectFrontierProofUnavailable
+			timing.reuseRejectFrontierProofUnavailable += uint64(reuse.rejectFrontierProofUnavailable)
 		}
 		if timing != nil {
 			reuseStart := time.Now()

--- a/parser.go
+++ b/parser.go
@@ -1409,19 +1409,23 @@ type IncrementalParseProfile struct {
 	// (external_scanner_quiescence.go). A nonzero count marks boundaries where
 	// scanner state, not fragility or byte drift, is the binding constraint.
 	ReuseRejectScannerUnquiescent uint64
-	RecoverSearches               uint64
-	RecoverStateChecks            uint64
-	RecoverStateSkips             uint64
-	RecoverSymbolSkips            uint64
-	RecoverLookups                uint64
-	RecoverHits                   uint64
-	MaxStacksSeen                 int
-	EntryScratchPeak              uint64
-	StopReason                    ParseStopReason
-	TokensConsumed                uint64
-	LastTokenEndByte              uint32
-	ExpectedEOFByte               uint32
-	ArenaBytesAllocated           int64
+	// ReuseRejectFrontierProofUnavailable counts compact-materialized non-leaf
+	// candidates rejected because exact scanner bytes do not prove the parser
+	// frontier that owned the original reduction.
+	ReuseRejectFrontierProofUnavailable uint64
+	RecoverSearches                     uint64
+	RecoverStateChecks                  uint64
+	RecoverStateSkips                   uint64
+	RecoverSymbolSkips                  uint64
+	RecoverLookups                      uint64
+	RecoverHits                         uint64
+	MaxStacksSeen                       int
+	EntryScratchPeak                    uint64
+	StopReason                          ParseStopReason
+	TokensConsumed                      uint64
+	LastTokenEndByte                    uint32
+	ExpectedEOFByte                     uint32
+	ArenaBytesAllocated                 int64
 	// ArenaBaselineBytes sums retained arena capacity before each attempt.
 	// Subtract it from ArenaBytesAllocated to measure total operation growth.
 	ArenaBaselineBytes    int64
@@ -1492,29 +1496,30 @@ type IncrementalParseProfile struct {
 }
 
 type incrementalParseTiming struct {
-	totalNanos                         int64
-	reuseNanos                         int64
-	reusedSubtrees                     uint64
-	reusedBytes                        uint64
-	newNodes                           uint64
-	reuseUnsupported                   bool
-	reuseUnsupportedReason             string
-	acceptedErrorRetryAttempts         uint8
-	acceptedErrorRetryAdopted          bool
-	acceptedErrorRetryMergePerKey      int
-	acceptedErrorRetryCause            IncrementalRetryCause
-	oldTreeReuseRoute                  bool
-	reuseRejectDirty                   uint64
-	reuseRejectAncestorDirtyBeforeEdit uint64
-	reuseRejectHasError                uint64
-	reuseRejectInvalidSpan             uint64
-	reuseRejectOutOfBounds             uint64
-	reuseRejectRootNonLeafChanged      uint64
-	reuseObservedPreGotoStateMismatch  uint64
-	reuseRejectLargeNonLeaf            uint64
-	reuseRejectStaleNonLeafBoundary    uint64
-	reuseRejectFragileNonLeaf          uint64
-	reuseRejectScannerUnquiescent      uint64
+	totalNanos                          int64
+	reuseNanos                          int64
+	reusedSubtrees                      uint64
+	reusedBytes                         uint64
+	newNodes                            uint64
+	reuseUnsupported                    bool
+	reuseUnsupportedReason              string
+	acceptedErrorRetryAttempts          uint8
+	acceptedErrorRetryAdopted           bool
+	acceptedErrorRetryMergePerKey       int
+	acceptedErrorRetryCause             IncrementalRetryCause
+	oldTreeReuseRoute                   bool
+	reuseRejectDirty                    uint64
+	reuseRejectAncestorDirtyBeforeEdit  uint64
+	reuseRejectHasError                 uint64
+	reuseRejectInvalidSpan              uint64
+	reuseRejectOutOfBounds              uint64
+	reuseRejectRootNonLeafChanged       uint64
+	reuseObservedPreGotoStateMismatch   uint64
+	reuseRejectLargeNonLeaf             uint64
+	reuseRejectStaleNonLeafBoundary     uint64
+	reuseRejectFragileNonLeaf           uint64
+	reuseRejectScannerUnquiescent       uint64
+	reuseRejectFrontierProofUnavailable uint64
 	// blockSpliceSteps counts top-level sibling reuses taken inside the W1
 	// block-splice composition loop (spec.campaign.oedit) -- one per sibling
 	// spliced without returning to the main parse-loop iteration. It is O(edit)
@@ -3260,6 +3265,7 @@ func (p *Parser) parseIncrementalInternalWithMergePerKeyOverride(source []byte, 
 			timing.reuseRejectStaleNonLeafBoundary += reuse.rejectStaleNonLeafBoundary
 			timing.reuseRejectFragileNonLeaf += reuse.rejectFragileNonLeaf
 			timing.reuseRejectScannerUnquiescent += reuse.rejectScannerUnquiescent
+			timing.reuseRejectFrontierProofUnavailable += reuse.rejectFrontierProofUnavailable
 		}
 		if timing != nil {
 			reuseStart := time.Now()

--- a/parser_api.go
+++ b/parser_api.go
@@ -214,15 +214,16 @@ func incrementalReuseUnsupportedReasonForTree(oldTree *Tree) string {
 }
 
 // checkpointedScannerPrefixFrontierUnproven reports the smallest prefix case
-// that cannot transfer a scanner-dependent reduction safely. A clean
+// that a prefix-sensitive scanner cannot transfer safely. A clean
 // predecessor gives the parser a known frontier; an edit before the second
 // top-level child does not. Keep the check generic across checkpointed
-// scanners and tree producers, and leave later siblings on the ordinary reuse
-// path. Compact trees need this early guard as well: their exact scanner
+// tree producers, and leave other certified scanners on their existing reuse
+// contracts. Compact trees need this early guard as well: their exact scanner
 // snapshots do not prove reduction ownership, and waiting for reuseCursor
 // would walk every compact candidate before rejecting it.
 func checkpointedScannerPrefixFrontierUnproven(oldTree *Tree) bool {
 	if oldTree == nil || !languageUsesExternalScannerCheckpoints(oldTree.language) ||
+		!languageRequiresExternalScannerPrefixFrontierProof(oldTree.language) ||
 		len(oldTree.edits) == 0 || oldTree.root == nil {
 		return false
 	}

--- a/parser_api.go
+++ b/parser_api.go
@@ -233,7 +233,7 @@ func checkpointedScannerPrefixFrontierUnproven(oldTree *Tree) bool {
 	boundary := uint32(0)
 	for index := 0; index < childCount; index++ {
 		entry, ok := nodeChildEntryAtNoMaterialize(oldTree.root, index)
-		if !ok || !stackEntryHasNode(entry) {
+		if !ok || !stackEntryHasNode(entry) || stackEntryNodeIsExtra(entry) {
 			continue
 		}
 		if !foundFirst {
@@ -253,11 +253,6 @@ func checkpointedScannerPrefixFrontierUnproven(oldTree *Tree) bool {
 	}
 	for editIndex := len(oldTree.edits) - 1; editIndex >= 0; editIndex-- {
 		edit := oldTree.edits[editIndex]
-		if edit.NewEndByte == edit.OldEndByte && edit.NewEndPoint == edit.OldEndPoint {
-			// Same-length, same-point substitutions can use the narrower
-			// independently authenticated leaf path.
-			continue
-		}
 		// Map the boundary from the coordinate space after this edit back to
 		// the space before it. An edit that reaches the boundary is unsafe.
 		boundaryBefore := boundary
@@ -282,6 +277,35 @@ func checkpointedScannerPrefixFrontierUnproven(oldTree *Tree) bool {
 		boundary = boundaryBefore
 	}
 	return false
+}
+
+// tryTokenInvariantReuseBeforePrefixFrontierFallback permits only the narrow
+// leaf path to bypass a prefix-sensitive scanner fallback. The leaf scan must
+// authenticate the new token under the recorded parser and scanner boundary.
+// A failed authentication returns control to the fresh-parse fallback.
+func (p *Parser) tryTokenInvariantReuseBeforePrefixFrontierFallback(source []byte, oldTree *Tree, timing *incrementalParseTiming) (*Tree, bool) {
+	if oldTreeDisablesIncrementalReuse(oldTree) {
+		return nil, false
+	}
+	if _, _, ok := p.tokenInvariantLeafEditCandidate(source, oldTree); !ok {
+		return nil, false
+	}
+	if p.checkDFALexer() != nil {
+		return nil, false
+	}
+	prevFactory := p.reparseFactory
+	p.reparseFactory = nil
+	defer func() {
+		p.reparseFactory = prevFactory
+	}()
+	ts := p.acquireParserDFATokenSource(source)
+	defer ts.Close()
+	tree, ok := p.tryTokenInvariantLeafEdit(source, oldTree, p.wrapIncludedRanges(ts), timing)
+	if !ok {
+		return nil, false
+	}
+	p.normalizeReturnedIncrementalTree(tree, oldTree, source)
+	return tree, true
 }
 
 func (p *Parser) tryTokenInvariantReuseForDisabledOldTree(source []byte, oldTree *Tree, timing *incrementalParseTiming) (*Tree, bool) {
@@ -1659,6 +1683,9 @@ func (p *Parser) parseIncrementalChanged(source []byte, oldTree *Tree) (*Tree, e
 		// scanner refusal and full-reparse work retain normal attribution.
 	}
 	if checkpointedScannerPrefixFrontierUnproven(oldTree) {
+		if tree, ok := p.tryTokenInvariantReuseBeforePrefixFrontierFallback(source, oldTree, nil); ok {
+			return tree, nil
+		}
 		return p.Parse(source)
 	}
 	if err := p.checkDFALexer(); err != nil {
@@ -1845,6 +1872,10 @@ func (p *Parser) parseIncrementalChangedProfiled(source []byte, oldTree *Tree) (
 		// the same scanner reason and work attribution as an ordinary fallback.
 	}
 	if checkpointedScannerPrefixFrontierUnproven(oldTree) {
+		timing := &incrementalParseTiming{}
+		if tree, ok := p.tryTokenInvariantReuseBeforePrefixFrontierFallback(source, oldTree, timing); ok {
+			return tree, timing.toProfile(), nil
+		}
 		start := time.Now()
 		tree, err := p.Parse(source)
 		return tree, profileFreshParseFallback(start, tree, checkpointedScannerPrefixFrontierUnsupportedReason), err

--- a/parser_api.go
+++ b/parser_api.go
@@ -184,6 +184,7 @@ func finalizeDeferredReturnedTreeTruncation(tree *Tree, _ []byte) {
 const (
 	forestIncrementalReuseUnsupportedReason            = "old tree was built by GSS forest fast path"
 	compactIncrementalReuseUnsupportedReason           = "old tree was compact-materialized without a scanner-quiescence proof"
+	checkpointedScannerPrefixFrontierUnsupportedReason = "external_scanner_prefix_frontier_unproven"
 	compactRecoverEOFIncrementalReuseUnsupportedReason = "old tree carried a compact recover_eof EOF runtime"
 )
 
@@ -210,6 +211,76 @@ func incrementalReuseUnsupportedReasonForTree(oldTree *Tree) string {
 		return compactIncrementalReuseUnsupportedReason
 	}
 	return forestIncrementalReuseUnsupportedReason
+}
+
+// checkpointedScannerPrefixFrontierUnproven reports the smallest prefix case
+// that cannot transfer a scanner-dependent reduction safely. A clean
+// predecessor gives the parser a known frontier; an edit before the second
+// top-level child does not. Keep the check generic across checkpointed
+// scanners and tree producers, and leave later siblings on the ordinary reuse
+// path. Compact trees need this early guard as well: their exact scanner
+// snapshots do not prove reduction ownership, and waiting for reuseCursor
+// would walk every compact candidate before rejecting it.
+func checkpointedScannerPrefixFrontierUnproven(oldTree *Tree) bool {
+	if oldTree == nil || !languageUsesExternalScannerCheckpoints(oldTree.language) ||
+		len(oldTree.edits) == 0 || oldTree.root == nil {
+		return false
+	}
+	childCount := nodeChildCountNoMaterialize(oldTree.root)
+	foundFirst := false
+	foundSecond := false
+	boundary := uint32(0)
+	for index := 0; index < childCount; index++ {
+		entry, ok := nodeChildEntryAtNoMaterialize(oldTree.root, index)
+		if !ok || !stackEntryHasNode(entry) {
+			continue
+		}
+		if !foundFirst {
+			foundFirst = true
+			continue
+		}
+		boundary = stackEntryNodeStartByte(entry)
+		foundSecond = true
+		break
+	}
+	if !foundFirst {
+		return false
+	}
+	if !foundSecond {
+		// With no later sibling, the root end is the conservative frontier.
+		boundary = oldTree.root.endByte
+	}
+	for editIndex := len(oldTree.edits) - 1; editIndex >= 0; editIndex-- {
+		edit := oldTree.edits[editIndex]
+		if edit.NewEndByte == edit.OldEndByte && edit.NewEndPoint == edit.OldEndPoint {
+			// Same-length, same-point substitutions can use the narrower
+			// independently authenticated leaf path.
+			continue
+		}
+		// Map the boundary from the coordinate space after this edit back to
+		// the space before it. An edit that reaches the boundary is unsafe.
+		boundaryBefore := boundary
+		switch {
+		case boundary < edit.StartByte:
+			// The edit starts after the frontier. The frontier is unchanged.
+		case boundary >= edit.NewEndByte:
+			delta := int64(edit.OldEndByte) - int64(edit.NewEndByte)
+			mapped := int64(boundary) + delta
+			if mapped < 0 {
+				mapped = 0
+			} else if mapped > int64(^uint32(0)) {
+				mapped = int64(^uint32(0))
+			}
+			boundaryBefore = uint32(mapped)
+		default:
+			return true
+		}
+		if edit.StartByte <= boundaryBefore {
+			return true
+		}
+		boundary = boundaryBefore
+	}
+	return false
 }
 
 func (p *Parser) tryTokenInvariantReuseForDisabledOldTree(source []byte, oldTree *Tree, timing *incrementalParseTiming) (*Tree, bool) {
@@ -391,6 +462,9 @@ func profileFreshParseFallback(start time.Time, tree *Tree, reason string) Incre
 	copyParseRuntimeToTiming(timing, *tree.rawParseRuntime())
 	profile = timing.toProfile()
 	profile.ReparseNanos = time.Since(start).Nanoseconds()
+	// A fresh fallback has no incremental arena delta for the timing defer to
+	// report. Publish the fallback tree's total node count explicitly instead.
+	profile.NewNodesAllocated = uint64(tree.rawParseRuntime().NodesAllocated)
 	profile.ReuseUnsupported = true
 	profile.ReuseUnsupportedReason = reason
 	return profile
@@ -1583,6 +1657,9 @@ func (p *Parser) parseIncrementalChanged(source []byte, oldTree *Tree) (*Tree, e
 		// A compact tree needs the incremental token-source fallback below so
 		// scanner refusal and full-reparse work retain normal attribution.
 	}
+	if checkpointedScannerPrefixFrontierUnproven(oldTree) {
+		return p.Parse(source)
+	}
 	if err := p.checkDFALexer(); err != nil {
 		return nil, err
 	}
@@ -1765,6 +1842,11 @@ func (p *Parser) parseIncrementalChangedProfiled(source []byte, oldTree *Tree) (
 		}
 		// Continue through the token-source path so a compact-tree decline keeps
 		// the same scanner reason and work attribution as an ordinary fallback.
+	}
+	if checkpointedScannerPrefixFrontierUnproven(oldTree) {
+		start := time.Now()
+		tree, err := p.Parse(source)
+		return tree, profileFreshParseFallback(start, tree, checkpointedScannerPrefixFrontierUnsupportedReason), err
 	}
 	if err := p.checkDFALexer(); err != nil {
 		return nil, IncrementalParseProfile{}, err

--- a/parser_big3_incremental_correctness_test.go
+++ b/parser_big3_incremental_correctness_test.go
@@ -15,10 +15,9 @@ import (
 // newProductionBig3Parser returns a parser pinned to the production route.
 // These incremental-correctness tests compare production incremental reparse
 // against production fresh parse and observe production-engine reuse profiles.
-// A compact-materialized base tree is hard-barred from incremental reuse
-// (decision 0008), so the base and fresh parses must stay on production; the
-// compact route's fresh-parse correctness is covered by the tagged scorecard
-// suite. Reuse-bar lift is the follow-on campaign.
+// The base and fresh parses stay on production so these tests isolate that
+// engine. Compact scanner-checkpoint reuse is covered by the tagged Stage 5
+// suite.
 func newProductionBig3Parser(lang *gotreesitter.Language) *gotreesitter.Parser {
 	p := gotreesitter.NewParser(lang)
 	p.SetAdmissionCandidateRoute(false)
@@ -114,7 +113,7 @@ func TestPythonIncrementalSingleByteDeleteSweepMatchesFresh(t *testing.T) {
 	}
 }
 
-func TestPythonLengthChangingEditFallsBackUntilDedentCheckpointsAreCertified(t *testing.T) {
+func TestPythonLengthChangingEditUsesDedentCheckpoints(t *testing.T) {
 	source, err := os.ReadFile("cgo_harness/corpus_structural/python_sample.py")
 	if err != nil {
 		t.Fatal(err)
@@ -144,11 +143,11 @@ func TestPythonLengthChangingEditFallsBackUntilDedentCheckpointsAreCertified(t *
 		t.Fatal(err)
 	}
 	defer incremental.Release()
-	if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" {
-		t.Fatalf("Python length-changing edit did not use the conservative scanner fallback: %+v", profile)
+	if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" || !profile.OldTreeReuseRoute {
+		t.Fatalf("Python length-changing edit did not use authenticated scanner reuse: %+v", profile)
 	}
-	if profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
-		t.Fatalf("Python scanner fallback reported old-tree reuse: %+v", profile)
+	if profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 || profile.ReuseRejectScannerUnquiescent == 0 {
+		t.Fatalf("Python length-changing edit did not preserve reuse or report invalidated scanner boundaries: %+v", profile)
 	}
 
 	fresh, err := newProductionBig3Parser(lang).Parse(edited)
@@ -156,7 +155,7 @@ func TestPythonLengthChangingEditFallsBackUntilDedentCheckpointsAreCertified(t *
 		t.Fatal(err)
 	}
 	defer fresh.Release()
-	requireCompleteParse(t, incremental, edited, lang, "incremental fallback")
+	requireCompleteParse(t, incremental, edited, lang, "incremental")
 	requireCompleteParse(t, fresh, edited, lang, "fresh")
 	incrementalInspection, err := benchfixtures.InspectGoTree(incremental.RootNode(), lang)
 	if err != nil {
@@ -167,7 +166,7 @@ func TestPythonLengthChangingEditFallsBackUntilDedentCheckpointsAreCertified(t *
 		t.Fatal(err)
 	}
 	if incrementalInspection.SHA256 != freshInspection.SHA256 {
-		t.Fatalf("Python conservative fallback differs from fresh parse: incremental=%s fresh=%s", incrementalInspection.SHA256, freshInspection.SHA256)
+		t.Fatalf("Python authenticated incremental parse differs from fresh parse: incremental=%s fresh=%s", incrementalInspection.SHA256, freshInspection.SHA256)
 	}
 }
 

--- a/parser_external_scanner_incremental_test.go
+++ b/parser_external_scanner_incremental_test.go
@@ -232,7 +232,7 @@ func replaceExternalScannerWitness(t *testing.T, source, oldText, replacement []
 	}
 }
 
-func TestPythonDerivedSameLengthTokenChangeDeclinesScannerReuse(t *testing.T) {
+func TestExternalScannerDerivedSameLengthTokenChangeInvalidatesScannerReuse(t *testing.T) {
 	for _, languageCase := range pythonDerivedIncrementalCases() {
 		languageCase := languageCase
 		t.Run(languageCase.name, func(t *testing.T) {
@@ -255,6 +255,7 @@ func TestPythonDerivedSameLengthTokenChangeDeclinesScannerReuse(t *testing.T) {
 
 					lang := languageCase.lang()
 					parser := gotreesitter.NewParser(lang)
+					parser.SetAdmissionCandidateRoute(false)
 					if route.includedRanges {
 						parser.SetIncludedRanges([]gotreesitter.Range{{
 							StartByte: 0,
@@ -281,11 +282,17 @@ func TestPythonDerivedSameLengthTokenChangeDeclinesScannerReuse(t *testing.T) {
 						t.Fatal(err)
 					}
 					defer incremental.Release()
-					if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" {
-						t.Fatalf("same-length token change did not preserve %s scanner refusal: %+v", languageCase.name, profile)
-					}
-					if profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
-						t.Fatalf("same-length token change reused old %s syntax: %+v", languageCase.name, profile)
+					if languageCase.name == "python" {
+						if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" {
+							t.Fatalf("same-length token change rejected authenticated Python scanner reuse: %+v", profile)
+						}
+					} else {
+						if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" {
+							t.Fatalf("same-length token change did not preserve %s scanner refusal: %+v", languageCase.name, profile)
+						}
+						if profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+							t.Fatalf("same-length token change reused old %s syntax: %+v", languageCase.name, profile)
+						}
 					}
 					if profile.TokensConsumed == 0 || profile.NewNodesAllocated == 0 {
 						t.Fatalf("same-length token change did not execute a full parse: %+v", profile)
@@ -327,9 +334,9 @@ func TestPythonDerivedTokenInvariantLeafReusePrecedesScannerFallback(t *testing.
 					lang := languageCase.lang()
 					parser := gotreesitter.NewParser(lang)
 					// This test locks the legacy production-tree contract: a
-					// token-invariant leaf edit is reauthenticated before the scanner
-					// opt-out fallback. Reuse-disabled compact stateful scanners are
-					// covered by TestStatefulScannerCompactLeafReauthenticationFailsClosed.
+					// token-invariant leaf edit is reauthenticated before any broader
+					// scanner-state reuse. Compact stateful scanner coverage lives in
+					// TestStatefulScannerCompactLeafReauthentication.
 					parser.SetAdmissionCandidateRoute(false)
 					if route.includedRanges {
 						parser.SetIncludedRanges([]gotreesitter.Range{{

--- a/parser_external_scanner_incremental_test.go
+++ b/parser_external_scanner_incremental_test.go
@@ -313,6 +313,86 @@ func TestExternalScannerDerivedSameLengthTokenChangeInvalidatesScannerReuse(t *t
 	}
 }
 
+// TestPythonSameSymbolScannerStateEditFallsBack proves that token identity and
+// width do not authenticate an external-scanner transition. Python scans both
+// prefixes as string_start, but only the f prefix enables interpolation.
+func TestPythonSameSymbolScannerStateEditFallsBack(t *testing.T) {
+	source := []byte("def first(value):\n    return u\"{x}\"\n\ndef second(value):\n    return \"unchanged\"\n")
+	marker := []byte("u\"{x}\"")
+	offset := bytes.Index(source, marker)
+	if offset < 0 {
+		t.Fatal("locked Python scanner-state witness is malformed")
+	}
+	edited := append([]byte(nil), source...)
+	edited[offset] = 'f'
+	edit := gotreesitter.InputEdit{
+		StartByte:   uint32(offset),
+		OldEndByte:  uint32(offset + 1),
+		NewEndByte:  uint32(offset + 1),
+		StartPoint:  pointForOffset(source, offset),
+		OldEndPoint: pointForOffset(source, offset+1),
+		NewEndPoint: pointForOffset(edited, offset+1),
+	}
+
+	for _, route := range []struct {
+		name           string
+		includedRanges bool
+	}{
+		{name: "direct"},
+		{name: "included_range", includedRanges: true},
+	} {
+		route := route
+		t.Run(route.name, func(t *testing.T) {
+			lang := grammars.PythonLanguage()
+			parser := gotreesitter.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(false)
+			if route.includedRanges {
+				parser.SetIncludedRanges([]gotreesitter.Range{{
+					StartByte: 0,
+					EndByte:   uint32(len(source)),
+					EndPoint:  pointForOffset(source, len(source)),
+				}})
+			}
+			oldTree, err := parser.Parse(source)
+			if err != nil {
+				t.Fatalf("old parse: %v", err)
+			}
+			defer oldTree.Release()
+			oldTree.Edit(edit)
+			incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+			if err != nil {
+				t.Fatalf("incremental parse: %v", err)
+			}
+			if incremental != oldTree {
+				defer incremental.Release()
+			}
+			if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_prefix_frontier_unproven" ||
+				profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+				t.Fatalf("same-symbol scanner-state edit bypassed prefix fallback: %+v", profile)
+			}
+			if profile.TokensConsumed == 0 || profile.NewNodesAllocated == 0 {
+				t.Fatalf("same-symbol scanner-state edit did not execute a fresh parse: %+v", profile)
+			}
+
+			freshParser := gotreesitter.NewParser(lang)
+			freshParser.SetAdmissionCandidateRoute(false)
+			if route.includedRanges {
+				freshParser.SetIncludedRanges([]gotreesitter.Range{{
+					StartByte: 0,
+					EndByte:   uint32(len(edited)),
+					EndPoint:  pointForOffset(edited, len(edited)),
+				}})
+			}
+			fresh, err := freshParser.Parse(edited)
+			if err != nil {
+				t.Fatalf("fresh parse: %v", err)
+			}
+			defer fresh.Release()
+			requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+		})
+	}
+}
+
 func TestPythonDerivedTokenInvariantLeafReusePrecedesScannerFallback(t *testing.T) {
 	for _, languageCase := range pythonDerivedIncrementalCases() {
 		languageCase := languageCase

--- a/parser_external_scanner_incremental_test.go
+++ b/parser_external_scanner_incremental_test.go
@@ -283,8 +283,11 @@ func TestExternalScannerDerivedSameLengthTokenChangeInvalidatesScannerReuse(t *t
 					}
 					defer incremental.Release()
 					if languageCase.name == "python" {
-						if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" {
-							t.Fatalf("same-length token change rejected authenticated Python scanner reuse: %+v", profile)
+						if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_prefix_frontier_unproven" {
+							t.Fatalf("same-length Python token-class change bypassed prefix fallback: %+v", profile)
+						}
+						if profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+							t.Fatalf("same-length Python token-class change reused old syntax: %+v", profile)
 						}
 					} else {
 						if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" {

--- a/parser_external_scanner_prefix_frontier_compact_test.go
+++ b/parser_external_scanner_prefix_frontier_compact_test.go
@@ -1,0 +1,118 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestCompactCheckpointedScannerPrefixFrontierFallbackAvoidsCandidateWalk
+// proves that a compact Python tree takes the generic first-child fallback
+// before reuseCursor scans its compact non-leaf candidates. The fresh parse
+// still visits the edited source, but the old compact tree contributes no
+// candidate-walk work.
+func TestCompactCheckpointedScannerPrefixFrontierFallbackAvoidsCandidateWalk(t *testing.T) {
+	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "512")
+	gts.ResetParseEnvConfigCacheForTests()
+	t.Cleanup(gts.ResetParseEnvConfigCacheForTests)
+	for _, targetBytes := range []int{20 * 1024, 137 * 1024} {
+		t.Run(fmt.Sprintf("%dKB", targetBytes/1024), func(t *testing.T) {
+			source := compactPrefixPythonSource(targetBytes)
+			const marker = "    return 0\n"
+			offset := bytes.Index(source, []byte(marker))
+			if offset < 0 {
+				t.Fatalf("compact Python fixture has no first-child marker %q", marker)
+			}
+
+			edited := make([]byte, 0, len(source)+4)
+			edited = append(edited, source[:offset]...)
+			edited = append(edited, []byte("    ")...)
+			edited = append(edited, source[offset:]...)
+			edit := gts.InputEdit{
+				StartByte:   uint32(offset),
+				OldEndByte:  uint32(offset),
+				NewEndByte:  uint32(offset + 4),
+				StartPoint:  compactPrefixPythonPointAt(source, offset),
+				OldEndPoint: compactPrefixPythonPointAt(source, offset),
+				NewEndPoint: compactPrefixPythonPointAt(edited, offset+4),
+			}
+
+			gts.ResetAdmissionCandidateCountersForTest()
+			parser := gts.NewParser(grammars.PythonLanguage())
+			parser.SetAdmissionCandidateRoute(true)
+			routedBefore, fallbackBefore := gts.AdmissionCandidateCounters()
+			oldTree, err := parser.Parse(source)
+			if err != nil {
+				t.Fatalf("compact base parse: %v", err)
+			}
+			defer oldTree.Release()
+			routedAfter, fallbackAfter := gts.AdmissionCandidateCounters()
+			if routedAfter != routedBefore+1 || fallbackAfter != fallbackBefore {
+				t.Fatalf("Python compact base route counters=%d/%d, want one route and no fallback", routedAfter-routedBefore, fallbackAfter-fallbackBefore)
+			}
+			if !oldTree.ParseRuntime().CompactExternalScannerCheckpointTransferProven {
+				t.Fatalf("compact base lacks scanner checkpoint transfer proof: runtime=%+v", oldTree.ParseRuntime())
+			}
+
+			oldTree.Edit(edit)
+			incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+			if err != nil {
+				t.Fatalf("compact first-child incremental parse: %v", err)
+			}
+			defer incremental.Release()
+			if profile.ReuseUnsupportedReason != "external_scanner_prefix_frontier_unproven" ||
+				!profile.ReuseUnsupported || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+				t.Fatalf("compact first-child fallback profile=%+v", profile)
+			}
+			if profile.ReuseCursorNanos != 0 || profile.ReuseRejectFrontierProofUnavailable != 0 {
+				t.Fatalf("compact first-child fallback scanned old candidates: reuse_nanos=%d frontier_rejects=%d profile=%+v", profile.ReuseCursorNanos, profile.ReuseRejectFrontierProofUnavailable, profile)
+			}
+			if want := uint64(incremental.ParseRuntime().NodesAllocated); profile.NewNodesAllocated != want {
+				t.Fatalf("compact fallback node attribution=%d, want fresh tree node count %d: %+v", profile.NewNodesAllocated, want, profile)
+			}
+			if got := incremental.RootNode().EndByte(); got != uint32(len(edited)) {
+				t.Fatalf("compact first-child root end=%d, want %d", got, len(edited))
+			}
+			freshParser := gts.NewParser(grammars.PythonLanguage())
+			freshParser.SetAdmissionCandidateRoute(false)
+			fresh, err := freshParser.Parse(edited)
+			if err != nil {
+				t.Fatalf("fresh Python oracle parse: %v", err)
+			}
+			defer fresh.Release()
+			requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, grammars.PythonLanguage())
+			if incremental.RootNode().HasError() != fresh.RootNode().HasError() {
+				t.Fatalf("compact first-child error state differs: incremental=%t fresh=%t", incremental.RootNode().HasError(), fresh.RootNode().HasError())
+			}
+			t.Logf("compact first-child fallback bytes=%d tokens=%d new_nodes=%d reparse_nanos=%d", len(source), profile.TokensConsumed, profile.NewNodesAllocated, profile.ReparseNanos)
+		})
+	}
+}
+
+func compactPrefixPythonSource(targetBytes int) []byte {
+	var source strings.Builder
+	source.Grow(targetBytes + 256)
+	for index := 0; source.Len() < targetBytes; index++ {
+		fmt.Fprintf(&source, "def f%d(a):\n    if a:\n        return 0\n    return 0\n\n", index)
+	}
+	return []byte(source.String())
+}
+
+func compactPrefixPythonPointAt(source []byte, offset int) gts.Point {
+	point := gts.Point{}
+	for _, b := range source[:offset] {
+		if b == '\n' {
+			point.Row++
+			point.Column = 0
+			continue
+		}
+		point.Column++
+	}
+	return point
+}

--- a/parser_external_scanner_prefix_frontier_test.go
+++ b/parser_external_scanner_prefix_frontier_test.go
@@ -18,7 +18,6 @@ func TestCheckpointedScannerPrefixFrontierFallback(t *testing.T) {
 		source  []byte
 		needle  []byte
 		replace []byte
-		isSQL   bool
 	}{
 		{
 			name:    "python_insert_first_child",
@@ -34,22 +33,6 @@ func TestCheckpointedScannerPrefixFrontierFallback(t *testing.T) {
 			needle:  []byte("return 111"),
 			replace: []byte("return 11"),
 		},
-		{
-			name:    "sql_insert_first_child",
-			lang:    grammars.SqlLanguage,
-			source:  []byte("SELECT $q$first$q$ AS first;\nSELECT $q$second$q$ AS second;\n"),
-			needle:  []byte("first"),
-			replace: []byte("firstx"),
-			isSQL:   true,
-		},
-		{
-			name:    "sql_delete_first_child",
-			lang:    grammars.SqlLanguage,
-			source:  []byte("SELECT $q$firstx$q$ AS first;\nSELECT $q$second$q$ AS second;\n"),
-			needle:  []byte("firstx"),
-			replace: []byte("first"),
-			isSQL:   true,
-		},
 	}
 
 	for _, tc := range cases {
@@ -64,9 +47,6 @@ func TestCheckpointedScannerPrefixFrontierFallback(t *testing.T) {
 			}
 			defer oldTree.Release()
 			requireCompleteParse(t, oldTree, tc.source, lang, "old")
-			if tc.isSQL {
-				requireSQLAcceptedEOF(t, oldTree, tc.source, "old")
-			}
 
 			edited, edit := replacePrefixFrontierWitness(t, tc.source, tc.needle, tc.replace)
 			oldTree.Edit(edit)
@@ -76,9 +56,6 @@ func TestCheckpointedScannerPrefixFrontierFallback(t *testing.T) {
 			}
 			defer incremental.Release()
 			requireCompleteParse(t, incremental, edited, lang, "incremental")
-			if tc.isSQL {
-				requireSQLAcceptedEOF(t, incremental, edited, "incremental")
-			}
 			if profile.ReuseUnsupportedReason != "external_scanner_prefix_frontier_unproven" {
 				t.Fatalf("fallback reason = %q, want external_scanner_prefix_frontier_unproven: %+v", profile.ReuseUnsupportedReason, profile)
 			}
@@ -100,9 +77,6 @@ func TestCheckpointedScannerPrefixFrontierFallback(t *testing.T) {
 			}
 			defer fresh.Release()
 			requireCompleteParse(t, fresh, edited, lang, "fresh")
-			if tc.isSQL {
-				requireSQLAcceptedEOF(t, fresh, edited, "fresh")
-			}
 			requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
 		})
 	}
@@ -115,7 +89,6 @@ func TestCheckpointedScannerPrefixFrontierAllowsLaterSiblingReuse(t *testing.T) 
 		source  []byte
 		needle  []byte
 		replace []byte
-		isSQL   bool
 	}{
 		{
 			name:    "python_insert_second_child",
@@ -131,14 +104,6 @@ func TestCheckpointedScannerPrefixFrontierAllowsLaterSiblingReuse(t *testing.T) 
 			needle:  []byte("return 222"),
 			replace: []byte("return 22"),
 		},
-		{
-			name:    "sql_insert_second_child",
-			lang:    grammars.SqlLanguage,
-			source:  []byte("SELECT $q$first$q$ AS first;\nSELECT $q$second$q$ AS second;\n"),
-			needle:  []byte("$q$second$q$"),
-			replace: []byte("$q$secondx$q$"),
-			isSQL:   true,
-		},
 	}
 
 	for _, tc := range cases {
@@ -152,9 +117,6 @@ func TestCheckpointedScannerPrefixFrontierAllowsLaterSiblingReuse(t *testing.T) 
 			}
 			defer oldTree.Release()
 			requireCompleteParse(t, oldTree, tc.source, lang, "old")
-			if tc.isSQL {
-				requireSQLAcceptedEOF(t, oldTree, tc.source, "old")
-			}
 
 			edited, edit := replacePrefixFrontierWitness(t, tc.source, tc.needle, tc.replace)
 			oldTree.Edit(edit)
@@ -164,9 +126,6 @@ func TestCheckpointedScannerPrefixFrontierAllowsLaterSiblingReuse(t *testing.T) 
 			}
 			defer incremental.Release()
 			requireCompleteParse(t, incremental, edited, lang, "incremental")
-			if tc.isSQL {
-				requireSQLAcceptedEOF(t, incremental, edited, "incremental")
-			}
 			if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" || !profile.OldTreeReuseRoute {
 				t.Fatalf("later-sibling edit did not stay on reuse route: %+v", profile)
 			}
@@ -182,12 +141,47 @@ func TestCheckpointedScannerPrefixFrontierAllowsLaterSiblingReuse(t *testing.T) 
 			}
 			defer fresh.Release()
 			requireCompleteParse(t, fresh, edited, lang, "fresh")
-			if tc.isSQL {
-				requireSQLAcceptedEOF(t, fresh, edited, "fresh")
-			}
 			requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
 		})
 	}
+}
+
+// TestCheckpointedScannerWithoutPrefixFrontierRequirementKeepsReuse proves
+// that Python's ownership guard does not reduce other scanner certifications.
+func TestCheckpointedScannerWithoutPrefixFrontierRequirementKeepsReuse(t *testing.T) {
+	source := []byte("SELECT $q$first$q$ AS first;\nSELECT $q$second$q$ AS second;\n")
+	lang := grammars.SqlLanguage()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	oldTree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("old SQL parse: %v", err)
+	}
+	defer oldTree.Release()
+	requireSQLAcceptedEOF(t, oldTree, source, "old")
+
+	edited, edit := replacePrefixFrontierWitness(t, source, []byte("first"), []byte("firstx"))
+	oldTree.Edit(edit)
+	incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatalf("incremental SQL parse: %v", err)
+	}
+	defer incremental.Release()
+	if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" || !profile.OldTreeReuseRoute ||
+		profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("SQL prefix edit lost certified reuse: %+v", profile)
+	}
+	requireSQLAcceptedEOF(t, incremental, edited, "incremental")
+
+	freshParser := gts.NewParser(lang)
+	freshParser.SetAdmissionCandidateRoute(false)
+	fresh, err := freshParser.Parse(edited)
+	if err != nil {
+		t.Fatalf("fresh SQL parse: %v", err)
+	}
+	defer fresh.Release()
+	requireSQLAcceptedEOF(t, fresh, edited, "fresh")
+	requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
 }
 
 // TestCheckpointedScannerPrefixFrontierCatchesSuffixDelete covers the

--- a/parser_external_scanner_prefix_frontier_test.go
+++ b/parser_external_scanner_prefix_frontier_test.go
@@ -10,7 +10,7 @@ import (
 
 // TestCheckpointedScannerPrefixFrontierFallback covers production trees.
 // Checkpoint bytes prove scanner state, but they do not prove the reduction
-// frontier after a length-changing edit inside the first top-level child.
+// frontier after an edit inside the first structural top-level child.
 func TestCheckpointedScannerPrefixFrontierFallback(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -32,6 +32,20 @@ func TestCheckpointedScannerPrefixFrontierFallback(t *testing.T) {
 			source:  []byte("def first():\n    return 111\n\ndef second():\n    return 2\n"),
 			needle:  []byte("return 111"),
 			replace: []byte("return 11"),
+		},
+		{
+			name:    "python_same_length_indent_state",
+			lang:    grammars.PythonLanguage,
+			source:  []byte("def first():\n        value = 1\n        return value\n\ndef second():\n    return 2\n"),
+			needle:  []byte("        return value"),
+			replace: []byte("\t       return value"),
+		},
+		{
+			name:    "python_leading_comment_extra",
+			lang:    grammars.PythonLanguage,
+			source:  []byte("# leading extra\n\ndef first():\n    return 1\n\ndef second():\n    return 2\n"),
+			needle:  []byte("return 1"),
+			replace: []byte("return 19"),
 		},
 	}
 

--- a/parser_external_scanner_prefix_frontier_test.go
+++ b/parser_external_scanner_prefix_frontier_test.go
@@ -1,0 +1,327 @@
+package gotreesitter_test
+
+import (
+	"bytes"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestCheckpointedScannerPrefixFrontierFallback covers production trees.
+// Checkpoint bytes prove scanner state, but they do not prove the reduction
+// frontier after a length-changing edit inside the first top-level child.
+func TestCheckpointedScannerPrefixFrontierFallback(t *testing.T) {
+	cases := []struct {
+		name    string
+		lang    func() *gts.Language
+		source  []byte
+		needle  []byte
+		replace []byte
+		isSQL   bool
+	}{
+		{
+			name:    "python_insert_first_child",
+			lang:    grammars.PythonLanguage,
+			source:  []byte("def first():\n    return 1\n\ndef second():\n    return 2\n"),
+			needle:  []byte("return 1"),
+			replace: []byte("return 19"),
+		},
+		{
+			name:    "python_delete_first_child",
+			lang:    grammars.PythonLanguage,
+			source:  []byte("def first():\n    return 111\n\ndef second():\n    return 2\n"),
+			needle:  []byte("return 111"),
+			replace: []byte("return 11"),
+		},
+		{
+			name:    "sql_insert_first_child",
+			lang:    grammars.SqlLanguage,
+			source:  []byte("SELECT $q$first$q$ AS first;\nSELECT $q$second$q$ AS second;\n"),
+			needle:  []byte("first"),
+			replace: []byte("firstx"),
+			isSQL:   true,
+		},
+		{
+			name:    "sql_delete_first_child",
+			lang:    grammars.SqlLanguage,
+			source:  []byte("SELECT $q$firstx$q$ AS first;\nSELECT $q$second$q$ AS second;\n"),
+			needle:  []byte("firstx"),
+			replace: []byte("first"),
+			isSQL:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lang := tc.lang()
+			parser := gts.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(false)
+
+			oldTree, err := parser.Parse(tc.source)
+			if err != nil {
+				t.Fatalf("old parse: %v", err)
+			}
+			defer oldTree.Release()
+			requireCompleteParse(t, oldTree, tc.source, lang, "old")
+			if tc.isSQL {
+				requireSQLAcceptedEOF(t, oldTree, tc.source, "old")
+			}
+
+			edited, edit := replacePrefixFrontierWitness(t, tc.source, tc.needle, tc.replace)
+			oldTree.Edit(edit)
+			incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+			if err != nil {
+				t.Fatalf("incremental parse: %v", err)
+			}
+			defer incremental.Release()
+			requireCompleteParse(t, incremental, edited, lang, "incremental")
+			if tc.isSQL {
+				requireSQLAcceptedEOF(t, incremental, edited, "incremental")
+			}
+			if profile.ReuseUnsupportedReason != "external_scanner_prefix_frontier_unproven" {
+				t.Fatalf("fallback reason = %q, want external_scanner_prefix_frontier_unproven: %+v", profile.ReuseUnsupportedReason, profile)
+			}
+			if !profile.ReuseUnsupported || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+				t.Fatalf("prefix fallback reported reuse: %+v", profile)
+			}
+			if profile.TokensConsumed == 0 || profile.NewNodesAllocated == 0 {
+				t.Fatalf("prefix fallback did not report fresh parse work: %+v", profile)
+			}
+			if want := uint64(incremental.ParseRuntime().NodesAllocated); profile.NewNodesAllocated != want {
+				t.Fatalf("prefix fallback node attribution=%d, want fresh tree node count %d: %+v", profile.NewNodesAllocated, want, profile)
+			}
+
+			freshParser := gts.NewParser(lang)
+			freshParser.SetAdmissionCandidateRoute(false)
+			fresh, err := freshParser.Parse(edited)
+			if err != nil {
+				t.Fatalf("fresh parse: %v", err)
+			}
+			defer fresh.Release()
+			requireCompleteParse(t, fresh, edited, lang, "fresh")
+			if tc.isSQL {
+				requireSQLAcceptedEOF(t, fresh, edited, "fresh")
+			}
+			requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+		})
+	}
+}
+
+func TestCheckpointedScannerPrefixFrontierAllowsLaterSiblingReuse(t *testing.T) {
+	cases := []struct {
+		name    string
+		lang    func() *gts.Language
+		source  []byte
+		needle  []byte
+		replace []byte
+		isSQL   bool
+	}{
+		{
+			name:    "python_insert_second_child",
+			lang:    grammars.PythonLanguage,
+			source:  []byte("def first():\n    return 1\n\ndef second():\n    return 2\n"),
+			needle:  []byte("return 2"),
+			replace: []byte("return 29"),
+		},
+		{
+			name:    "python_delete_second_child_pre_edit_coordinates",
+			lang:    grammars.PythonLanguage,
+			source:  []byte("def first():\n    return 1\n\ndef second():\n    return 222\n"),
+			needle:  []byte("return 222"),
+			replace: []byte("return 22"),
+		},
+		{
+			name:    "sql_insert_second_child",
+			lang:    grammars.SqlLanguage,
+			source:  []byte("SELECT $q$first$q$ AS first;\nSELECT $q$second$q$ AS second;\n"),
+			needle:  []byte("$q$second$q$"),
+			replace: []byte("$q$secondx$q$"),
+			isSQL:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lang := tc.lang()
+			parser := gts.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(false)
+			oldTree, err := parser.Parse(tc.source)
+			if err != nil {
+				t.Fatalf("old parse: %v", err)
+			}
+			defer oldTree.Release()
+			requireCompleteParse(t, oldTree, tc.source, lang, "old")
+			if tc.isSQL {
+				requireSQLAcceptedEOF(t, oldTree, tc.source, "old")
+			}
+
+			edited, edit := replacePrefixFrontierWitness(t, tc.source, tc.needle, tc.replace)
+			oldTree.Edit(edit)
+			incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+			if err != nil {
+				t.Fatalf("incremental parse: %v", err)
+			}
+			defer incremental.Release()
+			requireCompleteParse(t, incremental, edited, lang, "incremental")
+			if tc.isSQL {
+				requireSQLAcceptedEOF(t, incremental, edited, "incremental")
+			}
+			if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" || !profile.OldTreeReuseRoute {
+				t.Fatalf("later-sibling edit did not stay on reuse route: %+v", profile)
+			}
+			if profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+				t.Fatalf("later-sibling edit lost all reuse: %+v", profile)
+			}
+
+			freshParser := gts.NewParser(lang)
+			freshParser.SetAdmissionCandidateRoute(false)
+			fresh, err := freshParser.Parse(edited)
+			if err != nil {
+				t.Fatalf("fresh parse: %v", err)
+			}
+			defer fresh.Release()
+			requireCompleteParse(t, fresh, edited, lang, "fresh")
+			if tc.isSQL {
+				requireSQLAcceptedEOF(t, fresh, edited, "fresh")
+			}
+			requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+		})
+	}
+}
+
+// TestCheckpointedScannerPrefixFrontierCatchesSuffixDelete covers the
+// post-edit boundary case where a deletion moves the first child end to the
+// edit start. The old raw-coordinate check treated that boundary as clean.
+func TestCheckpointedScannerPrefixFrontierCatchesSuffixDelete(t *testing.T) {
+	source := []byte("def first():\n    return 111\n\ndef second():\n    return 2\n")
+	parser := gts.NewParser(grammars.PythonLanguage())
+	parser.SetAdmissionCandidateRoute(false)
+	oldTree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("old parse: %v", err)
+	}
+	defer oldTree.Release()
+	first := oldTree.RootNode().Child(0)
+	if first == nil || first.EndByte() == 0 {
+		t.Fatal("fixture has no first top-level child")
+	}
+	offset := int(first.EndByte()) - 1
+	if source[offset] < '0' || source[offset] > '9' {
+		t.Fatalf("first-child suffix byte=%q, want a digit", source[offset])
+	}
+	edited := append(append([]byte(nil), source[:offset]...), source[offset+1:]...)
+	edit := gts.InputEdit{
+		StartByte:   uint32(offset),
+		OldEndByte:  uint32(offset + 1),
+		NewEndByte:  uint32(offset),
+		StartPoint:  pointForOffset(source, offset),
+		OldEndPoint: pointForOffset(source, offset+1),
+		NewEndPoint: pointForOffset(edited, offset),
+	}
+	oldTree.Edit(edit)
+	incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatalf("suffix-delete incremental parse: %v", err)
+	}
+	defer incremental.Release()
+	if profile.ReuseUnsupportedReason != "external_scanner_prefix_frontier_unproven" ||
+		!profile.ReuseUnsupported || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+		t.Fatalf("suffix deletion bypassed frontier fallback: %+v", profile)
+	}
+	freshParser := gts.NewParser(grammars.PythonLanguage())
+	freshParser.SetAdmissionCandidateRoute(false)
+	fresh, err := freshParser.Parse(edited)
+	if err != nil {
+		t.Fatalf("suffix-delete fresh parse: %v", err)
+	}
+	defer fresh.Release()
+	requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, grammars.PythonLanguage())
+	if incremental.RootNode().HasError() != fresh.RootNode().HasError() {
+		t.Fatalf("suffix-delete error state differs: incremental=%t fresh=%t", incremental.RootNode().HasError(), fresh.RootNode().HasError())
+	}
+}
+
+// TestCheckpointedScannerPrefixFrontierMapsMultiEditHistory applies edits in
+// successive source coordinate spaces. It proves the first-child suffix
+// deletion cannot bypass the fallback after an earlier prefix deletion.
+func TestCheckpointedScannerPrefixFrontierMapsMultiEditHistory(t *testing.T) {
+	source := []byte("\n\ndef first():\n    return 111\n\ndef second():\n    return 2\n")
+	parser := gts.NewParser(grammars.PythonLanguage())
+	parser.SetAdmissionCandidateRoute(false)
+	oldTree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("multi-edit old parse: %v", err)
+	}
+	defer oldTree.Release()
+
+	withoutLeadingNewline := append([]byte(nil), source[1:]...)
+	leadingEdit := gts.InputEdit{
+		StartByte:   0,
+		OldEndByte:  1,
+		NewEndByte:  0,
+		StartPoint:  pointForOffset(source, 0),
+		OldEndPoint: pointForOffset(source, 1),
+		NewEndPoint: pointForOffset(withoutLeadingNewline, 0),
+	}
+	oldTree.Edit(leadingEdit)
+	first := oldTree.RootNode().Child(0)
+	if first == nil || first.EndByte() == 0 {
+		t.Fatal("multi-edit fixture has no first top-level child")
+	}
+	offset := int(first.EndByte()) - 1
+	if withoutLeadingNewline[offset] < '0' || withoutLeadingNewline[offset] > '9' {
+		t.Fatalf("multi-edit suffix byte=%q, want a digit", withoutLeadingNewline[offset])
+	}
+	edited := append(append([]byte(nil), withoutLeadingNewline[:offset]...), withoutLeadingNewline[offset+1:]...)
+	suffixEdit := gts.InputEdit{
+		StartByte:   uint32(offset),
+		OldEndByte:  uint32(offset + 1),
+		NewEndByte:  uint32(offset),
+		StartPoint:  pointForOffset(withoutLeadingNewline, offset),
+		OldEndPoint: pointForOffset(withoutLeadingNewline, offset+1),
+		NewEndPoint: pointForOffset(edited, offset),
+	}
+	oldTree.Edit(suffixEdit)
+	incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatalf("multi-edit incremental parse: %v", err)
+	}
+	defer incremental.Release()
+	if profile.ReuseUnsupportedReason != "external_scanner_prefix_frontier_unproven" ||
+		!profile.ReuseUnsupported || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+		t.Fatalf("multi-edit suffix deletion bypassed frontier fallback: %+v", profile)
+	}
+	freshParser := gts.NewParser(grammars.PythonLanguage())
+	freshParser.SetAdmissionCandidateRoute(false)
+	fresh, err := freshParser.Parse(edited)
+	if err != nil {
+		t.Fatalf("multi-edit fresh parse: %v", err)
+	}
+	defer fresh.Release()
+	requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, grammars.PythonLanguage())
+	if incremental.RootNode().HasError() != fresh.RootNode().HasError() {
+		t.Fatalf("multi-edit error state differs: incremental=%t fresh=%t", incremental.RootNode().HasError(), fresh.RootNode().HasError())
+	}
+}
+
+func replacePrefixFrontierWitness(t *testing.T, source, oldText, replacement []byte) ([]byte, gts.InputEdit) {
+	t.Helper()
+	offset := bytes.Index(source, oldText)
+	if offset < 0 {
+		t.Fatalf("fixture missing edit text %q", oldText)
+	}
+	oldEnd := offset + len(oldText)
+	edited := make([]byte, 0, len(source)-len(oldText)+len(replacement))
+	edited = append(edited, source[:offset]...)
+	edited = append(edited, replacement...)
+	edited = append(edited, source[oldEnd:]...)
+	return edited, gts.InputEdit{
+		StartByte:   uint32(offset),
+		OldEndByte:  uint32(oldEnd),
+		NewEndByte:  uint32(offset + len(replacement)),
+		StartPoint:  pointForOffset(source, offset),
+		OldEndPoint: pointForOffset(source, oldEnd),
+		NewEndPoint: pointForOffset(edited, offset+len(replacement)),
+	}
+}

--- a/parser_incremental_support.go
+++ b/parser_incremental_support.go
@@ -58,6 +58,7 @@ func (t *incrementalParseTiming) toProfile() IncrementalParseProfile {
 		ReuseRejectFragileNonLeaf:           t.reuseRejectFragileNonLeaf,
 		BlockSpliceSteps:                    t.blockSpliceSteps,
 		ReuseRejectScannerUnquiescent:       t.reuseRejectScannerUnquiescent,
+		ReuseRejectFrontierProofUnavailable: t.reuseRejectFrontierProofUnavailable,
 		RecoverSearches:                     t.recoverSearches,
 		RecoverStateChecks:                  t.recoverStateChecks,
 		RecoverStateSkips:                   t.recoverStateSkips,
@@ -166,6 +167,7 @@ func (t *incrementalParseTiming) addAttempt(other *incrementalParseTiming) {
 	t.reuseRejectFragileNonLeaf += other.reuseRejectFragileNonLeaf
 	t.blockSpliceSteps += other.blockSpliceSteps
 	t.reuseRejectScannerUnquiescent += other.reuseRejectScannerUnquiescent
+	t.reuseRejectFrontierProofUnavailable += other.reuseRejectFrontierProofUnavailable
 	t.recoverSearches += other.recoverSearches
 	t.recoverStateChecks += other.recoverStateChecks
 	t.recoverStateSkips += other.recoverStateSkips

--- a/parsercore_phase0_checkpoint_transfer_test.go
+++ b/parsercore_phase0_checkpoint_transfer_test.go
@@ -1,0 +1,59 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func TestCompactExternalScannerCheckpointTransferFailsClosed(t *testing.T) {
+	compact := &core.Core{}
+	arena := newNodeArena(arenaClassIncremental)
+	defer arena.Release()
+	node := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
+	view := core.MaterializationSubtreeView{
+		External:                       true,
+		Terminal:                       true,
+		ExternalScannerCheckpointExact: true,
+		ExternalScannerCheckpointStart: core.CheckpointID(1),
+		ExternalScannerCheckpointEnd:   core.CheckpointID(2),
+	}
+	beforeRecords := arena.externalScannerCheckpointRecords
+	beforeLeaves := arena.externalScannerCheckpointLeafNodes
+	if materializeCompactExternalScannerCheckpoint(compact, arena, node, view) {
+		t.Fatal("checkpoint transfer accepted missing core snapshots")
+	}
+	if arena.externalScannerCheckpointRecords != beforeRecords || arena.externalScannerCheckpointLeafNodes != beforeLeaves {
+		t.Fatalf("failed transfer changed checkpoint counters: records=%d/%d leaves=%d/%d", arena.externalScannerCheckpointRecords, beforeRecords, arena.externalScannerCheckpointLeafNodes, beforeLeaves)
+	}
+	if _, ok := externalScannerCheckpointRefForNode(node); ok {
+		t.Fatal("failed transfer left a usable node checkpoint")
+	}
+
+	foreignArena := newNodeArena(arenaClassIncremental)
+	defer foreignArena.Release()
+	foreignNode := newLeafNodeInArena(foreignArena, 1, true, 0, 1, Point{}, Point{Column: 1})
+	beforeSlots := arena.externalScannerCheckpointSlotsAllocated()
+	beforeBytes := arena.externalScannerCheckpointBytesAllocated()
+	beforePayload := arena.externalScannerSnapshotPayloadBytes
+	if materializeCompactExternalScannerCheckpoint(compact, arena, foreignNode, view) {
+		t.Fatal("checkpoint transfer accepted a node owned by another arena")
+	}
+	if arena.externalScannerCheckpointRecords != beforeRecords || arena.externalScannerCheckpointLeafNodes != beforeLeaves {
+		t.Fatalf("foreign-node transfer changed counters: records=%d/%d leaves=%d/%d", arena.externalScannerCheckpointRecords, beforeRecords, arena.externalScannerCheckpointLeafNodes, beforeLeaves)
+	}
+	if got := arena.externalScannerCheckpointSlotsAllocated(); got != beforeSlots {
+		t.Fatalf("foreign-node transfer allocated checkpoint slots: %d/%d", got, beforeSlots)
+	}
+	if got := arena.externalScannerCheckpointBytesAllocated(); got != beforeBytes {
+		t.Fatalf("foreign-node transfer allocated checkpoint bytes: %d/%d", got, beforeBytes)
+	}
+	if got := arena.externalScannerSnapshotPayloadBytes; got != beforePayload {
+		t.Fatalf("foreign-node transfer allocated snapshot payload: %d/%d", got, beforePayload)
+	}
+	if _, ok := externalScannerCheckpointRefForNode(foreignNode); ok {
+		t.Fatal("foreign-node transfer left a usable checkpoint")
+	}
+}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -6750,6 +6750,32 @@ func diagnosticParserCoreGapIsToleratedWithPoll(gap []byte, poll func() error) (
 	return true, nil
 }
 
+// materializeCompactExternalScannerCheckpoint copies the core-owned scanner
+// snapshots into the public arena. Core checkpoint IDs are not valid after
+// materialization, so retain only byte copies in the node sidecar.
+// It returns false unless the complete scanner provenance pair is attached.
+func materializeCompactExternalScannerCheckpoint(compact *core.Core, arena *nodeArena, node *Node, view core.MaterializationSubtreeView) bool {
+	if compact == nil || arena == nil || node == nil || node.ownerArena != arena || !view.ExternalScannerCheckpointExact ||
+		view.ExternalScannerCheckpointStart == 0 || view.ExternalScannerCheckpointEnd == 0 {
+		return false
+	}
+	start, startOK := compact.CopyCheckpointBytes(view.ExternalScannerCheckpointStart, nil)
+	end, endOK := compact.CopyCheckpointBytes(view.ExternalScannerCheckpointEnd, nil)
+	if !startOK || !endOK {
+		return false
+	}
+	checkpoint := arena.recordExternalScannerCompactCheckpoint(start, end)
+	if !externalScannerCheckpointRefComplete(checkpoint) {
+		return false
+	}
+	if arena.setExternalScannerCheckpoint(node, checkpoint) {
+		arena.externalScannerCheckpointLeafNodes++
+		arena.externalScannerCheckpointRecords++
+		return true
+	}
+	return false
+}
+
 // materializeDiagnosticParserCoreAcceptedSelection materializes the accepted
 // compact derivation into a public tree. When scratch is non-nil the runner's
 // reusable buffers back the transient materialization storage, so the warm
@@ -6788,6 +6814,16 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 	}
 
 	arena := acquireNodeArena(arenaClassFull)
+	// Compact external-token provenance is transferred into this arena below.
+	// Set the language identity before publishing the first checkpoint so the
+	// incremental reuse gate can authenticate the copied snapshots.
+	scannerProvenanceTransferProven := true
+	if languageUsesExternalScannerCheckpoints(parser.language) {
+		_, identityRequired, identityValid := externalScannerCheckpointIdentityStatus(parser.language)
+		if identityRequired {
+			scannerProvenanceTransferProven = identityValid && arena.setExternalScannerCheckpointIdentityForLanguage(parser.language)
+		}
+	}
 	owned := true
 	defer func() {
 		if owned {
@@ -6943,6 +6979,10 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 					arena, Symbol(view.Symbol), named, view.StartByte, view.EndByte,
 					points.point(view.StartByte), points.point(view.EndByte),
 				)
+				if languageUsesExternalScannerCheckpoints(parser.language) && view.External && view.Terminal &&
+					!materializeCompactExternalScannerCheckpoint(compact, arena, node, view) {
+					scannerProvenanceTransferProven = false
+				}
 				node.setExtra(view.Extra)
 				node.setExternalScannerToken(view.External)
 				// S5 recovery: a recovery-inserted MISSING terminal
@@ -7276,11 +7316,23 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 	}
 	// A recover_eof result carries an EOF runtime for the original source.
 	// Never let an edited copy enter incremental reuse with that stale boundary.
-	tree.incrementalReuseDisabled = rootFinalization == diagnosticParserCoreFinalizeRecoverEOF || !incrementalReuseProven
+	tree.incrementalReuseDisabled = rootFinalization == diagnosticParserCoreFinalizeRecoverEOF ||
+		!incrementalReuseProven || !scannerProvenanceTransferProven
 	tree.compactMaterialized = true
 	tree.setParseRuntime(ParseRuntime{
-		StopReason: ParseStopAccepted, SourceLen: sourceLen, ExpectedEOFByte: sourceLen,
-		RootEndByte: root.endByte, LastTokenEndByte: sourceLen, LastTokenSymbol: 0, LastTokenWasEOF: true,
+		StopReason:                                     ParseStopAccepted,
+		SourceLen:                                      sourceLen,
+		ExpectedEOFByte:                                sourceLen,
+		RootEndByte:                                    root.endByte,
+		LastTokenEndByte:                               sourceLen,
+		LastTokenSymbol:                                0,
+		LastTokenWasEOF:                                true,
+		ExternalScannerCheckpointRecords:               arena.externalScannerCheckpointRecords,
+		ExternalScannerCheckpointSlotsAllocated:        arena.externalScannerCheckpointSlotsAllocated(),
+		ExternalScannerCheckpointBytesAllocated:        arena.externalScannerCheckpointBytesAllocated(),
+		ExternalScannerSnapshotBytesAllocated:          arena.externalScannerSnapshotPayloadBytes,
+		ExternalScannerCheckpointLeafNodes:             arena.externalScannerCheckpointLeafNodes,
+		CompactExternalScannerCheckpointTransferProven: scannerProvenanceTransferProven,
 	})
 	return tree, nil
 }

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -999,9 +999,15 @@ func diagnosticParserCoreInternCheckpoint(compact *core.Core, bytes []byte) (cor
 	return id, DiagnosticParserCoreScannerCheckpoint{Length: int(length), SHA256: digest}, nil
 }
 
-func certifyParserCoreExternalPayloadQuiescence(compact *core.Core, lang *Language) {
-	if compact != nil && classifyExternalScannerQuiescence(lang) == scannerQuiescenceProven {
+func configureParserCoreScannerProvenance(compact *core.Core, lang *Language) {
+	if compact == nil {
+		return
+	}
+	if classifyExternalScannerQuiescence(lang) == scannerQuiescenceProven {
 		compact.CertifyExternalPayloadsQuiescent()
+	}
+	if languageUsesExternalScannerCheckpoints(lang) {
+		compact.EnableTerminalScannerCheckpointProvenance()
 	}
 }
 
@@ -1044,7 +1050,7 @@ func DiagnosticParseParserCorePrefix(scanner ExternalScanner, source []byte, opt
 	if err != nil {
 		return result, err
 	}
-	certifyParserCoreExternalPayloadQuiescence(compact, lang)
+	configureParserCoreScannerProvenance(compact, lang)
 	tokenSource := parser.acquireParserDFATokenSource(source)
 	if tokenSource == nil {
 		return result, errors.New("parser-core phase zero: production DFA unavailable")
@@ -6750,9 +6756,9 @@ func diagnosticParserCoreGapIsToleratedWithPoll(gap []byte, poll func() error) (
 	return true, nil
 }
 
-// materializeCompactExternalScannerCheckpoint copies the core-owned scanner
-// snapshots into the public arena. Core checkpoint IDs are not valid after
-// materialization, so retain only byte copies in the node sidecar.
+// materializeCompactExternalScannerCheckpoint copies one terminal's core-owned
+// scanner snapshots into the public arena. Core checkpoint IDs are not valid
+// after materialization, so retain only byte copies in the node sidecar.
 // It returns false unless the complete scanner provenance pair is attached.
 func materializeCompactExternalScannerCheckpoint(compact *core.Core, arena *nodeArena, node *Node, view core.MaterializationSubtreeView) bool {
 	if compact == nil || arena == nil || node == nil || node.ownerArena != arena || !view.ExternalScannerCheckpointExact ||
@@ -6979,7 +6985,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 					arena, Symbol(view.Symbol), named, view.StartByte, view.EndByte,
 					points.point(view.StartByte), points.point(view.EndByte),
 				)
-				if languageUsesExternalScannerCheckpoints(parser.language) && view.External && view.Terminal &&
+				if languageUsesExternalScannerCheckpoints(parser.language) && view.Terminal &&
 					!materializeCompactExternalScannerCheckpoint(compact, arena, node, view) {
 					scannerProvenanceTransferProven = false
 				}

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -98,7 +98,7 @@ func newParserCoreFreshFullRunner(scanner ExternalScanner, options DiagnosticPar
 	if err != nil {
 		return nil, err
 	}
-	certifyParserCoreExternalPayloadQuiescence(compact, lang)
+	configureParserCoreScannerProvenance(compact, lang)
 	return &parserCoreFreshFullRunner{
 		lang: lang, parser: parser, tables: tables, compact: compact, options: options,
 		allowConvergedReductionSplitDrops: true,

--- a/scanner_closure_external_test.go
+++ b/scanner_closure_external_test.go
@@ -9,12 +9,10 @@ import (
 	"github.com/odvcencio/gotreesitter/grammars"
 )
 
-// TestStatefulScannerCompactLeafReauthenticationFailsClosed exercises the real
-// compact candidate route. Python's scanner retains indentation and delimiter
-// stacks, so its compact tree remains reuse-disabled until scanner checkpoint
-// restoration is certified. A same-length leaf edit must therefore decline the
-// compact reauthentication route and return the exact forced-production tree.
-func TestStatefulScannerCompactLeafReauthenticationFailsClosed(t *testing.T) {
+// TestStatefulScannerCompactLeafReauthentication exercises the real compact
+// candidate route. Python's scanner retains indentation and delimiter stacks,
+// so a same-length leaf edit must pass the checkpoint reauthentication gate.
+func TestStatefulScannerCompactLeafReauthentication(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		source []byte
@@ -74,8 +72,8 @@ func TestStatefulScannerCompactLeafReauthenticationFailsClosed(t *testing.T) {
 				t.Fatalf("incremental parse: %v", err)
 			}
 			defer incremental.Release()
-			if !profile.ReuseUnsupported || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 || profile.ReparseNanos == 0 {
-				t.Fatalf("stateful compact tree entered reuse despite missing proof: %+v", profile)
+			if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+				t.Fatalf("stateful compact tree did not reauthenticate scanner checkpoints: %+v", profile)
 			}
 
 			freshParser := gotreesitter.NewParser(lang)

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "e1de4484b5655ab11057f70d9dc7b1245972d03f",
+  "source_revision": "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -970,16 +970,22 @@
       "control_ids": ["build.default", "build.compact.default", "build.incremental.phase0", "build.selectedstore.onepass", "build.parity.cgo", "env.GTS_CANONICAL_GO_INCREMENTAL", "env.GTS_CANONICAL_INCREMENTAL_RECEIPT_OUT", "env.GOT_PARSE_MEMORY_BUDGET_MB", "env.GOT_PARSE_PROGRESS"],
       "paths": [
         {"path": "incremental.go", "role": "implementation", "build_expression": "default", "symbol": "tryReuseSubtree"},
+        {"path": "external_scanner_adapter.go", "role": "implementation", "build_expression": "default", "symbol": "RequiresIncrementalPrefixFrontierProof"},
+        {"path": "external_scanner_checkpoints.go", "role": "implementation", "build_expression": "default", "symbol": "rebuildExternalScannerCheckpointForNode"},
         {"path": "language.go", "role": "implementation", "build_expression": "default", "symbol": "IncrementalPrefixFrontierExternalScanner"},
         {"path": "parser_api.go", "role": "implementation", "build_expression": "default", "symbol": "checkpointedScannerPrefixFrontierUnproven"},
         {"path": "parser_result_incremental_range.go", "role": "implementation", "build_expression": "default", "symbol": "incrementalReparsedTopLevelRanges"},
         {"path": "external_scanner_checkpoints_test.go", "role": "proof", "build_expression": "default", "symbol": "TestExternalScannerCheckpointCapabilitiesAreBehaviorBased"},
+        {"path": "external_scanner_checkpoints_test.go", "role": "proof", "build_expression": "default", "symbol": "TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots"},
+        {"path": "external_scanner_adapter_test.go", "role": "proof", "build_expression": "default", "symbol": "TestExternalScannerOrderAdapterPreservesOptionalCapabilities"},
         {"path": "grammars/python_parse_regression_test.go", "role": "proof", "build_expression": "default", "symbol": "TestPythonScannerSerializationFailsClosed"},
         {"path": "incremental_invariant_gate_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestIncrementalInvariantGatePython"},
         {"path": "w1_block_splice_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW1BlockSpliceOracleEquality"},
         {"path": "w1_leading_splice_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestLeadingSpliceOracleEqualityMiddleBottom"},
         {"path": "w1b_reduce_settle_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW1BSettleUnlocksGoTopLevelSiblingSplice"},
         {"path": "parser_go_scanner_quiescence_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestGoScannerQuiescenceOracleSweep"},
+        {"path": "issue728_incremental_reuse_regression_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestIssue728IncrementalReuseMeasurement"},
+        {"path": "parser_external_scanner_incremental_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestExternalScannerDerivedSameLengthTokenChangeInvalidatesScannerReuse"},
         {"path": "parser_external_scanner_prefix_frontier_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestCheckpointedScannerPrefixFrontierFallback"},
         {"path": "parser_external_scanner_prefix_frontier_compact_test.go", "role": "adversarial_test", "build_expression": "gts_parsercorephase0", "symbol": "TestCompactCheckpointedScannerPrefixFrontierFallbackAvoidsCandidateWalk"},
         {"path": "w5_editor_latency_gate_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW5EditorLatencyGate"},
@@ -987,12 +993,15 @@
         {"path": "parsercore_phase0_checkpoint_transfer_test.go", "role": "proof", "build_expression": "!gts_no_parsercorephase0", "symbol": "TestCompactExternalScannerCheckpointTransferFailsClosed"},
         {"path": "scanner_closure_external_test.go", "role": "proof", "build_expression": "gts_parsercorephase0", "symbol": "TestStatefulScannerCompactLeafReauthentication"},
         {"path": "cgo_harness/benchmark_go_canonical_incremental_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity", "symbol": "TestCanonicalGoIncrementalParity"},
-        {"path": "cgo_harness/stage5_compact_incremental_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity && !gts_no_parsercorephase0", "symbol": "TestStage5CompactPythonScannerCheckpointReuse"}
+        {"path": "cgo_harness/stage5_compact_incremental_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity && !gts_no_parsercorephase0", "symbol": "TestStage5CompactPythonScannerCheckpointReuse"},
+        {"path": "cgo_harness/stage5_compact_incremental_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity && !gts_no_parsercorephase0", "symbol": "TestStage5PythonPrefixFrontierAdversarialParity"}
       ],
       "test_commands": [
         {"name": "incremental invariant gate", "command": "go test -run '^TestIncrementalInvariantGate(Python|JavaScript|JSON|Go|Rust|CSS|C)$' -count=1 .", "working_dir": ".", "isolation": "local"},
         {"name": "O(edit) splice proofs", "command": "go test -run '^(TestW1|TestW1B|TestLeadingSplice|TestGoScannerQuiescenceOracleSweep|TestW5)' -count=1 .", "working_dir": ".", "isolation": "local"},
         {"name": "compact ParseState replay", "command": "go test -tags 'gts_parsercorephase0' -run '^TestParseStateReplayCompactDifferential$' -count=1 .", "working_dir": ".", "isolation": "local"},
+        {"name": "scanner frontier safety", "command": "go test . -run '^(TestExternalScannerOrderAdapterPreservesOptionalCapabilities|TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots|TestCheckpointedScannerPrefixFrontierFallback|TestPythonDerivedTokenInvariantLeafReusePrecedesScannerFallback|TestExternalScannerDerivedSameLengthTokenChangeInvalidatesScannerReuse)$' -count=1", "working_dir": ".", "isolation": "docker"},
+        {"name": "SQL scanner reuse preservation", "command": "go test . -run '^TestIssue728IncrementalReuseMeasurement$/^sql/' -count=1", "working_dir": ".", "isolation": "docker"},
         {"name": "Python scanner serialization", "command": "go test ./grammars -run '^TestPythonScannerSerialization(RecomputesInterpolatedStringState|FailsClosed)$' -count=1", "working_dir": ".", "isolation": "docker"},
         {"name": "compact scanner ownership proofs", "command": "go test -tags 'gts_parsercorephase0' -run '^(TestCompactExternalScannerCheckpointTransferFailsClosed|TestCompactCheckpointedScannerPrefixFrontierFallbackAvoidsCandidateWalk|TestStatefulScannerCompactLeafReauthentication)$' -count=1 .", "working_dir": ".", "isolation": "docker"},
         {"name": "locked four-way incremental parity", "command": "go test . -tags 'cgo treesitter_c_parity' -run '^TestCanonicalGoIncrementalParity$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"},
@@ -1010,7 +1019,7 @@
         {"id": "python-scanner-wide-indent", "kind": "synthetic_fixture", "path": "cgo_harness/stage5_compact_incremental_test.go", "source": "Python indentation widths 65535, 65536, and 131072 with forward and reverse edits.", "lock_or_digest": "exact locked-C trees, ranges, errors, reuse routes, and fallback telemetry at 5070ffd4594a819e8ebe78fa2bf651c197cbdce4"},
         {"id": "incremental-allowlist", "kind": "policy_lock", "path": "testdata/incremental_allowlist.json", "source_sha256": "58e96c69a23675b1b666789306e93fe3ce3756b2976cfb32fea9fc544229b810", "lock_or_digest": "ratchet entries must reproduce or be removed after confirmed fixes"}
       ],
-      "gates": ["fresh and incremental trees are structurally identical", "edits invalidate the correct version state", "scanner boundaries remain quiescent or fail closed", "unrelated certified scanners retain reuse", "reuse counters remain deterministic and nonzero where expected", "hot Parser and ParseRuntime layouts do not grow", "incremental memory and fallback budgets pass"],
+      "gates": ["fresh and incremental trees are structurally identical", "edits invalidate the correct version state", "scanner boundaries remain quiescent or fail closed", "rebuilt checkpoints copy snapshots into the destination arena", "unrelated certified scanners retain reuse", "reuse counters remain deterministic and nonzero where expected", "hot Parser and ParseRuntime layouts do not grow", "incremental memory and fallback budgets pass"],
       "telemetry": ["IncrementalParseProfile.ReusedBytes", "NewNodesAllocated", "ReuseRejectRootNonLeafChanged", "ReuseRejectScannerUnquiescent", "ReuseRejectFrontierProofUnavailable", "CompactExternalScannerCheckpointTransferProven", "BlockSpliceSteps", "ParseState replay receipt"],
       "plan_refs": [],
       "proof_receipts": [
@@ -1019,6 +1028,8 @@
         {"ref": "cgo_harness/stage5_compact_incremental_test.go#TestStage5CompactPythonScannerCheckpointReuse", "kind": "test", "source_revision": "5070ffd4594a819e8ebe78fa2bf651c197cbdce4", "status": "current"},
         {"ref": "cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonWideIndentTransitionParity", "kind": "test", "source_revision": "5070ffd4594a819e8ebe78fa2bf651c197cbdce4", "status": "current"},
         {"ref": "parser_external_scanner_prefix_frontier_test.go#TestCheckpointedScannerWithoutPrefixFrontierRequirementKeepsReuse", "kind": "test", "source_revision": "e1de4484b5655ab11057f70d9dc7b1245972d03f", "status": "current"},
+        {"ref": "external_scanner_checkpoints_test.go#TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots", "kind": "test", "source_revision": "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a", "status": "current"},
+        {"ref": "cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity", "kind": "test", "source_revision": "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a", "status": "current"},
         {"ref": "testdata/incremental_allowlist.json", "kind": "policy", "source_revision": "95a1d13156b82e2221415342c9ac8048f2caf644", "status": "current"}
       ],
       "deletion_condition": "Delete temporary O(edit) experiments only after canonical C parity, edit invalidation, exact tree, reuse, race, and memory receipts pass.",

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "72afa041e9ec2f02872724bbdce17694d89955d8",
+  "source_revision": "5070ffd4594a819e8ebe78fa2bf651c197cbdce4",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -120,7 +120,7 @@
       "expression": "default",
       "scope": "production",
       "read_sites": [
-        {"path": "incremental.go", "symbol": "tryReuseSubtree", "line": 612},
+        {"path": "incremental.go", "symbol": "tryReuseSubtree", "line": 636},
         {"path": "incremental_invariant_gate_test.go", "symbol": "TestIncrementalInvariantGate", "line": 192}
       ]
     },
@@ -960,24 +960,36 @@
       "owner": "incremental_edit_reuse",
       "campaigns": ["spec.campaign.oedit", "spec.campaign.post-admission-frontier", "spec.parser-graduation.v1#8.1"],
       "purpose": "Invalidate the correct version state after edits while preserving exact trees, scanner safety, reuse, and deterministic counters.",
-      "build_expressions": ["default", "!gts_no_parsercorephase0", "gts_parsercorephase0", "cgo && treesitter_c_parity"],
+      "build_expressions": [
+        "default",
+        "!gts_no_parsercorephase0",
+        "gts_parsercorephase0",
+        "cgo && treesitter_c_parity",
+        "cgo && treesitter_c_parity && !gts_no_parsercorephase0"
+      ],
       "control_ids": ["build.default", "build.compact.default", "build.incremental.phase0", "build.selectedstore.onepass", "build.parity.cgo", "env.GTS_CANONICAL_GO_INCREMENTAL", "env.GTS_CANONICAL_INCREMENTAL_RECEIPT_OUT", "env.GOT_PARSE_MEMORY_BUDGET_MB", "env.GOT_PARSE_PROGRESS"],
       "paths": [
         {"path": "incremental.go", "role": "implementation", "build_expression": "default", "symbol": "tryReuseSubtree"},
+        {"path": "parser_api.go", "role": "implementation", "build_expression": "default", "symbol": "checkpointedScannerPrefixFrontierUnproven"},
         {"path": "parser_result_incremental_range.go", "role": "implementation", "build_expression": "default", "symbol": "incrementalReparsedTopLevelRanges"},
         {"path": "incremental_invariant_gate_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestIncrementalInvariantGatePython"},
         {"path": "w1_block_splice_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW1BlockSpliceOracleEquality"},
         {"path": "w1_leading_splice_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestLeadingSpliceOracleEqualityMiddleBottom"},
         {"path": "w1b_reduce_settle_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW1BSettleUnlocksGoTopLevelSiblingSplice"},
         {"path": "parser_go_scanner_quiescence_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestGoScannerQuiescenceOracleSweep"},
+        {"path": "parser_external_scanner_prefix_frontier_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestCheckpointedScannerPrefixFrontierFallback"},
         {"path": "w5_editor_latency_gate_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW5EditorLatencyGate"},
-        {"path": "parsestate_replay_compact_diff_test.go", "role": "proof", "build_expression": "gts_parsercorephase0", "symbol": "TestParseStateReplayCompactDifferential"}
+        {"path": "parsestate_replay_compact_diff_test.go", "role": "proof", "build_expression": "gts_parsercorephase0", "symbol": "TestParseStateReplayCompactDifferential"},
+        {"path": "parsercore_phase0_checkpoint_transfer_test.go", "role": "proof", "build_expression": "!gts_no_parsercorephase0", "symbol": "TestCompactExternalScannerCheckpointTransferFailsClosed"},
+        {"path": "cgo_harness/stage5_compact_incremental_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity && !gts_no_parsercorephase0", "symbol": "TestStage5CompactPythonScannerCheckpointReuse"}
       ],
       "test_commands": [
         {"name": "incremental invariant gate", "command": "go test -run '^TestIncrementalInvariantGate(Python|JavaScript|JSON|Go|Rust|CSS|C)$' -count=1 .", "working_dir": ".", "isolation": "local"},
         {"name": "O(edit) splice proofs", "command": "go test -run '^(TestW1|TestW1B|TestLeadingSplice|TestGoScannerQuiescenceOracleSweep|TestW5)' -count=1 .", "working_dir": ".", "isolation": "local"},
         {"name": "compact ParseState replay", "command": "go test -tags 'gts_parsercorephase0' -run '^TestParseStateReplayCompactDifferential$' -count=1 .", "working_dir": ".", "isolation": "local"},
-        {"name": "locked four-way incremental parity", "command": "go test . -tags 'cgo treesitter_c_parity' -run '^TestCanonicalGoIncrementalParity$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+        {"name": "compact scanner ownership proofs", "command": "go test -tags 'gts_parsercorephase0' -run '^(TestCompactExternalScannerCheckpointTransferFailsClosed|TestCompactCheckpointedScannerPrefixFrontierFallbackAvoidsCandidateWalk|TestStatefulScannerCompactLeafReauthentication)$' -count=1 .", "working_dir": ".", "isolation": "docker"},
+        {"name": "locked four-way incremental parity", "command": "go test . -tags 'cgo treesitter_c_parity' -run '^TestCanonicalGoIncrementalParity$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"},
+        {"name": "Python scanner locked-C parity", "command": "go test . -tags 'cgo treesitter_c_parity' -run '^TestStage5' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
       ],
       "corpus": [
         {"id": "python", "kind": "incremental_fixture", "path": "testdata/incremental_gate/python_setup.py", "lock_or_digest": "source tree at 72afa041e9ec2f02872724bbdce17694d89955d8"},
@@ -988,14 +1000,17 @@
         {"id": "rust", "kind": "incremental_fixture", "path": "testdata/incremental_gate/rust_ast.rs", "lock_or_digest": "source tree at 72afa041e9ec2f02872724bbdce17694d89955d8"},
         {"id": "css", "kind": "incremental_fixture", "path": "testdata/incremental_gate/css_stylesheet.css", "lock_or_digest": "source tree at 72afa041e9ec2f02872724bbdce17694d89955d8"},
         {"id": "c", "kind": "incremental_fixture", "path": "testdata/incremental_gate/c_repeated_functions.c", "lock_or_digest": "source tree at 72afa041e9ec2f02872724bbdce17694d89955d8"},
+        {"id": "python-scanner-wide-indent", "kind": "synthetic_fixture", "path": "cgo_harness/stage5_compact_incremental_test.go", "source": "Python indentation widths 65535, 65536, and 131072 with forward and reverse edits.", "lock_or_digest": "exact locked-C trees, ranges, errors, reuse routes, and fallback telemetry at 5070ffd4594a819e8ebe78fa2bf651c197cbdce4"},
         {"id": "incremental-allowlist", "kind": "policy_lock", "path": "testdata/incremental_allowlist.json", "source_sha256": "58e96c69a23675b1b666789306e93fe3ce3756b2976cfb32fea9fc544229b810", "lock_or_digest": "ratchet entries must reproduce or be removed after confirmed fixes"}
       ],
       "gates": ["fresh and incremental trees are structurally identical", "edits invalidate the correct version state", "scanner boundaries remain quiescent or fail closed", "reuse counters remain deterministic and nonzero where expected", "incremental memory and fallback budgets pass"],
-      "telemetry": ["IncrementalParseProfile.ReusedBytes", "NewNodesAllocated", "ReuseRejectRootNonLeafChanged", "ReuseRejectScannerUnquiescent", "BlockSpliceSteps", "ParseState replay receipt"],
+      "telemetry": ["IncrementalParseProfile.ReusedBytes", "NewNodesAllocated", "ReuseRejectRootNonLeafChanged", "ReuseRejectScannerUnquiescent", "ReuseRejectFrontierProofUnavailable", "CompactExternalScannerCheckpointTransferProven", "BlockSpliceSteps", "ParseState replay receipt"],
       "plan_refs": [],
       "proof_receipts": [
         {"ref": "incremental_invariant_gate_test.go#TestIncrementalInvariantGatePython", "kind": "test", "source_revision": "bf7ab0567122e863ef831e8aa56dbee93127ad93", "status": "current"},
         {"ref": "w5_editor_latency_gate_test.go#TestW5EditorLatencyGate", "kind": "test", "source_revision": "e734c93543654818082e8d3ae3721cdb6fe9e4a5", "status": "current"},
+        {"ref": "cgo_harness/stage5_compact_incremental_test.go#TestStage5CompactPythonScannerCheckpointReuse", "kind": "test", "source_revision": "5070ffd4594a819e8ebe78fa2bf651c197cbdce4", "status": "current"},
+        {"ref": "cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonWideIndentTransitionParity", "kind": "test", "source_revision": "5070ffd4594a819e8ebe78fa2bf651c197cbdce4", "status": "current"},
         {"ref": "testdata/incremental_allowlist.json", "kind": "policy", "source_revision": "95a1d13156b82e2221415342c9ac8048f2caf644", "status": "current"}
       ],
       "deletion_condition": "Delete temporary O(edit) experiments only after canonical C parity, edit invalidation, exact tree, reuse, race, and memory receipts pass.",

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "5070ffd4594a819e8ebe78fa2bf651c197cbdce4",
+  "source_revision": "e1de4484b5655ab11057f70d9dc7b1245972d03f",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -970,23 +970,30 @@
       "control_ids": ["build.default", "build.compact.default", "build.incremental.phase0", "build.selectedstore.onepass", "build.parity.cgo", "env.GTS_CANONICAL_GO_INCREMENTAL", "env.GTS_CANONICAL_INCREMENTAL_RECEIPT_OUT", "env.GOT_PARSE_MEMORY_BUDGET_MB", "env.GOT_PARSE_PROGRESS"],
       "paths": [
         {"path": "incremental.go", "role": "implementation", "build_expression": "default", "symbol": "tryReuseSubtree"},
+        {"path": "language.go", "role": "implementation", "build_expression": "default", "symbol": "IncrementalPrefixFrontierExternalScanner"},
         {"path": "parser_api.go", "role": "implementation", "build_expression": "default", "symbol": "checkpointedScannerPrefixFrontierUnproven"},
         {"path": "parser_result_incremental_range.go", "role": "implementation", "build_expression": "default", "symbol": "incrementalReparsedTopLevelRanges"},
+        {"path": "external_scanner_checkpoints_test.go", "role": "proof", "build_expression": "default", "symbol": "TestExternalScannerCheckpointCapabilitiesAreBehaviorBased"},
+        {"path": "grammars/python_parse_regression_test.go", "role": "proof", "build_expression": "default", "symbol": "TestPythonScannerSerializationFailsClosed"},
         {"path": "incremental_invariant_gate_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestIncrementalInvariantGatePython"},
         {"path": "w1_block_splice_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW1BlockSpliceOracleEquality"},
         {"path": "w1_leading_splice_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestLeadingSpliceOracleEqualityMiddleBottom"},
         {"path": "w1b_reduce_settle_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW1BSettleUnlocksGoTopLevelSiblingSplice"},
         {"path": "parser_go_scanner_quiescence_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestGoScannerQuiescenceOracleSweep"},
         {"path": "parser_external_scanner_prefix_frontier_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestCheckpointedScannerPrefixFrontierFallback"},
+        {"path": "parser_external_scanner_prefix_frontier_compact_test.go", "role": "adversarial_test", "build_expression": "gts_parsercorephase0", "symbol": "TestCompactCheckpointedScannerPrefixFrontierFallbackAvoidsCandidateWalk"},
         {"path": "w5_editor_latency_gate_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW5EditorLatencyGate"},
         {"path": "parsestate_replay_compact_diff_test.go", "role": "proof", "build_expression": "gts_parsercorephase0", "symbol": "TestParseStateReplayCompactDifferential"},
         {"path": "parsercore_phase0_checkpoint_transfer_test.go", "role": "proof", "build_expression": "!gts_no_parsercorephase0", "symbol": "TestCompactExternalScannerCheckpointTransferFailsClosed"},
+        {"path": "scanner_closure_external_test.go", "role": "proof", "build_expression": "gts_parsercorephase0", "symbol": "TestStatefulScannerCompactLeafReauthentication"},
+        {"path": "cgo_harness/benchmark_go_canonical_incremental_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity", "symbol": "TestCanonicalGoIncrementalParity"},
         {"path": "cgo_harness/stage5_compact_incremental_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity && !gts_no_parsercorephase0", "symbol": "TestStage5CompactPythonScannerCheckpointReuse"}
       ],
       "test_commands": [
         {"name": "incremental invariant gate", "command": "go test -run '^TestIncrementalInvariantGate(Python|JavaScript|JSON|Go|Rust|CSS|C)$' -count=1 .", "working_dir": ".", "isolation": "local"},
         {"name": "O(edit) splice proofs", "command": "go test -run '^(TestW1|TestW1B|TestLeadingSplice|TestGoScannerQuiescenceOracleSweep|TestW5)' -count=1 .", "working_dir": ".", "isolation": "local"},
         {"name": "compact ParseState replay", "command": "go test -tags 'gts_parsercorephase0' -run '^TestParseStateReplayCompactDifferential$' -count=1 .", "working_dir": ".", "isolation": "local"},
+        {"name": "Python scanner serialization", "command": "go test ./grammars -run '^TestPythonScannerSerialization(RecomputesInterpolatedStringState|FailsClosed)$' -count=1", "working_dir": ".", "isolation": "docker"},
         {"name": "compact scanner ownership proofs", "command": "go test -tags 'gts_parsercorephase0' -run '^(TestCompactExternalScannerCheckpointTransferFailsClosed|TestCompactCheckpointedScannerPrefixFrontierFallbackAvoidsCandidateWalk|TestStatefulScannerCompactLeafReauthentication)$' -count=1 .", "working_dir": ".", "isolation": "docker"},
         {"name": "locked four-way incremental parity", "command": "go test . -tags 'cgo treesitter_c_parity' -run '^TestCanonicalGoIncrementalParity$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"},
         {"name": "Python scanner locked-C parity", "command": "go test . -tags 'cgo treesitter_c_parity' -run '^TestStage5' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
@@ -1003,7 +1010,7 @@
         {"id": "python-scanner-wide-indent", "kind": "synthetic_fixture", "path": "cgo_harness/stage5_compact_incremental_test.go", "source": "Python indentation widths 65535, 65536, and 131072 with forward and reverse edits.", "lock_or_digest": "exact locked-C trees, ranges, errors, reuse routes, and fallback telemetry at 5070ffd4594a819e8ebe78fa2bf651c197cbdce4"},
         {"id": "incremental-allowlist", "kind": "policy_lock", "path": "testdata/incremental_allowlist.json", "source_sha256": "58e96c69a23675b1b666789306e93fe3ce3756b2976cfb32fea9fc544229b810", "lock_or_digest": "ratchet entries must reproduce or be removed after confirmed fixes"}
       ],
-      "gates": ["fresh and incremental trees are structurally identical", "edits invalidate the correct version state", "scanner boundaries remain quiescent or fail closed", "reuse counters remain deterministic and nonzero where expected", "incremental memory and fallback budgets pass"],
+      "gates": ["fresh and incremental trees are structurally identical", "edits invalidate the correct version state", "scanner boundaries remain quiescent or fail closed", "unrelated certified scanners retain reuse", "reuse counters remain deterministic and nonzero where expected", "hot Parser and ParseRuntime layouts do not grow", "incremental memory and fallback budgets pass"],
       "telemetry": ["IncrementalParseProfile.ReusedBytes", "NewNodesAllocated", "ReuseRejectRootNonLeafChanged", "ReuseRejectScannerUnquiescent", "ReuseRejectFrontierProofUnavailable", "CompactExternalScannerCheckpointTransferProven", "BlockSpliceSteps", "ParseState replay receipt"],
       "plan_refs": [],
       "proof_receipts": [
@@ -1011,6 +1018,7 @@
         {"ref": "w5_editor_latency_gate_test.go#TestW5EditorLatencyGate", "kind": "test", "source_revision": "e734c93543654818082e8d3ae3721cdb6fe9e4a5", "status": "current"},
         {"ref": "cgo_harness/stage5_compact_incremental_test.go#TestStage5CompactPythonScannerCheckpointReuse", "kind": "test", "source_revision": "5070ffd4594a819e8ebe78fa2bf651c197cbdce4", "status": "current"},
         {"ref": "cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonWideIndentTransitionParity", "kind": "test", "source_revision": "5070ffd4594a819e8ebe78fa2bf651c197cbdce4", "status": "current"},
+        {"ref": "parser_external_scanner_prefix_frontier_test.go#TestCheckpointedScannerWithoutPrefixFrontierRequirementKeepsReuse", "kind": "test", "source_revision": "e1de4484b5655ab11057f70d9dc7b1245972d03f", "status": "current"},
         {"ref": "testdata/incremental_allowlist.json", "kind": "policy", "source_revision": "95a1d13156b82e2221415342c9ac8048f2caf644", "status": "current"}
       ],
       "deletion_condition": "Delete temporary O(edit) experiments only after canonical C parity, edit invalidation, exact tree, reuse, race, and memory receipts pass.",

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "425ffdc2eb919b82b38484a0b3a2107d5c7341f1",
+  "source_revision": "0d6683a465c6d20477c6a16b6b1f70ac2a90e87b",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -975,6 +975,9 @@
         {"path": "language.go", "role": "implementation", "build_expression": "default", "symbol": "IncrementalPrefixFrontierExternalScanner"},
         {"path": "parser_api.go", "role": "implementation", "build_expression": "default", "symbol": "checkpointedScannerPrefixFrontierUnproven"},
         {"path": "incremental_leaf_fastpath.go", "role": "implementation", "build_expression": "default", "symbol": "scanTokenInvariantEditedLeaf"},
+        {"path": "internal/parsercorephase0/core.go", "role": "implementation", "build_expression": "default", "symbol": "EnableTerminalScannerCheckpointProvenance"},
+        {"path": "internal/parsercorephase0/materialization_postorder_scratch.go", "role": "implementation", "build_expression": "default", "symbol": "VisitMaterializationPostorderWithScratch"},
+        {"path": "parsercore_phase0_driver.go", "role": "implementation", "build_expression": "!gts_no_parsercorephase0", "symbol": "configureParserCoreScannerProvenance"},
         {"path": "parser_result_incremental_range.go", "role": "implementation", "build_expression": "default", "symbol": "incrementalReparsedTopLevelRanges"},
         {"path": "external_scanner_checkpoints_test.go", "role": "proof", "build_expression": "default", "symbol": "TestExternalScannerCheckpointCapabilitiesAreBehaviorBased"},
         {"path": "external_scanner_checkpoints_test.go", "role": "proof", "build_expression": "default", "symbol": "TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots"},
@@ -993,6 +996,7 @@
         {"path": "parser_external_scanner_prefix_frontier_compact_test.go", "role": "adversarial_test", "build_expression": "gts_parsercorephase0", "symbol": "TestCompactCheckpointedScannerPrefixFrontierFallbackAvoidsCandidateWalk"},
         {"path": "w5_editor_latency_gate_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW5EditorLatencyGate"},
         {"path": "parsestate_replay_compact_diff_test.go", "role": "proof", "build_expression": "gts_parsercorephase0", "symbol": "TestParseStateReplayCompactDifferential"},
+        {"path": "internal/parsercorephase0/recursive_insert_test.go", "role": "proof", "build_expression": "default", "symbol": "TestAuthenticatedTerminalScannerProvenanceCoversOrdinaryLeaf"},
         {"path": "parsercore_phase0_checkpoint_transfer_test.go", "role": "proof", "build_expression": "!gts_no_parsercorephase0", "symbol": "TestCompactExternalScannerCheckpointTransferFailsClosed"},
         {"path": "scanner_closure_external_test.go", "role": "proof", "build_expression": "gts_parsercorephase0", "symbol": "TestStatefulScannerCompactLeafReauthentication"},
         {"path": "cgo_harness/benchmark_go_canonical_incremental_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity", "symbol": "TestCanonicalGoIncrementalParity"},
@@ -1007,6 +1011,7 @@
         {"name": "scanner frontier safety", "command": "go test . -run '^(TestExternalScannerOrderAdapterPreservesOptionalCapabilities|TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots|TestCheckpointedScannerPrefixFrontierFallback|TestPythonDerivedTokenInvariantLeafReusePrecedesScannerFallback|TestExternalScannerDerivedSameLengthTokenChangeInvalidatesScannerReuse|TestPythonSameSymbolScannerStateEditFallsBack|TestIncludedRangeCheckpointLeafProbeRestoresTokenProvenance)$' -count=1", "working_dir": ".", "isolation": "docker"},
         {"name": "SQL scanner reuse preservation", "command": "go test . -run '^TestIssue728IncrementalReuseMeasurement$/^sql/' -count=1", "working_dir": ".", "isolation": "docker"},
         {"name": "Python scanner serialization", "command": "go test ./grammars -run '^TestPythonScannerSerialization(RecomputesInterpolatedStringState|FailsClosed)$' -count=1", "working_dir": ".", "isolation": "docker"},
+        {"name": "compact terminal scanner provenance", "command": "go test ./internal/parsercorephase0 -run '^TestAuthenticatedTerminalScannerProvenanceCoversOrdinaryLeaf$' -count=1", "working_dir": ".", "isolation": "docker"},
         {"name": "compact scanner ownership proofs", "command": "go test -tags 'gts_parsercorephase0' -run '^(TestCompactExternalScannerCheckpointTransferFailsClosed|TestCompactCheckpointedScannerPrefixFrontierFallbackAvoidsCandidateWalk|TestStatefulScannerCompactLeafReauthentication)$' -count=1 .", "working_dir": ".", "isolation": "docker"},
         {"name": "locked four-way incremental parity", "command": "go test . -tags 'cgo treesitter_c_parity' -run '^TestCanonicalGoIncrementalParity$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"},
         {"name": "Python scanner locked-C parity", "command": "go test . -tags 'cgo treesitter_c_parity' -run '^TestStage5' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
@@ -1023,7 +1028,7 @@
         {"id": "python-scanner-wide-indent", "kind": "synthetic_fixture", "path": "cgo_harness/stage5_compact_incremental_test.go", "source": "Python indentation widths 65535, 65536, and 131072 with forward and reverse edits.", "lock_or_digest": "exact locked-C trees, ranges, errors, reuse routes, and fallback telemetry at 5070ffd4594a819e8ebe78fa2bf651c197cbdce4"},
         {"id": "incremental-allowlist", "kind": "policy_lock", "path": "testdata/incremental_allowlist.json", "source_sha256": "58e96c69a23675b1b666789306e93fe3ce3756b2976cfb32fea9fc544229b810", "lock_or_digest": "ratchet entries must reproduce or be removed after confirmed fixes"}
       ],
-      "gates": ["fresh and incremental trees are structurally identical", "edits invalidate the correct version state", "scanner boundaries remain quiescent or fail closed", "a failed scanner checkpoint proof cannot fall through to a fresh scanner", "successful and failed leaf probes restore token provenance", "rebuilt checkpoints copy snapshots into the destination arena", "unrelated certified scanners retain reuse", "reuse counters remain deterministic and nonzero where expected", "hot Parser and ParseRuntime layouts do not grow", "incremental memory and fallback budgets pass"],
+      "gates": ["fresh and incremental trees are structurally identical", "edits invalidate the correct version state", "scanner boundaries remain quiescent or fail closed", "every compact terminal owns complete scanner checkpoints for a checkpoint-capable language", "a failed scanner checkpoint proof cannot fall through to a fresh scanner", "successful and failed leaf probes restore token provenance", "rebuilt checkpoints copy snapshots into the destination arena", "unrelated certified scanners retain reuse", "reuse counters remain deterministic and nonzero where expected", "hot Parser and ParseRuntime layouts do not grow", "incremental memory and fallback budgets pass"],
       "telemetry": ["IncrementalParseProfile.ReusedBytes", "NewNodesAllocated", "ReuseRejectRootNonLeafChanged", "ReuseRejectScannerUnquiescent", "ReuseRejectFrontierProofUnavailable", "CompactExternalScannerCheckpointTransferProven", "BlockSpliceSteps", "ParseState replay receipt"],
       "plan_refs": [],
       "proof_receipts": [
@@ -1037,6 +1042,7 @@
         {"ref": "parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack", "kind": "test", "source_revision": "9bd3e9a971b323e2cdeed302aa045af174ffe53c", "status": "current"},
         {"ref": "cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonSameLengthScannerDelimiterParity", "kind": "test", "source_revision": "9bd3e9a971b323e2cdeed302aa045af174ffe53c", "status": "current"},
         {"ref": "incremental_leaf_fastpath_test.go#TestIncludedRangeCheckpointLeafProbeRestoresTokenProvenance", "kind": "test", "source_revision": "425ffdc2eb919b82b38484a0b3a2107d5c7341f1", "status": "current"},
+        {"ref": "internal/parsercorephase0/recursive_insert_test.go#TestAuthenticatedTerminalScannerProvenanceCoversOrdinaryLeaf", "kind": "test", "source_revision": "0d6683a465c6d20477c6a16b6b1f70ac2a90e87b", "status": "current"},
         {"ref": "testdata/incremental_allowlist.json", "kind": "policy", "source_revision": "95a1d13156b82e2221415342c9ac8048f2caf644", "status": "current"}
       ],
       "deletion_condition": "Delete temporary O(edit) experiments only after canonical C parity, edit invalidation, exact tree, reuse, race, and memory receipts pass.",

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
+  "source_revision": "425ffdc2eb919b82b38484a0b3a2107d5c7341f1",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -988,6 +988,7 @@
         {"path": "issue728_incremental_reuse_regression_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestIssue728IncrementalReuseMeasurement"},
         {"path": "parser_external_scanner_incremental_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestExternalScannerDerivedSameLengthTokenChangeInvalidatesScannerReuse"},
         {"path": "parser_external_scanner_incremental_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestPythonSameSymbolScannerStateEditFallsBack"},
+        {"path": "incremental_leaf_fastpath_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestIncludedRangeCheckpointLeafProbeRestoresTokenProvenance"},
         {"path": "parser_external_scanner_prefix_frontier_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestCheckpointedScannerPrefixFrontierFallback"},
         {"path": "parser_external_scanner_prefix_frontier_compact_test.go", "role": "adversarial_test", "build_expression": "gts_parsercorephase0", "symbol": "TestCompactCheckpointedScannerPrefixFrontierFallbackAvoidsCandidateWalk"},
         {"path": "w5_editor_latency_gate_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW5EditorLatencyGate"},
@@ -1003,7 +1004,7 @@
         {"name": "incremental invariant gate", "command": "go test -run '^TestIncrementalInvariantGate(Python|JavaScript|JSON|Go|Rust|CSS|C)$' -count=1 .", "working_dir": ".", "isolation": "local"},
         {"name": "O(edit) splice proofs", "command": "go test -run '^(TestW1|TestW1B|TestLeadingSplice|TestGoScannerQuiescenceOracleSweep|TestW5)' -count=1 .", "working_dir": ".", "isolation": "local"},
         {"name": "compact ParseState replay", "command": "go test -tags 'gts_parsercorephase0' -run '^TestParseStateReplayCompactDifferential$' -count=1 .", "working_dir": ".", "isolation": "local"},
-        {"name": "scanner frontier safety", "command": "go test . -run '^(TestExternalScannerOrderAdapterPreservesOptionalCapabilities|TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots|TestCheckpointedScannerPrefixFrontierFallback|TestPythonDerivedTokenInvariantLeafReusePrecedesScannerFallback|TestExternalScannerDerivedSameLengthTokenChangeInvalidatesScannerReuse|TestPythonSameSymbolScannerStateEditFallsBack)$' -count=1", "working_dir": ".", "isolation": "docker"},
+        {"name": "scanner frontier safety", "command": "go test . -run '^(TestExternalScannerOrderAdapterPreservesOptionalCapabilities|TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots|TestCheckpointedScannerPrefixFrontierFallback|TestPythonDerivedTokenInvariantLeafReusePrecedesScannerFallback|TestExternalScannerDerivedSameLengthTokenChangeInvalidatesScannerReuse|TestPythonSameSymbolScannerStateEditFallsBack|TestIncludedRangeCheckpointLeafProbeRestoresTokenProvenance)$' -count=1", "working_dir": ".", "isolation": "docker"},
         {"name": "SQL scanner reuse preservation", "command": "go test . -run '^TestIssue728IncrementalReuseMeasurement$/^sql/' -count=1", "working_dir": ".", "isolation": "docker"},
         {"name": "Python scanner serialization", "command": "go test ./grammars -run '^TestPythonScannerSerialization(RecomputesInterpolatedStringState|FailsClosed)$' -count=1", "working_dir": ".", "isolation": "docker"},
         {"name": "compact scanner ownership proofs", "command": "go test -tags 'gts_parsercorephase0' -run '^(TestCompactExternalScannerCheckpointTransferFailsClosed|TestCompactCheckpointedScannerPrefixFrontierFallbackAvoidsCandidateWalk|TestStatefulScannerCompactLeafReauthentication)$' -count=1 .", "working_dir": ".", "isolation": "docker"},
@@ -1022,7 +1023,7 @@
         {"id": "python-scanner-wide-indent", "kind": "synthetic_fixture", "path": "cgo_harness/stage5_compact_incremental_test.go", "source": "Python indentation widths 65535, 65536, and 131072 with forward and reverse edits.", "lock_or_digest": "exact locked-C trees, ranges, errors, reuse routes, and fallback telemetry at 5070ffd4594a819e8ebe78fa2bf651c197cbdce4"},
         {"id": "incremental-allowlist", "kind": "policy_lock", "path": "testdata/incremental_allowlist.json", "source_sha256": "58e96c69a23675b1b666789306e93fe3ce3756b2976cfb32fea9fc544229b810", "lock_or_digest": "ratchet entries must reproduce or be removed after confirmed fixes"}
       ],
-      "gates": ["fresh and incremental trees are structurally identical", "edits invalidate the correct version state", "scanner boundaries remain quiescent or fail closed", "a failed scanner checkpoint proof cannot fall through to a fresh scanner", "rebuilt checkpoints copy snapshots into the destination arena", "unrelated certified scanners retain reuse", "reuse counters remain deterministic and nonzero where expected", "hot Parser and ParseRuntime layouts do not grow", "incremental memory and fallback budgets pass"],
+      "gates": ["fresh and incremental trees are structurally identical", "edits invalidate the correct version state", "scanner boundaries remain quiescent or fail closed", "a failed scanner checkpoint proof cannot fall through to a fresh scanner", "successful and failed leaf probes restore token provenance", "rebuilt checkpoints copy snapshots into the destination arena", "unrelated certified scanners retain reuse", "reuse counters remain deterministic and nonzero where expected", "hot Parser and ParseRuntime layouts do not grow", "incremental memory and fallback budgets pass"],
       "telemetry": ["IncrementalParseProfile.ReusedBytes", "NewNodesAllocated", "ReuseRejectRootNonLeafChanged", "ReuseRejectScannerUnquiescent", "ReuseRejectFrontierProofUnavailable", "CompactExternalScannerCheckpointTransferProven", "BlockSpliceSteps", "ParseState replay receipt"],
       "plan_refs": [],
       "proof_receipts": [
@@ -1035,6 +1036,7 @@
         {"ref": "cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity", "kind": "test", "source_revision": "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a", "status": "current"},
         {"ref": "parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack", "kind": "test", "source_revision": "9bd3e9a971b323e2cdeed302aa045af174ffe53c", "status": "current"},
         {"ref": "cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonSameLengthScannerDelimiterParity", "kind": "test", "source_revision": "9bd3e9a971b323e2cdeed302aa045af174ffe53c", "status": "current"},
+        {"ref": "incremental_leaf_fastpath_test.go#TestIncludedRangeCheckpointLeafProbeRestoresTokenProvenance", "kind": "test", "source_revision": "425ffdc2eb919b82b38484a0b3a2107d5c7341f1", "status": "current"},
         {"ref": "testdata/incremental_allowlist.json", "kind": "policy", "source_revision": "95a1d13156b82e2221415342c9ac8048f2caf644", "status": "current"}
       ],
       "deletion_condition": "Delete temporary O(edit) experiments only after canonical C parity, edit invalidation, exact tree, reuse, race, and memory receipts pass.",

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
+  "source_revision": "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -974,6 +974,7 @@
         {"path": "external_scanner_checkpoints.go", "role": "implementation", "build_expression": "default", "symbol": "rebuildExternalScannerCheckpointForNode"},
         {"path": "language.go", "role": "implementation", "build_expression": "default", "symbol": "IncrementalPrefixFrontierExternalScanner"},
         {"path": "parser_api.go", "role": "implementation", "build_expression": "default", "symbol": "checkpointedScannerPrefixFrontierUnproven"},
+        {"path": "incremental_leaf_fastpath.go", "role": "implementation", "build_expression": "default", "symbol": "scanTokenInvariantEditedLeaf"},
         {"path": "parser_result_incremental_range.go", "role": "implementation", "build_expression": "default", "symbol": "incrementalReparsedTopLevelRanges"},
         {"path": "external_scanner_checkpoints_test.go", "role": "proof", "build_expression": "default", "symbol": "TestExternalScannerCheckpointCapabilitiesAreBehaviorBased"},
         {"path": "external_scanner_checkpoints_test.go", "role": "proof", "build_expression": "default", "symbol": "TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots"},
@@ -986,6 +987,7 @@
         {"path": "parser_go_scanner_quiescence_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestGoScannerQuiescenceOracleSweep"},
         {"path": "issue728_incremental_reuse_regression_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestIssue728IncrementalReuseMeasurement"},
         {"path": "parser_external_scanner_incremental_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestExternalScannerDerivedSameLengthTokenChangeInvalidatesScannerReuse"},
+        {"path": "parser_external_scanner_incremental_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestPythonSameSymbolScannerStateEditFallsBack"},
         {"path": "parser_external_scanner_prefix_frontier_test.go", "role": "adversarial_test", "build_expression": "default", "symbol": "TestCheckpointedScannerPrefixFrontierFallback"},
         {"path": "parser_external_scanner_prefix_frontier_compact_test.go", "role": "adversarial_test", "build_expression": "gts_parsercorephase0", "symbol": "TestCompactCheckpointedScannerPrefixFrontierFallbackAvoidsCandidateWalk"},
         {"path": "w5_editor_latency_gate_test.go", "role": "incremental_test", "build_expression": "default", "symbol": "TestW5EditorLatencyGate"},
@@ -994,13 +996,14 @@
         {"path": "scanner_closure_external_test.go", "role": "proof", "build_expression": "gts_parsercorephase0", "symbol": "TestStatefulScannerCompactLeafReauthentication"},
         {"path": "cgo_harness/benchmark_go_canonical_incremental_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity", "symbol": "TestCanonicalGoIncrementalParity"},
         {"path": "cgo_harness/stage5_compact_incremental_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity && !gts_no_parsercorephase0", "symbol": "TestStage5CompactPythonScannerCheckpointReuse"},
+        {"path": "cgo_harness/stage5_compact_incremental_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity && !gts_no_parsercorephase0", "symbol": "TestStage5PythonSameLengthScannerDelimiterParity"},
         {"path": "cgo_harness/stage5_compact_incremental_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity && !gts_no_parsercorephase0", "symbol": "TestStage5PythonPrefixFrontierAdversarialParity"}
       ],
       "test_commands": [
         {"name": "incremental invariant gate", "command": "go test -run '^TestIncrementalInvariantGate(Python|JavaScript|JSON|Go|Rust|CSS|C)$' -count=1 .", "working_dir": ".", "isolation": "local"},
         {"name": "O(edit) splice proofs", "command": "go test -run '^(TestW1|TestW1B|TestLeadingSplice|TestGoScannerQuiescenceOracleSweep|TestW5)' -count=1 .", "working_dir": ".", "isolation": "local"},
         {"name": "compact ParseState replay", "command": "go test -tags 'gts_parsercorephase0' -run '^TestParseStateReplayCompactDifferential$' -count=1 .", "working_dir": ".", "isolation": "local"},
-        {"name": "scanner frontier safety", "command": "go test . -run '^(TestExternalScannerOrderAdapterPreservesOptionalCapabilities|TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots|TestCheckpointedScannerPrefixFrontierFallback|TestPythonDerivedTokenInvariantLeafReusePrecedesScannerFallback|TestExternalScannerDerivedSameLengthTokenChangeInvalidatesScannerReuse)$' -count=1", "working_dir": ".", "isolation": "docker"},
+        {"name": "scanner frontier safety", "command": "go test . -run '^(TestExternalScannerOrderAdapterPreservesOptionalCapabilities|TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots|TestCheckpointedScannerPrefixFrontierFallback|TestPythonDerivedTokenInvariantLeafReusePrecedesScannerFallback|TestExternalScannerDerivedSameLengthTokenChangeInvalidatesScannerReuse|TestPythonSameSymbolScannerStateEditFallsBack)$' -count=1", "working_dir": ".", "isolation": "docker"},
         {"name": "SQL scanner reuse preservation", "command": "go test . -run '^TestIssue728IncrementalReuseMeasurement$/^sql/' -count=1", "working_dir": ".", "isolation": "docker"},
         {"name": "Python scanner serialization", "command": "go test ./grammars -run '^TestPythonScannerSerialization(RecomputesInterpolatedStringState|FailsClosed)$' -count=1", "working_dir": ".", "isolation": "docker"},
         {"name": "compact scanner ownership proofs", "command": "go test -tags 'gts_parsercorephase0' -run '^(TestCompactExternalScannerCheckpointTransferFailsClosed|TestCompactCheckpointedScannerPrefixFrontierFallbackAvoidsCandidateWalk|TestStatefulScannerCompactLeafReauthentication)$' -count=1 .", "working_dir": ".", "isolation": "docker"},
@@ -1019,7 +1022,7 @@
         {"id": "python-scanner-wide-indent", "kind": "synthetic_fixture", "path": "cgo_harness/stage5_compact_incremental_test.go", "source": "Python indentation widths 65535, 65536, and 131072 with forward and reverse edits.", "lock_or_digest": "exact locked-C trees, ranges, errors, reuse routes, and fallback telemetry at 5070ffd4594a819e8ebe78fa2bf651c197cbdce4"},
         {"id": "incremental-allowlist", "kind": "policy_lock", "path": "testdata/incremental_allowlist.json", "source_sha256": "58e96c69a23675b1b666789306e93fe3ce3756b2976cfb32fea9fc544229b810", "lock_or_digest": "ratchet entries must reproduce or be removed after confirmed fixes"}
       ],
-      "gates": ["fresh and incremental trees are structurally identical", "edits invalidate the correct version state", "scanner boundaries remain quiescent or fail closed", "rebuilt checkpoints copy snapshots into the destination arena", "unrelated certified scanners retain reuse", "reuse counters remain deterministic and nonzero where expected", "hot Parser and ParseRuntime layouts do not grow", "incremental memory and fallback budgets pass"],
+      "gates": ["fresh and incremental trees are structurally identical", "edits invalidate the correct version state", "scanner boundaries remain quiescent or fail closed", "a failed scanner checkpoint proof cannot fall through to a fresh scanner", "rebuilt checkpoints copy snapshots into the destination arena", "unrelated certified scanners retain reuse", "reuse counters remain deterministic and nonzero where expected", "hot Parser and ParseRuntime layouts do not grow", "incremental memory and fallback budgets pass"],
       "telemetry": ["IncrementalParseProfile.ReusedBytes", "NewNodesAllocated", "ReuseRejectRootNonLeafChanged", "ReuseRejectScannerUnquiescent", "ReuseRejectFrontierProofUnavailable", "CompactExternalScannerCheckpointTransferProven", "BlockSpliceSteps", "ParseState replay receipt"],
       "plan_refs": [],
       "proof_receipts": [
@@ -1030,6 +1033,8 @@
         {"ref": "parser_external_scanner_prefix_frontier_test.go#TestCheckpointedScannerWithoutPrefixFrontierRequirementKeepsReuse", "kind": "test", "source_revision": "e1de4484b5655ab11057f70d9dc7b1245972d03f", "status": "current"},
         {"ref": "external_scanner_checkpoints_test.go#TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots", "kind": "test", "source_revision": "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a", "status": "current"},
         {"ref": "cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity", "kind": "test", "source_revision": "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a", "status": "current"},
+        {"ref": "parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack", "kind": "test", "source_revision": "9bd3e9a971b323e2cdeed302aa045af174ffe53c", "status": "current"},
+        {"ref": "cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonSameLengthScannerDelimiterParity", "kind": "test", "source_revision": "9bd3e9a971b323e2cdeed302aa045af174ffe53c", "status": "current"},
         {"ref": "testdata/incremental_allowlist.json", "kind": "policy", "source_revision": "95a1d13156b82e2221415342c9ac8048f2caf644", "status": "current"}
       ],
       "deletion_condition": "Delete temporary O(edit) experiments only after canonical C parity, edit invalidation, exact tree, reuse, race, and memory receipts pass.",

--- a/tree.go
+++ b/tree.go
@@ -1006,6 +1006,10 @@ type ParseRuntime struct {
 	// usually discarded) against their own corpora, e.g. by walking a tree of
 	// known-valid source files and counting how often this is true.
 	CRecoverySwallowedErrorFallbackAttempted bool
+	// CompactExternalScannerCheckpointTransferProven reports whether compact
+	// materialization transferred every required scanner checkpoint into node
+	// sidecars. A false value disables later subtree reuse for that tree.
+	CompactExternalScannerCheckpointTransferProven bool
 	// CRecoverReductionCandidateCeilingHits and CRecoverMissingTokenCeilingHits
 	// count how many times this parse's cDoAllPotentialReductions /
 	// cHandleError missing-token search hit the
@@ -1245,15 +1249,11 @@ type ParseRuntime struct {
 	ReduceTiming                                  *ParseReduceTiming
 	ActionTiming                                  *ParseActionTiming
 
-	ExternalScannerCheckpointRecords        uint64
-	ExternalScannerCheckpointSlotsAllocated uint64
-	ExternalScannerCheckpointBytesAllocated int64
-	ExternalScannerSnapshotBytesAllocated   uint64
-	ExternalScannerCheckpointLeafNodes      uint64
-	// CompactExternalScannerCheckpointTransferProven reports whether compact
-	// materialization transferred every required scanner checkpoint into node
-	// sidecars. A false value disables later subtree reuse for that tree.
-	CompactExternalScannerCheckpointTransferProven   bool
+	ExternalScannerCheckpointRecords                 uint64
+	ExternalScannerCheckpointSlotsAllocated          uint64
+	ExternalScannerCheckpointBytesAllocated          int64
+	ExternalScannerSnapshotBytesAllocated            uint64
+	ExternalScannerCheckpointLeafNodes               uint64
 	CompactFullLeafCreated                           uint64
 	CompactFullLeafMaterialized                      uint64
 	CompactFullLeafMaterializedForParentReduce       uint64

--- a/tree.go
+++ b/tree.go
@@ -1245,11 +1245,15 @@ type ParseRuntime struct {
 	ReduceTiming                                  *ParseReduceTiming
 	ActionTiming                                  *ParseActionTiming
 
-	ExternalScannerCheckpointRecords                 uint64
-	ExternalScannerCheckpointSlotsAllocated          uint64
-	ExternalScannerCheckpointBytesAllocated          int64
-	ExternalScannerSnapshotBytesAllocated            uint64
-	ExternalScannerCheckpointLeafNodes               uint64
+	ExternalScannerCheckpointRecords        uint64
+	ExternalScannerCheckpointSlotsAllocated uint64
+	ExternalScannerCheckpointBytesAllocated int64
+	ExternalScannerSnapshotBytesAllocated   uint64
+	ExternalScannerCheckpointLeafNodes      uint64
+	// CompactExternalScannerCheckpointTransferProven reports whether compact
+	// materialization transferred every required scanner checkpoint into node
+	// sidecars. A false value disables later subtree reuse for that tree.
+	CompactExternalScannerCheckpointTransferProven   bool
 	CompactFullLeafCreated                           uint64
 	CompactFullLeafMaterialized                      uint64
 	CompactFullLeafMaterializedForParentReduce       uint64

--- a/tree.go
+++ b/tree.go
@@ -1007,8 +1007,8 @@ type ParseRuntime struct {
 	// known-valid source files and counting how often this is true.
 	CRecoverySwallowedErrorFallbackAttempted bool
 	// CompactExternalScannerCheckpointTransferProven reports whether compact
-	// materialization transferred every required scanner checkpoint into node
-	// sidecars. A false value disables later subtree reuse for that tree.
+	// materialization transferred every required terminal scanner checkpoint
+	// into node sidecars. A false value disables later subtree reuse.
 	CompactExternalScannerCheckpointTransferProven bool
 	// CRecoverReductionCandidateCeilingHits and CRecoverMissingTokenCeilingHits
 	// count how many times this parse's cDoAllPotentialReductions /

--- a/w5_editor_latency_gate_test.go
+++ b/w5_editor_latency_gate_test.go
@@ -48,8 +48,9 @@ package gotreesitter_test
 //     language holdback: direct fresh-oracle byte sweeps prove the generic
 //     fragility, byte-identity, and scanner gates are sufficient for this
 //     family. Their mid-file counters are now the same small constants at
-//     20KB and 137KB. python still declines reuse entirely (W4 indent-stack
-//     proof open).
+//     20KB and 137KB. Python now reuses checkpoint-authenticated middle and
+//     trailing siblings; a first-child length change still uses the
+//     conservative frontier fallback.
 //  2. ReusedBytes / len(editedSource), unlike the rejection counter, IS
 //     input-deterministic AND size-independent when position is expressed
 //     as a FRACTION of the file (not an absolute byte offset): a "middle"
@@ -103,7 +104,7 @@ package gotreesitter_test
 //	typescript  | 24 / 24 / 24  (measured 15-16 flat)          | 90 / 90 / 90  (measured ~97 flat)
 //	tsx         | 24 / 24 / 24  (measured 15-16 flat)          | 90 / 90 / 90  (measured ~97 flat)
 //	css         | 12 / 12 / 12  (measured 3-7 flat)            | 90 / 90 / 90  (measured ~96 flat)
-//	python      | 8  / -  / -   (declines reuse, W4 open)      | 0  / 0  / 0   (measured 0 -- see below)
+//	python      | 8  / 16 / 16  (first-child frontier fallback) | 0  / 90 / 90  (middle and trailing reuse)
 //
 // A "-" mid/bot ceiling means the cell's reject counter still scales with file
 // size (that language is not flattened), so no fixed bound is asserted there.
@@ -129,30 +130,23 @@ package gotreesitter_test
 //     the same fixture -- both are comfortably >= 95). This is the tracked
 //     "add a committed W1 measurement assertion" follow-up from that
 //     review, now enforced in CI instead of only recorded in a comment.
-//   - javascript, typescript, python: measured on this box via this harness;
-//     no campaign-recorded prior figure exists for these fixture cells.
-//     JavaScript/TypeScript leading reuse is fresh-oracle certified by #429,
-//     while Python's W4 indent-stack scanner-quiescence proof remains open.
-//   - python: MinByteReusePercent=0 at every position for insert/delete is
-//     an intentional "honest negative", not a placeholder. Measurement
-//     shows Python's insert/delete incremental parses currently take the
-//     oldTreeDisablesIncrementalReuse fresh-parse-fallback route
-//     unconditionally (ReusedBytes=0, NewNodesAllocated exactly equal to a
-//     full parse's node count, regardless of edit position) -- consistent
-//     with the campaign Status/W4 text listing "Python indent stack" as a
-//     still-open scanner-quiescence proof obligation: a column-shifting
-//     length-changing edit cannot yet be proven not to perturb the
-//     indent/dedent stack, so the parser conservatively declines reuse
-//     entirely rather than risk unsound splicing. Oracle equality (checked
-//     unconditionally, same as every other cell) is what actually protects
-//     Python today; this floor will ratchet upward as a natural follow-on
-//     once W4 lands for Python.
+//   - javascript, typescript, and python: measured on this box via this
+//     harness; no campaign-recorded prior figure exists for these fixture
+//     cells. JavaScript and TypeScript leading reuse is fresh-oracle certified
+//     by #429. Python's complete scanner checkpoints certify unaffected middle
+//     and trailing siblings. A first-child length change still lacks a generic
+//     parser-frontier proof, so it takes a fresh parse.
+//   - python: MinByteReusePercent=0 at the top position for insert/delete is
+//     an intentional conservative floor, not a placeholder. The early
+//     external_scanner_prefix_frontier_unproven fallback protects a changed
+//     first child from stale reduction ownership. Middle and trailing cells
+//     now use the 90% floor after checkpoint-authenticated reuse passed the
+//     focused Python and locked-C parity proofs.
 //   - Every language's REPLACE (same-length substitution) class measures
-//     ReusedBytes at ~100% universally, INCLUDING python: a same-length
-//     edit that does not change token boundaries or classification hits an
-//     unconditional single-token in-place substitution fast path before
-//     the reuse cursor / scanner-quiescence question is even reached. See
-//     w5ReplaceMinByteReusePercent.
+//     ReusedBytes at ~100% universally: a same-length edit that does not
+//     change token boundaries or classification hits an unconditional
+//     single-token in-place substitution fast path before the reuse cursor or
+//     scanner-quiescence question is reached. See w5ReplaceMinByteReusePercent.
 //
 // # Follow-ups this gate closes
 //
@@ -441,7 +435,8 @@ type w5Sample struct {
 }
 
 // w5ProductionParser keeps this incremental reuse gate on its certified route.
-// Compact-tree incremental reuse remains barred by decision 0008.
+// W5 pins fresh and incremental parses to production; compact checkpoint
+// admission has a separate first-child frontier gate.
 func w5ProductionParser(lang *gts.Language) *gts.Parser {
 	parser := gts.NewParser(lang)
 	parser.SetAdmissionCandidateRoute(false)
@@ -634,8 +629,8 @@ type w5Ceiling struct {
 // floor for the REPLACE edit class: a same-length substitution that does
 // not change a token's boundaries or classification hits an unconditional
 // single-token in-place fast path (measured ~100% on every gate language,
-// including python, where insert/delete currently measure 0 -- see the
-// file doc comment).
+// while Python's top-position insert/delete lane uses the frontier fallback
+// described in the file comment.
 const w5ReplaceMinByteReusePercent = 95
 
 // w5Ceilings is the committed ratchet: today's achieved level per
@@ -695,16 +690,13 @@ var w5Ceilings = map[string]w5Ceiling{
 		Middle:                     w5PositionCeiling{MinByteReusePercent: 90, MaxRootNonLeafChanged: 12},
 		Bottom:                     w5PositionCeiling{MinByteReusePercent: 90, MaxRootNonLeafChanged: 12},
 	},
-	// python: an honest negative, not a placeholder -- see the file doc
-	// comment's python bullet. Insert/delete measure 0% byte reuse today
-	// (the W4 Python indent-stack scanner-quiescence proof is still open),
-	// so the floor is 0 at every position; oracle equality is what actually
-	// protects Python here, and it is still checked unconditionally.
+	// python: first-child length edits use the conservative frontier fallback;
+	// middle and trailing edits reuse checkpoint-authenticated siblings.
 	"python": {
 		MaxRootNonLeafChangedAtTop: 8,
 		Top:                        w5PositionCeiling{MinByteReusePercent: 0},
-		Middle:                     w5PositionCeiling{MinByteReusePercent: 0},
-		Bottom:                     w5PositionCeiling{MinByteReusePercent: 0},
+		Middle:                     w5PositionCeiling{MinByteReusePercent: 90, MaxRootNonLeafChanged: 16},
+		Bottom:                     w5PositionCeiling{MinByteReusePercent: 90, MaxRootNonLeafChanged: 16},
 	},
 }
 


### PR DESCRIPTION
## Summary

- Certify Python external scanner checkpoints for incremental reuse.
- Transfer compact checkpoint bytes with exact language identity.
- Record scanner checkpoint pairs on every compact terminal for checkpoint-capable languages.
- Copy rebuilt checkpoint bytes into the destination arena before publication.
- Reject leaf reuse when checkpoint end-state authentication fails.
- Restore complete DFA token provenance after scanner leaf probes.
- Fail closed when Python prefix history or compact provenance is incomplete.
- Scope prefix-frontier proof to scanners that declare this behavioral requirement.
- Preserve reuse for certified CMake, SQL, Markdown, and unrelated checkpointed scanners.
- Preserve later-child reuse and same-length authenticated leaf reuse.
- Keep hot Parser and ParseRuntime layouts unchanged.
- Register the complete Stage 5 proof inventory and telemetry.

## Required proof

- The smallest C falsifier changes a real Python interpolation without changing its byte width.
- A one-byte `u`-to-`f` edit proves that equal `string_start` symbols and spans cannot replace scanner-state proof.
- A normal Python number leaf owns exact scanner states before and after its DFA token.
- Successful and rejected included-range probes restore all token-provenance fields.
- Same-length space-to-tab edits prove scanner state cannot bypass the prefix gate.
- A leading comment extra proves that extras do not move the structural frontier.
- Wide-indent cases cover 65,535, 65,536, and 131,072 spaces.
- Transition cases cross both boundaries in both directions.
- A mixed-arena collision test proves that rebuilt checkpoints copy the correct bytes.
- Exact assertions cover trees, ranges, errors, reuse routes, and fallback reasons.
- The locked oracle uses Python commit 26855eabccb19c6abf499fbc5b8dc7cc9ab8bc64.
- Focused Docker race checks pass after the ownership and frontier fixes.
- The O(edit) editor-latency workstream (W5) gate preserves about 95.5 percent reuse for middle and end edits.
- The emergency opt-out build and strict lifecycle history gate pass.
- This pull request contains no unrelated performance work.

## Docker evidence

- Compact ordinary-terminal checkpoint proof: `harness_out/docker/20260902T051011Z`
- Final scanner ownership and restoration root race gate: `harness_out/docker/20260902T051024Z`
- Final Stage 5 locked Python C race gate: `harness_out/docker/20260902T051056Z`
- Final Python W5 gate: `harness_out/docker/20260902T051135Z`
- Final isolated Python grammar parity: `harness_out/docker/20260902T051157Z-diag-python`
- Scanner-state and probe-restoration root race gate: `harness_out/docker/20260902T043225Z`
- Compact same-symbol locked-C race gate: `harness_out/docker/20260902T043310Z`
- Root scanner frontier race gate: `harness_out/docker/20260902T034103Z`
- SQL reuse preservation race gate: `harness_out/docker/20260902T034301Z`
- CMake reuse race gate: `harness_out/docker/20260902T034316Z`
- Markdown scanner certification race gate: `harness_out/docker/20260902T034339Z`
- SQL dollar-tag race gate: `harness_out/docker/20260902T034354Z`
- Scanner serialization gate: `harness_out/docker/20260902T025141Z`
- Emergency opt-out gate: `harness_out/docker/20260902T025202Z`

## Review focus

- Check that checkpoint-capable compact parsers attach a complete scanner pair to every terminal.
- Check complete-or-zero scanner serialization.
- Check mixed-arena checkpoint ownership and one-time publication accounting.
- Check failed checkpoint authentication cannot fall through to a fresh scanner.
- Check successful and rejected probes restore complete token provenance.
- Check same-length edits and leading extras at the prefix frontier.
- Check reverse mapping across Python edit history.
- Check unrelated scanner reuse and hot-layout stability.
- Check telemetry attribution for fresh fallback and validated reuse.
