### PR TITLE
test(compact-route): certify JSON5 against locked C

### DIFF
--- a/cgo_harness/stage6_json5_compact_certification_test.go
+++ b/cgo_harness/stage6_json5_compact_certification_test.go
@@ -1,0 +1,125 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0
+
+package cgoharness
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const stage6JSON5RecoverySource = "{foo:}\n"
+
+// TestStage6JSON5CompactCertification proves clean, recovery, and incremental
+// JSON5 shapes through compact admission against the locked C oracle.
+func TestStage6JSON5CompactCertification(t *testing.T) {
+	cases := []struct {
+		name      string
+		source    []byte
+		wantRoute bool
+	}{
+		{name: "smoke", source: []byte(grammars.ParseSmokeSample("json5")), wantRoute: true},
+		{name: "recovery", source: []byte(stage6JSON5RecoverySource), wantRoute: false},
+	}
+	language := grammars.Json5Language()
+	cLanguage, err := ParityCLanguage("json5")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cParser := sitter.NewParser()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			defer cParser.Close()
+			cTree := cParser.Parse(tc.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parser returned no tree")
+			}
+			defer cTree.Close()
+
+			parser := gotreesitter.NewParser(language)
+			parser.SetAdmissionCandidateRoute(true)
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			goTree, err := parser.Parse(tc.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer goTree.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			routedDelta := routedAfter - routedBefore
+			fallbackDelta := fallbackAfter - fallbackBefore
+			reason := gotreesitter.AdmissionCandidateLastFallbackReason()
+			t.Logf("route=%d/%d reason=%q", routedDelta, fallbackDelta, reason)
+
+			if tc.wantRoute {
+				if routedDelta != 1 || fallbackDelta != 0 {
+					t.Fatalf("clean case did not route through compact admission: %d/%d", routedDelta, fallbackDelta)
+				}
+				assertLockedCTreeExact(t, "JSON5 compact "+tc.name, goTree, language, cTree)
+				return
+			}
+			if routedDelta != 0 || fallbackDelta != 1 || !strings.Contains(reason, "recovery") {
+				t.Fatalf("recovery case route=%d/%d reason=%q", routedDelta, fallbackDelta, reason)
+			}
+			if goTree.RootNode().HasError() != cTree.RootNode().HasError() {
+				t.Fatalf("JSON5 recovery root error differs: Go=%v C=%v", goTree.RootNode().HasError(), cTree.RootNode().HasError())
+			}
+			if diff := FirstDivergenceDumpV1(goTree.RootNode(), language, cTree.RootNode()); diff != nil {
+				t.Fatalf("JSON5 recovery tree diverges from locked C: %+v", diff)
+			}
+		})
+	}
+
+	t.Run("incremental", func(t *testing.T) {
+		source := []byte(grammars.ParseSmokeSample("json5"))
+		offset := bytes.IndexByte(source, 'v')
+		if offset < 0 {
+			t.Fatal("JSON5 smoke source has no value edit witness")
+		}
+		edited := append([]byte(nil), source...)
+		edited[offset] = 'V'
+		parser := gotreesitter.NewParser(language)
+		parser.SetAdmissionCandidateRoute(true)
+		oldTree, err := parser.Parse(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer oldTree.Release()
+		oldTree.Edit(gotreesitter.InputEdit{
+			StartByte:   uint32(offset),
+			OldEndByte:  uint32(offset + 1),
+			NewEndByte:  uint32(offset + 1),
+			StartPoint:  pointAtOffset(source, offset),
+			OldEndPoint: pointAtOffset(source, offset+1),
+			NewEndPoint: pointAtOffset(edited, offset+1),
+		})
+		incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer incremental.Release()
+		t.Logf("profile=%+v", profile)
+		if profile.ReuseUnsupported || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+			t.Fatalf("JSON5 incremental reuse unavailable: %+v", profile)
+		}
+
+		cParser := sitter.NewParser()
+		if err := cParser.SetLanguage(cLanguage); err != nil {
+			t.Fatal(err)
+		}
+		defer cParser.Close()
+		cTree := cParser.Parse(edited, nil)
+		if cTree == nil || cTree.RootNode() == nil {
+			t.Fatal("C parser returned no edited tree")
+		}
+		defer cTree.Close()
+		assertLockedCTreeExact(t, "JSON5 compact incremental", incremental, language, cTree)
+	})
+}

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "030eeb6af96005367d4e4eb9ad92f204c72aa1d4"
+	compactRouteLifecycleSourceRevision               = "5f6c67f40ebfbc36798023462cf3eb97c4d0e43e"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -62,6 +62,7 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"cgo_harness/stage6_json_compact_certification_test.go#TestStage6JSONCompactCertification":                          "f737578353f60bee8de5f6413b9534cc8713cc51",
 	"cgo_harness/stage6_c_compact_certification_test.go#TestStage6CCompactCertification":                                "f5fc2537b3d8126bc1bdaeed6f42c0f21f139ffa",
 	"cgo_harness/stage6_css_compact_certification_test.go#TestStage6CSSCompactCertification":                            "030eeb6af96005367d4e4eb9ad92f204c72aa1d4",
