### PR TITLE
fix(parser): preserve missing recovery edit dependencies

### DIFF
--- a/admission_route_equality_leaf_tiling_test.go
+++ b/admission_route_equality_leaf_tiling_test.go
@@ -328,6 +328,8 @@ func TestCompactRouteDeclinesRetiredRecoveryWithoutAliasRule(t *testing.T) {
 
 func TestCompactRouteCompetesMissingInsertionWithErrorAbsorb(t *testing.T) {
 	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	gts.EnableArenaBreakdown(true)
+	t.Cleanup(func() { gts.EnableArenaBreakdown(false) })
 	lang := grammars.HtmlLanguage()
 	if !lang.CompactStrategy2ErrorRegionCertified || !lang.CompactMissingTokenInsertionCertified {
 		t.Fatal("the HTML artifact lacks complete compact recovery certification")
@@ -351,6 +353,10 @@ func TestCompactRouteCompetesMissingInsertionWithErrorAbsorb(t *testing.T) {
 	}
 	if !routeEqualityTreeContainsMissing(tree.RootNode()) {
 		t.Fatal("the selected recovery tree contains no missing terminal")
+	}
+	breakdown, recorded := tree.ArenaBreakdown()
+	if !recorded || breakdown.MissingNodeDependencyCount == 0 || breakdown.MissingNodeDependencyBytesAllocated == 0 {
+		t.Fatalf("compact recovery did not materialize missing-dependency telemetry: recorded=%t breakdown=%+v", recorded, breakdown)
 	}
 }
 

--- a/arena.go
+++ b/arena.go
@@ -124,6 +124,7 @@ type nodeArena struct {
 	compactCheckpointLeafSlabs      []compactCheckpointLeafSlab
 	compactCheckpointLeafSlabCursor int
 	finalChildSidecars              []finalChildSidecar
+	missingNodeDependencies         []missingNodeDependencyEntry
 	nodeFieldMetadataSlabs          []nodeFieldMetadataSlab
 	nodeFieldMetadataSlabCursor     int
 
@@ -556,6 +557,7 @@ func (a *nodeArena) reset() {
 	a.resetRawShapeChildSlabs()
 	a.resetRawShapeHashCache()
 	a.resetFinalChildSidecars()
+	a.resetMissingNodeDependencies()
 	a.resetCompactCheckpointLeafSlabs()
 	a.resetNodeFieldMetadataSlabs()
 	a.resetChildSlabs()
@@ -1880,6 +1882,7 @@ func (a *nodeArena) recomputeAllocatedBytes() {
 		a.rawShapeChildBytesAllocated() +
 		a.rawShapeHashCacheBytesAllocated() +
 		a.finalChildSidecarBytesAllocated() +
+		missingNodeDependencyEntryBytesForCap(cap(a.missingNodeDependencies)) +
 		a.compactCheckpointLeafBytesAllocated() +
 		a.childSliceBytesAllocated() +
 		a.fieldIDBytesAllocated() +
@@ -2240,7 +2243,9 @@ func (a *nodeArena) collectArenaBreakdown() *ArenaBreakdown {
 		RawShapeChildBytesAllocated:         a.rawShapeChildBytesAllocated(),
 		RawShapeHashCacheBytesAllocated:     a.rawShapeHashCacheBytesAllocated(),
 		FinalChildSidecarBytesAllocated:     a.finalChildSidecarBytesAllocated(),
+		MissingNodeDependencyBytesAllocated: missingNodeDependencyEntryBytesForCap(cap(a.missingNodeDependencies)),
 		CompactCheckpointLeafBytesAllocated: a.compactCheckpointLeafBytesAllocated(),
+		MissingNodeDependencyCount:          uint64(len(a.missingNodeDependencies)),
 		PendingChildEntriesAllocated:        a.pendingChildEntriesAllocated,
 		PendingChildEntryCapacity:           a.pendingChildEntryCapacity(),
 		PendingChildEntryWaste:              a.pendingChildEntryWaste(),

--- a/cgo_harness/cmd/parse_gap_report/main.go
+++ b/cgo_harness/cmd/parse_gap_report/main.go
@@ -1180,7 +1180,8 @@ func statsFromGoTree(r *runner, tree *gotreesitter.Tree, queryCaptures, cursorNo
 			breakdown.CompactFullLeafBytesAllocated +
 			breakdown.PendingParentBytesAllocated +
 			breakdown.PendingChildEntryBytesAllocated +
-			breakdown.FinalChildSidecarBytesAllocated
+			breakdown.FinalChildSidecarBytesAllocated +
+			breakdown.MissingNodeDependencyBytesAllocated
 		stats.ArenaChildB = breakdown.ChildSliceBytesAllocated
 		stats.ArenaFieldB = breakdown.NodeFieldMetadataBytesAllocated +
 			breakdown.FieldIDBytesAllocated +
@@ -1293,6 +1294,7 @@ func arenaLiveBytes(b gotreesitter.ArenaBreakdown, externalScannerCheckpointByte
 		b.RawShapeChildBytesAllocated +
 		b.RawShapeHashCacheBytesAllocated +
 		b.FinalChildSidecarBytesAllocated +
+		b.MissingNodeDependencyBytesAllocated +
 		b.CompactCheckpointLeafBytesAllocated +
 		b.ChildSliceBytesAllocated +
 		b.FieldIDBytesAllocated +

--- a/cgo_harness/cmd/parse_gap_report/main_test.go
+++ b/cgo_harness/cmd/parse_gap_report/main_test.go
@@ -319,6 +319,7 @@ func TestArenaLiveBytesIncludesEveryRuntimeArenaComponent(t *testing.T) {
 		RawShapeChildBytesAllocated:         7,
 		RawShapeHashCacheBytesAllocated:     13,
 		FinalChildSidecarBytesAllocated:     8,
+		MissingNodeDependencyBytesAllocated: 15,
 		CompactCheckpointLeafBytesAllocated: 9,
 		ChildSliceBytesAllocated:            10,
 		FieldIDBytesAllocated:               11,
@@ -326,7 +327,7 @@ func TestArenaLiveBytesIncludesEveryRuntimeArenaComponent(t *testing.T) {
 	}
 	runtime := gotreesitter.ParseRuntime{
 		ExternalScannerCheckpointBytesAllocated: 13,
-		ArenaBytesAllocated:                     118,
+		ArenaBytesAllocated:                     133,
 	}
 	if got, want := arenaLiveBytes(breakdown, runtime.ExternalScannerCheckpointBytesAllocated), runtime.ArenaBytesAllocated; got != want {
 		t.Fatalf("arenaLiveBytes = %d, runtime arena total = %d", got, want)

--- a/cgo_harness/missing_leaf_dependency_cgo_test.go
+++ b/cgo_harness/missing_leaf_dependency_cgo_test.go
@@ -1,0 +1,339 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const goMissingDependencyAssignmentTree = "(source_file (assignment_statement left: (expression_list (MISSING identifier)) right: (expression_list (identifier))))"
+
+func TestCMissingSemicolonLookaheadIncrementalParity(t *testing.T) {
+	source := []byte("int a int b;\n")
+	goLanguage := grammars.CLanguage()
+	gotreesitter.EnableArenaBreakdown(true)
+	t.Cleanup(func() { gotreesitter.EnableArenaBreakdown(false) })
+	cLanguage, err := COracleLanguage("c")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name        string
+		offset      int
+		replacement byte
+	}{
+		{name: "first_lookahead_byte", offset: 6, replacement: 'a'},
+		{name: "middle_lookahead_byte", offset: 7, replacement: 'a'},
+		{name: "last_lookahead_byte", offset: 8, replacement: 'x'},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			edited := append([]byte(nil), source...)
+			edited[test.offset] = test.replacement
+			edit := gotreesitter.InputEdit{
+				StartByte: uint32(test.offset), OldEndByte: uint32(test.offset + 1), NewEndByte: uint32(test.offset + 1),
+				StartPoint: gotreesitter.Point{Column: uint32(test.offset)}, OldEndPoint: gotreesitter.Point{Column: uint32(test.offset + 1)}, NewEndPoint: gotreesitter.Point{Column: uint32(test.offset + 1)},
+			}
+
+			goParser := gotreesitter.NewParser(goLanguage)
+			goOld, err := goParser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer goOld.Release()
+			goMissing := findFirstMissingDependencyGoNode(goOld.RootNode())
+			if goMissing == nil || goMissing.Type(goLanguage) != ";" || goMissing.StartByte() != 5 || goMissing.EndByte() != 5 {
+				t.Fatal("Go initial tree lacks the missing-semicolon witness")
+			}
+			breakdown, recorded := goOld.ArenaBreakdown()
+			if !recorded || breakdown.MissingNodeDependencyCount == 0 || breakdown.MissingNodeDependencyBytesAllocated == 0 {
+				t.Fatalf("Go parse did not record missing-dependency telemetry: recorded=%t breakdown=%+v", recorded, breakdown)
+			}
+
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cOld := cParser.Parse(source, nil)
+			if cOld == nil {
+				t.Fatal("C initial parse returned nil")
+			}
+			defer cOld.Close()
+			if diff := FirstDivergenceDumpV1(goOld.RootNode(), goLanguage, cOld.RootNode()); diff != nil {
+				t.Fatalf("initial Go tree differs from C: %+v", *diff)
+			}
+
+			goOld.Edit(edit)
+			if !goMissing.HasChanges() {
+				t.Fatalf("edit at lookahead byte %d did not invalidate the Go missing semicolon", test.offset)
+			}
+			cEdit := realCorpusCInputEdit(edit)
+			cOld.Edit(&cEdit)
+			cMissing := findFirstMissingDependencyCNode(cOld.RootNode())
+			if cMissing == nil || !cMissing.HasChanges() {
+				t.Fatalf("edit at lookahead byte %d did not invalidate the C missing semicolon", test.offset)
+			}
+
+			goIncremental, profile, err := goParser.ParseIncrementalProfiled(edited, goOld)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer goIncremental.Release()
+			goFresh, err := goParser.Parse(edited)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer goFresh.Release()
+			var goErrors []string
+			compareGoNodes(goIncremental.RootNode(), goLanguage, goFresh.RootNode(), "root", &goErrors)
+			if len(goErrors) != 0 {
+				t.Fatalf("incremental Go tree differs from fresh Go: %s", goErrors[0])
+			}
+
+			cIncremental := cParser.Parse(edited, cOld)
+			if cIncremental == nil {
+				t.Fatal("C incremental parse returned nil")
+			}
+			defer cIncremental.Close()
+			if diff := FirstDivergenceDumpV1(goIncremental.RootNode(), goLanguage, cIncremental.RootNode()); diff != nil {
+				t.Fatalf("incremental Go tree differs from incremental C: %+v; profile=%+v", *diff, profile)
+			}
+		})
+	}
+}
+
+func findFirstMissingDependencyGoNode(node *gotreesitter.Node) *gotreesitter.Node {
+	if node == nil {
+		return nil
+	}
+	if node.IsMissing() {
+		return node
+	}
+	for index := 0; index < node.ChildCount(); index++ {
+		if missing := findFirstMissingDependencyGoNode(node.Child(index)); missing != nil {
+			return missing
+		}
+	}
+	return nil
+}
+
+type missingDependencyOracleCase struct {
+	name             string
+	source           []byte
+	edited           []byte
+	oldRanges        []gotreesitter.Range
+	newRanges        []gotreesitter.Range
+	edit             gotreesitter.InputEdit
+	wantEdited       string
+	wantChanged      []gotreesitter.Range
+	wantRightChanged bool
+}
+
+// TestGoMissingLeafDependencyLockedCOracle pins the C behavior that package
+// five must preserve. Separate Go unit tests apply these dependency bounds to
+// sparse missing-node metadata. The current Go parser has an earlier recovery
+// topology difference for this source, so this test must not hide that gap by
+// comparing unlike initial trees.
+func TestGoMissingLeafDependencyLockedCOracle(t *testing.T) {
+	includedRange := gotreesitter.Range{
+		StartByte: 1, EndByte: 3,
+		StartPoint: gotreesitter.Point{Row: 1}, EndPoint: gotreesitter.Point{Row: 1, Column: 2},
+	}
+	cases := []missingDependencyOracleCase{
+		{
+			name: "included_padding_replacement", source: []byte("\n=i"), edited: []byte("x=i"),
+			oldRanges:  []gotreesitter.Range{includedRange},
+			newRanges:  []gotreesitter.Range{{StartByte: 1, EndByte: 3, StartPoint: gotreesitter.Point{Column: 1}, EndPoint: gotreesitter.Point{Column: 3}}},
+			edit:       gotreesitter.InputEdit{StartByte: 0, OldEndByte: 1, NewEndByte: 1, OldEndPoint: gotreesitter.Point{Row: 1}, NewEndPoint: gotreesitter.Point{Column: 1}},
+			wantEdited: goMissingDependencyAssignmentTree,
+		},
+		{
+			name: "included_padding_insertion", source: []byte("\n=i"), edited: []byte("x\n=i"),
+			oldRanges:  []gotreesitter.Range{includedRange},
+			newRanges:  []gotreesitter.Range{{StartByte: 2, EndByte: 4, StartPoint: gotreesitter.Point{Row: 1}, EndPoint: gotreesitter.Point{Row: 1, Column: 2}}},
+			edit:       gotreesitter.InputEdit{StartByte: 0, OldEndByte: 0, NewEndByte: 1, NewEndPoint: gotreesitter.Point{Column: 1}},
+			wantEdited: goMissingDependencyAssignmentTree,
+		},
+		{
+			name: "included_padding_deletion", source: []byte("\n=i"), edited: []byte("=i"),
+			oldRanges:  []gotreesitter.Range{includedRange},
+			newRanges:  []gotreesitter.Range{{StartByte: 0, EndByte: 2, EndPoint: gotreesitter.Point{Column: 2}}},
+			edit:       gotreesitter.InputEdit{StartByte: 0, OldEndByte: 1, NewEndByte: 0, OldEndPoint: gotreesitter.Point{Row: 1}},
+			wantEdited: goMissingDependencyAssignmentTree,
+		},
+		{
+			name: "included_lookahead_operator", source: []byte("\n=i"), edited: []byte("\n+i"),
+			oldRanges: []gotreesitter.Range{includedRange}, newRanges: []gotreesitter.Range{includedRange},
+			edit:        gotreesitter.InputEdit{StartByte: 1, OldEndByte: 2, NewEndByte: 2, StartPoint: gotreesitter.Point{Row: 1}, OldEndPoint: gotreesitter.Point{Row: 1, Column: 1}, NewEndPoint: gotreesitter.Point{Row: 1, Column: 1}},
+			wantEdited:  "(source_file (ERROR (unary_expression operand: (identifier))))",
+			wantChanged: []gotreesitter.Range{includedRange},
+		},
+		{
+			name: "included_lookahead_identifier", source: []byte("\n=i"), edited: []byte("\n=j"),
+			oldRanges: []gotreesitter.Range{includedRange}, newRanges: []gotreesitter.Range{includedRange},
+			edit:             gotreesitter.InputEdit{StartByte: 2, OldEndByte: 3, NewEndByte: 3, StartPoint: gotreesitter.Point{Row: 1, Column: 1}, OldEndPoint: gotreesitter.Point{Row: 1, Column: 2}, NewEndPoint: gotreesitter.Point{Row: 1, Column: 2}},
+			wantEdited:       goMissingDependencyAssignmentTree,
+			wantRightChanged: true,
+		},
+		{
+			name: "plain_lookahead_operator", source: []byte("=i"), edited: []byte("+i"),
+			edit:        gotreesitter.InputEdit{StartByte: 0, OldEndByte: 1, NewEndByte: 1, OldEndPoint: gotreesitter.Point{Column: 1}, NewEndPoint: gotreesitter.Point{Column: 1}},
+			wantEdited:  "(source_file (ERROR (unary_expression operand: (identifier))))",
+			wantChanged: []gotreesitter.Range{{StartByte: 0, EndByte: 2, EndPoint: gotreesitter.Point{Column: 2}}},
+		},
+		{
+			name: "plain_lookahead_identifier", source: []byte("=i"), edited: []byte("=j"),
+			edit:             gotreesitter.InputEdit{StartByte: 1, OldEndByte: 2, NewEndByte: 2, StartPoint: gotreesitter.Point{Column: 1}, OldEndPoint: gotreesitter.Point{Column: 2}, NewEndPoint: gotreesitter.Point{Column: 2}},
+			wantEdited:       goMissingDependencyAssignmentTree,
+			wantRightChanged: true,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			runGoMissingDependencyOracleCase(t, test)
+		})
+	}
+}
+
+func runGoMissingDependencyOracleCase(t *testing.T, test missingDependencyOracleCase) {
+	t.Helper()
+	cLanguage, err := COracleLanguage("go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatal(err)
+	}
+	if err := cParser.SetIncludedRanges(toCMissingDependencyRanges(test.oldRanges)); err != nil {
+		t.Fatal(err)
+	}
+	oldTree := cParser.Parse(test.source, nil)
+	if oldTree == nil {
+		t.Fatal("locked C initial parse returned nil")
+	}
+	defer oldTree.Close()
+	assertGoMissingDependencyOracleTree(t, oldTree.RootNode(), test.oldRanges)
+	oldMissing := findFirstMissingDependencyCNode(oldTree.RootNode())
+	oldRightIdentifier := findFirstCleanDependencyCIdentifier(oldTree.RootNode())
+	if oldMissing == nil || oldRightIdentifier == nil {
+		t.Fatal("locked C initial tree lacks the dependency witness nodes")
+	}
+
+	cEdit := sitter.InputEdit{
+		StartByte: uint(test.edit.StartByte), OldEndByte: uint(test.edit.OldEndByte), NewEndByte: uint(test.edit.NewEndByte),
+		StartPosition: toCMissingDependencyPoint(test.edit.StartPoint), OldEndPosition: toCMissingDependencyPoint(test.edit.OldEndPoint), NewEndPosition: toCMissingDependencyPoint(test.edit.NewEndPoint),
+	}
+	oldTree.Edit(&cEdit)
+	if !oldMissing.HasChanges() {
+		t.Fatal("locked C edit did not invalidate the missing-node dependency")
+	}
+	if oldRightIdentifier.HasChanges() != test.wantRightChanged {
+		t.Fatalf("locked C right identifier has_changes=%t, want %t", oldRightIdentifier.HasChanges(), test.wantRightChanged)
+	}
+	if err := cParser.SetIncludedRanges(toCMissingDependencyRanges(test.newRanges)); err != nil {
+		t.Fatal(err)
+	}
+	newTree := cParser.Parse(test.edited, oldTree)
+	if newTree == nil {
+		t.Fatal("locked C incremental parse returned nil")
+	}
+	defer newTree.Close()
+	if got := newTree.RootNode().ToSexp(); got != test.wantEdited {
+		t.Fatalf("edited C tree=%s, want %s", got, test.wantEdited)
+	}
+	if test.wantEdited == goMissingDependencyAssignmentTree {
+		assertGoMissingDependencyOracleTree(t, newTree.RootNode(), test.newRanges)
+	}
+	assertMissingDependencyChangedRanges(t, oldTree.ChangedRanges(newTree), test.wantChanged)
+}
+
+func assertGoMissingDependencyOracleTree(t *testing.T, root *sitter.Node, ranges []gotreesitter.Range) {
+	t.Helper()
+	if got := root.ToSexp(); got != goMissingDependencyAssignmentTree {
+		t.Fatalf("initial C tree=%s, want %s", got, goMissingDependencyAssignmentTree)
+	}
+	wantByte := uint(0)
+	wantPoint := sitter.Point{}
+	if len(ranges) != 0 {
+		wantByte = uint(ranges[0].StartByte)
+		wantPoint = toCMissingDependencyPoint(ranges[0].StartPoint)
+	}
+	missing := findFirstMissingDependencyCNode(root)
+	if missing == nil {
+		t.Fatal("initial C tree has no missing node")
+	}
+	if missing.Kind() != "identifier" || !missing.IsNamed() || !missing.IsMissing() || missing.IsExtra() || missing.IsError() || !missing.HasError() ||
+		missing.StartByte() != wantByte || missing.EndByte() != wantByte || missing.StartPosition() != wantPoint || missing.EndPosition() != wantPoint {
+		t.Fatalf("missing C node kind=%q named=%t missing=%t extra=%t error=%t has_error=%t bytes=%d..%d points=%+v..%+v", missing.Kind(), missing.IsNamed(), missing.IsMissing(), missing.IsExtra(), missing.IsError(), missing.HasError(), missing.StartByte(), missing.EndByte(), missing.StartPosition(), missing.EndPosition())
+	}
+}
+
+func findFirstMissingDependencyCNode(node *sitter.Node) *sitter.Node {
+	if node == nil {
+		return nil
+	}
+	if node.IsMissing() {
+		return node
+	}
+	for index := uint(0); index < node.ChildCount(); index++ {
+		if missing := findFirstMissingDependencyCNode(node.Child(index)); missing != nil {
+			return missing
+		}
+	}
+	return nil
+}
+
+func findFirstCleanDependencyCIdentifier(node *sitter.Node) *sitter.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Kind() == "identifier" && !node.IsMissing() {
+		return node
+	}
+	for index := uint(0); index < node.ChildCount(); index++ {
+		if identifier := findFirstCleanDependencyCIdentifier(node.Child(index)); identifier != nil {
+			return identifier
+		}
+	}
+	return nil
+}
+
+func assertMissingDependencyChangedRanges(t *testing.T, got []sitter.Range, want []gotreesitter.Range) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("changed range count=%d, want %d: got=%+v want=%+v", len(got), len(want), got, want)
+	}
+	for index := range want {
+		item := got[index]
+		converted := gotreesitter.Range{
+			StartByte: uint32(item.StartByte), EndByte: uint32(item.EndByte),
+			StartPoint: gotreesitter.Point{Row: uint32(item.StartPoint.Row), Column: uint32(item.StartPoint.Column)},
+			EndPoint:   gotreesitter.Point{Row: uint32(item.EndPoint.Row), Column: uint32(item.EndPoint.Column)},
+		}
+		if converted != want[index] {
+			t.Fatalf("changed range %d=%+v, want %+v", index, converted, want[index])
+		}
+	}
+}
+
+func toCMissingDependencyPoint(point gotreesitter.Point) sitter.Point {
+	return sitter.Point{Row: uint(point.Row), Column: uint(point.Column)}
+}
+
+func toCMissingDependencyRanges(ranges []gotreesitter.Range) []sitter.Range {
+	out := make([]sitter.Range, len(ranges))
+	for index, item := range ranges {
+		out[index] = sitter.Range{
+			StartByte: uint(item.StartByte), EndByte: uint(item.EndByte),
+			StartPoint: toCMissingDependencyPoint(item.StartPoint), EndPoint: toCMissingDependencyPoint(item.EndPoint),
+		}
+	}
+	return out
+}

--- a/external_lexer.go
+++ b/external_lexer.go
@@ -24,6 +24,10 @@ type ExternalLexer struct {
 
 	resultSymbol Symbol
 	hasResult    bool
+
+	// lookaheadEndByte records the largest lexer frontier observed while this
+	// scanner attempt ran. The token source carries it across scanner retries.
+	lookaheadEndByte uint32
 }
 
 func (l *ExternalLexer) reset(source []byte, pos int, row, col uint32) {
@@ -39,6 +43,7 @@ func (l *ExternalLexer) reset(source []byte, pos int, row, col uint32) {
 	l.advancedContent = false
 	l.resultSymbol = 0
 	l.hasResult = false
+	l.lookaheadEndByte = 0
 }
 
 func newExternalLexer(source []byte, pos int, row, col uint32) *ExternalLexer {
@@ -180,6 +185,30 @@ func (l *ExternalLexer) SetResultSymbol(sym Symbol) {
 	l.hasResult = true
 }
 
+// lookaheadEndByteAtCursor mirrors ts_lexer_finish for an external scanner.
+// Tree-sitter records one byte beyond the current cursor, plus four bytes when
+// the current lookahead is an invalid UTF-8 sequence.
+func (l *ExternalLexer) lookaheadEndByteAtCursor() uint32 {
+	if l == nil {
+		return 0
+	}
+	pos := l.pos
+	if pos < 0 {
+		pos = 0
+	}
+	frontier := uint64(pos) + 1
+	if pos < len(l.source) {
+		r, size := utf8.DecodeRune(l.source[pos:])
+		if r == utf8.RuneError && size == 1 && l.source[pos] >= utf8.RuneSelf {
+			frontier += 4
+		}
+	}
+	if frontier > uint64(^uint32(0)) {
+		return ^uint32(0)
+	}
+	return uint32(frontier)
+}
+
 // Column returns the current column (0-based) at the scanner cursor.
 func (l *ExternalLexer) Column() uint32 {
 	return l.point.Column
@@ -231,21 +260,31 @@ func (l *ExternalLexer) token() (Token, bool) {
 	// skipped bytes are re-encountered on the next scan, matching C
 	// tree-sitter semantics.
 	if endPos < l.startPos {
+		lookaheadEndByte := maxUint32(l.lookaheadEndByte, l.lookaheadEndByteAtCursor())
+		if lookaheadEndByte < uint32(endPos) {
+			lookaheadEndByte = uint32(endPos)
+		}
 		return Token{
-			Symbol:     l.resultSymbol,
-			StartByte:  uint32(endPos),
-			EndByte:    uint32(endPos),
-			StartPoint: endPoint,
-			EndPoint:   endPoint,
+			Symbol:                l.resultSymbol,
+			StartByte:             uint32(endPos),
+			EndByte:               uint32(endPos),
+			StartPoint:            endPoint,
+			EndPoint:              endPoint,
+			lexerLookaheadEndByte: lookaheadEndByte,
 		}, true
 	}
 
+	lookaheadEndByte := maxUint32(l.lookaheadEndByte, l.lookaheadEndByteAtCursor())
+	if lookaheadEndByte < uint32(endPos) {
+		lookaheadEndByte = uint32(endPos)
+	}
 	return Token{
-		Symbol:     l.resultSymbol,
-		Text:       bytesToStringNoCopy(l.source[l.startPos:endPos]),
-		StartByte:  uint32(l.startPos),
-		EndByte:    uint32(endPos),
-		StartPoint: l.startPoint,
-		EndPoint:   endPoint,
+		Symbol:                l.resultSymbol,
+		Text:                  bytesToStringNoCopy(l.source[l.startPos:endPos]),
+		StartByte:             uint32(l.startPos),
+		EndByte:               uint32(endPos),
+		StartPoint:            l.startPoint,
+		EndPoint:              endPoint,
+		lexerLookaheadEndByte: lookaheadEndByte,
 	}, true
 }

--- a/external_lexer_test.go
+++ b/external_lexer_test.go
@@ -32,6 +32,35 @@ func TestExternalLexerDefaultEndWithoutMarkEnd(t *testing.T) {
 	}
 }
 
+func TestExternalLexerCarriesCurrentLookaheadFrontier(t *testing.T) {
+	l := newExternalLexer([]byte{'a', 0xff}, 0, 0, 0)
+	l.Advance(false)
+	l.MarkEnd()
+	l.SetResultSymbol(1)
+
+	tok, ok := l.token()
+	if !ok {
+		t.Fatal("token() returned !ok")
+	}
+	if got, want := tokenLookaheadEndByte(tok), uint32(6); got != want {
+		t.Fatalf("lookahead end = %d, want invalid UTF-8 frontier %d", got, want)
+	}
+}
+
+func TestExternalLexerCarriesEOFLookaheadFrontier(t *testing.T) {
+	l := newExternalLexer([]byte("a"), 0, 0, 0)
+	l.Advance(false)
+	l.SetResultSymbol(1)
+
+	tok, ok := l.token()
+	if !ok {
+		t.Fatal("token() returned !ok")
+	}
+	if got, want := tokenLookaheadEndByte(tok), uint32(2); got != want {
+		t.Fatalf("lookahead end = %d, want EOF frontier %d", got, want)
+	}
+}
+
 func TestExternalLexerAdvanceSpacesSkip(t *testing.T) {
 	l := newExternalLexer([]byte("   x"), 0, 2, 4)
 	if got := l.AdvanceSpaces(true); got != 3 {

--- a/intern.go
+++ b/intern.go
@@ -334,6 +334,9 @@ func buildKeyFromNode(n *Node) internKey {
 // parseState-aware hit rates and quantify how many "duplicates" are
 // only artifacts of the blind measurement.
 func observeLeafInternFull(arena *nodeArena, n *Node) {
+	if arena == nil || n == nil || n.isMissing() {
+		return
+	}
 	if arena.internLeavesFull == nil {
 		arena.internLeavesFull = newInternTable()
 	}
@@ -350,6 +353,9 @@ func observeLeafInternFull(arena *nodeArena, n *Node) {
 // On miss, returns nil; the caller allocates and calls storeCanonicalLeaf
 // afterward.
 func lookupCanonicalLeafKey(arena *nodeArena, key internKey) *Node {
+	if arena == nil || key.flags&nodeFlagMissing != 0 {
+		return nil
+	}
 	if arena.internLeavesFull == nil {
 		arena.internLeavesFull = newInternTable()
 		return nil
@@ -373,6 +379,9 @@ func lookupCanonicalLeafKey(arena *nodeArena, key internKey) *Node {
 // the canonical entry for its key so subsequent shifts with the same
 // shape collapse to this pointer.
 func storeCanonicalLeaf(arena *nodeArena, leaf *Node) {
+	if arena == nil || leaf == nil || leaf.isMissing() {
+		return
+	}
 	if arena.internLeavesFull == nil {
 		arena.internLeavesFull = newInternTable()
 	}
@@ -383,7 +392,7 @@ func storeCanonicalLeaf(arena *nodeArena, leaf *Node) {
 // Caller must also pass the child slice for collision verification (two
 // distinct child slices could in principle hash equal).
 func (t *internTable) lookup(key internKey, children []*Node) *Node {
-	if t == nil || len(t.entries) == 0 {
+	if t == nil || len(t.entries) == 0 || key.flags&nodeFlagMissing != 0 {
 		return nil
 	}
 	t.lookups++
@@ -409,7 +418,7 @@ func (t *internTable) lookup(key internKey, children []*Node) *Node {
 // matching key, the existing node is preserved (first-wins) — callers
 // should look up before allocating.
 func (t *internTable) store(key internKey, node *Node) {
-	if t == nil || node == nil {
+	if t == nil || node == nil || key.flags&nodeFlagMissing != 0 || node.isMissing() {
 		return
 	}
 	if float64(t.occupied+1)/float64(len(t.entries)) > internTableMaxLoadFactor {

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1197,10 +1197,33 @@ type MaterializationSubtreeView struct {
 	// terminal (C ts_subtree_missing). Threaded to the public materializer so
 	// it can set the public node's own missing and has-error bits.
 	Missing bool
+	// MissingDependency carries C's sparse missing-leaf padding and lookahead
+	// metadata. It is valid only when MissingDependencyExact is true.
+	MissingDependency      MissingLeafDependency
+	MissingDependencyExact bool
 	// LexerSkippedPrefix is exact terminal provenance from the internal DFA.
 	// It is false for reductions, external tokens, and synthetic terminals.
 	LexerSkippedPrefix      bool
 	LexerSkippedPrefixStart uint32
+}
+
+// MissingLeafDependency preserves the source dependency of one zero-width
+// recovery insertion. Stack identifies the parser position before included-
+// range padding. Padding positions the visible leaf. LookaheadBytes extends
+// the edit dependency beyond the zero-width content.
+type MissingLeafDependency struct {
+	StackByte      uint32
+	StackRow       uint32
+	StackColumn    uint32
+	PaddingBytes   uint32
+	PaddingRows    uint32
+	PaddingColumn  uint32
+	LookaheadBytes uint32
+}
+
+type missingLeafProvenance struct {
+	payload    SubtreeID
+	dependency MissingLeafDependency
 }
 
 // Stats reports physical storage separately from semantic path counts. It is
@@ -1274,9 +1297,10 @@ type Core struct {
 	dropCohortLinkRefIndexes []uint32
 	dropCohortLinkRefJournal []dropCohortLinkRefMutation
 
-	subtrees             []subtreeRecord
-	externalProvenance   []externalPayloadProvenance
-	lexerSkippedPrefixes []lexerSkippedPrefixProvenance
+	subtrees              []subtreeRecord
+	externalProvenance    []externalPayloadProvenance
+	missingLeafProvenance []missingLeafProvenance
+	lexerSkippedPrefixes  []lexerSkippedPrefixProvenance
 	// recoveryDiscontinuityReductions records parents whose stack pop crossed
 	// a null recovery edge. C counts that edge for the pop depth, but it does
 	// not add a child to the materialized subtree.
@@ -1475,6 +1499,7 @@ type diagnosticOptions struct {
 
 type checkpoint struct {
 	nodes, nodeLineages, nodeCheckpoints, links, subtrees, externalProvenance int
+	missingLeafProvenance                                                     int
 	lexerSkippedPrefixes                                                      int
 	recoveryDiscontinuityReductions                                           int
 	children, fields, aliases                                                 int
@@ -1596,6 +1621,7 @@ func (c *Core) markInto(mark *checkpoint) {
 		links: len(c.links), subtrees: len(c.subtrees),
 		nodeCheckpoints:                 len(c.nodeCheckpoints),
 		externalProvenance:              len(c.externalProvenance),
+		missingLeafProvenance:           len(c.missingLeafProvenance),
 		lexerSkippedPrefixes:            len(c.lexerSkippedPrefixes),
 		recoveryDiscontinuityReductions: len(c.recoveryDiscontinuityReductions),
 		children:                        len(c.children), fields: len(c.fields), aliases: len(c.aliases),
@@ -1709,6 +1735,7 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 	c.subtrees = c.subtrees[:mark.subtrees]
 	c.eofRecoveryRoots = c.eofRecoveryRoots[:mark.eofRecoveryRoots]
 	c.externalProvenance = c.externalProvenance[:mark.externalProvenance]
+	c.missingLeafProvenance = c.missingLeafProvenance[:mark.missingLeafProvenance]
 	c.lexerSkippedPrefixes = c.lexerSkippedPrefixes[:mark.lexerSkippedPrefixes]
 	c.recoveryDiscontinuityReductions = c.recoveryDiscontinuityReductions[:mark.recoveryDiscontinuityReductions]
 	c.children = c.children[:mark.children]
@@ -2325,6 +2352,7 @@ func (c *Core) Reset() error {
 	c.subtrees = c.subtrees[:0]
 	c.eofRecoveryRoots = c.eofRecoveryRoots[:0]
 	c.externalProvenance = c.externalProvenance[:0]
+	c.missingLeafProvenance = c.missingLeafProvenance[:0]
 	c.lexerSkippedPrefixes = c.lexerSkippedPrefixes[:0]
 	c.recoveryDiscontinuityReductions = c.recoveryDiscontinuityReductions[:0]
 	c.children = c.children[:0]
@@ -4063,12 +4091,14 @@ func (c *Core) graphVersionIsDeterministic(root NodeID) (bool, error) {
 }
 
 type shallowPayloadClass struct {
-	symbol     Symbol
-	padding    uint32
-	size       uint32
-	childCount uint32
-	extra      bool
-	external   bool
+	symbol                 Symbol
+	padding                uint32
+	size                   uint32
+	childCount             uint32
+	missingDependency      MissingLeafDependency
+	missingDependencyExact bool
+	extra                  bool
+	external               bool
 }
 
 type recoveryMergeEquivalenceContext struct {
@@ -5104,6 +5134,16 @@ func (c *Core) subtreesStructurallyEqual(left, right SubtreeID) (bool, error) {
 			return false, nil
 		}
 	}
+	if l.missing {
+		leftDependency, leftExact := c.missingLeafDependency(left)
+		rightDependency, rightExact := c.missingLeafDependency(right)
+		if !leftExact || !rightExact {
+			return false, errors.New("parser-core phase zero: missing payload structural comparison lacks exact dependency provenance")
+		}
+		if leftDependency != rightDependency {
+			return false, nil
+		}
+	}
 	if !slices.Equal(
 		c.fields[l.firstField:l.firstField+l.fieldCount],
 		c.fields[r.firstField:r.firstField+r.fieldCount],
@@ -5166,11 +5206,18 @@ func (c *Core) shallowPayloadClass(prevID NodeID, payloadID SubtreeID) (shallowP
 	if payload.startByte < prev.byteOffset || payload.endByte < payload.startByte {
 		return shallowPayloadClass{}, false, errors.New("parser-core phase zero: invalid shallow payload extent")
 	}
-	return shallowPayloadClass{
+	class := shallowPayloadClass{
 		symbol: payload.symbol, padding: payload.startByte - prev.byteOffset,
 		size: payload.endByte - payload.startByte, childCount: payload.childCount,
 		extra: payload.extra, external: payload.external,
-	}, true, nil
+	}
+	if payload.missing {
+		class.missingDependency, class.missingDependencyExact = c.missingLeafDependency(payloadID)
+		if !class.missingDependencyExact {
+			return shallowPayloadClass{}, false, errors.New("parser-core phase zero: missing shallow payload lacks exact dependency provenance")
+		}
+	}
+	return class, true, nil
 }
 
 // replaceBoundaryLink publishes a new canonical adjacency while leaving the
@@ -6280,6 +6327,9 @@ func (c *Core) MaterializationView(id SubtreeID) (MaterializationSubtreeView, er
 			view.ExternalScannerCheckpointExact = true
 		}
 	}
+	if record.missing {
+		view.MissingDependency, view.MissingDependencyExact = c.missingLeafDependency(id)
+	}
 	view.LexerSkippedPrefixStart, view.LexerSkippedPrefix = c.lexerSkippedPrefix(id)
 	return view, nil
 }
@@ -6295,6 +6345,13 @@ func (c *Core) SubtreeArenaLen() int {
 }
 
 func (c *Core) validateMaterializationMetadata(id SubtreeID, record subtreeRecord) error {
+	if record.missing {
+		dependency, ok := c.missingLeafDependency(id)
+		positionedByte, addOK := addUint32Checked(dependency.StackByte, dependency.PaddingBytes)
+		if !ok || !addOK || record.startByte != positionedByte || record.endByte != positionedByte {
+			return errors.New("parser-core phase zero: missing leaf dependency provenance is stale")
+		}
+	}
 	// Production construction authenticates every terminal and reduction before
 	// publication. Compact arenas are immutable, so repeating the table remap at
 	// materialization adds no evidence. The flag is Core-scoped so subtreeRecord

--- a/internal/parsercorephase0/eof_recovery_shadow.go
+++ b/internal/parsercorephase0/eof_recovery_shadow.go
@@ -295,6 +295,7 @@ func planDiagnosticEOFRecoveryClone(live *Core, payloads []SubtreeID, providerWr
 		{len(live.eofRecoveryRoots), coreSubtreeIDBytes},
 		{len(live.recoveryDiscontinuityReductions), coreRecoveryDiscontinuityReductionBytes},
 		{len(live.externalProvenance), coreExternalProvenanceBytes},
+		{len(live.missingLeafProvenance), coreMissingLeafProvenanceBytes},
 		{len(live.lexerSkippedPrefixes), coreLexerSkippedPrefixBytes},
 		{len(live.children), coreChildRecordBytes},
 		{len(live.fields), coreFieldRecordBytes},
@@ -461,6 +462,7 @@ func cloneDiagnosticEOFRecoveryCore(
 	shadow.eofRecoveryRoots = cloneDiagnosticSlice(live.eofRecoveryRoots, 1)
 	shadow.recoveryDiscontinuityReductions = cloneDiagnosticSlice(live.recoveryDiscontinuityReductions, 0)
 	shadow.externalProvenance = cloneDiagnosticSlice(live.externalProvenance, 0)
+	shadow.missingLeafProvenance = cloneDiagnosticSlice(live.missingLeafProvenance, 0)
 	shadow.lexerSkippedPrefixes = cloneDiagnosticSlice(live.lexerSkippedPrefixes, 0)
 	shadow.children = cloneDiagnosticSlice(live.children, payloadCount)
 	shadow.fields = cloneDiagnosticSlice(live.fields, 0)
@@ -557,6 +559,7 @@ func diagnosticEOFRecoveryCopiedArenasEqual(live, shadow *Core) bool {
 		equalDiagnosticSlice(live.eofRecoveryRoots, shadow.eofRecoveryRoots[:len(live.eofRecoveryRoots)]) &&
 		equalDiagnosticSlice(live.recoveryDiscontinuityReductions, shadow.recoveryDiscontinuityReductions) &&
 		equalDiagnosticSlice(live.externalProvenance, shadow.externalProvenance) &&
+		equalDiagnosticSlice(live.missingLeafProvenance, shadow.missingLeafProvenance) &&
 		equalDiagnosticSlice(live.lexerSkippedPrefixes, shadow.lexerSkippedPrefixes) &&
 		equalDiagnosticSlice(live.children, shadow.children[:len(live.children)]) &&
 		equalDiagnosticSlice(live.fields, shadow.fields) &&
@@ -614,6 +617,7 @@ func diagnosticEOFRecoveryStorageDisjoint(live, shadow *Core) bool {
 		disjointDiagnosticSlice(live.eofRecoveryRoots, shadow.eofRecoveryRoots) &&
 		disjointDiagnosticSlice(live.recoveryDiscontinuityReductions, shadow.recoveryDiscontinuityReductions) &&
 		disjointDiagnosticSlice(live.externalProvenance, shadow.externalProvenance) &&
+		disjointDiagnosticSlice(live.missingLeafProvenance, shadow.missingLeafProvenance) &&
 		disjointDiagnosticSlice(live.lexerSkippedPrefixes, shadow.lexerSkippedPrefixes) &&
 		disjointDiagnosticSlice(live.children, shadow.children) &&
 		disjointDiagnosticSlice(live.fields, shadow.fields) &&

--- a/internal/parsercorephase0/materialization_postorder_scratch.go
+++ b/internal/parsercorephase0/materialization_postorder_scratch.go
@@ -141,6 +141,9 @@ func (c *Core) VisitMaterializationPostorderWithScratch(
 					view.ExternalScannerCheckpointExact = true
 				}
 			}
+			if record.missing {
+				view.MissingDependency, view.MissingDependencyExact = c.missingLeafDependency(top.id)
+			}
 			view.LexerSkippedPrefixStart, view.LexerSkippedPrefix = c.lexerSkippedPrefix(top.id)
 			if err := visit(top.id, view); err != nil {
 				return err

--- a/internal/parsercorephase0/missing_leaf.go
+++ b/internal/parsercorephase0/missing_leaf.go
@@ -1,6 +1,10 @@
 package parsercorephase0
 
-import "errors"
+import (
+	"errors"
+	"math"
+	"sort"
+)
 
 // compactMissingLeafStoredErrorCost is the pinned C cost of one missing
 // terminal: one recovery plus one missing-tree term.
@@ -21,19 +25,18 @@ const compactMissingLeafStoredErrorCost uint32 = 610
 // that stage.
 // ---------------------------------------------------------------------------
 
-// MissingLeaf publishes one zero-width recovery-inserted terminal.
+// MissingLeaf publishes one zero-width recovery-inserted terminal with no
+// padding or lookahead dependency. Recovery callers that have a live
+// lookahead must use MissingLeafWithDependency.
 //
 // C constructs the same object with ts_subtree_new_missing_leaf
 // (subtree.c:534-546): a leaf whose size is length_zero() and whose
 // is_missing bit is set. Two consequences of that construction are
 // reproduced here and must not be "simplified" away:
 //
-//   - The leaf is ZERO WIDTH. atByte is both its start and its end. C
-//     positions it at the stack's current byte offset: ts_parser__handle_error
-//     resets the lexer to the stack position and immediately marks the end
-//     (parser.c), so the computed padding is zero and the leaf carries no
-//     source text at all. A caller that passes a span here is describing
-//     something that is not a missing token.
+//   - The leaf is ZERO WIDTH. Included-range padding can position that empty
+//     content after the stack boundary. The sparse dependency receipt keeps
+//     the stack position, padding extent, and lookahead bytes separate.
 //
 //   - The leaf is NOT extra and NOT external. C passes false for external
 //     tokens and builds the leaf outside the scanner entirely; it is a
@@ -67,25 +70,77 @@ const compactMissingLeafStoredErrorCost uint32 = 610
 // Materialization validates reduction metadata, not this. The scheduler
 // caller must authenticate the symbol against its state before publishing.
 func (c *Core) MissingLeaf(symbol Symbol, atByte uint32) (id SubtreeID, err error) {
-	mark := c.mark()
-	defer c.completeTransaction(mark, &err)
-	return c.missingLeafUncheckpointed(symbol, atByte)
+	return c.MissingLeafWithDependency(symbol, MissingLeafDependency{StackByte: atByte})
 }
 
-func (c *Core) missingLeafUncheckpointed(symbol Symbol, atByte uint32) (SubtreeID, error) {
+// MissingLeafWithDependency publishes one missing terminal with C-equivalent
+// padding and lookahead metadata.
+func (c *Core) MissingLeafWithDependency(symbol Symbol, dependency MissingLeafDependency) (id SubtreeID, err error) {
+	mark := c.mark()
+	defer c.completeTransaction(mark, &err)
+	return c.missingLeafUncheckpointed(symbol, dependency)
+}
+
+func addUint32Checked(left, right uint32) (uint32, bool) {
+	if math.MaxUint32-left < right {
+		return 0, false
+	}
+	return left + right, true
+}
+
+func validateMissingLeafDependency(dependency MissingLeafDependency) (uint32, error) {
+	positionedByte, ok := addUint32Checked(dependency.StackByte, dependency.PaddingBytes)
+	if !ok {
+		return 0, errors.New("parser-core phase zero: missing leaf padding byte overflow")
+	}
+	if _, ok := addUint32Checked(positionedByte, dependency.LookaheadBytes); !ok {
+		return 0, errors.New("parser-core phase zero: missing leaf lookahead byte overflow")
+	}
+	if dependency.PaddingRows == 0 {
+		if _, ok := addUint32Checked(dependency.StackColumn, dependency.PaddingColumn); !ok {
+			return 0, errors.New("parser-core phase zero: missing leaf padding column overflow")
+		}
+	} else if _, ok := addUint32Checked(dependency.StackRow, dependency.PaddingRows); !ok {
+		return 0, errors.New("parser-core phase zero: missing leaf padding row overflow")
+	}
+	return positionedByte, nil
+}
+
+func (c *Core) missingLeafUncheckpointed(symbol Symbol, dependency MissingLeafDependency) (SubtreeID, error) {
 	if symbol == 0 {
 		return 0, errors.New("parser-core phase zero: missing leaf requires a real terminal symbol")
 	}
 	if symbol == ErrorRegionSymbol {
 		return 0, errors.New("parser-core phase zero: missing leaf cannot carry the ERROR symbol")
 	}
-	return c.appendSubtree(subtreeRecord{
+	positionedByte, err := validateMissingLeafDependency(dependency)
+	if err != nil {
+		return 0, err
+	}
+	payload, err := c.appendSubtree(subtreeRecord{
 		symbol:    symbol,
-		startByte: atByte,
-		endByte:   atByte,
+		startByte: positionedByte,
+		endByte:   positionedByte,
 		terminal:  true,
 		missing:   true,
 	}, nil, nil, nil)
+	if err != nil {
+		return 0, err
+	}
+	c.missingLeafProvenance = append(c.missingLeafProvenance, missingLeafProvenance{
+		payload: payload, dependency: dependency,
+	})
+	return payload, nil
+}
+
+func (c *Core) missingLeafDependency(payload SubtreeID) (MissingLeafDependency, bool) {
+	index := sort.Search(len(c.missingLeafProvenance), func(index int) bool {
+		return c.missingLeafProvenance[index].payload >= payload
+	})
+	if index >= len(c.missingLeafProvenance) || c.missingLeafProvenance[index].payload != payload {
+		return MissingLeafDependency{}, false
+	}
+	return c.missingLeafProvenance[index].dependency, true
 }
 
 // ShiftMissingLeaf publishes one missing terminal and attaches it to head at
@@ -106,34 +161,46 @@ func (c *Core) missingLeafUncheckpointed(symbol Symbol, atByte uint32) (SubtreeI
 // because the caller has already read the action row to find it and to run
 // C's reduce-action test on the result.
 func (c *Core) ShiftMissingLeaf(head Head, targetState StateID, symbol Symbol, atByte uint32) (out Head, err error) {
+	return c.ShiftMissingLeafWithDependency(head, targetState, symbol, MissingLeafDependency{StackByte: atByte})
+}
+
+// ShiftMissingLeafWithDependency attaches a missing terminal and its exact
+// source dependency.
+func (c *Core) ShiftMissingLeafWithDependency(head Head, targetState StateID, symbol Symbol, dependency MissingLeafDependency) (out Head, err error) {
 	if targetState == 0 {
 		return Head{}, errors.New("parser-core phase zero: missing leaf shift requires a real target state")
 	}
 	mark := c.mark()
 	defer c.completeTransaction(mark, &err)
-	return c.shiftMissingLeafUncheckpointed(head, targetState, symbol, atByte)
+	return c.shiftMissingLeafUncheckpointed(head, targetState, symbol, dependency)
 }
 
 // ShiftMissingLeafOwned attaches one authenticated missing leaf without
 // opening a nested ordinary checkpoint. Scheduler recovery uses this seam
 // inside a speculative transaction.
 func (c *Core) ShiftMissingLeafOwned(owner SchedulerTransactionToken, head Head, targetState StateID, symbol Symbol, atByte uint32) (out Head, err error) {
+	return c.ShiftMissingLeafWithDependencyOwned(owner, head, targetState, symbol, MissingLeafDependency{StackByte: atByte})
+}
+
+// ShiftMissingLeafWithDependencyOwned attaches one authenticated missing leaf
+// and its exact source dependency inside a scheduler transaction.
+func (c *Core) ShiftMissingLeafWithDependencyOwned(owner SchedulerTransactionToken, head Head, targetState StateID, symbol Symbol, dependency MissingLeafDependency) (out Head, err error) {
 	if err = c.beginSchedulerOwned(owner); err != nil {
 		return out, err
 	}
 	defer c.recoverSchedulerOwnedPanic(owner)
-	out, err = c.shiftMissingLeafUncheckpointed(head, targetState, symbol, atByte)
+	out, err = c.shiftMissingLeafUncheckpointed(head, targetState, symbol, dependency)
 	return out, c.finishSchedulerOwned(owner, err)
 }
 
-func (c *Core) shiftMissingLeafUncheckpointed(head Head, targetState StateID, symbol Symbol, atByte uint32) (out Head, err error) {
+func (c *Core) shiftMissingLeafUncheckpointed(head Head, targetState StateID, symbol Symbol, dependency MissingLeafDependency) (out Head, err error) {
 	if targetState == 0 {
 		return Head{}, errors.New("parser-core phase zero: missing leaf shift requires a real target state")
 	}
 	if _, err := c.node(head.Node); err != nil {
 		return Head{}, err
 	}
-	payload, err := c.missingLeafUncheckpointed(symbol, atByte)
+	payload, err := c.missingLeafUncheckpointed(symbol, dependency)
 	if err != nil {
 		return Head{}, err
 	}
@@ -145,7 +212,11 @@ func (c *Core) shiftMissingLeafUncheckpointed(head Head, targetState StateID, sy
 		return Head{}, errors.New("parser-core phase zero: missing leaf stored recovery cost overflow")
 	}
 	storedErrorCost := lineage.storedErrorCost + compactMissingLeafStoredErrorCost
-	outcome, err := c.condenseWithOutcomeAtomic(c.shiftedBoundaryKey(targetState, atByte), linkInput{
+	positionedByte, err := validateMissingLeafDependency(dependency)
+	if err != nil {
+		return Head{}, err
+	}
+	outcome, err := c.condenseWithOutcomeAtomic(c.shiftedBoundaryKey(targetState, positionedByte), linkInput{
 		prev: head.Node, payload: payload, storedErrorCost: storedErrorCost, hasStoredErrorCost: true,
 	})
 	return outcome.head, err

--- a/internal/parsercorephase0/missing_leaf_test.go
+++ b/internal/parsercorephase0/missing_leaf_test.go
@@ -1,6 +1,10 @@
 package parsercorephase0
 
-import "testing"
+import (
+	"errors"
+	"testing"
+	"unsafe"
+)
 
 // MissingLeaf is the compact representation of C's
 // ts_subtree_new_missing_leaf (subtree.c:534-546). These tests drive the Core
@@ -105,6 +109,127 @@ func TestMissingLeafSurfacesThroughMaterializationView(t *testing.T) {
 	}
 	if ordinaryView.Missing {
 		t.Fatal("an ordinary published terminal reported the missing bit")
+	}
+}
+
+func TestMissingLeafPreservesPaddingAndLookaheadDependency(t *testing.T) {
+	compact := newMissingLeafTestCore(t)
+	want := MissingLeafDependency{
+		StackByte: 4, StackRow: 1, StackColumn: 2,
+		PaddingBytes: 7, PaddingRows: 2, PaddingColumn: 3,
+		LookaheadBytes: 5,
+	}
+	id, err := compact.MissingLeafWithDependency(Symbol(3), want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, err := compact.MaterializationView(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.StartByte != 11 || view.EndByte != 11 || !view.MissingDependencyExact || view.MissingDependency != want {
+		t.Fatalf("materialization view=%+v, want zero-width byte 11 and dependency %+v", view, want)
+	}
+	if got := unsafe.Sizeof(subtreeRecord{}); got != 44 {
+		t.Fatalf("subtreeRecord size=%d, want 44", got)
+	}
+	if got := unsafe.Sizeof(missingLeafProvenance{}); got != 32 {
+		t.Fatalf("missing-leaf provenance size=%d, want 32", got)
+	}
+}
+
+func TestMissingLeafDependencyRollsBackWithTransaction(t *testing.T) {
+	compact := newMissingLeafTestCore(t)
+	before := compact.FootprintBytes()
+	sentinel := errors.New("rollback missing dependency")
+	err := compact.ApplyAtomic(func() error {
+		if _, err := compact.MissingLeafWithDependency(Symbol(3), MissingLeafDependency{
+			StackByte: 2, PaddingBytes: 3, LookaheadBytes: 4,
+		}); err != nil {
+			return err
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("rollback error=%v, want %v", err, sentinel)
+	}
+	if len(compact.subtrees) != 0 || len(compact.missingLeafProvenance) != 0 {
+		t.Fatalf("rollback retained subtrees=%d dependencies=%d", len(compact.subtrees), len(compact.missingLeafProvenance))
+	}
+	if compact.FootprintBytes() < before {
+		t.Fatalf("rollback footprint=%d, want retained capacity at least %d", compact.FootprintBytes(), before)
+	}
+}
+
+func TestMissingLeafDependencyRejectsOverflow(t *testing.T) {
+	compact := newMissingLeafTestCore(t)
+	for name, dependency := range map[string]MissingLeafDependency{
+		"padding-byte":   {StackByte: ^uint32(0), PaddingBytes: 1},
+		"lookahead-byte": {StackByte: ^uint32(0) - 1, PaddingBytes: 1, LookaheadBytes: 1},
+		"padding-row":    {StackRow: ^uint32(0), PaddingRows: 1},
+		"padding-column": {StackColumn: ^uint32(0), PaddingColumn: 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := compact.MissingLeafWithDependency(Symbol(3), dependency); err == nil {
+				t.Fatal("overflow dependency was accepted")
+			}
+		})
+	}
+}
+
+func TestMissingLeafDependencyRejectsStaleSidecar(t *testing.T) {
+	compact := newMissingLeafTestCore(t)
+	id, err := compact.MissingLeafWithDependency(Symbol(3), MissingLeafDependency{
+		StackByte: 2, StackColumn: 2, PaddingBytes: 3, PaddingColumn: 3, LookaheadBytes: 4,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact.missingLeafProvenance[0].payload = id + 1
+	err = compact.VisitMaterializationPostorder([]SubtreeID{id}, func() error { return nil }, func(SubtreeID, MaterializationSubtreeView) error { return nil })
+	if err == nil {
+		t.Fatal("materialization accepted a stale missing dependency sidecar")
+	}
+}
+
+func TestMissingLeafDependencySurfacesThroughPostorderVisitor(t *testing.T) {
+	compact := newMissingLeafTestCore(t)
+	want := MissingLeafDependency{
+		StackByte: 2, StackRow: 1, StackColumn: 4,
+		PaddingBytes: 3, PaddingRows: 2, PaddingColumn: 1, LookaheadBytes: 4,
+	}
+	id, err := compact.MissingLeafWithDependency(Symbol(3), want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got MissingLeafDependency
+	var exact bool
+	err = compact.VisitMaterializationPostorder([]SubtreeID{id}, func() error { return nil }, func(_ SubtreeID, view MaterializationSubtreeView) error {
+		got, exact = view.MissingDependency, view.MissingDependencyExact
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exact || got != want {
+		t.Fatalf("postorder dependency=%+v exact=%t, want %+v", got, exact, want)
+	}
+}
+
+func TestMissingLeafDependencyReleasesDeclinedReserve(t *testing.T) {
+	compact, err := New(&fakeTable{}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := compact.MissingLeafWithDependency(Symbol(3), MissingLeafDependency{StackByte: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	compact.releaseRecordArenaReserve()
+	if compact.missingLeafProvenance != nil {
+		t.Fatal("decline release retained missing-leaf provenance")
 	}
 }
 
@@ -224,6 +349,39 @@ func TestMissingLeafIsNotStructurallyEqualToCleanPayload(t *testing.T) {
 	}
 	if !equal {
 		t.Fatal("two identical clean payloads stopped comparing equal; the missing bit over-separated them")
+	}
+}
+
+func TestMissingLeafDependenciesPreventDuplicateFold(t *testing.T) {
+	compact, err := New(&fakeTable{}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(StateID(1), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := compact.MissingLeafWithDependency(Symbol(3), MissingLeafDependency{StackByte: 1, LookaheadBytes: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := compact.MissingLeafWithDependency(Symbol(3), MissingLeafDependency{StackByte: 1, LookaheadBytes: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	equal, err := compact.subtreesStructurallyEqual(left, right)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if equal {
+		t.Fatal("missing leaves with different lookahead dependencies compared equal")
+	}
+	equal, err = compact.shallowPayloadsEqual(seed.Node, left, seed.Node, right)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if equal {
+		t.Fatal("missing leaves with different lookahead dependencies shared a shallow fold class")
 	}
 }
 

--- a/internal/parsercorephase0/reset_test.go
+++ b/internal/parsercorephase0/reset_test.go
@@ -55,6 +55,7 @@ func TestResetRetainsConfigurationAndArenaCapacity(t *testing.T) {
 	wantCaps := [...]int{
 		cap(compact.nodes), cap(compact.nodeCheckpoints), cap(compact.links), cap(compact.subtrees),
 		cap(compact.externalProvenance),
+		cap(compact.missingLeafProvenance),
 		cap(compact.lexerSkippedPrefixes),
 		cap(compact.children), cap(compact.fields), cap(compact.aliases),
 		cap(compact.boundaries.slots), cap(compact.boundaryJournal), cap(compact.transactions),
@@ -70,6 +71,7 @@ func TestResetRetainsConfigurationAndArenaCapacity(t *testing.T) {
 	gotCaps := [...]int{
 		cap(compact.nodes), cap(compact.nodeCheckpoints), cap(compact.links), cap(compact.subtrees),
 		cap(compact.externalProvenance),
+		cap(compact.missingLeafProvenance),
 		cap(compact.lexerSkippedPrefixes),
 		cap(compact.children), cap(compact.fields), cap(compact.aliases),
 		cap(compact.boundaries.slots), cap(compact.boundaryJournal), cap(compact.transactions),
@@ -78,7 +80,7 @@ func TestResetRetainsConfigurationAndArenaCapacity(t *testing.T) {
 	if gotCaps != wantCaps {
 		t.Fatalf("reset changed retained capacities: got=%v want=%v", gotCaps, wantCaps)
 	}
-	if len(compact.nodes) != 0 || len(compact.nodeCheckpoints) != 0 || len(compact.links) != 0 || len(compact.subtrees) != 0 || len(compact.externalProvenance) != 0 || len(compact.lexerSkippedPrefixes) != 0 || len(compact.children) != 0 || len(compact.fields) != 0 || len(compact.aliases) != 0 || compact.boundaries.count != 0 || len(compact.boundaryJournal) != 0 || len(compact.transactions) != 0 {
+	if len(compact.nodes) != 0 || len(compact.nodeCheckpoints) != 0 || len(compact.links) != 0 || len(compact.subtrees) != 0 || len(compact.externalProvenance) != 0 || len(compact.missingLeafProvenance) != 0 || len(compact.lexerSkippedPrefixes) != 0 || len(compact.children) != 0 || len(compact.fields) != 0 || len(compact.aliases) != 0 || compact.boundaries.count != 0 || len(compact.boundaryJournal) != 0 || len(compact.transactions) != 0 {
 		t.Fatalf("reset retained logical state: nodes=%d node_checkpoints=%d links=%d subtrees=%d external_provenance=%d lexer_skipped_prefixes=%d children=%d fields=%d aliases=%d boundaries=%d journal=%d transactions=%d", len(compact.nodes), len(compact.nodeCheckpoints), len(compact.links), len(compact.subtrees), len(compact.externalProvenance), len(compact.lexerSkippedPrefixes), len(compact.children), len(compact.fields), len(compact.aliases), compact.boundaries.count, len(compact.boundaryJournal), len(compact.transactions))
 	}
 	if compact.frontier != 1 || compact.checkpoint != 0 || compact.nextTransaction != 0 || compact.Work() != (Work{}) {
@@ -119,6 +121,7 @@ func TestResetRejectsNilAndActiveTransactionWithoutMutation(t *testing.T) {
 		beforeLinks := append([]linkRecord(nil), compact.links...)
 		beforeSubtrees := append([]subtreeRecord(nil), compact.subtrees...)
 		beforeExternalProvenance := append([]externalPayloadProvenance(nil), compact.externalProvenance...)
+		beforeMissingLeafProvenance := append([]missingLeafProvenance(nil), compact.missingLeafProvenance...)
 		beforeLexerSkippedPrefixes := append([]lexerSkippedPrefixProvenance(nil), compact.lexerSkippedPrefixes...)
 		beforeChildren := append([]SubtreeID(nil), compact.children...)
 		beforeFields := append([]FieldMapEntry(nil), compact.fields...)
@@ -133,7 +136,7 @@ func TestResetRejectsNilAndActiveTransactionWithoutMutation(t *testing.T) {
 		if err := compact.Reset(); err == nil {
 			t.Fatal("reset during active transaction unexpectedly succeeded")
 		}
-		if !reflect.DeepEqual(compact.nodes, beforeNodes) || !reflect.DeepEqual(compact.nodeCheckpoints, beforeNodeCheckpoints) || !reflect.DeepEqual(compact.links, beforeLinks) || !reflect.DeepEqual(compact.subtrees, beforeSubtrees) || !reflect.DeepEqual(compact.externalProvenance, beforeExternalProvenance) || !reflect.DeepEqual(compact.lexerSkippedPrefixes, beforeLexerSkippedPrefixes) || !reflect.DeepEqual(compact.children, beforeChildren) || !reflect.DeepEqual(compact.fields, beforeFields) || !reflect.DeepEqual(compact.aliases, beforeAliases) || !reflect.DeepEqual(compact.boundaries.logicalMap(), beforeBoundaries) || !reflect.DeepEqual(compact.boundaries.snapshot(), beforeBoundaryIndex) || !reflect.DeepEqual(compact.boundaryJournal, beforeJournal) || !reflect.DeepEqual(compact.transactions, beforeTransactions) || compact.frontier != beforeFrontier || compact.checkpoint != beforeCheckpoint || compact.nextTransaction != beforeNext || compact.work != beforeWork {
+		if !reflect.DeepEqual(compact.nodes, beforeNodes) || !reflect.DeepEqual(compact.nodeCheckpoints, beforeNodeCheckpoints) || !reflect.DeepEqual(compact.links, beforeLinks) || !reflect.DeepEqual(compact.subtrees, beforeSubtrees) || !reflect.DeepEqual(compact.externalProvenance, beforeExternalProvenance) || !reflect.DeepEqual(compact.missingLeafProvenance, beforeMissingLeafProvenance) || !reflect.DeepEqual(compact.lexerSkippedPrefixes, beforeLexerSkippedPrefixes) || !reflect.DeepEqual(compact.children, beforeChildren) || !reflect.DeepEqual(compact.fields, beforeFields) || !reflect.DeepEqual(compact.aliases, beforeAliases) || !reflect.DeepEqual(compact.boundaries.logicalMap(), beforeBoundaries) || !reflect.DeepEqual(compact.boundaries.snapshot(), beforeBoundaryIndex) || !reflect.DeepEqual(compact.boundaryJournal, beforeJournal) || !reflect.DeepEqual(compact.transactions, beforeTransactions) || compact.frontier != beforeFrontier || compact.checkpoint != beforeCheckpoint || compact.nextTransaction != beforeNext || compact.work != beforeWork {
 			t.Fatal("rejected active reset mutated compact state")
 		}
 		if state, offset, err := compact.Boundary(seed); err != nil || state != 1 || offset != 0 {

--- a/internal/parsercorephase0/selected_store_test.go
+++ b/internal/parsercorephase0/selected_store_test.go
@@ -145,9 +145,13 @@ func TestSelectedBuildScratchCountsAndReleasesErrorFlags(t *testing.T) {
 	}
 
 	core.selectedBuild.resultHasError = make([]bool, coreRetentionCapBytes+1)
+	core.missingLeafProvenance = make([]missingLeafProvenance, 0, 1)
 	core.releaseOversizedRetention()
 	if core.selectedBuild.resultHasError != nil {
 		t.Fatal("retention release kept oversized selected-build error flags")
+	}
+	if core.missingLeafProvenance != nil {
+		t.Fatal("retention release kept missing-leaf provenance")
 	}
 }
 

--- a/internal/parsercorephase0/storage_bytes.go
+++ b/internal/parsercorephase0/storage_bytes.go
@@ -95,6 +95,7 @@ var (
 	coreNodeLineageRecordBytes              = uint64(unsafe.Sizeof(nodeLineageRecord{}))
 	coreCheckpointIDBytes                   = uint64(unsafe.Sizeof(CheckpointID(0)))
 	coreExternalProvenanceBytes             = uint64(unsafe.Sizeof(externalPayloadProvenance{}))
+	coreMissingLeafProvenanceBytes          = uint64(unsafe.Sizeof(missingLeafProvenance{}))
 	coreLexerSkippedPrefixBytes             = uint64(unsafe.Sizeof(lexerSkippedPrefixProvenance{}))
 	coreRecoveryDiscontinuityReductionBytes = uint64(unsafe.Sizeof(recoveryDiscontinuityReduction{}))
 	coreCheckpointRecordBytes               = uint64(unsafe.Sizeof(checkpointRecord{}))
@@ -163,6 +164,7 @@ func (c *Core) FootprintBytes() uint64 {
 	total += uint64(cap(c.nodeLineages)) * coreNodeLineageRecordBytes
 	total += uint64(cap(c.nodeCheckpoints)) * coreCheckpointIDBytes
 	total += uint64(cap(c.externalProvenance)) * coreExternalProvenanceBytes
+	total += uint64(cap(c.missingLeafProvenance)) * coreMissingLeafProvenanceBytes
 	total += uint64(cap(c.lexerSkippedPrefixes)) * coreLexerSkippedPrefixBytes
 	total += uint64(cap(c.boundaryJournal)) * coreBoundaryMutationBytes
 	total += uint64(cap(c.nodeLineageJournal)) * coreNodeLineageMutationBytes
@@ -322,6 +324,7 @@ func (c *Core) releaseRecordArenaReserve() {
 	c.subtrees = nil
 	c.eofRecoveryRoots = nil
 	c.recoveryDiscontinuityReductions = nil
+	c.missingLeafProvenance = nil
 	c.children = nil
 	c.dropCohortRefSpill = nil
 	c.dropCohortActions = nil
@@ -356,6 +359,7 @@ func (c *Core) releaseOversizedRetention() {
 	c.eofRecoveryRoots = nil
 	c.recoveryDiscontinuityReductions = nil
 	c.externalProvenance = nil
+	c.missingLeafProvenance = nil
 	c.lexerSkippedPrefixes = nil
 	c.children = nil
 	c.fields = nil

--- a/lexer.go
+++ b/lexer.go
@@ -23,6 +23,14 @@ type Token struct {
 	StartPoint Point
 	EndPoint   Point
 	Missing    bool
+	// lexerLookaheadEndByte is the farthest byte inspected while selecting a
+	// lexed token. Synthetic missing tokens retain that token's frontier.
+	lexerLookaheadEndByte uint32
+	// missingStack identifies the stack position before padding for a
+	// synthetic recovery token. It is never set on lexed input.
+	missingStackByte       uint32
+	missingStackPoint      Point
+	missingDependencyExact bool
 	// NoLookahead marks a synthetic EOF used to force EOF-table reductions
 	// without consuming input, matching tree-sitter's lex_state = -1.
 	NoLookahead bool
@@ -122,6 +130,13 @@ func (l *Lexer) NextWithErrorRuns(startState uint32) Token {
 }
 
 func (l *Lexer) next(startState uint32, emitErrorRuns bool) Token {
+	return l.nextWithFrontier(startState, emitErrorRuns, 0)
+}
+
+// nextWithFrontier carries the largest lexer frontier observed by every
+// attempt in one C-style lex call. C updates lookahead_end_byte after each
+// internal, external, and error-mode attempt, including attempts that fail.
+func (l *Lexer) nextWithFrontier(startState uint32, emitErrorRuns bool, lookaheadEndByte uint32) Token {
 	l.normalizeIncludedPosition()
 	l.skipLeadingBOM()
 	// C ts_parser__lex resets to the lex call's start position (before any
@@ -133,11 +148,13 @@ func (l *Lexer) next(startState uint32, emitErrorRuns bool) Token {
 	for {
 		// EOF check.
 		if l.atLogicalEOF() {
+			lookaheadEndByte = maxUint32(lookaheadEndByte, l.lookaheadEndByteAt(l.pos, false))
 			return Token{
-				StartByte:  uint32(l.pos),
-				EndByte:    uint32(l.pos),
-				StartPoint: Point{Row: l.row, Column: l.col},
-				EndPoint:   Point{Row: l.row, Column: l.col},
+				StartByte:             uint32(l.pos),
+				EndByte:               uint32(l.pos),
+				StartPoint:            Point{Row: l.row, Column: l.col},
+				EndPoint:              Point{Row: l.row, Column: l.col},
+				lexerLookaheadEndByte: lookaheadEndByte,
 			}
 		}
 
@@ -146,6 +163,7 @@ func (l *Lexer) next(startState uint32, emitErrorRuns bool) Token {
 		tokenStartCol := l.col
 
 		tok, ok := l.scan(startState, tokenStartPos, tokenStartRow, tokenStartCol)
+		lookaheadEndByte = maxUint32(lookaheadEndByte, tok.lexerLookaheadEndByte)
 		if ok {
 			if tok.Symbol == 0 {
 				// Skip token (whitespace). Verify the lexer actually
@@ -163,6 +181,7 @@ func (l *Lexer) next(startState uint32, emitErrorRuns bool) Token {
 				tok.lexerSkippedPrefix = true
 				tok.lexerSkippedPrefixStart = uint32(callStartPos)
 			}
+			tok.lexerLookaheadEndByte = lookaheadEndByte
 			return tok
 		}
 		skippedPrefix = false
@@ -176,10 +195,10 @@ func (l *Lexer) next(startState uint32, emitErrorRuns bool) Token {
 			// the error-run branch below on failure instead of recursing.
 			l.pos, l.row, l.col = callStartPos, callStartRow, callStartCol
 			l.includedRangeIdx = callStartRangeIdx
-			return l.next(l.errorRunLexState, true)
+			return l.nextWithFrontier(l.errorRunLexState, true, lookaheadEndByte)
 		}
-		if emitErrorRuns && l.hasErrorRunLexState && !l.canLexAt(l.errorRunLexState, tokenStartPos, tokenStartRow, tokenStartCol) {
-			return l.errorRunToken()
+		if emitErrorRuns && l.hasErrorRunLexState && !l.canLexAt(l.errorRunLexState, tokenStartPos, tokenStartRow, tokenStartCol, &lookaheadEndByte) {
+			return l.errorRunToken(&lookaheadEndByte)
 		}
 		// No accepting state was found. Skip one rune as error recovery.
 		l.skipOneRune()
@@ -196,10 +215,13 @@ func (l *Lexer) skipLeadingBOM() {
 
 // canLexAt reports whether the DFA can lex a token (or whitespace skip)
 // starting at the given position, without moving the lexer.
-func (l *Lexer) canLexAt(lexState uint32, pos int, row, col uint32) bool {
+func (l *Lexer) canLexAt(lexState uint32, pos int, row, col uint32, frontier *uint32) bool {
 	savedPos, savedRow, savedCol := l.pos, l.row, l.col
 	savedRangeIdx := l.includedRangeIdx
-	_, ok := l.scan(lexState, pos, row, col)
+	tok, ok := l.scan(lexState, pos, row, col)
+	if frontier != nil {
+		*frontier = maxUint32(*frontier, tok.lexerLookaheadEndByte)
+	}
 	l.pos, l.row, l.col = savedPos, savedRow, savedCol
 	l.includedRangeIdx = savedRangeIdx
 	return ok
@@ -210,7 +232,7 @@ func (l *Lexer) canLexAt(lexState uint32, pos int, row, col uint32) bool {
 // it as an errorSymbol token. The run ends at the first position where the
 // error-mode lex state can lex again, matching C's character-by-character
 // error skipping.
-func (l *Lexer) errorRunToken() Token {
+func (l *Lexer) errorRunToken(frontier *uint32) Token {
 	// Position the lexer at the real error start: scan records where the
 	// token attempt began after consuming skip (whitespace) transitions.
 	if l.failTokenStartPos > l.pos && l.failTokenStartPos <= len(l.source) {
@@ -222,29 +244,37 @@ func (l *Lexer) errorRunToken() Token {
 	l.normalizeIncludedPosition()
 	if l.atLogicalEOF() {
 		// Only whitespace remained: this is end-of-input, not an error run.
+		if frontier != nil {
+			*frontier = maxUint32(*frontier, l.lookaheadEndByteAt(l.pos, false))
+		}
 		return Token{
-			StartByte:  uint32(l.pos),
-			EndByte:    uint32(l.pos),
-			StartPoint: Point{Row: l.row, Column: l.col},
-			EndPoint:   Point{Row: l.row, Column: l.col},
+			StartByte:             uint32(l.pos),
+			EndByte:               uint32(l.pos),
+			StartPoint:            Point{Row: l.row, Column: l.col},
+			EndPoint:              Point{Row: l.row, Column: l.col},
+			lexerLookaheadEndByte: frontierValue(frontier),
 		}
 	}
 	startPos, startRow, startCol := l.pos, l.row, l.col
 
 	l.skipOneRune()
 	for !l.atLogicalEOF() {
-		if l.canLexAt(l.errorRunLexState, l.pos, l.row, l.col) {
+		if l.canLexAt(l.errorRunLexState, l.pos, l.row, l.col, frontier) {
 			break
 		}
 		l.skipOneRune()
 	}
+	if frontier != nil {
+		*frontier = maxUint32(*frontier, l.lookaheadEndByteAt(l.pos, false))
+	}
 	return Token{
-		Symbol:     errorSymbol,
-		Text:       l.tokenText(startPos, l.pos),
-		StartByte:  uint32(startPos),
-		EndByte:    uint32(l.pos),
-		StartPoint: Point{Row: startRow, Column: startCol},
-		EndPoint:   Point{Row: l.row, Column: l.col},
+		Symbol:                errorSymbol,
+		Text:                  l.tokenText(startPos, l.pos),
+		StartByte:             uint32(startPos),
+		EndByte:               uint32(l.pos),
+		StartPoint:            Point{Row: startRow, Column: startCol},
+		EndPoint:              Point{Row: l.row, Column: l.col},
+		lexerLookaheadEndByte: frontierValue(frontier),
 	}
 }
 
@@ -410,12 +440,17 @@ func (l *Lexer) scanContiguous(startState uint32, startPos int, startRow, startC
 		acceptSkip = true
 	}
 
+	lookaheadEndByte := l.lookaheadEndByteAt(scanPos, true)
+	if lookaheadEndByte < uint32(maxInt(acceptPos, 0)) {
+		lookaheadEndByte = uint32(maxInt(acceptPos, 0))
+	}
+
 	if acceptPos < 0 {
 		l.failTokenStartPos = tokenStartPos
 		l.failTokenStartRow = tokenStartRow
 		l.failTokenStartCol = tokenStartCol
 		l.failTokenStartRangeIdx = 0
-		return Token{}, false
+		return Token{lexerLookaheadEndByte: lookaheadEndByte}, false
 	}
 
 	// Rewind (or advance) to the accept position.
@@ -432,6 +467,7 @@ func (l *Lexer) scanContiguous(startState uint32, startPos int, startRow, startC
 			EndPoint:                Point{Row: acceptRow, Column: acceptCol},
 			lexerSkippedPrefix:      skippedPrefix,
 			lexerSkippedPrefixStart: uint32(startPos),
+			lexerLookaheadEndByte:   lookaheadEndByte,
 		}, true
 	}
 
@@ -445,7 +481,49 @@ func (l *Lexer) scanContiguous(startState uint32, startPos int, startRow, startC
 		lexerSkippedPrefix:      skippedPrefix,
 		lexerSkippedPrefixStart: uint32(startPos),
 		lexerInternalDFALexed:   true,
+		lexerLookaheadEndByte:   lookaheadEndByte,
 	}, true
+}
+
+func tokenLookaheadEndByte(token Token) uint32 {
+	if token.lexerLookaheadEndByte > token.EndByte {
+		return token.lexerLookaheadEndByte
+	}
+	return token.EndByte
+}
+
+func maxUint32(left, right uint32) uint32 {
+	if left >= right {
+		return left
+	}
+	return right
+}
+
+func frontierValue(frontier *uint32) uint32 {
+	if frontier == nil {
+		return 0
+	}
+	return *frontier
+}
+
+// lookaheadEndByteAt mirrors ts_lexer_finish. The C lexer records one byte
+// beyond the current cursor, plus four bytes when the current lookahead is an
+// invalid UTF-8 sequence. Included-range EOF must not inspect the source gap.
+func (l *Lexer) lookaheadEndByteAt(pos int, inspectInvalid bool) uint32 {
+	if pos < 0 {
+		pos = 0
+	}
+	frontier := uint64(pos) + 1
+	if inspectInvalid && pos < len(l.source) {
+		r, size := utf8.DecodeRune(l.source[pos:])
+		if r == utf8.RuneError && size == 1 && l.source[pos] >= utf8.RuneSelf {
+			frontier += 4
+		}
+	}
+	if frontier > uint64(^uint32(0)) {
+		return ^uint32(0)
+	}
+	return uint32(frontier)
 }
 
 // skipOneRune advances the lexer position by one rune, updating row/column.

--- a/lexer_included_ranges.go
+++ b/lexer_included_ranges.go
@@ -52,7 +52,7 @@ func (l *Lexer) normalizeIncludedCursor(cursor *includedLexerCursor) {
 			cursor.rangeIdx++
 			continue
 		}
-		if cursor.pos < start {
+		if cursor.pos <= start {
 			r := l.includedRanges[cursor.rangeIdx]
 			cursor.pos = start
 			cursor.row = r.StartPoint.Row
@@ -69,6 +69,42 @@ func (l *Lexer) normalizeIncludedCursor(cursor *includedLexerCursor) {
 	cursor.pos = endPos
 	cursor.row = endPoint.Row
 	cursor.col = endPoint.Column
+}
+
+// includedPointAtPosition returns the logical point for a source byte. It
+// applies the configured range points and uses the previous range endpoint for
+// a gap between ranges. The boolean is false before the first range.
+func (l *Lexer) includedPointAtPosition(pos int) (Point, bool) {
+	if l == nil || len(l.includedRanges) == 0 || pos < 0 || pos > len(l.source) {
+		return Point{}, false
+	}
+	var previousEnd Point
+	hasPrevious := false
+	for i := range l.includedRanges {
+		range_ := l.includedRanges[i]
+		start, end := l.includedRangeBounds(i)
+		if end <= start {
+			continue
+		}
+		if pos < start {
+			if hasPrevious {
+				return previousEnd, true
+			}
+			return Point{}, false
+		}
+		if pos == start {
+			return range_.StartPoint, true
+		}
+		if pos < end {
+			return advancePointByBytes(range_.StartPoint, l.source[start:pos]), true
+		}
+		previousEnd = range_.EndPoint
+		hasPrevious = true
+	}
+	if hasPrevious {
+		return previousEnd, true
+	}
+	return Point{}, false
 }
 
 func (l *Lexer) includedRangeBounds(index int) (int, int) {
@@ -369,12 +405,17 @@ func (l *Lexer) scanIncluded(startState uint32, startPos int, startRow, startCol
 		acceptSkip = true
 	}
 
+	lookaheadEndByte := l.lookaheadEndByteAt(scanCursor.pos, scanCursor.rangeIdx < len(l.includedRanges))
+	if lookaheadEndByte < uint32(maxInt(acceptPos, 0)) {
+		lookaheadEndByte = uint32(maxInt(acceptPos, 0))
+	}
+
 	if acceptPos < 0 {
 		l.failTokenStartPos = tokenStart.pos
 		l.failTokenStartRow = tokenStart.row
 		l.failTokenStartCol = tokenStart.col
 		l.failTokenStartRangeIdx = tokenStart.rangeIdx
-		return Token{}, false
+		return Token{lexerLookaheadEndByte: lookaheadEndByte}, false
 	}
 
 	l.pos = acceptPos
@@ -390,6 +431,7 @@ func (l *Lexer) scanIncluded(startState uint32, startPos int, startRow, startCol
 			EndPoint:                Point{Row: acceptRow, Column: acceptCol},
 			lexerSkippedPrefix:      skippedPrefix,
 			lexerSkippedPrefixStart: uint32(startPos),
+			lexerLookaheadEndByte:   lookaheadEndByte,
 		}, true
 	}
 
@@ -403,5 +445,6 @@ func (l *Lexer) scanIncluded(startState uint32, startPos int, startRow, startCol
 		lexerSkippedPrefix:      skippedPrefix,
 		lexerSkippedPrefixStart: uint32(startPos),
 		lexerInternalDFALexed:   true,
+		lexerLookaheadEndByte:   lookaheadEndByte,
 	}, true
 }

--- a/lexer_included_ranges_test.go
+++ b/lexer_included_ranges_test.go
@@ -4,6 +4,46 @@ import "testing"
 
 var includedRangeLexerTokenSink Token
 
+func TestLexerIncludedRangesNormalizeAtExactStartUsesCustomPoint(t *testing.T) {
+	lex := NewLexer(nil, []byte("xabc"))
+	lex.setIncludedRanges([]Range{{
+		StartByte:  1,
+		EndByte:    4,
+		StartPoint: Point{Row: 7, Column: 9},
+		EndPoint:   Point{Row: 7, Column: 12},
+	}})
+	cursor := includedLexerCursor{pos: 1, row: 0, col: 1, rangeIdx: 0}
+	lex.normalizeIncludedCursor(&cursor)
+	if cursor.pos != 1 || cursor.row != 7 || cursor.col != 9 {
+		t.Fatalf("cursor at included start = %+v, want byte 1 at row 7 column 9", cursor)
+	}
+}
+
+func TestLexerIncludedRangesLogicalPointAtPositionUsesRangeCoordinates(t *testing.T) {
+	lex := NewLexer(nil, []byte("xabc_yz"))
+	lex.setIncludedRanges([]Range{
+		{StartByte: 1, EndByte: 3, StartPoint: Point{Row: 7, Column: 9}, EndPoint: Point{Row: 7, Column: 11}},
+		{StartByte: 5, EndByte: 7, StartPoint: Point{Row: 10, Column: 4}, EndPoint: Point{Row: 10, Column: 6}},
+	})
+	tests := []struct {
+		pos  int
+		want Point
+	}{
+		{pos: 1, want: Point{Row: 7, Column: 9}},
+		{pos: 2, want: Point{Row: 7, Column: 10}},
+		{pos: 3, want: Point{Row: 7, Column: 11}},
+		{pos: 4, want: Point{Row: 7, Column: 11}},
+		{pos: 5, want: Point{Row: 10, Column: 4}},
+		{pos: 6, want: Point{Row: 10, Column: 5}},
+	}
+	for _, test := range tests {
+		got, ok := lex.includedPointAtPosition(test.pos)
+		if !ok || got != test.want {
+			t.Fatalf("logical point at byte %d = %+v exact=%t, want %+v", test.pos, got, ok, test.want)
+		}
+	}
+}
+
 func TestLexerIncludedRangesRespectTokenBoundaries(t *testing.T) {
 	lex := NewLexer(buildIdentNumberWSDFA(), []byte("xxalpha"))
 	lex.setIncludedRanges([]Range{{
@@ -24,6 +64,36 @@ func TestLexerIncludedRangesRespectTokenBoundaries(t *testing.T) {
 	eof := lex.Next(0)
 	if eof.Symbol != 0 || eof.StartByte != 5 || eof.EndByte != 5 {
 		t.Fatalf("EOF = %+v, want byte 5", eof)
+	}
+}
+
+func TestLexerIncludedRangesPreserveInspectedLookaheadEnd(t *testing.T) {
+	states := []LexState{
+		{Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: '=', Hi: '=', NextState: 1}}},
+		{AcceptToken: 1, Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: 'i', Hi: 'i', NextState: 2}}},
+		{Default: -1, EOF: -1},
+	}
+	lex := NewLexer(states, []byte("\n=i"))
+	lex.setIncludedRanges([]Range{{
+		StartByte: 1, EndByte: 3,
+		StartPoint: Point{Row: 1}, EndPoint: Point{Row: 1, Column: 2},
+	}})
+	token := lex.Next(0)
+	if token.StartByte != 1 || token.EndByte != 2 || tokenLookaheadEndByte(token) != 4 {
+		t.Fatalf("token bytes=%d..%d lookahead_end=%d, want 1..2 and 4", token.StartByte, token.EndByte, tokenLookaheadEndByte(token))
+	}
+}
+
+func TestLexerIncludedRangesAddsInvalidUTF8Lookahead(t *testing.T) {
+	states := []LexState{
+		{Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: 'a', Hi: 'a', NextState: 1}}},
+		{AcceptToken: 1, Default: -1, EOF: -1},
+	}
+	lex := NewLexer(states, []byte{'a', 0xff})
+	lex.setIncludedRanges([]Range{{StartByte: 0, EndByte: 2}})
+	token := lex.Next(0)
+	if token.Symbol != 1 || token.StartByte != 0 || token.EndByte != 1 || tokenLookaheadEndByte(token) != 6 {
+		t.Fatalf("token=%+v lookahead_end=%d, want invalid UTF-8 frontier 6", token, tokenLookaheadEndByte(token))
 	}
 }
 

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -114,6 +114,49 @@ func TestBasicTokens(t *testing.T) {
 	}
 }
 
+func TestLexerPreservesInspectedLookaheadEnd(t *testing.T) {
+	states := []LexState{
+		{Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: '=', Hi: '=', NextState: 1}}},
+		{AcceptToken: 1, Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: 'i', Hi: 'i', NextState: 2}}},
+		{Default: -1, EOF: -1},
+	}
+	lex := NewLexer(states, []byte("=i"))
+	token := lex.Next(0)
+	if token.StartByte != 0 || token.EndByte != 1 || tokenLookaheadEndByte(token) != 3 {
+		t.Fatalf("token bytes=%d..%d lookahead_end=%d, want 0..1 and 3", token.StartByte, token.EndByte, tokenLookaheadEndByte(token))
+	}
+}
+
+func TestLexerPreservesFailedAttemptFrontierAcrossErrorRetry(t *testing.T) {
+	states := []LexState{
+		{Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: '=', Hi: '=', NextState: 1}}},
+		{Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: 'i', Hi: 'i', NextState: 2}}},
+		{Default: -1, EOF: -1},
+		{Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: '=', Hi: '=', NextState: 4}}},
+		{AcceptToken: 1, Default: -1, EOF: -1},
+	}
+	lex := NewLexer(states, []byte("=i"))
+	lex.hasErrorRunLexState = true
+	lex.errorRunLexState = 3
+	lex.errorModeRetry = true
+	token := lex.NextWithErrorRuns(0)
+	if token.Symbol != 1 || token.StartByte != 0 || token.EndByte != 1 || tokenLookaheadEndByte(token) != 3 {
+		t.Fatalf("token=%+v lookahead_end=%d, want retried token 0..1 with failed-attempt frontier 3", token, tokenLookaheadEndByte(token))
+	}
+}
+
+func TestLexerAddsInvalidUTF8Lookahead(t *testing.T) {
+	states := []LexState{
+		{Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: 'a', Hi: 'a', NextState: 1}}},
+		{AcceptToken: 1, Default: -1, EOF: -1},
+	}
+	lex := NewLexer(states, []byte{'a', 0xff})
+	token := lex.Next(0)
+	if token.Symbol != 1 || token.StartByte != 0 || token.EndByte != 1 || tokenLookaheadEndByte(token) != 6 {
+		t.Fatalf("token=%+v lookahead_end=%d, want invalid UTF-8 frontier 6", token, tokenLookaheadEndByte(token))
+	}
+}
+
 // TestPositionTracking verifies that row/column positions are correctly
 // tracked across newlines.
 func TestPositionTracking(t *testing.T) {

--- a/missing_node_dependency.go
+++ b/missing_node_dependency.go
@@ -1,0 +1,378 @@
+package gotreesitter
+
+import "unsafe"
+
+// missingNodeDependency preserves C's padding and lookahead metadata for one
+// recovery-inserted leaf. The visible node stays zero width.
+type missingNodeDependency struct {
+	stackByte      uint32
+	stackPoint     Point
+	paddingBytes   uint32
+	paddingExtent  Point
+	lookaheadBytes uint32
+}
+
+type missingNodeDependencyEntry struct {
+	node       *Node
+	dependency missingNodeDependency
+}
+
+func missingNodeDependencyEntryBytesForCap(capacity int) int64 {
+	if capacity <= 0 {
+		return 0
+	}
+	return int64(capacity) * int64(unsafe.Sizeof(missingNodeDependencyEntry{}))
+}
+
+func (d missingNodeDependency) positionedByte() (uint32, bool) {
+	if ^uint32(0)-d.stackByte < d.paddingBytes {
+		return 0, false
+	}
+	return d.stackByte + d.paddingBytes, true
+}
+
+func (d missingNodeDependency) positionedPoint() (Point, bool) {
+	if d.paddingExtent.Row == 0 {
+		if ^uint32(0)-d.stackPoint.Column < d.paddingExtent.Column {
+			return Point{}, false
+		}
+		return Point{Row: d.stackPoint.Row, Column: d.stackPoint.Column + d.paddingExtent.Column}, true
+	}
+	if ^uint32(0)-d.stackPoint.Row < d.paddingExtent.Row {
+		return Point{}, false
+	}
+	return Point{Row: d.stackPoint.Row + d.paddingExtent.Row, Column: d.paddingExtent.Column}, true
+}
+
+func (d missingNodeDependency) endByte() (uint32, bool) {
+	positioned, ok := d.positionedByte()
+	if !ok || ^uint32(0)-positioned < d.lookaheadBytes {
+		return 0, false
+	}
+	return positioned + d.lookaheadBytes, true
+}
+
+func (a *nodeArena) setMissingNodeDependency(node *Node, dependency missingNodeDependency) bool {
+	if a == nil || node == nil || node.ownerArena != a || !node.isMissing() || node.startByte != node.endByte {
+		return false
+	}
+	positionedByte, byteOK := dependency.positionedByte()
+	positionedPoint, pointOK := dependency.positionedPoint()
+	if !byteOK || !pointOK || positionedByte != node.startByte || positionedPoint != node.startPoint || node.startPoint != node.endPoint {
+		return false
+	}
+	if _, ok := dependency.endByte(); !ok {
+		return false
+	}
+	for index := range a.missingNodeDependencies {
+		if a.missingNodeDependencies[index].node == node {
+			a.missingNodeDependencies[index].dependency = dependency
+			return true
+		}
+	}
+	before := cap(a.missingNodeDependencies)
+	a.missingNodeDependencies = append(a.missingNodeDependencies, missingNodeDependencyEntry{node: node, dependency: dependency})
+	a.allocatedBytes += missingNodeDependencyEntryBytesForCap(cap(a.missingNodeDependencies) - before)
+	return true
+}
+
+func missingNodeDependencyForNode(node *Node) (missingNodeDependency, bool) {
+	if node == nil || node.ownerArena == nil || !node.isMissing() {
+		return missingNodeDependency{}, false
+	}
+	entry, present := missingNodeDependencyEntryForNode(node)
+	if present {
+		positionedByte, byteOK := entry.dependency.positionedByte()
+		positionedPoint, pointOK := entry.dependency.positionedPoint()
+		if !byteOK || !pointOK || positionedByte != node.startByte || node.startByte != node.endByte ||
+			positionedPoint != node.startPoint || node.startPoint != node.endPoint {
+			return missingNodeDependency{}, false
+		}
+		if _, ok := entry.dependency.endByte(); !ok {
+			return missingNodeDependency{}, false
+		}
+		return entry.dependency, true
+	}
+	return missingNodeDependency{}, false
+}
+
+func missingNodeDependencyEntryForNode(node *Node) (missingNodeDependencyEntry, bool) {
+	if node == nil || node.ownerArena == nil || !node.isMissing() {
+		return missingNodeDependencyEntry{}, false
+	}
+	for _, entry := range node.ownerArena.missingNodeDependencies {
+		if entry.node == node {
+			return entry, true
+		}
+	}
+	return missingNodeDependencyEntry{}, false
+}
+
+func nodeEndsBeforeEditDependency(node *Node, editStart uint32) bool {
+	if dependency, ok := missingNodeDependencyForNode(node); ok {
+		end, valid := dependency.endByte()
+		return valid && end < editStart
+	}
+	if _, present := missingNodeDependencyEntryForNode(node); present {
+		return false
+	}
+	if node == nil {
+		return true
+	}
+	if node.hasError() {
+		for i := 0; i < nodeChildCountNoMaterialize(node); i++ {
+			child, ok := nodeChildEntryAtNoMaterialize(node, i)
+			if ok && !stackEntryEndsBeforeEditDependency(node.ownerArena, child, editStart) {
+				return false
+			}
+		}
+	}
+	return node.endByte <= editStart
+}
+
+// stackEntryEndsBeforeEditDependency keeps lazy final-child and pending-parent
+// entries reachable when a missing descendant depends on bytes after its span.
+func stackEntryEndsBeforeEditDependency(arena *nodeArena, entry stackEntry, editStart uint32) bool {
+	if !stackEntryHasNode(entry) {
+		return true
+	}
+	if node := stackEntryNode(entry); node != nil {
+		if !nodeEndsBeforeEditDependency(node, editStart) {
+			return false
+		}
+		if !node.hasError() {
+			return true
+		}
+		for i := 0; i < nodeChildCountNoMaterialize(node); i++ {
+			child, ok := nodeChildEntryAtNoMaterialize(node, i)
+			if ok && !stackEntryEndsBeforeEditDependency(node.ownerArena, child, editStart) {
+				return false
+			}
+		}
+		return true
+	}
+	if parent := stackEntryPendingParent(entry); parent != nil {
+		if parent.endByte > editStart {
+			return false
+		}
+		if !parent.hasError() {
+			return true
+		}
+		for i := 0; i < parent.childEntryCount(); i++ {
+			child := parent.childEntry(arena, i)
+			if stackEntryHasNode(child) && !stackEntryEndsBeforeEditDependency(arena, child, editStart) {
+				return false
+			}
+		}
+		return true
+	}
+	return stackEntryNodeEndByte(entry) <= editStart
+}
+
+// editMissingNodeDependency applies C's edit dependency boundary to one
+// zero-width missing leaf. It returns true when the edit reached the padding
+// or lookahead dependency and the ordinary span-only path must not skip it.
+func editMissingNodeDependency(node *Node, edit InputEdit, byteDelta, rowDelta int64) bool {
+	dependency, ok := missingNodeDependencyForNode(node)
+	if !ok {
+		if _, present := missingNodeDependencyEntryForNode(node); present {
+			node.setDirty(true)
+			if perfCountersEnabled {
+				perfRecordNodeEditMarked()
+			}
+			return true
+		}
+		return false
+	}
+	dependencyEnd, _ := dependency.endByte()
+	isNoop := inputEditBytesAreNoop(edit)
+	if edit.StartByte > dependencyEnd || (isNoop && edit.StartByte == dependencyEnd) ||
+		(edit.OldEndByte <= dependency.stackByte && edit.StartByte < dependency.stackByte) {
+		return false
+	}
+	positionedByte, _ := dependency.positionedByte()
+	positionedPoint, _ := dependency.positionedPoint()
+	if edit.StartByte < dependency.stackByte && edit.OldEndByte > dependency.stackByte {
+		dependency.stackByte = edit.NewEndByte
+		dependency.stackPoint = edit.NewEndPoint
+	}
+	node.setDirty(true)
+	if perfCountersEnabled {
+		perfRecordNodeEditMarked()
+	}
+
+	if edit.OldEndByte <= positionedByte {
+		positionedByte = addUint32Delta(positionedByte, byteDelta)
+		positionedPoint = shiftPointAfterEdit(positionedPoint, edit, rowDelta)
+	} else if edit.StartByte < positionedByte {
+		positionedByte = edit.NewEndByte
+		positionedPoint = edit.NewEndPoint
+	}
+	if positionedByte < dependency.stackByte {
+		positionedByte = dependency.stackByte
+		positionedPoint = dependency.stackPoint
+	}
+	dependency.paddingBytes = positionedByte - dependency.stackByte
+	paddingExtent, valid := pointExtentBetween(dependency.stackPoint, positionedPoint)
+	if !valid {
+		paddingExtent = Point{}
+		positionedPoint = dependency.stackPoint
+		dependency.paddingBytes = 0
+	}
+	dependency.paddingExtent = paddingExtent
+	node.startByte = positionedByte
+	node.endByte = positionedByte
+	node.startPoint = positionedPoint
+	node.endPoint = positionedPoint
+	if !node.ownerArena.setMissingNodeDependency(node, dependency) {
+		node.setDirty(true)
+	}
+	return true
+}
+
+func missingNodeDependencyNoopAtEnd(node *Node, edit InputEdit) bool {
+	if !inputEditBytesAreNoop(edit) {
+		return false
+	}
+	dependency, ok := missingNodeDependencyForNode(node)
+	if !ok {
+		return false
+	}
+	end, valid := dependency.endByte()
+	return valid && edit.StartByte == end
+}
+
+func inputEditBytesAreNoop(edit InputEdit) bool {
+	return edit.StartByte == edit.OldEndByte && edit.OldEndByte == edit.NewEndByte
+}
+
+func copyMissingNodeDependency(dst, src *Node, offset *cloneOffset) bool {
+	dependency, ok := missingNodeDependencyForNode(src)
+	if !ok || dst == nil || dst.ownerArena == nil {
+		return false
+	}
+	if offset != nil {
+		dependency.stackByte = addUint32Delta(dependency.stackByte, int64(offset.byteDelta))
+		dependency.stackPoint = offset.offsetPoint(dependency.stackPoint)
+	}
+	return dst.ownerArena.setMissingNodeDependency(dst, dependency)
+}
+
+func missingNodeDependencyFromToken(token Token) (missingNodeDependency, bool) {
+	if !token.Missing || !token.missingDependencyExact || token.StartByte < token.missingStackByte {
+		return missingNodeDependency{}, false
+	}
+	paddingExtent, ok := pointExtentBetween(token.missingStackPoint, token.StartPoint)
+	lookaheadEndByte := tokenLookaheadEndByte(token)
+	if !ok || lookaheadEndByte < token.missingStackByte {
+		return missingNodeDependency{}, false
+	}
+	dependency := missingNodeDependency{
+		stackByte: token.missingStackByte, stackPoint: token.missingStackPoint,
+		paddingBytes: token.StartByte - token.missingStackByte, paddingExtent: paddingExtent,
+		lookaheadBytes: lookaheadEndByte - token.missingStackByte,
+	}
+	positionedByte, byteOK := dependency.positionedByte()
+	positionedPoint, pointOK := dependency.positionedPoint()
+	if !byteOK || !pointOK || positionedByte != token.StartByte || positionedPoint != token.StartPoint || token.StartByte != token.EndByte {
+		return missingNodeDependency{}, false
+	}
+	if _, ok := dependency.endByte(); !ok {
+		return missingNodeDependency{}, false
+	}
+	return dependency, true
+}
+
+func (a *nodeArena) resetMissingNodeDependencies() {
+	if a == nil {
+		return
+	}
+	clear(a.missingNodeDependencies)
+	a.missingNodeDependencies = a.missingNodeDependencies[:0]
+}
+
+func pointExtentBetween(start, end Point) (Point, bool) {
+	if end.Row < start.Row || (end.Row == start.Row && end.Column < start.Column) {
+		return Point{}, false
+	}
+	if end.Row == start.Row {
+		return Point{Column: end.Column - start.Column}, true
+	}
+	return Point{Row: end.Row - start.Row, Column: end.Column}, true
+}
+
+// recoveryMissingNodeDependency mirrors the lexer reset that C performs
+// before it inserts a missing token. A reset outside all included ranges
+// snaps to the next range start. A reset inside a range keeps zero padding.
+func (p *Parser) recoveryMissingNodeDependency(stackByte uint32, stackPoint Point, lookahead Token) (missingNodeDependency, bool) {
+	lookaheadEndByte := tokenLookaheadEndByte(lookahead)
+	if p == nil || lookaheadEndByte < stackByte {
+		return missingNodeDependency{}, false
+	}
+	positionedByte := stackByte
+	positionedPoint := stackPoint
+	for _, included := range p.included {
+		if stackByte >= included.StartByte && stackByte < included.EndByte {
+			if stackByte == included.StartByte {
+				positionedPoint = included.StartPoint
+			}
+			break
+		}
+		if stackByte < included.StartByte {
+			positionedByte = included.StartByte
+			positionedPoint = included.StartPoint
+			break
+		}
+	}
+	paddingExtent, ok := pointExtentBetween(stackPoint, positionedPoint)
+	if !ok || positionedByte < stackByte {
+		return missingNodeDependency{}, false
+	}
+	dependency := missingNodeDependency{
+		stackByte:      stackByte,
+		stackPoint:     stackPoint,
+		paddingBytes:   positionedByte - stackByte,
+		paddingExtent:  paddingExtent,
+		lookaheadBytes: lookaheadEndByte - stackByte,
+	}
+	if _, ok := dependency.endByte(); !ok {
+		return missingNodeDependency{}, false
+	}
+	return dependency, true
+}
+
+func recoveryStackPosition(source []byte, stack *glrStack, lookahead Token) (uint32, Point, bool) {
+	if stack == nil {
+		return 0, Point{}, false
+	}
+	if top := stack.top(); stackEntryHasNode(top) && stackEntryNodeEndByte(top) <= lookahead.StartByte {
+		return stackEntryNodeEndByte(top), stackEntryNodeEndPoint(top), true
+	}
+	stackByte := stack.byteOffset
+	if stackByte > lookahead.StartByte || uint64(stackByte) > uint64(len(source)) {
+		return 0, Point{}, false
+	}
+	if stackByte == lookahead.StartByte {
+		return stackByte, lookahead.StartPoint, true
+	}
+	return stackByte, advancePointByBytes(Point{}, source[:stackByte]), true
+}
+
+func (p *Parser) recoveryMissingToken(source []byte, stack *glrStack, symbol Symbol, lookahead Token) (Token, bool) {
+	stackByte, stackPoint, ok := recoveryStackPosition(source, stack, lookahead)
+	if !ok {
+		return Token{}, false
+	}
+	dependency, exact := p.recoveryMissingNodeDependency(stackByte, stackPoint, lookahead)
+	if !exact {
+		return Token{}, false
+	}
+	positionedByte, _ := dependency.positionedByte()
+	positionedPoint, _ := dependency.positionedPoint()
+	return Token{
+		Symbol: symbol, StartByte: positionedByte, EndByte: positionedByte,
+		StartPoint: positionedPoint, EndPoint: positionedPoint, Missing: true,
+		lexerLookaheadEndByte: tokenLookaheadEndByte(lookahead),
+		missingStackByte:      stackByte, missingStackPoint: stackPoint, missingDependencyExact: true,
+	}, true
+}

--- a/missing_node_dependency_test.go
+++ b/missing_node_dependency_test.go
@@ -1,0 +1,429 @@
+package gotreesitter
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func newMissingDependencyTree(t *testing.T) (*Tree, *Node, missingNodeDependency) {
+	t.Helper()
+	arena := acquireNodeArena(arenaClassIncremental)
+	dependency := missingNodeDependency{
+		stackByte: 0, stackPoint: Point{},
+		paddingBytes: 3, paddingExtent: Point{Column: 3},
+		lookaheadBytes: 3,
+	}
+	node := newLeafNodeInArena(arena, 1, true, 3, 3, Point{Column: 3}, Point{Column: 3})
+	node.setMissing(true)
+	node.setHasError(true)
+	if !arena.setMissingNodeDependency(node, dependency) {
+		arena.Release()
+		t.Fatal("set missing dependency")
+	}
+	return &Tree{root: node, arena: arena, source: []byte("abcXYZ")}, node, dependency
+}
+
+func TestMissingNodeDependencyLayoutAndOwnership(t *testing.T) {
+	if got := unsafe.Sizeof(Node{}); got != 104 {
+		t.Fatalf("Node size=%d, want 104", got)
+	}
+	if got := unsafe.Sizeof(missingNodeDependencyEntry{}); got != 40 {
+		t.Fatalf("missing dependency entry size=%d, want 40", got)
+	}
+	tree, node, want := newMissingDependencyTree(t)
+	defer tree.Release()
+	if got, ok := missingNodeDependencyForNode(node); !ok || got != want {
+		t.Fatalf("dependency=%+v exact=%t, want %+v", got, ok, want)
+	}
+	breakdown := tree.arena.collectArenaBreakdown()
+	if breakdown.MissingNodeDependencyCount != 1 || breakdown.MissingNodeDependencyBytesAllocated < int64(unsafe.Sizeof(missingNodeDependencyEntry{})) {
+		t.Fatalf("missing dependency telemetry count=%d bytes=%d", breakdown.MissingNodeDependencyCount, breakdown.MissingNodeDependencyBytesAllocated)
+	}
+	foreign := acquireNodeArena(arenaClassIncremental)
+	defer foreign.Release()
+	if foreign.setMissingNodeDependency(node, want) {
+		t.Fatal("foreign arena accepted a missing dependency")
+	}
+}
+
+func TestRecoveryMissingNodeDependencyMatchesLexerReset(t *testing.T) {
+	parser := NewParser(nil)
+	parser.included = []Range{{
+		StartByte: 1, EndByte: 3,
+		StartPoint: Point{Row: 1}, EndPoint: Point{Row: 1, Column: 2},
+	}}
+	dependency, exact := parser.recoveryMissingNodeDependency(0, Point{}, Token{
+		StartByte: 1, EndByte: 2,
+		StartPoint: Point{Row: 1}, EndPoint: Point{Row: 1, Column: 1},
+		lexerLookaheadEndByte: 3,
+	})
+	want := missingNodeDependency{
+		stackByte: 0, stackPoint: Point{},
+		paddingBytes: 1, paddingExtent: Point{Row: 1},
+		lookaheadBytes: 3,
+	}
+	if !exact || dependency != want {
+		t.Fatalf("dependency=%+v exact=%t, want %+v", dependency, exact, want)
+	}
+}
+
+func TestRecoveryMissingNodeDependencyUsesIncludedRangeStartPoint(t *testing.T) {
+	parser := NewParser(nil)
+	parser.included = []Range{{
+		StartByte:  1,
+		EndByte:    3,
+		StartPoint: Point{Row: 7, Column: 9},
+		EndPoint:   Point{Row: 7, Column: 11},
+	}}
+	dependency, exact := parser.recoveryMissingNodeDependency(1, Point{Column: 1}, Token{
+		StartByte:             1,
+		EndByte:               2,
+		StartPoint:            Point{Row: 7, Column: 9},
+		EndPoint:              Point{Row: 7, Column: 10},
+		lexerLookaheadEndByte: 3,
+	})
+	if !exact {
+		t.Fatal("recovery missing dependency was not exact")
+	}
+	if got, ok := dependency.positionedPoint(); !ok || got != (Point{Row: 7, Column: 9}) {
+		t.Fatalf("positioned point=%+v exact=%t, want included start point", got, ok)
+	}
+}
+
+func TestRecoveryMissingTokenUsesEmptyStackPosition(t *testing.T) {
+	parser := NewParser(nil)
+	parser.included = []Range{{
+		StartByte: 1, EndByte: 3,
+		StartPoint: Point{Row: 1}, EndPoint: Point{Row: 1, Column: 2},
+	}}
+	stack := &glrStack{}
+	token, exact := parser.recoveryMissingToken([]byte("\n=i"), stack, 1, Token{
+		StartByte: 1, EndByte: 2,
+		StartPoint: Point{Row: 1}, EndPoint: Point{Row: 1, Column: 1},
+		lexerLookaheadEndByte: 3,
+	})
+	if !exact || !token.Missing || token.StartByte != 1 || token.EndByte != 1 ||
+		token.StartPoint != (Point{Row: 1}) || token.EndPoint != (Point{Row: 1}) ||
+		!token.missingDependencyExact {
+		t.Fatalf("missing token=%+v exact=%t", token, exact)
+	}
+	dependency, dependencyExact := missingNodeDependencyFromToken(token)
+	if !dependencyExact || dependency.lookaheadBytes != 3 {
+		t.Fatalf("token dependency=%+v exact=%t", dependency, dependencyExact)
+	}
+}
+
+func TestMissingNodeDependencySurvivesTreeCopy(t *testing.T) {
+	tree, _, want := newMissingDependencyTree(t)
+	copyTree := tree.Copy()
+	defer copyTree.Release()
+	tree.Release()
+	if got, ok := missingNodeDependencyForNode(copyTree.root); !ok || got != want {
+		t.Fatalf("copied dependency=%+v exact=%t, want %+v", got, ok, want)
+	}
+}
+
+func TestMissingNodeDependencyArenaAccountingIsExact(t *testing.T) {
+	arena := acquireNodeArena(arenaClassIncremental)
+	defer arena.Release()
+	node := newLeafNodeInArena(arena, 1, true, 3, 3, Point{Column: 3}, Point{Column: 3})
+	node.setMissing(true)
+	dependency := missingNodeDependency{
+		paddingBytes: 3, paddingExtent: Point{Column: 3}, lookaheadBytes: 3,
+	}
+	before := arena.allocatedBytes
+	beforeCapacity := cap(arena.missingNodeDependencies)
+	if !arena.setMissingNodeDependency(node, dependency) {
+		t.Fatal("set missing dependency")
+	}
+	wantDelta := missingNodeDependencyEntryBytesForCap(cap(arena.missingNodeDependencies) - beforeCapacity)
+	if got := arena.allocatedBytes - before; got != wantDelta {
+		t.Fatalf("allocated byte delta=%d, want %d", got, wantDelta)
+	}
+	wantAllocated := arena.allocatedBytes
+	arena.recomputeAllocatedBytes()
+	if arena.allocatedBytes != wantAllocated {
+		t.Fatalf("recomputed allocated bytes=%d, want %d", arena.allocatedBytes, wantAllocated)
+	}
+}
+
+func TestMissingNodeDependencyLookupKeepsTwoEntriesDistinct(t *testing.T) {
+	arena := acquireNodeArena(arenaClassIncremental)
+	defer arena.Release()
+	dependencies := []missingNodeDependency{
+		{paddingBytes: 2, paddingExtent: Point{Column: 2}, lookaheadBytes: 3},
+		{stackByte: 5, stackPoint: Point{Column: 5}, paddingBytes: 1, paddingExtent: Point{Column: 1}, lookaheadBytes: 4},
+	}
+	for index, dependency := range dependencies {
+		position, _ := dependency.positionedByte()
+		point, _ := dependency.positionedPoint()
+		node := newLeafNodeInArena(arena, Symbol(index+1), true, position, position, point, point)
+		node.setMissing(true)
+		if !arena.setMissingNodeDependency(node, dependency) {
+			t.Fatalf("set dependency %d", index)
+		}
+		if got, ok := missingNodeDependencyForNode(node); !ok || got != dependency {
+			t.Fatalf("dependency %d=%+v exact=%t, want %+v", index, got, ok, dependency)
+		}
+	}
+}
+
+func TestMissingNodeDependencyInvalidatesPaddingAndLookahead(t *testing.T) {
+	for offset := uint32(0); offset < 6; offset++ {
+		t.Run(string(rune('0'+offset)), func(t *testing.T) {
+			tree, node, _ := newMissingDependencyTree(t)
+			defer tree.Release()
+			tree.Edit(InputEdit{
+				StartByte: offset, OldEndByte: offset + 1, NewEndByte: offset + 1,
+				StartPoint: Point{Column: offset}, OldEndPoint: Point{Column: offset + 1}, NewEndPoint: Point{Column: offset + 1},
+			})
+			if !node.dirty() {
+				t.Fatalf("edit at dependency byte %d did not dirty the missing leaf", offset)
+			}
+		})
+	}
+}
+
+func TestMissingNodeDependencyTracksPaddingInsertion(t *testing.T) {
+	tree, node, want := newMissingDependencyTree(t)
+	defer tree.Release()
+	tree.Edit(InputEdit{
+		StartByte: 1, OldEndByte: 1, NewEndByte: 2,
+		StartPoint: Point{Column: 1}, OldEndPoint: Point{Column: 1}, NewEndPoint: Point{Column: 2},
+	})
+	if !node.dirty() {
+		t.Fatal("padding insertion did not dirty the missing leaf")
+	}
+	want.paddingBytes++
+	want.paddingExtent.Column++
+	if node.startByte != 4 || node.endByte != 4 || node.startPoint != (Point{Column: 4}) || node.endPoint != (Point{Column: 4}) {
+		t.Fatalf("positioned missing node=%d..%d %+v..%+v, want zero-width byte 4", node.startByte, node.endByte, node.startPoint, node.endPoint)
+	}
+	if got, ok := missingNodeDependencyForNode(node); !ok || got != want {
+		t.Fatalf("edited dependency=%+v exact=%t, want %+v", got, ok, want)
+	}
+}
+
+func TestMissingNodeDependencyInvalidatesInsertionAtStack(t *testing.T) {
+	tree, node, want := newMissingDependencyTree(t)
+	defer tree.Release()
+	tree.Edit(InputEdit{
+		StartByte: 0, OldEndByte: 0, NewEndByte: 1,
+		StartPoint: Point{}, OldEndPoint: Point{}, NewEndPoint: Point{Column: 1},
+	})
+	want.paddingBytes++
+	want.paddingExtent.Column++
+	if !node.dirty() || node.startByte != 4 || node.endByte != 4 {
+		t.Fatalf("stack insertion produced node=%d..%d dirty=%t, want dirty zero-width byte 4", node.startByte, node.endByte, node.dirty())
+	}
+	if got, ok := missingNodeDependencyForNode(node); !ok || got != want {
+		t.Fatalf("edited dependency=%+v exact=%t, want %+v", got, ok, want)
+	}
+}
+
+func TestMissingNodeDependencyTracksEditAcrossStackBoundary(t *testing.T) {
+	arena := acquireNodeArena(arenaClassIncremental)
+	dependency := missingNodeDependency{
+		stackByte: 3, stackPoint: Point{Column: 3},
+		paddingBytes: 2, paddingExtent: Point{Column: 2}, lookaheadBytes: 2,
+	}
+	node := newLeafNodeInArena(arena, 1, true, 5, 5, Point{Column: 5}, Point{Column: 5})
+	node.setMissing(true)
+	node.setHasError(true)
+	if !arena.setMissingNodeDependency(node, dependency) {
+		arena.Release()
+		t.Fatal("set missing dependency")
+	}
+	tree := &Tree{root: node, arena: arena, source: []byte("abcdeXY")}
+	defer tree.Release()
+	tree.Edit(InputEdit{
+		StartByte: 2, OldEndByte: 4, NewEndByte: 2,
+		StartPoint: Point{Column: 2}, OldEndPoint: Point{Column: 4}, NewEndPoint: Point{Column: 2},
+	})
+	dependency.stackByte = 2
+	dependency.stackPoint = Point{Column: 2}
+	dependency.paddingBytes = 1
+	dependency.paddingExtent = Point{Column: 1}
+	if !node.dirty() || node.startByte != 3 || node.endByte != 3 {
+		t.Fatalf("cross-stack edit produced node=%d..%d dirty=%t, want dirty zero-width byte 3", node.startByte, node.endByte, node.dirty())
+	}
+	if got, ok := missingNodeDependencyForNode(node); !ok || got != dependency {
+		t.Fatalf("edited dependency=%+v exact=%t, want %+v", got, ok, dependency)
+	}
+}
+
+func TestMissingNodeDependencyShiftsAfterEarlierEdit(t *testing.T) {
+	arena := acquireNodeArena(arenaClassIncremental)
+	dependency := missingNodeDependency{
+		stackByte: 3, stackPoint: Point{Column: 3},
+		paddingBytes: 2, paddingExtent: Point{Column: 2}, lookaheadBytes: 2,
+	}
+	node := newLeafNodeInArena(arena, 1, true, 5, 5, Point{Column: 5}, Point{Column: 5})
+	node.setMissing(true)
+	node.setHasError(true)
+	if !arena.setMissingNodeDependency(node, dependency) {
+		t.Fatal("set missing dependency")
+	}
+	tree := &Tree{root: node, arena: arena, source: []byte("abcdeXY")}
+	defer tree.Release()
+	tree.Edit(InputEdit{
+		StartByte: 0, OldEndByte: 0, NewEndByte: 1,
+		StartPoint: Point{}, OldEndPoint: Point{}, NewEndPoint: Point{Column: 1},
+	})
+	dependency.stackByte++
+	dependency.stackPoint.Column++
+	if node.startByte != 6 || node.endByte != 6 || node.dirty() {
+		t.Fatalf("shifted node=%d..%d dirty=%t, want clean zero-width byte 6", node.startByte, node.endByte, node.dirty())
+	}
+	if got, ok := missingNodeDependencyForNode(node); !ok || got != dependency {
+		t.Fatalf("shifted dependency=%+v exact=%t, want %+v", got, ok, dependency)
+	}
+}
+
+func TestMissingNodeDependencyResetClearsPointers(t *testing.T) {
+	tree, _, _ := newMissingDependencyTree(t)
+	arena := tree.arena
+	tree.Release()
+	if len(arena.missingNodeDependencies) != 0 {
+		t.Fatalf("arena reset retained %d missing dependencies", len(arena.missingNodeDependencies))
+	}
+}
+
+func TestMissingNodeDependencyStaleReceiptFailsClosed(t *testing.T) {
+	tree, node, _ := newMissingDependencyTree(t)
+	defer tree.Release()
+	node.startByte++
+	node.endByte++
+	tree.Edit(InputEdit{
+		StartByte: 100, OldEndByte: 101, NewEndByte: 101,
+		StartPoint: Point{Column: 100}, OldEndPoint: Point{Column: 101}, NewEndPoint: Point{Column: 101},
+	})
+	if !node.dirty() {
+		t.Fatal("stale missing dependency allowed span-only edit skip")
+	}
+	node.setDirty(false)
+	copyTree := tree.Copy()
+	defer copyTree.Release()
+	if !copyTree.root.dirty() {
+		t.Fatal("stale missing dependency produced a clean copied node")
+	}
+}
+
+func TestInputEditNoopUsesBytesOnlyAtMissingDependencyEnd(t *testing.T) {
+	tree, node, want := newMissingDependencyTree(t)
+	defer tree.Release()
+	tree.Edit(InputEdit{
+		StartByte: 6, OldEndByte: 6, NewEndByte: 6,
+		StartPoint: Point{}, OldEndPoint: Point{Row: 1, Column: 7}, NewEndPoint: Point{Row: 2, Column: 3},
+	})
+	if node.dirty() {
+		t.Fatal("byte-only no-op at dependency end dirtied the missing leaf")
+	}
+	if got, ok := missingNodeDependencyForNode(node); !ok || got != want {
+		t.Fatalf("no-op changed dependency=%+v exact=%t, want %+v", got, ok, want)
+	}
+}
+
+func TestTreeEditUpdatesIncludedRangesLikeC(t *testing.T) {
+	tree := &Tree{includedRanges: []Range{
+		{StartByte: 2, EndByte: 4, StartPoint: Point{Column: 2}, EndPoint: Point{Column: 4}},
+		{StartByte: 8, EndByte: 10, StartPoint: Point{Row: 1, Column: 2}, EndPoint: Point{Row: 1, Column: 4}},
+	}}
+	tree.Edit(InputEdit{
+		StartByte: 3, OldEndByte: 5, NewEndByte: 6,
+		StartPoint: Point{Column: 3}, OldEndPoint: Point{Column: 5}, NewEndPoint: Point{Column: 6},
+	})
+	want := []Range{
+		{StartByte: 2, EndByte: 3, StartPoint: Point{Column: 2}, EndPoint: Point{Column: 3}},
+		{StartByte: 9, EndByte: 11, StartPoint: Point{Row: 1, Column: 2}, EndPoint: Point{Row: 1, Column: 4}},
+	}
+	if len(tree.includedRanges) != len(want) {
+		t.Fatalf("included range count=%d, want %d", len(tree.includedRanges), len(want))
+	}
+	for i := range want {
+		if tree.includedRanges[i] != want[i] {
+			t.Fatalf("included range %d=%+v, want %+v", i, tree.includedRanges[i], want[i])
+		}
+	}
+}
+
+func TestTreeEditIncludedRangesShiftsPureInsertion(t *testing.T) {
+	tree := &Tree{includedRanges: []Range{
+		{StartByte: 0, EndByte: 1, StartPoint: Point{}, EndPoint: Point{Column: 1}},
+		{StartByte: 3, EndByte: 5, StartPoint: Point{Column: 3}, EndPoint: Point{Column: 5}},
+	}}
+	tree.Edit(InputEdit{
+		StartByte: 1, OldEndByte: 1, NewEndByte: 2,
+		StartPoint: Point{Column: 1}, OldEndPoint: Point{Column: 1}, NewEndPoint: Point{Column: 2},
+	})
+	want := []Range{
+		{StartByte: 0, EndByte: 2, StartPoint: Point{}, EndPoint: Point{Column: 2}},
+		{StartByte: 4, EndByte: 6, StartPoint: Point{Column: 4}, EndPoint: Point{Column: 6}},
+	}
+	for i := range want {
+		if tree.includedRanges[i] != want[i] {
+			t.Fatalf("included range %d=%+v, want %+v", i, tree.includedRanges[i], want[i])
+		}
+	}
+}
+
+func newMissingDependencyFinalChildTree(t *testing.T) (*Tree, *Node, *Node) {
+	t.Helper()
+	arena := acquireNodeArena(arenaClassIncremental)
+	arena.finalChildRefs = true
+	dependency := missingNodeDependency{
+		stackByte: 0, stackPoint: Point{},
+		paddingBytes: 3, paddingExtent: Point{Column: 3},
+		lookaheadBytes: 3,
+	}
+	missing := newLeafNodeInArena(arena, 1, true, 3, 3, Point{Column: 3}, Point{Column: 3})
+	missing.setMissing(true)
+	missing.setHasError(true)
+	if !arena.setMissingNodeDependency(missing, dependency) {
+		arena.Release()
+		t.Fatal("set missing dependency")
+	}
+	parent := newPendingParentInArena(arena, 2, true, 4,
+		[]stackEntry{newStackEntryNode(missing.parseState, missing)},
+		0, 8, Point{}, Point{Column: 8}, true)
+	entry := newStackEntryPendingParent(parent.parseState, parent)
+	root := materializeStackEntryPendingParent(arena, &entry, pendingParentMaterializeForFinalTree)
+	if root == nil || !nodeHasFinalChildRefs(root) {
+		arena.Release()
+		t.Fatal("materialize final child refs")
+	}
+	return &Tree{root: root, arena: arena, source: []byte("abcXYZ123")}, root, missing
+}
+
+func TestTreeEditFinalChildSkipConsultsMissingDependency(t *testing.T) {
+	tree, root, missing := newMissingDependencyFinalChildTree(t)
+	defer tree.Release()
+	tree.Edit(InputEdit{
+		StartByte: 4, OldEndByte: 4, NewEndByte: 5,
+		StartPoint: Point{Column: 4}, OldEndPoint: Point{Column: 4}, NewEndPoint: Point{Column: 5},
+	})
+	if !missing.dirty() {
+		t.Fatal("final-child skip ignored a missing descendant dependency")
+	}
+	if len(root.children) != 0 || root.ownerArena.finalChildRefsMaterializedParents != 0 {
+		t.Fatalf("edit materialized final child refs: children=%d parents=%d", len(root.children), root.ownerArena.finalChildRefsMaterializedParents)
+	}
+}
+
+func TestEditPendingParentSkipConsultsMissingDependency(t *testing.T) {
+	tree, missing, _ := newMissingDependencyTree(t)
+	defer tree.Release()
+	parent := newPendingParentInArena(tree.arena, 2, true, 4,
+		[]stackEntry{newStackEntryNode(missing.parseState, missing)},
+		0, 3, Point{}, Point{Column: 3}, true)
+	editStackEntryWithDelta(tree.arena, newStackEntryPendingParent(parent.parseState, parent), InputEdit{
+		StartByte: 4, OldEndByte: 4, NewEndByte: 5,
+		StartPoint: Point{Column: 4}, OldEndPoint: Point{Column: 4}, NewEndPoint: Point{Column: 5},
+	}, 1, 0, true, nil, nil)
+	if !missing.dirty() {
+		t.Fatal("pending-parent skip ignored a missing descendant dependency")
+	}
+	if got := parent.childEntry(tree.arena, 0); stackEntryNode(got) != missing {
+		t.Fatal("pending edit replaced the child node")
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -2383,19 +2383,9 @@ func (p *Parser) tryInsertMissingSingleShift(source []byte, s *glrStack, tok Tok
 	}
 
 	p.markCRecoveryCostCompetitionRelevant() // missing-token insertion makes costs relevant
-	missingTok := Token{
-		Symbol:     candidateSym,
-		StartByte:  tok.StartByte,
-		EndByte:    tok.StartByte,
-		StartPoint: tok.StartPoint,
-		EndPoint:   tok.StartPoint,
-		Missing:    true,
-	}
-	if top := s.top(); stackEntryHasNode(top) && stackEntryNodeEndByte(top) <= tok.StartByte {
-		missingTok.StartByte = stackEntryNodeEndByte(top)
-		missingTok.EndByte = stackEntryNodeEndByte(top)
-		missingTok.StartPoint = stackEntryNodeEndPoint(top)
-		missingTok.EndPoint = stackEntryNodeEndPoint(top)
+	missingTok, exact := p.recoveryMissingToken(source, s, candidateSym, tok)
+	if !exact {
+		return false
 	}
 	p.applyAction(source, s, candidateAct, missingTok, new(bool), nodeCount, arena, entryScratch, gssScratch, nil, false, trackChildErrors)
 	if p.rejectUndrainedPendingForkStacks(s) {
@@ -2890,7 +2880,7 @@ func (p *Parser) tryAdvanceEOFOnSingleStack(s *glrStack, tok Token, expectedEOFB
 	return false
 }
 
-func (p *Parser) tryInsertMissingSingleShiftAtEOF(s *glrStack, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch) bool {
+func (p *Parser) tryInsertMissingSingleShiftAtEOF(source []byte, s *glrStack, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch) bool {
 	if p == nil || p.language == nil || s == nil || s.dead || tok.NoLookahead || tok.Symbol != 0 || tok.StartByte != tok.EndByte {
 		return false
 	}
@@ -2936,15 +2926,11 @@ func (p *Parser) tryInsertMissingSingleShiftAtEOF(s *glrStack, tok Token, nodeCo
 	}
 
 	p.markCRecoveryCostCompetitionRelevant() // missing-token insertion makes costs relevant
-	missingTok := Token{
-		Symbol:     candidateSym,
-		StartByte:  tok.StartByte,
-		EndByte:    tok.StartByte,
-		StartPoint: tok.StartPoint,
-		EndPoint:   tok.StartPoint,
-		Missing:    true,
+	missingTok, exact := p.recoveryMissingToken(source, s, candidateSym, tok)
+	if !exact {
+		return false
 	}
-	p.applyAction(nil, s, candidateAct, missingTok, new(bool), nodeCount, arena, entryScratch, gssScratch, nil, false, nil)
+	p.applyAction(source, s, candidateAct, missingTok, new(bool), nodeCount, arena, entryScratch, gssScratch, nil, false, nil)
 	if p.rejectUndrainedPendingForkStacks(s) {
 		return false
 	}
@@ -3062,7 +3048,7 @@ func (p *Parser) advanceTrailingEOFPrefix(prefix *glrStack, prefixEOF Token, exp
 	if p.tryAdvanceEOFOnSingleStack(prefix, prefixEOF, expectedEOFByte, source, nodeCount, arena, entryScratch, gssScratch, tmpEntries) {
 		return false, true
 	}
-	if !p.tryInsertMissingSingleShiftAtEOF(prefix, prefixEOF, nodeCount, arena, entryScratch, gssScratch) {
+	if !p.tryInsertMissingSingleShiftAtEOF(source, prefix, prefixEOF, nodeCount, arena, entryScratch, gssScratch) {
 		return false, false
 	}
 	if !p.tryAdvanceEOFOnSingleStack(prefix, prefixEOF, expectedEOFByte, source, nodeCount, arena, entryScratch, gssScratch, tmpEntries) {
@@ -8258,6 +8244,12 @@ func (p *Parser) applyExtraShiftAction(s *glrStack, currentState StateID, act Pa
 	if isMissing {
 		leaf.setMissing(true)
 		leaf.setHasError(true)
+		if tok.missingDependencyExact {
+			dependency, exact := missingNodeDependencyFromToken(tok)
+			if !exact || !arena.setMissingNodeDependency(leaf, dependency) {
+				leaf.setDirty(true)
+			}
+		}
 		if trackChildErrors != nil {
 			*trackChildErrors = true
 		}

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -2996,11 +2996,14 @@ func (d *dfaTokenSource) CanRelexFromTokenStart(tok Token) bool {
 }
 
 type dfaRelexSnapshot struct {
-	lexerPos                 int
-	lexerRow                 uint32
-	lexerCol                 uint32
-	lexerRangeIdx            int
-	externalScannerPresent   bool
+	lexerPos               int
+	lexerRow               uint32
+	lexerCol               uint32
+	lexerRangeIdx          int
+	externalScannerPresent bool
+	// externalLookaheadEndByte is the aggregate for the current C-style
+	// lex call. Capture and restore it for rollback, but exclude it from
+	// equal because it is not persistent scanner state.
 	externalLookaheadEndByte uint32
 
 	// Lexer.scan records the beginning of its most recent failed token
@@ -3036,7 +3039,6 @@ func (s dfaRelexSnapshot) equal(other dfaRelexSnapshot) bool {
 	return s.lexerPos == other.lexerPos && s.lexerRow == other.lexerRow &&
 		s.lexerCol == other.lexerCol && s.lexerRangeIdx == other.lexerRangeIdx &&
 		s.externalScannerPresent == other.externalScannerPresent &&
-		s.externalLookaheadEndByte == other.externalLookaheadEndByte &&
 		s.failTokenStartPos == other.failTokenStartPos &&
 		s.failTokenStartRow == other.failTokenStartRow &&
 		s.failTokenStartCol == other.failTokenStartCol &&

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -33,6 +33,7 @@ type dfaTokenSource struct {
 	externalCompare             []byte
 	externalLexer               ExternalLexer
 	externalRetryLexer          ExternalLexer
+	externalLookaheadEndByte    uint32
 	lastExternalTokenStartByte  uint32
 	lastExternalTokenEndByte    uint32
 	lastExternalTokenValid      bool
@@ -413,6 +414,7 @@ func (d *dfaTokenSource) Reset(source []byte) {
 	d.lastExternalTokenStartByte = 0
 	d.lastExternalTokenEndByte = 0
 	d.lastExternalTokenValid = false
+	d.externalLookaheadEndByte = 0
 	d.lastExternalTokenWasExtra = false
 	d.externalTokenEndSameAsStart = false
 	d.lastTokenStartByte = 0
@@ -469,6 +471,7 @@ func (d *dfaTokenSource) Close() {
 	d.lastExternalTokenStartByte = 0
 	d.lastExternalTokenEndByte = 0
 	d.lastExternalTokenValid = false
+	d.externalLookaheadEndByte = 0
 	d.lastExternalTokenWasExtra = false
 	d.externalTokenEndSameAsStart = false
 	d.lastTokenStartByte = 0
@@ -485,6 +488,11 @@ func (d *dfaTokenSource) Close() {
 var DebugDFA atomic.Bool
 
 func (d *dfaTokenSource) Next() Token {
+	if d != nil {
+		// A token-source read mirrors one C ts_parser__lex call. Preserve the
+		// maximum frontier only across attempts within this read.
+		d.externalLookaheadEndByte = 0
+	}
 	if d != nil && d.lexer != nil {
 		d.lexer.skipLeadingBOM()
 	}
@@ -511,6 +519,7 @@ func (d *dfaTokenSource) Next() Token {
 		}
 		if d.shouldForceEOFLookahead() {
 			tok := d.syntheticEOFLookaheadToken()
+			tok = d.attachTokenLookaheadFrontier(tok, true)
 			d.lastTokenValid = false
 			d.lastExternalTokenValid = false
 			d.lastExternalTokenWasExtra = false
@@ -659,6 +668,7 @@ func (d *dfaTokenSource) Next() Token {
 			d.zeroWidthPos = -1
 			d.zeroWidthCount = 0
 		}
+		tok = d.attachTokenLookaheadFrontier(tok, !tokenFromExternal && !tok.lexerInternalDFALexed)
 
 		if perfCountersEnabled {
 			consumed := d.lexer.pos - startPos
@@ -721,6 +731,28 @@ func (d *dfaTokenSource) Next() Token {
 			(!d.hasExternalScanner || d.usesExternalCheckpoints)
 		return tok
 	}
+}
+
+// attachTokenLookaheadFrontier preserves the largest external-scanner
+// frontier observed during this token-source read. Synthetic replacements do
+// not have a scanner token, so derive their frontier from their resulting end.
+func (d *dfaTokenSource) attachTokenLookaheadFrontier(tok Token, synthetic bool) Token {
+	if d == nil {
+		return tok
+	}
+	frontier := maxUint32(tok.lexerLookaheadEndByte, d.externalLookaheadEndByte)
+	if synthetic && d.lexer != nil {
+		endPos := uint64(tok.EndByte)
+		if endPos > uint64(len(d.lexer.source)) {
+			endPos = uint64(len(d.lexer.source))
+		}
+		frontier = maxUint32(frontier, d.lexer.lookaheadEndByteAt(int(endPos), true))
+	}
+	if frontier < tok.EndByte {
+		frontier = tok.EndByte
+	}
+	tok.lexerLookaheadEndByte = frontier
+	return tok
 }
 
 func (d *dfaTokenSource) SetParserState(state StateID) {
@@ -1016,6 +1048,7 @@ func (d *dfaTokenSource) SeekTokenFrontier(pos uint32, pt Point) {
 	d.lexer.col = pt.Column
 	d.lexer.includedRangeIdx = 0
 	d.lexer.normalizeIncludedPosition()
+	d.externalLookaheadEndByte = 0
 }
 
 // tokensSameLex compares tokenization identity, not the lex path that
@@ -3302,6 +3335,7 @@ func (d *dfaTokenSource) beginRelexAt(target int, pt Point) {
 	d.lastTokenStartByte = 0
 	d.lastTokenEndByte = 0
 	d.lastTokenValid = false
+	d.externalLookaheadEndByte = 0
 	if len(d.externalTokenEnd) > 0 {
 		d.externalTokenEnd = d.externalTokenEnd[:0]
 	}
@@ -3496,6 +3530,7 @@ func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
 		if !ok {
 			return Token{}, false
 		}
+		tok = d.attachTokenLookaheadFrontier(tok, true)
 		d.trackZeroWidthExternalToken(tok)
 		d.lexer.pos = int(tok.EndByte)
 		d.lexer.row = tok.EndPoint.Row
@@ -3511,6 +3546,7 @@ func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
 				if DebugDFA.Load() {
 					fmt.Printf("  EXT synthetic %s %d %d state=%d\n", d.symbolName(tok.Symbol), tok.StartByte, tok.EndByte, d.state)
 				}
+				tok = d.attachTokenLookaheadFrontier(tok, true)
 				d.trackZeroWidthExternalToken(tok)
 				d.lexer.pos = int(tok.EndByte)
 				d.lexer.row = tok.EndPoint.Row
@@ -3527,9 +3563,11 @@ func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
 	if !ok {
 		return Token{}, false
 	}
+	tok = d.attachTokenLookaheadFrontier(tok, false)
 	tok.ExternalScannerToken = true
 	tok.ExternalScannerStartByte = uint32(d.lexer.pos)
 	if splitTok, endPos, endRow, endCol, ok := d.splitSwiftWideCloseAngleToken(tok, states); ok {
+		splitTok = d.attachTokenLookaheadFrontier(splitTok, false)
 		d.lexer.pos = endPos
 		d.lexer.row = endRow
 		d.lexer.col = endCol
@@ -3537,6 +3575,7 @@ func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
 	}
 
 	if dfaTok, endPos, endRow, endCol, ok := d.preferDFASemicolonOverJSXText(tok, states); ok {
+		dfaTok = d.attachTokenLookaheadFrontier(dfaTok, false)
 		d.lexer.pos = endPos
 		d.lexer.row = endRow
 		d.lexer.col = endCol
@@ -3548,6 +3587,7 @@ func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
 	d.lexer.pos = int(tok.EndByte)
 	d.lexer.row = tok.EndPoint.Row
 	d.lexer.col = tok.EndPoint.Column
+	tok = d.attachTokenLookaheadFrontier(tok, false)
 	return tok, true
 }
 
@@ -4152,6 +4192,14 @@ func (d *dfaTokenSource) runExternalScannerWithRetry(el *ExternalLexer, valid []
 	if d == nil || d.language == nil || d.language.ExternalScanner == nil || el == nil {
 		return false
 	}
+	recordFrontier := func(scannerLexer *ExternalLexer) {
+		if scannerLexer == nil {
+			return
+		}
+		scannerLexer.lookaheadEndByte = maxUint32(scannerLexer.lookaheadEndByte, scannerLexer.lookaheadEndByteAtCursor())
+		d.externalLookaheadEndByte = maxUint32(d.externalLookaheadEndByte, scannerLexer.lookaheadEndByte)
+		scannerLexer.lookaheadEndByte = maxUint32(scannerLexer.lookaheadEndByte, d.externalLookaheadEndByte)
+	}
 	var snapshot []byte
 	retainFailureState := d.externalScannerRetainsStateOnScanFailure()
 	// Retention takes precedence if a scanner reports both capabilities.
@@ -4163,7 +4211,9 @@ func (d *dfaTokenSource) runExternalScannerWithRetry(el *ExternalLexer, valid []
 		}
 	}
 	if preserveFailureState {
-		if RunExternalScanner(d.language, d.externalPayload, el, valid) {
+		foundToken := RunExternalScanner(d.language, d.externalPayload, el, valid)
+		recordFrontier(el)
+		if foundToken {
 			return true
 		}
 		if !el.hasResult {
@@ -4173,7 +4223,9 @@ func (d *dfaTokenSource) runExternalScannerWithRetry(el *ExternalLexer, valid []
 		snapshot = d.captureExternalScannerStateInto(&d.externalRetrySnap)
 	} else {
 		snapshot = d.captureExternalScannerStateInto(&d.externalRetrySnap)
-		if RunExternalScanner(d.language, d.externalPayload, el, valid) {
+		foundToken := RunExternalScanner(d.language, d.externalPayload, el, valid)
+		recordFrontier(el)
+		if foundToken {
 			return true
 		}
 		if !el.hasResult {
@@ -4211,7 +4263,9 @@ func (d *dfaTokenSource) runExternalScannerWithRetry(el *ExternalLexer, valid []
 		d.restoreExternalScannerState(snapshot)
 		retryLexer := &d.externalRetryLexer
 		retryLexer.reset(d.lexer.source, d.lexer.pos, d.lexer.row, d.lexer.col)
-		if RunExternalScanner(d.language, d.externalPayload, retryLexer, masked) {
+		foundToken := RunExternalScanner(d.language, d.externalPayload, retryLexer, masked)
+		recordFrontier(retryLexer)
+		if foundToken {
 			*el = *retryLexer
 			return true
 		}

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -1051,12 +1051,28 @@ func (d *dfaTokenSource) SeekTokenFrontier(pos uint32, pt Point) {
 	d.externalLookaheadEndByte = 0
 }
 
-// tokensSameLex compares tokenization identity, not the lex path that
-// produced the token. isKeyword records the promotion path, so it must
-// not take part in a same-tokenization test.
+// tokensSameLex compares full tokenization state, including the dependency
+// frontier, not the lex path that produced the token. isKeyword records the
+// promotion path, so it must not take part in a same-tokenization test.
 func tokensSameLex(a, b Token) bool {
 	a.isKeyword, b.isKeyword = false, false
 	return a == b
+}
+
+// tokensSameLexForGLRCandidate compares the token surface used by GLR
+// candidate routing. The lexer frontier is dependency metadata, not lexical
+// identity, so callers must merge it separately when candidates match.
+func tokensSameLexForGLRCandidate(a, b Token) bool {
+	a.lexerLookaheadEndByte = 0
+	b.lexerLookaheadEndByte = 0
+	return tokensSameLex(a, b)
+}
+
+func mergeTokenLookaheadFrontier(dst *Token, src Token) {
+	if dst == nil {
+		return
+	}
+	dst.lexerLookaheadEndByte = maxUint32(dst.lexerLookaheadEndByte, src.lexerLookaheadEndByte)
 }
 
 func (d *dfaTokenSource) PeekTokenFrontier(states []StateID, dst []tokenCandidate) (tokenFrontier, bool) {
@@ -1140,7 +1156,8 @@ func (d *dfaTokenSource) PeekTokenFrontier(states []StateID, dst []tokenCandidat
 
 		merged := false
 		for i := range dst {
-			if tokensSameLex(dst[i].Tok, candTok) && dst[i].EndPos == candEndPos && dst[i].EndRow == candEndRow && dst[i].EndCol == candEndCol {
+			if tokensSameLexForGLRCandidate(dst[i].Tok, candTok) && dst[i].EndPos == candEndPos && dst[i].EndRow == candEndRow && dst[i].EndCol == candEndCol {
+				mergeTokenLookaheadFrontier(&dst[i].Tok, candTok)
 				dst[i].RouteMask |= routeMask
 				merged = true
 				break
@@ -1188,7 +1205,7 @@ func (d *dfaTokenSource) tokenFrontierRouteMask(states []StateID, tok Token, end
 
 func (d *dfaTokenSource) stateProducesTokenFrontierCandidate(state StateID, tok Token, endPos int, endRow, endCol uint32) bool {
 	stateTok, stateEndPos, stateEndRow, stateEndCol := d.scanPreferredTokenForState(state)
-	return tokensSameLex(stateTok, tok) && stateEndPos == endPos && stateEndRow == endRow && stateEndCol == endCol
+	return tokensSameLexForGLRCandidate(stateTok, tok) && stateEndPos == endPos && stateEndRow == endRow && stateEndCol == endCol
 }
 
 // nextGLRUnionDFAToken tries each unique GLR stack state's lex mode and
@@ -1277,7 +1294,7 @@ func (d *dfaTokenSource) nextGLRUnionDFAToken() (Token, bool) {
 				continue
 			}
 			stateTok, stateEndPos, stateEndRow, stateEndCol := d.glrUnionScanForState(liveState)
-			if !tokensSameLex(stateTok, candTok) || stateEndPos != candEndPos || stateEndRow != candEndRow || stateEndCol != candEndCol {
+			if !tokensSameLexForGLRCandidate(stateTok, candTok) || stateEndPos != candEndPos || stateEndRow != candEndRow || stateEndCol != candEndCol {
 				continue
 			}
 			score++
@@ -1357,6 +1374,17 @@ func (d *dfaTokenSource) nextGLRUnionDFAToken() (Token, bool) {
 		d.lexer.col = startCol
 		d.lexer.includedRangeIdx = startRangeIdx
 		return Token{}, false
+	}
+	// Preserve the largest dependency frontier among every scanned candidate
+	// with the elected token surface. Candidate identity ignores this field,
+	// but the returned token must retain the complete invalidation extent.
+	for i := range d.glrUnionScanScratch {
+		scan := &d.glrUnionScanScratch[i]
+		if !tokensSameLexForGLRCandidate(scan.tok, bestTok) ||
+			scan.endPos != bestEndPos || scan.endRow != bestEndRow || scan.endCol != bestEndCol {
+			continue
+		}
+		mergeTokenLookaheadFrontier(&bestTok, scan.tok)
 	}
 
 	d.lexer.pos = bestEndPos
@@ -2968,11 +2996,12 @@ func (d *dfaTokenSource) CanRelexFromTokenStart(tok Token) bool {
 }
 
 type dfaRelexSnapshot struct {
-	lexerPos               int
-	lexerRow               uint32
-	lexerCol               uint32
-	lexerRangeIdx          int
-	externalScannerPresent bool
+	lexerPos                 int
+	lexerRow                 uint32
+	lexerCol                 uint32
+	lexerRangeIdx            int
+	externalScannerPresent   bool
+	externalLookaheadEndByte uint32
 
 	// Lexer.scan records the beginning of its most recent failed token
 	// attempt. NextWithErrorRuns uses these coordinates to delimit the next
@@ -3007,6 +3036,7 @@ func (s dfaRelexSnapshot) equal(other dfaRelexSnapshot) bool {
 	return s.lexerPos == other.lexerPos && s.lexerRow == other.lexerRow &&
 		s.lexerCol == other.lexerCol && s.lexerRangeIdx == other.lexerRangeIdx &&
 		s.externalScannerPresent == other.externalScannerPresent &&
+		s.externalLookaheadEndByte == other.externalLookaheadEndByte &&
 		s.failTokenStartPos == other.failTokenStartPos &&
 		s.failTokenStartRow == other.failTokenStartRow &&
 		s.failTokenStartCol == other.failTokenStartCol &&
@@ -3097,6 +3127,7 @@ func (d *dfaTokenSource) snapshotRelexStateIntoScratch(scratch *dfaRelexSnapshot
 		lexerCol:                    d.lexer.col,
 		lexerRangeIdx:               d.lexer.includedRangeIdx,
 		externalScannerPresent:      d.hasExternalScanner,
+		externalLookaheadEndByte:    d.externalLookaheadEndByte,
 		failTokenStartPos:           d.lexer.failTokenStartPos,
 		failTokenStartRow:           d.lexer.failTokenStartRow,
 		failTokenStartCol:           d.lexer.failTokenStartCol,
@@ -3156,6 +3187,7 @@ func (d *dfaTokenSource) snapshotRelexStateWithExternalBuffer(buf []byte) (dfaRe
 		lexerCol:                    d.lexer.col,
 		lexerRangeIdx:               d.lexer.includedRangeIdx,
 		externalScannerPresent:      d.hasExternalScanner,
+		externalLookaheadEndByte:    d.externalLookaheadEndByte,
 		failTokenStartPos:           d.lexer.failTokenStartPos,
 		failTokenStartRow:           d.lexer.failTokenStartRow,
 		failTokenStartCol:           d.lexer.failTokenStartCol,
@@ -3202,6 +3234,7 @@ func (s dfaRelexSnapshot) restore(d *dfaTokenSource) {
 	d.lexer.failTokenStartRow = s.failTokenStartRow
 	d.lexer.failTokenStartCol = s.failTokenStartCol
 	d.lexer.failTokenStartRangeIdx = s.failTokenStartRangeIdx
+	d.externalLookaheadEndByte = s.externalLookaheadEndByte
 	if d.hasExternalScanner && d.language != nil && d.language.ExternalScanner != nil {
 		d.language.ExternalScanner.Deserialize(d.externalPayload, s.externalPayload)
 	}

--- a/parser_dfa_union_route_test.go
+++ b/parser_dfa_union_route_test.go
@@ -56,3 +56,77 @@ func TestNextGLRUnionDFATokenScoresOnlyStatesProducingCandidate(t *testing.T) {
 		t.Fatalf("token span = %d..%d, want 0..2", tok.StartByte, tok.EndByte)
 	}
 }
+
+func TestGLRUnionMergesEquivalentCandidatesWithMaximumLookaheadFrontier(t *testing.T) {
+	lowFrontier := Token{Symbol: 1, StartByte: 0, EndByte: 1, lexerLookaheadEndByte: 2}
+	highFrontier := lowFrontier
+	highFrontier.lexerLookaheadEndByte = 3
+	if tokensSameLex(lowFrontier, highFrontier) {
+		t.Fatal("strict token equality ignored distinct lookahead frontiers")
+	}
+	if !tokensSameLexForGLRCandidate(lowFrontier, highFrontier) {
+		t.Fatal("GLR candidate equality rejected the same token surface")
+	}
+
+	lang := &Language{
+		Name:        "glr-union-frontier-test",
+		SymbolNames: []string{"end", "a"},
+		SymbolCount: 2,
+		TokenCount:  2,
+		StateCount:  3,
+		LexStates: []LexState{
+			{Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: 'a', Hi: 'a', NextState: 1}}},
+			{AcceptToken: 1, Default: -1, EOF: -1},
+			{Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: 'a', Hi: 'a', NextState: 3}}},
+			{AcceptToken: 1, Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: 'b', Hi: 'b', NextState: 4}}},
+			{Default: -1, EOF: -1},
+		},
+		LexModes: []LexMode{
+			{},
+			{LexState: 0},
+			{LexState: 2},
+		},
+	}
+	lookup := func(state StateID, sym Symbol) uint16 {
+		if (state == 1 || state == 2) && sym == 1 {
+			return 1
+		}
+		return 0
+	}
+	newSource := func() *dfaTokenSource {
+		return &dfaTokenSource{
+			lexer:             NewLexer(lang.LexStates, []byte("ab")),
+			language:          lang,
+			state:             1,
+			glrStates:         []StateID{1, 2},
+			lookupActionIndex: lookup,
+		}
+	}
+
+	peek := newSource()
+	frontier, ok := peek.PeekTokenFrontier(nil, nil)
+	if !ok {
+		t.Fatal("PeekTokenFrontier returned false")
+	}
+	if got, want := len(frontier.Candidates), 1; got != want {
+		t.Fatalf("candidate count = %d, want %d: %#v", got, want, frontier.Candidates)
+	}
+	if got, want := frontier.Candidates[0].RouteMask, uint16(0b11); got != want {
+		t.Fatalf("route mask = %#x, want %#x", got, want)
+	}
+	if got, want := tokenLookaheadEndByte(frontier.Candidates[0].Tok), uint32(3); got != want {
+		t.Fatalf("peek frontier = %d, want maximum candidate frontier %d", got, want)
+	}
+
+	union := newSource()
+	tok, ok := union.nextGLRUnionDFAToken()
+	if !ok {
+		t.Fatal("nextGLRUnionDFAToken returned false")
+	}
+	if got, want := tok.Symbol, Symbol(1); got != want {
+		t.Fatalf("token symbol = %d, want %d", got, want)
+	}
+	if got, want := tokenLookaheadEndByte(tok), uint32(3); got != want {
+		t.Fatalf("union frontier = %d, want maximum candidate frontier %d", got, want)
+	}
+}

--- a/parser_external_retry_test.go
+++ b/parser_external_retry_test.go
@@ -1,11 +1,14 @@
 package gotreesitter
 
-import "testing"
+import (
+	"testing"
+	"unicode/utf8"
+)
 
 type retryingExternalScanner struct{}
 
-func (retryingExternalScanner) Create() any { return nil }
-func (retryingExternalScanner) Destroy(any) {}
+func (retryingExternalScanner) Create() any               { return nil }
+func (retryingExternalScanner) Destroy(any)               {}
 func (retryingExternalScanner) Serialize(any, []byte) int { return 0 }
 func (retryingExternalScanner) Deserialize(any, []byte)   {}
 
@@ -61,5 +64,137 @@ func TestNextExternalTokenRetriesScannerAfterFailedPreferredCandidate(t *testing
 	}
 	if got, want := tok.EndByte, uint32(1); got != want {
 		t.Fatalf("EndByte = %d, want %d", got, want)
+	}
+}
+
+type frontierRetryExternalScanner struct{}
+
+func (frontierRetryExternalScanner) Create() any               { return nil }
+func (frontierRetryExternalScanner) Destroy(any)               {}
+func (frontierRetryExternalScanner) Serialize(any, []byte) int { return 0 }
+func (frontierRetryExternalScanner) Deserialize(any, []byte)   {}
+func (frontierRetryExternalScanner) Scan(_ any, lexer *ExternalLexer, valid []bool) bool {
+	if len(valid) > 0 && valid[0] {
+		// Leave the cursor on an invalid byte. C still records its current
+		// position plus the four-byte invalid-code-point lookahead.
+		if lexer.Lookahead() == utf8.RuneError {
+			lexer.SetResultSymbol(Symbol(2))
+		}
+		return false
+	}
+	if len(valid) > 1 && valid[1] {
+		lexer.Advance(false)
+		lexer.MarkEnd()
+		lexer.SetResultSymbol(Symbol(3))
+		return true
+	}
+	return false
+}
+
+func TestExternalScannerRetryPreservesMaximumInvalidUTF8Frontier(t *testing.T) {
+	lang := &Language{
+		Name:               "test",
+		SymbolNames:        []string{"end", "x", "first_ext", "second_ext"},
+		SymbolCount:        4,
+		TokenCount:         4,
+		ExternalTokenCount: 2,
+		StateCount:         2,
+		LexStates:          []LexState{{Default: -1, EOF: -1}},
+		LexModes:           []LexMode{{LexState: 0}, {LexState: 0, ExternalLexState: 1}},
+		ExternalSymbols:    []Symbol{2, 3},
+		ExternalLexStates:  [][]bool{{false, false}, {true, true}},
+		ExternalScanner:    frontierRetryExternalScanner{},
+	}
+	d := &dfaTokenSource{
+		lexer:             NewLexer(lang.LexStates, []byte{0xff}),
+		language:          lang,
+		state:             1,
+		lookupActionIndex: func(StateID, Symbol) uint16 { return 1 },
+	}
+
+	tok, ok := d.nextExternalToken()
+	if !ok {
+		t.Fatal("nextExternalToken returned ok=false, want true")
+	}
+	if got, want := tok.Symbol, Symbol(3); got != want {
+		t.Fatalf("token symbol = %d, want %d", got, want)
+	}
+	if got, want := tokenLookaheadEndByte(tok), uint32(5); got != want {
+		t.Fatalf("lookahead end = %d, want failed-attempt invalid UTF-8 frontier %d", got, want)
+	}
+}
+
+type frontierFailingExternalScanner struct{}
+
+func (frontierFailingExternalScanner) Create() any               { return nil }
+func (frontierFailingExternalScanner) Destroy(any)               {}
+func (frontierFailingExternalScanner) Serialize(any, []byte) int { return 0 }
+func (frontierFailingExternalScanner) Deserialize(any, []byte)   {}
+func (frontierFailingExternalScanner) Scan(_ any, lexer *ExternalLexer, _ []bool) bool {
+	for lexer.Lookahead() != 0 {
+		lexer.Advance(false)
+	}
+	return false
+}
+
+func TestInternalTokenPreservesFailedExternalScannerFrontier(t *testing.T) {
+	lang := &Language{
+		Name:               "test",
+		SymbolNames:        []string{"end", "x", "external"},
+		SymbolCount:        3,
+		TokenCount:         2,
+		ExternalTokenCount: 1,
+		StateCount:         1,
+		LexStates: []LexState{
+			{Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: 'a', Hi: 'a', NextState: 1}}},
+			{AcceptToken: 1, Default: -1, EOF: -1},
+		},
+		LexModes:          []LexMode{{LexState: 0, ExternalLexState: 0}},
+		ExternalSymbols:   []Symbol{2},
+		ExternalLexStates: [][]bool{{true}},
+		ExternalScanner:   frontierFailingExternalScanner{},
+	}
+	d := &dfaTokenSource{
+		lexer:              NewLexer(lang.LexStates, []byte("aXXX")),
+		language:           lang,
+		state:              0,
+		lookupActionIndex:  func(StateID, Symbol) uint16 { return 1 },
+		hasExternalScanner: true,
+		hasExternalSymbols: true,
+	}
+
+	tok := d.Next()
+	if got, want := tok.Symbol, Symbol(1); got != want {
+		t.Fatalf("token symbol = %d, want %d", got, want)
+	}
+	if got, want := tokenLookaheadEndByte(tok), uint32(5); got != want {
+		t.Fatalf("lookahead end = %d, want failed external frontier %d", got, want)
+	}
+}
+
+func TestSyntheticExternalTokenCarriesResultingCursorFrontier(t *testing.T) {
+	lang := &Language{
+		Name:              "test",
+		SymbolNames:       []string{"end", "_line_break"},
+		SymbolCount:       2,
+		TokenCount:        2,
+		ExternalSymbols:   []Symbol{1},
+		ExternalLexStates: [][]bool{{true}},
+		LexModes:          []LexMode{{LexState: 0, ExternalLexState: 0}},
+		LexStates:         []LexState{{Default: -1, EOF: -1}},
+	}
+	d := &dfaTokenSource{
+		lexer:             NewLexer(lang.LexStates, []byte("\nx")),
+		language:          lang,
+		lookupActionIndex: func(StateID, Symbol) uint16 { return 1 },
+	}
+	initDFATokenSourceWithCRecovery(d, d.lexer, lang, d.lookupActionIndex, nil, nil, nil, false)
+
+	tok := d.Next()
+	if got, want := tok.Symbol, Symbol(1); got != want {
+		t.Fatalf("token symbol = %d, want %d", got, want)
+	}
+	if got, want := tokenLookaheadEndByte(tok), uint32(2); got != want {
+		t.Fatalf("lookahead end = %d, want synthetic cursor frontier %d", got, want)
 	}
 }

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -3742,19 +3742,9 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 				}
 				cand.cRec = nil
 				cand.cRecoverMissingGroup = nil
-				missingTok := Token{
-					Symbol:     ms,
-					StartByte:  tok.StartByte,
-					EndByte:    tok.StartByte,
-					StartPoint: tok.StartPoint,
-					EndPoint:   tok.StartPoint,
-					Missing:    true,
-				}
-				if top := cand.top(); stackEntryHasNode(top) && stackEntryNodeEndByte(top) <= tok.StartByte {
-					missingTok.StartByte = stackEntryNodeEndByte(top)
-					missingTok.EndByte = stackEntryNodeEndByte(top)
-					missingTok.StartPoint = stackEntryNodeEndPoint(top)
-					missingTok.EndPoint = stackEntryNodeEndPoint(top)
+				missingTok, exact := p.recoveryMissingToken(source, &cand, ms, tok)
+				if !exact {
+					continue
 				}
 				var dummy bool
 				p.applyAction(source, &cand, shiftAct, missingTok, &dummy, nodeCount, arena, entryScratch, gssScratch, nil, false, trackChildErrors)

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -2622,7 +2622,11 @@ func (p *Parser) applyShiftAction(s *glrStack, act ParseAction, tok Token, nodeC
 			flags |= nodeFlagLexerSkippedPrefixAtSourceStart
 		}
 		substituteActive := internLeavesSubstituteEnabled || (p != nil && p.leafInternByLang)
-		if substituteActive {
+		// Missing leaves carry recovery padding and lookahead provenance in a
+		// sparse sidecar. The visible leaf key cannot represent that provenance,
+		// so never substitute or store a missing leaf in the canonical table.
+		// This also keeps a failed sidecar write from publishing an unsafe entry.
+		if substituteActive && !isMissing {
 			key := internKey{
 				symbol:       uint32(tok.Symbol),
 				flags:        internedLeafFlags(flags),
@@ -2662,6 +2666,12 @@ func (p *Parser) applyShiftAction(s *glrStack, act ParseAction, tok Token, nodeC
 		if isMissing {
 			leaf.setMissing(true)
 			leaf.setHasError(true)
+			if tok.missingDependencyExact {
+				dependency, exact := missingNodeDependencyFromToken(tok)
+				if !exact || arena == nil || !arena.setMissingNodeDependency(leaf, dependency) {
+					leaf.setDirty(true)
+				}
+			}
 			if trackChildErrors != nil {
 				*trackChildErrors = true
 			}
@@ -2681,7 +2691,7 @@ func (p *Parser) applyShiftAction(s *glrStack, act ParseAction, tok Token, nodeC
 				observeLeafInternFull(arena, leaf)
 			}
 		}
-		if substituteActive {
+		if substituteActive && !isMissing {
 			storeCanonicalLeaf(arena, leaf)
 		}
 		p.pushStackNode(s, targetState, leaf, entryScratch, gssScratch)
@@ -9005,6 +9015,7 @@ func aliasedNodeInArena(arena *nodeArena, lang *Language, n *Node, alias Symbol)
 		cloned.setNamed(lang.SymbolMetadata[alias].Named)
 	}
 	cloned.ownerArena = arena
+	copyMissingNodeDependencyForClone(cloned, n)
 	copyExternalScannerCheckpointToNode(cloned, n)
 	return cloned
 }
@@ -9185,6 +9196,7 @@ func cloneNodeInArena(arena *nodeArena, n *Node) *Node {
 	cloned.errorRankCache = 0
 	cloned.ownerArena = arena
 	cloneNodeFieldMetadataHeaderInto(cloned, n, arena)
+	copyMissingNodeDependencyForClone(cloned, n)
 	copyExternalScannerCheckpointToNode(cloned, n)
 	if nodeHasFinalChildRefs(n) {
 		childCount := nodeChildCountNoMaterialize(n)
@@ -9198,6 +9210,17 @@ func cloneNodeInArena(arena *nodeArena, n *Node) *Node {
 		cloned.childIndex = -1
 	}
 	return cloned
+}
+
+// copyMissingNodeDependencyForClone carries recovery provenance to a clone.
+// A stale or rejected receipt makes the clone dirty so reuse cannot skip it.
+func copyMissingNodeDependencyForClone(dst, src *Node) {
+	if copyMissingNodeDependency(dst, src, nil) {
+		return
+	}
+	if _, present := missingNodeDependencyEntryForNode(src); present {
+		dst.setDirty(true)
+	}
 }
 
 func materializeHiddenNodeForAlias(arena *nodeArena, lang *Language, n *Node) *Node {

--- a/parser_reduce_missing_clone_test.go
+++ b/parser_reduce_missing_clone_test.go
@@ -1,0 +1,102 @@
+package gotreesitter
+
+import "testing"
+
+func TestParserReduceClonesCopyMissingNodeDependency(t *testing.T) {
+	tests := []struct {
+		name  string
+		clone func(*nodeArena, *Node) *Node
+	}{
+		{
+			name: "alias",
+			clone: func(arena *nodeArena, node *Node) *Node {
+				return aliasedNodeInArena(arena, nil, node, 2)
+			},
+		},
+		{
+			name:  "generic",
+			clone: cloneNodeInArena,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceArena, source, want := newParserReduceMissingCloneFixture(t)
+			defer sourceArena.Release()
+			destinationArena := acquireNodeArena(arenaClassIncremental)
+			defer destinationArena.Release()
+
+			clone := test.clone(destinationArena, source)
+			if clone == nil {
+				t.Fatal("clone = nil")
+			}
+			if clone.ownerArena != destinationArena {
+				t.Fatal("clone owner arena does not match destination")
+			}
+			if clone.dirty() {
+				t.Fatal("valid missing dependency made the clone dirty")
+			}
+			if got, ok := missingNodeDependencyForNode(clone); !ok || got != want {
+				t.Fatalf("cloned dependency=%+v exact=%t, want %+v", got, ok, want)
+			}
+		})
+	}
+}
+
+func TestParserReduceClonesFailClosedForStaleMissingNodeDependency(t *testing.T) {
+	tests := []struct {
+		name  string
+		clone func(*nodeArena, *Node) *Node
+	}{
+		{
+			name: "alias",
+			clone: func(arena *nodeArena, node *Node) *Node {
+				return aliasedNodeInArena(arena, nil, node, 2)
+			},
+		},
+		{
+			name:  "generic",
+			clone: cloneNodeInArena,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceArena, source, _ := newParserReduceMissingCloneFixture(t)
+			defer sourceArena.Release()
+			destinationArena := acquireNodeArena(arenaClassIncremental)
+			defer destinationArena.Release()
+
+			source.startByte++
+			source.endByte++
+			clone := test.clone(destinationArena, source)
+			if clone == nil {
+				t.Fatal("clone = nil")
+			}
+			if !clone.dirty() {
+				t.Fatal("stale missing dependency did not dirty the clone")
+			}
+			if _, present := missingNodeDependencyEntryForNode(clone); present {
+				t.Fatal("stale missing dependency was copied to the clone")
+			}
+		})
+	}
+}
+
+func newParserReduceMissingCloneFixture(t *testing.T) (*nodeArena, *Node, missingNodeDependency) {
+	t.Helper()
+	arena := acquireNodeArena(arenaClassIncremental)
+	dependency := missingNodeDependency{
+		stackByte: 0, stackPoint: Point{},
+		paddingBytes: 3, paddingExtent: Point{Column: 3},
+		lookaheadBytes: 3,
+	}
+	node := newLeafNodeInArena(arena, 1, true, 3, 3, Point{Column: 3}, Point{Column: 3})
+	node.setMissing(true)
+	node.setHasError(true)
+	if !arena.setMissingNodeDependency(node, dependency) {
+		arena.Release()
+		t.Fatal("set missing dependency")
+	}
+	return arena, node, dependency
+}

--- a/parser_reduce_missing_intern_test.go
+++ b/parser_reduce_missing_intern_test.go
@@ -1,0 +1,86 @@
+package gotreesitter
+
+import "testing"
+
+func TestMissingLeafShiftDoesNotInternDependencyProvenance(t *testing.T) {
+	oldObserve, oldSubstitute := internLeavesObserveEnabled, internLeavesSubstituteEnabled
+	t.Cleanup(func() {
+		internLeavesObserveEnabled = oldObserve
+		internLeavesSubstituteEnabled = oldSubstitute
+	})
+	internLeavesObserveEnabled = false
+	internLeavesSubstituteEnabled = true
+
+	parser := NewParser(buildArithmeticLanguage())
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	act := ParseAction{Type: ParseActionShift, State: 1}
+	first := applyMissingLeafInternTestShift(t, parser, arena, act, Token{
+		Symbol: 1, StartByte: 3, EndByte: 3,
+		StartPoint: Point{Column: 3}, EndPoint: Point{Column: 3}, Missing: true,
+		missingStackByte: 0, missingStackPoint: Point{},
+		lexerLookaheadEndByte: 5, missingDependencyExact: true,
+	})
+	second := applyMissingLeafInternTestShift(t, parser, arena, act, Token{
+		Symbol: 1, StartByte: 3, EndByte: 3,
+		StartPoint: Point{Column: 3}, EndPoint: Point{Column: 3}, Missing: true,
+		missingStackByte: 1, missingStackPoint: Point{Column: 1},
+		lexerLookaheadEndByte: 6, missingDependencyExact: true,
+	})
+	if first == second {
+		t.Fatal("missing leaves with different dependency provenance were canonicalized")
+	}
+	firstDependency, firstOK := missingNodeDependencyForNode(first)
+	secondDependency, secondOK := missingNodeDependencyForNode(second)
+	if !firstOK || !secondOK {
+		t.Fatalf("missing dependency receipts: first=%+v exact=%t second=%+v exact=%t", firstDependency, firstOK, secondDependency, secondOK)
+	}
+	if firstDependency == secondDependency {
+		t.Fatalf("missing dependency provenance collapsed: first=%+v second=%+v", firstDependency, secondDependency)
+	}
+	if arena.internLeavesFull != nil && arena.internLeavesFull.stats().Stores != 0 {
+		t.Fatalf("missing leaf entered canonical table: %+v", arena.internLeavesFull.stats())
+	}
+}
+
+func TestMissingLeafShiftSetterFailureDoesNotPublishCanonicalEntry(t *testing.T) {
+	oldObserve, oldSubstitute := internLeavesObserveEnabled, internLeavesSubstituteEnabled
+	t.Cleanup(func() {
+		internLeavesObserveEnabled = oldObserve
+		internLeavesSubstituteEnabled = oldSubstitute
+	})
+	internLeavesObserveEnabled = false
+	internLeavesSubstituteEnabled = true
+
+	parser := NewParser(buildArithmeticLanguage())
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	invalid := applyMissingLeafInternTestShift(t, parser, arena, ParseAction{Type: ParseActionShift, State: 1}, Token{
+		Symbol: 1, StartByte: 3, EndByte: 3,
+		StartPoint: Point{Column: 3}, EndPoint: Point{Column: 3}, Missing: true,
+		missingStackByte: 4, missingStackPoint: Point{Column: 4},
+		lexerLookaheadEndByte: 5, missingDependencyExact: true,
+	})
+	if !invalid.dirty() {
+		t.Fatal("failed missing dependency write did not mark the leaf dirty")
+	}
+	if _, ok := missingNodeDependencyEntryForNode(invalid); ok {
+		t.Fatal("failed missing dependency write published a sidecar receipt")
+	}
+	if arena.internLeavesFull != nil && arena.internLeavesFull.stats().Stores != 0 {
+		t.Fatalf("failed missing leaf entered canonical table: %+v", arena.internLeavesFull.stats())
+	}
+}
+
+func applyMissingLeafInternTestShift(t *testing.T, parser *Parser, arena *nodeArena, act ParseAction, tok Token) *Node {
+	t.Helper()
+	stack := newGLRStack(0)
+	nodeCount := 0
+	trackChildErrors := false
+	parser.applyShiftAction(&stack, act, tok, &nodeCount, arena, nil, nil, &trackChildErrors)
+	node := stackEntryNode(stack.top())
+	if node == nil {
+		t.Fatal("missing shift did not push a node")
+	}
+	return node
+}

--- a/parser_relex_state_test.go
+++ b/parser_relex_state_test.go
@@ -90,6 +90,31 @@ func TestSameSurfaceRelexTokenRequiresSameSpanAndSurface(t *testing.T) {
 	}
 }
 
+func TestDFARelexSnapshotRestoresExternalLookaheadFrontier(t *testing.T) {
+	d := &dfaTokenSource{
+		lexer: NewLexer([]LexState{{Default: -1, EOF: -1}}, []byte("x")),
+	}
+	d.externalLookaheadEndByte = 17
+	snapshot := d.snapshotRelexState()
+	if got, want := snapshot.externalLookaheadEndByte, uint32(17); got != want {
+		t.Fatalf("snapshot frontier = %d, want %d", got, want)
+	}
+	scratchSnapshot := d.snapshotRelexStateWithScratch(&dfaRelexSnapshotScratch{})
+	if got, want := scratchSnapshot.externalLookaheadEndByte, uint32(17); got != want {
+		t.Fatalf("scratch snapshot frontier = %d, want %d", got, want)
+	}
+
+	d.externalLookaheadEndByte = 31
+	changed := d.snapshotRelexState()
+	if snapshot.equal(changed) {
+		t.Fatal("snapshots with different external frontiers compare equal")
+	}
+	snapshot.restore(d)
+	if got, want := d.externalLookaheadEndByte, uint32(17); got != want {
+		t.Fatalf("restored frontier = %d, want %d", got, want)
+	}
+}
+
 func TestNoLiveStackCanAcceptLookaheadRequiresEveryEligibleVersionToReject(t *testing.T) {
 	lang := &Language{
 		StateCount:  4,

--- a/parser_relex_state_test.go
+++ b/parser_relex_state_test.go
@@ -106,8 +106,8 @@ func TestDFARelexSnapshotRestoresExternalLookaheadFrontier(t *testing.T) {
 
 	d.externalLookaheadEndByte = 31
 	changed := d.snapshotRelexState()
-	if snapshot.equal(changed) {
-		t.Fatal("snapshots with different external frontiers compare equal")
+	if !snapshot.equal(changed) {
+		t.Fatal("transient external frontiers changed semantic snapshot equality")
 	}
 	snapshot.restore(d)
 	if got, want := d.externalLookaheadEndByte, uint32(17); got != want {

--- a/parser_runtime_test.go
+++ b/parser_runtime_test.go
@@ -1212,6 +1212,7 @@ func assertParseRuntimeArenaBreakdown(t *testing.T, tree *Tree, rt ParseRuntime)
 		arenaBreakdown.RawShapeChildBytesAllocated +
 		arenaBreakdown.RawShapeHashCacheBytesAllocated +
 		arenaBreakdown.FinalChildSidecarBytesAllocated +
+		arenaBreakdown.MissingNodeDependencyBytesAllocated +
 		arenaBreakdown.CompactCheckpointLeafBytesAllocated +
 		arenaBreakdown.ChildSliceBytesAllocated +
 		arenaBreakdown.FieldIDBytesAllocated +

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -7120,6 +7120,20 @@ func materializeCompactExternalScannerCheckpoint(compact *core.Core, arena *node
 	return false
 }
 
+func materializeCompactMissingNodeDependency(arena *nodeArena, node *Node, view core.MaterializationSubtreeView) bool {
+	if arena == nil || node == nil || node.ownerArena != arena || !view.Missing || !view.MissingDependencyExact {
+		return false
+	}
+	stackPoint := Point{Row: view.MissingDependency.StackRow, Column: view.MissingDependency.StackColumn}
+	return arena.setMissingNodeDependency(node, missingNodeDependency{
+		stackByte:      view.MissingDependency.StackByte,
+		stackPoint:     stackPoint,
+		paddingBytes:   view.MissingDependency.PaddingBytes,
+		paddingExtent:  Point{Row: view.MissingDependency.PaddingRows, Column: view.MissingDependency.PaddingColumn},
+		lookaheadBytes: view.MissingDependency.LookaheadBytes,
+	})
+}
+
 // materializeDiagnosticParserCoreAcceptedSelection materializes the accepted
 // compact derivation into a public tree. When scratch is non-nil the runner's
 // reusable buffers back the transient materialization storage, so the warm
@@ -7359,6 +7373,9 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				if view.Missing {
 					node.setMissing(true)
 					node.setHasError(true)
+					if !materializeCompactMissingNodeDependency(arena, node, view) {
+						return fmt.Errorf("parser-core phase zero: missing leaf dependency transfer failed: node=%d@%+v dependency=%+v", node.startByte, node.startPoint, view.MissingDependency)
+					}
 				}
 				hasErrorByID[id] = view.Missing || Symbol(view.Symbol) == errorSymbol
 				// No markFragile here: fragile is a reduce/conflict-arm property
@@ -7699,6 +7716,10 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 		ExternalScannerCheckpointLeafNodes:             arena.externalScannerCheckpointLeafNodes,
 		CompactExternalScannerCheckpointTransferProven: scannerProvenanceTransferProven,
 	})
+	if arena.breakdownEnabled {
+		breakdown := arena.collectArenaBreakdown()
+		tree.setArenaBreakdown(breakdown)
+	}
 	return tree, nil
 }
 

--- a/parsercore_phase0_missing_dependency_transfer_test.go
+++ b/parsercore_phase0_missing_dependency_transfer_test.go
@@ -1,0 +1,75 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func TestCompactMaterializationTransfersMissingDependency(t *testing.T) {
+	arena := acquireNodeArena(arenaClassIncremental)
+	defer arena.Release()
+	node := newLeafNodeInArena(arena, 1, true, 3, 3, Point{Column: 3}, Point{Column: 3})
+	node.setMissing(true)
+	node.setHasError(true)
+	view := core.MaterializationSubtreeView{
+		Missing: true, MissingDependencyExact: true,
+		MissingDependency: core.MissingLeafDependency{
+			StackByte: 0, PaddingBytes: 3, PaddingColumn: 3, LookaheadBytes: 3,
+		},
+	}
+	if !materializeCompactMissingNodeDependency(arena, node, view) {
+		t.Fatal("exact compact missing dependency did not transfer")
+	}
+	want := missingNodeDependency{
+		stackByte: 0, stackPoint: Point{},
+		paddingBytes: 3, paddingExtent: Point{Column: 3}, lookaheadBytes: 3,
+	}
+	if got, ok := missingNodeDependencyForNode(node); !ok || got != want {
+		t.Fatalf("transferred dependency=%+v exact=%t, want %+v", got, ok, want)
+	}
+}
+
+func TestCompactMaterializationRejectsMissingDependencyWithoutReceipt(t *testing.T) {
+	arena := acquireNodeArena(arenaClassIncremental)
+	defer arena.Release()
+	node := newLeafNodeInArena(arena, 1, true, 3, 3, Point{Column: 3}, Point{Column: 3})
+	node.setMissing(true)
+	if materializeCompactMissingNodeDependency(arena, node, core.MaterializationSubtreeView{Missing: true}) {
+		t.Fatal("compact materialization accepted missing dependency without an exact receipt")
+	}
+}
+
+func TestCompactMaterializationRejectsUnauthenticatedZeroPaddingPoint(t *testing.T) {
+	arena := acquireNodeArena(arenaClassIncremental)
+	defer arena.Release()
+	point := Point{Row: 1, Column: 2}
+	node := newLeafNodeInArena(arena, 1, true, 3, 3, point, point)
+	node.setMissing(true)
+	view := core.MaterializationSubtreeView{
+		Missing: true, MissingDependencyExact: true,
+		MissingDependency: core.MissingLeafDependency{StackByte: 3},
+	}
+	if materializeCompactMissingNodeDependency(arena, node, view) {
+		t.Fatal("compact materialization rewrote an unauthenticated stack point")
+	}
+}
+
+func TestCompactMaterializationAcceptsAuthenticatedZeroPaddingPoint(t *testing.T) {
+	arena := acquireNodeArena(arenaClassIncremental)
+	defer arena.Release()
+	point := Point{Row: 1, Column: 2}
+	node := newLeafNodeInArena(arena, 1, true, 3, 3, point, point)
+	node.setMissing(true)
+	view := core.MaterializationSubtreeView{
+		Missing: true, MissingDependencyExact: true,
+		MissingDependency: core.MissingLeafDependency{
+			StackByte: 3, StackRow: point.Row, StackColumn: point.Column,
+		},
+	}
+	if !materializeCompactMissingNodeDependency(arena, node, view) {
+		t.Fatal("compact materialization rejected an authenticated stack point")
+	}
+}

--- a/parsercore_phase0_recovery_lineage_fork_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_fork_internal_test.go
@@ -379,6 +379,49 @@ func TestS5MissingInsertionUsesFixedRecoveryPosition(t *testing.T) {
 	}
 }
 
+func TestS5MissingLeafDependencyUsesIncludedRangeReset(t *testing.T) {
+	source := []byte("\n=i")
+	lexer := NewLexer(nil, source)
+	lexer.setIncludedRanges([]Range{{
+		StartByte: 1, EndByte: 3,
+		StartPoint: Point{Row: 1}, EndPoint: Point{Row: 1, Column: 2},
+	}})
+	dependency, err := s5MissingLeafDependency(lexer, source, 0, 4)
+	if err != nil {
+		t.Fatalf("s5MissingLeafDependency: %v", err)
+	}
+	want := core.MissingLeafDependency{
+		StackByte: 0, StackRow: 0, StackColumn: 0,
+		PaddingBytes: 1, PaddingRows: 1, PaddingColumn: 0,
+		LookaheadBytes: 4,
+	}
+	if dependency != want {
+		t.Fatalf("dependency=%+v, want %+v", dependency, want)
+	}
+}
+
+func TestS5MissingLeafDependencyUsesLogicalIncludedRangeStartPoint(t *testing.T) {
+	source := []byte("xabc")
+	lexer := NewLexer(nil, source)
+	lexer.setIncludedRanges([]Range{{
+		StartByte:  1,
+		EndByte:    4,
+		StartPoint: Point{Row: 7, Column: 9},
+		EndPoint:   Point{Row: 7, Column: 12},
+	}})
+	dependency, err := s5MissingLeafDependency(lexer, source, 1, 2)
+	if err != nil {
+		t.Fatalf("s5MissingLeafDependency: %v", err)
+	}
+	want := core.MissingLeafDependency{
+		StackByte: 1, StackRow: 7, StackColumn: 9,
+		LookaheadBytes: 1,
+	}
+	if dependency != want {
+		t.Fatalf("dependency=%+v, want %+v", dependency, want)
+	}
+}
+
 func TestS3SecondIndependentErrorRegionDeclines(t *testing.T) {
 	scheduler := newRecoveryLineageForkScheduler(t, true)
 	scheduler.s3RegionOpened = true

--- a/parsercore_phase0_s5.go
+++ b/parsercore_phase0_s5.go
@@ -722,6 +722,51 @@ func (s *diagnosticParserCoreGenericScheduler) s5RecoveryBaseline(headers []diag
 	return maximum, true, nil
 }
 
+// s5MissingLeafDependency reproduces the lexer reset and mark-end sequence
+// that C uses before it publishes a missing leaf. The compact boundary stores
+// the parser position before padding, so included-range normalization must run
+// against a copy of the lexer cursor and must not mutate the live token source.
+func s5MissingLeafDependency(lexer *Lexer, source []byte, stackByte, lookaheadEndByte uint32) (core.MissingLeafDependency, error) {
+	if uint64(stackByte) > uint64(len(source)) || lookaheadEndByte < stackByte {
+		return core.MissingLeafDependency{}, errors.New("parser-core phase zero: S5 missing dependency is outside source")
+	}
+	stackPoint := advancePointByBytes(Point{}, source[:stackByte])
+	positionedByte := stackByte
+	positionedPoint := stackPoint
+	if lexer != nil && len(lexer.includedRanges) != 0 {
+		if logicalPoint, ok := lexer.includedPointAtPosition(int(stackByte)); ok {
+			stackPoint = logicalPoint
+		}
+		cursor := includedLexerCursor{
+			pos:      int(stackByte),
+			row:      stackPoint.Row,
+			col:      stackPoint.Column,
+			rangeIdx: lexer.includedRangeIndexForPosition(int(stackByte)),
+		}
+		lexer.normalizeIncludedCursor(&cursor)
+		positionedByte = uint32(cursor.pos)
+		positionedPoint = Point{Row: cursor.row, Column: cursor.col}
+	}
+
+	var paddingBytes uint32
+	if positionedByte >= stackByte {
+		paddingBytes = positionedByte - stackByte
+	}
+	paddingExtent := Point{}
+	if extent, ok := pointExtentBetween(stackPoint, positionedPoint); ok && positionedByte >= stackByte {
+		paddingExtent = extent
+	}
+	return core.MissingLeafDependency{
+		StackByte:      stackByte,
+		StackRow:       stackPoint.Row,
+		StackColumn:    stackPoint.Column,
+		PaddingBytes:   paddingBytes,
+		PaddingRows:    paddingExtent.Row,
+		PaddingColumn:  paddingExtent.Column,
+		LookaheadBytes: lookaheadEndByte - stackByte,
+	}, nil
+}
+
 func (s *diagnosticParserCoreGenericScheduler) s5ShiftMissingLeafOwned(
 	owner core.SchedulerTransactionToken,
 	headerIndex int,
@@ -732,7 +777,20 @@ func (s *diagnosticParserCoreGenericScheduler) s5ShiftMissingLeafOwned(
 	if headerIndex < 0 || headerIndex >= len(s.headers) {
 		return errors.New("parser-core phase zero: S5 missing header index is out of range")
 	}
-	head, err := s.compact.ShiftMissingLeafOwned(owner, s.headers[headerIndex].head, targetState, symbol, byteOffset)
+	source := s.options.materializationSource
+	if source == nil && s.tokenSource != nil && s.tokenSource.lexer != nil {
+		source = s.tokenSource.lexer.source
+	}
+	lookaheadEndByte := tokenLookaheadEndByte(s.token)
+	lexer := (*Lexer)(nil)
+	if s.tokenSource != nil {
+		lexer = s.tokenSource.lexer
+	}
+	dependency, err := s5MissingLeafDependency(lexer, source, byteOffset, lookaheadEndByte)
+	if err != nil {
+		return err
+	}
+	head, err := s.compact.ShiftMissingLeafWithDependencyOwned(owner, s.headers[headerIndex].head, targetState, symbol, dependency)
 	if err != nil {
 		return err
 	}

--- a/parsercore_phase0_s5_legacy.go
+++ b/parsercore_phase0_s5_legacy.go
@@ -174,7 +174,20 @@ func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertionLegacy(
 		return false, nil
 	}
 
-	missingHead, insertErr := s.compact.ShiftMissingLeaf(scanHead, targetState, core.Symbol(missing), byteOffset)
+	source := s.options.materializationSource
+	var lexer *Lexer
+	if s.tokenSource != nil {
+		lexer = s.tokenSource.lexer
+		if source == nil && lexer != nil {
+			source = lexer.source
+		}
+	}
+	dependency, dependencyErr := s5MissingLeafDependency(lexer, source, byteOffset, tokenLookaheadEndByte(s.token))
+	if dependencyErr != nil {
+		restore()
+		return false, dependencyErr
+	}
+	missingHead, insertErr := s.compact.ShiftMissingLeafWithDependency(scanHead, targetState, core.Symbol(missing), dependency)
 	if insertErr != nil {
 		restore()
 		return false, insertErr

--- a/tree.go
+++ b/tree.go
@@ -1431,7 +1431,9 @@ type ArenaBreakdown struct {
 	RawShapeChildBytesAllocated         int64
 	RawShapeHashCacheBytesAllocated     int64
 	FinalChildSidecarBytesAllocated     int64
+	MissingNodeDependencyBytesAllocated int64
 	CompactCheckpointLeafBytesAllocated int64
+	MissingNodeDependencyCount          uint64
 	PendingChildEntriesAllocated        uint64
 	PendingChildEntryCapacity           uint64
 	PendingChildEntryWaste              uint64
@@ -3614,6 +3616,11 @@ func cloneNodeHeaderInto(dst, src *Node, arena *nodeArena, offset *cloneOffset) 
 	dst.parent = nil
 	dst.childIndex = -1
 	dst.ownerArena = arena
+	if !copyMissingNodeDependency(dst, src, offset) {
+		if _, present := missingNodeDependencyEntryForNode(src); present {
+			dst.setDirty(true)
+		}
+	}
 	if arena != nil && src.ownerArena != nil {
 		arena.inheritExternalScannerCheckpointIdentity(src.ownerArena)
 	}
@@ -4177,6 +4184,52 @@ func inputEditIsNoop(edit InputEdit) bool {
 		edit.OldEndPoint == edit.NewEndPoint
 }
 
+func subtractPointDelta(a, b Point) Point {
+	if a.Row > b.Row {
+		return Point{Row: a.Row - b.Row, Column: a.Column}
+	}
+	column := uint32(0)
+	if a.Column >= b.Column {
+		column = a.Column - b.Column
+	}
+	return Point{Column: column}
+}
+
+func (t *Tree) editIncludedRanges(edit InputEdit) {
+	if t == nil {
+		return
+	}
+	for i := range t.includedRanges {
+		range_ := &t.includedRanges[i]
+		if range_.EndByte >= edit.OldEndByte {
+			if range_.EndByte != ^uint32(0) {
+				range_.EndByte = edit.NewEndByte + (range_.EndByte - edit.OldEndByte)
+				range_.EndPoint = addPointDelta(edit.NewEndPoint,
+					subtractPointDelta(range_.EndPoint, edit.OldEndPoint))
+				if range_.EndByte < edit.NewEndByte {
+					range_.EndByte = ^uint32(0)
+					range_.EndPoint = Point{Row: ^uint32(0), Column: ^uint32(0)}
+				}
+			}
+		} else if range_.EndByte > edit.StartByte {
+			range_.EndByte = edit.StartByte
+			range_.EndPoint = edit.StartPoint
+		}
+		if range_.StartByte >= edit.OldEndByte {
+			range_.StartByte = edit.NewEndByte + (range_.StartByte - edit.OldEndByte)
+			range_.StartPoint = addPointDelta(edit.NewEndPoint,
+				subtractPointDelta(range_.StartPoint, edit.OldEndPoint))
+			if range_.StartByte < edit.NewEndByte {
+				range_.StartByte = ^uint32(0)
+				range_.StartPoint = Point{Row: ^uint32(0), Column: ^uint32(0)}
+			}
+		} else if range_.StartByte > edit.StartByte {
+			range_.StartByte = edit.StartByte
+			range_.StartPoint = edit.StartPoint
+		}
+	}
+}
+
 func inputEditIsSingleByteReplacement(edit InputEdit) bool {
 	return edit.NewEndByte == edit.OldEndByte &&
 		edit.OldEndByte > edit.StartByte &&
@@ -4198,6 +4251,7 @@ func (t *Tree) Edit(edit InputEdit) {
 	}
 	t.edits = append(t.edits, edit)
 	t.lastEditedLeaf = nil
+	t.editIncludedRanges(edit)
 	if t.root != nil {
 		if inputEditIsSingleByteReplacement(edit) {
 			editNodeSingleByteReplacement(t.root, edit, &t.lastEditedLeaf)
@@ -4291,7 +4345,16 @@ func addUint32Delta(value uint32, delta int64) uint32 {
 
 // editNodeSingleByteReplacement marks the affected path without recomputing unchanged spans.
 func editNodeSingleByteReplacement(n *Node, edit InputEdit, leafHint **Node) {
-	if n.endByte <= edit.StartByte || n.startByte >= edit.OldEndByte {
+	if editMissingNodeDependency(n, edit, 0, 0) {
+		if leafHint != nil {
+			*leafHint = n
+		}
+		return
+	}
+	if missingNodeDependencyNoopAtEnd(n, edit) {
+		return
+	}
+	if nodeEndsBeforeEditDependency(n, edit.StartByte) || n.startByte >= edit.OldEndByte {
 		return
 	}
 	if nodeHasFinalChildRefs(n) {
@@ -4307,7 +4370,7 @@ func editNodeSingleByteReplacement(n *Node, edit InputEdit, leafHint **Node) {
 
 	descended := false
 	for _, child := range n.children {
-		if child.endByte <= edit.StartByte {
+		if nodeEndsBeforeEditDependency(child, edit.StartByte) {
 			continue
 		}
 		if child.startByte >= edit.OldEndByte {
@@ -4322,8 +4385,17 @@ func editNodeSingleByteReplacement(n *Node, edit InputEdit, leafHint **Node) {
 }
 
 func editNodeWithDelta(n *Node, edit InputEdit, byteDelta, rowDelta int64, hasTailShift bool, shiftScratch *[]*Node, leafHint **Node) {
+	if editMissingNodeDependency(n, edit, byteDelta, rowDelta) {
+		if leafHint != nil {
+			*leafHint = n
+		}
+		return
+	}
+	if missingNodeDependencyNoopAtEnd(n, edit) {
+		return
+	}
 	// If the node ends before the edit starts, it's completely unaffected.
-	if n.endByte <= edit.StartByte {
+	if nodeEndsBeforeEditDependency(n, edit.StartByte) {
 		return
 	}
 
@@ -4332,10 +4404,18 @@ func editNodeWithDelta(n *Node, edit InputEdit, byteDelta, rowDelta int64, hasTa
 		if !hasTailShift {
 			return
 		}
+		dependency, hasMissingDependency := missingNodeDependencyForNode(n)
 		n.startByte = addUint32Delta(n.startByte, byteDelta)
 		n.endByte = addUint32Delta(n.endByte, byteDelta)
 		n.startPoint = shiftPointAfterEdit(n.startPoint, edit, rowDelta)
 		n.endPoint = shiftPointAfterEdit(n.endPoint, edit, rowDelta)
+		if hasMissingDependency {
+			dependency.stackByte = addUint32Delta(dependency.stackByte, byteDelta)
+			dependency.stackPoint = shiftPointAfterEdit(dependency.stackPoint, edit, rowDelta)
+			if !n.ownerArena.setMissingNodeDependency(n, dependency) {
+				n.setDirty(true)
+			}
+		}
 		shiftNodeChildrenAfterEdit(n, edit, byteDelta, rowDelta, shiftScratch)
 		return
 	}
@@ -4364,7 +4444,7 @@ func editNodeWithDelta(n *Node, edit InputEdit, byteDelta, rowDelta int64, hasTa
 	childCount := nodeChildCountNoMaterialize(n)
 	if !nodeHasFinalChildRefs(n) {
 		for _, c := range n.children {
-			if c.endByte <= edit.StartByte {
+			if nodeEndsBeforeEditDependency(c, edit.StartByte) {
 				continue
 			}
 			if c.startByte >= edit.OldEndByte {
@@ -4383,7 +4463,7 @@ func editNodeWithDelta(n *Node, edit InputEdit, byteDelta, rowDelta int64, hasTa
 			if ok && perfCountersEnabled {
 				perfRecordNodeEditCompactRef()
 			}
-			if !ok || stackEntryNodeEndByte(entry) <= edit.StartByte {
+			if !ok || stackEntryEndsBeforeEditDependency(n.ownerArena, entry, edit.StartByte) {
 				continue
 			}
 			if stackEntryNodeStartByte(entry) >= edit.OldEndByte {
@@ -4407,7 +4487,7 @@ func editStackEntryWithDelta(arena *nodeArena, entry stackEntry, edit InputEdit,
 		editNodeWithDelta(node, edit, byteDelta, rowDelta, hasTailShift, shiftScratch, leafHint)
 		return
 	}
-	if !stackEntryHasNode(entry) || stackEntryNodeEndByte(entry) <= edit.StartByte {
+	if !stackEntryHasNode(entry) || stackEntryEndsBeforeEditDependency(arena, entry, edit.StartByte) {
 		return
 	}
 	if stackEntryNodeStartByte(entry) >= edit.OldEndByte {
@@ -4439,7 +4519,7 @@ func editStackEntryWithDelta(arena *nodeArena, entry stackEntry, edit InputEdit,
 	childCount := parent.childEntryCount()
 	for i := 0; i < childCount; i++ {
 		child := parent.childEntry(arena, i)
-		if !stackEntryHasNode(child) || stackEntryNodeEndByte(child) <= edit.StartByte {
+		if !stackEntryHasNode(child) || stackEntryEndsBeforeEditDependency(arena, child, edit.StartByte) {
 			continue
 		}
 		if stackEntryNodeStartByte(child) >= edit.OldEndByte {
@@ -4550,12 +4630,20 @@ func shiftSubtreeAfterEdit(roots []*Node, edit InputEdit, byteDelta, rowDelta in
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
+		dependency, hasMissingDependency := missingNodeDependencyForNode(n)
 
 		n.startByte = addUint32Delta(n.startByte, byteDelta)
 		n.endByte = addUint32Delta(n.endByte, byteDelta)
 
 		n.startPoint = shiftPointAfterEdit(n.startPoint, edit, rowDelta)
 		n.endPoint = shiftPointAfterEdit(n.endPoint, edit, rowDelta)
+		if hasMissingDependency {
+			dependency.stackByte = addUint32Delta(dependency.stackByte, byteDelta)
+			dependency.stackPoint = shiftPointAfterEdit(dependency.stackPoint, edit, rowDelta)
+			if !n.ownerArena.setMissingNodeDependency(n, dependency) {
+				n.setDirty(true)
+			}
+		}
 
 		if !nodeHasFinalChildRefs(n) {
 			stack = append(stack, n.children...)


### PR DESCRIPTION
## What does this PR do?

Preserve C-equivalent padding and lookahead dependencies for zero-width missing leaves.

Thread exact dependency data through compact storage, materialization, clones, tree edits, and arena telemetry. Close #1060.

## Why this approach?

Use sparse sidecars in both compact and public arenas. This keeps the 44-byte compact subtree record unchanged.

Capture the farthest internal and external lexer frontier. Preserve it across failed scans, retries, synthetic tokens, and included ranges.

Fail closed when a dependency receipt is stale or cannot transfer.

## Correctness

- [x] Focused package and unit tests cover the touched behavior.
- [x] Both compact build modes pass focused tests.
- [x] The real C incremental witness passes for all three lookahead bytes.
- [x] The locked C oracle covers padding edits, lookahead edits, ranges, points, flags, and changed ranges.
- [x] The C grammar Docker run remains at the baseline: 20/25 exact and 23/25 error-free.
- [x] The isolated root package and compact-core package sweep passes.
- [x] No Docker run reported an out-of-memory event.

Evidence:

- Focused code gate: harness_out/docker/20260904T044023Z-issue1060-final-gate
- C oracle: harness_out/docker/20260904T044148Z-issue1060-c-oracle
- Arena accounting: harness_out/docker/20260904T044231Z-issue1060-accounting
- Package sweep: harness_out/docker/20260904T045209Z-issue1060-package-gate-clean
- C grammar: harness_out/docker/20260904T050027Z-diag-c_lang

The package sweep excluded TestCompactRouteLifecycleAllowsStaleReceiptOutsideCurrentLineage. Its linked-worktree Git path is not available inside the Docker mount. The focused route tests passed.

## Performance

- [x] Performance is not the goal of this correctness PR.
- [x] The C grammar run stayed bounded at 1,206,848 KiB maximum resident set size.
- [x] Correctness and performance evidence remain separate.

## Maintainability

- [x] Keep missing metadata sparse.
- [x] Keep the compact subtree record at 44 bytes.
- [x] Account for sidecar capacity in arena totals and reports.
- [x] Avoid unrelated performance or release work.
- [x] Add no dependencies.

## Self-review

- [x] Reviewed the full diff and all ownership paths.
- [x] Verified rollback, reset, retention, cloning, and materialization.
- [x] Verified internal, external, retry, invalid UTF-8, and included-range frontiers.
- [x] Ran independent Luna reviews for the implementation, oracle, and gate coverage.

## Due diligence

- [x] Checked the C missing-leaf construction and edit contract.
- [x] Used Canopy for scoped symbol and reference checks.
- [x] Kept this PR within package 5 incremental integration.