### PR TITLE
Preserve precedence-bearing hidden reductions

### DIFF
--- a/grammargen/flatten_hidden_test.go
+++ b/grammargen/flatten_hidden_test.go
@@ -1,8 +1,190 @@
 package grammargen
 
 import (
+	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/odvcencio/gotreesitter"
 )
+
+func TestFlattenHiddenMixedPassthroughPreservesReductionPrecedence(t *testing.T) {
+	tests := []struct {
+		name string
+		wrap func(*Rule) *Rule
+	}{
+		{"static", func(r *Rule) *Rule { return Prec(7, r) }},
+		{"explicit_zero", func(r *Rule) *Rule { return Prec(0, r) }},
+		{"negative", func(r *Rule) *Rule { return Prec(-1, r) }},
+		{"left", func(r *Rule) *Rule { return PrecLeft(0, r) }},
+		{"right", func(r *Rule) *Rule { return PrecRight(0, r) }},
+		{"dynamic", func(r *Rule) *Rule { return PrecDynamic(3, r) }},
+		{"dynamic_zero", func(r *Rule) *Rule { return PrecDynamic(0, r) }},
+		{"field", func(r *Rule) *Rule { return Field("value", PrecLeft(7, r)) }},
+		{"alias", func(r *Rule) *Rule { return Alias(PrecLeft(7, r), "value", true) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, outer := range []bool{false, true} {
+				g := NewGrammar("preserve_reduction_precedence")
+				g.Define("document", Seq(Sym("_value"), Str("!")))
+				compound := Seq(Str("("), Sym("number"), Str(")"))
+				rule := Choice(tt.wrap(Sym("number")), compound)
+				if outer {
+					rule = tt.wrap(Choice(Sym("number"), compound))
+				}
+				g.Define("_value", rule)
+				g.Define("number", Pat(`[0-9]+`))
+				want := cloneRule(g.Rules["_value"])
+				wantDocument := cloneRule(g.Rules["document"])
+
+				got := flattenHiddenChoiceAlts(g, nil)
+				if !reflect.DeepEqual(got.Rules["_value"], want) {
+					t.Errorf("outer=%t: changed the precedence-bearing reduction", outer)
+				}
+				if !reflect.DeepEqual(got.Rules["document"], wantDocument) {
+					t.Errorf("outer=%t: bypassed the precedence-bearing reduction", outer)
+				}
+			}
+		})
+	}
+}
+
+func TestFlattenHiddenPrecedenceRetainsChildReductions(t *testing.T) {
+	g := NewGrammar("preserve_child_reductions")
+	g.Define("document", Sym("_wrapper"))
+	g.Define("_wrapper", PrecLeft(7, Choice(Sym("_retained"), Sym("_replaced"), Seq(Str("("), Str(")")))))
+	g.Define("_retained", PrecRight(0, Choice(Sym("a"), Sym("b"))))
+	g.Define("_replaced", Choice(Sym("c"), Seq(Str("["), Sym("c"), Str("]"))))
+	for _, name := range []string{"a", "b", "c"} {
+		g.Define(name, Str(name))
+	}
+	got := flattenHiddenChoiceAlts(g, nil)
+	refs := map[string]bool{}
+	for _, alt := range getTopLevelChoiceAlts(got.Rules["_wrapper"]) {
+		if name, ok := directSymbolRefName(alt); ok {
+			refs[name] = true
+		}
+	}
+	want := map[string]bool{"_retained": true, "_replaced": true}
+	if !reflect.DeepEqual(refs, want) {
+		t.Fatalf("wrapper references = %v, want %v", refs, want)
+	}
+}
+
+func TestFlattenHiddenPrecedencePreservesChildClosureBeforeSkip(t *testing.T) {
+	for _, name := range []string{"wide_choice", "configured_preserve", "cyclic_child", "generated_bridge"} {
+		t.Run(name, func(t *testing.T) {
+			g := NewGrammar("preserve_child_closure")
+			g.Define("document", Sym("_root"))
+			alts := []*Rule{PrecLeft(7, Sym("_child")), Seq(Str("("), Str(")"))}
+			if name == "wide_choice" {
+				for i := 1; i <= 8; i++ {
+					alts = append(alts, Str(strings.Repeat("x", i)))
+				}
+			}
+			g.Define("_root", Choice(alts...))
+			g.Define("_child", Choice(Sym("a"), Seq(Str("["), Str("]"))))
+			g.Define("a", Str("a"))
+			if name == "configured_preserve" {
+				g.PreserveHiddenChoicePassthrough = []string{"_root"}
+			}
+			if name == "cyclic_child" {
+				g.Define("_child", Choice(Sym("_cycle"), Seq(Str("["), Str("]"))))
+				g.Define("_cycle", Choice(Sym("_child"), Sym("a")))
+			}
+			var generated map[string]bool
+			if name == "generated_bridge" {
+				g.Define("_root", Choice(PrecLeft(7, Sym("repeat_aux")), Seq(Str("("), Str(")"))))
+				g.Define("repeat_aux", Sym("_child"))
+				generated = map[string]bool{"repeat_aux": true}
+			}
+			wantRoot, wantChild := cloneRule(g.Rules["_root"]), cloneRule(g.Rules["_child"])
+			got := flattenHiddenChoiceAlts(g, generated)
+			if !reflect.DeepEqual(got.Rules["_root"], wantRoot) || !reflect.DeepEqual(got.Rules["_child"], wantChild) {
+				t.Fatal("flattening bypassed a protected child reduction")
+			}
+		})
+	}
+}
+
+func TestHiddenMixedPassthroughPrecedenceMatchesC(t *testing.T) {
+	// Tree-sitter v0.24.7 reduces _app before '&'. Both competing actions
+	// have precedence 7 and left associativity. The result has no compound.
+	g := NewGrammar("hidden_passthrough_precedence")
+	g.Define("source_file", Sym("_apps"))
+	g.Define("_apps", PrecLeft(0, Choice(
+		Seq(Sym("_app"), Repeat(Seq(Str(","), Sym("_app")))),
+		Seq(Sym("_app"), Repeat(Seq(Str("&"), Sym("_app")))),
+	)))
+	g.Define("_app", PrecLeft(7, Choice(
+		Sym("_atom"), Sym("compound"), Seq(Sym("_atom"), Str("("), Str(")")),
+	)))
+	g.Define("_atom", Sym("identifier"))
+	g.Define("compound", PrecLeft(7, Seq(Sym("_atom"), Repeat1(Seq(Str("&"), Sym("_atom"))))))
+	g.Define("identifier", Pat(`[A-Z]`))
+	ng, err := Normalize(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundReduction := false
+	for _, prod := range ng.Productions {
+		lhs := ng.Symbols[prod.LHS].Name
+		if lhs == "_app" && len(prod.RHS) == 1 && ng.Symbols[prod.RHS[0]].Name == "_atom" {
+			foundReduction = true
+			if prod.Prec != 7 || prod.Assoc != AssocLeft || !prod.HasExplicitPrec {
+				t.Errorf("_app reduction lost its precedence: %+v", prod)
+			}
+		}
+		if lhs == "_apps" || strings.HasPrefix(lhs, "_apps_repeat") {
+			for _, id := range prod.RHS {
+				if name := ng.Symbols[id].Name; name == "_atom" || name == "compound" {
+					t.Errorf("%s bypasses the _app reduction with %s", lhs, name)
+				}
+			}
+		}
+	}
+	if !foundReduction {
+		t.Fatal("normalization removed _app -> _atom")
+	}
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, source := range []string{"A", "A&B", "A,B", "A&B&C"} {
+		t.Run(source, func(t *testing.T) {
+			parser := gotreesitter.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(false)
+			tree, err := parser.Parse([]byte(source))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tree.Release()
+			root := tree.RootNode()
+			if root.Type(lang) != "source_file" || root.HasError() || root.StartByte() != 0 || root.EndByte() != uint32(len(source)) ||
+				root.StartPoint() != (gotreesitter.Point{}) || root.EndPoint() != (gotreesitter.Point{Column: uint32(len(source))}) {
+				t.Fatalf("unexpected root: %s, range [%d,%d)", root.SExpr(lang), root.StartByte(), root.EndByte())
+			}
+			if root.ChildCount() != len(source) {
+				t.Fatalf("child count = %d, want %d: %s", root.ChildCount(), len(source), root.SExpr(lang))
+			}
+			for i := 0; i < len(source); i++ {
+				child := root.Child(i)
+				wantType := "identifier"
+				if i%2 != 0 {
+					wantType = source[i : i+1]
+				}
+				if child.Type(lang) != wantType || child.IsNamed() != (i%2 == 0) ||
+					child.StartByte() != uint32(i) || child.EndByte() != uint32(i+1) ||
+					child.StartPoint() != (gotreesitter.Point{Column: uint32(i)}) ||
+					child.EndPoint() != (gotreesitter.Point{Column: uint32(i + 1)}) ||
+					child.ChildCount() != 0 || child.IsMissing() || child.HasError() {
+					t.Errorf("child %d = %s [%d,%d), want %s [%d,%d)", i, child.SExpr(lang), child.StartByte(), child.EndByte(), wantType, i, i+1)
+				}
+			}
+		})
+	}
+}
 
 // TestFlattenHiddenPassthrough verifies that cc=1 productions of hidden
 // nonterminals are removed and distributed into parent productions.

--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -4279,10 +4279,12 @@ func deduplicateProductions(prods []Production) []Production {
 //	_H → Seq(P, Q)                   (only compound alts kept)
 //	A → Choice(_H, X, Y, Z)          (pass-through alts inlined)
 //
-// This matches tree-sitter C's flatten_grammar.cc behavior.
+// Preserve precedence-bearing mixed reductions and their unary child reductions.
+// All-pass-through rules otherwise retain the existing closure approximation.
 func flattenHiddenChoiceAlts(g *Grammar, generatedHiddenRules map[string]bool) *Grammar {
 	// 1. Identify hidden nonterminals with mixed pass-through and compound alts.
 	flattenMap := make(map[string]*flattenInfo)
+	preserveReduction := make(map[string]bool)
 	preservePassthrough := stringSetFromSlice(g.PreserveHiddenChoicePassthrough)
 	aliasReferenced := hiddenSymbolsReferencedUnderAlias(g, generatedHiddenRules)
 	continuationFirsts := continuationFirstsByHiddenSymbol(g, generatedHiddenRules)
@@ -4316,11 +4318,12 @@ func flattenHiddenChoiceAlts(g *Grammar, generatedHiddenRules map[string]bool) *
 		}
 
 		var pt, compound []*Rule
+		preservePrecedence := false
 		for _, alt := range alts {
 			if isSingleSymRef(alt) {
-				// PREC belongs to the hidden rule's own productions, not to
-				// consumer rules that inline its alternatives — leaking it
-				// breaks shift/reduce resolution at the call site.
+				if passthroughHasPrecedence(alt) {
+					preservePrecedence = true
+				}
 				pt = append(pt, stripTopPrec(alt))
 			} else {
 				compound = append(compound, alt)
@@ -4328,6 +4331,12 @@ func flattenHiddenChoiceAlts(g *Grammar, generatedHiddenRules map[string]bool) *
 		}
 
 		if len(pt) == 0 {
+			continue
+		}
+		// Mixed choices lose their unary productions during flattening.
+		// Precedence belongs to those reductions, not to their callers.
+		if preservePrecedence && len(compound) > 0 {
+			preserveReduction[name] = true
 			continue
 		}
 
@@ -4463,6 +4472,31 @@ func flattenHiddenChoiceAlts(g *Grammar, generatedHiddenRules map[string]bool) *
 		}
 	}
 
+	// Preserve the unary child reductions that feed precedence-sensitive rules.
+	// A sibling must not bypass those reductions and compete at a different state.
+	var pending []string
+	for _, name := range g.RuleOrder {
+		if preserveReduction[name] {
+			pending = append(pending, name)
+		}
+	}
+	for i := 0; i < len(pending); i++ {
+		rule := g.Rules[pending[i]]
+		alts := getTopLevelChoiceAlts(rule)
+		if alts == nil {
+			alts = []*Rule{rule}
+		}
+		for _, alt := range alts {
+			name, ok := directSymbolRefName(alt)
+			if !ok || preserveReduction[name] || g.Rules[name] == nil ||
+				(!strings.HasPrefix(name, "_") && !generatedHiddenRules[name]) {
+				continue
+			}
+			preserveReduction[name] = true
+			delete(flattenMap, name)
+			pending = append(pending, name)
+		}
+	}
 	if len(flattenMap) == 0 {
 		return g
 	}
@@ -4904,6 +4938,23 @@ func isSingleSymRef(r *Rule) bool {
 	}
 	// A single symbol, pattern, or string literal all produce cc=1 productions.
 	return r.Kind == RuleSymbol || r.Kind == RulePattern || r.Kind == RuleString
+}
+
+func passthroughHasPrecedence(r *Rule) bool {
+	for r != nil {
+		switch r.Kind {
+		case RulePrec, RulePrecLeft, RulePrecRight, RulePrecDynamic:
+			return true
+		case RuleAlias, RuleField:
+			if len(r.Children) == 0 {
+				return false
+			}
+			r = r.Children[0]
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 func directSymbolRefName(r *Rule) (string, bool) {

--- a/grammargen/parity_real_corpus_test.go
+++ b/grammargen/parity_real_corpus_test.go
@@ -283,6 +283,9 @@ func TestMultiGrammarImportRealCorpusParity(t *testing.T) {
 
 			genParser := gotreesitter.NewParser(genLang)
 			refParser := gotreesitter.NewParser(refLang)
+			// Compare grammar tables without compact routing changes.
+			genParser.SetAdmissionCandidateRoute(false)
+			refParser.SetAdmissionCandidateRoute(false)
 			if parseTimeoutMicros > 0 {
 				genParser.SetTimeoutMicros(parseTimeoutMicros)
 				refParser.SetTimeoutMicros(parseTimeoutMicros)

--- a/grammargen/scala_annotation_parity_test.go
+++ b/grammargen/scala_annotation_parity_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/odvcencio/gotreesitter"
 )
 
-func TestScalaAnnotationArgumentsMatchLockedC(t *testing.T) {
+func TestScalaConstructorOwnershipMatchesLockedC(t *testing.T) {
 	generated, reference := loadImportedParityLanguages(t, "scala")
 	tests := []struct {
 		name     string
@@ -38,16 +38,48 @@ func TestScalaAnnotationArgumentsMatchLockedC(t *testing.T) {
 			name:   "annotated_class_template_constructor_control",
 			source: "class A@a() { val c: C(42) = value }\n",
 		},
+		{
+			name:     "two_parents_with_template",
+			source:   "class F extends A with B {}\n",
+			expected: "(compilation_unit (class_definition (identifier) (extends_clause (type_identifier) (type_identifier)) (template_body)))",
+		},
+		{
+			name:     "two_parents_without_template",
+			source:   "class F extends A with B\n",
+			expected: "(compilation_unit (class_definition (identifier) (extends_clause (type_identifier) (type_identifier))))",
+		},
+		{
+			name:     "one_parent_control",
+			source:   "class F extends A {}\n",
+			expected: "(compilation_unit (class_definition (identifier) (extends_clause (type_identifier)) (template_body)))",
+		},
+		{
+			name:     "qualified_parents",
+			source:   "class F extends a.A with b.B {}\n",
+			expected: "(compilation_unit (class_definition (identifier) (extends_clause (stable_type_identifier (identifier) (type_identifier)) (stable_type_identifier (identifier) (type_identifier))) (template_body)))",
+		},
+		{
+			name:   "generic_parent",
+			source: "class A extends B[C] {}\n",
+		},
+		{
+			name:   "qualified_generic_parent",
+			source: "class A extends B.C[D, E] {}\n",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			data := []byte(test.source)
-			generatedTree, err := gotreesitter.NewParser(generated).Parse(data)
+			generatedParser := gotreesitter.NewParser(generated)
+			generatedParser.SetAdmissionCandidateRoute(false)
+			generatedTree, err := generatedParser.Parse(data)
 			if err != nil {
 				t.Fatalf("generated parse: %v", err)
 			}
 			defer generatedTree.Release()
-			referenceTree, err := gotreesitter.NewParser(reference).Parse(data)
+			referenceParser := gotreesitter.NewParser(reference)
+			referenceParser.SetAdmissionCandidateRoute(false)
+			referenceTree, err := referenceParser.Parse(data)
 			if err != nil {
 				t.Fatalf("locked C parse: %v", err)
 			}


### PR DESCRIPTION
## Change

Preserve precedence-bearing mixed hidden reductions and the unary hidden reductions that feed them. Do not flatten their alternatives into sibling rules.

The old transformation removed Scala's constructor reduction and allowed compound types to consume separate parents or a class body. Preserving only the parent reduction was insufficient: flattening its child could still change the conflict state.

The closure follows unary hidden references only. It terminates on cycles and includes generated hidden auxiliaries. Unrelated pure pass-through expansion stays unchanged.

No Scala-specific hint, LR arbitration change, repeat rewrite, parser routing change, or performance optimization remains.

## Regression coverage

- Pin static, dynamic, zero, negative, and associative precedence under field and alias wrappers.
- Assert the normalized reduction graph and exact C-derived leaves for a small A&B grammar.
- Cover wide choices, configured preservation, cycles, and generated hidden bridges.
- Compare twelve Scala annotation, inheritance, template, and generic-parent cases with the locked reference.
- Disable compact routing in generator comparisons to keep attribution separate.

## Verification

Docker checks passed for the focused normalization, conflict, JSON, calculator, and GLR tests. All twelve Scala controls passed.

Strict JavaScript corpus parity passed: 25/25 error-free, S-expression, and deep matches.

The same locked Scala corpus improved against HEAD 2c19a78c:

| Result | HEAD | This change |
|---|---:|---:|
| Error-free samples | 11/25 | 13/25 |
| Exact deep trees | 7/25 | 9/25 |

The Scala grammar remains locked to 97aead18d97708190a51d4f551ea9b05b60641c9. Strict Scala certification still fails. This PR does not close #1067 or graduate the compact route.

Independent review checked closure termination, metadata propagation, skipped roots, generated auxiliaries, and exact sample identities. No new failing sample identity appeared in the final comparison.

Reproduce the focused case with the locked Scala checkout mounted at /tmp/grammar_parity/scala:

```sh
go test ./grammargen -run '^(TestFlattenHidden|TestHiddenMixedPassthrough|TestScalaConstructorOwnershipMatchesLockedC)' -count=1
```

Run that command through cgo_harness/docker/run_parity_in_docker.sh. Use run_single_grammar_parity.sh javascript --require-parity for the independent grammar gate.