+	"cgo_harness/stage6_json5_compact_certification_test.go#TestStage6JSON5CompactCertification":                        "5f6c67f40ebfbc36798023462cf3eb97c4d0e43e",
 	"external_scanner_checkpoints_test.go#TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots":            "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity":                    "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack":                         "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
@@ -84,6 +85,7 @@ var compactRouteLifecycleKnownCorpusTreeSHA256 = map[string]string{
 	"json-compact-smoke":       "a6a9ea2b18c6a1299d3b6c92150ac65bb6bdb4d3e5471835bf6a8ceabe37e36e",
 	"c-compact-smoke":          "b35547117f044e74311e70eeb45bd3967598fdca38a963937e2eeaad29bed7b7",
 	"css-compact-smoke":        "1363ea554c5d75bffc553bce1514068e02eb934c204f585e452ddc9211ea4af0",
+	"json5-compact-smoke":      "84634d0f446a4af1d216bd534c2456006827b71c13a99f0fdfc4f71c76d19dc8",
 }
 
 type compactRouteLifecycleRegistry struct {

--- a/testdata/compact_route_campaign_inventory_v1.json
+++ b/testdata/compact_route_campaign_inventory_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-inventory/v1",
-  "source_revision": "030eeb6af96005367d4e4eb9ad92f204c72aa1d4",
+  "source_revision": "5f6c67f40ebfbc36798023462cf3eb97c4d0e43e",
   "scope": "Graduation-critical build tags and environment controls.",
   "entries": [
     {"id":"build-parsercorephase0","kind":"build_tag","identifier":"gts_parsercorephase0","owner":"graph_head_lifecycle","stage":2,"status":"graduated","lifecycle_control":"build.phase0.internal","gate":"Equivalent physical heads retain every node, error region, lineage, and checkpoint.","final_receipt":"stage-2-physical-graph-head-merge","deletion_condition":"Delete the diagnostic build tag after the physical-head topology receipt is current."},

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "030eeb6af96005367d4e4eb9ad92f204c72aa1d4",
+  "source_revision": "5f6c67f40ebfbc36798023462cf3eb97c4d0e43e",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -1075,6 +1075,7 @@
         {"path": "cgo_harness/stage6_json_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6JSONCompactCertification"},
         {"path": "cgo_harness/stage6_c_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6CCompactCertification"},
         {"path": "cgo_harness/stage6_css_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6CSSCompactCertification"},
+        {"path": "cgo_harness/stage6_json5_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6JSON5CompactCertification"},
         {"path": "cgo_harness/docker/run_single_grammar_parity.sh", "role": "certification", "build_expression": "default", "symbol": "run_single_grammar_parity.sh"},
         {"path": "cgo_harness/docker/run_grammargen_focus_targets.sh", "role": "certification", "build_expression": "default", "symbol": "run_grammargen_focus_targets.sh"},
         {"path": "docs/compact-route-real-corpus-matrix.md", "role": "corpus_policy", "build_expression": "default", "symbol": "Current compact-graduation matrix"}
@@ -1112,7 +1113,11 @@
         {"name": "CSS one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh css", "working_dir": ".", "isolation": "docker"},
         {"name": "CSS real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs css", "working_dir": ".", "isolation": "docker"},
         {"name": "CSS C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs css", "working_dir": ".", "isolation": "docker"},
-        {"name": "CSS compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6CSSCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+        {"name": "CSS compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6CSSCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"},
+        {"name": "JSON5 one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh json5", "working_dir": ".", "isolation": "docker"},
+        {"name": "JSON5 real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs json5", "working_dir": ".", "isolation": "docker"},
+        {"name": "JSON5 C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs json5", "working_dir": ".", "isolation": "docker"},
+        {"name": "JSON5 compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6JSON5CompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
       ],
       "corpus": [
         {"id": "real-corpus-matrix", "kind": "authenticated_external_manifest", "path": "cgo_harness/corpus_real/manifest.json", "source": "External manifest is not present in this worktree.", "availability": "unavailable", "lock_status": "unlocked", "plan": "Acquire the authenticated manifest in an isolated certification run before Stage 6.", "lock_or_digest": ""},
@@ -1124,7 +1129,8 @@
         {"id": "rust-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "fn main() { let x = 1; }\n", "source_sha256": "5ea70a939eaf182a1d392818bc49b8f25a74334f1002a409865050305a1abf5e", "tree_sha256": "f7120d52d2861af7fe4dc6b6d7f0073404236fe8cc6f812f9e40a16253521c63", "availability": "available", "lock_status": "locked", "plan": "Keep the Rust clean, recovery, raw-string, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 80c9ed104785d46acd84a88c6df225836c876a32"},
         {"id": "json-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "{\"a\": 1}\n", "source_sha256": "e8c628edc9968ef0c668f54e0ba2636b35503357eb1aca0ddc828aeace432f67", "tree_sha256": "a6a9ea2b18c6a1299d3b6c92150ac65bb6bdb4d3e5471835bf6a8ceabe37e36e", "availability": "available", "lock_status": "locked", "plan": "Keep the JSON clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at f737578353f60bee8de5f6413b9534cc8713cc51"},
         {"id": "c-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "int main(void) { return 0; }\n", "source_sha256": "2ad75d95660563887d8d3f1d0ae1dcf18c2379cbd83a5c72f5ab276351ee6949", "tree_sha256": "b35547117f044e74311e70eeb45bd3967598fdca38a963937e2eeaad29bed7b7", "availability": "available", "lock_status": "locked", "plan": "Keep the C clean, declaration, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at f5fc2537b3d8126bc1bdaeed6f42c0f21f139ffa"},
-        {"id": "css-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "body { color: red; }\n", "source_sha256": "9767e91e9d4b0334e59a1d389e9801bc6a2c5c4a5500a3c2c7915687965b2c16", "tree_sha256": "1363ea554c5d75bffc553bce1514068e02eb934c204f585e452ddc9211ea4af0", "availability": "available", "lock_status": "locked", "plan": "Keep the CSS clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 030eeb6af96005367d4e4eb9ad92f204c72aa1d4"}
+        {"id": "css-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "body { color: red; }\n", "source_sha256": "9767e91e9d4b0334e59a1d389e9801bc6a2c5c4a5500a3c2c7915687965b2c16", "tree_sha256": "1363ea554c5d75bffc553bce1514068e02eb934c204f585e452ddc9211ea4af0", "availability": "available", "lock_status": "locked", "plan": "Keep the CSS clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 030eeb6af96005367d4e4eb9ad92f204c72aa1d4"},
+        {"id": "json5-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "{ \"key\": \"value\" }\n", "source_sha256": "4b62535130112385645094ffd8fe8714453bc3639d48bd8acad45b3cacd2e7aa", "tree_sha256": "84634d0f446a4af1d216bd534c2456006827b71c13a99f0fdfc4f71c76d19dc8", "availability": "available", "lock_status": "locked", "plan": "Keep the JSON5 clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 5f6c67f40ebfbc36798023462cf3eb97c4d0e43e"}
       ],
       "gates": ["exact tree shape and node fields", "exact ranges and error or missing flags", "exact C and Go grammar identities", "incremental result parity", "one grammar per isolated Docker run", "zero silent divergence and explicit fallback accounting"],
       "telemetry": ["PASS/FALLBACK/DIVERGE/SKIP/ERROR scorecard rows", "deep-tree digest", "exact mismatch path and field", "fallback reason", "derivation-set receipt"],
@@ -1142,7 +1148,8 @@
         {"ref": "cgo_harness/stage6_rust_compact_certification_test.go#TestStage6RustCompactCertification", "kind": "test", "source_revision": "80c9ed104785d46acd84a88c6df225836c876a32", "status": "current"},
         {"ref": "cgo_harness/stage6_json_compact_certification_test.go#TestStage6JSONCompactCertification", "kind": "test", "source_revision": "f737578353f60bee8de5f6413b9534cc8713cc51", "status": "current"},
         {"ref": "cgo_harness/stage6_c_compact_certification_test.go#TestStage6CCompactCertification", "kind": "test", "source_revision": "f5fc2537b3d8126bc1bdaeed6f42c0f21f139ffa", "status": "current"},
-        {"ref": "cgo_harness/stage6_css_compact_certification_test.go#TestStage6CSSCompactCertification", "kind": "test", "source_revision": "030eeb6af96005367d4e4eb9ad92f204c72aa1d4", "status": "current"}
+        {"ref": "cgo_harness/stage6_css_compact_certification_test.go#TestStage6CSSCompactCertification", "kind": "test", "source_revision": "030eeb6af96005367d4e4eb9ad92f204c72aa1d4", "status": "current"},
+        {"ref": "cgo_harness/stage6_json5_compact_certification_test.go#TestStage6JSON5CompactCertification", "kind": "test", "source_revision": "5f6c67f40ebfbc36798023462cf3eb97c4d0e43e", "status": "current"}
       ],
       "deletion_condition": "Delete certification scaffolding only after every supported grammar has a current locked-C receipt for trees, fields, ranges, errors, and incremental edits.",
       "retention": "preserve_receipt",


### PR DESCRIPTION
## Summary

- Add the Stage 6 JSON5 compact-route certification test.
- Compare clean, recovery, and incremental results with the locked C oracle.
- Register the JSON5 proof, corpus digest, commands, and lifecycle receipt.

## Required proof

- Clean smoke source routes through compact admission once with no fallback.
- Recovery source `{foo:}\n` falls back once with a recovery reason and matches C tree shape, ranges, and error flags.
- Incremental edit changes `value` to `Value`, reuses one subtree and 19 bytes, and matches the fresh C tree.
- The test records the deep tree digest `84634d0f446a4af1d216bd534c2456006827b71c13a99f0fdfc4f71c76d19dc8`.

## Receipts

- Focused certificate: `harness_out/docker/20260902T144345Z-stage6-json5-certification-final`.
- Focused race certificate: `harness_out/docker/20260902T145303Z-stage6-json5-certification-race`.
- One-grammar Docker parity: 25/25 no-error, sexpr, and deep parity; `harness_out/docker/20260902T143526Z-diag-json5`.
- Generated C parity: 20/20 tree parity with zero divergences; `harness_out/grammargen_cparity/20260902_073535`.
- Lifecycle and inventory validators pass: `harness_out/docker/20260902T144255Z`.
- No parser implementation or performance changes are included.