### PR TITLE
test(compact-route): certify Go Mod against locked C

### DIFF
--- a/cgo_harness/stage6_gomod_compact_certification_test.go
+++ b/cgo_harness/stage6_gomod_compact_certification_test.go
@@ -1,0 +1,125 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0
+
+package cgoharness
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const stage6GomodRecoverySource = "module example.com/foo\n\ngo\n"
+
+// TestStage6GomodCompactCertification proves clean, recovery, and incremental
+// Gomod shapes through compact admission against the locked C oracle.
+func TestStage6GomodCompactCertification(t *testing.T) {
+	cases := []struct {
+		name      string
+		source    []byte
+		wantRoute bool
+	}{
+		{name: "smoke", source: []byte(grammars.ParseSmokeSample("gomod")), wantRoute: true},
+		{name: "recovery", source: []byte(stage6GomodRecoverySource), wantRoute: false},
+	}
+	language := grammars.GomodLanguage()
+	cLanguage, err := ParityCLanguage("gomod")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cParser := sitter.NewParser()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			defer cParser.Close()
+			cTree := cParser.Parse(tc.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parser returned no tree")
+			}
+			defer cTree.Close()
+
+			parser := gotreesitter.NewParser(language)
+			parser.SetAdmissionCandidateRoute(true)
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			goTree, err := parser.Parse(tc.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer goTree.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			routedDelta := routedAfter - routedBefore
+			fallbackDelta := fallbackAfter - fallbackBefore
+			reason := gotreesitter.AdmissionCandidateLastFallbackReason()
+			t.Logf("route=%d/%d reason=%q", routedDelta, fallbackDelta, reason)
+
+			if tc.wantRoute {
+				if routedDelta != 1 || fallbackDelta != 0 {
+					t.Fatalf("clean case did not route through compact admission: %d/%d", routedDelta, fallbackDelta)
+				}
+				assertLockedCTreeExact(t, "Gomod compact "+tc.name, goTree, language, cTree)
+				return
+			}
+			if routedDelta != 0 || fallbackDelta != 1 || !strings.Contains(reason, "recovery") {
+				t.Fatalf("recovery case route=%d/%d reason=%q", routedDelta, fallbackDelta, reason)
+			}
+			if goTree.RootNode().HasError() != cTree.RootNode().HasError() {
+				t.Fatalf("Gomod recovery root error differs: Go=%v C=%v", goTree.RootNode().HasError(), cTree.RootNode().HasError())
+			}
+			if diff := FirstDivergenceDumpV1(goTree.RootNode(), language, cTree.RootNode()); diff != nil {
+				t.Fatalf("Gomod recovery tree diverges from locked C: %+v", diff)
+			}
+		})
+	}
+
+	t.Run("incremental", func(t *testing.T) {
+		source := []byte(grammars.ParseSmokeSample("gomod"))
+		offset := bytes.Index(source, []byte("example"))
+		if offset < 0 {
+			t.Fatal("Gomod smoke source has no module edit witness")
+		}
+		edited := append([]byte(nil), source...)
+		edited[offset] = 'w'
+		parser := gotreesitter.NewParser(language)
+		parser.SetAdmissionCandidateRoute(true)
+		oldTree, err := parser.Parse(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer oldTree.Release()
+		oldTree.Edit(gotreesitter.InputEdit{
+			StartByte:   uint32(offset),
+			OldEndByte:  uint32(offset + 1),
+			NewEndByte:  uint32(offset + 1),
+			StartPoint:  pointAtOffset(source, offset),
+			OldEndPoint: pointAtOffset(source, offset+1),
+			NewEndPoint: pointAtOffset(edited, offset+1),
+		})
+		incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer incremental.Release()
+		t.Logf("profile=%+v", profile)
+		if profile.ReuseUnsupported || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+			t.Fatalf("Gomod incremental reuse unavailable: %+v", profile)
+		}
+
+		cParser := sitter.NewParser()
+		if err := cParser.SetLanguage(cLanguage); err != nil {
+			t.Fatal(err)
+		}
+		defer cParser.Close()
+		cTree := cParser.Parse(edited, nil)
+		if cTree == nil || cTree.RootNode() == nil {
+			t.Fatal("C parser returned no edited tree")
+		}
+		defer cTree.Close()
+		assertLockedCTreeExact(t, "Gomod compact incremental", incremental, language, cTree)
+	})
+}

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "95f6a662cde03046c951fad083ea1ce31f58987a"
+	compactRouteLifecycleSourceRevision               = "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -64,6 +64,7 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"cgo_harness/stage6_css_compact_certification_test.go#TestStage6CSSCompactCertification":                            "030eeb6af96005367d4e4eb9ad92f204c72aa1d4",
 	"cgo_harness/stage6_json5_compact_certification_test.go#TestStage6JSON5CompactCertification":                        "5f6c67f40ebfbc36798023462cf3eb97c4d0e43e",
 	"cgo_harness/stage6_graphql_compact_certification_test.go#TestStage6GraphQLCompactCertification":                    "95f6a662cde03046c951fad083ea1ce31f58987a",
