### PR TITLE
parser: reserve forest links on demand

### DIFF
--- a/glr_forest.go
+++ b/glr_forest.go
@@ -1564,6 +1564,13 @@ func coalesceForestWithRawAndAlternatives(p *Parser, arena *nodeArena, index *gs
 		return node
 	}
 	firstLink := len(node.links) == 0
+	// Most nodes have one link. Reserve the full language cap only when a
+	// second distinct path proves that this node needs it.
+	if len(node.links) == cap(node.links) {
+		grown := slab.linkSlice(linkCap)
+		grown = append(grown, node.links...)
+		node.links = grown
+	}
 	node.links = append(node.links, gssLink{prev: prev, prevDirty: forestNodeDirty(prev), subtree: entry, score: score, errorCost: errorCost})
 	forestRecordAlternative(alternatives, entry, node)
 	forestRecordMinLinkScore(node, firstLink, score)
@@ -3180,7 +3187,7 @@ func (s *gssForestNodeSlab) alloc(state StateID, byteOffset uint32, _ int, error
 	n.byteOffset = byteOffset
 	n.errorCost = errorCost
 	n.minLinkScore = 0
-	n.links = s.linkSlice()
+	n.links = s.linkSlice(1)
 	n.dirty = 0
 	n.processedEpoch = 0
 	n.processedDirty = 0
@@ -3201,14 +3208,12 @@ func (s *gssForestNodeSlab) alloc(state StateID, byteOffset uint32, _ int, error
 	return n
 }
 
-// linkSlice hands out a zero-length slice backed by the shared link buffer with
-// enough capacity for the capped forest fan-out. The pooled slab makes this a
-// retained scratch cost and avoids per-node append growth on ambiguous states.
-func (s *gssForestNodeSlab) linkSlice() []gssLink {
-	const initCap = forestMaxLinksPerNode
+// linkSlice hands out a zero-length slice with the requested capacity from the
+// shared link buffer. The pooled slab keeps link growth in retained scratch.
+func (s *gssForestNodeSlab) linkSlice(capacity int) []gssLink {
 	if len(s.linkBatches) == 0 {
 		s.linkBatches = append(s.linkBatches, make([]gssLink, gssForestLinkBatchCap))
-	} else if s.linkIdx+initCap > len(s.linkBatches[s.linkBatch]) {
+	} else if s.linkIdx+capacity > len(s.linkBatches[s.linkBatch]) {
 		s.linkBatch++
 		s.linkIdx = 0
 		if s.linkBatch >= len(s.linkBatches) {
@@ -3216,8 +3221,8 @@ func (s *gssForestNodeSlab) linkSlice() []gssLink {
 		}
 	}
 	buf := s.linkBatches[s.linkBatch]
-	sl := buf[s.linkIdx : s.linkIdx : s.linkIdx+initCap]
-	s.linkIdx += initCap
+	sl := buf[s.linkIdx : s.linkIdx : s.linkIdx+capacity]
+	s.linkIdx += capacity
 	return sl
 }
 

--- a/glr_forest_test.go
+++ b/glr_forest_test.go
@@ -326,20 +326,27 @@ func TestReduceOverForestLinearPrefixForkedWithExtra(t *testing.T) {
 }
 
 // TestCoalesceForestSharesNode proves coalesceForest dedups by (state,byteOffset)
-// into one node with multiple links — the O(1), no-deep-compare mechanism.
+// into one node and grows its link storage only when a second path arrives.
 func TestCoalesceForestSharesNode(t *testing.T) {
+	const linkCap = 2
 	var idx gssForestIndex
 	idx.init(0)
 	slab := &gssForestNodeSlab{}
 	base := &gssForestNode{state: 0}
 	// Two distinct parses reach (state=5, byteOffset=42).
-	a := coalesceForest(&idx, slab, 5, 42, base, stackEntry{state: 100}, 3, 0, forestMaxLinksPerNode)
-	b := coalesceForest(&idx, slab, 5, 42, base, stackEntry{state: 101}, 7, 0, forestMaxLinksPerNode)
+	a := coalesceForest(&idx, slab, 5, 42, base, stackEntry{state: 100}, 3, 0, linkCap)
+	if got := cap(a.links); got != 1 {
+		t.Fatalf("first link capacity = %d, want 1", got)
+	}
+	b := coalesceForest(&idx, slab, 5, 42, base, stackEntry{state: 101}, 7, 0, linkCap)
 	if a != b {
 		t.Fatal("coalesceForest created two nodes for the same (state,byteOffset)")
 	}
 	if len(a.links) != 2 {
 		t.Fatalf("want 2 links on the coalesced node, got %d", len(a.links))
+	}
+	if got := cap(a.links); got != linkCap {
+		t.Fatalf("promoted link capacity = %d, want %d", got, linkCap)
 	}
 	if a.noExtraDepth != 1 {
 		t.Fatalf("want no-extra depth 1, got %d", a.noExtraDepth)
@@ -351,7 +358,7 @@ func TestCoalesceForestSharesNode(t *testing.T) {
 		t.Fatalf("want best link score 7, got %v", best)
 	}
 	// A different (state,byteOffset) is a separate node.
-	c := coalesceForest(&idx, slab, 6, 42, base, stackEntry{state: 102}, 1, 0, forestMaxLinksPerNode)
+	c := coalesceForest(&idx, slab, 6, 42, base, stackEntry{state: 102}, 1, 0, linkCap)
 	if c == a {
 		t.Fatal("distinct (state,byteOffset) coalesced into the same node")
 	}
@@ -715,14 +722,15 @@ func TestGSSForestIndexLookupCacheClearsOnReset(t *testing.T) {
 }
 
 func TestGSSForestNodeSlabReleaseClearsPointers(t *testing.T) {
+	var index gssForestIndex
+	index.init(0)
 	slab := &gssForestNodeSlab{}
-	base := slab.alloc(1, 0, 0, 0)
-	node := slab.alloc(2, 1, 0, 0)
-	nodeLinkStart := slab.linkIdx - forestMaxLinksPerNode
-	node.links = append(node.links, gssLink{
-		prev:    base,
-		subtree: stackEntry{state: 3},
-	})
+	base := &gssForestNode{state: 1}
+	secondBase := &gssForestNode{state: 2}
+	coalesceForest(&index, slab, 2, 1, base, stackEntry{state: 3}, 0, 0, forestMaxLinksPerNode)
+	nodeLinkStart := slab.linkIdx - 1
+	coalesceForest(&index, slab, 2, 1, secondBase, stackEntry{state: 4}, 0, 0, forestMaxLinksPerNode)
+	promotedLinkStart := slab.linkIdx - forestMaxLinksPerNode
 
 	if len(slab.nodeBatches) == 0 || len(slab.linkBatches) == 0 {
 		t.Fatal("expected slab batches to be allocated")
@@ -730,12 +738,18 @@ func TestGSSForestNodeSlabReleaseClearsPointers(t *testing.T) {
 	if got := slab.linkBatches[0][nodeLinkStart].prev; got != base {
 		t.Fatalf("test setup failed: link batch prev = %p, want %p", got, base)
 	}
+	if got := slab.linkBatches[0][promotedLinkStart+1].prev; got != secondBase {
+		t.Fatalf("test setup failed: promoted link prev = %p, want %p", got, secondBase)
+	}
 	slab.resetForRelease()
 	if got := slab.nodeBatches[0][0].links; got != nil {
 		t.Fatalf("node batch retained stale links slice: %v", got)
 	}
 	if got := slab.linkBatches[0][nodeLinkStart].prev; got != nil {
 		t.Fatalf("link batch retained stale prev pointer: %p", got)
+	}
+	if got := slab.linkBatches[0][promotedLinkStart+1].prev; got != nil {
+		t.Fatalf("promoted link batch retained stale prev pointer: %p", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reserve one pooled link slot for a new graph-structured stack forest node.
- Grow to the existing language cap only when a second distinct path arrives.
- Keep scoring, deduplication, fan-out caps, parser routing, and tree construction unchanged.

## Evidence

The exact webpack `schemas/WebpackOptions.check.js` fixture is 398,395 bytes. Both revisions accept all bytes and produce tree SHA-256 `0d829f8189228dd0df2cfbb5565d646b6029395ae0bbedc3ee6af4691f548f3a`.

On a fresh process with `GOMAXPROCS=1` and the forest route enabled:

| Metric | Base | This PR | Change |
|---|---:|---:|---:|
| first-pass allocated bytes | 402,210,944 | 252,256,192 | -37.28% |
| warm allocated bytes | 196,266,912 | 46,373,720 | -76.37% |
| maximum RSS | 402,489,344 | 250,527,744 | -37.75% |
| retired instructions, three parses | 15,491,629,863 | 11,546,780,902 | -25.46% |

## Correctness

- Focused forest unit tests pass in a 4 GiB, one-CPU Docker container.
- Strict JavaScript real-corpus parity passes: no-error 25/25, S-expression 25/25, deep 25/25.
- Focused TypeScript parity tests pass.
- The exact webpack parse stays accepted and byte-complete.

The fixed-time CMake benchmark is excluded from latency claims. Unrelated host load exceeded 70 during the final run.
