### PR TITLE
add(cgo_harness): Scala falsifier tests for package-two merge parity

### DIFF
--- a/cgo_harness/package2_scala_falsifier_test.go
+++ b/cgo_harness/package2_scala_falsifier_test.go
@@ -1,0 +1,493 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// Package-two adversarial lane witnesses (issue #1063; supports #1057 and
+// #1053). Package two -- physical GSS merging through a nullable recovery
+// discontinuity edge -- is not implemented yet. These tests lock the
+// minimal falsifiers as regression tests before implementation starts, so
+// an implementation attempt cannot silently regress the Go production route
+// or silently start diverging from the locked C oracle on the compact
+// route. All four witnesses use the locked Scala grammar.
+//
+// Every witness runs the same four checks, in order:
+//
+//  1. The locked C oracle tree: exact S-expression, root range, error flag,
+//     the missing-leaf position the issue names, and the deep digest.
+//  2. The Go production route (candidate route forced off) against the
+//     same fields.
+//  3. The Go compact route (candidate route forced on): an exact match, or
+//     an explicit fallback recorded through the admission counters.
+//  4. One incremental edit: insert one space at byte 1, apply the edit to
+//     the old Go tree, reparse incrementally, and compare against a fresh
+//     Go parse and a fresh C parse of the edited source.
+
+// package2ScalaFalsifierWitness pins one locked-C regression witness.
+type package2ScalaFalsifierWitness struct {
+	// name identifies the witness in log lines and failure messages.
+	name string
+	// source is the exact byte sequence under test.
+	source string
+	// sourceSHA256 pins source so the witness cannot drift silently.
+	sourceSHA256 string
+
+	// wantCSExpr is the exact named-node S-expression the locked C oracle
+	// must publish.
+	wantCSExpr string
+	// wantRootType and wantRootHasError pin the published root shape. The
+	// root range is always 0..len(source) for these witnesses.
+	wantRootType     string
+	wantRootHasError bool
+	// wantMissingKind and wantMissingByte pin the position the issue names
+	// for the missing leaf C inserts during recovery.
+	wantMissingKind string
+	wantMissingByte uint32
+	// wantNoErrorNode asserts C published no visible ERROR node even though
+	// the root carries HasError -- see #1053's true EOF composition
+	// witness.
+	wantNoErrorNode bool
+	// wantDeepDigest pins the C oracle's deep tree digest.
+	wantDeepDigest string
+
+	// wantProductionMatchesC records whether the Go production route (the
+	// candidate route forced off) is expected to match C exactly today. If
+	// this is false, the test records the first divergence with t.Skipf
+	// instead of weakening the assertion -- that is a finding for #1056.
+	wantProductionMatchesC bool
+
+	// wantCompactExact records whether the Go compact route (the candidate
+	// route forced on) is expected to match C exactly today. Package two is
+	// not implemented, so every locked witness here expects fallback
+	// (false). The assertion below accepts either outcome explicitly so the
+	// test keeps passing once package two makes the route exact, and logs
+	// which outcome occurred.
+	wantCompactExact bool
+	// wantCompactFallbackReasonPart, when wantCompactExact is false, must be
+	// a substring of the recorded fallback reason. Silent divergence
+	// (neither an exact match nor a recorded fallback) fails the test.
+	wantCompactFallbackReasonPart string
+
+	// wantEditedMissingByte pins the missing-leaf byte after the byte-1
+	// space-insertion edit exercised in step 4.
+	wantEditedMissingByte uint32
+	// wantIncrementalReuseUnsupported records whether ParseIncrementalProfiled
+	// is expected to report ReuseUnsupported for the edit. The Scala owned
+	// scanner does not support reuse yet (see #1054), so every locked
+	// witness here expects true.
+	wantIncrementalReuseUnsupported bool
+}
+
+// TestPackage2ScalaFalsifierPhysicalMergeMinimal locks `(y; `, the smallest
+// physical-merge falsifier from #1053/#1057. Locked C selects the
+// missing-closing-parenthesis tree at cost 610; five physical merges retain
+// six absorber paths; there is no ancestor or EOF recovery.
+func TestPackage2ScalaFalsifierPhysicalMergeMinimal(t *testing.T) {
+	runPackage2ScalaFalsifierWitness(t, package2ScalaFalsifierWitness{
+		name:                            "physical_merge_minimal",
+		source:                          "(y; ",
+		sourceSHA256:                    "80bfe1eb9ff4fb73fa504f6210d5c628431913736b1093c4c70f354ecd408e64",
+		wantCSExpr:                      "(compilation_unit (parenthesized_expression (identifier)))",
+		wantRootType:                    "compilation_unit",
+		wantRootHasError:                true,
+		wantMissingKind:                 ")",
+		wantMissingByte:                 2,
+		wantDeepDigest:                  "06d2d9f6b02599ec5be0808330bf1c62e49b8cb0b146d094ceaa28b9185c79b6",
+		wantProductionMatchesC:          true,
+		wantCompactExact:                false,
+		wantCompactFallbackReasonPart:   "recovery",
+		wantEditedMissingByte:           3,
+		wantIncrementalReuseUnsupported: true,
+	})
+}
+
+// TestPackage2ScalaFalsifierOwnedLexerComposition locks `((y)->; `, the
+// owned-lexer composition witness from #1053: two lexer widths and one
+// viability drop before the same recovery obligation as the minimal
+// witness.
+func TestPackage2ScalaFalsifierOwnedLexerComposition(t *testing.T) {
+	runPackage2ScalaFalsifierWitness(t, package2ScalaFalsifierWitness{
+		name:                            "owned_lexer_composition",
+		source:                          "((y)->; ",
+		sourceSHA256:                    "2645c366cd69f43fb554d3556dbe127f0d1ff834d6197ea21cb9b0228a54e0a5",
+		wantCSExpr:                      "(compilation_unit (parenthesized_expression (postfix_expression (parenthesized_expression (identifier)) (operator_identifier))))",
+		wantRootType:                    "compilation_unit",
+		wantRootHasError:                true,
+		wantMissingKind:                 ")",
+		wantMissingByte:                 6,
+		wantDeepDigest:                  "c0de79617c3e1bdac71c1686e5d6a3d4b2fb375aca9f69902aee974c5ca9f852",
+		wantProductionMatchesC:          true,
+		wantCompactExact:                false,
+		wantCompactFallbackReasonPart:   "recovery",
+		wantEditedMissingByte:           7,
+		wantIncrementalReuseUnsupported: true,
+	})
+}
+
+// TestPackage2ScalaFalsifierNoSummaryEOF locks `(y;` (no trailing space),
+// the no-summary EOF rung from #1053. It separates multi-path recover_eof
+// from group-wide summary recovery.
+func TestPackage2ScalaFalsifierNoSummaryEOF(t *testing.T) {
+	runPackage2ScalaFalsifierWitness(t, package2ScalaFalsifierWitness{
+		name:                            "no_summary_eof",
+		source:                          "(y;",
+		sourceSHA256:                    "cbc573a6f4346115614483aeb27146bbcbcdaf1dae24fec7a4d0968a6f57e61a",
+		wantCSExpr:                      "(compilation_unit (parenthesized_expression (identifier)))",
+		wantRootType:                    "compilation_unit",
+		wantRootHasError:                true,
+		wantMissingKind:                 ")",
+		wantMissingByte:                 2,
+		wantDeepDigest:                  "c32aa60988eb48fd8de48b59f40125eb648ecf9507cc7cf06651e3e153d59b1b",
+		wantProductionMatchesC:          true,
+		wantCompactExact:                false,
+		wantCompactFallbackReasonPart:   "recovery",
+		wantEditedMissingByte:           3,
+		wantIncrementalReuseUnsupported: true,
+	})
+}
+
+// TestPackage2ScalaFalsifierTrueEOFComposition locks `((y)->` (6 bytes),
+// the true EOF composition witness from #1053. C publishes
+// `(compilation_unit (parenthesized_expression (postfix_expression
+// (parenthesized_expression (identifier)) (operator_identifier))))` with
+// one missing `)` at byte 6; the root carries HasError, but C publishes no
+// visible ERROR node.
+func TestPackage2ScalaFalsifierTrueEOFComposition(t *testing.T) {
+	runPackage2ScalaFalsifierWitness(t, package2ScalaFalsifierWitness{
+		name:                            "true_eof_composition",
+		source:                          "((y)->",
+		sourceSHA256:                    "66568f2d2cf310e447ed512da7a3fad0be45158327905c4ffd0dd857bd90934c",
+		wantCSExpr:                      "(compilation_unit (parenthesized_expression (postfix_expression (parenthesized_expression (identifier)) (operator_identifier))))",
+		wantRootType:                    "compilation_unit",
+		wantRootHasError:                true,
+		wantMissingKind:                 ")",
+		wantMissingByte:                 6,
+		wantNoErrorNode:                 true,
+		wantDeepDigest:                  "03a458abd5832f6326e03b833a3890ea8d48ca43eb91ada1951bb020871f49a6",
+		wantProductionMatchesC:          true,
+		wantCompactExact:                false,
+		wantCompactFallbackReasonPart:   "recovery",
+		wantEditedMissingByte:           7,
+		wantIncrementalReuseUnsupported: true,
+	})
+}
+
+func runPackage2ScalaFalsifierWitness(t *testing.T, w package2ScalaFalsifierWitness) {
+	t.Helper()
+	source := []byte(w.source)
+	if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != w.sourceSHA256 {
+		t.Fatalf("%s source SHA-256=%s, want %s (witness source drifted)", w.name, got, w.sourceSHA256)
+	}
+
+	cLanguage, err := ParityCLanguage("scala")
+	if err != nil {
+		t.Fatalf("%s: load locked Scala C language: %v", w.name, err)
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatalf("%s: set locked Scala C language: %v", w.name, err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatalf("%s: locked C parser returned no root", w.name)
+	}
+	t.Cleanup(cTree.Close)
+	cRoot := cTree.RootNode()
+
+	// Step 1: the locked C oracle tree, exactly.
+	if got := formatCNodeSExpr(cRoot); got != w.wantCSExpr {
+		t.Fatalf("%s: locked C tree=%q, want %q", w.name, got, w.wantCSExpr)
+	}
+	if cRoot.Kind() != w.wantRootType || cRoot.StartByte() != 0 || cRoot.EndByte() != uint(len(source)) || cRoot.HasError() != w.wantRootHasError {
+		t.Fatalf("%s: locked C root type/range/error=%q/%d..%d/%t, want %s/0..%d/%t",
+			w.name, cRoot.Kind(), cRoot.StartByte(), cRoot.EndByte(), cRoot.HasError(),
+			w.wantRootType, len(source), w.wantRootHasError)
+	}
+	cMissing := findMissingCNodes(cRoot)
+	if len(cMissing) != 1 || cMissing[0].kind != w.wantMissingKind || cMissing[0].byteOffset != w.wantMissingByte {
+		t.Fatalf("%s: locked C missing leaves=%+v, want exactly one %q at byte %d", w.name, cMissing, w.wantMissingKind, w.wantMissingByte)
+	}
+	if w.wantNoErrorNode {
+		if path := findErrorCNode(cRoot, "/"+cRoot.Kind()); path != "" {
+			t.Fatalf("%s: locked C tree has a visible ERROR node at %s, want none", w.name, path)
+		}
+	}
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatalf("%s: inspect locked C tree: %v", w.name, err)
+	}
+	if cDigest != w.wantDeepDigest {
+		t.Fatalf("%s: locked C deep digest=%s, want %s", w.name, cDigest, w.wantDeepDigest)
+	}
+	t.Logf("%s: locked C oracle exact -- sexpr, root 0..%d/error=%t, missing %q@%d, digest %s",
+		w.name, len(source), w.wantRootHasError, w.wantMissingKind, w.wantMissingByte, cDigest)
+
+	entry := grammars.DetectLanguageByName("scala")
+	if entry == nil || entry.Language() == nil {
+		t.Fatalf("%s: Scala Go grammar is unavailable", w.name)
+	}
+	goLanguage := entry.Language()
+
+	// Step 2: the Go production route (candidate route forced off).
+	prodParser := gotreesitter.NewParser(goLanguage)
+	prodParser.SetAdmissionCandidateRoute(false)
+	prodTree, err := prodParser.Parse(source)
+	if err != nil {
+		t.Fatalf("%s: production parse: %v", w.name, err)
+	}
+	t.Cleanup(prodTree.Release)
+	prodRoot := prodTree.RootNode()
+
+	if diff := FirstDivergenceDumpV1(prodRoot, goLanguage, cRoot); diff != nil {
+		if !w.wantProductionMatchesC {
+			t.Skipf("%s: PACKAGE-2 FINDING FOR #1056 -- Go production route diverges from locked C at %s: category=%s go=%q c=%q",
+				w.name, diff.Path, diff.Category, diff.GoValue, diff.CValue)
+		}
+		t.Fatalf("%s: production tree diverges from locked C: %+v", w.name, *diff)
+	}
+	if diff := firstLockedCTreeFlagDivergence(prodRoot, goLanguage, cRoot, "/"+prodRoot.Type(goLanguage)); diff != nil {
+		if !w.wantProductionMatchesC {
+			t.Skipf("%s: PACKAGE-2 FINDING FOR #1056 -- Go production route flags diverge from locked C: %v", w.name, diff)
+		}
+		t.Fatalf("%s: production flags diverge from locked C: %v", w.name, diff)
+	}
+	if !w.wantProductionMatchesC {
+		t.Fatalf("%s: witness declared a known production divergence but none was observed -- update wantProductionMatchesC", w.name)
+	}
+	prodMissing := findMissingGoNodes(prodRoot, goLanguage)
+	if len(prodMissing) != 1 || prodMissing[0].kind != w.wantMissingKind || prodMissing[0].byteOffset != w.wantMissingByte {
+		t.Fatalf("%s: production missing leaves=%+v, want exactly one %q at byte %d", w.name, prodMissing, w.wantMissingKind, w.wantMissingByte)
+	}
+	prodInspection, err := benchfixtures.InspectGoTree(prodRoot, goLanguage)
+	if err != nil {
+		t.Fatalf("%s: inspect production tree: %v", w.name, err)
+	}
+	if prodInspection.SHA256 != cDigest {
+		t.Fatalf("%s: production deep digest=%s, want locked C %s", w.name, prodInspection.SHA256, cDigest)
+	}
+	t.Logf("%s: Go production route matches locked C exactly (digest %s)", w.name, prodInspection.SHA256)
+
+	// Step 3: the Go compact route (candidate route forced on). Package two
+	// is not implemented, so an explicit fallback is expected today. Either
+	// outcome must be recorded explicitly through the admission counters --
+	// silent divergence fails the test.
+	beforeRouted, beforeFallback := gotreesitter.AdmissionCandidateCounters()
+	compactParser := gotreesitter.NewParser(goLanguage)
+	compactParser.SetAdmissionCandidateRoute(true)
+	compactTree, err := compactParser.Parse(source)
+	if err != nil {
+		t.Fatalf("%s: compact candidate parse: %v", w.name, err)
+	}
+	t.Cleanup(compactTree.Release)
+	routed, fallback := gotreesitter.AdmissionCandidateCounters()
+	routedDelta := routed - beforeRouted
+	fallbackDelta := fallback - beforeFallback
+	reason := gotreesitter.AdmissionCandidateLastFallbackReason()
+
+	switch {
+	case routedDelta == 1 && fallbackDelta == 0:
+		compactRoot := compactTree.RootNode()
+		if diff := FirstDivergenceDumpV1(compactRoot, goLanguage, cRoot); diff != nil {
+			t.Fatalf("%s: compact route reported an exact route but the tree diverges from locked C: %+v", w.name, *diff)
+		}
+		if diff := firstLockedCTreeFlagDivergence(compactRoot, goLanguage, cRoot, "/"+compactRoot.Type(goLanguage)); diff != nil {
+			t.Fatalf("%s: compact route reported an exact route but flags diverge from locked C: %v", w.name, diff)
+		}
+		compactInspection, err := benchfixtures.InspectGoTree(compactRoot, goLanguage)
+		if err != nil {
+			t.Fatalf("%s: inspect compact tree: %v", w.name, err)
+		}
+		if compactInspection.SHA256 != cDigest {
+			t.Fatalf("%s: compact route reported an exact route but deep digest=%s, want locked C %s", w.name, compactInspection.SHA256, cDigest)
+		}
+		if !w.wantCompactExact {
+			t.Logf("%s: PACKAGE-2 OUTCOME: compact route now matches locked C exactly (package two appears implemented) -- update wantCompactExact", w.name)
+		} else {
+			t.Logf("%s: compact route matches locked C exactly (digest %s)", w.name, compactInspection.SHA256)
+		}
+	case routedDelta == 0 && fallbackDelta == 1:
+		if w.wantCompactFallbackReasonPart != "" && !strings.Contains(reason, w.wantCompactFallbackReasonPart) {
+			t.Fatalf("%s: compact route fallback reason=%q, want substring %q", w.name, reason, w.wantCompactFallbackReasonPart)
+		}
+		t.Logf("%s: PACKAGE-2 OUTCOME: compact route fell back explicitly, reason=%q", w.name, reason)
+	default:
+		t.Fatalf("%s: compact route admission counters=%d routed/%d fallback, want exactly one of (1,0) or (0,1) -- silent divergence risk; reason=%q",
+			w.name, routedDelta, fallbackDelta, reason)
+	}
+
+	// Step 4: one incremental edit -- insert one space at byte 1.
+	editParser := gotreesitter.NewParser(goLanguage)
+	editParser.SetAdmissionCandidateRoute(false)
+	oldTree, err := editParser.Parse(source)
+	if err != nil {
+		t.Fatalf("%s: build old tree for incremental edit: %v", w.name, err)
+	}
+	t.Cleanup(oldTree.Release)
+
+	edited := make([]byte, 0, len(source)+1)
+	edited = append(edited, source[:1]...)
+	edited = append(edited, ' ')
+	edited = append(edited, source[1:]...)
+
+	edit := gotreesitter.InputEdit{
+		StartByte:   1,
+		OldEndByte:  1,
+		NewEndByte:  2,
+		StartPoint:  pointAtOffset(source, 1),
+		OldEndPoint: pointAtOffset(source, 1),
+		NewEndPoint: pointAtOffset(edited, 2),
+	}
+	oldTree.Edit(edit)
+	incTree, profile, err := editParser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatalf("%s: incremental parse: %v", w.name, err)
+	}
+	t.Cleanup(incTree.Release)
+
+	if profile.ReuseUnsupported != w.wantIncrementalReuseUnsupported {
+		t.Fatalf("%s: incremental ReuseUnsupported=%t, want %t (reason=%q)", w.name, profile.ReuseUnsupported, w.wantIncrementalReuseUnsupported, profile.ReuseUnsupportedReason)
+	}
+	if w.wantIncrementalReuseUnsupported && profile.ReuseUnsupportedReason == "" {
+		t.Fatalf("%s: incremental ReuseUnsupported=true but ReuseUnsupportedReason is empty", w.name)
+	}
+	t.Logf("%s: incremental ReuseUnsupported=%t reason=%q reusedSubtrees=%d reusedBytes=%d",
+		w.name, profile.ReuseUnsupported, profile.ReuseUnsupportedReason, profile.ReusedSubtrees, profile.ReusedBytes)
+
+	freshEditedParser := gotreesitter.NewParser(goLanguage)
+	freshEditedParser.SetAdmissionCandidateRoute(false)
+	freshEditedTree, err := freshEditedParser.Parse(edited)
+	if err != nil {
+		t.Fatalf("%s: fresh Go parse of edited source: %v", w.name, err)
+	}
+	t.Cleanup(freshEditedTree.Release)
+	freshEditedRoot := freshEditedTree.RootNode()
+
+	cEditedParser := sitter.NewParser()
+	t.Cleanup(cEditedParser.Close)
+	if err := cEditedParser.SetLanguage(cLanguage); err != nil {
+		t.Fatalf("%s: set locked Scala C language for edited parse: %v", w.name, err)
+	}
+	cEditedTree := cEditedParser.Parse(edited, nil)
+	if cEditedTree == nil || cEditedTree.RootNode() == nil {
+		t.Fatalf("%s: locked C parser returned no root for edited source", w.name)
+	}
+	t.Cleanup(cEditedTree.Close)
+	cEditedRoot := cEditedTree.RootNode()
+
+	cEditedMissing := findMissingCNodes(cEditedRoot)
+	if len(cEditedMissing) != 1 || cEditedMissing[0].kind != w.wantMissingKind || cEditedMissing[0].byteOffset != w.wantEditedMissingByte {
+		t.Fatalf("%s: locked C edited missing leaves=%+v, want exactly one %q at byte %d", w.name, cEditedMissing, w.wantMissingKind, w.wantEditedMissingByte)
+	}
+
+	incRoot := incTree.RootNode()
+	if diff := FirstDivergenceDumpV1(incRoot, goLanguage, cEditedRoot); diff != nil {
+		t.Fatalf("%s: incremental tree diverges from locked C fresh-edited parse: %+v", w.name, *diff)
+	}
+	if diff := firstLockedCTreeFlagDivergence(incRoot, goLanguage, cEditedRoot, "/"+incRoot.Type(goLanguage)); diff != nil {
+		t.Fatalf("%s: incremental flags diverge from locked C fresh-edited parse: %v", w.name, diff)
+	}
+	if diff := FirstDivergenceDumpV1(freshEditedRoot, goLanguage, cEditedRoot); diff != nil {
+		t.Fatalf("%s: fresh Go edited parse diverges from locked C fresh-edited parse: %+v", w.name, *diff)
+	}
+	if diff := firstLockedCTreeFlagDivergence(freshEditedRoot, goLanguage, cEditedRoot, "/"+freshEditedRoot.Type(goLanguage)); diff != nil {
+		t.Fatalf("%s: fresh Go edited parse flags diverge from locked C fresh-edited parse: %v", w.name, diff)
+	}
+
+	cEditedDigest, err := COracleDeepDigest(cEditedTree)
+	if err != nil {
+		t.Fatalf("%s: inspect locked C edited tree: %v", w.name, err)
+	}
+	incInspection, err := benchfixtures.InspectGoTree(incRoot, goLanguage)
+	if err != nil {
+		t.Fatalf("%s: inspect incremental Go tree: %v", w.name, err)
+	}
+	if incInspection.SHA256 != cEditedDigest {
+		t.Fatalf("%s: incremental deep digest=%s, want locked C edited %s", w.name, incInspection.SHA256, cEditedDigest)
+	}
+	freshEditedInspection, err := benchfixtures.InspectGoTree(freshEditedRoot, goLanguage)
+	if err != nil {
+		t.Fatalf("%s: inspect fresh edited Go tree: %v", w.name, err)
+	}
+	if freshEditedInspection.SHA256 != cEditedDigest {
+		t.Fatalf("%s: fresh edited deep digest=%s, want locked C edited %s", w.name, freshEditedInspection.SHA256, cEditedDigest)
+	}
+	t.Logf("%s: incremental edit at byte 1 == fresh Go parse == locked C fresh parse of edited source (digest %s)", w.name, cEditedDigest)
+}
+
+// package2MissingLeaf records one missing-leaf node found during a tree
+// walk: its symbol kind and byte offset.
+type package2MissingLeaf struct {
+	kind       string
+	byteOffset uint32
+}
+
+func findMissingCNodes(n *sitter.Node) []package2MissingLeaf {
+	var out []package2MissingLeaf
+	var walk func(node *sitter.Node)
+	walk = func(node *sitter.Node) {
+		if node == nil {
+			return
+		}
+		if node.IsMissing() {
+			out = append(out, package2MissingLeaf{kind: node.Kind(), byteOffset: uint32(node.StartByte())})
+		}
+		count := node.ChildCount()
+		for i := uint(0); i < count; i++ {
+			walk(node.Child(i))
+		}
+	}
+	walk(n)
+	return out
+}
+
+func findMissingGoNodes(n *gotreesitter.Node, lang *gotreesitter.Language) []package2MissingLeaf {
+	var out []package2MissingLeaf
+	var walk func(node *gotreesitter.Node)
+	walk = func(node *gotreesitter.Node) {
+		if node == nil {
+			return
+		}
+		if node.IsMissing() {
+			out = append(out, package2MissingLeaf{kind: node.Type(lang), byteOffset: node.StartByte()})
+		}
+		for i := 0; i < node.ChildCount(); i++ {
+			walk(node.Child(i))
+		}
+	}
+	walk(n)
+	return out
+}
+
+// findErrorCNode returns the path of the first ERROR-kind node found in the
+// tree, or "" if none exists.
+func findErrorCNode(n *sitter.Node, path string) string {
+	if n == nil {
+		return ""
+	}
+	if n.IsError() {
+		return path
+	}
+	count := n.ChildCount()
+	for i := uint(0); i < count; i++ {
+		child := n.Child(i)
+		if child == nil {
+			continue
+		}
+		if found := findErrorCNode(child, fmt.Sprintf("%s/%s[%d]", path, child.Kind(), i)); found != "" {
+			return found
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

Package two — physical GSS merging through a nullable recovery discontinuity edge — is not implemented yet. This branch locks the minimal falsifiers as regression tests before implementation starts. The locked tests prevent an implementation attempt from regressing the Go production route or from diverging silently from the locked C oracle on the compact route. All four witnesses use the locked Scala grammar.

## Changes

- Add cgo_harness/package2_scala_falsifier_test.go behind the `cgo && treesitter_c_parity` build tags.
- Add four locked-C Scala witnesses: the minimal physical merge `(y; `, the owned-lexer composition `((y)->; `, the no-summary EOF rung `(y;`, and the true EOF composition `((y)->`.
- Check four things in every witness, in order: the exact locked C tree, the Go production route, the Go compact route, and one incremental edit.
- Pin each C tree on the named-node S-expression, root type and range, error flag, the missing-leaf kind and byte the issue names, and the deep tree digest.
- Pin each witness source with a SHA-256 digest, so a witness source cannot drift silently.
- Force the admission candidate route off for the production check, and compare the tree, the flags, the missing leaf, and the deep digest against C.
- Force the candidate route on for the compact check, and require one explicit recorded outcome: an exact route or a recorded fallback with reason substring "recovery". Admission counters that record neither fail the test as a silent-divergence risk.
- Accept an exact compact match today with a log line that names package two as apparently implemented, so the same test keeps passing after the implementation lands.
- Insert one space at byte 1, apply the edit, and reparse incrementally. Compare the incremental tree and a fresh Go parse against a fresh C parse of the edited source.
- Assert ParseIncrementalProfiled reports ReuseUnsupported with a non-empty reason, because the Scala owned scanner does not support reuse yet.
- Report a production-route divergence as a recorded finding instead of weakening the assertion, when the witness declares a known divergence.

## Testing

The host build links a locally built C grammar artifact whose SHA-256 does not match the locked grammar identity the other Stage 6 receipts pin, so this run used the Docker harness for the true locked-C oracle.

- `bash cgo_harness/docker/run_parity_in_docker.sh --label package2-falsifier-run --no-build --timeout 15m -- "cd /workspace/cgo_harness && go test . -tags treesitter_c_parity -run 'Package2ScalaFalsifier' -count=1 -v -timeout 12m"`
- Result: `PASS`, all four witnesses green. Artifact: `harness_out/docker/20260903T082531Z-package2-falsifier-run/container.log`.
- `gofmt -l cgo_harness/package2_scala_falsifier_test.go` (run inside the same container): no output.
- `go vet -tags treesitter_c_parity .` (run inside `cgo_harness`, same container): no findings in the new file. Four pre-existing findings remain in unrelated files (`b4b_alternative_set_v2_kotlin_adjudication_test.go`, `compact_javascript_s5_scan_test.go`, `compact_t3_oracle_adjudication_test.go`, `parity_cgo_test.go`).
- Negative control: a deliberately wrong deep-digest constant in one witness made the test fail with the expected mismatch message, then the constant was restored. This confirms the digest assertion is load-bearing, not vacuous.

Per-witness result against the locked C oracle:

- `(y; `: Go production route matches C exactly (digest `06d2d9f6...`). Compact route falls back with reason `did not accept EOF: generic scheduler has no table action for the elected token`. Incremental edit at byte 1 matches both a fresh Go parse and a fresh C parse of the edited source.
- `((y)->; `: same production match, same compact fallback reason, same incremental match.
- `(y;`: same production match, same compact fallback reason, same incremental match.
- `((y)->`: same production match, same compact fallback reason, same incremental match; the locked C tree carries `HasError` on the root with no visible ERROR node, as asserted.

No production divergence from locked C was found on any of the four witnesses, so no `t.Skipf` finding for #1056 applies here.

## Related Issues

- Refs #1063
- Refs #1057
- Refs #1053
- Refs #1054

## Review Focus

Confirm each witness fails on a silent compact-route divergence (neither an exact route nor a recorded fallback), and that an exact compact match does not pass without an explicit log and an update to wantCompactExact. Also confirm the new helpers do not collide with existing helpers in the package.
