### PR TITLE
add(grammars/rust): certify checkpointed compact reuse

### DIFF
--- a/cgo_harness/stage6_rust_compact_certification_test.go
+++ b/cgo_harness/stage6_rust_compact_certification_test.go
@@ -1,0 +1,145 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0
+
+package cgoharness
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// TestStage6RustCompactCertification proves clean, scanner, recovery, and
+// incremental Rust shapes against the locked C oracle.
+func TestStage6RustCompactCertification(t *testing.T) {
+	cases := []struct {
+		name           string
+		source         []byte
+		wantRoute      bool
+		wantReasonPart string
+	}{
+		{name: "smoke", source: []byte(grammars.ParseSmokeSample("rust")), wantRoute: true},
+		{name: "trait_impl", source: []byte("trait T { fn f(&self); }\nstruct S;\nimpl T for S { fn f(&self) {} }\n"), wantRoute: true},
+		{name: "match", source: []byte("fn f(x: Option<i32>) -> i32 { match x { Some(v) => v, None => 0 } }\n"), wantRoute: true},
+		{name: "raw_string", source: []byte("fn main() { let raw = r###\"hello\"###; let after = 3; }\n"), wantRoute: true},
+		{name: "recovery", source: []byte("fn f( {\n let x = 1;\n}\n"), wantReasonPart: "recovery"},
+	}
+	language := grammars.RustLanguage()
+	if reusable, ok := language.ExternalScanner.(gotreesitter.IncrementalReuseExternalScanner); !ok || !reusable.SupportsIncrementalReuse() {
+		t.Fatal("Rust scanner does not advertise incremental reuse")
+	}
+	if checkpointed, ok := language.ExternalScanner.(gotreesitter.CheckpointedExternalScanner); !ok || !checkpointed.UsesExternalScannerCheckpoints() {
+		t.Fatal("Rust scanner does not advertise scanner checkpoints")
+	}
+	cLanguage, err := ParityCLanguage("rust")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cParser := sitter.NewParser()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			defer cParser.Close()
+			cTree := cParser.Parse(tc.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parser returned no tree")
+			}
+			defer cTree.Close()
+
+			parser := gotreesitter.NewParser(language)
+			parser.SetAdmissionCandidateRoute(true)
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			goTree, err := parser.Parse(tc.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer goTree.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			routedDelta := routedAfter - routedBefore
+			fallbackDelta := fallbackAfter - fallbackBefore
+			reason := gotreesitter.AdmissionCandidateLastFallbackReason()
+			t.Logf("route=%d/%d reason=%q", routedDelta, fallbackDelta, reason)
+
+			if tc.wantRoute {
+				if routedDelta != 1 || fallbackDelta != 0 {
+					t.Fatalf("clean case did not route through compact admission: %d/%d", routedDelta, fallbackDelta)
+				}
+				assertLockedCTreeExact(t, "Rust compact "+tc.name, goTree, language, cTree)
+			} else {
+				if routedDelta != 0 || fallbackDelta != 1 {
+					t.Fatalf("recovery case did not fall back once: %d/%d", routedDelta, fallbackDelta)
+				}
+				if tc.wantReasonPart != "" && !strings.Contains(reason, tc.wantReasonPart) {
+					t.Fatalf("fallback reason=%q, want substring %q", reason, tc.wantReasonPart)
+				}
+				if goTree.RootNode().HasError() != cTree.RootNode().HasError() {
+					t.Fatalf("Rust %s root error differs: Rust=%v C=%v", tc.name, goTree.RootNode().HasError(), cTree.RootNode().HasError())
+				}
+				if diff := FirstDivergenceDumpV1(goTree.RootNode(), language, cTree.RootNode()); diff != nil {
+					t.Fatalf("Rust %s error tree diverges from locked C: %+v", tc.name, diff)
+				}
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		src  []byte
+		old  []byte
+		new  []byte
+	}{
+		{name: "smoke", src: []byte(grammars.ParseSmokeSample("rust")), old: []byte("1"), new: []byte("2")},
+		{name: "raw_string_after", src: []byte("fn main() { let raw = r###\"hello\"###; let after = 3; }\n"), old: []byte("3"), new: []byte("4")},
+		{name: "raw_string_content", src: []byte("fn main() { let raw = r###\"hello\"###; let after = 3; }\n"), old: []byte("hello"), new: []byte("hullo")},
+	} {
+		t.Run("incremental_"+tc.name, func(t *testing.T) {
+			oldTreeParser := gotreesitter.NewParser(language)
+			oldTree, err := oldTreeParser.Parse(tc.src)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer oldTree.Release()
+			offset := bytes.Index(tc.src, tc.old)
+			if offset < 0 || len(tc.old) != len(tc.new) {
+				t.Fatalf("invalid edit witness old=%q", tc.old)
+			}
+			edited := append([]byte(nil), tc.src...)
+			copy(edited[offset:offset+len(tc.new)], tc.new)
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(offset),
+				OldEndByte:  uint32(offset + len(tc.old)),
+				NewEndByte:  uint32(offset + len(tc.new)),
+				StartPoint:  pointAtOffset(tc.src, offset),
+				OldEndPoint: pointAtOffset(tc.src, offset+len(tc.old)),
+				NewEndPoint: pointAtOffset(edited, offset+len(tc.new)),
+			})
+			incremental, profile, err := oldTreeParser.ParseIncrementalProfiled(edited, oldTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer incremental.Release()
+			t.Logf("profile=%+v", profile)
+			if profile.ReuseUnsupported || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+				t.Fatalf("Rust incremental certification did not reuse the clean prefix: %+v", profile)
+			}
+
+			cParser := sitter.NewParser()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			defer cParser.Close()
+			cTree := cParser.Parse(edited, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parser returned no edited tree")
+			}
+			defer cTree.Close()
+			assertLockedCTreeExact(t, "Rust compact incremental "+tc.name, incremental, language, cTree)
+		})
+	}
+}

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "9ec95dbcbc9a18071b697ce260e49189c0966036"
+	compactRouteLifecycleSourceRevision               = "80c9ed104785d46acd84a88c6df225836c876a32"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -58,6 +58,7 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"cgo_harness/stage6_python_compact_certification_test.go#TestStage6PythonCompactCertification":                      "8c6a8e1fe472ade08462b91a2ba00624ab437d61",
 	"cgo_harness/stage6_javascript_compact_certification_test.go#TestStage6JavaScriptCompactCertification":              "2455af16a52e4a886ae5a32842a98bb623f6671c",
 	"cgo_harness/stage6_go_compact_certification_test.go#TestStage6GoCompactCertification":                              "9ec95dbcbc9a18071b697ce260e49189c0966036",
