### PR TITLE
test(compact-route): certify Todo.txt against locked C

### DIFF
--- a/cgo_harness/stage6_todotxt_compact_certification_test.go
+++ b/cgo_harness/stage6_todotxt_compact_certification_test.go
@@ -1,0 +1,125 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0
+
+package cgoharness
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const stage6TodotxtRecoverySource = "(A)\n"
+
+// TestStage6TodotxtCompactCertification proves clean, recovery, and incremental
+// Todo.txt shapes through compact admission against the locked C oracle.
+func TestStage6TodotxtCompactCertification(t *testing.T) {
+	cases := []struct {
+		name      string
+		source    []byte
+		wantRoute bool
+	}{
+		{name: "smoke", source: []byte(grammars.ParseSmokeSample("todotxt")), wantRoute: true},
+		{name: "recovery", source: []byte(stage6TodotxtRecoverySource), wantRoute: false},
+	}
+	language := grammars.TodotxtLanguage()
+	cLanguage, err := ParityCLanguage("todotxt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cParser := sitter.NewParser()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			defer cParser.Close()
+			cTree := cParser.Parse(tc.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parser returned no tree")
+			}
+			defer cTree.Close()
+
+			parser := gotreesitter.NewParser(language)
+			parser.SetAdmissionCandidateRoute(true)
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			goTree, err := parser.Parse(tc.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer goTree.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			routedDelta := routedAfter - routedBefore
+			fallbackDelta := fallbackAfter - fallbackBefore
+			reason := gotreesitter.AdmissionCandidateLastFallbackReason()
+			t.Logf("route=%d/%d reason=%q", routedDelta, fallbackDelta, reason)
+
+			if tc.wantRoute {
+				if routedDelta != 1 || fallbackDelta != 0 {
+					t.Fatalf("clean case did not route through compact admission: %d/%d", routedDelta, fallbackDelta)
+				}
+				assertLockedCTreeExact(t, "Todo.txt compact "+tc.name, goTree, language, cTree)
+				return
+			}
+			if routedDelta != 0 || fallbackDelta != 1 || !strings.Contains(reason, "recovery") {
+				t.Fatalf("recovery case route=%d/%d reason=%q", routedDelta, fallbackDelta, reason)
+			}
+			if goTree.RootNode().HasError() != cTree.RootNode().HasError() {
+				t.Fatalf("Todo.txt recovery root error differs: Go=%v C=%v", goTree.RootNode().HasError(), cTree.RootNode().HasError())
+			}
+			if diff := FirstDivergenceDumpV1(goTree.RootNode(), language, cTree.RootNode()); diff != nil {
+				t.Fatalf("Todo.txt recovery tree diverges from locked C: %+v", diff)
+			}
+		})
+	}
+
+	t.Run("incremental", func(t *testing.T) {
+		source := []byte(grammars.ParseSmokeSample("todotxt"))
+		offset := bytes.Index(source, []byte("milk"))
+		if offset < 0 {
+			t.Fatal("Todo.txt smoke source has no item edit witness")
+		}
+		edited := append([]byte(nil), source...)
+		edited[offset] = 's'
+		parser := gotreesitter.NewParser(language)
+		parser.SetAdmissionCandidateRoute(true)
+		oldTree, err := parser.Parse(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer oldTree.Release()
+		oldTree.Edit(gotreesitter.InputEdit{
+			StartByte:   uint32(offset),
+			OldEndByte:  uint32(offset + 1),
+			NewEndByte:  uint32(offset + 1),
+			StartPoint:  pointAtOffset(source, offset),
+			OldEndPoint: pointAtOffset(source, offset+1),
+			NewEndPoint: pointAtOffset(edited, offset+1),
+		})
+		incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer incremental.Release()
+		t.Logf("profile=%+v", profile)
+		if profile.ReuseUnsupported || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+			t.Fatalf("Todo.txt incremental reuse unavailable: %+v", profile)
+		}
+
+		cParser := sitter.NewParser()
+		if err := cParser.SetLanguage(cLanguage); err != nil {
+			t.Fatal(err)
+		}
+		defer cParser.Close()
+		cTree := cParser.Parse(edited, nil)
+		if cTree == nil || cTree.RootNode() == nil {
+			t.Fatal("C parser returned no edited tree")
+		}
+		defer cTree.Close()
+		assertLockedCTreeExact(t, "Todo.txt compact incremental", incremental, language, cTree)
+	})
+}

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4"
+	compactRouteLifecycleSourceRevision               = "080491a0d7bef8efc3293ef91a3b1e613aeb390d"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -65,6 +65,7 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"cgo_harness/stage6_json5_compact_certification_test.go#TestStage6JSON5CompactCertification":                        "5f6c67f40ebfbc36798023462cf3eb97c4d0e43e",
 	"cgo_harness/stage6_graphql_compact_certification_test.go#TestStage6GraphQLCompactCertification":                    "95f6a662cde03046c951fad083ea1ce31f58987a",
 	"cgo_harness/stage6_gomod_compact_certification_test.go#TestStage6GomodCompactCertification":                        "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4",
