### PR TITLE
test(cgo_harness): add JavaScript compact route certification

### DIFF
--- a/cgo_harness/stage6_javascript_compact_certification_test.go
+++ b/cgo_harness/stage6_javascript_compact_certification_test.go
@@ -1,0 +1,107 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0
+
+package cgoharness
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const stage6JavaScriptRecoverySource = "const f = (a) => a + 1;&\nclass A { m() { return 1 } }\n\n"
+
+// TestStage6JavaScriptCompactCertification proves clean and recovery
+// JavaScript shapes through the compact route against locked C output.
+func TestStage6JavaScriptCompactCertification(t *testing.T) {
+	cases := []struct {
+		name           string
+		source         []byte
+		wantReasonPart string
+	}{
+		{name: "smoke", source: []byte(grammars.ParseSmokeSample("javascript"))},
+		{name: "recovery_keyword", source: []byte(stage6JavaScriptRecoverySource), wantReasonPart: ""},
+		{name: "ternary", source: []byte("const value = condition ? left : right;\n")},
+	}
+	language := grammars.JavascriptLanguage()
+	cLanguage, err := ParityCLanguage("javascript")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cParser := sitter.NewParser()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			defer cParser.Close()
+			cTree := cParser.Parse(tc.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parser returned no tree")
+			}
+			defer cTree.Close()
+
+			parser := gotreesitter.NewParser(language)
+			parser.SetAdmissionCandidateRoute(true)
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			fresh, err := parser.Parse(tc.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer fresh.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			routedDelta := routedAfter - routedBefore
+			fallbackDelta := fallbackAfter - fallbackBefore
+			reason := gotreesitter.AdmissionCandidateLastFallbackReason()
+			t.Logf("route=%d/%d reason=%q", routedDelta, fallbackDelta, reason)
+			if routedDelta != 1 || fallbackDelta != 0 {
+				t.Fatalf("JavaScript %s did not route through compact admission: %d/%d", tc.name, routedDelta, fallbackDelta)
+			}
+			if tc.wantReasonPart != "" && !strings.Contains(reason, tc.wantReasonPart) {
+				t.Fatalf("fallback reason=%q, want substring %q", reason, tc.wantReasonPart)
+			}
+			if fresh.RootNode().HasError() != cTree.RootNode().HasError() {
+				t.Fatalf("JavaScript %s root error differs: Go=%v C=%v", tc.name, fresh.RootNode().HasError(), cTree.RootNode().HasError())
+			}
+			if diff := FirstDivergenceDumpV1(fresh.RootNode(), language, cTree.RootNode()); diff != nil {
+				t.Fatalf("JavaScript %s tree diverges from locked C: %+v", tc.name, diff)
+			}
+
+			if tc.name != "smoke" {
+				return
+			}
+			offset := bytes.IndexByte(tc.source, '1')
+			if offset < 0 {
+				t.Fatal("JavaScript smoke source has no numeric edit witness")
+			}
+			edited := append([]byte(nil), tc.source...)
+			edited[offset] = '2'
+			edit := gotreesitter.InputEdit{
+				StartByte: uint32(offset), OldEndByte: uint32(offset + 1), NewEndByte: uint32(offset + 1),
+				StartPoint: pointAtOffset(tc.source, offset), OldEndPoint: pointAtOffset(tc.source, offset + 1), NewEndPoint: pointAtOffset(edited, offset + 1),
+			}
+			fresh.Edit(edit)
+			incremental, profile, err := parser.ParseIncrementalProfiled(edited, fresh)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer incremental.Release()
+			t.Logf("incremental profile=%+v", profile)
+			if profile.ReuseUnsupported {
+				t.Fatalf("JavaScript incremental certification fell back: %+v", profile)
+			}
+			cEdited := cParser.Parse(edited, nil)
+			if cEdited == nil || cEdited.RootNode() == nil {
+				t.Fatal("C parser returned no edited tree")
+			}
+			defer cEdited.Close()
+			if diff := FirstDivergenceDumpV1(incremental.RootNode(), language, cEdited.RootNode()); diff != nil {
+				t.Fatalf("JavaScript incremental tree diverges from locked C: %+v", diff)
+			}
+		})
+	}
+}

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "8c6a8e1fe472ade08462b91a2ba00624ab437d61"
+	compactRouteLifecycleSourceRevision               = "2455af16a52e4a886ae5a32842a98bb623f6671c"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -56,6 +56,7 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"cgo_harness/stage5_sole_child_padding_probe_test.go#TestStage5SoleChildHorizontalPaddingProbe":                     "90f60a65c61d87768b1221b78cb0f66d25aff8ec",
 	"cgo_harness/stage6_typescript_compact_certification_test.go#TestStage6TypeScriptCompactCertification":              "0df3c2ab3b33fcd3374cf426ad7ea2a18ea33411",
 	"cgo_harness/stage6_python_compact_certification_test.go#TestStage6PythonCompactCertification":                      "8c6a8e1fe472ade08462b91a2ba00624ab437d61",
