### PR TITLE
Add compact physical graph-head recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1281,7 +1281,7 @@ jobs:
             --test-parallel 1 \
             --c-ref-build-jobs 1 \
             --timeout 20m \
-            -- "cd /workspace && go test . -tags gts_parsercorephase0 -run '^TestPackage2ScalaStrictReceipt(Composition)?$' -count=1 -parallel 1 -timeout 20m -v && cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^TestPackage2ScalaFalsifier(PhysicalMergeMinimal|OwnedLexerComposition)$' -count=1 -parallel 1 -timeout 20m -v"
+            -- "cd /workspace && go test -tags gts_parsercorephase0 ./internal/parsercorephase0 -run '^(TestS5RecoveryDiscontinuityLinkValidation|TestS5DiscontinuityReaderSemantics|TestS5SixHeadPhysicalMergeRetainsPaths)$' -count=1 -parallel 1 -timeout 20m -v && go test . -tags gts_parsercorephase0 -run '^TestPackage2ScalaStrictReceipt(Composition)?$' -count=1 -parallel 1 -timeout 20m -v && cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^TestPackage2Scala(Falsifier(PhysicalMergeMinimal|OwnedLexerComposition|NoSummaryEOF|TrueEOFComposition)|IncrementalCleanMissingTransitions)$' -count=1 -parallel 1 -timeout 20m -v"
 
   # merge-event-census-cgo runs stage M0 of spec.merge-time-election.v1: the
   # census that counts stack-merge events on both sides and breaks production's

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1267,6 +1267,22 @@ jobs:
             --timeout 20m \
             -- "cd /workspace && go test . -tags gts_parsercorephase0 -run '^(TestDiagnosticParserCoreVersionLexerSnapshot(BindsCheckpointIdentity|RejectsIncompleteCheckpointIdentity)|TestDiagnosticParserCoreOwnedLexer(SeedingSkipsAcceptedHeader|ActivationRejectsOpenRecoveryRegion)|TestExternalScannerOrderAdapter(PreservesOptionalCapabilities|KeepsLegacyCheckpointIdentityOptional|RequiresTargetGrammarCheckpointIdentity|BindsAuthenticatedTargetAcrossNestedAdapters))$' -count=1 -parallel 1 -timeout 20m -v && cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^TestCompactPerVersionLexerScalaCOracle$' -count=1 -parallel 1 -timeout 20m -v"
 
+      - name: Compact physical graph-head package-two witnesses
+        run: |
+          GTS_PARITY_MODE=smoke \
+          GTS_PARITY_C_REF_BUILD_CACHE=0 \
+          bash cgo_harness/docker/run_parity_in_docker.sh \
+            --label ci-compact-physical-head-scala \
+            --memory 8g \
+            --cpus 2 \
+            --pids 4096 \
+            --gomemlimit 6GiB \
+            --goflags -p=1 \
+            --test-parallel 1 \
+            --c-ref-build-jobs 1 \
+            --timeout 20m \
+            -- "cd /workspace && go test . -tags gts_parsercorephase0 -run '^TestPackage2ScalaStrictReceipt(Composition)?$' -count=1 -parallel 1 -timeout 20m -v && cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^TestPackage2ScalaFalsifier(PhysicalMergeMinimal|OwnedLexerComposition)$' -count=1 -parallel 1 -timeout 20m -v"
+
   # merge-event-census-cgo runs stage M0 of spec.merge-time-election.v1: the
   # census that counts stack-merge events on both sides and breaks production's
   # refusals down by gate. Every cgo parity lane in this file runs a FIXED

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -71,6 +71,7 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		allowCompactRecoverEOF:            allowRecoverEOF,
 		allowCompactStackSummaryRecovery:  p.language.CompactStackSummaryRecoveryCertified,
 		allowCompactMissingTokenInsertion: p.language.CompactMissingTokenInsertionCertified,
+		allowCompactFaithfulS5Recovery:    p.language.CompactFaithfulS5RecoveryCertified,
 		allowCompactRecoveryLineageSelection: p.language.CompactStrategy2ErrorRegionCertified &&
 			(p.language.CompactStackSummaryRecoveryCertified || p.language.CompactMissingTokenInsertionCertified),
 		allowCompactRecoveryTrailingLineageRetirement: p.language.CompactRecoveryTrailingLineageRetirementCertified,

--- a/cgo_harness/package2_scala_falsifier_test.go
+++ b/cgo_harness/package2_scala_falsifier_test.go
@@ -16,7 +16,7 @@ import (
 
 // Package-two adversarial lane witnesses (issue #1063; supports #1057 and
 // #1053). These tests lock the smallest physical GSS merge cases through a
-// nullable recovery discontinuity edge. The first two witnesses require the
+// nullable recovery discontinuity edge. The first three witnesses require the
 // compact route to publish the locked C result. All four use locked Scala.
 //
 // Every witness runs the same four checks, in order:
@@ -65,8 +65,8 @@ type package2ScalaFalsifierWitness struct {
 	wantProductionMatchesC bool
 
 	// wantCompactExact records whether the Go compact route (the candidate
-	// route forced on) must match C exactly. The two package-two witnesses
-	// below are strict: generic recovery fallback is not an accepted result.
+	// route forced on) must match C exactly. The certified package-two
+	// witnesses are strict: generic recovery fallback is not accepted.
 	wantCompactExact bool
 	// wantCompactFallbackReasonPart, when wantCompactExact is false, must be
 	// a substring of the recorded fallback reason. Silent divergence
@@ -142,8 +142,7 @@ func TestPackage2ScalaFalsifierNoSummaryEOF(t *testing.T) {
 		wantMissingByte:                 2,
 		wantDeepDigest:                  "c32aa60988eb48fd8de48b59f40125eb648ecf9507cc7cf06651e3e153d59b1b",
 		wantProductionMatchesC:          true,
-		wantCompactExact:                false,
-		wantCompactFallbackReasonPart:   "recovery",
+		wantCompactExact:                true,
 		wantEditedMissingByte:           3,
 		wantIncrementalReuseUnsupported: true,
 	})
@@ -173,6 +172,147 @@ func TestPackage2ScalaFalsifierTrueEOFComposition(t *testing.T) {
 		wantEditedMissingByte:           7,
 		wantIncrementalReuseUnsupported: true,
 	})
+}
+
+// TestPackage2ScalaIncrementalCleanMissingTransitions proves both invalidation
+// directions around the smallest package-two recovery point. Scala scanner
+// reuse still fails closed, so package five must later replace this full reparse
+// with authenticated reuse without changing either result.
+func TestPackage2ScalaIncrementalCleanMissingTransitions(t *testing.T) {
+	clean := []byte("(y); ")
+	missing := []byte("(y; ")
+	entry := grammars.DetectLanguageByName("scala")
+	if entry == nil || entry.Language() == nil {
+		t.Fatal("Scala Go grammar is unavailable")
+	}
+	goLanguage := entry.Language()
+	cLanguage, err := ParityCLanguage("scala")
+	if err != nil {
+		t.Fatalf("load locked Scala C language: %v", err)
+	}
+
+	parser := gotreesitter.NewParser(goLanguage)
+	parser.SetAdmissionCandidateRoute(false)
+	cleanTree, err := parser.Parse(clean)
+	if err != nil {
+		t.Fatalf("parse clean source: %v", err)
+	}
+	t.Cleanup(cleanTree.Release)
+
+	deleteClose := gotreesitter.InputEdit{
+		StartByte: 2, OldEndByte: 3, NewEndByte: 2,
+		StartPoint:  pointAtOffset(clean, 2),
+		OldEndPoint: pointAtOffset(clean, 3),
+		NewEndPoint: pointAtOffset(missing, 2),
+	}
+	cleanTree.Edit(deleteClose)
+	missingTree, missingProfile, err := parser.ParseIncrementalProfiled(missing, cleanTree)
+	if err != nil {
+		t.Fatalf("delete closing parenthesis: %v", err)
+	}
+	t.Cleanup(missingTree.Release)
+	if !missingProfile.ReuseUnsupported || missingProfile.ReuseUnsupportedReason == "" {
+		t.Fatalf("delete profile=%+v, want explicit scanner reuse decline", missingProfile)
+	}
+	assertPackage2ScalaTransitionEndpoint(t, goLanguage, cLanguage, missing, missingTree, true, 1)
+
+	insertClose := gotreesitter.InputEdit{
+		StartByte: 2, OldEndByte: 2, NewEndByte: 3,
+		StartPoint:  pointAtOffset(missing, 2),
+		OldEndPoint: pointAtOffset(missing, 2),
+		NewEndPoint: pointAtOffset(clean, 3),
+	}
+	missingTree.Edit(insertClose)
+	restoredTree, restoredProfile, err := parser.ParseIncrementalProfiled(clean, missingTree)
+	if err != nil {
+		t.Fatalf("restore closing parenthesis: %v", err)
+	}
+	t.Cleanup(restoredTree.Release)
+	if !restoredProfile.ReuseUnsupported || restoredProfile.ReuseUnsupportedReason == "" {
+		t.Fatalf("restore profile=%+v, want explicit scanner reuse decline", restoredProfile)
+	}
+	assertPackage2ScalaTransitionEndpoint(t, goLanguage, cLanguage, clean, restoredTree, false, 0)
+}
+
+func assertPackage2ScalaTransitionEndpoint(
+	t *testing.T,
+	goLanguage *gotreesitter.Language,
+	cLanguage *sitter.Language,
+	source []byte,
+	incremental *gotreesitter.Tree,
+	wantError bool,
+	wantMissing int,
+) {
+	t.Helper()
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatalf("set locked Scala C language: %v", err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("locked Scala C parser returned no endpoint tree")
+	}
+	t.Cleanup(cTree.Close)
+	cRoot := cTree.RootNode()
+	if cRoot.HasError() != wantError || len(findMissingCNodes(cRoot)) != wantMissing {
+		t.Fatalf("locked C endpoint error/missing=%t/%d, want %t/%d", cRoot.HasError(), len(findMissingCNodes(cRoot)), wantError, wantMissing)
+	}
+
+	assertGoEndpoint := func(label string, tree *gotreesitter.Tree) {
+		t.Helper()
+		root := tree.RootNode()
+		if diff := FirstDivergenceDumpV1(root, goLanguage, cRoot); diff != nil {
+			t.Fatalf("%s endpoint diverges from locked C: %+v", label, *diff)
+		}
+		if diff := firstLockedCTreeFlagDivergence(root, goLanguage, cRoot, "/"+root.Type(goLanguage)); diff != nil {
+			t.Fatalf("%s endpoint flags diverge from locked C: %v", label, diff)
+		}
+		if root.HasError() != wantError || len(findMissingGoNodes(root, goLanguage)) != wantMissing {
+			t.Fatalf("%s endpoint error/missing=%t/%d, want %t/%d", label, root.HasError(), len(findMissingGoNodes(root, goLanguage)), wantError, wantMissing)
+		}
+	}
+	assertGoEndpoint("incremental", incremental)
+
+	freshParser := gotreesitter.NewParser(goLanguage)
+	freshParser.SetAdmissionCandidateRoute(false)
+	freshTree, err := freshParser.Parse(source)
+	if err != nil {
+		t.Fatalf("fresh endpoint parse: %v", err)
+	}
+	t.Cleanup(freshTree.Release)
+	assertGoEndpoint("fresh production", freshTree)
+
+	beforeRouted, beforeFallback := gotreesitter.AdmissionCandidateCounters()
+	compactParser := gotreesitter.NewParser(goLanguage)
+	compactParser.SetAdmissionCandidateRoute(true)
+	compactTree, err := compactParser.Parse(source)
+	if err != nil {
+		t.Fatalf("compact endpoint parse: %v", err)
+	}
+	t.Cleanup(compactTree.Release)
+	routed, fallback := gotreesitter.AdmissionCandidateCounters()
+	if routed-beforeRouted != 1 || fallback-beforeFallback != 0 {
+		t.Fatalf("compact endpoint routed/fallback=%d/%d, want 1/0; reason=%q", routed-beforeRouted, fallback-beforeFallback, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+	assertGoEndpoint("fresh compact", compactTree)
+
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatalf("inspect locked C endpoint: %v", err)
+	}
+	for _, candidate := range []struct {
+		name string
+		tree *gotreesitter.Tree
+	}{{"incremental", incremental}, {"fresh production", freshTree}, {"fresh compact", compactTree}} {
+		inspection, err := benchfixtures.InspectGoTree(candidate.tree.RootNode(), goLanguage)
+		if err != nil {
+			t.Fatalf("inspect %s endpoint: %v", candidate.name, err)
+		}
+		if inspection.SHA256 != cDigest {
+			t.Fatalf("%s endpoint digest=%s, want locked C %s", candidate.name, inspection.SHA256, cDigest)
+		}
+	}
 }
 
 func runPackage2ScalaFalsifierWitness(t *testing.T, w package2ScalaFalsifierWitness) {
@@ -272,8 +412,8 @@ func runPackage2ScalaFalsifierWitness(t *testing.T, w package2ScalaFalsifierWitn
 	t.Logf("%s: Go production route matches locked C exactly (digest %s)", w.name, prodInspection.SHA256)
 
 	// Step 3: the Go compact route, with the candidate route forced on. The
-	// package-two witnesses require an exact route. Later EOF witnesses still
-	// require an explicit fallback. Silent divergence fails the test.
+	// certified package-two witnesses require an exact route. The true EOF
+	// witness still requires an explicit fallback. Silent divergence fails.
 	beforeRouted, beforeFallback := gotreesitter.AdmissionCandidateCounters()
 	compactParser := gotreesitter.NewParser(goLanguage)
 	compactParser.SetAdmissionCandidateRoute(true)

--- a/cgo_harness/package2_scala_falsifier_test.go
+++ b/cgo_harness/package2_scala_falsifier_test.go
@@ -271,10 +271,9 @@ func runPackage2ScalaFalsifierWitness(t *testing.T, w package2ScalaFalsifierWitn
 	}
 	t.Logf("%s: Go production route matches locked C exactly (digest %s)", w.name, prodInspection.SHA256)
 
-	// Step 3: the Go compact route (candidate route forced on). Package two
-	// is not implemented, so an explicit fallback is expected today. Either
-	// outcome must be recorded explicitly through the admission counters --
-	// silent divergence fails the test.
+	// Step 3: the Go compact route, with the candidate route forced on. The
+	// package-two witnesses require an exact route. Later EOF witnesses still
+	// require an explicit fallback. Silent divergence fails the test.
 	beforeRouted, beforeFallback := gotreesitter.AdmissionCandidateCounters()
 	compactParser := gotreesitter.NewParser(goLanguage)
 	compactParser.SetAdmissionCandidateRoute(true)

--- a/cgo_harness/package2_scala_falsifier_test.go
+++ b/cgo_harness/package2_scala_falsifier_test.go
@@ -15,12 +15,9 @@ import (
 )
 
 // Package-two adversarial lane witnesses (issue #1063; supports #1057 and
-// #1053). Package two -- physical GSS merging through a nullable recovery
-// discontinuity edge -- is not implemented yet. These tests lock the
-// minimal falsifiers as regression tests before implementation starts, so
-// an implementation attempt cannot silently regress the Go production route
-// or silently start diverging from the locked C oracle on the compact
-// route. All four witnesses use the locked Scala grammar.
+// #1053). These tests lock the smallest physical GSS merge cases through a
+// nullable recovery discontinuity edge. The first two witnesses require the
+// compact route to publish the locked C result. All four use locked Scala.
 //
 // Every witness runs the same four checks, in order:
 //
@@ -28,8 +25,8 @@ import (
 //     the missing-leaf position the issue names, and the deep digest.
 //  2. The Go production route (candidate route forced off) against the
 //     same fields.
-//  3. The Go compact route (candidate route forced on): an exact match, or
-//     an explicit fallback recorded through the admission counters.
+//  3. The Go compact route (candidate route forced on): an exact match for
+//     strict witnesses, or an explicit fallback for transitional witnesses.
 //  4. One incremental edit: insert one space at byte 1, apply the edit to
 //     the old Go tree, reparse incrementally, and compare against a fresh
 //     Go parse and a fresh C parse of the edited source.
@@ -68,11 +65,8 @@ type package2ScalaFalsifierWitness struct {
 	wantProductionMatchesC bool
 
 	// wantCompactExact records whether the Go compact route (the candidate
-	// route forced on) is expected to match C exactly today. Package two is
-	// not implemented, so every locked witness here expects fallback
-	// (false). The assertion below accepts either outcome explicitly so the
-	// test keeps passing once package two makes the route exact, and logs
-	// which outcome occurred.
+	// route forced on) must match C exactly. The two package-two witnesses
+	// below are strict: generic recovery fallback is not an accepted result.
 	wantCompactExact bool
 	// wantCompactFallbackReasonPart, when wantCompactExact is false, must be
 	// a substring of the recorded fallback reason. Silent divergence
@@ -105,8 +99,7 @@ func TestPackage2ScalaFalsifierPhysicalMergeMinimal(t *testing.T) {
 		wantMissingByte:                 2,
 		wantDeepDigest:                  "06d2d9f6b02599ec5be0808330bf1c62e49b8cb0b146d094ceaa28b9185c79b6",
 		wantProductionMatchesC:          true,
-		wantCompactExact:                false,
-		wantCompactFallbackReasonPart:   "recovery",
+		wantCompactExact:                true,
 		wantEditedMissingByte:           3,
 		wantIncrementalReuseUnsupported: true,
 	})
@@ -128,8 +121,7 @@ func TestPackage2ScalaFalsifierOwnedLexerComposition(t *testing.T) {
 		wantMissingByte:                 6,
 		wantDeepDigest:                  "c0de79617c3e1bdac71c1686e5d6a3d4b2fb375aca9f69902aee974c5ca9f852",
 		wantProductionMatchesC:          true,
-		wantCompactExact:                false,
-		wantCompactFallbackReasonPart:   "recovery",
+		wantCompactExact:                true,
 		wantEditedMissingByte:           7,
 		wantIncrementalReuseUnsupported: true,
 	})
@@ -318,6 +310,10 @@ func runPackage2ScalaFalsifierWitness(t *testing.T, w package2ScalaFalsifierWitn
 			t.Logf("%s: compact route matches locked C exactly (digest %s)", w.name, compactInspection.SHA256)
 		}
 	case routedDelta == 0 && fallbackDelta == 1:
+		if w.wantCompactExact {
+			t.Fatalf("%s: compact route used generic recovery fallback, want the exact compact route (routed=%d fallback=%d reason=%q)",
+				w.name, routedDelta, fallbackDelta, reason)
+		}
 		if w.wantCompactFallbackReasonPart != "" && !strings.Contains(reason, w.wantCompactFallbackReasonPart) {
 			t.Fatalf("%s: compact route fallback reason=%q, want substring %q", w.name, reason, w.wantCompactFallbackReasonPart)
 		}

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -33,6 +33,7 @@ type builtinLanguageRuntimeProfile struct {
 	compactRecoverEOFArtifact           gotreesitter.CompactRecoverEOFArtifactReceipt
 	compactStackSummaryRecovery         bool
 	compactMissingTokenInsertion        bool
+	compactFaithfulS5Recovery           bool
 	compactRecoveryTrailingRetirement   bool
 	compactRecoveryErrorModeKeyword     bool
 	compactRecoveryTerminalAliases      []compactRecoveryTerminalAliasProfile
@@ -191,6 +192,7 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		blobSHA256:                          mustRuntimeProfileSHA256("8bc4a20f983ea8c8873c28430f089ba2bbbf00a995dd29f575bf2bc598d29dfa"),
 		compactStrategy2ErrorRegion:         true,
 		compactMissingTokenInsertion:        true,
+		compactFaithfulS5Recovery:           true,
 		compactPrimaryAcceptDerivation:      true,
 		compactAcceptanceStructuralElection: true,
 		compactRecoveryTrailingRetirement:   true,
@@ -802,6 +804,10 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	}
 	if profile.compactMissingTokenInsertion && !lang.CompactMissingTokenInsertionCertified {
 		lang.CompactMissingTokenInsertionCertified = true
+		changed = true
+	}
+	if profile.compactFaithfulS5Recovery && !lang.CompactFaithfulS5RecoveryCertified {
+		lang.CompactFaithfulS5RecoveryCertified = true
 		changed = true
 	}
 	if profile.compactRecoveryTrailingRetirement && !lang.CompactRecoveryTrailingLineageRetirementCertified {

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -184,6 +184,18 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		},
 		compactRecoveryPlainFirst: true,
 	},
+	// The locked Scala artifact certifies S5 missing insertion through a
+	// physical graph-head merge and a per-version lexer split. The profile
+	// excludes stack-summary and EOF recovery, which remain separate packages.
+	"scala": {
+		blobSHA256:                          mustRuntimeProfileSHA256("8bc4a20f983ea8c8873c28430f089ba2bbbf00a995dd29f575bf2bc598d29dfa"),
+		compactStrategy2ErrorRegion:         true,
+		compactMissingTokenInsertion:        true,
+		compactPrimaryAcceptDerivation:      true,
+		compactAcceptanceStructuralElection: true,
+		compactRecoveryTrailingRetirement:   true,
+		compactRecoveryErrorModeKeyword:     true,
+	},
 	// These scanner-backed grammars have certified the first retry ladder's
 	// selected accepted-error tree as authoritative. Repeating the whole ladder
 	// does not improve the selected tree and imposes a full additional parse.

--- a/grammars/runtime_profiles_eof_retirement_test.go
+++ b/grammars/runtime_profiles_eof_retirement_test.go
@@ -51,9 +51,9 @@ func TestCompactGraduationGrantDenominatorAfterEOFRetirement(t *testing.T) {
 	if len(eofSiblingGrants) != 0 {
 		t.Errorf("EOF sibling grants remain: %v", eofSiblingGrants)
 	}
-	if activeFlags != 19 || len(activeGrammars) != 12 {
+	if activeFlags != 22 || len(activeGrammars) != 13 {
 		t.Errorf(
-			"compact profile denominator is %d flags across %d grammars, want 19 across 12",
+			"compact profile denominator is %d flags across %d grammars, want 22 across 13",
 			activeFlags,
 			len(activeGrammars),
 		)

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -63,6 +63,9 @@ func TestHTMLProfileCertifiesCompleteCompactRecovery(t *testing.T) {
 	if lang.CompactRecoveryPlainFirstCertified {
 		t.Fatal("the HTML profile unexpectedly enabled plain-first recovery")
 	}
+	if lang.CompactFaithfulS5RecoveryCertified {
+		t.Fatal("the HTML profile unexpectedly enabled the Scala S5 route")
+	}
 	uncertified := &gotreesitter.Language{}
 	if attachBuiltinLanguageRuntimeProfile("html", sha256.Sum256([]byte("wrong html blob")), uncertified) ||
 		uncertified.CompactStrategy2ErrorRegionCertified || uncertified.CompactMissingTokenInsertionCertified ||
@@ -130,6 +133,9 @@ func TestJavaScriptProfileCertifiesCompactRecoveryFrontier(t *testing.T) {
 		!lang.CompactRecoveryErrorModeKeywordCaptureCertified {
 		t.Fatal("the JavaScript profile did not attach its compact recovery capabilities")
 	}
+	if lang.CompactFaithfulS5RecoveryCertified {
+		t.Fatal("the JavaScript profile unexpectedly enabled the Scala S5 route")
+	}
 	wantAliases := []gotreesitter.CompactRecoveryTerminalAliasRule{
 		{ResumeState: 20, ResumeSymbol: 54, AliasSymbol: 261},
 		{ResumeState: 231, ResumeSymbol: 85, AliasSymbol: 261},
@@ -153,6 +159,7 @@ func TestScalaProfileCertifiesPackageTwoRecovery(t *testing.T) {
 	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
 	lang := ScalaLanguage()
 	if !lang.CompactStrategy2ErrorRegionCertified || !lang.CompactMissingTokenInsertionCertified ||
+		!lang.CompactFaithfulS5RecoveryCertified ||
 		!lang.CompactPrimaryAcceptanceDerivationCertified ||
 		!lang.CompactAcceptanceStructuralElectionCertified ||
 		!lang.CompactRecoveryTrailingLineageRetirementCertified ||
@@ -166,6 +173,7 @@ func TestScalaProfileCertifiesPackageTwoRecovery(t *testing.T) {
 	if attachBuiltinLanguageRuntimeProfile("scala", sha256.Sum256([]byte("wrong scala blob")), uncertified) ||
 		uncertified.CompactStrategy2ErrorRegionCertified ||
 		uncertified.CompactMissingTokenInsertionCertified ||
+		uncertified.CompactFaithfulS5RecoveryCertified ||
 		uncertified.CompactPrimaryAcceptanceDerivationCertified ||
 		uncertified.CompactAcceptanceStructuralElectionCertified ||
 		uncertified.CompactRecoveryTrailingLineageRetirementCertified ||

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -149,6 +149,31 @@ func TestJavaScriptProfileCertifiesCompactRecoveryFrontier(t *testing.T) {
 	}
 }
 
+func TestScalaProfileCertifiesPackageTwoRecovery(t *testing.T) {
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+	lang := ScalaLanguage()
+	if !lang.CompactStrategy2ErrorRegionCertified || !lang.CompactMissingTokenInsertionCertified ||
+		!lang.CompactPrimaryAcceptanceDerivationCertified ||
+		!lang.CompactAcceptanceStructuralElectionCertified ||
+		!lang.CompactRecoveryTrailingLineageRetirementCertified ||
+		!lang.CompactRecoveryErrorModeKeywordCaptureCertified {
+		t.Fatal("the Scala profile did not attach its package-two recovery capabilities")
+	}
+	if lang.CompactStackSummaryRecoveryCertified || lang.CompactRecoverEOFCertified {
+		t.Fatal("the Scala package-two profile enabled a later recovery package")
+	}
+	uncertified := &gotreesitter.Language{}
+	if attachBuiltinLanguageRuntimeProfile("scala", sha256.Sum256([]byte("wrong scala blob")), uncertified) ||
+		uncertified.CompactStrategy2ErrorRegionCertified ||
+		uncertified.CompactMissingTokenInsertionCertified ||
+		uncertified.CompactPrimaryAcceptanceDerivationCertified ||
+		uncertified.CompactAcceptanceStructuralElectionCertified ||
+		uncertified.CompactRecoveryTrailingLineageRetirementCertified ||
+		uncertified.CompactRecoveryErrorModeKeywordCaptureCertified {
+		t.Fatal("a mismatched Scala blob received package-two recovery certification")
+	}
+}
+
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	// 42 = the prior 41 plus the F# unary-wrapper materialization profile.
 	// Bash, Haskell, and JavaScript reuse their existing exact profiles.
@@ -192,7 +217,8 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	// 50 = the prior 49 plus the Markdown inline entry. It certifies four exact
 	// compact conflict rows while production parsing ignores them.
 	// 51 = the prior 50 plus the irreducible YAML recover_eof EOF-root entry.
-	if got, want := len(builtinLanguageRuntimeProfiles), 51; got != want {
+	// 52 = the prior 51 plus the certified Scala package-two recovery entry.
+	if got, want := len(builtinLanguageRuntimeProfiles), 52; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}

--- a/internal/parsercorephase0/ancestor_recovery.go
+++ b/internal/parsercorephase0/ancestor_recovery.go
@@ -230,7 +230,27 @@ func (c *Core) RecoverToAncestorStateOwned(owner SchedulerTransactionToken, cand
 		return out, err
 	}
 	defer c.recoverSchedulerOwnedPanic(owner)
-	out, err = c.recoverToAncestorStateUncheckpointed(candidate)
+	out, err = c.recoverToAncestorStateUncheckpointed(candidate, nil)
+	return out, c.finishSchedulerOwned(owner, err)
+}
+
+// RecoverToAncestorStateWithCostOwned publishes the complete cumulative cost
+// of the ERROR link and each trailing extra link before boundary publication.
+// The callback must return the authenticated cost for its complete output.
+func (c *Core) RecoverToAncestorStateWithCostOwned(
+	owner SchedulerTransactionToken,
+	candidate StackSummaryCandidate,
+	cost ReductionOutputCostFunc,
+) (out Head, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return out, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if cost == nil {
+		err = errors.New("parser-core phase zero: ancestor recovery cost callback is required")
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	out, err = c.recoverToAncestorStateUncheckpointed(candidate, cost)
 	return out, c.finishSchedulerOwned(owner, err)
 }
 
@@ -254,7 +274,7 @@ func (c *Core) StackSummaryCandidateRecoverable(candidate StackSummaryCandidate)
 	return true, nil
 }
 
-func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandidate) (Head, error) {
+func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandidate, cost ReductionOutputCostFunc) (Head, error) {
 	if candidate.owner != c {
 		return Head{}, errors.New("parser-core phase zero: stack-summary candidate belongs to a different core")
 	}
@@ -328,6 +348,14 @@ func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandid
 
 	out := Head{Node: target}
 	errorLink := linkInput{prev: target, payload: errorPayload, scoreDelta: score, order: order}
+	if cost != nil {
+		storedErrorCost, costErr := cost(errorLink.prev, errorLink.payload)
+		if costErr != nil {
+			return Head{}, costErr
+		}
+		errorLink.storedErrorCost = storedErrorCost
+		errorLink.hasStoredErrorCost = true
+	}
 	if trailing == 0 {
 		outcome, err := c.condenseWithOutcomeAtomic(c.shiftedBoundaryKey(candidate.state, last.endByte), errorLink)
 		return outcome.head, err
@@ -348,6 +376,14 @@ func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandid
 		input := linkInput{prev: out.Node, payload: link.payload, scoreDelta: link.scoreDelta}
 		if link.hasOrder() {
 			input.order = ForkOrder{Present: true, Value: link.order}
+		}
+		if cost != nil {
+			storedErrorCost, costErr := cost(input.prev, input.payload)
+			if costErr != nil {
+				return Head{}, costErr
+			}
+			input.storedErrorCost = storedErrorCost
+			input.hasStoredErrorCost = true
 		}
 		if index == 0 {
 			outcome, err := c.condenseWithOutcomeAtomic(c.shiftedBoundaryKey(candidate.state, payload.endByte), input)

--- a/internal/parsercorephase0/ancestor_recovery.go
+++ b/internal/parsercorephase0/ancestor_recovery.go
@@ -113,19 +113,29 @@ func (c *Core) StackSummaryCandidates(head Head, maxDepth int) ([]StackSummaryCa
 				return nil, err
 			}
 			for _, link := range links {
+				if err := link.validateShape(); err != nil {
+					return nil, err
+				}
 				if link.prev == 0 || link.prev >= item.node {
 					return nil, errors.New("parser-core phase zero: stack-summary predecessor does not decrease")
 				}
-				payload, err := c.subtree(link.payload)
-				if err != nil {
-					return nil, err
-				}
 				nextDepth := depth
-				if !payload.extra {
+				if link.isRecoveryDiscontinuity() {
 					if depth == maxDepth {
 						continue
 					}
 					nextDepth++
+				} else {
+					payload, err := c.subtree(link.payload)
+					if err != nil {
+						return nil, err
+					}
+					if !payload.extra {
+						if depth == maxDepth {
+							continue
+						}
+						nextDepth++
+					}
 				}
 				if item.linkDepth == math.MaxUint16 {
 					return nil, errors.New("parser-core phase zero: stack-summary link depth overflow")
@@ -177,6 +187,12 @@ func (c *Core) AncestorStateWithActionExists(head Head, lookahead Symbol, maxDep
 					return false, errors.New("parser-core phase zero: ancestor adjacency out of range")
 				}
 				link := c.links[linkID-1]
+				if err := link.validateShape(); err != nil {
+					return false, err
+				}
+				if link.prev == 0 || link.prev >= id {
+					return false, errors.New("parser-core phase zero: ancestor predecessor does not decrease")
+				}
 				if link.prev != 0 && !visited[link.prev] {
 					visited[link.prev] = true
 					if len(visited) > maxVisitedNodes {
@@ -259,6 +275,9 @@ func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandid
 	depth := len(links)
 	trailing := 0
 	for trailing < depth {
+		if links[trailing].isRecoveryDiscontinuity() {
+			break
+		}
 		payload, err := c.subtree(links[trailing].payload)
 		if err != nil {
 			return Head{}, err
@@ -277,6 +296,9 @@ func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandid
 	var order ForkOrder
 	for index := depth - 1; index >= trailing; index-- {
 		link := links[index]
+		if link.isRecoveryDiscontinuity() {
+			continue
+		}
 		children = append(children, link.payload)
 		score, err = checkedAddScore(score, link.scoreDelta)
 		if err != nil {
@@ -285,6 +307,9 @@ func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandid
 		if link.hasOrder() {
 			order = ForkOrder{Present: true, Value: link.order}
 		}
+	}
+	if len(children) == 0 {
+		return Head{}, errors.New("parser-core phase zero: ancestor recovery path has no ERROR payload")
 	}
 	first, err := c.subtree(children[0])
 	if err != nil {
@@ -313,6 +338,9 @@ func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandid
 	}
 	for index := trailing - 1; index >= 0; index-- {
 		link := links[index]
+		if link.isRecoveryDiscontinuity() {
+			continue
+		}
 		payload, err := c.subtree(link.payload)
 		if err != nil {
 			return Head{}, err
@@ -381,19 +409,29 @@ func (c *Core) uniqueAncestorRecoveryPath(candidate StackSummaryCandidate) ([]li
 			return err
 		}
 		for _, link := range links {
+			if err := link.validateShape(); err != nil {
+				return err
+			}
 			if link.prev == 0 || link.prev >= id {
 				return errors.New("parser-core phase zero: ancestor recovery predecessor does not decrease")
 			}
-			payload, err := c.subtree(link.payload)
-			if err != nil {
-				return err
-			}
 			nextDepth := depth
-			if !payload.extra {
+			if link.isRecoveryDiscontinuity() {
 				if depth == wantDepth {
 					continue
 				}
 				nextDepth++
+			} else {
+				payload, err := c.subtree(link.payload)
+				if err != nil {
+					return err
+				}
+				if !payload.extra {
+					if depth == wantDepth {
+						continue
+					}
+					nextDepth++
+				}
 			}
 			steps++
 			if steps > maxSteps {

--- a/internal/parsercorephase0/ancestor_recovery_test.go
+++ b/internal/parsercorephase0/ancestor_recovery_test.go
@@ -596,3 +596,57 @@ func TestRecoverToAncestorStateRepushesTrailingExtrasOutsideError(t *testing.T) 
 		t.Fatalf("recovery storage delta=%+v -> %+v, want N+3/L+3/S+1/C+1", before, after)
 	}
 }
+
+func TestRecoverToAncestorStateWithCostAccumulatesTrailingExtras(t *testing.T) {
+	const lookahead = Symbol(9)
+	tables := &fakeTable{actions: map[tableCell][]Action{
+		{state: 1, symbol: lookahead}: {{Type: ActionShift, State: 2}},
+	}}
+	compact := newAncestorRecoveryTestCore(t, tables, Limits{})
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact.nodeLineages[seed.Node-1].storedErrorCost = 9
+	child := appendAncestorRecoveryPayload(t, compact, 1, 0, 1, false)
+	firstExtra := appendAncestorRecoveryPayload(t, compact, 2, 1, 2, true)
+	secondExtra := appendAncestorRecoveryPayload(t, compact, 3, 2, 3, true)
+	head := appendAncestorRecoveryHead(t, compact, seed, 2, child)
+	head = appendAncestorRecoveryHead(t, compact, head, 3, firstExtra)
+	head = appendAncestorRecoveryHead(t, compact, head, 4, secondExtra)
+	candidates, err := compact.StackSummaryCandidates(head, 3)
+	if err != nil || len(candidates) != 3 {
+		t.Fatalf("candidates=%+v err=%v, want three summary entries", candidates, err)
+	}
+	candidate := ancestorRecoveryCandidateForState(t, candidates, 1)
+	cost := func(prev NodeID, payload SubtreeID) (uint32, error) {
+		prefix, prefixErr := compact.RecoveryStoredErrorCost(Head{Node: prev})
+		if prefixErr != nil {
+			return 0, prefixErr
+		}
+		record, recordErr := compact.subtree(payload)
+		if recordErr != nil {
+			return 0, recordErr
+		}
+		increment := uint32(1)
+		if record.symbol == ErrorRegionSymbol {
+			increment = 100
+		}
+		return prefix + increment, nil
+	}
+	var recovered Head
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		recovered, err = compact.RecoverToAncestorStateWithCostOwned(owner, candidate, cost)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("RecoverToAncestorStateWithCostOwned: %v", err)
+	}
+	got, err := compact.RecoveryStoredErrorCost(recovered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 111 {
+		t.Fatalf("recovered stored cost=%d, want 111", got)
+	}
+}

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -490,9 +490,13 @@ type precedenceMaximumWitness struct {
 }
 
 type nodeLineageRecord struct {
-	owner          uint32
-	dropCohortRefs DropCohortRefSet
-	set            AlternativeSet
+	owner uint32
+	// storedErrorCost is the exact C stack-node error cost carried by this
+	// graph node. Recovery discontinuity merges compare it before they add a
+	// null edge. Keep it in lineage metadata so nodeRecord stays size-stable.
+	storedErrorCost uint32
+	dropCohortRefs  DropCohortRefSet
+	set             AlternativeSet
 	// transition only, deleted at stage 3 cleanup (spec.b4b-alternative-set.v1
 	// section 3.2):
 	lineage   uint16
@@ -513,16 +517,17 @@ type nodeLineageRecord struct {
 // nodeLineageJournal append already names every field, so this reorder is
 // layout-only and touches no call site).
 type nodeLineageMutation struct {
-	node           NodeID
-	owner          uint32
-	dropCohortRefs DropCohortRefSet
-	setSpillRef    uint32
-	setCount       uint8
-	setFlags       uint8
-	lineage        uint16
-	rank           CleanPathRankSelection
-	converged      bool
-	blended        bool
+	node            NodeID
+	owner           uint32
+	dropCohortRefs  DropCohortRefSet
+	setSpillRef     uint32
+	setCount        uint8
+	setFlags        uint8
+	lineage         uint16
+	rank            CleanPathRankSelection
+	converged       bool
+	blended         bool
+	storedErrorCost uint32
 }
 
 // alternativeSetInlineCapacity is the fixed inline member width of
@@ -1723,6 +1728,7 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 			continue
 		}
 		c.nodeLineages[nodeIndex].owner = mutation.owner
+		c.nodeLineages[nodeIndex].storedErrorCost = mutation.storedErrorCost
 		c.nodeLineages[nodeIndex].dropCohortRefs = mutation.dropCohortRefs
 		c.nodeLineages[nodeIndex].set.count = mutation.setCount
 		c.nodeLineages[nodeIndex].set.flags = mutation.setFlags
@@ -2067,6 +2073,93 @@ func (c *Core) ApplySchedulerAtomic(fn func(SchedulerTransactionToken) error) (e
 		frame.clearInactive()
 	}()
 	err = fn(token)
+	return err
+}
+
+// ApplySchedulerSpeculation runs one authenticated nested scheduler trial.
+// A declined trial rolls back its Core checkpoint without poisoning the outer
+// session. An operation error poisons that session and blocks its commit.
+// Nested trials must complete in last-in-first-out order.
+func (c *Core) ApplySchedulerSpeculation(
+	parent SchedulerTransactionToken,
+	fn func(SchedulerTransactionToken) (bool, error),
+) (err error) {
+	if c == nil {
+		return errors.New("parser-core phase zero: scheduler speculation on nil core")
+	}
+	if fn == nil {
+		return c.poisonSchedulerTransaction(parent, errors.New("parser-core phase zero: nil scheduler speculation"))
+	}
+	if err = c.validateSchedulerTransaction(parent); err != nil {
+		return c.poisonSchedulerTransaction(parent, err)
+	}
+	frame := &c.schedulerFrame
+	outerMark := frame.mark
+	outerPoison := frame.poisoned
+	if c.nextTransaction == math.MaxUint64 {
+		return c.poisonSchedulerTransaction(parent, errors.New("parser-core phase zero: scheduler speculation identity overflow"))
+	}
+	var mark checkpoint
+	c.markInto(&mark)
+	frame.mark = mark
+	child := SchedulerTransactionToken{owner: c, epoch: frame.epoch, transaction: mark.transaction}
+	var speculationCommitResult bool
+	defer func() {
+		recovered := recover()
+		if recovered != nil {
+			phase0ASetRollbackCause(c, Phase0ARollbackPanic)
+			c.restoreCheckpoint(&mark)
+			frame.mark = outerMark
+			cause := fmt.Errorf("parser-core phase zero: scheduler speculation panicked: %v", recovered)
+			if frame.poisoned == nil {
+				frame.poisoned = outerPoison
+				if outerPoison == nil {
+					frame.poisoned = cause
+				}
+			}
+			panic(recovered)
+		}
+		if err != nil {
+			// The callback error is returned after restoring the child checkpoint.
+			// Preserve an earlier poison, but report a new callback poison when
+			// the owned operation supplied one.
+			phase0ASetRollbackCause(c, Phase0ARollbackReturnedError)
+			c.restoreCheckpoint(&mark)
+			frame.mark = outerMark
+			cause := err
+			if outerPoison == nil && frame.poisoned != nil {
+				cause = frame.poisoned
+			}
+			if outerPoison == nil {
+				frame.poisoned = cause
+			}
+			err = cause
+			return
+		}
+		// A callback that ignored an owned-operation failure leaves the child
+		// frame poisoned even when it returned no error. Roll it back and carry
+		// that failure to the outer owner.
+		if outerPoison == nil && frame.poisoned != nil {
+			cause := frame.poisoned
+			phase0ASetRollbackCause(c, Phase0ARollbackSchedulerPoison)
+			c.restoreCheckpoint(&mark)
+			frame.mark = outerMark
+			if outerPoison == nil {
+				frame.poisoned = cause
+			}
+			err = cause
+			return
+		}
+		if !speculationCommitResult {
+			phase0ASetRollbackCause(c, Phase0ARollbackReturnedError)
+			c.restoreCheckpoint(&mark)
+			frame.mark = outerMark
+			return
+		}
+		c.commit(mark)
+		frame.mark = outerMark
+	}()
+	speculationCommitResult, err = fn(child)
 	return err
 }
 
@@ -4455,10 +4548,19 @@ func (c *Core) predecessorBoundariesMatch(leftID, rightID NodeID) (bool, error) 
 	}
 	leftCheckpoint, leftExact := c.nodeScannerCheckpoint(leftID)
 	rightCheckpoint, rightExact := c.nodeScannerCheckpoint(rightID)
+	leftLineage, leftLineageErr := c.nodeLineage(leftID)
+	rightLineage, rightLineageErr := c.nodeLineage(rightID)
+	if leftLineageErr != nil {
+		return false, leftLineageErr
+	}
+	if rightLineageErr != nil {
+		return false, rightLineageErr
+	}
 	return left.state == right.state &&
 		left.byteOffset == right.byteOffset &&
 		leftExact && rightExact &&
-		leftCheckpoint == rightCheckpoint, nil
+		leftCheckpoint == rightCheckpoint &&
+		leftLineage.storedErrorCost == rightLineage.storedErrorCost, nil
 }
 
 func (c *Core) nodeScannerCheckpoint(id NodeID) (CheckpointID, bool) {

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -129,7 +129,7 @@ type ClassifiedBoundary struct {
 	owner       *Core
 	actions     ActionRow
 	phase       uint64
-	transaction uint64
+	transaction uint32
 	head        Head
 	state       StateID
 	byteOffset  uint32
@@ -2666,9 +2666,13 @@ func (c *Core) ClassifyBoundary(head Head, lookahead Symbol) (ClassifiedBoundary
 	if err != nil {
 		return ClassifiedBoundary{}, err
 	}
+	transaction, err := c.currentClassificationTransaction()
+	if err != nil {
+		return ClassifiedBoundary{}, err
+	}
 	return ClassifiedBoundary{
 		owner: c, actions: actions, phase: c.classificationPhase,
-		transaction: c.currentClassificationTransaction(),
+		transaction: transaction,
 		head:        head, state: node.state, byteOffset: node.byteOffset, lookahead: lookahead,
 	}, nil
 }
@@ -2694,18 +2698,26 @@ func (c *Core) ClassifyBoundaryWithRow(head Head, lookahead Symbol, actions Acti
 	if err != nil {
 		return ClassifiedBoundary{}, err
 	}
+	transaction, err := c.currentClassificationTransaction()
+	if err != nil {
+		return ClassifiedBoundary{}, err
+	}
 	return ClassifiedBoundary{
 		owner: c, actions: actions, phase: c.classificationPhase,
-		transaction: c.currentClassificationTransaction(),
+		transaction: transaction,
 		head:        head, state: node.state, byteOffset: node.byteOffset, lookahead: lookahead,
 	}, nil
 }
 
-func (c *Core) currentClassificationTransaction() uint64 {
+func (c *Core) currentClassificationTransaction() (uint32, error) {
 	if c == nil || len(c.transactions) == 0 {
-		return 0
+		return 0, nil
 	}
-	return c.transactions[len(c.transactions)-1]
+	transaction := c.transactions[len(c.transactions)-1]
+	if transaction > math.MaxUint32 {
+		return 0, errors.New("parser-core phase zero: classification transaction exceeds compact capability range")
+	}
+	return uint32(transaction), nil
 }
 
 func (c *Core) validateClassification(boundary ClassifiedBoundary) error {
@@ -2717,7 +2729,7 @@ func (c *Core) validateClassification(boundary ClassifiedBoundary) error {
 	}
 	if boundary.transaction != 0 {
 		for _, transaction := range c.transactions {
-			if transaction == boundary.transaction {
+			if transaction == uint64(boundary.transaction) {
 				return nil
 			}
 		}

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -733,9 +733,40 @@ type linkRecord struct {
 	flags      uint32
 }
 
-const linkFlagHasOrder uint32 = 1 << iota
+const (
+	linkFlagHasOrder uint32 = 1 << iota
+	linkFlagRecoveryDiscontinuity
+)
+
+const linkKnownFlags = linkFlagHasOrder | linkFlagRecoveryDiscontinuity
 
 func (l linkRecord) hasOrder() bool { return l.flags&linkFlagHasOrder != 0 }
+
+func (l linkRecord) isRecoveryDiscontinuity() bool {
+	return l.flags&linkFlagRecoveryDiscontinuity != 0
+}
+
+func (l linkRecord) validateShape() error {
+	if l.flags&^linkKnownFlags != 0 {
+		return errors.New("parser-core phase zero: link has unknown flags")
+	}
+	if l.isRecoveryDiscontinuity() {
+		if l.payload != 0 {
+			return errors.New("parser-core phase zero: recovery discontinuity has a payload")
+		}
+		if l.scoreDelta != 0 {
+			return errors.New("parser-core phase zero: recovery discontinuity has a score delta")
+		}
+		if l.hasOrder() || l.order != 0 {
+			return errors.New("parser-core phase zero: recovery discontinuity has branch order")
+		}
+		return nil
+	}
+	if l.payload == 0 {
+		return errors.New("parser-core phase zero: ordinary link has no payload")
+	}
+	return nil
+}
 
 func (c *Core) nodePrecedenceMaximum(id NodeID) (precedenceCandidate, error) {
 	node, err := c.node(id)
@@ -746,9 +777,15 @@ func (c *Core) nodePrecedenceMaximum(id NodeID) (precedenceCandidate, error) {
 }
 
 func (c *Core) linkPrecedenceMaximum(link linkRecord) (precedenceCandidate, error) {
+	if err := link.validateShape(); err != nil {
+		return precedenceCandidate{}, err
+	}
 	predecessor, err := c.nodePrecedenceMaximum(link.prev)
 	if err != nil {
 		return precedenceCandidate{}, err
+	}
+	if link.isRecoveryDiscontinuity() {
+		return predecessor, nil
 	}
 	contribution, err := c.effectivePayloadPrecedence(link.payload, link.scoreDelta)
 	if err != nil {
@@ -1430,6 +1467,7 @@ type checkpoint struct {
 	nodes, nodeLineages, nodeCheckpoints, links, subtrees, externalProvenance int
 	lexerSkippedPrefixes                                                      int
 	children, fields, aliases                                                 int
+	alternativeSpillArena                                                     int
 	eofRecoveryRoots                                                          int
 	dropCohortLinkRefIndexes                                                  int
 	dropCohortLinkRefJournal                                                  int
@@ -1549,7 +1587,8 @@ func (c *Core) markInto(mark *checkpoint) {
 		externalProvenance:   len(c.externalProvenance),
 		lexerSkippedPrefixes: len(c.lexerSkippedPrefixes),
 		children:             len(c.children), fields: len(c.fields), aliases: len(c.aliases),
-		eofRecoveryRoots: len(c.eofRecoveryRoots),
+		alternativeSpillArena: len(c.alternativeSpillArena),
+		eofRecoveryRoots:      len(c.eofRecoveryRoots),
 
 		dropCohortLinkRefIndexes: len(c.dropCohortLinkRefIndexes),
 		dropCohortLinkRefJournal: len(c.dropCohortLinkRefJournal),
@@ -1662,6 +1701,7 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 	c.children = c.children[:mark.children]
 	c.fields = c.fields[:mark.fields]
 	c.aliases = c.aliases[:mark.aliases]
+	c.alternativeSpillArena = c.alternativeSpillArena[:mark.alternativeSpillArena]
 	c.frontier = mark.frontier
 	c.checkpoint = mark.checkpoint
 	c.work = mark.work
@@ -3642,6 +3682,9 @@ func (c *Core) condenseDirectAppend(key boundaryKey, probe boundaryProbe, prevPa
 }
 
 func (c *Core) linkEqualInput(link linkRecord, in linkInput) (bool, error) {
+	if err := link.validateShape(); err != nil {
+		return false, err
+	}
 	return link.prev == in.prev && link.payload == in.payload && link.scoreDelta == in.scoreDelta &&
 		link.hasOrder() == in.order.Present && (!link.hasOrder() || link.order == in.order.Value), nil
 }
@@ -3694,15 +3737,21 @@ func (c *Core) graphVersionIsDeterministic(root NodeID) (bool, error) {
 				return false, errors.New("parser-core phase zero: historical forest has an invalid link")
 			}
 			link := c.links[linkID-1]
+			if err := link.validateShape(); err != nil {
+				return false, err
+			}
+			if link.prev == 0 || link.prev >= id {
+				return false, errors.New("parser-core phase zero: historical forest predecessor is not earlier than its node")
+			}
+			if link.isRecoveryDiscontinuity() {
+				return false, nil
+			}
 			payload, err := c.subtree(link.payload)
 			if err != nil {
 				return false, err
 			}
 			if payload.fragile {
 				return false, nil
-			}
-			if link.prev >= id {
-				return false, errors.New("parser-core phase zero: historical forest predecessor is not earlier than its node")
 			}
 			stack = append(stack, link.prev)
 			linkID = link.next
@@ -3759,6 +3808,9 @@ func (c *Core) effectivePayloadPrecedence(payloadID SubtreeID, aggregate int64) 
 // node-level precedence that C updates for the shallow non-exact case.
 func (c *Core) factorExactPredecessor(key boundaryKey, probe boundaryProbe, oldID NodeID, oldLinks []linkRecord, in linkInput, folded *precedenceMaximumWitness) (out condenseOutcome, handled bool, err error) {
 	for index, incumbent := range oldLinks {
+		if incumbent.isRecoveryDiscontinuity() {
+			continue
+		}
 		if incumbent.prev == in.prev {
 			continue
 		}
@@ -4006,16 +4058,98 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 		return append(slices.Clone(links), incoming), true, nil
 	}
 	c.recordLinkUnionAttempt()
-	_, incomingExact, err := c.subtreeExternalProvenance(incoming.payload)
-	if err != nil {
-		c.recordLinkUnionRejected()
-		return nil, false, err
-	}
-	if !incomingExact {
-		c.recordLinkUnionRejected()
-		return nil, false, errors.New("parser-core phase zero: recursive insertion declined inexact external payload provenance")
+	incomingDiscontinuity := incoming.isRecoveryDiscontinuity()
+	if !incomingDiscontinuity {
+		_, incomingExact, err := c.subtreeExternalProvenance(incoming.payload)
+		if err != nil {
+			c.recordLinkUnionRejected()
+			return nil, false, err
+		}
+		if !incomingExact {
+			c.recordLinkUnionRejected()
+			return nil, false, errors.New("parser-core phase zero: recursive insertion declined inexact external payload provenance")
+		}
 	}
 	for index, incumbent := range links {
+		if err := incumbent.validateShape(); err != nil {
+			c.recordLinkUnionRejected()
+			return nil, false, err
+		}
+		incumbentDiscontinuity := incumbent.isRecoveryDiscontinuity()
+		if incomingDiscontinuity || incumbentDiscontinuity {
+			if !incomingDiscontinuity || !incumbentDiscontinuity {
+				continue
+			}
+			if c.linkRecordsEqual(incumbent, incoming) {
+				c.recordLinkUnionDuplicateNoop()
+				if phase0AEnabled {
+					phase0AMergeDecision(c, index, phase0ATransitionDuplicateDrop)
+				}
+				return links, false, nil
+			}
+			mergeable, err := c.predecessorBoundariesMatch(incumbent.prev, incoming.prev)
+			if err != nil {
+				c.recordLinkUnionRejected()
+				return nil, false, err
+			}
+			if !mergeable {
+				continue
+			}
+			related, err := c.nodesAncestryRelated(incumbent.prev, incoming.prev)
+			if err != nil {
+				c.recordLinkUnionRejected()
+				return nil, false, err
+			}
+			if related {
+				// C keeps a NULL edge when the two predecessors cannot form a
+				// distinct recursive merge, including an ancestry-related pair.
+				continue
+			}
+			if !c.linkEdgesEqual(incumbent, incoming) {
+				c.recordLinkUnionRejected()
+				return nil, false, errors.New("parser-core phase zero: recursive insertion declined non-exact discontinuity edge")
+			}
+			if depth >= maxRecursiveInsertDepth {
+				c.recordLinkUnionRejected()
+				return nil, false, errors.New("parser-core phase zero: recursive insertion depth limit")
+			}
+			if phase0AEnabled {
+				phase0ABeginPredecessorMerge(c, incumbent.prev, incoming.prev)
+			}
+			nestedFolded := precedenceMaximumWitness{}
+			merged, changed, err := c.mergePredecessorsBounded(incumbent.prev, incoming.prev, depth+1, &nestedFolded)
+			if err != nil {
+				if phase0AEnabled {
+					phase0AAbortPredecessorMerge(c)
+				}
+				c.recordLinkUnionRejected()
+				return nil, false, err
+			}
+			if !changed {
+				if err := c.observeDiscardedLink(folded, incoming); err != nil {
+					c.recordLinkUnionRejected()
+					return nil, false, err
+				}
+				if phase0AEnabled {
+					phase0AAbortPredecessorMerge(c)
+					phase0AMergeDecision(c, index, phase0ATransitionDuplicateDrop)
+				}
+				c.recordLinkUnionDuplicateNoop()
+				return links, false, nil
+			}
+			if phase0AEnabled {
+				phase0AObserveAdjacencyPublished(c, merged)
+				phase0AMergeRecursiveDecision(c, index, merged)
+			}
+			if err := c.observeDiscardedLink(folded, incoming); err != nil {
+				c.recordLinkUnionRejected()
+				return nil, false, err
+			}
+			updated := slices.Clone(links)
+			updated[index].prev = merged
+			c.recordLinkUnionRecursiveChanged()
+			return updated, true, nil
+		}
 		_, incumbentExact, err := c.subtreeExternalProvenance(incumbent.payload)
 		if err != nil {
 			c.recordLinkUnionRejected()
@@ -4356,12 +4490,12 @@ func (c *Core) shallowPayloadsEqual(leftPrev NodeID, leftPayload SubtreeID, righ
 }
 
 func (c *Core) linkEdgeEqualInput(link linkRecord, in linkInput) bool {
-	return link.payload == in.payload && link.scoreDelta == in.scoreDelta &&
+	return !link.isRecoveryDiscontinuity() && link.payload == in.payload && link.scoreDelta == in.scoreDelta &&
 		link.hasOrder() == in.order.Present && (!link.hasOrder() || link.order == in.order.Value)
 }
 
 func (c *Core) linkEdgesEqual(left, right linkRecord) bool {
-	return left.payload == right.payload && left.scoreDelta == right.scoreDelta &&
+	return left.flags == right.flags && left.payload == right.payload && left.scoreDelta == right.scoreDelta &&
 		left.hasOrder() == right.hasOrder() && (!left.hasOrder() || left.order == right.order)
 }
 
@@ -4661,14 +4795,15 @@ func (c *Core) replaceBoundaryLink(key boundaryKey, probe boundaryProbe, old nod
 }
 
 type popPath struct {
-	prev          NodeID
-	cleanPathRank CleanPathRankSelection
-	children      []SubtreeID
-	trailing      []pathPayload
-	score         int64
-	order         ForkOrder
-	startByte     uint32
-	structuralEnd uint32
+	prev                  NodeID
+	cleanPathRank         CleanPathRankSelection
+	recoveryDiscontinuity bool
+	children              []SubtreeID
+	trailing              []pathPayload
+	score                 int64
+	order                 ForkOrder
+	startByte             uint32
+	structuralEnd         uint32
 }
 
 type pathPayload struct {
@@ -4804,6 +4939,10 @@ func (c *Core) markCleanProductionRank(paths []popPath) {
 	var rank cleanPathRankAccumulator
 	for index := range paths {
 		path := &paths[index]
+		if path.recoveryDiscontinuity {
+			markCleanPathRankUnknown(paths)
+			return
+		}
 		for _, payload := range path.children {
 			hasExternal, err := c.cleanPathPayloadHasExternal(payload)
 			if err != nil || hasExternal {
@@ -4921,6 +5060,12 @@ descend:
 			if link.next != 0 {
 				return false, errors.New("parser-core phase zero: clean path single link has a successor")
 			}
+			if err := link.validateShape(); err != nil {
+				return false, err
+			}
+			if link.isRecoveryDiscontinuity() {
+				return false, nil
+			}
 			hasExternal, err := c.cleanPathPayloadHasExternal(link.payload)
 			if err != nil || hasExternal {
 				return false, err
@@ -4973,6 +5118,12 @@ descend:
 		link := frame[cursor]
 		scratch.revOrders[frameIndex].Value++
 		var err error
+		if err := link.validateShape(); err != nil {
+			return false, err
+		}
+		if link.isRecoveryDiscontinuity() {
+			return false, nil
+		}
 		hasExternal, err := c.cleanPathPayloadHasExternal(link.payload)
 		if err != nil || hasExternal {
 			return false, err
@@ -5052,14 +5203,63 @@ func (c *Core) popPaths(head NodeID, childCount int) (out []popPath, err error) 
 			// Every published graph edge points to an older node. The strict local
 			// decrease proves acyclicity without a traversal map while still
 			// rejecting corrupted diagnostic arena records before recursion.
+			if err := link.validateShape(); err != nil {
+				return err
+			}
 			if link.prev == 0 || link.prev >= id {
 				return errors.New("parser-core phase zero: graph predecessor does not decrease")
+			}
+			linkOrder := ForkOrder{Value: link.order, Present: link.hasOrder()}
+			if link.isRecoveryDiscontinuity() {
+				scratch.rev = append(scratch.rev, 0)
+				scratch.revScores = append(scratch.revScores, 0)
+				scratch.revOrders = append(scratch.revOrders, ForkOrder{})
+				next := remaining - 1
+				if next == 0 {
+					if uint64(len(scratch.paths)) >= c.limits.MaxPopPaths {
+						return errors.New("parser-core phase zero: pop enumeration cap")
+					}
+					path := scratch.nextPath()
+					path.prev = link.prev
+					for i := len(scratch.rev) - 1; i >= 0; i-- {
+						if scratch.rev[i] == 0 {
+							path.recoveryDiscontinuity = true
+							continue
+						}
+						path.children = append(path.children, scratch.rev[i])
+						path.score, err = checkedAddScore(path.score, scratch.revScores[i])
+						if err != nil {
+							return err
+						}
+						if scratch.revOrders[i].Present {
+							path.order = scratch.revOrders[i]
+						}
+					}
+					if path.prev != 0 {
+						previous, nodeErr := c.node(path.prev)
+						if nodeErr != nil {
+							return nodeErr
+						}
+						path.startByte, path.structuralEnd = previous.byteOffset, previous.byteOffset
+					}
+					for i := len(scratch.trailing) - 1; i >= 0; i-- {
+						path.trailing = append(path.trailing, scratch.trailing[i])
+						if scratch.trailing[i].order.Present {
+							path.order = scratch.trailing[i].order
+						}
+					}
+				} else if err := walk(link.prev, next, false, structuralEnd, depth+1); err != nil {
+					return err
+				}
+				scratch.rev = scratch.rev[:len(scratch.rev)-1]
+				scratch.revScores = scratch.revScores[:len(scratch.revScores)-1]
+				scratch.revOrders = scratch.revOrders[:len(scratch.revOrders)-1]
+				continue
 			}
 			payload, err := c.subtree(link.payload)
 			if err != nil {
 				return err
 			}
-			linkOrder := ForkOrder{Value: link.order, Present: link.hasOrder()}
 			if payload.extra && peelingTrailing {
 				scratch.trailing = append(scratch.trailing, pathPayload{payload: link.payload, scoreDelta: link.scoreDelta, order: linkOrder})
 				if err := walk(link.prev, remaining, true, structuralEnd, depth+1); err != nil {
@@ -5094,9 +5294,24 @@ func (c *Core) popPaths(head NodeID, childCount int) (out []popPath, err error) 
 				}
 				path := scratch.nextPath()
 				path.prev = link.prev
-				path.startByte = payload.startByte
 				path.structuralEnd = nextStructuralEnd
+				haveStartByte := false
 				for i := len(scratch.rev) - 1; i >= 0; i-- {
+					if scratch.rev[i] == 0 {
+						path.recoveryDiscontinuity = true
+						continue
+					}
+					payloadRecord, payloadErr := c.subtree(scratch.rev[i])
+					if payloadErr != nil {
+						return payloadErr
+					}
+					if !payloadRecord.extra && !haveStartByte {
+						path.startByte = payloadRecord.startByte
+						haveStartByte = true
+						if path.structuralEnd == 0 {
+							path.structuralEnd = payloadRecord.endByte
+						}
+					}
 					path.children = append(path.children, scratch.rev[i])
 					path.score, err = checkedAddScore(path.score, scratch.revScores[i])
 					if err != nil {
@@ -5105,6 +5320,13 @@ func (c *Core) popPaths(head NodeID, childCount int) (out []popPath, err error) 
 					if scratch.revOrders[i].Present {
 						path.order = scratch.revOrders[i]
 					}
+				}
+				if !haveStartByte && path.prev != 0 {
+					previous, nodeErr := c.node(path.prev)
+					if nodeErr != nil {
+						return nodeErr
+					}
+					path.startByte, path.structuralEnd = previous.byteOffset, previous.byteOffset
 				}
 				for i := len(scratch.trailing) - 1; i >= 0; i-- {
 					path.trailing = append(path.trailing, scratch.trailing[i])
@@ -5166,6 +5388,54 @@ func (c *Core) popSingleLinkPath(head NodeID, childCount int, scratch *popEnumer
 		if link.prev == 0 || link.prev >= id {
 			return false, errors.New("parser-core phase zero: graph predecessor does not decrease")
 		}
+		if err := link.validateShape(); err != nil {
+			return false, err
+		}
+		if link.isRecoveryDiscontinuity() {
+			scratch.rev = append(scratch.rev, 0)
+			scratch.revScores = append(scratch.revScores, 0)
+			scratch.revOrders = append(scratch.revOrders, ForkOrder{})
+			peelingTrailing = false
+			remaining--
+			if remaining != 0 {
+				id = link.prev
+				continue
+			}
+			if uint64(len(scratch.paths)) >= c.limits.MaxPopPaths {
+				return false, errors.New("parser-core phase zero: pop enumeration cap")
+			}
+			path := scratch.nextPath()
+			path.prev = link.prev
+			path.recoveryDiscontinuity = true
+			for index := len(scratch.rev) - 1; index >= 0; index-- {
+				if scratch.rev[index] == 0 {
+					path.recoveryDiscontinuity = true
+					continue
+				}
+				path.children = append(path.children, scratch.rev[index])
+				path.score, err = checkedAddScore(path.score, scratch.revScores[index])
+				if err != nil {
+					return false, err
+				}
+				if scratch.revOrders[index].Present {
+					path.order = scratch.revOrders[index]
+				}
+			}
+			if path.prev != 0 {
+				previous, nodeErr := c.node(path.prev)
+				if nodeErr != nil {
+					return false, nodeErr
+				}
+				path.startByte, path.structuralEnd = previous.byteOffset, previous.byteOffset
+			}
+			for index := len(scratch.trailing) - 1; index >= 0; index-- {
+				path.trailing = append(path.trailing, scratch.trailing[index])
+				if scratch.trailing[index].order.Present {
+					path.order = scratch.trailing[index].order
+				}
+			}
+			return true, nil
+		}
 		payload, err := c.subtree(link.payload)
 		if err != nil {
 			return false, err
@@ -5197,9 +5467,24 @@ func (c *Core) popSingleLinkPath(head NodeID, childCount int, scratch *popEnumer
 		}
 		path := scratch.nextPath()
 		path.prev = link.prev
-		path.startByte = payload.startByte
 		path.structuralEnd = structuralEnd
+		haveStartByte := false
 		for index := len(scratch.rev) - 1; index >= 0; index-- {
+			if scratch.rev[index] == 0 {
+				path.recoveryDiscontinuity = true
+				continue
+			}
+			payloadRecord, payloadErr := c.subtree(scratch.rev[index])
+			if payloadErr != nil {
+				return false, payloadErr
+			}
+			if !payloadRecord.extra && !haveStartByte {
+				path.startByte = payloadRecord.startByte
+				haveStartByte = true
+				if path.structuralEnd == 0 {
+					path.structuralEnd = payloadRecord.endByte
+				}
+			}
 			path.children = append(path.children, scratch.rev[index])
 			path.score, err = checkedAddScore(path.score, scratch.revScores[index])
 			if err != nil {
@@ -5208,6 +5493,13 @@ func (c *Core) popSingleLinkPath(head NodeID, childCount int, scratch *popEnumer
 			if scratch.revOrders[index].Present {
 				path.order = scratch.revOrders[index]
 			}
+		}
+		if !haveStartByte && path.prev != 0 {
+			previous, nodeErr := c.node(path.prev)
+			if nodeErr != nil {
+				return false, nodeErr
+			}
+			path.startByte, path.structuralEnd = previous.byteOffset, previous.byteOffset
 		}
 		for index := len(scratch.trailing) - 1; index >= 0; index-- {
 			path.trailing = append(path.trailing, scratch.trailing[index])
@@ -5260,6 +5552,9 @@ func (c *Core) Derivations(head Head) ([]Derivation, error) {
 			return nil, err
 		}
 		for _, link := range links {
+			if err := link.validateShape(); err != nil {
+				return nil, err
+			}
 			prefixes, err := walk(link.prev)
 			if err != nil {
 				return nil, err
@@ -5274,7 +5569,9 @@ func (c *Core) Derivations(head Head) ([]Derivation, error) {
 				}
 				path := Derivation{Score: score}
 				path.Payloads = append(path.Payloads, prefix.Payloads...)
-				path.Payloads = append(path.Payloads, link.payload)
+				if link.payload != 0 {
+					path.Payloads = append(path.Payloads, link.payload)
+				}
 				path.BranchOrder = prefix.BranchOrder
 				path.HasBranchOrder = prefix.HasBranchOrder
 				if link.hasOrder() {
@@ -5325,6 +5622,9 @@ func (c *Core) singleDerivation(id NodeID) (Derivation, bool, error) {
 			return Derivation{}, true, errors.New("parser-core phase zero: link adjacency out of range")
 		}
 		link := c.links[linkID-1]
+		if err := link.validateShape(); err != nil {
+			return Derivation{}, true, err
+		}
 		if link.next != 0 {
 			if link.next == linkID {
 				return Derivation{}, true, errors.New("parser-core phase zero: adjacency cycle")
@@ -5341,7 +5641,7 @@ func (c *Core) singleDerivation(id NodeID) (Derivation, bool, error) {
 		id = link.prev
 	}
 
-	path := Derivation{Payloads: make([]SubtreeID, len(reverseLinks))}
+	path := Derivation{Payloads: make([]SubtreeID, 0, len(reverseLinks))}
 	for reverseIndex := len(reverseLinks) - 1; reverseIndex >= 0; reverseIndex-- {
 		link := c.links[reverseLinks[reverseIndex]-1]
 		score, err := checkedAddScore(path.Score, link.scoreDelta)
@@ -5349,7 +5649,9 @@ func (c *Core) singleDerivation(id NodeID) (Derivation, bool, error) {
 			return Derivation{}, true, err
 		}
 		path.Score = score
-		path.Payloads[len(reverseLinks)-1-reverseIndex] = link.payload
+		if link.payload != 0 {
+			path.Payloads = append(path.Payloads, link.payload)
+		}
 		if link.hasOrder() {
 			path.BranchOrder = link.order
 			path.HasBranchOrder = true
@@ -5702,7 +6004,7 @@ func (c *Core) appendNodeRecord(r nodeRecord, checkpoint CheckpointID) (NodeID, 
 		}
 	}
 	next := NodeID(uint64(len(c.nodes)) + 1)
-	if err := c.validatePublishedNodeDAG(r, next); err != nil {
+	if err := c.validatePublishedNodeDAGAt(r, next, checkpoint); err != nil {
 		return 0, err
 	}
 	c.nodes = append(c.nodes, r)
@@ -5719,6 +6021,10 @@ func (c *Core) appendNodeRecord(r nodeRecord, checkpoint CheckpointID) (NodeID, 
 // cycle. The bounded adjacency walk also keeps malformed internal/diagnostic
 // records fail closed without a hash table.
 func (c *Core) validatePublishedNodeDAG(r nodeRecord, next NodeID) error {
+	return c.validatePublishedNodeDAGAt(r, next, c.checkpoint)
+}
+
+func (c *Core) validatePublishedNodeDAGAt(r nodeRecord, next NodeID, checkpoint CheckpointID) error {
 	count := uint64(r.linkCount)
 	if count == 0 {
 		if r.firstLink != 0 {
@@ -5741,8 +6047,27 @@ func (c *Core) validatePublishedNodeDAG(r nodeRecord, next NodeID) error {
 			return errors.New("parser-core phase zero: link adjacency out of range")
 		}
 		link := c.links[id-1]
+		if err := link.validateShape(); err != nil {
+			return err
+		}
 		if link.prev == 0 || link.prev >= next {
 			return fmt.Errorf("parser-core phase zero: graph predecessor %d must be lower than new node %d", link.prev, next)
+		}
+		if link.isRecoveryDiscontinuity() {
+			if r.state != 0 {
+				return errors.New("parser-core phase zero: recovery discontinuity must target ERROR_STATE")
+			}
+			previous, err := c.node(link.prev)
+			if err != nil {
+				return err
+			}
+			if previous.byteOffset != r.byteOffset {
+				return errors.New("parser-core phase zero: recovery discontinuity must be zero-width")
+			}
+			previousCheckpoint, exact := c.nodeScannerCheckpoint(link.prev)
+			if !exact || previousCheckpoint != checkpoint {
+				return errors.New("parser-core phase zero: recovery discontinuity scanner checkpoint is not exact")
+			}
 		}
 		id = link.next
 	}
@@ -6174,6 +6499,9 @@ func (c *Core) nodeLinks(n nodeRecord) ([]linkRecord, error) {
 			return nil, errors.New("parser-core phase zero: link adjacency out of range")
 		}
 		link := c.links[id-1]
+		if err := link.validateShape(); err != nil {
+			return nil, err
+		}
 		links = append(links, link)
 		if uint64(len(links)) > uint64(n.linkCount) {
 			return nil, errors.New("parser-core phase zero: adjacency exceeds recorded link count")
@@ -6230,6 +6558,9 @@ func (c *Core) nodeLinksIntoBounded(dst []linkRecord, n nodeRecord, maxCount uin
 			return dst, errors.New("parser-core phase zero: link adjacency out of range")
 		}
 		link := c.links[id-1]
+		if err := link.validateShape(); err != nil {
+			return dst, err
+		}
 		dst[index] = link
 		id = link.next
 	}

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -126,13 +126,14 @@ type ActionRow struct {
 // another core or after Reset/BeginFrontier has invalidated its arena/frontier
 // identity. The action row remains immutable.
 type ClassifiedBoundary struct {
-	owner      *Core
-	actions    ActionRow
-	phase      uint64
-	head       Head
-	state      StateID
-	byteOffset uint32
-	lookahead  Symbol
+	owner       *Core
+	actions     ActionRow
+	phase       uint64
+	transaction uint64
+	head        Head
+	state       StateID
+	byteOffset  uint32
+	lookahead   Symbol
 }
 
 // Head returns the compact head authenticated by this classification.
@@ -2090,12 +2091,13 @@ func (c *Core) ApplySchedulerSpeculation(
 	if fn == nil {
 		return c.poisonSchedulerTransaction(parent, errors.New("parser-core phase zero: nil scheduler speculation"))
 	}
-	if err = c.validateSchedulerTransaction(parent); err != nil {
+	if err = c.validateSchedulerSpeculationParent(parent); err != nil {
 		return c.poisonSchedulerTransaction(parent, err)
 	}
 	frame := &c.schedulerFrame
 	outerMark := frame.mark
 	outerPoison := frame.poisoned
+	outerClassificationPhase := c.classificationPhase
 	if c.nextTransaction == math.MaxUint64 {
 		return c.poisonSchedulerTransaction(parent, errors.New("parser-core phase zero: scheduler speculation identity overflow"))
 	}
@@ -2109,6 +2111,7 @@ func (c *Core) ApplySchedulerSpeculation(
 		if recovered != nil {
 			phase0ASetRollbackCause(c, Phase0ARollbackPanic)
 			c.restoreCheckpoint(&mark)
+			c.classificationPhase = outerClassificationPhase
 			frame.mark = outerMark
 			cause := fmt.Errorf("parser-core phase zero: scheduler speculation panicked: %v", recovered)
 			if frame.poisoned == nil {
@@ -2125,6 +2128,7 @@ func (c *Core) ApplySchedulerSpeculation(
 			// the owned operation supplied one.
 			phase0ASetRollbackCause(c, Phase0ARollbackReturnedError)
 			c.restoreCheckpoint(&mark)
+			c.classificationPhase = outerClassificationPhase
 			frame.mark = outerMark
 			cause := err
 			if outerPoison == nil && frame.poisoned != nil {
@@ -2143,6 +2147,7 @@ func (c *Core) ApplySchedulerSpeculation(
 			cause := frame.poisoned
 			phase0ASetRollbackCause(c, Phase0ARollbackSchedulerPoison)
 			c.restoreCheckpoint(&mark)
+			c.classificationPhase = outerClassificationPhase
 			frame.mark = outerMark
 			if outerPoison == nil {
 				frame.poisoned = cause
@@ -2153,6 +2158,7 @@ func (c *Core) ApplySchedulerSpeculation(
 		if !speculationCommitResult {
 			phase0ASetRollbackCause(c, Phase0ARollbackReturnedError)
 			c.restoreCheckpoint(&mark)
+			c.classificationPhase = outerClassificationPhase
 			frame.mark = outerMark
 			return
 		}
@@ -2161,6 +2167,29 @@ func (c *Core) ApplySchedulerSpeculation(
 	}()
 	speculationCommitResult, err = fn(child)
 	return err
+}
+
+// validateSchedulerSpeculationParent authenticates a scheduler parent while
+// allowing internal transaction marks below it. Only the speculation seam may
+// use this ancestor check; ordinary owned operations still require the exact
+// top transaction.
+func (c *Core) validateSchedulerSpeculationParent(token SchedulerTransactionToken) error {
+	frame := &c.schedulerFrame
+	if token.owner != c {
+		return errors.New("parser-core phase zero: scheduler transaction token belongs to a different core")
+	}
+	if !frame.active || token.epoch == 0 || token.epoch != frame.epoch || token.transaction != frame.mark.transaction {
+		return errors.New("parser-core phase zero: stale scheduler transaction token")
+	}
+	if frame.fresh {
+		return nil
+	}
+	for _, transaction := range c.transactions {
+		if transaction == token.transaction {
+			return nil
+		}
+	}
+	return errors.New("parser-core phase zero: scheduler transaction token is not an active ancestor")
 }
 
 func (c *Core) writeBoundary(key boundaryKey, id NodeID) error {
@@ -2639,7 +2668,8 @@ func (c *Core) ClassifyBoundary(head Head, lookahead Symbol) (ClassifiedBoundary
 	}
 	return ClassifiedBoundary{
 		owner: c, actions: actions, phase: c.classificationPhase,
-		head: head, state: node.state, byteOffset: node.byteOffset, lookahead: lookahead,
+		transaction: c.currentClassificationTransaction(),
+		head:        head, state: node.state, byteOffset: node.byteOffset, lookahead: lookahead,
 	}, nil
 }
 
@@ -2666,8 +2696,16 @@ func (c *Core) ClassifyBoundaryWithRow(head Head, lookahead Symbol, actions Acti
 	}
 	return ClassifiedBoundary{
 		owner: c, actions: actions, phase: c.classificationPhase,
-		head: head, state: node.state, byteOffset: node.byteOffset, lookahead: lookahead,
+		transaction: c.currentClassificationTransaction(),
+		head:        head, state: node.state, byteOffset: node.byteOffset, lookahead: lookahead,
 	}, nil
+}
+
+func (c *Core) currentClassificationTransaction() uint64 {
+	if c == nil || len(c.transactions) == 0 {
+		return 0
+	}
+	return c.transactions[len(c.transactions)-1]
 }
 
 func (c *Core) validateClassification(boundary ClassifiedBoundary) error {
@@ -2676,6 +2714,14 @@ func (c *Core) validateClassification(boundary ClassifiedBoundary) error {
 	}
 	if boundary.phase == 0 || boundary.phase != c.classificationPhase {
 		return errors.New("parser-core phase zero: classified boundary is stale")
+	}
+	if boundary.transaction != 0 {
+		for _, transaction := range c.transactions {
+			if transaction == boundary.transaction {
+				return nil
+			}
+		}
+		return errors.New("parser-core phase zero: classified boundary transaction is stale")
 	}
 	return nil
 }
@@ -3039,7 +3085,7 @@ func (c *Core) ReduceOutputsInto(dst []ReductionOutput, head Head, lookahead Sym
 func (c *Core) ReduceOutputsClassifiedInto(dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder) (frontier []ReductionOutput, err error) {
 	mark := c.mark()
 	defer c.completeTransaction(mark, &err)
-	return c.reduceOutputsClassifiedIntoUncheckpointed(SchedulerTransactionToken{}, dst, boundary, actionOrdinal, fork)
+	return c.reduceOutputsClassifiedIntoUncheckpointed(SchedulerTransactionToken{}, dst, boundary, actionOrdinal, fork, nil)
 }
 
 func (c *Core) reductionParentForPath(
@@ -3289,6 +3335,29 @@ func reductionParentIdentityEqual(
 	return left == right && slices.Equal(leftChildren, rightChildren) && slices.Equal(leftFields, rightFields) && slices.Equal(leftAliases, rightAliases)
 }
 
+// inheritedStoredErrorCost returns the prefix cost used by a single-link
+// publication. Multi-link publications must supply their authenticated target
+// cost because alternate links can split cost between predecessor and payload.
+func (c *Core) inheritedStoredErrorCost(links []linkRecord) (uint32, error) {
+	if len(links) == 0 {
+		return 0, nil
+	}
+	first, err := c.nodeLineage(links[0].prev)
+	if err != nil {
+		return 0, err
+	}
+	return first.storedErrorCost, nil
+}
+
+func (c *Core) publishInheritedStoredErrorCost(head Head, cost uint32) error {
+	lineage, err := c.nodeLineage(head.Node)
+	if err != nil {
+		return err
+	}
+	lineage.storedErrorCost = cost
+	return nil
+}
+
 // appendPrivate adds one exact single-link node without publishing an
 // intermediate boundary for cross-path condensation. Reduction paths with
 // trailing extras use it so only their final (state, byte) boundary merges.
@@ -3298,6 +3367,10 @@ func (c *Core) appendPrivate(state StateID, byteOffset uint32, in linkInput) (He
 		return Head{}, err
 	}
 	if _, err := c.subtree(in.payload); err != nil {
+		return Head{}, err
+	}
+	storedErrorCost, err := c.storedErrorCostForLink(in)
+	if err != nil {
 		return Head{}, err
 	}
 	maximum, err := c.linkPrecedenceMaximum(linkRecord{
@@ -3328,6 +3401,9 @@ func (c *Core) appendPrivate(state StateID, byteOffset uint32, in linkInput) (He
 	if err != nil {
 		return Head{}, err
 	}
+	if err := c.publishInheritedStoredErrorCost(Head{Node: id}, storedErrorCost); err != nil {
+		return Head{}, err
+	}
 	if phase0AEnabled {
 		phase0AObservePrivatePublication(c, state, byteOffset, in, linkID, id)
 	}
@@ -3350,10 +3426,31 @@ func (c *Core) action(head Head, lookahead Symbol, ordinal int) (Action, error) 
 }
 
 type linkInput struct {
-	prev       NodeID
-	payload    SubtreeID
-	scoreDelta int64
-	order      ForkOrder
+	prev               NodeID
+	payload            SubtreeID
+	scoreDelta         int64
+	order              ForkOrder
+	storedErrorCost    uint32
+	hasStoredErrorCost bool
+}
+
+// ReductionOutputCostFunc computes the complete stored recovery cost for one
+// reduction output before Core publishes or condenses its boundary. The
+// scheduler owns the cost model. Core only authenticates the resulting value.
+type ReductionOutputCostFunc func(prev NodeID, payload SubtreeID) (uint32, error)
+
+func (c *Core) storedErrorCostForLink(in linkInput) (uint32, error) {
+	lineage, err := c.nodeLineage(in.prev)
+	if err != nil {
+		return 0, err
+	}
+	if in.hasStoredErrorCost {
+		if in.storedErrorCost < lineage.storedErrorCost {
+			return 0, errors.New("parser-core phase zero: expected stored recovery cost is below its predecessor")
+		}
+		return in.storedErrorCost, nil
+	}
+	return c.inheritedStoredErrorCost([]linkRecord{{prev: in.prev}})
 }
 
 type condenseChange uint8
@@ -3413,6 +3510,10 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 	if _, err := c.subtree(in.payload); err != nil {
 		return condenseOutcome{}, err
 	}
+	storedErrorCost, err := c.storedErrorCostForLink(in)
+	if err != nil {
+		return condenseOutcome{}, err
+	}
 	probe, oldID := c.boundaries.probe(boundaryIdentityFromKey(key))
 	if !probe.found {
 		// No incumbent has ever published this boundary in the current
@@ -3432,7 +3533,16 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 		// function depends on is untouched -- this function still cannot
 		// prove a caller can never roll back past this append, so it does
 		// not weaken that contract.
-		return c.condenseDirectAppend(key, probe, prev.pathCount, in)
+		return c.condenseDirectAppend(key, probe, prev.pathCount, in, storedErrorCost)
+	}
+	if c.condenseNodeIsLive(oldID) {
+		oldLineage, lineageErr := c.nodeLineage(oldID)
+		if lineageErr != nil {
+			return condenseOutcome{}, lineageErr
+		}
+		if oldLineage.storedErrorCost != storedErrorCost {
+			return condenseOutcome{}, errors.New("parser-core phase zero: condense heads have different stored recovery costs")
+		}
 	}
 	historicalBoundarySplit := false
 	var historicalCleanPathRank CleanPathRankSelection
@@ -3592,7 +3702,7 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 					if phase0AEnabled {
 						phase0ABeginReplacement(c, key, in, oldID, incumbent)
 					}
-					head, err := c.replaceBoundaryLink(key, probe, old, oldLinks, incumbent, in)
+					head, err := c.replaceBoundaryLink(key, probe, oldID, old, oldLinks, incumbent, in)
 					if err != nil {
 						c.recordLinkUnionRejected()
 					} else {
@@ -3709,6 +3819,9 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 	if err != nil {
 		return condenseOutcome{}, err
 	}
+	if err := c.publishInheritedStoredErrorCost(Head{Node: id}, storedErrorCost); err != nil {
+		return condenseOutcome{}, err
+	}
 	if err := c.publishBoundary(probe, id); err != nil {
 		if oldID != 0 {
 			c.recordLinkUnionRejected()
@@ -3736,7 +3849,7 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 // condenseOutcome shape (change: condenseNew, every historical* field at its
 // zero value). publishBoundary keeps deciding journal writes from
 // len(c.transactions) unchanged; this helper does not touch that contract.
-func (c *Core) condenseDirectAppend(key boundaryKey, probe boundaryProbe, prevPathCount uint64, in linkInput) (condenseOutcome, error) {
+func (c *Core) condenseDirectAppend(key boundaryKey, probe boundaryProbe, prevPathCount uint64, in linkInput, storedErrorCost uint32) (condenseOutcome, error) {
 	if uint64(len(c.links))+1 > uint64(c.limits.MaxLinks) || uint64(len(c.links)) >= math.MaxUint32 {
 		return condenseOutcome{}, errors.New("parser-core phase zero: link arena cap")
 	}
@@ -3763,6 +3876,9 @@ func (c *Core) condenseDirectAppend(key boundaryKey, probe boundaryProbe, prevPa
 		firstLink: uint32(linkID), linkCount: 1, pathCount: prevPathCount,
 	}, key.checkpoint, maximum.value)
 	if err != nil {
+		return condenseOutcome{}, err
+	}
+	if err := c.publishInheritedStoredErrorCost(Head{Node: id}, storedErrorCost); err != nil {
 		return condenseOutcome{}, err
 	}
 	if err := c.publishBoundary(probe, id); err != nil {
@@ -4016,7 +4132,14 @@ func (c *Core) factorExactPredecessorMerge(key boundaryKey, probe boundaryProbe,
 	if phase0AEnabled {
 		phase0APrepareFactorOuter(c, key, in, oldID, index, merged)
 	}
-	id, appendErr := c.appendAdjacencyNodeAtWithPrecedence(key.state, key.byteOffset, key.checkpoint, rebuilt, *folded)
+	oldLineage, appendErr := c.nodeLineage(oldID)
+	if appendErr != nil {
+		return condenseOutcome{}, true, appendErr
+	}
+	id, appendErr := c.appendAdjacencyNodeAtWithPrecedenceAndStoredErrorCost(
+		key.state, key.byteOffset, key.checkpoint, rebuilt, *folded,
+		oldLineage.storedErrorCost, true,
+	)
 	if appendErr != nil {
 		return condenseOutcome{}, true, appendErr
 	}
@@ -4064,8 +4187,17 @@ func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int, folde
 	*folded = precedenceMaximumWitness{seed: leftMaximum.value, hasSeed: true}
 	leftCheckpoint, leftExact := c.nodeScannerCheckpoint(leftID)
 	rightCheckpoint, rightExact := c.nodeScannerCheckpoint(rightID)
+	leftLineage, err := c.nodeLineage(leftID)
+	if err != nil {
+		return 0, false, err
+	}
+	rightLineage, err := c.nodeLineage(rightID)
+	if err != nil {
+		return 0, false, err
+	}
 	if left.state != right.state || left.byteOffset != right.byteOffset ||
-		!leftExact || !rightExact || leftCheckpoint != rightCheckpoint {
+		!leftExact || !rightExact || leftCheckpoint != rightCheckpoint ||
+		leftLineage.storedErrorCost != rightLineage.storedErrorCost {
 		return 0, false, errors.New("parser-core phase zero: recursive predecessors are not boundary-equivalent")
 	}
 	related, err := c.nodesAncestryRelated(leftID, rightID)
@@ -4117,7 +4249,10 @@ func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int, folde
 		}
 		return leftID, false, nil
 	}
-	merged, err := c.appendAdjacencyNodeAtWithPrecedence(left.state, left.byteOffset, leftCheckpoint, links, *folded)
+	merged, err := c.appendAdjacencyNodeAtWithPrecedenceAndStoredErrorCost(
+		left.state, left.byteOffset, leftCheckpoint, links, *folded,
+		leftLineage.storedErrorCost, true,
+	)
 	if err != nil {
 		return 0, false, err
 	}
@@ -4659,7 +4794,9 @@ func (c *Core) appendAdjacencyNode(state StateID, byteOffset uint32, links []lin
 }
 
 func (c *Core) appendAdjacencyNodeAt(state StateID, byteOffset uint32, checkpoint CheckpointID, links []linkRecord) (NodeID, error) {
-	return c.appendAdjacencyNodeAtWithPrecedence(state, byteOffset, checkpoint, links, precedenceMaximumWitness{})
+	return c.appendAdjacencyNodeAtWithPrecedenceAndStoredErrorCost(
+		state, byteOffset, checkpoint, links, precedenceMaximumWitness{}, 0, false,
+	)
 }
 
 // appendAdjacencyNodeAtWithPrecedence publishes an adjacency with its folded
@@ -4669,6 +4806,23 @@ func (c *Core) appendAdjacencyNodeAt(state StateID, byteOffset uint32, checkpoin
 // Neither shape verifies the value against outside evidence; the C rule
 // table in the precedence rule-table tests is the behavioral contract.
 func (c *Core) appendAdjacencyNodeAtWithPrecedence(state StateID, byteOffset uint32, checkpoint CheckpointID, links []linkRecord, folded precedenceMaximumWitness) (NodeID, error) {
+	return c.appendAdjacencyNodeAtWithPrecedenceAndStoredErrorCost(
+		state, byteOffset, checkpoint, links, folded, 0, false,
+	)
+}
+
+// appendAdjacencyNodeAtWithPrecedenceAndStoredErrorCost publishes an adjacency
+// with an authenticated cumulative recovery cost. The target cost belongs to
+// the merged node, not to any one predecessor link.
+func (c *Core) appendAdjacencyNodeAtWithPrecedenceAndStoredErrorCost(
+	state StateID,
+	byteOffset uint32,
+	checkpoint CheckpointID,
+	links []linkRecord,
+	folded precedenceMaximumWitness,
+	storedErrorCost uint32,
+	storedErrorCostAuthenticated bool,
+) (NodeID, error) {
 	if len(links) == 0 {
 		return 0, errors.New("parser-core phase zero: recursive insertion produced empty adjacency")
 	}
@@ -4693,6 +4847,13 @@ func (c *Core) appendAdjacencyNodeAtWithPrecedence(state StateID, byteOffset uin
 		}
 		pathCount = saturatingAddPaths(pathCount, prev.pathCount)
 	}
+	if !storedErrorCostAuthenticated {
+		inherited, err := c.inheritedStoredErrorCost(links)
+		if err != nil {
+			return 0, err
+		}
+		storedErrorCost = inherited
+	}
 	maximum, err := c.computePrecedenceMaximum(links, folded)
 	if err != nil {
 		return 0, err
@@ -4705,10 +4866,17 @@ func (c *Core) appendAdjacencyNodeAtWithPrecedence(state StateID, byteOffset uin
 		c.addWork(&c.work.GraphLinkAdditionsProxy, 1)
 		first = LinkID(len(c.links))
 	}
-	return c.appendNodeAtWithMaximum(nodeRecord{
+	id, err := c.appendNodeAtWithMaximum(nodeRecord{
 		state: state, byteOffset: byteOffset, firstLink: uint32(first),
 		linkCount: uint32(len(links)), pathCount: pathCount,
 	}, checkpoint, maximum.value)
+	if err != nil {
+		return 0, err
+	}
+	if err := c.publishInheritedStoredErrorCost(Head{Node: id}, storedErrorCost); err != nil {
+		return 0, err
+	}
+	return id, nil
 }
 
 // subtreesStructurallyEqual reports whether two compact payload subtrees are the
@@ -4839,9 +5007,20 @@ func (c *Core) shallowPayloadClass(prevID NodeID, payloadID SubtreeID) (shallowP
 // historical head and every link reachable from it immutable. oldLinks are in
 // stable insertion order, so rebuilding them through prepends preserves the
 // order observed by nodeLinks.
-func (c *Core) replaceBoundaryLink(key boundaryKey, probe boundaryProbe, old nodeRecord, oldLinks []linkRecord, candidate int, in linkInput) (Head, error) {
+func (c *Core) replaceBoundaryLink(key boundaryKey, probe boundaryProbe, oldID NodeID, old nodeRecord, oldLinks []linkRecord, candidate int, in linkInput) (Head, error) {
 	if candidate < 0 || candidate >= len(oldLinks) || uint32(len(oldLinks)) != old.linkCount {
 		return Head{}, errors.New("parser-core phase zero: invalid shallow-fold candidate")
+	}
+	incomingCost, err := c.storedErrorCostForLink(in)
+	if err != nil {
+		return Head{}, err
+	}
+	oldLineage, err := c.nodeLineage(oldID)
+	if err != nil {
+		return Head{}, err
+	}
+	if oldLineage.storedErrorCost != incomingCost {
+		return Head{}, errors.New("parser-core phase zero: replacement heads have different stored recovery costs")
 	}
 	if uint64(len(c.links))+uint64(len(oldLinks)) > uint64(c.limits.MaxLinks) || uint64(len(c.links))+uint64(len(oldLinks)) > math.MaxUint32 {
 		return Head{}, errors.New("parser-core phase zero: link arena cap")
@@ -4885,6 +5064,9 @@ func (c *Core) replaceBoundaryLink(key boundaryKey, probe boundaryProbe, old nod
 		if c.dropCohortLinkRefIndexes != nil {
 			c.dropCohortLinkRefIndexes = c.dropCohortLinkRefIndexes[:linkRefMark]
 		}
+		return Head{}, err
+	}
+	if err := c.publishInheritedStoredErrorCost(Head{Node: id}, incomingCost); err != nil {
 		return Head{}, err
 	}
 	if err := c.publishBoundary(probe, id); err != nil {

--- a/internal/parsercorephase0/drop_cohort_arena.go
+++ b/internal/parsercorephase0/drop_cohort_arena.go
@@ -948,15 +948,16 @@ func (c *Core) AbandonDropCohortOwned(owner SchedulerTransactionToken, cohort Dr
 }
 
 const (
-	dropCohortDerivationFormatVersion uint32 = 2
-	dropCohortTagRecordBegin                 = 0xD2
-	dropCohortTagRecordEnd                   = 0xD3
-	dropCohortTagPathBegin                   = 0xB0
-	dropCohortTagPathEnd                     = 0xB1
-	dropCohortTagBoundary                    = 0xA0
-	dropCohortTagEdge                        = 0xA1
-	dropCohortTagSubtreeBegin                = 0xC0
-	dropCohortTagSubtreeEnd                  = 0xC1
+	dropCohortDerivationFormatVersion  uint32 = 2
+	dropCohortTagRecordBegin                  = 0xD2
+	dropCohortTagRecordEnd                    = 0xD3
+	dropCohortTagPathBegin                    = 0xB0
+	dropCohortTagPathEnd                      = 0xB1
+	dropCohortTagBoundary                     = 0xA0
+	dropCohortTagEdge                         = 0xA1
+	dropCohortTagRecoveryDiscontinuity        = 0xA2
+	dropCohortTagSubtreeBegin                 = 0xC0
+	dropCohortTagSubtreeEnd                   = 0xC1
 )
 
 // dropCohortPathStep keeps arena identities only while traversing one graph.
@@ -1481,6 +1482,21 @@ func (c *Core) dropCohortCompareBoundary(left, right NodeID) (int, error) {
 }
 
 func (c *Core) dropCohortCompareLinks(left, right linkRecord) (int, error) {
+	if err := left.validateShape(); err != nil {
+		return 0, err
+	}
+	if err := right.validateShape(); err != nil {
+		return 0, err
+	}
+	if left.isRecoveryDiscontinuity() != right.isRecoveryDiscontinuity() {
+		if !left.isRecoveryDiscontinuity() {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	if left.isRecoveryDiscontinuity() {
+		return c.dropCohortCompareBoundary(left.prev, right.prev)
+	}
 	if left.scoreDelta != right.scoreDelta {
 		if left.scoreDelta < right.scoreDelta {
 			return -1, nil
@@ -1621,6 +1637,9 @@ func (c *Core) dropCohortSortedLinks(id NodeID) (result dropCohortSortedLinksRes
 		}
 		seen[len(seen)-1] = linkID
 		link := c.links[linkID-1]
+		if err := link.validateShape(); err != nil {
+			return result, err
+		}
 		if link.prev == 0 || link.prev >= id || uint64(link.next) > uint64(len(c.links)) {
 			return result, errors.New("parser-core phase zero: drop-cohort derivation graph is invalid")
 		}
@@ -1746,6 +1765,15 @@ func (c *Core) dropCohortEncodeAllPaths(e *dropCohortEncoder, id NodeID, path []
 		}
 		for index := len(path) - 1; index >= 0; index-- {
 			step := path[index]
+			if step.payload == 0 {
+				if err := e.u8(dropCohortTagRecoveryDiscontinuity); err != nil {
+					return path, err
+				}
+				if err := c.dropCohortEncodeBoundary(e, step.node); err != nil {
+					return path, err
+				}
+				continue
+			}
 			if err := e.u8(dropCohortTagEdge); err != nil {
 				return path, err
 			}
@@ -1780,6 +1808,9 @@ func (c *Core) dropCohortEncodeAllPaths(e *dropCohortEncoder, id NodeID, path []
 		return path, nil
 	}
 	for _, link := range links.links {
+		if err := link.validateShape(); err != nil {
+			return path, err
+		}
 		childOrder := order
 		if link.hasOrder() {
 			childOrder = ForkOrder{Value: link.order, Present: true}

--- a/internal/parsercorephase0/eof_admission_view.go
+++ b/internal/parsercorephase0/eof_admission_view.go
@@ -208,14 +208,19 @@ func (c *Core) VisitEOFAdmissionExactPath(
 		if link.prev == 0 || link.prev >= id {
 			return result, fmt.Errorf("%w: predecessor does not decrease", ErrEOFAdmissionMalformed)
 		}
-		if link.payload == 0 || uint64(link.payload) > uint64(len(c.subtrees)) {
+		if err := link.validateShape(); err != nil {
+			return result, fmt.Errorf("%w: %v", ErrEOFAdmissionMalformed, err)
+		}
+		if link.isRecoveryDiscontinuity() {
+			return result, fmt.Errorf("%w: recovery discontinuity requires a recovery-aware visitor", ErrEOFAdmissionMalformed)
+		}
+		if link.payload != 0 && uint64(link.payload) > uint64(len(c.subtrees)) {
 			return result, fmt.Errorf("%w: payload is outside its arena", ErrEOFAdmissionMalformed)
 		}
 		reverse[result.Links] = linkID
 		result.Links++
 		id = link.prev
 	}
-	result.Payloads = result.Links
 	for reverseIndex := int(result.Links) - 1; reverseIndex >= 0; reverseIndex-- {
 		link := c.links[reverse[reverseIndex]-1]
 		score, err := checkedAddScore(result.Score, link.scoreDelta)
@@ -227,9 +232,12 @@ func (c *Core) VisitEOFAdmissionExactPath(
 			result.BranchOrder = link.order
 			result.HasBranchOrder = true
 		}
-		ordinal := result.Links - 1 - uint32(reverseIndex)
-		if err := visit(ordinal, link.payload); err != nil {
-			return result, err
+		if link.payload != 0 {
+			ordinal := result.Payloads
+			result.Payloads++
+			if err := visit(ordinal, link.payload); err != nil {
+				return result, err
+			}
 		}
 		if err := c.checkEOFAdmissionGeneration(generation); err != nil {
 			return result, err

--- a/internal/parsercorephase0/eof_recovery_live.go
+++ b/internal/parsercorephase0/eof_recovery_live.go
@@ -40,11 +40,51 @@ func (c *Core) RecoverEOFAcceptOwned(
 	return out, root, nil
 }
 
+// RecoverEOFAcceptWithCostOwned publishes the synthetic ERROR root with its
+// authenticated cumulative cost. The root replaces the old path, so its cost
+// does not inherit the predecessor path cost.
+func (c *Core) RecoverEOFAcceptWithCostOwned(
+	owner SchedulerTransactionToken,
+	head Head,
+	payloads []SubtreeID,
+	startByte uint32,
+	endByte uint32,
+	cost ReductionOutputCostFunc,
+) (out Head, root SubtreeID, err error) {
+	if c == nil {
+		return Head{}, 0, errors.New("parser-core phase zero: recover_eof accept on nil core")
+	}
+	err = c.RunSchedulerOwned(owner, func() error {
+		if cost == nil {
+			return errors.New("parser-core phase zero: recover_eof cost callback is required")
+		}
+		var operationErr error
+		out, root, operationErr = c.recoverEOFAcceptUncheckpointedWithCost(
+			head, payloads, startByte, endByte, cost,
+		)
+		return operationErr
+	})
+	if err != nil {
+		return Head{}, 0, err
+	}
+	return out, root, nil
+}
+
 func (c *Core) recoverEOFAcceptUncheckpointed(
 	head Head,
 	payloads []SubtreeID,
 	startByte uint32,
 	endByte uint32,
+) (Head, SubtreeID, error) {
+	return c.recoverEOFAcceptUncheckpointedWithCost(head, payloads, startByte, endByte, nil)
+}
+
+func (c *Core) recoverEOFAcceptUncheckpointedWithCost(
+	head Head,
+	payloads []SubtreeID,
+	startByte uint32,
+	endByte uint32,
+	cost ReductionOutputCostFunc,
 ) (Head, SubtreeID, error) {
 	if head.Node == 0 {
 		return Head{}, 0, errors.New("parser-core phase zero: recover_eof accept requires a head")
@@ -92,6 +132,19 @@ func (c *Core) recoverEOFAcceptUncheckpointed(
 	if err != nil {
 		return Head{}, 0, err
 	}
+	var storedErrorCost uint32
+	if cost != nil {
+		computed, costErr := cost(base, root)
+		if costErr != nil {
+			return Head{}, 0, costErr
+		}
+		storedErrorCost, costErr = c.storedErrorCostForLink(linkInput{
+			prev: base, payload: root, storedErrorCost: computed, hasStoredErrorCost: true,
+		})
+		if costErr != nil {
+			return Head{}, 0, costErr
+		}
+	}
 	linkID := c.appendGraphLink(linkRecord{prev: base, payload: root})
 	c.addWork(&c.work.GraphLinkAdditionsProxy, 1)
 	newNode, err := c.appendNodeAt(nodeRecord{
@@ -100,6 +153,11 @@ func (c *Core) recoverEOFAcceptUncheckpointed(
 	}, c.checkpoint)
 	if err != nil {
 		return Head{}, 0, err
+	}
+	if cost != nil {
+		if err := c.publishInheritedStoredErrorCost(Head{Node: newNode}, storedErrorCost); err != nil {
+			return Head{}, 0, err
+		}
 	}
 	return Head{Node: newNode}, root, nil
 }

--- a/internal/parsercorephase0/eof_recovery_live_test.go
+++ b/internal/parsercorephase0/eof_recovery_live_test.go
@@ -100,6 +100,50 @@ func TestRecoverEOFAcceptOwnedPublishesExactNonExtraRoot(t *testing.T) {
 	}
 }
 
+func TestRecoverEOFAcceptWithCostPublishesSyntheticRootCost(t *testing.T) {
+	fixture := newRecoverEOFAcceptFixture(t)
+	fixture.core.nodeLineages[fixture.head.Node-1].storedErrorCost = 99
+	var recovered Head
+	var root SubtreeID
+	err := fixture.core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		var operationErr error
+		recovered, root, operationErr = fixture.core.RecoverEOFAcceptWithCostOwned(
+			owner, fixture.head, fixture.payload, 0, 2,
+			func(prev NodeID, payload SubtreeID) (uint32, error) {
+				prefix, prefixErr := fixture.core.RecoveryStoredErrorCost(Head{Node: prev})
+				if prefixErr != nil {
+					return 0, prefixErr
+				}
+				if prefix != 0 {
+					return 0, errors.New("recover_eof cost callback inherited the replaced path")
+				}
+				view, viewErr := fixture.core.Subtree(payload)
+				if viewErr != nil {
+					return 0, viewErr
+				}
+				if view.Symbol != ErrorRegionSymbol {
+					return 0, errors.New("recover_eof cost callback received a non-ERROR root")
+				}
+				return 77, nil
+			},
+		)
+		return operationErr
+	})
+	if err != nil {
+		t.Fatalf("RecoverEOFAcceptWithCostOwned: %v", err)
+	}
+	if root == 0 || recovered.Node == 0 {
+		t.Fatalf("recover_eof returned recovered=%+v root=%d", recovered, root)
+	}
+	got, err := fixture.core.RecoveryStoredErrorCost(recovered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 77 {
+		t.Fatalf("recover_eof stored cost=%d, want 77", got)
+	}
+}
+
 func TestRecoverEOFAcceptOwnedRejectsForeignOwnerWithoutMutation(t *testing.T) {
 	fixture := newRecoverEOFAcceptFixture(t)
 	foreign := newRecoverEOFAcceptFixture(t)

--- a/internal/parsercorephase0/error_region.go
+++ b/internal/parsercorephase0/error_region.go
@@ -118,12 +118,16 @@ func (c *Core) ErrorRegionLeaf(symbol Symbol, startByte, endByte uint32, extra b
 // resuming before absorbing one -- would need this split reproduced (or an
 // explicit decline guarding it) before certifying; do not assume this gap
 // is closed by extrapolation from html's own witnesses.
-func (c *Core) ErrorRegionResume(preErrorHead Head, preErrorState StateID, startByte, endByte uint32, children []SubtreeID) (out Head, err error) {
+func (c *Core) errorRegionResumeUncheckpointed(
+	preErrorHead Head,
+	preErrorState StateID,
+	startByte, endByte uint32,
+	children []SubtreeID,
+	cost ReductionOutputCostFunc,
+) (out Head, err error) {
 	if len(children) == 0 {
 		return Head{}, errors.New("parser-core phase zero: error region resume has no absorbed children")
 	}
-	mark := c.mark()
-	defer c.completeTransaction(mark, &err)
 	if _, err := c.node(preErrorHead.Node); err != nil {
 		return Head{}, err
 	}
@@ -147,7 +151,39 @@ func (c *Core) ErrorRegionResume(preErrorHead Head, preErrorState StateID, start
 	if err != nil {
 		return Head{}, err
 	}
-	return c.condense(c.shiftedBoundaryKey(preErrorState, endByte), linkInput{
-		prev: preErrorHead.Node, payload: payload,
-	})
+	in := linkInput{prev: preErrorHead.Node, payload: payload}
+	if cost != nil {
+		storedErrorCost, costErr := cost(in.prev, in.payload)
+		if costErr != nil {
+			return Head{}, costErr
+		}
+		in.storedErrorCost = storedErrorCost
+		in.hasStoredErrorCost = true
+	}
+	return c.condense(c.shiftedBoundaryKey(preErrorState, endByte), in)
+}
+
+// ErrorRegionResume publishes one ERROR container over the region's existing
+// children. It keeps the historical no-cost wrapper for clean callers.
+func (c *Core) ErrorRegionResume(preErrorHead Head, preErrorState StateID, startByte, endByte uint32, children []SubtreeID) (out Head, err error) {
+	mark := c.mark()
+	defer c.completeTransaction(mark, &err)
+	return c.errorRegionResumeUncheckpointed(preErrorHead, preErrorState, startByte, endByte, children, nil)
+}
+
+// ErrorRegionResumeWithCost publishes the authenticated cumulative recovery
+// cost before the new ERROR boundary can condense or publish.
+func (c *Core) ErrorRegionResumeWithCost(
+	preErrorHead Head,
+	preErrorState StateID,
+	startByte, endByte uint32,
+	children []SubtreeID,
+	cost ReductionOutputCostFunc,
+) (out Head, err error) {
+	if cost == nil {
+		return Head{}, errors.New("parser-core phase zero: error-region cost callback is required")
+	}
+	mark := c.mark()
+	defer c.completeTransaction(mark, &err)
+	return c.errorRegionResumeUncheckpointed(preErrorHead, preErrorState, startByte, endByte, children, cost)
 }

--- a/internal/parsercorephase0/link_provenance.go
+++ b/internal/parsercorephase0/link_provenance.go
@@ -64,6 +64,9 @@ func (c *Core) resolveDropCohortLinkRange(r LinkRange) ([]LinkID, error) {
 			return nil, errors.New("parser-core phase zero: link range leaves the graph")
 		}
 		link := c.links[current-1]
+		if err := link.validateShape(); err != nil {
+			return nil, err
+		}
 		if link.prev == 0 || uint64(link.prev) > uint64(len(c.nodes)) {
 			return nil, errors.New("parser-core phase zero: link range has an invalid predecessor")
 		}

--- a/internal/parsercorephase0/missing_leaf.go
+++ b/internal/parsercorephase0/missing_leaf.go
@@ -146,7 +146,10 @@ func (c *Core) UniqueStateSpine(head Head, maxDepth int) ([]StateID, bool, error
 			return nil, false, errors.New("parser-core phase zero: state spine adjacency is out of range")
 		}
 		link := c.links[linkID-1]
-		if link.prev == 0 {
+		if err := link.validateShape(); err != nil {
+			return nil, false, err
+		}
+		if link.prev == 0 || link.prev >= id {
 			return nil, false, errors.New("parser-core phase zero: state spine link has no predecessor")
 		}
 		id = link.prev

--- a/internal/parsercorephase0/missing_leaf.go
+++ b/internal/parsercorephase0/missing_leaf.go
@@ -67,14 +67,18 @@ const compactMissingLeafStoredErrorCost uint32 = 610
 // Materialization validates reduction metadata, not this. The scheduler
 // caller must authenticate the symbol against its state before publishing.
 func (c *Core) MissingLeaf(symbol Symbol, atByte uint32) (id SubtreeID, err error) {
+	mark := c.mark()
+	defer c.completeTransaction(mark, &err)
+	return c.missingLeafUncheckpointed(symbol, atByte)
+}
+
+func (c *Core) missingLeafUncheckpointed(symbol Symbol, atByte uint32) (SubtreeID, error) {
 	if symbol == 0 {
 		return 0, errors.New("parser-core phase zero: missing leaf requires a real terminal symbol")
 	}
 	if symbol == ErrorRegionSymbol {
 		return 0, errors.New("parser-core phase zero: missing leaf cannot carry the ERROR symbol")
 	}
-	mark := c.mark()
-	defer c.completeTransaction(mark, &err)
 	return c.appendSubtree(subtreeRecord{
 		symbol:    symbol,
 		startByte: atByte,
@@ -107,10 +111,29 @@ func (c *Core) ShiftMissingLeaf(head Head, targetState StateID, symbol Symbol, a
 	}
 	mark := c.mark()
 	defer c.completeTransaction(mark, &err)
+	return c.shiftMissingLeafUncheckpointed(head, targetState, symbol, atByte)
+}
+
+// ShiftMissingLeafOwned attaches one authenticated missing leaf without
+// opening a nested ordinary checkpoint. Scheduler recovery uses this seam
+// inside a speculative transaction.
+func (c *Core) ShiftMissingLeafOwned(owner SchedulerTransactionToken, head Head, targetState StateID, symbol Symbol, atByte uint32) (out Head, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return out, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	out, err = c.shiftMissingLeafUncheckpointed(head, targetState, symbol, atByte)
+	return out, c.finishSchedulerOwned(owner, err)
+}
+
+func (c *Core) shiftMissingLeafUncheckpointed(head Head, targetState StateID, symbol Symbol, atByte uint32) (out Head, err error) {
+	if targetState == 0 {
+		return Head{}, errors.New("parser-core phase zero: missing leaf shift requires a real target state")
+	}
 	if _, err := c.node(head.Node); err != nil {
 		return Head{}, err
 	}
-	payload, err := c.MissingLeaf(symbol, atByte)
+	payload, err := c.missingLeafUncheckpointed(symbol, atByte)
 	if err != nil {
 		return Head{}, err
 	}
@@ -122,9 +145,10 @@ func (c *Core) ShiftMissingLeaf(head Head, targetState StateID, symbol Symbol, a
 		return Head{}, errors.New("parser-core phase zero: missing leaf stored recovery cost overflow")
 	}
 	storedErrorCost := lineage.storedErrorCost + compactMissingLeafStoredErrorCost
-	return c.condense(c.shiftedBoundaryKey(targetState, atByte), linkInput{
+	outcome, err := c.condenseWithOutcomeAtomic(c.shiftedBoundaryKey(targetState, atByte), linkInput{
 		prev: head.Node, payload: payload, storedErrorCost: storedErrorCost, hasStoredErrorCost: true,
 	})
+	return outcome.head, err
 }
 
 // UniqueStateSpine returns the state stack below head, from the seed to head.

--- a/internal/parsercorephase0/missing_leaf.go
+++ b/internal/parsercorephase0/missing_leaf.go
@@ -2,6 +2,10 @@ package parsercorephase0
 
 import "errors"
 
+// compactMissingLeafStoredErrorCost is the pinned C cost of one missing
+// terminal: one recovery plus one missing-tree term.
+const compactMissingLeafStoredErrorCost uint32 = 610
+
 // ---------------------------------------------------------------------------
 // missing_leaf.go -- compact support for C's recovery-inserted MISSING
 // terminal.
@@ -110,8 +114,16 @@ func (c *Core) ShiftMissingLeaf(head Head, targetState StateID, symbol Symbol, a
 	if err != nil {
 		return Head{}, err
 	}
+	lineage, err := c.nodeLineage(head.Node)
+	if err != nil {
+		return Head{}, err
+	}
+	if ^uint32(0)-lineage.storedErrorCost < compactMissingLeafStoredErrorCost {
+		return Head{}, errors.New("parser-core phase zero: missing leaf stored recovery cost overflow")
+	}
+	storedErrorCost := lineage.storedErrorCost + compactMissingLeafStoredErrorCost
 	return c.condense(c.shiftedBoundaryKey(targetState, atByte), linkInput{
-		prev: head.Node, payload: payload,
+		prev: head.Node, payload: payload, storedErrorCost: storedErrorCost, hasStoredErrorCost: true,
 	})
 }
 

--- a/internal/parsercorephase0/missing_leaf_test.go
+++ b/internal/parsercorephase0/missing_leaf_test.go
@@ -281,7 +281,10 @@ func TestUniqueStateSpineRequiresOneCompletePath(t *testing.T) {
 		t.Fatalf("second payload: %v", err)
 	}
 	key := compact.shiftedBoundaryKey(StateID(3), 0)
-	ambiguous, err := compact.condense(key, linkInput{prev: seed.Node, payload: first})
+	ambiguous, err := compact.condense(key, linkInput{
+		prev: seed.Node, payload: first,
+		storedErrorCost: compactMissingLeafStoredErrorCost, hasStoredErrorCost: true,
+	})
 	if err != nil {
 		t.Fatalf("first condense: %v", err)
 	}

--- a/internal/parsercorephase0/phase0a_factor_provenance.go
+++ b/internal/parsercorephase0/phase0a_factor_provenance.go
@@ -387,6 +387,9 @@ func phase0AStableLinkIDs(core *Core, id NodeID) ([]LinkID, bool) {
 		if next == 0 || uint64(next) > uint64(len(core.links)) {
 			return nil, false
 		}
+		if err := core.links[next-1].validateShape(); err != nil {
+			return nil, false
+		}
 		ids[index] = next
 		next = core.links[next-1].next
 	}

--- a/internal/parsercorephase0/phase0a_routes.go
+++ b/internal/parsercorephase0/phase0a_routes.go
@@ -37,21 +37,22 @@ const (
 )
 
 type Phase0APopRouteLinkRecord struct {
-	Route               uint64
-	TransactionID       uint64
-	Ordinal             uint32
-	Segment             Phase0APopRouteSegment
-	SegmentOrdinal      uint32
-	Link                LinkID
-	Node                NodeID
-	Predecessor         NodeID
-	Payload             SubtreeID
-	ScoreDelta          int64
-	Order               uint64
-	HasOrder            bool
-	RolledBack          bool
-	RollbackTransaction uint64
-	RollbackCause       Phase0ARollbackCause
+	Route                 uint64
+	TransactionID         uint64
+	Ordinal               uint32
+	Segment               Phase0APopRouteSegment
+	SegmentOrdinal        uint32
+	Link                  LinkID
+	Node                  NodeID
+	Predecessor           NodeID
+	Payload               SubtreeID
+	ScoreDelta            int64
+	Order                 uint64
+	HasOrder              bool
+	RecoveryDiscontinuity bool
+	RolledBack            bool
+	RollbackTransaction   uint64
+	RollbackCause         Phase0ARollbackCause
 }
 
 // Phase0AAcceptedSelectionRecord freezes the unique physical root-to-head
@@ -84,16 +85,17 @@ type Phase0ASelectionCapabilityRecord struct {
 // ResolvedLowerLink is the final source-adjacency lower link after applying
 // every selector-route translation; it is zero only at the graph seed.
 type Phase0AAcceptedLinkRecord struct {
-	Namespace          CoreRunNamespace
-	Generation         uint64
-	Ordinal            uint32
-	Link               LinkID
-	Payload            SubtreeID
-	BoundExpression    Phase0AExpressionID
-	ResolvedExpression Phase0AExpressionID
-	ResolvedLowerLink  LinkID
-	Occurrence         ConstructionOccurrenceKey
-	Edge               IncomingEdgeKey
+	Namespace             CoreRunNamespace
+	Generation            uint64
+	Ordinal               uint32
+	Link                  LinkID
+	Payload               SubtreeID
+	RecoveryDiscontinuity bool
+	BoundExpression       Phase0AExpressionID
+	ResolvedExpression    Phase0AExpressionID
+	ResolvedLowerLink     LinkID
+	Occurrence            ConstructionOccurrenceKey
+	Edge                  IncomingEdgeKey
 }
 
 type phase0ARouteObserver struct {
@@ -267,6 +269,9 @@ func phase0AStablePhysicalLinks(core *Core, id NodeID) ([]phase0APhysicalLink, e
 			return nil, errors.New("parser-core phase zero A: physical adjacency is unavailable")
 		}
 		link := core.links[next-1]
+		if err := link.validateShape(); err != nil {
+			return nil, err
+		}
 		out[index] = phase0APhysicalLink{id: next, node: id, record: link}
 		next = link.next
 	}
@@ -308,14 +313,90 @@ func phase0AEnumeratePopRoutes(core *Core, head NodeID, childCount int) ([]phase
 		}
 		for _, physical := range links {
 			link := physical.record
+			if err := link.validateShape(); err != nil {
+				return err
+			}
 			if link.prev == 0 || link.prev >= id {
 				return errors.New("parser-core phase zero A: physical pop predecessor does not decrease")
+			}
+			order := ForkOrder{Value: link.order, Present: link.hasOrder()}
+			if link.isRecoveryDiscontinuity() {
+				revLinks = append(revLinks, physical.id)
+				revNodes = append(revNodes, physical.node)
+				revPrevs = append(revPrevs, link.prev)
+				revPayloads = append(revPayloads, 0)
+				revScores = append(revScores, 0)
+				revOrders = append(revOrders, ForkOrder{})
+				next := remaining - 1
+				if next == 0 {
+					if uint64(len(out)) >= core.limits.MaxPopPaths {
+						return errors.New("parser-core phase zero A: physical pop enumeration cap")
+					}
+					path := phase0APhysicalPopPath{prev: link.prev, structuralEnd: structuralEnd}
+					haveStartByte := false
+					for index := len(revLinks) - 1; index >= 0; index-- {
+						path.links = append(path.links, revLinks[index])
+						path.linkNodes = append(path.linkNodes, revNodes[index])
+						path.linkPrevs = append(path.linkPrevs, revPrevs[index])
+						path.linkScores = append(path.linkScores, revScores[index])
+						path.linkOrders = append(path.linkOrders, revOrders[index])
+						if revPayloads[index] == 0 {
+							continue
+						}
+						path.children = append(path.children, revPayloads[index])
+						payloadRecord, payloadErr := core.subtree(revPayloads[index])
+						if payloadErr != nil {
+							return payloadErr
+						}
+						if !payloadRecord.extra && !haveStartByte {
+							path.startByte, haveStartByte = payloadRecord.startByte, true
+							if path.structuralEnd == 0 {
+								path.structuralEnd = payloadRecord.endByte
+							}
+						}
+						path.score, err = checkedAddScore(path.score, revScores[index])
+						if err != nil {
+							return err
+						}
+						if revOrders[index].Present {
+							path.order = revOrders[index]
+						}
+					}
+					if !haveStartByte && path.prev != 0 {
+						previous, nodeErr := core.node(path.prev)
+						if nodeErr != nil {
+							return nodeErr
+						}
+						path.startByte, path.structuralEnd = previous.byteOffset, previous.byteOffset
+					}
+					path.retainedCount = uint32(len(path.links))
+					for index := len(trailingLinks) - 1; index >= 0; index-- {
+						path.links = append(path.links, trailingLinks[index])
+						path.linkNodes = append(path.linkNodes, trailingNodes[index])
+						path.linkPrevs = append(path.linkPrevs, trailingPrevs[index])
+						path.linkScores = append(path.linkScores, trailingScores[index])
+						path.linkOrders = append(path.linkOrders, trailingOrders[index])
+						path.trailing = append(path.trailing, trailingPayloads[index])
+						if trailingOrders[index].Present {
+							path.order = trailingOrders[index]
+						}
+					}
+					out = append(out, path)
+				} else if err := walk(link.prev, next, false, structuralEnd); err != nil {
+					return err
+				}
+				revLinks = revLinks[:len(revLinks)-1]
+				revNodes = revNodes[:len(revNodes)-1]
+				revPrevs = revPrevs[:len(revPrevs)-1]
+				revPayloads = revPayloads[:len(revPayloads)-1]
+				revScores = revScores[:len(revScores)-1]
+				revOrders = revOrders[:len(revOrders)-1]
+				continue
 			}
 			payload, err := core.subtree(link.payload)
 			if err != nil {
 				return err
 			}
-			order := ForkOrder{Value: link.order, Present: link.hasOrder()}
 			if payload.extra && peelingTrailing {
 				trailingLinks = append(trailingLinks, physical.id)
 				trailingNodes = append(trailingNodes, physical.node)
@@ -359,7 +440,9 @@ func phase0AEnumeratePopRoutes(core *Core, head NodeID, childCount int) ([]phase
 					path.linkPrevs = append(path.linkPrevs, revPrevs[index])
 					path.linkScores = append(path.linkScores, revScores[index])
 					path.linkOrders = append(path.linkOrders, revOrders[index])
-					path.children = append(path.children, revPayloads[index])
+					if revPayloads[index] != 0 {
+						path.children = append(path.children, revPayloads[index])
+					}
 					path.score, err = checkedAddScore(path.score, revScores[index])
 					if err != nil {
 						return err
@@ -440,7 +523,7 @@ func phase0AObservePopRoutes(core *Core, head NodeID, childCount int, production
 			wantTrailing[trailingIndex] = want.trailing[trailingIndex].payload
 		}
 		if len(got.links) != len(got.linkNodes) || len(got.links) != len(got.linkPrevs) || len(got.links) != len(got.linkScores) || len(got.links) != len(got.linkOrders) || uint64(got.retainedCount) > uint64(len(got.links)) ||
-			uint64(got.retainedCount) != uint64(len(want.children)) || uint64(len(got.links))-uint64(got.retainedCount) != uint64(len(want.trailing)) ||
+			uint64(len(got.children)) != uint64(len(want.children)) || uint64(len(got.links))-uint64(got.retainedCount) != uint64(len(want.trailing)) ||
 			got.prev != want.prev || got.score != want.score || got.order != want.order || got.startByte != want.startByte || got.structuralEnd != want.structuralEnd || !phase0ASameSubtrees(got.children, want.children) || !phase0ASameSubtrees(got.trailing, wantTrailing) {
 			phase0AStickyLocked(observer, &Phase0AError{Kind: Phase0AErrorAmbiguousReference, Namespace: observer.run, Detail: "physical pop path does not exactly match production ordinal"})
 			return
@@ -484,6 +567,7 @@ func phase0AObservePopRoutes(core *Core, head NodeID, childCount int, production
 				Route: id, TransactionID: pending.transaction, Ordinal: uint32(ordinal), Segment: segment, SegmentOrdinal: segmentOrdinal,
 				Link: linkID, Node: route.linkNodes[ordinal], Predecessor: route.linkPrevs[ordinal], Payload: link.payload,
 				ScoreDelta: route.linkScores[ordinal], Order: route.linkOrders[ordinal].Value, HasOrder: route.linkOrders[ordinal].Present,
+				RecoveryDiscontinuity: link.payload == 0,
 			})
 		}
 	}
@@ -568,7 +652,7 @@ func phase0AValidateCurrentRouteLink(core *Core, observer *phase0AObserver, row 
 		}
 		matches++
 		link := candidate.record
-		if link.prev != row.Predecessor || link.payload != row.Payload || link.scoreDelta != row.ScoreDelta || link.hasOrder() != row.HasOrder || (row.HasOrder && link.order != row.Order) {
+		if link.prev != row.Predecessor || link.payload != row.Payload || link.scoreDelta != row.ScoreDelta || link.hasOrder() != row.HasOrder || (row.HasOrder && link.order != row.Order) || link.isRecoveryDiscontinuity() != row.RecoveryDiscontinuity {
 			return &Phase0AError{Kind: Phase0AErrorStaleReference, Namespace: observer.run, Detail: "source trailing physical link changed identity"}
 		}
 	}
@@ -833,6 +917,9 @@ func phase0AEnumeratePhysicalDerivations(core *Core, head Head) ([]phase0APhysic
 		}
 		var out []phase0APhysicalDerivation
 		for _, physical := range links {
+			if err := physical.record.validateShape(); err != nil {
+				return nil, err
+			}
 			if physical.record.prev == 0 || physical.record.prev >= id {
 				return nil, errors.New("parser-core phase zero A: accepted physical predecessor does not decrease")
 			}
@@ -852,7 +939,9 @@ func phase0AEnumeratePhysicalDerivations(core *Core, head Head) ([]phase0APhysic
 				path.links = append(path.links, prefix.links...)
 				path.links = append(path.links, physical.id)
 				path.payloads = append(path.payloads, prefix.payloads...)
-				path.payloads = append(path.payloads, physical.record.payload)
+				if physical.record.payload != 0 {
+					path.payloads = append(path.payloads, physical.record.payload)
+				}
 				if physical.record.hasOrder() {
 					path.branchOrder, path.hasBranchOrder = physical.record.order, true
 				}
@@ -1159,14 +1248,24 @@ func (core *Core) ObservePhase0AAcceptedSelection(capability Phase0AAcceptedSele
 	}()
 	selectedIndex := phase0ABuildSelectedIndex(observer)
 	resolved := make([]Phase0AAcceptedLinkRecord, len(got.links))
+	payloadIndex := 0
+	selectedLower := LinkID(0)
 	for index, link := range got.links {
+		if core.links[link-1].isRecoveryDiscontinuity() {
+			resolved[index] = Phase0AAcceptedLinkRecord{
+				Ordinal: uint32(index), Link: link, RecoveryDiscontinuity: true,
+				ResolvedLowerLink: selectedLower,
+			}
+			continue
+		}
+		if payloadIndex >= len(got.payloads) {
+			return phase0AStickyLocked(observer, &Phase0AError{Kind: Phase0AErrorCrossBoundary, Namespace: observer.run, Detail: "accepted physical payload census is incomplete"})
+		}
+		payload := got.payloads[payloadIndex]
+		payloadIndex++
 		bound, err := phase0ASelectedLookupError(observer, selectedIndex.bindings[link], "accepted root binding is unavailable or non-unique")
 		if err != nil {
 			return phase0AStickyLocked(observer, err.(*Phase0AError))
-		}
-		selectedLower := LinkID(0)
-		if index > 0 {
-			selectedLower = got.links[index-1]
 		}
 		direct, resolvedLower, err := phase0AResolveSelectedExpressionLocked(core, observer, selectedIndex, bound, selectedLower)
 		if err != nil {
@@ -1179,9 +1278,10 @@ func (core *Core) ObservePhase0AAcceptedSelection(capability Phase0AAcceptedSele
 			return phase0AStickyLocked(observer, err.(*Phase0AError))
 		}
 		resolved[index] = Phase0AAcceptedLinkRecord{
-			Ordinal: uint32(index), Link: link, Payload: got.payloads[index], BoundExpression: bound,
+			Ordinal: uint32(index), Link: link, Payload: payload, BoundExpression: bound,
 			ResolvedExpression: direct.ID, ResolvedLowerLink: resolvedLower, Occurrence: direct.Occurrence, Edge: direct.Edge,
 		}
+		selectedLower = link
 	}
 	generation := observer.route.nextSelection + 1
 	selectedTree, selectedOccurrences, err := phase0ABuildSelectedOccurrenceSnapshotLocked(core, observer, selectedIndex, generation, resolved)

--- a/internal/parsercorephase0/phase0a_selected_occurrences.go
+++ b/internal/parsercorephase0/phase0a_selected_occurrences.go
@@ -857,7 +857,12 @@ func phase0ABuildSelectedOccurrenceSnapshotLocked(core *Core, observer *phase0AO
 	active := make(map[phase0AOccurrenceJoin]struct{})
 	seen := make(map[phase0AOccurrenceJoin]struct{})
 	var snapshot Phase0ASelectedOccurrenceSnapshot
-	snapshot.Namespace, snapshot.Generation, snapshot.RootCount = observer.run, generation, uint32(len(accepted))
+	snapshot.Namespace, snapshot.Generation = observer.run, generation
+	for _, root := range accepted {
+		if !root.RecoveryDiscontinuity && root.Payload != 0 {
+			snapshot.RootCount++
+		}
+	}
 	var visit func(ConstructionOccurrenceKey, IncomingEdgeKey, SubtreeID, LinkID, LinkID, uint64, uint32, uint32) error
 	visit = func(occurrence ConstructionOccurrenceKey, edge IncomingEdgeKey, payload SubtreeID, sourceLink, selectedLower LinkID, parent uint64, childOrdinal, depth uint32) error {
 		if uint64(depth) > depthLimit {
@@ -953,6 +958,7 @@ func phase0ABuildSelectedOccurrenceSnapshotLocked(core *Core, observer *phase0AO
 			}
 			lower := selectedLower
 			var previousNode NodeID
+			selectedChildren := uint32(0)
 			for index := uint32(0); index < route.LinkCount; index++ {
 				row, err := phase0AExactRouteLinkLocked(observer, route, index)
 				if err != nil {
@@ -975,6 +981,9 @@ func phase0ABuildSelectedOccurrenceSnapshotLocked(core *Core, observer *phase0AO
 					}
 					continue
 				}
+				if row.RecoveryDiscontinuity {
+					continue
+				}
 				if row.Segment != Phase0APopRouteRetained || row.SegmentOrdinal != index {
 					return &Phase0AError{Kind: Phase0AErrorCrossBoundary, Namespace: observer.run, Detail: "selected retained route segment identity drifted"}
 				}
@@ -988,12 +997,13 @@ func phase0ABuildSelectedOccurrenceSnapshotLocked(core *Core, observer *phase0AO
 				if err := visit(direct.Occurrence, direct.Edge, row.Payload, row.Link, resolvedLower, ordinal, index, depth+1); err != nil {
 					return err
 				}
+				selectedChildren++
 				lower = row.Link
 			}
 			if previousNode != route.Head {
 				return &Phase0AError{Kind: Phase0AErrorCrossBoundary, Namespace: observer.run, Detail: "selected reduction route ends at another head"}
 			}
-			records[ordinal-1].ChildCount = route.RetainedLinkCount
+			records[ordinal-1].ChildCount = selectedChildren
 			return nil
 		default:
 			return &Phase0AError{Kind: Phase0AErrorStaleReference, Namespace: observer.run, Detail: "selected occurrence has unknown construction kind"}
@@ -1001,9 +1011,15 @@ func phase0ABuildSelectedOccurrenceSnapshotLocked(core *Core, observer *phase0AO
 	}
 
 	for index, root := range accepted {
+		if root.RecoveryDiscontinuity || root.Payload == 0 {
+			continue
+		}
 		lower := LinkID(0)
-		if index > 0 {
-			lower = accepted[index-1].Link
+		for prior := index - 1; prior >= 0; prior-- {
+			if !accepted[prior].RecoveryDiscontinuity && accepted[prior].Payload != 0 {
+				lower = accepted[prior].Link
+				break
+			}
 		}
 		if root.ResolvedLowerLink != lower && root.BoundExpression == root.ResolvedExpression {
 			return Phase0ASelectedOccurrenceSnapshot{}, nil, &Phase0AError{Kind: Phase0AErrorStaleReference, Namespace: observer.run, Detail: "direct accepted link changed resolved lower identity"}

--- a/internal/parsercorephase0/physical_head_merge_stage2_test.go
+++ b/internal/parsercorephase0/physical_head_merge_stage2_test.go
@@ -384,6 +384,8 @@ func TestStage2PhysicalHeadMergeRollsBackCapacityFailure(t *testing.T) {
 
 func TestStage2PhysicalHeadMergeRejectsRecoveryCost(t *testing.T) {
 	compact, left, right, _, _ := newStage2PhysicalHeadPair(t)
+	compact.nodeLineages[left.Node-1].storedErrorCost = 610
+	compact.nodeLineages[right.Node-1].storedErrorCost = 610
 	beforeNodes, beforeLinks := len(compact.nodes), len(compact.links)
 	beforeBoundaries := compact.BoundaryIndexStats()
 	beforeWork := compact.Work()
@@ -398,6 +400,64 @@ func TestStage2PhysicalHeadMergeRejectsRecoveryCost(t *testing.T) {
 	if len(compact.nodes) != beforeNodes || len(compact.links) != beforeLinks ||
 		compact.BoundaryIndexStats() != beforeBoundaries || compact.Work() != beforeWork {
 		t.Fatal("recovery-cost rejection changed compact state")
+	}
+}
+
+func TestRecursiveMergeUsesTargetCostForMixedLinkSplits(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxNodes: 32, MaxLinks: 32, MaxSubtrees: 16})
+	leftBase, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightBase, err := compact.appendNode(nodeRecord{state: 1, byteOffset: 0, pathCount: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact.nodeLineages[rightBase-1].storedErrorCost = 5
+	payload, err := compact.appendSubtree(subtreeRecord{symbol: 9, endByte: 1, terminal: true}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftLink := compact.appendGraphLink(linkRecord{prev: leftBase.Node, payload: payload})
+	leftNode, err := compact.appendNode(nodeRecord{
+		state: 3, byteOffset: 1, firstLink: uint32(leftLink), linkCount: 1, pathCount: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightLink := compact.appendGraphLink(linkRecord{prev: rightBase, payload: payload})
+	rightNode, err := compact.appendNode(nodeRecord{
+		state: 3, byteOffset: 1, firstLink: uint32(rightLink), linkCount: 1, pathCount: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The two top heads have the same cumulative cost. Their lower
+	// predecessors have different cost splits, so recursive insertion must
+	// retain both links and publish the authenticated target cost.
+	compact.nodeLineages[leftNode-1].storedErrorCost = 10
+	compact.nodeLineages[rightNode-1].storedErrorCost = 10
+	folded := precedenceMaximumWitness{}
+	merged, changed, err := compact.mergePredecessorsBounded(leftNode, rightNode, 0, &folded)
+	if err != nil {
+		t.Fatalf("mergePredecessorsBounded: %v", err)
+	}
+	if !changed {
+		t.Fatal("mixed link split did not publish a merged predecessor")
+	}
+	cost, err := compact.RecoveryStoredErrorCost(Head{Node: merged})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cost != 10 {
+		t.Fatalf("merged target cost=%d, want authenticated cost 10", cost)
+	}
+	mergedNode, err := compact.node(merged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mergedNode.linkCount != 2 {
+		t.Fatalf("merged link count=%d, want both mixed-split links", mergedNode.linkCount)
 	}
 }
 

--- a/internal/parsercorephase0/physical_head_merge_stage2_test.go
+++ b/internal/parsercorephase0/physical_head_merge_stage2_test.go
@@ -103,73 +103,82 @@ func TestStage2PhysicalHeadMergeUnionsEquivalentDistinctNodes(t *testing.T) {
 	}
 }
 
-func TestStage2PhysicalHeadMergeAtSixVersionBoundaryRetainsEveryPath(t *testing.T) {
-	compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 16, MaxPopPaths: 16})
-	headCount := 6
-	candidates := make([]CondenseCandidate, 0, headCount)
-	wantPayloads := make(map[SubtreeID]bool, headCount)
-	for index := 0; index < headCount; index++ {
-		root, err := compact.Seed(StateID(index+1), 0)
-		if err != nil {
-			t.Fatal(err)
-		}
-		payload, err := compact.appendSubtree(subtreeRecord{
-			symbol: Symbol(index + 10), startByte: 0, endByte: 1, terminal: true,
-		}, nil, nil, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		link := compact.appendGraphLink(linkRecord{prev: root.Node, payload: payload})
-		node, err := compact.appendNode(nodeRecord{
-			state: 7, byteOffset: 1, firstLink: uint32(link), linkCount: 1, pathCount: 1,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		head := Head{Node: node}
-		candidates = append(candidates, CondenseCandidate{Head: head})
-		wantPayloads[payload] = true
-	}
+func TestStage2PhysicalHeadMergeAtAndPastSixVersionBoundaryRetainsEveryPath(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		headCount int
+	}{
+		{name: "at_boundary", headCount: 6},
+		{name: "past_boundary", headCount: 7},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 16, MaxPopPaths: 16})
+			candidates := make([]CondenseCandidate, 0, test.headCount)
+			wantPayloads := make(map[SubtreeID]bool, test.headCount)
+			for index := 0; index < test.headCount; index++ {
+				root, err := compact.Seed(StateID(index+1), 0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				payload, err := compact.appendSubtree(subtreeRecord{
+					symbol: Symbol(index + 10), startByte: 0, endByte: 1, terminal: true,
+				}, nil, nil, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				link := compact.appendGraphLink(linkRecord{prev: root.Node, payload: payload})
+				node, err := compact.appendNode(nodeRecord{
+					state: 7, byteOffset: 1, firstLink: uint32(link), linkCount: 1, pathCount: 1,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				head := Head{Node: node}
+				candidates = append(candidates, CondenseCandidate{Head: head})
+				wantPayloads[payload] = true
+			}
 
-	before := compact.Work()
-	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
-		return compact.ReindexCondenseCandidatesOwned(owner, candidates)
-	})
-	if err != nil {
-		t.Fatalf("ReindexCondenseCandidatesOwned: %v", err)
-	}
-	canonical, ok := compact.CanonicalBoundary(7, 1, false, 0)
-	if !ok {
-		t.Fatal("six-version condense did not publish a canonical boundary")
-	}
-	stats, err := compact.Stats(canonical)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if stats.CurrentExactPaths != uint64(headCount) {
-		t.Fatalf("six-version physical head paths=%d, want %d", stats.CurrentExactPaths, headCount)
-	}
-	derivations, err := compact.Derivations(canonical)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(derivations) != headCount {
-		t.Fatalf("six-version derivations=%d, want %d", len(derivations), headCount)
-	}
-	for _, derivation := range derivations {
-		if len(derivation.Payloads) != 1 || !wantPayloads[derivation.Payloads[0]] {
-			t.Fatalf("six-version derivation=%+v lost a path", derivation)
-		}
-		delete(wantPayloads, derivation.Payloads[0])
-	}
-	if len(wantPayloads) != 0 {
-		t.Fatalf("six-version merge lost payloads=%v", wantPayloads)
-	}
-	after := compact.Work()
-	if after.PhysicalHeadMergeAttempts-before.PhysicalHeadMergeAttempts != uint64(headCount-1) ||
-		after.PhysicalHeadMergeSuccesses-before.PhysicalHeadMergeSuccesses != uint64(headCount-1) ||
-		after.PhysicalHeadMergeInputLinks-before.PhysicalHeadMergeInputLinks != uint64(headCount-1) {
-		t.Fatalf("six-version merge telemetry=%+v before=%+v", after, before)
+			before := compact.Work()
+			err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				return compact.ReindexCondenseCandidatesOwned(owner, candidates)
+			})
+			if err != nil {
+				t.Fatalf("ReindexCondenseCandidatesOwned: %v", err)
+			}
+			canonical, ok := compact.CanonicalBoundary(7, 1, false, 0)
+			if !ok {
+				t.Fatal("condense did not publish a canonical boundary")
+			}
+			stats, err := compact.Stats(canonical)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stats.CurrentExactPaths != uint64(test.headCount) {
+				t.Fatalf("physical head paths=%d, want %d", stats.CurrentExactPaths, test.headCount)
+			}
+			derivations, err := compact.Derivations(canonical)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(derivations) != test.headCount {
+				t.Fatalf("derivations=%d, want %d", len(derivations), test.headCount)
+			}
+			for _, derivation := range derivations {
+				if len(derivation.Payloads) != 1 || !wantPayloads[derivation.Payloads[0]] {
+					t.Fatalf("derivation=%+v lost a path", derivation)
+				}
+				delete(wantPayloads, derivation.Payloads[0])
+			}
+			if len(wantPayloads) != 0 {
+				t.Fatalf("merge lost payloads=%v", wantPayloads)
+			}
+			after := compact.Work()
+			if after.PhysicalHeadMergeAttempts-before.PhysicalHeadMergeAttempts != uint64(test.headCount-1) ||
+				after.PhysicalHeadMergeSuccesses-before.PhysicalHeadMergeSuccesses != uint64(test.headCount-1) ||
+				after.PhysicalHeadMergeInputLinks-before.PhysicalHeadMergeInputLinks != uint64(test.headCount-1) {
+				t.Fatalf("merge telemetry=%+v before=%+v", after, before)
+			}
+		})
 	}
 }
 

--- a/internal/parsercorephase0/recovery_cost.go
+++ b/internal/parsercorephase0/recovery_cost.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 )
 
 // ---------------------------------------------------------------------------
@@ -486,4 +487,261 @@ func RecoveryCompareVersions(a, b RecoveryErrorStatus) RecoveryComparison {
 		return RecoveryComparisonPreferRight
 	}
 	return RecoveryComparisonNone
+}
+
+// RecoveryGraphAggregate summarizes every physical path below one compact
+// graph head. It keeps the stored precedence certificate separate from the
+// path pricing values so recovery selection can apply both rules exactly.
+type RecoveryGraphAggregate struct {
+	MaximumVisibleCount     uint32
+	MinimumErrorCost        uint32
+	MaximumErrorCost        uint32
+	StoredPrecedenceMaximum int64
+	PathCount               uint64
+}
+
+// RecoveryGraphAggregateLimitError reports a graph aggregate that exceeds a
+// Core traversal limit. The aggregate never calls Derivations before it stops.
+var RecoveryGraphAggregateLimitError = errors.New("parser-core phase zero: recovery graph aggregate limit")
+
+type recoveryGraphAggregateNode struct {
+	maximumVisible uint32
+	minimumCost    uint32
+	maximumCost    uint32
+	pathCount      uint64
+	supported      bool
+	valid          bool
+}
+
+// RecoveryCostNode exposes one immutable compact subtree through the recovery
+// pricing interface. Core stores no row spans, so it rejects published ERROR
+// records and exposes only row-free clean and missing records.
+func (c *Core) RecoveryCostNode(id SubtreeID) (RecoveryCostNode, error) {
+	record, err := c.subtree(id)
+	if err != nil {
+		return RecoveryCostNode{}, err
+	}
+	if record.symbol == RecoveryErrorSymbol {
+		return RecoveryCostNode{}, errors.New("parser-core phase zero: compact ERROR subtree has no authenticated row spans")
+	}
+	childStart, childEnd := uint64(record.firstChild), uint64(record.firstChild)+uint64(record.childCount)
+	if childEnd > uint64(len(c.children)) {
+		return RecoveryCostNode{}, errors.New("parser-core phase zero: recovery cost child range is outside the arena")
+	}
+	aliasStart, aliasEnd := uint64(record.firstAlias), uint64(record.firstAlias)+uint64(record.aliasCount)
+	if aliasEnd > uint64(len(c.aliases)) {
+		return RecoveryCostNode{}, errors.New("parser-core phase zero: recovery cost alias range is outside the arena")
+	}
+	return RecoveryCostNode{
+		Symbol:    record.symbol,
+		Extra:     record.extra,
+		Missing:   record.missing,
+		StartByte: record.startByte,
+		EndByte:   record.endByte,
+		Children:  c.children[childStart:childEnd],
+		Aliases:   c.aliases[aliasStart:aliasEnd],
+	}, nil
+}
+
+func checkedRecoveryAggregateAdd(left, right uint32) (uint32, error) {
+	if math.MaxUint32-left < right {
+		return 0, errors.New("parser-core phase zero: recovery graph aggregate arithmetic overflow")
+	}
+	return left + right, nil
+}
+
+// RecoveryGraphAggregateForHead computes bounded pricing facts with dynamic
+// programming over decreasing NodeIDs. A false supported result means paths
+// have unequal error costs and the caller must decline aggregate pricing.
+func (c *Core) RecoveryGraphAggregateForHead(
+	head Head,
+	symbols []SelectedSymbolPolicy,
+	source RecoveryCostSource,
+) (result RecoveryGraphAggregate, supported bool, err error) {
+	if c == nil {
+		return result, false, errors.New("parser-core phase zero: recovery graph aggregate on nil core")
+	}
+	if source == nil {
+		return result, false, errors.New("parser-core phase zero: recovery graph aggregate requires an exact cost source")
+	}
+	if head.Node == 0 || uint64(head.Node) > uint64(len(c.nodes)) {
+		return result, false, errors.New("parser-core phase zero: recovery graph aggregate head is unavailable")
+	}
+	// NodeIDs are dense and every graph edge points to a lower ID. First mark
+	// the reachable nodes, then run the increasing-ID dynamic program only on
+	// that induced graph. Unrelated historical nodes cannot consume this call's
+	// traversal limits or cause unrelated malformed records to reject it.
+	reachable := make(map[NodeID]struct{})
+	reachableIDs := make([]NodeID, 0, 16)
+	stack := []NodeID{head.Node}
+	defer func() {
+		clear(reachable)
+		clear(reachableIDs)
+		clear(stack)
+	}()
+	var reachableNodes uint64
+	var reachableLinks uint64
+	for len(stack) != 0 {
+		last := len(stack) - 1
+		id := stack[last]
+		stack = stack[:last]
+		if id == 0 || id > head.Node {
+			return result, false, errors.New("parser-core phase zero: recovery graph aggregate predecessor is invalid")
+		}
+		if _, ok := reachable[id]; ok {
+			continue
+		}
+		reachable[id] = struct{}{}
+		reachableIDs = append(reachableIDs, id)
+		reachableNodes++
+		if reachableNodes > uint64(c.limits.MaxNodes) {
+			return result, false, fmt.Errorf("%w: reachable node graph", RecoveryGraphAggregateLimitError)
+		}
+		node := c.nodes[id-1]
+		if node.linkCount == 0 {
+			if node.firstLink != 0 {
+				return result, false, errors.New("parser-core phase zero: recovery graph aggregate empty node has a link")
+			}
+			continue
+		}
+		if uint64(node.linkCount) > uint64(c.limits.MaxLinksPerBoundary) || uint64(node.linkCount) > uint64(c.limits.MaxLinks) {
+			return result, false, fmt.Errorf("%w: boundary links", RecoveryGraphAggregateLimitError)
+		}
+		var inline [inlineAdjacencyCapacity]linkRecord
+		links, linkErr := c.publishedNodeLinksInto(inline[:0], node)
+		if linkErr != nil {
+			return result, false, linkErr
+		}
+		reachableLinks += uint64(len(links))
+		if reachableLinks > uint64(c.limits.MaxLinks) {
+			return result, false, fmt.Errorf("%w: reachable link graph", RecoveryGraphAggregateLimitError)
+		}
+		for _, link := range links {
+			if err := link.validateShape(); err != nil {
+				return result, false, err
+			}
+			if link.prev == 0 || link.prev >= id {
+				return result, false, errors.New("parser-core phase zero: recovery graph aggregate predecessor is invalid")
+			}
+			stack = append(stack, link.prev)
+		}
+	}
+
+	// NodeIDs decrease along every edge. Sort only the reachable IDs, then use
+	// a map for the dynamic-programming values so numeric arena gaps stay free.
+	slices.Sort(reachableIDs)
+	dp := make(map[NodeID]recoveryGraphAggregateNode, len(reachableIDs))
+	defer func() { clear(dp) }()
+	memo := &RecoveryCostMemo{}
+	defer memo.Reset()
+	supported = true
+	for _, rawID := range reachableIDs {
+		node := c.nodes[rawID-1]
+		current := recoveryGraphAggregateNode{supported: true}
+		if node.linkCount == 0 {
+			if node.firstLink != 0 || node.pathCount != 1 {
+				return result, false, errors.New("parser-core phase zero: recovery graph aggregate malformed seed")
+			}
+			current.minimumCost = 0
+			current.maximumCost = 0
+			current.pathCount = 1
+			current.valid = true
+			dp[rawID] = current
+			continue
+		}
+		var inline [inlineAdjacencyCapacity]linkRecord
+		links, linkErr := c.publishedNodeLinksInto(inline[:0], node)
+		if linkErr != nil {
+			return result, false, linkErr
+		}
+		if uint64(len(links)) > uint64(c.limits.MaxLinksPerBoundary) || uint64(len(links)) > uint64(c.limits.MaxLinks) {
+			return result, false, fmt.Errorf("%w: boundary links", RecoveryGraphAggregateLimitError)
+		}
+		for _, link := range links {
+			if err := link.validateShape(); err != nil {
+				return result, false, err
+			}
+			prefix, prefixOK := dp[link.prev]
+			if link.prev == 0 || link.prev >= rawID || !prefixOK || !prefix.valid {
+				return result, false, errors.New("parser-core phase zero: recovery graph aggregate predecessor is invalid")
+			}
+			candidateVisible := prefix.maximumVisible
+			candidateMinCost := prefix.minimumCost
+			candidateMaxCost := prefix.maximumCost
+			candidateSupported := prefix.supported
+			if !link.isRecoveryDiscontinuity() {
+				visible, visibleErr := RecoveryNodeVisibleSubtreeCount(symbols, source, link.payload)
+				if visibleErr != nil {
+					return result, false, visibleErr
+				}
+				cost, costErr := RecoveryNodeErrorCostMemo(symbols, source, memo, link.payload)
+				if costErr != nil {
+					return result, false, costErr
+				}
+				candidateVisible, err = checkedRecoveryAggregateAdd(prefix.maximumVisible, visible)
+				if err != nil {
+					return result, false, err
+				}
+				candidateMinCost, err = checkedRecoveryAggregateAdd(prefix.minimumCost, cost)
+				if err != nil {
+					return result, false, err
+				}
+				candidateMaxCost, err = checkedRecoveryAggregateAdd(prefix.maximumCost, cost)
+				if err != nil {
+					return result, false, err
+				}
+			}
+			if !current.valid || candidateVisible > current.maximumVisible {
+				current.maximumVisible = candidateVisible
+			}
+			if !current.valid || current.pathCount == 0 {
+				current.minimumCost = candidateMinCost
+				current.maximumCost = candidateMaxCost
+			} else {
+				if candidateMinCost < current.minimumCost {
+					current.minimumCost = candidateMinCost
+				}
+				if candidateMaxCost > current.maximumCost {
+					current.maximumCost = candidateMaxCost
+				}
+			}
+			current.pathCount = saturatingAddPaths(current.pathCount, prefix.pathCount)
+			if current.pathCount > uint64(c.limits.MaxDerivations) {
+				return result, false, fmt.Errorf("%w: derivation paths", RecoveryGraphAggregateLimitError)
+			}
+			current.supported = current.supported && candidateSupported
+			current.valid = true
+		}
+		if current.pathCount == 0 {
+			return result, false, errors.New("parser-core phase zero: recovery graph aggregate has no paths")
+		}
+		if node.pathCount != math.MaxUint64 && node.pathCount != current.pathCount {
+			return result, false, fmt.Errorf("parser-core phase zero: recovery graph aggregate path-count mismatch: computed %d, recorded %d", current.pathCount, node.pathCount)
+		}
+		current.supported = current.supported && current.minimumCost == current.maximumCost
+		dp[rawID] = current
+	}
+
+	aggregate, aggregateOK := dp[head.Node]
+	if !aggregateOK || !aggregate.valid {
+		return result, false, errors.New("parser-core phase zero: recovery graph aggregate head is unreachable")
+	}
+	result = RecoveryGraphAggregate{
+		MaximumVisibleCount:     aggregate.maximumVisible,
+		MinimumErrorCost:        aggregate.minimumCost,
+		MaximumErrorCost:        aggregate.maximumCost,
+		StoredPrecedenceMaximum: c.nodes[head.Node-1].precedenceMax,
+		PathCount:               aggregate.pathCount,
+	}
+	return result, aggregate.supported, nil
+}
+
+// RecoveryGraphAggregate keeps a concise receiver-first spelling for callers
+// that already use the exported aggregate name as their operation.
+func (c *Core) RecoveryGraphAggregate(
+	symbols []SelectedSymbolPolicy,
+	source RecoveryCostSource,
+	head Head,
+) (RecoveryGraphAggregate, bool, error) {
+	return c.RecoveryGraphAggregateForHead(head, symbols, source)
 }

--- a/internal/parsercorephase0/recovery_discontinuity.go
+++ b/internal/parsercorephase0/recovery_discontinuity.go
@@ -55,11 +55,15 @@ func (c *Core) appendRecoveryDiscontinuityUncheckpointed(
 	if err != nil {
 		return Head{}, err
 	}
+	previousLineage, err := c.nodeLineage(predecessor.Node)
+	if err != nil {
+		return Head{}, err
+	}
 	link := linkRecord{prev: predecessor.Node, flags: linkFlagRecoveryDiscontinuity}
 	maximum := precedenceMaximumWitness{seed: previous.precedenceMax, hasSeed: true}
-	node, err := c.appendAdjacencyNodeAtWithPrecedence(
+	node, err := c.appendAdjacencyNodeAtWithPrecedenceAndStoredErrorCost(
 		context.ErrorState, context.ByteOffset, context.Checkpoint,
-		[]linkRecord{link}, maximum,
+		[]linkRecord{link}, maximum, previousLineage.storedErrorCost, true,
 	)
 	if err != nil {
 		return Head{}, err
@@ -197,9 +201,9 @@ func (c *Core) mergeRecoveryDiscontinuityHeadsUncheckpointed(
 		c.addWork(&c.work.PhysicalHeadMergeSuccesses, 1)
 		return incumbent, nil
 	}
-	merged, err := c.appendAdjacencyNodeAtWithPrecedence(
+	merged, err := c.appendAdjacencyNodeAtWithPrecedenceAndStoredErrorCost(
 		context.ErrorState, context.ByteOffset, context.Checkpoint,
-		links, folded,
+		links, folded, leftLineage.storedErrorCost, true,
 	)
 	if err != nil {
 		return Head{}, err

--- a/internal/parsercorephase0/recovery_discontinuity.go
+++ b/internal/parsercorephase0/recovery_discontinuity.go
@@ -1,0 +1,207 @@
+package parsercorephase0
+
+import (
+	"errors"
+)
+
+// RecoveryDiscontinuityContext authenticates the zero-width ERROR_STATE
+// boundary at which a recovery discontinuity is published. The scheduler
+// supplies the grammar state, byte position, and scanner checkpoint together.
+type RecoveryDiscontinuityContext struct {
+	ErrorState StateID
+	ByteOffset uint32
+	Checkpoint CheckpointID
+}
+
+func (c *Core) validateRecoveryDiscontinuityContext(
+	predecessor Head,
+	context RecoveryDiscontinuityContext,
+) (*nodeRecord, error) {
+	if c == nil {
+		return nil, errors.New("parser-core phase zero: recovery discontinuity on nil core")
+	}
+	if context.ErrorState != 0 {
+		return nil, errors.New("parser-core phase zero: recovery discontinuity requires ERROR_STATE")
+	}
+	previous, err := c.node(predecessor.Node)
+	if err != nil {
+		return nil, err
+	}
+	if previous.byteOffset != context.ByteOffset {
+		return nil, errors.New("parser-core phase zero: recovery discontinuity is not zero-width")
+	}
+	previousCheckpoint, exact := c.nodeScannerCheckpoint(predecessor.Node)
+	if !exact || previousCheckpoint != context.Checkpoint {
+		return nil, errors.New("parser-core phase zero: recovery discontinuity scanner checkpoint is not exact")
+	}
+	return previous, nil
+}
+
+func (c *Core) appendRecoveryDiscontinuityUncheckpointed(
+	predecessor Head,
+	context RecoveryDiscontinuityContext,
+) (Head, error) {
+	previous, err := c.validateRecoveryDiscontinuityContext(predecessor, context)
+	if err != nil {
+		return Head{}, err
+	}
+	link := linkRecord{prev: predecessor.Node, flags: linkFlagRecoveryDiscontinuity}
+	maximum := precedenceMaximumWitness{seed: previous.precedenceMax, hasSeed: true}
+	node, err := c.appendAdjacencyNodeAtWithPrecedence(
+		context.ErrorState, context.ByteOffset, context.Checkpoint,
+		[]linkRecord{link}, maximum,
+	)
+	if err != nil {
+		return Head{}, err
+	}
+	if err := c.copyRecoveryDiscontinuityLineage(predecessor.Node, node); err != nil {
+		return Head{}, err
+	}
+	return Head{Node: node}, nil
+}
+
+// copyRecoveryDiscontinuityLineage carries predecessor history onto the new
+// marker without electing a scheduler owner. The copy aliases only immutable
+// reference-set spill segments; later unions append to a separate segment.
+func (c *Core) copyRecoveryDiscontinuityLineage(source, target NodeID) error {
+	from, err := c.nodeLineage(source)
+	if err != nil {
+		return err
+	}
+	to, err := c.nodeLineage(target)
+	if err != nil {
+		return err
+	}
+	*to = *from
+	to.owner = 0
+	return nil
+}
+
+// AppendRecoveryDiscontinuityOwned publishes one scheduler-authenticated
+// zero-width recovery edge. Ordinary shift and reduction inputs cannot create
+// this edge because they expose no nullable payload form.
+func (c *Core) AppendRecoveryDiscontinuityOwned(
+	owner SchedulerTransactionToken,
+	predecessor Head,
+	context RecoveryDiscontinuityContext,
+) (out Head, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return out, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	out, err = c.appendRecoveryDiscontinuityUncheckpointed(predecessor, context)
+	return out, c.finishSchedulerOwned(owner, err)
+}
+
+func (c *Core) recoveryDiscontinuityHeadLinks(head Head) (nodeRecord, []linkRecord, error) {
+	node, err := c.node(head.Node)
+	if err != nil {
+		return nodeRecord{}, nil, err
+	}
+	if node.linkCount == 0 || node.firstLink == 0 || uint64(node.firstLink) > uint64(len(c.links)) {
+		return nodeRecord{}, nil, errors.New("parser-core phase zero: recovery discontinuity head has no edges")
+	}
+	var inline [inlineAdjacencyCapacity]linkRecord
+	links, err := c.publishedNodeLinksInto(inline[:0], *node)
+	if err != nil {
+		return nodeRecord{}, nil, err
+	}
+	for _, link := range links {
+		if err := link.validateShape(); err != nil {
+			return nodeRecord{}, nil, err
+		}
+		if !link.isRecoveryDiscontinuity() {
+			return nodeRecord{}, nil, errors.New("parser-core phase zero: recovery discontinuity head has a payload edge")
+		}
+		if link.prev == 0 || link.prev >= head.Node {
+			return nodeRecord{}, nil, errors.New("parser-core phase zero: recovery discontinuity predecessor does not decrease")
+		}
+	}
+	return *node, links, nil
+}
+
+func (c *Core) mergeRecoveryDiscontinuityHeadsUncheckpointed(
+	context RecoveryDiscontinuityContext,
+	incumbent Head,
+	incoming Head,
+) (Head, error) {
+	if context.ErrorState != 0 {
+		return Head{}, errors.New("parser-core phase zero: recovery discontinuity requires ERROR_STATE")
+	}
+	if incumbent == incoming {
+		return incumbent, nil
+	}
+	left, leftLinks, err := c.recoveryDiscontinuityHeadLinks(incumbent)
+	if err != nil {
+		return Head{}, err
+	}
+	right, rightLinks, err := c.recoveryDiscontinuityHeadLinks(incoming)
+	if err != nil {
+		return Head{}, err
+	}
+	if left.state != context.ErrorState || right.state != context.ErrorState ||
+		left.byteOffset != context.ByteOffset || right.byteOffset != context.ByteOffset {
+		return Head{}, errors.New("parser-core phase zero: recovery discontinuity heads are outside ERROR_STATE context")
+	}
+	leftCheckpoint, leftExact := c.nodeScannerCheckpoint(incumbent.Node)
+	rightCheckpoint, rightExact := c.nodeScannerCheckpoint(incoming.Node)
+	if !leftExact || !rightExact || leftCheckpoint != context.Checkpoint || rightCheckpoint != context.Checkpoint {
+		return Head{}, errors.New("parser-core phase zero: recovery discontinuity heads have different scanner checkpoints")
+	}
+	c.addWork(&c.work.PhysicalHeadMergeAttempts, 1)
+	c.addWork(&c.work.PhysicalHeadMergeInputLinks, uint64(len(rightLinks)))
+	links := append([]linkRecord(nil), leftLinks...)
+	leftMaximum, err := c.nodePrecedenceMaximum(incumbent.Node)
+	if err != nil {
+		return Head{}, err
+	}
+	folded := precedenceMaximumWitness{seed: leftMaximum.value, hasSeed: true}
+	changed := false
+	for _, link := range rightLinks {
+		var inserted bool
+		links, inserted, err = c.insertLinkBounded(context.ErrorState, context.ByteOffset, links, link, 0, &folded)
+		if err != nil {
+			return Head{}, err
+		}
+		changed = changed || inserted
+	}
+	maximum, err := c.computePrecedenceMaximum(links, folded)
+	if err != nil {
+		return Head{}, err
+	}
+	if !changed && maximum.value <= leftMaximum.value {
+		if err := c.mergeNodeLineageMetadata(incumbent.Node, incoming.Node, incumbent.Node); err != nil {
+			return Head{}, err
+		}
+		c.addWork(&c.work.PhysicalHeadMergeSuccesses, 1)
+		return incumbent, nil
+	}
+	merged, err := c.appendAdjacencyNodeAtWithPrecedence(
+		context.ErrorState, context.ByteOffset, context.Checkpoint,
+		links, folded,
+	)
+	if err != nil {
+		return Head{}, err
+	}
+	if err := c.mergeNodeLineageMetadata(incumbent.Node, incoming.Node, merged); err != nil {
+		return Head{}, err
+	}
+	c.addWork(&c.work.PhysicalHeadMergeSuccesses, 1)
+	return Head{Node: merged}, nil
+}
+
+// MergeRecoveryDiscontinuityHeadsOwned merges two scheduler-authenticated
+// marker heads after recursively merging their older predecessor graphs.
+func (c *Core) MergeRecoveryDiscontinuityHeadsOwned(
+	owner SchedulerTransactionToken,
+	context RecoveryDiscontinuityContext,
+	incumbent Head,
+	incoming Head,
+) (out Head, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return out, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	out, err = c.mergeRecoveryDiscontinuityHeadsUncheckpointed(context, incumbent, incoming)
+	return out, c.finishSchedulerOwned(owner, err)
+}

--- a/internal/parsercorephase0/recovery_discontinuity.go
+++ b/internal/parsercorephase0/recovery_discontinuity.go
@@ -13,6 +13,16 @@ type RecoveryDiscontinuityContext struct {
 	Checkpoint CheckpointID
 }
 
+// RecoveryStoredErrorCost returns the authenticated C stack-node error cost
+// stored on one graph head. It supports scheduler pricing and merge audits.
+func (c *Core) RecoveryStoredErrorCost(head Head) (uint32, error) {
+	lineage, err := c.nodeLineage(head.Node)
+	if err != nil {
+		return 0, err
+	}
+	return lineage.storedErrorCost, nil
+}
+
 func (c *Core) validateRecoveryDiscontinuityContext(
 	predecessor Head,
 	context RecoveryDiscontinuityContext,
@@ -147,6 +157,17 @@ func (c *Core) mergeRecoveryDiscontinuityHeadsUncheckpointed(
 	rightCheckpoint, rightExact := c.nodeScannerCheckpoint(incoming.Node)
 	if !leftExact || !rightExact || leftCheckpoint != context.Checkpoint || rightCheckpoint != context.Checkpoint {
 		return Head{}, errors.New("parser-core phase zero: recovery discontinuity heads have different scanner checkpoints")
+	}
+	leftLineage, err := c.nodeLineage(incumbent.Node)
+	if err != nil {
+		return Head{}, err
+	}
+	rightLineage, err := c.nodeLineage(incoming.Node)
+	if err != nil {
+		return Head{}, err
+	}
+	if leftLineage.storedErrorCost != rightLineage.storedErrorCost {
+		return Head{}, errors.New("parser-core phase zero: recovery discontinuity heads have different stored recovery costs")
 	}
 	c.addWork(&c.work.PhysicalHeadMergeAttempts, 1)
 	c.addWork(&c.work.PhysicalHeadMergeInputLinks, uint64(len(rightLinks)))

--- a/internal/parsercorephase0/recovery_discontinuity_test.go
+++ b/internal/parsercorephase0/recovery_discontinuity_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -361,14 +362,8 @@ func TestRecoveryDiscontinuityMergeRejectsDifferentStoredCostsBeforeMutation(t *
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
-		if err := core.RecordHeadStoredErrorCostOwned(owner, leftSeed, 7); err != nil {
-			return err
-		}
-		return core.RecordHeadStoredErrorCostOwned(owner, rightSeed, 8)
-	}); err != nil {
-		t.Fatal(err)
-	}
+	core.nodeLineages[leftSeed.Node-1].storedErrorCost = 7
+	core.nodeLineages[rightSeed.Node-1].storedErrorCost = 8
 	var left, right Head
 	context := RecoveryDiscontinuityContext{ByteOffset: 0}
 	if err := core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
@@ -400,5 +395,54 @@ func TestRecoveryDiscontinuityMergeRejectsDifferentStoredCostsBeforeMutation(t *
 	}
 	if len(core.nodes) != beforeNodes || len(core.links) != beforeLinks || core.Work() != beforeWork {
 		t.Fatalf("rejected merge mutated graph or telemetry: nodes=%d/%d links=%d/%d work=%+v/%+v", len(core.nodes), beforeNodes, len(core.links), beforeLinks, core.Work(), beforeWork)
+	}
+}
+
+func TestRecordHeadStoredErrorCostRequiresFreshSpeculationPublication(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxNodes: 64, MaxLinks: 64, MaxDerivations: 8, MaxPopPaths: 8})
+	seed, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	core.nodeLineages[seed.Node-1].storedErrorCost = 7
+	if err := core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if err := core.RecordHeadStoredErrorCostOwned(owner, seed, 7); err != nil {
+			return err
+		}
+		return core.RecordHeadStoredErrorCostOwned(owner, seed, 8)
+	}); err == nil || !strings.Contains(err.Error(), "published node") {
+		t.Fatalf("published node rewrite error=%v", err)
+	}
+	if got, err := core.RecoveryStoredErrorCost(seed); err != nil || got != 7 {
+		t.Fatalf("published node cost=%d err=%v, want 7", got, err)
+	}
+	err = core.ApplySchedulerAtomic(func(outer SchedulerTransactionToken) error {
+		return core.ApplySchedulerSpeculation(outer, func(inner SchedulerTransactionToken) (bool, error) {
+			return false, core.RecordHeadStoredErrorCostOwned(inner, seed, 8)
+		})
+	})
+	if err == nil || !strings.Contains(err.Error(), "published node") {
+		t.Fatalf("speculative published node rewrite error=%v", err)
+	}
+
+	var fresh Head
+	err = core.ApplySchedulerAtomic(func(outer SchedulerTransactionToken) error {
+		return core.ApplySchedulerSpeculation(outer, func(inner SchedulerTransactionToken) (bool, error) {
+			var appendErr error
+			fresh, appendErr = core.AppendRecoveryDiscontinuityOwned(inner, seed, RecoveryDiscontinuityContext{ByteOffset: 0})
+			if appendErr != nil {
+				return false, appendErr
+			}
+			if appendErr = core.RecordHeadStoredErrorCostOwned(inner, fresh, 9); appendErr != nil {
+				return false, appendErr
+			}
+			return true, nil
+		})
+	})
+	if err != nil {
+		t.Fatalf("fresh speculative publication err=%v", err)
+	}
+	if got, err := core.RecoveryStoredErrorCost(fresh); err != nil || got != 9 {
+		t.Fatalf("fresh node cost=%d err=%v, want 9", got, err)
 	}
 }

--- a/internal/parsercorephase0/recovery_discontinuity_test.go
+++ b/internal/parsercorephase0/recovery_discontinuity_test.go
@@ -1,0 +1,352 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func recoveryDiscontinuityTestSet(core *Core, first, second uint16) AlternativeSet {
+	var set AlternativeSet
+	if !core.alternativeSetInsert(&set, packAlternativeSetMember(first, 0)) ||
+		!core.alternativeSetInsert(&set, packAlternativeSetMember(second, 0)) {
+		panic("recovery discontinuity test set insertion failed")
+	}
+	return set
+}
+
+func recoveryDiscontinuityTestRefs(t *testing.T, core *Core, first, second uint64) DropCohortRefSet {
+	t.Helper()
+	var refs DropCohortRefSet
+	for _, sequence := range []uint64{first, second} {
+		if !core.AddDropCohortRef(&refs, DropCohortRef{Owner: 7, Epoch: 3, Sequence: sequence, Branch: 0}) {
+			t.Fatalf("failed to add test drop-cohort reference %d", sequence)
+		}
+	}
+	return refs
+}
+
+func recoveryDiscontinuityTestLineage(
+	t *testing.T,
+	core *Core,
+	owner uint32,
+	head Head,
+	set AlternativeSet,
+	refs DropCohortRefSet,
+) {
+	t.Helper()
+	if err := core.ApplySchedulerAtomic(func(token SchedulerTransactionToken) error {
+		if err := core.RecordHeadLineageOwned(token, head, CleanPathRankSelected, 11, set, false, true, refs); err != nil {
+			return err
+		}
+		return core.RecordHeadOwnerOwned(token, head, owner)
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRecoveryDiscontinuityOwnedCopiesAndUnionsLineage(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxNodes: 128, MaxLinks: 128, MaxSubtrees: 128, MaxDerivations: 16, MaxPopPaths: 16})
+	leftSeed, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightSeed, err := core.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftSet := recoveryDiscontinuityTestSet(core, 1, 2)
+	rightSet := recoveryDiscontinuityTestSet(core, 3, 4)
+	leftRefs := recoveryDiscontinuityTestRefs(t, core, 1, 2)
+	rightRefs := recoveryDiscontinuityTestRefs(t, core, 3, 4)
+	recoveryDiscontinuityTestLineage(t, core, 101, leftSeed, leftSet, leftRefs)
+	recoveryDiscontinuityTestLineage(t, core, 102, rightSeed, rightSet, rightRefs)
+	context := RecoveryDiscontinuityContext{ByteOffset: 0}
+	var left, right Head
+	err = core.ApplySchedulerAtomic(func(token SchedulerTransactionToken) error {
+		var innerErr error
+		left, innerErr = core.AppendRecoveryDiscontinuityOwned(token, leftSeed, context)
+		if innerErr != nil {
+			return innerErr
+		}
+		right, innerErr = core.AppendRecoveryDiscontinuityOwned(token, rightSeed, context)
+		return innerErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftLineage, err := core.nodeLineage(left.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leftLineage.owner != 0 || leftLineage.rank != CleanPathRankSelected || leftLineage.lineage != 11 {
+		t.Fatalf("copied marker lineage=%+v, want owner zero and selected lineage 11", leftLineage)
+	}
+	if got, ok := core.AlternativeSetMembers(leftLineage.set); !ok || !slices.Equal(got, []uint32{packAlternativeSetMember(1, 0), packAlternativeSetMember(2, 0)}) {
+		t.Fatalf("copied marker alternative set=%v/%t", got, ok)
+	}
+	if got := recoveryDiscontinuityTestRefs(t, core, 1, 2); leftLineage.dropCohortRefs != got {
+		t.Fatalf("copied marker references=%+v, want %+v", leftLineage.dropCohortRefs, got)
+	}
+
+	var merged Head
+	err = core.ApplySchedulerAtomic(func(token SchedulerTransactionToken) error {
+		var mergeErr error
+		merged, mergeErr = core.MergeRecoveryDiscontinuityHeadsOwned(token, context, left, right)
+		return mergeErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mergedNode, err := core.node(merged.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mergedNode.state != 0 || mergedNode.byteOffset != 0 || mergedNode.linkCount != 2 {
+		t.Fatalf("merged marker node=%+v, want ERROR_STATE zero-width two links", mergedNode)
+	}
+	mergedLineage, err := core.nodeLineage(merged.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mergedLineage.owner != 0 || mergedLineage.rank != CleanPathRankSelected || mergedLineage.lineage != 11 {
+		t.Fatalf("merged marker lineage=%+v, want scheduler owner zero and lineage 11", mergedLineage)
+	}
+	gotSet, ok := core.AlternativeSetMembers(mergedLineage.set)
+	if !ok || !slices.Equal(gotSet, []uint32{
+		packAlternativeSetMember(1, 0), packAlternativeSetMember(2, 0),
+		packAlternativeSetMember(3, 0), packAlternativeSetMember(4, 0),
+	}) {
+		t.Fatalf("merged marker alternative set=%v/%t", gotSet, ok)
+	}
+	wantRefs := recoveryDiscontinuityTestRefs(t, core, 1, 2)
+	if !core.UnionDropCohortRefs(&wantRefs, rightRefs) || mergedLineage.dropCohortRefs.Len() != wantRefs.Len() {
+		t.Fatalf("merged marker references=%+v, want union %+v", mergedLineage.dropCohortRefs, wantRefs)
+	}
+	if stats, statsErr := core.Stats(merged); statsErr != nil || stats.CurrentExactPaths != 2 {
+		t.Fatalf("merged marker stats=%+v err=%v, want two paths", stats, statsErr)
+	}
+	derivations, err := core.Derivations(merged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(derivations) != 2 {
+		t.Fatalf("merged marker derivations=%+v, want two paths", derivations)
+	}
+	for _, derivation := range derivations {
+		if len(derivation.Payloads) != 0 || derivation.Score != 0 || derivation.HasBranchOrder {
+			t.Fatalf("merged marker derivation=%+v, want no child, score, or order", derivation)
+		}
+	}
+	work := core.Work()
+	if work.PhysicalHeadMergeAttempts != 1 || work.PhysicalHeadMergeInputLinks != 1 || work.PhysicalHeadMergeSuccesses != 1 {
+		t.Fatalf("marker merge telemetry=%+v, want one attempt, input link, and success", work)
+	}
+}
+
+func TestRecoveryDiscontinuityRejectsUnauthenticatedContextAndOrdinaryNullableLink(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxNodes: 32, MaxLinks: 32, MaxSubtrees: 32, MaxDerivations: 8, MaxPopPaths: 8})
+	seed, err := core.Seed(3, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, context := range []RecoveryDiscontinuityContext{
+		{ErrorState: 1, ByteOffset: 0},
+		{ByteOffset: 1},
+		{ByteOffset: 0, Checkpoint: 1},
+	} {
+		before := len(core.nodes)
+		err := core.ApplySchedulerAtomic(func(token SchedulerTransactionToken) error {
+			_, appendErr := core.AppendRecoveryDiscontinuityOwned(token, seed, context)
+			return appendErr
+		})
+		if err == nil {
+			t.Fatalf("context=%+v was accepted", context)
+		}
+		if len(core.nodes) != before {
+			t.Fatalf("context=%+v changed node arena after rejection", context)
+		}
+	}
+	if _, err := core.appendAdjacencyNode(0, 0, []linkRecord{{prev: seed.Node}}); err == nil {
+		t.Fatal("ordinary zero-payload link was accepted")
+	}
+}
+
+func TestRecoveryGraphAggregatePreservesMarkerPrefixAndDeclinesUnequalCosts(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxNodes: 256, MaxLinks: 256, MaxSubtrees: 256, MaxChildren: 256, MaxDerivations: 16, MaxPopPaths: 16})
+	seed, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanPayload, err := core.appendSubtree(subtreeRecord{symbol: 1, startByte: 0, endByte: 0, terminal: true}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanPred, err := core.appendAdjacencyNode(2, 0, []linkRecord{{prev: seed.Node, payload: cleanPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingPayload, err := core.MissingLeaf(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingPred, err := core.appendAdjacencyNode(3, 0, []linkRecord{{prev: seed.Node, payload: missingPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	context := RecoveryDiscontinuityContext{ByteOffset: 0}
+	var cleanHead, missingHead Head
+	err = core.ApplySchedulerAtomic(func(token SchedulerTransactionToken) error {
+		var innerErr error
+		cleanHead, innerErr = core.AppendRecoveryDiscontinuityOwned(token, Head{Node: cleanPred}, context)
+		if innerErr != nil {
+			return innerErr
+		}
+		missingHead, innerErr = core.AppendRecoveryDiscontinuityOwned(token, Head{Node: missingPred}, context)
+		return innerErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var aggregateHead Head
+	err = core.ApplySchedulerAtomic(func(token SchedulerTransactionToken) error {
+		var mergeErr error
+		aggregateHead, mergeErr = core.MergeRecoveryDiscontinuityHeadsOwned(token, context, cleanHead, missingHead)
+		return mergeErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbols := make([]SelectedSymbolPolicy, 3)
+	symbols[1].Visible = true
+	symbols[2].Visible = true
+	aggregate, supported, err := core.RecoveryGraphAggregateForHead(aggregateHead, symbols, core)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if supported {
+		t.Fatal("unequal recovery path costs were reported as supported")
+	}
+	if aggregate.MaximumVisibleCount != 1 || aggregate.MinimumErrorCost != 0 || aggregate.MaximumErrorCost != RecoveryCostPerMissingTree+RecoveryCostPerRecovery || aggregate.StoredPrecedenceMaximum != 0 || aggregate.PathCount != 2 {
+		t.Fatalf("aggregate=%+v, want visible 1, costs 0/%d, precedence 0, paths 2", aggregate, RecoveryCostPerMissingTree+RecoveryCostPerRecovery)
+	}
+}
+
+func TestRecoveryGraphAggregateIgnoresUnreachableMalformedNode(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxNodes: 256, MaxLinks: 256, MaxSubtrees: 256, MaxDerivations: 8, MaxPopPaths: 8})
+	seed, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unreachablePayload, err := core.appendSubtree(subtreeRecord{symbol: 1, terminal: true}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unreachableLink := core.appendGraphLink(linkRecord{prev: seed.Node, payload: unreachablePayload})
+	if _, err := core.appendNode(nodeRecord{state: 7, byteOffset: 0, firstLink: uint32(unreachableLink), linkCount: 1, pathCount: 1}); err != nil {
+		t.Fatal(err)
+	}
+	visiblePayload, err := core.appendSubtree(subtreeRecord{symbol: 1, startByte: 0, endByte: 0, terminal: true}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	visibleHead, err := core.appendAdjacencyNode(2, 0, []linkRecord{{prev: seed.Node, payload: visiblePayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Corrupt only the unrelated node after the aggregate's reachable head is built.
+	core.links[unreachableLink-1].payload = 0
+	symbols := []SelectedSymbolPolicy{{}, {Visible: true}}
+	aggregate, supported, err := core.RecoveryGraphAggregateForHead(Head{Node: visibleHead}, symbols, core)
+	if err != nil || !supported || aggregate.PathCount != 1 || aggregate.MaximumVisibleCount != 1 {
+		t.Fatalf("reachable aggregate=%+v supported=%t err=%v", aggregate, supported, err)
+	}
+}
+
+func TestRecoveryGraphAggregateRequiresExactCostSource(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxDerivations: 4, MaxPopPaths: 4})
+	seed, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, supported, err := core.RecoveryGraphAggregateForHead(seed, nil, nil); err == nil || supported {
+		t.Fatalf("nil source result=%t err=%v, want fail closed", supported, err)
+	}
+	errorPayload, err := core.appendSubtree(subtreeRecord{symbol: ErrorRegionSymbol, startByte: 0, endByte: 1}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	errorHead, err := core.appendAdjacencyNode(2, 1, []linkRecord{{prev: seed.Node, payload: errorPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, supported, err := core.RecoveryGraphAggregateForHead(Head{Node: errorHead}, nil, core); err == nil || supported {
+		t.Fatalf("row-free Core source result=%t err=%v, want ERROR row-span failure", supported, err)
+	}
+}
+
+func TestEOFAdmissionRejectsRecoveryDiscontinuityWithoutRecoveryVisitor(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxNodes: 32, MaxLinks: 32, MaxDerivations: 4, MaxPopPaths: 4})
+	seed, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var head Head
+	if err := core.ApplySchedulerAtomic(func(token SchedulerTransactionToken) error {
+		var appendErr error
+		head, appendErr = core.AppendRecoveryDiscontinuityOwned(token, seed, RecoveryDiscontinuityContext{ByteOffset: 0})
+		return appendErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, err = core.VisitEOFAdmissionExactPath(head, core.AuthenticationGeneration(), nil, func(uint32, SubtreeID) error { return nil })
+	if err == nil || !errors.Is(err, ErrEOFAdmissionMalformed) {
+		t.Fatalf("marker EOF admission error=%v, want malformed fail-closed error", err)
+	}
+}
+
+func TestRecoveryDiscontinuityMergeRollbackRestoresLineageSpill(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxNodes: 128, MaxLinks: 128, MaxSubtrees: 128, MaxDerivations: 16, MaxPopPaths: 16})
+	leftSeed, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightSeed, err := core.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recoveryDiscontinuityTestLineage(t, core, 201, leftSeed, recoveryDiscontinuityTestSet(core, 1, 2), recoveryDiscontinuityTestRefs(t, core, 1, 2))
+	recoveryDiscontinuityTestLineage(t, core, 202, rightSeed, recoveryDiscontinuityTestSet(core, 3, 4), recoveryDiscontinuityTestRefs(t, core, 3, 4))
+	context := RecoveryDiscontinuityContext{ByteOffset: 0}
+	var left, right Head
+	if err := core.ApplySchedulerAtomic(func(token SchedulerTransactionToken) error {
+		var innerErr error
+		left, innerErr = core.AppendRecoveryDiscontinuityOwned(token, leftSeed, context)
+		if innerErr != nil {
+			return innerErr
+		}
+		right, innerErr = core.AppendRecoveryDiscontinuityOwned(token, rightSeed, context)
+		return innerErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	beforeNodes := len(core.nodes)
+	beforeLinks := len(core.links)
+	beforeSpill := slices.Clone(core.alternativeSpillArena)
+	beforeLineages := slices.Clone(core.nodeLineages)
+	beforeWork := core.Work()
+	sentinel := errors.New("recovery discontinuity rollback")
+	err = core.ApplySchedulerAtomic(func(token SchedulerTransactionToken) error {
+		if _, mergeErr := core.MergeRecoveryDiscontinuityHeadsOwned(token, context, left, right); mergeErr != nil {
+			return mergeErr
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("rollback error=%v, want %v", err, sentinel)
+	}
+	if len(core.nodes) != beforeNodes || len(core.links) != beforeLinks || !slices.Equal(core.alternativeSpillArena, beforeSpill) || !reflect.DeepEqual(core.nodeLineages, beforeLineages) || core.Work() != beforeWork {
+		t.Fatalf("rollback changed nodes=%d/%d links=%d/%d spill=%v/%v lineages equal=%t work=%+v/%+v", len(core.nodes), beforeNodes, len(core.links), beforeLinks, core.alternativeSpillArena, beforeSpill, reflect.DeepEqual(core.nodeLineages, beforeLineages), core.Work(), beforeWork)
+	}
+}

--- a/internal/parsercorephase0/recovery_discontinuity_test.go
+++ b/internal/parsercorephase0/recovery_discontinuity_test.go
@@ -350,3 +350,55 @@ func TestRecoveryDiscontinuityMergeRollbackRestoresLineageSpill(t *testing.T) {
 		t.Fatalf("rollback changed nodes=%d/%d links=%d/%d spill=%v/%v lineages equal=%t work=%+v/%+v", len(core.nodes), beforeNodes, len(core.links), beforeLinks, core.alternativeSpillArena, beforeSpill, reflect.DeepEqual(core.nodeLineages, beforeLineages), core.Work(), beforeWork)
 	}
 }
+
+func TestRecoveryDiscontinuityMergeRejectsDifferentStoredCostsBeforeMutation(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxNodes: 64, MaxLinks: 64, MaxDerivations: 8, MaxPopPaths: 8})
+	leftSeed, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightSeed, err := core.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if err := core.RecordHeadStoredErrorCostOwned(owner, leftSeed, 7); err != nil {
+			return err
+		}
+		return core.RecordHeadStoredErrorCostOwned(owner, rightSeed, 8)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var left, right Head
+	context := RecoveryDiscontinuityContext{ByteOffset: 0}
+	if err := core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		var appendErr error
+		left, appendErr = core.AppendRecoveryDiscontinuityOwned(owner, leftSeed, context)
+		if appendErr != nil {
+			return appendErr
+		}
+		right, appendErr = core.AppendRecoveryDiscontinuityOwned(owner, rightSeed, context)
+		return appendErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	leftCost, err := core.RecoveryStoredErrorCost(left)
+	if err != nil || leftCost != 7 {
+		t.Fatalf("left marker stored cost=%d err=%v, want 7", leftCost, err)
+	}
+	rightCost, err := core.RecoveryStoredErrorCost(right)
+	if err != nil || rightCost != 8 {
+		t.Fatalf("right marker stored cost=%d err=%v, want 8", rightCost, err)
+	}
+	beforeNodes, beforeLinks, beforeWork := len(core.nodes), len(core.links), core.Work()
+	err = core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, mergeErr := core.MergeRecoveryDiscontinuityHeadsOwned(owner, context, left, right)
+		return mergeErr
+	})
+	if err == nil {
+		t.Fatal("different stored costs unexpectedly merged")
+	}
+	if len(core.nodes) != beforeNodes || len(core.links) != beforeLinks || core.Work() != beforeWork {
+		t.Fatalf("rejected merge mutated graph or telemetry: nodes=%d/%d links=%d/%d work=%+v/%+v", len(core.nodes), beforeNodes, len(core.links), beforeLinks, core.Work(), beforeWork)
+	}
+}

--- a/internal/parsercorephase0/reduction_cost_publication_test.go
+++ b/internal/parsercorephase0/reduction_cost_publication_test.go
@@ -1,0 +1,114 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func newReductionCostPublicationFixture(t *testing.T) (*Core, ClassifiedBoundary) {
+	t.Helper()
+	tables := &fakeTable{
+		actions: map[tableCell][]Action{
+			{state: 3, symbol: 9}: {{Type: ActionReduce, Symbol: 2, ChildCount: 1}},
+		},
+		gotos: map[tableCell]StateID{{state: 1, symbol: 2}: 4},
+	}
+	compact, err := New(tables, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.ShiftMissingLeaf(seed, 3, 7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary, err := compact.ClassifyBoundary(head, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return compact, boundary
+}
+
+func TestReductionCostCallbackPublishesCumulativeMissingCost(t *testing.T) {
+	compact, boundary := newReductionCostPublicationFixture(t)
+	var outputs []ReductionOutput
+	callbackCalls := 0
+	err := compact.RunFreshSchedulerSession(func(owner SchedulerTransactionToken) error {
+		var err error
+		outputs, err = compact.ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesAndCostOwned(
+			owner, nil, nil, boundary, 0, ForkOrder{},
+			func(prev NodeID, payload SubtreeID) (uint32, error) {
+				callbackCalls++
+				view, viewErr := compact.Subtree(payload)
+				if viewErr != nil {
+					return 0, viewErr
+				}
+				if len(view.Children) != 1 {
+					return 0, errors.New("reduction callback received an unexpected parent shape")
+				}
+				child, childErr := compact.Subtree(view.Children[0])
+				if childErr != nil {
+					return 0, childErr
+				}
+				if !child.Missing {
+					return 0, errors.New("reduction callback lost the missing child")
+				}
+				prefix, prefixErr := compact.RecoveryStoredErrorCost(Head{Node: prev})
+				if prefixErr != nil {
+					return 0, prefixErr
+				}
+				return prefix + compactMissingLeafStoredErrorCost, nil
+			},
+		)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("cost-aware reduction: %v", err)
+	}
+	if callbackCalls != 1 || len(outputs) != 1 {
+		t.Fatalf("callback calls=%d outputs=%d, want one callback and one output", callbackCalls, len(outputs))
+	}
+	cost, err := compact.RecoveryStoredErrorCost(outputs[0].Head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cost != compactMissingLeafStoredErrorCost {
+		t.Fatalf("reduction output stored cost=%d, want %d before any boundary merge", cost, compactMissingLeafStoredErrorCost)
+	}
+}
+
+func TestCostAwareReductionRejectsNilCallbackBeforeMutation(t *testing.T) {
+	for _, corridor := range []bool{false, true} {
+		name := "generic"
+		if corridor {
+			name = "corridor"
+		}
+		t.Run(name, func(t *testing.T) {
+			compact, boundary := newReductionCostPublicationFixture(t)
+			before := captureSchedulerTransactionState(compact)
+			err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				if corridor {
+					_, _ = compact.ReduceOutputsCorridorClassifiedIntoWithLiveCondenseCandidatesAndCostOwned(
+						owner, nil, nil, boundary, ForkOrder{}, nil,
+					)
+					return nil
+				}
+				_, _ = compact.ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesAndCostOwned(
+					owner, nil, nil, boundary, 0, ForkOrder{}, nil,
+				)
+				return nil
+			})
+			if err == nil || !strings.Contains(err.Error(), "cost callback is required") {
+				t.Fatalf("nil cost callback error=%v", err)
+			}
+			if got := captureSchedulerTransactionState(compact); !reflect.DeepEqual(got, before) {
+				t.Fatalf("nil cost callback mutated compact state: got=%+v before=%+v", got, before)
+			}
+		})
+	}
+}

--- a/internal/parsercorephase0/s5_physical_head_falsifier_test.go
+++ b/internal/parsercorephase0/s5_physical_head_falsifier_test.go
@@ -31,7 +31,7 @@ func newS5DiscontinuityFixture(t *testing.T) (*Core, Head, Head, linkRecord) {
 		t.Fatal(err)
 	}
 	link := linkRecord{prev: seed.Node, flags: s5RecoveryDiscontinuityFlag}
-	node, linkID := appendS5SyntheticNode(t, core, 31, 1, link, 1)
+	node, linkID := appendS5SyntheticNode(t, core, 0, 0, link, 1)
 	return core, seed, Head{Node: node}, core.links[linkID-1]
 }
 
@@ -108,7 +108,7 @@ func TestS5RecoveryDiscontinuityLinkValidation(t *testing.T) {
 			linkID := core.appendGraphLink(link)
 			next := NodeID(len(core.nodes) + 1)
 			err = core.validatePublishedNodeDAG(nodeRecord{
-				state: 31, byteOffset: 1, firstLink: uint32(linkID), linkCount: 1, pathCount: 1,
+				state: 0, byteOffset: 0, firstLink: uint32(linkID), linkCount: 1, pathCount: 1,
 			}, next)
 			if test.wantError && err == nil {
 				t.Fatalf("link=%+v was accepted", link)
@@ -203,7 +203,7 @@ func newS5SixHeadCandidates(t *testing.T) (*Core, []CondenseCandidate, map[Subtr
 		if err != nil {
 			t.Fatal(err)
 		}
-		head, _ := appendS5SyntheticNode(t, core, 500, 1, linkRecord{
+		head, _ := appendS5SyntheticNode(t, core, 0, 0, linkRecord{
 			prev: predecessor, flags: s5RecoveryDiscontinuityFlag,
 		}, 1)
 		candidates = append(candidates, CondenseCandidate{
@@ -237,53 +237,51 @@ func TestS5SixHeadPhysicalMergeRetainsPaths(t *testing.T) {
 	before := core.Work()
 	err := core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
 		return core.RunSchedulerOwned(owner, func() error {
-			return core.runLiveCondenseCandidates(candidates, func() error {
-				if len(core.condenseCandidates) != 2 {
-					return &s5AssertionError{message: "live scope did not keep the absorber and missing lineages separate"}
-				}
-				var absorber, missing Head
-				for _, candidate := range core.condenseCandidates {
-					stats, err := core.Stats(candidate.Head)
-					if err != nil {
-						return err
-					}
-					switch stats.CurrentExactPaths {
-					case 6:
-						absorber = candidate.Head
-					case 1:
-						missing = candidate.Head
-					default:
-						return &s5AssertionError{message: "unexpected physical path count in live scope"}
-					}
-				}
-				if absorber.Node == 0 || missing.Node == 0 {
-					return &s5AssertionError{message: "live scope lost one recovery lineage"}
-				}
-				derivations, err := core.Derivations(absorber)
+			context := RecoveryDiscontinuityContext{ErrorState: 0, ByteOffset: 0, Checkpoint: 0}
+			absorber := candidates[0].Head
+			for index := 1; index < 6; index++ {
+				merged, err := core.MergeRecoveryDiscontinuityHeadsOwned(owner, context, absorber, candidates[index].Head)
 				if err != nil {
 					return err
 				}
-				if len(derivations) != 6 {
-					return &s5AssertionError{message: "absorber derivation count is not six"}
+				absorber = merged
+			}
+			missing := candidates[6].Head
+			absorberStats, err := core.Stats(absorber)
+			if err != nil {
+				return err
+			}
+			missingStats, err := core.Stats(missing)
+			if err != nil {
+				return err
+			}
+			if absorberStats.CurrentExactPaths != 6 || missingStats.CurrentExactPaths != 1 {
+				return &s5AssertionError{message: "recovery merge lost one lineage"}
+			}
+			derivations, err := core.Derivations(absorber)
+			if err != nil {
+				return err
+			}
+			if len(derivations) != 6 {
+				return &s5AssertionError{message: "absorber derivation count is not six"}
+			}
+			for _, derivation := range derivations {
+				if len(derivation.Payloads) != 1 || !wantPayloads[derivation.Payloads[0]] {
+					return &s5AssertionError{message: "absorber lost a predecessor payload or exposed subtree zero"}
 				}
-				for _, derivation := range derivations {
-					if len(derivation.Payloads) != 1 || !wantPayloads[derivation.Payloads[0]] {
-						return &s5AssertionError{message: "absorber lost a predecessor payload or exposed subtree zero"}
-					}
-					delete(wantPayloads, derivation.Payloads[0])
-				}
-				if len(wantPayloads) != 0 {
-					return &s5AssertionError{message: "absorber lost one of six predecessor paths"}
-				}
-				missingDerivations, err := core.Derivations(missing)
-				if err != nil {
-					return err
-				}
-				if len(missingDerivations) != 1 || len(missingDerivations[0].Payloads) != 1 || missingDerivations[0].Payloads[0] != missingPayload {
-					return &s5AssertionError{message: "missing lineage did not remain separate"}
-				}
-				return nil
-			})
+				delete(wantPayloads, derivation.Payloads[0])
+			}
+			if len(wantPayloads) != 0 {
+				return &s5AssertionError{message: "absorber lost one of six predecessor paths"}
+			}
+			missingDerivations, err := core.Derivations(missing)
+			if err != nil {
+				return err
+			}
+			if len(missingDerivations) != 1 || len(missingDerivations[0].Payloads) != 1 || missingDerivations[0].Payloads[0] != missingPayload {
+				return &s5AssertionError{message: "missing lineage did not remain separate"}
+			}
+			return nil
 		})
 	})
 	if err != nil {

--- a/internal/parsercorephase0/s5_physical_head_falsifier_test.go
+++ b/internal/parsercorephase0/s5_physical_head_falsifier_test.go
@@ -1,0 +1,302 @@
+//go:build gts_parsercorephase0
+
+package parsercorephase0
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// Keep this value aligned with the first free link flag after linkFlagHasOrder.
+const s5RecoveryDiscontinuityFlag uint32 = 1 << 1
+
+func appendS5SyntheticNode(t *testing.T, core *Core, state StateID, byteOffset uint32, link linkRecord, pathCount uint64) (NodeID, LinkID) {
+	t.Helper()
+	linkID := core.appendGraphLink(link)
+	node, err := core.appendNodeRecord(nodeRecord{
+		state: state, byteOffset: byteOffset,
+		firstLink: uint32(linkID), linkCount: 1, pathCount: pathCount,
+	}, core.checkpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return node, linkID
+}
+
+func newS5DiscontinuityFixture(t *testing.T) (*Core, Head, Head, linkRecord) {
+	t.Helper()
+	core := newTinyCoreWithLimits(t, Limits{MaxDerivations: 16, MaxPopPaths: 16})
+	seed, err := core.Seed(17, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := linkRecord{prev: seed.Node, flags: s5RecoveryDiscontinuityFlag}
+	node, linkID := appendS5SyntheticNode(t, core, 31, 1, link, 1)
+	return core, seed, Head{Node: node}, core.links[linkID-1]
+}
+
+func TestS5RecoveryDiscontinuityLinkValidation(t *testing.T) {
+	if got := unsafe.Sizeof(linkRecord{}); got != 32 {
+		t.Fatalf("linkRecord size=%d, want 32", got)
+	}
+	if got := unsafe.Sizeof(subtreeRecord{}); got != 44 {
+		t.Fatalf("subtreeRecord size=%d, want 44", got)
+	}
+
+	tests := []struct {
+		name      string
+		makeLink  func(seed NodeID, payload SubtreeID) linkRecord
+		wantError bool
+	}{
+		{
+			name: "sanctioned null edge",
+			makeLink: func(seed NodeID, _ SubtreeID) linkRecord {
+				return linkRecord{prev: seed, flags: s5RecoveryDiscontinuityFlag}
+			},
+		},
+		{
+			name: "ordinary zero payload",
+			makeLink: func(seed NodeID, _ SubtreeID) linkRecord {
+				return linkRecord{prev: seed}
+			},
+			wantError: true,
+		},
+		{
+			name: "flagged nonzero payload",
+			makeLink: func(seed NodeID, payload SubtreeID) linkRecord {
+				return linkRecord{prev: seed, payload: payload, flags: s5RecoveryDiscontinuityFlag}
+			},
+			wantError: true,
+		},
+		{
+			name: "flagged score",
+			makeLink: func(seed NodeID, _ SubtreeID) linkRecord {
+				return linkRecord{prev: seed, scoreDelta: 1, flags: s5RecoveryDiscontinuityFlag}
+			},
+			wantError: true,
+		},
+		{
+			name: "flagged branch order",
+			makeLink: func(seed NodeID, _ SubtreeID) linkRecord {
+				return linkRecord{prev: seed, order: 1, flags: s5RecoveryDiscontinuityFlag | linkFlagHasOrder}
+			},
+			wantError: true,
+		},
+		{
+			name: "unknown flag",
+			makeLink: func(seed NodeID, _ SubtreeID) linkRecord {
+				return linkRecord{prev: seed, flags: s5RecoveryDiscontinuityFlag | 1<<2}
+			},
+			wantError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			core := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+			seed, err := core.Seed(17, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			payload, err := core.appendSubtree(subtreeRecord{
+				symbol: 91, startByte: 0, endByte: 1, terminal: true,
+			}, nil, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			link := test.makeLink(seed.Node, payload)
+			linkID := core.appendGraphLink(link)
+			next := NodeID(len(core.nodes) + 1)
+			err = core.validatePublishedNodeDAG(nodeRecord{
+				state: 31, byteOffset: 1, firstLink: uint32(linkID), linkCount: 1, pathCount: 1,
+			}, next)
+			if test.wantError && err == nil {
+				t.Fatalf("link=%+v was accepted", link)
+			}
+			if !test.wantError && err != nil {
+				t.Fatalf("link=%+v was rejected: %v", link, err)
+			}
+		})
+	}
+}
+
+func TestS5DiscontinuityReaderSemantics(t *testing.T) {
+	t.Run("precedence maximum omits null payload", func(t *testing.T) {
+		core, seed, _, link := newS5DiscontinuityFixture(t)
+		got, err := core.linkPrecedenceMaximum(link)
+		if err != nil {
+			t.Fatalf("linkPrecedenceMaximum: %v", err)
+		}
+		if got.value != 0 {
+			t.Fatalf("precedence maximum=%d, want predecessor maximum 0 from seed %d", got.value, seed.Node)
+		}
+	})
+
+	t.Run("derivations omit null payload", func(t *testing.T) {
+		core, seed, head, _ := newS5DiscontinuityFixture(t)
+		derivations, err := core.Derivations(head)
+		if err != nil {
+			t.Fatalf("Derivations: %v", err)
+		}
+		if len(derivations) != 1 {
+			t.Fatalf("derivations=%d, want one path through seed %d", len(derivations), seed.Node)
+		}
+		path := derivations[0]
+		if len(path.Payloads) != 0 || path.Score != 0 || path.HasBranchOrder {
+			t.Fatalf("null-edge derivation=%+v, want no payload, score, or order", path)
+		}
+	})
+
+	t.Run("pop counts the slot without a child", func(t *testing.T) {
+		core, seed, head, _ := newS5DiscontinuityFixture(t)
+		paths, err := core.popPaths(head.Node, 1)
+		if err != nil {
+			t.Fatalf("popPaths: %v", err)
+		}
+		if len(paths) != 1 {
+			t.Fatalf("pop paths=%d, want one path through seed %d", len(paths), seed.Node)
+		}
+		path := paths[0]
+		if path.prev != seed.Node || len(path.children) != 0 || len(path.trailing) != 0 || path.score != 0 || path.order.Present {
+			t.Fatalf("null-edge pop path=%+v, want one structural slot and no payload", path)
+		}
+	})
+
+	t.Run("summary depth counts the slot", func(t *testing.T) {
+		core, seed, head, _ := newS5DiscontinuityFixture(t)
+		candidates, err := core.StackSummaryCandidates(head, 1)
+		if err != nil {
+			t.Fatalf("StackSummaryCandidates: %v", err)
+		}
+		if len(candidates) != 1 {
+			t.Fatalf("summary candidates=%d, want one entry for seed %d", len(candidates), seed.Node)
+		}
+		candidate := candidates[0]
+		if candidate.Depth() != 1 || candidate.State() != 17 || candidate.ByteOffset() != 0 {
+			t.Fatalf("summary candidate depth/state/byte=%d/%d/%d, want 1/17/0", candidate.Depth(), candidate.State(), candidate.ByteOffset())
+		}
+	})
+
+	t.Run("edge identity includes the discontinuity flag", func(t *testing.T) {
+		core, seed, _, link := newS5DiscontinuityFixture(t)
+		ordinary := linkRecord{prev: seed.Node}
+		if core.linkEdgesEqual(link, ordinary) {
+			t.Fatalf("flagged link=%+v compared equal to ordinary link=%+v", link, ordinary)
+		}
+	})
+}
+
+func newS5SixHeadCandidates(t *testing.T) (*Core, []CondenseCandidate, map[SubtreeID]bool, SubtreeID) {
+	t.Helper()
+	core := newTinyCoreWithLimits(t, Limits{MaxDerivations: 32, MaxPopPaths: 32})
+	candidates := make([]CondenseCandidate, 0, 7)
+	wantPayloads := make(map[SubtreeID]bool, 6)
+	for index := 0; index < 6; index++ {
+		seed, err := core.Seed(StateID(index+1), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload := appendShallowPayload(t, core, shallowPayloadSpec{
+			symbol: Symbol(index + 100), startByte: 0, endByte: 1,
+		})
+		predecessor, err := core.appendAdjacencyNode(400, 0, []linkRecord{{prev: seed.Node, payload: payload}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		head, _ := appendS5SyntheticNode(t, core, 500, 1, linkRecord{
+			prev: predecessor, flags: s5RecoveryDiscontinuityFlag,
+		}, 1)
+		candidates = append(candidates, CondenseCandidate{
+			Head: Head{Node: head}, MergeIdentity: 41,
+		})
+		wantPayloads[payload] = true
+	}
+
+	missingSeed, err := core.Seed(99, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingPayload, err := core.appendSubtree(subtreeRecord{
+		symbol: 900, startByte: 0, endByte: 1, missing: true, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingHead, err := core.appendAdjacencyNode(500, 1, []linkRecord{{prev: missingSeed.Node, payload: missingPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidates = append(candidates, CondenseCandidate{
+		Head: Head{Node: missingHead}, MergeIdentity: 42,
+	})
+	return core, candidates, wantPayloads, missingPayload
+}
+
+func TestS5SixHeadPhysicalMergeRetainsPaths(t *testing.T) {
+	core, candidates, wantPayloads, missingPayload := newS5SixHeadCandidates(t)
+	before := core.Work()
+	err := core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return core.RunSchedulerOwned(owner, func() error {
+			return core.runLiveCondenseCandidates(candidates, func() error {
+				if len(core.condenseCandidates) != 2 {
+					return &s5AssertionError{message: "live scope did not keep the absorber and missing lineages separate"}
+				}
+				var absorber, missing Head
+				for _, candidate := range core.condenseCandidates {
+					stats, err := core.Stats(candidate.Head)
+					if err != nil {
+						return err
+					}
+					switch stats.CurrentExactPaths {
+					case 6:
+						absorber = candidate.Head
+					case 1:
+						missing = candidate.Head
+					default:
+						return &s5AssertionError{message: "unexpected physical path count in live scope"}
+					}
+				}
+				if absorber.Node == 0 || missing.Node == 0 {
+					return &s5AssertionError{message: "live scope lost one recovery lineage"}
+				}
+				derivations, err := core.Derivations(absorber)
+				if err != nil {
+					return err
+				}
+				if len(derivations) != 6 {
+					return &s5AssertionError{message: "absorber derivation count is not six"}
+				}
+				for _, derivation := range derivations {
+					if len(derivation.Payloads) != 1 || !wantPayloads[derivation.Payloads[0]] {
+						return &s5AssertionError{message: "absorber lost a predecessor payload or exposed subtree zero"}
+					}
+					delete(wantPayloads, derivation.Payloads[0])
+				}
+				if len(wantPayloads) != 0 {
+					return &s5AssertionError{message: "absorber lost one of six predecessor paths"}
+				}
+				missingDerivations, err := core.Derivations(missing)
+				if err != nil {
+					return err
+				}
+				if len(missingDerivations) != 1 || len(missingDerivations[0].Payloads) != 1 || missingDerivations[0].Payloads[0] != missingPayload {
+					return &s5AssertionError{message: "missing lineage did not remain separate"}
+				}
+				return nil
+			})
+		})
+	})
+	if err != nil {
+		t.Fatalf("six-head physical merge: %v", err)
+	}
+	after := core.Work()
+	if after.PhysicalHeadMergeAttempts-before.PhysicalHeadMergeAttempts != 5 ||
+		after.PhysicalHeadMergeSuccesses-before.PhysicalHeadMergeSuccesses != 5 ||
+		after.PhysicalHeadMergeInputLinks-before.PhysicalHeadMergeInputLinks != 5 {
+		t.Fatalf("physical merge telemetry=%+v before=%+v, want five attempts, successes, and input links", after, before)
+	}
+}
+
+type s5AssertionError struct{ message string }
+
+func (e *s5AssertionError) Error() string { return e.message }

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -777,6 +777,40 @@ func (c *Core) ErrorRegionResumeWithLiveCondenseCandidatesOwned(
 	return out, c.finishSchedulerOwned(owner, err)
 }
 
+// ErrorRegionResumeWithLiveCondenseCandidatesAndCostOwned publishes one
+// recovery ERROR region with an authenticated cumulative cost while keeping
+// unrelated live candidates outside its condensation scope.
+func (c *Core) ErrorRegionResumeWithLiveCondenseCandidatesAndCostOwned(
+	owner SchedulerTransactionToken,
+	candidates []CondenseCandidate,
+	preErrorHead Head,
+	preErrorState StateID,
+	startByte, endByte uint32,
+	children []SubtreeID,
+	cost ReductionOutputCostFunc,
+) (out Head, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return out, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if err = c.enterLiveCondenseCandidates(candidates); err != nil {
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	if cost == nil {
+		err = errors.New("parser-core phase zero: error-region cost callback is required")
+		c.clearLiveCondenseCandidates()
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	if c.schedulerFrame.fresh {
+		out, err = c.ErrorRegionResumeWithCost(preErrorHead, preErrorState, startByte, endByte, children, cost)
+		c.clearLiveCondenseCandidates()
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	defer c.clearLiveCondenseCandidates()
+	out, err = c.ErrorRegionResumeWithCost(preErrorHead, preErrorState, startByte, endByte, children, cost)
+	return out, c.finishSchedulerOwned(owner, err)
+}
+
 // ShiftDirectWithLiveCondenseCandidatesOwned applies a corridor-proven shift
 // without rebuilding a ClassifiedBoundary or running the generic shift path.
 // The caller must validate the action shape from the immutable corridor program.

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -533,6 +533,16 @@ func (c *Core) mergeEquivalentHeadsAtBoundaryUncheckpointed(
 	if err != nil {
 		return Head{}, err
 	}
+	for _, link := range links {
+		if link.isRecoveryDiscontinuity() {
+			return Head{}, errors.New("parser-core phase zero: recovery discontinuity requires its dedicated merge seam")
+		}
+	}
+	for _, link := range incomingLinks {
+		if link.isRecoveryDiscontinuity() {
+			return Head{}, errors.New("parser-core phase zero: recovery discontinuity requires its dedicated merge seam")
+		}
+	}
 	// Count only pairs that pass the clean boundary and scanner predicates.
 	// C's wider attempt counter also includes pairs that fail those predicates.
 	c.addWork(&c.work.PhysicalHeadMergeAttempts, 1)

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -342,6 +342,12 @@ func (c *Core) recordNodeLineageMember(head Head, event, branch uint16) error {
 // It is the non-closure setup half of runLiveCondenseCandidates, factored out
 // so the hot shift/reduce/cohort dispatch paths can call it directly.
 func (c *Core) enterLiveCondenseCandidates(candidates []CondenseCandidate) error {
+	return c.enterLiveCondenseCandidatesWithCost(candidates, false)
+}
+
+// enterLiveCondenseCandidatesWithCost installs a live candidate scope and
+// optionally admits equal authenticated recovery costs.
+func (c *Core) enterLiveCondenseCandidatesWithCost(candidates []CondenseCandidate, allowNonzeroCost bool) error {
 	if c.condenseScopeActive {
 		return errors.New("parser-core phase zero: nested live condense candidate scope")
 	}
@@ -349,7 +355,7 @@ func (c *Core) enterLiveCondenseCandidates(candidates []CondenseCandidate) error
 		return errors.New("parser-core phase zero: live condense candidate scope requires a scheduler transaction")
 	}
 	owned := append(c.condenseCandidates[:0], candidates...)
-	normalized, err := c.mergeLiveCondenseCandidatesUncheckpointed(owned)
+	normalized, err := c.mergeLiveCondenseCandidatesUncheckpointedWithCost(owned, allowNonzeroCost)
 	if err != nil {
 		clear(c.condenseCandidates)
 		c.condenseCandidates = c.condenseCandidates[:0]
@@ -362,6 +368,10 @@ func (c *Core) enterLiveCondenseCandidates(candidates []CondenseCandidate) error
 }
 
 func (c *Core) mergeLiveCondenseCandidatesUncheckpointed(candidates []CondenseCandidate) ([]CondenseCandidate, error) {
+	return c.mergeLiveCondenseCandidatesUncheckpointedWithCost(candidates, false)
+}
+
+func (c *Core) mergeLiveCondenseCandidatesUncheckpointedWithCost(candidates []CondenseCandidate, allowNonzeroCost bool) ([]CondenseCandidate, error) {
 	write := 0
 	for _, candidate := range candidates {
 		lineage, err := c.nodeLineage(candidate.Head.Node)
@@ -371,7 +381,7 @@ func (c *Core) mergeLiveCondenseCandidatesUncheckpointed(candidates []CondenseCa
 		if candidate.ErrorCost != lineage.storedErrorCost {
 			return nil, errors.New("parser-core phase zero: condense candidate error cost does not match its head")
 		}
-		if candidate.ErrorCost != 0 {
+		if candidate.ErrorCost != 0 && !allowNonzeroCost {
 			return nil, errors.New("parser-core phase zero: physical head merge requires zero error cost")
 		}
 		if err := c.recordNodeLineageRefs(candidate.Head, candidate.DropCohortRefs); err != nil {
@@ -430,7 +440,7 @@ func (c *Core) mergeLiveCondenseCandidatesUncheckpointed(candidates []CondenseCa
 				write++
 				continue
 			}
-			merged, err := c.mergeEquivalentHeadsAtBoundaryUncheckpointed(key, group.Head, candidate.Head)
+			merged, err := c.mergeEquivalentHeadsAtBoundaryUncheckpointedWithCost(key, group.Head, candidate.Head, allowNonzeroCost)
 			if err != nil {
 				return nil, err
 			}
@@ -548,6 +558,19 @@ func (c *Core) mergeEquivalentHeadsAtBoundaryUncheckpointed(
 	incumbent Head,
 	incoming Head,
 ) (Head, error) {
+	return c.mergeEquivalentHeadsAtBoundaryUncheckpointedWithCost(key, incumbent, incoming, false)
+}
+
+// mergeEquivalentHeadsAtBoundaryUncheckpointedWithCost merges equivalent
+// heads after the caller authenticates their complete stored cost. Recovery
+// reductions use the cost-enabled form because equal nonzero paths remain
+// physically mergeable in the C stack.
+func (c *Core) mergeEquivalentHeadsAtBoundaryUncheckpointedWithCost(
+	key boundaryKey,
+	incumbent Head,
+	incoming Head,
+	allowNonzeroCost bool,
+) (Head, error) {
 	if key.frontier != c.frontier {
 		return Head{}, errors.New("parser-core phase zero: physical head merge frontier mismatch")
 	}
@@ -582,7 +605,7 @@ func (c *Core) mergeEquivalentHeadsAtBoundaryUncheckpointed(
 	if leftLineage.storedErrorCost != rightLineage.storedErrorCost {
 		return Head{}, errors.New("parser-core phase zero: physical heads have different stored recovery costs")
 	}
-	if leftLineage.storedErrorCost != 0 {
+	if leftLineage.storedErrorCost != 0 && !allowNonzeroCost {
 		return Head{}, errors.New("parser-core phase zero: physical head merge requires zero error cost")
 	}
 	related, err := c.nodesAncestryRelated(incumbent.Node, incoming.Node)
@@ -664,6 +687,57 @@ func (c *Core) mergeEquivalentHeadsAtBoundaryUncheckpointed(
 	}
 	c.addWork(&c.work.PhysicalHeadMergeSuccesses, 1)
 	return Head{Node: merged}, nil
+}
+
+// MergeEquivalentHeadsOwned merges two clean scheduler heads under one
+// authenticated owner. The scheduler supplies the complete boundary key.
+// Recovery-costed heads use a separate pricing route and cannot enter this
+// clean merge seam.
+func (c *Core) MergeEquivalentHeadsOwned(
+	owner SchedulerTransactionToken,
+	state StateID,
+	byteOffset uint32,
+	checkpoint CheckpointID,
+	shifted bool,
+	incumbent Head,
+	incoming Head,
+) (out Head, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return out, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	key := boundaryKey{
+		frontier: c.frontier, state: state, byteOffset: byteOffset,
+		shifted: shifted, checkpoint: checkpoint,
+	}
+	out, err = c.mergeEquivalentHeadsAtBoundaryUncheckpointed(key, incumbent, incoming)
+	return out, c.finishSchedulerOwned(owner, err)
+}
+
+// MergeEquivalentHeadsWithStoredErrorCostOwned merges equal-cost scheduler
+// heads under one authenticated owner. The Core checks the stored cost before
+// it emits merge work or graph links.
+func (c *Core) MergeEquivalentHeadsWithStoredErrorCostOwned(
+	owner SchedulerTransactionToken,
+	state StateID,
+	byteOffset uint32,
+	checkpoint CheckpointID,
+	shifted bool,
+	incumbent Head,
+	incoming Head,
+) (out Head, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return out, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	key := boundaryKey{
+		frontier: c.frontier, state: state, byteOffset: byteOffset,
+		shifted: shifted, checkpoint: checkpoint,
+	}
+	out, err = c.mergeEquivalentHeadsAtBoundaryUncheckpointedWithCost(
+		key, incumbent, incoming, true,
+	)
+	return out, c.finishSchedulerOwned(owner, err)
 }
 
 // mergeNodeLineageMetadata preserves the histories represented by a physical
@@ -793,7 +867,7 @@ func (c *Core) ErrorRegionResumeWithLiveCondenseCandidatesAndCostOwned(
 		return out, err
 	}
 	defer c.recoverSchedulerOwnedPanic(owner)
-	if err = c.enterLiveCondenseCandidates(candidates); err != nil {
+	if err = c.enterLiveCondenseCandidatesWithCost(candidates, true); err != nil {
 		return out, c.finishSchedulerOwned(owner, err)
 	}
 	if cost == nil {
@@ -1276,7 +1350,7 @@ func (c *Core) ReduceOutputsCorridorClassifiedIntoWithLiveCondenseCandidatesAndC
 		return frontier, err
 	}
 	defer c.recoverSchedulerOwnedPanic(owner)
-	if err = c.enterLiveCondenseCandidates(candidates); err != nil {
+	if err = c.enterLiveCondenseCandidatesWithCost(candidates, true); err != nil {
 		return frontier, c.finishSchedulerOwned(owner, err)
 	}
 	if c.schedulerFrame.fresh {
@@ -1302,7 +1376,7 @@ func (c *Core) reduceOutputsClassifiedIntoMaybeLiveScopedOwned(owner SchedulerTr
 		frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(owner, dst, boundary, actionOrdinal, fork, cost)
 		return frontier, c.finishSchedulerOwned(owner, err)
 	}
-	if err = c.enterLiveCondenseCandidates(candidates); err != nil {
+	if err = c.enterLiveCondenseCandidatesWithCost(candidates, cost != nil); err != nil {
 		return frontier, c.finishSchedulerOwned(owner, err)
 	}
 	if c.schedulerFrame.fresh {

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -202,6 +202,14 @@ func (c *Core) recordNodeStoredErrorCost(head Head, cost uint32) error {
 	if node.storedErrorCost == cost {
 		return nil
 	}
+	frame := &c.schedulerFrame
+	if !frame.active || len(c.transactions) == 0 ||
+		c.transactions[len(c.transactions)-1] != frame.mark.transaction {
+		return errors.New("parser-core phase zero: stored recovery cost requires a nested scheduler speculation")
+	}
+	if uint64(head.Node) <= uint64(frame.mark.nodeLineages) {
+		return errors.New("parser-core phase zero: stored recovery cost cannot rewrite a published node")
+	}
 	if len(c.transactions) != 0 {
 		c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
 			node: head.Node, owner: node.owner, dropCohortRefs: node.dropCohortRefs,
@@ -356,6 +364,13 @@ func (c *Core) enterLiveCondenseCandidates(candidates []CondenseCandidate) error
 func (c *Core) mergeLiveCondenseCandidatesUncheckpointed(candidates []CondenseCandidate) ([]CondenseCandidate, error) {
 	write := 0
 	for _, candidate := range candidates {
+		lineage, err := c.nodeLineage(candidate.Head.Node)
+		if err != nil {
+			return nil, err
+		}
+		if candidate.ErrorCost != lineage.storedErrorCost {
+			return nil, errors.New("parser-core phase zero: condense candidate error cost does not match its head")
+		}
 		if candidate.ErrorCost != 0 {
 			return nil, errors.New("parser-core phase zero: physical head merge requires zero error cost")
 		}
@@ -458,6 +473,13 @@ func (c *Core) clearLiveCondenseCandidates() {
 func (c *Core) reindexCondenseCandidatesUncheckpointed(candidates []CondenseCandidate) error {
 	c.boundaries.advanceGeneration()
 	for index, candidate := range candidates {
+		lineage, err := c.nodeLineage(candidate.Head.Node)
+		if err != nil {
+			return err
+		}
+		if candidate.ErrorCost != lineage.storedErrorCost {
+			return errors.New("parser-core phase zero: condense candidate error cost does not match its head")
+		}
 		if candidate.ErrorCost != 0 {
 			return errors.New("parser-core phase zero: physical head merge requires zero error cost")
 		}
@@ -549,6 +571,20 @@ func (c *Core) mergeEquivalentHeadsAtBoundaryUncheckpointed(
 	if !leftExact || !rightExact || leftCheckpoint != rightCheckpoint {
 		return Head{}, errors.New("parser-core phase zero: physical heads have different scanner provenance")
 	}
+	leftLineage, err := c.nodeLineage(incumbent.Node)
+	if err != nil {
+		return Head{}, err
+	}
+	rightLineage, err := c.nodeLineage(incoming.Node)
+	if err != nil {
+		return Head{}, err
+	}
+	if leftLineage.storedErrorCost != rightLineage.storedErrorCost {
+		return Head{}, errors.New("parser-core phase zero: physical heads have different stored recovery costs")
+	}
+	if leftLineage.storedErrorCost != 0 {
+		return Head{}, errors.New("parser-core phase zero: physical head merge requires zero error cost")
+	}
 	related, err := c.nodesAncestryRelated(incumbent.Node, incoming.Node)
 	if err != nil {
 		return Head{}, err
@@ -609,8 +645,9 @@ func (c *Core) mergeEquivalentHeadsAtBoundaryUncheckpointed(
 	// key.checkpoint authenticates the current lookahead boundary. The graph
 	// node checkpoint authenticates the last consumed external scanner state.
 	// Keep the source node checkpoint when those two identities differ.
-	merged, err := c.appendAdjacencyNodeAtWithPrecedence(
+	merged, err := c.appendAdjacencyNodeAtWithPrecedenceAndStoredErrorCost(
 		key.state, key.byteOffset, leftCheckpoint, links, folded,
+		leftLineage.storedErrorCost, true,
 	)
 	if err != nil {
 		return Head{}, err
@@ -1125,13 +1162,36 @@ func (c *Core) shiftExtraClassifiedCohortUncheckpointed(boundaries []ClassifiedB
 // ReduceOutputsClassifiedIntoOwned authenticates the scheduler owner, then
 // delegates to the standalone reduction's uncheckpointed implementation.
 func (c *Core) ReduceOutputsClassifiedIntoOwned(owner SchedulerTransactionToken, dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder) (frontier []ReductionOutput, err error) {
-	return c.reduceOutputsClassifiedIntoMaybeLiveScopedOwned(owner, nil, false, dst, boundary, actionOrdinal, fork)
+	return c.reduceOutputsClassifiedIntoMaybeLiveScopedOwned(owner, nil, false, dst, boundary, actionOrdinal, fork, nil)
 }
 
 // ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesOwned scopes the condense candidates
 // and reduces under one scheduler ownership check.
 func (c *Core) ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesOwned(owner SchedulerTransactionToken, candidates []CondenseCandidate, dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder) (frontier []ReductionOutput, err error) {
-	return c.reduceOutputsClassifiedIntoMaybeLiveScopedOwned(owner, candidates, true, dst, boundary, actionOrdinal, fork)
+	return c.reduceOutputsClassifiedIntoMaybeLiveScopedOwned(owner, candidates, true, dst, boundary, actionOrdinal, fork, nil)
+}
+
+// ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesAndCostOwned applies
+// one reduction while authenticating output costs before any boundary can
+// fold or publish.
+func (c *Core) ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesAndCostOwned(
+	owner SchedulerTransactionToken,
+	candidates []CondenseCandidate,
+	dst []ReductionOutput,
+	boundary ClassifiedBoundary,
+	actionOrdinal int,
+	fork ForkOrder,
+	cost ReductionOutputCostFunc,
+) (frontier []ReductionOutput, err error) {
+	if cost == nil {
+		if err = c.beginSchedulerOwned(owner); err != nil {
+			return frontier, err
+		}
+		return frontier, c.finishSchedulerOwned(owner, errors.New("parser-core phase zero: reduction cost callback is required"))
+	}
+	return c.reduceOutputsClassifiedIntoMaybeLiveScopedOwned(
+		owner, candidates, true, dst, boundary, actionOrdinal, fork, cost,
+	)
 }
 
 // ReduceOutputsCorridorClassifiedIntoWithLiveCondenseCandidatesOwned applies
@@ -1162,33 +1222,66 @@ func (c *Core) ReduceOutputsCorridorClassifiedIntoWithLiveCondenseCandidatesOwne
 	return frontier, c.finishSchedulerOwned(owner, err)
 }
 
+// ReduceOutputsCorridorClassifiedIntoWithLiveCondenseCandidatesAndCostOwned
+// is the corridor form of the authenticated reduction-cost seam.
+func (c *Core) ReduceOutputsCorridorClassifiedIntoWithLiveCondenseCandidatesAndCostOwned(
+	owner SchedulerTransactionToken,
+	candidates []CondenseCandidate,
+	dst []ReductionOutput,
+	boundary ClassifiedBoundary,
+	fork ForkOrder,
+	cost ReductionOutputCostFunc,
+) (frontier []ReductionOutput, err error) {
+	if cost == nil {
+		if err = c.beginSchedulerOwned(owner); err != nil {
+			return frontier, err
+		}
+		return frontier, c.finishSchedulerOwned(owner, errors.New("parser-core phase zero: reduction cost callback is required"))
+	}
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return frontier, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if err = c.enterLiveCondenseCandidates(candidates); err != nil {
+		return frontier, c.finishSchedulerOwned(owner, err)
+	}
+	if c.schedulerFrame.fresh {
+		frontier, err = c.reduceOutputsCorridorClassifiedIntoUncheckpointedWithCost(owner, dst, boundary, fork, cost)
+		c.clearLiveCondenseCandidates()
+		return frontier, c.finishSchedulerOwned(owner, err)
+	}
+	defer c.clearLiveCondenseCandidates()
+	frontier, err = c.reduceOutputsCorridorClassifiedIntoUncheckpointedWithCost(owner, dst, boundary, fork, cost)
+	return frontier, c.finishSchedulerOwned(owner, err)
+}
+
 // reduceOutputsClassifiedIntoMaybeLiveScopedOwned inlines the former
 // runSchedulerMaybeLiveScopedOwned/runLiveCondenseCandidates closure chain;
 // see shiftClassifiedMaybeLiveScopedOwned's doc comment for the equivalence
 // argument, which applies identically here.
-func (c *Core) reduceOutputsClassifiedIntoMaybeLiveScopedOwned(owner SchedulerTransactionToken, candidates []CondenseCandidate, liveScoped bool, dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder) (frontier []ReductionOutput, err error) {
+func (c *Core) reduceOutputsClassifiedIntoMaybeLiveScopedOwned(owner SchedulerTransactionToken, candidates []CondenseCandidate, liveScoped bool, dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder, cost ReductionOutputCostFunc) (frontier []ReductionOutput, err error) {
 	if err = c.beginSchedulerOwned(owner); err != nil {
 		return frontier, err
 	}
 	defer c.recoverSchedulerOwnedPanic(owner)
 	if !liveScoped {
-		frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(owner, dst, boundary, actionOrdinal, fork)
+		frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(owner, dst, boundary, actionOrdinal, fork, cost)
 		return frontier, c.finishSchedulerOwned(owner, err)
 	}
 	if err = c.enterLiveCondenseCandidates(candidates); err != nil {
 		return frontier, c.finishSchedulerOwned(owner, err)
 	}
 	if c.schedulerFrame.fresh {
-		frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(owner, dst, boundary, actionOrdinal, fork)
+		frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(owner, dst, boundary, actionOrdinal, fork, cost)
 		c.clearLiveCondenseCandidates()
 		return frontier, c.finishSchedulerOwned(owner, err)
 	}
 	defer c.clearLiveCondenseCandidates()
-	frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(owner, dst, boundary, actionOrdinal, fork)
+	frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(owner, dst, boundary, actionOrdinal, fork, cost)
 	return frontier, c.finishSchedulerOwned(owner, err)
 }
 
-func (c *Core) reduceOutputsClassifiedIntoUncheckpointed(owner SchedulerTransactionToken, dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder) ([]ReductionOutput, error) {
+func (c *Core) reduceOutputsClassifiedIntoUncheckpointed(owner SchedulerTransactionToken, dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder, cost ReductionOutputCostFunc) ([]ReductionOutput, error) {
 	frontier := dst[:0]
 	if c.popScratch.busy {
 		return nil, errors.New("parser-core phase zero: reentrant reduction while pop scratch is active")
@@ -1200,7 +1293,7 @@ func (c *Core) reduceOutputsClassifiedIntoUncheckpointed(owner SchedulerTransact
 	defer c.popScratch.resetLogical()
 	c.reductionScratch.begin()
 	defer c.reductionScratch.finish()
-	return c.reduceOutputsClassifiedIntoActive(owner, frontier, boundary, actionOrdinal, fork, false)
+	return c.reduceOutputsClassifiedIntoActive(owner, frontier, boundary, actionOrdinal, fork, false, cost)
 }
 
 func (c *Core) historicalImportEnvelope(owner SchedulerTransactionToken, refs DropCohortRefSet, historicalNode NodeID) (int, bool) {
@@ -1293,6 +1386,10 @@ func (c *Core) authenticateHistoricalDropCohortImport(
 }
 
 func (c *Core) reduceOutputsCorridorClassifiedIntoUncheckpointed(owner SchedulerTransactionToken, dst []ReductionOutput, boundary ClassifiedBoundary, fork ForkOrder) ([]ReductionOutput, error) {
+	return c.reduceOutputsCorridorClassifiedIntoUncheckpointedWithCost(owner, dst, boundary, fork, nil)
+}
+
+func (c *Core) reduceOutputsCorridorClassifiedIntoUncheckpointedWithCost(owner SchedulerTransactionToken, dst []ReductionOutput, boundary ClassifiedBoundary, fork ForkOrder, cost ReductionOutputCostFunc) ([]ReductionOutput, error) {
 	frontier := dst[:0]
 	if c.popScratch.busy {
 		return nil, errors.New("parser-core phase zero: reentrant reduction while pop scratch is active")
@@ -1301,10 +1398,10 @@ func (c *Core) reduceOutputsCorridorClassifiedIntoUncheckpointed(owner Scheduler
 	defer c.popScratch.resetLogical()
 	c.reductionScratch.begin()
 	defer c.reductionScratch.finish()
-	return c.reduceOutputsClassifiedIntoActive(owner, frontier, boundary, 0, fork, true)
+	return c.reduceOutputsClassifiedIntoActive(owner, frontier, boundary, 0, fork, true, cost)
 }
 
-func (c *Core) reduceOutputsClassifiedIntoActive(owner SchedulerTransactionToken, frontier []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder, corridorTrusted bool) ([]ReductionOutput, error) {
+func (c *Core) reduceOutputsClassifiedIntoActive(owner SchedulerTransactionToken, frontier []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder, corridorTrusted bool, cost ReductionOutputCostFunc) ([]ReductionOutput, error) {
 	var act *Action
 	var err error
 	if corridorTrusted {
@@ -1402,6 +1499,14 @@ func (c *Core) reduceOutputsClassifiedIntoActive(owner SchedulerTransactionToken
 			return nil, err
 		}
 		parentLink := linkInput{prev: path.prev, payload: payload, scoreDelta: scoreDelta, order: order}
+		if cost != nil {
+			storedErrorCost, costErr := cost(path.prev, payload)
+			if costErr != nil {
+				return nil, costErr
+			}
+			parentLink.storedErrorCost = storedErrorCost
+			parentLink.hasStoredErrorCost = true
+		}
 		phase0AObserveReductionOccurrence(c, parentLink, key)
 		var out Head
 		var outcome condenseOutcome
@@ -1421,6 +1526,14 @@ func (c *Core) reduceOutputsClassifiedIntoActive(owner SchedulerTransactionToken
 			}
 			key = c.boundaryKey(gotoState, extra.endByte)
 			extraLink := linkInput{prev: out.Node, payload: trailing.payload, scoreDelta: trailing.scoreDelta}
+			if cost != nil {
+				storedErrorCost, costErr := cost(out.Node, trailing.payload)
+				if costErr != nil {
+					return nil, costErr
+				}
+				extraLink.storedErrorCost = storedErrorCost
+				extraLink.hasStoredErrorCost = true
+			}
 			if phase0AEnabled {
 				phase0AObserveTrailingExtraMigration(c, uint32(index), key, extraLink)
 			}

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -147,6 +147,7 @@ func (c *Core) recordNodeLineage(head Head, rank CleanPathRankSelection, lineage
 			node: head.Node, owner: node.owner, dropCohortRefs: node.dropCohortRefs,
 			setCount: node.set.count, setFlags: node.set.flags, setSpillRef: node.set.spillRef,
 			lineage: node.lineage, rank: node.rank, converged: node.converged, blended: node.blended,
+			storedErrorCost: node.storedErrorCost,
 		})
 	}
 	node.rank = nextRank
@@ -176,11 +177,41 @@ func (c *Core) RecordHeadOwnerOwned(owner SchedulerTransactionToken, head Head, 
 				node: head.Node, owner: node.owner, dropCohortRefs: node.dropCohortRefs,
 				setCount: node.set.count, setFlags: node.set.flags, setSpillRef: node.set.spillRef,
 				lineage: node.lineage, rank: node.rank, converged: node.converged, blended: node.blended,
+				storedErrorCost: node.storedErrorCost,
 			})
 		}
 		node.owner = lineage
 		return nil
 	})
+}
+
+// RecordHeadStoredErrorCostOwned publishes the exact C stack-node error cost
+// carried by one recovery head. The cost is lineage metadata, so nodeRecord
+// remains compact and all updates stay rollback-safe.
+func (c *Core) RecordHeadStoredErrorCostOwned(owner SchedulerTransactionToken, head Head, cost uint32) error {
+	return c.RunSchedulerOwned(owner, func() error {
+		return c.recordNodeStoredErrorCost(head, cost)
+	})
+}
+
+func (c *Core) recordNodeStoredErrorCost(head Head, cost uint32) error {
+	node, err := c.nodeLineage(head.Node)
+	if err != nil {
+		return err
+	}
+	if node.storedErrorCost == cost {
+		return nil
+	}
+	if len(c.transactions) != 0 {
+		c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
+			node: head.Node, owner: node.owner, dropCohortRefs: node.dropCohortRefs,
+			setCount: node.set.count, setFlags: node.set.flags, setSpillRef: node.set.spillRef,
+			lineage: node.lineage, rank: node.rank, converged: node.converged, blended: node.blended,
+			storedErrorCost: node.storedErrorCost,
+		})
+	}
+	node.storedErrorCost = cost
+	return nil
 }
 
 // RecordHeadLineageSetOwned unions set into one compact head's node record.
@@ -222,6 +253,7 @@ func (c *Core) recordNodeLineageSet(head Head, set AlternativeSet, setBlended bo
 			node: head.Node, owner: node.owner, dropCohortRefs: node.dropCohortRefs,
 			setCount: before.count, setFlags: before.flags, setSpillRef: before.spillRef,
 			lineage: node.lineage, rank: node.rank, converged: node.converged, blended: beforeBlended,
+			storedErrorCost: node.storedErrorCost,
 		})
 	}
 	node.blended = nextBlended
@@ -258,6 +290,7 @@ func (c *Core) recordNodeLineageRefs(head Head, refs DropCohortRefSet) error {
 			node: head.Node, owner: node.owner, dropCohortRefs: before,
 			setCount: node.set.count, setFlags: node.set.flags, setSpillRef: node.set.spillRef,
 			lineage: node.lineage, rank: node.rank, converged: node.converged, blended: node.blended,
+			storedErrorCost: node.storedErrorCost,
 		})
 	}
 	return nil
@@ -289,6 +322,7 @@ func (c *Core) recordNodeLineageMember(head Head, event, branch uint16) error {
 			node: head.Node, owner: node.owner, dropCohortRefs: node.dropCohortRefs,
 			setCount: before.count, setFlags: before.flags, setSpillRef: before.spillRef,
 			lineage: node.lineage, rank: node.rank, converged: node.converged, blended: node.blended,
+			storedErrorCost: node.storedErrorCost,
 		})
 	}
 	return nil
@@ -607,12 +641,16 @@ func (c *Core) mergeNodeLineageMetadata(leftID, rightID, targetID NodeID) error 
 	if err != nil {
 		return err
 	}
+	if left.storedErrorCost != right.storedErrorCost {
+		return errors.New("parser-core phase zero: merged heads have different stored recovery costs")
+	}
 	target, err := c.nodeLineage(targetID)
 	if err != nil {
 		return err
 	}
 	before := *target
 	merged := nodeLineageRecord{}
+	merged.storedErrorCost = left.storedErrorCost
 	if targetID == leftID {
 		merged.owner = left.owner
 	}
@@ -635,6 +673,7 @@ func (c *Core) mergeNodeLineageMetadata(leftID, rightID, targetID NodeID) error 
 			node: targetID, owner: before.owner, dropCohortRefs: before.dropCohortRefs,
 			setCount: before.set.count, setFlags: before.set.flags, setSpillRef: before.set.spillRef,
 			lineage: before.lineage, rank: before.rank, converged: before.converged, blended: before.blended,
+			storedErrorCost: before.storedErrorCost,
 		})
 	}
 	*target = merged

--- a/internal/parsercorephase0/scheduler_transaction_test.go
+++ b/internal/parsercorephase0/scheduler_transaction_test.go
@@ -2,6 +2,7 @@ package parsercorephase0
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -312,34 +313,148 @@ func TestSchedulerSpeculationRollsBackFreshAndOrdinarySessions(t *testing.T) {
 			if got := captureSchedulerTransactionState(compact); !reflect.DeepEqual(got, before) {
 				t.Fatalf("ordinary declined speculation changed state: got=%+v want=%+v", got, before)
 			}
+			if _, err := compact.ShiftClassified(boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); err != nil {
+				return err
+			}
 			return nil
 		})
 		if err != nil {
 			t.Fatalf("ordinary speculation err=%v", err)
 		}
-		if got := captureSchedulerTransactionState(compact); !reflect.DeepEqual(got, before) {
-			t.Fatalf("ordinary outer commit changed declined state: got=%+v want=%+v", got, before)
+		if compact.Work().Shifts != 1 {
+			t.Fatalf("ordinary outer shift after decline work=%+v", compact.Work())
 		}
 	})
 
 	t.Run("fresh", func(t *testing.T) {
 		compact, _, boundary := newSchedulerTransactionShiftFixture(t)
-		before := captureSchedulerTransactionState(compact)
 		err := compact.RunFreshSchedulerSession(func(outer SchedulerTransactionToken) error {
-			return compact.ApplySchedulerSpeculation(outer, func(inner SchedulerTransactionToken) (bool, error) {
+			if err := compact.ApplySchedulerSpeculation(outer, func(inner SchedulerTransactionToken) (bool, error) {
 				if _, err := compact.ShiftClassifiedOwned(inner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); err != nil {
 					return false, err
 				}
 				return false, nil
-			})
+			}); err != nil {
+				return err
+			}
+			_, err := compact.ShiftClassified(boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{})
+			return err
 		})
 		if err != nil {
 			t.Fatalf("fresh speculation err=%v", err)
 		}
-		if got := captureSchedulerTransactionState(compact); !reflect.DeepEqual(got, before) {
-			t.Fatalf("fresh declined speculation changed state: got=%+v want=%+v", got, before)
+		if compact.Work().Shifts != 1 {
+			t.Fatalf("fresh outer shift after decline work=%+v", compact.Work())
 		}
 	})
+}
+
+func TestSchedulerSpeculationAuthenticatesOrdinaryAncestorBelowAtomicMark(t *testing.T) {
+	for _, commit := range []bool{false, true} {
+		t.Run(fmt.Sprintf("commit_%t", commit), func(t *testing.T) {
+			compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+			err := compact.ApplySchedulerAtomic(func(outer SchedulerTransactionToken) error {
+				return compact.ApplyAtomic(func() error {
+					return compact.ApplySchedulerSpeculation(outer, func(inner SchedulerTransactionToken) (bool, error) {
+						if _, err := compact.ShiftClassifiedOwned(inner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); err != nil {
+							return false, err
+						}
+						return commit, nil
+					})
+				})
+			})
+			if err != nil {
+				t.Fatalf("speculation below internal transaction failed: %v", err)
+			}
+			wantShifts := uint64(0)
+			if commit {
+				wantShifts = 1
+			}
+			if compact.Work().Shifts != wantShifts {
+				t.Fatalf("shifts=%d, want %d", compact.Work().Shifts, wantShifts)
+			}
+		})
+	}
+}
+
+func TestNestedSchedulerSpeculationPreservesOuterClassification(t *testing.T) {
+	compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+	err := compact.ApplySchedulerAtomic(func(outer SchedulerTransactionToken) error {
+		return compact.ApplySchedulerSpeculation(outer, func(first SchedulerTransactionToken) (bool, error) {
+			if err := compact.ApplySchedulerSpeculation(first, func(second SchedulerTransactionToken) (bool, error) {
+				if _, err := compact.ShiftClassifiedOwned(second, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); err != nil {
+					return false, err
+				}
+				return false, nil
+			}); err != nil {
+				return false, err
+			}
+			if _, err := compact.ShiftClassifiedOwned(first, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); err != nil {
+				return false, err
+			}
+			return false, nil
+		})
+	})
+	if err != nil {
+		t.Fatalf("nested speculation err=%v", err)
+	}
+}
+
+func TestSchedulerSpeculationInvalidatesChildClassificationOnly(t *testing.T) {
+	for _, fresh := range []bool{false, true} {
+		t.Run(fmt.Sprintf("fresh_%t", fresh), func(t *testing.T) {
+			compact, _, outerBoundary := newSchedulerTransactionShiftFixture(t)
+			var childBoundary ClassifiedBoundary
+			run := func(outer SchedulerTransactionToken) error {
+				if err := compact.ApplySchedulerSpeculation(outer, func(inner SchedulerTransactionToken) (bool, error) {
+					childHead, err := compact.ShiftClassifiedOwned(inner, outerBoundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{})
+					if err != nil {
+						return false, err
+					}
+					childBoundary, err = compact.ClassifyBoundary(childHead, 9)
+					return false, err
+				}); err != nil {
+					return err
+				}
+				if err := compact.validateClassification(childBoundary); err == nil || !strings.Contains(err.Error(), "transaction is stale") {
+					return fmt.Errorf("child classification after decline: %v", err)
+				}
+				_, err := compact.ShiftClassifiedOwned(outer, outerBoundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{})
+				return err
+			}
+			var err error
+			if fresh {
+				err = compact.RunFreshSchedulerSession(run)
+			} else {
+				err = compact.ApplySchedulerAtomic(run)
+			}
+			if err != nil {
+				t.Fatalf("speculation classification isolation: %v", err)
+			}
+		})
+	}
+
+	compact, _, outerBoundary := newSchedulerTransactionShiftFixture(t)
+	var childBoundary ClassifiedBoundary
+	err := compact.ApplySchedulerAtomic(func(outer SchedulerTransactionToken) error {
+		if err := compact.ApplySchedulerSpeculation(outer, func(inner SchedulerTransactionToken) (bool, error) {
+			childHead, err := compact.ShiftClassifiedOwned(inner, outerBoundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{})
+			if err != nil {
+				return false, err
+			}
+			childBoundary, err = compact.ClassifyBoundary(childHead, 9)
+			return true, err
+		}); err != nil {
+			return err
+		}
+		if err := compact.validateClassification(childBoundary); err == nil || !strings.Contains(err.Error(), "transaction is stale") {
+			return fmt.Errorf("child classification after commit: %v", err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("committed speculation classification isolation: %v", err)
+	}
 }
 
 func TestSchedulerSpeculationIgnoredErrorPoisonsOuter(t *testing.T) {

--- a/internal/parsercorephase0/scheduler_transaction_test.go
+++ b/internal/parsercorephase0/scheduler_transaction_test.go
@@ -3,6 +3,7 @@ package parsercorephase0
 import (
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -397,6 +398,15 @@ func TestNestedSchedulerSpeculationPreservesOuterClassification(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("nested speculation err=%v", err)
+	}
+}
+
+func TestClassificationRejectsTransactionBeyondCompactCapabilityRange(t *testing.T) {
+	compact, seed, _ := newSchedulerTransactionShiftFixture(t)
+	compact.transactions = []uint64{math.MaxUint32 + 1}
+	if _, err := compact.ClassifyBoundary(seed, 9); err == nil ||
+		!strings.Contains(err.Error(), "classification transaction exceeds compact capability range") {
+		t.Fatalf("oversized classification transaction error=%v", err)
 	}
 }
 

--- a/internal/parsercorephase0/scheduler_transaction_test.go
+++ b/internal/parsercorephase0/scheduler_transaction_test.go
@@ -296,6 +296,85 @@ func TestFreshSchedulerSessionRejectsRetainedToken(t *testing.T) {
 	}
 }
 
+func TestSchedulerSpeculationRollsBackFreshAndOrdinarySessions(t *testing.T) {
+	t.Run("ordinary", func(t *testing.T) {
+		compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+		before := captureSchedulerTransactionState(compact)
+		err := compact.ApplySchedulerAtomic(func(outer SchedulerTransactionToken) error {
+			if err := compact.ApplySchedulerSpeculation(outer, func(inner SchedulerTransactionToken) (bool, error) {
+				if _, err := compact.ShiftClassifiedOwned(inner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); err != nil {
+					return false, err
+				}
+				return false, nil
+			}); err != nil {
+				return err
+			}
+			if got := captureSchedulerTransactionState(compact); !reflect.DeepEqual(got, before) {
+				t.Fatalf("ordinary declined speculation changed state: got=%+v want=%+v", got, before)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("ordinary speculation err=%v", err)
+		}
+		if got := captureSchedulerTransactionState(compact); !reflect.DeepEqual(got, before) {
+			t.Fatalf("ordinary outer commit changed declined state: got=%+v want=%+v", got, before)
+		}
+	})
+
+	t.Run("fresh", func(t *testing.T) {
+		compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+		before := captureSchedulerTransactionState(compact)
+		err := compact.RunFreshSchedulerSession(func(outer SchedulerTransactionToken) error {
+			return compact.ApplySchedulerSpeculation(outer, func(inner SchedulerTransactionToken) (bool, error) {
+				if _, err := compact.ShiftClassifiedOwned(inner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); err != nil {
+					return false, err
+				}
+				return false, nil
+			})
+		})
+		if err != nil {
+			t.Fatalf("fresh speculation err=%v", err)
+		}
+		if got := captureSchedulerTransactionState(compact); !reflect.DeepEqual(got, before) {
+			t.Fatalf("fresh declined speculation changed state: got=%+v want=%+v", got, before)
+		}
+	})
+}
+
+func TestSchedulerSpeculationIgnoredErrorPoisonsOuter(t *testing.T) {
+	compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+	before := captureSchedulerTransactionState(compact)
+	err := compact.ApplySchedulerAtomic(func(outer SchedulerTransactionToken) error {
+		return compact.ApplySchedulerSpeculation(outer, func(inner SchedulerTransactionToken) (bool, error) {
+			_, _ = compact.ShiftClassifiedOwned(inner, boundary, 1, Token{Symbol: 9, EndByte: 1}, ForkOrder{})
+			return false, nil
+		})
+	})
+	if err == nil {
+		t.Fatalf("ignored speculative error did not poison outer: %v", err)
+	}
+	if got := captureSchedulerTransactionState(compact); !reflect.DeepEqual(got, before) {
+		t.Fatalf("poisoned speculation changed state: got=%+v want=%+v", got, before)
+	}
+}
+
+func TestSchedulerSpeculationRejectsOuterTokenDuringChild(t *testing.T) {
+	compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+	err := compact.ApplySchedulerAtomic(func(outer SchedulerTransactionToken) error {
+		return compact.ApplySchedulerSpeculation(outer, func(SchedulerTransactionToken) (bool, error) {
+			_, err := compact.ShiftClassifiedOwned(outer, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{})
+			if err == nil || !strings.Contains(err.Error(), "stale") {
+				return false, errors.New("outer token was accepted during child speculation")
+			}
+			return false, nil
+		})
+	})
+	if err == nil {
+		t.Fatalf("outer-token misuse did not poison session: %v", err)
+	}
+}
+
 func TestSchedulerTransactionInsideStandaloneOwner(t *testing.T) {
 	t.Run("outer-rollback", func(t *testing.T) {
 		compact, _, boundary := newSchedulerTransactionShiftFixture(t)

--- a/internal/parsercorephase0/selected_store.go
+++ b/internal/parsercorephase0/selected_store.go
@@ -158,6 +158,7 @@ const (
 	// public tree sets the node's missing and has-error bits, the projection
 	// would report an ordinary zero-width token.
 	selectedNodeFlagMissing
+	selectedNodeFlagHasError
 )
 
 // SelectedNodeRecord is one immutable logical occurrence after hidden-parent
@@ -184,6 +185,9 @@ func (r SelectedNodeRecord) Terminal() bool { return r.flags&selectedNodeFlagTer
 // Missing reports a recovery-inserted zero-width terminal (C ts_subtree_missing).
 func (r SelectedNodeRecord) Missing() bool { return r.flags&selectedNodeFlagMissing != 0 }
 
+// HasError reports recovery content on this occurrence or its descendants.
+func (r SelectedNodeRecord) HasError() bool { return r.flags&selectedNodeFlagHasError != 0 }
+
 // SelectedStore is the sealed, pointer-free selected syntax backing store.
 // IDs are occurrence identities; repeated compact SubtreeIDs remain distinct.
 type SelectedStore struct {
@@ -200,20 +204,22 @@ type selectedStoreBacking struct {
 }
 
 type selectedStoreBuildScratch struct {
-	raw         []selectedRawOccurrence
-	rawChildren []uint32
-	rawRoots    []uint32
-	results     []SelectedNodeID
-	precedence  []int32
-	collect     []uint32
-	logical     []SelectedNodeID
-	rootIDs     []SelectedNodeID
-	stack       []selectedOccurrenceFrame
+	raw            []selectedRawOccurrence
+	rawChildren    []uint32
+	rawRoots       []uint32
+	results        []SelectedNodeID
+	resultHasError []bool
+	precedence     []int32
+	collect        []uint32
+	logical        []SelectedNodeID
+	rootIDs        []SelectedNodeID
+	stack          []selectedOccurrenceFrame
 }
 
 type selectedOccurrenceFrame struct {
 	occurrence uint32
 	next       uint32
+	hasError   bool
 }
 
 func (s *SelectedStore) Root() SelectedNodeID {
@@ -483,6 +489,8 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 	}
 	results := resizeSelectedScratch(c.selectedBuild.results, len(raw))
 	c.selectedBuild.results = results
+	resultHasError := resizeSelectedScratch(c.selectedBuild.resultHasError, len(raw))
+	c.selectedBuild.resultHasError = resultHasError
 	wantRetained := uint64(len(raw)+retainedAliasCount)*uint64(unsafe.Sizeof(SelectedNodeRecord{})) +
 		uint64(len(raw)-len(roots)+retainedAliasCount)*uint64(unsafe.Sizeof(SelectedNodeID(0)))
 	if wantRetained > c.limits.MaxSelectedBytes {
@@ -526,9 +534,13 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 		if !ok {
 			return nil, fmt.Errorf("parser-core phase zero: selected symbol %d is outside policy", symbol)
 		}
+		hasError := record.missing || record.symbol == ErrorRegionSymbol
 		logical = logical[:0]
 		for childIndex := uint32(0); childIndex < uint32(occ.childCount); childIndex++ {
 			rawChild := rawChildren[occ.firstChild+childIndex]
+			if resultHasError[rawChild] {
+				hasError = true
+			}
 			start := len(logical)
 			collect = append(collect[:0], rawChild)
 			for len(collect) != 0 {
@@ -554,13 +566,16 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 			child := &store.records[childID-1]
 			rule := policy.unary(record.symbol, child.Symbol)
 			if !child.Extra() && (rule == SelectedUnaryPass || rule == SelectedUnaryRenameLeaf && child.ChildCount == 0) {
+				if hasError {
+					child.flags |= selectedNodeFlagHasError
+				}
 				if rule == SelectedUnaryRenameLeaf {
 					child.Symbol = record.symbol
-					child.flags = selectedFlags(policy.Symbols[record.symbol], child.Extra(), child.External(), child.Terminal(), child.Missing())
+					child.flags = selectedFlags(policy.Symbols[record.symbol], child.Extra(), child.External(), child.Terminal(), child.Missing(), child.HasError())
 				}
 				if occ.alias != 0 && !retainAliasChild {
 					child.Symbol = occ.alias
-					child.flags = selectedFlags(meta, child.Extra(), child.External(), child.Terminal(), child.Missing())
+					child.flags = selectedFlags(meta, child.Extra(), child.External(), child.Terminal(), child.Missing(), child.HasError())
 				}
 				child.ProductionID = record.productionID
 				delta, err := checkedSelectedPrecedence(precedenceDeltas[childID-1], int32(record.dynamicPrecedence))
@@ -578,11 +593,13 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 					}
 				}
 				results[index] = childID
+				resultHasError[index] = hasError
 				continue
 			}
 		}
 
 		if !meta.Visible && !record.extra {
+			resultHasError[index] = hasError
 			continue
 		}
 		if len(logical) > math.MaxUint16 || uint64(len(store.children))+uint64(len(logical)) > math.MaxUint32 || uint64(len(store.records)) >= math.MaxUint32 {
@@ -591,7 +608,7 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 		id := SelectedNodeID(uint64(len(store.records)) + 1)
 		first := uint32(len(store.children))
 		store.children = append(store.children, logical...)
-		flags := selectedFlags(meta, record.extra, record.external, record.terminal, record.missing)
+		flags := selectedFlags(meta, record.extra, record.external, record.terminal, record.missing, hasError)
 		startByte, endByte := record.startByte, record.endByte
 		if len(logical) != 0 {
 			firstChild := store.records[logical[0]-1]
@@ -625,6 +642,7 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 			}
 		}
 		results[index] = id
+		resultHasError[index] = hasError
 	}
 
 	rootIDs := c.selectedBuild.rootIDs[:0]
@@ -685,6 +703,8 @@ func (c *Core) finishSelectedBuildScratch() {
 	c.selectedBuild.rawRoots = c.selectedBuild.rawRoots[:0]
 	clear(c.selectedBuild.results)
 	c.selectedBuild.results = c.selectedBuild.results[:0]
+	clear(c.selectedBuild.resultHasError)
+	c.selectedBuild.resultHasError = c.selectedBuild.resultHasError[:0]
 	c.selectedBuild.precedence = c.selectedBuild.precedence[:0]
 	c.selectedBuild.collect = c.selectedBuild.collect[:0]
 	c.selectedBuild.logical = c.selectedBuild.logical[:0]
@@ -918,7 +938,7 @@ func (s *SelectedStore) normalizeCaseBoundary(current *SelectedNodeRecord, nextS
 	}
 }
 
-func selectedFlags(meta SelectedSymbolPolicy, extra, external, terminal, missing bool) uint8 {
+func selectedFlags(meta SelectedSymbolPolicy, extra, external, terminal, missing, hasError bool) uint8 {
 	var flags uint8
 	if meta.Named {
 		flags |= selectedNodeFlagNamed
@@ -934,6 +954,9 @@ func selectedFlags(meta SelectedSymbolPolicy, extra, external, terminal, missing
 	}
 	if missing {
 		flags |= selectedNodeFlagMissing
+	}
+	if hasError {
+		flags |= selectedNodeFlagHasError
 	}
 	return flags
 }
@@ -964,7 +987,7 @@ func appendSelectedRetainedAliasWrapper(
 	store.records = append(store.records, SelectedNodeRecord{
 		FirstChild: first, StartByte: child.StartByte, EndByte: child.EndByte,
 		Symbol: alias, Field: field, ProductionID: productionID, ChildCount: 1,
-		flags: selectedFlags(meta, false, false, false, false),
+		flags: selectedFlags(meta, false, false, false, false, child.HasError()),
 	})
 	precedenceDeltas = append(precedenceDeltas, 0)
 	child = &store.records[childID-1]

--- a/internal/parsercorephase0/selected_store_builder_onepass.go
+++ b/internal/parsercorephase0/selected_store_builder_onepass.go
@@ -150,19 +150,23 @@ func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStore
 				return nil, fmt.Errorf("parser-core phase zero: selected symbol %d is outside policy", symbol)
 			}
 
+			hasError := frame.hasError || record.missing || record.symbol == ErrorRegionSymbol
 			folded := false
 			if !record.terminal && record.childCount == 1 && record.fieldCount == 0 && record.aliasCount == 0 && len(logical)-logicalStart == 1 {
 				childID := logical[logicalStart]
 				child := &store.records[childID-1]
 				rule := policy.unary(record.symbol, child.Symbol)
 				if !child.Extra() && (rule == SelectedUnaryPass || rule == SelectedUnaryRenameLeaf && child.ChildCount == 0) {
+					if hasError {
+						child.flags |= selectedNodeFlagHasError
+					}
 					if rule == SelectedUnaryRenameLeaf {
 						child.Symbol = record.symbol
-						child.flags = selectedFlags(policy.Symbols[record.symbol], child.Extra(), child.External(), child.Terminal(), child.Missing())
+						child.flags = selectedFlags(policy.Symbols[record.symbol], child.Extra(), child.External(), child.Terminal(), child.Missing(), child.HasError())
 					}
 					if alias != 0 && !retainAliasChild {
 						child.Symbol = alias
-						child.flags = selectedFlags(meta, child.Extra(), child.External(), child.Terminal(), child.Missing())
+						child.flags = selectedFlags(meta, child.Extra(), child.External(), child.Terminal(), child.Missing(), child.HasError())
 					}
 					child.ProductionID = record.productionID
 					delta, err := checkedSelectedPrecedence(precedenceDeltas[childID-1], int32(record.dynamicPrecedence))
@@ -203,7 +207,7 @@ func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStore
 				first := uint32(len(store.children))
 				children := logical[logicalStart:]
 				store.children = append(store.children, children...)
-				flags := selectedFlags(meta, record.extra, record.external, record.terminal, record.missing)
+				flags := selectedFlags(meta, record.extra, record.external, record.terminal, record.missing, hasError)
 				startByte, endByte := record.startByte, record.endByte
 				if len(children) != 0 {
 					firstChild := store.records[children[0]-1]
@@ -246,6 +250,9 @@ func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStore
 			}
 			if field != 0 && !retainAliasChild {
 				store.applyDirectField(logical[logicalStart:], field)
+			}
+			if frameIndex > 0 && hasError {
+				stack[frameIndex-1].hasError = true
 			}
 			stack = stack[:frameIndex]
 			payloads = payloads[:frameIndex]

--- a/internal/parsercorephase0/selected_store_test.go
+++ b/internal/parsercorephase0/selected_store_test.go
@@ -69,6 +69,88 @@ func TestSelectedStoreElidesHiddenParentsBeforeSeal(t *testing.T) {
 	}
 }
 
+func TestSelectedStorePropagatesHiddenMissingErrors(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		nested         bool
+		visibleMissing bool
+	}{
+		{name: "hidden"},
+		{name: "nested-hidden", nested: true},
+		{name: "visible", visibleMissing: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			compact, err := New(&fakeTable{}, Limits{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			missing, err := compact.appendSubtree(subtreeRecord{
+				symbol: 3, terminal: true, missing: true,
+			}, nil, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			child := missing
+			if test.nested {
+				child, err = compact.appendSubtree(subtreeRecord{symbol: 4}, []SubtreeID{missing}, nil, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			root, err := compact.appendSubtree(subtreeRecord{symbol: 2}, []SubtreeID{child}, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			visible := []Symbol{2}
+			if test.visibleMissing {
+				visible = append(visible, 3)
+			}
+			store, err := compact.BuildSelectedStore([]SubtreeID{root}, selectedStoreTestPolicy(t, visible...), nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Release()
+			rootRecord, ok := store.Record(store.Root())
+			if !ok || !rootRecord.HasError() || rootRecord.Missing() {
+				t.Fatalf("root=%+v, want an ordinary root with error content", rootRecord)
+			}
+			wantChildren := uint16(0)
+			if test.visibleMissing {
+				wantChildren = 1
+			}
+			if rootRecord.ChildCount != wantChildren {
+				t.Fatalf("root children=%d, want %d", rootRecord.ChildCount, wantChildren)
+			}
+			if test.visibleMissing {
+				childID, childOK := store.Child(rootRecord, 0)
+				childRecord, recordOK := store.Record(childID)
+				if !childOK || !recordOK || !childRecord.Missing() || !childRecord.HasError() {
+					t.Fatalf("visible missing child=%+v child_ok=%t record_ok=%t", childRecord, childOK, recordOK)
+				}
+			}
+		})
+	}
+}
+
+func TestSelectedBuildScratchCountsAndReleasesErrorFlags(t *testing.T) {
+	core, err := New(&fakeTable{}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := core.FootprintBytes()
+	core.selectedBuild.resultHasError = make([]bool, 0, 17)
+	want := uint64(cap(core.selectedBuild.resultHasError)) * uint64(unsafe.Sizeof(bool(false)))
+	if got := core.FootprintBytes() - before; got != want {
+		t.Fatalf("error-flag scratch footprint=%d, want %d", got, want)
+	}
+
+	core.selectedBuild.resultHasError = make([]bool, coreRetentionCapBytes+1)
+	core.releaseOversizedRetention()
+	if core.selectedBuild.resultHasError != nil {
+		t.Fatal("retention release kept oversized selected-build error flags")
+	}
+}
+
 func TestSelectedStoreRetainsCompiledAliasChildOccurrence(t *testing.T) {
 	for _, folded := range []bool{false, true} {
 		name := "nonfolded"

--- a/internal/parsercorephase0/storage_bytes.go
+++ b/internal/parsercorephase0/storage_bytes.go
@@ -116,6 +116,7 @@ var (
 	coreBoundaryKeyEntryBytes     = uint64(unsafe.Sizeof(boundaryKey{})) + uint64(unsafe.Sizeof(int(0)))
 	coreUint16Bytes               = uint64(unsafe.Sizeof(uint16(0)))
 	coreDropCohortRefBytes        = uint64(unsafe.Sizeof(DropCohortRef{}))
+	coreBoolBytes                 = uint64(unsafe.Sizeof(bool(false)))
 )
 
 // FootprintBytes returns a cheap, deterministic, O(1) estimate of the compact
@@ -197,6 +198,7 @@ func (c *Core) FootprintBytes() uint64 {
 	total += c.boundaries.footprintBytes()
 	total += c.popScratch.footprintBytes()
 	total += c.reductionScratch.footprintBytes()
+	total += uint64(cap(c.selectedBuild.resultHasError)) * coreBoolBytes
 	total += selectedStoreRetainedBytes(cap(c.selectedPool.records), cap(c.selectedPool.children))
 
 	return total
@@ -384,6 +386,7 @@ func (c *Core) releaseOversizedRetention() {
 	c.boundaries.dropOversized()
 	c.popScratch.dropOversized()
 	c.reductionScratch.dropOversized()
+	c.selectedBuild.resultHasError = nil
 	c.selectedPool = selectedStoreBacking{}
 }
 

--- a/language.go
+++ b/language.go
@@ -906,6 +906,11 @@ type Language struct {
 	// Custom and adapted languages retain the false default.
 	CompactMissingTokenInsertionCertified bool
 
+	// CompactFaithfulS5RecoveryCertified permits the complete S5 scan
+	// to merge equivalent physical recovery heads. The legacy bounded S5 path
+	// remains active without this exact artifact capability.
+	CompactFaithfulS5RecoveryCertified bool
+
 	// CompactRecoveryTrailingLineageRetirementCertified permits the compact
 	// scheduler to retire one trailing no-action missing lineage after the
 	// earlier error-absorb lineage consumed the same elected token. This is the

--- a/parsercore_phase0_canonical_scratch_internal_test.go
+++ b/parsercore_phase0_canonical_scratch_internal_test.go
@@ -416,7 +416,7 @@ func TestDiagnosticParserCoreCanonicalScratchMappedSpillPreservesSemantics(t *te
 	}
 }
 
-func TestDiagnosticParserCoreCanonicalScratchUsesSemanticVersionStateIdentity(t *testing.T) {
+func TestDiagnosticParserCoreCanonicalScratchPreservesLexerSnapshotOwners(t *testing.T) {
 	for _, count := range []int{2, 9} {
 		for _, changed := range []bool{false, true} {
 			name := fmt.Sprintf("count-%d", count)
@@ -483,15 +483,17 @@ func TestDiagnosticParserCoreCanonicalScratchUsesSemanticVersionStateIdentity(t 
 				if err != nil {
 					t.Fatal(err)
 				}
-				want := 1
-				if changed {
-					want = 2
-				}
+				want := 2
 				if len(out) != want {
-					t.Fatalf("semantic keys produced %d headers, want %d: %+v", len(out), want, out)
+					t.Fatalf("owner keys produced %d headers, want %d: %+v", len(out), want, out)
 				}
-				if !changed && out[0].versionState != leftState {
-					t.Fatalf("canonical winner did not retain the first header version state: got=%p want=%p", out[0].versionState, leftState)
+				seenLeft, seenRight := false, false
+				for _, header := range out {
+					seenLeft = seenLeft || header.versionState == leftState
+					seenRight = seenRight || header.versionState == rightState
+				}
+				if !seenLeft || !seenRight {
+					t.Fatalf("canonical output lost a lexer snapshot owner: %+v", out)
 				}
 				if count > diagnosticParserCoreLinearCanonicalLimit && scratch.groups == nil {
 					t.Fatal("mapped canonicalization did not allocate its group map")

--- a/parsercore_phase0_canonical_scratch_internal_test.go
+++ b/parsercore_phase0_canonical_scratch_internal_test.go
@@ -4,6 +4,7 @@ package gotreesitter
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"runtime"
 	"testing"
@@ -412,6 +413,91 @@ func TestDiagnosticParserCoreCanonicalScratchMappedSpillPreservesSemantics(t *te
 	last := out[len(out)-1]
 	if last.head != heads[0] || last.creationSeq != 99 || last.paused || last.freshness != 0 || last.checkpoint != checkpoint {
 		t.Fatalf("mapped spill duplicate winner=%+v", last)
+	}
+}
+
+func TestDiagnosticParserCoreCanonicalScratchUsesSemanticVersionStateIdentity(t *testing.T) {
+	for _, count := range []int{2, 9} {
+		for _, changed := range []bool{false, true} {
+			name := fmt.Sprintf("count-%d", count)
+			if changed {
+				name += "-semantic-change"
+			}
+			t.Run(name, func(t *testing.T) {
+				compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+				snapshot := &diagnosticParserCoreVersionLexerSnapshot{
+					compact: compact, coreGeneration: compact.ResetGeneration(),
+					language: &Language{Name: "canonical-test"},
+				}
+				leftRequest := diagnosticParserCoreVersionLexerRequest{
+					electionIndex: 1, headerCreationSeq: 2, state: 3,
+					token:  Token{Symbol: 7, StartByte: 4, EndByte: 5, isKeyword: true},
+					before: snapshot, after: snapshot.clone(),
+					beforeCheckpoint: snapshot.beforeCheckpointInfo,
+					afterCheckpoint:  snapshot.afterCheckpointInfo,
+					beforeID:         snapshot.beforeCheckpoint, afterID: snapshot.afterCheckpoint,
+					raggedSpan: true, valid: true,
+				}
+				rightRequest := leftRequest
+				rightRequest.electionIndex = 19
+				rightRequest.headerCreationSeq = 23
+				rightRequest.token.isKeyword = false
+				rightRequest.before = snapshot.clone()
+				rightRequest.after = snapshot.clone()
+				scheduler := &diagnosticParserCoreGenericScheduler{
+					compact: compact,
+					versionLexerRequests: []diagnosticParserCoreVersionLexerRequest{
+						leftRequest, rightRequest,
+					},
+				}
+				leftState := &diagnosticParserCoreVersionState{
+					relexSnapshot: snapshot, lexerRequest: 1,
+				}
+				rightState := &diagnosticParserCoreVersionState{
+					relexSnapshot: snapshot.clone(), lexerRequest: 2,
+				}
+				if changed {
+					rightState.recoveryGroup = 1
+				}
+				scratch := diagnosticParserCoreCanonicalScratch{
+					versionStateEqual: scheduler.versionLexerStateEqual,
+				}
+				headers := make([]diagnosticParserCoreHeader, count)
+				for index := range headers {
+					state := leftState
+					if index != 0 {
+						state = rightState
+					}
+					headers[index] = diagnosticParserCoreHeader{
+						head: head, creationSeq: uint64(index + 1),
+						freshness: func() core.ReductionFreshness {
+							if index == 0 {
+								return 0
+							}
+							return core.ReductionNew
+						}(),
+						versionState: state,
+					}
+				}
+				out, err := scratch.canonicalize(compact, headers)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := 1
+				if changed {
+					want = 2
+				}
+				if len(out) != want {
+					t.Fatalf("semantic keys produced %d headers, want %d: %+v", len(out), want, out)
+				}
+				if !changed && out[0].versionState != leftState {
+					t.Fatalf("canonical winner did not retain the first header version state: got=%p want=%p", out[0].versionState, leftState)
+				}
+				if count > diagnosticParserCoreLinearCanonicalLimit && scratch.groups == nil {
+					t.Fatal("mapped canonicalization did not allocate its group map")
+				}
+			})
+		}
 	}
 }
 

--- a/parsercore_phase0_classified_internal_test.go
+++ b/parsercore_phase0_classified_internal_test.go
@@ -15,7 +15,7 @@ func mustDiagnosticParserCoreGenericCell(t testing.TB, compact *core.Core, heade
 	if err != nil {
 		t.Fatal(err)
 	}
-	return diagnosticParserCoreGenericCell{headerIndex: headerIndex, boundary: boundary}
+	return diagnosticParserCoreGenericCell{headerIndex: int32(headerIndex), boundary: boundary}
 }
 
 func TestDiagnosticParserCoreClassifiedBoundaryAndReductionPlanShape(t *testing.T) {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -3971,7 +3971,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyCompactEOFRecoveryAdmission(
 	}
 	siblings := make([]int, 0, len(s.headers)-1)
 	for index := range s.headers {
-		if index != cell.headerIndex {
+		if index != int(cell.headerIndex) {
 			siblings = append(siblings, index)
 		}
 	}
@@ -3984,7 +3984,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyCompactEOFRecoveryAdmission(
 	// Census the complete frontier at the safe pre-apply point. Applying the
 	// accept can mutate the compact head and retire its sibling, so later reads
 	// cannot reconstruct this admission history without observing live state.
-	s.censusEOFAcceptHistoryFrontier(cell.headerIndex, siblings)
+	s.censusEOFAcceptHistoryFrontier(int(cell.headerIndex), siblings)
 	if applyErr := s.applyGenericAccept(before, cell); applyErr != nil {
 		return rollback(applyErr)
 	}
@@ -4547,9 +4547,9 @@ const (
 )
 
 type diagnosticParserCoreGenericCell struct {
-	headerIndex     int
 	boundary        core.ClassifiedBoundary
-	selectedOrdinal int
+	headerIndex     int32
+	selectedOrdinal int32
 	// versionLexerRequest is a one-based index into the scheduler's request
 	// sidecar. Zero keeps the shared-election fast path.
 	versionLexerRequest uint32
@@ -4616,7 +4616,7 @@ func (cell *diagnosticParserCoreGenericCell) descriptor() core.ActionRowDescript
 }
 func (cell *diagnosticParserCoreGenericCell) kind() core.ActionRowKind {
 	if cell.selectedBy == diagnosticParserCoreCellSelectionConflictPolicy {
-		switch cell.actions().At(cell.selectedOrdinal).Type {
+		switch cell.actions().At(int(cell.selectedOrdinal)).Type {
 		case core.ActionShift:
 			return core.ActionRowShift
 		case core.ActionReduce:
@@ -4633,7 +4633,7 @@ func (cell *diagnosticParserCoreGenericCell) kind() core.ActionRowKind {
 }
 func (cell *diagnosticParserCoreGenericCell) selectedActionOrdinal() int {
 	if cell.selectedBy != diagnosticParserCoreCellSelectionNone {
-		return cell.selectedOrdinal
+		return int(cell.selectedOrdinal)
 	}
 	return 0
 }
@@ -4993,7 +4993,7 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestForCell(
 	if s == nil || requestIndex < 0 || requestIndex >= len(s.versionLexerRequests) {
 		return nil, errors.New("parser-core phase zero: version lexer cell request is out of range")
 	}
-	if cell.headerIndex < 0 || cell.headerIndex >= len(s.headers) {
+	if cell.headerIndex < 0 || int(cell.headerIndex) >= len(s.headers) {
 		return nil, errors.New("parser-core phase zero: version lexer cell header is out of range")
 	}
 	request := &s.versionLexerRequests[requestIndex]
@@ -8392,7 +8392,7 @@ func (s *diagnosticParserCoreGenericScheduler) classifyVersionLexerCell(
 		return diagnosticParserCoreGenericCell{}, true, nil, nil
 	}
 	cell := diagnosticParserCoreGenericCell{
-		headerIndex: index, boundary: boundary, versionLexerRequest: requestReference,
+		headerIndex: int32(index), boundary: boundary, versionLexerRequest: requestReference,
 	}
 	if ordinal, ok := diagnosticParserCoreConflictPolicyOrdinal(
 		s.tokenSource.language,
@@ -8401,13 +8401,13 @@ func (s *diagnosticParserCoreGenericScheduler) classifyVersionLexerCell(
 		actions,
 		len(s.headers),
 	); ok {
-		cell.selectedOrdinal = ordinal
+		cell.selectedOrdinal = int32(ordinal)
 		cell.selectedBy = diagnosticParserCoreCellSelectionConflictPolicy
 	}
 	if cell.selectedBy == diagnosticParserCoreCellSelectionNone &&
 		actions.Descriptor().Kind() == core.ActionRowUnsupported {
 		if ordinal, ok := diagnosticParserCoreRepetitionFoldOrdinal(s.tokenSource.language, actions); ok {
-			cell.selectedOrdinal = ordinal
+			cell.selectedOrdinal = int32(ordinal)
 			cell.selectedBy = diagnosticParserCoreCellSelectionRepetitionFold
 		} else if _, ok := diagnosticParserCoreSingleReduceRepetitionShiftOrdinal(actions); ok &&
 			cRepetitionSkipOptOut[s.tokenSource.language.Name] {
@@ -8571,7 +8571,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchVersionLexerPassActive() 
 			s.headers[cells[acceptCell].headerIndex].isRecoveryLineage()
 		if !competingRecoveryAccept && (len(s.headers) != 1 || len(cells) != 1 || len(noActionIndices) != 0) {
 			return &diagnosticParserCoreGenericUnsupported{
-				boundary: DiagnosticParserCoreAccept, detail: "generic scheduler owned lexer accept requires one live version", headerIndex: cells[acceptCell].headerIndex,
+				boundary: DiagnosticParserCoreAccept, detail: "generic scheduler owned lexer accept requires one live version", headerIndex: int(cells[acceptCell].headerIndex),
 			}, nil
 		}
 		selected, operation = acceptCell, core.ActionRowAccept
@@ -8593,7 +8593,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchVersionLexerPassActive() 
 			boundary: DiagnosticParserCoreRoute, detail: "generic scheduler owned lexer dispatch found no supported action",
 		}, nil
 	}
-	selectedHeader := cells[selected].headerIndex
+	selectedHeader := int(cells[selected].headerIndex)
 	cell, noAction, unsupported, err := s.classifyVersionLexerCell(selectedHeader, false)
 	if err != nil || unsupported != nil {
 		return unsupported, err
@@ -8964,7 +8964,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			}
 		}
 		cell := diagnosticParserCoreGenericCell{
-			headerIndex:   index,
+			headerIndex:   int32(index),
 			boundary:      boundary,
 			relexedSymbol: relexedSymbol,
 		}
@@ -8976,13 +8976,13 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				actions,
 				len(s.headers),
 			); ok {
-				cell.selectedOrdinal = ordinal
+				cell.selectedOrdinal = int32(ordinal)
 				cell.selectedBy = diagnosticParserCoreCellSelectionConflictPolicy
 			}
 			if cell.selectedBy == diagnosticParserCoreCellSelectionNone &&
 				actions.Descriptor().Kind() == core.ActionRowUnsupported {
 				if ordinal, ok := diagnosticParserCoreRepetitionFoldOrdinal(s.tokenSource.language, actions); ok {
-					cell.selectedOrdinal = ordinal
+					cell.selectedOrdinal = int32(ordinal)
 					cell.selectedBy = diagnosticParserCoreCellSelectionRepetitionFold
 				} else if _, ok := diagnosticParserCoreSingleReduceRepetitionShiftOrdinal(actions); ok &&
 					cRepetitionSkipOptOut[s.tokenSource.language.Name] {
@@ -9028,7 +9028,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 		// still need the token (ExtraShift, Accept) or are never supported
 		// (Empty, Unsupported) keep paying the full per-pass call unchanged.
 		if cell.selectedBy == diagnosticParserCoreCellSelectionNone && !descriptor.DispatchSupported() {
-			if unsupported := diagnosticParserCoreGenericUnsupportedCellDescriptor(cell.headerIndex, cell.dispatchToken(s.token), cell.actions(), descriptor); unsupported != nil {
+			if unsupported := diagnosticParserCoreGenericUnsupportedCellDescriptor(int(cell.headerIndex), cell.dispatchToken(s.token), cell.actions(), descriptor); unsupported != nil {
 				return unsupported, nil
 			}
 		}
@@ -9217,7 +9217,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				return &diagnosticParserCoreGenericUnsupported{
 					boundary:    DiagnosticParserCoreAccept,
 					detail:      s.eofRecoveryAdmission.declineReason,
-					headerIndex: cell.headerIndex,
+					headerIndex: int(cell.headerIndex),
 				}, nil
 			}
 		}
@@ -9229,14 +9229,14 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 		competingRecoveryAccept := recoveryCompetition && s.headers[cell.headerIndex].isRecoveryLineage()
 		if !soleAccept && !certifiedAcceptWithDeadSiblings && !competingRecoveryAccept {
 			return &diagnosticParserCoreGenericUnsupported{
-				boundary: DiagnosticParserCoreAccept, detail: "generic scheduler requires a sole homogeneous accept frontier", headerIndex: cell.headerIndex,
+				boundary: DiagnosticParserCoreAccept, detail: "generic scheduler requires a sole homogeneous accept frontier", headerIndex: int(cell.headerIndex),
 			}, nil
 		}
 		if certifiedAcceptWithDeadSiblings {
 			// The G2 EOF-history census observes the complete frontier before
 			// acceptance canonicalization removes its no-action siblings. The
 			// default build supplies an empty inlined stub.
-			s.censusEOFAcceptHistoryFrontier(cell.headerIndex, noActionIndices)
+			s.censusEOFAcceptHistoryFrontier(int(cell.headerIndex), noActionIndices)
 		}
 		if err := s.applyGenericAccept(before, cell); err != nil {
 			return nil, err
@@ -9274,14 +9274,14 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 	if extraCells != 0 {
 		if extraCells != len(cells) || len(cells) != len(s.headers) || len(noActionIndices) != 0 {
 			return &diagnosticParserCoreGenericUnsupported{
-				boundary: DiagnosticParserCoreExtra, detail: "generic scheduler requires a homogeneous all-runnable extra cohort", headerIndex: cells[0].headerIndex,
+				boundary: DiagnosticParserCoreExtra, detail: "generic scheduler requires a homogeneous all-runnable extra cohort", headerIndex: int(cells[0].headerIndex),
 			}, nil
 		}
 		for index := 1; index < len(cells); index++ {
 			cell := &cells[index]
 			if cell.dispatchToken(s.token) != cells[0].dispatchToken(s.token) {
 				return &diagnosticParserCoreGenericUnsupported{
-					boundary: DiagnosticParserCoreExtra, detail: "generic scheduler extra cohort requires one tokenization", headerIndex: cell.headerIndex,
+					boundary: DiagnosticParserCoreExtra, detail: "generic scheduler extra cohort requires one tokenization", headerIndex: int(cell.headerIndex),
 				}, nil
 			}
 		}
@@ -10281,7 +10281,7 @@ func (s *diagnosticParserCoreGenericScheduler) zeroWidthExtraShiftWithoutProgres
 			return &diagnosticParserCoreGenericUnsupported{
 				boundary:    DiagnosticParserCoreRoute,
 				detail:      "generic scheduler zero-width extra shift has no scanner or parser-state progress",
-				headerIndex: cell.headerIndex,
+				headerIndex: int(cell.headerIndex),
 			}
 		}
 	}
@@ -10339,7 +10339,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericAcceptOwned(owner cor
 		s.receipt.Rounds = append(s.receipt.Rounds, DiagnosticParserCoreDispatchRound{
 			Index: len(s.receipt.Rounds), Before: before,
 			Actions: []DiagnosticParserCoreRoundAction{{
-				HeaderIndex: cell.headerIndex, State: StateID(cell.boundary.State()), ByteOffset: cell.boundary.ByteOffset(),
+				HeaderIndex: int(cell.headerIndex), State: StateID(cell.boundary.State()), ByteOffset: cell.boundary.ByteOffset(),
 				Ordinal: 0, Action: rootParserCoreAction(cell.actions().At(0)),
 			}},
 			After: after,
@@ -11596,7 +11596,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		s.condenseCandidates = s.condenseCandidates[:0]
 		candidates = s.condenseCandidates
 	} else {
-		candidates = s.collectCondenseCandidates(cell.headerIndex)
+		candidates = s.collectCondenseCandidates(int(cell.headerIndex))
 	}
 	ordinal := cell.selectedActionOrdinal()
 	if cell.selectsConflictReduction() {
@@ -11799,7 +11799,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 			// the physical-head merge package.
 			adopted, err := s.adoptUpdatedReductionSiblingOwned(
 				owner,
-				cell.headerIndex,
+				int(cell.headerIndex),
 				output.Head,
 				rank,
 				lineage,
@@ -11829,7 +11829,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		if output.Freshness == core.ReductionUpdated {
 			adopted, err := s.adoptUpdatedReductionSiblingOwned(
 				owner,
-				cell.headerIndex,
+				int(cell.headerIndex),
 				output.Head,
 				rank,
 				lineage,
@@ -11901,7 +11901,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 	} else if len(replacements) == 1 {
 		s.headers[cell.headerIndex] = replacements[0]
 	} else {
-		s.headers = replaceDiagnosticParserCoreHeader(s.headers, cell.headerIndex, replacements)
+		s.headers = replaceDiagnosticParserCoreHeader(s.headers, int(cell.headerIndex), replacements)
 	}
 	if madeFreshProgress {
 		s.epochProgress = true
@@ -11928,7 +11928,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		s.receipt.Rounds = append(s.receipt.Rounds, DiagnosticParserCoreDispatchRound{
 			Index: len(s.receipt.Rounds), Before: before,
 			Actions: []DiagnosticParserCoreRoundAction{{
-				HeaderIndex: cell.headerIndex, State: StateID(cell.boundary.State()), ByteOffset: cell.boundary.ByteOffset(),
+				HeaderIndex: int(cell.headerIndex), State: StateID(cell.boundary.State()), ByteOffset: cell.boundary.ByteOffset(),
 				Ordinal: ordinal, Action: rootParserCoreAction(cell.actions().At(ordinal)),
 			}},
 			After: after,
@@ -12276,7 +12276,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	if err = s.reserveDispatches(1); err != nil {
 		return err
 	}
-	if err = s.reindexCondenseCandidatesOwned(owner, cell.headerIndex); err != nil {
+	if err = s.reindexCondenseCandidatesOwned(owner, int(cell.headerIndex)); err != nil {
 		return err
 	}
 	externalStatsBefore, err := s.genericExternalStats(affectedHead, token)
@@ -12289,7 +12289,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	}
 	defer s.conflictScratch.finish()
 	execution, err := executeDiagnosticParserCoreGenericConflictDetailed(
-		s.compact, owner, s.headers[cell.headerIndex], cell.headerIndex, token, cell.boundary,
+		s.compact, owner, s.headers[cell.headerIndex], int(cell.headerIndex), token, cell.boundary,
 		s.branchOrder, &s.nextCleanPathLineage,
 		s.options.captureLexerSkippedPrefixProvenance,
 		cell.selectedBy == diagnosticParserCoreCellSelectionRepetitionFork,
@@ -12316,7 +12316,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	}
 	for ordinal := range execution.armRanges {
 		arm := execution.arm(ordinal)
-		kept, adopted, reconcileErr := s.reconcileGenericConflictOutputs(owner, cell.headerIndex, arm)
+		kept, adopted, reconcileErr := s.reconcileGenericConflictOutputs(owner, int(cell.headerIndex), arm)
 		if reconcileErr != nil {
 			return reconcileErr
 		}
@@ -12467,7 +12467,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 		roundIndex = round.Index
 		s.receipt.Rounds = append(s.receipt.Rounds, round)
 		conflict := DiagnosticParserCoreGenericConflict{
-			ElectionIndex: s.electionIndex, Token: token, HeaderIndex: cell.headerIndex,
+			ElectionIndex: s.electionIndex, Token: token, HeaderIndex: int(cell.headerIndex),
 			BranchOrderBefore: branchOrderBefore, BranchOrderAfter: s.branchOrder,
 			NextCreationSeqBefore: nextSeqBefore, NextCreationSeqAfter: s.nextSeq,
 			Round: round, Prefix: prefixReceipts,
@@ -12590,7 +12590,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 				LexerSkippedPrefixLength: diagnosticParserCoreLexerSkippedPrefixLength(token, s.options.captureLexerSkippedPrefixProvenance),
 			}
 			head, err := s.compact.ShiftClassifiedWithLiveCondenseCandidatesOwned(
-				owner, s.collectCondenseCandidates(cell.headerIndex),
+				owner, s.collectCondenseCandidates(int(cell.headerIndex)),
 				cell.boundary, ordinal, shifted, core.ForkOrder{},
 			)
 			if err != nil {
@@ -12625,7 +12625,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 			cell := &cells[index]
 			ordinal := cell.selectedActionOrdinal()
 			actions[index] = DiagnosticParserCoreRoundAction{
-				HeaderIndex: cell.headerIndex, State: StateID(cell.boundary.State()), ByteOffset: cell.boundary.ByteOffset(),
+				HeaderIndex: int(cell.headerIndex), State: StateID(cell.boundary.State()), ByteOffset: cell.boundary.ByteOffset(),
 				Ordinal: ordinal, Action: rootParserCoreAction(cell.actions().At(ordinal)),
 			}
 		}
@@ -12706,7 +12706,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 					}
 				}
 				head, shiftErr := s.compact.ShiftClassifiedWithLiveCondenseCandidatesOwned(
-					owner, s.collectCondenseCandidates(cell.headerIndex), cell.boundary, 0,
+					owner, s.collectCondenseCandidates(int(cell.headerIndex)), cell.boundary, 0,
 					core.Token{
 						Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte,
 						Extra: true, External: token.ExternalScannerToken,
@@ -12789,7 +12789,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 			for index := range cells {
 				cell := &cells[index]
 				actions[index] = DiagnosticParserCoreRoundAction{
-					HeaderIndex: cell.headerIndex, State: StateID(cell.boundary.State()), ByteOffset: cell.boundary.ByteOffset(),
+					HeaderIndex: int(cell.headerIndex), State: StateID(cell.boundary.State()), ByteOffset: cell.boundary.ByteOffset(),
 					Ordinal: 0, Action: rootParserCoreAction(cell.actions().At(0)),
 				}
 			}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -4954,7 +4954,7 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestForHeader(inde
 	base := header.versionLexerSnapshot()
 	request := &s.versionLexerRequests[reference-1]
 	if request.valid && request.electionIndex == s.electionIndex &&
-		request.token.StartByte == byteOffset &&
+		diagnosticParserCoreVersionLexerRequestStartsAtBoundary(request, byteOffset) &&
 		diagnosticParserCoreVersionLexerSnapshotEqual(request.before, base) {
 		return request
 	}
@@ -4976,7 +4976,7 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestReferenceForHe
 	}
 	request := &s.versionLexerRequests[reference-1]
 	if request.valid && request.electionIndex == s.electionIndex &&
-		request.token.StartByte == byteOffset &&
+		diagnosticParserCoreVersionLexerRequestStartsAtBoundary(request, byteOffset) &&
 		diagnosticParserCoreVersionLexerSnapshotEqual(request.before, header.versionLexerSnapshot()) {
 		return reference
 	}
@@ -5000,11 +5000,29 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestForCell(
 	header := &s.headers[cell.headerIndex]
 	if !request.valid || request.electionIndex != s.electionIndex ||
 		cell.versionLexerRequest != header.versionLexerRequestReference() ||
-		request.token.StartByte != cell.boundary.ByteOffset() || cell.boundary.Head() != header.head ||
+		!diagnosticParserCoreVersionLexerRequestStartsAtBoundary(request, cell.boundary.ByteOffset()) ||
+		cell.boundary.Head() != header.head ||
 		!diagnosticParserCoreVersionLexerSnapshotEqual(request.before, header.versionLexerSnapshot()) {
 		return nil, errors.New("parser-core phase zero: version lexer cell request is stale")
 	}
 	return request, nil
+}
+
+// diagnosticParserCoreVersionLexerRequestStartsAtBoundary authenticates the
+// cursor that produced a per-version token. A lexer can skip leading trivia,
+// so the token can start after the graph boundary. The owned before snapshot
+// must still start exactly at that boundary.
+func diagnosticParserCoreVersionLexerRequestStartsAtBoundary(
+	request *diagnosticParserCoreVersionLexerRequest,
+	byteOffset uint32,
+) bool {
+	if request == nil || request.before == nil || request.before.dfa.lexerPos < 0 ||
+		uint64(request.before.dfa.lexerPos) > math.MaxUint32 ||
+		uint32(request.before.dfa.lexerPos) != byteOffset ||
+		request.token.StartByte < byteOffset || request.token.EndByte < request.token.StartByte {
+		return false
+	}
+	return true
 }
 
 func (s *diagnosticParserCoreGenericScheduler) clearVersionLexerRequests() {
@@ -5183,25 +5201,60 @@ func (s *diagnosticParserCoreGenericScheduler) newVersionLexerSnapshot(
 // election start. It runs only when a ragged token activates ownership; clean
 // parses retain the zero-overhead shared path.
 func (s *diagnosticParserCoreGenericScheduler) seedVersionLexerOwnership() error {
+	return s.seedVersionLexerOwnershipMode(false)
+}
+
+// seedVersionLexerOwnershipMode can admit one exact mixed recovery frontier.
+// Unshifted versions start at the shared election's before cursor. A shifted
+// absorber owns the shared after cursor that it already consumed.
+func (s *diagnosticParserCoreGenericScheduler) seedVersionLexerOwnershipMode(
+	allowShiftedRecovery bool,
+) error {
 	if s == nil || !s.versionLexerBeforeValid || s.tokenSource == nil || s.tokenSource.language == nil {
 		return errors.New("parser-core phase zero: version lexer seed lacks an election snapshot")
 	}
 	if s.versionLexerBeforeElection != s.electionIndex || s.versionLexerBeforeCheckpoint != s.checkpointBeforeID {
 		return errors.New("parser-core phase zero: version lexer seed snapshot belongs to another election")
 	}
-	var seed *diagnosticParserCoreVersionLexerSnapshot
+	var beforeSeed *diagnosticParserCoreVersionLexerSnapshot
+	var afterSeed *diagnosticParserCoreVersionLexerSnapshot
+	var afterDFA dfaRelexSnapshot
+	if allowShiftedRecovery {
+		// The exact S5 mixed frontier stays inside one parser run. Its owned
+		// snapshots bind the live language, scanner implementation, compact
+		// generation, and serialized scanner payload. It does not require the
+		// stronger cross-tree checkpoint identity used by incremental reuse.
+		if s.tokenSource.lexer == nil || s.tokenSource.lexer.pos != int(s.token.EndByte) {
+			return errors.New("parser-core phase zero: mixed recovery lexer seed lacks an exact shared after cursor")
+		}
+		afterDFA = s.tokenSource.snapshotRelexState()
+	}
 	err := s.withVersionLexerOwner(func(owner core.SchedulerTransactionToken) error {
 		var seedErr error
-		seed, seedErr = s.newVersionLexerSnapshot(owner, s.versionLexerBefore, s.checkpointBeforeID, s.checkpointBeforeID)
+		beforeSeed, seedErr = s.newVersionLexerSnapshot(owner, s.versionLexerBefore, s.checkpointBeforeID, s.checkpointBeforeID)
+		if seedErr != nil || !allowShiftedRecovery {
+			return seedErr
+		}
+		afterSeed = s.equivalentVersionLexerSnapshot(afterDFA, s.checkpointID, s.checkpointID)
+		if afterSeed != nil {
+			return nil
+		}
+		afterSeed, seedErr = s.newVersionLexerSnapshot(owner, afterDFA, s.checkpointID, s.checkpointID)
 		return seedErr
 	})
 	if err != nil {
 		return err
 	}
-	if err := seed.validateDestination(s.compact, s.tokenSource.language); err != nil {
+	if err := beforeSeed.validateDestination(s.compact, s.tokenSource.language); err != nil {
 		return err
 	}
+	if allowShiftedRecovery {
+		if err := afterSeed.validateDestination(s.compact, s.tokenSource.language); err != nil {
+			return err
+		}
+	}
 	type seedStateKey struct {
+		snapshot                *diagnosticParserCoreVersionLexerSnapshot
 		region                  *diagnosticParserCoreS3Region
 		recoveryGroup           uint64
 		missingGroup            uint64
@@ -5215,15 +5268,22 @@ func (s *diagnosticParserCoreGenericScheduler) seedVersionLexerOwnership() error
 			continue
 		}
 		baseline, baselineSet := header.recoveryNodeBaseline()
+		seed := beforeSeed
+		if header.shifted {
+			if !allowShiftedRecovery || header.recoveryRegion() == nil {
+				return errors.New("parser-core phase zero: shifted lexer seed is not an owned recovery absorber")
+			}
+			seed = afterSeed
+		}
 		key := seedStateKey{
-			region: header.recoveryRegion(), recoveryGroup: header.recoveryGroupIdentity(),
+			snapshot: seed, region: header.recoveryRegion(), recoveryGroup: header.recoveryGroupIdentity(),
 			missingGroup:         header.recoveryMissingGroupIdentity(),
 			recoveryNodeBaseline: baseline, recoveryNodeBaselineSet: baselineSet,
 		}
 		state := states[key]
 		if state == nil {
 			header.publishVersionState(
-				key.region, seed, 0, key.recoveryGroup, key.missingGroup,
+				key.region, key.snapshot, 0, key.recoveryGroup, key.missingGroup,
 				key.recoveryNodeBaseline, key.recoveryNodeBaselineSet,
 			)
 			state = header.versionState
@@ -5308,8 +5368,9 @@ func (s *diagnosticParserCoreGenericScheduler) requestVersionLexerHeader(index i
 		afterCheckpoint:   afterSnapshot.afterCheckpointInfo,
 		beforeID:          beforeID,
 		afterID:           afterID,
-		raggedSpan:        s.electionIndex == s.versionLexerBeforeElection && token.StartByte == s.token.StartByte && token.EndByte != s.token.EndByte,
-		valid:             true,
+		raggedSpan: s.electionIndex == s.versionLexerBeforeElection &&
+			(token.StartByte != s.token.StartByte || token.EndByte != s.token.EndByte),
+		valid: true,
 	}
 	s.versionLexerRequests = append(s.versionLexerRequests, request)
 	requestReference := uint32(len(s.versionLexerRequests))
@@ -5411,11 +5472,12 @@ func (s *diagnosticParserCoreGenericScheduler) activateVersionLexerOwnershipAtRa
 			headerIndex: raggedHeaderIndex,
 		}, nil
 	}
+	mixedRecovery := s5MissingLineageNeedsOwnedLexer(s, []int{raggedHeaderIndex})
 	// An open recovery region owns its scanner and parser frontier as one
 	// recovery lineage. Do not mix a new lexer-ownership tranche into any
-	// sibling until the recovery region closes.
+	// sibling unless this is the exact S5 absorber/missing frontier.
 	for index, header := range s.headers {
-		if header.recoveryRegion() != nil {
+		if header.recoveryRegion() != nil && (!mixedRecovery || !header.shifted || index == raggedHeaderIndex) {
 			return &diagnosticParserCoreGenericUnsupported{
 				boundary:    DiagnosticParserCoreRoute,
 				detail:      diagnosticParserCoreOwnedDispatchPendingDetail + ": ragged ownership has an open recovery region",
@@ -5423,11 +5485,10 @@ func (s *diagnosticParserCoreGenericScheduler) activateVersionLexerOwnershipAtRa
 			}, nil
 		}
 	}
-	// A shifted header already consumed the shared token and therefore cannot
-	// be seeded at this election's token start. Keep this activation slice
-	// fail-closed until the scheduler owns that mixed frontier explicitly.
+	// A shifted ordinary header cannot be seeded at this election's token
+	// start. The exact S5 absorber instead receives the shared after cursor.
 	for index, header := range s.headers {
-		if header.shifted && !header.accepted {
+		if header.shifted && !header.accepted && !mixedRecovery {
 			return &diagnosticParserCoreGenericUnsupported{
 				boundary:    DiagnosticParserCoreRoute,
 				detail:      diagnosticParserCoreOwnedDispatchPendingDetail + ": ragged ownership has a shifted sibling",
@@ -5458,11 +5519,11 @@ func (s *diagnosticParserCoreGenericScheduler) activateVersionLexerOwnershipAtRa
 		s.work = workBefore
 		s.versionLexerOwnershipActive = false
 	}()
-	if err = s.seedVersionLexerOwnership(); err != nil {
+	if err = s.seedVersionLexerOwnershipMode(mixedRecovery); err != nil {
 		return nil, err
 	}
 	for index := range s.headers {
-		if s.headers[index].accepted {
+		if s.headers[index].accepted || s.headers[index].shifted {
 			continue
 		}
 		if err = s.requestHeaderLexerToken(index); err != nil {
@@ -6066,6 +6127,7 @@ type parserCoreRunnerScratch struct {
 	recoveryTerminalAliasSymbol    Symbol
 	recoveryTerminalAliasCertified bool
 	nodesByID                      []*Node
+	hasErrorByID                   []bool
 	nodes                          []*Node
 	linkScratch                    []*Node
 	lineStarts                     []uint32
@@ -6333,6 +6395,12 @@ func (s *parserCoreRunnerScratch) resetTreeBuffers() {
 	s.recoveryTerminalAliasSymbol = 0
 	s.recoveryTerminalAliasCertified = false
 	s.nodesByID = clearNodeScratch(s.nodesByID)
+	if cap(s.hasErrorByID) > parserCoreMaxRetainedNodeScratch {
+		s.hasErrorByID = nil
+	} else {
+		clear(s.hasErrorByID)
+		s.hasErrorByID = s.hasErrorByID[:0]
+	}
 	s.nodes = clearNodeScratch(s.nodes)
 	s.linkScratch = clearNodeScratch(s.linkScratch)
 	if cap(s.lineStarts) > parserCoreMaxRetainedLineStarts {
@@ -7074,11 +7142,20 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 	// compact ID owns exactly one public node in this tree.
 	nodesByIDLen := uint64(stats.Subtrees) + 1
 	var nodesByID []*Node
+	var hasErrorByID []bool
 	if scratch != nil && nodesByIDLen <= uint64(math.MaxInt) {
 		scratch.nodesByID = parserCoreNodeSlice(scratch.nodesByID, int(nodesByIDLen))
 		nodesByID = scratch.nodesByID
+		if cap(scratch.hasErrorByID) < int(nodesByIDLen) {
+			scratch.hasErrorByID = make([]bool, int(nodesByIDLen))
+		} else {
+			scratch.hasErrorByID = scratch.hasErrorByID[:int(nodesByIDLen)]
+			clear(scratch.hasErrorByID)
+		}
+		hasErrorByID = scratch.hasErrorByID
 	} else {
 		nodesByID = make([]*Node, nodesByIDLen)
+		hasErrorByID = make([]bool, nodesByIDLen)
 	}
 	if err := poll(); err != nil {
 		return nil, err
@@ -7221,19 +7298,14 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				// the flag up through every enclosing reduce with no
 				// additional code.
 				//
-				// The propagation argument holds only while the leaf survives into
-				// its parent's children. Production's reduce path drops an
-				// invisible child that has no children of its own
-				// (appendReduceChildItemToScratch, parser_reduce.go), and
-				// production's own missing-shift path compensates with an
-				// explicit out-parameter signal (parser.go's
-				// `*trackChildErrors = true`). This branch reproduces the
-				// flags but not that signal. The S5 scan therefore declines its
-				// first viable candidate when that terminal is hidden.
+				// Hidden missing leaves can disappear during parent construction.
+				// hasErrorByID carries their error state through that collapse. This
+				// matches production's explicit trackChildErrors signal.
 				if view.Missing {
 					node.setMissing(true)
 					node.setHasError(true)
 				}
+				hasErrorByID[id] = view.Missing || Symbol(view.Symbol) == errorSymbol
 				// No markFragile here: fragile is a reduce/conflict-arm property
 				// (subtreeRecord.fragile is only ever set on reductions), so a
 				// terminal record is never fragile. The reduce branches below
@@ -7243,12 +7315,16 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 			}
 
 			entries := materializationScratch.entriesFor(len(view.Children))
+			subtreeHasError := Symbol(view.Symbol) == errorSymbol
 			structuralChildren := 0
 			for index, childID := range view.Children {
 				if uint64(childID) >= uint64(len(nodesByID)) || nodesByID[childID] == nil {
 					return errors.New("parser-core phase zero: compact materialization traversal omitted a child")
 				}
 				child := nodesByID[childID]
+				if hasErrorByID[childID] {
+					subtreeHasError = true
+				}
 				entries[index] = newStackEntryNode(0, child)
 				if !child.isExtra() {
 					structuralChildren++
@@ -7338,6 +7414,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				// walk (tree.go) -- no further HasError code is needed
 				// anywhere else in this file.
 				parent.setHasError(true)
+				hasErrorByID[id] = true
 				markFragile(parent, view.Fragile)
 				stamp(id, parent, false)
 				return nil
@@ -7350,6 +7427,10 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				child.productionID = view.ProductionID
 				child.dynamicPrecedence += int32(view.DynamicPrecedence)
 				markFragile(child, view.Fragile)
+				if subtreeHasError {
+					child.setHasError(true)
+				}
+				hasErrorByID[id] = subtreeHasError
 				stamp(id, child, false)
 				return nil
 			}
@@ -7366,6 +7447,10 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				child.productionID = view.ProductionID
 				child.dynamicPrecedence += int32(view.DynamicPrecedence)
 				markFragile(child, view.Fragile)
+				if subtreeHasError {
+					child.setHasError(true)
+				}
+				hasErrorByID[id] = subtreeHasError
 				stamp(id, child, false)
 				return nil
 			}
@@ -7378,6 +7463,10 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 			parent.startPoint = points.point(view.StartByte)
 			parent.endPoint = points.point(view.EndByte)
 			parent.setExtra(view.Extra)
+			if subtreeHasError {
+				parent.setHasError(true)
+			}
+			hasErrorByID[id] = subtreeHasError
 			markFragile(parent, view.Fragile)
 			stamp(id, parent, false)
 			return nil
@@ -8149,6 +8238,10 @@ func (s *diagnosticParserCoreGenericScheduler) run() error {
 		if stop != nil {
 			return s.finish(stop.boundary, stop.detail, stop.headerIndex)
 		}
+		if s.receipt != nil &&
+			(s.receipt.Acceptance != nil || s.receipt.Completion != nil || s.receipt.Stop.Detail != "") {
+			return nil
+		}
 	}
 }
 
@@ -8471,9 +8564,12 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchVersionLexerPassActive() 
 	}
 	selected := -1
 	operation := core.ActionRowEmpty
+	competingRecoveryAccept := false
 	switch {
 	case acceptCell >= 0:
-		if len(s.headers) != 1 || len(cells) != 1 || len(noActionIndices) != 0 {
+		competingRecoveryAccept = s.competingRecoveryFrontier() &&
+			s.headers[cells[acceptCell].headerIndex].isRecoveryLineage()
+		if !competingRecoveryAccept && (len(s.headers) != 1 || len(cells) != 1 || len(noActionIndices) != 0) {
 			return &diagnosticParserCoreGenericUnsupported{
 				boundary: DiagnosticParserCoreAccept, detail: "generic scheduler owned lexer accept requires one live version", headerIndex: cells[acceptCell].headerIndex,
 			}, nil
@@ -8521,7 +8617,13 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchVersionLexerPassActive() 
 	err = s.withVersionLexerRequest(cell, func() error {
 		switch operation {
 		case core.ActionRowAccept:
-			return s.applyGenericAccept(before, cell)
+			if err := s.applyGenericAccept(before, cell); err != nil {
+				return err
+			}
+			if competingRecoveryAccept {
+				return s.completeAcceptance()
+			}
+			return nil
 		case core.ActionRowExtraShift:
 			return s.applyGenericExtraShifts(before, []diagnosticParserCoreGenericCell{cell})
 		case core.ActionRowReduce:
@@ -8964,6 +9066,9 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			return nil, s.dropGenericNoActionHeads(noActionIndices)
 		}
 		if len(noActionIndices) != 0 {
+			if s5MissingLineageNeedsOwnedLexer(s, noActionIndices) {
+				return s.activateVersionLexerOwnershipAtRagged(noActionIndices[0])
+			}
 			// pausedNoActionHeads == 0, deferredNoActionHeads == 0, and
 			// raggedRelexNoActionHeads == 0 mean every no-action head
 			// reached this point through a genuinely empty action row (no
@@ -9977,187 +10082,10 @@ func (s *diagnosticParserCoreGenericScheduler) s4TryStackSummaryRecovery(index i
 	return true, nil
 }
 
-const (
-	s5MissingTokenMaxSpineDepth  = 4096
-	s5MissingTokenMaxSimulations = 256
-)
-
-// s5TryMissingTokenInsertion forks one no-action head into two versions.
-// The original version absorbs the real token through S3. Its copied sibling
-// inserts C's lowest viable missing terminal. This order matches C's version
-// list, which is load-bearing for equal-cost recovery selection.
+// s5TryMissingTokenInsertion runs the complete scheduler-level S5 recovery
+// competition. The implementation lives in parsercore_phase0_s5.go.
 func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertion(index int) (handled bool, err error) {
-	if !s.s5MissingTokenAdmitted() || len(s.headers) != 1 || index != 0 {
-		return false, nil
-	}
-	original := s.headers[index]
-	if original.recoveryRegion() != nil || s.token.Missing || s.token.NoLookahead ||
-		s.token.Symbol == errorSymbol || s.s5MissingInsertions >= maxDiagnosticParserCoreMissingInsertions {
-		return false, nil
-	}
-	if s.tokenSource == nil || s.tokenSource.language == nil {
-		return false, nil
-	}
-	tokenCount := s.tokenSource.language.TokenCount
-	if tokenCount <= 1 || tokenCount > uint32(math.MaxUint16) {
-		return false, nil
-	}
-
-	// C closes productions before it scans for a missing terminal. Keep the
-	// original header unchanged unless the complete two-version fork succeeds.
-	closedHead, closedChanged, closeOK, closeErr := s.s3CloseInProgressProductions(original.head)
-	if closeErr != nil {
-		return false, closeErr
-	}
-	if !closeOK {
-		return false, nil
-	}
-	scanHead := original.head
-	if closedChanged {
-		scanHead = closedHead
-	}
-	state, byteOffset, boundaryErr := s.compact.Boundary(scanHead)
-	if boundaryErr != nil {
-		return false, boundaryErr
-	}
-	if byteOffset > s.token.StartByte {
-		return false, nil
-	}
-	spine, spineOK, spineErr := s.compact.UniqueStateSpine(scanHead, s5MissingTokenMaxSpineDepth)
-	if spineErr != nil {
-		return false, spineErr
-	}
-	if !spineOK || len(spine) == 0 || spine[len(spine)-1] != state {
-		return false, nil
-	}
-
-	simulation := make([]core.StateID, len(spine)+1)
-	copy(simulation, spine)
-	var missing Symbol
-	var targetState core.StateID
-	simulations := 0
-	for rawSymbol := uint32(1); rawSymbol < tokenCount; rawSymbol++ {
-		if rawSymbol%64 == 0 {
-			if pollErr := s.pollStopControl(); pollErr != nil {
-				return false, pollErr
-			}
-		}
-		candidate := Symbol(rawSymbol)
-		row, rowErr := s.compact.Actions(state, core.Symbol(candidate))
-		if rowErr != nil {
-			return false, rowErr
-		}
-		if row.Len() == 0 {
-			continue
-		}
-		last := row.At(row.Len() - 1)
-		if last.Type != core.ActionShift {
-			continue
-		}
-		nextState := core.StateID(last.State)
-		if last.Extra {
-			nextState = state
-		}
-		if nextState == 0 || nextState == state {
-			continue
-		}
-		nextRow, nextErr := s.compact.Actions(nextState, core.Symbol(s.token.Symbol))
-		if nextErr != nil {
-			return false, nextErr
-		}
-		if nextRow.Len() == 0 || nextRow.At(0).Type != core.ActionReduce {
-			continue
-		}
-		simulations++
-		if simulations > s5MissingTokenMaxSimulations {
-			return false, nil
-		}
-		simulation[len(simulation)-1] = nextState
-		canShift, shiftErr := s.compact.CanShiftAfterReductions(simulation, core.Symbol(s.token.Symbol))
-		if shiftErr != nil {
-			return false, shiftErr
-		}
-		if !canShift {
-			continue
-		}
-		// This materializer cannot propagate the error bit after a hidden,
-		// childless missing terminal is spliced out. C selects the first viable
-		// symbol, so decline the whole scan instead of trying a later symbol.
-		if index := int(candidate); index < len(s.tokenSource.language.SymbolMetadata) &&
-			!s.tokenSource.language.SymbolMetadata[index].Visible {
-			return false, nil
-		}
-		missing = candidate
-		targetState = nextState
-		break
-	}
-	if missing == 0 {
-		return false, nil
-	}
-	if s.nextSeq == math.MaxUint64 {
-		return false, errors.New("parser-core phase zero: recovery fork creation sequence overflow")
-	}
-	recoveryBaseline, baselineOK, baselineErr := s.recoveryNodeBaselineForHead(scanHead)
-	if baselineErr != nil {
-		return false, baselineErr
-	}
-	if !baselineOK {
-		return false, nil
-	}
-	missingBaseline, missingBaselineSet := original.recoveryNodeBaseline()
-	if !missingBaselineSet {
-		missingBaseline = 0
-		missingBaselineSet = true
-	} else if missingBaseline > recoveryBaseline {
-		// C clamps the copied stack head before it forks the missing version.
-		missingBaseline = recoveryBaseline
-	}
-	recoveryGroup := s.nextSeq
-
-	// Replace the sole head temporarily. This lets the existing S3 primitive
-	// build the absorb lineage without duplicating its fail-closed checks.
-	absorbHeader := original
-	absorbHeader.head = scanHead
-	absorbHeader.paused = false
-	absorbHeader.shifted = false
-	missingHeader := absorbHeader
-	missingHeader.creationSeq = s.nextSeq
-	replacements := [...]diagnosticParserCoreHeader{absorbHeader, missingHeader}
-	s.invalidateVerifierHeaderBinding()
-	s.headers = replaceDiagnosticParserCoreHeader(s.headers, index, replacements[:])
-	restore := func() {
-		s.invalidateVerifierHeaderBinding()
-		clear(s.headers)
-		s.headers = s.headers[:1]
-		s.headers[0] = original
-	}
-
-	absorbed, absorbErr := s.s3TryOpenErrorRegionWithAlternatives(index, true)
-	if absorbErr != nil {
-		restore()
-		return false, absorbErr
-	}
-	if !absorbed || s.headers[index].recoveryRegion() == nil || !s.headers[index].shifted {
-		restore()
-		return false, nil
-	}
-
-	missingHead, insertErr := s.compact.ShiftMissingLeaf(scanHead, targetState, core.Symbol(missing), byteOffset)
-	if insertErr != nil {
-		restore()
-		return false, insertErr
-	}
-	s.headers[index+1].head = missingHead
-	s.headers[index].publishRecoveryCondenseState(recoveryGroup, 0, recoveryBaseline, true)
-	s.headers[index+1].publishRecoveryCondenseState(
-		0, recoveryGroup, missingBaseline, missingBaselineSet,
-	)
-	s.headers[index].markRecoveryLineage()
-	s.headers[index+1].markRecoveryLineage()
-	s.recoveryIsolation = true
-	s.nextSeq++
-	s.s5MissingInsertions++
-	return true, nil
+	return s.s5TryMissingTokenInsertionFaithful(index)
 }
 
 // s3TryOpenErrorRegion attempts to open (and immediately begin absorbing
@@ -10473,16 +10401,32 @@ func (s *diagnosticParserCoreGenericScheduler) collapseToRecoveryWinner(winner i
 // A returned error means something is wrong with the compact state itself; a
 // false resolved means the shape is simply not ours to decide.
 func (s *diagnosticParserCoreGenericScheduler) selectCompetingRecoveryLineage() (int, bool, error) {
+	indices := make([]int, len(s.headers))
+	for index := range indices {
+		indices[index] = index
+	}
+	return s.selectCompetingRecoveryLineageIndices(indices)
+}
+
+// selectCompetingRecoveryLineageIndices prices the supplied stack versions
+// in frontier order. Acceptance passes only finished versions. Direct policy
+// tests pass the complete frontier.
+func (s *diagnosticParserCoreGenericScheduler) selectCompetingRecoveryLineageIndices(
+	indices []int,
+) (int, bool, error) {
 	if s == nil || !s.options.allowCompactRecoveryLineageSelection {
 		return 0, false, nil
 	}
-	if len(s.headers) < 2 {
+	if len(indices) < 2 {
 		return 0, false, nil
 	}
-	for index := range s.headers {
-		if !s.headers[index].isRecoveryLineage() {
+	prior := -1
+	for _, index := range indices {
+		if index <= prior || index < 0 || index >= len(s.headers) ||
+			!s.headers[index].isRecoveryLineage() {
 			return 0, false, nil
 		}
+		prior = index
 	}
 	if s.tokenSource == nil || s.tokenSource.language == nil {
 		return 0, false, nil
@@ -10502,30 +10446,30 @@ func (s *diagnosticParserCoreGenericScheduler) selectCompetingRecoveryLineage() 
 		// counted decline, so match it rather than aborting the whole route.
 		return 0, false, nil
 	}
-	inputs := make([]diagnosticParserCoreLineageInput, 0, len(s.headers))
-	for index := range s.headers {
-		inputs = append(inputs, diagnosticParserCoreLineageInput{
-			Head:                 s.headers[index].head,
-			OpenRecoverySegments: s.headers[index].recoveryOpenSegments(),
-		})
-	}
 	var memo core.RecoveryCostMemo
-	priced, err := diagnosticParserCorePriceLineages(
-		inputs, diagnosticParserCoreRecoverySymbolPolicy(s.tokenSource.language), costSource, &memo,
-	)
-	if err != nil {
-		// Every pricing failure is a decline here, matching how the sole-head
-		// path classifies the identical conditions (compactDerivationsForAcceptance
-		// wraps the enumeration cap into a decline one step later). Returning a
-		// raw error instead would abort the compact route uncounted, and would
-		// classify the same condition two different ways in the census.
-		return 0, false, nil
+	defer memo.Reset()
+	symbols := diagnosticParserCoreRecoverySymbolPolicy(s.tokenSource.language)
+	priced := make([]diagnosticParserCoreLineage, 0, len(indices))
+	for _, index := range indices {
+		entry, supported, priceErr := s.recoveryCondenseEntry(
+			s.headers[index], symbols, costSource, &memo,
+		)
+		if priceErr != nil || !supported {
+			// A pricing failure is a counted decline here. A raw error would
+			// classify the same condition differently from sole-head pricing.
+			return 0, false, nil
+		}
+		priced = append(priced, diagnosticParserCoreLineage{
+			Head:  s.headers[index].head,
+			Cost:  entry.status.Cost,
+			Score: int64(entry.status.DynPrec),
+		})
 	}
 	winner, err := diagnosticParserCoreSelectRecoveryLineage(priced)
 	if err != nil {
 		return 0, false, nil
 	}
-	return winner, true, nil
+	return indices[winner], true, nil
 }
 
 func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() (err error) {
@@ -10551,13 +10495,28 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() (err error) 
 	competitionWinner := 0
 	competitionResolved := false
 	if len(s.headers) != 1 {
-		var selectErr error
-		competitionWinner, competitionResolved, selectErr = s.selectCompetingRecoveryLineage()
-		if selectErr != nil {
-			return selectErr
+		acceptedIndices := make([]int, 0, len(s.headers))
+		for index := range s.headers {
+			if s.headers[index].accepted {
+				acceptedIndices = append(acceptedIndices, index)
+			}
 		}
-		if !competitionResolved {
+		switch len(acceptedIndices) {
+		case 0:
 			return s.finish(DiagnosticParserCoreAccept, "generic scheduler requires one accepted compact head", 0)
+		case 1:
+			competitionWinner = acceptedIndices[0]
+			competitionResolved = true
+		default:
+			var selectErr error
+			competitionWinner, competitionResolved, selectErr =
+				s.selectCompetingRecoveryLineageIndices(acceptedIndices)
+			if selectErr != nil {
+				return selectErr
+			}
+			if !competitionResolved {
+				return s.finish(DiagnosticParserCoreAccept, "generic scheduler requires one accepted compact head", 0)
+			}
 		}
 	}
 	if metadataAdmission {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -114,6 +114,9 @@ type DiagnosticParserCorePrefixOptions struct {
 	// no-action head into missing-token and error-absorb recovery lineages.
 	// Language.CompactMissingTokenInsertionCertified is its artifact gate.
 	allowCompactMissingTokenInsertion bool
+	// allowCompactFaithfulS5Recovery selects the complete S5 physical
+	// graph-head scan. Uncertified artifacts retain the bounded legacy scan.
+	allowCompactFaithfulS5Recovery bool
 	// allowCompactRecoveryLineageSelection permits completeAcceptance to
 	// resolve MORE THAN ONE accepted head by pricing the competing recovery
 	// lineages and publishing the cheaper tree, instead of declining.
@@ -10082,10 +10085,13 @@ func (s *diagnosticParserCoreGenericScheduler) s4TryStackSummaryRecovery(index i
 	return true, nil
 }
 
-// s5TryMissingTokenInsertion runs the complete scheduler-level S5 recovery
-// competition. The implementation lives in parsercore_phase0_s5.go.
+// s5TryMissingTokenInsertion selects the artifact-certified S5 implementation.
+// Other artifacts retain their previously certified bounded recovery path.
 func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertion(index int) (handled bool, err error) {
-	return s.s5TryMissingTokenInsertionFaithful(index)
+	if s.options.allowCompactFaithfulS5Recovery {
+		return s.s5TryMissingTokenInsertionFaithful(index)
+	}
+	return s.s5TryMissingTokenInsertionLegacy(index)
 }
 
 // s3TryOpenErrorRegion attempts to open (and immediately begin absorbing

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -397,6 +397,24 @@ type DiagnosticParserCoreHeaderPathReceipt struct {
 // from the compact core's physical arena storage.
 type DiagnosticParserCoreGenericWork struct {
 	Passes uint64
+	// PotentialReductionActions counts C-style any-terminal reduction actions
+	// examined by the staged S5 frontier.
+	PotentialReductionActions uint64
+	// PotentialReductionOutputs counts physical outputs returned by staged S5
+	// reduction actions.
+	PotentialReductionOutputs uint64
+	// ReductionPromotions counts outputs promoted into an earlier local source
+	// slot after a positive-child reduction.
+	ReductionPromotions uint64
+	// MissingTokenTrials counts viable missing-terminal trial candidates.
+	MissingTokenTrials uint64
+	// MissingTokenCommits counts committed missing-terminal versions.
+	MissingTokenCommits uint64
+	// RecoveryDiscontinuityMerges counts committed recovery-head merges.
+	RecoveryDiscontinuityMerges uint64
+	// RecoveryCeilingDeclines counts staged recovery searches that hit a
+	// configured ceiling and then declined.
+	RecoveryCeilingDeclines uint64
 	// StackSummaryRecoveryForks counts S4 forks that retain both the
 	// ancestor-recovered lineage and the error-absorb lineage.
 	StackSummaryRecoveryForks uint64
@@ -624,6 +642,13 @@ type DiagnosticParserCoreGenericScheduler struct {
 	PerVersionLexAcceptedRaggedSpans uint64
 	PerVersionLexViabilityDrops      uint64
 	PeakLiveVersions                 uint64
+	PotentialReductionActions        uint64
+	PotentialReductionOutputs        uint64
+	ReductionPromotions              uint64
+	MissingTokenTrials               uint64
+	MissingTokenCommits              uint64
+	RecoveryDiscontinuityMerges      uint64
+	RecoveryCeilingDeclines          uint64
 }
 
 type DiagnosticParserCorePrefixResult struct {
@@ -4532,6 +4557,31 @@ type diagnosticParserCoreGenericCell struct {
 	corridorTrustedReduction bool
 }
 
+// diagnosticParserCoreS5Work keeps recovery-search work private until the
+// complete S5 route commits. A declined route must publish no staged work.
+type diagnosticParserCoreS5Work struct {
+	potentialReductionActions   uint64
+	potentialReductionOutputs   uint64
+	reductionPromotions         uint64
+	missingTokenTrials          uint64
+	missingTokenCommits         uint64
+	recoveryDiscontinuityMerges uint64
+	recoveryCeilingDeclines     uint64
+}
+
+func (s *diagnosticParserCoreGenericScheduler) commitS5Work(staged diagnosticParserCoreS5Work) {
+	if s == nil {
+		return
+	}
+	s.work.add(&s.work.PotentialReductionActions, staged.potentialReductionActions)
+	s.work.add(&s.work.PotentialReductionOutputs, staged.potentialReductionOutputs)
+	s.work.add(&s.work.ReductionPromotions, staged.reductionPromotions)
+	s.work.add(&s.work.MissingTokenTrials, staged.missingTokenTrials)
+	s.work.add(&s.work.MissingTokenCommits, staged.missingTokenCommits)
+	s.work.add(&s.work.RecoveryDiscontinuityMerges, staged.recoveryDiscontinuityMerges)
+	s.work.add(&s.work.RecoveryCeilingDeclines, staged.recoveryCeilingDeclines)
+}
+
 func (cell *diagnosticParserCoreGenericCell) actions() core.ActionRow { return cell.boundary.Actions() }
 func (cell *diagnosticParserCoreGenericCell) dispatchToken(shared Token) Token {
 	if cell.relexedSymbol != 0 {
@@ -4890,7 +4940,8 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestForHeader(inde
 	base := header.versionLexerSnapshot()
 	request := &s.versionLexerRequests[reference-1]
 	if request.valid && request.electionIndex == s.electionIndex &&
-		request.token.StartByte == byteOffset && request.before == base {
+		request.token.StartByte == byteOffset &&
+		diagnosticParserCoreVersionLexerSnapshotEqual(request.before, base) {
 		return request
 	}
 	return nil
@@ -4911,7 +4962,8 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestReferenceForHe
 	}
 	request := &s.versionLexerRequests[reference-1]
 	if request.valid && request.electionIndex == s.electionIndex &&
-		request.token.StartByte == byteOffset && request.before == header.versionLexerSnapshot() {
+		request.token.StartByte == byteOffset &&
+		diagnosticParserCoreVersionLexerSnapshotEqual(request.before, header.versionLexerSnapshot()) {
 		return reference
 	}
 	return 0
@@ -4935,7 +4987,7 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestForCell(
 	if !request.valid || request.electionIndex != s.electionIndex ||
 		cell.versionLexerRequest != header.versionLexerRequestReference() ||
 		request.token.StartByte != cell.boundary.ByteOffset() || cell.boundary.Head() != header.head ||
-		request.before != header.versionLexerSnapshot() {
+		!diagnosticParserCoreVersionLexerSnapshotEqual(request.before, header.versionLexerSnapshot()) {
 		return nil, errors.New("parser-core phase zero: version lexer cell request is stale")
 	}
 	return request, nil
@@ -5020,7 +5072,8 @@ func (s *diagnosticParserCoreGenericScheduler) installEquivalentVersionLexerStat
 	missingGroup := header.recoveryMissingGroupIdentity()
 	baseline, baselineSet := header.recoveryNodeBaseline()
 	matches := func(state *diagnosticParserCoreVersionState) bool {
-		return state != nil && state.s3Region == region && state.relexSnapshot == snapshot &&
+		return state != nil && state.s3Region == region &&
+			diagnosticParserCoreVersionLexerSnapshotEqual(state.relexSnapshot, snapshot) &&
 			state.lexerRequest == requestReference && state.recoveryGroup == recoveryGroup &&
 			state.missingGroup == missingGroup && state.recoveryNodeBaseline == baseline &&
 			state.recoveryNodeBaselineSet == baselineSet
@@ -5056,7 +5109,7 @@ func (s *diagnosticParserCoreGenericScheduler) equivalentVersionLexerSnapshot(
 	beforeID core.CheckpointID,
 	afterID core.CheckpointID,
 ) *diagnosticParserCoreVersionLexerSnapshot {
-	if s == nil {
+	if s == nil || s.compact == nil || s.tokenSource == nil || s.tokenSource.language == nil {
 		return nil
 	}
 	var identity [32]byte
@@ -5065,12 +5118,21 @@ func (s *diagnosticParserCoreGenericScheduler) equivalentVersionLexerSnapshot(
 	if s.tokenSource != nil {
 		identity, identityRequired, identityValid = diagnosticParserCoreVersionLexerCheckpointIdentity(s.tokenSource.language)
 	}
+	contract, contractErr := diagnosticParserCoreVersionLexerScannerContractForLanguage(s.tokenSource.language)
+	if contractErr != nil {
+		return nil
+	}
 	matches := func(snapshot *diagnosticParserCoreVersionLexerSnapshot) bool {
-		return snapshot != nil && snapshot.beforeCheckpoint == beforeID &&
+		return snapshot != nil && snapshot.compact == s.compact &&
+			snapshot.coreGeneration == s.compact.ResetGeneration() &&
+			snapshot.language == s.tokenSource.language &&
+			snapshot.scanner.equal(contract) &&
+			snapshot.beforeCheckpoint == beforeID &&
 			snapshot.afterCheckpoint == afterID && snapshot.dfa.equal(dfa) &&
 			snapshot.checkpointIdentityRequired == identityRequired &&
 			snapshot.checkpointIdentityValid == identityValid &&
-			(!identityRequired || (identityValid && snapshot.checkpointIdentity == identity))
+			(!identityRequired || (identityValid && snapshot.checkpointIdentity == identity)) &&
+			snapshot.validate() == nil
 	}
 	for index := range s.headers {
 		if snapshot := s.headers[index].versionLexerSnapshot(); matches(snapshot) {
@@ -8285,7 +8347,7 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerNoActionDropEligible(
 		for requestIndex := range s.versionLexerRequests {
 			request := &s.versionLexerRequests[requestIndex]
 			if !request.valid || request.electionIndex != s.electionIndex ||
-				request.after != header.versionLexerSnapshot() {
+				!diagnosticParserCoreVersionLexerSnapshotEqual(request.after, header.versionLexerSnapshot()) {
 				continue
 			}
 			if !startSet {
@@ -11493,7 +11555,14 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReduction(before []Di
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner core.SchedulerTransactionToken, before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) error {
-	recoveryAmbiguitySource := s.headers[cell.headerIndex].isRecoveryLineage()
+	header := s.headers[cell.headerIndex]
+	recoveryAmbiguitySource := header.isRecoveryLineage()
+	storedHeadCost, costErr := s.compact.RecoveryStoredErrorCost(cell.boundary.Head())
+	if costErr != nil {
+		return costErr
+	}
+	recoveryCostRequired := recoveryAmbiguitySource || header.recoveryRegion() != nil ||
+		header.isRecoveryCosted() || storedHeadCost != 0
 	if err := s.reserveDispatches(1); err != nil {
 		return err
 	}
@@ -11523,16 +11592,59 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 	defer func() {
 		_ = s.compact.SetDropCohortSelectionContextOwned(owner, core.DropCohortSelectionNone)
 	}()
+	var reductionCost core.ReductionOutputCostFunc
+	var reductionCostMemo core.RecoveryCostMemo
+	if recoveryCostRequired && len(s.options.materializationSource) == 0 {
+		return errors.New("parser-core phase zero: recovery reduction requires a bound materialization source")
+	}
+	if recoveryCostRequired {
+		costSource, costErr := newDiagnosticParserCoreRecoveryCostSource(
+			s.compact, s.options.materializationSource,
+		)
+		if costErr != nil {
+			return costErr
+		}
+		symbols := diagnosticParserCoreRecoverySymbolPolicy(s.tokenSource.language)
+		reductionCost = func(prev core.NodeID, payload core.SubtreeID) (uint32, error) {
+			prefix, prefixErr := s.compact.RecoveryStoredErrorCost(core.Head{Node: prev})
+			if prefixErr != nil {
+				return 0, prefixErr
+			}
+			payloadCost, payloadErr := core.RecoveryNodeErrorCostMemo(
+				symbols, costSource, &reductionCostMemo, payload,
+			)
+			if payloadErr != nil {
+				return 0, payloadErr
+			}
+			if math.MaxUint32-prefix < payloadCost {
+				return 0, errors.New("parser-core phase zero: reduction recovery cost overflow")
+			}
+			return prefix + payloadCost, nil
+		}
+		defer reductionCostMemo.Reset()
+	}
 	var outputs []core.ReductionOutput
 	var err error
 	if cell.corridorTrustedReduction {
-		outputs, err = s.compact.ReduceOutputsCorridorClassifiedIntoWithLiveCondenseCandidatesOwned(
-			owner, candidates, s.reductionOutputs, cell.boundary, core.ForkOrder{},
-		)
+		if reductionCost == nil {
+			outputs, err = s.compact.ReduceOutputsCorridorClassifiedIntoWithLiveCondenseCandidatesOwned(
+				owner, candidates, s.reductionOutputs, cell.boundary, core.ForkOrder{},
+			)
+		} else {
+			outputs, err = s.compact.ReduceOutputsCorridorClassifiedIntoWithLiveCondenseCandidatesAndCostOwned(
+				owner, candidates, s.reductionOutputs, cell.boundary, core.ForkOrder{}, reductionCost,
+			)
+		}
 	} else {
-		outputs, err = s.compact.ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesOwned(
-			owner, candidates, s.reductionOutputs, cell.boundary, ordinal, core.ForkOrder{},
-		)
+		if reductionCost == nil {
+			outputs, err = s.compact.ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesOwned(
+				owner, candidates, s.reductionOutputs, cell.boundary, ordinal, core.ForkOrder{},
+			)
+		} else {
+			outputs, err = s.compact.ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesAndCostOwned(
+				owner, candidates, s.reductionOutputs, cell.boundary, ordinal, core.ForkOrder{}, reductionCost,
+			)
+		}
 	}
 	if err != nil {
 		return err
@@ -11893,7 +12005,7 @@ func (s *diagnosticParserCoreGenericScheduler) condenseCandidateMergeIdentity(in
 		return 0
 	}
 	for prior := 0; prior < index; prior++ {
-		if s.headers[prior].versionState == state {
+		if s.versionLexerStateEqual(s.headers[prior].versionState, state) {
 			return uint16(prior + 1)
 		}
 	}
@@ -11956,7 +12068,7 @@ func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(
 			continue
 		}
 		header := s.headers[index]
-		if header.versionState != sourceVersionState {
+		if !s.versionLexerStateEqual(header.versionState, sourceVersionState) {
 			// A canonical head does not prove equal version history. Keep forks
 			// with distinct immutable state as separate versions.
 			continue
@@ -12305,7 +12417,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 		for index := range s.headers {
 			header := &s.headers[index]
 			if !header.shifted || header.versionLexerRequestReference() != cell.versionLexerRequest ||
-				header.versionLexerSnapshot() != versionLexerRequest.before {
+				!diagnosticParserCoreVersionLexerSnapshotEqual(header.versionLexerSnapshot(), versionLexerRequest.before) {
 				continue
 			}
 			if err := s.publishVersionLexerShiftOnHeaderOwned(owner, header, versionLexerRequest); err != nil {
@@ -13192,6 +13304,13 @@ func (s *diagnosticParserCoreGenericScheduler) publishTotals() {
 	s.receipt.PerVersionLexAcceptedRaggedSpans = s.work.PerVersionLexAcceptedRaggedSpans
 	s.receipt.PerVersionLexViabilityDrops = s.work.PerVersionLexViabilityDrops
 	s.receipt.PeakLiveVersions = s.work.PeakLiveVersions
+	s.receipt.PotentialReductionActions = s.work.PotentialReductionActions
+	s.receipt.PotentialReductionOutputs = s.work.PotentialReductionOutputs
+	s.receipt.ReductionPromotions = s.work.ReductionPromotions
+	s.receipt.MissingTokenTrials = s.work.MissingTokenTrials
+	s.receipt.MissingTokenCommits = s.work.MissingTokenCommits
+	s.receipt.RecoveryDiscontinuityMerges = s.work.RecoveryDiscontinuityMerges
+	s.receipt.RecoveryCeilingDeclines = s.work.RecoveryCeilingDeclines
 }
 
 func authenticatedParserCoreGoLanguage(scanner ExternalScanner) (*Language, error) {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2172,6 +2172,10 @@ type diagnosticParserCoreCanonicalScratch struct {
 	groupsBucketCount   uint64
 	groupsBucketBytes   uint64
 	groupsRetainedBytes uint64
+	// versionStateEqual selects a prior semantic representative for each
+	// canonical key. The representative keeps the comparable key compact and
+	// avoids hashing mutable snapshot slices.
+	versionStateEqual func(left, right *diagnosticParserCoreVersionState) bool
 }
 
 const (
@@ -2374,6 +2378,15 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeWithMutation(
 			// Preserve the pre-ownership canonical key. Recovery isolation keeps
 			// region-bearing versions separate when that distinction matters.
 			versionState = nil
+		}
+		if versionState != nil && s.versionStateEqual != nil {
+			for prior := 0; prior < index; prior++ {
+				representative := s.keys[prior].versionState
+				if representative != nil && s.versionStateEqual(representative, versionState) {
+					versionState = representative
+					break
+				}
+			}
 		}
 		key := diagnosticParserCorePhaseHead{
 			head: header.head, shifted: header.shifted, accepted: header.accepted,
@@ -4283,6 +4296,7 @@ func clearDiagnosticParserCoreGenericSchedulerVersionState(scheduler *diagnostic
 	clearDiagnosticParserCorePhaseHeadBacking(scheduler.canonicalScratch.keys)
 	clearDiagnosticParserCorePhaseHeadBacking(scheduler.canonicalScratch.inlineKeys[:])
 	clear(scheduler.canonicalScratch.groups)
+	scheduler.canonicalScratch.versionStateEqual = nil
 	if cap(scheduler.versionLexerRequests) != 0 {
 		clear(scheduler.versionLexerRequests[:cap(scheduler.versionLexerRequests)])
 	}
@@ -8670,13 +8684,18 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				// compact equivalent of cRecoverToState's
 				// pushStackNode(fork, goal, errNode, ...)), then fall through
 				// to ordinary classification below using the refreshed head.
+				recoveryCost, recoveryCostMemo, costErr := s.recoveryOutputCostFunc()
+				if costErr != nil {
+					return nil, costErr
+				}
+				defer recoveryCostMemo.Reset()
 				var newHead core.Head
 				var resumeErr error
 				if s.recoveryIsolation {
 					resume := func(owner core.SchedulerTransactionToken) error {
-						newHead, resumeErr = s.compact.ErrorRegionResumeWithLiveCondenseCandidatesOwned(
+						newHead, resumeErr = s.compact.ErrorRegionResumeWithLiveCondenseCandidatesAndCostOwned(
 							owner, s.collectCondenseCandidates(index), header.head, region.state,
-							region.startByte, region.endByte, region.children,
+							region.startByte, region.endByte, region.children, recoveryCost,
 						)
 						return resumeErr
 					}
@@ -8686,8 +8705,9 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 						resumeErr = s.compact.ApplySchedulerAtomic(resume)
 					}
 				} else {
-					newHead, resumeErr = s.compact.ErrorRegionResume(
+					newHead, resumeErr = s.compact.ErrorRegionResumeWithCost(
 						header.head, region.state, region.startByte, region.endByte, region.children,
+						recoveryCost,
 					)
 				}
 				if resumeErr != nil {
@@ -9466,12 +9486,17 @@ func (s *diagnosticParserCoreGenericScheduler) tryRecoverEOFAccept(index int) (b
 	if err := s.reserveDispatches(1); err != nil {
 		return false, err
 	}
+	recoveryCost, recoveryCostMemo, costErr := s.recoveryOutputCostFunc()
+	if costErr != nil {
+		return false, costErr
+	}
+	defer recoveryCostMemo.Reset()
 	var recovered core.Head
 	var root core.SubtreeID
 	apply := func(owner core.SchedulerTransactionToken) error {
 		var applyErr error
-		recovered, root, applyErr = s.compact.RecoverEOFAcceptOwned(
-			owner, selectedHead, payloads, startByte, endByte,
+		recovered, root, applyErr = s.compact.RecoverEOFAcceptWithCostOwned(
+			owner, selectedHead, payloads, startByte, endByte, recoveryCost,
 		)
 		return applyErr
 	}
@@ -9915,11 +9940,17 @@ func (s *diagnosticParserCoreGenericScheduler) s4TryStackSummaryRecovery(index i
 		restore()
 		return false, nil
 	}
+	recoveryCost, recoveryCostMemo, costErr := s.recoveryOutputCostFunc()
+	if costErr != nil {
+		restore()
+		return false, costErr
+	}
+	defer recoveryCostMemo.Reset()
 
 	var recoveredHead core.Head
 	recover := func(owner core.SchedulerTransactionToken) error {
 		var recoverErr error
-		recoveredHead, recoverErr = s.compact.RecoverToAncestorStateOwned(owner, elected)
+		recoveredHead, recoverErr = s.compact.RecoverToAncestorStateWithCostOwned(owner, elected, recoveryCost)
 		return recoverErr
 	}
 	if s.freshSessionOwner != nil {
@@ -11554,6 +11585,38 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReduction(before []Di
 	})
 }
 
+// recoveryOutputCostFunc binds the row-aware recovery cost source for one
+// scheduler operation. Core receives the complete prefix-plus-payload cost.
+func (s *diagnosticParserCoreGenericScheduler) recoveryOutputCostFunc() (core.ReductionOutputCostFunc, *core.RecoveryCostMemo, error) {
+	if s == nil || s.compact == nil || s.tokenSource == nil || s.tokenSource.language == nil {
+		return nil, nil, errors.New("parser-core phase zero: recovery cost source is unavailable")
+	}
+	if len(s.options.materializationSource) == 0 {
+		return nil, nil, errors.New("parser-core phase zero: recovery cost source requires non-empty materialization source")
+	}
+	source, err := newDiagnosticParserCoreRecoveryCostSource(s.compact, s.options.materializationSource)
+	if err != nil {
+		return nil, nil, err
+	}
+	symbols := diagnosticParserCoreRecoverySymbolPolicy(s.tokenSource.language)
+	memo := new(core.RecoveryCostMemo)
+	cost := func(prev core.NodeID, payload core.SubtreeID) (uint32, error) {
+		prefix, prefixErr := s.compact.RecoveryStoredErrorCost(core.Head{Node: prev})
+		if prefixErr != nil {
+			return 0, prefixErr
+		}
+		payloadCost, payloadErr := core.RecoveryNodeErrorCostMemo(symbols, source, memo, payload)
+		if payloadErr != nil {
+			return 0, payloadErr
+		}
+		if math.MaxUint32-prefix < payloadCost {
+			return 0, errors.New("parser-core phase zero: recovery output cost overflow")
+		}
+		return prefix + payloadCost, nil
+	}
+	return cost, memo, nil
+}
+
 func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner core.SchedulerTransactionToken, before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) error {
 	header := s.headers[cell.headerIndex]
 	recoveryAmbiguitySource := header.isRecoveryLineage()
@@ -11593,33 +11656,12 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		_ = s.compact.SetDropCohortSelectionContextOwned(owner, core.DropCohortSelectionNone)
 	}()
 	var reductionCost core.ReductionOutputCostFunc
-	var reductionCostMemo core.RecoveryCostMemo
-	if recoveryCostRequired && len(s.options.materializationSource) == 0 {
-		return errors.New("parser-core phase zero: recovery reduction requires a bound materialization source")
-	}
+	var reductionCostMemo *core.RecoveryCostMemo
 	if recoveryCostRequired {
-		costSource, costErr := newDiagnosticParserCoreRecoveryCostSource(
-			s.compact, s.options.materializationSource,
-		)
+		var costErr error
+		reductionCost, reductionCostMemo, costErr = s.recoveryOutputCostFunc()
 		if costErr != nil {
 			return costErr
-		}
-		symbols := diagnosticParserCoreRecoverySymbolPolicy(s.tokenSource.language)
-		reductionCost = func(prev core.NodeID, payload core.SubtreeID) (uint32, error) {
-			prefix, prefixErr := s.compact.RecoveryStoredErrorCost(core.Head{Node: prev})
-			if prefixErr != nil {
-				return 0, prefixErr
-			}
-			payloadCost, payloadErr := core.RecoveryNodeErrorCostMemo(
-				symbols, costSource, &reductionCostMemo, payload,
-			)
-			if payloadErr != nil {
-				return 0, payloadErr
-			}
-			if math.MaxUint32-prefix < payloadCost {
-				return 0, errors.New("parser-core phase zero: reduction recovery cost overflow")
-			}
-			return prefix + payloadCost, nil
 		}
 		defer reductionCostMemo.Reset()
 	}
@@ -12999,6 +13041,11 @@ func (s *diagnosticParserCoreGenericScheduler) canonicalizeOwned(owner core.Sche
 }
 
 func (s *diagnosticParserCoreGenericScheduler) canonicalizeOwnedWithMutation(owner core.SchedulerTransactionToken, expected core.DropCohortProducerMutation) error {
+	previousVersionStateEqual := s.canonicalScratch.versionStateEqual
+	s.canonicalScratch.versionStateEqual = s.versionLexerStateEqual
+	defer func() {
+		s.canonicalScratch.versionStateEqual = previousVersionStateEqual
+	}()
 	var headers []diagnosticParserCoreHeader
 	var mutation core.DropCohortProducerMutation
 	var err error

--- a/parsercore_phase0_generic_freshness_internal_test.go
+++ b/parsercore_phase0_generic_freshness_internal_test.go
@@ -175,13 +175,20 @@ func TestDiagnosticParserCoreRecoveryReductionForkPreservesMarkers(t *testing.T)
 		t.Fatal(err)
 	}
 	scheduler := &diagnosticParserCoreGenericScheduler{
-		compact:              compact,
+		compact: compact,
+		tokenSource: &dfaTokenSource{language: &Language{
+			SymbolCount: 10,
+			SymbolMetadata: []SymbolMetadata{
+				8: {Visible: true, Named: true},
+			},
+		}},
 		headers:              []diagnosticParserCoreHeader{{head: head, creationSeq: 3}},
 		token:                Token{Symbol: 9, StartByte: 1, EndByte: 2},
 		nextSeq:              10,
 		nextCleanPathLineage: 1,
 		options: DiagnosticParserCorePrefixOptions{
 			MaxDispatches:                        20,
+			materializationSource:                []byte("a?"),
 			allowCompactRecoveryLineageSelection: true,
 		},
 		receipt: &DiagnosticParserCoreGenericScheduler{},

--- a/parsercore_phase0_package2_strict_internal_test.go
+++ b/parsercore_phase0_package2_strict_internal_test.go
@@ -1,0 +1,148 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	_ "embed"
+	"testing"
+)
+
+// Keep this internal test in package gotreesitter without importing the
+// grammars package, which would create an import cycle.
+//
+//go:embed grammars/grammar_blobs/scala.bin
+var package2ScalaBlob []byte
+
+// package2ScalaStrictRunner enables the complete package-two capability bundle
+// on a private language copy. The production profile stays unchanged until
+// the locked Scala witnesses pass this receipt test.
+func package2ScalaStrictRunner(t *testing.T) *parserCoreFreshFullRunner {
+	t.Helper()
+	lang, err := LoadLanguage(package2ScalaBlob)
+	if err != nil {
+		t.Fatalf("decode Scala grammar: %v", err)
+	}
+	lang.Name = "scala"
+	lang.CompactStrategy2ErrorRegionCertified = true
+	lang.CompactMissingTokenInsertionCertified = true
+	lang.CompactStackSummaryRecoveryCertified = false
+	lang.CompactPrimaryAcceptanceDerivationCertified = true
+	lang.CompactAcceptanceStructuralElectionCertified = true
+	lang.CompactRecoveryTrailingLineageRetirementCertified = true
+	lang.CompactRecoveryErrorModeKeywordCaptureCertified = true
+	parser := NewParser(lang)
+	runner, err := newAdmissionCandidateRunner(parser)
+	if err != nil {
+		t.Fatalf("new Scala package-two runner: %v", err)
+	}
+	t.Cleanup(func() {
+		if runner.compact != nil {
+			if err := runner.compact.ResetReleasingRetention(); err != nil {
+				t.Errorf("reset Scala package-two runner: %v", err)
+			}
+		}
+	})
+	return runner
+}
+
+// TestPackage2ScalaStrictReceipt locks the compact S5 receipt for the
+// smallest witness. It requires exact routing and C's five physical merges.
+func TestPackage2ScalaStrictReceipt(t *testing.T) {
+	runner := package2ScalaStrictRunner(t)
+	const source = "(y; "
+	_, _, runErr := runner.executeSchedulerOpenWithObserverAndErrorRuns(
+		[]byte(source), runner.compact, true, diagnosticParserCoreSeedObserver{}, true,
+	)
+	generic := runner.scheduler.receipt
+	if runErr != nil {
+		if generic != nil {
+			t.Fatalf("compact route declined: %v; stop=%+v work=%+v", runErr, generic.Stop, generic.Stop.Work)
+		}
+		t.Fatalf("compact route declined before receipt: %v", runErr)
+	}
+	if generic == nil {
+		t.Fatal("compact route returned no scheduler receipt")
+	}
+	if generic.Stop.Boundary != "" {
+		t.Fatalf("compact receipt stopped at %s: %s", generic.Stop.Boundary, generic.Stop.Detail)
+	}
+	acceptance := generic.Acceptance
+	if acceptance == nil {
+		t.Fatalf("compact receipt has no acceptance: %+v", *generic)
+	}
+	work := acceptance.Work
+	if work.ActionLookups == 0 || work.Dispatches == 0 || work.Elections == 0 {
+		t.Fatalf("S5 receipt lacks action/output/trial work: %+v", work)
+	}
+	if runner.scheduler.s5MissingInsertions != 1 {
+		t.Fatalf("S5 insertion commits=%d, want one", runner.scheduler.s5MissingInsertions)
+	}
+	if work.StackSummaryRecoveryForks != 0 || work.RecoverEOFAccepts != 0 || work.RecoveryVersionCapDrops != 0 {
+		t.Fatalf("S5 receipt used an unsupported recovery or ceiling path: %+v", work)
+	}
+	if work.RecoveryLineageSelections == 0 {
+		t.Fatalf("S5 receipt did not record recovery-lineage selection: %+v", work)
+	}
+	coreWork := acceptance.CoreWork
+	if got, want := coreWork.PhysicalHeadMergeAttempts, uint64(5); got != want {
+		t.Fatalf("physical merge attempts=%d, want %d", got, want)
+	}
+	if got, want := coreWork.PhysicalHeadMergeSuccesses, uint64(5); got != want {
+		t.Fatalf("physical merge successes=%d, want %d", got, want)
+	}
+	if got, want := coreWork.PhysicalHeadMergeInputLinks, uint64(5); got != want {
+		t.Fatalf("physical merge input links=%d, want %d", got, want)
+	}
+	if got, want := coreWork.PredecessorLinkUnionAlternateAppended, uint64(5); got != want {
+		t.Fatalf("alternate links=%d, want %d", got, want)
+	}
+	if coreWork.PredecessorLinkUnionRecursiveChanged != 0 {
+		t.Fatalf("recursive link changes=%d, want zero", coreWork.PredecessorLinkUnionRecursiveChanged)
+	}
+	t.Logf("Scala package-two strict receipt: acceptance=%+v work=%+v core=%+v", acceptance.Header.Header, work, coreWork)
+}
+
+// TestPackage2ScalaStrictReceiptComposition locks the shorter merge topology
+// in the owned-lexer composition witness.
+func TestPackage2ScalaStrictReceiptComposition(t *testing.T) {
+	runner := package2ScalaStrictRunner(t)
+	const source = "((y)->; "
+	_, _, runErr := runner.executeSchedulerOpenWithObserverAndErrorRuns(
+		[]byte(source), runner.compact, true, diagnosticParserCoreSeedObserver{}, true,
+	)
+	generic := runner.scheduler.receipt
+	if runErr != nil {
+		if generic != nil {
+			t.Fatalf("compact composition route declined: %v; stop=%+v work=%+v", runErr, generic.Stop, generic.Stop.Work)
+		}
+		t.Fatalf("compact composition route declined before receipt: %v", runErr)
+	}
+	if generic == nil || generic.Acceptance == nil {
+		t.Fatalf("compact composition receipt has no acceptance: %+v", generic)
+	}
+	work := generic.Acceptance.Work
+	if work.ActionLookups == 0 || work.Dispatches == 0 || work.Elections == 0 {
+		t.Fatalf("composition S5 receipt lacks action/output/trial work: %+v", work)
+	}
+	if runner.scheduler.s5MissingInsertions != 1 || work.StackSummaryRecoveryForks != 0 || work.RecoverEOFAccepts != 0 || work.RecoveryVersionCapDrops != 0 {
+		t.Fatalf("composition S5 receipt has wrong fork or ceiling telemetry: insertions=%d work=%+v", runner.scheduler.s5MissingInsertions, work)
+	}
+	if work.RecoveryLineageSelections == 0 {
+		t.Fatalf("composition S5 receipt did not select a recovery lineage: %+v", work)
+	}
+	coreWork := generic.Acceptance.CoreWork
+	for name, got := range map[string]uint64{
+		"attempts":        coreWork.PhysicalHeadMergeAttempts,
+		"successes":       coreWork.PhysicalHeadMergeSuccesses,
+		"input_links":     coreWork.PhysicalHeadMergeInputLinks,
+		"alternate_links": coreWork.PredecessorLinkUnionAlternateAppended,
+	} {
+		if got != 3 {
+			t.Fatalf("composition %s=%d, want 3; acceptance=%+v core=%+v", name, got, generic.Acceptance.Header.Header, coreWork)
+		}
+	}
+	if coreWork.PredecessorLinkUnionRecursiveChanged != 0 {
+		t.Fatalf("composition recursive link changes=%d, want zero", coreWork.PredecessorLinkUnionRecursiveChanged)
+	}
+	t.Logf("Scala package-two composition strict receipt: work=%+v core=%+v", work, coreWork)
+}

--- a/parsercore_phase0_package2_strict_internal_test.go
+++ b/parsercore_phase0_package2_strict_internal_test.go
@@ -5,6 +5,8 @@ package gotreesitter
 import (
 	_ "embed"
 	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
 )
 
 // Keep this internal test in package gotreesitter without importing the
@@ -14,8 +16,8 @@ import (
 var package2ScalaBlob []byte
 
 // package2ScalaStrictRunner enables the complete package-two capability bundle
-// on a private language copy. The production profile stays unchanged until
-// the locked Scala witnesses pass this receipt test.
+// on a private language copy. The exact-blob profile uses the same flags only
+// after the locked Scala witnesses pass this receipt test.
 func package2ScalaStrictRunner(t *testing.T) *parserCoreFreshFullRunner {
 	t.Helper()
 	lang, err := LoadLanguage(package2ScalaBlob)
@@ -35,6 +37,7 @@ func package2ScalaStrictRunner(t *testing.T) *parserCoreFreshFullRunner {
 	if err != nil {
 		t.Fatalf("new Scala package-two runner: %v", err)
 	}
+	runner.options.ReceiptMode = DiagnosticParserCoreReceiptFull
 	t.Cleanup(func() {
 		if runner.compact != nil {
 			if err := runner.compact.ResetReleasingRetention(); err != nil {
@@ -43,6 +46,97 @@ func package2ScalaStrictRunner(t *testing.T) *parserCoreFreshFullRunner {
 		}
 	})
 	return runner
+}
+
+func requirePackage2ScalaTree(
+	t *testing.T,
+	runner *parserCoreFreshFullRunner,
+	source string,
+	wantSExpr string,
+	wantDigest string,
+	wantMissingByte uint32,
+) {
+	t.Helper()
+	tree, err := runner.materializeSelection([]byte(source), runner.compact, &runner.scheduler)
+	if err != nil {
+		t.Fatalf("materialize compact selection: %v", err)
+	}
+	defer tree.Release()
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("materialized compact selection has no root")
+	}
+	if got := root.SExpr(runner.lang); got != wantSExpr {
+		t.Fatalf("S-expression=%q, want %q", got, wantSExpr)
+	}
+	if root.StartByte() != 0 || root.EndByte() != uint32(len(source)) ||
+		root.IsError() || !root.HasError() {
+		t.Fatalf("root=%d..%d error=%t has_error=%t, want 0..%d non-error with error content",
+			root.StartByte(), root.EndByte(), root.IsError(), root.HasError(), len(source))
+	}
+	missingCount := 0
+	walkResultTree(root, func(node *Node) {
+		if !node.IsMissing() {
+			return
+		}
+		missingCount++
+		if node.StartByte() != wantMissingByte || node.EndByte() != wantMissingByte || !node.HasError() {
+			t.Errorf("missing node=%d..%d has_error=%t, want %d..%d with error content",
+				node.StartByte(), node.EndByte(), node.HasError(), wantMissingByte, wantMissingByte)
+		}
+	})
+	if missingCount != 1 {
+		t.Fatalf("materialized missing nodes=%d, want one", missingCount)
+	}
+	if got := requireDiagnosticParserCoreCanonicalTreeDigest(t, tree, runner.lang); got != wantDigest {
+		t.Fatalf("canonical tree digest=%s, want %s", got, wantDigest)
+	}
+	cost, err := runner.compact.RecoveryStoredErrorCost(runner.scheduler.acceptedHead)
+	if err != nil {
+		t.Fatalf("read selected recovery cost: %v", err)
+	}
+	if cost != uint32(core.RecoveryCostPerMissingTree+core.RecoveryCostPerRecovery) {
+		t.Fatalf("selected stored recovery cost=%d, want 610", cost)
+	}
+}
+
+func requirePackage2ScalaOwnedEOFRequest(
+	t *testing.T,
+	runner *parserCoreFreshFullRunner,
+	state StateID,
+	beforeByte uint32,
+	eofByte uint32,
+	wantPublicCount int,
+) {
+	t.Helper()
+	if runner == nil || runner.scheduler.receipt == nil {
+		t.Fatal("Scala package-two owned lexer receipt is unavailable")
+	}
+	requests := runner.scheduler.versionLexerRequests
+	if len(requests) != 1 {
+		t.Fatalf("Scala package-two owned lexer requests=%d, want one", len(requests))
+	}
+	request := requests[0]
+	if request.state != state || request.token.Symbol != 0 ||
+		request.token.StartByte != eofByte || request.token.EndByte != eofByte ||
+		request.token.Missing || request.token.NoLookahead || request.token.ExternalScannerToken ||
+		request.token.lexerInternalDFALexed {
+		t.Fatalf("Scala package-two owned lexer request=%+v, want state %d authenticated EOF at %d", request, state, eofByte)
+	}
+	if request.before == nil || request.after == nil ||
+		request.before.dfa.lexerPos != int(beforeByte) || request.after.dfa.lexerPos != int(eofByte) {
+		t.Fatalf("Scala package-two owned lexer cursors=%+v/%+v, want %d..%d", request.before, request.after, beforeByte, eofByte)
+	}
+	public := runner.scheduler.receipt.VersionLexerRequests
+	if len(public) != wantPublicCount {
+		t.Fatalf("Scala package-two public owned lexer receipts=%d, want %d: %+v", len(public), wantPublicCount, public)
+	}
+	eof := public[len(public)-1]
+	if eof.State != state || eof.Token.Symbol != 0 ||
+		eof.Token.StartByte != eofByte || eof.Token.EndByte != eofByte ||
+		eof.InternalDFAToken {
+		t.Fatalf("Scala package-two public owned lexer receipt=%+v", public)
+	}
 }
 
 // TestPackage2ScalaStrictReceipt locks the compact S5 receipt for the
@@ -71,17 +165,19 @@ func TestPackage2ScalaStrictReceipt(t *testing.T) {
 		t.Fatalf("compact receipt has no acceptance: %+v", *generic)
 	}
 	work := acceptance.Work
-	if work.ActionLookups == 0 || work.Dispatches == 0 || work.Elections == 0 {
-		t.Fatalf("S5 receipt lacks action/output/trial work: %+v", work)
+	if work.PotentialReductionActions != 9 || work.PotentialReductionOutputs != 9 ||
+		work.ReductionPromotions != 4 || work.MissingTokenTrials != 1 ||
+		work.MissingTokenCommits != 1 || work.RecoveryDiscontinuityMerges != 5 ||
+		work.RecoveryLineageSelections != 1 || work.RecoveryCondensePasses != 4 {
+		t.Fatalf("S5 receipt has wrong exact recovery work: %+v", work)
 	}
 	if runner.scheduler.s5MissingInsertions != 1 {
 		t.Fatalf("S5 insertion commits=%d, want one", runner.scheduler.s5MissingInsertions)
 	}
-	if work.StackSummaryRecoveryForks != 0 || work.RecoverEOFAccepts != 0 || work.RecoveryVersionCapDrops != 0 {
+	if work.StackSummaryRecoveryForks != 0 || work.RecoverEOFAccepts != 0 ||
+		work.RecoveryVersionCapDrops != 0 || work.RecoveryLineageRetirements != 0 ||
+		work.RecoveryAmbiguityForks != 0 || work.RecoveryCeilingDeclines != 0 {
 		t.Fatalf("S5 receipt used an unsupported recovery or ceiling path: %+v", work)
-	}
-	if work.RecoveryLineageSelections == 0 {
-		t.Fatalf("S5 receipt did not record recovery-lineage selection: %+v", work)
 	}
 	coreWork := acceptance.CoreWork
 	if got, want := coreWork.PhysicalHeadMergeAttempts, uint64(5); got != want {
@@ -99,6 +195,13 @@ func TestPackage2ScalaStrictReceipt(t *testing.T) {
 	if coreWork.PredecessorLinkUnionRecursiveChanged != 0 {
 		t.Fatalf("recursive link changes=%d, want zero", coreWork.PredecessorLinkUnionRecursiveChanged)
 	}
+	requirePackage2ScalaOwnedEOFRequest(t, runner, 429, 3, 4, 1)
+	requirePackage2ScalaTree(
+		t, runner, source,
+		"(compilation_unit (parenthesized_expression (identifier)))",
+		"06d2d9f6b02599ec5be0808330bf1c62e49b8cb0b146d094ceaa28b9185c79b6",
+		2,
+	)
 	t.Logf("Scala package-two strict receipt: acceptance=%+v work=%+v core=%+v", acceptance.Header.Header, work, coreWork)
 }
 
@@ -121,14 +224,17 @@ func TestPackage2ScalaStrictReceiptComposition(t *testing.T) {
 		t.Fatalf("compact composition receipt has no acceptance: %+v", generic)
 	}
 	work := generic.Acceptance.Work
-	if work.ActionLookups == 0 || work.Dispatches == 0 || work.Elections == 0 {
-		t.Fatalf("composition S5 receipt lacks action/output/trial work: %+v", work)
+	if work.PotentialReductionActions != 7 || work.PotentialReductionOutputs != 7 ||
+		work.ReductionPromotions != 4 || work.MissingTokenTrials != 1 ||
+		work.MissingTokenCommits != 1 || work.RecoveryDiscontinuityMerges != 3 ||
+		work.RecoveryLineageSelections != 1 || work.RecoveryCondensePasses != 4 {
+		t.Fatalf("composition S5 receipt has wrong exact recovery work: %+v", work)
 	}
-	if runner.scheduler.s5MissingInsertions != 1 || work.StackSummaryRecoveryForks != 0 || work.RecoverEOFAccepts != 0 || work.RecoveryVersionCapDrops != 0 {
+	if runner.scheduler.s5MissingInsertions != 1 || work.StackSummaryRecoveryForks != 0 ||
+		work.RecoverEOFAccepts != 0 || work.RecoveryVersionCapDrops != 0 ||
+		work.RecoveryLineageRetirements != 0 || work.RecoveryAmbiguityForks != 0 ||
+		work.RecoveryCeilingDeclines != 0 {
 		t.Fatalf("composition S5 receipt has wrong fork or ceiling telemetry: insertions=%d work=%+v", runner.scheduler.s5MissingInsertions, work)
-	}
-	if work.RecoveryLineageSelections == 0 {
-		t.Fatalf("composition S5 receipt did not select a recovery lineage: %+v", work)
 	}
 	coreWork := generic.Acceptance.CoreWork
 	for name, got := range map[string]uint64{
@@ -144,5 +250,23 @@ func TestPackage2ScalaStrictReceiptComposition(t *testing.T) {
 	if coreWork.PredecessorLinkUnionRecursiveChanged != 0 {
 		t.Fatalf("composition recursive link changes=%d, want zero", coreWork.PredecessorLinkUnionRecursiveChanged)
 	}
+	requirePackage2ScalaOwnedEOFRequest(t, runner, 429, 7, 8, 3)
+	public := runner.scheduler.receipt.VersionLexerRequests
+	if public[0].ElectionIndex != 4 || public[0].HeaderCreationSeq != 0 ||
+		public[0].State != 10712 || public[0].Token.Symbol != 79 ||
+		public[0].Token.StartByte != 4 || public[0].Token.EndByte != 6 ||
+		public[0].Token.Text != "->" || !public[0].InternalDFAToken ||
+		public[1].ElectionIndex != 4 || public[1].HeaderCreationSeq != 1 ||
+		public[1].State != 18766 || public[1].Token.Symbol != 23 ||
+		public[1].Token.StartByte != 4 || public[1].Token.EndByte != 5 ||
+		public[1].Token.Text != "-" || !public[1].InternalDFAToken {
+		t.Fatalf("composition owned lexer fork receipts=%+v", public[:2])
+	}
+	requirePackage2ScalaTree(
+		t, runner, source,
+		"(compilation_unit (parenthesized_expression (postfix_expression (parenthesized_expression (identifier)) (operator_identifier))))",
+		"c0de79617c3e1bdac71c1686e5d6a3d4b2fb375aca9f69902aee974c5ca9f852",
+		6,
+	)
 	t.Logf("Scala package-two composition strict receipt: work=%+v core=%+v", work, coreWork)
 }

--- a/parsercore_phase0_package2_strict_internal_test.go
+++ b/parsercore_phase0_package2_strict_internal_test.go
@@ -27,6 +27,7 @@ func package2ScalaStrictRunner(t *testing.T) *parserCoreFreshFullRunner {
 	lang.Name = "scala"
 	lang.CompactStrategy2ErrorRegionCertified = true
 	lang.CompactMissingTokenInsertionCertified = true
+	lang.CompactFaithfulS5RecoveryCertified = true
 	lang.CompactStackSummaryRecoveryCertified = false
 	lang.CompactPrimaryAcceptanceDerivationCertified = true
 	lang.CompactAcceptanceStructuralElectionCertified = true

--- a/parsercore_phase0_per_version_lexer_snapshot_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_snapshot_internal_test.go
@@ -191,6 +191,45 @@ func TestDiagnosticParserCoreVersionLexerSnapshotCloneDoesNotAlias(t *testing.T)
 	}
 }
 
+func TestDiagnosticParserCoreVersionLexerSemanticEqualityIgnoresCloneAndKeywordPath(t *testing.T) {
+	compact, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
+	clone := snapshot.clone()
+	if !diagnosticParserCoreVersionLexerSnapshotEqual(snapshot, clone) {
+		t.Fatal("equivalent lexer snapshots did not compare equal")
+	}
+	left := diagnosticParserCoreVersionLexerRequest{
+		electionIndex: 4, headerCreationSeq: 9, state: 3,
+		token:  Token{Symbol: 7, StartByte: 12, EndByte: 17, isKeyword: true},
+		before: snapshot, after: snapshot.clone(),
+		beforeCheckpoint: snapshot.beforeCheckpointInfo,
+		afterCheckpoint:  snapshot.afterCheckpointInfo,
+		beforeID:         snapshot.beforeCheckpoint, afterID: snapshot.afterCheckpoint,
+		raggedSpan: true, valid: true,
+	}
+	right := left
+	right.electionIndex = 11
+	right.headerCreationSeq = 19
+	right.token.isKeyword = false
+	right.before = snapshot.clone()
+	right.after = snapshot.clone()
+	if !diagnosticParserCoreVersionLexerRequestEqual(&left, &right) {
+		t.Fatal("semantically equal lexer requests did not compare equal")
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact:              compact,
+		versionLexerRequests: []diagnosticParserCoreVersionLexerRequest{left, right},
+	}
+	leftState := &diagnosticParserCoreVersionState{relexSnapshot: snapshot, lexerRequest: 1}
+	rightState := &diagnosticParserCoreVersionState{relexSnapshot: clone, lexerRequest: 2}
+	if !scheduler.versionLexerStateEqual(leftState, rightState) {
+		t.Fatal("equivalent requests with distinct references did not compare equal")
+	}
+	right.token.EndByte++
+	if diagnosticParserCoreVersionLexerRequestEqual(&left, &right) {
+		t.Fatal("different lexer request span compared equal")
+	}
+}
+
 func TestDiagnosticParserCoreVersionLexerSnapshotInterleavedErrorRunRestoration(t *testing.T) {
 	states := []LexState{
 		{

--- a/parsercore_phase0_per_version_lexer_snapshot_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_snapshot_internal_test.go
@@ -191,7 +191,7 @@ func TestDiagnosticParserCoreVersionLexerSnapshotCloneDoesNotAlias(t *testing.T)
 	}
 }
 
-func TestDiagnosticParserCoreVersionLexerSemanticEqualityIgnoresCloneAndKeywordPath(t *testing.T) {
+func TestDiagnosticParserCoreVersionLexerCloneEqualityPreservesDistinctOwners(t *testing.T) {
 	compact, snapshot := newDiagnosticParserCoreVersionLexerTestSnapshot(t)
 	clone := snapshot.clone()
 	if !diagnosticParserCoreVersionLexerSnapshotEqual(snapshot, clone) {
@@ -221,8 +221,8 @@ func TestDiagnosticParserCoreVersionLexerSemanticEqualityIgnoresCloneAndKeywordP
 	}
 	leftState := &diagnosticParserCoreVersionState{relexSnapshot: snapshot, lexerRequest: 1}
 	rightState := &diagnosticParserCoreVersionState{relexSnapshot: clone, lexerRequest: 2}
-	if !scheduler.versionLexerStateEqual(leftState, rightState) {
-		t.Fatal("equivalent requests with distinct references did not compare equal")
+	if scheduler.versionLexerStateEqual(leftState, rightState) {
+		t.Fatal("distinct lexer snapshot owners compared equal")
 	}
 	right.token.EndByte++
 	if diagnosticParserCoreVersionLexerRequestEqual(&left, &right) {

--- a/parsercore_phase0_per_version_lexer_state.go
+++ b/parsercore_phase0_per_version_lexer_state.go
@@ -159,9 +159,9 @@ func diagnosticParserCoreVersionLexerRequestEqual(
 		left.valid == right.valid
 }
 
-// versionLexerStateEqual compares scheduler state without treating a request
-// reference as semantic identity. Resolve both nonzero references before
-// comparing them. Recovery regions remain pointer-identified graph owners.
+// versionLexerStateEqual compares scheduler ownership. Snapshot pointers and
+// recovery regions identify graph owners. Resolve request references only
+// after the owner identities match.
 func (s *diagnosticParserCoreGenericScheduler) versionLexerStateEqual(
 	left, right *diagnosticParserCoreVersionState,
 ) bool {
@@ -169,7 +169,7 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerStateEqual(
 		return left == right
 	}
 	if left.s3Region != right.s3Region ||
-		!diagnosticParserCoreVersionLexerSnapshotEqual(left.relexSnapshot, right.relexSnapshot) ||
+		left.relexSnapshot != right.relexSnapshot ||
 		left.recoveryGroup != right.recoveryGroup ||
 		left.missingGroup != right.missingGroup ||
 		left.recoveryNodeBaseline != right.recoveryNodeBaseline ||

--- a/parsercore_phase0_per_version_lexer_state.go
+++ b/parsercore_phase0_per_version_lexer_state.go
@@ -3,6 +3,7 @@
 package gotreesitter
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -111,6 +112,81 @@ func diagnosticParserCoreVersionLexerCheckpointIdentity(language *Language) ([32
 
 func (s diagnosticParserCoreVersionLexerScannerContract) equal(other diagnosticParserCoreVersionLexerScannerContract) bool {
 	return s == other
+}
+
+// diagnosticParserCoreVersionLexerSnapshotEqual compares the complete
+// immutable identity of two owned lexer snapshots. Do not use pointer
+// identity here. A scheduler rollback can publish an equivalent copy.
+func diagnosticParserCoreVersionLexerSnapshotEqual(
+	left, right *diagnosticParserCoreVersionLexerSnapshot,
+) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.compact == right.compact &&
+		left.coreGeneration == right.coreGeneration &&
+		left.language == right.language &&
+		left.scanner.equal(right.scanner) &&
+		left.checkpointIdentity == right.checkpointIdentity &&
+		left.checkpointIdentityRequired == right.checkpointIdentityRequired &&
+		left.checkpointIdentityValid == right.checkpointIdentityValid &&
+		left.dfa.equal(right.dfa) &&
+		left.beforeCheckpoint == right.beforeCheckpoint &&
+		left.afterCheckpoint == right.afterCheckpoint &&
+		bytes.Equal(left.beforeCheckpointBytes, right.beforeCheckpointBytes) &&
+		bytes.Equal(left.afterCheckpointBytes, right.afterCheckpointBytes) &&
+		left.beforeCheckpointInfo == right.beforeCheckpointInfo &&
+		left.afterCheckpointInfo == right.afterCheckpointInfo
+}
+
+// diagnosticParserCoreVersionLexerRequestEqual compares lexer request state,
+// excluding scheduler lifecycle provenance such as election and creation IDs.
+func diagnosticParserCoreVersionLexerRequestEqual(
+	left, right *diagnosticParserCoreVersionLexerRequest,
+) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.state == right.state &&
+		tokensSameLex(left.token, right.token) &&
+		diagnosticParserCoreVersionLexerSnapshotEqual(left.before, right.before) &&
+		left.beforeCheckpoint == right.beforeCheckpoint &&
+		diagnosticParserCoreVersionLexerSnapshotEqual(left.after, right.after) &&
+		left.afterCheckpoint == right.afterCheckpoint &&
+		left.beforeID == right.beforeID &&
+		left.afterID == right.afterID &&
+		left.raggedSpan == right.raggedSpan &&
+		left.valid == right.valid
+}
+
+// versionLexerStateEqual compares scheduler state without treating a request
+// reference as semantic identity. Resolve both nonzero references before
+// comparing them. Recovery regions remain pointer-identified graph owners.
+func (s *diagnosticParserCoreGenericScheduler) versionLexerStateEqual(
+	left, right *diagnosticParserCoreVersionState,
+) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	if left.s3Region != right.s3Region ||
+		!diagnosticParserCoreVersionLexerSnapshotEqual(left.relexSnapshot, right.relexSnapshot) ||
+		left.recoveryGroup != right.recoveryGroup ||
+		left.missingGroup != right.missingGroup ||
+		left.recoveryNodeBaseline != right.recoveryNodeBaseline ||
+		left.recoveryNodeBaselineSet != right.recoveryNodeBaselineSet {
+		return false
+	}
+	if left.lexerRequest == 0 || right.lexerRequest == 0 {
+		return left.lexerRequest == right.lexerRequest
+	}
+	if s == nil || int(left.lexerRequest) > len(s.versionLexerRequests) ||
+		int(right.lexerRequest) > len(s.versionLexerRequests) {
+		return false
+	}
+	return diagnosticParserCoreVersionLexerRequestEqual(
+		&s.versionLexerRequests[left.lexerRequest-1],
+		&s.versionLexerRequests[right.lexerRequest-1],
+	)
 }
 
 // cloneBytesForDiagnosticParserCoreVersion copies a byte slice while

--- a/parsercore_phase0_physical_head_merge_stage2_internal_test.go
+++ b/parsercore_phase0_physical_head_merge_stage2_internal_test.go
@@ -376,8 +376,8 @@ func TestStage2PhysicalHeadMergeFailsClosedAcrossDistinctLexerOwnership(t *testi
 	}
 	scheduler := diagnosticParserCoreGenericScheduler{compact: compact, headers: []diagnosticParserCoreHeader{
 		{head: source},
-		{head: left, versionState: &diagnosticParserCoreVersionState{relexSnapshot: &diagnosticParserCoreVersionLexerSnapshot{}}},
-		{head: right, versionState: &diagnosticParserCoreVersionState{relexSnapshot: &diagnosticParserCoreVersionLexerSnapshot{}}},
+		{head: left, versionState: &diagnosticParserCoreVersionState{relexSnapshot: &diagnosticParserCoreVersionLexerSnapshot{coreGeneration: 1}}},
+		{head: right, versionState: &diagnosticParserCoreVersionState{relexSnapshot: &diagnosticParserCoreVersionLexerSnapshot{coreGeneration: 2}}},
 	}}
 	before := compact.Work()
 	err = compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {

--- a/parsercore_phase0_recovery_condense.go
+++ b/parsercore_phase0_recovery_condense.go
@@ -224,24 +224,19 @@ func (s *diagnosticParserCoreGenericScheduler) recoveryCondenseEntry(
 	src *diagnosticParserCoreRecoveryCostSource,
 	memo *core.RecoveryCostMemo,
 ) (diagnosticParserCoreRecoveryCondenseEntry, bool, error) {
-	derivations, err := s.compact.Derivations(header.head)
-	if err != nil {
-		if errors.Is(err, core.ErrDerivationEnumerationCap) {
-			return diagnosticParserCoreRecoveryCondenseEntry{}, false, nil
-		}
-		return diagnosticParserCoreRecoveryCondenseEntry{}, false, err
-	}
-	if len(derivations) != 1 {
-		return diagnosticParserCoreRecoveryCondenseEntry{}, false, nil
-	}
-	derivation := derivations[0]
-	if int64(int(derivation.Score)) != derivation.Score {
-		return diagnosticParserCoreRecoveryCondenseEntry{}, false, nil
-	}
-	stackCost, err := diagnosticParserCoreDerivationErrorCost(symbols, src, memo, derivation)
+	// Recovery heads can contain several physical paths after the S5 marker
+	// merge. Price the graph aggregate directly, instead of enumerating paths.
+	// The aggregate rejects unequal path costs and reports the maximum visible
+	// count needed by C's node-count tie band.
+	aggregate, supported, err := s.compact.RecoveryGraphAggregateForHead(header.head, symbols, src)
 	if err != nil {
 		return diagnosticParserCoreRecoveryCondenseEntry{}, false, err
 	}
+	if !supported {
+		return diagnosticParserCoreRecoveryCondenseEntry{}, false, nil
+	}
+	stackCost := aggregate.MinimumErrorCost
+	currentCount := aggregate.MaximumVisibleCount
 	state, byteOffset, err := s.compact.Boundary(header.head)
 	if err != nil {
 		return diagnosticParserCoreRecoveryCondenseEntry{}, false, err
@@ -260,21 +255,29 @@ func (s *diagnosticParserCoreGenericScheduler) recoveryCondenseEntry(
 			if regionErr != nil {
 				return diagnosticParserCoreRecoveryCondenseEntry{}, false, regionErr
 			}
+			if math.MaxUint32-stackCost < regionCost {
+				return diagnosticParserCoreRecoveryCondenseEntry{}, false, errors.New("parser-core phase zero: recovery condense cost overflow")
+			}
 			stackCost += regionCost
+			regionCount, countErr := diagnosticParserCoreOpenRegionVisibleNodeCount(symbols, src, region)
+			if countErr != nil {
+				return diagnosticParserCoreRecoveryCondenseEntry{}, false, countErr
+			}
+			if math.MaxUint32-currentCount < regionCount {
+				return diagnosticParserCoreRecoveryCondenseEntry{}, false, errors.New("parser-core phase zero: recovery condense visible-node count overflow")
+			}
+			currentCount += regionCount
 		}
 	}
 	openSegments := header.recoveryOpenSegments()
 	if openSegments < 0 {
 		return diagnosticParserCoreRecoveryCondenseEntry{}, false, errors.New("parser-core phase zero: negative recovery segment count")
 	}
-	stackCost += uint32(openSegments) * uint32(core.RecoveryCostPerRecovery)
-
-	currentCount, err := diagnosticParserCoreRecoveryCumulativeVisibleNodeCount(
-		derivation, region, symbols, src,
-	)
-	if err != nil {
-		return diagnosticParserCoreRecoveryCondenseEntry{}, false, err
+	openCost := uint64(openSegments) * uint64(core.RecoveryCostPerRecovery)
+	if openCost > math.MaxUint32 || stackCost > math.MaxUint32-uint32(openCost) {
+		return diagnosticParserCoreRecoveryCondenseEntry{}, false, errors.New("parser-core phase zero: recovery condense open-segment cost overflow")
 	}
+	stackCost += uint32(openCost)
 	baseline, baselineSet := header.recoveryNodeBaseline()
 	if !baselineSet {
 		return diagnosticParserCoreRecoveryCondenseEntry{}, false, nil
@@ -290,10 +293,13 @@ func (s *diagnosticParserCoreGenericScheduler) recoveryCondenseEntry(
 	if uint64(nodeCount) > uint64(math.MaxInt) {
 		return diagnosticParserCoreRecoveryCondenseEntry{}, false, nil
 	}
+	if aggregate.StoredPrecedenceMaximum > int64(math.MaxInt) || aggregate.StoredPrecedenceMaximum < -int64(math.MaxInt)-1 {
+		return diagnosticParserCoreRecoveryCondenseEntry{}, false, nil
+	}
 	return diagnosticParserCoreRecoveryCondenseEntry{
 		header: header,
 		status: core.RecoveryVersionStatus(
-			stackCost, header.paused, int(nodeCount), int(derivation.Score), region != nil,
+			stackCost, header.paused, int(nodeCount), int(aggregate.StoredPrecedenceMaximum), region != nil,
 		),
 		key: diagnosticParserCoreRecoveryCondenseKey{
 			state: state, byteOffset: byteOffset, cost: stackCost,

--- a/parsercore_phase0_recovery_cost_source.go
+++ b/parsercore_phase0_recovery_cost_source.go
@@ -4,6 +4,7 @@ package gotreesitter
 
 import (
 	"errors"
+	"math"
 	"sort"
 
 	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
@@ -246,46 +247,40 @@ type diagnosticParserCoreLineageInput struct {
 var errDiagnosticParserCoreLineageTie = errors.New("parser-core phase zero: competing recovery lineages tie beyond the modeled selection ladder")
 
 // diagnosticParserCorePriceLineages prices each candidate head so the
-// selection ladder can order them. It refuses any head that does not carry
-// exactly one derivation, for the reason diagnosticParserCoreLineageErrorCost
-// already states: the comparison is defined on one lineage.
+// selection ladder can order them. A physically merged head is one stack
+// version, not several recovery competitors. The graph aggregate admits it
+// only when every physical path has the same authenticated recovery cost.
 func diagnosticParserCorePriceLineages(
 	inputs []diagnosticParserCoreLineageInput,
 	symbols []core.SelectedSymbolPolicy,
 	src *diagnosticParserCoreRecoveryCostSource,
-	memo *core.RecoveryCostMemo,
+	_ *core.RecoveryCostMemo,
 ) ([]diagnosticParserCoreLineage, error) {
 	if src == nil || src.compact == nil {
 		return nil, errors.New("parser-core phase zero: lineage pricing requires a bound cost source")
 	}
 	out := make([]diagnosticParserCoreLineage, 0, len(inputs))
 	for _, in := range inputs {
-		// One Derivations call per head: pricing needs the payloads and
-		// ordering needs the Score. The Core comes from src, so the
-		// derivations and the arena they are priced against cannot disagree.
-		derivations, err := src.compact.Derivations(in.Head)
+		aggregate, supported, err := src.compact.RecoveryGraphAggregateForHead(in.Head, symbols, src)
 		if err != nil {
-			if errors.Is(err, core.ErrDerivationEnumerationCap) {
-				// A head with more paths than the enumeration cap is the most
-				// ambiguous shape there is. Report it as the same decline every
-				// other ambiguous head gets, not as a hard failure.
+			if errors.Is(err, core.RecoveryGraphAggregateLimitError) {
 				return nil, diagnosticParserCoreLineageCostUnavailable
 			}
 			return nil, err
 		}
-		if len(derivations) != 1 {
+		if !supported {
 			return nil, diagnosticParserCoreLineageCostUnavailable
-		}
-		cost, err := diagnosticParserCoreDerivationErrorCost(symbols, src, memo, derivations[0])
-		if err != nil {
-			return nil, err
 		}
 		if in.OpenRecoverySegments < 0 {
 			return nil, errors.New("parser-core phase zero: negative open-recovery segment count")
 		}
-		cost += uint32(core.RecoveryCostPerRecovery) * uint32(in.OpenRecoverySegments)
+		openCost := uint64(in.OpenRecoverySegments) * uint64(core.RecoveryCostPerRecovery)
+		if openCost > math.MaxUint32 || uint64(aggregate.MinimumErrorCost)+openCost > math.MaxUint32 {
+			return nil, errors.New("parser-core phase zero: recovery lineage cost overflow")
+		}
+		cost := aggregate.MinimumErrorCost + uint32(openCost)
 		out = append(out, diagnosticParserCoreLineage{
-			Head: in.Head, Cost: cost, Score: derivations[0].Score,
+			Head: in.Head, Cost: cost, Score: aggregate.StoredPrecedenceMaximum,
 		})
 	}
 	return out, nil

--- a/parsercore_phase0_recovery_cost_source_internal_test.go
+++ b/parsercore_phase0_recovery_cost_source_internal_test.go
@@ -134,6 +134,54 @@ func TestRecoveryCostSourcePricesErrorRegionSpanAndRows(t *testing.T) {
 	}
 }
 
+// TestRecoveryCostSourcePublishesResumedHeadCost proves that the authenticated
+// ERROR cost reaches the new head before its boundary is published.
+func TestRecoveryCostSourcePublishesResumedHeadCost(t *testing.T) {
+	compact, src := newRecoveryCostFixture(t, "ab\ncd\nef")
+	child, err := compact.ErrorRegionLeaf(core.Symbol(5), 0, 7, false)
+	if err != nil {
+		t.Fatalf("ErrorRegionLeaf: %v", err)
+	}
+	seed, err := compact.Seed(core.StateID(1), 0)
+	if err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	var memo core.RecoveryCostMemo
+	cost := func(prev core.NodeID, payload core.SubtreeID) (uint32, error) {
+		prefix, prefixErr := compact.RecoveryStoredErrorCost(core.Head{Node: prev})
+		if prefixErr != nil {
+			return 0, prefixErr
+		}
+		payloadCost, payloadErr := core.RecoveryNodeErrorCostMemo(
+			visibleSymbols(8), src, &memo, payload,
+		)
+		if payloadErr != nil {
+			return 0, payloadErr
+		}
+		return prefix + payloadCost, nil
+	}
+	head, err := compact.ErrorRegionResumeWithCost(
+		seed, core.StateID(1), 0, 7, []core.SubtreeID{child}, cost,
+	)
+	if err != nil {
+		t.Fatalf("ErrorRegionResumeWithCost: %v", err)
+	}
+	got, err := compact.RecoveryStoredErrorCost(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = core.RecoveryCostPerRecovery +
+		core.RecoveryCostPerSkippedChar*7 +
+		core.RecoveryCostPerSkippedLine*2 +
+		core.RecoveryCostPerSkippedTree
+	if got != want {
+		t.Fatalf("resumed head stored cost=%d, want %d", got, want)
+	}
+	if got != 667 {
+		t.Fatalf("resumed head stored cost=%d, want locked value 667", got)
+	}
+}
+
 // TestRecoveryCostSourceRowsTrackNewlines pins the row computation the ERROR
 // formula depends on.
 func TestRecoveryCostSourceRowsTrackNewlines(t *testing.T) {

--- a/parsercore_phase0_recovery_cost_source_internal_test.go
+++ b/parsercore_phase0_recovery_cost_source_internal_test.go
@@ -419,10 +419,10 @@ func TestSelectRecoveryLineageSingletonAndEmpty(t *testing.T) {
 	}
 }
 
-// TestPriceLineagesRefusesAmbiguousHead proves pricing carries the
-// single-lineage requirement through to the selection entry point, rather than
-// silently pricing one arbitrary path of an ambiguous head.
-func TestPriceLineagesRefusesAmbiguousHead(t *testing.T) {
+// TestPriceLineagesAcceptsEqualCostPhysicalHead proves a merged graph head
+// remains one recovery version. Pricing admits it only because every path has
+// the same complete recovery cost.
+func TestPriceLineagesAcceptsEqualCostPhysicalHead(t *testing.T) {
 	compact, src := newRecoveryCostFixture(t, "abcdef")
 	seedA, err := compact.Seed(core.StateID(1), 0)
 	if err != nil {
@@ -447,8 +447,14 @@ func TestPriceLineagesRefusesAmbiguousHead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ErrorRegionResume: %v", err)
 	}
-	if _, err := diagnosticParserCorePriceLineages([]diagnosticParserCoreLineageInput{{Head: ambiguous}}, visibleSymbols(8), src, nil); !errors.Is(err, diagnosticParserCoreLineageCostUnavailable) {
-		t.Fatalf("pricing an ambiguous head returned %v, want a refusal", err)
+	priced, err := diagnosticParserCorePriceLineages(
+		[]diagnosticParserCoreLineageInput{{Head: ambiguous}}, visibleSymbols(8), src, nil,
+	)
+	if err != nil {
+		t.Fatalf("price equal-cost physical head: %v", err)
+	}
+	if len(priced) != 1 || priced[0].Cost != 603 || priced[0].Score != 0 {
+		t.Fatalf("priced physical head=%+v, want one cost-603 lineage", priced)
 	}
 }
 

--- a/parsercore_phase0_recovery_lineage_fork_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_fork_internal_test.go
@@ -113,6 +113,7 @@ func newRecoveryLineageForkSchedulerWithTable(
 			Recovery:                             true,
 			allowCompactStrategy2ErrorRegion:     true,
 			allowCompactMissingTokenInsertion:    true,
+			allowCompactFaithfulS5Recovery:       true,
 			allowCompactRecoveryLineageSelection: armed,
 		},
 	}

--- a/parsercore_phase0_recovery_lineage_fork_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_fork_internal_test.go
@@ -3,6 +3,7 @@
 package gotreesitter
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -11,11 +12,47 @@ import (
 
 type recoveryLineageForkTable struct{}
 
+type recoveryLineageForkFaultTable struct {
+	recoveryLineageForkTable
+	stateTwoLookaheadCalls int
+	returnError            error
+	panicValue             any
+}
+
+type recoveryLineageForkLaterReduceTable struct{ recoveryLineageForkTable }
+
+func (table recoveryLineageForkLaterReduceTable) Actions(state core.StateID, symbol core.Symbol) (core.ActionRow, error) {
+	if state == 2 && symbol == 4 {
+		return core.NewActionRow([]core.Action{
+			{Type: core.ActionShift, State: 4},
+			{Type: core.ActionReduce, Symbol: 5, ChildCount: 1},
+		}, false), nil
+	}
+	return table.recoveryLineageForkTable.Actions(state, symbol)
+}
+
+func (table *recoveryLineageForkFaultTable) Actions(state core.StateID, symbol core.Symbol) (core.ActionRow, error) {
+	if state == 2 && symbol == 4 {
+		table.stateTwoLookaheadCalls++
+		if table.stateTwoLookaheadCalls == 2 {
+			if table.panicValue != nil {
+				panic(table.panicValue)
+			}
+			if table.returnError != nil {
+				return core.ActionRow{}, table.returnError
+			}
+		}
+	}
+	return table.recoveryLineageForkTable.Actions(state, symbol)
+}
+
 func (recoveryLineageForkTable) Actions(state core.StateID, symbol core.Symbol) (core.ActionRow, error) {
 	var actions []core.Action
 	switch {
 	case state == 1 && symbol == 2:
 		actions = []core.Action{{Type: core.ActionShift, State: 2}}
+	case state == 1 && symbol == 3:
+		actions = []core.Action{{Type: core.ActionShift, Extra: true}}
 	case state == 2 && symbol == 4:
 		actions = []core.Action{{Type: core.ActionReduce, Symbol: 5, ChildCount: 1}}
 	case state == 3 && symbol == 4:
@@ -40,8 +77,16 @@ func (recoveryLineageForkTable) ProductionAliases(uint16, int) ([]core.Symbol, e
 }
 
 func newRecoveryLineageForkScheduler(t *testing.T, armed bool) *diagnosticParserCoreGenericScheduler {
+	return newRecoveryLineageForkSchedulerWithTable(t, recoveryLineageForkTable{}, armed)
+}
+
+func newRecoveryLineageForkSchedulerWithTable(
+	t *testing.T,
+	table core.TableView,
+	armed bool,
+) *diagnosticParserCoreGenericScheduler {
 	t.Helper()
-	compact, err := core.New(recoveryLineageForkTable{}, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	compact, err := core.New(table, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,21 +95,57 @@ func newRecoveryLineageForkScheduler(t *testing.T, armed bool) *diagnosticParser
 		t.Fatalf("Seed: %v", err)
 	}
 	lang := &Language{TokenCount: 5, SymbolCount: 5}
+	tokenSource := &dfaTokenSource{
+		language: lang,
+		lexer:    &Lexer{source: []byte("a?"), pos: 2, col: 2},
+	}
 	return &diagnosticParserCoreGenericScheduler{
-		compact: compact,
-		tokenSource: &dfaTokenSource{
-			language: lang,
-			lexer:    &Lexer{source: []byte("a?")},
-		},
-		headers: []diagnosticParserCoreHeader{{head: seed, creationSeq: 3}},
-		token:   Token{Symbol: 4, StartByte: 1, EndByte: 2},
-		nextSeq: 10,
+		compact:                      compact,
+		tokenSource:                  tokenSource,
+		headers:                      []diagnosticParserCoreHeader{{head: seed, creationSeq: 3}},
+		token:                        Token{Symbol: 4, StartByte: 1, EndByte: 2},
+		nextSeq:                      10,
+		versionLexerBefore:           dfaRelexSnapshot{lexerPos: 1, lexerCol: 1},
+		versionLexerBeforeValid:      true,
+		versionLexerBeforeElection:   0,
+		versionLexerBeforeCheckpoint: 0,
 		options: DiagnosticParserCorePrefixOptions{
 			Recovery:                             true,
 			allowCompactStrategy2ErrorRegion:     true,
 			allowCompactMissingTokenInsertion:    true,
 			allowCompactRecoveryLineageSelection: armed,
 		},
+	}
+}
+
+func requireS5ForkRollback(
+	t *testing.T,
+	scheduler *diagnosticParserCoreGenericScheduler,
+	original diagnosticParserCoreHeader,
+	beforeStats core.Stats,
+	beforeWork core.Work,
+	receipt *DiagnosticParserCoreGenericScheduler,
+) {
+	t.Helper()
+	if len(scheduler.headers) != 1 || scheduler.headers[0] != original {
+		t.Fatalf("S5 rollback changed the frontier: %+v", scheduler.headers)
+	}
+	afterStats, err := scheduler.compact.Stats(original.head)
+	if err != nil || afterStats != beforeStats || scheduler.compact.Work() != beforeWork {
+		t.Fatalf("S5 rollback changed the core: stats=%+v/%+v work=%+v/%+v err=%v",
+			afterStats, beforeStats, scheduler.compact.Work(), beforeWork, err)
+	}
+	if scheduler.receipt != receipt || scheduler.receipt.Tokens != 7 {
+		t.Fatalf("S5 rollback changed the receipt pointer or value: pointer=%p/%p receipt=%+v",
+			scheduler.receipt, receipt, scheduler.receipt)
+	}
+	if scheduler.verifierHeaderPtr != nil || scheduler.verifierBound != 0 {
+		t.Fatalf("S5 rollback retained a stale verifier binding: pointer=%p bound=%d",
+			scheduler.verifierHeaderPtr, scheduler.verifierBound)
+	}
+	if scheduler.nextSeq != 10 || scheduler.s5MissingInsertions != 0 || scheduler.recoveryIsolation {
+		t.Fatalf("S5 rollback changed scheduler state: next=%d insertions=%d isolated=%t",
+			scheduler.nextSeq, scheduler.s5MissingInsertions, scheduler.recoveryIsolation)
 	}
 }
 
@@ -95,8 +176,8 @@ func TestS5MissingInsertionForkPublishesBothRecoveryLineages(t *testing.T) {
 	if !scheduler.headers[0].shifted || scheduler.headers[0].recoveryRegion() == nil {
 		t.Fatalf("absorb lineage did not consume the real token: %+v", scheduler.headers[0])
 	}
-	if scheduler.headers[0].creationSeq != 3 || scheduler.headers[1].creationSeq != 10 || scheduler.nextSeq != 11 {
-		t.Fatalf("creation sequence=%d/%d next=%d, want 3/10 next 11",
+	if scheduler.headers[0].creationSeq != 3 || scheduler.headers[1].creationSeq != 11 || scheduler.nextSeq != 12 {
+		t.Fatalf("creation sequence=%d/%d next=%d, want 3/11 next 12",
 			scheduler.headers[0].creationSeq, scheduler.headers[1].creationSeq, scheduler.nextSeq)
 	}
 	if scheduler.headers[0].recoveryGroupIdentity() != 10 ||
@@ -124,7 +205,14 @@ func TestS5MissingInsertionForkPublishesBothRecoveryLineages(t *testing.T) {
 	if len(derivations) != 1 || len(derivations[0].Payloads) != 1 {
 		t.Fatalf("missing derivations=%+v, want one payload", derivations)
 	}
-	missing, err := scheduler.compact.MaterializationView(derivations[0].Payloads[0])
+	reduced, err := scheduler.compact.MaterializationView(derivations[0].Payloads[0])
+	if err != nil {
+		t.Fatalf("reduced missing payload: %v", err)
+	}
+	if reduced.Symbol != 5 || len(reduced.Children) != 1 || !reduced.Fragile {
+		t.Fatalf("reduced missing payload=%+v, want symbol 5 with one child", reduced)
+	}
+	missing, err := scheduler.compact.MaterializationView(reduced.Children[0])
 	if err != nil {
 		t.Fatalf("missing payload: %v", err)
 	}
@@ -159,6 +247,68 @@ func TestS5MissingInsertionClampsInheritedBaselineBeforeFork(t *testing.T) {
 		if baseline, set := scheduler.headers[index].recoveryNodeBaseline(); !set || baseline != 0 {
 			t.Fatalf("S5 header %d baseline=%d/%t, want clamped 0/true", index, baseline, set)
 		}
+	}
+}
+
+func TestS5MissingInsertionUsesFixedRecoveryPosition(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	extraHead, err := scheduler.compact.Shift(
+		scheduler.headers[0].head, core.Symbol(3), 0,
+		core.Token{Symbol: 3, StartByte: 1, EndByte: 3, Extra: true}, core.ForkOrder{},
+	)
+	if err != nil {
+		t.Fatalf("shift trailing extra: %v", err)
+	}
+	if _, byteOffset, boundaryErr := scheduler.compact.Boundary(extraHead); boundaryErr != nil || byteOffset != 3 {
+		t.Fatalf("trailing-extra boundary=%d err=%v, want byte 3", byteOffset, boundaryErr)
+	}
+
+	var trial []diagnosticParserCoreHeader
+	err = scheduler.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		var viable bool
+		trial, viable, _, err = scheduler.s5TryMissingCandidateOwned(
+			owner,
+			[]diagnosticParserCoreHeader{{head: extraHead, creationSeq: 3}},
+			0, core.Symbol(2), core.StateID(2), 2, &diagnosticParserCoreS5Work{},
+		)
+		if err != nil {
+			return err
+		}
+		if !viable {
+			return errors.New("fixed-position missing candidate was not viable")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(trial) == 0 {
+		t.Fatal("fixed-position missing trial returned no headers")
+	}
+	derivations, err := scheduler.compact.Derivations(trial[0].head)
+	if err != nil || len(derivations) != 1 {
+		t.Fatalf("trial derivations=%+v err=%v", derivations, err)
+	}
+	stack := append([]core.SubtreeID(nil), derivations[0].Payloads...)
+	found := false
+	for len(stack) != 0 {
+		last := len(stack) - 1
+		payload := stack[last]
+		stack = stack[:last]
+		view, viewErr := scheduler.compact.MaterializationView(payload)
+		if viewErr != nil {
+			t.Fatal(viewErr)
+		}
+		if view.Missing {
+			found = true
+			if view.StartByte != 2 || view.EndByte != 2 {
+				t.Fatalf("missing leaf range=%d..%d, want fixed recovery position 2..2", view.StartByte, view.EndByte)
+			}
+		}
+		stack = append(stack, view.Children...)
+	}
+	if !found {
+		t.Fatal("trial did not retain the missing leaf")
 	}
 }
 
@@ -283,13 +433,8 @@ func TestS5MissingInsertionForkDeclinesUnrepresentableTokenCount(t *testing.T) {
 	}
 }
 
-func TestS5MissingInsertionForkDeclinesHiddenFirstCandidate(t *testing.T) {
-	scheduler := newRecoveryLineageForkScheduler(t, true)
-	scheduler.tokenSource.language.SymbolMetadata = make([]SymbolMetadata, 5)
-	for index := range scheduler.tokenSource.language.SymbolMetadata {
-		scheduler.tokenSource.language.SymbolMetadata[index].Visible = true
-	}
-	scheduler.tokenSource.language.SymbolMetadata[2].Visible = false
+func TestS5MissingInsertionForkRequiresLeadingReduceAction(t *testing.T) {
+	scheduler := newRecoveryLineageForkSchedulerWithTable(t, recoveryLineageForkLaterReduceTable{}, true)
 	original := scheduler.headers[0]
 
 	handled, err := scheduler.s5TryMissingTokenInsertion(0)
@@ -297,15 +442,83 @@ func TestS5MissingInsertionForkDeclinesHiddenFirstCandidate(t *testing.T) {
 		t.Fatalf("s5TryMissingTokenInsertion: %v", err)
 	}
 	if handled || len(scheduler.headers) != 1 || scheduler.headers[0] != original {
-		t.Fatalf("hidden candidate changed the frontier: handled=%t headers=%+v", handled, scheduler.headers)
+		t.Fatalf("later reduce action admitted a missing candidate: handled=%t headers=%+v", handled, scheduler.headers)
 	}
 	if scheduler.s5MissingInsertions != 0 || scheduler.nextSeq != 10 || scheduler.recoveryIsolation {
-		t.Fatalf("hidden candidate changed state: insertions=%d next=%d isolated=%t",
+		t.Fatalf("later reduce action changed state: insertions=%d next=%d isolated=%t",
 			scheduler.s5MissingInsertions, scheduler.nextSeq, scheduler.recoveryIsolation)
 	}
 }
 
-func TestS5MissingInsertionForkRestoresFrontierWhenAbsorbDeclines(t *testing.T) {
+func TestS5UpdatedReductionFreshnessTargetsAdoptedSibling(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	head := scheduler.headers[0].head
+	scheduler.headers = []diagnosticParserCoreHeader{
+		{head: head, creationSeq: 1},
+		{head: head, creationSeq: 2},
+		{head: head, creationSeq: 3},
+	}
+	slot, err := scheduler.s5UpdatedReductionSiblingIndex(0, head)
+	if err != nil || slot != 1 {
+		t.Fatalf("S5 adoption slot=%d err=%v, want first exact sibling 1", slot, err)
+	}
+	err = scheduler.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		adopted, adoptErr := scheduler.adoptUpdatedReductionSiblingOwned(
+			owner, 0, head, core.CleanPathRankNotApplicable, 0,
+			core.AlternativeSet{}, false, core.DropCohortRefSet{}, false, false,
+			core.DropCohortProducerSiblingAdoption,
+		)
+		if adoptErr != nil {
+			return adoptErr
+		}
+		if !adopted {
+			return errors.New("S5 exact sibling was not adopted")
+		}
+		scheduler.headers[slot].freshness = core.ReductionUpdated
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("adopt S5 sibling: %v", err)
+	}
+	if scheduler.headers[1].freshness != core.ReductionUpdated ||
+		scheduler.headers[2].freshness != core.ReductionFreshness(0) {
+		t.Fatalf("S5 freshness targeted the wrong sibling: %+v", scheduler.headers)
+	}
+}
+
+func TestS5MissingInsertionForkAcceptsHiddenFirstCandidate(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	scheduler.tokenSource.language.SymbolMetadata = make([]SymbolMetadata, 5)
+	for index := range scheduler.tokenSource.language.SymbolMetadata {
+		scheduler.tokenSource.language.SymbolMetadata[index].Visible = true
+	}
+	scheduler.tokenSource.language.SymbolMetadata[2].Visible = false
+	handled, err := scheduler.s5TryMissingTokenInsertion(0)
+	if err != nil {
+		t.Fatalf("s5TryMissingTokenInsertion: %v", err)
+	}
+	if !handled || len(scheduler.headers) != 2 {
+		t.Fatalf("hidden candidate did not fork: handled=%t headers=%+v", handled, scheduler.headers)
+	}
+	if scheduler.s5MissingInsertions != 1 || scheduler.nextSeq != 12 || !scheduler.recoveryIsolation {
+		t.Fatalf("hidden candidate state: insertions=%d next=%d isolated=%t",
+			scheduler.s5MissingInsertions, scheduler.nextSeq, scheduler.recoveryIsolation)
+	}
+	derivations, err := scheduler.compact.Derivations(scheduler.headers[1].head)
+	if err != nil || len(derivations) != 1 || len(derivations[0].Payloads) != 1 {
+		t.Fatalf("hidden missing derivations=%+v err=%v", derivations, err)
+	}
+	reduced, err := scheduler.compact.MaterializationView(derivations[0].Payloads[0])
+	if err != nil || reduced.Symbol != 5 || len(reduced.Children) != 1 {
+		t.Fatalf("hidden reduced payload=%+v err=%v", reduced, err)
+	}
+	missing, err := scheduler.compact.MaterializationView(reduced.Children[0])
+	if err != nil || !missing.Missing || missing.Symbol != 2 {
+		t.Fatalf("hidden missing payload=%+v err=%v", missing, err)
+	}
+}
+
+func TestS5MissingInsertionForkAcceptsZeroOffsetAbsorb(t *testing.T) {
 	scheduler := newRecoveryLineageForkScheduler(t, true)
 	seed, err := scheduler.compact.Seed(core.StateID(1), 0)
 	if err != nil {
@@ -314,23 +527,95 @@ func TestS5MissingInsertionForkRestoresFrontierWhenAbsorbDeclines(t *testing.T) 
 	scheduler.headers[0].head = seed
 	scheduler.token = Token{Symbol: 4, StartByte: 0, EndByte: 1}
 	scheduler.tokenSource.lexer.source = []byte("?")
-	original := scheduler.headers[0]
-
 	handled, err := scheduler.s5TryMissingTokenInsertion(0)
 	if err != nil {
 		t.Fatalf("s5TryMissingTokenInsertion: %v", err)
 	}
-	if handled || len(scheduler.headers) != 1 || scheduler.headers[0] != original {
-		t.Fatalf("declined absorb changed the frontier: handled=%t headers=%+v", handled, scheduler.headers)
+	if !handled || len(scheduler.headers) != 2 {
+		t.Fatalf("zero-offset absorb did not fork: handled=%t headers=%+v", handled, scheduler.headers)
 	}
-	if scheduler.s5MissingInsertions != 0 || scheduler.nextSeq != 10 || scheduler.recoveryIsolation {
-		t.Fatalf("declined absorb changed state: insertions=%d next=%d isolated=%t",
+	if scheduler.s5MissingInsertions != 1 || scheduler.nextSeq != 12 || !scheduler.recoveryIsolation {
+		t.Fatalf("zero-offset absorb state: insertions=%d next=%d isolated=%t",
 			scheduler.s5MissingInsertions, scheduler.nextSeq, scheduler.recoveryIsolation)
 	}
+	region := scheduler.headers[0].recoveryRegion()
+	if region == nil || region.startByte != 0 || region.endByte != 1 {
+		t.Fatalf("zero-offset region=%+v", region)
+	}
+}
+
+func TestS5MissingInsertionForkRestoresFullTransactionOnDecline(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	scheduler.token = Token{Symbol: 3, StartByte: 1, EndByte: 2}
+	receipt := &DiagnosticParserCoreGenericScheduler{Tokens: 7}
+	scheduler.receipt = receipt
+	scheduler.verifierHeaderPtr = &scheduler.headers[0]
+	scheduler.verifierBound = len(scheduler.headers)
+	original := scheduler.headers[0]
+	beforeStats, err := scheduler.compact.Stats(original.head)
+	if err != nil {
+		t.Fatalf("read pre-decline stats: %v", err)
+	}
+	beforeWork := scheduler.compact.Work()
+
+	handled, err := scheduler.s5TryMissingTokenInsertion(0)
+	if err != nil || handled {
+		t.Fatalf("S5 decline handled=%t err=%v", handled, err)
+	}
+	requireS5ForkRollback(t, scheduler, original, beforeStats, beforeWork, receipt)
+}
+
+func TestS5MissingInsertionForkRestoresFullTransactionOnError(t *testing.T) {
+	sentinel := errors.New("S5 action fault")
+	table := &recoveryLineageForkFaultTable{returnError: sentinel}
+	scheduler := newRecoveryLineageForkSchedulerWithTable(t, table, true)
+	receipt := &DiagnosticParserCoreGenericScheduler{Tokens: 7}
+	scheduler.receipt = receipt
+	scheduler.verifierHeaderPtr = &scheduler.headers[0]
+	scheduler.verifierBound = len(scheduler.headers)
+	original := scheduler.headers[0]
+	beforeStats, err := scheduler.compact.Stats(original.head)
+	if err != nil {
+		t.Fatalf("read pre-error stats: %v", err)
+	}
+	beforeWork := scheduler.compact.Work()
+
+	handled, err := scheduler.s5TryMissingTokenInsertion(0)
+	if handled || !errors.Is(err, sentinel) {
+		t.Fatalf("S5 error handled=%t err=%v, want sentinel", handled, err)
+	}
+	requireS5ForkRollback(t, scheduler, original, beforeStats, beforeWork, receipt)
+}
+
+func TestS5MissingInsertionForkRestoresFullTransactionOnPanic(t *testing.T) {
+	const sentinel = "S5 action panic"
+	table := &recoveryLineageForkFaultTable{panicValue: sentinel}
+	scheduler := newRecoveryLineageForkSchedulerWithTable(t, table, true)
+	receipt := &DiagnosticParserCoreGenericScheduler{Tokens: 7}
+	scheduler.receipt = receipt
+	scheduler.verifierHeaderPtr = &scheduler.headers[0]
+	scheduler.verifierBound = len(scheduler.headers)
+	original := scheduler.headers[0]
+	beforeStats, err := scheduler.compact.Stats(original.head)
+	if err != nil {
+		t.Fatalf("read pre-panic stats: %v", err)
+	}
+	beforeWork := scheduler.compact.Work()
+
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != sentinel {
+				t.Fatalf("S5 recovered panic=%v, want %q", recovered, sentinel)
+			}
+		}()
+		_, _ = scheduler.s5TryMissingTokenInsertion(0)
+	}()
+	requireS5ForkRollback(t, scheduler, original, beforeStats, beforeWork, receipt)
 }
 
 func TestRecoveryCompetitionDoesNotUseOrdinaryNoActionDrop(t *testing.T) {
 	scheduler := newRecoveryLineageForkScheduler(t, true)
+	scheduler.receipt = &DiagnosticParserCoreGenericScheduler{}
 	handled, err := scheduler.s5TryMissingTokenInsertion(0)
 	if err != nil || !handled {
 		t.Fatalf("fork: handled=%t err=%v", handled, err)
@@ -342,11 +627,15 @@ func TestRecoveryCompetitionDoesNotUseOrdinaryNoActionDrop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dispatchPass: %v", err)
 	}
-	if unsupported == nil || unsupported.boundary != DiagnosticParserCoreRecovery {
-		t.Fatalf("unsupported=%+v, want a recovery decline", unsupported)
+	if unsupported != nil {
+		t.Fatalf("unsupported=%+v, want owned recovery dispatch", unsupported)
 	}
 	if len(scheduler.headers) != 2 {
 		t.Fatalf("ordinary no-action logic dropped a recovery version: headers=%d", len(scheduler.headers))
+	}
+	if !scheduler.versionLexerOwnershipActive || len(scheduler.versionLexerRequests) != 1 {
+		t.Fatalf("owned recovery dispatch was not armed: active=%t requests=%d",
+			scheduler.versionLexerOwnershipActive, len(scheduler.versionLexerRequests))
 	}
 }
 

--- a/parsercore_phase0_s5.go
+++ b/parsercore_phase0_s5.go
@@ -1,0 +1,1105 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"math"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// diagnosticParserCoreS5ReductionMode selects the C recovery reduction scan.
+// AnyTerminal excludes EOF. ExactToken scans only the supplied symbol.
+type diagnosticParserCoreS5ReductionMode uint8
+
+const (
+	diagnosticParserCoreS5AnyTerminal diagnosticParserCoreS5ReductionMode = iota
+	diagnosticParserCoreS5ExactToken
+)
+
+type diagnosticParserCoreS5ReductionAction struct {
+	symbol  core.Symbol
+	value   core.Action
+	ordinal int
+}
+
+type diagnosticParserCoreS5ReductionKey struct {
+	symbol core.Symbol
+	count  uint8
+}
+
+type diagnosticParserCoreS5ReductionMetadata struct {
+	rank                    core.CleanPathRankSelection
+	lineage                 uint16
+	set                     core.AlternativeSet
+	setBlended              bool
+	convergedReductionSplit bool
+	resurrectionUnproved    bool
+	dropCohortRefs          core.DropCohortRefSet
+}
+
+// s5MissingLineageNeedsOwnedLexer identifies the C condense-tail shape in
+// which the absorber consumed the shared token and the missing sibling must
+// request its next token from its own byte and parser state.
+func s5MissingLineageNeedsOwnedLexer(
+	s *diagnosticParserCoreGenericScheduler,
+	indices []int,
+) bool {
+	if s == nil || !s.recoveryIsolation || s.s5MissingInsertions == 0 ||
+		len(s.headers) != 2 || len(indices) != 1 {
+		return false
+	}
+	missingIndex := indices[0]
+	if missingIndex < 0 || missingIndex >= len(s.headers) {
+		return false
+	}
+	missing := &s.headers[missingIndex]
+	missingGroup := missing.recoveryMissingGroupIdentity()
+	if missingGroup == 0 || missing.recoveryRegion() != nil || missing.paused ||
+		!missing.isRecoveryLineage() {
+		return false
+	}
+	for index := range s.headers {
+		if index == missingIndex {
+			continue
+		}
+		absorber := &s.headers[index]
+		if absorber.shifted && absorber.isRecoveryLineage() &&
+			absorber.recoveryGroupIdentity() == missingGroup {
+			return true
+		}
+	}
+	return false
+}
+
+// diagnosticParserCoreS5SchedulerSnapshot protects scheduler state that Core
+// does not include in its transaction checkpoint.
+type diagnosticParserCoreS5SchedulerSnapshot struct {
+	value                diagnosticParserCoreGenericScheduler
+	receipt              DiagnosticParserCoreGenericScheduler
+	receiptPointer       *DiagnosticParserCoreGenericScheduler
+	receiptPresent       bool
+	receiptIsBacking     bool
+	tokenSourceSnapshot  dfaRelexSnapshot
+	tokenSourceState     StateID
+	tokenSourceGLRStates []StateID
+	tokenSourcePresent   bool
+}
+
+func diagnosticParserCoreS5CloneSlice[T any](src []T) []T {
+	if src == nil {
+		return nil
+	}
+	out := make([]T, len(src))
+	copy(out, src)
+	return out
+}
+
+func captureDiagnosticParserCoreS5Scheduler(s *diagnosticParserCoreGenericScheduler) diagnosticParserCoreS5SchedulerSnapshot {
+	if s == nil {
+		return diagnosticParserCoreS5SchedulerSnapshot{}
+	}
+	value := *s
+	value.headers = diagnosticParserCoreS5CloneSlice(s.headers)
+	value.versionLexerRequests = diagnosticParserCoreS5CloneSlice(s.versionLexerRequests)
+	value.reductionOutputs = diagnosticParserCoreS5CloneSlice(s.reductionOutputs)
+	value.reductionReplacements = diagnosticParserCoreS5CloneSlice(s.reductionReplacements)
+	value.recoveryCondenseScratch = diagnosticParserCoreS5CloneSlice(s.recoveryCondenseScratch)
+	value.recoveryCondenseOrderScratch = diagnosticParserCoreS5CloneSlice(s.recoveryCondenseOrderScratch)
+	value.classifiedBoundaries = diagnosticParserCoreS5CloneSlice(s.classifiedBoundaries)
+	value.condenseCandidates = diagnosticParserCoreS5CloneSlice(s.condenseCandidates)
+	value.electStates = diagnosticParserCoreS5CloneSlice(s.electStates)
+	value.electGLRStates = diagnosticParserCoreS5CloneSlice(s.electGLRStates)
+	value.acceptedPayloads = diagnosticParserCoreS5CloneSlice(s.acceptedPayloads)
+	value.summaryHeaderScratch = diagnosticParserCoreS5CloneSlice(s.summaryHeaderScratch)
+	value.dispatchScratch.cells = diagnosticParserCoreS5CloneSlice(s.dispatchScratch.cells)
+	value.dispatchScratch.noActionIndices = diagnosticParserCoreS5CloneSlice(s.dispatchScratch.noActionIndices)
+	value.conflictScratch.actionOutputs = diagnosticParserCoreS5CloneSlice(s.conflictScratch.actionOutputs)
+	value.conflictScratch.reductionOutputs = diagnosticParserCoreS5CloneSlice(s.conflictScratch.reductionOutputs)
+	value.conflictScratch.outputs = diagnosticParserCoreS5CloneSlice(s.conflictScratch.outputs)
+	value.conflictScratch.armRanges = diagnosticParserCoreS5CloneSlice(s.conflictScratch.armRanges)
+	value.conflictScratch.adopted = diagnosticParserCoreS5CloneSlice(s.conflictScratch.adopted)
+	value.conflictScratch.headerAssembly = diagnosticParserCoreS5CloneSlice(s.conflictScratch.headerAssembly)
+	value.headerRollbackScratch.headers = diagnosticParserCoreS5CloneSlice(s.headerRollbackScratch.headers)
+	value.footprintRefs = diagnosticParserCoreS5CloneSlice(s.footprintRefs)
+	value.canonicalScratch.keys = diagnosticParserCoreS5CloneSlice(s.canonicalScratch.keys)
+	value.canonicalScratch.headerBuffers[0] = diagnosticParserCoreS5CloneSlice(s.canonicalScratch.headerBuffers[0])
+	value.canonicalScratch.headerBuffers[1] = diagnosticParserCoreS5CloneSlice(s.canonicalScratch.headerBuffers[1])
+	if s.canonicalScratch.groups != nil {
+		value.canonicalScratch.groups = make(map[diagnosticParserCorePhaseHead]diagnosticParserCoreCanonicalGroup, len(s.canonicalScratch.groups))
+		for key, group := range s.canonicalScratch.groups {
+			value.canonicalScratch.groups[key] = group
+		}
+	}
+	if s.receipt != nil {
+		value.receipt = nil
+	}
+	snapshot := diagnosticParserCoreS5SchedulerSnapshot{value: value}
+	if s.receipt != nil {
+		snapshot.receipt = *s.receipt
+		snapshot.receiptPointer = s.receipt
+		snapshot.receiptPresent = true
+		snapshot.receiptIsBacking = s.receipt == &s.receiptBacking
+		snapshot.receipt.StartHeaders = diagnosticParserCoreS5CloneSlice(s.receipt.StartHeaders)
+		snapshot.receipt.Rounds = diagnosticParserCoreS5CloneSlice(s.receipt.Rounds)
+		snapshot.receipt.Conflicts = diagnosticParserCoreS5CloneSlice(s.receipt.Conflicts)
+		snapshot.receipt.ExternalShifts = diagnosticParserCoreS5CloneSlice(s.receipt.ExternalShifts)
+		snapshot.receipt.Elections = diagnosticParserCoreS5CloneSlice(s.receipt.Elections)
+		snapshot.receipt.VersionLexerRequests = diagnosticParserCoreS5CloneSlice(s.receipt.VersionLexerRequests)
+		snapshot.receipt.NoActionDrops = diagnosticParserCoreS5CloneSlice(s.receipt.NoActionDrops)
+	}
+	if s.tokenSource != nil && s.tokenSource.lexer != nil {
+		snapshot.tokenSourcePresent = true
+		snapshot.tokenSourceSnapshot = cloneDiagnosticParserCoreDFARelexSnapshot(s.tokenSource.snapshotRelexState())
+		snapshot.tokenSourceState = s.tokenSource.state
+		snapshot.tokenSourceGLRStates = diagnosticParserCoreS5CloneSlice(s.tokenSource.glrStates)
+	}
+	return snapshot
+}
+
+func (snapshot diagnosticParserCoreS5SchedulerSnapshot) restore(s *diagnosticParserCoreGenericScheduler) {
+	if s == nil {
+		return
+	}
+	value := snapshot.value
+	*s = value
+	if snapshot.receiptPresent {
+		if snapshot.receiptIsBacking {
+			s.receiptBacking = snapshot.receipt
+			s.receipt = &s.receiptBacking
+		} else if snapshot.receiptPointer != nil {
+			*snapshot.receiptPointer = snapshot.receipt
+			s.receipt = snapshot.receiptPointer
+		}
+	}
+	s.verifierHeaderPtr = nil
+	s.verifierBound = 0
+	if snapshot.tokenSourcePresent && s.tokenSource != nil && s.tokenSource.lexer != nil {
+		snapshot.tokenSourceSnapshot.restore(s.tokenSource)
+		s.tokenSource.state = snapshot.tokenSourceState
+		s.tokenSource.glrStates = diagnosticParserCoreS5CloneSlice(snapshot.tokenSourceGLRStates)
+	}
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s5RecoverySource() (*diagnosticParserCoreRecoveryCostSource, error) {
+	if s == nil || s.compact == nil || s.tokenSource == nil {
+		return nil, errors.New("parser-core phase zero: S5 recovery source is unavailable")
+	}
+	source := s.options.materializationSource
+	if len(source) == 0 && s.tokenSource.lexer != nil {
+		// Direct scheduler fixtures bind only the lexer source. Production
+		// materialization keeps its authenticated source in options.
+		source = s.tokenSource.lexer.source
+	}
+	return newDiagnosticParserCoreRecoveryCostSource(s.compact, source)
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s5RecoveryOutputCostFunc() (core.ReductionOutputCostFunc, *core.RecoveryCostMemo, error) {
+	source, err := s.s5RecoverySource()
+	if err != nil {
+		return nil, nil, err
+	}
+	if s.tokenSource == nil || s.tokenSource.language == nil {
+		return nil, nil, errors.New("parser-core phase zero: S5 recovery language is unavailable")
+	}
+	symbols := diagnosticParserCoreRecoverySymbolPolicy(s.tokenSource.language)
+	memo := new(core.RecoveryCostMemo)
+	cost := func(prev core.NodeID, payload core.SubtreeID) (uint32, error) {
+		prefix, err := s.compact.RecoveryStoredErrorCost(core.Head{Node: prev})
+		if err != nil {
+			return 0, err
+		}
+		payloadCost, err := core.RecoveryNodeErrorCostMemo(symbols, source, memo, payload)
+		if err != nil {
+			return 0, err
+		}
+		if math.MaxUint32-prefix < payloadCost {
+			return 0, errors.New("parser-core phase zero: S5 recovery output cost overflow")
+		}
+		return prefix + payloadCost, nil
+	}
+	return cost, memo, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s5CollectReductionActions(
+	state core.StateID,
+	mode diagnosticParserCoreS5ReductionMode,
+	lookahead core.Symbol,
+) ([]diagnosticParserCoreS5ReductionAction, bool, error) {
+	if s == nil || s.tokenSource == nil || s.tokenSource.language == nil {
+		return nil, false, errors.New("parser-core phase zero: S5 action table is unavailable")
+	}
+	var symbols []core.Symbol
+	if mode == diagnosticParserCoreS5ExactToken {
+		symbols = []core.Symbol{lookahead}
+	} else {
+		tokenCount := core.Symbol(s.tokenSource.language.TokenCount)
+		if tokenCount <= 1 {
+			return nil, false, nil
+		}
+		symbols = make([]core.Symbol, 0, int(tokenCount)-1)
+		for symbol := core.Symbol(1); symbol < tokenCount; symbol++ {
+			symbols = append(symbols, symbol)
+		}
+	}
+	seen := make(map[diagnosticParserCoreS5ReductionKey]struct{})
+	actions := make([]diagnosticParserCoreS5ReductionAction, 0, 4)
+	hasShift := false
+	for symbolIndex, symbol := range symbols {
+		if symbolIndex&63 == 0 {
+			if err := s.pollStopControl(); err != nil {
+				return nil, false, err
+			}
+		}
+		row, err := s.compact.Actions(state, symbol)
+		if err != nil {
+			return nil, false, err
+		}
+		for ordinal := 0; ordinal < row.Len(); ordinal++ {
+			action := row.At(ordinal)
+			switch action.Type {
+			case core.ActionShift:
+				if !action.Extra && !action.Repetition {
+					hasShift = true
+				}
+			case core.ActionRecover:
+				if !action.Extra && !action.Repetition {
+					hasShift = true
+				}
+			case core.ActionReduce:
+				if action.ChildCount == 0 {
+					continue
+				}
+				key := diagnosticParserCoreS5ReductionKey{symbol: action.Symbol, count: action.ChildCount}
+				if _, exists := seen[key]; exists {
+					continue
+				}
+				seen[key] = struct{}{}
+				actions = append(actions, diagnosticParserCoreS5ReductionAction{
+					symbol: symbol, value: action, ordinal: ordinal,
+				})
+			}
+		}
+	}
+	return actions, hasShift, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s5CondenseCandidates(
+	start, end, source int,
+) []core.CondenseCandidate {
+	out := make([]core.CondenseCandidate, 0, max(end-start, 0))
+	for index := start; index < end && index < len(s.headers); index++ {
+		if index == source {
+			continue
+		}
+		header := s.headers[index]
+		if header.accepted || header.paused || header.recoveryRegion() != nil ||
+			header.isRecoveryLineage() || header.isRecoveryCosted() {
+			continue
+		}
+		storedCost, err := s.compact.RecoveryStoredErrorCost(header.head)
+		if err != nil {
+			// The caller cannot return an error from this scratch builder. Leave
+			// malformed or unavailable heads out of the candidate scope; the
+			// reduction itself authenticates its source and reports any failure.
+			continue
+		}
+		out = append(out, core.CondenseCandidate{
+			Head: header.head, Checkpoint: header.checkpoint,
+			DropCohortRefs: header.dropCohortRefs, ErrorCost: storedCost,
+			MergeIdentity: s.condenseCandidateMergeIdentity(index), Shifted: header.shifted,
+		})
+	}
+	return out
+}
+
+// s5MergeReductionVersionOwned applies C's pre-classification merge only to
+// the versions created by this frontier call. The incumbent keeps its slot.
+func (s *diagnosticParserCoreGenericScheduler) s5MergeReductionVersionOwned(
+	owner core.SchedulerTransactionToken,
+	incumbentIndex, incomingIndex int,
+) (bool, error) {
+	if incumbentIndex < 0 || incomingIndex < 0 || incumbentIndex >= incomingIndex || incomingIndex >= len(s.headers) {
+		return false, errors.New("parser-core phase zero: S5 reduction merge indices are invalid")
+	}
+	incumbent := &s.headers[incumbentIndex]
+	incoming := &s.headers[incomingIndex]
+	if incumbent.accepted || incoming.accepted || incumbent.paused || incoming.paused ||
+		incumbent.recoveryRegion() != nil || incoming.recoveryRegion() != nil ||
+		incumbent.isRecoveryLineage() || incoming.isRecoveryLineage() ||
+		incumbent.isRecoveryCosted() || incoming.isRecoveryCosted() {
+		return false, nil
+	}
+	if !s.versionLexerStateEqual(incumbent.versionState, incoming.versionState) ||
+		incumbent.checkpoint != incoming.checkpoint || incumbent.shifted != incoming.shifted {
+		return false, nil
+	}
+	incumbentState, incumbentByte, err := s.compact.Boundary(incumbent.head)
+	if err != nil {
+		return false, err
+	}
+	incomingState, incomingByte, err := s.compact.Boundary(incoming.head)
+	if err != nil {
+		return false, err
+	}
+	if incumbentState != incomingState || incumbentByte != incomingByte {
+		return false, nil
+	}
+	incumbentCost, err := s.compact.RecoveryStoredErrorCost(incumbent.head)
+	if err != nil {
+		return false, err
+	}
+	incomingCost, err := s.compact.RecoveryStoredErrorCost(incoming.head)
+	if err != nil {
+		return false, err
+	}
+	if incumbentCost != incomingCost {
+		return false, nil
+	}
+	merged, err := s.compact.MergeEquivalentHeadsWithStoredErrorCostOwned(
+		owner, incumbentState, incumbentByte, incumbent.checkpoint,
+		incumbent.shifted, incumbent.head, incoming.head,
+	)
+	if err != nil {
+		return false, err
+	}
+	incumbent.head = merged
+	incumbent.frontierSequence = mergeDiagnosticParserCoreFrontier(
+		incumbent.frontierSequence, incoming.frontierSequence,
+	)
+	incumbent.cleanPathRank, incumbent.cleanPathLineage = mergeDiagnosticParserCoreCleanPathLineage(
+		incumbent.cleanPathRank, incumbent.cleanPathLineage,
+		incoming.cleanPathRank, incoming.cleanPathLineage,
+	)
+	incumbent.convergedReductionSplit = incumbent.convergedReductionSplit || incoming.convergedReductionSplit
+	incumbent.resurrectionUnproved = incumbent.resurrectionUnproved || incoming.resurrectionUnproved
+	if incoming.altSet.Len() != 0 {
+		incomparable := s.compact.AlternativeSetIncomparable(incumbent.altSet, incoming.altSet)
+		s.compact.UnionAlternativeSet(&incumbent.altSet, incoming.altSet)
+		incumbent.blended = incumbent.blended || incoming.blended || incomparable
+	}
+	if !incoming.dropCohortRefs.Empty() || incoming.dropCohortRefs.Overflowed() || incoming.dropCohortRefs.Blended() {
+		if _, err := s.compact.UnionDropCohortRefsChecked(&incumbent.dropCohortRefs, incoming.dropCohortRefs); err != nil {
+			return false, err
+		}
+	}
+	s.invalidateVerifierHeaderBinding()
+	copy(s.headers[incomingIndex:], s.headers[incomingIndex+1:])
+	clear(s.headers[len(s.headers)-1:])
+	s.headers = s.headers[:len(s.headers)-1]
+	return true, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s5ReductionOutputMetadata(
+	output core.ReductionOutput,
+	outputIndex int,
+	lineage uint16,
+) diagnosticParserCoreS5ReductionMetadata {
+	metadata := diagnosticParserCoreS5ReductionMetadata{
+		rank:    output.CleanPathRank,
+		lineage: lineage,
+		convergedReductionSplit: output.MultiplePopPaths ||
+			output.HistoricalBoundaryProvenance == core.HistoricalBoundaryConverged,
+		resurrectionUnproved: output.HistoricalBoundaryProvenance == core.HistoricalBoundaryUnproved,
+		dropCohortRefs:       output.DropCohortRefs,
+	}
+	if output.MultiplePopPaths {
+		metadata.set = core.NewAlternativeSetMember(lineage, uint16(outputIndex))
+	} else if output.HistoricalBoundaryProvenance == core.HistoricalBoundaryConverged {
+		metadata.rank = output.HistoricalCleanPathRank
+		metadata.lineage = output.HistoricalCleanPathLineage
+	}
+	if output.HistoricalBoundaryProvenance == core.HistoricalBoundaryConverged &&
+		output.HistoricalAlternativeSet.Len() != 0 {
+		incomparable := s.compact.AlternativeSetIncomparable(metadata.set, output.HistoricalAlternativeSet)
+		s.compact.UnionAlternativeSet(&metadata.set, output.HistoricalAlternativeSet)
+		metadata.setBlended = output.HistoricalBlended || incomparable
+	}
+	return metadata
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s5ApplyReductionOutputMetadata(
+	header *diagnosticParserCoreHeader,
+	output core.ReductionOutput,
+	metadata diagnosticParserCoreS5ReductionMetadata,
+) error {
+	if header == nil {
+		return errors.New("parser-core phase zero: nil S5 reduction header")
+	}
+	header.head = output.Head
+	header.paused = false
+	header.accepted = false
+	header.shifted = false
+	header.freshness = output.Freshness
+	header.convergedReductionSplit = header.convergedReductionSplit || metadata.convergedReductionSplit
+	header.resurrectionUnproved = header.resurrectionUnproved || metadata.resurrectionUnproved
+	applyDiagnosticParserCoreCleanPathOutput(header, metadata.rank, metadata.lineage)
+	if metadata.set.Len() != 0 {
+		s.compact.UnionAlternativeSet(&header.altSet, metadata.set)
+		header.blended = header.blended || metadata.setBlended
+	}
+	if !metadata.dropCohortRefs.Empty() || metadata.dropCohortRefs.Overflowed() || metadata.dropCohortRefs.Blended() {
+		if _, err := s.compact.UnionDropCohortRefsChecked(&header.dropCohortRefs, metadata.dropCohortRefs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// s5UpdatedReductionSiblingIndex mirrors the ordinary adoption selector. The
+// S5 caller retains the exact destination so it never assigns freshness to a
+// different same-boundary header after adoption.
+func (s *diagnosticParserCoreGenericScheduler) s5UpdatedReductionSiblingIndex(
+	source int,
+	head core.Head,
+) (int, error) {
+	if s == nil || source < 0 || source >= len(s.headers) {
+		return -1, errors.New("parser-core phase zero: S5 sibling adoption source is out of range")
+	}
+	sourceVersionState := s.headers[source].versionState
+	for index := range s.headers {
+		if index == source {
+			continue
+		}
+		if s.recoveryIsolation &&
+			(s.headers[source].isRecoveryLineage() || s.headers[index].isRecoveryLineage()) {
+			continue
+		}
+		header := s.headers[index]
+		if !s.versionLexerStateEqual(header.versionState, sourceVersionState) {
+			continue
+		}
+		state, byteOffset, err := s.compact.Boundary(header.head)
+		if err != nil {
+			return -1, err
+		}
+		canonical, ok := s.compact.CanonicalBoundary(state, byteOffset, header.shifted, header.checkpoint)
+		if ok && canonical == head {
+			return index, nil
+		}
+	}
+	return -1, nil
+}
+
+// s5RunReductionFrontierOwned ports C's do_all_potential_reductions for the
+// compact scheduler. The caller owns the surrounding scheduler speculation.
+func (s *diagnosticParserCoreGenericScheduler) s5RunReductionFrontierOwned(
+	owner core.SchedulerTransactionToken,
+	start int,
+	mode diagnosticParserCoreS5ReductionMode,
+	lookahead core.Symbol,
+	staged *diagnosticParserCoreS5Work,
+) (canShift bool, err error) {
+	if s == nil || staged == nil || start < 0 || start >= len(s.headers) {
+		return false, errors.New("parser-core phase zero: S5 reduction frontier is incomplete")
+	}
+	initialVersionCount := len(s.headers)
+	startingVersion := start
+	version := start
+	iteration := uint64(0)
+	for version < len(s.headers) {
+		if iteration == math.MaxUint64 {
+			return false, errors.New("parser-core phase zero: S5 reduction iteration overflow")
+		}
+		promotionIndex := iteration
+		iteration++
+		prePassVersionCount := len(s.headers)
+		if version < 0 || version >= prePassVersionCount {
+			break
+		}
+		// C merges the current version with only versions created by this
+		// frontier call before it reads the current action row. Never fold
+		// against the original scheduler suffix here.
+		merged := false
+		for prior := initialVersionCount; prior < version; prior++ {
+			if prior >= len(s.headers) {
+				break
+			}
+			merged, err = s.s5MergeReductionVersionOwned(owner, prior, version)
+			if err != nil {
+				return false, err
+			}
+			if merged {
+				break
+			}
+		}
+		if merged {
+			continue
+		}
+		header := s.headers[version]
+		state, _, err := s.compact.Boundary(header.head)
+		if err != nil {
+			return false, err
+		}
+		actions, hasShift, err := s.s5CollectReductionActions(state, mode, lookahead)
+		if err != nil {
+			return false, err
+		}
+		lastReduction := -1
+		for _, reduction := range actions {
+			staged.potentialReductionActions++
+			// C can merge a new reduction output into any lower live version,
+			// except the reduction source. Capture that frontier before this
+			// action can append more versions.
+			preActionVersionCount := len(s.headers)
+			boundary, err := s.compact.ClassifyBoundary(header.head, reduction.symbol)
+			if err != nil {
+				return false, err
+			}
+			candidates := s.s5CondenseCandidates(0, preActionVersionCount, version)
+			storedCost, err := s.compact.RecoveryStoredErrorCost(header.head)
+			if err != nil {
+				return false, err
+			}
+			var cost core.ReductionOutputCostFunc
+			var memo *core.RecoveryCostMemo
+			if storedCost != 0 || header.recoveryRegion() != nil || header.isRecoveryCosted() || header.isRecoveryLineage() {
+				cost, memo, err = s.s5RecoveryOutputCostFunc()
+				if err != nil {
+					return false, err
+				}
+			}
+			var outputs []core.ReductionOutput
+			s.compact.SetReduceConflictContext(true)
+			func() {
+				defer s.compact.SetReduceConflictContext(false)
+				if cost == nil {
+					outputs, err = s.compact.ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesOwned(
+						owner, candidates, s.reductionOutputs, boundary, reduction.ordinal, core.ForkOrder{},
+					)
+				} else {
+					outputs, err = s.compact.ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesAndCostOwned(
+						owner, candidates, s.reductionOutputs, boundary, reduction.ordinal, core.ForkOrder{}, cost,
+					)
+				}
+			}()
+			if memo != nil {
+				memo.Reset()
+			}
+			if err != nil {
+				return false, err
+			}
+			staged.potentialReductionOutputs += uint64(len(outputs))
+			actionReductionVersion := -1
+			var lineage uint16
+			if len(outputs) != 0 && outputs[0].MultiplePopPaths {
+				lineage, err = nextDiagnosticParserCoreCleanPathLineage(&s.nextCleanPathLineage)
+				if err != nil {
+					return false, err
+				}
+				if err := s.compact.RecordReductionLineageOwned(owner, outputs, lineage); err != nil {
+					return false, err
+				}
+			}
+			for outputIndex, output := range outputs {
+				if output.Freshness != core.ReductionUnchanged && output.Freshness != core.ReductionUpdated && output.Freshness != core.ReductionNew {
+					return false, errors.New("parser-core phase zero: S5 reduction returned invalid freshness")
+				}
+				metadata := s.s5ReductionOutputMetadata(output, outputIndex, lineage)
+				if output.Freshness == core.ReductionUnchanged || output.Freshness == core.ReductionUpdated {
+					slot, slotErr := s.s5UpdatedReductionSiblingIndex(version, output.Head)
+					if slotErr != nil {
+						return false, slotErr
+					}
+					if slot < 0 {
+						return false, errors.New("parser-core phase zero: S5 reduction output lost its scheduler version")
+					}
+					adopted, adoptErr := s.adoptUpdatedReductionSiblingOwned(
+						owner, version, output.Head,
+						metadata.rank, metadata.lineage, metadata.set, metadata.setBlended,
+						metadata.dropCohortRefs, metadata.convergedReductionSplit,
+						metadata.resurrectionUnproved, core.DropCohortProducerSiblingAdoption,
+					)
+					if adoptErr != nil {
+						return false, adoptErr
+					}
+					if !adopted {
+						return false, errors.New("parser-core phase zero: S5 reduction output lost its scheduler version")
+					}
+					s.headers[slot].freshness = output.Freshness
+					// C reports STACK_VERSION_NONE for an output already
+					// represented by a live version. It must never become a
+					// promotion candidate merely because its metadata changed.
+					continue
+				}
+				if output.Freshness != core.ReductionNew {
+					continue
+				}
+				replacement := header
+				if err := s.s5ApplyReductionOutputMetadata(&replacement, output, metadata); err != nil {
+					return false, err
+				}
+				if s.nextSeq == math.MaxUint64 {
+					return false, errors.New("parser-core phase zero: S5 reduction creation sequence overflow")
+				}
+				replacement.creationSeq = s.nextSeq
+				s.nextSeq++
+				s.headers = append(s.headers, replacement)
+				if actionReductionVersion < 0 {
+					actionReductionVersion = len(s.headers) - 1
+				}
+			}
+			// C overwrites reduction_version after each action, including an
+			// action that produced no new physical version.
+			lastReduction = actionReductionVersion
+			header = s.headers[version]
+		}
+		if hasShift {
+			canShift = true
+		}
+		if hasShift {
+			if version == startingVersion {
+				// The original suffix has already been classified by the
+				// scheduler. Continue with only outputs appended by this pass.
+				version = prePassVersionCount
+			} else {
+				version++
+			}
+			continue
+		}
+		if lastReduction >= 0 && promotionIndex < 6 {
+			promoted := s.headers[lastReduction]
+			if lastReduction <= version {
+				return false, errors.New("parser-core phase zero: S5 reduction promotion order is invalid")
+			}
+			s.headers[version] = promoted
+			s.invalidateVerifierHeaderBinding()
+			copy(s.headers[lastReduction:], s.headers[lastReduction+1:])
+			clear(s.headers[len(s.headers)-1:])
+			s.headers = s.headers[:len(s.headers)-1]
+			staged.reductionPromotions++
+			continue
+		}
+		if mode == diagnosticParserCoreS5ExactToken {
+			generatedStart := prePassVersionCount
+			copy(s.headers[version:], s.headers[version+1:])
+			clear(s.headers[len(s.headers)-1:])
+			s.headers = s.headers[:len(s.headers)-1]
+			if version < generatedStart {
+				generatedStart--
+			}
+			next := version + 1
+			if next < generatedStart {
+				next = generatedStart
+			}
+			version = next
+			continue
+		}
+		if version == startingVersion {
+			version = prePassVersionCount
+		} else {
+			version++
+		}
+	}
+	return canShift, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s5RecoveryBaseline(headers []diagnosticParserCoreHeader) (uint32, bool, error) {
+	source, err := s.s5RecoverySource()
+	if err != nil {
+		return 0, false, err
+	}
+	if s.tokenSource == nil || s.tokenSource.language == nil {
+		return 0, false, nil
+	}
+	symbols := diagnosticParserCoreRecoverySymbolPolicy(s.tokenSource.language)
+	var maximum uint32
+	for _, header := range headers {
+		aggregate, supported, err := s.compact.RecoveryGraphAggregateForHead(header.head, symbols, source)
+		if err != nil {
+			return 0, false, err
+		}
+		if !supported {
+			return 0, false, nil
+		}
+		if aggregate.MaximumVisibleCount > maximum {
+			maximum = aggregate.MaximumVisibleCount
+		}
+	}
+	return maximum, true, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s5ShiftMissingLeafOwned(
+	owner core.SchedulerTransactionToken,
+	headerIndex int,
+	targetState core.StateID,
+	symbol core.Symbol,
+	byteOffset uint32,
+) error {
+	if headerIndex < 0 || headerIndex >= len(s.headers) {
+		return errors.New("parser-core phase zero: S5 missing header index is out of range")
+	}
+	head, err := s.compact.ShiftMissingLeafOwned(owner, s.headers[headerIndex].head, targetState, symbol, byteOffset)
+	if err != nil {
+		return err
+	}
+	s.headers[headerIndex].head = head
+	s.headers[headerIndex].shifted = false
+	s.headers[headerIndex].paused = false
+	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s5TryMissingCandidateOwned(
+	owner core.SchedulerTransactionToken,
+	anyHeaders []diagnosticParserCoreHeader,
+	anyIndex int,
+	missing core.Symbol,
+	targetState core.StateID,
+	byteOffset uint32,
+	staged *diagnosticParserCoreS5Work,
+) ([]diagnosticParserCoreHeader, bool, uint64, error) {
+	if anyIndex < 0 || anyIndex >= len(anyHeaders) {
+		return nil, false, 0, errors.New("parser-core phase zero: S5 missing candidate index is out of range")
+	}
+	snapshot := captureDiagnosticParserCoreS5Scheduler(s)
+	stagedBefore := *staged
+	var trialHeaders []diagnosticParserCoreHeader
+	var trialSeq uint64
+	viable := false
+	err := s.compact.ApplySchedulerSpeculation(owner, func(trialOwner core.SchedulerTransactionToken) (bool, error) {
+		s.headers = []diagnosticParserCoreHeader{anyHeaders[anyIndex]}
+		if s.nextSeq == math.MaxUint64 {
+			return false, errors.New("parser-core phase zero: S5 missing creation sequence overflow")
+		}
+		trialSeq = s.nextSeq
+		s.headers[0].creationSeq = trialSeq
+		s.nextSeq++
+		if err := s.s5ShiftMissingLeafOwned(trialOwner, 0, targetState, missing, byteOffset); err != nil {
+			return false, err
+		}
+		canShift, err := s.s5RunReductionFrontierOwned(trialOwner, 0, diagnosticParserCoreS5ExactToken, core.Symbol(s.token.Symbol), staged)
+		if err != nil {
+			return false, err
+		}
+		if !canShift || len(s.headers) == 0 {
+			return false, nil
+		}
+		trialHeaders = diagnosticParserCoreS5CloneSlice(s.headers)
+		viable = true
+		return true, nil
+	})
+	if err != nil {
+		snapshot.restore(s)
+		*staged = stagedBefore
+		return nil, false, 0, err
+	}
+	if !viable {
+		snapshot.restore(s)
+		*staged = stagedBefore
+		return nil, false, 0, nil
+	}
+	return trialHeaders, true, trialSeq, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s5AppendAndMergeAbsorberOwned(
+	owner core.SchedulerTransactionToken,
+	anyHeaders []diagnosticParserCoreHeader,
+	baseline uint32,
+	recoveryGroup uint64,
+	staged *diagnosticParserCoreS5Work,
+) (diagnosticParserCoreHeader, error) {
+	if len(anyHeaders) == 0 {
+		return diagnosticParserCoreHeader{}, errors.New("parser-core phase zero: S5 absorber has no reduction heads")
+	}
+	state, byteOffset, err := s.compact.Boundary(anyHeaders[0].head)
+	if err != nil {
+		return diagnosticParserCoreHeader{}, err
+	}
+	if byteOffset > s.token.StartByte {
+		return diagnosticParserCoreHeader{}, errors.New("parser-core phase zero: S5 absorber boundary passes the token start")
+	}
+	checkpoint := anyHeaders[0].checkpoint
+	storedCost, err := s.compact.RecoveryStoredErrorCost(anyHeaders[0].head)
+	if err != nil {
+		return diagnosticParserCoreHeader{}, err
+	}
+	context := core.RecoveryDiscontinuityContext{ErrorState: 0, ByteOffset: byteOffset, Checkpoint: checkpoint}
+	markers := make([]core.Head, 0, len(anyHeaders))
+	for _, header := range anyHeaders {
+		_, candidateByte, err := s.compact.Boundary(header.head)
+		if err != nil {
+			return diagnosticParserCoreHeader{}, err
+		}
+		if candidateByte != byteOffset || header.checkpoint != checkpoint {
+			return diagnosticParserCoreHeader{}, errors.New("parser-core phase zero: S5 absorber heads do not share a boundary")
+		}
+		candidateCost, err := s.compact.RecoveryStoredErrorCost(header.head)
+		if err != nil {
+			return diagnosticParserCoreHeader{}, err
+		}
+		if candidateCost != storedCost {
+			return diagnosticParserCoreHeader{}, nil
+		}
+		if !s.versionLexerStateEqual(anyHeaders[0].versionState, header.versionState) {
+			return diagnosticParserCoreHeader{}, nil
+		}
+		marker, err := s.compact.AppendRecoveryDiscontinuityOwned(owner, header.head, context)
+		if err != nil {
+			return diagnosticParserCoreHeader{}, err
+		}
+		markers = append(markers, marker)
+	}
+	incumbent := markers[0]
+	for index := 1; index < len(markers); index++ {
+		merged, err := s.compact.MergeRecoveryDiscontinuityHeadsOwned(owner, context, incumbent, markers[index])
+		if err != nil {
+			return diagnosticParserCoreHeader{}, err
+		}
+		incumbent = merged
+		staged.recoveryDiscontinuityMerges++
+	}
+	tokenExtra, err := s3TokenIsExtraShift(s.compact, s.token.Symbol)
+	if err != nil {
+		return diagnosticParserCoreHeader{}, err
+	}
+	leaf, err := s.compact.ErrorRegionLeaf(core.Symbol(s.token.Symbol), s.token.StartByte, s.token.EndByte, tokenExtra)
+	if err != nil {
+		return diagnosticParserCoreHeader{}, err
+	}
+	absorb := anyHeaders[0]
+	absorb.head = incumbent
+	absorb.paused = false
+	absorb.shifted = true
+	absorb.accepted = false
+	absorb.openRecoveryRegion(&diagnosticParserCoreS3Region{
+		state: state, startByte: s.token.StartByte, endByte: s.token.EndByte,
+		children: []core.SubtreeID{leaf},
+	})
+	absorb.publishRecoveryCondenseState(recoveryGroup, 0, baseline, true)
+	absorb.markRecoveryCosted()
+	for _, header := range anyHeaders[1:] {
+		absorb.frontierSequence = mergeDiagnosticParserCoreFrontier(
+			absorb.frontierSequence, header.frontierSequence,
+		)
+		absorb.cleanPathRank, absorb.cleanPathLineage = mergeDiagnosticParserCoreCleanPathLineage(
+			absorb.cleanPathRank, absorb.cleanPathLineage,
+			header.cleanPathRank, header.cleanPathLineage,
+		)
+		absorb.convergedReductionSplit = absorb.convergedReductionSplit || header.convergedReductionSplit
+		absorb.resurrectionUnproved = absorb.resurrectionUnproved || header.resurrectionUnproved
+		if _, err := s.compact.UnionDropCohortRefsChecked(&absorb.dropCohortRefs, header.dropCohortRefs); err != nil {
+			return diagnosticParserCoreHeader{}, err
+		}
+		s.compact.UnionAlternativeSet(&absorb.altSet, header.altSet)
+		absorb.blended = absorb.blended || header.blended
+	}
+	s.s3RegionOpened = true
+	return absorb, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s5RunOwned(
+	owner core.SchedulerTransactionToken,
+	index int,
+	staged *diagnosticParserCoreS5Work,
+) (bool, error) {
+	if !s.s5MissingTokenAdmitted() || len(s.headers) != 1 || index != 0 ||
+		s.s5MissingInsertions >= maxDiagnosticParserCoreMissingInsertions {
+		return false, nil
+	}
+	if s.token.Missing || s.token.NoLookahead || s.token.Symbol == errorSymbol || s.token.Symbol == 0 ||
+		s.tokenSource == nil || s.tokenSource.language == nil || s.headers[index].recoveryRegion() != nil {
+		return false, nil
+	}
+	tokenCount := core.Symbol(s.tokenSource.language.TokenCount)
+	if tokenCount <= 1 || tokenCount > math.MaxUint16 {
+		return false, nil
+	}
+	original := s.headers[index]
+	_, originalByte, err := s.compact.Boundary(original.head)
+	if err != nil {
+		return false, err
+	}
+	if originalByte > s.token.StartByte {
+		return false, nil
+	}
+	if _, err := s.compact.RecoveryStoredErrorCost(original.head); err != nil {
+		return false, err
+	}
+	if _, err := s.s5RunReductionFrontierOwned(owner, index, diagnosticParserCoreS5AnyTerminal, core.Symbol(s.token.Symbol), staged); err != nil {
+		return false, err
+	}
+	anyHeaders := diagnosticParserCoreS5CloneSlice(s.headers)
+	if len(anyHeaders) == 0 {
+		return false, nil
+	}
+	var missingHeaders []diagnosticParserCoreHeader
+	var missingGroup uint64
+	for anyIndex := range anyHeaders {
+		state, byteOffset, err := s.compact.Boundary(anyHeaders[anyIndex].head)
+		if err != nil {
+			return false, err
+		}
+		if byteOffset > s.token.StartByte {
+			continue
+		}
+		for rawSymbol := core.Symbol(1); rawSymbol < tokenCount; rawSymbol++ {
+			if uint32(rawSymbol)&63 == 0 {
+				if err := s.pollStopControl(); err != nil {
+					return false, err
+				}
+			}
+			row, err := s.compact.Actions(state, rawSymbol)
+			if err != nil {
+				return false, err
+			}
+			if row.Len() == 0 {
+				continue
+			}
+			last := row.At(row.Len() - 1)
+			if last.Type != core.ActionShift {
+				continue
+			}
+			nextState := last.State
+			if last.Extra {
+				nextState = state
+			}
+			if nextState == 0 || nextState == state {
+				continue
+			}
+			nextRow, err := s.compact.Actions(nextState, core.Symbol(s.token.Symbol))
+			if err != nil {
+				return false, err
+			}
+			// C's ts_language_has_reduce_action checks only the leading action.
+			// A later reduce arm does not admit a missing-token trial.
+			if nextRow.Len() == 0 || nextRow.At(0).Type != core.ActionReduce {
+				continue
+			}
+			staged.missingTokenTrials++
+			trial, viable, seq, err := s.s5TryMissingCandidateOwned(owner, anyHeaders, anyIndex, rawSymbol, nextState, originalByte, staged)
+			if err != nil {
+				return false, err
+			}
+			if !viable {
+				continue
+			}
+			missingHeaders = trial
+			missingGroup = seq
+			break
+		}
+		if len(missingHeaders) != 0 {
+			break
+		}
+	}
+	if len(missingHeaders) == 0 {
+		return false, nil
+	}
+	baseline, baselineOK, err := s.s5RecoveryBaseline(anyHeaders)
+	if err != nil {
+		return false, err
+	}
+	if !baselineOK {
+		return false, nil
+	}
+	s.headers = anyHeaders
+	absorb, err := s.s5AppendAndMergeAbsorberOwned(owner, anyHeaders, baseline, missingGroup, staged)
+	if err != nil {
+		return false, err
+	}
+	if absorb.head.Node == 0 {
+		return false, nil
+	}
+	missingBaseline, missingBaselineSet := original.recoveryNodeBaseline()
+	if !missingBaselineSet {
+		missingBaseline = 0
+		missingBaselineSet = true
+	} else if missingBaseline > baseline {
+		missingBaseline = baseline
+	}
+	for index := range missingHeaders {
+		missingHeaders[index].publishRecoveryCondenseState(0, missingGroup, missingBaseline, missingBaselineSet)
+		missingHeaders[index].paused = false
+		missingHeaders[index].shifted = false
+		missingHeaders[index].markRecoveryCosted()
+	}
+	absorb.publishRecoveryCondenseState(missingGroup, 0, baseline, true)
+	absorb.markRecoveryLineage()
+	for index := range missingHeaders {
+		missingHeaders[index].markRecoveryLineage()
+	}
+	replacements := make([]diagnosticParserCoreHeader, 1, 1+len(missingHeaders))
+	replacements[0] = absorb
+	replacements = append(replacements, missingHeaders...)
+	s.invalidateVerifierHeaderBinding()
+	// The AnyTerminal frontier can contain several generated reductions.
+	// Replace every old slot so unmarked dead versions cannot cross the
+	// recovery competition boundary.
+	clear(s.headers)
+	s.headers = s.headers[:0]
+	s.headers = append(s.headers, replacements...)
+	s.recoveryIsolation = true
+	s.epochProgress = true
+	s.s5MissingInsertions++
+	staged.missingTokenCommits++
+	// Match ordinary scheduler publication. Canonicalization clears stale
+	// freshness and reconciles equivalent physical heads before ownership is
+	// persisted for the next dispatch.
+	if err := s.canonicalizeOwned(owner); err != nil {
+		return false, err
+	}
+	if err := s.persistHeaderLineageOwned(owner); err != nil {
+		return false, err
+	}
+	if uint64(len(s.headers)) > s.work.PeakLiveVersions {
+		s.work.PeakLiveVersions = uint64(len(s.headers))
+	}
+	return true, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertionFaithful(index int) (handled bool, err error) {
+	// Keep unsupported shapes on the cheap path. The full snapshot is reserved
+	// for an admitted sole header that can enter the S5 transaction.
+	if s == nil || s.compact == nil || !s.s5MissingTokenAdmitted() ||
+		len(s.headers) != 1 || index != 0 ||
+		s.s5MissingInsertions >= maxDiagnosticParserCoreMissingInsertions ||
+		s.token.Missing || s.token.NoLookahead || s.token.Symbol == errorSymbol ||
+		s.token.Symbol == 0 || s.tokenSource == nil || s.tokenSource.language == nil ||
+		s.headers[0].recoveryRegion() != nil {
+		return false, nil
+	}
+	snapshot := captureDiagnosticParserCoreS5Scheduler(s)
+	staged := diagnosticParserCoreS5Work{}
+	restored := false
+	restore := func() {
+		if restored {
+			return
+		}
+		snapshot.restore(s)
+		restored = true
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			restore()
+			panic(recovered)
+		}
+		if err != nil || !handled {
+			restore()
+		}
+	}()
+	run := func(parent core.SchedulerTransactionToken) error {
+		var committed bool
+		if err := s.compact.ApplySchedulerSpeculation(parent, func(owner core.SchedulerTransactionToken) (bool, error) {
+			var runErr error
+			committed, runErr = s.s5RunOwned(owner, index, &staged)
+			return committed, runErr
+		}); err != nil {
+			return err
+		}
+		if !committed {
+			return nil
+		}
+		s.commitS5Work(staged)
+		handled = true
+		return nil
+	}
+	if s.freshSessionOwner != nil {
+		err = run(*s.freshSessionOwner)
+	} else {
+		err = s.compact.ApplySchedulerAtomic(run)
+	}
+	if err != nil {
+		handled = false
+	}
+	return handled, err
+}

--- a/parsercore_phase0_s5_legacy.go
+++ b/parsercore_phase0_s5_legacy.go
@@ -1,0 +1,193 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"math"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+const (
+	s5MissingTokenMaxSpineDepth  = 4096
+	s5MissingTokenMaxSimulations = 256
+)
+
+// s5TryMissingTokenInsertionLegacy forks one no-action head into two versions.
+// The original version absorbs the real token through S3. Its copied sibling
+// inserts C's lowest viable missing terminal. This order matches C's version
+// list, which is load-bearing for equal-cost recovery selection.
+func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertionLegacy(index int) (handled bool, err error) {
+	if !s.s5MissingTokenAdmitted() || len(s.headers) != 1 || index != 0 {
+		return false, nil
+	}
+	original := s.headers[index]
+	if original.recoveryRegion() != nil || s.token.Missing || s.token.NoLookahead ||
+		s.token.Symbol == errorSymbol || s.s5MissingInsertions >= maxDiagnosticParserCoreMissingInsertions {
+		return false, nil
+	}
+	if s.tokenSource == nil || s.tokenSource.language == nil {
+		return false, nil
+	}
+	tokenCount := s.tokenSource.language.TokenCount
+	if tokenCount <= 1 || tokenCount > uint32(math.MaxUint16) {
+		return false, nil
+	}
+
+	// C closes productions before it scans for a missing terminal. Keep the
+	// original header unchanged unless the complete two-version fork succeeds.
+	closedHead, closedChanged, closeOK, closeErr := s.s3CloseInProgressProductions(original.head)
+	if closeErr != nil {
+		return false, closeErr
+	}
+	if !closeOK {
+		return false, nil
+	}
+	scanHead := original.head
+	if closedChanged {
+		scanHead = closedHead
+	}
+	state, byteOffset, boundaryErr := s.compact.Boundary(scanHead)
+	if boundaryErr != nil {
+		return false, boundaryErr
+	}
+	if byteOffset > s.token.StartByte {
+		return false, nil
+	}
+	spine, spineOK, spineErr := s.compact.UniqueStateSpine(scanHead, s5MissingTokenMaxSpineDepth)
+	if spineErr != nil {
+		return false, spineErr
+	}
+	if !spineOK || len(spine) == 0 || spine[len(spine)-1] != state {
+		return false, nil
+	}
+
+	simulation := make([]core.StateID, len(spine)+1)
+	copy(simulation, spine)
+	var missing Symbol
+	var targetState core.StateID
+	simulations := 0
+	for rawSymbol := uint32(1); rawSymbol < tokenCount; rawSymbol++ {
+		if rawSymbol%64 == 0 {
+			if pollErr := s.pollStopControl(); pollErr != nil {
+				return false, pollErr
+			}
+		}
+		candidate := Symbol(rawSymbol)
+		row, rowErr := s.compact.Actions(state, core.Symbol(candidate))
+		if rowErr != nil {
+			return false, rowErr
+		}
+		if row.Len() == 0 {
+			continue
+		}
+		last := row.At(row.Len() - 1)
+		if last.Type != core.ActionShift {
+			continue
+		}
+		nextState := core.StateID(last.State)
+		if last.Extra {
+			nextState = state
+		}
+		if nextState == 0 || nextState == state {
+			continue
+		}
+		nextRow, nextErr := s.compact.Actions(nextState, core.Symbol(s.token.Symbol))
+		if nextErr != nil {
+			return false, nextErr
+		}
+		if nextRow.Len() == 0 || nextRow.At(0).Type != core.ActionReduce {
+			continue
+		}
+		simulations++
+		if simulations > s5MissingTokenMaxSimulations {
+			return false, nil
+		}
+		simulation[len(simulation)-1] = nextState
+		canShift, shiftErr := s.compact.CanShiftAfterReductions(simulation, core.Symbol(s.token.Symbol))
+		if shiftErr != nil {
+			return false, shiftErr
+		}
+		if !canShift {
+			continue
+		}
+		// This materializer cannot propagate the error bit after a hidden,
+		// childless missing terminal is spliced out. C selects the first viable
+		// symbol, so decline the whole scan instead of trying a later symbol.
+		if index := int(candidate); index < len(s.tokenSource.language.SymbolMetadata) &&
+			!s.tokenSource.language.SymbolMetadata[index].Visible {
+			return false, nil
+		}
+		missing = candidate
+		targetState = nextState
+		break
+	}
+	if missing == 0 {
+		return false, nil
+	}
+	if s.nextSeq == math.MaxUint64 {
+		return false, errors.New("parser-core phase zero: recovery fork creation sequence overflow")
+	}
+	recoveryBaseline, baselineOK, baselineErr := s.recoveryNodeBaselineForHead(scanHead)
+	if baselineErr != nil {
+		return false, baselineErr
+	}
+	if !baselineOK {
+		return false, nil
+	}
+	missingBaseline, missingBaselineSet := original.recoveryNodeBaseline()
+	if !missingBaselineSet {
+		missingBaseline = 0
+		missingBaselineSet = true
+	} else if missingBaseline > recoveryBaseline {
+		// C clamps the copied stack head before it forks the missing version.
+		missingBaseline = recoveryBaseline
+	}
+	recoveryGroup := s.nextSeq
+
+	// Replace the sole head temporarily. This lets the existing S3 primitive
+	// build the absorb lineage without duplicating its fail-closed checks.
+	absorbHeader := original
+	absorbHeader.head = scanHead
+	absorbHeader.paused = false
+	absorbHeader.shifted = false
+	missingHeader := absorbHeader
+	missingHeader.creationSeq = s.nextSeq
+	replacements := [...]diagnosticParserCoreHeader{absorbHeader, missingHeader}
+	s.invalidateVerifierHeaderBinding()
+	s.headers = replaceDiagnosticParserCoreHeader(s.headers, index, replacements[:])
+	restore := func() {
+		s.invalidateVerifierHeaderBinding()
+		clear(s.headers)
+		s.headers = s.headers[:1]
+		s.headers[0] = original
+	}
+
+	absorbed, absorbErr := s.s3TryOpenErrorRegionWithAlternatives(index, true)
+	if absorbErr != nil {
+		restore()
+		return false, absorbErr
+	}
+	if !absorbed || s.headers[index].recoveryRegion() == nil || !s.headers[index].shifted {
+		restore()
+		return false, nil
+	}
+
+	missingHead, insertErr := s.compact.ShiftMissingLeaf(scanHead, targetState, core.Symbol(missing), byteOffset)
+	if insertErr != nil {
+		restore()
+		return false, insertErr
+	}
+	s.headers[index+1].head = missingHead
+	s.headers[index].publishRecoveryCondenseState(recoveryGroup, 0, recoveryBaseline, true)
+	s.headers[index+1].publishRecoveryCondenseState(
+		0, recoveryGroup, missingBaseline, missingBaselineSet,
+	)
+	s.headers[index].markRecoveryLineage()
+	s.headers[index+1].markRecoveryLineage()
+	s.recoveryIsolation = true
+	s.nextSeq++
+	s.s5MissingInsertions++
+	return true, nil
+}

--- a/parsercore_phase0_selected_query.go
+++ b/parsercore_phase0_selected_query.go
@@ -39,9 +39,13 @@ func (r selectedStoreQueryReader) IsNamed(id core.SelectedNodeID) bool {
 	return named
 }
 
-// The selected clean-full route cannot contain recovery-inserted nodes. Query
-// admission rejects MISSING patterns before the matcher reaches this reader.
-func (selectedStoreQueryReader) IsMissing(core.SelectedNodeID) bool { return false }
+func (r selectedStoreQueryReader) IsMissing(id core.SelectedNodeID) bool {
+	if r.store == nil {
+		return false
+	}
+	record, ok := r.store.Record(id)
+	return ok && record.Missing()
+}
 
 func (r selectedStoreQueryReader) Type(id core.SelectedNodeID, lang *Language) string {
 	symbol := r.Symbol(id)

--- a/parsercore_phase0_stack_summary_recovery_internal_test.go
+++ b/parsercore_phase0_stack_summary_recovery_internal_test.go
@@ -62,6 +62,7 @@ func newStackSummaryRecoveryForkScheduler(t *testing.T, armed bool) *diagnosticP
 		nextSeq: 10,
 		options: DiagnosticParserCorePrefixOptions{
 			Recovery:                             true,
+			materializationSource:                []byte("a?"),
 			allowCompactStrategy2ErrorRegion:     true,
 			allowCompactStackSummaryRecovery:     armed,
 			allowCompactRecoveryLineageSelection: true,

--- a/parsercore_selected_store_internal_test.go
+++ b/parsercore_selected_store_internal_test.go
@@ -105,9 +105,10 @@ func requireDiagnosticParserCoreSelectedStoreMatchesTree(t testing.TB, store *co
 		terminal := current.node.ChildCount() == 0
 		if Symbol(record.Symbol) != current.node.symbol || record.StartByte != current.node.startByte || record.EndByte != current.node.endByte ||
 			record.Named() != current.node.IsNamed() || record.Extra() != current.node.IsExtra() || record.External() != current.node.hasFlag(nodeFlagExternalScannerToken) ||
-			record.Terminal() != terminal || int(record.ChildCount) != current.node.ChildCount() || FieldID(current.field) != treeField ||
+			record.Terminal() != terminal || record.Missing() != current.node.IsMissing() || record.HasError() != current.node.HasError() ||
+			int(record.ChildCount) != current.node.ChildCount() || FieldID(current.field) != treeField ||
 			record.ProductionID != current.node.productionID || record.DynamicPrecedence != current.node.dynamicPrecedence {
-			t.Fatalf("selected store metadata mismatch visit=%d store=%+v tree={sym:%d span:%d..%d named:%t extra:%t external:%t terminal:%t children:%d field:%d production:%d precedence:%d type:%s}", visited, record, current.node.symbol, current.node.startByte, current.node.endByte, current.node.IsNamed(), current.node.IsExtra(), current.node.hasFlag(nodeFlagExternalScannerToken), terminal, current.node.ChildCount(), treeField, current.node.productionID, current.node.dynamicPrecedence, current.node.Type(lang))
+			t.Fatalf("selected store metadata mismatch visit=%d store=%+v tree={sym:%d span:%d..%d named:%t extra:%t external:%t terminal:%t missing:%t has_error:%t children:%d field:%d production:%d precedence:%d type:%s}", visited, record, current.node.symbol, current.node.startByte, current.node.endByte, current.node.IsNamed(), current.node.IsExtra(), current.node.hasFlag(nodeFlagExternalScannerToken), terminal, current.node.IsMissing(), current.node.HasError(), current.node.ChildCount(), treeField, current.node.productionID, current.node.dynamicPrecedence, current.node.Type(lang))
 		}
 		for index := int(record.ChildCount) - 1; index >= 0; index-- {
 			childID, _ := store.Child(record, uint32(index))

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -131,7 +131,7 @@
       "scope": "production",
       "read_sites": [
         {"path": "admission_switch_candidate.go", "symbol": "tryCompactFullParseRoute", "line": 204},
-        {"path": "parsercore_phase0_driver.go", "symbol": "DiagnosticParserCoreGenericScheduler", "line": 603},
+        {"path": "parsercore_phase0_driver.go", "symbol": "DiagnosticParserCoreGenericScheduler", "line": 619},
         {"path": "parsercore_phase0_fresh_full_runner.go", "symbol": "parserCoreFreshFullRunner", "line": 27}
       ]
     },


### PR DESCRIPTION
## Scope

Implement package two of the compact-parser graduation funnel. The compact route now performs the C-style S5 missing-token competition and physically merges equivalent graph heads.

The change keeps recovery cost, error regions, lexer ownership, lineage, checkpoints, and selected-tree error state intact. It certifies only the exact Scala artifact. Stack-summary and end-of-file recovery remain separate packages.

## Required proof

- Add minimal missing-versus-absorb falsifiers.
- Cover six-head and seven-head merge boundaries.
- Preserve distinct error regions and lexer snapshots.
- Mark all S5 reduction output as fragile.
- Use the fixed C recovery position for every missing candidate.
- Prove exact tree, range, error, and digest parity for two Scala witnesses.
- Record merge and owned-lexer telemetry.
- Account for retained missing-error scratch memory.

## Verification

- Focused root parser tests passed.
- Both selected-store modes passed.
- The full internal parser-core package passed.
- The full grammar package passed.
- The isolated Docker Scala C comparison passed.
- Docker reported no out-of-memory kill or timeout.

Locked C digests:

- 06d2d9f6b02599ec5be0808330bf1c62e49b8cb0b146d094ceaa28b9185c79b6
- c0de79617c3e1bdac71c1686e5d6a3d4b2fb375aca9f69902aee974c5ca9f852