+	"cgo_harness/stage6_todotxt_compact_certification_test.go#TestStage6TodotxtCompactCertification":                    "080491a0d7bef8efc3293ef91a3b1e613aeb390d",
 	"external_scanner_checkpoints_test.go#TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots":            "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity":                    "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack":                         "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
@@ -90,6 +91,7 @@ var compactRouteLifecycleKnownCorpusTreeSHA256 = map[string]string{
 	"json5-compact-smoke":      "84634d0f446a4af1d216bd534c2456006827b71c13a99f0fdfc4f71c76d19dc8",
 	"graphql-compact-smoke":     "6f9260d83a72d90ec6bc009dfb7cad8d9c3be34daa4168884d539de31ea5f094",
 	"gomod-compact-smoke":       "eab97016de62bfda36b75049cfcb0753639b518ec065590f1f5e64a4dc2132b3",
+	"todotxt-compact-smoke":     "15665e03ab3a66f0dd188960881f6ec2c13bd4ac912746490c7e9cae8a72aac5",
 }
 
 type compactRouteLifecycleRegistry struct {

--- a/testdata/compact_route_campaign_inventory_v1.json
+++ b/testdata/compact_route_campaign_inventory_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-inventory/v1",
-  "source_revision": "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4",
+  "source_revision": "080491a0d7bef8efc3293ef91a3b1e613aeb390d",
   "scope": "Graduation-critical build tags and environment controls.",
   "entries": [
     {"id":"build-parsercorephase0","kind":"build_tag","identifier":"gts_parsercorephase0","owner":"graph_head_lifecycle","stage":2,"status":"graduated","lifecycle_control":"build.phase0.internal","gate":"Equivalent physical heads retain every node, error region, lineage, and checkpoint.","final_receipt":"stage-2-physical-graph-head-merge","deletion_condition":"Delete the diagnostic build tag after the physical-head topology receipt is current."},

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4",
+  "source_revision": "080491a0d7bef8efc3293ef91a3b1e613aeb390d",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -1078,6 +1078,7 @@
         {"path": "cgo_harness/stage6_json5_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6JSON5CompactCertification"},
         {"path": "cgo_harness/stage6_graphql_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6GraphQLCompactCertification"},
         {"path": "cgo_harness/stage6_gomod_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6GomodCompactCertification"},
+        {"path": "cgo_harness/stage6_todotxt_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6TodotxtCompactCertification"},
         {"path": "cgo_harness/docker/run_single_grammar_parity.sh", "role": "certification", "build_expression": "default", "symbol": "run_single_grammar_parity.sh"},
         {"path": "cgo_harness/docker/run_grammargen_focus_targets.sh", "role": "certification", "build_expression": "default", "symbol": "run_grammargen_focus_targets.sh"},
         {"path": "docs/compact-route-real-corpus-matrix.md", "role": "corpus_policy", "build_expression": "default", "symbol": "Current compact-graduation matrix"}
@@ -1127,7 +1128,11 @@
         {"name": "Go Mod one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh gomod", "working_dir": ".", "isolation": "docker"},
         {"name": "Go Mod real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs gomod", "working_dir": ".", "isolation": "docker"},
         {"name": "Go Mod C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs gomod", "working_dir": ".", "isolation": "docker"},
-        {"name": "Go Mod compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6GomodCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+        {"name": "Go Mod compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6GomodCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"},
+        {"name": "Todo.txt one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh todotxt", "working_dir": ".", "isolation": "docker"},
+        {"name": "Todo.txt real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs todotxt", "working_dir": ".", "isolation": "docker"},
+        {"name": "Todo.txt C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs todotxt", "working_dir": ".", "isolation": "docker"},
+        {"name": "Todo.txt compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6TodotxtCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
       ],
       "corpus": [
         {"id": "real-corpus-matrix", "kind": "authenticated_external_manifest", "path": "cgo_harness/corpus_real/manifest.json", "source": "External manifest is not present in this worktree.", "availability": "unavailable", "lock_status": "unlocked", "plan": "Acquire the authenticated manifest in an isolated certification run before Stage 6.", "lock_or_digest": ""},
@@ -1142,7 +1147,8 @@
         {"id": "css-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "body { color: red; }\n", "source_sha256": "9767e91e9d4b0334e59a1d389e9801bc6a2c5c4a5500a3c2c7915687965b2c16", "tree_sha256": "1363ea554c5d75bffc553bce1514068e02eb934c204f585e452ddc9211ea4af0", "availability": "available", "lock_status": "locked", "plan": "Keep the CSS clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 030eeb6af96005367d4e4eb9ad92f204c72aa1d4"},
         {"id": "json5-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "{ \"key\": \"value\" }\n", "source_sha256": "4b62535130112385645094ffd8fe8714453bc3639d48bd8acad45b3cacd2e7aa", "tree_sha256": "84634d0f446a4af1d216bd534c2456006827b71c13a99f0fdfc4f71c76d19dc8", "availability": "available", "lock_status": "locked", "plan": "Keep the JSON5 clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 5f6c67f40ebfbc36798023462cf3eb97c4d0e43e"},
         {"id": "graphql-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "type Query { hello: String }\n", "source_sha256": "6857b6d6b31b106e76fbdc47a590386ae89aeb43b0d0e82ca61fc4bde360485d", "tree_sha256": "6f9260d83a72d90ec6bc009dfb7cad8d9c3be34daa4168884d539de31ea5f094", "availability": "available", "lock_status": "locked", "plan": "Keep the GraphQL clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 95f6a662cde03046c951fad083ea1ce31f58987a"},
-        {"id": "gomod-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "module example.com/foo\n\ngo 1.21\n", "source_sha256": "b9026fa110a33332ec050cbb545a1f23ee0895b817bdf380eb86c8a84036f6ed", "tree_sha256": "eab97016de62bfda36b75049cfcb0753639b518ec065590f1f5e64a4dc2132b3", "availability": "available", "lock_status": "locked", "plan": "Keep the Go Mod clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4"}
+        {"id": "gomod-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "module example.com/foo\n\ngo 1.21\n", "source_sha256": "b9026fa110a33332ec050cbb545a1f23ee0895b817bdf380eb86c8a84036f6ed", "tree_sha256": "eab97016de62bfda36b75049cfcb0753639b518ec065590f1f5e64a4dc2132b3", "availability": "available", "lock_status": "locked", "plan": "Keep the Go Mod clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4"},
+        {"id": "todotxt-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "(A) Buy milk @store\n", "source_sha256": "458bc226a66b9e7e7ea0a421d3e25db96f64bcc459e94ec47617b5eb79731a6f", "tree_sha256": "15665e03ab3a66f0dd188960881f6ec2c13bd4ac912746490c7e9cae8a72aac5", "availability": "available", "lock_status": "locked", "plan": "Keep the Todo.txt clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 080491a0d7bef8efc3293ef91a3b1e613aeb390d"}
       ],
       "gates": ["exact tree shape and node fields", "exact ranges and error or missing flags", "exact C and Go grammar identities", "incremental result parity", "one grammar per isolated Docker run", "zero silent divergence and explicit fallback accounting"],
       "telemetry": ["PASS/FALLBACK/DIVERGE/SKIP/ERROR scorecard rows", "deep-tree digest", "exact mismatch path and field", "fallback reason", "derivation-set receipt"],
@@ -1163,7 +1169,8 @@
         {"ref": "cgo_harness/stage6_css_compact_certification_test.go#TestStage6CSSCompactCertification", "kind": "test", "source_revision": "030eeb6af96005367d4e4eb9ad92f204c72aa1d4", "status": "current"},
         {"ref": "cgo_harness/stage6_json5_compact_certification_test.go#TestStage6JSON5CompactCertification", "kind": "test", "source_revision": "5f6c67f40ebfbc36798023462cf3eb97c4d0e43e", "status": "current"},
         {"ref": "cgo_harness/stage6_graphql_compact_certification_test.go#TestStage6GraphQLCompactCertification", "kind": "test", "source_revision": "95f6a662cde03046c951fad083ea1ce31f58987a", "status": "current"},
-        {"ref": "cgo_harness/stage6_gomod_compact_certification_test.go#TestStage6GomodCompactCertification", "kind": "test", "source_revision": "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4", "status": "current"}
+        {"ref": "cgo_harness/stage6_gomod_compact_certification_test.go#TestStage6GomodCompactCertification", "kind": "test", "source_revision": "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4", "status": "current"},
+        {"ref": "cgo_harness/stage6_todotxt_compact_certification_test.go#TestStage6TodotxtCompactCertification", "kind": "test", "source_revision": "080491a0d7bef8efc3293ef91a3b1e613aeb390d", "status": "current"}
       ],
       "deletion_condition": "Delete certification scaffolding only after every supported grammar has a current locked-C receipt for trees, fields, ranges, errors, and incremental edits.",
       "retention": "preserve_receipt",


### PR DESCRIPTION
## Summary

Certify the Todo.txt grammar as the next Stage 6 compact-route candidate.

This change updates the campaign registry and adds no parser behavior.

## Proof

- Clean source `(A) Buy milk @store\n` routes through compact admission with route counters `1/0`.
- The clean tree digest is `15665e03ab3a66f0dd188960881f6ec2c13bd4ac912746490c7e9cae8a72aac5`.
- Recovery source `(A)\n` records route counters `0/1` and an explicit recovery fallback reason.
- The recovery tree matches the locked C tree exactly.
- The incremental edit changes `milk` to `silk` and reuses two subtrees and nine bytes.
- The incremental tree matches the locked C tree exactly.
- Focused parity passed in Docker at `/home/draco/work/gts-compact-stage6-todotxt-certification-20260902/harness_out/docker/20260902T153331Z`.
- Focused race passed in Docker at `/home/draco/work/gts-compact-stage6-todotxt-certification-20260902/harness_out/docker/20260902T153403Z`.
- Todo.txt one-grammar parity passed 19/19 at `/home/draco/work/gts-compact-stage6-todotxt-certification-20260902/harness_out/docker/20260902T153036Z-diag-todotxt`.
- Generated-C parity passed 1/1 at `/home/draco/work/gts-compact-stage6-todotxt-certification-20260902/harness_out/grammargen_cparity/20260902_083351-stage6-todotxt`.
- Lifecycle and inventory validation passed in Docker at `/home/draco/work/gts-compact-stage6-todotxt-certification-20260902/harness_out/docker/20260902T155301Z`.

## Scope

- Add the Todo.txt certification path, commands, corpus digest, and proof receipt.
- Keep all existing certification receipts unchanged.
- Leave performance work outside this core review.