+	"cgo_harness/stage6_javascript_compact_certification_test.go#TestStage6JavaScriptCompactCertification":              "2455af16a52e4a886ae5a32842a98bb623f6671c",
 	"external_scanner_checkpoints_test.go#TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots":            "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity":                    "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack":                         "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
@@ -72,6 +73,7 @@ var compactRouteLifecycleKnownCorpusTreeSHA256 = map[string]string{
 	"scala-owned-width":        "81dc569b1ad3d567ed158aea75fd30a388ec1f4d3e1cbdd08c29a6535bd456d3",
 	"typescript-compact-smoke": "840eb4cf52faf1b944dacf47bb13591a5fd61fbfe33f196172094d4b4acab907",
 	"python-compact-smoke":     "7d857f4d100cc7c7bf61bd1e77845066add55e2fd4f82e60309203ceb8569543",
+	"javascript-compact-smoke": "ed169501f3515f625f9337c18ffe3f67ba41b1573df02e07cc54d85a26978501",
 }
 
 type compactRouteLifecycleRegistry struct {

--- a/testdata/compact_route_campaign_inventory_v1.json
+++ b/testdata/compact_route_campaign_inventory_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-inventory/v1",
-  "source_revision": "8c6a8e1fe472ade08462b91a2ba00624ab437d61",
+  "source_revision": "2455af16a52e4a886ae5a32842a98bb623f6671c",
   "scope": "Graduation-critical build tags and environment controls.",
   "entries": [
     {"id":"build-parsercorephase0","kind":"build_tag","identifier":"gts_parsercorephase0","owner":"graph_head_lifecycle","stage":2,"status":"graduated","lifecycle_control":"build.phase0.internal","gate":"Equivalent physical heads retain every node, error region, lineage, and checkpoint.","final_receipt":"stage-2-physical-graph-head-merge","deletion_condition":"Delete the diagnostic build tag after the physical-head topology receipt is current."},

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "8c6a8e1fe472ade08462b91a2ba00624ab437d61",
+  "source_revision": "2455af16a52e4a886ae5a32842a98bb623f6671c",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -1069,6 +1069,7 @@
         {"path": "cgo_harness/derivation_set_differential_test.go", "role": "c_oracle", "build_expression": "cgo && treesitter_c_parity && gts_derivation_set_census", "symbol": "TestDerivationSetDifferentialBaselineCensus"},
         {"path": "cgo_harness/stage6_typescript_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6TypeScriptCompactCertification"},
         {"path": "cgo_harness/stage6_python_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6PythonCompactCertification"},
+        {"path": "cgo_harness/stage6_javascript_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6JavaScriptCompactCertification"},
         {"path": "cgo_harness/docker/run_single_grammar_parity.sh", "role": "certification", "build_expression": "default", "symbol": "run_single_grammar_parity.sh"},
         {"path": "cgo_harness/docker/run_grammargen_focus_targets.sh", "role": "certification", "build_expression": "default", "symbol": "run_grammargen_focus_targets.sh"},
         {"path": "docs/compact-route-real-corpus-matrix.md", "role": "corpus_policy", "build_expression": "default", "symbol": "Current compact-graduation matrix"}
@@ -1082,13 +1083,18 @@
         {"name": "Python one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh python", "working_dir": ".", "isolation": "docker"},
         {"name": "Python real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs python", "working_dir": ".", "isolation": "docker"},
         {"name": "Python C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs python", "working_dir": ".", "isolation": "docker"},
-        {"name": "Python compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6PythonCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+        {"name": "Python compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6PythonCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"},
+        {"name": "JavaScript one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh javascript", "working_dir": ".", "isolation": "docker"},
+        {"name": "JavaScript real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs javascript", "working_dir": ".", "isolation": "docker"},
+        {"name": "JavaScript C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs javascript", "working_dir": ".", "isolation": "docker"},
+        {"name": "JavaScript compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6JavaScriptCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
       ],
       "corpus": [
         {"id": "real-corpus-matrix", "kind": "authenticated_external_manifest", "path": "cgo_harness/corpus_real/manifest.json", "source": "External manifest is not present in this worktree.", "availability": "unavailable", "lock_status": "unlocked", "plan": "Acquire the authenticated manifest in an isolated certification run before Stage 6.", "lock_or_digest": ""},
         {"id": "grammar-lock", "kind": "grammar_lock", "path": "grammars/languages.lock", "lock_or_digest": "grammar lock file is tracked; verify each source and generated artifact identity"},
         {"id": "typescript-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "function f(): number { return 1; }\n", "source_sha256": "091455371625186f6b1d8c33589e90d8ef478563db392e55faf79e184d4efc72", "tree_sha256": "840eb4cf52faf1b944dacf47bb13591a5fd61fbfe33f196172094d4b4acab907", "availability": "available", "lock_status": "locked", "plan": "Keep the smoke fixture as the first current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at b10e071e441f9163ffa6486aba389840428bdccf"},
-        {"id": "python-compact-smoke", "kind": "synthetic_fixture", "path": "cgo_harness/stage6_python_compact_certification_test.go", "source": "def f():\n    return 1\n", "source_sha256": "5b76d0962c09ab4ee309fac65fad3568c97abdec983b405146ae3e86a235e352", "tree_sha256": "7d857f4d100cc7c7bf61bd1e77845066add55e2fd4f82e60309203ceb8569543", "availability": "available", "lock_status": "locked", "plan": "Keep the Python clean and recovery fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 8c6a8e1fe472ade08462b91a2ba00624ab437d61"}
+        {"id": "python-compact-smoke", "kind": "synthetic_fixture", "path": "cgo_harness/stage6_python_compact_certification_test.go", "source": "def f():\n    return 1\n", "source_sha256": "5b76d0962c09ab4ee309fac65fad3568c97abdec983b405146ae3e86a235e352", "tree_sha256": "7d857f4d100cc7c7bf61bd1e77845066add55e2fd4f82e60309203ceb8569543", "availability": "available", "lock_status": "locked", "plan": "Keep the Python clean and recovery fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 8c6a8e1fe472ade08462b91a2ba00624ab437d61"},
+        {"id": "javascript-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "function f() { return 1; }\nconst x = () => x + 1;\n", "source_sha256": "093a91b4c009bfbd15f42a1181a31c48672c97009362c6ac12ea2f57be4ad7f1", "tree_sha256": "ed169501f3515f625f9337c18ffe3f67ba41b1573df02e07cc54d85a26978501", "availability": "available", "lock_status": "locked", "plan": "Keep the JavaScript clean, recovery, and ambiguity fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 2455af16a52e4a886ae5a32842a98bb623f6671c"}
       ],
       "gates": ["exact tree shape and node fields", "exact ranges and error or missing flags", "exact C and Go grammar identities", "incremental result parity", "one grammar per isolated Docker run", "zero silent divergence and explicit fallback accounting"],
       "telemetry": ["PASS/FALLBACK/DIVERGE/SKIP/ERROR scorecard rows", "deep-tree digest", "exact mismatch path and field", "fallback reason", "derivation-set receipt"],
@@ -1100,7 +1106,8 @@
         {"ref": "docs/compact-route-coverage-census.md", "kind": "document", "source_revision": "38d86d417fc6209228b8b175bc2aa7bb9700b8d3", "status": "stale"},
         {"ref": "docs/a8-derivation-divergence-certificate-v1.md", "kind": "document", "source_revision": "acccb81d20128e337a35ee274a2e3e3631b73b1a", "status": "stale"},
         {"ref": "cgo_harness/stage6_typescript_compact_certification_test.go#TestStage6TypeScriptCompactCertification", "kind": "test", "source_revision": "0df3c2ab3b33fcd3374cf426ad7ea2a18ea33411", "status": "current"},
-        {"ref": "cgo_harness/stage6_python_compact_certification_test.go#TestStage6PythonCompactCertification", "kind": "test", "source_revision": "8c6a8e1fe472ade08462b91a2ba00624ab437d61", "status": "current"}
+        {"ref": "cgo_harness/stage6_python_compact_certification_test.go#TestStage6PythonCompactCertification", "kind": "test", "source_revision": "8c6a8e1fe472ade08462b91a2ba00624ab437d61", "status": "current"},
+        {"ref": "cgo_harness/stage6_javascript_compact_certification_test.go#TestStage6JavaScriptCompactCertification", "kind": "test", "source_revision": "2455af16a52e4a886ae5a32842a98bb623f6671c", "status": "current"}
       ],
       "deletion_condition": "Delete certification scaffolding only after every supported grammar has a current locked-C receipt for trees, fields, ranges, errors, and incremental edits.",
       "retention": "preserve_receipt",


### PR DESCRIPTION
## Summary

- Add a Stage 6 JavaScript compact-route certificate.
- Compare clean, recovery, and ternary trees with locked C output.
- Verify compact admission counters and root error agreement.
- Certify a single-byte incremental edit with reuse.
- Register the JavaScript fixture and isolated Docker gates.

## Evidence

- Focused Docker test passes.
- Three cases route once with zero fallback.
- Recovery and ambiguity trees match C.
- Incremental smoke edit reuses 50 bytes and matches C.

This PR contains certification work only. It does not change parser implementation.