### PR TITLE
Admit compact recovery trees to incremental reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           GTS_COMPAT_TAIL_ELISION_EXHAUSTIVE=1 \
           GOMAXPROCS=1 \
           go test -tags gts_parsercorephase0 . \
-            -run '^(TestAdmissionCandidateScorecard206|TestAdmissionSwitchRoutePrecedenceRatchet|TestAdmissionCandidateYAMLZeroWidthDepth|TestAdmissionCandidateRepresentativeDepthRatchet|TestAdmissionCompactTreeCarriesIncrementalReuseProof|TestDiagnosticParserCoreClassifiedBoundaryAndReductionPlanShape|TestDiagnosticParserCoreSummaryReceiptPreservesExactRewrite|TestCompatTailElisionEquivalenceSmokeExhaustive)$' \
+            -run '^(TestAdmissionCandidateScorecard206|TestAdmissionSwitchRoutePrecedenceRatchet|TestAdmissionCandidateYAMLZeroWidthDepth|TestAdmissionCandidateRepresentativeDepthRatchet|TestAdmissionCompactTreeCarriesIncrementalReuseProof|TestCompactJavaScriptRecoveryIncrementalReuse|TestDiagnosticParserCoreClassifiedBoundaryAndReductionPlanShape|TestDiagnosticParserCoreSummaryReceiptPreservesExactRewrite|TestCompatTailElisionEquivalenceSmokeExhaustive)$' \
             -count=1 -timeout 10m
 
   phase0_tagged_suite:
@@ -1250,6 +1250,38 @@ jobs:
             --c-ref-build-jobs 1 \
             --timeout 20m \
             --run '^(TestCompactT3OracleAdjudication|TestCompactT3JavaScriptRecoveryProfileCharacterization|TestCompactT3JavaScriptRecoveryRouteSeedOracleParity|TestCompactT3JavaScriptRecoveryMutationDifferential|TestCompactJavaScriptS5RecoveryMutationDifferential|TestCompactRouteLockedCExceptions)$'
+
+      - name: Compact recovery incremental JavaScript witnesses
+        run: |
+          GTS_PARITY_MODE=smoke \
+          GTS_PARITY_C_REF_BUILD_CACHE=0 \
+          bash cgo_harness/docker/run_parity_in_docker.sh \
+            --label ci-compact-recovery-incremental-javascript \
+            --memory 8g \
+            --cpus 2 \
+            --pids 4096 \
+            --gomemlimit 6GiB \
+            --goflags -p=1 \
+            --test-parallel 1 \
+            --c-ref-build-jobs 1 \
+            --timeout 20m \
+            -- "cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^(TestCompactRecoveryJavaScriptIncrementalCOracle|TestCompactRecoveryJavaScriptInsertionRegression)$' -count=1 -parallel 1 -timeout 20m -v"
+
+      - name: Compact recovery incremental YAML witness
+        run: |
+          GTS_PARITY_MODE=smoke \
+          GTS_PARITY_C_REF_BUILD_CACHE=0 \
+          bash cgo_harness/docker/run_parity_in_docker.sh \
+            --label ci-compact-recovery-incremental-yaml \
+            --memory 8g \
+            --cpus 2 \
+            --pids 4096 \
+            --gomemlimit 6GiB \
+            --goflags -p=1 \
+            --test-parallel 1 \
+            --c-ref-build-jobs 1 \
+            --timeout 20m \
+            -- "cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^TestCompactRecoveryYAMLRecoverEOFIncrementalCOracle$' -count=1 -parallel 1 -timeout 20m -v"
 
       - name: Compact per-version lexer package-one witnesses
         run: |

--- a/admission_recover_eof_admission_test.go
+++ b/admission_recover_eof_admission_test.go
@@ -3,7 +3,6 @@
 package gotreesitter_test
 
 import (
-	"strings"
 	"testing"
 
 	gts "github.com/odvcencio/gotreesitter"
@@ -140,7 +139,7 @@ func TestAdmissionRecoverEOFPayloadCountFallsBackForUnfinishedYAML(t *testing.T)
 	}
 }
 
