### PR TITLE
certify JSON compact route in Stage 6

### DIFF
--- a/cgo_harness/stage6_json_compact_certification_test.go
+++ b/cgo_harness/stage6_json_compact_certification_test.go
@@ -1,0 +1,129 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0
+
+package cgoharness
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const (
+	stage6JSONNestedSource   = "{\"items\":[{\"id\":1,\"ok\":true},{\"id\":2,\"ok\":false}],\"name\":\"x\"}\n"
+	stage6JSONRecoverySource = "{\"a\":1\n"
+)
+
+// TestStage6JSONCompactCertification proves clean and recovery JSON shapes
+// through compact admission against the locked C oracle.
+func TestStage6JSONCompactCertification(t *testing.T) {
+	cases := []struct {
+		name      string
+		source    []byte
+		wantRoute bool
+	}{
+		{name: "smoke", source: []byte(grammars.ParseSmokeSample("json")), wantRoute: true},
+		{name: "nested", source: []byte(stage6JSONNestedSource), wantRoute: true},
+		{name: "recovery", source: []byte(stage6JSONRecoverySource), wantRoute: false},
+	}
+	language := grammars.JsonLanguage()
+	cLanguage, err := ParityCLanguage("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cParser := sitter.NewParser()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			defer cParser.Close()
+			cTree := cParser.Parse(tc.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parser returned no tree")
+			}
+			defer cTree.Close()
+
+			parser := gotreesitter.NewParser(language)
+			parser.SetAdmissionCandidateRoute(true)
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			goTree, err := parser.Parse(tc.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer goTree.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			routedDelta := routedAfter - routedBefore
+			fallbackDelta := fallbackAfter - fallbackBefore
+			reason := gotreesitter.AdmissionCandidateLastFallbackReason()
+			t.Logf("route=%d/%d reason=%q", routedDelta, fallbackDelta, reason)
+
+			if tc.wantRoute {
+				if routedDelta != 1 || fallbackDelta != 0 {
+					t.Fatalf("clean case did not route through compact admission: %d/%d", routedDelta, fallbackDelta)
+				}
+				assertLockedCTreeExact(t, "JSON compact "+tc.name, goTree, language, cTree)
+			} else {
+				if routedDelta != 0 || fallbackDelta != 1 || !strings.Contains(reason, "recovery") {
+					t.Fatalf("recovery case route=%d/%d reason=%q", routedDelta, fallbackDelta, reason)
+				}
+				if goTree.RootNode().HasError() != cTree.RootNode().HasError() {
+					t.Fatalf("JSON recovery root error differs: Go=%v C=%v", goTree.RootNode().HasError(), cTree.RootNode().HasError())
+				}
+				if diff := FirstDivergenceDumpV1(goTree.RootNode(), language, cTree.RootNode()); diff != nil {
+					t.Fatalf("JSON recovery tree diverges from locked C: %+v", diff)
+				}
+			}
+		})
+	}
+
+	t.Run("incremental", func(t *testing.T) {
+		source := []byte(grammars.ParseSmokeSample("json"))
+		offset := bytes.IndexByte(source, '1')
+		if offset < 0 {
+			t.Fatal("JSON smoke source has no numeric edit witness")
+		}
+		edited := append([]byte(nil), source...)
+		edited[offset] = '2'
+		parser := gotreesitter.NewParser(language)
+		parser.SetAdmissionCandidateRoute(true)
+		oldTree, err := parser.Parse(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer oldTree.Release()
+		oldTree.Edit(gotreesitter.InputEdit{
+			StartByte:   uint32(offset),
+			OldEndByte:  uint32(offset + 1),
+			NewEndByte:  uint32(offset + 1),
+			StartPoint:  pointAtOffset(source, offset),
+			OldEndPoint: pointAtOffset(source, offset+1),
+			NewEndPoint: pointAtOffset(edited, offset+1),
+		})
+		incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer incremental.Release()
+		t.Logf("profile=%+v", profile)
+		if profile.ReuseUnsupported || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+			t.Fatalf("JSON incremental reuse unavailable: %+v", profile)
+		}
+
+		cParser := sitter.NewParser()
+		if err := cParser.SetLanguage(cLanguage); err != nil {
+			t.Fatal(err)
+		}
+		defer cParser.Close()
+		cTree := cParser.Parse(edited, nil)
+		if cTree == nil || cTree.RootNode() == nil {
+			t.Fatal("C parser returned no edited tree")
+		}
+		defer cTree.Close()
+		assertLockedCTreeExact(t, "JSON compact incremental", incremental, language, cTree)
+	})
+}

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "80c9ed104785d46acd84a88c6df225836c876a32"
+	compactRouteLifecycleSourceRevision               = "f737578353f60bee8de5f6413b9534cc8713cc51"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -59,6 +59,7 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"cgo_harness/stage6_javascript_compact_certification_test.go#TestStage6JavaScriptCompactCertification":              "2455af16a52e4a886ae5a32842a98bb623f6671c",
 	"cgo_harness/stage6_go_compact_certification_test.go#TestStage6GoCompactCertification":                              "9ec95dbcbc9a18071b697ce260e49189c0966036",
 	"cgo_harness/stage6_rust_compact_certification_test.go#TestStage6RustCompactCertification":                        "80c9ed104785d46acd84a88c6df225836c876a32",
