### PR TITLE
Enable certified S5 EOF missing insertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1281,7 +1281,7 @@ jobs:
             --test-parallel 1 \
             --c-ref-build-jobs 1 \
             --timeout 20m \
-            -- "cd /workspace && go test -tags gts_parsercorephase0 ./internal/parsercorephase0 -run '^(TestS5RecoveryDiscontinuityLinkValidation|TestS5DiscontinuityReaderSemantics|TestS5SixHeadPhysicalMergeRetainsPaths)$' -count=1 -parallel 1 -timeout 20m -v && go test . -tags gts_parsercorephase0 -run '^TestPackage2ScalaStrictReceipt(Composition)?$' -count=1 -parallel 1 -timeout 20m -v && cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^TestPackage2Scala(Falsifier(PhysicalMergeMinimal|OwnedLexerComposition|NoSummaryEOF|TrueEOFComposition)|IncrementalCleanMissingTransitions)$' -count=1 -parallel 1 -timeout 20m -v"
+            -- "cd /workspace && go test -tags gts_parsercorephase0 ./internal/parsercorephase0 -run '^(TestS5RecoveryDiscontinuityLinkValidation|TestS5DiscontinuityReaderSemantics|TestS5SixHeadPhysicalMergeRetainsPaths)$' -count=1 -parallel 1 -timeout 20m -v && go test . -tags gts_parsercorephase0 -run '^(TestPackage2ScalaStrictReceipt(Composition)?|TestStage6(S5PotentialReductionCollectorTreatsAcceptAsShiftable|ScalaEOFReduction(BeforeMissingInsertion|RequiresExactArtifactCapability)))$' -count=1 -parallel 1 -timeout 20m -v && cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^TestPackage2Scala(Falsifier(PhysicalMergeMinimal|OwnedLexerComposition|NoSummaryEOF|TrueEOFComposition)|Incremental(EOFComposition)?CleanMissingTransitions)$' -count=1 -parallel 1 -timeout 20m -v"
 
   # merge-event-census-cgo runs stage M0 of spec.merge-time-election.v1: the
   # census that counts stack-merge events on both sides and breaks production's

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -71,6 +71,7 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		allowCompactRecoverEOF:            allowRecoverEOF,
 		allowCompactStackSummaryRecovery:  p.language.CompactStackSummaryRecoveryCertified,
 		allowCompactMissingTokenInsertion: p.language.CompactMissingTokenInsertionCertified,
+		allowCompactS5EOFMissingInsertion: p.language.CompactS5EOFMissingInsertionCertified,
 		allowCompactFaithfulS5Recovery:    p.language.CompactFaithfulS5RecoveryCertified,
 		allowCompactRecoveryLineageSelection: p.language.CompactStrategy2ErrorRegionCertified &&
 			(p.language.CompactStackSummaryRecoveryCertified || p.language.CompactMissingTokenInsertionCertified),

--- a/cgo_harness/package2_scala_falsifier_test.go
+++ b/cgo_harness/package2_scala_falsifier_test.go
@@ -16,7 +16,7 @@ import (
 
 // Package-two adversarial lane witnesses (issue #1063; supports #1057 and
 // #1053). These tests lock the smallest physical GSS merge cases through a
-// nullable recovery discontinuity edge. The first three witnesses require the
+// nullable recovery discontinuity edge. All four witnesses require the
 // compact route to publish the locked C result. All four use locked Scala.
 //
 // Every witness runs the same four checks, in order:
@@ -167,8 +167,7 @@ func TestPackage2ScalaFalsifierTrueEOFComposition(t *testing.T) {
 		wantNoErrorNode:                 true,
 		wantDeepDigest:                  "03a458abd5832f6326e03b833a3890ea8d48ca43eb91ada1951bb020871f49a6",
 		wantProductionMatchesC:          true,
-		wantCompactExact:                false,
-		wantCompactFallbackReasonPart:   "recovery",
+		wantCompactExact:                true,
 		wantEditedMissingByte:           7,
 		wantIncrementalReuseUnsupported: true,
 	})