+	"cgo_harness/stage6_rust_compact_certification_test.go#TestStage6RustCompactCertification":                        "80c9ed104785d46acd84a88c6df225836c876a32",
 	"external_scanner_checkpoints_test.go#TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots":            "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity":                    "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack":                         "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
@@ -76,6 +77,7 @@ var compactRouteLifecycleKnownCorpusTreeSHA256 = map[string]string{
 	"python-compact-smoke":     "7d857f4d100cc7c7bf61bd1e77845066add55e2fd4f82e60309203ceb8569543",
 	"javascript-compact-smoke": "ed169501f3515f625f9337c18ffe3f67ba41b1573df02e07cc54d85a26978501",
 	"go-compact-smoke":         "94fcf4849cea5bcccc24ae0a1e70ee06218e0daad96434b74c27864db9fe0c81",
+	"rust-compact-smoke":       "f7120d52d2861af7fe4dc6b6d7f0073404236fe8cc6f812f9e40a16253521c63",
 }
 
 type compactRouteLifecycleRegistry struct {

--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -576,7 +576,7 @@ silently widening HTML admission.
 | `ron` | certified reuse |
 | `rst` | fallback (uncertified) |
 | `ruby` | fallback (uncertified) |
-| `rust` | fallback (uncertified) |
+| `rust` | certified reuse |
 | `scala` | fallback (uncertified) |
 | `scss` | certified reuse |
 | `sql` | certified reuse |

--- a/grammars/rust_scanner.go
+++ b/grammars/rust_scanner.go
@@ -148,6 +148,14 @@ func (RustExternalScanner) Deserialize(payload any, buf []byte) {
 	}
 }
 
+// SupportsIncrementalReuse reports that the Rust scanner can restore its
+// complete serialized state at a reused subtree boundary.
+func (RustExternalScanner) SupportsIncrementalReuse() bool { return true }
+
+// UsesExternalScannerCheckpoints requires reuse to authenticate the raw-string
+// hash count before it resumes scanning after a reused subtree.
+func (RustExternalScanner) UsesExternalScannerCheckpoints() bool { return true }
+
 func (scanner RustExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	var semanticValid [rustTokenCount]bool
 	validSymbols = scanner.remapValidSymbols(validSymbols, &semanticValid)

--- a/parser_big3_incremental_correctness_test.go
+++ b/parser_big3_incremental_correctness_test.go
@@ -468,7 +468,7 @@ func TestMalformedGoIncrementalRunsOneBaseMergeRetryAndKeepsFirstResult(t *testi
 	}
 }
 
