### PR TITLE
Preserve C parity across recovery ambiguity

### DIFF
--- a/cgo_harness/stage6_scala_recovery_ambiguity_parity_test.go
+++ b/cgo_harness/stage6_scala_recovery_ambiguity_parity_test.go
@@ -1,0 +1,74 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestStage6ScalaRecoveryThroughAmbiguityParity(t *testing.T) {
+	source := []byte("val f = (: Int) => x\n")
+	const wantSExpr = "(compilation_unit (val_definition (identifier) (lambda_expression (bindings (ERROR) (binding (identifier))) (identifier))))"
+	const wantDigest = "454a064cdf50bdcfa6eb1cdfd1faaebcda41a02995dea6befbe356bb42ed8dda"
+
+	cLanguage, err := ParityCLanguage("scala")
+	if err != nil {
+		t.Fatalf("load locked Scala C parser: %v", err)
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatalf("set locked Scala C language: %v", err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("locked C parser returned no root")
+	}
+	t.Cleanup(cTree.Close)
+	cRoot := cTree.RootNode()
+	if got := formatCNodeSExpr(cRoot); got != wantSExpr {
+		t.Fatalf("locked C S-expression=%q, want %q", got, wantSExpr)
+	}
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatalf("inspect locked Scala C tree: %v", err)
+	}
+	if cDigest != wantDigest {
+		t.Fatalf("locked Scala C digest=%s, want %s", cDigest, wantDigest)
+	}
+
+	entry := grammars.DetectLanguageByName("scala")
+	if entry == nil || entry.Language() == nil {
+		t.Fatal("Scala Go grammar is unavailable")
+	}
+	goLanguage := entry.Language()
+	goParser := gotreesitter.NewParser(goLanguage)
+	goParser.SetAdmissionCandidateRoute(true)
+	goTree, err := goParser.Parse(source)
+	if err != nil {
+		t.Fatalf("compact candidate parse: %v", err)
+	}
+	if goTree == nil || goTree.RootNode() == nil {
+		t.Fatal("compact candidate returned no root")
+	}
+	t.Cleanup(goTree.Release)
+	goRoot := goTree.RootNode()
+	if got := goRoot.SExpr(goLanguage); got != wantSExpr {
+		t.Fatalf("compact Scala S-expression=%q, want %q; fallback=%q", got, wantSExpr, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+	if diff := FirstDivergenceDumpV1(goRoot, goLanguage, cRoot); diff != nil {
+		t.Fatalf("compact Scala tree diverges from locked C: %+v", *diff)
+	}
+	inspection, err := benchfixtures.InspectGoTree(goRoot, goLanguage)
+	if err != nil {
+		t.Fatalf("inspect compact Scala tree: %v", err)
+	}
+	if inspection.SHA256 != cDigest {
+		t.Fatalf("compact Scala digest=%s, want locked C %s", inspection.SHA256, cDigest)
+	}
+}

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1277,9 +1277,13 @@ type Core struct {
 	subtrees             []subtreeRecord
 	externalProvenance   []externalPayloadProvenance
 	lexerSkippedPrefixes []lexerSkippedPrefixProvenance
-	children             []SubtreeID
-	fields               []FieldMapEntry
-	aliases              []Symbol
+	// recoveryDiscontinuityReductions records parents whose stack pop crossed
+	// a null recovery edge. C counts that edge for the pop depth, but it does
+	// not add a child to the materialized subtree.
+	recoveryDiscontinuityReductions []recoveryDiscontinuityReduction
+	children                        []SubtreeID
+	fields                          []FieldMapEntry
+	aliases                         []Symbol
 	// eofRecoveryRoots records synthetic non-extra ERROR roots published by
 	// RecoverEOFAcceptOwned. Keep this provenance outside subtreeRecord: that
 	// record is size-pinned at 44 bytes for every compact payload.
@@ -1472,6 +1476,7 @@ type diagnosticOptions struct {
 type checkpoint struct {
 	nodes, nodeLineages, nodeCheckpoints, links, subtrees, externalProvenance int
 	lexerSkippedPrefixes                                                      int
+	recoveryDiscontinuityReductions                                           int
 	children, fields, aliases                                                 int
 	alternativeSpillArena                                                     int
 	eofRecoveryRoots                                                          int
@@ -1589,10 +1594,11 @@ func (c *Core) markInto(mark *checkpoint) {
 	*mark = checkpoint{
 		nodes: len(c.nodes), nodeLineages: len(c.nodeLineages),
 		links: len(c.links), subtrees: len(c.subtrees),
-		nodeCheckpoints:      len(c.nodeCheckpoints),
-		externalProvenance:   len(c.externalProvenance),
-		lexerSkippedPrefixes: len(c.lexerSkippedPrefixes),
-		children:             len(c.children), fields: len(c.fields), aliases: len(c.aliases),
+		nodeCheckpoints:                 len(c.nodeCheckpoints),
+		externalProvenance:              len(c.externalProvenance),
+		lexerSkippedPrefixes:            len(c.lexerSkippedPrefixes),
+		recoveryDiscontinuityReductions: len(c.recoveryDiscontinuityReductions),
+		children:                        len(c.children), fields: len(c.fields), aliases: len(c.aliases),
 		alternativeSpillArena: len(c.alternativeSpillArena),
 		eofRecoveryRoots:      len(c.eofRecoveryRoots),
 
@@ -1704,6 +1710,7 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 	c.eofRecoveryRoots = c.eofRecoveryRoots[:mark.eofRecoveryRoots]
 	c.externalProvenance = c.externalProvenance[:mark.externalProvenance]
 	c.lexerSkippedPrefixes = c.lexerSkippedPrefixes[:mark.lexerSkippedPrefixes]
+	c.recoveryDiscontinuityReductions = c.recoveryDiscontinuityReductions[:mark.recoveryDiscontinuityReductions]
 	c.children = c.children[:mark.children]
 	c.fields = c.fields[:mark.fields]
 	c.aliases = c.aliases[:mark.aliases]
@@ -2319,6 +2326,7 @@ func (c *Core) Reset() error {
 	c.eofRecoveryRoots = c.eofRecoveryRoots[:0]
 	c.externalProvenance = c.externalProvenance[:0]
 	c.lexerSkippedPrefixes = c.lexerSkippedPrefixes[:0]
+	c.recoveryDiscontinuityReductions = c.recoveryDiscontinuityReductions[:0]
 	c.children = c.children[:0]
 	c.fields = c.fields[:0]
 	c.aliases = c.aliases[:0]
@@ -3109,7 +3117,15 @@ func (c *Core) reductionParentForPath(
 	multiPop bool,
 	scratch *reductionOutputScratch,
 ) (SubtreeID, int64, ForkOrder, error) {
-	fields, aliases, err := c.remapReductionPlan(path.children, plan, scratch)
+	materializationPlan := plan
+	if path.recoveryDiscontinuity {
+		adjusted, err := truncateReductionPlanForRecoveryDiscontinuity(c, path.children, plan)
+		if err != nil {
+			return 0, 0, ForkOrder{}, err
+		}
+		materializationPlan = &adjusted
+	}
+	fields, aliases, err := c.remapReductionPlan(path.children, materializationPlan, scratch)
 	if err != nil {
 		return 0, 0, ForkOrder{}, err
 	}
@@ -3182,7 +3198,62 @@ func (c *Core) reductionParentForPath(
 			rec.fragile = true
 		}
 	}
+	if path.recoveryDiscontinuity {
+		c.recordRecoveryDiscontinuityReduction(payload, act.ChildCount)
+	}
 	return payload, scoreDelta, order, nil
+}
+
+type recoveryDiscontinuityReduction struct {
+	payload       SubtreeID
+	popChildCount uint8
+}
+
+func truncateReductionPlanForRecoveryDiscontinuity(c *Core, children []SubtreeID, plan *ReductionPlan) (ReductionPlan, error) {
+	if plan == nil {
+		return ReductionPlan{}, errors.New("parser-core phase zero: nil recovery-discontinuity reduction plan")
+	}
+	structuralCount := 0
+	for _, child := range children {
+		payload, err := c.subtree(child)
+		if err != nil {
+			return ReductionPlan{}, err
+		}
+		if !payload.extra {
+			structuralCount++
+		}
+	}
+	fields := make([]FieldMapEntry, 0, len(plan.fields))
+	for _, field := range plan.fields {
+		if int(field.ChildIndex) < structuralCount {
+			fields = append(fields, field)
+		}
+	}
+	aliases := plan.aliases
+	if len(aliases) > structuralCount {
+		aliases = aliases[:structuralCount]
+	}
+	return NewReductionPlan(plan.productionID, structuralCount, fields, aliases)
+}
+
+func (c *Core) recordRecoveryDiscontinuityReduction(payload SubtreeID, popChildCount uint8) {
+	for _, provenance := range c.recoveryDiscontinuityReductions {
+		if provenance.payload == payload {
+			return
+		}
+	}
+	c.recoveryDiscontinuityReductions = append(c.recoveryDiscontinuityReductions, recoveryDiscontinuityReduction{
+		payload: payload, popChildCount: popChildCount,
+	})
+}
+
+func (c *Core) recoveryDiscontinuityReductionPopCount(payload SubtreeID) (uint8, bool) {
+	for _, provenance := range c.recoveryDiscontinuityReductions {
+		if provenance.payload == payload {
+			return provenance.popChildCount, true
+		}
+	}
+	return 0, false
 }
 
 func (c *Core) reductionPlan(act Action) (ReductionPlan, error) {
@@ -3996,6 +4067,54 @@ type shallowPayloadClass struct {
 	external   bool
 }
 
+type recoveryMergeEquivalenceContext struct {
+	symbols []SelectedSymbolPolicy
+	source  RecoveryCostSource
+	memo    *RecoveryCostMemo
+}
+
+func (c *Core) recoveryMergePayloadsEquivalent(
+	leftPrev NodeID,
+	leftPayload SubtreeID,
+	rightPrev NodeID,
+	rightPayload SubtreeID,
+	context *recoveryMergeEquivalenceContext,
+) (bool, error) {
+	if leftPayload == rightPayload {
+		return true, nil
+	}
+	if context == nil || context.source == nil || len(context.symbols) == 0 {
+		return false, errors.New("parser-core phase zero: recovery merge equivalence context is unavailable")
+	}
+	left, err := c.subtree(leftPayload)
+	if err != nil {
+		return false, err
+	}
+	right, err := c.subtree(rightPayload)
+	if err != nil {
+		return false, err
+	}
+	if left.symbol != right.symbol {
+		return false, nil
+	}
+	leftCost, err := RecoveryNodeErrorCostMemo(context.symbols, context.source, context.memo, leftPayload)
+	if err != nil {
+		return false, err
+	}
+	rightCost, err := RecoveryNodeErrorCostMemo(context.symbols, context.source, context.memo, rightPayload)
+	if err != nil {
+		return false, err
+	}
+	if leftCost > 0 && rightCost > 0 {
+		return true, nil
+	}
+	shallow, err := c.shallowPayloadsEqual(leftPrev, leftPayload, rightPrev, rightPayload)
+	if err != nil || !shallow {
+		return shallow, err
+	}
+	return c.subtreeScannerStatePairsEqual(leftPayload, rightPayload)
+}
+
 func (c *Core) shallowPayloadClassEqual(link linkRecord, in linkInput) (bool, error) {
 	if link.prev != in.prev {
 		return false, nil
@@ -4173,6 +4292,15 @@ func (c *Core) factorExactPredecessorMerge(key boundaryKey, probe boundaryProbe,
 const maxRecursiveInsertDepth = 16
 
 func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int, folded *precedenceMaximumWitness) (NodeID, bool, error) {
+	return c.mergePredecessorsBoundedWithRecovery(leftID, rightID, depth, folded, nil)
+}
+
+func (c *Core) mergePredecessorsBoundedWithRecovery(
+	leftID, rightID NodeID,
+	depth int,
+	folded *precedenceMaximumWitness,
+	recovery *recoveryMergeEquivalenceContext,
+) (NodeID, bool, error) {
 	if depth > maxRecursiveInsertDepth {
 		return 0, false, errors.New("parser-core phase zero: recursive insertion depth limit")
 	}
@@ -4233,7 +4361,9 @@ func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int, folde
 	changed := false
 	for _, incoming := range rightLinks {
 		var inserted bool
-		links, inserted, err = c.insertLinkBounded(left.state, left.byteOffset, links, incoming, depth, folded)
+		links, inserted, err = c.insertLinkBoundedWithRecovery(
+			left.state, left.byteOffset, links, incoming, depth, folded, recovery,
+		)
 		if err != nil {
 			return 0, false, err
 		}
@@ -4281,6 +4411,18 @@ func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int, folde
 // predecessors recurse only when their complete outer edges are exact.
 
 func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkRecord, incoming linkRecord, depth int, folded *precedenceMaximumWitness) ([]linkRecord, bool, error) {
+	return c.insertLinkBoundedWithRecovery(state, byteOffset, links, incoming, depth, folded, nil)
+}
+
+func (c *Core) insertLinkBoundedWithRecovery(
+	state StateID,
+	byteOffset uint32,
+	links []linkRecord,
+	incoming linkRecord,
+	depth int,
+	folded *precedenceMaximumWitness,
+	recovery *recoveryMergeEquivalenceContext,
+) ([]linkRecord, bool, error) {
 	if folded == nil {
 		c.recordLinkUnionRejected()
 		return nil, false, errors.New("parser-core phase zero: missing folded precedence maximum witness")
@@ -4357,7 +4499,9 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 				phase0ABeginPredecessorMerge(c, incumbent.prev, incoming.prev)
 			}
 			nestedFolded := precedenceMaximumWitness{}
-			merged, changed, err := c.mergePredecessorsBounded(incumbent.prev, incoming.prev, depth+1, &nestedFolded)
+			merged, changed, err := c.mergePredecessorsBoundedWithRecovery(
+				incumbent.prev, incoming.prev, depth+1, &nestedFolded, recovery,
+			)
 			if err != nil {
 				if phase0AEnabled {
 					phase0AAbortPredecessorMerge(c)
@@ -4413,7 +4557,17 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 			c.recordLinkUnionRejected()
 			return nil, false, err
 		}
-		if !shallow {
+		equivalent := shallow
+		if recovery != nil {
+			equivalent, err = c.recoveryMergePayloadsEquivalent(
+				incumbent.prev, incumbent.payload, incoming.prev, incoming.payload, recovery,
+			)
+			if err != nil {
+				c.recordLinkUnionRejected()
+				return nil, false, err
+			}
+		}
+		if !equivalent {
 			continue
 		}
 		if incumbent.prev == incoming.prev {
@@ -4458,7 +4612,7 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 		if !mergeable {
 			continue
 		}
-		if !c.linkEdgesEqual(incumbent, incoming) {
+		if recovery == nil && !c.linkEdgesEqual(incumbent, incoming) {
 			c.recordLinkUnionRejected()
 			return nil, false, errors.New("parser-core phase zero: recursive insertion declined non-exact nested edge")
 		}
@@ -4470,7 +4624,9 @@ func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkR
 			phase0ABeginPredecessorMerge(c, incumbent.prev, incoming.prev)
 		}
 		nestedFolded := precedenceMaximumWitness{}
-		merged, changed, err := c.mergePredecessorsBounded(incumbent.prev, incoming.prev, depth+1, &nestedFolded)
+		merged, changed, err := c.mergePredecessorsBoundedWithRecovery(
+			incumbent.prev, incoming.prev, depth+1, &nestedFolded, recovery,
+		)
 		if err != nil {
 			if phase0AEnabled {
 				phase0AAbortPredecessorMerge(c)
@@ -6174,9 +6330,19 @@ func (c *Core) validateGenericMaterializationMetadata(id SubtreeID, record subtr
 			structuralCount++
 		}
 	}
-	plan, err := c.reductionPlanForPair(record.productionID, structuralCount)
+	planChildCount := structuralCount
+	if popChildCount, ok := c.recoveryDiscontinuityReductionPopCount(id); ok {
+		planChildCount = int(popChildCount)
+	}
+	plan, err := c.reductionPlanForPair(record.productionID, planChildCount)
 	if err != nil {
 		return err
+	}
+	if planChildCount != structuralCount {
+		plan, err = truncateReductionPlanForRecoveryDiscontinuity(c, children, &plan)
+		if err != nil {
+			return err
+		}
 	}
 	fields, aliases, err := c.remapReductionPlan(children, &plan, &c.reductionScratch)
 	if err != nil {

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -3522,6 +3522,10 @@ type linkInput struct {
 // scheduler owns the cost model. Core only authenticates the resulting value.
 type ReductionOutputCostFunc func(prev NodeID, payload SubtreeID) (uint32, error)
 
+// PayloadErrorPresenceFunc reports whether one payload carries a positive
+// recovery error cost. The scheduler owns the recovery pricing model.
+type PayloadErrorPresenceFunc func(payload SubtreeID) (bool, error)
+
 func (c *Core) storedErrorCostForLink(in linkInput) (uint32, error) {
 	lineage, err := c.nodeLineage(in.prev)
 	if err != nil {
@@ -4068,9 +4072,7 @@ type shallowPayloadClass struct {
 }
 
 type recoveryMergeEquivalenceContext struct {
-	symbols []SelectedSymbolPolicy
-	source  RecoveryCostSource
-	memo    *RecoveryCostMemo
+	payloadHasError PayloadErrorPresenceFunc
 }
 
 func (c *Core) recoveryMergePayloadsEquivalent(
@@ -4083,7 +4085,7 @@ func (c *Core) recoveryMergePayloadsEquivalent(
 	if leftPayload == rightPayload {
 		return true, nil
 	}
-	if context == nil || context.source == nil || len(context.symbols) == 0 {
+	if context == nil || context.payloadHasError == nil {
 		return false, errors.New("parser-core phase zero: recovery merge equivalence context is unavailable")
 	}
 	left, err := c.subtree(leftPayload)
@@ -4097,15 +4099,15 @@ func (c *Core) recoveryMergePayloadsEquivalent(
 	if left.symbol != right.symbol {
 		return false, nil
 	}
-	leftCost, err := RecoveryNodeErrorCostMemo(context.symbols, context.source, context.memo, leftPayload)
+	leftHasError, err := context.payloadHasError(leftPayload)
 	if err != nil {
 		return false, err
 	}
-	rightCost, err := RecoveryNodeErrorCostMemo(context.symbols, context.source, context.memo, rightPayload)
+	rightHasError, err := context.payloadHasError(rightPayload)
 	if err != nil {
 		return false, err
 	}
-	if leftCost > 0 && rightCost > 0 {
+	if leftHasError && rightHasError {
 		return true, nil
 	}
 	shallow, err := c.shallowPayloadsEqual(leftPrev, leftPayload, rightPrev, rightPayload)

--- a/internal/parsercorephase0/eof_recovery_shadow.go
+++ b/internal/parsercorephase0/eof_recovery_shadow.go
@@ -293,6 +293,7 @@ func planDiagnosticEOFRecoveryClone(live *Core, payloads []SubtreeID, providerWr
 		{len(live.links), coreLinkRecordBytes},
 		{len(live.subtrees), coreSubtreeRecordBytes},
 		{len(live.eofRecoveryRoots), coreSubtreeIDBytes},
+		{len(live.recoveryDiscontinuityReductions), coreRecoveryDiscontinuityReductionBytes},
 		{len(live.externalProvenance), coreExternalProvenanceBytes},
 		{len(live.lexerSkippedPrefixes), coreLexerSkippedPrefixBytes},
 		{len(live.children), coreChildRecordBytes},
@@ -458,6 +459,7 @@ func cloneDiagnosticEOFRecoveryCore(
 	shadow.links = cloneDiagnosticSlice(live.links, 0)
 	shadow.subtrees = cloneDiagnosticSlice(live.subtrees, 1)
 	shadow.eofRecoveryRoots = cloneDiagnosticSlice(live.eofRecoveryRoots, 1)
+	shadow.recoveryDiscontinuityReductions = cloneDiagnosticSlice(live.recoveryDiscontinuityReductions, 0)
 	shadow.externalProvenance = cloneDiagnosticSlice(live.externalProvenance, 0)
 	shadow.lexerSkippedPrefixes = cloneDiagnosticSlice(live.lexerSkippedPrefixes, 0)
 	shadow.children = cloneDiagnosticSlice(live.children, payloadCount)
@@ -543,6 +545,7 @@ func cloneDiagnosticSlice[T any](source []T, extraCapacity int) []T {
 func diagnosticEOFRecoveryCopiedArenasEqual(live, shadow *Core) bool {
 	if live == nil || shadow == nil || len(shadow.subtrees) < len(live.subtrees) ||
 		len(shadow.eofRecoveryRoots) < len(live.eofRecoveryRoots) ||
+		len(shadow.recoveryDiscontinuityReductions) < len(live.recoveryDiscontinuityReductions) ||
 		len(shadow.children) < len(live.children) {
 		return false
 	}
@@ -552,6 +555,7 @@ func diagnosticEOFRecoveryCopiedArenasEqual(live, shadow *Core) bool {
 		equalDiagnosticSlice(live.links, shadow.links) &&
 		equalDiagnosticSlice(live.subtrees, shadow.subtrees[:len(live.subtrees)]) &&
 		equalDiagnosticSlice(live.eofRecoveryRoots, shadow.eofRecoveryRoots[:len(live.eofRecoveryRoots)]) &&
+		equalDiagnosticSlice(live.recoveryDiscontinuityReductions, shadow.recoveryDiscontinuityReductions) &&
 		equalDiagnosticSlice(live.externalProvenance, shadow.externalProvenance) &&
 		equalDiagnosticSlice(live.lexerSkippedPrefixes, shadow.lexerSkippedPrefixes) &&
 		equalDiagnosticSlice(live.children, shadow.children[:len(live.children)]) &&
@@ -608,6 +612,7 @@ func diagnosticEOFRecoveryStorageDisjoint(live, shadow *Core) bool {
 		disjointDiagnosticSlice(live.links, shadow.links) &&
 		disjointDiagnosticSlice(live.subtrees, shadow.subtrees) &&
 		disjointDiagnosticSlice(live.eofRecoveryRoots, shadow.eofRecoveryRoots) &&
+		disjointDiagnosticSlice(live.recoveryDiscontinuityReductions, shadow.recoveryDiscontinuityReductions) &&
 		disjointDiagnosticSlice(live.externalProvenance, shadow.externalProvenance) &&
 		disjointDiagnosticSlice(live.lexerSkippedPrefixes, shadow.lexerSkippedPrefixes) &&
 		disjointDiagnosticSlice(live.children, shadow.children) &&

--- a/internal/parsercorephase0/error_region.go
+++ b/internal/parsercorephase0/error_region.go
@@ -82,7 +82,12 @@ func (c *Core) ErrorRegionLeaf(symbol Symbol, startByte, endByte uint32, extra b
 // preErrorHead at preErrorState, publishing the resumed head strategy 2's
 // absorb-then-resume step produces (the compact equivalent of production's
 // pushStackNode(fork, goal, errNode, ...), cRecoverToState,
-// parser_recover_c.go:3743). The resumed head is keyed as a shift boundary
+// parser_recover_c.go:3743). When preErrorHead is an S5 recovery
+// discontinuity, this operation replaces that null marker with the ERROR
+// subtree on every predecessor that matches the requested recovery state.
+// Other marker predecessors remain recovery candidates for different states;
+// they are not derivations of this resumed head. The resumed head is keyed as
+// a shift boundary
 // (shiftedBoundaryKey), matching the shape of every other terminal-carrying
 // attachment onto a head (scheduler_owned.go's shiftClassifiedUncheckpointed):
 // the ERROR container is, from the boundary index's point of view, one more
@@ -150,6 +155,47 @@ func (c *Core) errorRegionResumeUncheckpointed(
 	}, children, nil, nil)
 	if err != nil {
 		return Head{}, err
+	}
+	preErrorNode, err := c.node(preErrorHead.Node)
+	if err != nil {
+		return Head{}, err
+	}
+	if preErrorNode.state == 0 {
+		_, links, markerErr := c.recoveryDiscontinuityHeadLinks(preErrorHead)
+		if markerErr != nil {
+			return Head{}, markerErr
+		}
+		if preErrorNode.byteOffset > startByte {
+			return Head{}, errors.New("parser-core phase zero: recovery discontinuity resume starts before its marker")
+		}
+		var resumed Head
+		for _, link := range links {
+			predecessor, predecessorErr := c.node(link.prev)
+			if predecessorErr != nil {
+				return Head{}, predecessorErr
+			}
+			if predecessor.state != preErrorState {
+				continue
+			}
+			in := linkInput{prev: link.prev, payload: payload}
+			if cost != nil {
+				storedErrorCost, costErr := cost(in.prev, in.payload)
+				if costErr != nil {
+					return Head{}, costErr
+				}
+				in.storedErrorCost = storedErrorCost
+				in.hasStoredErrorCost = true
+			}
+			outcome, condenseErr := c.condenseWithOutcomeAtomic(c.shiftedBoundaryKey(preErrorState, endByte), in)
+			if condenseErr != nil {
+				return Head{}, condenseErr
+			}
+			resumed = outcome.head
+		}
+		if resumed.Node == 0 {
+			return Head{}, errors.New("parser-core phase zero: recovery discontinuity has no matching resume predecessor")
+		}
+		return resumed, nil
 	}
 	in := linkInput{prev: preErrorHead.Node, payload: payload}
 	if cost != nil {

--- a/internal/parsercorephase0/recovery_discontinuity_test.go
+++ b/internal/parsercorephase0/recovery_discontinuity_test.go
@@ -146,6 +146,361 @@ func TestRecoveryDiscontinuityOwnedCopiesAndUnionsLineage(t *testing.T) {
 	}
 }
 
+func TestErrorRegionResumeReplacesRecoveryDiscontinuity(t *testing.T) {
+	tables := &fakeTable{
+		actions: map[tableCell][]Action{
+			{state: 1, symbol: 30}: {{Type: ActionShift, State: 2}},
+			{state: 2, symbol: 31}: {{Type: ActionShift, State: 3}},
+			{state: 3, symbol: 32}: {{Type: ActionShift, State: 4}},
+			{state: 4, symbol: 9}:  {{Type: ActionReduce, Symbol: 20, ChildCount: 3, ProductionID: 5}},
+		},
+		gotos: map[tableCell]StateID{{state: 1, symbol: 20}: 5},
+	}
+	compact, err := New(tables, Limits{MaxDerivations: 4, MaxPopPaths: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err = compact.Shift(head, 30, 0, Token{Symbol: 30, StartByte: 0, EndByte: 1}, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		var appendErr error
+		head, appendErr = compact.AppendRecoveryDiscontinuityOwned(owner, head, RecoveryDiscontinuityContext{ByteOffset: 1})
+		return appendErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	marker := head
+	regionChild, err := compact.ErrorRegionLeaf(99, 1, 2, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err = compact.ErrorRegionResumeWithCost(head, 2, 1, 2, []SubtreeID{regionChild},
+		func(NodeID, SubtreeID) (uint32, error) { return 7, nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if head == marker {
+		t.Fatal("error-region resume retained the recovery discontinuity marker")
+	}
+	if canonical, ok := compact.CanonicalBoundary(2, 2, true, 0); !ok || canonical != head {
+		t.Fatalf("resumed canonical boundary=%+v/%t, want %+v", canonical, ok, head)
+	}
+	if cost, err := compact.RecoveryStoredErrorCost(head); err != nil || cost != 7 {
+		t.Fatalf("resumed recovery cost=%d err=%v, want 7", cost, err)
+	}
+	if cost, err := compact.RecoveryStoredErrorCost(marker); err != nil || cost != 0 {
+		t.Fatalf("marker recovery cost=%d err=%v, want zero", cost, err)
+	}
+	markerNode, err := compact.node(marker.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if markerNode.state != 0 || markerNode.byteOffset != 1 {
+		t.Fatalf("source marker=%+v, want ERROR_STATE at byte 1", markerNode)
+	}
+	if work := compact.Work(); work.PhysicalHeadMergeAttempts != 0 ||
+		work.PhysicalHeadMergeInputLinks != 0 || work.PhysicalHeadMergeSuccesses != 0 {
+		t.Fatalf("single marker resume reported a physical merge: %+v", work)
+	}
+	paths, err := compact.Derivations(head)
+	if err != nil || len(paths) != 1 || len(paths[0].Payloads) != 2 {
+		t.Fatalf("resumed derivations=%+v err=%v, want one path with shift and ERROR", paths, err)
+	}
+	resumedError, err := compact.Subtree(paths[0].Payloads[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resumedError.Symbol != ErrorRegionSymbol || !resumedError.Extra ||
+		resumedError.StartByte != 1 || resumedError.EndByte != 2 ||
+		!slices.Equal(resumedError.Children, []SubtreeID{regionChild}) {
+		t.Fatalf("resumed ERROR=%+v", resumedError)
+	}
+
+	head, err = compact.Shift(head, 31, 0, Token{Symbol: 31, StartByte: 2, EndByte: 3}, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err = compact.Shift(head, 32, 0, Token{Symbol: 32, StartByte: 3, EndByte: 4}, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	frontier, err := compact.Reduce(head, 9, 0, ForkOrder{})
+	if err != nil || len(frontier) != 1 {
+		t.Fatalf("reduce frontier=%v err=%v", frontier, err)
+	}
+	state, byteOffset, err := compact.Boundary(frontier[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != 5 || byteOffset != 4 {
+		t.Fatalf("reduced boundary=%d@%d, want 5@4", state, byteOffset)
+	}
+}
+
+func TestErrorRegionResumeReplacesMergedRecoveryDiscontinuities(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxNodes: 64, MaxLinks: 64, MaxSubtrees: 64, MaxDerivations: 8, MaxPopPaths: 8})
+	leftSeed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightSeed, err := compact.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftPayload, err := compact.appendSubtree(subtreeRecord{symbol: 10, terminal: true}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightPayload, err := compact.appendSubtree(subtreeRecord{symbol: 11, terminal: true}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftNode, err := compact.appendAdjacencyNode(7, 0, []linkRecord{{prev: leftSeed.Node, payload: leftPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightNode, err := compact.appendAdjacencyNode(7, 0, []linkRecord{{prev: rightSeed.Node, payload: rightPayload}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	context := RecoveryDiscontinuityContext{ByteOffset: 0}
+	var mergedMarker Head
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		left, appendErr := compact.AppendRecoveryDiscontinuityOwned(owner, Head{Node: leftNode}, context)
+		if appendErr != nil {
+			return appendErr
+		}
+		right, appendErr := compact.AppendRecoveryDiscontinuityOwned(owner, Head{Node: rightNode}, context)
+		if appendErr != nil {
+			return appendErr
+		}
+		mergedMarker, appendErr = compact.MergeRecoveryDiscontinuityHeadsOwned(owner, context, left, right)
+		return appendErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	regionChild, err := compact.ErrorRegionLeaf(99, 0, 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resumed, err := compact.ErrorRegionResumeWithCost(mergedMarker, 7, 0, 1, []SubtreeID{regionChild},
+		func(NodeID, SubtreeID) (uint32, error) { return 7, nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	resumedNode, err := compact.node(resumed.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	links, err := compact.nodeLinks(*resumedNode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 1 || links[0].isRecoveryDiscontinuity() || links[0].payload == 0 || links[0].prev == mergedMarker.Node {
+		t.Fatalf("resumed links=%+v, want one ERROR link over a merged predecessor", links)
+	}
+	paths, err := compact.Derivations(resumed)
+	if err != nil || len(paths) != 2 {
+		t.Fatalf("resumed derivations=%+v err=%v, want two", paths, err)
+	}
+	firstPayloads := make([]SubtreeID, 0, len(paths))
+	for _, path := range paths {
+		if len(path.Payloads) != 2 || path.Payloads[1] != links[0].payload {
+			t.Fatalf("resumed derivation=%+v, want predecessor payload plus shared ERROR", path)
+		}
+		firstPayloads = append(firstPayloads, path.Payloads[0])
+	}
+	slices.Sort(firstPayloads)
+	wantFirstPayloads := []SubtreeID{leftPayload, rightPayload}
+	slices.Sort(wantFirstPayloads)
+	if !slices.Equal(firstPayloads, wantFirstPayloads) {
+		t.Fatalf("resumed predecessor payloads=%v, want %v", firstPayloads, wantFirstPayloads)
+	}
+	if cost, err := compact.RecoveryStoredErrorCost(resumed); err != nil || cost != 7 {
+		t.Fatalf("resumed recovery cost=%d err=%v, want 7", cost, err)
+	}
+}
+
+func TestErrorRegionResumeSelectsMatchingMixedMarkerState(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxNodes: 64, MaxLinks: 64, MaxSubtrees: 64, MaxDerivations: 8, MaxPopPaths: 8})
+	left, err := compact.Seed(7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := compact.Seed(8, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	context := RecoveryDiscontinuityContext{ByteOffset: 0}
+	var merged Head
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		leftMarker, appendErr := compact.AppendRecoveryDiscontinuityOwned(owner, left, context)
+		if appendErr != nil {
+			return appendErr
+		}
+		rightMarker, appendErr := compact.AppendRecoveryDiscontinuityOwned(owner, right, context)
+		if appendErr != nil {
+			return appendErr
+		}
+		merged, appendErr = compact.MergeRecoveryDiscontinuityHeadsOwned(owner, context, leftMarker, rightMarker)
+		return appendErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := compact.ErrorRegionLeaf(99, 0, 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resumed, err := compact.ErrorRegionResume(merged, 7, 0, 1, []SubtreeID{child})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := compact.Derivations(resumed)
+	if err != nil || len(paths) != 1 || len(paths[0].Payloads) != 1 || paths[0].Payloads[0] == 0 {
+		t.Fatalf("mixed-state resumed derivations=%+v err=%v, want one matching path", paths, err)
+	}
+	resumedNode, err := compact.node(resumed.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	links, err := compact.nodeLinks(*resumedNode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 1 || links[0].prev != left.Node || links[0].prev == right.Node {
+		t.Fatalf("mixed-state resumed links=%+v, want only state-7 predecessor %d", links, left.Node)
+	}
+}
+
+func TestErrorRegionResumePreservesGapBeforeFirstErrorToken(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxNodes: 32, MaxLinks: 32, MaxSubtrees: 32, MaxDerivations: 4, MaxPopPaths: 4})
+	seed, err := compact.Seed(7, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var marker Head
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		var appendErr error
+		marker, appendErr = compact.AppendRecoveryDiscontinuityOwned(owner, seed, RecoveryDiscontinuityContext{ByteOffset: 0})
+		return appendErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := compact.ErrorRegionLeaf(99, 1, 2, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resumed, err := compact.ErrorRegionResume(marker, 7, 1, 2, []SubtreeID{child})
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, byteOffset, err := compact.Boundary(resumed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != 7 || byteOffset != 2 {
+		t.Fatalf("gap resume boundary=%d@%d, want 7@2", state, byteOffset)
+	}
+	paths, err := compact.Derivations(resumed)
+	if err != nil || len(paths) != 1 || len(paths[0].Payloads) != 1 {
+		t.Fatalf("gap resume derivations=%+v err=%v", paths, err)
+	}
+	region, err := compact.Subtree(paths[0].Payloads[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if region.StartByte != 1 || region.EndByte != 2 || !slices.Equal(region.Children, []SubtreeID{child}) {
+		t.Fatalf("gap resume ERROR=%+v", region)
+	}
+}
+
+func TestRecoveryDiscontinuityReductionCompactsChildrenLikeC(t *testing.T) {
+	tables := &fakeTable{
+		actions: map[tableCell][]Action{
+			{state: 1, symbol: 30}: {{Type: ActionShift, State: 2}},
+			{state: 0, symbol: 31}: {{Type: ActionShift, State: 3}},
+			{state: 3, symbol: 9}:  {{Type: ActionReduce, Symbol: 20, ChildCount: 3, ProductionID: 5}},
+		},
+		gotos: map[tableCell]StateID{{state: 1, symbol: 20}: 4},
+		fields: map[uint16][]FieldMapEntry{5: {
+			{FieldID: 1, ChildIndex: 0},
+			{FieldID: 2, ChildIndex: 1},
+			{FieldID: 3, ChildIndex: 2},
+		}},
+		aliases: map[productionKey][]Symbol{{productionID: 5, childCount: 3}: {101, 102, 103}},
+	}
+	compact, err := New(tables, Limits{MaxDerivations: 4, MaxPopPaths: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err = compact.Shift(head, 30, 0, Token{Symbol: 30, StartByte: 0, EndByte: 1}, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		var appendErr error
+		head, appendErr = compact.AppendRecoveryDiscontinuityOwned(owner, head, RecoveryDiscontinuityContext{ByteOffset: 1})
+		return appendErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err = compact.Shift(head, 31, 0, Token{Symbol: 31, StartByte: 1, EndByte: 2}, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	storageBefore := compact.StorageBytes()
+	frontier, err := compact.Reduce(head, 9, 0, ForkOrder{})
+	if err != nil || len(frontier) != 1 {
+		t.Fatalf("reduce frontier=%v err=%v", frontier, err)
+	}
+	paths, err := compact.Derivations(frontier[0])
+	if err != nil || len(paths) != 1 || len(paths[0].Payloads) != 1 {
+		t.Fatalf("reduced derivations=%v err=%v", paths, err)
+	}
+	parent, err := compact.Subtree(paths[0].Payloads[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parent.Children) != 2 || !reflect.DeepEqual(parent.Fields, []FieldMapEntry{
+		{FieldID: 1, ChildIndex: 0},
+		{FieldID: 2, ChildIndex: 1},
+	}) || !slices.Equal(parent.Aliases, []Symbol{101, 102}) {
+		t.Fatalf("compacted recovery parent=%+v", parent)
+	}
+	if len(compact.recoveryDiscontinuityReductions) != 1 ||
+		compact.recoveryDiscontinuityReductions[0] != (recoveryDiscontinuityReduction{payload: paths[0].Payloads[0], popChildCount: 3}) {
+		t.Fatalf("recovery reduction provenance=%+v", compact.recoveryDiscontinuityReductions)
+	}
+	if got := compact.StorageBytes() - storageBefore; got < coreRecoveryDiscontinuityReductionBytes {
+		t.Fatalf("storage growth=%d, want at least provenance size %d", got, coreRecoveryDiscontinuityReductionBytes)
+	}
+	compact.metadataConstructionAuthenticated = false
+	if _, err := compact.MaterializationView(paths[0].Payloads[0]); err != nil {
+		t.Fatalf("validate compacted metadata: %v", err)
+	}
+	if err := compact.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	if len(compact.recoveryDiscontinuityReductions) != 0 {
+		t.Fatalf("reset retained recovery reduction provenance: %+v", compact.recoveryDiscontinuityReductions)
+	}
+}
+
 func TestRecoveryDiscontinuityRejectsUnauthenticatedContextAndOrdinaryNullableLink(t *testing.T) {
 	core := newTinyCoreWithLimits(t, Limits{MaxNodes: 32, MaxLinks: 32, MaxSubtrees: 32, MaxDerivations: 8, MaxPopPaths: 8})
 	seed, err := core.Seed(3, 0)

--- a/internal/parsercorephase0/reduction_cost_publication_test.go
+++ b/internal/parsercorephase0/reduction_cost_publication_test.go
@@ -40,8 +40,8 @@ func TestReductionCostCallbackPublishesCumulativeMissingCost(t *testing.T) {
 	callbackCalls := 0
 	err := compact.RunFreshSchedulerSession(func(owner SchedulerTransactionToken) error {
 		var err error
-		outputs, err = compact.ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesAndCostOwned(
-			owner, nil, nil, boundary, 0, ForkOrder{},
+		outputs, err = compact.ReduceOutputsClassifiedIntoWithCostOwned(
+			owner, nil, boundary, 0, ForkOrder{},
 			func(prev NodeID, payload SubtreeID) (uint32, error) {
 				callbackCalls++
 				view, viewErr := compact.Subtree(payload)
@@ -83,18 +83,20 @@ func TestReductionCostCallbackPublishesCumulativeMissingCost(t *testing.T) {
 }
 
 func TestCostAwareReductionRejectsNilCallbackBeforeMutation(t *testing.T) {
-	for _, corridor := range []bool{false, true} {
-		name := "generic"
-		if corridor {
-			name = "corridor"
-		}
-		t.Run(name, func(t *testing.T) {
+	for _, mode := range []string{"generic", "generic-live", "corridor"} {
+		t.Run(mode, func(t *testing.T) {
 			compact, boundary := newReductionCostPublicationFixture(t)
 			before := captureSchedulerTransactionState(compact)
 			err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
-				if corridor {
+				if mode == "corridor" {
 					_, _ = compact.ReduceOutputsCorridorClassifiedIntoWithLiveCondenseCandidatesAndCostOwned(
 						owner, nil, nil, boundary, ForkOrder{}, nil,
+					)
+					return nil
+				}
+				if mode == "generic" {
+					_, _ = compact.ReduceOutputsClassifiedIntoWithCostOwned(
+						owner, nil, boundary, 0, ForkOrder{}, nil,
 					)
 					return nil
 				}

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -755,8 +755,8 @@ func (c *Core) MergeEquivalentHeadsWithStoredErrorCostOwned(
 }
 
 // MergeEquivalentRecoveryHeadsOwned merges equal-cost recovery heads with
-// C's positive-error subtree equivalence rule. The caller supplies the exact
-// symbol policy and the row-aware source used for recovery pricing.
+// C's positive-error subtree equivalence rule. The scheduler supplies the
+// recovery pricing decision through a callback.
 func (c *Core) MergeEquivalentRecoveryHeadsOwned(
 	owner SchedulerTransactionToken,
 	state StateID,
@@ -765,15 +765,13 @@ func (c *Core) MergeEquivalentRecoveryHeadsOwned(
 	shifted bool,
 	incumbent Head,
 	incoming Head,
-	symbols []SelectedSymbolPolicy,
-	source RecoveryCostSource,
-	memo *RecoveryCostMemo,
+	payloadHasError PayloadErrorPresenceFunc,
 ) (out Head, err error) {
 	if err = c.beginSchedulerOwned(owner); err != nil {
 		return out, err
 	}
 	defer c.recoverSchedulerOwnedPanic(owner)
-	if len(symbols) == 0 || source == nil {
+	if payloadHasError == nil {
 		return out, c.finishSchedulerOwned(
 			owner,
 			errors.New("parser-core phase zero: recovery head merge pricing context is unavailable"),
@@ -783,7 +781,7 @@ func (c *Core) MergeEquivalentRecoveryHeadsOwned(
 		frontier: c.frontier, state: state, byteOffset: byteOffset,
 		shifted: shifted, checkpoint: checkpoint,
 	}
-	context := recoveryMergeEquivalenceContext{symbols: symbols, source: source, memo: memo}
+	context := recoveryMergeEquivalenceContext{payloadHasError: payloadHasError}
 	out, err = c.mergeEquivalentHeadsAtBoundaryUncheckpointedWithRecovery(
 		key, incumbent, incoming, true, &context,
 	)

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -571,6 +571,18 @@ func (c *Core) mergeEquivalentHeadsAtBoundaryUncheckpointedWithCost(
 	incoming Head,
 	allowNonzeroCost bool,
 ) (Head, error) {
+	return c.mergeEquivalentHeadsAtBoundaryUncheckpointedWithRecovery(
+		key, incumbent, incoming, allowNonzeroCost, nil,
+	)
+}
+
+func (c *Core) mergeEquivalentHeadsAtBoundaryUncheckpointedWithRecovery(
+	key boundaryKey,
+	incumbent Head,
+	incoming Head,
+	allowNonzeroCost bool,
+	recovery *recoveryMergeEquivalenceContext,
+) (Head, error) {
 	if key.frontier != c.frontier {
 		return Head{}, errors.New("parser-core phase zero: physical head merge frontier mismatch")
 	}
@@ -648,7 +660,9 @@ func (c *Core) mergeEquivalentHeadsAtBoundaryUncheckpointedWithCost(
 	changed := false
 	for _, link := range incomingLinks {
 		var inserted bool
-		links, inserted, err = c.insertLinkBounded(key.state, key.byteOffset, links, link, 0, &folded)
+		links, inserted, err = c.insertLinkBoundedWithRecovery(
+			key.state, key.byteOffset, links, link, 0, &folded, recovery,
+		)
 		if err != nil {
 			return Head{}, err
 		}
@@ -736,6 +750,42 @@ func (c *Core) MergeEquivalentHeadsWithStoredErrorCostOwned(
 	}
 	out, err = c.mergeEquivalentHeadsAtBoundaryUncheckpointedWithCost(
 		key, incumbent, incoming, true,
+	)
+	return out, c.finishSchedulerOwned(owner, err)
+}
+
+// MergeEquivalentRecoveryHeadsOwned merges equal-cost recovery heads with
+// C's positive-error subtree equivalence rule. The caller supplies the exact
+// symbol policy and the row-aware source used for recovery pricing.
+func (c *Core) MergeEquivalentRecoveryHeadsOwned(
+	owner SchedulerTransactionToken,
+	state StateID,
+	byteOffset uint32,
+	checkpoint CheckpointID,
+	shifted bool,
+	incumbent Head,
+	incoming Head,
+	symbols []SelectedSymbolPolicy,
+	source RecoveryCostSource,
+	memo *RecoveryCostMemo,
+) (out Head, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return out, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if len(symbols) == 0 || source == nil {
+		return out, c.finishSchedulerOwned(
+			owner,
+			errors.New("parser-core phase zero: recovery head merge pricing context is unavailable"),
+		)
+	}
+	key := boundaryKey{
+		frontier: c.frontier, state: state, byteOffset: byteOffset,
+		shifted: shifted, checkpoint: checkpoint,
+	}
+	context := recoveryMergeEquivalenceContext{symbols: symbols, source: source, memo: memo}
+	out, err = c.mergeEquivalentHeadsAtBoundaryUncheckpointedWithRecovery(
+		key, incumbent, incoming, true, &context,
 	)
 	return out, c.finishSchedulerOwned(owner, err)
 }
@@ -1271,6 +1321,27 @@ func (c *Core) shiftExtraClassifiedCohortUncheckpointed(boundaries []ClassifiedB
 // delegates to the standalone reduction's uncheckpointed implementation.
 func (c *Core) ReduceOutputsClassifiedIntoOwned(owner SchedulerTransactionToken, dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder) (frontier []ReductionOutput, err error) {
 	return c.reduceOutputsClassifiedIntoMaybeLiveScopedOwned(owner, nil, false, dst, boundary, actionOrdinal, fork, nil)
+}
+
+// ReduceOutputsClassifiedIntoWithCostOwned applies one standalone reduction
+// and authenticates its cumulative recovery cost before publication.
+func (c *Core) ReduceOutputsClassifiedIntoWithCostOwned(
+	owner SchedulerTransactionToken,
+	dst []ReductionOutput,
+	boundary ClassifiedBoundary,
+	actionOrdinal int,
+	fork ForkOrder,
+	cost ReductionOutputCostFunc,
+) (frontier []ReductionOutput, err error) {
+	if cost == nil {
+		if err = c.beginSchedulerOwned(owner); err != nil {
+			return frontier, err
+		}
+		return frontier, c.finishSchedulerOwned(owner, errors.New("parser-core phase zero: reduction cost callback is required"))
+	}
+	return c.reduceOutputsClassifiedIntoMaybeLiveScopedOwned(
+		owner, nil, false, dst, boundary, actionOrdinal, fork, cost,
+	)
 }
 
 // ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesOwned scopes the condense candidates

--- a/internal/parsercorephase0/storage_bytes.go
+++ b/internal/parsercorephase0/storage_bytes.go
@@ -64,6 +64,7 @@ func (c *Core) StorageBytes() uint64 {
 		uint64(len(c.dropCohortLinkRefIndexes))*coreUint32Bytes +
 		uint64(len(c.subtrees))*coreSubtreeRecordBytes +
 		uint64(len(c.eofRecoveryRoots))*coreSubtreeIDBytes +
+		uint64(len(c.recoveryDiscontinuityReductions))*coreRecoveryDiscontinuityReductionBytes +
 		uint64(len(c.children))*coreChildRecordBytes +
 		uint64(len(c.fields))*coreFieldRecordBytes +
 		uint64(len(c.aliases))*coreAliasRecordBytes +
@@ -91,32 +92,33 @@ func (c *Core) StorageBytes() uint64 {
 // checkpoint interner, the boundary index, producer scratch, and scheduler
 // scratch buffers.
 var (
-	coreNodeLineageRecordBytes    = uint64(unsafe.Sizeof(nodeLineageRecord{}))
-	coreCheckpointIDBytes         = uint64(unsafe.Sizeof(CheckpointID(0)))
-	coreExternalProvenanceBytes   = uint64(unsafe.Sizeof(externalPayloadProvenance{}))
-	coreLexerSkippedPrefixBytes   = uint64(unsafe.Sizeof(lexerSkippedPrefixProvenance{}))
-	coreCheckpointRecordBytes     = uint64(unsafe.Sizeof(checkpointRecord{}))
-	coreCheckpointBucketBytes     = uint64(unsafe.Sizeof([32]byte{})) + uint64(unsafe.Sizeof(CheckpointID(0)))
-	coreBoundarySlotBytes         = uint64(unsafe.Sizeof(boundarySlot{}))
-	coreBoundaryMutationBytes     = uint64(unsafe.Sizeof(boundaryMutation{}))
-	coreNodeLineageMutationBytes  = uint64(unsafe.Sizeof(nodeLineageMutation{}))
-	coreUint32Bytes               = uint64(unsafe.Sizeof(uint32(0)))
-	coreCondenseCandidateBytes    = uint64(unsafe.Sizeof(CondenseCandidate{}))
-	coreUint64Bytes               = uint64(unsafe.Sizeof(uint64(0)))
-	coreNodeIDBytes               = uint64(unsafe.Sizeof(NodeID(0)))
-	coreHeadBytes                 = uint64(unsafe.Sizeof(Head{}))
-	coreLinkRecordSliceBytes      = uint64(unsafe.Sizeof([]linkRecord(nil)))
-	coreSubtreeIDBytes            = uint64(unsafe.Sizeof(SubtreeID(0)))
-	coreDropCohortPathStepBytes   = uint64(unsafe.Sizeof(dropCohortPathStep{}))
-	coreInt64Bytes                = uint64(unsafe.Sizeof(int64(0)))
-	coreForkOrderBytes            = uint64(unsafe.Sizeof(ForkOrder{}))
-	corePathPayloadBytes          = uint64(unsafe.Sizeof(pathPayload{}))
-	corePopPathBytes              = uint64(unsafe.Sizeof(popPath{}))
-	coreReductionBoundaryOutBytes = uint64(unsafe.Sizeof(reductionBoundaryOutput{}))
-	coreBoundaryKeyEntryBytes     = uint64(unsafe.Sizeof(boundaryKey{})) + uint64(unsafe.Sizeof(int(0)))
-	coreUint16Bytes               = uint64(unsafe.Sizeof(uint16(0)))
-	coreDropCohortRefBytes        = uint64(unsafe.Sizeof(DropCohortRef{}))
-	coreBoolBytes                 = uint64(unsafe.Sizeof(bool(false)))
+	coreNodeLineageRecordBytes              = uint64(unsafe.Sizeof(nodeLineageRecord{}))
+	coreCheckpointIDBytes                   = uint64(unsafe.Sizeof(CheckpointID(0)))
+	coreExternalProvenanceBytes             = uint64(unsafe.Sizeof(externalPayloadProvenance{}))
+	coreLexerSkippedPrefixBytes             = uint64(unsafe.Sizeof(lexerSkippedPrefixProvenance{}))
+	coreRecoveryDiscontinuityReductionBytes = uint64(unsafe.Sizeof(recoveryDiscontinuityReduction{}))
+	coreCheckpointRecordBytes               = uint64(unsafe.Sizeof(checkpointRecord{}))
+	coreCheckpointBucketBytes               = uint64(unsafe.Sizeof([32]byte{})) + uint64(unsafe.Sizeof(CheckpointID(0)))
+	coreBoundarySlotBytes                   = uint64(unsafe.Sizeof(boundarySlot{}))
+	coreBoundaryMutationBytes               = uint64(unsafe.Sizeof(boundaryMutation{}))
+	coreNodeLineageMutationBytes            = uint64(unsafe.Sizeof(nodeLineageMutation{}))
+	coreUint32Bytes                         = uint64(unsafe.Sizeof(uint32(0)))
+	coreCondenseCandidateBytes              = uint64(unsafe.Sizeof(CondenseCandidate{}))
+	coreUint64Bytes                         = uint64(unsafe.Sizeof(uint64(0)))
+	coreNodeIDBytes                         = uint64(unsafe.Sizeof(NodeID(0)))
+	coreHeadBytes                           = uint64(unsafe.Sizeof(Head{}))
+	coreLinkRecordSliceBytes                = uint64(unsafe.Sizeof([]linkRecord(nil)))
+	coreSubtreeIDBytes                      = uint64(unsafe.Sizeof(SubtreeID(0)))
+	coreDropCohortPathStepBytes             = uint64(unsafe.Sizeof(dropCohortPathStep{}))
+	coreInt64Bytes                          = uint64(unsafe.Sizeof(int64(0)))
+	coreForkOrderBytes                      = uint64(unsafe.Sizeof(ForkOrder{}))
+	corePathPayloadBytes                    = uint64(unsafe.Sizeof(pathPayload{}))
+	corePopPathBytes                        = uint64(unsafe.Sizeof(popPath{}))
+	coreReductionBoundaryOutBytes           = uint64(unsafe.Sizeof(reductionBoundaryOutput{}))
+	coreBoundaryKeyEntryBytes               = uint64(unsafe.Sizeof(boundaryKey{})) + uint64(unsafe.Sizeof(int(0)))
+	coreUint16Bytes                         = uint64(unsafe.Sizeof(uint16(0)))
+	coreDropCohortRefBytes                  = uint64(unsafe.Sizeof(DropCohortRef{}))
+	coreBoolBytes                           = uint64(unsafe.Sizeof(bool(false)))
 )
 
 // FootprintBytes returns a cheap, deterministic, O(1) estimate of the compact
@@ -153,6 +155,7 @@ func (c *Core) FootprintBytes() uint64 {
 		uint64(cap(c.links))*coreLinkRecordBytes +
 		uint64(cap(c.subtrees))*coreSubtreeRecordBytes +
 		uint64(cap(c.eofRecoveryRoots))*coreSubtreeIDBytes +
+		uint64(cap(c.recoveryDiscontinuityReductions))*coreRecoveryDiscontinuityReductionBytes +
 		uint64(cap(c.children))*coreChildRecordBytes +
 		uint64(cap(c.fields))*coreFieldRecordBytes +
 		uint64(cap(c.aliases))*coreAliasRecordBytes
@@ -318,6 +321,7 @@ func (c *Core) releaseRecordArenaReserve() {
 	c.dropCohortLinkRefJournal = nil
 	c.subtrees = nil
 	c.eofRecoveryRoots = nil
+	c.recoveryDiscontinuityReductions = nil
 	c.children = nil
 	c.dropCohortRefSpill = nil
 	c.dropCohortActions = nil
@@ -350,6 +354,7 @@ func (c *Core) releaseOversizedRetention() {
 	c.dropCohortLinkRefJournal = nil
 	c.subtrees = nil
 	c.eofRecoveryRoots = nil
+	c.recoveryDiscontinuityReductions = nil
 	c.externalProvenance = nil
 	c.lexerSkippedPrefixes = nil
 	c.children = nil

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1992,6 +1992,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 	branchOrder uint64,
 	nextCleanPathLineage *uint16,
 	captureLexerSkippedPrefixProvenance bool,
+	reductionCost core.ReductionOutputCostFunc,
 	allowRepetitionFork bool,
 	collectReceipts bool,
 	scratch *diagnosticParserCoreConflictScratch,
@@ -2046,6 +2047,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 				scratch.actionOutputs[:0], scratch.reductionOutputs[:0], compact, owner, classified, token,
 				action, ordinal, core.ForkOrder{Present: true, Value: trialOrder}, nextCleanPathLineage,
 				captureLexerSkippedPrefixProvenance,
+				reductionCost,
 			)
 			if applyErr != nil {
 				return applyErr
@@ -2094,6 +2096,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 			scratch.actionOutputs[:0], scratch.reductionOutputs[:0], compact, owner, classified, token,
 			primaryAction, 0, core.ForkOrder{}, nextCleanPathLineage,
 			captureLexerSkippedPrefixProvenance,
+			reductionCost,
 		)
 		if applyErr != nil {
 			return applyErr
@@ -4957,7 +4960,8 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestForHeader(inde
 	base := header.versionLexerSnapshot()
 	request := &s.versionLexerRequests[reference-1]
 	if request.valid && request.electionIndex == s.electionIndex &&
-		diagnosticParserCoreVersionLexerRequestStartsAtBoundary(request, byteOffset) &&
+		diagnosticParserCoreVersionLexerRequestStartsAtOwnedSnapshot(request, byteOffset) &&
+		s.versionLexerRequestSnapshotsValid(request) &&
 		diagnosticParserCoreVersionLexerSnapshotEqual(request.before, base) {
 		return request
 	}
@@ -4979,7 +4983,8 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestReferenceForHe
 	}
 	request := &s.versionLexerRequests[reference-1]
 	if request.valid && request.electionIndex == s.electionIndex &&
-		diagnosticParserCoreVersionLexerRequestStartsAtBoundary(request, byteOffset) &&
+		diagnosticParserCoreVersionLexerRequestStartsAtOwnedSnapshot(request, byteOffset) &&
+		s.versionLexerRequestSnapshotsValid(request) &&
 		diagnosticParserCoreVersionLexerSnapshotEqual(request.before, header.versionLexerSnapshot()) {
 		return reference
 	}
@@ -5003,7 +5008,8 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestForCell(
 	header := &s.headers[cell.headerIndex]
 	if !request.valid || request.electionIndex != s.electionIndex ||
 		cell.versionLexerRequest != header.versionLexerRequestReference() ||
-		!diagnosticParserCoreVersionLexerRequestStartsAtBoundary(request, cell.boundary.ByteOffset()) ||
+		!diagnosticParserCoreVersionLexerRequestStartsAtOwnedSnapshot(request, cell.boundary.ByteOffset()) ||
+		!s.versionLexerRequestSnapshotsValid(request) ||
 		cell.boundary.Head() != header.head ||
 		!diagnosticParserCoreVersionLexerSnapshotEqual(request.before, header.versionLexerSnapshot()) {
 		return nil, errors.New("parser-core phase zero: version lexer cell request is stale")
@@ -5011,21 +5017,43 @@ func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestForCell(
 	return request, nil
 }
 
-// diagnosticParserCoreVersionLexerRequestStartsAtBoundary authenticates the
-// cursor that produced a per-version token. A lexer can skip leading trivia,
-// so the token can start after the graph boundary. The owned before snapshot
-// must still start exactly at that boundary.
-func diagnosticParserCoreVersionLexerRequestStartsAtBoundary(
+// diagnosticParserCoreVersionLexerRequestStartsAtOwnedSnapshot validates the
+// token span against its owned cursor. A reduction preserves lookahead but can
+// move the graph head to a node with an earlier start byte or a new parser
+// state. The header-owned reference and snapshot authenticate the request.
+func diagnosticParserCoreVersionLexerRequestStartsAtOwnedSnapshot(
 	request *diagnosticParserCoreVersionLexerRequest,
-	byteOffset uint32,
+	boundaryByte uint32,
 ) bool {
 	if request == nil || request.before == nil || request.before.dfa.lexerPos < 0 ||
 		uint64(request.before.dfa.lexerPos) > math.MaxUint32 ||
-		uint32(request.before.dfa.lexerPos) != byteOffset ||
-		request.token.StartByte < byteOffset || request.token.EndByte < request.token.StartByte {
+		request.token.StartByte < uint32(request.before.dfa.lexerPos) ||
+		request.token.StartByte < boundaryByte ||
+		request.token.EndByte < request.token.StartByte {
 		return false
 	}
 	return true
+}
+
+func (s *diagnosticParserCoreGenericScheduler) versionLexerRequestSnapshotsValid(
+	request *diagnosticParserCoreVersionLexerRequest,
+) bool {
+	if s == nil || s.compact == nil || s.tokenSource == nil || s.tokenSource.language == nil ||
+		request == nil || request.before == nil || request.after == nil {
+		return false
+	}
+	for _, snapshot := range []*diagnosticParserCoreVersionLexerSnapshot{request.before, request.after} {
+		if err := snapshot.validateDestination(s.compact, s.tokenSource.language); err != nil {
+			return false
+		}
+		if err := snapshot.validate(); err != nil {
+			return false
+		}
+	}
+	return request.beforeID == request.before.afterCheckpoint &&
+		request.afterID == request.after.afterCheckpoint &&
+		request.beforeCheckpoint == request.before.afterCheckpointInfo &&
+		request.afterCheckpoint == request.after.afterCheckpointInfo
 }
 
 func (s *diagnosticParserCoreGenericScheduler) clearVersionLexerRequests() {
@@ -5273,7 +5301,7 @@ func (s *diagnosticParserCoreGenericScheduler) seedVersionLexerOwnershipMode(
 		baseline, baselineSet := header.recoveryNodeBaseline()
 		seed := beforeSeed
 		if header.shifted {
-			if !allowShiftedRecovery || header.recoveryRegion() == nil {
+			if !allowShiftedRecovery || !header.isRecoveryLineage() {
 				return errors.New("parser-core phase zero: shifted lexer seed is not an owned recovery absorber")
 			}
 			seed = afterSeed
@@ -5475,7 +5503,8 @@ func (s *diagnosticParserCoreGenericScheduler) activateVersionLexerOwnershipAtRa
 			headerIndex: raggedHeaderIndex,
 		}, nil
 	}
-	mixedRecovery := s5MissingLineageNeedsOwnedLexer(s, []int{raggedHeaderIndex})
+	mixedRecovery := s5MissingLineageNeedsOwnedLexer(s, []int{raggedHeaderIndex}) ||
+		s.recoveryAmbiguityNeedsOwnedLexer(raggedHeaderIndex)
 	// An open recovery region owns its scanner and parser frontier as one
 	// recovery lineage. Do not mix a new lexer-ownership tranche into any
 	// sibling unless this is the exact S5 absorber/missing frontier.
@@ -5536,6 +5565,29 @@ func (s *diagnosticParserCoreGenericScheduler) activateVersionLexerOwnershipAtRa
 	s.versionLexerOwnershipActive = true
 	rollback = false
 	return nil, nil
+}
+
+// recoveryAmbiguityNeedsOwnedLexer admits a recovery frontier after an
+// ordinary grammar fork. Shifted arms own the shared after cursor. The
+// no-action witness relexes from the shared before cursor.
+func (s *diagnosticParserCoreGenericScheduler) recoveryAmbiguityNeedsOwnedLexer(witnessIndex int) bool {
+	if s == nil || witnessIndex < 0 || witnessIndex >= len(s.headers) ||
+		s.work.RecoveryAmbiguityForks == 0 || !s.competingRecoveryFrontier() ||
+		s.headers[witnessIndex].shifted || s.headers[witnessIndex].accepted ||
+		s.headers[witnessIndex].recoveryRegion() != nil {
+		return false
+	}
+	shifted := 0
+	for index := range s.headers {
+		header := &s.headers[index]
+		if header.accepted || header.paused || header.checkpoint != s.checkpointID {
+			return false
+		}
+		if header.shifted {
+			shifted++
+		}
+	}
+	return shifted != 0
 }
 
 func (s *diagnosticParserCoreGenericScheduler) bindVersionLexerRequest(
@@ -8370,7 +8422,10 @@ func (s *diagnosticParserCoreGenericScheduler) classifyVersionLexerCell(
 	}
 	requestReference := s.versionLexerRequestReferenceForHeader(index)
 	if requestReference == 0 {
-		return diagnosticParserCoreGenericCell{}, false, nil, errors.New("parser-core phase zero: version lexer request was not published")
+		return diagnosticParserCoreGenericCell{}, false, nil, fmt.Errorf(
+			"parser-core phase zero: version lexer request was not published for header %d",
+			index,
+		)
 	}
 	request := &s.versionLexerRequests[requestReference-1]
 	if err := s.bindVersionLexerRequest(request); err != nil {
@@ -8948,16 +9003,9 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 						s.dispatchScratch.noActionIndices = append(s.dispatchScratch.noActionIndices, index)
 						continue
 					}
-					if verified, ok := diagnosticParserCoreSameSpanRelex(s.token, relexed); ok {
-						relexedSymbol = verified.Symbol
-						cellToken = verified
-						boundary, err = s.compact.ClassifyBoundary(header.head, core.Symbol(cellToken.Symbol))
-						if err != nil {
-							return nil, err
-						}
-						s.work.ActionLookups++
-						actions = boundary.Actions()
-						workCountRecordResolvedActionCell(actions.Len())
+					if relexed.Symbol != 0 && relexed.Symbol != s.token.Symbol &&
+						relexed.StartByte == s.token.StartByte && relexed.EndByte == s.token.EndByte {
+						return s.activateVersionLexerOwnershipAtRagged(index)
 					}
 				}
 			}
@@ -12268,7 +12316,23 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflict(before []Dia
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner core.SchedulerTransactionToken, before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) (err error) {
 	branchOrderBefore, nextSeqBefore := s.branchOrder, s.nextSeq
-	recoveryAmbiguitySource := s.headers[cell.headerIndex].isRecoveryLineage()
+	header := s.headers[cell.headerIndex]
+	recoveryAmbiguitySource := header.isRecoveryLineage()
+	storedHeadCost, costErr := s.compact.RecoveryStoredErrorCost(cell.boundary.Head())
+	if costErr != nil {
+		return costErr
+	}
+	recoveryCostRequired := recoveryAmbiguitySource || header.recoveryRegion() != nil ||
+		header.isRecoveryCosted() || storedHeadCost != 0
+	var reductionCost core.ReductionOutputCostFunc
+	var reductionCostMemo *core.RecoveryCostMemo
+	if recoveryCostRequired {
+		reductionCost, reductionCostMemo, costErr = s.recoveryOutputCostFunc()
+		if costErr != nil {
+			return costErr
+		}
+		defer reductionCostMemo.Reset()
+	}
 	token := cell.dispatchToken(s.token)
 	scannerBefore, scannerAfter := s.currentElection.ScannerBefore, s.currentElection.ScannerAfter
 	affectedHead := cell.boundary.Head()
@@ -12298,6 +12362,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 		s.compact, owner, s.headers[cell.headerIndex], int(cell.headerIndex), token, cell.boundary,
 		s.branchOrder, &s.nextCleanPathLineage,
 		s.options.captureLexerSkippedPrefixProvenance,
+		reductionCost,
 		cell.selectedBy == diagnosticParserCoreCellSelectionRepetitionFork,
 		s.fullReceipts(), &s.conflictScratch,
 	)
@@ -13025,7 +13090,7 @@ func (s *diagnosticParserCoreGenericScheduler) canonicalizeOwnedWithMutation(own
 	if s.recoveryIsolation {
 		var drops uint64
 		var applied bool
-		headers, drops, applied, err = s.condenseRecoveryVersions(headers)
+		headers, drops, applied, err = s.condenseRecoveryVersions(owner, headers)
 		if err != nil {
 			// The recovery canonicalizer copied header-owned pointers into its
 			// alternate buffer. Release that failed frontier before rollback.
@@ -13376,6 +13441,7 @@ func applyParserCoreConflictActionInto(
 	fork core.ForkOrder,
 	nextCleanPathLineage *uint16,
 	captureLexerSkippedPrefixProvenance bool,
+	reductionCost core.ReductionOutputCostFunc,
 ) ([]diagnosticParserCoreActionOutput, []core.ReductionOutput, error) {
 	if action.Type != core.ActionReduce {
 		switch action.Type {
@@ -13397,7 +13463,15 @@ func applyParserCoreConflictActionInto(
 			return nil, reductionDst, errors.New("parser-core phase zero: unknown conflict action")
 		}
 	}
-	outputs, err := compact.ReduceOutputsClassifiedIntoOwned(owner, reductionDst, classified, ordinal, fork)
+	var outputs []core.ReductionOutput
+	var err error
+	if reductionCost == nil {
+		outputs, err = compact.ReduceOutputsClassifiedIntoOwned(owner, reductionDst, classified, ordinal, fork)
+	} else {
+		outputs, err = compact.ReduceOutputsClassifiedIntoWithCostOwned(
+			owner, reductionDst, classified, ordinal, fork, reductionCost,
+		)
+	}
 	if err != nil {
 		return nil, outputs, err
 	}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -5568,8 +5568,8 @@ func (s *diagnosticParserCoreGenericScheduler) activateVersionLexerOwnershipAtRa
 }
 
 // recoveryAmbiguityNeedsOwnedLexer admits a recovery frontier after an
-// ordinary grammar fork. Shifted arms own the shared after cursor. The
-// no-action witness relexes from the shared before cursor.
+// ordinary grammar fork. Dispatch classifies every header before it executes
+// any shift, so each admitted header must still own the shared before cursor.
 func (s *diagnosticParserCoreGenericScheduler) recoveryAmbiguityNeedsOwnedLexer(witnessIndex int) bool {
 	if s == nil || witnessIndex < 0 || witnessIndex >= len(s.headers) ||
 		s.work.RecoveryAmbiguityForks == 0 || !s.competingRecoveryFrontier() ||
@@ -5577,17 +5577,14 @@ func (s *diagnosticParserCoreGenericScheduler) recoveryAmbiguityNeedsOwnedLexer(
 		s.headers[witnessIndex].recoveryRegion() != nil {
 		return false
 	}
-	shifted := 0
 	for index := range s.headers {
 		header := &s.headers[index]
-		if header.accepted || header.paused || header.checkpoint != s.checkpointID {
+		if header.shifted || header.accepted || header.paused ||
+			header.checkpoint != s.checkpointID || header.recoveryRegion() != nil {
 			return false
 		}
-		if header.shifted {
-			shifted++
-		}
 	}
-	return shifted != 0
+	return true
 }
 
 func (s *diagnosticParserCoreGenericScheduler) bindVersionLexerRequest(
@@ -9004,8 +9001,20 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 						continue
 					}
 					if relexed.Symbol != 0 && relexed.Symbol != s.token.Symbol &&
-						relexed.StartByte == s.token.StartByte && relexed.EndByte == s.token.EndByte {
+						relexed.StartByte == s.token.StartByte && relexed.EndByte == s.token.EndByte &&
+						s.recoveryAmbiguityNeedsOwnedLexer(index) {
 						return s.activateVersionLexerOwnershipAtRagged(index)
+					}
+					if verified, ok := diagnosticParserCoreSameSpanRelex(s.token, relexed); ok {
+						relexedSymbol = verified.Symbol
+						cellToken = verified
+						boundary, err = s.compact.ClassifyBoundary(header.head, core.Symbol(cellToken.Symbol))
+						if err != nil {
+							return nil, err
+						}
+						s.work.ActionLookups++
+						actions = boundary.Actions()
+						workCountRecordResolvedActionCell(actions.Len())
 					}
 				}
 			}

--- a/parsercore_phase0_generic_conflict_internal_test.go
+++ b/parsercore_phase0_generic_conflict_internal_test.go
@@ -735,6 +735,8 @@ func TestDiagnosticParserCoreGenericConflictArbitraryNOrdering(t *testing.T) {
 		},
 		receipt: &DiagnosticParserCoreGenericScheduler{},
 	}
+	scheduler.tokenSource = &dfaTokenSource{language: &Language{TokenCount: 10}}
+	scheduler.options.materializationSource = []byte("x")
 	cell := mustDiagnosticParserCoreGenericCell(t, compact, 2, headers[2], 9)
 	if err := scheduler.applyGenericConflict(before, cell); err != nil {
 		t.Fatal(err)
@@ -789,6 +791,75 @@ func TestDiagnosticParserCoreGenericConflictArbitraryNOrdering(t *testing.T) {
 			payload.ProductionID != 0 || payload.DynamicPrecedence != 0 || len(payload.Children) != 0 || len(payload.Fields) != 0 || len(payload.Aliases) != 0 ||
 			!payload.Terminal || !payload.External || payload.Extra {
 			t.Fatalf("external conflict payload %d=%+v", index, payload)
+		}
+	}
+}
+
+func TestDiagnosticParserCoreRecoveryConflictPricesReductionBeforePublication(t *testing.T) {
+	table := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 3, symbol: 10}: {
+				{Type: core.ActionReduce, Symbol: 7, ChildCount: 1},
+				{Type: core.ActionShift, State: 11},
+			},
+		},
+		gotos: map[genericConflictCell]core.StateID{{state: 1, symbol: 7}: 4},
+	}
+	compact, err := core.New(table, core.Limits{MaxDerivations: 4, MaxPopPaths: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.ShiftMissingLeaf(seed, 3, 5, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := diagnosticParserCoreHeader{head: head, creationSeq: 1}
+	header.markRecoveryLineage()
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		headers: []diagnosticParserCoreHeader{header},
+		token:   Token{Symbol: 10, StartByte: 0, EndByte: 1},
+		tokenSource: &dfaTokenSource{language: &Language{
+			TokenCount: 11,
+			SymbolMetadata: []SymbolMetadata{
+				{}, {}, {}, {}, {}, {Visible: true},
+			},
+		}},
+		branchOrder: 1,
+		nextSeq:     2,
+		options: DiagnosticParserCorePrefixOptions{
+			MaxDispatches:         10,
+			materializationSource: []byte("x"),
+		},
+		receipt: &DiagnosticParserCoreGenericScheduler{},
+	}
+	before, err := diagnosticParserCoreHeaderReceipts(compact, scheduler.headers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cell := mustDiagnosticParserCoreGenericCell(t, compact, 0, header, 10)
+	if err := scheduler.applyGenericConflict(before, cell); err != nil {
+		t.Fatal(err)
+	}
+	if len(scheduler.headers) != 2 {
+		t.Fatalf("recovery conflict headers=%d, want two", len(scheduler.headers))
+	}
+	for index, output := range scheduler.headers {
+		cost, costErr := compact.RecoveryStoredErrorCost(output.head)
+		if costErr != nil {
+			t.Fatal(costErr)
+		}
+		if cost != core.RecoveryCostPerMissingTree+core.RecoveryCostPerRecovery ||
+			!output.isRecoveryLineage() || !output.isRecoveryCosted() {
+			state, _, boundaryErr := compact.Boundary(output.head)
+			if boundaryErr != nil {
+				t.Fatal(boundaryErr)
+			}
+			t.Fatalf("output %d state=%d cost=%d recovery=%t costed=%t", index, state, cost, output.isRecoveryLineage(), output.isRecoveryCosted())
 		}
 	}
 }

--- a/parsercore_phase0_per_version_lexer_lifecycle_internal_test.go
+++ b/parsercore_phase0_per_version_lexer_lifecycle_internal_test.go
@@ -59,13 +59,197 @@ func newDiagnosticParserCoreOwnedLexerRequest(
 	after *diagnosticParserCoreVersionLexerSnapshot,
 ) diagnosticParserCoreVersionLexerRequest {
 	return diagnosticParserCoreVersionLexerRequest{
-		electionIndex: electionIndex,
-		state:         state,
-		token:         token,
-		before:        before,
-		after:         after,
-		valid:         true,
+		electionIndex:    electionIndex,
+		state:            state,
+		token:            token,
+		before:           before,
+		after:            after,
+		beforeCheckpoint: before.afterCheckpointInfo,
+		afterCheckpoint:  after.afterCheckpointInfo,
+		beforeID:         before.afterCheckpoint,
+		afterID:          after.afterCheckpoint,
+		valid:            true,
 	}
+}
+
+func TestDiagnosticParserCoreOwnedLexerRequestSurvivesReducedHeadStart(t *testing.T) {
+	table := &genericConflictTable{cells: map[genericConflictCell][]core.Action{
+		{state: 7, symbol: 9}: {{Type: core.ActionShift, State: 8}},
+	}}
+	compact, err := core.New(table, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(7, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	language := &Language{Name: "owned-lexer-reduced-head-start-test"}
+	before := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 15)
+	after := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 18)
+	request := newDiagnosticParserCoreOwnedLexerRequest(
+		4,
+		7,
+		Token{Symbol: 9, StartByte: 16, EndByte: 18},
+		before,
+		after,
+	)
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		tokenSource: &dfaTokenSource{
+			lexer:    &Lexer{},
+			language: language,
+		},
+		headers: []diagnosticParserCoreHeader{{
+			head: head,
+			versionState: &diagnosticParserCoreVersionState{
+				relexSnapshot: before,
+				lexerRequest:  1,
+			},
+		}},
+		electionIndex:        4,
+		versionLexerRequests: []diagnosticParserCoreVersionLexerRequest{request},
+	}
+	if got := scheduler.versionLexerRequestForHeader(0); got != &scheduler.versionLexerRequests[0] {
+		t.Fatalf("request for reduced head=%p, want %p", got, &scheduler.versionLexerRequests[0])
+	}
+	boundary, err := compact.ClassifyBoundary(head, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cell := diagnosticParserCoreGenericCell{headerIndex: 0, boundary: boundary, versionLexerRequest: 1}
+	if got, err := scheduler.versionLexerRequestForCell(cell); err != nil || got != &scheduler.versionLexerRequests[0] {
+		t.Fatalf("cell request=%p err=%v, want %p", got, err, &scheduler.versionLexerRequests[0])
+	}
+	reducedHead, err := compact.Seed(8, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler.headers[0].head = reducedHead
+	if got := scheduler.versionLexerRequestForHeader(0); got != &scheduler.versionLexerRequests[0] {
+		t.Fatalf("request after parser-state reduction=%p, want %p", got, &scheduler.versionLexerRequests[0])
+	}
+	reducedBoundary, err := compact.ClassifyBoundary(reducedHead, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reducedCell := diagnosticParserCoreGenericCell{headerIndex: 0, boundary: reducedBoundary, versionLexerRequest: 1}
+	if got, err := scheduler.versionLexerRequestForCell(reducedCell); err != nil || got != &scheduler.versionLexerRequests[0] {
+		t.Fatalf("reduced cell request=%p err=%v, want %p", got, err, &scheduler.versionLexerRequests[0])
+	}
+}
+
+func TestDiagnosticParserCoreOwnedLexerRequestRejectsTokenBeforeCurrentBoundary(t *testing.T) {
+	table := &genericConflictTable{cells: map[genericConflictCell][]core.Action{
+		{state: 7, symbol: 9}: {{Type: core.ActionShift, State: 8}},
+	}}
+	compact, err := core.New(table, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(7, 17)
+	if err != nil {
+		t.Fatal(err)
+	}
+	language := &Language{Name: "owned-lexer-later-boundary-test"}
+	before := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 15)
+	after := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 18)
+	request := newDiagnosticParserCoreOwnedLexerRequest(
+		4,
+		7,
+		Token{Symbol: 9, StartByte: 16, EndByte: 18},
+		before,
+		after,
+	)
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		tokenSource: &dfaTokenSource{
+			lexer:    &Lexer{},
+			language: language,
+		},
+		headers: []diagnosticParserCoreHeader{{
+			head: head,
+			versionState: &diagnosticParserCoreVersionState{
+				relexSnapshot: before,
+				lexerRequest:  1,
+			},
+		}},
+		electionIndex:        4,
+		versionLexerRequests: []diagnosticParserCoreVersionLexerRequest{request},
+	}
+	if got := scheduler.versionLexerRequestForHeader(0); got != nil {
+		t.Fatalf("request before current boundary=%+v, want nil", got)
+	}
+	boundary, err := compact.ClassifyBoundary(head, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cell := diagnosticParserCoreGenericCell{headerIndex: 0, boundary: boundary, versionLexerRequest: 1}
+	if got, err := scheduler.versionLexerRequestForCell(cell); got != nil || err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("cell request=%p err=%v, want stale rejection", got, err)
+	}
+}
+
+func TestDiagnosticParserCoreOwnedLexerRequestRejectsInvalidSnapshots(t *testing.T) {
+	table := &genericConflictTable{cells: map[genericConflictCell][]core.Action{
+		{state: 7, symbol: 9}: {{Type: core.ActionShift, State: 8}},
+	}}
+	compact, err := core.New(table, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(7, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	language := &Language{Name: "owned-lexer-invalid-snapshot-test"}
+	before := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 9)
+	after := newDiagnosticParserCoreOwnedLexerSnapshot(t, compact, language, 10)
+	request := newDiagnosticParserCoreOwnedLexerRequest(
+		4,
+		7,
+		Token{Symbol: 9, StartByte: 9, EndByte: 10},
+		before,
+		after,
+	)
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		tokenSource: &dfaTokenSource{
+			lexer:    &Lexer{},
+			language: language,
+		},
+		headers: []diagnosticParserCoreHeader{{
+			head: head,
+			versionState: &diagnosticParserCoreVersionState{
+				relexSnapshot: before,
+				lexerRequest:  1,
+			},
+		}},
+		electionIndex:        4,
+		versionLexerRequests: []diagnosticParserCoreVersionLexerRequest{request},
+	}
+	boundary, err := compact.ClassifyBoundary(head, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cell := diagnosticParserCoreGenericCell{headerIndex: 0, boundary: boundary, versionLexerRequest: 1}
+
+	t.Run("reset generation", func(t *testing.T) {
+		before.coreGeneration++
+		if got := scheduler.versionLexerRequestForHeader(0); got != nil {
+			t.Fatalf("request with stale generation=%+v, want nil", got)
+		}
+		before.coreGeneration--
+	})
+
+	t.Run("nil after snapshot", func(t *testing.T) {
+		saved := scheduler.versionLexerRequests[0].after
+		scheduler.versionLexerRequests[0].after = nil
+		if got, err := scheduler.versionLexerRequestForCell(cell); got != nil || err == nil || !strings.Contains(err.Error(), "stale") {
+			t.Fatalf("malformed cell request=%p err=%v, want stale rejection", got, err)
+		}
+		scheduler.versionLexerRequests[0].after = saved
+	})
 }
 
 func TestDiagnosticParserCoreOwnedLexerSeedingSkipsAcceptedHeader(t *testing.T) {

--- a/parsercore_phase0_recovery_condense.go
+++ b/parsercore_phase0_recovery_condense.go
@@ -46,6 +46,84 @@ func diagnosticParserCoreMergeEquivalentRecoveryStatus(
 	}
 }
 
+func (s *diagnosticParserCoreGenericScheduler) mergeEquivalentRecoveryCondenseEntriesOwned(
+	owner core.SchedulerTransactionToken,
+	target *diagnosticParserCoreRecoveryCondenseEntry,
+	candidate diagnosticParserCoreRecoveryCondenseEntry,
+	symbols []core.SelectedSymbolPolicy,
+	source core.RecoveryCostSource,
+	memo *core.RecoveryCostMemo,
+) (bool, error) {
+	if s == nil || s.compact == nil || target == nil || target.header.accepted ||
+		candidate.header.accepted || target.header.paused || candidate.header.paused ||
+		target.header.recoveryRegion() != nil || candidate.header.recoveryRegion() != nil ||
+		target.key != candidate.key ||
+		!s.versionLexerStateEqual(target.header.versionState, candidate.header.versionState) {
+		return false, nil
+	}
+	incumbent := target.header.head
+	incoming := candidate.header.head
+	canonical, ok := s.compact.CanonicalBoundary(
+		target.key.state,
+		target.key.byteOffset,
+		target.key.shifted,
+		target.key.checkpoint,
+	)
+	if !ok {
+		return false, nil
+	}
+	if canonical == incoming {
+		incumbent, incoming = incoming, incumbent
+	} else if canonical != incumbent {
+		return false, nil
+	}
+	merged, err := s.compact.MergeEquivalentRecoveryHeadsOwned(
+		owner,
+		target.key.state,
+		target.key.byteOffset,
+		target.key.checkpoint,
+		target.key.shifted,
+		incumbent,
+		incoming,
+		symbols,
+		source,
+		memo,
+	)
+	if err != nil {
+		return false, err
+	}
+	target.header.head = merged
+	target.header.recoveryFlags |= candidate.header.recoveryFlags
+	target.header.frontierSequence = mergeDiagnosticParserCoreFrontier(
+		target.header.frontierSequence,
+		candidate.header.frontierSequence,
+	)
+	target.header.cleanPathRank, target.header.cleanPathLineage = mergeDiagnosticParserCoreCleanPathLineage(
+		target.header.cleanPathRank,
+		target.header.cleanPathLineage,
+		candidate.header.cleanPathRank,
+		candidate.header.cleanPathLineage,
+	)
+	target.header.convergedReductionSplit = target.header.convergedReductionSplit || candidate.header.convergedReductionSplit
+	target.header.resurrectionUnproved = target.header.resurrectionUnproved || candidate.header.resurrectionUnproved
+	if candidate.header.altSet.Len() != 0 {
+		incomparable := s.compact.AlternativeSetIncomparable(target.header.altSet, candidate.header.altSet)
+		s.compact.UnionAlternativeSet(&target.header.altSet, candidate.header.altSet)
+		target.header.blended = target.header.blended || candidate.header.blended || incomparable
+	}
+	if !candidate.header.dropCohortRefs.Empty() || candidate.header.dropCohortRefs.Overflowed() || candidate.header.dropCohortRefs.Blended() {
+		if _, err := s.compact.UnionDropCohortRefsChecked(
+			&target.header.dropCohortRefs,
+			candidate.header.dropCohortRefs,
+		); err != nil {
+			return false, err
+		}
+	}
+	diagnosticParserCoreMergeEquivalentRecoveryStatus(target, candidate)
+	s.invalidateVerifierHeaderBinding()
+	return true, nil
+}
+
 func diagnosticParserCoreRecoveryCondenseSameGroup(
 	left, right diagnosticParserCoreRecoveryCondenseEntry,
 ) bool {
@@ -315,6 +393,7 @@ func (s *diagnosticParserCoreGenericScheduler) recoveryCondenseEntry(
 // it keeps the first six distinct merge keys. Accepted versions stay outside
 // the competition and retain their acceptance order.
 func (s *diagnosticParserCoreGenericScheduler) condenseRecoveryVersions(
+	owner core.SchedulerTransactionToken,
 	headers []diagnosticParserCoreHeader,
 ) ([]diagnosticParserCoreHeader, uint64, bool, error) {
 	if s == nil || s.compact == nil || !s.recoveryIsolation ||
@@ -369,17 +448,33 @@ func (s *diagnosticParserCoreGenericScheduler) condenseRecoveryVersions(
 			clearScratch()
 			return headers, 0, false, nil
 		}
-		scratch = append(scratch, entry)
-		representative := true
-		for prior := 0; prior < len(scratch)-1; prior++ {
+		representative := -1
+		for prior := range scratch {
 			if scratch[prior].key == entry.key {
-				representative = false
-				diagnosticParserCoreMergeEquivalentRecoveryStatus(&scratch[prior], entry)
+				representative = prior
 				break
 			}
 		}
-		if representative {
+		if representative < 0 {
+			scratch = append(scratch, entry)
 			order = append(order, len(scratch)-1)
+			continue
+		}
+		merged, mergeErr := s.mergeEquivalentRecoveryCondenseEntriesOwned(
+			owner,
+			&scratch[representative],
+			entry,
+			symbols,
+			src,
+			&memo,
+		)
+		if mergeErr != nil {
+			clearScratch()
+			return headers, 0, false, mergeErr
+		}
+		if !merged {
+			scratch = append(scratch, entry)
+			diagnosticParserCoreMergeEquivalentRecoveryStatus(&scratch[representative], entry)
 		}
 	}
 	activeEntries := len(scratch)

--- a/parsercore_phase0_recovery_condense.go
+++ b/parsercore_phase0_recovery_condense.go
@@ -77,6 +77,10 @@ func (s *diagnosticParserCoreGenericScheduler) mergeEquivalentRecoveryCondenseEn
 	} else if canonical != incumbent {
 		return false, nil
 	}
+	payloadHasError := func(payload core.SubtreeID) (bool, error) {
+		cost, err := core.RecoveryNodeErrorCostMemo(symbols, source, memo, payload)
+		return cost > 0, err
+	}
 	merged, err := s.compact.MergeEquivalentRecoveryHeadsOwned(
 		owner,
 		target.key.state,
@@ -85,9 +89,7 @@ func (s *diagnosticParserCoreGenericScheduler) mergeEquivalentRecoveryCondenseEn
 		target.key.shifted,
 		incumbent,
 		incoming,
-		symbols,
-		source,
-		memo,
+		payloadHasError,
 	)
 	if err != nil {
 		return false, err

--- a/parsercore_phase0_recovery_lineage_fork_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_fork_internal_test.go
@@ -234,6 +234,72 @@ func TestS5MissingInsertionForkPublishesBothRecoveryLineages(t *testing.T) {
 	}
 }
 
+func TestS5AbsorberPreservesMixedParserStatesForRecoverySelection(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	other, err := scheduler.compact.Seed(core.StateID(3), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	headers := []diagnosticParserCoreHeader{
+		scheduler.headers[0],
+		{head: other, creationSeq: 4},
+	}
+	staged := diagnosticParserCoreS5Work{}
+	var absorb diagnosticParserCoreHeader
+	err = scheduler.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		var absorbErr error
+		absorb, absorbErr = scheduler.s5AppendAndMergeAbsorberOwned(owner, headers, 0, 1, &staged)
+		return absorbErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if absorb.head.Node == 0 {
+		t.Fatal("mixed-state absorber did not publish a recovery marker")
+	}
+	stats, err := scheduler.compact.Stats(absorb.head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.CurrentExactPaths != 2 || staged.recoveryDiscontinuityMerges != 1 {
+		t.Fatalf("mixed-state absorber stats=%+v work=%+v, want two paths and one marker merge", stats, staged)
+	}
+	region := absorb.recoveryRegion()
+	if region == nil || region.state != 1 {
+		t.Fatalf("mixed-state recovery region=%+v, want first recovery state 1", region)
+	}
+}
+
+func TestS5AbsorberPreservesLexerGapBeforeErrorRegion(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	scheduler.token.StartByte = 2
+	scheduler.token.EndByte = 3
+	staged := diagnosticParserCoreS5Work{}
+	var absorb diagnosticParserCoreHeader
+	err := scheduler.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		var absorbErr error
+		absorb, absorbErr = scheduler.s5AppendAndMergeAbsorberOwned(owner, scheduler.headers, 0, 1, &staged)
+		return absorbErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if absorb.head.Node == 0 {
+		t.Fatal("lexer-gap absorber did not publish a recovery marker")
+	}
+	state, byteOffset, err := scheduler.compact.Boundary(absorb.head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != 0 || byteOffset != 1 {
+		t.Fatalf("lexer-gap marker=%d@%d, want ERROR_STATE at byte 1", state, byteOffset)
+	}
+	region := absorb.recoveryRegion()
+	if region == nil || region.state != 1 || region.startByte != 2 || region.endByte != 3 || len(region.children) != 1 {
+		t.Fatalf("lexer-gap region=%+v, want state 1 over bytes 2..3", region)
+	}
+}
+
 func TestS5MissingInsertionClampsInheritedBaselineBeforeFork(t *testing.T) {
 	scheduler := newRecoveryLineageForkScheduler(t, true)
 	scheduler.headers[0].publishRecoveryCondenseState(0, 0, 9, true)

--- a/parsercore_phase0_s5.go
+++ b/parsercore_phase0_s5.go
@@ -815,7 +815,6 @@ func (s *diagnosticParserCoreGenericScheduler) s5AppendAndMergeAbsorberOwned(
 		return diagnosticParserCoreHeader{}, err
 	}
 	context := core.RecoveryDiscontinuityContext{ErrorState: 0, ByteOffset: byteOffset, Checkpoint: checkpoint}
-	markers := make([]core.Head, 0, len(anyHeaders))
 	for _, header := range anyHeaders {
 		_, candidateByte, err := s.compact.Boundary(header.head)
 		if err != nil {
@@ -834,6 +833,9 @@ func (s *diagnosticParserCoreGenericScheduler) s5AppendAndMergeAbsorberOwned(
 		if !s.versionLexerStateEqual(anyHeaders[0].versionState, header.versionState) {
 			return diagnosticParserCoreHeader{}, nil
 		}
+	}
+	markers := make([]core.Head, 0, len(anyHeaders))
+	for _, header := range anyHeaders {
 		marker, err := s.compact.AppendRecoveryDiscontinuityOwned(owner, header.head, context)
 		if err != nil {
 			return diagnosticParserCoreHeader{}, err

--- a/parsercore_phase0_stage6_scala_recovery_ambiguity_internal_test.go
+++ b/parsercore_phase0_stage6_scala_recovery_ambiguity_internal_test.go
@@ -1,0 +1,87 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import "testing"
+
+// TestStage6ScalaRecoveryThroughAmbiguity locks the first Scala grammar-
+// certification witness. C selects the absorbed-error lineage after an
+// ordinary grammar fork. The compact route must make the same selection.
+func TestStage6ScalaRecoveryThroughAmbiguity(t *testing.T) {
+	runner := package2ScalaStrictRunner(t)
+	const source = "val f = (: Int) => x\n"
+	_, tokenSource, runErr := runner.executeSchedulerOpenWithObserverAndErrorRuns(
+		[]byte(source), runner.compact, true, diagnosticParserCoreSeedObserver{}, true,
+	)
+	if tokenSource != nil {
+		tokenSource.Close()
+	}
+	if runErr != nil {
+		if runner.scheduler.receipt != nil {
+			t.Fatalf("compact route declined: %v; stop=%+v", runErr, runner.scheduler.receipt.Stop)
+		}
+		t.Fatalf("compact route declined before receipt: %v", runErr)
+	}
+	if runner.scheduler.receipt == nil || runner.scheduler.receipt.Acceptance == nil {
+		t.Fatalf("compact route returned no acceptance: %+v", runner.scheduler.receipt)
+	}
+
+	acceptance := runner.scheduler.receipt.Acceptance
+	work := acceptance.Work
+	if work.RecoveryAmbiguityForks == 0 || work.RecoveryLineageSelections != 1 || work.Accepts != 1 {
+		t.Fatalf("recovery competition did not execute as required: %+v", work)
+	}
+	if acceptance.CoreWork.PhysicalHeadMergeAttempts == 0 || acceptance.CoreWork.PhysicalHeadMergeSuccesses == 0 {
+		t.Fatalf("physical recovery merging did not execute: %+v", acceptance.CoreWork)
+	}
+	if len(runner.scheduler.versionLexerRequests) == 0 {
+		t.Fatal("per-version lexer ownership did not execute")
+	}
+
+	tree, err := runner.materializeSelection([]byte(source), runner.compact, &runner.scheduler)
+	if err != nil {
+		t.Fatalf("materialize compact selection: %v", err)
+	}
+	defer tree.Release()
+	root := tree.RootNode()
+	const wantSExpr = "(compilation_unit (val_definition (identifier) (lambda_expression (bindings (ERROR) (binding (identifier))) (identifier))))"
+	if got := root.SExpr(runner.lang); got != wantSExpr {
+		t.Fatalf("S-expression=%q, want %q", got, wantSExpr)
+	}
+	if root.StartByte() != 0 || root.EndByte() != uint32(len(source)) || root.IsError() || !root.HasError() {
+		t.Fatalf("root=%d..%d error=%t has_error=%t, want 0..%d non-error with error content",
+			root.StartByte(), root.EndByte(), root.IsError(), root.HasError(), len(source))
+	}
+
+	var errorNode, binding *Node
+	missingCount := 0
+	walkResultTree(root, func(node *Node) {
+		if node.IsMissing() {
+			missingCount++
+		}
+		switch node.Type(runner.lang) {
+		case "ERROR":
+			errorNode = node
+		case "binding":
+			binding = node
+		}
+	})
+	if missingCount != 0 {
+		t.Fatalf("materialized missing nodes=%d, want zero", missingCount)
+	}
+	if errorNode == nil || errorNode.StartByte() != 9 || errorNode.EndByte() != 10 || !errorNode.IsError() {
+		t.Fatalf("ERROR node=%v, want error 9..10", errorNode)
+	}
+	if errorNode.ChildCount() != 1 || errorNode.Child(0).Type(runner.lang) != ":" ||
+		errorNode.Child(0).StartByte() != 9 || errorNode.Child(0).EndByte() != 10 {
+		t.Fatalf("ERROR child shape is wrong: %v", errorNode)
+	}
+	if binding == nil || binding.StartByte() != 11 || binding.EndByte() != 14 || binding.ChildCount() != 1 ||
+		binding.Child(0).Type(runner.lang) != "identifier" || binding.Child(0).Text([]byte(source)) != "Int" {
+		t.Fatalf("binding shape is wrong: %v", binding)
+	}
+	const wantDigest = "454a064cdf50bdcfa6eb1cdfd1faaebcda41a02995dea6befbe356bb42ed8dda"
+	if got := requireDiagnosticParserCoreCanonicalTreeDigest(t, tree, runner.lang); got != wantDigest {
+		t.Fatalf("canonical tree digest=%s, want %s", got, wantDigest)
+	}
+}


### PR DESCRIPTION
Stage 6 grammar certification found a Scala recovery topology mismatch.

The compact route resumed above the null recovery marker. Later reductions counted that marker and reached the wrong parser state.

This change:

- replaces the marker with the ERROR subtree on matching recovery predecessors;
- preserves mixed recovery-state candidates and same-state graph paths;
- carries recovery costs through reductions and physical merging;
- strengthens per-version lexer ownership checks;
- pins the locked Scala tree, ranges, errors, telemetry, and deep digest.

Verification:

- focused parser-core recovery tests pass;
- earlier Scala package gates pass;
- both compact build-tag configurations compile;
- the locked Scala C comparison passes in Docker;
- the Scala diagnostic corpus remains at its existing 6/25 deep-parity baseline.

No performance work or release cleanup is included.