### PR TITLE
parsercore: own external scanner state during version relex

### DIFF
--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -3,6 +3,7 @@
 package gotreesitter
 
 import (
+	"bytes"
 	"crypto/sha256"
 	_ "embed"
 	"encoding/binary"
@@ -4697,10 +4698,18 @@ func (s *diagnosticParserCoreGenericScheduler) relexTokenForState(state StateID,
 	if lang == nil || len(lang.LexStates) == 0 || int(state) >= len(lang.LexModes) {
 		return tok, false
 	}
-	// A stateless external scanner has no checkpoint identity for this probe.
-	// Keep that route unchanged until each header can own its scanner state.
-	if lang.ExternalScanner != nil && s.checkpoint.Length == 0 {
-		return tok, false
+	// An external scanner can only enter the per-version probe when its
+	// checkpoint is complete and identity-bearing. Restore the election-start
+	// payload before the scan, then restore the shared post-election payload on
+	// every exit. A stateful scanner without this contract keeps the old,
+	// internal-DFA-only behavior and fails closed.
+	if lang.ExternalScanner != nil {
+		if relexed, ok := s.relexExternalTokenForState(state, tok); ok {
+			return relexed, true
+		}
+		if s.checkpoint.Length == 0 {
+			return tok, false
+		}
 	}
 	if tok.Symbol == 0 || tok.Symbol == errorSymbol || tok.Missing || tok.NoLookahead ||
 		tok.StartByte >= tok.EndByte || int(tok.StartByte) >= len(source) {
@@ -4747,6 +4756,72 @@ func (s *diagnosticParserCoreGenericScheduler) relexTokenForState(state StateID,
 		return tok, false
 	}
 	return relexed, true
+}
+
+// relexExternalTokenForState probes one parser state's external scanner from
+// the shared election-start checkpoint. It returns a witness when the token
+// identity or the serialized scanner state differs from the shared election.
+// The token source is restored before the caller can dispatch another header.
+func (s *diagnosticParserCoreGenericScheduler) relexExternalTokenForState(state StateID, shared Token) (Token, bool) {
+	if s == nil || s.tokenSource == nil || s.tokenSource.lexer == nil || !s.versionLexerBeforeValid {
+		return shared, false
+	}
+	d := s.tokenSource
+	lang := d.language
+	if lang == nil || lang.ExternalScanner == nil || !languageUsesExternalScannerCheckpoints(lang) {
+		return shared, false
+	}
+	provider, ok := lang.ExternalScanner.(ExternalScannerCheckpointIdentityProvider)
+	if !ok || !provider.UsesExternalScannerCheckpoints() {
+		return shared, false
+	}
+	identity, ok := provider.CheckpointIdentity()
+	if !ok || !identity.complete() || !s.versionLexerBefore.externalScannerPresent || len(s.versionLexerBefore.externalPayload) == 0 {
+		return shared, false
+	}
+	if int(state) >= len(lang.LexModes) {
+		return shared, false
+	}
+	// Keep the source exactly as the shared election left it. The snapshot
+	// restore below may call Deserialize, so capture the current state first.
+	prior := d.snapshotRelexState()
+	priorState := d.state
+	priorGLRStates := d.glrStates
+	defer func() {
+		prior.restore(d)
+		d.SetParserState(priorState)
+		d.SetGLRStates(priorGLRStates)
+	}()
+
+	// A production scheduler has an authenticated compact core. The direct
+	// helper tests use the same snapshot type without a core, so retain the
+	// raw DFA restore as a test-only fallback after the capability checks above.
+	if s.compact != nil {
+		length, digest, ok := s.compact.CheckpointReceipt(s.checkpointBeforeID)
+		beforeInfo := parserCoreCheckpoint(s.versionLexerBefore.externalPayload)
+		if !ok || uint64(len(s.versionLexerBefore.externalPayload)) != uint64(length) ||
+			digest != beforeInfo.SHA256 {
+			return shared, false
+		}
+	}
+	s.versionLexerBefore.restore(d)
+	d.SetParserState(state)
+	d.SetGLRStates(nil)
+	candidate := d.Next()
+	if candidate.Symbol == 0 || candidate.NoLookahead || candidate.Missing ||
+		!candidate.ExternalScannerToken || candidate.StartByte != shared.StartByte {
+		return shared, false
+	}
+	// Compare the scanner payload after the state-specific scan. Equal token
+	// bytes can still leave different scanner states, which must also activate
+	// ownership for the next election.
+	candidateAfter := d.snapshotRelexState()
+	sharedAfter := prior
+	if candidate.Symbol == shared.Symbol && candidate.StartByte == shared.StartByte &&
+		candidate.EndByte == shared.EndByte && bytes.Equal(candidateAfter.externalPayload, sharedAfter.externalPayload) {
+		return shared, false
+	}
+	return candidate, true
 }
 
 // withVersionLexerOwner runs one snapshot publication under the scheduler's
@@ -8595,6 +8670,13 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			if len(s.headers) > 1 {
 				relexed, ok := s.relexTokenForState(state, s.token)
 				if ok {
+					// External scanner output carries mutable state beyond the
+					// token span. Keep the entire frontier on owned requests,
+					// even when the scanner produced the same-width token, so a
+					// later election cannot observe a sibling's payload.
+					if relexed.ExternalScannerToken {
+						return s.activateVersionLexerOwnershipAtRagged(index)
+					}
 					if relexed.EndByte != s.token.EndByte {
 						if raggedRelexNoActionHeads == 0 {
 							raggedRelexWitness = relexed

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -992,6 +992,9 @@ func parserCoreCheckpoint(bytes []byte) DiagnosticParserCoreScannerCheckpoint {
 // prefixes keep distinct identifier pairs distinct without allocating on the
 // election hot path.
 func parserCoreExternalScannerIdentityFingerprint(identity ExternalScannerCheckpointIdentity) [32]byte {
+	if !identity.complete() {
+		return [32]byte{}
+	}
 	var encoded [8 + 2*externalScannerCheckpointIdentityMaxBytes]byte
 	offset := 0
 	binary.LittleEndian.PutUint16(encoded[offset:], uint16(len(identity.Scanner)))

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -3,7 +3,6 @@
 package gotreesitter
 
 import (
-	"bytes"
 	"crypto/sha256"
 	_ "embed"
 	"encoding/binary"
@@ -986,6 +985,24 @@ func parserCoreCheckpoint(bytes []byte) DiagnosticParserCoreScannerCheckpoint {
 		return parserCoreEmptyCheckpoint
 	}
 	return DiagnosticParserCoreScannerCheckpoint{Length: len(bytes), SHA256: sha256.Sum256(bytes)}
+}
+
+// parserCoreExternalScannerIdentityFingerprint binds one election snapshot to
+// the scanner and grammar identity that produced its serialized state. Length
+// prefixes keep distinct identifier pairs distinct without allocating on the
+// election hot path.
+func parserCoreExternalScannerIdentityFingerprint(identity ExternalScannerCheckpointIdentity) [32]byte {
+	var encoded [8 + 2*externalScannerCheckpointIdentityMaxBytes]byte
+	offset := 0
+	binary.LittleEndian.PutUint16(encoded[offset:], uint16(len(identity.Scanner)))
+	offset += 2
+	copy(encoded[offset:], identity.Scanner)
+	offset += len(identity.Scanner)
+	binary.LittleEndian.PutUint16(encoded[offset:], uint16(len(identity.Grammar)))
+	offset += 2
+	copy(encoded[offset:], identity.Grammar)
+	offset += len(identity.Grammar)
+	return sha256.Sum256(encoded[:offset])
 }
 
 func diagnosticParserCoreInternCheckpoint(compact *core.Core, bytes []byte) (core.CheckpointID, DiagnosticParserCoreScannerCheckpoint, error) {
@@ -2712,22 +2729,24 @@ type diagnosticParserCoreVersionLexerRequest struct {
 }
 
 type diagnosticParserCoreGenericScheduler struct {
-	compact                      *core.Core
-	tokenSource                  *dfaTokenSource
-	scannerScratch               *[]byte
-	headers                      []diagnosticParserCoreHeader
-	token                        Token
-	checkpoint                   DiagnosticParserCoreScannerCheckpoint
-	checkpointBeforeID           core.CheckpointID
-	checkpointID                 core.CheckpointID
-	currentElection              DiagnosticParserCoreElection
-	tokenCell                    diagnosticParserCoreTokenCell
-	versionLexerBefore           dfaRelexSnapshot
-	versionLexerBeforeScratch    dfaRelexSnapshotScratch
-	versionLexerBeforeValid      bool
-	versionLexerBeforeElection   int
-	versionLexerBeforeCheckpoint core.CheckpointID
-	versionLexerRequests         []diagnosticParserCoreVersionLexerRequest
+	compact                         *core.Core
+	tokenSource                     *dfaTokenSource
+	scannerScratch                  *[]byte
+	headers                         []diagnosticParserCoreHeader
+	token                           Token
+	checkpoint                      DiagnosticParserCoreScannerCheckpoint
+	checkpointBeforeID              core.CheckpointID
+	checkpointID                    core.CheckpointID
+	currentElection                 DiagnosticParserCoreElection
+	tokenCell                       diagnosticParserCoreTokenCell
+	versionLexerBefore              dfaRelexSnapshot
+	versionLexerBeforeScratch       dfaRelexSnapshotScratch
+	versionLexerBeforeValid         bool
+	versionLexerBeforeIdentity      [32]byte
+	versionLexerBeforeIdentityValid bool
+	versionLexerBeforeElection      int
+	versionLexerBeforeCheckpoint    core.CheckpointID
+	versionLexerRequests            []diagnosticParserCoreVersionLexerRequest
 	// versionLexerOwnershipActive marks the ragged election that switched this
 	// scheduler from its shared-token fast path to owned per-header cursors.
 	// versionLexerOwnershipActive keeps each live header on its own DFA and
@@ -4241,6 +4260,8 @@ func clearDiagnosticParserCoreGenericSchedulerVersionState(scheduler *diagnostic
 	}
 	scheduler.versionLexerBefore = dfaRelexSnapshot{}
 	scheduler.versionLexerBeforeValid = false
+	scheduler.versionLexerBeforeIdentity = [32]byte{}
+	scheduler.versionLexerBeforeIdentityValid = false
 	scheduler.versionLexerBeforeElection = 0
 	scheduler.versionLexerBeforeCheckpoint = 0
 	scheduler.versionLexerOwnershipActive = false
@@ -4680,12 +4701,14 @@ func diagnosticParserCoreConflictPolicyOrdinal(
 // relexTokenForState mirrors production's per-stack lexer: each no-action
 // header re-lexes at its own byte position under its own current state's
 // lex mode, exactly like a live C stack version, instead of trusting the
-// shared election's tokenization. The probe accepts any genuine internal-
-// DFA token that starts where the shared election started; it may differ
-// in Symbol and/or EndByte/EndPoint from the shared token. The caller alone
-// decides what to do with a different EndByte. dispatchPassActive switches
-// that shape to owned per-header requests before any shared action executes.
-// This probe only decides whether a same-start token exists at all.
+// shared election's tokenization. Internal-DFA tokens use a scratch lexer.
+// Checkpointed external scanners use the election-start snapshot and compare
+// the complete post-scan cursor state. The probe accepts any genuine token
+// that starts where the shared election started; it may differ in Symbol,
+// scanner state, or EndByte/EndPoint. The caller alone decides what to do
+// with a different EndByte. dispatchPassActive switches that shape to owned
+// per-header requests before any shared action executes. This probe only
+// decides whether a same-start token exists at all.
 //
 // DisablePerHeaderSpanUnlockedRelex restores the pre-D2-1 span-locked
 // probe: only an exact-span (same StartByte and EndByte) relex is eligible.
@@ -4779,6 +4802,11 @@ func (s *diagnosticParserCoreGenericScheduler) relexExternalTokenForState(state 
 	if !ok || !identity.complete() || !s.versionLexerBefore.externalScannerPresent || len(s.versionLexerBefore.externalPayload) == 0 {
 		return shared, false
 	}
+	if s.compact != nil {
+		if !s.versionLexerBeforeIdentityValid || parserCoreExternalScannerIdentityFingerprint(identity) != s.versionLexerBeforeIdentity {
+			return shared, false
+		}
+	}
 	if int(state) >= len(lang.LexModes) {
 		return shared, false
 	}
@@ -4817,8 +4845,7 @@ func (s *diagnosticParserCoreGenericScheduler) relexExternalTokenForState(state 
 	// ownership for the next election.
 	candidateAfter := d.snapshotRelexState()
 	sharedAfter := prior
-	if candidate.Symbol == shared.Symbol && candidate.StartByte == shared.StartByte &&
-		candidate.EndByte == shared.EndByte && bytes.Equal(candidateAfter.externalPayload, sharedAfter.externalPayload) {
+	if tokensSameLex(candidate, shared) && candidateAfter.equal(sharedAfter) {
 		return shared, false
 	}
 	return candidate, true
@@ -5252,6 +5279,16 @@ func (s *diagnosticParserCoreGenericScheduler) captureSharedElectionSnapshotFrom
 
 func (s *diagnosticParserCoreGenericScheduler) finishSharedElectionSnapshotCapture() error {
 	s.versionLexerBeforeValid = true
+	s.versionLexerBeforeIdentity = [32]byte{}
+	s.versionLexerBeforeIdentityValid = false
+	if s.tokenSource != nil && s.tokenSource.language != nil && languageUsesExternalScannerCheckpoints(s.tokenSource.language) {
+		if provider, ok := s.tokenSource.language.ExternalScanner.(ExternalScannerCheckpointIdentityProvider); ok {
+			if identity, ok := provider.CheckpointIdentity(); ok && identity.complete() {
+				s.versionLexerBeforeIdentity = parserCoreExternalScannerIdentityFingerprint(identity)
+				s.versionLexerBeforeIdentityValid = true
+			}
+		}
+	}
 	s.versionLexerBeforeElection = s.electionIndex + 1
 	s.versionLexerBeforeCheckpoint = s.checkpointID
 	return nil

--- a/parsercore_phase0_state_relex_internal_test.go
+++ b/parsercore_phase0_state_relex_internal_test.go
@@ -4,7 +4,10 @@ package gotreesitter
 
 import "testing"
 
-type phase0OwnedExternalScanner struct{}
+type phase0OwnedExternalScanner struct {
+	sameSymbol bool
+	fail       bool
+}
 
 type phase0OwnedExternalScannerState struct {
 	value byte
@@ -42,11 +45,15 @@ func (phase0OwnedExternalScanner) CheckpointIdentity() (ExternalScannerCheckpoin
 	}, true
 }
 
-func (phase0OwnedExternalScanner) Scan(payload any, lexer *ExternalLexer, valid []bool) bool {
+func (scanner phase0OwnedExternalScanner) Scan(payload any, lexer *ExternalLexer, valid []bool) bool {
 	if lexer.Lookahead() != 'x' {
 		return false
 	}
 	state := payload.(*phase0OwnedExternalScannerState)
+	if scanner.fail {
+		state.value = 9
+		return false
+	}
 	switch {
 	case len(valid) > 0 && valid[0]:
 		state.value = 1
@@ -58,7 +65,11 @@ func (phase0OwnedExternalScanner) Scan(payload any, lexer *ExternalLexer, valid 
 		state.value = 2
 		lexer.Advance(false)
 		lexer.MarkEnd()
-		lexer.SetResultSymbol(Symbol(12))
+		if scanner.sameSymbol {
+			lexer.SetResultSymbol(Symbol(11))
+		} else {
+			lexer.SetResultSymbol(Symbol(12))
+		}
 		return true
 	default:
 		return false
@@ -66,6 +77,10 @@ func (phase0OwnedExternalScanner) Scan(payload any, lexer *ExternalLexer, valid 
 }
 
 func phase0OwnedExternalLanguage() *Language {
+	return phase0OwnedExternalLanguageWithScanner(phase0OwnedExternalScanner{})
+}
+
+func phase0OwnedExternalLanguageWithScanner(scanner phase0OwnedExternalScanner) *Language {
 	return &Language{
 		Name:               "phase0-owned-external",
 		SymbolCount:        13,
@@ -77,7 +92,7 @@ func phase0OwnedExternalLanguage() *Language {
 			{ExternalLexState: 2},
 		},
 		LexStates:       []LexState{{}},
-		ExternalScanner: phase0OwnedExternalScanner{},
+		ExternalScanner: scanner,
 		ExternalSymbols: []Symbol{11, 12},
 		ExternalLexStates: [][]bool{
 			{false, false},
@@ -121,6 +136,70 @@ func TestDiagnosticParserCoreExternalVersionRelexOwnsCheckpoint(t *testing.T) {
 	}
 	if got := tokenSource.lexer.pos; got != 1 {
 		t.Fatalf("shared lexer position after probe = %d, want 1", got)
+	}
+}
+
+func TestDiagnosticParserCoreExternalVersionRelexDetectsStateOnlyDivergence(t *testing.T) {
+	lang := phase0OwnedExternalLanguageWithScanner(phase0OwnedExternalScanner{sameSymbol: true})
+	source := []byte("x")
+	lookup := func(StateID, Symbol) uint16 { return 1 }
+	tokenSource := newDFATokenSourceDirect(NewLexer(lang.LexStates, source), lang, lookup, nil, nil, nil)
+	defer tokenSource.Close()
+	tokenSource.SetParserState(0)
+	before := tokenSource.snapshotRelexState()
+	shared := tokenSource.Next()
+	if shared.Symbol != Symbol(11) || !shared.ExternalScannerToken || shared.StartByte != 0 || shared.EndByte != 1 {
+		t.Fatalf("shared external token = %+v, want symbol 11 at 0..1", shared)
+	}
+	sharedState := tokenSource.externalPayload.(*phase0OwnedExternalScannerState).value
+	candidate, ok := (&diagnosticParserCoreGenericScheduler{
+		tokenSource:             tokenSource,
+		versionLexerBefore:      before,
+		versionLexerBeforeValid: true,
+	}).relexTokenForState(1, shared)
+	if !ok {
+		t.Fatal("external per-version relex = false, want a scanner-state witness")
+	}
+	if candidate.Symbol != shared.Symbol || candidate.StartByte != shared.StartByte || candidate.EndByte != shared.EndByte {
+		t.Fatalf("state-only candidate = %+v, want same symbol and span as shared %+v", candidate, shared)
+	}
+	if got := tokenSource.externalPayload.(*phase0OwnedExternalScannerState).value; got != sharedState {
+		t.Fatalf("shared scanner payload after state-only probe = %d, want restored %d", got, sharedState)
+	}
+	if got := tokenSource.lexer.pos; got != 1 {
+		t.Fatalf("shared lexer position after state-only probe = %d, want 1", got)
+	}
+}
+
+func TestDiagnosticParserCoreExternalVersionRelexRestoresAfterFailedScan(t *testing.T) {
+	lang := phase0OwnedExternalLanguage()
+	source := []byte("x")
+	lookup := func(StateID, Symbol) uint16 { return 1 }
+	tokenSource := newDFATokenSourceDirect(NewLexer(lang.LexStates, source), lang, lookup, nil, nil, nil)
+	defer tokenSource.Close()
+	tokenSource.SetParserState(0)
+	before := tokenSource.snapshotRelexState()
+	shared := tokenSource.Next()
+	if shared.Symbol != Symbol(11) {
+		t.Fatalf("successful shared token = %+v, want symbol 11", shared)
+	}
+	lang.ExternalScanner = phase0OwnedExternalScanner{fail: true}
+	// Keep the token source's payload and switch only the scanner behavior. The
+	// failing implementation mutates the payload before it returns false.
+	sharedState := tokenSource.externalPayload.(*phase0OwnedExternalScannerState).value
+	candidate, ok := (&diagnosticParserCoreGenericScheduler{
+		tokenSource:             tokenSource,
+		versionLexerBefore:      before,
+		versionLexerBeforeValid: true,
+	}).relexTokenForState(1, shared)
+	if ok || candidate != shared {
+		t.Fatalf("failed external probe = %+v/%t, want shared token/false", candidate, ok)
+	}
+	if got := tokenSource.externalPayload.(*phase0OwnedExternalScannerState).value; got != sharedState {
+		t.Fatalf("shared scanner payload after failed probe = %d, want restored %d", got, sharedState)
+	}
+	if got := tokenSource.lexer.pos; got != 1 {
+		t.Fatalf("shared lexer position after failed probe = %d, want 1", got)
 	}
 }
 
@@ -258,11 +337,10 @@ func DiagnosticParserCoreSameSpanRelexForTest(shared, relexed Token) (Token, boo
 // external test package can pin the probe's own contract (D2-1 Phase 1
 // item 2) against a real witness, independent of dispatchPassActive's own
 // caller-side ragged-end decline (covered separately by
-// RunStateDependentRelexSchedulerForTest). checkpointLength only needs to
-// be non-zero for a language with an external scanner: the probe reads
-// nothing else from the checkpoint (Lexer.scan only needs DFA fields), so
-// any non-zero value satisfies the "this header owns checkpoint identity"
-// guard without a real serialized scanner snapshot.
+// RunStateDependentRelexSchedulerForTest). checkpointLength only needs to be
+// non-zero for the internal-DFA fallback. The external-scanner path requires
+// a real election snapshot and an identity-bearing checkpointed scanner;
+// direct tests that omit that state remain on the legacy internal-DFA probe.
 func RelexTokenForStateForTest(
 	lang *Language, source []byte, checkpointLength int,
 	options DiagnosticParserCorePrefixOptions, state StateID, tok Token,

--- a/parsercore_phase0_state_relex_internal_test.go
+++ b/parsercore_phase0_state_relex_internal_test.go
@@ -2,11 +2,24 @@
 
 package gotreesitter
 
-import "testing"
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
 
 type phase0OwnedExternalScanner struct {
 	sameSymbol bool
 	fail       bool
+}
+
+type phase0MismatchedExternalScanner struct{ phase0OwnedExternalScanner }
+
+func (phase0MismatchedExternalScanner) CheckpointIdentity() (ExternalScannerCheckpointIdentity, bool) {
+	return ExternalScannerCheckpointIdentity{
+		Scanner: []byte("phase0-mismatched-external-scanner-v1"),
+		Grammar: []byte("phase0-mismatched-external-grammar-v1"),
+	}, true
 }
 
 type phase0OwnedExternalScannerState struct {
@@ -200,6 +213,38 @@ func TestDiagnosticParserCoreExternalVersionRelexRestoresAfterFailedScan(t *test
 	}
 	if got := tokenSource.lexer.pos; got != 1 {
 		t.Fatalf("shared lexer position after failed probe = %d, want 1", got)
+	}
+}
+
+func TestDiagnosticParserCoreExternalVersionRelexRejectsIdentityDrift(t *testing.T) {
+	lang := phase0OwnedExternalLanguage()
+	source := []byte("x")
+	lookup := func(StateID, Symbol) uint16 { return 1 }
+	tokenSource := newDFATokenSourceDirect(NewLexer(lang.LexStates, source), lang, lookup, nil, nil, nil)
+	defer tokenSource.Close()
+	tokenSource.SetParserState(0)
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact:     &core.Core{},
+		tokenSource: tokenSource,
+	}
+	if err := scheduler.captureSharedElectionSnapshot(); err != nil {
+		t.Fatalf("capture election snapshot: %v", err)
+	}
+	shared := tokenSource.Next()
+	if shared.Symbol != Symbol(11) || !scheduler.versionLexerBeforeIdentityValid {
+		t.Fatalf("shared token=%+v identity-valid=%t, want symbol 11 and captured identity", shared, scheduler.versionLexerBeforeIdentityValid)
+	}
+	sharedState := tokenSource.externalPayload.(*phase0OwnedExternalScannerState).value
+	lang.ExternalScanner = phase0MismatchedExternalScanner{}
+	candidate, ok := scheduler.relexTokenForState(1, shared)
+	if ok || candidate != shared {
+		t.Fatalf("identity-drift probe = %+v/%t, want shared token/false", candidate, ok)
+	}
+	if got := tokenSource.externalPayload.(*phase0OwnedExternalScannerState).value; got != sharedState {
+		t.Fatalf("shared scanner payload after identity drift = %d, want %d", got, sharedState)
+	}
+	if got := tokenSource.lexer.pos; got != 1 {
+		t.Fatalf("shared lexer position after identity drift = %d, want 1", got)
 	}
 }
 

--- a/parsercore_phase0_state_relex_internal_test.go
+++ b/parsercore_phase0_state_relex_internal_test.go
@@ -4,6 +4,126 @@ package gotreesitter
 
 import "testing"
 
+type phase0OwnedExternalScanner struct{}
+
+type phase0OwnedExternalScannerState struct {
+	value byte
+}
+
+func (phase0OwnedExternalScanner) Create() any {
+	return &phase0OwnedExternalScannerState{}
+}
+
+func (phase0OwnedExternalScanner) Destroy(any) {}
+
+func (phase0OwnedExternalScanner) Serialize(payload any, buf []byte) int {
+	if len(buf) == 0 {
+		return 0
+	}
+	buf[0] = payload.(*phase0OwnedExternalScannerState).value
+	return 1
+}
+
+func (phase0OwnedExternalScanner) Deserialize(payload any, buf []byte) {
+	state := payload.(*phase0OwnedExternalScannerState)
+	if len(buf) == 0 {
+		state.value = 0
+		return
+	}
+	state.value = buf[0]
+}
+
+func (phase0OwnedExternalScanner) UsesExternalScannerCheckpoints() bool { return true }
+
+func (phase0OwnedExternalScanner) CheckpointIdentity() (ExternalScannerCheckpointIdentity, bool) {
+	return ExternalScannerCheckpointIdentity{
+		Scanner: []byte("phase0-owned-external-scanner-v1"),
+		Grammar: []byte("phase0-owned-external-grammar-v1"),
+	}, true
+}
+
+func (phase0OwnedExternalScanner) Scan(payload any, lexer *ExternalLexer, valid []bool) bool {
+	if lexer.Lookahead() != 'x' {
+		return false
+	}
+	state := payload.(*phase0OwnedExternalScannerState)
+	switch {
+	case len(valid) > 0 && valid[0]:
+		state.value = 1
+		lexer.Advance(false)
+		lexer.MarkEnd()
+		lexer.SetResultSymbol(Symbol(11))
+		return true
+	case len(valid) > 1 && valid[1]:
+		state.value = 2
+		lexer.Advance(false)
+		lexer.MarkEnd()
+		lexer.SetResultSymbol(Symbol(12))
+		return true
+	default:
+		return false
+	}
+}
+
+func phase0OwnedExternalLanguage() *Language {
+	return &Language{
+		Name:               "phase0-owned-external",
+		SymbolCount:        13,
+		TokenCount:         13,
+		ExternalTokenCount: 2,
+		SymbolNames:        make([]string, 13),
+		LexModes: []LexMode{
+			{ExternalLexState: 1},
+			{ExternalLexState: 2},
+		},
+		LexStates:       []LexState{{}},
+		ExternalScanner: phase0OwnedExternalScanner{},
+		ExternalSymbols: []Symbol{11, 12},
+		ExternalLexStates: [][]bool{
+			{false, false},
+			{true, false},
+			{false, true},
+		},
+	}
+}
+
+func TestDiagnosticParserCoreExternalVersionRelexOwnsCheckpoint(t *testing.T) {
+	lang := phase0OwnedExternalLanguage()
+	source := []byte("x")
+	lookup := func(StateID, Symbol) uint16 { return 1 }
+	tokenSource := newDFATokenSourceDirect(NewLexer(lang.LexStates, source), lang, lookup, nil, nil, nil)
+	defer tokenSource.Close()
+	tokenSource.SetParserState(0)
+	before := tokenSource.snapshotRelexState()
+	shared := tokenSource.Next()
+	if shared.Symbol != Symbol(11) || !shared.ExternalScannerToken || shared.StartByte != 0 || shared.EndByte != 1 {
+		t.Fatalf("shared external token = %+v, want symbol 11 at 0..1", shared)
+	}
+	sharedState := tokenSource.externalPayload.(*phase0OwnedExternalScannerState).value
+	if sharedState != 1 {
+		t.Fatalf("shared scanner state = %d, want 1", sharedState)
+	}
+
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		tokenSource:             tokenSource,
+		versionLexerBefore:      before,
+		versionLexerBeforeValid: true,
+	}
+	candidate, ok := scheduler.relexTokenForState(1, shared)
+	if !ok {
+		t.Fatal("external per-version relex = false, want a divergent scanner token")
+	}
+	if candidate.Symbol != Symbol(12) || !candidate.ExternalScannerToken || candidate.StartByte != 0 || candidate.EndByte != 1 {
+		t.Fatalf("candidate external token = %+v, want symbol 12 at 0..1", candidate)
+	}
+	if got := tokenSource.externalPayload.(*phase0OwnedExternalScannerState).value; got != sharedState {
+		t.Fatalf("shared scanner payload after probe = %d, want restored %d", got, sharedState)
+	}
+	if got := tokenSource.lexer.pos; got != 1 {
+		t.Fatalf("shared lexer position after probe = %d, want 1", got)
+	}
+}
+
 func TestDiagnosticParserCoreSameSpanRelexReconstructsExactToken(t *testing.T) {
 	shared := Token{
 		Symbol:                   3,


### PR DESCRIPTION
## Summary

Add a fail-closed external-scanner probe to the compact per-version lexer path.

The probe restores the election-start checkpoint, scans one parser state, compares the token and complete post-scan cursor state, and restores the shared source on every exit. A scanner without an identity-bearing complete checkpoint keeps the existing internal-DFA-only path. Same-width external divergence now activates owned requests for the complete frontier.

## Proof

- Smallest falsifier: two parser states use different external symbols for the same byte span.
- State-only falsifier: both states emit the same symbol and span but leave different serialized scanner state.
- Failed-scan falsifier: a scanner mutates its payload, returns false, and the shared payload is restored.
- Identity binding: a scanner or grammar identity that changes after election capture blocks the external probe.
- Focused tests: `TestDiagnosticParserCoreExternalVersionRelex*`.
- Docker focused phase-zero suite passed: `harness_out/docker/20260902T203441Z`.
- Existing per-version width, Scala, production activation, and D2 span tests passed.
- Existing SQL blocker receipt probes remained unchanged.
- Both parser build-tag probes passed.

## Scope

This PR changes only compact lexer-state relex and its focused tests. It does not enable incremental reuse or alter unsupported scanners.