-func TestMalformedRustUnsupportedReuseDoesNotRunBaseMergeRetry(t *testing.T) {
+func TestMalformedRustIncrementalRunsOneBaseMergeRetryAndKeepsFirstResult(t *testing.T) {
 	lang := grammars.RustLanguage()
 	original := []byte("fn main() { let x = 1; }\n")
 	offset := bytes.LastIndexByte(original, '}')
@@ -504,10 +504,26 @@ func TestMalformedRustUnsupportedReuseDoesNotRunBaseMergeRetry(t *testing.T) {
 		incremental.RootNode().HasError() != fresh.RootNode().HasError() {
 		t.Fatalf("malformed Rust incremental/fresh mismatch incremental=%s fresh=%s", incremental.RootNode().SExpr(lang), fresh.RootNode().SExpr(lang))
 	}
+	incrementalInspection, err := benchfixtures.InspectGoTree(incremental.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freshInspection, err := benchfixtures.InspectGoTree(fresh.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if incrementalInspection.SHA256 != freshInspection.SHA256 {
+		t.Fatalf("malformed Rust deep digest incremental=%s fresh=%s", incrementalInspection.SHA256, freshInspection.SHA256)
+	}
 	rt := incremental.ParseRuntime()
-	if !profile.ReuseUnsupported || profile.OldTreeReuseRoute || rt.IncrementalOldTreeReuseRoute ||
-		profile.AcceptedErrorRetryAttempts != 0 || rt.IncrementalAcceptedErrorRetryAttempts != 0 {
-		t.Fatalf("malformed Rust unsupported route profile=%+v runtime=%+v", profile, rt)
+	if profile.AcceptedErrorRetryAttempts != 1 || rt.IncrementalAcceptedErrorRetryAttempts != 1 ||
+		profile.AcceptedErrorRetryAdopted || rt.IncrementalAcceptedErrorRetryAdopted ||
+		profile.AcceptedErrorRetryMergePerKey != 1 || !profile.OldTreeReuseRoute || !rt.IncrementalOldTreeReuseRoute {
+		t.Fatalf("malformed Rust retry profile=%+v runtime=%+v", profile, rt)
+	}
+	incremental.Release()
+	if oldTree.RootNode() == nil || oldTree.RootNode().HasError() {
+		t.Fatal("releasing retained first Rust incremental result invalidated caller-owned old tree")
 	}
 }
 

--- a/testdata/compact_route_campaign_inventory_v1.json
+++ b/testdata/compact_route_campaign_inventory_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-inventory/v1",
-  "source_revision": "9ec95dbcbc9a18071b697ce260e49189c0966036",
+  "source_revision": "80c9ed104785d46acd84a88c6df225836c876a32",
   "scope": "Graduation-critical build tags and environment controls.",
   "entries": [
     {"id":"build-parsercorephase0","kind":"build_tag","identifier":"gts_parsercorephase0","owner":"graph_head_lifecycle","stage":2,"status":"graduated","lifecycle_control":"build.phase0.internal","gate":"Equivalent physical heads retain every node, error region, lineage, and checkpoint.","final_receipt":"stage-2-physical-graph-head-merge","deletion_condition":"Delete the diagnostic build tag after the physical-head topology receipt is current."},

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "9ec95dbcbc9a18071b697ce260e49189c0966036",
+  "source_revision": "80c9ed104785d46acd84a88c6df225836c876a32",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -1071,6 +1071,7 @@
         {"path": "cgo_harness/stage6_python_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6PythonCompactCertification"},
         {"path": "cgo_harness/stage6_javascript_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6JavaScriptCompactCertification"},
         {"path": "cgo_harness/stage6_go_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6GoCompactCertification"},
+        {"path": "cgo_harness/stage6_rust_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6RustCompactCertification"},
         {"path": "cgo_harness/docker/run_single_grammar_parity.sh", "role": "certification", "build_expression": "default", "symbol": "run_single_grammar_parity.sh"},
         {"path": "cgo_harness/docker/run_grammargen_focus_targets.sh", "role": "certification", "build_expression": "default", "symbol": "run_grammargen_focus_targets.sh"},
         {"path": "docs/compact-route-real-corpus-matrix.md", "role": "corpus_policy", "build_expression": "default", "symbol": "Current compact-graduation matrix"}
@@ -1092,7 +1093,11 @@
         {"name": "Go one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh go", "working_dir": ".", "isolation": "docker"},
         {"name": "Go real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs go", "working_dir": ".", "isolation": "docker"},
         {"name": "Go C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs go", "working_dir": ".", "isolation": "docker"},
-        {"name": "Go compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6GoCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+        {"name": "Go compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6GoCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"},
+        {"name": "Rust one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh rust", "working_dir": ".", "isolation": "docker"},
+        {"name": "Rust real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs rust", "working_dir": ".", "isolation": "docker"},
+        {"name": "Rust C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs rust", "working_dir": ".", "isolation": "docker"},
+        {"name": "Rust compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6RustCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
       ],
       "corpus": [
         {"id": "real-corpus-matrix", "kind": "authenticated_external_manifest", "path": "cgo_harness/corpus_real/manifest.json", "source": "External manifest is not present in this worktree.", "availability": "unavailable", "lock_status": "unlocked", "plan": "Acquire the authenticated manifest in an isolated certification run before Stage 6.", "lock_or_digest": ""},
@@ -1100,7 +1105,8 @@
         {"id": "typescript-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "function f(): number { return 1; }\n", "source_sha256": "091455371625186f6b1d8c33589e90d8ef478563db392e55faf79e184d4efc72", "tree_sha256": "840eb4cf52faf1b944dacf47bb13591a5fd61fbfe33f196172094d4b4acab907", "availability": "available", "lock_status": "locked", "plan": "Keep the smoke fixture as the first current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at b10e071e441f9163ffa6486aba389840428bdccf"},
         {"id": "python-compact-smoke", "kind": "synthetic_fixture", "path": "cgo_harness/stage6_python_compact_certification_test.go", "source": "def f():\n    return 1\n", "source_sha256": "5b76d0962c09ab4ee309fac65fad3568c97abdec983b405146ae3e86a235e352", "tree_sha256": "7d857f4d100cc7c7bf61bd1e77845066add55e2fd4f82e60309203ceb8569543", "availability": "available", "lock_status": "locked", "plan": "Keep the Python clean and recovery fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 8c6a8e1fe472ade08462b91a2ba00624ab437d61"},
         {"id": "javascript-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "function f() { return 1; }\nconst x = () => x + 1;\n", "source_sha256": "093a91b4c009bfbd15f42a1181a31c48672c97009362c6ac12ea2f57be4ad7f1", "tree_sha256": "ed169501f3515f625f9337c18ffe3f67ba41b1573df02e07cc54d85a26978501", "availability": "available", "lock_status": "locked", "plan": "Keep the JavaScript clean, recovery, and ambiguity fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 2455af16a52e4a886ae5a32842a98bb623f6671c"},
-        {"id": "go-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "package main\n\nfunc main() {\n\tprintln(1)\n}\n", "source_sha256": "0496c51d052fc6f7fa761b9b317e16a3e15073cbe271f56163db4b61bf2e8220", "tree_sha256": "94fcf4849cea5bcccc24ae0a1e70ee06218e0daad96434b74c27864db9fe0c81", "availability": "available", "lock_status": "locked", "plan": "Keep the Go clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 9ec95dbcbc9a18071b697ce260e49189c0966036"}
+        {"id": "go-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "package main\n\nfunc main() {\n\tprintln(1)\n}\n", "source_sha256": "0496c51d052fc6f7fa761b9b317e16a3e15073cbe271f56163db4b61bf2e8220", "tree_sha256": "94fcf4849cea5bcccc24ae0a1e70ee06218e0daad96434b74c27864db9fe0c81", "availability": "available", "lock_status": "locked", "plan": "Keep the Go clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 9ec95dbcbc9a18071b697ce260e49189c0966036"},
+        {"id": "rust-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "fn main() { let x = 1; }\n", "source_sha256": "5ea70a939eaf182a1d392818bc49b8f25a74334f1002a409865050305a1abf5e", "tree_sha256": "f7120d52d2861af7fe4dc6b6d7f0073404236fe8cc6f812f9e40a16253521c63", "availability": "available", "lock_status": "locked", "plan": "Keep the Rust clean, recovery, raw-string, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 80c9ed104785d46acd84a88c6df225836c876a32"}
       ],
       "gates": ["exact tree shape and node fields", "exact ranges and error or missing flags", "exact C and Go grammar identities", "incremental result parity", "one grammar per isolated Docker run", "zero silent divergence and explicit fallback accounting"],
       "telemetry": ["PASS/FALLBACK/DIVERGE/SKIP/ERROR scorecard rows", "deep-tree digest", "exact mismatch path and field", "fallback reason", "derivation-set receipt"],
@@ -1114,7 +1120,8 @@
         {"ref": "cgo_harness/stage6_typescript_compact_certification_test.go#TestStage6TypeScriptCompactCertification", "kind": "test", "source_revision": "0df3c2ab3b33fcd3374cf426ad7ea2a18ea33411", "status": "current"},
         {"ref": "cgo_harness/stage6_python_compact_certification_test.go#TestStage6PythonCompactCertification", "kind": "test", "source_revision": "8c6a8e1fe472ade08462b91a2ba00624ab437d61", "status": "current"},
         {"ref": "cgo_harness/stage6_javascript_compact_certification_test.go#TestStage6JavaScriptCompactCertification", "kind": "test", "source_revision": "2455af16a52e4a886ae5a32842a98bb623f6671c", "status": "current"},
-        {"ref": "cgo_harness/stage6_go_compact_certification_test.go#TestStage6GoCompactCertification", "kind": "test", "source_revision": "9ec95dbcbc9a18071b697ce260e49189c0966036", "status": "current"}
+        {"ref": "cgo_harness/stage6_go_compact_certification_test.go#TestStage6GoCompactCertification", "kind": "test", "source_revision": "9ec95dbcbc9a18071b697ce260e49189c0966036", "status": "current"},
+        {"ref": "cgo_harness/stage6_rust_compact_certification_test.go#TestStage6RustCompactCertification", "kind": "test", "source_revision": "80c9ed104785d46acd84a88c6df225836c876a32", "status": "current"}
       ],
       "deletion_condition": "Delete certification scaffolding only after every supported grammar has a current locked-C receipt for trees, fields, ranges, errors, and incremental edits.",
       "retention": "preserve_receipt",


### PR DESCRIPTION
## Summary

- Declare the Rust external scanner safe for incremental reuse.
- Require scanner checkpoints so reused subtrees restore the raw-string hash count.
- Add a Stage 6 Rust certificate for clean, recovery, raw-string, and incremental trees.
- Compare exact symbols, fields, ranges, flags, errors, and deep digests with the locked C oracle.
- Update the malformed Rust regression to record the supported reuse and one base-merge retry.
- Register the Rust receipt, corpus digest, commands, and source revision.

## Required gate

The clean cases route through compact admission once and produce no fallback.
The recovery case falls back once and records a recovery reason.
The incremental cases reuse one subtree and preserve exact C trees.
The raw-string cases exercise checkpoint restore both after and inside a three-hash string.

## Evidence

- Rust compact Stage 6 certificate: Docker pass.
- Rust one-grammar smoke parity: 10 of 10 deep-parity cases.
- Generated Rust grammar C focus: 20 of 20 deep-parity cases.
- Lifecycle and inventory registry tests: Docker pass.
- Focused Rust root tests and 333 incremental sites: Docker pass.

## Verification commands

```text
bash cgo_harness/docker/run_parity_in_docker.sh --repo-root /home/draco/work/gts-compact-stage6-rust-certification-20260902 --label stage6-rust-certification-final --no-build --timeout 20m --run '^TestStage6RustCompactCertification$' -- 'cd /workspace/cgo_harness && go test . -tags "cgo treesitter_c_parity gts_parsercorephase0" -run "^TestStage6RustCompactCertification$" -count=1 -v'
bash cgo_harness/docker/run_single_grammar_parity.sh rust --no-build --profile smoke --max-cases 10 --require-parity --timeout 10m
bash cgo_harness/docker/run_grammargen_c_parity.sh --src-dir /home/draco/work/gts-compact-stage6-rust-certification-20260902 --langs rust --max-cases 20 --timeout 10 --label stage6-rust-cgo-final --no-build
bash cgo_harness/docker/run_parity_in_docker.sh --repo-root /home/draco/work/gts-compact-stage6-rust-certification-20260902 --label stage6-rust-lifecycle-final --no-build --timeout 20m -- "cd /workspace && go test . -run '^TestCompactRouteCampaignLifecycleRegistry$|^TestCompactRouteCampaignInventory$' -count=1 -v"
```