+	"cgo_harness/stage6_json_compact_certification_test.go#TestStage6JSONCompactCertification":                        "f737578353f60bee8de5f6413b9534cc8713cc51",
 	"external_scanner_checkpoints_test.go#TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots":            "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity":                    "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack":                         "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
@@ -78,6 +79,7 @@ var compactRouteLifecycleKnownCorpusTreeSHA256 = map[string]string{
 	"javascript-compact-smoke": "ed169501f3515f625f9337c18ffe3f67ba41b1573df02e07cc54d85a26978501",
 	"go-compact-smoke":         "94fcf4849cea5bcccc24ae0a1e70ee06218e0daad96434b74c27864db9fe0c81",
 	"rust-compact-smoke":       "f7120d52d2861af7fe4dc6b6d7f0073404236fe8cc6f812f9e40a16253521c63",
+	"json-compact-smoke":       "a6a9ea2b18c6a1299d3b6c92150ac65bb6bdb4d3e5471835bf6a8ceabe37e36e",
 }
 
 type compactRouteLifecycleRegistry struct {

--- a/testdata/compact_route_campaign_inventory_v1.json
+++ b/testdata/compact_route_campaign_inventory_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-inventory/v1",
-  "source_revision": "80c9ed104785d46acd84a88c6df225836c876a32",
+  "source_revision": "f737578353f60bee8de5f6413b9534cc8713cc51",
   "scope": "Graduation-critical build tags and environment controls.",
   "entries": [
     {"id":"build-parsercorephase0","kind":"build_tag","identifier":"gts_parsercorephase0","owner":"graph_head_lifecycle","stage":2,"status":"graduated","lifecycle_control":"build.phase0.internal","gate":"Equivalent physical heads retain every node, error region, lineage, and checkpoint.","final_receipt":"stage-2-physical-graph-head-merge","deletion_condition":"Delete the diagnostic build tag after the physical-head topology receipt is current."},

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "80c9ed104785d46acd84a88c6df225836c876a32",
+  "source_revision": "f737578353f60bee8de5f6413b9534cc8713cc51",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -1072,6 +1072,7 @@
         {"path": "cgo_harness/stage6_javascript_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6JavaScriptCompactCertification"},
         {"path": "cgo_harness/stage6_go_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6GoCompactCertification"},
         {"path": "cgo_harness/stage6_rust_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6RustCompactCertification"},
+        {"path": "cgo_harness/stage6_json_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6JSONCompactCertification"},
         {"path": "cgo_harness/docker/run_single_grammar_parity.sh", "role": "certification", "build_expression": "default", "symbol": "run_single_grammar_parity.sh"},
         {"path": "cgo_harness/docker/run_grammargen_focus_targets.sh", "role": "certification", "build_expression": "default", "symbol": "run_grammargen_focus_targets.sh"},
         {"path": "docs/compact-route-real-corpus-matrix.md", "role": "corpus_policy", "build_expression": "default", "symbol": "Current compact-graduation matrix"}
@@ -1097,7 +1098,11 @@
         {"name": "Rust one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh rust", "working_dir": ".", "isolation": "docker"},
         {"name": "Rust real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs rust", "working_dir": ".", "isolation": "docker"},
         {"name": "Rust C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs rust", "working_dir": ".", "isolation": "docker"},
-        {"name": "Rust compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6RustCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+        {"name": "Rust compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6RustCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"},
+        {"name": "JSON one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh json", "working_dir": ".", "isolation": "docker"},
+        {"name": "JSON real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs json", "working_dir": ".", "isolation": "docker"},
+        {"name": "JSON C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs json", "working_dir": ".", "isolation": "docker"},
+        {"name": "JSON compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6JSONCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
       ],
       "corpus": [
         {"id": "real-corpus-matrix", "kind": "authenticated_external_manifest", "path": "cgo_harness/corpus_real/manifest.json", "source": "External manifest is not present in this worktree.", "availability": "unavailable", "lock_status": "unlocked", "plan": "Acquire the authenticated manifest in an isolated certification run before Stage 6.", "lock_or_digest": ""},
@@ -1106,7 +1111,8 @@
         {"id": "python-compact-smoke", "kind": "synthetic_fixture", "path": "cgo_harness/stage6_python_compact_certification_test.go", "source": "def f():\n    return 1\n", "source_sha256": "5b76d0962c09ab4ee309fac65fad3568c97abdec983b405146ae3e86a235e352", "tree_sha256": "7d857f4d100cc7c7bf61bd1e77845066add55e2fd4f82e60309203ceb8569543", "availability": "available", "lock_status": "locked", "plan": "Keep the Python clean and recovery fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 8c6a8e1fe472ade08462b91a2ba00624ab437d61"},
         {"id": "javascript-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "function f() { return 1; }\nconst x = () => x + 1;\n", "source_sha256": "093a91b4c009bfbd15f42a1181a31c48672c97009362c6ac12ea2f57be4ad7f1", "tree_sha256": "ed169501f3515f625f9337c18ffe3f67ba41b1573df02e07cc54d85a26978501", "availability": "available", "lock_status": "locked", "plan": "Keep the JavaScript clean, recovery, and ambiguity fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 2455af16a52e4a886ae5a32842a98bb623f6671c"},
         {"id": "go-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "package main\n\nfunc main() {\n\tprintln(1)\n}\n", "source_sha256": "0496c51d052fc6f7fa761b9b317e16a3e15073cbe271f56163db4b61bf2e8220", "tree_sha256": "94fcf4849cea5bcccc24ae0a1e70ee06218e0daad96434b74c27864db9fe0c81", "availability": "available", "lock_status": "locked", "plan": "Keep the Go clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 9ec95dbcbc9a18071b697ce260e49189c0966036"},
-        {"id": "rust-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "fn main() { let x = 1; }\n", "source_sha256": "5ea70a939eaf182a1d392818bc49b8f25a74334f1002a409865050305a1abf5e", "tree_sha256": "f7120d52d2861af7fe4dc6b6d7f0073404236fe8cc6f812f9e40a16253521c63", "availability": "available", "lock_status": "locked", "plan": "Keep the Rust clean, recovery, raw-string, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 80c9ed104785d46acd84a88c6df225836c876a32"}
+        {"id": "rust-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "fn main() { let x = 1; }\n", "source_sha256": "5ea70a939eaf182a1d392818bc49b8f25a74334f1002a409865050305a1abf5e", "tree_sha256": "f7120d52d2861af7fe4dc6b6d7f0073404236fe8cc6f812f9e40a16253521c63", "availability": "available", "lock_status": "locked", "plan": "Keep the Rust clean, recovery, raw-string, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 80c9ed104785d46acd84a88c6df225836c876a32"},
+        {"id": "json-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "{\"a\": 1}\n", "source_sha256": "e8c628edc9968ef0c668f54e0ba2636b35503357eb1aca0ddc828aeace432f67", "tree_sha256": "a6a9ea2b18c6a1299d3b6c92150ac65bb6bdb4d3e5471835bf6a8ceabe37e36e", "availability": "available", "lock_status": "locked", "plan": "Keep the JSON clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at f737578353f60bee8de5f6413b9534cc8713cc51"}
       ],
       "gates": ["exact tree shape and node fields", "exact ranges and error or missing flags", "exact C and Go grammar identities", "incremental result parity", "one grammar per isolated Docker run", "zero silent divergence and explicit fallback accounting"],
       "telemetry": ["PASS/FALLBACK/DIVERGE/SKIP/ERROR scorecard rows", "deep-tree digest", "exact mismatch path and field", "fallback reason", "derivation-set receipt"],
@@ -1121,7 +1127,8 @@
         {"ref": "cgo_harness/stage6_python_compact_certification_test.go#TestStage6PythonCompactCertification", "kind": "test", "source_revision": "8c6a8e1fe472ade08462b91a2ba00624ab437d61", "status": "current"},
         {"ref": "cgo_harness/stage6_javascript_compact_certification_test.go#TestStage6JavaScriptCompactCertification", "kind": "test", "source_revision": "2455af16a52e4a886ae5a32842a98bb623f6671c", "status": "current"},
         {"ref": "cgo_harness/stage6_go_compact_certification_test.go#TestStage6GoCompactCertification", "kind": "test", "source_revision": "9ec95dbcbc9a18071b697ce260e49189c0966036", "status": "current"},
-        {"ref": "cgo_harness/stage6_rust_compact_certification_test.go#TestStage6RustCompactCertification", "kind": "test", "source_revision": "80c9ed104785d46acd84a88c6df225836c876a32", "status": "current"}
+        {"ref": "cgo_harness/stage6_rust_compact_certification_test.go#TestStage6RustCompactCertification", "kind": "test", "source_revision": "80c9ed104785d46acd84a88c6df225836c876a32", "status": "current"},
+        {"ref": "cgo_harness/stage6_json_compact_certification_test.go#TestStage6JSONCompactCertification", "kind": "test", "source_revision": "f737578353f60bee8de5f6413b9534cc8713cc51", "status": "current"}
       ],
       "deletion_condition": "Delete certification scaffolding only after every supported grammar has a current locked-C receipt for trees, fields, ranges, errors, and incremental edits.",
       "retention": "preserve_receipt",


### PR DESCRIPTION
## Summary

Certify the JSON compact route against the locked C baseline.

- Add clean, nested, recovery, and incremental JSON witnesses.
- Require compact admission for clean cases and explicit recovery fallback.
- Require exact symbols, fields, spans, points, flags, errors, and tree digests.
- Record incremental subtree and byte reuse.
- Register the JSON proof, commands, corpus digest, and source revision in both campaign registries.

## Verification

- Focused certificate: `TestStage6JSONCompactCertification` passed in Docker.
- Lifecycle and inventory validators passed in Docker.
- JSON one-grammar smoke parity: 6/6 deep parity.
- JSON generated C parity: 6/6 tree parity, 0 divergences.

Artifacts remain under `harness_out/docker/` and `harness_out/grammargen_cparity/`.