@@ -179,8 +178,21 @@ func TestPackage2ScalaFalsifierTrueEOFComposition(t *testing.T) {
 // reuse still fails closed, so package five must later replace this full reparse
 // with authenticated reuse without changing either result.
 func TestPackage2ScalaIncrementalCleanMissingTransitions(t *testing.T) {
-	clean := []byte("(y); ")
-	missing := []byte("(y; ")
+	runPackage2ScalaIncrementalCleanMissingTransitions(t, []byte("(y); "), []byte("(y; "), 2)
+}
+
+// TestPackage2ScalaIncrementalEOFCompositionCleanMissingTransitions locks the
+// clean control and both edit directions for the true EOF composition witness.
+func TestPackage2ScalaIncrementalEOFCompositionCleanMissingTransitions(t *testing.T) {
+	runPackage2ScalaIncrementalCleanMissingTransitions(t, []byte("((y)->)"), []byte("((y)->"), 6)
+}
+
+func runPackage2ScalaIncrementalCleanMissingTransitions(
+	t *testing.T,
+	clean, missing []byte,
+	closeByte int,
+) {
+	t.Helper()
 	entry := grammars.DetectLanguageByName("scala")
 	if entry == nil || entry.Language() == nil {
 		t.Fatal("Scala Go grammar is unavailable")
@@ -200,10 +212,10 @@ func TestPackage2ScalaIncrementalCleanMissingTransitions(t *testing.T) {
 	t.Cleanup(cleanTree.Release)
 
 	deleteClose := gotreesitter.InputEdit{
-		StartByte: 2, OldEndByte: 3, NewEndByte: 2,
-		StartPoint:  pointAtOffset(clean, 2),
-		OldEndPoint: pointAtOffset(clean, 3),
-		NewEndPoint: pointAtOffset(missing, 2),
+		StartByte: uint32(closeByte), OldEndByte: uint32(closeByte + 1), NewEndByte: uint32(closeByte),
+		StartPoint:  pointAtOffset(clean, closeByte),
+		OldEndPoint: pointAtOffset(clean, closeByte+1),
+		NewEndPoint: pointAtOffset(missing, closeByte),
 	}
 	cleanTree.Edit(deleteClose)
 	missingTree, missingProfile, err := parser.ParseIncrementalProfiled(missing, cleanTree)
@@ -217,10 +229,10 @@ func TestPackage2ScalaIncrementalCleanMissingTransitions(t *testing.T) {
 	assertPackage2ScalaTransitionEndpoint(t, goLanguage, cLanguage, missing, missingTree, true, 1)
 
 	insertClose := gotreesitter.InputEdit{
-		StartByte: 2, OldEndByte: 2, NewEndByte: 3,
-		StartPoint:  pointAtOffset(missing, 2),
-		OldEndPoint: pointAtOffset(missing, 2),
-		NewEndPoint: pointAtOffset(clean, 3),
+		StartByte: uint32(closeByte), OldEndByte: uint32(closeByte), NewEndByte: uint32(closeByte + 1),
+		StartPoint:  pointAtOffset(missing, closeByte),
+		OldEndPoint: pointAtOffset(missing, closeByte),
+		NewEndPoint: pointAtOffset(clean, closeByte+1),
 	}
 	missingTree.Edit(insertClose)
 	restoredTree, restoredProfile, err := parser.ParseIncrementalProfiled(clean, missingTree)
@@ -412,8 +424,8 @@ func runPackage2ScalaFalsifierWitness(t *testing.T, w package2ScalaFalsifierWitn
 	t.Logf("%s: Go production route matches locked C exactly (digest %s)", w.name, prodInspection.SHA256)
 
 	// Step 3: the Go compact route, with the candidate route forced on. The
-	// certified package-two witnesses require an exact route. The true EOF
-	// witness still requires an explicit fallback. Silent divergence fails.
+	// certified package-two witnesses require an exact route. Silent divergence
+	// fails.
 	beforeRouted, beforeFallback := gotreesitter.AdmissionCandidateCounters()
 	compactParser := gotreesitter.NewParser(goLanguage)
 	compactParser.SetAdmissionCandidateRoute(true)

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -33,6 +33,7 @@ type builtinLanguageRuntimeProfile struct {
 	compactRecoverEOFArtifact           gotreesitter.CompactRecoverEOFArtifactReceipt
 	compactStackSummaryRecovery         bool
 	compactMissingTokenInsertion        bool
+	compactS5EOFMissingInsertion        bool
 	compactFaithfulS5Recovery           bool
 	compactRecoveryTrailingRetirement   bool
 	compactRecoveryErrorModeKeyword     bool
@@ -186,12 +187,14 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		compactRecoveryPlainFirst: true,
 	},
 	// The locked Scala artifact certifies S5 missing insertion through a
-	// physical graph-head merge and a per-version lexer split. The profile
-	// excludes stack-summary and EOF recovery, which remain separate packages.
+	// physical graph-head merge and a per-version lexer split. It also certifies
+	// S5 reductions before one missing insertion at EOF. The profile excludes
+	// stack-summary recovery and the distinct recover_eof ERROR-root route.
 	"scala": {
 		blobSHA256:                          mustRuntimeProfileSHA256("8bc4a20f983ea8c8873c28430f089ba2bbbf00a995dd29f575bf2bc598d29dfa"),
 		compactStrategy2ErrorRegion:         true,
 		compactMissingTokenInsertion:        true,
+		compactS5EOFMissingInsertion:        true,
 		compactFaithfulS5Recovery:           true,
 		compactPrimaryAcceptDerivation:      true,
 		compactAcceptanceStructuralElection: true,
@@ -804,6 +807,10 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	}
 	if profile.compactMissingTokenInsertion && !lang.CompactMissingTokenInsertionCertified {
 		lang.CompactMissingTokenInsertionCertified = true
+		changed = true
+	}
+	if profile.compactS5EOFMissingInsertion && !lang.CompactS5EOFMissingInsertionCertified {
+		lang.CompactS5EOFMissingInsertionCertified = true
 		changed = true
 	}
 	if profile.compactFaithfulS5Recovery && !lang.CompactFaithfulS5RecoveryCertified {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -60,6 +60,9 @@ func TestHTMLProfileCertifiesCompleteCompactRecovery(t *testing.T) {
 	if !lang.CompactStrategy2ErrorRegionCertified || !lang.CompactMissingTokenInsertionCertified {
 		t.Fatal("the HTML profile did not attach both compact recovery capabilities")
 	}
+	if lang.CompactS5EOFMissingInsertionCertified {
+		t.Fatal("the HTML profile unexpectedly enabled EOF S5 missing insertion")
+	}
 	if lang.CompactRecoveryPlainFirstCertified {
 		t.Fatal("the HTML profile unexpectedly enabled plain-first recovery")
 	}
@@ -136,6 +139,9 @@ func TestJavaScriptProfileCertifiesCompactRecoveryFrontier(t *testing.T) {
 	if lang.CompactFaithfulS5RecoveryCertified {
 		t.Fatal("the JavaScript profile unexpectedly enabled the Scala S5 route")
 	}
+	if lang.CompactS5EOFMissingInsertionCertified {
+		t.Fatal("the JavaScript profile unexpectedly enabled EOF S5 missing insertion")
+	}
 	wantAliases := []gotreesitter.CompactRecoveryTerminalAliasRule{
 		{ResumeState: 20, ResumeSymbol: 54, AliasSymbol: 261},
 		{ResumeState: 231, ResumeSymbol: 85, AliasSymbol: 261},
@@ -159,6 +165,7 @@ func TestScalaProfileCertifiesPackageTwoRecovery(t *testing.T) {
 	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
 	lang := ScalaLanguage()
 	if !lang.CompactStrategy2ErrorRegionCertified || !lang.CompactMissingTokenInsertionCertified ||
+		!lang.CompactS5EOFMissingInsertionCertified ||
 		!lang.CompactFaithfulS5RecoveryCertified ||
 		!lang.CompactPrimaryAcceptanceDerivationCertified ||
 		!lang.CompactAcceptanceStructuralElectionCertified ||
@@ -173,6 +180,7 @@ func TestScalaProfileCertifiesPackageTwoRecovery(t *testing.T) {
 	if attachBuiltinLanguageRuntimeProfile("scala", sha256.Sum256([]byte("wrong scala blob")), uncertified) ||
 		uncertified.CompactStrategy2ErrorRegionCertified ||
 		uncertified.CompactMissingTokenInsertionCertified ||
+		uncertified.CompactS5EOFMissingInsertionCertified ||
 		uncertified.CompactFaithfulS5RecoveryCertified ||
 		uncertified.CompactPrimaryAcceptanceDerivationCertified ||
 		uncertified.CompactAcceptanceStructuralElectionCertified ||

--- a/language.go
+++ b/language.go
@@ -906,6 +906,15 @@ type Language struct {
 	// Custom and adapted languages retain the false default.
 	CompactMissingTokenInsertionCertified bool
 
+	// CompactS5EOFMissingInsertionCertified permits the compact fresh-full
+	// route to run S5 reductions and missing-token insertion when the elected
+	// token is EOF. This is distinct from CompactRecoverEOFCertified: S5
+	// publishes a grammar root with a missing leaf, not a recover_eof ERROR
+	// root. Exact built-in profiles set this only after locked-C parity proves
+	// the complete EOF competition. Custom and adapted languages retain the
+	// false default.
+	CompactS5EOFMissingInsertionCertified bool
+
 	// CompactFaithfulS5RecoveryCertified permits the complete S5 scan
 	// to merge equivalent physical recovery heads. The legacy bounded S5 path
 	// remains active without this exact artifact capability.

--- a/parser_derived_tables_internal_test.go
+++ b/parser_derived_tables_internal_test.go
@@ -186,6 +186,7 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 	restoreStructuralElection := lang.CompactAcceptanceStructuralElectionCertified
 	restoreLexerSkippedPrefix := lang.CompactLexerSkippedPrefixTilingCertified
 	restoreMissingInsertion := lang.CompactMissingTokenInsertionCertified
+	restoreS5EOFInsertion := lang.CompactS5EOFMissingInsertionCertified
 	restoreErrorModeKeyword := lang.CompactRecoveryErrorModeKeywordCaptureCertified
 	restoreSplitDrops := lang.CompactConvergedReductionSplitDropsCertified
 	restoreScanner := lang.ExternalScanner
@@ -197,6 +198,7 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 		lang.CompactAcceptanceStructuralElectionCertified = restoreStructuralElection
 		lang.CompactLexerSkippedPrefixTilingCertified = restoreLexerSkippedPrefix
 		lang.CompactMissingTokenInsertionCertified = restoreMissingInsertion
+		lang.CompactS5EOFMissingInsertionCertified = restoreS5EOFInsertion
 		lang.CompactRecoveryErrorModeKeywordCaptureCertified = restoreErrorModeKeyword
 		lang.CompactConvergedReductionSplitDropsCertified = restoreSplitDrops
 		lang.ExternalScanner = restoreScanner
@@ -208,6 +210,7 @@ func TestParserDerivedTablesReadOnlyPostLoadMutableFields(t *testing.T) {
 	lang.CompactAcceptanceStructuralElectionCertified = !restoreStructuralElection
 	lang.CompactLexerSkippedPrefixTilingCertified = !restoreLexerSkippedPrefix
 	lang.CompactMissingTokenInsertionCertified = !restoreMissingInsertion
+	lang.CompactS5EOFMissingInsertionCertified = !restoreS5EOFInsertion
 	lang.CompactRecoveryErrorModeKeywordCaptureCertified = !restoreErrorModeKeyword
 	lang.CompactConvergedReductionSplitDropsCertified = !restoreSplitDrops
 	lang.ExternalScanner = nil

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -114,6 +114,9 @@ type DiagnosticParserCorePrefixOptions struct {
 	// no-action head into missing-token and error-absorb recovery lineages.
 	// Language.CompactMissingTokenInsertionCertified is its artifact gate.
 	allowCompactMissingTokenInsertion bool
+	// allowCompactS5EOFMissingInsertion permits S5 only when the elected token
+	// is EOF. The admission route binds it from an exact artifact capability.
+	allowCompactS5EOFMissingInsertion bool
 	// allowCompactFaithfulS5Recovery selects the complete S5 physical
 	// graph-head scan. Uncertified artifacts retain the bounded legacy scan.
 	allowCompactFaithfulS5Recovery bool
@@ -9114,6 +9117,23 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 		}
 	}
 	if len(cells) == 0 {
+		if recoveryCompetition && s.options.allowCompactS5EOFMissingInsertion &&
+			s.s5MissingInsertions != 0 &&
+			s.token.Symbol == 0 &&
+			s.token.StartByte == s.token.EndByte && !s.token.Missing &&
+			!s.token.NoLookahead && !s.token.ExternalScannerToken &&
+			pausedNoActionHeads == 0 && deferredNoActionHeads == 0 &&
+			raggedRelexNoActionHeads == 0 {
+			accepted := 0
+			for index := range s.headers {
+				if s.headers[index].accepted {
+					accepted++
+				}
+			}
+			if accepted != 0 && accepted+len(noActionIndices) == len(s.headers) {
+				return nil, s.completeAcceptance()
+			}
+		}
 		if !s.recoveryIsolation && diagnosticParserCoreGenericNoActionDropEligible(s.headers, noActionIndices, s.epochProgress) {
 			if s.options.recordDropCohortFrontiers {
 				if err := s.publishDropCohortFrontierOwned(noActionIndices); err != nil {

--- a/parsercore_phase0_package2_strict_internal_test.go
+++ b/parsercore_phase0_package2_strict_internal_test.go
@@ -27,6 +27,7 @@ func package2ScalaStrictRunner(t *testing.T) *parserCoreFreshFullRunner {
 	lang.Name = "scala"
 	lang.CompactStrategy2ErrorRegionCertified = true
 	lang.CompactMissingTokenInsertionCertified = true
+	lang.CompactS5EOFMissingInsertionCertified = true
 	lang.CompactFaithfulS5RecoveryCertified = true
 	lang.CompactStackSummaryRecoveryCertified = false
 	lang.CompactPrimaryAcceptanceDerivationCertified = true

--- a/parsercore_phase0_s5.go
+++ b/parsercore_phase0_s5.go
@@ -267,6 +267,8 @@ func (s *diagnosticParserCoreGenericScheduler) s5CollectReductionActions(
 				if !action.Extra && !action.Repetition {
 					hasShift = true
 				}
+			case core.ActionAccept:
+				hasShift = true
 			case core.ActionReduce:
 				if action.ChildCount == 0 {
 					continue
@@ -768,7 +770,13 @@ func (s *diagnosticParserCoreGenericScheduler) s5TryMissingCandidateOwned(
 		if err := s.s5ShiftMissingLeafOwned(trialOwner, 0, targetState, missing, byteOffset); err != nil {
 			return false, err
 		}
-		canShift, err := s.s5RunReductionFrontierOwned(trialOwner, 0, diagnosticParserCoreS5ExactToken, core.Symbol(s.token.Symbol), staged)
+		mode := diagnosticParserCoreS5ExactToken
+		if s.token.Symbol == 0 {
+			// Native tree-sitter treats symbol zero as the any-lookahead
+			// sentinel during the EOF missing-token trial.
+			mode = diagnosticParserCoreS5AnyTerminal
+		}
+		canShift, err := s.s5RunReductionFrontierOwned(trialOwner, 0, mode, core.Symbol(s.token.Symbol), staged)
 		if err != nil {
 			return false, err
 		}
@@ -899,8 +907,11 @@ func (s *diagnosticParserCoreGenericScheduler) s5RunOwned(
 		s.s5MissingInsertions >= maxDiagnosticParserCoreMissingInsertions {
 		return false, nil
 	}
-	if s.token.Missing || s.token.NoLookahead || s.token.Symbol == errorSymbol || s.token.Symbol == 0 ||
+	if s.token.Missing || s.token.NoLookahead || s.token.Symbol == errorSymbol ||
 		s.tokenSource == nil || s.tokenSource.language == nil || s.headers[index].recoveryRegion() != nil {
+		return false, nil
+	}
+	if s.token.Symbol == 0 && !s.options.allowCompactS5EOFMissingInsertion {
 		return false, nil
 	}
 	tokenCount := core.Symbol(s.tokenSource.language.TokenCount)
@@ -987,6 +998,36 @@ func (s *diagnosticParserCoreGenericScheduler) s5RunOwned(
 	if len(missingHeaders) == 0 {
 		return false, nil
 	}
+	if s.token.Symbol == 0 {
+		missingBaseline, missingBaselineSet := original.recoveryNodeBaseline()
+		if !missingBaselineSet {
+			missingBaselineSet = true
+		}
+		for index := range missingHeaders {
+			missingHeaders[index].publishRecoveryCondenseState(0, missingGroup, missingBaseline, missingBaselineSet)
+			missingHeaders[index].paused = false
+			missingHeaders[index].shifted = false
+			missingHeaders[index].markRecoveryCosted()
+			missingHeaders[index].markRecoveryLineage()
+		}
+		s.invalidateVerifierHeaderBinding()
+		clear(s.headers)
+		s.headers = append(s.headers[:0], missingHeaders...)
+		s.recoveryIsolation = true
+		s.epochProgress = true
+		s.s5MissingInsertions++
+		staged.missingTokenCommits++
+		if err := s.canonicalizeOwned(owner); err != nil {
+			return false, err
+		}
+		if err := s.persistHeaderLineageOwned(owner); err != nil {
+			return false, err
+		}
+		if uint64(len(s.headers)) > s.work.PeakLiveVersions {
+			s.work.PeakLiveVersions = uint64(len(s.headers))
+		}
+		return true, nil
+	}
 	baseline, baselineOK, err := s.s5RecoveryBaseline(anyHeaders)
 	if err != nil {
 		return false, err
@@ -1056,8 +1097,11 @@ func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertionFaithfu
 		len(s.headers) != 1 || index != 0 ||
 		s.s5MissingInsertions >= maxDiagnosticParserCoreMissingInsertions ||
 		s.token.Missing || s.token.NoLookahead || s.token.Symbol == errorSymbol ||
-		s.token.Symbol == 0 || s.tokenSource == nil || s.tokenSource.language == nil ||
+		s.tokenSource == nil || s.tokenSource.language == nil ||
 		s.headers[0].recoveryRegion() != nil {
+		return false, nil
+	}
+	if s.token.Symbol == 0 && !s.options.allowCompactS5EOFMissingInsertion {
 		return false, nil
 	}
 	snapshot := captureDiagnosticParserCoreS5Scheduler(s)

--- a/parsercore_phase0_stage6_scala_eof_recovery_internal_test.go
+++ b/parsercore_phase0_stage6_scala_eof_recovery_internal_test.go
@@ -1,0 +1,123 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func TestStage6S5PotentialReductionCollectorTreatsAcceptAsShiftable(t *testing.T) {
+	table := &genericConflictTable{cells: map[genericConflictCell][]core.Action{
+		{state: 5, symbol: 1}: {{Type: core.ActionAccept}},
+	}}
+	compact, err := core.New(table, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact: compact,
+		tokenSource: &dfaTokenSource{language: &Language{
+			TokenCount: 2,
+		}},
+	}
+	reductions, canShift, err := scheduler.s5CollectReductionActions(
+		5, diagnosticParserCoreS5AnyTerminal, 0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !canShift || len(reductions) != 0 {
+		t.Fatalf("accept row returned canShift=%t reductions=%d, want true/0", canShift, len(reductions))
+	}
+}
+
+// TestStage6ScalaEOFReductionBeforeMissingInsertion locks the six-byte EOF
+// witness from issue #1053. C reduces the owned-width survivor before it
+// inserts one missing closing parenthesis at byte 6.
+func TestStage6ScalaEOFReductionBeforeMissingInsertion(t *testing.T) {
+	runner := package2ScalaStrictRunner(t)
+	const source = "((y)->"
+	_, tokenSource, runErr := runner.executeSchedulerOpenWithObserverAndErrorRuns(
+		[]byte(source), runner.compact, true, diagnosticParserCoreSeedObserver{}, true,
+	)
+	if tokenSource != nil {
+		tokenSource.Close()
+	}
+	if runErr != nil {
+		if runner.scheduler.receipt != nil {
+			t.Fatalf("compact route declined: %v; stop=%+v", runErr, runner.scheduler.receipt.Stop)
+		}
+		t.Fatalf("compact route declined before receipt: %v", runErr)
+	}
+	if runner.scheduler.receipt == nil || runner.scheduler.receipt.Acceptance == nil {
+		t.Fatalf("compact route returned no acceptance: %+v", runner.scheduler.receipt)
+	}
+
+	work := runner.scheduler.receipt.Acceptance.Work
+	if work.Passes != 20 || work.PotentialReductionActions != 8 ||
+		work.PotentialReductionOutputs != 8 || work.ReductionPromotions != 0 ||
+		work.MissingTokenTrials != 1 || work.MissingTokenCommits != 1 ||
+		work.RecoveryLineageSelections != 1 || work.RecoveryCondensePasses != 7 ||
+		work.SingleHeaderPasses != 6 || work.ActionLookups != 42 ||
+		work.Dispatches != 17 || work.Conflicts != 1 || work.ConflictActions != 2 ||
+		work.Forks != 1 || work.ConflictActionArmsAdmitted != 2 ||
+		work.CausalConflictForks != 1 || work.ConflictHeads != 2 ||
+		work.Reductions != 9 || work.OrdinaryShifts != 6 ||
+		work.OrdinaryCohorts != 1 || work.Accepts != 1 || work.NoActionDrops != 1 ||
+		work.Elections != 6 || work.PerVersionLexRequests != 2 ||
+		work.PerVersionLexRestores != 2 || work.PerVersionLexPublications != 7 ||
+		work.PerVersionLexViabilityDrops != 1 || work.PeakLiveVersions != 6 ||
+		work.Canonicalizations != 17 || work.PeakHeaders != 6 || work.Overflow {
+		t.Fatalf("EOF recovery work receipt drifted: %+v", work)
+	}
+	coreWork := runner.scheduler.receipt.Acceptance.CoreWork
+	if coreWork.Shifts != 6 || coreWork.Reductions != 19 ||
+		coreWork.ReductionPopRequests != 19 || coreWork.EmittedPopPaths != 19 ||
+		coreWork.EmittedPopPayloads != 26 || coreWork.PhysicalHeadMergeAttempts != 4 ||
+		coreWork.PhysicalHeadMergeSuccesses != 4 || coreWork.PhysicalHeadMergeInputLinks != 4 ||
+		coreWork.PredecessorLinkUnionAttempts != 4 || coreWork.PredecessorLinkUnionDuplicateNoop != 4 ||
+		coreWork.GraphLinkAdditionsProxy != 26 || coreWork.LeafConstructionsProxy != 6 ||
+		coreWork.ParentConstructionsProxy != 19 || coreWork.Overflow {
+		t.Fatalf("EOF recovery core receipt drifted: %+v", coreWork)
+	}
+
+	requirePackage2ScalaTree(
+		t, runner, source,
+		"(compilation_unit (parenthesized_expression (postfix_expression (parenthesized_expression (identifier)) (operator_identifier))))",
+		"03a458abd5832f6326e03b833a3890ea8d48ca43eb91ada1951bb020871f49a6",
+		6,
+	)
+	tree, err := runner.materializeSelection([]byte(source), runner.compact, &runner.scheduler)
+	if err != nil {
+		t.Fatalf("materialize compact EOF selection: %v", err)
+	}
+	defer tree.Release()
+	walkResultTree(tree.RootNode(), func(node *Node) {
+		if node.Type(runner.lang) == "ERROR" {
+			t.Errorf("compact EOF tree contains a visible ERROR node: %s", tree.RootNode().SExpr(runner.lang))
+		}
+	})
+	t.Logf("Scala EOF recovery receipt: work=%+v core=%+v", work, runner.scheduler.receipt.Acceptance.CoreWork)
+}
+
+func TestStage6ScalaEOFReductionRequiresExactArtifactCapability(t *testing.T) {
+	runner := package2ScalaStrictRunner(t)
+	runner.options.allowCompactS5EOFMissingInsertion = false
+	_, tokenSource, runErr := runner.executeSchedulerOpenWithObserverAndErrorRuns(
+		[]byte("((y)->"), runner.compact, true, diagnosticParserCoreSeedObserver{}, true,
+	)
+	if tokenSource != nil {
+		tokenSource.Close()
+	}
+	if runErr == nil {
+		t.Fatal("uncertified EOF S5 route unexpectedly accepted")
+	}
+	if runner.scheduler.receipt == nil {
+		t.Fatal("uncertified EOF S5 route returned no decline receipt")
+	}
+	if got := runner.scheduler.work.MissingTokenTrials; got != 0 {
+		t.Fatalf("uncertified EOF S5 route ran %d missing-token trials, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Run the bounded S5 reduction frontier before a Scala missing-token scan at EOF.
- Admit accepted recovery versions while unfinished EOF siblings remain.
- Bind the behavior to the exact Scala grammar artifact.
- Treat Accept as a viable C-style reduction continuation.

## Locked C witness

Source: `((y)->`

The compact route now publishes the locked C tree and deep digest. It inserts one missing `)` at byte 6 and publishes no visible ERROR node.

## Proof

- The exact scheduler receipt pins eight potential reductions, one insertion, one lineage selection, and a six-version peak.
- The clean-to-missing and missing-to-clean edits match fresh C and fresh Go.
- The isolated Scala Docker package passes all four recovery witnesses.
- The focused Docker race gate passes.
- The 206-language admission ratchet reports 201 pass, five skip, zero divergence, and zero fallback.
- HTML and JavaScript recovery oracle suites remain green.

Closes #1053