### PR TITLE
test(compact-route): certify PEM against locked C

### DIFF
--- a/cgo_harness/stage6_pem_compact_certification_test.go
+++ b/cgo_harness/stage6_pem_compact_certification_test.go
@@ -1,0 +1,123 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0
+
+package cgoharness
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const stage6PEMRecoverySource = "-----BEGIN CERTIFICATE-----\nMIIC\n"
+
+// TestStage6PEMCompactCertification proves clean, recovery, and incremental
+// PEM shapes through compact admission against the locked C oracle.
+func TestStage6PEMCompactCertification(t *testing.T) {
+	cases := []struct {
+		name      string
+		source    []byte
+		wantRoute bool
+	}{
+		{name: "smoke", source: []byte(grammars.ParseSmokeSample("pem")), wantRoute: true},
+		{name: "recovery", source: []byte(stage6PEMRecoverySource), wantRoute: false},
+	}
+	language := grammars.PemLanguage()
+	cLanguage, err := ParityCLanguage("pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cParser := sitter.NewParser()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			defer cParser.Close()
+			cTree := cParser.Parse(tc.source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C parser returned no tree")
+			}
+			defer cTree.Close()
+
+			parser := gotreesitter.NewParser(language)
+			parser.SetAdmissionCandidateRoute(true)
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			goTree, err := parser.Parse(tc.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer goTree.Release()
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			routedDelta := routedAfter - routedBefore
+			fallbackDelta := fallbackAfter - fallbackBefore
+			reason := gotreesitter.AdmissionCandidateLastFallbackReason()
+			t.Logf("route=%d/%d reason=%q", routedDelta, fallbackDelta, reason)
+
+			if tc.wantRoute {
+				if routedDelta != 1 || fallbackDelta != 0 {
+					t.Fatalf("clean case did not route through compact admission: %d/%d", routedDelta, fallbackDelta)
+				}
+				assertLockedCTreeExact(t, "PEM compact "+tc.name, goTree, language, cTree)
+				return
+			}
+			if routedDelta != 0 || fallbackDelta != 1 || !strings.Contains(reason, "recovery") {
+				t.Fatalf("recovery case route=%d/%d reason=%q", routedDelta, fallbackDelta, reason)
+			}
+			if divergences := compactT3StructuralDivergences(goTree.RootNode(), language, cTree.RootNode()); len(divergences) != 0 {
+				t.Fatalf("PEM compact recovery diverges from C at %d node(s); first: %s", len(divergences), compactT3FormatDivergence(divergences[0]))
+			}
+		})
+	}
+
+	t.Run("incremental", func(t *testing.T) {
+		source := []byte(grammars.ParseSmokeSample("pem"))
+		offset := bytes.Index(source, []byte("MIIC"))
+		if offset < 0 {
+			t.Fatal("PEM smoke source has no payload edit witness")
+		}
+		edited := append([]byte(nil), source[:offset]...)
+		edited = append(edited, "MIIX"...)
+		edited = append(edited, source[offset+len("MIIC"):]...)
+		parser := gotreesitter.NewParser(language)
+		parser.SetAdmissionCandidateRoute(true)
+		oldTree, err := parser.Parse(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer oldTree.Release()
+		oldTree.Edit(gotreesitter.InputEdit{
+			StartByte:   uint32(offset),
+			OldEndByte:  uint32(offset + len("MIIC")),
+			NewEndByte:  uint32(offset + len("MIIX")),
+			StartPoint:  pointAtOffset(source, offset),
+			OldEndPoint: pointAtOffset(source, offset+len("MIIC")),
+			NewEndPoint: pointAtOffset(edited, offset+len("MIIX")),
+		})
+		incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer incremental.Release()
+		t.Logf("profile=%+v", profile)
+		if profile.ReuseUnsupported || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+			t.Fatalf("PEM incremental reuse unavailable: %+v", profile)
+		}
+
+		cParser := sitter.NewParser()
+		if err := cParser.SetLanguage(cLanguage); err != nil {
+			t.Fatal(err)
+		}
+		defer cParser.Close()
+		cTree := cParser.Parse(edited, nil)
+		if cTree == nil || cTree.RootNode() == nil {
+			t.Fatal("C parser returned no edited tree")
+		}
+		defer cTree.Close()
+		assertLockedCTreeExact(t, "PEM compact incremental", incremental, language, cTree)
+	})
+}

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	compactRouteLifecycleRegistryPath                 = "testdata/compact_route_campaign_lifecycle_v1.json"
-	compactRouteLifecycleSourceRevision               = "5e03f98cf1c272fd32b3a4d932ec14c2a41870a3"
+	compactRouteLifecycleSourceRevision               = "6946ea8e626f259f3befa2d750e4234436a8d5e2"
 	compactRouteLifecycleHistoricalProofEnv           = "GTS_REQUIRE_HISTORICAL_RECEIPT_PROOF"
 	compactRouteLifecycleReceiptPolicyCurrentRequired = "current_required"
 	compactRouteLifecycleReceiptPolicyHistoricalOnly  = "historical_only"
