### PR TITLE
add(parsercore): bind owned lexer snapshots to scanner identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -882,7 +882,7 @@ jobs:
             --timeout 20m \
             --run '^(TestCompactT3OracleAdjudication|TestCompactT3JavaScriptRecoveryProfileCharacterization|TestCompactT3JavaScriptRecoveryRouteSeedOracleParity|TestCompactT3JavaScriptRecoveryMutationDifferential|TestCompactJavaScriptS5RecoveryMutationDifferential|TestCompactRouteLockedCExceptions)$'
 
-      - name: Compact per-version lexer Scala C-oracle witness
+      - name: Compact per-version lexer package-one witnesses
         run: |
           GTS_PARITY_MODE=smoke \
           GTS_PARITY_C_REF_BUILD_CACHE=0 \
@@ -896,7 +896,7 @@ jobs:
             --test-parallel 1 \
             --c-ref-build-jobs 1 \
             --timeout 20m \
-            -- "cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^TestCompactPerVersionLexerScalaCOracle$' -count=1 -parallel 1 -timeout 20m -v"
+            -- "cd /workspace && go test . -tags gts_parsercorephase0 -run '^(TestDiagnosticParserCoreVersionLexerSnapshot(BindsCheckpointIdentity|RejectsIncompleteCheckpointIdentity)|TestDiagnosticParserCoreOwnedLexer(SeedingSkipsAcceptedHeader|ActivationRejectsOpenRecoveryRegion)|TestExternalScannerOrderAdapter(PreservesOptionalCapabilities|KeepsLegacyCheckpointIdentityOptional|RequiresTargetGrammarCheckpointIdentity|BindsAuthenticatedTargetAcrossNestedAdapters))$' -count=1 -parallel 1 -timeout 20m -v && cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^TestCompactPerVersionLexerScalaCOracle$' -count=1 -parallel 1 -timeout 20m -v"
 
   # merge-event-census-cgo runs stage M0 of spec.merge-time-election.v1: the
   # census that counts stack-merge events on both sides and breaks production's

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -882,6 +882,22 @@ jobs:
             --timeout 20m \
             --run '^(TestCompactT3OracleAdjudication|TestCompactT3JavaScriptRecoveryProfileCharacterization|TestCompactT3JavaScriptRecoveryRouteSeedOracleParity|TestCompactT3JavaScriptRecoveryMutationDifferential|TestCompactJavaScriptS5RecoveryMutationDifferential|TestCompactRouteLockedCExceptions)$'
 
+      - name: Compact per-version lexer Scala C-oracle witness
+        run: |
+          GTS_PARITY_MODE=smoke \
+          GTS_PARITY_C_REF_BUILD_CACHE=0 \
+          bash cgo_harness/docker/run_parity_in_docker.sh \
+            --label ci-compact-per-version-lexer-scala \
+            --memory 8g \
+            --cpus 2 \
+            --pids 4096 \
+            --gomemlimit 6GiB \
+            --goflags -p=1 \
+            --test-parallel 1 \
+            --c-ref-build-jobs 1 \
+            --timeout 20m \
+            -- "cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^TestCompactPerVersionLexerScalaCOracle$' -count=1 -parallel 1 -timeout 20m -v"
+
   # merge-event-census-cgo runs stage M0 of spec.merge-time-election.v1: the
   # census that counts stack-merge events on both sides and breaks production's
   # refusals down by gate. Every cgo parity lane in this file runs a FIXED

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,11 @@ for tags and release notes while still in `0.x`.
 
 ### Correctness
 
+- Bind identity-bearing external scanner checkpoints to compact per-version
+  lexer snapshots. Reject incomplete or changed identities before restore,
+  publication, or sidecar sharing. Forward identities through scanner order
+  adapters. Preserve legacy scanner behavior.
+
 - Graduated the Markdown inline smoke route with four exact, compact-only
   conflict policies bound to the built-in grammar blob. Three repetition
   reductions require at least two live compact headers. The HTML entry row

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,9 +101,10 @@ for tags and release notes while still in `0.x`.
 ### Correctness
 
 - Bind identity-bearing external scanner checkpoints to compact per-version
-  lexer snapshots. Reject incomplete or changed identities before restore,
-  publication, or sidecar sharing. Forward identities through scanner order
-  adapters. Preserve legacy scanner behavior.
+  lexer snapshots. Reject incomplete identities before publication. Reject
+  changed identities before restore or owned snapshot publication. Do not
+  share an equivalent sidecar after identity drift. Forward identities through
+  scanner order adapters. Preserve legacy scanner behavior.
 
 - Graduated the Markdown inline smoke route with four exact, compact-only
   conflict policies bound to the built-in grammar blob. Three repetition

--- a/external_scanner_adapter.go
+++ b/external_scanner_adapter.go
@@ -73,6 +73,17 @@ func (a *externalScannerOrderAdapter) UsesExternalScannerCheckpoints() bool {
 	return ok && checkpointed.UsesExternalScannerCheckpoints()
 }
 