+	"cgo_harness/stage6_gomod_compact_certification_test.go#TestStage6GomodCompactCertification":                        "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4",
 	"external_scanner_checkpoints_test.go#TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots":            "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity":                    "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack":                         "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
@@ -88,6 +89,7 @@ var compactRouteLifecycleKnownCorpusTreeSHA256 = map[string]string{
 	"css-compact-smoke":        "1363ea554c5d75bffc553bce1514068e02eb934c204f585e452ddc9211ea4af0",
 	"json5-compact-smoke":      "84634d0f446a4af1d216bd534c2456006827b71c13a99f0fdfc4f71c76d19dc8",
 	"graphql-compact-smoke":     "6f9260d83a72d90ec6bc009dfb7cad8d9c3be34daa4168884d539de31ea5f094",
+	"gomod-compact-smoke":       "eab97016de62bfda36b75049cfcb0753639b518ec065590f1f5e64a4dc2132b3",
 }
 
 type compactRouteLifecycleRegistry struct {

--- a/testdata/compact_route_campaign_inventory_v1.json
+++ b/testdata/compact_route_campaign_inventory_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-inventory/v1",
-  "source_revision": "95f6a662cde03046c951fad083ea1ce31f58987a",
+  "source_revision": "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4",
   "scope": "Graduation-critical build tags and environment controls.",
   "entries": [
     {"id":"build-parsercorephase0","kind":"build_tag","identifier":"gts_parsercorephase0","owner":"graph_head_lifecycle","stage":2,"status":"graduated","lifecycle_control":"build.phase0.internal","gate":"Equivalent physical heads retain every node, error region, lineage, and checkpoint.","final_receipt":"stage-2-physical-graph-head-merge","deletion_condition":"Delete the diagnostic build tag after the physical-head topology receipt is current."},

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "95f6a662cde03046c951fad083ea1ce31f58987a",
+  "source_revision": "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -1077,6 +1077,7 @@
         {"path": "cgo_harness/stage6_css_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6CSSCompactCertification"},
         {"path": "cgo_harness/stage6_json5_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6JSON5CompactCertification"},
         {"path": "cgo_harness/stage6_graphql_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6GraphQLCompactCertification"},
+        {"path": "cgo_harness/stage6_gomod_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6GomodCompactCertification"},
         {"path": "cgo_harness/docker/run_single_grammar_parity.sh", "role": "certification", "build_expression": "default", "symbol": "run_single_grammar_parity.sh"},
         {"path": "cgo_harness/docker/run_grammargen_focus_targets.sh", "role": "certification", "build_expression": "default", "symbol": "run_grammargen_focus_targets.sh"},
         {"path": "docs/compact-route-real-corpus-matrix.md", "role": "corpus_policy", "build_expression": "default", "symbol": "Current compact-graduation matrix"}
@@ -1122,7 +1123,11 @@
         {"name": "GraphQL one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh graphql", "working_dir": ".", "isolation": "docker"},
         {"name": "GraphQL real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs graphql", "working_dir": ".", "isolation": "docker"},
         {"name": "GraphQL C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs graphql", "working_dir": ".", "isolation": "docker"},
-        {"name": "GraphQL compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6GraphQLCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+        {"name": "GraphQL compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6GraphQLCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"},
+        {"name": "Go Mod one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh gomod", "working_dir": ".", "isolation": "docker"},
+        {"name": "Go Mod real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs gomod", "working_dir": ".", "isolation": "docker"},
+        {"name": "Go Mod C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs gomod", "working_dir": ".", "isolation": "docker"},
+        {"name": "Go Mod compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6GomodCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
       ],
       "corpus": [
         {"id": "real-corpus-matrix", "kind": "authenticated_external_manifest", "path": "cgo_harness/corpus_real/manifest.json", "source": "External manifest is not present in this worktree.", "availability": "unavailable", "lock_status": "unlocked", "plan": "Acquire the authenticated manifest in an isolated certification run before Stage 6.", "lock_or_digest": ""},
@@ -1136,7 +1141,8 @@
         {"id": "c-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "int main(void) { return 0; }\n", "source_sha256": "2ad75d95660563887d8d3f1d0ae1dcf18c2379cbd83a5c72f5ab276351ee6949", "tree_sha256": "b35547117f044e74311e70eeb45bd3967598fdca38a963937e2eeaad29bed7b7", "availability": "available", "lock_status": "locked", "plan": "Keep the C clean, declaration, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at f5fc2537b3d8126bc1bdaeed6f42c0f21f139ffa"},
         {"id": "css-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "body { color: red; }\n", "source_sha256": "9767e91e9d4b0334e59a1d389e9801bc6a2c5c4a5500a3c2c7915687965b2c16", "tree_sha256": "1363ea554c5d75bffc553bce1514068e02eb934c204f585e452ddc9211ea4af0", "availability": "available", "lock_status": "locked", "plan": "Keep the CSS clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 030eeb6af96005367d4e4eb9ad92f204c72aa1d4"},
         {"id": "json5-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "{ \"key\": \"value\" }\n", "source_sha256": "4b62535130112385645094ffd8fe8714453bc3639d48bd8acad45b3cacd2e7aa", "tree_sha256": "84634d0f446a4af1d216bd534c2456006827b71c13a99f0fdfc4f71c76d19dc8", "availability": "available", "lock_status": "locked", "plan": "Keep the JSON5 clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 5f6c67f40ebfbc36798023462cf3eb97c4d0e43e"},
-        {"id": "graphql-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "type Query { hello: String }\n", "source_sha256": "6857b6d6b31b106e76fbdc47a590386ae89aeb43b0d0e82ca61fc4bde360485d", "tree_sha256": "6f9260d83a72d90ec6bc009dfb7cad8d9c3be34daa4168884d539de31ea5f094", "availability": "available", "lock_status": "locked", "plan": "Keep the GraphQL clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 95f6a662cde03046c951fad083ea1ce31f58987a"}
+        {"id": "graphql-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "type Query { hello: String }\n", "source_sha256": "6857b6d6b31b106e76fbdc47a590386ae89aeb43b0d0e82ca61fc4bde360485d", "tree_sha256": "6f9260d83a72d90ec6bc009dfb7cad8d9c3be34daa4168884d539de31ea5f094", "availability": "available", "lock_status": "locked", "plan": "Keep the GraphQL clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 95f6a662cde03046c951fad083ea1ce31f58987a"},
+        {"id": "gomod-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "module example.com/foo\n\ngo 1.21\n", "source_sha256": "b9026fa110a33332ec050cbb545a1f23ee0895b817bdf380eb86c8a84036f6ed", "tree_sha256": "eab97016de62bfda36b75049cfcb0753639b518ec065590f1f5e64a4dc2132b3", "availability": "available", "lock_status": "locked", "plan": "Keep the Go Mod clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4"}
       ],
       "gates": ["exact tree shape and node fields", "exact ranges and error or missing flags", "exact C and Go grammar identities", "incremental result parity", "one grammar per isolated Docker run", "zero silent divergence and explicit fallback accounting"],
       "telemetry": ["PASS/FALLBACK/DIVERGE/SKIP/ERROR scorecard rows", "deep-tree digest", "exact mismatch path and field", "fallback reason", "derivation-set receipt"],
@@ -1156,7 +1162,8 @@
         {"ref": "cgo_harness/stage6_c_compact_certification_test.go#TestStage6CCompactCertification", "kind": "test", "source_revision": "f5fc2537b3d8126bc1bdaeed6f42c0f21f139ffa", "status": "current"},
         {"ref": "cgo_harness/stage6_css_compact_certification_test.go#TestStage6CSSCompactCertification", "kind": "test", "source_revision": "030eeb6af96005367d4e4eb9ad92f204c72aa1d4", "status": "current"},
         {"ref": "cgo_harness/stage6_json5_compact_certification_test.go#TestStage6JSON5CompactCertification", "kind": "test", "source_revision": "5f6c67f40ebfbc36798023462cf3eb97c4d0e43e", "status": "current"},
-        {"ref": "cgo_harness/stage6_graphql_compact_certification_test.go#TestStage6GraphQLCompactCertification", "kind": "test", "source_revision": "95f6a662cde03046c951fad083ea1ce31f58987a", "status": "current"}
+        {"ref": "cgo_harness/stage6_graphql_compact_certification_test.go#TestStage6GraphQLCompactCertification", "kind": "test", "source_revision": "95f6a662cde03046c951fad083ea1ce31f58987a", "status": "current"},
+        {"ref": "cgo_harness/stage6_gomod_compact_certification_test.go#TestStage6GomodCompactCertification", "kind": "test", "source_revision": "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4", "status": "current"}
       ],
       "deletion_condition": "Delete certification scaffolding only after every supported grammar has a current locked-C receipt for trees, fields, ranges, errors, and incremental edits.",
       "retention": "preserve_receipt",


### PR DESCRIPTION
## Summary

Certify Go Mod as the next Stage 6 compact-route grammar.

- Exercise clean admission, recovery fallback, and incremental reuse.
- Compare exact trees, ranges, and error flags with the locked C oracle.
- Record the fixture, proof receipt, and Docker commands in both campaign registries.

## Evidence

- Clean smoke: route 1/0; locked-C tree digest `eab97016de62bfda36b75049cfcb0753639b518ec065590f1f5e64a4dc2132b3`.
- Recovery fixture `module example.com/foo` with a missing Go version: route 0/1 with a recovery fallback reason; exact C tree.
- Incremental edit of the module name: one reused subtree and 6 reused bytes; exact C tree.
- Focused Docker receipt: `/home/draco/work/gts-compact-stage6-gomod-certification-20260902/harness_out/docker/20260902T144843Z-stage6-gomod-certification-probe`.
- Race Docker receipt: `/home/draco/work/gts-compact-stage6-gomod-certification-20260902/harness_out/docker/20260902T145455Z-stage6-gomod-certification-race`.
- One-grammar parity: 20/20 at `/home/draco/work/gts-compact-stage6-gomod-certification-20260902/harness_out/docker/20260902T144853Z-diag-gomod`.
- Generated-C parity: 4/4 at `/home/draco/work/gts-compact-stage6-gomod-certification-20260902/harness_out/grammargen_cparity/20260902_074902`.
- Lifecycle and inventory registry gate passes in Docker at `/home/draco/work/gts-compact-stage6-gomod-certification-20260902/harness_out/docker/20260902T152603Z`.

This PR contains certification and registry evidence only. It does not change parser behavior.