@@ -67,8 +67,9 @@ var compactRouteLifecycleKnownProofRevisions = map[string]string{
 	"cgo_harness/stage6_gomod_compact_certification_test.go#TestStage6GomodCompactCertification":                        "fd0a0aaaeb0db1cb18b31f9bc1994f784a085de4",
 	"cgo_harness/stage6_todotxt_compact_certification_test.go#TestStage6TodotxtCompactCertification":                    "080491a0d7bef8efc3293ef91a3b1e613aeb390d",
 	"cgo_harness/stage6_cpon_compact_certification_test.go#TestStage6CponCompactCertification":                          "fa6600c27f8115ab69e417d0c1210344e2a3ca8b",
-	"cgo_harness/stage6_dot_compact_certification_test.go#TestStage6DotCompactCertification":                             "a8fe2517f01989d8c509416a7960ea37e428fe85",
-	"cgo_harness/stage6_git_config_compact_certification_test.go#TestStage6GitConfigCompactCertification":                "5e03f98cf1c272fd32b3a4d932ec14c2a41870a3",
+	"cgo_harness/stage6_dot_compact_certification_test.go#TestStage6DotCompactCertification":                            "a8fe2517f01989d8c509416a7960ea37e428fe85",
+	"cgo_harness/stage6_git_config_compact_certification_test.go#TestStage6GitConfigCompactCertification":               "5e03f98cf1c272fd32b3a4d932ec14c2a41870a3",
+	"cgo_harness/stage6_pem_compact_certification_test.go#TestStage6PEMCompactCertification":                            "6946ea8e626f259f3befa2d750e4234436a8d5e2",
 	"external_scanner_checkpoints_test.go#TestRebuildExternalScannerCheckpointsCopiesBorrowedArenaSnapshots":            "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"cgo_harness/stage5_compact_incremental_test.go#TestStage5PythonPrefixFrontierAdversarialParity":                    "b4833798bb7d934bcb8d280a7cd5937d34fa2c9a",
 	"parser_external_scanner_incremental_test.go#TestPythonSameSymbolScannerStateEditFallsBack":                         "9bd3e9a971b323e2cdeed302aa045af174ffe53c",
@@ -92,12 +93,13 @@ var compactRouteLifecycleKnownCorpusTreeSHA256 = map[string]string{
 	"c-compact-smoke":          "b35547117f044e74311e70eeb45bd3967598fdca38a963937e2eeaad29bed7b7",
 	"css-compact-smoke":        "1363ea554c5d75bffc553bce1514068e02eb934c204f585e452ddc9211ea4af0",
 	"json5-compact-smoke":      "84634d0f446a4af1d216bd534c2456006827b71c13a99f0fdfc4f71c76d19dc8",
-	"graphql-compact-smoke":     "6f9260d83a72d90ec6bc009dfb7cad8d9c3be34daa4168884d539de31ea5f094",
-	"gomod-compact-smoke":       "eab97016de62bfda36b75049cfcb0753639b518ec065590f1f5e64a4dc2132b3",
-	"todotxt-compact-smoke":     "15665e03ab3a66f0dd188960881f6ec2c13bd4ac912746490c7e9cae8a72aac5",
-	"cpon-compact-smoke":        "0ac7f03dc4d2a0f6de4148930841e6340ce0b97b129342f2dc07cbe2026dc5a9",
-	"dot-compact-smoke":         "03102896b4bdd72288ad5db8c80a35d7a81dd76d950a0805121ebe050e7172e7",
-	"git-config-compact-smoke":  "268737056e942dc56ebd44fa5970556bf48bde4e59c5ad293f8273c0d52c75a3",
+	"graphql-compact-smoke":    "6f9260d83a72d90ec6bc009dfb7cad8d9c3be34daa4168884d539de31ea5f094",
+	"gomod-compact-smoke":      "eab97016de62bfda36b75049cfcb0753639b518ec065590f1f5e64a4dc2132b3",
+	"todotxt-compact-smoke":    "15665e03ab3a66f0dd188960881f6ec2c13bd4ac912746490c7e9cae8a72aac5",
+	"cpon-compact-smoke":       "0ac7f03dc4d2a0f6de4148930841e6340ce0b97b129342f2dc07cbe2026dc5a9",
+	"dot-compact-smoke":        "03102896b4bdd72288ad5db8c80a35d7a81dd76d950a0805121ebe050e7172e7",
+	"git-config-compact-smoke": "268737056e942dc56ebd44fa5970556bf48bde4e59c5ad293f8273c0d52c75a3",
+	"pem-compact-smoke":        "5fd2abf117233cfbda17feb34a4bddd443138bc85450e6b2f55b2cec71521899",
 }
 
 type compactRouteLifecycleRegistry struct {

--- a/testdata/compact_route_campaign_inventory_v1.json
+++ b/testdata/compact_route_campaign_inventory_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-inventory/v1",
-  "source_revision": "5e03f98cf1c272fd32b3a4d932ec14c2a41870a3",
+  "source_revision": "6946ea8e626f259f3befa2d750e4234436a8d5e2",
   "scope": "Graduation-critical build tags and environment controls.",
   "entries": [
     {"id":"build-parsercorephase0","kind":"build_tag","identifier":"gts_parsercorephase0","owner":"graph_head_lifecycle","stage":2,"status":"graduated","lifecycle_control":"build.phase0.internal","gate":"Equivalent physical heads retain every node, error region, lineage, and checkpoint.","final_receipt":"stage-2-physical-graph-head-merge","deletion_condition":"Delete the diagnostic build tag after the physical-head topology receipt is current."},

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "gotreesitter/compact-route-campaign-lifecycle/v1",
-  "source_revision": "5e03f98cf1c272fd32b3a4d932ec14c2a41870a3",
+  "source_revision": "6946ea8e626f259f3befa2d750e4234436a8d5e2",
   "scope": "Compact parser graduation stages, proof lanes, controls, corpus identity, and receipt retirement.",
   "authority": [
     "spec.parser-graduation.v1#8.1",
@@ -1082,6 +1082,7 @@
         {"path": "cgo_harness/stage6_cpon_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6CponCompactCertification"},
         {"path": "cgo_harness/stage6_dot_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6DotCompactCertification"},
         {"path": "cgo_harness/stage6_git_config_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6GitConfigCompactCertification"},
+        {"path": "cgo_harness/stage6_pem_compact_certification_test.go", "role": "certification", "build_expression": "cgo && treesitter_c_parity && gts_parsercorephase0", "symbol": "TestStage6PEMCompactCertification"},
         {"path": "cgo_harness/docker/run_single_grammar_parity.sh", "role": "certification", "build_expression": "default", "symbol": "run_single_grammar_parity.sh"},
         {"path": "cgo_harness/docker/run_grammargen_focus_targets.sh", "role": "certification", "build_expression": "default", "symbol": "run_grammargen_focus_targets.sh"},
         {"path": "docs/compact-route-real-corpus-matrix.md", "role": "corpus_policy", "build_expression": "default", "symbol": "Current compact-graduation matrix"}
@@ -1147,7 +1148,11 @@
         {"name": "Git Config one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh git_config", "working_dir": ".", "isolation": "docker"},
         {"name": "Git Config real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs git_config", "working_dir": ".", "isolation": "docker"},
         {"name": "Git Config C focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs git_config", "working_dir": ".", "isolation": "docker"},
-        {"name": "Git Config compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6GitConfigCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
+        {"name": "Git Config compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6GitConfigCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"},
+        {"name": "PEM one-grammar parity", "command": "bash cgo_harness/docker/run_single_grammar_parity.sh pem", "working_dir": ".", "isolation": "docker"},
+        {"name": "PEM real-corpus focus", "command": "bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs pem", "working_dir": ".", "isolation": "docker"},
+        {"name": "PEM C focus", "command": "bash cgo_harness/docker/run_grammargen_c_parity.sh --langs pem", "working_dir": ".", "isolation": "docker"},
+        {"name": "PEM compact candidate C parity", "command": "go test . -tags 'cgo treesitter_c_parity gts_parsercorephase0' -run '^TestStage6PEMCompactCertification$' -count=1 -v", "working_dir": "cgo_harness", "isolation": "docker"}
       ],
       "corpus": [
         {"id": "real-corpus-matrix", "kind": "authenticated_external_manifest", "path": "cgo_harness/corpus_real/manifest.json", "source": "External manifest is not present in this worktree.", "availability": "unavailable", "lock_status": "unlocked", "plan": "Acquire the authenticated manifest in an isolated certification run before Stage 6.", "lock_or_digest": ""},
@@ -1166,7 +1171,8 @@
         {"id": "todotxt-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "(A) Buy milk @store\n", "source_sha256": "458bc226a66b9e7e7ea0a421d3e25db96f64bcc459e94ec47617b5eb79731a6f", "tree_sha256": "15665e03ab3a66f0dd188960881f6ec2c13bd4ac912746490c7e9cae8a72aac5", "availability": "available", "lock_status": "locked", "plan": "Keep the Todo.txt clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 080491a0d7bef8efc3293ef91a3b1e613aeb390d"},
         {"id": "cpon-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "{\"a\":1}\n", "source_sha256": "e346432021b04179518d9614f3560ccd71354a4ee101ddcb893d6959a9d6301c", "tree_sha256": "0ac7f03dc4d2a0f6de4148930841e6340ce0b97b129342f2dc07cbe2026dc5a9", "availability": "available", "lock_status": "locked", "plan": "Keep the CPON clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at fa6600c27f8115ab69e417d0c1210344e2a3ca8b"},
         {"id": "dot-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "digraph G { a -> b; }\n", "source_sha256": "68f36e392f5ff2d52741ec9b12aee145558323ed751aaa0b6537d80f3ce04212", "tree_sha256": "03102896b4bdd72288ad5db8c80a35d7a81dd76d950a0805121ebe050e7172e7", "availability": "available", "lock_status": "locked", "plan": "Keep the DOT clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at a8fe2517f01989d8c509416a7960ea37e428fe85"},
-        {"id": "git-config-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "[core]\n\tbare = false\n", "source_sha256": "bc6c44e1ecf71142efc0eb0bf69268dfbeb9e018b34b00b510d50f9bf57bff90", "tree_sha256": "268737056e942dc56ebd44fa5970556bf48bde4e59c5ad293f8273c0d52c75a3", "availability": "available", "lock_status": "locked", "plan": "Keep the Git Config clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 5e03f98cf1c272fd32b3a4d932ec14c2a41870a3"}
+        {"id": "git-config-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "[core]\n\tbare = false\n", "source_sha256": "bc6c44e1ecf71142efc0eb0bf69268dfbeb9e018b34b00b510d50f9bf57bff90", "tree_sha256": "268737056e942dc56ebd44fa5970556bf48bde4e59c5ad293f8273c0d52c75a3", "availability": "available", "lock_status": "locked", "plan": "Keep the Git Config clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 5e03f98cf1c272fd32b3a4d932ec14c2a41870a3"},
+        {"id": "pem-compact-smoke", "kind": "synthetic_fixture", "path": "grammars/smoke_samples.go", "source": "-----BEGIN CERTIFICATE-----\nMIIC\n-----END CERTIFICATE-----\n", "source_sha256": "f0b30b964b3b3aff7b4df8ad94104be38aa3f4ab7a2046d64a0ae662c433bb07", "tree_sha256": "5fd2abf117233cfbda17feb34a4bddd443138bc85450e6b2f55b2cec71521899", "availability": "available", "lock_status": "locked", "plan": "Keep the PEM clean, recovery, and incremental fixtures as the next current Stage 6 compact-route certificate.", "lock_or_digest": "grammar lock plus locked-C exact tree digest at 731e5dfc7a20ffacfbe84377799e5b01bdfa2208"}
       ],
       "gates": ["exact tree shape and node fields", "exact ranges and error or missing flags", "exact C and Go grammar identities", "incremental result parity", "one grammar per isolated Docker run", "zero silent divergence and explicit fallback accounting"],
       "telemetry": ["PASS/FALLBACK/DIVERGE/SKIP/ERROR scorecard rows", "deep-tree digest", "exact mismatch path and field", "fallback reason", "derivation-set receipt"],
@@ -1191,7 +1197,8 @@
         {"ref": "cgo_harness/stage6_todotxt_compact_certification_test.go#TestStage6TodotxtCompactCertification", "kind": "test", "source_revision": "080491a0d7bef8efc3293ef91a3b1e613aeb390d", "status": "current"},
         {"ref": "cgo_harness/stage6_cpon_compact_certification_test.go#TestStage6CponCompactCertification", "kind": "test", "source_revision": "fa6600c27f8115ab69e417d0c1210344e2a3ca8b", "status": "current"},
         {"ref": "cgo_harness/stage6_dot_compact_certification_test.go#TestStage6DotCompactCertification", "kind": "test", "source_revision": "a8fe2517f01989d8c509416a7960ea37e428fe85", "status": "current"},
-        {"ref": "cgo_harness/stage6_git_config_compact_certification_test.go#TestStage6GitConfigCompactCertification", "kind": "test", "source_revision": "5e03f98cf1c272fd32b3a4d932ec14c2a41870a3", "status": "current"}
+        {"ref": "cgo_harness/stage6_git_config_compact_certification_test.go#TestStage6GitConfigCompactCertification", "kind": "test", "source_revision": "5e03f98cf1c272fd32b3a4d932ec14c2a41870a3", "status": "current"},
+        {"ref": "cgo_harness/stage6_pem_compact_certification_test.go#TestStage6PEMCompactCertification", "kind": "test", "source_revision": "6946ea8e626f259f3befa2d750e4234436a8d5e2", "status": "current"}
       ],
       "deletion_condition": "Delete certification scaffolding only after every supported grammar has a current locked-C receipt for trees, fields, ranges, errors, and incremental edits.",
       "retention": "preserve_receipt",


### PR DESCRIPTION
## Summary

Certify the PEM compact route against the locked C oracle.

This is the sole active core review. It adds no parser implementation or performance change.

## Smallest C-oracle falsifier

- Clean source: `-----BEGIN CERTIFICATE-----\nMIIC\n-----END CERTIFICATE-----\n`.
- Recovery source: `-----BEGIN CERTIFICATE-----\nMIIC\n`.
- Incremental edit: replace `MIIC` with `MIIX`.

## Required proof

- Exact clean tree, fields, ranges, points, and flags match C.
- Recovery publishes the C error tree and records a compact-route fallback.
- Incremental output matches C and reuses 9 subtrees and 47 bytes.
- Clean tree digest: `5fd2abf117233cfbda17feb34a4bddd443138bc85450e6b2f55b2cec71521899`.
- Clean source digest: `f0b30b964b3b3aff7b4df8ad94104be38aa3f4ab7a2046d64a0ae662c433bb07`.

## Isolated receipts

- Focused compact proof: `harness_out/docker/20260902T172419Z-stage6-pem-final`.
- Race proof: `harness_out/docker/20260902T172449Z-stage6-pem-final-race`.
- Lifecycle registry: `harness_out/docker/20260902T172403Z-stage6-pem-registry-final`.
- Real-corpus PEM parity: `harness_out/docker/20260902T172428Z-diag-pem` (5/5 deep parity).
- Generated-C PEM parity: `harness_out/grammargen_cparity/20260902_102438-stage6-pem-final` (5/5, zero divergences).

## Telemetry

- Clean route: `1/0`.
- Recovery route: `0/1`, reason `recovery-entered`.
- Incremental route: accepted, with reuse counters recorded by the proof.
- No out-of-memory or timeout result occurred.

## Scope and cleanup

- Register the PEM test, fixture digest, commands, and proof receipt in the campaign registry.
- Preserve the Git Config certification receipt while advancing the registry revision.
- Keep performance work separate from this correctness change.
