### PR TITLE
test(compact-route): certify DOT against locked C

### DIFF
--- a/cgo_harness/stage6_dot_compact_certification_test.go
+++ b/cgo_harness/stage6_dot_compact_certification_test.go
@@ -1,0 +1,122 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0
+
+package cgoharness
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const stage6DotRecoverySource = "digraph G { a -> }\n"
+
+// TestStage6DotCompactCertification proves clean, recovery, and incremental
+// DOT shapes through compact admission against the locked C oracle.
+func TestStage6DotCompactCertification(t *testing.T) {
+	cases := []struct {
+		name      string
+		source    []byte
+		wantRoute bool
+	}{
+		{name: "smoke", source: []byte(grammars.ParseSmokeSample("dot")), wantRoute: true},
+		{name: "recovery", source: []byte(stage6DotRecoverySource), wantRoute: false},
+	}
+	language := grammars.DotLanguage()
+	cLanguage, err := ParityCLanguage("dot")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cParser := sitter.NewParser()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			defer cParser.Close()
+			cTree := cParser.Parse(tc.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parser returned no tree")
+			}
+			defer cTree.Close()
+
+			parser := gotreesitter.NewParser(language)
+			parser.SetAdmissionCandidateRoute(true)
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			goTree, err := parser.Parse(tc.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer goTree.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			routedDelta := routedAfter - routedBefore
+			fallbackDelta := fallbackAfter - fallbackBefore
+			reason := gotreesitter.AdmissionCandidateLastFallbackReason()
+			t.Logf("route=%d/%d reason=%q", routedDelta, fallbackDelta, reason)
+
+			if tc.wantRoute {
+				if routedDelta != 1 || fallbackDelta != 0 {
+					t.Fatalf("clean case did not route through compact admission: %d/%d", routedDelta, fallbackDelta)
+				}
+				assertLockedCTreeExact(t, "DOT compact "+tc.name, goTree, language, cTree)
+				return
+			}
+			if routedDelta != 0 || fallbackDelta != 1 || !strings.Contains(reason, "recovery") {
+				t.Fatalf("recovery case route=%d/%d reason=%q", routedDelta, fallbackDelta, reason)
+			}
+			if divergences := compactT3StructuralDivergences(goTree.RootNode(), language, cTree.RootNode()); len(divergences) != 0 {
+				t.Fatalf("DOT compact recovery diverges from C at %d node(s); first: %s", len(divergences), compactT3FormatDivergence(divergences[0]))
+			}
+		})
+	}
+
+	t.Run("incremental", func(t *testing.T) {
+		source := []byte("digraph G { a -> b; }\n\n")
+		offset := bytes.LastIndexByte(source, '\n')
+		if offset < 0 {
+			t.Fatal("DOT smoke source has no node edit witness")
+		}
+		edited := append([]byte(nil), source...)
+		edited[offset] = ' '
+		parser := gotreesitter.NewParser(language)
+		parser.SetAdmissionCandidateRoute(true)
+		oldTree, err := parser.Parse(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer oldTree.Release()
+		oldTree.Edit(gotreesitter.InputEdit{
+			StartByte:   uint32(offset),
+			OldEndByte:  uint32(offset + 1),
+			NewEndByte:  uint32(offset + 1),
+			StartPoint:  pointAtOffset(source, offset),
+			OldEndPoint: pointAtOffset(source, offset+1),
+			NewEndPoint: pointAtOffset(edited, offset+1),
+		})
+		incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer incremental.Release()
+		t.Logf("profile=%+v", profile)
+		if profile.ReuseUnsupported || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+			t.Fatalf("DOT incremental reuse unavailable: %+v", profile)
+		}
+
+		cParser := sitter.NewParser()
+		if err := cParser.SetLanguage(cLanguage); err != nil {
+			t.Fatal(err)
+		}
+		defer cParser.Close()
+		cTree := cParser.Parse(edited, nil)
+		if cTree == nil || cTree.RootNode() == nil {
+			t.Fatal("C parser returned no edited tree")
+		}
+		defer cTree.Close()
+		assertLockedCTreeExact(t, "DOT compact incremental", incremental, language, cTree)
+	})
+}

