### PR TITLE
fix(incremental): reuse sole-child padding edits with scanner checkpoints

### DIFF
--- a/cgo_harness/stage5_sole_child_padding_probe_test.go
+++ b/cgo_harness/stage5_sole_child_padding_probe_test.go
@@ -1,0 +1,122 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestStage5SoleChildHorizontalPaddingProbe(t *testing.T) {
+	sources := [][]byte{
+		[]byte("def classify(value):\n    if value:\n        return \"present\"\n    return \"missing\"\n"),
+		[]byte("def nested(value):\n    if value:\n        for item in value:\n            if item:\n                return item\n    return None\n"),
+		[]byte("class Box:\n    def value(self):\n        if True:\n            return 1\n        return 0\n"),
+	}
+	for sourceIndex, source := range sources {
+		for lineStart := 0; lineStart < len(source); {
+			if lineStart > 0 && source[lineStart-1] != '\n' {
+				lineStart++
+				continue
+			}
+			nextLine := bytes.IndexByte(source[lineStart:], '\n')
+			if nextLine < 0 {
+				nextLine = len(source) - lineStart
+			}
+			lineEnd := lineStart + nextLine
+			indentEnd := lineStart
+			for indentEnd < lineEnd && (source[indentEnd] == ' ' || source[indentEnd] == '\t') {
+				indentEnd++
+			}
+			if indentEnd > lineStart {
+				t.Run(fmt.Sprintf("source_%d_line_%d_insert", sourceIndex, lineStart), func(t *testing.T) {
+					runSoleChildPaddingEdit(t, source, lineStart, lineStart, []byte(" "))
+				})
+				t.Run(fmt.Sprintf("source_%d_line_%d_delete", sourceIndex, lineStart), func(t *testing.T) {
+					runSoleChildPaddingEdit(t, source, lineStart, lineStart+1, nil)
+				})
+			}
+			lineStart = lineEnd + 1
+		}
+	}
+}
+
+func runSoleChildPaddingEdit(t *testing.T, source []byte, start, oldEnd int, replacement []byte) {
+	t.Helper()
+	edited := make([]byte, 0, len(source)-(oldEnd-start)+len(replacement))
+	edited = append(edited, source[:start]...)
+	edited = append(edited, replacement...)
+	edited = append(edited, source[oldEnd:]...)
+	point := func(src []byte, offset int) gotreesitter.Point {
+		var p gotreesitter.Point
+		for _, b := range src[:offset] {
+			if b == '\n' {
+				p.Row++
+				p.Column = 0
+			} else {
+				p.Column++
+			}
+		}
+		return p
+	}
+	edit := gotreesitter.InputEdit{
+		StartByte: uint32(start), OldEndByte: uint32(oldEnd), NewEndByte: uint32(start + len(replacement)),
+		StartPoint: point(source, start), OldEndPoint: point(source, oldEnd), NewEndPoint: point(edited, start+len(replacement)),
+	}
+	lang := grammars.PythonLanguage()
+	parser := gotreesitter.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	oldTree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldTree.Edit(edit)
+	incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oldTree.Release()
+	defer incremental.Release()
+	if profile.ReuseUnsupported {
+		t.Fatalf("padding edit unexpectedly fell back: %+v", profile)
+	}
+	fresh, err := parser.Parse(edited)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fresh.Release()
+	goDigest, err := benchfixtures.InspectGoTree(incremental.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freshDigest, err := benchfixtures.InspectGoTree(fresh.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if goDigest.SHA256 != freshDigest.SHA256 {
+		t.Fatalf("incremental != fresh: %s != %s profile=%+v", goDigest.SHA256, freshDigest.SHA256, profile)
+	}
+	cLang, err := ParityCLanguage("python")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse(edited, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("C parser returned nil tree")
+	}
+	defer cTree.Close()
+	if diff := FirstDivergenceDumpV1(incremental.RootNode(), lang, cTree.RootNode()); diff != nil {
+		t.Fatalf("incremental != C: %s profile=%+v", formatRealCorpusDivergence(diff), profile)
+	}
+}

--- a/parser_api.go
+++ b/parser_api.go
@@ -220,8 +220,10 @@ func incrementalReuseUnsupportedReasonForTree(oldTree *Tree) string {
 // tree producers, and leave other certified scanners on their existing reuse
 // contracts. Compact trees need this early guard as well: their exact scanner
 // snapshots do not prove reduction ownership, and waiting for reuseCursor
-// would walk every compact candidate before rejecting it.
-func checkpointedScannerPrefixFrontierUnproven(oldTree *Tree) bool {
+// would walk every compact candidate before rejecting it. source is the
+// edited source; the sole-child exception accepts one horizontal-padding edit
+// only when its old and new spans remain at a line start.
+func checkpointedScannerPrefixFrontierUnproven(source []byte, oldTree *Tree) bool {
 	if oldTree == nil || !languageUsesExternalScannerCheckpoints(oldTree.language) ||
 		!languageRequiresExternalScannerPrefixFrontierProof(oldTree.language) ||
 		len(oldTree.edits) == 0 || oldTree.root == nil {
@@ -248,7 +250,13 @@ func checkpointedScannerPrefixFrontierUnproven(oldTree *Tree) bool {
 		return false
 	}
 	if !foundSecond {
-		// With no later sibling, the root end is the conservative frontier.
+		// With no later sibling, a single edit that changes only horizontal
+		// padding at a line start cannot cross a later top-level reduction.
+		// Scanner checkpoints and the normal node-state gates still guard reuse
+		// inside the sole child. Keep all other sole-child edits conservative.
+		if len(oldTree.edits) == 1 && checkpointedScannerSoleChildPaddingEdit(oldTree.Source(), source, oldTree.edits[0]) {
+			return false
+		}
 		boundary = oldTree.root.endByte
 	}
 	for editIndex := len(oldTree.edits) - 1; editIndex >= 0; editIndex-- {
@@ -277,6 +285,41 @@ func checkpointedScannerPrefixFrontierUnproven(oldTree *Tree) bool {
 		boundary = boundaryBefore
 	}
 	return false
+}
+
+// checkpointedScannerSoleChildPaddingEdit recognizes the only edit that can
+// move a sole child's indentation frontier without changing a token's bytes.
+// Keep the proof narrow: a later newline, comment, or token change remains on
+// the conservative fallback path.
+func checkpointedScannerSoleChildPaddingEdit(oldSource, newSource []byte, edit InputEdit) bool {
+	if edit.StartByte > edit.OldEndByte || int(edit.OldEndByte) > len(oldSource) {
+		return false
+	}
+	if edit.NewEndByte < edit.StartByte || int(edit.NewEndByte) > len(newSource) {
+		return false
+	}
+	start := int(edit.StartByte)
+	end := int(edit.OldEndByte)
+	for _, b := range oldSource[start:end] {
+		if b != ' ' && b != '\t' {
+			return false
+		}
+	}
+	for _, b := range newSource[start:int(edit.NewEndByte)] {
+		if b != ' ' && b != '\t' {
+			return false
+		}
+	}
+	lineStart := start
+	for lineStart > 0 && oldSource[lineStart-1] != '\n' {
+		lineStart--
+	}
+	for _, b := range oldSource[lineStart:start] {
+		if b != ' ' && b != '\t' {
+			return false
+		}
+	}
+	return true
 }
 
 // tryTokenInvariantReuseBeforePrefixFrontierFallback permits only the narrow
@@ -1682,7 +1725,7 @@ func (p *Parser) parseIncrementalChanged(source []byte, oldTree *Tree) (*Tree, e
 		// A compact tree needs the incremental token-source fallback below so
 		// scanner refusal and full-reparse work retain normal attribution.
 	}
-	if checkpointedScannerPrefixFrontierUnproven(oldTree) {
+	if checkpointedScannerPrefixFrontierUnproven(source, oldTree) {
 		if tree, ok := p.tryTokenInvariantReuseBeforePrefixFrontierFallback(source, oldTree, nil); ok {
 			return tree, nil
 		}
@@ -1871,7 +1914,7 @@ func (p *Parser) parseIncrementalChangedProfiled(source []byte, oldTree *Tree) (
 		// Continue through the token-source path so a compact-tree decline keeps
 		// the same scanner reason and work attribution as an ordinary fallback.
 	}
-	if checkpointedScannerPrefixFrontierUnproven(oldTree) {
+	if checkpointedScannerPrefixFrontierUnproven(source, oldTree) {
 		timing := &incrementalParseTiming{}
 		if tree, ok := p.tryTokenInvariantReuseBeforePrefixFrontierFallback(source, oldTree, timing); ok {
 			return tree, timing.toProfile(), nil

--- a/parser_external_scanner_prefix_frontier_test.go
+++ b/parser_external_scanner_prefix_frontier_test.go
@@ -198,6 +198,63 @@ func TestCheckpointedScannerWithoutPrefixFrontierRequirementKeepsReuse(t *testin
 	requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
 }
 
+// TestCheckpointedScannerPrefixFrontierAllowsSoleChildReuse proves that a
+// prefix-sensitive scanner can reuse unchanged leaves when the old root has
+// one structural child. There is no later top-level reduction whose ownership
+// can cross the edit, so the ordinary parser-state and scanner checkpoints are
+// sufficient.
+func TestCheckpointedScannerPrefixFrontierAllowsSoleChildReuse(t *testing.T) {
+	source := []byte("def classify(value):\n    if value:\n        return \"present\"\n    return \"missing\"\n")
+	const offset = 60
+	if offset >= len(source) || source[offset] != ' ' {
+		t.Fatalf("sole-child witness changed at byte %d: got %q", offset, source[offset])
+	}
+	edited := append(append([]byte(nil), source[:offset]...), append([]byte("    "), source[offset:]...)...)
+	edit := gts.InputEdit{
+		StartByte:   offset,
+		OldEndByte:  offset,
+		NewEndByte:  offset + 4,
+		StartPoint:  pointForOffset(source, offset),
+		OldEndPoint: pointForOffset(source, offset),
+		NewEndPoint: pointForOffset(edited, offset+4),
+	}
+
+	lang := grammars.PythonLanguage()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	oldTree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("old parse: %v", err)
+	}
+	defer oldTree.Release()
+	if got := oldTree.RootNode().ChildCount(); got != 1 {
+		t.Fatalf("sole-child witness root children=%d, want 1", got)
+	}
+	oldTree.Edit(edit)
+	incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatalf("incremental parse: %v", err)
+	}
+	defer incremental.Release()
+	if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" || !profile.OldTreeReuseRoute {
+		t.Fatalf("sole-child edit did not stay on reuse route: %+v", profile)
+	}
+	if profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("sole-child edit lost unchanged-leaf reuse: %+v", profile)
+	}
+
+	freshParser := gts.NewParser(lang)
+	freshParser.SetAdmissionCandidateRoute(false)
+	fresh, err := freshParser.Parse(edited)
+	if err != nil {
+		t.Fatalf("fresh parse: %v", err)
+	}
+	defer fresh.Release()
+	requireCompleteParse(t, incremental, edited, lang, "incremental")
+	requireCompleteParse(t, fresh, edited, lang, "fresh")
+	requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+}
+
 // TestCheckpointedScannerPrefixFrontierCatchesSuffixDelete covers the
 // post-edit boundary case where a deletion moves the first child end to the
 // edit start. The old raw-coordinate check treated that boundary as clean.


### PR DESCRIPTION
## Summary

- Allow a sole top-level parser child to reuse scanner checkpoints after one line-start spaces or tabs edit.
- Keep token changes, comments, newlines, and multi-edit histories on the conservative fallback path.
- Add focused Go and C parity regressions for nested Python indentation edits.

## Smallest failing case

The canonical `python_scanner_dedent` fixture has one top-level function. An edit that inserts four spaces before its final `return` previously reported `external_scanner_prefix_frontier_unproven` and forced a full parse.

The edit changes indentation inside the sole child. It does not cross a later top-level reduction, so the scanner checkpoint and parser-state checks can prove reuse.

## Implementation

Pass the edited source into the prefix-frontier check. Permit reuse only when all of these conditions hold:

- the old root has one structural child;
- the edit history has one edit;
- the old and new edit spans contain only spaces or tabs;
- the old edit begins after only spaces or tabs on its line.

Preserve the existing conservative fallback for token changes, comments, newlines, and multi-edit histories.

## Verification

Run the focused tests in Docker with `cgo` and `treesitter_c_parity` tags.

- Stage 5 root invariant suite: pass.
- Stage 5 Python parity suite: pass.
- Canonical four-way incremental parity: seven cases pass.
- Prefix-frontier unit suite: pass.
- Three-fixture sole-child insert and delete probe: 24 cases pass.
- Combined tagged root and C gates: pass.

Artifacts are recorded under `harness_out/docker/` for the reproducible runs.

This pull request contains correctness work only. It contains no unrelated performance changes.