-func TestAdmissionRecoverEOFIncrementalMarkerForcesFreshTree(t *testing.T) {
+func TestAdmissionRecoverEOFIncrementalMarkerFallsBackForUncertifiedScanner(t *testing.T) {
 	lang := grammars.YamlLanguage()
 	parser := gts.NewParser(lang)
 	parser.SetAdmissionCandidateRoute(true)
@@ -183,12 +182,26 @@ func TestAdmissionRecoverEOFIncrementalMarkerForcesFreshTree(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer want.Release()
-	if got.RootNode().SExpr(lang) != want.RootNode().SExpr(lang) {
-		t.Fatalf("incremental marker tree=%s want fresh=%s", got.RootNode().SExpr(lang), want.RootNode().SExpr(lang))
+	gotRoot, wantRoot := got.RootNode(), want.RootNode()
+	if gotRoot.SExpr(lang) != wantRoot.SExpr(lang) || gotRoot.Range() != wantRoot.Range() {
+		t.Fatalf("incremental marker fallback tree=%s range=%+v want fresh=%s range=%+v",
+			gotRoot.SExpr(lang), gotRoot.Range(), wantRoot.SExpr(lang), wantRoot.Range())
 	}
-	if profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 ||
-		!profile.ReuseUnsupported || !strings.Contains(profile.ReuseUnsupportedReason, "compact") {
-		t.Fatalf("recover_eof marker reused old tree: %+v", profile)
+	requireIncrementalDeepTreeMatchesFresh(t, got, want, lang)
+	if profile.ReuseUnsupportedReason == "old tree carried a compact recover_eof EOF runtime" {
+		t.Fatalf("recover_eof marker reported the obsolete permanent bar: %+v", profile)
+	}
+	if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" ||
+		profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+		t.Fatalf("recover_eof marker did not fail closed for the uncertified scanner: %+v", profile)
+	}
+	runtime := got.ParseRuntime()
+	if runtime.StopReason != gts.ParseStopAccepted || !runtime.LastTokenWasEOF ||
+		runtime.SourceLen != uint32(len(newSource)) || runtime.LastTokenEndByte != uint32(len(newSource)) ||
+		runtime.ExpectedEOFByte != uint32(len(newSource)) || runtime.RootEndByte != uint32(len(newSource)) ||
+		runtime.RootEndByte != got.RootNode().EndByte() ||
+		runtime.IncrementalOldTreeReuseRoute {
+		t.Fatalf("recover_eof fallback runtime=%+v, want fresh EOF at %d", runtime, len(newSource))
 	}
 }
 

--- a/cgo_harness/compact_recovery_incremental_admission_cgo_test.go
+++ b/cgo_harness/compact_recovery_incremental_admission_cgo_test.go
@@ -1,0 +1,481 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0
+
+package cgoharness
+
+import (
+	"bytes"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const compactRecoveryJavaScriptSource = "const f = (a) => a + 1;&\nclass A { m() { return 1 } }\n\n"
+
+// TestCompactRecoveryJavaScriptIncrementalCOracle compares the deletion edit
+// with fresh and incremental C trees. The class declaration is a clean
+// sibling; the ERROR node must be rebuilt when the ampersand changes.
+func TestCompactRecoveryJavaScriptIncrementalCOracle(t *testing.T) {
+	goLanguage := grammars.JavascriptLanguage()
+	if !goLanguage.CompactStrategy2ErrorRegionCertified {
+		t.Fatal("JavaScript strategy-2 recovery is not certified")
+	}
+	cLanguage, err := ParityCLanguage("javascript")
+	if err != nil {
+		t.Fatalf("load JavaScript C oracle: %v", err)
+	}
+
+	original := []byte(compactRecoveryJavaScriptSource)
+	ampersand := bytes.IndexByte(original, '&')
+	if ampersand < 0 {
+		t.Fatal("JavaScript recovery witness has no ampersand")
+	}
+	withoutAmpersand := append([]byte(nil), original[:ampersand]...)
+	withoutAmpersand = append(withoutAmpersand, original[ampersand+1:]...)
+
+	edit := gotreesitter.InputEdit{
+		StartByte:   uint32(ampersand),
+		OldEndByte:  uint32(ampersand + 1),
+		NewEndByte:  uint32(ampersand),
+		StartPoint:  pointAtOffset(original, ampersand),
+		OldEndPoint: pointAtOffset(original, ampersand+1),
+		NewEndPoint: pointAtOffset(withoutAmpersand, ampersand),
+	}
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatalf("set JavaScript C oracle: %v", err)
+	}
+	cInitial := cParser.Parse(original, nil)
+	if cInitial == nil || cInitial.RootNode() == nil {
+		t.Fatal("C initial parse returned no root")
+	}
+	t.Cleanup(cInitial.Close)
+
+	goParser := gotreesitter.NewParser(goLanguage)
+	goParser.SetAdmissionCandidateRoute(true)
+	initialRoutedBefore, initialFallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	goInitial, err := goParser.Parse(original)
+	if err != nil {
+		t.Fatalf("compact Go initial parse: %v", err)
+	}
+	t.Cleanup(goInitial.Release)
+	initialRoutedAfter, initialFallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if initialRoutedAfter-initialRoutedBefore != 1 || initialFallbackAfter-initialFallbackBefore != 0 {
+		t.Fatalf("initial route counters=%d/%d, want 1/0; reason=%q", initialRoutedAfter-initialRoutedBefore, initialFallbackAfter-initialFallbackBefore, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+
+	compactRecoveryAssertCParity(t, "compact initial", goInitial.RootNode(), goLanguage, cInitial)
+	cleanSibling := compactRecoveryFindCleanDirectChild(goInitial.RootNode(), goLanguage, "class_declaration")
+	if cleanSibling == nil {
+		t.Fatalf("initial Go tree has no clean class sibling: %s", goInitial.RootNode().SExpr(goLanguage))
+	}
+	recoveryNode := compactRecoveryFindProblemNode(goInitial.RootNode())
+	if recoveryNode == nil {
+		t.Fatalf("initial Go tree has no recovery node: %s", goInitial.RootNode().SExpr(goLanguage))
+	}
+
+	cFresh := cParser.Parse(withoutAmpersand, nil)
+	if cFresh == nil || cFresh.RootNode() == nil {
+		t.Fatal("C fresh edited parse returned no root")
+	}
+	t.Cleanup(cFresh.Close)
+
+	cOld := cParser.Parse(original, nil)
+	if cOld == nil || cOld.RootNode() == nil {
+		t.Fatal("C old parse returned no root")
+	}
+	cEdit := realCorpusCInputEdit(edit)
+	cOld.Edit(&cEdit)
+	cRecovery := compactRecoveryFindCProblemNode(cOld.RootNode())
+	if cRecovery == nil || !cRecovery.HasChanges() {
+		t.Fatal("C edit did not invalidate the recovery node")
+	}
+	cIncremental := cParser.Parse(withoutAmpersand, cOld)
+	cOld.Close()
+	if cIncremental == nil || cIncremental.RootNode() == nil {
+		t.Fatal("C incremental parse returned no root")
+	}
+	t.Cleanup(cIncremental.Close)
+
+	cFreshDigest, err := COracleDeepDigest(cFresh)
+	if err != nil {
+		t.Fatalf("digest C fresh edited tree: %v", err)
+	}
+	cIncrementalDigest, err := COracleDeepDigest(cIncremental)
+	if err != nil {
+		t.Fatalf("digest C incremental edited tree: %v", err)
+	}
+	if cIncrementalDigest != cFreshDigest {
+		t.Fatalf("C incremental digest=%s, want fresh C digest=%s", cIncrementalDigest, cFreshDigest)
+	}
+
+	initialRootSExpr := goInitial.RootNode().SExpr(goLanguage)
+	initialRootRange := goInitial.RootNode().Range()
+	initialEditCount := len(goInitial.Edits())
+	incrementalBase := goInitial.Copy()
+	if incrementalBase == nil || incrementalBase == goInitial || incrementalBase.RootNode() == goInitial.RootNode() {
+		t.Fatal("Tree.Copy did not isolate the JavaScript recovery tree")
+	}
+	if got := incrementalBase.RootNode().SExpr(goLanguage); got != initialRootSExpr {
+		t.Fatalf("Tree.Copy changed the initial tree: got=%q want=%q", got, initialRootSExpr)
+	}
+	cleanSibling = compactRecoveryFindCleanDirectChild(incrementalBase.RootNode(), goLanguage, "class_declaration")
+	recoveryNode = compactRecoveryFindProblemNode(incrementalBase.RootNode())
+	if cleanSibling == nil || recoveryNode == nil {
+		t.Fatal("Tree.Copy lost the clean sibling or recovery node")
+	}
+	t.Cleanup(incrementalBase.Release)
+	incrementalBase.Edit(edit)
+	if !recoveryNode.HasChanges() {
+		t.Fatal("Go edit did not invalidate the recovery node")
+	}
+
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	goIncremental, profile, err := goParser.ParseIncrementalProfiled(withoutAmpersand, incrementalBase)
+	if err != nil {
+		t.Fatalf("Go incremental parse: %v", err)
+	}
+	if goIncremental != incrementalBase {
+		t.Cleanup(goIncremental.Release)
+	}
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter != routedBefore || fallbackAfter != fallbackBefore {
+		t.Fatalf("incremental parse changed admission counters: before=%d/%d after=%d/%d", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+	}
+	if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" || !profile.OldTreeReuseRoute {
+		t.Fatalf("incremental reuse route was not admitted: %+v", profile)
+	}
+	if profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("incremental route reused no clean sibling: %+v", profile)
+	}
+	if profile.ReuseRejectHasError == 0 && profile.ReuseRejectFragileNonLeaf == 0 {
+		t.Fatalf("incremental route recorded no recovery rejection: %+v", profile)
+	}
+	if compactRecoveryContainsNode(goIncremental.RootNode(), recoveryNode) {
+		t.Fatal("incremental tree reused the edited recovery node")
+	}
+	if !compactRecoveryContainsNode(goIncremental.RootNode(), cleanSibling) {
+		t.Fatal("incremental tree did not reuse the clean class sibling")
+	}
+	compactRecoveryAssertCParity(t, "incremental versus fresh C", goIncremental.RootNode(), goLanguage, cFresh)
+	compactRecoveryAssertCParity(t, "incremental versus incremental C", goIncremental.RootNode(), goLanguage, cIncremental)
+
+	if got := goInitial.RootNode().SExpr(goLanguage); got != initialRootSExpr || goInitial.RootNode().Range() != initialRootRange || len(goInitial.Edits()) != initialEditCount {
+		t.Fatalf("editing Tree.Copy changed the original: sexpr=%q range=%+v edits=%d", got, goInitial.RootNode().Range(), len(goInitial.Edits()))
+	}
+}
+
+// TestCompactRecoveryJavaScriptInsertionRegression compares compact insertion
+// with fresh Go production parsing. Fresh Go has a pre-existing C parity gap
+// for this recovery witness, so insertion is not part of the C certification.
+func TestCompactRecoveryJavaScriptInsertionRegression(t *testing.T) {
+	lang := grammars.JavascriptLanguage()
+	if !lang.CompactStrategy2ErrorRegionCertified {
+		t.Fatal("JavaScript strategy-2 recovery is not certified")
+	}
+	source := []byte(compactRecoveryJavaScriptSource)
+	ampersand := bytes.IndexByte(source, '&')
+	if ampersand < 0 {
+		t.Fatal("JavaScript recovery witness has no ampersand")
+	}
+	withoutAmpersand := append([]byte(nil), source[:ampersand]...)
+	withoutAmpersand = append(withoutAmpersand, source[ampersand+1:]...)
+	edit := gotreesitter.InputEdit{
+		StartByte:   uint32(ampersand),
+		OldEndByte:  uint32(ampersand),
+		NewEndByte:  uint32(ampersand + 1),
+		StartPoint:  pointAtOffset(withoutAmpersand, ampersand),
+		OldEndPoint: pointAtOffset(withoutAmpersand, ampersand),
+		NewEndPoint: pointAtOffset(source, ampersand+1),
+	}
+
+	parser := gotreesitter.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	oldTree, err := parser.Parse(withoutAmpersand)
+	if err != nil {
+		t.Fatalf("compact Go insertion base parse: %v", err)
+	}
+	defer oldTree.Release()
+	oldTree.Edit(edit)
+	incremental, profile, err := parser.ParseIncrementalProfiled(source, oldTree)
+	if err != nil {
+		t.Fatalf("compact Go insertion incremental parse: %v", err)
+	}
+	if incremental != oldTree {
+		t.Cleanup(incremental.Release)
+	}
+	if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" || !profile.OldTreeReuseRoute ||
+		profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("compact Go insertion did not preserve the production reuse route: %+v", profile)
+	}
+
+	freshParser := gotreesitter.NewParser(lang)
+	freshParser.SetAdmissionCandidateRoute(false)
+	fresh, err := freshParser.Parse(source)
+	if err != nil {
+		t.Fatalf("fresh Go insertion parse: %v", err)
+	}
+	defer fresh.Release()
+	incrementalDigest, err := benchfixtures.InspectGoTree(incremental.RootNode(), lang)
+	if err != nil {
+		t.Fatalf("inspect compact Go insertion tree: %v", err)
+	}
+	freshDigest, err := benchfixtures.InspectGoTree(fresh.RootNode(), lang)
+	if err != nil {
+		t.Fatalf("inspect fresh Go insertion tree: %v", err)
+	}
+	if incrementalDigest.SHA256 != freshDigest.SHA256 {
+		t.Fatalf("compact Go insertion digest=%s, want fresh Go digest=%s; incremental=%s fresh=%s",
+			incrementalDigest.SHA256, freshDigest.SHA256, incremental.RootNode().SExpr(lang), fresh.RootNode().SExpr(lang))
+	}
+}
+
+// TestCompactRecoveryYAMLRecoverEOFIncrementalCOracle compares the certified
+// recover_eof tree and proves that its uncertified scanner fails closed.
+func TestCompactRecoveryYAMLRecoverEOFIncrementalCOracle(t *testing.T) {
+	goLanguage := grammars.YamlLanguage()
+	if !goLanguage.CompactRecoverEOFCertified {
+		t.Fatal("YAML recover_eof is not certified")
+	}
+	cLanguage, err := ParityCLanguage("yaml")
+	if err != nil {
+		t.Fatalf("load YAML C oracle: %v", err)
+	}
+	source := []byte("[\n")
+	edited := []byte("[]\n")
+	edit := gotreesitter.InputEdit{
+		StartByte:   1,
+		OldEndByte:  1,
+		NewEndByte:  2,
+		StartPoint:  gotreesitter.Point{Row: 0, Column: 1},
+		OldEndPoint: gotreesitter.Point{Row: 0, Column: 1},
+		NewEndPoint: gotreesitter.Point{Row: 0, Column: 2},
+	}
+
+	cParser := sitter.NewParser()
+	t.Cleanup(cParser.Close)
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatalf("set YAML C oracle: %v", err)
+	}
+	cInitial := cParser.Parse(source, nil)
+	if cInitial == nil || cInitial.RootNode() == nil {
+		t.Fatal("YAML C initial parse returned no root")
+	}
+	t.Cleanup(cInitial.Close)
+
+	goParser := gotreesitter.NewParser(goLanguage)
+	goParser.SetAdmissionCandidateRoute(true)
+	initialRoutedBefore, initialFallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	goInitial, err := goParser.Parse(source)
+	if err != nil {
+		t.Fatalf("YAML compact initial parse: %v", err)
+	}
+	t.Cleanup(goInitial.Release)
+	initialRoutedAfter, initialFallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if initialRoutedAfter-initialRoutedBefore != 1 || initialFallbackAfter-initialFallbackBefore != 0 {
+		t.Fatalf("YAML initial route counters=%d/%d, want 1/0; reason=%q", initialRoutedAfter-initialRoutedBefore, initialFallbackAfter-initialFallbackBefore, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+	compactRecoveryAssertCParity(t, "YAML compact initial", goInitial.RootNode(), goLanguage, cInitial)
+
+	cFresh := cParser.Parse(edited, nil)
+	if cFresh == nil || cFresh.RootNode() == nil {
+		t.Fatal("YAML C fresh edited parse returned no root")
+	}
+	t.Cleanup(cFresh.Close)
+	cOld := cParser.Parse(source, nil)
+	if cOld == nil || cOld.RootNode() == nil {
+		t.Fatal("YAML C old parse returned no root")
+	}
+	cEdit := realCorpusCInputEdit(edit)
+	cOld.Edit(&cEdit)
+	cIncremental := cParser.Parse(edited, cOld)
+	cOld.Close()
+	if cIncremental == nil || cIncremental.RootNode() == nil {
+		t.Fatal("YAML C incremental parse returned no root")
+	}
+	t.Cleanup(cIncremental.Close)
+	cFreshDigest, err := COracleDeepDigest(cFresh)
+	if err != nil {
+		t.Fatalf("digest YAML C fresh tree: %v", err)
+	}
+	cIncrementalDigest, err := COracleDeepDigest(cIncremental)
+	if err != nil {
+		t.Fatalf("digest YAML C incremental tree: %v", err)
+	}
+	if cIncrementalDigest != cFreshDigest {
+		t.Fatalf("YAML C incremental digest=%s, want fresh C digest=%s", cIncrementalDigest, cFreshDigest)
+	}
+
+	goInitial.Edit(edit)
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	goIncremental, profile, err := goParser.ParseIncrementalProfiled(edited, goInitial)
+	if err != nil {
+		t.Fatalf("YAML Go incremental parse: %v", err)
+	}
+	if goIncremental != goInitial {
+		t.Cleanup(goIncremental.Release)
+	}
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter != routedBefore || fallbackAfter != fallbackBefore {
+		t.Fatalf("YAML incremental parse changed admission counters: before=%d/%d after=%d/%d", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+	}
+	if profile.ReuseUnsupportedReason == "old tree carried a compact recover_eof EOF runtime" {
+		t.Fatalf("YAML recover_eof reported the obsolete permanent bar: %+v", profile)
+	}
+	if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" ||
+		profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+		t.Fatalf("YAML recover_eof did not fail closed for the uncertified scanner: %+v", profile)
+	}
+	compactRecoveryAssertCParity(t, "YAML incremental versus fresh C", goIncremental.RootNode(), goLanguage, cFresh)
+	compactRecoveryAssertCParity(t, "YAML incremental versus incremental C", goIncremental.RootNode(), goLanguage, cIncremental)
+	finalRuntime := goIncremental.ParseRuntime()
+	if finalRuntime.StopReason != gotreesitter.ParseStopAccepted || finalRuntime.Truncated ||
+		!finalRuntime.LastTokenWasEOF || finalRuntime.LastTokenEndByte != uint32(len(edited)) ||
+		finalRuntime.ExpectedEOFByte != uint32(len(edited)) || finalRuntime.RootEndByte != uint32(len(edited)) ||
+		finalRuntime.RootEndByte != goIncremental.RootNode().EndByte() {
+		t.Fatalf("YAML recover_eof fallback runtime=%+v, want fresh EOF at %d", finalRuntime, len(edited))
+	}
+}
+
+type compactRecoveryErrorSummary struct {
+	isError  int
+	missing  int
+	hasError int
+}
+
+func compactRecoveryAssertCParity(t *testing.T, label string, goRoot *gotreesitter.Node, goLanguage *gotreesitter.Language, cTree *sitter.Tree) {
+	t.Helper()
+	if cTree == nil {
+		t.Fatalf("%s has a nil C tree", label)
+	}
+	cRoot := cTree.RootNode()
+	if goRoot == nil || cRoot == nil {
+		t.Fatalf("%s has a nil root: Go=%v C=%v", label, goRoot == nil, cRoot == nil)
+	}
+	if divergences := compactT3StructuralDivergences(goRoot, goLanguage, cRoot); len(divergences) != 0 {
+		t.Fatalf("%s has %d structural divergences; first=%s", label, len(divergences), compactT3FormatDivergence(divergences[0]))
+	}
+	goDigest, err := benchfixtures.InspectGoTree(goRoot, goLanguage)
+	if err != nil {
+		t.Fatalf("%s inspect Go tree: %v", label, err)
+	}
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatalf("%s inspect C tree: %v", label, err)
+	}
+	if goDigest.SHA256 != cDigest {
+		t.Fatalf("%s deep digest Go=%s C=%s", label, goDigest.SHA256, cDigest)
+	}
+	goSummary := compactRecoveryGoErrorSummary(goRoot)
+	cSummary := compactRecoveryCErrorSummary(cRoot)
+	if goSummary != cSummary {
+		t.Fatalf("%s error summary Go=%+v C=%+v", label, goSummary, cSummary)
+	}
+}
+
+func compactRecoveryFindCleanDirectChild(root *gotreesitter.Node, language *gotreesitter.Language, kind string) *gotreesitter.Node {
+	if root == nil || language == nil {
+		return nil
+	}
+	for index := 0; index < root.ChildCount(); index++ {
+		child := root.Child(index)
+		if child != nil && child.Type(language) == kind && !child.IsError() && !child.IsMissing() && !child.HasError() && !child.IsExtra() {
+			return child
+		}
+	}
+	return nil
+}
+
+func compactRecoveryFindProblemNode(root *gotreesitter.Node) *gotreesitter.Node {
+	if root == nil {
+		return nil
+	}
+	if root.IsError() || root.IsMissing() {
+		return root
+	}
+	for index := 0; index < root.ChildCount(); index++ {
+		if problem := compactRecoveryFindProblemNode(root.Child(index)); problem != nil {
+			return problem
+		}
+	}
+	return nil
+}
+
+func compactRecoveryFindCProblemNode(root *sitter.Node) *sitter.Node {
+	if root == nil {
+		return nil
+	}
+	if root.IsError() || root.IsMissing() {
+		return root
+	}
+	for index := uint(0); index < root.ChildCount(); index++ {
+		if problem := compactRecoveryFindCProblemNode(root.Child(index)); problem != nil {
+			return problem
+		}
+	}
+	return nil
+}
+
+func compactRecoveryContainsNode(root, target *gotreesitter.Node) bool {
+	if root == nil || target == nil {
+		return false
+	}
+	if root == target {
+		return true
+	}
+	for index := 0; index < root.ChildCount(); index++ {
+		if compactRecoveryContainsNode(root.Child(index), target) {
+			return true
+		}
+	}
+	return false
+}
+
+func compactRecoveryGoErrorSummary(root *gotreesitter.Node) compactRecoveryErrorSummary {
+	if root == nil {
+		return compactRecoveryErrorSummary{}
+	}
+	summary := compactRecoveryErrorSummary{}
+	if root.IsError() {
+		summary.isError++
+	}
+	if root.IsMissing() {
+		summary.missing++
+	}
+	if root.HasError() {
+		summary.hasError++
+	}
+	for index := 0; index < root.ChildCount(); index++ {
+		child := compactRecoveryGoErrorSummary(root.Child(index))
+		summary.isError += child.isError
+		summary.missing += child.missing
+		summary.hasError += child.hasError
+	}
+	return summary
+}
+
+func compactRecoveryCErrorSummary(root *sitter.Node) compactRecoveryErrorSummary {
+	if root == nil {
+		return compactRecoveryErrorSummary{}
+	}
+	summary := compactRecoveryErrorSummary{}
+	if root.IsError() {
+		summary.isError++
+	}
+	if root.IsMissing() {
+		summary.missing++
+	}
+	if root.HasError() {
+		summary.hasError++
+	}
+	for index := uint(0); index < root.ChildCount(); index++ {
+		child := compactRecoveryCErrorSummary(root.Child(index))
+		summary.isError += child.isError
+		summary.missing += child.missing
+		summary.hasError += child.hasError
+	}
+	return summary
+}

--- a/compact_recovery_incremental_admission_test.go
+++ b/compact_recovery_incremental_admission_test.go
@@ -1,0 +1,202 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"bytes"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// jsLog6RecoverySource is the pinned js_log_6 witness from the same manifest.
+const jsLog6RecoverySource = "const f = (a) => a + 1;&\nclass A { m() { return 1 } }\n\n"
+
+// TestCompactJavaScriptRecoveryIncrementalReuse proves that Tree.Copy
+// keeps recovery provenance private while retaining the incremental reuse proof.
+func TestCompactJavaScriptRecoveryIncrementalReuse(t *testing.T) {
+	lang := grammars.JavascriptLanguage()
+	if !lang.CompactStrategy2ErrorRegionCertified {
+		t.Fatal("JavaScript strategy-2 recovery is not certified")
+	}
+	source := []byte(jsLog6RecoverySource)
+	editOffset := bytes.IndexByte(source, '&')
+	if editOffset < 0 {
+		t.Fatal("js_log_6 witness has no recovery edit byte")
+	}
+	edited := append([]byte(nil), source[:editOffset]...)
+	edited = append(edited, source[editOffset+1:]...)
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	oldTree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("compact JavaScript parse: %v", err)
+	}
+	defer oldTree.Release()
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if routed != 1 || fallback != 0 {
+		t.Fatalf("compact JavaScript route counters=%d/%d, want 1/0; reason=%q", routed, fallback, gts.AdmissionCandidateLastFallbackReason())
+	}
+	if !oldTree.RootNode().HasErrorOrMissing() {
+		t.Fatalf("JavaScript witness has no recovery node: %s", oldTree.RootNode().SExpr(lang))
+	}
+
+	originalRoot := oldTree.RootNode()
+	originalSExpr := originalRoot.SExpr(lang)
+	originalRange := originalRoot.Range()
+	originalEdits := len(oldTree.Edits())
+	copyTree := oldTree.Copy()
+	if copyTree == nil {
+		t.Fatal("Tree.Copy returned nil")
+	}
+	defer copyTree.Release()
+	if copyTree == oldTree || copyTree.RootNode() == originalRoot {
+		t.Fatal("Tree.Copy did not isolate the root node")
+	}
+	if got := copyTree.RootNode().SExpr(lang); got != originalSExpr {
+		t.Fatalf("Tree.Copy changed the recovery tree: got %q want %q", got, originalSExpr)
+	}
+
+	cleanSibling := compactRecoveryCleanDirectChildOfType(copyTree.RootNode(), lang, "class_declaration")
+	if cleanSibling == nil {
+		t.Fatalf("JavaScript witness has no clean class sibling: %s", copyTree.RootNode().SExpr(lang))
+	}
+	recoveryNode := compactRecoveryFirstErrorOrMissing(copyTree.RootNode())
+	if recoveryNode == nil {
+		t.Fatalf("JavaScript witness has no explicit recovery node: %s", copyTree.RootNode().SExpr(lang))
+	}
+
+	routedBefore, fallbackBefore := gts.AdmissionCandidateCounters()
+	copyTree.Edit(gts.InputEdit{
+		StartByte:   uint32(editOffset),
+		OldEndByte:  uint32(editOffset + 1),
+		NewEndByte:  uint32(editOffset),
+		StartPoint:  pointAtOffset(source, editOffset),
+		OldEndPoint: pointAtOffset(source, editOffset+1),
+		NewEndPoint: pointAtOffset(edited, editOffset),
+	})
+	if recoveryNode.StartByte() != recoveryNode.EndByte() {
+		t.Fatalf("deleted recovery node span=%d..%d, want zero width", recoveryNode.StartByte(), recoveryNode.EndByte())
+	}
+	if len(copyTree.Edits()) != 1 || len(oldTree.Edits()) != originalEdits {
+		t.Fatalf("Tree.Copy edit ownership changed: copy edits=%d original edits=%d", len(copyTree.Edits()), len(oldTree.Edits()))
+	}
+	if got := oldTree.RootNode().SExpr(lang); got != originalSExpr || oldTree.RootNode().Range() != originalRange {
+		t.Fatalf("editing Tree.Copy changed the original: sexpr=%q range=%+v", got, oldTree.RootNode().Range())
+	}
+
+	incremental, profile, err := parser.ParseIncrementalProfiled(edited, copyTree)
+	if err != nil {
+		t.Fatalf("JavaScript recovery copy incremental parse: %v", err)
+	}
+	defer incremental.Release()
+	routedAfter, fallbackAfter := gts.AdmissionCandidateCounters()
+	if routedAfter != routedBefore || fallbackAfter != fallbackBefore {
+		t.Fatalf("incremental parse changed admission counters: before=%d/%d after=%d/%d", routedBefore, fallbackBefore, routedAfter, fallbackAfter)
+	}
+	if profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "" || !profile.OldTreeReuseRoute {
+		t.Fatalf("copied JavaScript recovery tree dropped the reuse proof: %+v", profile)
+	}
+	if profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("copied JavaScript recovery edit reused no clean sibling: %+v", profile)
+	}
+	if profile.ReuseRejectHasError == 0 && profile.ReuseRejectFragileNonLeaf == 0 {
+		t.Fatalf("copied JavaScript recovery edit did not reject an ERROR or fragile candidate: %+v", profile)
+	}
+	if compactRecoveryTreeContainsNode(incremental.RootNode(), recoveryNode) {
+		t.Fatal("incremental tree reused the copied recovery node")
+	}
+	if !compactRecoveryTreeContainsNode(incremental.RootNode(), cleanSibling) {
+		t.Fatal("incremental tree did not reuse the copied clean class sibling")
+	}
+	if got := oldTree.RootNode().SExpr(lang); got != originalSExpr || oldTree.RootNode().Range() != originalRange || len(oldTree.Edits()) != originalEdits {
+		t.Fatalf("incremental copy parse changed the original tree: sexpr=%q range=%+v edits=%d", got, oldTree.RootNode().Range(), len(oldTree.Edits()))
+	}
+
+	freshParser := gts.NewParser(lang)
+	freshParser.SetAdmissionCandidateRoute(false)
+	fresh, err := freshParser.Parse(edited)
+	if err != nil {
+		t.Fatalf("fresh JavaScript production parse: %v", err)
+	}
+	defer fresh.Release()
+	requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+
+	// The first incremental result has a production root and a reused compact
+	// class. Restore the recovery byte to prove that the marked descendant keeps
+	// its exact frontier requirement after the tree-level compact marker clears.
+	incremental.Edit(gts.InputEdit{
+		StartByte:   uint32(editOffset),
+		OldEndByte:  uint32(editOffset),
+		NewEndByte:  uint32(editOffset + 1),
+		StartPoint:  pointAtOffset(edited, editOffset),
+		OldEndPoint: pointAtOffset(edited, editOffset),
+		NewEndPoint: pointAtOffset(source, editOffset+1),
+	})
+	restored, restoredProfile, err := parser.ParseIncrementalProfiled(source, incremental)
+	if err != nil {
+		t.Fatalf("restore JavaScript recovery byte: %v", err)
+	}
+	defer restored.Release()
+	if restoredProfile.ReuseUnsupported || !restoredProfile.OldTreeReuseRoute {
+		t.Fatalf("second incremental generation did not use the reuse route: %+v", restoredProfile)
+	}
+	freshOriginal, err := freshParser.Parse(source)
+	if err != nil {
+		t.Fatalf("fresh restored JavaScript production parse: %v", err)
+	}
+	defer freshOriginal.Release()
+	requireIncrementalDeepTreeMatchesFresh(t, restored, freshOriginal, lang)
+}
+
+func compactRecoveryCleanDirectChildOfType(root *gts.Node, lang *gts.Language, typ string) *gts.Node {
+	if root == nil || lang == nil {
+		return nil
+	}
+	for index := 0; index < root.ChildCount(); index++ {
+		child := root.Child(index)
+		if child != nil && !child.IsError() && !child.IsMissing() && !child.HasErrorOrMissing() && child.Type(lang) == typ {
+			return child
+		}
+	}
+	return nil
+}
+
+func compactRecoveryFirstErrorOrMissing(root *gts.Node) *gts.Node {
+	var found *gts.Node
+	var walk func(*gts.Node) bool
+	walk = func(node *gts.Node) bool {
+		if node.IsError() || node.IsMissing() {
+			found = node
+			return false
+		}
+		for index := 0; index < node.ChildCount(); index++ {
+			if !walk(node.Child(index)) {
+				return false
+			}
+		}
+		return true
+	}
+	if root != nil {
+		walk(root)
+	}
+	return found
+}
+
+func compactRecoveryTreeContainsNode(root, target *gts.Node) bool {
+	if root == nil || target == nil {
+		return false
+	}
+	if root == target {
+		return true
+	}
+	for index := 0; index < root.ChildCount(); index++ {
+		if compactRecoveryTreeContainsNode(root.Child(index), target) {
+			return true
+		}
+	}
+	return false
+}

--- a/compact_route_campaign_lifecycle_test.go
+++ b/compact_route_campaign_lifecycle_test.go
@@ -520,11 +520,23 @@ func TestCompactRouteLifecycleRejectsStaleReadSite(t *testing.T) {
 	}
 	site := registry.Controls[0].ReadSites[0]
 	t.Run("stale line", func(t *testing.T) {
-		stale := site
-		stale.Line = 1
-		if err := compactRouteLifecycleReadSiteError(root, "negative", stale); err == nil {
-			t.Fatal("stale read-site line was accepted")
+		resolved, err := compactRouteLifecycleResolvePath(root, site.Path, true)
+		if err != nil {
+			t.Fatal(err)
 		}
+		data, err := os.ReadFile(resolved)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lineCount := len(strings.Split(string(data), "\n"))
+		for line := 1; line <= lineCount; line++ {
+			stale := site
+			stale.Line = line
+			if compactRouteLifecycleReadSiteError(root, "negative", stale) != nil {
+				return
+			}
+		}
+		t.Fatal("could not construct a stale in-range read-site line")
 	})
 	t.Run("stale symbol", func(t *testing.T) {
 		stale := site

--- a/incremental.go
+++ b/incremental.go
@@ -85,15 +85,10 @@ type reuseCursor struct {
 	// shift and checkpoint checks; non-leaves stay barred until that proof exists.
 	rejectFrontierProofUnavailable uint32
 	forestFastPath                 bool
-	// compactMaterialized marks old trees whose node states came from compact
-	// replay. Checkpoint snapshots authenticate scanner state, but they do not
-	// prove the parser frontier after a non-leaf reduction. Keep compact
-	// checkpoint reuse at independently revalidated leaves until that ownership
-	// proof exists.
-	compactMaterialized        bool
-	compactCheckpointedScanner bool
-	languageName               string // cached for language-specific reuse safety policies
-	strictTopLevelOwnership    bool   // forest trees and certified stateless scanners require the recorded normal-dispatch frontier
+	compactRecovery                bool
+	compactCheckpointedScanner     bool
+	languageName                   string // cached for language-specific reuse safety policies
+	strictTopLevelOwnership        bool   // forest trees and certified stateless scanners require the recorded normal-dispatch frontier
 }
 
 // reuseScratch holds reusable buffers for incremental reuse traversal.
@@ -143,13 +138,14 @@ func (c *reuseCursor) reset(oldTree *Tree, source []byte, scratch *reuseScratch)
 	c.rejectScannerUnquiescent = 0
 	c.rejectFrontierProofUnavailable = 0
 	c.forestFastPath = oldTree.forestFastPath
-	c.compactMaterialized = oldTree.compactMaterialized
-	c.compactCheckpointedScanner = c.compactMaterialized && languageUsesExternalScannerCheckpoints(oldTree.language)
+	compactMaterialized := oldTree.compactMaterialized
+	c.compactRecovery = compactMaterialized && oldTree.root != nil && oldTree.root.hasError()
+	c.compactCheckpointedScanner = compactMaterialized && languageUsesExternalScannerCheckpoints(oldTree.language)
 	c.languageName = ""
 	// Every forest node records the GSS state that owned its original reduce.
 	// A compatible goto alone cannot transfer that ownership after an edit, so
 	// forest-built top-level candidates always require an exact pre-goto match.
-	c.strictTopLevelOwnership = c.forestFastPath
+	c.strictTopLevelOwnership = c.forestFastPath || c.compactRecovery
 	if oldTree.language != nil {
 		c.languageName = oldTree.language.Name
 		if stateless, ok := oldTree.language.ExternalScanner.(StatelessExternalScanner); ok {
@@ -167,14 +163,32 @@ func (c *reuseCursor) reset(oldTree *Tree, source []byte, scratch *reuseScratch)
 	childCount := nodeChildCountNoMaterialize(root)
 	if c.hasEdits && root != nil && childCount > 0 {
 		firstAffected := -1
-		for i := 0; i < childCount; i++ {
-			entry, ok := nodeChildEntryAtNoMaterialize(root, i)
-			if !ok {
-				continue
+		if c.compactRecovery {
+			// Tree.Edit can clamp a dirty child that lies in a deleted recovery
+			// region to zero width. Prefer that direct dirty child before the
+			// historical end-byte probe, or the first clean suffix sibling becomes
+			// the apparent edited item and loses its reuse boundary.
+			for i := 0; i < childCount; i++ {
+				entry, ok := nodeChildEntryAtNoMaterialize(root, i)
+				if !ok {
+					continue
+				}
+				if stackEntryNodeDirty(entry) && stackEntryNodeStartByte(entry) <= c.minEditAt {
+					firstAffected = i
+					break
+				}
 			}
-			if stackEntryNodeEndByte(entry) > c.minEditAt {
-				firstAffected = i
-				break
+		}
+		if firstAffected < 0 {
+			for i := 0; i < childCount; i++ {
+				entry, ok := nodeChildEntryAtNoMaterialize(root, i)
+				if !ok {
+					continue
+				}
+				if stackEntryNodeEndByte(entry) > c.minEditAt {
+					firstAffected = i
+					break
+				}
 			}
 		}
 		if firstAffected >= 0 {
@@ -238,7 +252,7 @@ func (c *reuseCursor) releaseNodeRefs() {
 	c.newSource = nil
 	c.edits = nil
 	c.forestFastPath = false
-	c.compactMaterialized = false
+	c.compactRecovery = false
 	c.compactCheckpointedScanner = false
 	c.languageName = ""
 	if cap(c.stack) > 0 {
@@ -333,6 +347,15 @@ func (c *reuseCursor) collectTopLevelCandidates(start uint32) bool {
 	if c == nil || c.topLevelParent == nil || c.topLevelIndex >= c.topLevelEnd {
 		return false
 	}
+	// C rejects an error-bearing parent and then descends into its children.
+	// The indexed top-level path has no child fallback, so disable it for a
+	// recovery root and let advance perform that descent.
+	if c.compactRecovery && c.topLevelParent.hasError() {
+		// Keep the parent so direct clean siblings can still pass the ordinary
+		// ownership and frontier checks after the indexed scan is disabled.
+		c.topLevelIndex = c.topLevelEnd
+		return false
+	}
 	for c.topLevelIndex < c.topLevelEnd {
 		entry, ok := nodeChildEntryAtNoMaterialize(c.topLevelParent, c.topLevelIndex)
 		if !ok || !stackEntryHasNode(entry) {
@@ -371,7 +394,8 @@ func (c *reuseCursor) collectTopLevelCandidates(start uint32) bool {
 			}
 			n := nodeChildAtForReason(c.topLevelParent, c.topLevelIndex-1, materializeForEdit)
 			if n != nil {
-				if c.compactCheckpointedScanner && n.ChildCount() > 0 {
+				if c.compactCheckpointedScanner && n.ChildCount() > 0 &&
+					!(n.isCompactMaterialized() && compactNodeStateProofAvailable(n)) {
 					// A clean compact sibling may carry exact scanner bytes while
 					// its reduction frontier remains unproven. Leave it for the
 					// parser and keep scanning later siblings on the next request.
@@ -411,6 +435,14 @@ func (c *reuseCursor) reusableIndexedEntry(entry stackEntry) bool {
 	if stackEntryNodeHasError(entry) {
 		c.rejectHasError++
 		return false
+	}
+	if n := stackEntryNode(entry); n != nil && n.isCompactMaterialized() {
+		if compactNodeRecoveryBearing(n) {
+			return false
+		}
+		if !compactNodeStateProofAvailable(n) {
+			return false
+		}
 	}
 	if end <= start {
 		c.rejectInvalidSpan++
@@ -498,6 +530,14 @@ func (c *reuseCursor) advance() *Node {
 		if cur.hasError() {
 			c.rejectHasError++
 			continue
+		}
+		if cur.isCompactMaterialized() {
+			if compactNodeRecoveryBearing(cur) {
+				continue
+			}
+			if !compactNodeStateProofAvailable(cur) {
+				continue
+			}
 		}
 		if cur.endByte <= cur.startByte {
 			c.rejectInvalidSpan++
@@ -645,8 +685,12 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 
 	state := s.top().state
 	for _, n := range candidates {
+		if n != nil && n.isCompactMaterialized() && !compactNodeMayBeReused(n) {
+			continue
+		}
 		if n.ChildCount() > 0 {
-			if idx.compactCheckpointedScanner {
+			if idx.compactCheckpointedScanner &&
+				!(n.isCompactMaterialized() && compactNodeStateProofAvailable(n)) {
 				idx.rejectFrontierProofUnavailable++
 				continue
 			}
@@ -665,7 +709,7 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 			// compatible-goto contract.
 			if !fullRootUndo && !topLevelCandidateOwnsCurrentFrontier(n, state) {
 				idx.observedPreGotoStateMismatch++
-				if idx.strictTopLevelOwnership || idx.topLevelSpliceLeading {
+				if idx.strictTopLevelOwnership || idx.topLevelSpliceLeading || n.isCompactMaterialized() {
 					continue
 				}
 			}
@@ -706,13 +750,17 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 		if n == nil || n.ChildCount() == 0 || n.parent == nil {
 			continue
 		}
+		if n.isCompactMaterialized() && !compactNodeMayBeReused(n) {
+			continue
+		}
 		// Compact replay records exact scanner snapshots, but a checkpoint at a
 		// reduction boundary does not identify the parser state for the next
 		// token. A length-changing indentation edit can keep that snapshot equal
 		// while changing whether the next statement belongs to the reduction.
 		// Reuse leaves, whose shift state and token span are independently checked;
 		// reparse compact non-leaf reductions until frontier ownership is recorded.
-		if idx.compactCheckpointedScanner {
+		if idx.compactCheckpointedScanner &&
+			!(n.isCompactMaterialized() && compactNodeStateProofAvailable(n)) {
 			idx.rejectFrontierProofUnavailable++
 			continue
 		}

--- a/incremental_test.go
+++ b/incremental_test.go
@@ -365,6 +365,42 @@ func TestParseIncrementalReleaseKeepsBorrowedNodesAlive(t *testing.T) {
 	}
 }
 
+func TestParseReuseStateRetainsTransitiveBorrowedArenaLifecycle(t *testing.T) {
+	inherited := acquireNodeArena(arenaClassFull)
+	child := newLeafNodeInArena(inherited, 1, true, 0, 1, Point{}, Point{Column: 1})
+	oldest := newTreeWithArenas(child, []byte("x"), nil, inherited, nil)
+
+	direct := acquireNodeArena(arenaClassIncremental)
+	parent := newParentNodeInArena(direct, 2, true, []*Node{child}, nil, 0)
+	inherited.Retain()
+	old := newTreeWithArenas(parent, []byte("x"), nil, direct, []*nodeArena{inherited})
+
+	primary := acquireNodeArena(arenaClassIncremental)
+	state := parseReuseState{}
+	state.markReused(parent, primary)
+	newest := newTreeWithArenas(parent, []byte("x"), nil, primary, state.retainBorrowed(primary))
+	if len(newest.borrowedArena) != 2 {
+		t.Fatalf("newest tree borrowed arenas=%d, want two reachable owners", len(newest.borrowedArena))
+	}
+
+	oldest.Release()
+	old.Release()
+	if got := child.EndByte(); got != 1 {
+		t.Fatalf("transitively borrowed child end byte=%d after prior releases, want 1", got)
+	}
+	if got := child.Type(&Language{SymbolNames: []string{"EOF", "child"}}); got != "child" {
+		t.Fatalf("transitively borrowed child type=%q after prior releases, want child", got)
+	}
+	if direct.refs.Load() != 1 || inherited.refs.Load() != 1 {
+		t.Fatalf("newest tree refs direct=%d inherited=%d, want 1/1", direct.refs.Load(), inherited.refs.Load())
+	}
+
+	newest.Release()
+	if direct.refs.Load() != 0 || inherited.refs.Load() != 0 || primary.refs.Load() != 0 {
+		t.Fatalf("released refs direct=%d inherited=%d primary=%d, want 0/0/0", direct.refs.Load(), inherited.refs.Load(), primary.refs.Load())
+	}
+}
+
 func assertTreeHasNoDirtyNodes(t *testing.T, root *Node) {
 	t.Helper()
 	if root == nil {

--- a/parser.go
+++ b/parser.go
@@ -3149,7 +3149,7 @@ func (p *Parser) parseIncrementalInternalWithMergePerKeyOverride(source []byte, 
 		if timing != nil {
 			timing.reuseUnsupported = true
 			timing.reuseUnsupportedReason = incrementalReuseUnsupportedReasonForTree(oldTree)
-			if oldTree != nil && oldTree.compactMaterialized && !compactRecoverEOFTreeMarked(oldTree) {
+			if oldTree != nil && oldTree.compactMaterialized {
 				if reason := incrementalReuseUnavailableReason(ts); reason != "" {
 					timing.reuseUnsupportedReason = reason
 				}

--- a/parser.go
+++ b/parser.go
@@ -1608,6 +1608,7 @@ type incrementalParseTiming struct {
 type parseReuseState struct {
 	reusedAny bool
 	arenaRefs []*nodeArena
+	arenaWalk []*Node
 }
 
 // NewParser creates a new Parser for the given language.

--- a/parser_api.go
+++ b/parser_api.go
@@ -185,28 +185,23 @@ const (
 	forestIncrementalReuseUnsupportedReason            = "old tree was built by GSS forest fast path"
 	compactIncrementalReuseUnsupportedReason           = "old tree was compact-materialized without a scanner-quiescence proof"
 	checkpointedScannerPrefixFrontierUnsupportedReason = "external_scanner_prefix_frontier_unproven"
-	compactRecoverEOFIncrementalReuseUnsupportedReason = "old tree carried a compact recover_eof EOF runtime"
 )
 
 const forestRecoveryFallbackReuseReason = "forest_recovery_fallback"
 
 func oldTreeDisablesIncrementalReuse(oldTree *Tree) bool {
-	return oldTree != nil && (oldTree.incrementalReuseDisabled || compactRecoverEOFTreeMarked(oldTree))
+	return oldTree != nil && oldTree.incrementalReuseDisabled
 }
 
 // compactRecoverEOFTreeMarked identifies the one compact tree whose root
-// carries raw recover_eof framing. Its scanner runtime describes the old
-// source's end-of-file boundary, so incremental reuse must not trust it after
-// an edit until a fresh parse rebuilds that runtime.
+// carries raw recover_eof framing. The marker remains useful for result-span
+// finalization, but it is no longer a permanent incremental-reuse bar.
 func compactRecoverEOFTreeMarked(tree *Tree) bool {
 	return tree != nil && tree.compactMaterialized && tree.root != nil &&
 		tree.root.hasFlag(nodeFlagCompactRecoverEOF)
 }
 
 func incrementalReuseUnsupportedReasonForTree(oldTree *Tree) string {
-	if compactRecoverEOFTreeMarked(oldTree) {
-		return compactRecoverEOFIncrementalReuseUnsupportedReason
-	}
 	if oldTree != nil && oldTree.compactMaterialized {
 		return compactIncrementalReuseUnsupportedReason
 	}

--- a/parser_incremental_support.go
+++ b/parser_incremental_support.go
@@ -8,11 +8,28 @@ func (s *parseReuseState) markReused(node *Node, primary *nodeArena) {
 	if node == nil {
 		return
 	}
-	s.arenaRefs = appendUniqueArenaRef(s.arenaRefs, node.ownerArena, primary)
+	s.arenaWalk = append(s.arenaWalk[:0], node)
+	for len(s.arenaWalk) > 0 {
+		last := len(s.arenaWalk) - 1
+		current := s.arenaWalk[last]
+		s.arenaWalk = s.arenaWalk[:last]
+		if current == nil {
+			continue
+		}
+		s.arenaRefs = appendUniqueArenaRef(s.arenaRefs, current.ownerArena, primary)
+		for i := nodeChildCountNoMaterialize(current) - 1; i >= 0; i-- {
+			child := nodeChildAtForReason(current, i, materializeForEdit)
+			if child != nil {
+				s.arenaWalk = append(s.arenaWalk, child)
+			}
+		}
+	}
+	clear(s.arenaWalk)
+	s.arenaWalk = s.arenaWalk[:0]
 }
 
 func (s *parseReuseState) retainBorrowed(primary *nodeArena) []*nodeArena {
-	if s == nil || !s.reusedAny || len(s.arenaRefs) == 0 {
+	if s == nil || !s.reusedAny {
 		return nil
 	}
 	uniq := uniqueArenas(s.arenaRefs, primary)

--- a/parser_result_javascript_typescript_compat_test.go
+++ b/parser_result_javascript_typescript_compat_test.go
@@ -158,6 +158,104 @@ func TestTreeRootNodeAppliesDeferredTypeScriptCompatibility(t *testing.T) {
 	}
 }
 
+func TestDeferredTypeScriptCompatibilityInvalidatesCompactReuseProof(t *testing.T) {
+	t.Run("unchanged compact tree", func(t *testing.T) {
+		lang, _, _ := newDeferredCompatDynamicImportFixture()
+		arena := newNodeArena(arenaClassFull)
+		identifier := newLeafNodeInArena(arena, 12, true, 0, 3, Point{}, Point{Column: 3})
+		root := newParentNodeInArena(arena, 1, true, []*Node{identifier}, nil, 0)
+		for _, node := range []*Node{root, identifier} {
+			node.setCompactMaterialized(true)
+			node.setCompactParseStateProof(true)
+			if node.ChildCount() > 0 {
+				node.setCompactPreGotoStateProof(true)
+			}
+		}
+		tree := newTreeWithArenas(root, []byte("foo"), lang, arena, nil)
+		tree.deferResultCompatibility()
+
+		_ = tree.RootNode()
+		if tree.incrementalReuseDisabled {
+			t.Fatal("unchanged deferred compatibility disabled compact reuse")
+		}
+	})
+
+	t.Run("pure compact tree", func(t *testing.T) {
+		lang, root, stmt := newDeferredCompatDynamicImportFixture()
+		root.setCompactMaterialized(true)
+		root.setCompactParseStateProof(true)
+		root.setCompactPreGotoStateProof(true)
+		stmt.setCompactMaterialized(true)
+		stmt.setCompactParseStateProof(true)
+		tree := newTreeWithArenas(root, []byte("import"), lang, root.ownerArena, nil)
+		tree.deferResultCompatibility()
+
+		if !compactTreeIncrementalReuseProven(root) {
+			t.Fatal("fixture lacks compact reuse proof before compatibility")
+		}
+		_ = tree.RootNode()
+		if !tree.incrementalReuseDisabled {
+			t.Fatal("deferred compatibility kept stale compact reuse proof")
+		}
+		if compactTreeIncrementalReuseProven(root) {
+			t.Fatal("compatibility rewrite unexpectedly retained compact reuse proof")
+		}
+	})
+
+	t.Run("mixed incremental lineage", func(t *testing.T) {
+		lang, root, stmt := newDeferredCompatDynamicImportFixture()
+		stmt.setCompactMaterialized(true)
+		stmt.setCompactParseStateProof(true)
+		tree := newTreeWithArenas(root, []byte("import"), lang, root.ownerArena, nil)
+		tree.deferResultCompatibility()
+
+		if !compactTreeContainsMaterializedNode(root) {
+			t.Fatal("fixture lacks inherited compact descendant")
+		}
+		if tree.incrementalReuseDisabled {
+			t.Fatal("fixture disabled incremental reuse before compatibility")
+		}
+		_ = tree.RootNode()
+		if !tree.incrementalReuseDisabled {
+			t.Fatal("deferred compatibility kept mixed compact lineage reusable")
+		}
+	})
+
+	t.Run("in-place child removal", func(t *testing.T) {
+		lang, _, _ := newDeferredCompatDynamicImportFixture()
+		arena := newNodeArena(arenaClassFull)
+		keyword := newLeafNodeInArena(arena, 2, false, 0, 6, Point{}, Point{Column: 6})
+		identifier := newParentNodeInArena(arena, 12, true, []*Node{keyword}, nil, 0)
+		root := newParentNodeInArena(arena, 1, true, []*Node{identifier}, nil, 0)
+		for _, node := range []*Node{root, identifier, keyword} {
+			node.setCompactMaterialized(true)
+			node.setCompactParseStateProof(true)
+			if node.ChildCount() > 0 {
+				node.setCompactPreGotoStateProof(true)
+			}
+		}
+		tree := newTreeWithArenas(root, []byte("import"), lang, arena, nil)
+		tree.deferResultCompatibility()
+
+		if !compactTreeIncrementalReuseProven(root) {
+			t.Fatal("fixture lacks compact reuse proof before compatibility")
+		}
+		if got := resultChildCount(identifier); got != 1 {
+			t.Fatalf("identifier child count before compatibility=%d, want 1", got)
+		}
+		_ = tree.RootNode()
+		if got := resultChildCount(identifier); got != 0 {
+			t.Fatalf("identifier child count after compatibility=%d, want 0", got)
+		}
+		if !compactTreeIncrementalReuseProven(root) {
+			t.Fatal("in-place rewrite unexpectedly cleared the stale proof bits")
+		}
+		if !tree.incrementalReuseDisabled {
+			t.Fatal("in-place compatibility rewrite kept compact lineage reusable")
+		}
+	})
+}
+
 func TestTreeUTF16DescendantAppliesDeferredTypeScriptCompatibility(t *testing.T) {
 	lang, root, stmt := newDeferredCompatDynamicImportFixture()
 	source, sourceMap := encodeUTF16ToUTF8WithMap([]uint16{'i', 'm', 'p', 'o', 'r', 't'})

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -51,7 +51,11 @@ func newResultRootBuild(p *Parser, source []byte, arena *nodeArena, oldTree *Tre
 			build.hasExpectedRoot = true
 		}
 	}
-	if oldTree != nil && oldTree.RootNode() != nil {
+	// A compact recover_eof tree deliberately exposes its C ERROR root rather
+	// than the grammar result root. Do not use that transient symbol to frame a
+	// fresh incremental result, or the normal grammar root becomes nested under
+	// a stale recovery wrapper after the EOF edit is repaired.
+	if oldTree != nil && oldTree.RootNode() != nil && !compactRecoverEOFTreeMarked(oldTree) {
 		build.expectedRootSymbol = oldTree.RootNode().symbol
 		build.hasExpectedRoot = true
 	}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -7242,8 +7242,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 		}
 		defer replayStates.release()
 	}
-	incrementalReuseProven := replayStates != nil && compactIncrementalReuseProvenForLanguage(parser.language)
-	stamp := func(id core.SubtreeID, node *Node, terminal bool) {
+	stamp := func(id core.SubtreeID, node *Node) {
 		// Stamp the reconstructed state for THIS derivation id onto the node
 		// that materializes it. For a unary collapse chain the driver visits the
 		// ids inner-to-outer (postorder) and reuses one node object, so the last
@@ -7260,21 +7259,27 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 		// parseState is the "unknown -> recompute" sentinel (incremental
 		// self-healing), which is strictly safer than stamping a known-wrong but
 		// trusted non-zero state (Phase-3 Lane 3 review amendment 1).
+		if node != nil {
+			// A visible node can represent several compact ids when unary
+			// reductions collapse during materialization. Clear every stamped
+			// field before applying the outermost id, so an inner proof cannot
+			// survive an outer abstention.
+			node.setCompactMaterialized(true)
+			node.setCompactParseStateProof(false)
+			node.setCompactPreGotoStateProof(false)
+			node.parseState = 0
+			node.preGotoState = 0
+		}
 		if replayStates != nil && node != nil {
 			pre, ps, preOk, psOk := replayStates.get(id)
-			if terminal {
-				incrementalReuseProven = incrementalReuseProven && psOk
-			} else {
-				incrementalReuseProven = incrementalReuseProven && preOk
-			}
 			if psOk {
 				node.parseState = ps
+				node.setCompactParseStateProof(true)
 			}
 			if preOk {
 				node.preGotoState = pre
+				node.setCompactPreGotoStateProof(true)
 			}
-		} else {
-			incrementalReuseProven = false
 		}
 		nodesByID[id] = node
 	}
@@ -7382,7 +7387,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				// (subtreeRecord.fragile is only ever set on reductions), so a
 				// terminal record is never fragile. The reduce branches below
 				// carry the bit.
-				stamp(id, node, true)
+				stamp(id, node)
 				return nil
 			}
 
@@ -7488,7 +7493,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				parent.setHasError(true)
 				hasErrorByID[id] = true
 				markFragile(parent, view.Fragile)
-				stamp(id, parent, false)
+				stamp(id, parent)
 				return nil
 			}
 			action := ParseAction{
@@ -7503,7 +7508,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 					child.setHasError(true)
 				}
 				hasErrorByID[id] = subtreeHasError
-				stamp(id, child, false)
+				stamp(id, child)
 				return nil
 			}
 			children, fieldIDs, fieldSources, _ := parser.buildReduceChildrenWithPath(
@@ -7523,7 +7528,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 					child.setHasError(true)
 				}
 				hasErrorByID[id] = subtreeHasError
-				stamp(id, child, false)
+				stamp(id, child)
 				return nil
 			}
 			parent := newParentNodeInArenaWithFieldSources(
@@ -7540,7 +7545,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 			}
 			hasErrorByID[id] = subtreeHasError
 			markFragile(parent, view.Fragile)
-			stamp(id, parent, false)
+			stamp(id, parent)
 			return nil
 		}
 		if scratch != nil {
@@ -7696,11 +7701,15 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 			),
 		})
 	}
-	// A recover_eof result carries an EOF runtime for the original source.
-	// Never let an edited copy enter incremental reuse with that stale boundary.
-	tree.incrementalReuseDisabled = rootFinalization == diagnosticParserCoreFinalizeRecoverEOF ||
-		!incrementalReuseProven || !scannerProvenanceTransferProven
 	tree.compactMaterialized = true
+	// Compact trees remain eligible only when replay authenticated every
+	// potentially reusable visible node and the scanner transfer is proven.
+	// Recovery-bearing nodes stay excluded by the reuse cursor, which descends
+	// to clean siblings while preserving the ordinary scanner gate.
+	compactIncrementalReuseProven := replayStates != nil &&
+		compactIncrementalReuseProvenForLanguage(parser.language) &&
+		scannerProvenanceTransferProven && compactTreeIncrementalReuseProven(root)
+	tree.incrementalReuseDisabled = !compactIncrementalReuseProven
 	tree.setParseRuntime(ParseRuntime{
 		StopReason:                                     ParseStopAccepted,
 		SourceLen:                                      sourceLen,

--- a/parsestate_reuse_bar_test.go
+++ b/parsestate_reuse_bar_test.go
@@ -220,6 +220,9 @@ func requireCompactIncrementalStateProof(t *testing.T, tree *Tree) {
 		last := len(stack) - 1
 		node := stack[last]
 		stack = stack[:last]
+		if !node.isCompactMaterialized() || !compactNodeStateProofAvailable(node) {
+			t.Fatalf("proof-carrying node %s %d..%d lacks authenticated compact state", node.Type(tree.language), node.startByte, node.endByte)
+		}
 		children := node.ChildCount()
 		if children == 0 {
 			if node.parseState == 0 {

--- a/testdata/compact_route_campaign_lifecycle_v1.json
+++ b/testdata/compact_route_campaign_lifecycle_v1.json
@@ -120,7 +120,6 @@
       "expression": "default",
       "scope": "production",
       "read_sites": [
-        {"path": "incremental.go", "symbol": "tryReuseSubtree", "line": 636},
         {"path": "incremental_invariant_gate_test.go", "symbol": "TestIncrementalInvariantGate", "line": 192}
       ]
     },

--- a/tree.go
+++ b/tree.go
@@ -2777,11 +2777,14 @@ func (t *Tree) ensureResultCompatibility() {
 		if t.root == nil || t.language == nil {
 			return
 		}
+		hadCompactLineage := t.compactMaterialized || compactTreeContainsMaterializedNode(t.root)
+		compatibilitySnapshot := snapshotCompactCompatibilityTree(t.root, hadCompactLineage)
 		if !parsePhaseTimingEnabled() {
 			parser := &Parser{language: t.language}
 			result := normalizeResultCompatibility(t.root, t.source, parser, nil)
 			t.resultErrorSummary = result.errorSummary
 			t.resultCompatibilityApplied = !parseStopReasonIsActive(result.stopReason)
+			t.disableIncrementalReuseAfterCompactCompatibility(compatibilitySnapshot)
 			// Diagnostic-only, mirrors the timing-enabled branch below: without
 			// this, every deferred-compatibility language (typescript/tsx by
 			// default, see shouldDeferResultCompatibility) would
@@ -2802,10 +2805,161 @@ func (t *Tree) ensureResultCompatibility() {
 		result := normalizeResultCompatibility(t.root, t.source, parser, nil)
 		t.resultErrorSummary = result.errorSummary
 		t.resultCompatibilityApplied = !parseStopReasonIsActive(result.stopReason)
+		t.disableIncrementalReuseAfterCompactCompatibility(compatibilitySnapshot)
 		timing.addResultCompatibility(start)
 		t.parseRuntime.ResultCompatibilityNanos += timing.resultCompatibilityNanos
 		parser.copyNormalizationStats(&t.parseRuntime)
 	})
+}
+
+func (t *Tree) disableIncrementalReuseAfterCompactCompatibility(snapshot *compactCompatibilityTreeSnapshot) {
+	if t != nil && snapshot != nil && !snapshot.matches(t.root) {
+		t.incrementalReuseDisabled = true
+	}
+}
+
+type compactCompatibilityNodeSnapshot struct {
+	node              *Node
+	children          []*Node
+	fieldIDs          []FieldID
+	fieldSources      []uint8
+	startPoint        Point
+	endPoint          Point
+	startByte         uint32
+	endByte           uint32
+	parseState        StateID
+	preGotoState      StateID
+	equivVersion      uint32
+	dynamicPrecedence int32
+	symbol            Symbol
+	productionID      uint16
+	semanticFlags     nodeFlags
+}
+
+type compactCompatibilityTreeSnapshot struct {
+	root  *Node
+	nodes []compactCompatibilityNodeSnapshot
+}
+
+func snapshotCompactCompatibilityTree(root *Node, enabled bool) *compactCompatibilityTreeSnapshot {
+	if !enabled || root == nil {
+		return nil
+	}
+	snapshot := &compactCompatibilityTreeSnapshot{root: root}
+	stack := []*Node{root}
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		node := stack[last]
+		stack = stack[:last]
+		if node == nil {
+			continue
+		}
+		children := append([]*Node(nil), nodeChildrenForReason(node, materializeForEdit)...)
+		snapshot.nodes = append(snapshot.nodes, compactCompatibilityNodeSnapshot{
+			node:              node,
+			children:          children,
+			fieldIDs:          append([]FieldID(nil), node.fieldIDs()...),
+			fieldSources:      append([]uint8(nil), node.fieldSources()...),
+			startPoint:        node.startPoint,
+			endPoint:          node.endPoint,
+			startByte:         node.startByte,
+			endByte:           node.endByte,
+			parseState:        node.parseState,
+			preGotoState:      node.preGotoState,
+			equivVersion:      node.equivVersion,
+			dynamicPrecedence: node.dynamicPrecedence,
+			symbol:            node.symbol,
+			productionID:      node.productionID,
+			semanticFlags:     node.flags &^ (nodeFlagFieldIDCacheComputed | nodeFlagFieldIDCacheHasFieldIDs),
+		})
+		for i := len(children) - 1; i >= 0; i-- {
+			stack = append(stack, children[i])
+		}
+	}
+	return snapshot
+}
+
+func (s *compactCompatibilityTreeSnapshot) matches(root *Node) bool {
+	if s == nil || s.root != root {
+		return false
+	}
+	for _, before := range s.nodes {
+		node := before.node
+		if node == nil ||
+			node.startPoint != before.startPoint || node.endPoint != before.endPoint ||
+			node.startByte != before.startByte || node.endByte != before.endByte ||
+			node.parseState != before.parseState || node.preGotoState != before.preGotoState ||
+			node.equivVersion != before.equivVersion || node.dynamicPrecedence != before.dynamicPrecedence ||
+			node.symbol != before.symbol || node.productionID != before.productionID ||
+			node.flags&^(nodeFlagFieldIDCacheComputed|nodeFlagFieldIDCacheHasFieldIDs) != before.semanticFlags ||
+			!sameNodePointers(node.children, before.children) ||
+			!sameFieldIDs(node.fieldIDs(), before.fieldIDs) ||
+			!sameBytes(node.fieldSources(), before.fieldSources) {
+			return false
+		}
+	}
+	return true
+}
+
+func sameNodePointers(left, right []*Node) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sameFieldIDs(left, right []FieldID) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sameBytes(left, right []uint8) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func compactTreeContainsMaterializedNode(root *Node) bool {
+	if root == nil {
+		return false
+	}
+	stack := []*Node{root}
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		node := stack[last]
+		stack = stack[:last]
+		if node == nil {
+			continue
+		}
+		if node.isCompactMaterialized() {
+			return true
+		}
+		for i := nodeChildCountNoMaterialize(node) - 1; i >= 0; i-- {
+			child := nodeChildAtForReason(node, i, materializeForEdit)
+			if child != nil {
+				stack = append(stack, child)
+			}
+		}
+	}
+	return false
 }
 
 func newParentNode(arena *nodeArena, sym Symbol, named bool, children []*Node, fieldIDs []FieldID, productionID uint16) *Node {

--- a/tree.go
+++ b/tree.go
@@ -95,6 +95,12 @@ const (
 	// raw C span must survive public result finalization. It is runtime-only
 	// provenance and fits the existing uint16 flag budget.
 	nodeFlagCompactRecoverEOF
+	// nodeFlagCompactMaterialized marks nodes whose parser-state metadata came
+	// from compact materialization. The remaining two bits record which state
+	// fields were authenticated by table replay. These flags are runtime-only.
+	nodeFlagCompactMaterialized
+	nodeFlagCompactParseStateProven
+	nodeFlagCompactPreGotoStateProven
 )
 
 func (n *Node) hasFlag(flag nodeFlags) bool {
@@ -121,6 +127,111 @@ func (n *Node) isExternalScannerToken() bool {
 	return n != nil && n.hasFlag(nodeFlagExternalScannerToken)
 }
 func (n *Node) setExternalScannerToken(v bool) { n.setFlag(nodeFlagExternalScannerToken, v) }
+
+func (n *Node) isCompactMaterialized() bool {
+	return n != nil && n.hasFlag(nodeFlagCompactMaterialized)
+}
+
+func (n *Node) setCompactMaterialized(v bool) {
+	if n != nil {
+		n.setFlag(nodeFlagCompactMaterialized, v)
+	}
+}
+
+func (n *Node) hasCompactParseStateProof() bool {
+	return n != nil && n.hasFlag(nodeFlagCompactParseStateProven)
+}
+
+func (n *Node) setCompactParseStateProof(v bool) {
+	if n != nil {
+		n.setFlag(nodeFlagCompactParseStateProven, v)
+	}
+}
+
+func (n *Node) hasCompactPreGotoStateProof() bool {
+	return n != nil && n.hasFlag(nodeFlagCompactPreGotoStateProven)
+}
+
+func (n *Node) setCompactPreGotoStateProof(v bool) {
+	if n != nil {
+		n.setFlag(nodeFlagCompactPreGotoStateProven, v)
+	}
+}
+
+func compactNodeRecoveryBearing(n *Node) bool {
+	if n == nil {
+		return false
+	}
+	if n.hasError() || n.isMissing() || n.symbol == errorSymbol || n.isFragile() {
+		return true
+	}
+	// A clean leaf nested below an explicit recovery node has no independent
+	// parser-frontier proof. Keep it with the recovery region so the cursor
+	// descends to a clean sibling instead of splicing part of that region.
+	for parent := n.parent; parent != nil; parent = parent.parent {
+		if parent.isMissing() || parent.symbol == errorSymbol || parent.isFragile() {
+			return true
+		}
+	}
+	return false
+}
+
+func compactNodeStateProofAvailable(n *Node) bool {
+	if n == nil || !n.isCompactMaterialized() {
+		return true
+	}
+	if !n.hasCompactParseStateProof() {
+		return false
+	}
+	return n.ChildCount() == 0 || n.hasCompactPreGotoStateProof()
+}
+
+// compactNodeMayBeReused reports whether a compact node has enough
+// authenticated metadata for the incremental parser to splice it.
+// Recovery-bearing nodes remain barred because the cursor must descend into
+// them and rebuild their unstable region.
+func compactNodeMayBeReused(n *Node) bool {
+	if n == nil {
+		return false
+	}
+	if !n.isCompactMaterialized() {
+		return true
+	}
+	if compactNodeRecoveryBearing(n) {
+		return false
+	}
+	return compactNodeStateProofAvailable(n)
+}
+
+// compactTreeIncrementalReuseProven checks the visible nodes that can reach
+// the reuse cursor. Error, missing, and fragile nodes are intentionally
+// excluded because C rejects them before descending to clean descendants.
+func compactTreeIncrementalReuseProven(root *Node) bool {
+	if root == nil {
+		return false
+	}
+	stack := []*Node{root}
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		n := stack[last]
+		stack = stack[:last]
+		if n == nil {
+			continue
+		}
+		if !compactNodeRecoveryBearing(n) {
+			if !n.isCompactMaterialized() || !compactNodeStateProofAvailable(n) {
+				return false
+			}
+		}
+		for i := nodeChildCountNoMaterialize(n) - 1; i >= 0; i-- {
+			child := nodeChildAtForReason(n, i, materializeForEdit)
+			if child != nil {
+				stack = append(stack, child)
+			}
+		}
+	}
+	return true
+}
 
 func (n *Node) setLexerSkippedPrefixAtSourceStart(v bool) {
 	n.setFlag(nodeFlagLexerSkippedPrefixAtSourceStart, v)

--- a/w1_sibling_splice_realparse_test.go
+++ b/w1_sibling_splice_realparse_test.go
@@ -37,6 +37,7 @@ func TestRealParseFragileGateCounterFiresOnAmbiguousGoTopLevelDecls(t *testing.T
 	oldSrc := src.Bytes()
 
 	parser := gotreesitter.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
 	oldTree, err := parser.Parse(oldSrc)
 	if err != nil {
 		t.Fatalf("base parse: %v", err)


### PR DESCRIPTION
Closes #1066.

## Summary

- Preserve authenticated parser states on compact materialized nodes.
- Reject recovery-bearing regions and reuse clean siblings.
- Require exact frontier ownership across later incremental generations.
- Rebuild edited end-of-file recovery results through scanner-safe fallback.
- Remove the permanent compact `recover_eof` reuse veto.

## Verification

- Focused tests pass with the default, compact, and emergency build modes.
- JavaScript and YAML C-oracle tests pass in separate Docker runs.
- The Python scanner checkpoint test passes in Docker.
- JavaScript real-corpus parity passes 25 of 25 cases.
- Node and parser layout gates pass.
- Independent final review found no P0 or P1 blocker.