--- a/cgo_harness/stage6_dot_compact_certification_test.go
+++ b/cgo_harness/stage6_dot_compact_certification_test.go
@@ -78,7 +78,7 @@ func TestStage6DotCompactCertification(t *testing.T) {
 		source := []byte("digraph G { a -> b; }\n\n")
 		offset := bytes.LastIndexByte(source, '\n')
 		if offset < 0 {
-			t.Fatal("DOT smoke source has no node edit witness")
+			t.Fatal("DOT incremental source has no whitespace edit witness")
 		}
 		edited := append([]byte(nil), source...)
 		edited[offset] = ' '

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "fa6600c27f8115ab69e417d0c1210344e2a3ca8b"
+	compactRouteLifecycleSourceRevision               = "45163683490691aeb4ecfc62b4557478a1221315"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -67,6 +67,7 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"cgo_harness/stage6_gomod_compact_certification_test.go#TestStage6GomodCompactCertification":                        "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4",
 	"cgo_harness/stage6_todotxt_compact_certification_test.go#TestStage6TodotxtCompactCertification":                    "080491a0d7bef8efc3293ef91a3b1e613aeb390d",
 	"cgo_harness/stage6_cpon_compact_certification_test.go#TestStage6CponCompactCertification":                          "fa6600c27f8115ab69e417d0c1210344e2a3ca8b",
+	"cgo_harness/stage6_dot_compact_certification_test.go#TestStage6DotCompactCertification":                             "45163683490691aeb4ecfc62b4557478a1221315",
 	"external_scanner_checkpoints_test.go#TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots":            "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity":                    "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack":                         "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
@@ -94,6 +95,7 @@ var compactRouteLifecycleKnownCorpusTreeSHA256 = map[string]string{
 	"gomod-compact-smoke":       "eab97016de62bfda36b75049cfcb0753639b518ec065590f1f5e64a4dc2132b3",
 	"todotxt-compact-smoke":     "15665e03ab3a66f0dd188960881f6ec2c13bd4ac912746490c7e9cae8a72aac5",
 	"cpon-compact-smoke":        "0ac7f03dc4d2a0f6de4148930841e6340ce0b97b129342f2dc07cbe2026dc5a9",
+	"dot-compact-smoke":         "03102896b4bdd72288ad5db8c80a35d7a81dd76d950a0805121ebe050e7172e7",
 }
 
 type compactRouteLifecycleRegistry struct {

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "45163683490691aeb4ecfc62b4557478a1221315"
+	compactRouteLifecycleSourceRevision               = "a8fe2517f01989d8c509416a7960ea37e428fe85"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -67,7 +67,7 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"cgo_harness/stage6_gomod_compact_certification_test.go#TestStage6GomodCompactCertification":                        "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4",
 	"cgo_harness/stage6_todotxt_compact_certification_test.go#TestStage6TodotxtCompactCertification":                    "080491a0d7bef8efc3293ef91a3b1e613aeb390d",
 	"cgo_harness/stage6_cpon_compact_certification_test.go#TestStage6CponCompactCertification":                          "fa6600c27f8115ab69e417d0c1210344e2a3ca8b",
-	"cgo_harness/stage6_dot_compact_certification_test.go#TestStage6DotCompactCertification":                             "45163683490691aeb4ecfc62b4557478a1221315",
+	"cgo_harness/stage6_dot_compact_certification_test.go#TestStage6DotCompactCertification":                             "a8fe2517f01989d8c509416a7960ea37e428fe85",
 	"external_scanner_checkpoints_test.go#TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots":            "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity":                    "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack":                         "9bd3e9a971b323e2cdeed302aa045af174ffe53c",

--- a/testdata/compact_route_campaign_inventory_v1.json
+++ b/testdata/compact_route_campaign_inventory_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-inventory/v1",
-  "source_revision": "fa6600c27f8115ab69e417d0c1210344e2a3ca8b",
+  "source_revision": "45163683490691aeb4ecfc62b4557478a1221315",
   "scope": "Graduation-critical build tags and environment controls.",
   "entries": [
     {"id":"build-parsercorephase0","kind":"build_tag","identifier":"gts_parsercorephase0","owner":"graph_head_lifecycle","stage":2,"status":"graduated","lifecycle_control":"build.phase0.internal","gate":"Equivalent physical heads retain every node, error region, lineage, and checkpoint.","final_receipt":"stage-2-physical-graph-head-merge","deletion_condition":"Delete the diagnostic build tag after the physical-head topology receipt is current."},

--- a/testdata/compact_route_campaign_inventory_v1.json
+++ b/testdata/compact_route_campaign_inventory_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-inventory/v1",
-  "source_revision": "45163683490691aeb4ecfc62b4557478a1221315",
+  "source_revision": "a8fe2517f01989d8c509416a7960ea37e428fe85",
   "scope": "Graduation-critical build tags and environment controls.",
   "entries": [
     {"id":"build-parsercorephase0","kind":"build_tag","identifier":"gts_parsercorephase0","owner":"graph_head_lifecycle","stage":2,"status":"graduated","lifecycle_control":"build.phase0.internal","gate":"Equivalent physical heads retain every node, error region, lineage, and checkpoint.","final_receipt":"stage-2-physical-graph-head-merge","deletion_condition":"Delete the diagnostic build tag after the physical-head topology receipt is current."},

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "fa6600c27f8115ab69e417d0c1210344e2a3ca8b",
+  "source_revision": "45163683490691aeb4ecfc62b4557478a1221315",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -1080,6 +1080,7 @@
         {"path": "cgo_harness/stage6_gomod_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6GomodCompactCertification"},
         {"path": "cgo_harness/stage6_todotxt_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6TodotxtCompactCertification"},
         {"path": "cgo_harness/stage6_cpon_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6CponCompactCertification"},
+        {"path": "cgo_harness/stage6_dot_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6DotCompactCertification"},
         {"path": "cgo_harness/docker/run_single_grammar_parity.sh", "role": "certification", "build_expression": "default", "symbol": "run_single_grammar_parity.sh"},
         {"path": "cgo_harness/docker/run_grammargen_focus_targets.sh", "role": "certification", "build_expression": "default", "symbol": "run_grammargen_focus_targets.sh"},
         {"path": "docs/compact-route-real-corpus-matrix.md", "role": "corpus_policy", "build_expression": "default", "symbol": "Current compact-graduation matrix"}
@@ -1137,7 +1138,11 @@
         {"name": "CPON one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh cpon", "working_dir": ".", "isolation": "docker"},
         {"name": "CPON real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs cpon", "working_dir": ".", "isolation": "docker"},
         {"name": "CPON C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs cpon", "working_dir": ".", "isolation": "docker"},
-        {"name": "CPON compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6CponCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+        {"name": "CPON compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6CponCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"},
+        {"name": "DOT one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh dot", "working_dir": ".", "isolation": "docker"},
+        {"name": "DOT real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs dot", "working_dir": ".", "isolation": "docker"},
+        {"name": "DOT C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs dot", "working_dir": ".", "isolation": "docker"},
+        {"name": "DOT compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6DotCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
       ],
       "corpus": [
         {"id": "real-corpus-matrix", "kind": "authenticated_external_manifest", "path": "cgo_harness/corpus_real/manifest.json", "source": "External manifest is not present in this worktree.", "availability": "unavailable", "lock_status": "unlocked", "plan": "Acquire the authenticated manifest in an isolated certification run before Stage 6.", "lock_or_digest": ""},
@@ -1154,7 +1159,8 @@
         {"id": "graphql-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "type Query { hello: String }\n", "source_sha256": "6857b6d6b31b106e76fbdc47a590386ae89aeb43b0d0e82ca61fc4bde360485d", "tree_sha256": "6f9260d83a72d90ec6bc009dfb7cad8d9c3be34daa4168884d539de31ea5f094", "availability": "available", "lock_status": "locked", "plan": "Keep the GraphQL clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 95f6a662cde03046c951fad083ea1ce31f58987a"},
         {"id": "gomod-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "module example.com/foo\n\ngo 1.21\n", "source_sha256": "b9026fa110a33332ec050cbb545a1f23ee0895b817bdf380eb86c8a84036f6ed", "tree_sha256": "eab97016de62bfda36b75049cfcb0753639b518ec065590f1f5e64a4dc2132b3", "availability": "available", "lock_status": "locked", "plan": "Keep the Go Mod clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4"},
         {"id": "todotxt-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "(A) Buy milk @store\n", "source_sha256": "458bc226a66b9e7e7ea0a421d3e25db96f64bcc459e94ec47617b5eb79731a6f", "tree_sha256": "15665e03ab3a66f0dd188960881f6ec2c13bd4ac912746490c7e9cae8a72aac5", "availability": "available", "lock_status": "locked", "plan": "Keep the Todo.txt clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 080491a0d7bef8efc3293ef91a3b1e613aeb390d"},
-        {"id": "cpon-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "{\"a\":1}\n", "source_sha256": "e346432021b04179518d9614f3560ccd71354a4ee101ddcb893d6959a9d6301c", "tree_sha256": "0ac7f03dc4d2a0f6de4148930841e6340ce0b97b129342f2dc07cbe2026dc5a9", "availability": "available", "lock_status": "locked", "plan": "Keep the CPON clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at fa6600c27f8115ab69e417d0c1210344e2a3ca8b"}
+        {"id": "cpon-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "{\"a\":1}\n", "source_sha256": "e346432021b04179518d9614f3560ccd71354a4ee101ddcb893d6959a9d6301c", "tree_sha256": "0ac7f03dc4d2a0f6de4148930841e6340ce0b97b129342f2dc07cbe2026dc5a9", "availability": "available", "lock_status": "locked", "plan": "Keep the CPON clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at fa6600c27f8115ab69e417d0c1210344e2a3ca8b"},
+        {"id": "dot-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "digraph G { a -> b; }\n", "source_sha256": "68f36e392f5ff2d52741ec9b12aee145558323ed751aaa0b6537d80f3ce04212", "tree_sha256": "03102896b4bdd72288ad5db8c80a35d7a81dd76d950a0805121ebe050e7172e7", "availability": "available", "lock_status": "locked", "plan": "Keep the DOT clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 45163683490691aeb4ecfc62b4557478a1221315"}
       ],
       "gates": ["exact tree shape and node fields", "exact ranges and error or missing flags", "exact C and Go grammar identities", "incremental result parity", "one grammar per isolated Docker run", "zero silent divergence and explicit fallback accounting"],
       "telemetry": ["PASS/FALLBACK/DIVERGE/SKIP/ERROR scorecard rows", "deep-tree digest", "exact mismatch path and field", "fallback reason", "derivation-set receipt"],
@@ -1177,7 +1183,8 @@
         {"ref": "cgo_harness/stage6_graphql_compact_certification_test.go#TestStage6GraphQLCompactCertification", "kind": "test", "source_revision": "95f6a662cde03046c951fad083ea1ce31f58987a", "status": "current"},
         {"ref": "cgo_harness/stage6_gomod_compact_certification_test.go#TestStage6GomodCompactCertification", "kind": "test", "source_revision": "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4", "status": "current"},
         {"ref": "cgo_harness/stage6_todotxt_compact_certification_test.go#TestStage6TodotxtCompactCertification", "kind": "test", "source_revision": "080491a0d7bef8efc3293ef91a3b1e613aeb390d", "status": "current"},
-        {"ref": "cgo_harness/stage6_cpon_compact_certification_test.go#TestStage6CponCompactCertification", "kind": "test", "source_revision": "fa6600c27f8115ab69e417d0c1210344e2a3ca8b", "status": "current"}
+        {"ref": "cgo_harness/stage6_cpon_compact_certification_test.go#TestStage6CponCompactCertification", "kind": "test", "source_revision": "fa6600c27f8115ab69e417d0c1210344e2a3ca8b", "status": "current"},
+        {"ref": "cgo_harness/stage6_dot_compact_certification_test.go#TestStage6DotCompactCertification", "kind": "test", "source_revision": "45163683490691aeb4ecfc62b4557478a1221315", "status": "current"}
       ],
       "deletion_condition": "Delete certification scaffolding only after every supported grammar has a current locked-C receipt for trees, fields, ranges, errors, and incremental edits.",
       "retention": "preserve_receipt",

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "45163683490691aeb4ecfc62b4557478a1221315",
+  "source_revision": "a8fe2517f01989d8c509416a7960ea37e428fe85",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -1160,7 +1160,7 @@
         {"id": "gomod-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "module example.com/foo\n\ngo 1.21\n", "source_sha256": "b9026fa110a33332ec050cbb545a1f23ee0895b817bdf380eb86c8a84036f6ed", "tree_sha256": "eab97016de62bfda36b75049cfcb0753639b518ec065590f1f5e64a4dc2132b3", "availability": "available", "lock_status": "locked", "plan": "Keep the Go Mod clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4"},
         {"id": "todotxt-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "(A) Buy milk @store\n", "source_sha256": "458bc226a66b9e7e7ea0a421d3e25db96f64bcc459e94ec47617b5eb79731a6f", "tree_sha256": "15665e03ab3a66f0dd188960881f6ec2c13bd4ac912746490c7e9cae8a72aac5", "availability": "available", "lock_status": "locked", "plan": "Keep the Todo.txt clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 080491a0d7bef8efc3293ef91a3b1e613aeb390d"},
         {"id": "cpon-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "{\"a\":1}\n", "source_sha256": "e346432021b04179518d9614f3560ccd71354a4ee101ddcb893d6959a9d6301c", "tree_sha256": "0ac7f03dc4d2a0f6de4148930841e6340ce0b97b129342f2dc07cbe2026dc5a9", "availability": "available", "lock_status": "locked", "plan": "Keep the CPON clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at fa6600c27f8115ab69e417d0c1210344e2a3ca8b"},
-        {"id": "dot-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "digraph G { a -> b; }\n", "source_sha256": "68f36e392f5ff2d52741ec9b12aee145558323ed751aaa0b6537d80f3ce04212", "tree_sha256": "03102896b4bdd72288ad5db8c80a35d7a81dd76d950a0805121ebe050e7172e7", "availability": "available", "lock_status": "locked", "plan": "Keep the DOT clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 45163683490691aeb4ecfc62b4557478a1221315"}
+        {"id": "dot-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "digraph G { a -> b; }\n", "source_sha256": "68f36e392f5ff2d52741ec9b12aee145558323ed751aaa0b6537d80f3ce04212", "tree_sha256": "03102896b4bdd72288ad5db8c80a35d7a81dd76d950a0805121ebe050e7172e7", "availability": "available", "lock_status": "locked", "plan": "Keep the DOT clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at a8fe2517f01989d8c509416a7960ea37e428fe85"}
       ],
       "gates": ["exact tree shape and node fields", "exact ranges and error or missing flags", "exact C and Go grammar identities", "incremental result parity", "one grammar per isolated Docker run", "zero silent divergence and explicit fallback accounting"],
       "telemetry": ["PASS/FALLBACK/DIVERGE/SKIP/ERROR scorecard rows", "deep-tree digest", "exact mismatch path and field", "fallback reason", "derivation-set receipt"],
@@ -1184,7 +1184,7 @@
         {"ref": "cgo_harness/stage6_gomod_compact_certification_test.go#TestStage6GomodCompactCertification", "kind": "test", "source_revision": "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4", "status": "current"},
         {"ref": "cgo_harness/stage6_todotxt_compact_certification_test.go#TestStage6TodotxtCompactCertification", "kind": "test", "source_revision": "080491a0d7bef8efc3293ef91a3b1e613aeb390d", "status": "current"},
         {"ref": "cgo_harness/stage6_cpon_compact_certification_test.go#TestStage6CponCompactCertification", "kind": "test", "source_revision": "fa6600c27f8115ab69e417d0c1210344e2a3ca8b", "status": "current"},
-        {"ref": "cgo_harness/stage6_dot_compact_certification_test.go#TestStage6DotCompactCertification", "kind": "test", "source_revision": "45163683490691aeb4ecfc62b4557478a1221315", "status": "current"}
+        {"ref": "cgo_harness/stage6_dot_compact_certification_test.go#TestStage6DotCompactCertification", "kind": "test", "source_revision": "a8fe2517f01989d8c509416a7960ea37e428fe85", "status": "current"}
       ],
       "deletion_condition": "Delete certification scaffolding only after every supported grammar has a current locked-C receipt for trees, fields, ranges, errors, and incremental edits.",
       "retention": "preserve_receipt",


### PR DESCRIPTION
## Summary

Certify the DOT compact route against the locked tree-sitter C oracle.

The test covers one clean parse, one recovery fallback, and one incremental edit.
The registry records the proof file, gate commands, fixture digest, and receipt revision.

## Required proof

- Clean smoke: compact route `1/0`; exact tree digest `03102896b4bdd72288ad5db8c80a35d7a81dd76d950a0805121ebe050e7172e7`.
- Recovery source `digraph G { a -> }`: fallback `0/1`; reason includes `recovery`; structural fields and error spans match C.
- Incremental source `digraph G { a -> b; }\n\n`: trailing-whitespace edit reuses 3 subtrees and 9 bytes; exact C tree matches.

## Verification

- Focused Docker test: `/home/draco/work/gts-compact-stage6-dot-certification-20260902/harness_out/docker/20260902T163432Z`.
- Focused race test: `/home/draco/work/gts-compact-stage6-dot-certification-20260902/harness_out/docker/20260902T163442Z`.
- One-grammar parity: `/home/draco/work/gts-compact-stage6-dot-certification-20260902/harness_out/docker/20260902T163415Z-diag-dot` (11/11).
- Generated C parity: `/home/draco/work/gts-compact-stage6-dot-certification-20260902/harness_out/grammargen_cparity/20260902_093422-stage6-dot-final` (11/11).
- Lifecycle and inventory registry: `/home/draco/work/gts-compact-stage6-dot-certification-20260902/harness_out/docker/20260902T163617Z`.

No parser implementation or performance code changes are included.
