### PR TITLE
document(docs): Add extraction and cleanup steps to GCP runbook

### DIFF
--- a/docs/v10-gcp-fleet-measurement-runbook.md
+++ b/docs/v10-gcp-fleet-measurement-runbook.md
@@ -182,6 +182,22 @@ no source errors. The sparse Git clones can use substantial disk space.
 Keep at least 40 GB free after materializing the corpus. Increase the boot
 disk size when the host has less free space.
 
+Extract the languages whose fixtures are embedded inside another syntax. The
+fleet runner reads them from `.gts-extracted/<language>` directories, and
+`real_corpus_sources` does not create those directories:
+
+~~~sh
+cd /srv/gotreesitter-perf/gotreesitter/cgo_harness
+GOWORK=off go run ./cmd/real_corpus_extract \
+  --root /srv/gotreesitter-perf/corpus_sources \
+  --langs comment,doxygen,gitcommit,jsdoc,markdown_inline
+~~~
+
+Confirm that each of the five directories exists before the scan. A missing
+directory produces a `no_corpus` coverage finding for that language and
+removes its rows from the fleet denominator. The 2026-08-30 run lost 12 rows
+this way.
+
 ## Run the authoritative full fleet
 
 Build the pinned local Docker image and run the scan from the checked-out
@@ -354,3 +370,8 @@ gcloud compute instances delete "$VM_NAME" \
 
 If the VM terminates before the output is copied, mark the run incomplete.
 Do not merge incomplete artifacts into the authoritative fleet scoreboard.
+
+Delete the instance in the same session as the harvest. A stopped instance
+still bills its boot disk, and a running one bills the machine until spot
+preemption. Confirm with `gcloud compute instances list` that no `gts-v10-*`
+instance remains.


### PR DESCRIPTION
## Summary

The GCP fleet measurement runbook missed two steps that caused data loss and avoidable cost. Five languages embed their fixtures inside another syntax, so the scan reports them as missing corpus unless an operator extracts them first. The runbook also did not say when to delete the fleet VM, which kept billing after the harvest finished.

## Changes

- Document the `real_corpus_extract` step for the comment, doxygen, gitcommit, jsdoc, and markdown_inline languages, including the exact command and the `.gts-extracted/<language>` output path the fleet runner reads.
- Warn that a missing extracted directory yields a `no_corpus` finding and drops that language's rows from the fleet denominator, citing the 12 rows lost on the 2026-08-30 run.
- Require deletion of the instance in the same session as the harvest, because a stopped VM still bills its boot disk and a running one bills the machine until spot preemption.
- Add the `gcloud compute instances list` check that confirms no `gts-v10-*` instance remains.

## Testing

- Read the updated sections in docs/v10-gcp-fleet-measurement-runbook.md and confirm the extract command matches `cgo_harness/cmd/real_corpus_extract` flags.
- Run `go build ./...` inside `cgo_harness` to confirm the referenced extract command still compiles.

## Review Focus

Check that the language list in the extract command matches the languages that real_corpus_sources does not materialize, and that the command paths match the fleet runner's expected working directory.