### PR TITLE
Keep focused grammar tests offline

### DIFF
--- a/cgo_harness/docker/run_grammargen_gates.sh
+++ b/cgo_harness/docker/run_grammargen_gates.sh
@@ -208,6 +208,10 @@ gate0() {
 set -eo pipefail
 cd /workspace
 
+if ! timeout --signal=TERM --kill-after=5s 90s bash grammargen/testdata/grammar_parity_setup.sh; then
+  echo "WARNING: Markdown corpus setup failed; import parity may skip missing fixtures." >&2
+fi
+
 echo "--- Gate 0a: grammargen unit tests ---"
 go test ./grammargen -run '^Test(JSON|Calc|GLR|Keyword|Ext|AliasSuper|Parity|MultiGrammarImportPipeline)' \
   -count=1 -v -timeout 10m 2>&1
@@ -242,6 +246,10 @@ gate1() {
   read -r -d '' cmd <<'GATE1_CMD' || true
 set -eo pipefail
 cd /workspace
+
+if ! timeout --signal=TERM --kill-after=5s 90s bash grammargen/testdata/grammar_parity_setup.sh; then
+  echo "WARNING: Markdown corpus setup failed; import parity may skip missing fixtures." >&2
+fi
 
 echo "--- Gate 1a: full unit test suite ---"
 go test ./... -count=1 -timeout 15m 2>&1

--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -25,7 +25,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
@@ -34,25 +33,6 @@ import (
 	"github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
-
-// TestMain ensures the out-of-tree tree-sitter-markdown corpus required by the
-// markdown / markdown_inline parity entries is present before any tests run.
-// If the pinned corpus is missing, it invokes testdata/grammar_parity_setup.sh
-// to clone and check out the pinned upstream SHA. Failures here are warnings,
-// not fatal — individual tests that need the corpus can skip themselves.
-func TestMain(m *testing.M) {
-	const corpusMarker = "/tmp/grammar_parity/markdown/tree-sitter-markdown-inline/src/grammar.json"
-	if _, err := os.Stat(corpusMarker); os.IsNotExist(err) {
-		cmd := exec.Command("bash", "testdata/grammar_parity_setup.sh")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			fmt.Fprintf(os.Stderr, "WARNING: grammar parity corpus setup failed: %v\n", err)
-			// Don't fail TestMain — let individual tests skip if they need the corpus.
-		}
-	}
-	os.Exit(m.Run())
-}
 
 // ── Node-by-node tree comparison infrastructure ─────────────────────────────
 

--- a/grammargen/testdata/grammar_parity_setup.sh
+++ b/grammargen/testdata/grammar_parity_setup.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-# Sets up the out-of-tree grammar.json corpus needed by parity_test.go's
-# markdown / markdown_inline entries. Idempotent — does nothing if already
-# set up. Pins the upstream tree-sitter-markdown to a specific SHA so the
-# parity corpus is reproducible across checkouts.
+# Provision the pinned Markdown corpus before an explicit import parity run.
+# Unit tests do not download this corpus.
 
 set -euo pipefail
 
@@ -10,9 +8,20 @@ PINNED_SHA="c3570720f7f7bbad22fe96603f106276618e0cf5"
 UPSTREAM_URL="https://github.com/tree-sitter-grammars/tree-sitter-markdown"
 TARGET_DIR="/tmp/grammar_parity/markdown"
 
+verify_corpus() {
+  local grammar
+  for grammar in tree-sitter-markdown tree-sitter-markdown-inline; do
+    if [[ ! -s "$TARGET_DIR/$grammar/src/grammar.json" ]]; then
+      echo "missing pinned corpus: $TARGET_DIR/$grammar/src/grammar.json" >&2
+      return 1
+    fi
+  done
+}
+
 if [ -d "$TARGET_DIR/.git" ]; then
   current_sha=$(git -C "$TARGET_DIR" rev-parse HEAD)
   if [ "$current_sha" = "$PINNED_SHA" ]; then
+    verify_corpus
     exit 0
   fi
   echo "tree-sitter-markdown at $TARGET_DIR is at $current_sha, expected $PINNED_SHA; resyncing..."
@@ -23,6 +32,7 @@ if [ -d "$TARGET_DIR/.git" ]; then
   # Use reset --hard rather than checkout so a dirty working tree (which is
   # disposable scratch under /tmp/grammar_parity) doesn't make resync fail.
   git -C "$TARGET_DIR" reset --hard "$PINNED_SHA"
+  verify_corpus
   exit 0
 fi
 
@@ -41,3 +51,4 @@ fi
 mkdir -p "$(dirname "$TARGET_DIR")"
 git clone "$UPSTREAM_URL" "$TARGET_DIR"
 git -C "$TARGET_DIR" checkout "$PINNED_SHA"
+verify_corpus


### PR DESCRIPTION
## Change

Remove the global TestMain download. Focused grammar tests no longer clone Markdown before execution.

Gate 0 and Gate 1 now provision the pinned fixtures explicitly. Each setup has a 90-second deadline and a five-second termination grace period. Both fixture files must exist and contain data.

Keep the existing warning-and-skip policy. Add no workflow, matrix, required gate, or report framework.

## Verification

- Offline Docker reproduced the baseline download attempt during TestJSONNormalize.
- Updated focused tests and compile checks passed without creating a corpus directory.
- Explicit Markdown import parity passed: 1/1 exact.
- Five setup behaviors passed in offline Docker.
- Shell syntax, formatting, and diff checks passed.
- Independent review found and removed a proposed CI download that would not exercise the fixtures.

Markdown-inline generation exceeded the diagnostic container's 4 GiB limit. This change does not modify generation. Gate 0 retains its existing 8 GiB limit.