+// CheckpointIdentity preserves the inner scanner identity across external
+// symbol-order adaptation. The target language remains bound by the snapshot
+// language pointer and parser table identity.
+func (a *externalScannerOrderAdapter) CheckpointIdentity() (ExternalScannerCheckpointIdentity, bool) {
+	provider, ok := a.optionalInner().(ExternalScannerCheckpointIdentityProvider)
+	if !ok || !provider.UsesExternalScannerCheckpoints() {
+		return ExternalScannerCheckpointIdentity{}, false
+	}
+	return provider.CheckpointIdentity()
+}
+
 func (a *externalScannerOrderAdapter) RequiresIncrementalPrefixFrontierProof() bool {
 	prefixSensitive, ok := a.optionalInner().(IncrementalPrefixFrontierExternalScanner)
 	return ok && prefixSensitive.RequiresIncrementalPrefixFrontierProof()

--- a/external_scanner_adapter.go
+++ b/external_scanner_adapter.go
@@ -11,6 +11,8 @@ type externalScannerOrderAdapter struct {
 	sourceCount          int   // len(sourceExt), for sizing sourceValid in Scan
 	sourceSymbolToIndex  map[Symbol]int
 	sourceResultToTarget map[Symbol]Symbol
+	targetGrammar        [32]byte
+	targetGrammarValid   bool
 }
 
 type externalScannerOrderAdapterPayload struct {
@@ -73,15 +75,22 @@ func (a *externalScannerOrderAdapter) UsesExternalScannerCheckpoints() bool {
 	return ok && checkpointed.UsesExternalScannerCheckpoints()
 }
 
-// CheckpointIdentity preserves the inner scanner identity across external
-// symbol-order adaptation. The target language remains bound by the snapshot
-// language pointer and parser table identity.
+// CheckpointIdentity preserves the inner scanner implementation identity and
+// binds it to the target language's exact grammar blob. An identity-bearing
+// source scanner cannot authenticate an adapted target without that blob.
 func (a *externalScannerOrderAdapter) CheckpointIdentity() (ExternalScannerCheckpointIdentity, bool) {
-	provider, ok := a.optionalInner().(ExternalScannerCheckpointIdentityProvider)
-	if !ok || !provider.UsesExternalScannerCheckpoints() {
+	provider, required := externalScannerCheckpointIdentitySourceProviderForScanner(a.optionalInner())
+	if !required || !a.targetGrammarValid {
 		return ExternalScannerCheckpointIdentity{}, false
 	}
-	return provider.CheckpointIdentity()
+	identity, ok := provider.CheckpointIdentity()
+	if !ok || !identity.complete() {
+		return ExternalScannerCheckpointIdentity{}, false
+	}
+	return ExternalScannerCheckpointIdentity{
+		Scanner: append([]byte(nil), identity.Scanner...),
+		Grammar: append([]byte(nil), a.targetGrammar[:]...),
+	}, true
 }
 
 func (a *externalScannerOrderAdapter) RequiresIncrementalPrefixFrontierProof() bool {
@@ -213,6 +222,7 @@ func AdaptExternalScannerByExternalOrder(sourceLang, targetLang *Language) (Exte
 	nSource := len(sourceExt)
 	mapping := buildExternalScannerOrderMapping(sourceLang, targetLang)
 	adaptExternalLexStatesByExternalOrder(sourceLang, targetLang, mapping.targetToSource)
+	targetGrammar, targetGrammarValid := targetLang.GrammarBlobSHA256()
 
 	return &externalScannerOrderAdapter{
 		inner:                sourceLang.ExternalScanner,
@@ -220,6 +230,8 @@ func AdaptExternalScannerByExternalOrder(sourceLang, targetLang *Language) (Exte
 		sourceCount:          nSource,
 		sourceSymbolToIndex:  buildExternalSymbolIndex(sourceExt),
 		sourceResultToTarget: mapping.sourceResultToTarget,
+		targetGrammar:        targetGrammar,
+		targetGrammarValid:   targetGrammarValid,
 	}, true
 }
 

--- a/external_scanner_adapter.go
+++ b/external_scanner_adapter.go
@@ -70,6 +70,11 @@ func (a *externalScannerOrderAdapter) SupportsIncrementalReuse() bool {
 	return ok && reusable.SupportsIncrementalReuse()
 }
 
+func (a *externalScannerOrderAdapter) SupportsIncrementalReuseFromErrorTree() bool {
+	reusable, ok := a.optionalInner().(ErrorTreeIncrementalReuseExternalScanner)
+	return ok && reusable.SupportsIncrementalReuseFromErrorTree()
+}
+
 func (a *externalScannerOrderAdapter) UsesExternalScannerCheckpoints() bool {
 	checkpointed, ok := a.optionalInner().(CheckpointedExternalScanner)
 	return ok && checkpointed.UsesExternalScannerCheckpoints()

--- a/external_scanner_adapter_test.go
+++ b/external_scanner_adapter_test.go
@@ -39,6 +39,12 @@ func (*capabilityExternalScanner) SupportsIncrementalReuse() bool { return true 
 func (*capabilityExternalScanner) UsesExternalScannerCheckpoints() bool {
 	return true
 }
+func (*capabilityExternalScanner) CheckpointIdentity() (ExternalScannerCheckpointIdentity, bool) {
+	return ExternalScannerCheckpointIdentity{
+		Scanner: []byte("adapter-test-scanner-v1"),
+		Grammar: []byte("adapter-test-grammar-v1"),
+	}, true
+}
 func (*capabilityExternalScanner) RequiresIncrementalPrefixFrontierProof() bool {
 	return true
 }
@@ -75,6 +81,12 @@ func TestExternalScannerOrderAdapterPreservesOptionalCapabilities(t *testing.T) 
 	if checkpointed, ok := adapted.(CheckpointedExternalScanner); !ok || !checkpointed.UsesExternalScannerCheckpoints() {
 		t.Fatal("checkpoint capability was not preserved")
 	}
+	if identityProvider, ok := adapted.(ExternalScannerCheckpointIdentityProvider); !ok {
+		t.Fatal("checkpoint identity capability was not preserved")
+	} else if got, valid := identityProvider.CheckpointIdentity(); !valid ||
+		string(got.Scanner) != "adapter-test-scanner-v1" || string(got.Grammar) != "adapter-test-grammar-v1" {
+		t.Fatalf("adapted checkpoint identity = %+v/%t, want the inner identity", got, valid)
+	}
 	if prefixSensitive, ok := adapted.(IncrementalPrefixFrontierExternalScanner); !ok || !prefixSensitive.RequiresIncrementalPrefixFrontierProof() {
 		t.Fatal("incremental prefix-frontier capability was not preserved")
 	}
@@ -89,6 +101,22 @@ func TestExternalScannerOrderAdapterPreservesOptionalCapabilities(t *testing.T) 
 	}
 	if retaining, ok := adapted.(FailureStateRetainingExternalScanner); !ok || retaining.RetainsStateOnScanFailure() {
 		t.Fatal("adapter reported failure retention for a preserving scanner")
+	}
+}
+
+func TestExternalScannerOrderAdapterKeepsLegacyCheckpointIdentityOptional(t *testing.T) {
+	sourceLang := &Language{
+		ExternalSymbols: []Symbol{1},
+		ExternalScanner: c26qLegacyCheckpointScanner{},
+	}
+	targetLang := &Language{ExternalSymbols: []Symbol{2}}
+	adapted, ok := AdaptExternalScannerByExternalOrder(sourceLang, targetLang)
+	if !ok {
+		t.Fatal("adapter not created")
+	}
+	identity, required, valid := externalScannerCheckpointIdentityStatus(&Language{ExternalScanner: adapted})
+	if required || !valid || len(identity.Scanner) != 0 || len(identity.Grammar) != 0 {
+		t.Fatalf("legacy adapted identity status = %+v/%t/%t, want optional and valid", identity, required, valid)
 	}
 }
 

--- a/external_scanner_adapter_test.go
+++ b/external_scanner_adapter_test.go
@@ -39,6 +39,9 @@ type staleResultExternalScanner struct {
 type capabilityExternalScanner struct{ recordingExternalScanner }
 
 func (*capabilityExternalScanner) SupportsIncrementalReuse() bool { return true }
+func (*capabilityExternalScanner) SupportsIncrementalReuseFromErrorTree() bool {
+	return false
+}
 func (*capabilityExternalScanner) UsesExternalScannerCheckpoints() bool {
 	return true
 }
@@ -83,6 +86,10 @@ func TestExternalScannerOrderAdapterPreservesOptionalCapabilities(t *testing.T) 
 	}
 	if reusable, ok := adapted.(IncrementalReuseExternalScanner); !ok || !reusable.SupportsIncrementalReuse() {
 		t.Fatal("incremental-reuse capability was not preserved")
+	}
+	if errorTreeReusable, ok := adapted.(ErrorTreeIncrementalReuseExternalScanner); !ok ||
+		errorTreeReusable.SupportsIncrementalReuseFromErrorTree() {
+		t.Fatal("error-tree incremental reuse restriction was not preserved")
 	}
 	if checkpointed, ok := adapted.(CheckpointedExternalScanner); !ok || !checkpointed.UsesExternalScannerCheckpoints() {
 		t.Fatal("checkpoint capability was not preserved")

--- a/external_scanner_adapter_test.go
+++ b/external_scanner_adapter_test.go
@@ -1,6 +1,9 @@
 package gotreesitter
 
-import "testing"
+import (
+	"crypto/sha256"
+	"testing"
+)
 
 type recordingExternalScanner struct {
 	seen [][]bool
@@ -71,6 +74,9 @@ func TestExternalScannerOrderAdapterPreservesOptionalCapabilities(t *testing.T) 
 		SymbolNames:     []string{"", "", "a"},
 		ExternalSymbols: []Symbol{2},
 	}
+	targetGrammar := sha256.Sum256([]byte("adapter-target-grammar-v1"))
+	targetLang.grammarBlobSHA256 = targetGrammar
+	targetLang.grammarBlobSHA256Valid = true
 	adapted, ok := AdaptExternalScannerByExternalOrder(sourceLang, targetLang)
 	if !ok {
 		t.Fatal("adapter not created")
@@ -84,8 +90,8 @@ func TestExternalScannerOrderAdapterPreservesOptionalCapabilities(t *testing.T) 
 	if identityProvider, ok := adapted.(ExternalScannerCheckpointIdentityProvider); !ok {
 		t.Fatal("checkpoint identity capability was not preserved")
 	} else if got, valid := identityProvider.CheckpointIdentity(); !valid ||
-		string(got.Scanner) != "adapter-test-scanner-v1" || string(got.Grammar) != "adapter-test-grammar-v1" {
-		t.Fatalf("adapted checkpoint identity = %+v/%t, want the inner identity", got, valid)
+		string(got.Scanner) != "adapter-test-scanner-v1" || string(got.Grammar) != string(targetGrammar[:]) {
+		t.Fatalf("adapted checkpoint identity = %+v/%t, want the inner scanner and target grammar", got, valid)
 	}
 	if prefixSensitive, ok := adapted.(IncrementalPrefixFrontierExternalScanner); !ok || !prefixSensitive.RequiresIncrementalPrefixFrontierProof() {
 		t.Fatal("incremental prefix-frontier capability was not preserved")
@@ -101,6 +107,67 @@ func TestExternalScannerOrderAdapterPreservesOptionalCapabilities(t *testing.T) 
 	}
 	if retaining, ok := adapted.(FailureStateRetainingExternalScanner); !ok || retaining.RetainsStateOnScanFailure() {
 		t.Fatal("adapter reported failure retention for a preserving scanner")
+	}
+}
+
+func TestExternalScannerOrderAdapterRequiresTargetGrammarCheckpointIdentity(t *testing.T) {
+	sourceLang := &Language{
+		SymbolNames:     []string{"", "a"},
+		ExternalSymbols: []Symbol{1},
+		ExternalScanner: &capabilityExternalScanner{},
+	}
+	targetLang := &Language{
+		SymbolNames:     []string{"", "", "a"},
+		ExternalSymbols: []Symbol{2},
+	}
+	adapted, ok := AdaptExternalScannerByExternalOrder(sourceLang, targetLang)
+	if !ok {
+		t.Fatal("adapter not created")
+	}
+	provider, ok := adapted.(ExternalScannerCheckpointIdentityProvider)
+	if !ok {
+		t.Fatal("identity-bearing source did not produce an identity-bearing adapter")
+	}
+	if identity, valid := provider.CheckpointIdentity(); valid || identity.complete() {
+		t.Fatalf("unauthenticated target identity = %+v/%t, want incomplete and invalid", identity, valid)
+	}
+	identity, required, valid := externalScannerCheckpointIdentityStatus(&Language{ExternalScanner: adapted})
+	if !required || valid || identity.complete() {
+		t.Fatalf("unauthenticated target status = %+v/%t/%t, want required and invalid", identity, required, valid)
+	}
+}
+
+func TestExternalScannerOrderAdapterBindsAuthenticatedTargetAcrossNestedAdapters(t *testing.T) {
+	sourceLang := &Language{
+		SymbolNames:     []string{"", "a"},
+		ExternalSymbols: []Symbol{1},
+		ExternalScanner: &capabilityExternalScanner{},
+	}
+	intermediate := &Language{
+		SymbolNames:     []string{"", "", "a"},
+		ExternalSymbols: []Symbol{2},
+	}
+	adapted, ok := AdaptExternalScannerByExternalOrder(sourceLang, intermediate)
+	if !ok {
+		t.Fatal("intermediate adapter not created")
+	}
+	intermediate.ExternalScanner = adapted
+
+	targetGrammar := sha256.Sum256([]byte("nested-adapter-target-grammar-v1"))
+	target := &Language{
+		SymbolNames:            []string{"", "", "", "a"},
+		ExternalSymbols:        []Symbol{3},
+		grammarBlobSHA256:      targetGrammar,
+		grammarBlobSHA256Valid: true,
+	}
+	adapted, ok = AdaptExternalScannerByExternalOrder(intermediate, target)
+	if !ok {
+		t.Fatal("target adapter not created")
+	}
+	identity, required, valid := externalScannerCheckpointIdentityStatus(&Language{ExternalScanner: adapted})
+	if !required || !valid || string(identity.Scanner) != "adapter-test-scanner-v1" ||
+		string(identity.Grammar) != string(targetGrammar[:]) {
+		t.Fatalf("nested target status = %+v/%t/%t, want the source scanner and target grammar", identity, required, valid)
 	}
 }
 

--- a/external_scanner_checkpoint_capability.go
+++ b/external_scanner_checkpoint_capability.go
@@ -16,11 +16,34 @@ type ExternalScannerCheckpointIdentity struct {
 // checkpointed scanner. CheckpointIdentity must return stable identifiers for
 // the scanner implementation and the exact grammar blob.
 //
-// The production parser consumes this capability only at the checkpoint-aware
-// incremental reuse boundary. It does not alter GLR scheduling or recovery.
+// The production parser consumes this capability at checkpoint-aware
+// incremental reuse and per-version lexer ownership boundaries. It does not
+// alter GLR scheduling or recovery election.
 type ExternalScannerCheckpointIdentityProvider interface {
 	CheckpointedExternalScanner
 	CheckpointIdentity() (ExternalScannerCheckpointIdentity, bool)
+}
+
+// externalScannerCheckpointIdentityProviderForScanner finds an identity
+// provider without promoting a legacy order adapter to the identity contract.
+// Adapters forward a provider from their inner scanner when one exists.
+func externalScannerCheckpointIdentityProviderForScanner(
+	scanner ExternalScanner,
+) (ExternalScannerCheckpointIdentityProvider, bool) {
+	if scanner == nil {
+		return nil, false
+	}
+	if adapter, ok := scanner.(*externalScannerOrderAdapter); ok {
+		if adapter == nil {
+			return nil, false
+		}
+		return externalScannerCheckpointIdentityProviderForScanner(adapter.optionalInner())
+	}
+	provider, ok := scanner.(ExternalScannerCheckpointIdentityProvider)
+	if !ok || !provider.UsesExternalScannerCheckpoints() {
+		return nil, false
+	}
+	return provider, true
 }
 
 // externalScannerCheckpointIdentityState stores one immutable identity for an
@@ -115,8 +138,8 @@ func externalScannerCheckpointIdentityStatus(lang *Language) (ExternalScannerChe
 	if lang == nil || lang.ExternalScanner == nil {
 		return ExternalScannerCheckpointIdentity{}, false, true
 	}
-	provider, ok := lang.ExternalScanner.(ExternalScannerCheckpointIdentityProvider)
-	if !ok || !provider.UsesExternalScannerCheckpoints() {
+	provider, required := externalScannerCheckpointIdentityProviderForScanner(lang.ExternalScanner)
+	if !required {
 		return ExternalScannerCheckpointIdentity{}, false, true
 	}
 	identity, ok := provider.CheckpointIdentity()
@@ -221,8 +244,8 @@ func captureExternalScannerCheckpointRecord(
 	if scanner == nil || tokenStartByte > tokenEndByte {
 		return externalScannerCheckpointRecord{}, false
 	}
-	provider, ok := scanner.(ExternalScannerCheckpointIdentityProvider)
-	if !ok || !provider.UsesExternalScannerCheckpoints() {
+	provider, ok := externalScannerCheckpointIdentityProviderForScanner(scanner)
+	if !ok {
 		return externalScannerCheckpointRecord{}, false
 	}
 	identity, ok := provider.CheckpointIdentity()
@@ -255,8 +278,8 @@ func (r externalScannerCheckpointRecord) restore(scanner ExternalScanner, payloa
 	if scanner == nil || !r.complete() {
 		return false
 	}
-	provider, ok := scanner.(ExternalScannerCheckpointIdentityProvider)
-	if !ok || !provider.UsesExternalScannerCheckpoints() {
+	provider, ok := externalScannerCheckpointIdentityProviderForScanner(scanner)
+	if !ok {
 		return false
 	}
 	identity, ok := provider.CheckpointIdentity()

--- a/external_scanner_checkpoint_capability.go
+++ b/external_scanner_checkpoint_capability.go
@@ -24,9 +24,31 @@ type ExternalScannerCheckpointIdentityProvider interface {
 	CheckpointIdentity() (ExternalScannerCheckpointIdentity, bool)
 }
 
+// externalScannerCheckpointIdentitySourceProviderForScanner unwraps order
+// adapters to find the scanner implementation identity they preserve.
+func externalScannerCheckpointIdentitySourceProviderForScanner(
+	scanner ExternalScanner,
+) (ExternalScannerCheckpointIdentityProvider, bool) {
+	if scanner == nil {
+		return nil, false
+	}
+	if adapter, ok := scanner.(*externalScannerOrderAdapter); ok {
+		if adapter == nil {
+			return nil, false
+		}
+		return externalScannerCheckpointIdentitySourceProviderForScanner(adapter.optionalInner())
+	}
+	provider, ok := scanner.(ExternalScannerCheckpointIdentityProvider)
+	if !ok || !provider.UsesExternalScannerCheckpoints() {
+		return nil, false
+	}
+	return provider, true
+}
+
 // externalScannerCheckpointIdentityProviderForScanner finds an identity
 // provider without promoting a legacy order adapter to the identity contract.
-// Adapters forward a provider from their inner scanner when one exists.
+// An identity-bearing order adapter remains required even when its target
+// grammar identity is unavailable, so callers fail closed.
 func externalScannerCheckpointIdentityProviderForScanner(
 	scanner ExternalScanner,
 ) (ExternalScannerCheckpointIdentityProvider, bool) {
@@ -37,13 +59,13 @@ func externalScannerCheckpointIdentityProviderForScanner(
 		if adapter == nil {
 			return nil, false
 		}
-		return externalScannerCheckpointIdentityProviderForScanner(adapter.optionalInner())
+		_, required := externalScannerCheckpointIdentitySourceProviderForScanner(adapter.optionalInner())
+		if !required {
+			return nil, false
+		}
+		return adapter, true
 	}
-	provider, ok := scanner.(ExternalScannerCheckpointIdentityProvider)
-	if !ok || !provider.UsesExternalScannerCheckpoints() {
-		return nil, false
-	}
-	return provider, true
+	return externalScannerCheckpointIdentitySourceProviderForScanner(scanner)
 }
 
 // externalScannerCheckpointIdentityState stores one immutable identity for an

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -5059,7 +5059,9 @@ func (s *diagnosticParserCoreGenericScheduler) equivalentVersionLexerSnapshot(
 	if s == nil {
 		return nil
 	}
-	identity, identityRequired, identityValid := diagnosticParserCoreVersionLexerCheckpointIdentity(nil)
+	var identity [32]byte
+	identityRequired := false
+	identityValid := false
 	if s.tokenSource != nil {
 		identity, identityRequired, identityValid = diagnosticParserCoreVersionLexerCheckpointIdentity(s.tokenSource.language)
 	}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -4797,8 +4797,8 @@ func (s *diagnosticParserCoreGenericScheduler) relexExternalTokenForState(state 
 	if lang == nil || lang.ExternalScanner == nil || !languageUsesExternalScannerCheckpoints(lang) {
 		return shared, false
 	}
-	provider, ok := lang.ExternalScanner.(ExternalScannerCheckpointIdentityProvider)
-	if !ok || !provider.UsesExternalScannerCheckpoints() {
+	provider, ok := externalScannerCheckpointIdentityProviderForScanner(lang.ExternalScanner)
+	if !ok {
 		return shared, false
 	}
 	identity, ok := provider.CheckpointIdentity()
@@ -5295,7 +5295,7 @@ func (s *diagnosticParserCoreGenericScheduler) finishSharedElectionSnapshotCaptu
 	s.versionLexerBeforeIdentity = [32]byte{}
 	s.versionLexerBeforeIdentityValid = false
 	if s.tokenSource != nil && s.tokenSource.language != nil && languageUsesExternalScannerCheckpoints(s.tokenSource.language) {
-		if provider, ok := s.tokenSource.language.ExternalScanner.(ExternalScannerCheckpointIdentityProvider); ok {
+		if provider, ok := externalScannerCheckpointIdentityProviderForScanner(s.tokenSource.language.ExternalScanner); ok {
 			if identity, ok := provider.CheckpointIdentity(); ok && identity.complete() {
 				s.versionLexerBeforeIdentity = parserCoreExternalScannerIdentityFingerprint(identity)
 				s.versionLexerBeforeIdentityValid = true

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -5059,9 +5059,16 @@ func (s *diagnosticParserCoreGenericScheduler) equivalentVersionLexerSnapshot(
 	if s == nil {
 		return nil
 	}
+	identity, identityRequired, identityValid := diagnosticParserCoreVersionLexerCheckpointIdentity(nil)
+	if s.tokenSource != nil {
+		identity, identityRequired, identityValid = diagnosticParserCoreVersionLexerCheckpointIdentity(s.tokenSource.language)
+	}
 	matches := func(snapshot *diagnosticParserCoreVersionLexerSnapshot) bool {
 		return snapshot != nil && snapshot.beforeCheckpoint == beforeID &&
-			snapshot.afterCheckpoint == afterID && snapshot.dfa.equal(dfa)
+			snapshot.afterCheckpoint == afterID && snapshot.dfa.equal(dfa) &&
+			snapshot.checkpointIdentityRequired == identityRequired &&
+			snapshot.checkpointIdentityValid == identityValid &&
+			(!identityRequired || (identityValid && snapshot.checkpointIdentity == identity))
 	}
 	for index := range s.headers {
 		if snapshot := s.headers[index].versionLexerSnapshot(); matches(snapshot) {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -5133,6 +5133,9 @@ func (s *diagnosticParserCoreGenericScheduler) seedVersionLexerOwnership() error
 	states := make(map[seedStateKey]*diagnosticParserCoreVersionState)
 	for index := range s.headers {
 		header := &s.headers[index]
+		if header.accepted {
+			continue
+		}
 		baseline, baselineSet := header.recoveryNodeBaseline()
 		key := seedStateKey{
 			region: header.recoveryRegion(), recoveryGroup: header.recoveryGroupIdentity(),
@@ -5329,6 +5332,18 @@ func (s *diagnosticParserCoreGenericScheduler) activateVersionLexerOwnershipAtRa
 			detail:      diagnosticParserCoreOwnedDispatchPendingDetail + ": ownership is already active",
 			headerIndex: raggedHeaderIndex,
 		}, nil
+	}
+	// An open recovery region owns its scanner and parser frontier as one
+	// recovery lineage. Do not mix a new lexer-ownership tranche into any
+	// sibling until the recovery region closes.
+	for index, header := range s.headers {
+		if header.recoveryRegion() != nil {
+			return &diagnosticParserCoreGenericUnsupported{
+				boundary:    DiagnosticParserCoreRoute,
+				detail:      diagnosticParserCoreOwnedDispatchPendingDetail + ": ragged ownership has an open recovery region",
+				headerIndex: index,
+			}, nil
+		}
 	}
 	// A shifted header already consumed the shared token and therefore cannot
 	// be seeded at this election's token start. Keep this activation slice

--- a/parsercore_phase0_per_version_lexer_lifecycle_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_lifecycle_internal_test.go
@@ -68,6 +68,105 @@ func newDiagnosticParserCoreOwnedLexerRequest(
 	}
 }
 
+func TestDiagnosticParserCoreOwnedLexerSeedingSkipsAcceptedHeader(t *testing.T) {
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	acceptedHead, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	liveHead, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	language := &Language{Name: "owned-lexer-accepted-seed-test"}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact:     compact,
+		tokenSource: newDFATokenSourceDirect(NewLexer(nil, nil), language, nil, nil, nil, nil),
+		headers: []diagnosticParserCoreHeader{
+			{head: acceptedHead, accepted: true},
+			{head: liveHead},
+		},
+		versionLexerBefore:           dfaRelexSnapshot{},
+		versionLexerBeforeValid:      true,
+		versionLexerBeforeElection:   5,
+		versionLexerBeforeCheckpoint: 0,
+		checkpointBeforeID:           0,
+		checkpointID:                 0,
+		electionIndex:                5,
+	}
+	if err := scheduler.seedVersionLexerOwnership(); err != nil {
+		t.Fatalf("seed owned lexer frontier: %v", err)
+	}
+	if scheduler.headers[0].versionState != nil || scheduler.headers[0].versionLexerSnapshot() != nil ||
+		scheduler.headers[0].versionLexerRequestReference() != 0 {
+		t.Fatalf("seeding populated accepted header: %+v", scheduler.headers[0])
+	}
+	if scheduler.headers[1].versionLexerSnapshot() == nil || scheduler.headers[1].versionLexerRequestReference() != 0 {
+		t.Fatalf("seeding did not publish the live header cursor: %+v", scheduler.headers[1])
+	}
+	if scheduler.work.PerVersionLexPublications != 1 {
+		t.Fatalf("seed publications=%d, want one live header", scheduler.work.PerVersionLexPublications)
+	}
+}
+
+func TestDiagnosticParserCoreOwnedLexerActivationRejectsOpenRecoveryRegion(t *testing.T) {
+	compact, err := core.New(&genericConflictTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recoveryHead, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ordinaryHead, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	language := &Language{Name: "owned-lexer-open-recovery-activation-test"}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact:     compact,
+		tokenSource: newDFATokenSourceDirect(NewLexer(nil, nil), language, nil, nil, nil, nil),
+		headers: []diagnosticParserCoreHeader{
+			{
+				head: recoveryHead,
+				versionState: &diagnosticParserCoreVersionState{
+					s3Region: &diagnosticParserCoreS3Region{state: 1},
+				},
+			},
+			{head: ordinaryHead},
+		},
+		versionLexerBefore:           dfaRelexSnapshot{},
+		versionLexerBeforeValid:      true,
+		versionLexerBeforeElection:   5,
+		versionLexerBeforeCheckpoint: 0,
+		checkpointBeforeID:           0,
+		checkpointID:                 0,
+		electionIndex:                5,
+		receipt:                      &DiagnosticParserCoreGenericScheduler{},
+	}
+	beforeHeaders := append([]diagnosticParserCoreHeader(nil), scheduler.headers...)
+	stop, err := scheduler.activateVersionLexerOwnershipAtRagged(1)
+	if err != nil {
+		t.Fatalf("activate owned lexer frontier: %v", err)
+	}
+	if stop == nil || stop.boundary != DiagnosticParserCoreRoute ||
+		!strings.Contains(stop.detail, "open recovery region") || stop.headerIndex != 0 {
+		t.Fatalf("open recovery activation stop=%+v", stop)
+	}
+	if scheduler.versionLexerOwnershipActive || len(scheduler.versionLexerRequests) != 0 ||
+		!reflect.DeepEqual(scheduler.headers, beforeHeaders) || scheduler.work != (DiagnosticParserCoreGenericWork{}) {
+		t.Fatalf("blocked activation mutated state: active=%t requests=%d headers=%+v work=%+v",
+			scheduler.versionLexerOwnershipActive,
+			len(scheduler.versionLexerRequests),
+			scheduler.headers,
+			scheduler.work,
+		)
+	}
+}
+
 func TestDiagnosticParserCoreOwnedLexerBindingRestoresAfterErrorAndPanic(t *testing.T) {
 	table := &genericConflictTable{cells: map[genericConflictCell][]core.Action{
 		{state: 1, symbol: 9}: {{Type: core.ActionShift, State: 2}},

--- a/parsercore_phase0_per_version_lexer_snapshot_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_snapshot_internal_test.go
@@ -5,6 +5,7 @@ package gotreesitter
 import (
 	"bytes"
 	"reflect"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -693,7 +694,10 @@ func TestDiagnosticParserCoreVersionLexerSnapshotBindsCheckpointIdentity(t *test
 	}); err != nil {
 		t.Fatalf("construct identity-bound snapshot: %v", err)
 	}
-	if snapshot == nil || !snapshot.checkpointIdentityValid || snapshot.checkpointIdentity == ([32]byte{}) {
+	if snapshot == nil {
+		t.Fatal("constructed checkpoint identity snapshot is nil")
+	}
+	if !snapshot.checkpointIdentityValid || snapshot.checkpointIdentity == ([32]byte{}) {
 		t.Fatalf("snapshot identity=%x/%t, want a non-zero authenticated identity", snapshot.checkpointIdentity, snapshot.checkpointIdentityValid)
 	}
 	if !snapshot.checkpointIdentityRequired {
@@ -718,6 +722,13 @@ func TestDiagnosticParserCoreVersionLexerSnapshotBindsCheckpointIdentity(t *test
 	}
 	if got := target.snapshotRelexState(); !got.equal(beforeTarget) {
 		t.Fatalf("identity-mismatch restore mutated target state: got=%+v want=%+v", got, beforeTarget)
+	}
+	var header diagnosticParserCoreHeader
+	if err := header.publishVersionLexerSnapshot(compact, language, snapshot); err == nil {
+		t.Fatal("publication accepted a changed checkpoint identity")
+	}
+	if header.versionState != nil {
+		t.Fatal("failed identity-drift publication installed version state")
 	}
 
 	scanner.grammarID = []byte("grammar-c26l")
@@ -753,8 +764,8 @@ func TestDiagnosticParserCoreVersionLexerSnapshotRejectsIncompleteCheckpointIden
 		_, err := newDiagnosticParserCoreVersionLexerSnapshot(compact, language, owner, dfa, before, after)
 		return err
 	})
-	if err == nil {
-		t.Fatal("snapshot accepted an incomplete checkpoint identity")
+	if err == nil || !strings.Contains(err.Error(), "requires a complete checkpoint identity") {
+		t.Fatalf("incomplete checkpoint identity error=%v, want the identity rejection", err)
 	}
 }
 

--- a/parsercore_phase0_per_version_lexer_snapshot_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_snapshot_internal_test.go
@@ -678,6 +678,86 @@ func TestDiagnosticParserCoreVersionLexerSnapshotRejectsScannerReplacement(t *te
 	}
 }
 
+func TestDiagnosticParserCoreVersionLexerSnapshotBindsCheckpointIdentity(t *testing.T) {
+	compact, before, after := newDiagnosticParserCoreVersionLexerTestCore(t)
+	scanner := newC26lCheckpointScanner()
+	language := &Language{Name: "checkpoint-identity-snapshot-test", ExternalScanner: scanner}
+	dfa := diagnosticParserCoreVersionLexerTestDFA()
+	dfa.externalScannerPresent = true
+	dfa.externalPayload = []byte{1, 2, 3}
+	var snapshot *diagnosticParserCoreVersionLexerSnapshot
+	if err := compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		var err error
+		snapshot, err = newDiagnosticParserCoreVersionLexerSnapshot(compact, language, owner, dfa, before, after)
+		return err
+	}); err != nil {
+		t.Fatalf("construct identity-bound snapshot: %v", err)
+	}
+	if snapshot == nil || !snapshot.checkpointIdentityValid || snapshot.checkpointIdentity == ([32]byte{}) {
+		t.Fatalf("snapshot identity=%x/%t, want a non-zero authenticated identity", snapshot.checkpointIdentity, snapshot.checkpointIdentityValid)
+	}
+	if !snapshot.checkpointIdentityRequired {
+		t.Fatal("snapshot did not record that its scanner requires checkpoint identity")
+	}
+	clone := snapshot.clone()
+	if clone == nil || clone.checkpointIdentity != snapshot.checkpointIdentity ||
+		!clone.checkpointIdentityRequired || !clone.checkpointIdentityValid {
+		t.Fatal("snapshot clone lost checkpoint identity")
+	}
+
+	target := &dfaTokenSource{
+		lexer:              &Lexer{source: []byte("abc"), pos: 4, row: 5, col: 6},
+		language:           language,
+		hasExternalScanner: true,
+		externalPayload:    scanner.Create(),
+	}
+	beforeTarget := target.snapshotRelexState()
+	scanner.grammarID = []byte("checkpoint-identity-drift")
+	if err := snapshot.restore(compact, target); err == nil {
+		t.Fatal("restore accepted a changed checkpoint identity")
+	}
+	if got := target.snapshotRelexState(); !got.equal(beforeTarget) {
+		t.Fatalf("identity-mismatch restore mutated target state: got=%+v want=%+v", got, beforeTarget)
+	}
+
+	scanner.grammarID = []byte("grammar-c26l")
+	if err := snapshot.restore(compact, target); err != nil {
+		t.Fatalf("restore rejected the original checkpoint identity: %v", err)
+	}
+
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact:     compact,
+		tokenSource: &dfaTokenSource{language: language},
+		headers: []diagnosticParserCoreHeader{{
+			versionState: &diagnosticParserCoreVersionState{relexSnapshot: snapshot},
+		}},
+	}
+	if got := scheduler.equivalentVersionLexerSnapshot(snapshot.dfa, before, after); got != snapshot {
+		t.Fatalf("equivalent snapshot lookup = %p, want %p", got, snapshot)
+	}
+	scanner.grammarID = []byte("checkpoint-identity-drift-again")
+	if got := scheduler.equivalentVersionLexerSnapshot(snapshot.dfa, before, after); got != nil {
+		t.Fatalf("equivalent snapshot lookup reused identity-drifted snapshot %p", got)
+	}
+}
+
+func TestDiagnosticParserCoreVersionLexerSnapshotRejectsIncompleteCheckpointIdentity(t *testing.T) {
+	compact, before, after := newDiagnosticParserCoreVersionLexerTestCore(t)
+	scanner := newC26lCheckpointScanner()
+	scanner.identityOK = false
+	language := &Language{Name: "incomplete-checkpoint-identity-snapshot-test", ExternalScanner: scanner}
+	dfa := diagnosticParserCoreVersionLexerTestDFA()
+	dfa.externalScannerPresent = true
+	dfa.externalPayload = []byte{1, 2, 3}
+	err := compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		_, err := newDiagnosticParserCoreVersionLexerSnapshot(compact, language, owner, dfa, before, after)
+		return err
+	})
+	if err == nil {
+		t.Fatal("snapshot accepted an incomplete checkpoint identity")
+	}
+}
+
 func TestDiagnosticParserCoreVersionLexerSnapshotRejectsUnrepresentableScannerState(t *testing.T) {
 	compact, before, after := newDiagnosticParserCoreVersionLexerTestCore(t)
 	dfa := diagnosticParserCoreVersionLexerTestDFA()

--- a/parsercore_phase0_per_version_lexer_state.go
+++ b/parsercore_phase0_per_version_lexer_state.go
@@ -29,7 +29,15 @@ type diagnosticParserCoreVersionLexerSnapshot struct {
 	coreGeneration uint64
 	language       *Language
 	scanner        diagnosticParserCoreVersionLexerScannerContract
-	dfa            dfaRelexSnapshot
+	// checkpointIdentity authenticates the scanner and grammar that produced
+	// this snapshot when the scanner exposes the identity-bearing checkpoint
+	// capability. Keep this optional for legacy checkpointed scanners: those
+	// scanners still use the legacy scheduler path, but existing internal DFA
+	// ownership does not need a new grammar identity.
+	checkpointIdentity         [32]byte
+	checkpointIdentityRequired bool
+	checkpointIdentityValid    bool
+	dfa                        dfaRelexSnapshot
 
 	beforeCheckpoint      core.CheckpointID
 	afterCheckpoint       core.CheckpointID
@@ -87,6 +95,26 @@ func diagnosticParserCoreVersionLexerScannerContractForLanguage(language *Langua
 	return contract, nil
 }
 
+// diagnosticParserCoreVersionLexerCheckpointIdentity reports the stable
+// scanner-and-grammar identity for a checkpoint-capable language. The second
+// result reports whether the language requires the identity capability. The
+// third result reports whether the current identity is complete.
+func diagnosticParserCoreVersionLexerCheckpointIdentity(language *Language) ([32]byte, bool, bool) {
+	if language == nil || language.ExternalScanner == nil ||
+		!languageUsesExternalScannerCheckpoints(language) {
+		return [32]byte{}, false, false
+	}
+	provider, required := externalScannerCheckpointIdentityProviderForScanner(language.ExternalScanner)
+	if !required {
+		return [32]byte{}, false, false
+	}
+	identity, ok := provider.CheckpointIdentity()
+	if !ok || !identity.complete() {
+		return [32]byte{}, true, false
+	}
+	return parserCoreExternalScannerIdentityFingerprint(identity), true, true
+}
+
 func (s diagnosticParserCoreVersionLexerScannerContract) equal(other diagnosticParserCoreVersionLexerScannerContract) bool {
 	return s == other
 }
@@ -127,17 +155,20 @@ func (s *diagnosticParserCoreVersionLexerSnapshot) clone() *diagnosticParserCore
 		return nil
 	}
 	return &diagnosticParserCoreVersionLexerSnapshot{
-		compact:               s.compact,
-		coreGeneration:        s.coreGeneration,
-		language:              s.language,
-		scanner:               s.scanner,
-		dfa:                   cloneDiagnosticParserCoreDFARelexSnapshot(s.dfa),
-		beforeCheckpoint:      s.beforeCheckpoint,
-		afterCheckpoint:       s.afterCheckpoint,
-		beforeCheckpointBytes: cloneBytesForDiagnosticParserCoreVersion(s.beforeCheckpointBytes),
-		afterCheckpointBytes:  cloneBytesForDiagnosticParserCoreVersion(s.afterCheckpointBytes),
-		beforeCheckpointInfo:  s.beforeCheckpointInfo,
-		afterCheckpointInfo:   s.afterCheckpointInfo,
+		compact:                    s.compact,
+		coreGeneration:             s.coreGeneration,
+		language:                   s.language,
+		scanner:                    s.scanner,
+		checkpointIdentity:         s.checkpointIdentity,
+		checkpointIdentityRequired: s.checkpointIdentityRequired,
+		checkpointIdentityValid:    s.checkpointIdentityValid,
+		dfa:                        cloneDiagnosticParserCoreDFARelexSnapshot(s.dfa),
+		beforeCheckpoint:           s.beforeCheckpoint,
+		afterCheckpoint:            s.afterCheckpoint,
+		beforeCheckpointBytes:      cloneBytesForDiagnosticParserCoreVersion(s.beforeCheckpointBytes),
+		afterCheckpointBytes:       cloneBytesForDiagnosticParserCoreVersion(s.afterCheckpointBytes),
+		beforeCheckpointInfo:       s.beforeCheckpointInfo,
+		afterCheckpointInfo:        s.afterCheckpointInfo,
 	}
 }
 
@@ -209,18 +240,25 @@ func newDiagnosticParserCoreVersionLexerSnapshot(
 	if generation == 0 {
 		return nil, errors.New("parser-core phase zero: version lexer snapshot requires an authenticated reset generation")
 	}
+	checkpointIdentity, checkpointIdentityRequired, checkpointIdentityValid := diagnosticParserCoreVersionLexerCheckpointIdentity(language)
+	if checkpointIdentityRequired && !checkpointIdentityValid {
+		return nil, errors.New("parser-core phase zero: version lexer snapshot requires a complete checkpoint identity")
+	}
 	return &diagnosticParserCoreVersionLexerSnapshot{
-		compact:               compact,
-		coreGeneration:        generation,
-		language:              language,
-		scanner:               scanner,
-		dfa:                   cloneDiagnosticParserCoreDFARelexSnapshot(dfa),
-		beforeCheckpoint:      beforeCheckpoint,
-		afterCheckpoint:       afterCheckpoint,
-		beforeCheckpointBytes: beforeBytes,
-		afterCheckpointBytes:  afterBytes,
-		beforeCheckpointInfo:  beforeInfo,
-		afterCheckpointInfo:   afterInfo,
+		compact:                    compact,
+		coreGeneration:             generation,
+		language:                   language,
+		scanner:                    scanner,
+		checkpointIdentity:         checkpointIdentity,
+		checkpointIdentityRequired: checkpointIdentityRequired,
+		checkpointIdentityValid:    checkpointIdentityValid,
+		dfa:                        cloneDiagnosticParserCoreDFARelexSnapshot(dfa),
+		beforeCheckpoint:           beforeCheckpoint,
+		afterCheckpoint:            afterCheckpoint,
+		beforeCheckpointBytes:      beforeBytes,
+		afterCheckpointBytes:       afterBytes,
+		beforeCheckpointInfo:       beforeInfo,
+		afterCheckpointInfo:        afterInfo,
 	}, nil
 }
 
@@ -250,6 +288,14 @@ func (s *diagnosticParserCoreVersionLexerSnapshot) validateDestination(compact *
 	}
 	if !s.scanner.equal(scanner) {
 		return errors.New("parser-core phase zero: version lexer snapshot scanner contract changed")
+	}
+	identity, identityRequired, identityValid := diagnosticParserCoreVersionLexerCheckpointIdentity(language)
+	if s.checkpointIdentityRequired != identityRequired {
+		return errors.New("parser-core phase zero: version lexer snapshot checkpoint capability changed")
+	}
+	if s.checkpointIdentityRequired &&
+		(!s.checkpointIdentityValid || !identityValid || identity != s.checkpointIdentity) {
+		return errors.New("parser-core phase zero: version lexer snapshot checkpoint identity changed")
 	}
 	if err := s.validateGeneration(); err != nil {
 		return err

--- a/parsercore_phase0_per_version_lexer_state.go
+++ b/parsercore_phase0_per_version_lexer_state.go
@@ -31,12 +31,11 @@ type diagnosticParserCoreVersionLexerSnapshot struct {
 	scanner        diagnosticParserCoreVersionLexerScannerContract
 	// checkpointIdentity authenticates the scanner and grammar that produced
 	// this snapshot when the scanner exposes the identity-bearing checkpoint
-	// capability. Keep this optional for legacy checkpointed scanners: those
-	// scanners still use the legacy scheduler path, but existing internal DFA
-	// ownership does not need a new grammar identity.
+	// capability. Legacy checkpointed scanners keep this optional because
+	// internal DFA ownership does not require a grammar identity.
 	checkpointIdentity         [32]byte
 	checkpointIdentityRequired bool
-	checkpointIdentityValid    bool
+	checkpointIdentityValid    bool // Published snapshots set this exactly when required.
 	dfa                        dfaRelexSnapshot
 
 	beforeCheckpoint      core.CheckpointID
@@ -100,16 +99,11 @@ func diagnosticParserCoreVersionLexerScannerContractForLanguage(language *Langua
 // result reports whether the language requires the identity capability. The
 // third result reports whether the current identity is complete.
 func diagnosticParserCoreVersionLexerCheckpointIdentity(language *Language) ([32]byte, bool, bool) {
-	if language == nil || language.ExternalScanner == nil ||
-		!languageUsesExternalScannerCheckpoints(language) {
-		return [32]byte{}, false, false
-	}
-	provider, required := externalScannerCheckpointIdentityProviderForScanner(language.ExternalScanner)
+	identity, required, valid := externalScannerCheckpointIdentityStatus(language)
 	if !required {
 		return [32]byte{}, false, false
 	}
-	identity, ok := provider.CheckpointIdentity()
-	if !ok || !identity.complete() {
+	if !valid {
 		return [32]byte{}, true, false
 	}
 	return parserCoreExternalScannerIdentityFingerprint(identity), true, true
@@ -154,22 +148,11 @@ func (s *diagnosticParserCoreVersionLexerSnapshot) clone() *diagnosticParserCore
 	if s == nil {
 		return nil
 	}
-	return &diagnosticParserCoreVersionLexerSnapshot{
-		compact:                    s.compact,
-		coreGeneration:             s.coreGeneration,
-		language:                   s.language,
-		scanner:                    s.scanner,
-		checkpointIdentity:         s.checkpointIdentity,
-		checkpointIdentityRequired: s.checkpointIdentityRequired,
-		checkpointIdentityValid:    s.checkpointIdentityValid,
-		dfa:                        cloneDiagnosticParserCoreDFARelexSnapshot(s.dfa),
-		beforeCheckpoint:           s.beforeCheckpoint,
-		afterCheckpoint:            s.afterCheckpoint,
-		beforeCheckpointBytes:      cloneBytesForDiagnosticParserCoreVersion(s.beforeCheckpointBytes),
-		afterCheckpointBytes:       cloneBytesForDiagnosticParserCoreVersion(s.afterCheckpointBytes),
-		beforeCheckpointInfo:       s.beforeCheckpointInfo,
-		afterCheckpointInfo:        s.afterCheckpointInfo,
-	}
+	out := *s
+	out.dfa = cloneDiagnosticParserCoreDFARelexSnapshot(s.dfa)
+	out.beforeCheckpointBytes = cloneBytesForDiagnosticParserCoreVersion(s.beforeCheckpointBytes)
+	out.afterCheckpointBytes = cloneBytesForDiagnosticParserCoreVersion(s.afterCheckpointBytes)
+	return &out
 }
 
 // copyDiagnosticParserCoreVersionCheckpoint obtains a complete private copy


### PR DESCRIPTION
## Summary

Bind each compact owned-lexer snapshot to its external scanner and exact grammar blob.

- Reject incomplete identities before snapshot publication.
- Reject identity drift before restore, publication, or equivalent snapshot reuse.
- Bind scanner order adapters to the target grammar blob.
- Preserve restrictive scanner capabilities across adapters.
- Keep legacy checkpointed scanners outside the new identity contract.
- Skip accepted headers during ownership seeding.
- Reject ownership activation while a recovery region remains open.

This pull request keeps compact admission unchanged. It supplies the authenticated ownership prerequisite for recovery, merging, and edit reuse.

## Proof

The focused tests prove these conditions:

- Two lexer versions can consume different widths and select the C-equivalent Scala tree.
- A cloned snapshot preserves its complete identity.
- Restore and publication reject grammar identity drift without target mutation.
- Snapshot construction rejects an incomplete identity.
- Equivalent snapshot lookup rejects identity drift.
- Adapters bind the source scanner implementation to the target grammar blob.
- Nested adapters bind the final authenticated target.
- Legacy adapters remain optional.
- Accepted headers receive no owned cursor.
- Open recovery blocks a new ownership tranche.
- The scheduler header remains 224 bytes.

## Validation

- Focused tests pass with and without `gts_parsercorephase0`.
- Generated-language scanner tests pass.
- `actionlint` passes.
- The isolated package certificate passes in Docker.
- The Scala locked-C oracle passes in the same Docker run.
- Docker reported no timeout and no out-of-memory event.

Artifact: `harness_out/docker/20260903T050516Z-pr1051-package1-review-clean`

The persistent CI job runs the same identity, lifecycle, adapter, and Scala oracle witnesses.

## Graduation boundary

This is the only active core implementation pull request.

Do not start physical graph-head merging before this pull request merges. Track that next package in issue #1057.

Track full Scala grammar certification in issue #1067. Its generated-parser mismatches remain outside this package-one gate.
