### PR TITLE
fix(grammargen): match C leaf shape for capitalized keywords

### DIFF
--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -3383,11 +3383,9 @@ func isPlainVisibleNamedLeafStringLiteral(g *Grammar, ruleName, s string) bool {
 	// minimal, targeted extension, not the full ownership rule: a
 	// uniquely-owned rule whose value differs from an identifier only by
 	// case, like "True" (see TestCapitalizedPlainStringRuleStaysWrapper),
-	// would also collapse under real tree-sitter's shape-irrelevant
-	// ownership rule, but grammargen still keeps it wrapped — a
-	// pre-existing gap, predating this change and not fixed by it, tracked
-	// separately from the punctuation/identifier shape buckets extended
-	// here.
+	// also collapses under real tree-sitter's shape-irrelevant ownership rule
+	// when a word token owns the keyword. Keep the no-word case unchanged so
+	// ordinary capitalized string rules retain their established wrapper.
 	if isSafePlainPunctuationLiteral(s) || isBackslashEscapedNamedLeafLiteral(s) {
 		return true
 	}
@@ -3417,6 +3415,7 @@ func isPlainVisibleNamedLeafStringLiteral(g *Grammar, ruleName, s string) bool {
 		if ruleName == "" || !symbolNameReferencedElsewhere(g, ruleName) {
 			return false
 		}
+		return isIdentifierLikeKeywordLiteral(s)
 	}
 	return isLowercaseIdentifierLikeKeywordLiteral(s)
 }

--- a/grammargen/python_keyword_test.go
+++ b/grammargen/python_keyword_test.go
@@ -151,6 +151,39 @@ func TestPythonGenerateLanguageEmitsReservedWords(t *testing.T) {
 	}
 }
 
+func TestPythonGeneratedBooleanKeywordsAreLeafTokens(t *testing.T) {
+	gram := loadPythonGrammarJSONForTest(t)
+	ng, err := Normalize(gram)
+	if err != nil {
+		t.Fatalf("normalize Python grammar: %v", err)
+	}
+	for _, name := range []string{"true", "false", "none"} {
+		if got := symbolKind(t, ng, name); got != SymbolNamedToken {
+			t.Fatalf("%s kind = %v, want SymbolNamedToken", name, got)
+		}
+	}
+
+	lang, err := GenerateLanguage(gram)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+	tree, err := gotreesitter.NewParser(lang).Parse([]byte("True\nFalse\nNone\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+	root := tree.RootNode()
+	if root.HasError() || root.ChildCount() != 3 {
+		t.Fatalf("tree = %s, want three clean children", root.SExpr(lang))
+	}
+	for i := 0; i < root.ChildCount(); i++ {
+		child := root.Child(i)
+		if got := child.ChildCount(); got != 0 {
+			t.Fatalf("child %d (%s) has %d children, want leaf; tree=%s", i, child.Type(lang), got, root.SExpr(lang))
+		}
+	}
+}
+
 func TestPythonGeneratedLanguageEnablesCRecoveryCostCompetitionByDefault(t *testing.T) {
 	gram := loadPythonGrammarJSONForTest(t)
 	lang, err := GenerateLanguage(gram)


### PR DESCRIPTION
## Summary

Tree-sitter C emits Python `True`, `False`, and `None` as named leaf tokens. Grammargen kept each token behind an anonymous child.

When a word token owns a reachable plain string rule, classify every identifier-like spelling as a named leaf. Keep unowned capitalized rules unchanged.

## Proof

- The smallest failing source is `True\nFalse\nNone\n`.
- The focused test asserts named-token symbols and zero child counts.
- Docker grammargen C parity passes 20 of 20 samples with zero divergences.
- Docker focused grammargen tests pass.
- The change contains no performance work.

## Receipts

- C parity artifact: `harness_out/grammargen_cparity/20260902_050019-stage6-python-cgo-after-leaf-fix`.
- Focused Docker artifact: `harness_out/docker/20260902T120057Z-python-leaf-focused`.

The branch is based on `origin/main` after JavaScript Stage 6 certification.