### PR TITLE
Run eligible incremental parses on the compact engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,9 @@ jobs:
           TestAdmissionSwitchCandidateDigestMatchesProduction
           TestAdmissionSwitchEligibilityFailsClosedForReuse
           TestAdmissionSwitchGrammargenLRRoutesCompactByDefault
-          TestAdmissionSwitchParseIncrementalNeverRoutes
+          TestAdmissionSwitchParseIncrementalDoesNotCountFullRoute
+          TestCompactIncrementalExecution.*
+          TestCompactBorrowed.*
           TestAdmissionSwitchParseProductionWhenOff
           TestAdmissionSwitchParseRoutesCandidateWhenOn
           TestAdmissionSwitchRecoveryDoesNotLeakCompactTree
@@ -1250,6 +1252,16 @@ jobs:
             --c-ref-build-jobs 1 \
             --timeout 20m \
             --run '^(TestCompactT3OracleAdjudication|TestCompactT3JavaScriptRecoveryProfileCharacterization|TestCompactT3JavaScriptRecoveryRouteSeedOracleParity|TestCompactT3JavaScriptRecoveryMutationDifferential|TestCompactJavaScriptS5RecoveryMutationDifferential|TestCompactRouteLockedCExceptions)$'
+
+      - name: Compact incremental Go execution
+        run: |
+          bash cgo_harness/docker/run_parity_in_docker.sh \
+            --label ci-compact-incremental-go-execution \
+            --memory 4g \
+            --cpus 2 \
+            --gomemlimit 3GiB \
+            --wall-timeout 10m \
+            -- "cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^(TestGoCompactIncrementalExecutionParity|TestStage6GoCompactCertification)$' -count=1 -parallel 1 -timeout 5m -v"
 
       - name: Compact recovery incremental JavaScript witnesses
         run: |

--- a/admission_switch_candidate_test.go
+++ b/admission_switch_candidate_test.go
@@ -202,10 +202,8 @@ func TestAdmissionSwitchEligibilityFailsClosedForReuse(t *testing.T) {
 	}
 }
 
-// TestAdmissionSwitchParseIncrementalNeverRoutes proves that even with the
-// switch forced on, ParseIncremental stays on production: the candidate route's
-// routed counter never moves across an incremental reparse.
-func TestAdmissionSwitchParseIncrementalNeverRoutes(t *testing.T) {
+// Incremental attempts must not change counters reserved for full parsing.
+func TestAdmissionSwitchParseIncrementalDoesNotCountFullRoute(t *testing.T) {
 	resetAdmissionCandidateCounters()
 	p := newAdmissionCandidateGoParser(t)
 	p.SetAdmissionCandidateRoute(true)
@@ -238,10 +236,10 @@ func TestAdmissionSwitchParseIncrementalNeverRoutes(t *testing.T) {
 	}
 	routedAfterIncremental, _ := AdmissionCandidateCounters()
 	if routedAfterIncremental != routedAfterFresh {
-		t.Fatalf("ParseIncremental routed to the candidate: routed %d -> %d", routedAfterFresh, routedAfterIncremental)
+		t.Fatalf("ParseIncremental changed full-route counts: %d -> %d", routedAfterFresh, routedAfterIncremental)
 	}
-	if newTree != nil && newTree.compactMaterialized {
-		t.Fatal("ParseIncremental produced a compact-materialized tree")
+	if newTree != nil && newTree.compactMaterialized && !newTree.rawParseRuntime().CompactIncrementalReuseRoute {
+		t.Fatal("ParseIncremental published a compact tree without incremental execution")
 	}
 }
 

--- a/admission_switch_stub.go
+++ b/admission_switch_stub.go
@@ -2,6 +2,10 @@
 
 package gotreesitter
 
+func (p *Parser) attemptCompactIncrementalParse(_ []byte, _ *Tree, _ *incrementalParseTiming) (*Tree, string) {
+	return nil, ""
+}
+
 // tryCompactFullParseRoute is the emergency-build stub for the compact
 // candidate route. Phase-3 admission promoted the compact engine into the
 // default build; the emergency opt-out tag gts_no_parsercorephase0 compiles the

--- a/admission_switch_stub.go
+++ b/admission_switch_stub.go
@@ -2,6 +2,8 @@
 
 package gotreesitter
 
+func (p *Parser) recordLegacyParserEntry() {}
+
 func (p *Parser) attemptCompactIncrementalParse(_ []byte, _ *Tree, _ *incrementalParseTiming) (*Tree, string) {
 	return nil, ""
 }

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -153,10 +153,8 @@ func TestAdmissionSwitchGlobalOnRoutesFreshParse(t *testing.T) {
 	}
 }
 
-// TestAdmissionSwitchParseIncrementalNeverConsultsCandidate proves that even
-// with the switch forced on, ParseIncremental never consults the candidate
-// route: it is a reuse-consuming path barred from compact trees.
-func TestAdmissionSwitchParseIncrementalNeverConsultsCandidate(t *testing.T) {
+// Incremental attempts must not change counters reserved for full parsing.
+func TestAdmissionSwitchParseIncrementalDoesNotCountFullCandidate(t *testing.T) {
 	restore := gts.AdmissionCandidateRouteDefault()
 	defer gts.SetAdmissionCandidateRouteDefault(restore)
 	gts.SetAdmissionCandidateRouteDefault(true)
@@ -189,7 +187,7 @@ func TestAdmissionSwitchParseIncrementalNeverConsultsCandidate(t *testing.T) {
 		defer newTree.Release()
 	}
 	if got := admissionRoutingEvents(t); got != before {
-		t.Fatalf("ParseIncremental consulted the candidate route: %d -> %d", before, got)
+		t.Fatalf("ParseIncremental changed full-route counts: %d -> %d", before, got)
 	}
 }
 

--- a/cgo_harness/go_compact_incremental_execution_test.go
+++ b/cgo_harness/go_compact_incremental_execution_test.go
@@ -1,0 +1,104 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package cgoharness
+
+import (
+	"bytes"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestGoCompactIncrementalExecutionParity(t *testing.T) {
+	for _, tc := range []struct {
+		name, separator, before, after string
+		reuse                          bool
+	}{
+		{"growth", "", "1", "1+3", true},
+		{"comment", "// between declarations\n", "1", "1+3", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := []byte("package p\nfunc a() { _ = 1 }\n" + tc.separator + "func b() { _ = 2 }\n")
+			offset := bytes.Index(source, []byte(tc.before))
+			edited := bytes.Replace(source, []byte(tc.before), []byte(tc.after), 1)
+			edit := gts.InputEdit{StartByte: uint32(offset), OldEndByte: uint32(offset + len(tc.before)), NewEndByte: uint32(offset + len(tc.after)), StartPoint: pointAtOffset(source, offset), OldEndPoint: pointAtOffset(source, offset+len(tc.before)), NewEndPoint: pointAtOffset(edited, offset+len(tc.after))}
+			language := grammars.GoLanguage()
+			parser := gts.NewParser(language)
+			parser.SetAdmissionCandidateRoute(true)
+			old, err := parser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			oldB := findGoNodeByTypeAndStart(old.RootNode(), language, "function_declaration", uint32(bytes.Index(source, []byte("func b"))))
+			if oldB == nil {
+				old.Release()
+				t.Fatal("initial tree has no function b")
+			}
+			old.Edit(edit)
+			routed, fallback := gts.AdmissionCandidateCounters()
+			next, profile, err := parser.ParseIncrementalProfiled(edited, old)
+			old.Release()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer next.Release()
+			if r, f := gts.AdmissionCandidateCounters(); r != routed || f != fallback {
+				t.Fatal("incremental parse changed full admission counters")
+			}
+			if tc.reuse {
+				newB := findGoNodeByTypeAndStart(next.RootNode(), language, "function_declaration", uint32(bytes.Index(edited, []byte("func b"))))
+				if newB != oldB {
+					t.Fatal("function b lost its node identity")
+				}
+				if profile.ReuseUnsupported || !profile.OldTreeReuseRoute || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+					t.Fatalf("missing reuse: %+v", profile)
+				}
+			}
+			cLanguage, err := ParityCLanguage("go")
+			if err != nil {
+				t.Fatal(err)
+			}
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cOld := cParser.Parse(source, nil)
+			if cOld == nil {
+				t.Fatal("C parser returned no source tree")
+			}
+			cEdit := realCorpusCInputEdit(edit)
+			cOld.Edit(&cEdit)
+			cIncremental := cParser.Parse(edited, cOld)
+			cOld.Close()
+			cFresh := cParser.Parse(edited, nil)
+			if cIncremental == nil || cFresh == nil {
+				t.Fatal("C parser returned no result")
+			}
+			defer cIncremental.Close()
+			defer cFresh.Close()
+			for _, oracle := range []*sitter.Tree{cFresh, cIncremental} {
+				if next.RootNode().HasError() != oracle.RootNode().HasError() {
+					t.Fatal("root error differs from C")
+				}
+				if diff := FirstDivergenceDumpV1(next.RootNode(), language, oracle.RootNode()); diff != nil {
+					t.Fatalf("C tree divergence: %+v", diff)
+				}
+				if diff := firstLockedCTreeFlagDivergence(next.RootNode(), language, oracle.RootNode(), "/source_file"); diff != nil {
+					t.Fatal(diff)
+				}
+				if tc.reuse {
+					assertLockedCTreeExact(t, tc.name, next, language, oracle)
+				}
+			}
+			if tc.reuse {
+				runtime := next.ParseRuntime()
+				if !runtime.CompactIncrementalReuseRoute || runtime.CompactIncrementalReusedSubtrees == 0 || runtime.CompactIncrementalReusedBytes == 0 {
+					t.Fatalf("missing compact execution: decline=%q", runtime.CompactIncrementalFallbackReason)
+				}
+			}
+		})
+	}
+}

--- a/compact_incremental_execution_test.go
+++ b/compact_incremental_execution_test.go
@@ -36,7 +36,8 @@ func TestCompactIncrementalExecutionLifetime(t *testing.T) {
 				}
 				old.Edit(edit)
 				routed, fallback := AdmissionCandidateCounters()
-				legacyRuns := parser.legacyParseRuns
+				runner := parser.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+				legacyRuns := runner.legacyParseRuns
 				next, profile, err := parser.ParseIncrementalProfiled(edited, old)
 				if err != nil {
 					t.Fatal(err)
@@ -56,7 +57,7 @@ func TestCompactIncrementalExecutionLifetime(t *testing.T) {
 				if !next.compactMaterialized {
 					t.Fatalf("incremental tree is not compact: replacement=%q decline=%q", replacement, next.rawParseRuntime().CompactIncrementalFallbackReason)
 				}
-				if parser.legacyParseRuns != legacyRuns {
+				if runner.legacyParseRuns != legacyRuns {
 					t.Fatal("compact incremental parse invoked the legacy parser")
 				}
 				runtime := next.ParseRuntime()

--- a/compact_incremental_execution_test.go
+++ b/compact_incremental_execution_test.go
@@ -1,0 +1,342 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCompactIncrementalExecutionLifetime(t *testing.T) {
+	for _, separator := range []string{"", "// between declarations\n"} {
+		t.Run(separator, func(t *testing.T) {
+			source := []byte("package p\nfunc a() { _ = 1 }\n" + separator + "func b() { _ = 2 }\n")
+			parser := newAdmissionCandidateGoParser(t)
+			parser.SetAdmissionCandidateRoute(true)
+			old, err := parser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if old != nil {
+					old.Release()
+				}
+			}()
+			if !old.compactMaterialized {
+				t.Fatal("initial tree is not compact")
+			}
+			for _, replacement := range []string{"1+3", "1+3+4"} {
+				offset := bytes.IndexByte(source, '1')
+				end := bytes.Index(source[offset:], []byte(" }")) + offset
+				edited, edit := compactExecutionEdit(source, offset, end, replacement)
+				oldB := compactExecutionNode(old.RootNode(), parser.language, "function_declaration", uint32(bytes.Index(source, []byte("func b"))))
+				if oldB == nil {
+					t.Fatal("initial tree has no function b")
+				}
+				old.Edit(edit)
+				routed, fallback := AdmissionCandidateCounters()
+				legacyRuns := parser.legacyParseRuns
+				next, profile, err := parser.ParseIncrementalProfiled(edited, old)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if next == old {
+					t.Fatal("edited parse returned the old tree")
+				}
+				old.Release()
+				old = next
+				if r, f := AdmissionCandidateCounters(); r != routed || f != fallback {
+					t.Fatal("incremental parse changed full admission counters")
+				}
+				newB := compactExecutionNode(next.RootNode(), parser.language, "function_declaration", uint32(bytes.Index(edited, []byte("func b"))))
+				if newB != oldB {
+					t.Fatalf("function b lost its node identity: decline=%q", next.rawParseRuntime().CompactIncrementalFallbackReason)
+				}
+				if !next.compactMaterialized {
+					t.Fatalf("incremental tree is not compact: replacement=%q decline=%q", replacement, next.rawParseRuntime().CompactIncrementalFallbackReason)
+				}
+				if parser.legacyParseRuns != legacyRuns {
+					t.Fatal("compact incremental parse invoked the legacy parser")
+				}
+				runtime := next.ParseRuntime()
+				if !runtime.CompactIncrementalReuseRoute || runtime.CompactIncrementalReusedSubtrees == 0 || runtime.CompactIncrementalReusedBytes == 0 {
+					t.Fatalf("missing compact execution: %+v", runtime)
+				}
+				if runtime.CompactIncrementalReusedSubtrees != profile.ReusedSubtrees || runtime.CompactIncrementalReusedBytes != profile.ReusedBytes {
+					t.Fatalf("compact reuse counters disagree with the profile: runtime=%+v profile=%+v", runtime, profile)
+				}
+				if profile.ReuseUnsupported || !profile.OldTreeReuseRoute || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+					t.Fatalf("missing reuse: %+v", profile)
+				}
+				if !runtime.IncrementalOldTreeReuseRoute || profile.StopReason != ParseStopAccepted ||
+					profile.LastTokenEndByte != uint32(len(edited)) || profile.ExpectedEOFByte != uint32(len(edited)) ||
+					profile.ReuseCursorNanos <= 0 || profile.ReparseNanos <= 0 ||
+					profile.NewNodesAllocated != uint64(runtime.NodesAllocated) {
+					t.Fatalf("compact profile omitted execution metadata: %+v", profile)
+				}
+				if next.RootNode().HasError() || newB.Text(edited) != "func b() { _ = 2 }" {
+					t.Fatal("released source tree damaged the result")
+				}
+				freshParser := NewParser(parser.language)
+				freshParser.SetAdmissionCandidateRoute(true)
+				fresh, err := freshParser.Parse(edited)
+				if err != nil {
+					t.Fatal(err)
+				}
+				freshRuntime := fresh.ParseRuntime()
+				freshCompact := fresh.compactMaterialized
+				fresh.Release()
+				if !freshCompact {
+					t.Fatal("fresh comparison tree is not compact")
+				}
+				if runtime.TokensConsumed == 0 || runtime.TokensConsumed >= freshRuntime.TokensConsumed {
+					t.Fatalf("compact reuse did not skip tokens: incremental=%d fresh=%d", runtime.TokensConsumed, freshRuntime.TokensConsumed)
+				}
+				if runtime.CompactReductions == 0 || runtime.CompactReductions >= freshRuntime.CompactReductions {
+					t.Fatalf("compact reuse did not skip reductions: incremental=%d fresh=%d", runtime.CompactReductions, freshRuntime.CompactReductions)
+				}
+				if runtime.NodesAllocated <= 0 || runtime.NodesAllocated >= freshRuntime.NodesAllocated {
+					t.Fatalf("compact reuse did not avoid node allocation: incremental=%d fresh=%d", runtime.NodesAllocated, freshRuntime.NodesAllocated)
+				}
+				copyTree := next.Copy()
+				rootRange, bRange := next.RootNode().Range(), newB.Range()
+				copySource, copyEdit := compactExecutionEdit(edited, 0, 0, "\n")
+				copyTree.Edit(copyEdit)
+				if next.RootNode().Range() != rootRange || newB.Range() != bRange || len(next.Edits()) != 0 {
+					t.Fatal("editing a copy changed the source tree")
+				}
+				if copyTree.RootNode() == next.RootNode() || copyTree.RootNode().EndByte() != uint32(len(copySource)) {
+					t.Fatal("copy did not isolate the tree")
+				}
+				copyTree.Release()
+				source = edited
+			}
+		})
+	}
+}
+
+func TestCompactIncrementalExecutionLanguageMismatch(t *testing.T) {
+	parser := newAdmissionCandidateGoParser(t)
+	parser.SetAdmissionCandidateRoute(true)
+	source := []byte("package p\nfunc a() { _ = 1 }\nfunc b() { _ = 2 }\n")
+	old, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer old.Release()
+	otherLanguage := *parser.language
+	other := NewParser(&otherLanguage)
+	other.SetAdmissionCandidateRoute(true)
+	edited, edit := compactExecutionEdit(source, bytes.IndexByte(source, '1'), bytes.IndexByte(source, '1')+1, "1+3")
+	old.Edit(edit)
+	next, profile, err := other.ParseIncrementalProfiled(edited, old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer next.Release()
+	if profile.ReusedSubtrees != 0 {
+		t.Fatalf("mismatched language reused nodes: %+v", profile)
+	}
+	if next.ParseRuntime().CompactIncrementalReuseRoute {
+		t.Fatal("mismatched language entered compact reuse")
+	}
+	if next.RootNode().HasError() {
+		t.Fatal("mismatched language fallback produced an error")
+	}
+}
+
+// This test checks recovery fallback against production. It does not certify C parity.
+func TestCompactIncrementalExecutionMissingBraceRejectsWrongSplice(t *testing.T) {
+	parser := newAdmissionCandidateGoParser(t)
+	parser.SetAdmissionCandidateRoute(true)
+	source := []byte("package p\nfunc a() { _ = 1 }\nfunc b() { _ = 2 }\n")
+	old, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer old.Release()
+	oldB := compactExecutionNode(old.RootNode(), parser.language, "function_declaration", uint32(bytes.Index(source, []byte("func b"))))
+	if oldB == nil {
+		t.Fatal("initial tree has no function b")
+	}
+	offset := bytes.IndexByte(source, '}')
+	edited, edit := compactExecutionEdit(source, offset, offset+1, "")
+	old.Edit(edit)
+	next, _, err := parser.ParseIncrementalProfiled(edited, old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer next.Release()
+	if compactExecutionContains(next.RootNode(), oldB) {
+		t.Fatal("recovery reused function b in the wrong context")
+	}
+	if next.ParseRuntime().CompactIncrementalReuseRoute {
+		t.Fatal("recovery incorrectly accepted compact incremental reuse")
+	}
+	if !next.RootNode().HasError() {
+		t.Fatal("the missing brace produced no recovery error")
+	}
+	freshParser := NewParser(parser.language)
+	freshParser.SetAdmissionCandidateRoute(false)
+	fresh, err := freshParser.Parse(edited)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fresh.Release()
+	compactExecutionEqual(t, next.RootNode(), fresh.RootNode(), parser.language)
+}
+
+func TestCompactIncrementalExecutionCancellation(t *testing.T) {
+	parser := newAdmissionCandidateGoParser(t)
+	parser.SetAdmissionCandidateRoute(true)
+	source := []byte("package p\nfunc a() { _ = 1 }\nfunc b() { _ = 2 }\n")
+	old, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer old.Release()
+	offset := bytes.IndexByte(source, '1')
+	edited, edit := compactExecutionEdit(source, offset, offset+1, "1+3")
+	old.Edit(edit)
+	cancelled := uint32(1)
+	parser.SetCancellationFlag(&cancelled)
+	next, _, err := parser.ParseIncrementalProfiled(edited, old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer next.Release()
+	if next.ParseStopReason() != ParseStopCancelled || !next.ParseStoppedEarly() {
+		t.Fatalf("cancelled incremental parse continued: %s", next.ParseRuntime().Summary())
+	}
+	if next.ParseRuntime().CompactIncrementalReuseRoute {
+		t.Fatal("cancelled parse published compact incremental success")
+	}
+	parser.SetCancellationFlag(nil)
+	retry, _, err := parser.ParseIncrementalProfiled(edited, old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer retry.Release()
+	if retry.RootNode().HasError() || !retry.ParseRuntime().CompactIncrementalReuseRoute {
+		t.Fatal("cancelled attempt damaged the next compact parse")
+	}
+}
+
+func TestCompactIncrementalExecutionMemoryBudgetReleasesRetention(t *testing.T) {
+	requireCandidateRouteBudgetMB(t, 128)
+	parser := newAdmissionCandidateGoParser(t)
+	parser.SetAdmissionCandidateRoute(true)
+	source := []byte("package p\nfunc a() {\n" + strings.Repeat("_ = 1\n", 5000) + "}\nfunc b() { _ = 2 }\n")
+	old, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer old.Release()
+	if !old.compactMaterialized || old.RootNode().HasError() {
+		t.Fatal("memory test requires a clean compact source tree")
+	}
+	oldB := compactExecutionNode(old.RootNode(), parser.language, "function_declaration", uint32(bytes.Index(source, []byte("func b"))))
+	if oldB == nil {
+		t.Fatal("initial tree has no function b")
+	}
+	offset := bytes.IndexByte(source, '1')
+	edited, edit := compactExecutionEdit(source, offset, offset+1, "1+3")
+	old.Edit(edit)
+	snapshot := old.Copy()
+	defer snapshot.Release()
+	before := admissionCandidateCompactFootprintBytes(parser)
+	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "1")
+	ResetParseEnvConfigCacheForTests()
+	DrainArenaPools()
+	stopped, _, err := parser.ParseIncrementalProfiled(edited, old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopped.Release()
+	runtime := stopped.ParseRuntime()
+	if runtime.CompactIncrementalReuseRoute || !strings.Contains(runtime.CompactIncrementalFallbackReason, "memory_budget") {
+		t.Fatalf("low budget did not decline compact reuse: route=%t reason=%q", runtime.CompactIncrementalReuseRoute, runtime.CompactIncrementalFallbackReason)
+	}
+	if got := admissionCandidateCompactStorageBytes(parser); got != 0 {
+		t.Fatalf("declined runner retains %d live bytes", got)
+	}
+	after := admissionCandidateCompactFootprintBytes(parser)
+	if after >= before || after > 64<<20 {
+		t.Fatalf("declined runner did not release retained capacity: before=%d after=%d", before, after)
+	}
+	runner, ok := parser.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+	if !ok || runner == nil {
+		t.Fatal("the cached compact runner disappeared")
+	}
+	if runner.options.compactIncrementalReuse != nil || runner.scheduler.options.compactIncrementalReuse != nil || runner.scratch.incrementalReuse != nil {
+		t.Fatal("declined runner retains borrowed tree references")
+	}
+	compactExecutionEqual(t, old.RootNode(), snapshot.RootNode(), parser.language)
+	if oldB.Text(edited) != "func b() { _ = 2 }" {
+		t.Fatal("budget decline damaged the old sibling")
+	}
+	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "128")
+	ResetParseEnvConfigCacheForTests()
+	retry, _, err := parser.ParseIncrementalProfiled(edited, old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer retry.Release()
+	if !retry.ParseRuntime().CompactIncrementalReuseRoute || retry.RootNode().HasError() {
+		t.Fatalf("budget reset did not restore compact reuse: %q", retry.ParseRuntime().CompactIncrementalFallbackReason)
+	}
+	if got := compactExecutionNode(retry.RootNode(), parser.language, "function_declaration", uint32(bytes.Index(edited, []byte("func b")))); got != oldB {
+		t.Fatal("budget retry lost the old sibling identity")
+	}
+}
+
+func compactExecutionContains(node, target *Node) bool {
+	if node == target {
+		return true
+	}
+	for i := 0; i < node.ChildCount(); i++ {
+		if compactExecutionContains(node.Child(i), target) {
+			return true
+		}
+	}
+	return false
+}
+
+func compactExecutionEqual(t *testing.T, actual, expected *Node, language *Language) {
+	t.Helper()
+	if actual.Symbol() != expected.Symbol() || actual.Range() != expected.Range() ||
+		actual.IsNamed() != expected.IsNamed() || actual.IsExtra() != expected.IsExtra() ||
+		actual.IsMissing() != expected.IsMissing() || actual.IsError() != expected.IsError() ||
+		actual.HasError() != expected.HasError() || actual.ChildCount() != expected.ChildCount() {
+		t.Fatalf("incremental node differs from fresh production: kind=%s range=%+v expected=%s range=%+v", actual.Type(language), actual.Range(), expected.Type(language), expected.Range())
+	}
+	for i := 0; i < actual.ChildCount(); i++ {
+		if actual.FieldNameForChild(i, language) != expected.FieldNameForChild(i, language) {
+			t.Fatal("incremental field differs from fresh production")
+		}
+		compactExecutionEqual(t, actual.Child(i), expected.Child(i), language)
+	}
+}
+
+func compactExecutionEdit(source []byte, start, end int, replacement string) ([]byte, InputEdit) {
+	edited := append([]byte(nil), source[:start]...)
+	edited = append(edited, replacement...)
+	edited = append(edited, source[end:]...)
+	return edited, InputEdit{StartByte: uint32(start), OldEndByte: uint32(end), NewEndByte: uint32(start + len(replacement)), StartPoint: admissionTestPointAtByte(source, start), OldEndPoint: admissionTestPointAtByte(source, end), NewEndPoint: admissionTestPointAtByte(edited, start+len(replacement))}
+}
+
+func compactExecutionNode(node *Node, language *Language, kind string, start uint32) *Node {
+	if node == nil {
+		return nil
+	}
+	if node.Type(language) == kind && node.StartByte() == start {
+		return node
+	}
+	for i := 0; i < node.ChildCount(); i++ {
+		if found := compactExecutionNode(node.Child(i), language, kind, start); found != nil {
+			return found
+		}
+	}
+	return nil
+}

--- a/internal/parsercorephase0/c_selection_compare.go
+++ b/internal/parsercorephase0/c_selection_compare.go
@@ -48,6 +48,14 @@ func (c *Core) CompareCSelectionSubtrees(left, right SubtreeID) (int, error) {
 		if err != nil {
 			return 0, err
 		}
+		leftReuse, leftOpaque := c.reusedSubtree(pair.left)
+		rightReuse, rightOpaque := c.reusedSubtree(pair.right)
+		if leftOpaque || rightOpaque {
+			if leftOpaque && rightOpaque && leftReuse == rightReuse {
+				continue
+			}
+			return 0, errors.New("parser-core phase zero: C selection cannot inspect an opaque reused subtree")
+		}
 		if leftRecord.symbol < rightRecord.symbol {
 			return -1, nil
 		}

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1068,6 +1068,8 @@ const (
 	subtreeExternalProvenanceExactNoExternal
 	subtreeExternalProvenanceExactHasExternal
 	subtreeExternalProvenanceInexactHasExternal
+	// Borrowed descendants remain opaque. This marker supplies no scanner provenance.
+	subtreeExternalProvenanceReusedOpaque
 )
 
 // pathMeta is stored on a graph link. ScoreDelta includes the contributions
@@ -1148,7 +1150,8 @@ type Derivation struct {
 type SubtreeView struct {
 	Symbol            Symbol
 	ProductionID      uint16
-	DynamicPrecedence int16
+	DynamicPrecedence int32
+	ReusedKey         uint32
 	StartByte         uint32
 	EndByte           uint32
 	Children          []SubtreeID
@@ -1171,16 +1174,18 @@ type SubtreeView struct {
 // must not retain or mutate them. The copying Subtree diagnostic API remains
 // the stable inspection surface.
 type MaterializationSubtreeView struct {
-	Symbol            Symbol
-	ProductionID      uint16
-	DynamicPrecedence int16
-	StartByte         uint32
-	EndByte           uint32
-	Children          []SubtreeID
-	Aliases           []Symbol
-	Extra             bool
-	External          bool
-	Terminal          bool
+	Symbol                          Symbol
+	ProductionID                    uint16
+	DynamicPrecedence               int32
+	ReusedKey                       uint32
+	ReusedPreGotoState, ReusedState StateID
+	StartByte                       uint32
+	EndByte                         uint32
+	Children                        []SubtreeID
+	Aliases                         []Symbol
+	Extra                           bool
+	External                        bool
+	Terminal                        bool
 	// ExternalScannerCheckpointStart and ExternalScannerCheckpointEnd identify
 	// the serialized scanner states before and after this terminal. They are
 	// zero when the subtree has no authenticated scanner provenance. The
@@ -1301,6 +1306,8 @@ type Core struct {
 	externalProvenance    []externalPayloadProvenance
 	missingLeafProvenance []missingLeafProvenance
 	lexerSkippedPrefixes  []lexerSkippedPrefixProvenance
+	reusedSubtrees        []reusedSubtreeProvenance
+	reuseProof            reuseValidationProof
 	// recoveryDiscontinuityReductions records parents whose stack pop crossed
 	// a null recovery edge. C counts that edge for the pop depth, but it does
 	// not add a child to the materialized subtree.
@@ -1501,6 +1508,8 @@ type checkpoint struct {
 	nodes, nodeLineages, nodeCheckpoints, links, subtrees, externalProvenance int
 	missingLeafProvenance                                                     int
 	lexerSkippedPrefixes                                                      int
+	reusedSubtrees                                                            int
+	reuseProof                                                                reuseValidationProof
 	recoveryDiscontinuityReductions                                           int
 	children, fields, aliases                                                 int
 	alternativeSpillArena                                                     int
@@ -1623,6 +1632,8 @@ func (c *Core) markInto(mark *checkpoint) {
 		externalProvenance:              len(c.externalProvenance),
 		missingLeafProvenance:           len(c.missingLeafProvenance),
 		lexerSkippedPrefixes:            len(c.lexerSkippedPrefixes),
+		reusedSubtrees:                  len(c.reusedSubtrees),
+		reuseProof:                      c.reuseProof,
 		recoveryDiscontinuityReductions: len(c.recoveryDiscontinuityReductions),
 		children:                        len(c.children), fields: len(c.fields), aliases: len(c.aliases),
 		alternativeSpillArena: len(c.alternativeSpillArena),
@@ -1737,6 +1748,11 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 	c.externalProvenance = c.externalProvenance[:mark.externalProvenance]
 	c.missingLeafProvenance = c.missingLeafProvenance[:mark.missingLeafProvenance]
 	c.lexerSkippedPrefixes = c.lexerSkippedPrefixes[:mark.lexerSkippedPrefixes]
+	c.reusedSubtrees = c.reusedSubtrees[:mark.reusedSubtrees]
+	c.reuseProof.subtrees = mark.reuseProof.subtrees
+	c.reuseProof.nodes = mark.reuseProof.nodes
+	// Invalidation remains sticky because published fragility changes can survive rollback.
+	c.reuseProof.invalid = c.reuseProof.invalid || mark.reuseProof.invalid
 	c.recoveryDiscontinuityReductions = c.recoveryDiscontinuityReductions[:mark.recoveryDiscontinuityReductions]
 	c.children = c.children[:mark.children]
 	c.fields = c.fields[:mark.fields]
@@ -2354,6 +2370,8 @@ func (c *Core) Reset() error {
 	c.externalProvenance = c.externalProvenance[:0]
 	c.missingLeafProvenance = c.missingLeafProvenance[:0]
 	c.lexerSkippedPrefixes = c.lexerSkippedPrefixes[:0]
+	c.reusedSubtrees = c.reusedSubtrees[:0]
+	c.reuseProof = reuseValidationProof{}
 	c.recoveryDiscontinuityReductions = c.recoveryDiscontinuityReductions[:0]
 	c.children = c.children[:0]
 	c.fields = c.fields[:0]
@@ -3222,9 +3240,7 @@ func (c *Core) reductionParentForPath(
 		// is fragile, since the ambiguous derivation proves the shape was
 		// not uniquely determined. Monotone set-only, safe on a shared
 		// record (see the field doc comment).
-		if rec, err := c.subtree(payload); err == nil && rec != nil && !rec.fragile {
-			rec.fragile = true
-		}
+		c.markSubtreeFragile(payload)
 	}
 	if path.recoveryDiscontinuity {
 		c.recordRecoveryDiscontinuityReduction(payload, act.ChildCount)
@@ -3466,6 +3482,7 @@ func (c *Core) publishInheritedStoredErrorCost(head Head, cost uint32) error {
 		return err
 	}
 	lineage.storedErrorCost = cost
+	c.invalidateReusedLineageProof(head.Node, *lineage)
 	return nil
 }
 
@@ -4167,7 +4184,7 @@ func (c *Core) effectivePayloadPrecedence(payloadID SubtreeID, aggregate int64) 
 	if err != nil {
 		return 0, err
 	}
-	if payload.childCount == 0 {
+	if payload.childCount == 0 && payload.externalProvenanceState != subtreeExternalProvenanceReusedOpaque {
 		return 0, nil
 	}
 	return aggregate, nil
@@ -4717,6 +4734,7 @@ func (c *Core) insertLinkBoundedWithRecovery(
 
 // subtreeExternalProvenance reports whether a payload contains an external
 // terminal and whether every such terminal has an exact scanner-state pair.
+// A language quiescence certificate removes scanner obligations without proving that external tokens are absent.
 func (c *Core) subtreeExternalProvenance(root SubtreeID) (hasExternal, exact bool, err error) {
 	record, err := c.subtree(root)
 	if err != nil {
@@ -4790,6 +4808,9 @@ func (c *Core) subtreeScannerStatePairsEqual(left, right SubtreeID) (bool, error
 		if err != nil {
 			return 0, err
 		}
+		if record.externalProvenanceState == subtreeExternalProvenanceReusedOpaque {
+			return 0, errors.New("parser-core phase zero: reused subtree has no transferred scanner-state proof")
+		}
 		if !record.external || !record.terminal {
 			return 0, nil
 		}
@@ -4819,6 +4840,9 @@ func (state subtreeExternalProvenanceState) result() (hasExternal, exact, cached
 	switch state {
 	case subtreeExternalProvenanceExactNoExternal:
 		return false, true, true
+	case subtreeExternalProvenanceReusedOpaque:
+		// Hidden descendants may contain external tokens without transferred checkpoints.
+		return true, false, true
 	case subtreeExternalProvenanceExactHasExternal:
 		return true, true, true
 	case subtreeExternalProvenanceInexactHasExternal:
@@ -5112,6 +5136,11 @@ func (c *Core) subtreesStructurallyEqual(left, right SubtreeID) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	leftReuse, leftOpaque := c.reusedSubtree(left)
+	rightReuse, rightOpaque := c.reusedSubtree(right)
+	if leftOpaque || rightOpaque {
+		return leftOpaque && rightOpaque && leftReuse == rightReuse, nil
+	}
 	if l.symbol != r.symbol || l.productionID != r.productionID || l.dynamicPrecedence != r.dynamicPrecedence ||
 		l.startByte != r.startByte || l.endByte != r.endByte || l.childCount != r.childCount ||
 		l.fieldCount != r.fieldCount || l.aliasCount != r.aliasCount ||
@@ -5178,6 +5207,9 @@ func (c *Core) shallowPayloadClass(prevID NodeID, payloadID SubtreeID) (shallowP
 	payload, err := c.subtree(payloadID)
 	if err != nil {
 		return shallowPayloadClass{}, false, err
+	}
+	if payload.externalProvenanceState == subtreeExternalProvenanceReusedOpaque {
+		return shallowPayloadClass{}, false, nil
 	}
 	// This class is the compact port of C's stack__subtree_is_equivalent
 	// (stack.c:181-197), MINUS one clause. C tests, in order: same pointer;
@@ -6174,11 +6206,14 @@ func (c *Core) Subtree(id SubtreeID) (SubtreeView, error) {
 		return SubtreeView{}, err
 	}
 	view := SubtreeView{
-		Symbol: r.symbol, ProductionID: r.productionID, DynamicPrecedence: r.dynamicPrecedence,
+		Symbol: r.symbol, ProductionID: r.productionID, DynamicPrecedence: int32(r.dynamicPrecedence),
 		StartByte: r.startByte, EndByte: r.endByte, Extra: r.extra, External: r.external, Terminal: r.terminal,
 		Missing: r.missing,
 	}
 	view.LexerSkippedPrefixStart, view.LexerSkippedPrefix = c.lexerSkippedPrefix(id)
+	if reused, ok := c.reusedSubtree(id); ok {
+		view.ReusedKey, view.DynamicPrecedence = reused.Key, reused.DynamicPrecedence
+	}
 	view.Children = append(view.Children, c.children[r.firstChild:r.firstChild+r.childCount]...)
 	view.Fields = append(view.Fields, c.fields[r.firstField:r.firstField+r.fieldCount]...)
 	view.Aliases = append(view.Aliases, c.aliases[r.firstAlias:r.firstAlias+r.aliasCount]...)
@@ -6216,6 +6251,10 @@ func (c *Core) MaterializationOrder(roots []SubtreeID, poll func() error) ([]Sub
 		next uint32
 	}
 	order := make([]SubtreeID, 0, len(c.subtrees))
+	var reusedOwners map[uint32]SubtreeID
+	if len(c.reusedSubtrees) != 0 {
+		reusedOwners = make(map[uint32]SubtreeID)
+	}
 	var work uint64
 	pollWork := func() error {
 		work++
@@ -6267,6 +6306,9 @@ func (c *Core) MaterializationOrder(roots []SubtreeID, poll func() error) ([]Sub
 			if err := c.validateMaterializationMetadata(top.id, *record); err != nil {
 				return nil, err
 			}
+			if err := c.claimReusedOwnership(top.id, reusedOwners); err != nil {
+				return nil, err
+			}
 			colors[top.id] = 2
 			order = append(order, top.id)
 			stack = stack[:len(stack)-1]
@@ -6309,7 +6351,7 @@ func (c *Core) MaterializationView(id SubtreeID) (MaterializationSubtreeView, er
 	view := MaterializationSubtreeView{
 		Symbol:            record.symbol,
 		ProductionID:      record.productionID,
-		DynamicPrecedence: record.dynamicPrecedence,
+		DynamicPrecedence: int32(record.dynamicPrecedence),
 		StartByte:         record.startByte,
 		EndByte:           record.endByte,
 		Children:          c.children[record.firstChild : record.firstChild+record.childCount],
@@ -6331,6 +6373,7 @@ func (c *Core) MaterializationView(id SubtreeID) (MaterializationSubtreeView, er
 		view.MissingDependency, view.MissingDependencyExact = c.missingLeafDependency(id)
 	}
 	view.LexerSkippedPrefixStart, view.LexerSkippedPrefix = c.lexerSkippedPrefix(id)
+	c.applyReusedMaterializationView(id, &view)
 	return view, nil
 }
 
@@ -6345,6 +6388,9 @@ func (c *Core) SubtreeArenaLen() int {
 }
 
 func (c *Core) validateMaterializationMetadata(id SubtreeID, record subtreeRecord) error {
+	if record.externalProvenanceState == subtreeExternalProvenanceReusedOpaque {
+		return c.validateReusedRecord(id, record)
+	}
 	if record.missing {
 		dependency, ok := c.missingLeafDependency(id)
 		positionedByte, addOK := addUint32Checked(dependency.StackByte, dependency.PaddingBytes)
@@ -6473,6 +6519,9 @@ func (c *Core) RawSelectedSubtreeCensus(roots []SubtreeID) (RawSelectedCensus, e
 		active[item.id] = true
 		stack = append(stack, frame{id: item.id, exit: true})
 		record := c.subtrees[item.id-1]
+		if record.externalProvenanceState == subtreeExternalProvenanceReusedOpaque {
+			return RawSelectedCensus{}, errors.New("parser-core phase zero: raw census cannot inspect a reused subtree")
+		}
 		if err := add(&census.Nodes); err != nil {
 			return census, err
 		}
@@ -7004,7 +7053,13 @@ func (c *Core) subtree(id SubtreeID) (*subtreeRecord, error) {
 	if id == 0 || uint64(id) > uint64(len(c.subtrees)) {
 		return nil, fmt.Errorf("parser-core phase zero: invalid subtree id %d", id)
 	}
-	return &c.subtrees[id-1], nil
+	record := &c.subtrees[id-1]
+	if record.externalProvenanceState == subtreeExternalProvenanceReusedOpaque {
+		if err := c.validateReusedRecord(id, *record); err != nil {
+			return nil, err
+		}
+	}
+	return record, nil
 }
 
 func (c *Core) nodeLinks(n nodeRecord) ([]linkRecord, error) {

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -147,7 +147,7 @@ func TestPinnedGoConflictAndReductionMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if view.Symbol != wantReduce.Symbol || view.ProductionID != wantReduce.ProductionID || view.DynamicPrecedence != wantReduce.DynamicPrecedence {
+	if view.Symbol != wantReduce.Symbol || view.ProductionID != wantReduce.ProductionID || view.DynamicPrecedence != int32(wantReduce.DynamicPrecedence) {
 		t.Fatalf("reduction identity = (%d,%d,%d), want (%d,%d,%d)", view.Symbol, view.ProductionID, view.DynamicPrecedence, wantReduce.Symbol, wantReduce.ProductionID, wantReduce.DynamicPrecedence)
 	}
 	if len(view.Fields) != 0 {

--- a/internal/parsercorephase0/drop_cohort_arena.go
+++ b/internal/parsercorephase0/drop_cohort_arena.go
@@ -1166,6 +1166,9 @@ func dropCohortSliceBounds(first, count uint32, length int) (int, int, error) {
 }
 
 func (c *Core) dropCohortEncodeSubtree(e *dropCohortEncoder, payload SubtreeID, depth uint64) (Symbol, error) {
+	if _, opaque := c.reusedSubtree(payload); opaque {
+		return 0, errors.New("parser-core phase zero: drop-cohort encoding cannot inspect a reused subtree")
+	}
 	if depth >= uint64(c.limits.MaxSubtrees) {
 		return 0, errors.New("parser-core phase zero: drop-cohort subtree depth cap")
 	}
@@ -1299,6 +1302,14 @@ func (c *Core) dropCohortCompareCheckpoint(left, right CheckpointID) (int, error
 func (c *Core) dropCohortCompareSubtree(left, right SubtreeID) (int, error) {
 	if left == right {
 		return 0, nil
+	}
+	leftReuse, leftOpaque := c.reusedSubtree(left)
+	rightReuse, rightOpaque := c.reusedSubtree(right)
+	if leftOpaque || rightOpaque {
+		if leftOpaque && rightOpaque && leftReuse == rightReuse {
+			return 0, nil
+		}
+		return 0, errors.New("parser-core phase zero: drop-cohort comparison cannot inspect a reused subtree")
 	}
 	l, err := c.subtree(left)
 	if err != nil {

--- a/internal/parsercorephase0/eof_admission_view.go
+++ b/internal/parsercorephase0/eof_admission_view.go
@@ -129,6 +129,9 @@ func (c *Core) VisitEOFAdmissionSubtree(
 	if record.startByte > record.endByte {
 		return fmt.Errorf("%w: subtree span is reversed", ErrEOFAdmissionMalformed)
 	}
+	if record.externalProvenanceState == subtreeExternalProvenanceReusedOpaque {
+		return fmt.Errorf("%w: recovery admission cannot inspect a reused subtree", ErrEOFAdmissionMalformed)
+	}
 	view := EOFAdmissionSubtreeView{
 		Generation:        generation,
 		Identity:          id,

--- a/internal/parsercorephase0/materialization_postorder_scratch.go
+++ b/internal/parsercorephase0/materialization_postorder_scratch.go
@@ -85,6 +85,10 @@ func (c *Core) VisitMaterializationPostorderWithScratch(
 	defer scratch.Reset()
 
 	colors := scratch.colors
+	var reusedOwners map[uint32]SubtreeID
+	if len(c.reusedSubtrees) != 0 {
+		reusedOwners = make(map[uint32]SubtreeID)
+	}
 	var visited, work uint64
 	for _, root := range roots {
 		record, err := c.subtree(root)
@@ -126,9 +130,12 @@ func (c *Core) VisitMaterializationPostorderWithScratch(
 			if err := c.validateMaterializationMetadata(top.id, *record); err != nil {
 				return err
 			}
+			if err := c.claimReusedOwnership(top.id, reusedOwners); err != nil {
+				return err
+			}
 			view := MaterializationSubtreeView{
 				Symbol: record.symbol, ProductionID: record.productionID,
-				DynamicPrecedence: record.dynamicPrecedence,
+				DynamicPrecedence: int32(record.dynamicPrecedence),
 				StartByte:         record.startByte, EndByte: record.endByte,
 				Children: c.children[record.firstChild : record.firstChild+record.childCount],
 				Extra:    record.extra, External: record.external, Terminal: record.terminal,
@@ -145,6 +152,7 @@ func (c *Core) VisitMaterializationPostorderWithScratch(
 				view.MissingDependency, view.MissingDependencyExact = c.missingLeafDependency(top.id)
 			}
 			view.LexerSkippedPrefixStart, view.LexerSkippedPrefix = c.lexerSkippedPrefix(top.id)
+			c.applyReusedMaterializationView(top.id, &view)
 			if err := visit(top.id, view); err != nil {
 				return err
 			}

--- a/internal/parsercorephase0/materialization_replay.go
+++ b/internal/parsercorephase0/materialization_replay.go
@@ -28,10 +28,12 @@ func (c *Core) MaterializationReplayChild(children MaterializationReplayChildren
 // MaterializationReplayView exposes only the compact fields that parse-state
 // replay consumes.
 type MaterializationReplayView struct {
-	Symbol   Symbol
-	Children MaterializationReplayChildren
-	Extra    bool
-	Terminal bool
+	ReusedKey                       uint32
+	ReusedPreGotoState, ReusedState StateID
+	Symbol                          Symbol
+	Children                        MaterializationReplayChildren
+	Extra                           bool
+	Terminal                        bool
 }
 
 // MaterializationReplayView returns one borrowed parse-state replay view.
@@ -40,7 +42,7 @@ func (c *Core) MaterializationReplayView(id SubtreeID) (MaterializationReplayVie
 	if err != nil {
 		return MaterializationReplayView{}, err
 	}
-	return MaterializationReplayView{
+	view := MaterializationReplayView{
 		Symbol: record.symbol,
 		Children: MaterializationReplayChildren{
 			first: record.firstChild,
@@ -48,5 +50,10 @@ func (c *Core) MaterializationReplayView(id SubtreeID) (MaterializationReplayVie
 		},
 		Extra:    record.extra,
 		Terminal: record.terminal,
-	}, nil
+	}
+	if reused, ok := c.reusedSubtree(id); ok {
+		view.ReusedKey = reused.Key
+		view.ReusedPreGotoState, view.ReusedState = reused.PreGotoState, reused.State
+	}
+	return view, nil
 }

--- a/internal/parsercorephase0/metadata_auth_ratchet_test.go
+++ b/internal/parsercorephase0/metadata_auth_ratchet_test.go
@@ -12,9 +12,10 @@ import (
 
 func TestMetadataAuthenticationLexicalProvenanceRatchet(t *testing.T) {
 	allowedRawAppenders := map[string]int{
-		"appendAuthenticatedTerminal": 0,
-		"appendSubtree":               0,
-		"reductionParentForPath":      0,
+		"PushReusedSubtreeOwnedWithPoll": 0,
+		"appendAuthenticatedTerminal":    0,
+		"appendSubtree":                  0,
+		"reductionParentForPath":         0,
 	}
 	allowedTerminalCallers := map[string]int{
 		"appendDiagnosticPayload":                     0,

--- a/internal/parsercorephase0/phase0a_selected_occurrences.go
+++ b/internal/parsercorephase0/phase0a_selected_occurrences.go
@@ -1159,6 +1159,9 @@ func phase0ASelectedCompactWindows(core *Core, namespace CoreRunNamespace, id Su
 		return subtreeRecord{}, nil, nil, nil, &Phase0AError{Kind: Phase0AErrorStaleReference, Namespace: namespace, Detail: "selected compact record is unavailable"}
 	}
 	record := core.subtrees[id-1]
+	if record.externalProvenanceState == subtreeExternalProvenanceReusedOpaque {
+		return subtreeRecord{}, nil, nil, nil, &Phase0AError{Kind: Phase0AErrorStaleReference, Namespace: namespace, Detail: "selected occurrence cannot inspect a reused subtree"}
+	}
 	childEnd := uint64(record.firstChild) + uint64(record.childCount)
 	fieldEnd := uint64(record.firstField) + uint64(record.fieldCount)
 	aliasEnd := uint64(record.firstAlias) + uint64(record.aliasCount)

--- a/internal/parsercorephase0/recovery_discontinuity.go
+++ b/internal/parsercorephase0/recovery_discontinuity.go
@@ -88,6 +88,7 @@ func (c *Core) copyRecoveryDiscontinuityLineage(source, target NodeID) error {
 	}
 	*to = *from
 	to.owner = 0
+	c.invalidateReusedLineageProof(target, *to)
 	return nil
 }
 

--- a/internal/parsercorephase0/reused_subtree.go
+++ b/internal/parsercorephase0/reused_subtree.go
@@ -1,0 +1,233 @@
+package parsercorephase0
+
+import "errors"
+
+// ReusedSubtree describes one clean public nonterminal authenticated by the scheduler.
+// Key identifies the same immutable public node throughout this core generation.
+// The scheduler authenticates source bytes, node identity, and a stateless scanner.
+// Borrowed descendants may contain external tokens. This descriptor certifies no checkpoints.
+type ReusedSubtree struct {
+	Key                 uint32
+	Symbol              Symbol
+	PreGotoState, State StateID
+	StartByte, EndByte  uint32
+	DynamicPrecedence   int32
+}
+
+type reusedSubtreeProvenance struct {
+	payload    SubtreeID
+	descriptor ReusedSubtree
+}
+
+type reuseValidationProof struct {
+	subtrees uint32
+	nodes    uint32
+	invalid  bool
+}
+
+// PushReusedSubtreeOwned publishes one opaque nonterminal through its authenticated goto.
+// The scheduler must decline conflicts and recovery after this operation.
+func (c *Core) PushReusedSubtreeOwned(owner SchedulerTransactionToken, head Head, reused ReusedSubtree) (out Head, payload SubtreeID, err error) {
+	return c.PushReusedSubtreeOwnedWithPoll(owner, head, reused, nil)
+}
+
+// PushReusedSubtreeOwnedWithPoll checks cancellation while validating newly allocated records.
+// Keys must increase strictly. The complete allocated corridor must remain clean.
+func (c *Core) PushReusedSubtreeOwnedWithPoll(owner SchedulerTransactionToken, head Head, reused ReusedSubtree, poll func() error) (out Head, payload SubtreeID, err error) {
+	err = c.RunSchedulerOwned(owner, func() error {
+		node, err := c.node(head.Node)
+		if err != nil {
+			return err
+		}
+		if reused.Key == 0 || reused.Symbol == 0 || reused.Symbol >= ErrorRegionSymbol-1 ||
+			reused.StartByte >= reused.EndByte || reused.StartByte < node.byteOffset ||
+			node.state != reused.PreGotoState || reused.State == 0 || c.reduceConflictContext ||
+			!c.metadataConstructionAuthenticated {
+			return errors.New("parser-core phase zero: invalid reused nonterminal boundary")
+		}
+		target, err := c.tables.Goto(reused.PreGotoState, reused.Symbol)
+		if err != nil {
+			return err
+		}
+		if target != reused.State {
+			return errors.New("parser-core phase zero: reused nonterminal goto mismatch")
+		}
+		if len(c.reusedSubtrees) != 0 && reused.Key <= c.reusedSubtrees[len(c.reusedSubtrees)-1].descriptor.Key {
+			return errors.New("parser-core phase zero: reused keys must increase strictly")
+		}
+		if err := c.validateReusedHead(head, poll); err != nil {
+			return err
+		}
+		payload, err = c.appendSubtreeRecord(subtreeRecord{
+			symbol: reused.Symbol, startByte: reused.StartByte, endByte: reused.EndByte,
+		}, nil, nil, nil)
+		if err != nil {
+			return err
+		}
+		c.subtrees[payload-1].externalProvenanceState = subtreeExternalProvenanceReusedOpaque
+		c.reusedSubtrees = append(c.reusedSubtrees, reusedSubtreeProvenance{payload: payload, descriptor: reused})
+		out, err = c.appendPrivate(reused.State, reused.EndByte, linkInput{
+			prev: head.Node, payload: payload, scoreDelta: int64(reused.DynamicPrecedence),
+		})
+		return err
+	})
+	if err != nil {
+		return Head{}, 0, err
+	}
+	return out, payload, nil
+}
+
+func (c *Core) validateReusedHead(head Head, poll func() error) error {
+	if c.reuseProof.invalid {
+		return errors.New("parser-core phase zero: reused corridor proof was invalidated")
+	}
+	if _, err := c.node(head.Node); err != nil {
+		return err
+	}
+	if poll == nil {
+		poll = func() error { return nil }
+	}
+	if err := poll(); err != nil {
+		return err
+	}
+	work := uint32(0)
+	step := func() error {
+		work++
+		if work&127 == 0 {
+			return poll()
+		}
+		return nil
+	}
+	// Child identifiers precede parents. Each completed prefix therefore proves all descendants.
+	for uint64(c.reuseProof.subtrees) < uint64(len(c.subtrees)) {
+		if err := step(); err != nil {
+			return err
+		}
+		id := SubtreeID(c.reuseProof.subtrees + 1)
+		r, err := c.subtree(id)
+		if err != nil {
+			return err
+		}
+		if r.missing || r.fragile || r.symbol >= ErrorRegionSymbol-1 {
+			return errors.New("parser-core phase zero: reused head contains an unclean payload")
+		}
+		if r.external && (!r.terminal || !c.externalPayloadsQuiescent) {
+			return errors.New("parser-core phase zero: reused head requires certified quiescent external tokens")
+		}
+		childEnd := uint64(r.firstChild) + uint64(r.childCount)
+		if childEnd > uint64(len(c.children)) {
+			return errors.New("parser-core phase zero: reused head has invalid child window")
+		}
+		for _, child := range c.children[r.firstChild:childEnd] {
+			if err := step(); err != nil {
+				return err
+			}
+			if child == 0 || child >= id {
+				return errors.New("parser-core phase zero: reused head has invalid child order")
+			}
+		}
+		c.reuseProof.subtrees++
+	}
+	// Graph topology is immutable. Mutation seams invalidate proofs of unsafe lineage changes.
+	for uint64(c.reuseProof.nodes) < uint64(len(c.nodes)) {
+		if err := step(); err != nil {
+			return err
+		}
+		id := NodeID(c.reuseProof.nodes + 1)
+		node := &c.nodes[id-1]
+		lineage, err := c.nodeLineage(id)
+		if err != nil {
+			return err
+		}
+		if node.pathCount != 1 || node.linkCount > 1 || !reuseLineageClean(*lineage) {
+			return errors.New("parser-core phase zero: reuse requires one clean exact corridor")
+		}
+		if node.linkCount == 0 {
+			if node.firstLink != 0 {
+				return errors.New("parser-core phase zero: reused corridor has invalid seed adjacency")
+			}
+		} else {
+			if node.firstLink == 0 || uint64(node.firstLink) > uint64(len(c.links)) {
+				return errors.New("parser-core phase zero: reused corridor has invalid link identifier")
+			}
+			link := c.links[node.firstLink-1]
+			if err := link.validateShape(); err != nil {
+				return err
+			}
+			if link.next != 0 || link.isRecoveryDiscontinuity() || link.hasOrder() || link.prev == 0 || link.prev >= id ||
+				link.payload == 0 || uint64(link.payload) > uint64(c.reuseProof.subtrees) {
+				return errors.New("parser-core phase zero: reused corridor has invalid or ambiguous ancestry")
+			}
+		}
+		c.reuseProof.nodes++
+	}
+	return poll()
+}
+
+func reuseLineageClean(lineage nodeLineageRecord) bool {
+	return lineage.storedErrorCost == 0 && !lineage.blended && !lineage.converged && lineage.set.count == 0 && lineage.lineage == 0
+}
+
+func (c *Core) invalidateReusedSubtreeProof(id SubtreeID) {
+	if id != 0 && uint64(id) <= uint64(c.reuseProof.subtrees) {
+		c.reuseProof.invalid = true
+	}
+}
+
+func (c *Core) markSubtreeFragile(id SubtreeID) {
+	if record, err := c.subtree(id); err == nil && !record.fragile {
+		record.fragile = true
+		c.invalidateReusedSubtreeProof(id)
+	}
+}
+
+func (c *Core) invalidateReusedLineageProof(id NodeID, lineage nodeLineageRecord) {
+	if id != 0 && uint64(id) <= uint64(c.reuseProof.nodes) && !reuseLineageClean(lineage) {
+		c.reuseProof.invalid = true
+	}
+}
+
+func (c *Core) reusedSubtree(id SubtreeID) (ReusedSubtree, bool) {
+	low, high := 0, len(c.reusedSubtrees)
+	for low < high {
+		mid := low + (high-low)/2
+		if c.reusedSubtrees[mid].payload < id {
+			low = mid + 1
+		} else {
+			high = mid
+		}
+	}
+	if low == len(c.reusedSubtrees) || c.reusedSubtrees[low].payload != id {
+		return ReusedSubtree{}, false
+	}
+	return c.reusedSubtrees[low].descriptor, true
+}
+
+func (c *Core) validateReusedRecord(id SubtreeID, r subtreeRecord) error {
+	reused, ok := c.reusedSubtree(id)
+	if !ok || reused.Key == 0 || reused.Symbol != r.symbol || reused.StartByte != r.startByte ||
+		reused.EndByte != r.endByte || r.startByte >= r.endByte || r.terminal || r.extra ||
+		r.external || r.missing || r.fragile || r.childCount != 0 || r.fieldCount != 0 ||
+		r.aliasCount != 0 || r.productionID != 0 || r.dynamicPrecedence != 0 {
+		return errors.New("parser-core phase zero: reused nonterminal provenance is stale")
+	}
+	return nil
+}
+
+func (c *Core) applyReusedMaterializationView(id SubtreeID, view *MaterializationSubtreeView) {
+	if reused, ok := c.reusedSubtree(id); ok {
+		view.ReusedKey = reused.Key
+		view.ReusedPreGotoState, view.ReusedState = reused.PreGotoState, reused.State
+		view.DynamicPrecedence = reused.DynamicPrecedence
+	}
+}
+
+func (c *Core) claimReusedOwnership(id SubtreeID, owners map[uint32]SubtreeID) error {
+	if reused, ok := c.reusedSubtree(id); ok {
+		if owners[reused.Key] != 0 {
+			return errors.New("parser-core phase zero: reused node has repeated public-tree ownership")
+		}
+		owners[reused.Key] = id
+	}
+	return nil
+}

--- a/internal/parsercorephase0/reused_subtree_proof_test.go
+++ b/internal/parsercorephase0/reused_subtree_proof_test.go
@@ -1,0 +1,194 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestReusedSubtreeProofVisitsScaleWithNewRecords(t *testing.T) {
+	for _, reduced := range []bool{false, true} {
+		for _, count := range []uint32{512, 1024} {
+			c, head, reused := reusedFixture(t)
+			tables := c.tables.(*fakeTable)
+			tables.gotos[tableCell{state: 1, symbol: 100}] = 1
+			polls := 0
+			err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				for index := uint32(0); index < count; index++ {
+					reused.Key, reused.State = index+1, 1
+					reused.StartByte, reused.EndByte = index, index+1
+					var err error
+					head, _, err = c.PushReusedSubtreeOwnedWithPoll(owner, head, reused, func() error { polls++; return nil })
+					if err != nil {
+						return err
+					}
+					if reduced && index > 0 {
+						// Build an authenticated binary list through the real reduction seam.
+						tables.gotos[tableCell{state: 1, symbol: 101}] = 1
+						tables.actions = map[tableCell][]Action{{state: 1, symbol: 0}: {{Type: ActionReduce, Symbol: 101, ChildCount: 2}}}
+						boundary, err := c.ClassifyBoundary(head, 0)
+						if err != nil {
+							return err
+						}
+						outputs, err := c.ReduceOutputsClassifiedIntoOwned(owner, nil, boundary, 0, ForkOrder{})
+						if err != nil {
+							return err
+						}
+						if len(outputs) != 1 {
+							t.Fatalf("list reduction produced %d outputs", len(outputs))
+						}
+						head = outputs[0].Head
+					}
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("reduced=%t count=%d: %v", reduced, count, err)
+			}
+			// Each splice adds fewer than 128 validation units. Prefix rescans would add intermediate polls.
+			if polls != 2*int(count) {
+				t.Fatalf("reduced=%t count=%d polls=%d, want %d", reduced, count, polls, 2*count)
+			}
+			if uint64(c.reuseProof.nodes) >= uint64(len(c.nodes)) || c.reuseProof.subtrees == 0 {
+				t.Fatal("proof cursors did not track publication")
+			}
+		}
+	}
+}
+
+func TestReusedSubtreeProofInvalidatesPriorMutations(t *testing.T) {
+	for _, mutation := range []string{"fragility", "lineage", "recovery cost", "lineage copy"} {
+		t.Run(mutation, func(t *testing.T) {
+			c, seed, reused := reusedFixture(t)
+			c.tables.(*fakeTable).actions = map[tableCell][]Action{{state: 1, symbol: 1}: {{Type: ActionShift, State: 1}}}
+			head, err := c.Shift(seed, 1, 0, Token{Symbol: 1, EndByte: 1}, ForkOrder{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				_, _, err := c.PushReusedSubtreeOwned(owner, head, reused)
+				return err
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch mutation {
+			case "fragility":
+				c.markSubtreeFragile(1)
+			case "lineage":
+				err = c.recordNodeLineage(seed, CleanPathRankSelected, 1)
+			case "recovery cost":
+				err = c.publishInheritedStoredErrorCost(seed, 1)
+			case "lineage copy":
+				other, appendErr := c.Seed(1, 0)
+				if appendErr != nil {
+					t.Fatal(appendErr)
+				}
+				if err = c.publishInheritedStoredErrorCost(other, 1); err == nil {
+					err = c.copyRecoveryDiscontinuityLineage(other.Node, seed.Node)
+				}
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !c.reuseProof.invalid {
+				t.Fatal("mutation did not invalidate a proven prefix")
+			}
+			reused.Key++
+			err = c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				_, _, err := c.PushReusedSubtreeOwned(owner, head, reused)
+				return err
+			})
+			if err == nil {
+				t.Fatal("stale proof admitted reuse")
+			}
+			if err := c.Reset(); err != nil {
+				t.Fatal(err)
+			}
+			if c.reuseProof != (reuseValidationProof{}) {
+				t.Fatal("reset retained a proof")
+			}
+			seed, err = c.Seed(1, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			reused.Key = 1
+			err = c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				_, _, err := c.PushReusedSubtreeOwned(owner, seed, reused)
+				return err
+			})
+			if err != nil {
+				t.Fatalf("reset failed to admit a new clean generation: %v", err)
+			}
+		})
+	}
+}
+
+func TestReusedSubtreeProofRollbackAndOrderedKeys(t *testing.T) {
+	c, head, reused := reusedFixture(t)
+	stop := errors.New("stop")
+	err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, _, err := c.PushReusedSubtreeOwned(owner, head, reused)
+		if err != nil {
+			return err
+		}
+		return stop
+	})
+	if !errors.Is(err, stop) || c.reuseProof != (reuseValidationProof{}) {
+		t.Fatalf("rollback kept unpublished proof: %+v %v", c.reuseProof, err)
+	}
+	err = c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, _, err := c.PushReusedSubtreeOwned(owner, head, reused)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := c.reuseProof
+	for _, key := range []uint32{0, 1} {
+		reused.Key = key
+		err = c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+			_, _, err := c.PushReusedSubtreeOwned(owner, head, reused)
+			return err
+		})
+		if err == nil || c.reuseProof != before || len(c.reusedSubtrees) != 1 {
+			t.Fatal("duplicate key committed")
+		}
+	}
+	err = c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if err := c.RecordHeadLineageOwned(owner, head, CleanPathRankSelected, 1, AlternativeSet{}, false, false); err != nil {
+			return err
+		}
+		return stop
+	})
+	if !errors.Is(err, stop) || !c.reuseProof.invalid || c.nodeLineages[head.Node-1].converged {
+		t.Fatal("rollback resurrected a proof or retained lineage mutation")
+	}
+}
+
+func TestReusedSubtreeProofPollRollsBackPartialValidation(t *testing.T) {
+	c, head, reused := reusedFixture(t)
+	c.tables.(*fakeTable).actions = map[tableCell][]Action{{state: 1, symbol: 1}: {{Type: ActionShift, State: 1}}}
+	for index := uint32(0); index < 300; index++ {
+		var err error
+		head, err = c.Shift(head, 1, 0, Token{Symbol: 1, StartByte: index, EndByte: index + 1}, ForkOrder{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	reused.StartByte, reused.EndByte = 300, 310
+	stop := errors.New("cancel validation")
+	polls := 0
+	err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, _, err := c.PushReusedSubtreeOwnedWithPoll(owner, head, reused, func() error {
+			polls++
+			if polls == 2 {
+				return stop
+			}
+			return nil
+		})
+		return err
+	})
+	if !errors.Is(err, stop) || polls != 2 || c.reuseProof != (reuseValidationProof{}) || len(c.reusedSubtrees) != 0 {
+		t.Fatalf("partial validation was published: %+v %v", c.reuseProof, err)
+	}
+}

--- a/internal/parsercorephase0/reused_subtree_test.go
+++ b/internal/parsercorephase0/reused_subtree_test.go
@@ -1,0 +1,310 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"unsafe"
+)
+
+func reusedFixture(t *testing.T) (*Core, Head, ReusedSubtree) {
+	t.Helper()
+	c, err := New(&fakeTable{gotos: map[tableCell]StateID{{state: 1, symbol: 100}: 2}}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := c.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c, head, ReusedSubtree{Key: 1, Symbol: 100, PreGotoState: 1, State: 2, StartByte: 2, EndByte: 10, DynamicPrecedence: math.MaxInt32}
+}
+
+func TestReusedSubtreePublicationAndWidePrecedence(t *testing.T) {
+	for _, precedence := range []int32{math.MinInt32, math.MaxInt32} {
+		c, head, reused := reusedFixture(t)
+		reused.DynamicPrecedence = precedence
+		var out Head
+		var payload SubtreeID
+		err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) (err error) {
+			out, payload, err = c.PushReusedSubtreeOwned(owner, head, reused)
+			return err
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		state, end, err := c.Boundary(out)
+		if err != nil || state != 2 || end != 10 {
+			t.Fatalf("boundary = %d, %d, %v", state, end, err)
+		}
+		paths, err := c.Derivations(out)
+		if err != nil || len(paths) != 1 || paths[0].Score != int64(precedence) {
+			t.Fatalf("paths = %+v, %v", paths, err)
+		}
+		if c.nodes[out.Node-1].precedenceMax != int64(precedence) {
+			t.Fatal("borrowed precedence was discarded as a leaf")
+		}
+		view, err := c.MaterializationView(payload)
+		if err != nil || view.ReusedKey != reused.Key || view.Terminal || len(view.Children) != 0 || view.DynamicPrecedence != precedence || view.ReusedState != 2 || view.ReusedPreGotoState != 1 {
+			t.Fatalf("view = %+v, %v", view, err)
+		}
+		replay, err := c.MaterializationReplayView(payload)
+		if err != nil || replay.ReusedKey != reused.Key || replay.Terminal || replay.ReusedState != 2 {
+			t.Fatalf("replay = %+v, %v", replay, err)
+		}
+		visits := 0
+		err = c.VisitMaterializationPostorder([]SubtreeID{payload}, nil, func(_ SubtreeID, view MaterializationSubtreeView) error {
+			visits++
+			if view.ReusedKey != reused.Key || view.DynamicPrecedence != precedence || view.Terminal {
+				t.Fatal("postorder lost borrowed metadata")
+			}
+			return nil
+		})
+		if err != nil || visits != 1 {
+			t.Fatalf("visits = %d, %v", visits, err)
+		}
+		if _, err := c.MaterializationOrder([]SubtreeID{payload, payload}, nil); err == nil {
+			t.Fatal("repeated ownership was accepted")
+		}
+		if _, err := c.BuildSelectedStore([]SubtreeID{payload}, SelectedStorePolicy{}, nil, nil); err == nil {
+			t.Fatal("selected store expanded opaque payload")
+		}
+		if unsafe.Sizeof(subtreeRecord{}) != 44 {
+			t.Fatal("subtree record grew")
+		}
+	}
+}
+
+func TestReusedSubtreeInvalidAdmission(t *testing.T) {
+	cases := []struct {
+		name  string
+		alter func(*Core, Head, *ReusedSubtree)
+	}{
+		{"zero key", func(_ *Core, _ Head, r *ReusedSubtree) { r.Key = 0 }},
+		{"wrong state", func(_ *Core, _ Head, r *ReusedSubtree) { r.PreGotoState = 3 }},
+		{"wrong goto", func(_ *Core, _ Head, r *ReusedSubtree) { r.State = 3 }},
+		{"zero width", func(_ *Core, _ Head, r *ReusedSubtree) { r.EndByte = r.StartByte }},
+		{"before head", func(c *Core, h Head, _ *ReusedSubtree) { c.nodes[h.Node-1].byteOffset = 3 }},
+		{"ambiguous", func(c *Core, h Head, _ *ReusedSubtree) { c.nodes[h.Node-1].pathCount = 2 }},
+		{"recovery", func(c *Core, h Head, _ *ReusedSubtree) { c.nodeLineages[h.Node-1].storedErrorCost = 1 }},
+		{"conflict", func(c *Core, _ Head, _ *ReusedSubtree) { c.reduceConflictContext = true }},
+		{"unauthenticated", func(c *Core, _ Head, _ *ReusedSubtree) { c.metadataConstructionAuthenticated = false }},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			c, head, reused := reusedFixture(t)
+			test.alter(c, head, &reused)
+			err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				_, _, err := c.PushReusedSubtreeOwned(owner, head, reused)
+				return err
+			})
+			if err == nil || len(c.reusedSubtrees) != 0 || len(c.subtrees) != 0 {
+				t.Fatalf("invalid admission committed: %v", err)
+			}
+		})
+	}
+}
+
+func TestReusedSubtreeRollbackResetAndOwner(t *testing.T) {
+	c, head, reused := reusedFixture(t)
+	before := c.StorageBytes()
+	stop := errors.New("stop")
+	var stale SchedulerTransactionToken
+	err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		stale = owner
+		if _, _, err := c.PushReusedSubtreeOwned(owner, head, reused); err != nil {
+			return err
+		}
+		if c.StorageBytes() < before+coreReusedSubtreeBytes || c.FootprintBytes() < coreReusedSubtreeBytes {
+			t.Fatal("borrowed sidecar omitted from memory accounting")
+		}
+		return stop
+	})
+	if !errors.Is(err, stop) || len(c.reusedSubtrees) != 0 || c.StorageBytes() != before {
+		t.Fatalf("rollback failed: %v", err)
+	}
+	if _, _, err := c.PushReusedSubtreeOwned(stale, head, reused); err == nil {
+		t.Fatal("stale owner accepted")
+	}
+	err = c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, _, err := c.PushReusedSubtreeOwned(owner, head, reused)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Reset(); err != nil || len(c.reusedSubtrees) != 0 {
+		t.Fatalf("reset failed: %v", err)
+	}
+	if cap(c.reusedSubtrees) == 0 {
+		t.Fatal("ordinary reset dropped bounded sidecar retention")
+	}
+	if err := c.ResetReleasingRetention(); err != nil || c.reusedSubtrees != nil {
+		t.Fatalf("release failed: %v", err)
+	}
+}
+
+func TestReusedSubtreeOpaqueComparisonsAndAuthentication(t *testing.T) {
+	c, head, reused := reusedFixture(t)
+	var first, same, other SubtreeID
+	err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) (err error) {
+		if _, first, err = c.PushReusedSubtreeOwned(owner, head, reused); err != nil {
+			return err
+		}
+		reused.Key++
+		_, other, err = c.PushReusedSubtreeOwned(owner, head, reused)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Corrupt publication to exercise duplicate public ownership independently of ordered-key admission.
+	same = SubtreeID(len(c.subtrees) + 1)
+	c.subtrees = append(c.subtrees, c.subtrees[first-1])
+	descriptor, _ := c.reusedSubtree(first)
+	c.reusedSubtrees = append(c.reusedSubtrees, reusedSubtreeProvenance{payload: same, descriptor: descriptor})
+	if equal, err := c.subtreesStructurallyEqual(first, same); err != nil || !equal {
+		t.Fatalf("same identity differs: %v", err)
+	}
+	if equal, err := c.subtreesStructurallyEqual(first, other); err != nil || equal {
+		t.Fatalf("different identities equal: %v", err)
+	}
+	if comparison, err := c.CompareCSelectionSubtrees(first, same); err != nil || comparison != 0 {
+		t.Fatalf("same selection identity differs: %v", err)
+	}
+	if _, err := c.CompareCSelectionSubtrees(first, other); err == nil {
+		t.Fatal("opaque C comparison guessed child count")
+	}
+	if _, err := c.dropCohortCompareSubtree(first, other); err == nil {
+		t.Fatal("drop-cohort comparison guessed opaque identity")
+	}
+	if _, err := c.MaterializationOrder([]SubtreeID{first, same}, nil); err == nil {
+		t.Fatal("distinct payloads claimed the same public node")
+	}
+	if err := c.VisitMaterializationPostorder([]SubtreeID{first, same}, nil, func(SubtreeID, MaterializationSubtreeView) error { return nil }); err == nil {
+		t.Fatal("postorder accepted repeated borrowed ownership")
+	}
+	if _, err := c.RawSelectedSubtreeCensus([]SubtreeID{first}); err == nil {
+		t.Fatal("raw census counted opaque content as a leaf")
+	}
+	if equal, err := c.shallowPayloadsEqual(head.Node, first, head.Node, other); err != nil || equal {
+		t.Fatalf("opaque shallow class compared equal: %v", err)
+	}
+	c.reusedSubtrees = nil
+	if _, err := c.MaterializationView(first); err == nil {
+		t.Fatal("missing borrowed provenance was accepted")
+	}
+	if _, err := c.MaterializationOrder([]SubtreeID{first}, nil); err == nil {
+		t.Fatal("missing provenance was treated as an empty reduction")
+	}
+}
+
+func TestReusedSubtreeReductionPreservesWideContribution(t *testing.T) {
+	c, head, reused := reusedFixture(t)
+	tables := c.tables.(*fakeTable)
+	tables.actions = map[tableCell][]Action{{state: 2, symbol: 0}: {{Type: ActionReduce, Symbol: 101, ChildCount: 1, DynamicPrecedence: -7}}}
+	tables.gotos[tableCell{state: 1, symbol: 101}] = 3
+	var borrowed SubtreeID
+	err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) (err error) {
+		head, borrowed, err = c.PushReusedSubtreeOwned(owner, head, reused)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	heads, err := c.Reduce(head, 0, 0, ForkOrder{})
+	if err != nil || len(heads) != 1 {
+		t.Fatalf("reduce = %v, %v", heads, err)
+	}
+	paths, err := c.Derivations(heads[0])
+	if err != nil || len(paths) != 1 || paths[0].Score != int64(reused.DynamicPrecedence)-7 {
+		t.Fatalf("reduced paths = %+v, %v", paths, err)
+	}
+	view, err := c.MaterializationView(paths[0].Payloads[0])
+	if err != nil || len(view.Children) != 1 || view.Children[0] != borrowed || view.ReusedKey != 0 {
+		t.Fatalf("parent = %+v, %v", view, err)
+	}
+	order, err := c.MaterializationOrder(paths[0].Payloads, nil)
+	if err != nil || len(order) != 2 || order[0] != borrowed {
+		t.Fatalf("materialization order = %v, %v", order, err)
+	}
+}
+
+func TestReusedSubtreeForeignOwnerPoisonsTransaction(t *testing.T) {
+	c, head, reused := reusedFixture(t)
+	foreign, _, _ := reusedFixture(t)
+	err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		owner.owner = foreign
+		_, _, _ = c.PushReusedSubtreeOwned(owner, head, reused)
+		return nil
+	})
+	if err == nil || len(c.subtrees) != 0 || len(c.reusedSubtrees) != 0 {
+		t.Fatal("foreign owner was accepted")
+	}
+}
+
+func TestReusedSubtreeCleanExternalAncestorRequiresQuiescence(t *testing.T) {
+	for _, test := range []struct {
+		name                        string
+		certified, fragile, missing bool
+		wantSuccess                 bool
+	}{
+		{name: "certified", certified: true, wantSuccess: true},
+		{name: "uncertified"},
+		{name: "fragile", certified: true, fragile: true},
+		{name: "missing", certified: true, missing: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c, head, reused := reusedFixture(t)
+			if test.certified {
+				c.CertifyExternalPayloadsQuiescent()
+			}
+			c.tables.(*fakeTable).actions = map[tableCell][]Action{
+				{state: 1, symbol: 1}: {{Type: ActionShift, State: 1}},
+			}
+			var err error
+			head, err = c.Shift(head, 1, 0, Token{Symbol: 1, EndByte: 1, External: true}, ForkOrder{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.subtrees[0].fragile, c.subtrees[0].missing = test.fragile, test.missing
+			err = c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				_, _, err := c.PushReusedSubtreeOwned(owner, head, reused)
+				return err
+			})
+			if (err == nil) != test.wantSuccess {
+				t.Fatalf("reuse success = %t, want %t: %v", err == nil, test.wantSuccess, err)
+			}
+		})
+	}
+}
+
+func TestReusedSubtreeDoesNotCertifyHiddenScannerProvenance(t *testing.T) {
+	c, head, reused := reusedFixture(t)
+	var payload SubtreeID
+	err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) (err error) {
+		_, payload, err = c.PushReusedSubtreeOwned(owner, head, reused)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hasExternal, exact, err := c.subtreeExternalProvenance(payload)
+	if err != nil || !hasExternal || exact {
+		t.Fatalf("opaque scanner proof = %t, %t, %v", hasExternal, exact, err)
+	}
+	view, err := c.MaterializationView(payload)
+	if err != nil || view.ExternalScannerCheckpointExact || view.ExternalScannerCheckpointStart != 0 || view.ExternalScannerCheckpointEnd != 0 {
+		t.Fatalf("borrowed checkpoint transfer = %+v, %v", view, err)
+	}
+	if _, err := c.subtreeScannerStatePairsEqual(payload, payload); err == nil {
+		t.Fatal("borrowed scanner state was assumed empty")
+	}
+	c.CertifyExternalPayloadsQuiescent()
+	if _, exact, err := c.subtreeExternalProvenance(payload); err != nil || !exact {
+		t.Fatalf("language quiescence certificate was ignored: %v", err)
+	}
+	if _, exact, _ := c.subtrees[payload-1].externalProvenanceState.result(); exact {
+		t.Fatal("language certificate rewrote opaque checkpoint provenance")
+	}
+}

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -153,6 +153,7 @@ func (c *Core) recordNodeLineage(head Head, rank CleanPathRankSelection, lineage
 	node.rank = nextRank
 	node.lineage = nextLineage
 	node.converged = nextConverged
+	c.invalidateReusedLineageProof(head.Node, *node)
 	return nil
 }
 
@@ -219,6 +220,7 @@ func (c *Core) recordNodeStoredErrorCost(head Head, cost uint32) error {
 		})
 	}
 	node.storedErrorCost = cost
+	c.invalidateReusedLineageProof(head.Node, *node)
 	return nil
 }
 
@@ -265,6 +267,7 @@ func (c *Core) recordNodeLineageSet(head Head, set AlternativeSet, setBlended bo
 		})
 	}
 	node.blended = nextBlended
+	c.invalidateReusedLineageProof(head.Node, *node)
 	return nil
 }
 
@@ -325,6 +328,7 @@ func (c *Core) recordNodeLineageMember(head Head, event, branch uint16) error {
 	if !c.alternativeSetInsert(&node.set, packAlternativeSetMember(event, branch)) {
 		return nil
 	}
+	c.invalidateReusedLineageProof(head.Node, *node)
 	if len(c.transactions) != 0 {
 		c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
 			node: head.Node, owner: node.owner, dropCohortRefs: node.dropCohortRefs,
@@ -836,6 +840,7 @@ func (c *Core) mergeNodeLineageMetadata(leftID, rightID, targetID NodeID) error 
 		})
 	}
 	*target = merged
+	c.invalidateReusedLineageProof(targetID, *target)
 	return nil
 }
 

--- a/internal/parsercorephase0/selected_store.go
+++ b/internal/parsercorephase0/selected_store.go
@@ -459,6 +459,9 @@ type selectedRawOccurrence struct {
 }
 
 func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStorePolicy, source []byte, poll func() error) (*SelectedStore, error) {
+	if c != nil && len(c.reusedSubtrees) != 0 {
+		return nil, errors.New("parser-core phase zero: selected store cannot expand reused subtrees")
+	}
 	if c == nil || len(roots) == 0 {
 		return nil, errors.New("parser-core phase zero: selected store requires accepted roots")
 	}

--- a/internal/parsercorephase0/selected_store_builder_onepass.go
+++ b/internal/parsercorephase0/selected_store_builder_onepass.go
@@ -23,6 +23,9 @@ func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy,
 // stack carries next-child/logical-window state, collect carries payload IDs,
 // and rawRoots carries packed alias/field provenance.
 func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStorePolicy, source []byte, poll func() error) (*SelectedStore, error) {
+	if c != nil && len(c.reusedSubtrees) != 0 {
+		return nil, errors.New("parser-core phase zero: selected store cannot expand reused subtrees")
+	}
 	if c == nil || len(roots) == 0 {
 		return nil, errors.New("parser-core phase zero: selected store requires accepted roots")
 	}

--- a/internal/parsercorephase0/storage_bytes.go
+++ b/internal/parsercorephase0/storage_bytes.go
@@ -63,6 +63,7 @@ func (c *Core) StorageBytes() uint64 {
 		uint64(len(c.links))*coreLinkRecordBytes +
 		uint64(len(c.dropCohortLinkRefIndexes))*coreUint32Bytes +
 		uint64(len(c.subtrees))*coreSubtreeRecordBytes +
+		uint64(len(c.reusedSubtrees))*coreReusedSubtreeBytes +
 		uint64(len(c.eofRecoveryRoots))*coreSubtreeIDBytes +
 		uint64(len(c.recoveryDiscontinuityReductions))*coreRecoveryDiscontinuityReductionBytes +
 		uint64(len(c.children))*coreChildRecordBytes +
@@ -97,6 +98,7 @@ var (
 	coreExternalProvenanceBytes             = uint64(unsafe.Sizeof(externalPayloadProvenance{}))
 	coreMissingLeafProvenanceBytes          = uint64(unsafe.Sizeof(missingLeafProvenance{}))
 	coreLexerSkippedPrefixBytes             = uint64(unsafe.Sizeof(lexerSkippedPrefixProvenance{}))
+	coreReusedSubtreeBytes                  = uint64(unsafe.Sizeof(reusedSubtreeProvenance{}))
 	coreRecoveryDiscontinuityReductionBytes = uint64(unsafe.Sizeof(recoveryDiscontinuityReduction{}))
 	coreCheckpointRecordBytes               = uint64(unsafe.Sizeof(checkpointRecord{}))
 	coreCheckpointBucketBytes               = uint64(unsafe.Sizeof([32]byte{})) + uint64(unsafe.Sizeof(CheckpointID(0)))
@@ -166,6 +168,7 @@ func (c *Core) FootprintBytes() uint64 {
 	total += uint64(cap(c.externalProvenance)) * coreExternalProvenanceBytes
 	total += uint64(cap(c.missingLeafProvenance)) * coreMissingLeafProvenanceBytes
 	total += uint64(cap(c.lexerSkippedPrefixes)) * coreLexerSkippedPrefixBytes
+	total += uint64(cap(c.reusedSubtrees)) * coreReusedSubtreeBytes
 	total += uint64(cap(c.boundaryJournal)) * coreBoundaryMutationBytes
 	total += uint64(cap(c.nodeLineageJournal)) * coreNodeLineageMutationBytes
 	total += uint64(cap(c.dropCohortLinkRefIndexes)) * coreUint32Bytes
@@ -322,6 +325,7 @@ func (c *Core) releaseRecordArenaReserve() {
 	c.dropCohortLinkRefIndexes = nil
 	c.dropCohortLinkRefJournal = nil
 	c.subtrees = nil
+	c.reusedSubtrees = nil
 	c.eofRecoveryRoots = nil
 	c.recoveryDiscontinuityReductions = nil
 	c.missingLeafProvenance = nil
@@ -356,6 +360,7 @@ func (c *Core) releaseOversizedRetention() {
 	c.dropCohortLinkRefIndexes = nil
 	c.dropCohortLinkRefJournal = nil
 	c.subtrees = nil
+	c.reusedSubtrees = nil
 	c.eofRecoveryRoots = nil
 	c.recoveryDiscontinuityReductions = nil
 	c.externalProvenance = nil

--- a/parser.go
+++ b/parser.go
@@ -17,8 +17,6 @@ import (
 // Parser is not safe for concurrent use. Use one parser per goroutine, a
 // ParserPool, or guard shared parser instances with external synchronization.
 type Parser struct {
-	// legacyParseRuns counts actual legacy engine entries for route verification.
-	legacyParseRuns     uint64
 	language            *Language
 	reuseCursor         reuseCursor
 	reuseScratch        reuseScratch
@@ -4597,7 +4595,7 @@ func compactPackedGSSVersionOrderActiveForParse(language *Language, reuse *reuse
 // Stacks that error out are dropped. Only duplicate stack versions are
 // merged; distinct alternatives are preserved.
 func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor, oldTree *Tree, arenaClass arenaClass, timing *incrementalParseTiming, maxStacksOverride int, maxNodesOverride int, maxMergePerKeyOverride int, deterministicExternalConflicts bool) *Tree {
-	p.legacyParseRuns++
+	p.recordLegacyParserEntry()
 	workCountAttempt := workCountBeginParseAttempt(maxStacksOverride, maxNodesOverride, maxMergePerKeyOverride)
 	parseStart := time.Now()
 	previousMemoryBudgetDiag := p.parseMemoryBudgetDiag

--- a/parser.go
+++ b/parser.go
@@ -17,6 +17,8 @@ import (
 // Parser is not safe for concurrent use. Use one parser per goroutine, a
 // ParserPool, or guard shared parser instances with external synchronization.
 type Parser struct {
+	// legacyParseRuns counts actual legacy engine entries for route verification.
+	legacyParseRuns     uint64
 	language            *Language
 	reuseCursor         reuseCursor
 	reuseScratch        reuseScratch
@@ -4595,6 +4597,7 @@ func compactPackedGSSVersionOrderActiveForParse(language *Language, reuse *reuse
 // Stacks that error out are dropped. Only duplicate stack versions are
 // merged; distinct alternatives are preserved.
 func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor, oldTree *Tree, arenaClass arenaClass, timing *incrementalParseTiming, maxStacksOverride int, maxNodesOverride int, maxMergePerKeyOverride int, deterministicExternalConflicts bool) *Tree {
+	p.legacyParseRuns++
 	workCountAttempt := workCountBeginParseAttempt(maxStacksOverride, maxNodesOverride, maxMergePerKeyOverride)
 	parseStart := time.Now()
 	previousMemoryBudgetDiag := p.parseMemoryBudgetDiag

--- a/parser_api.go
+++ b/parser_api.go
@@ -1703,14 +1703,21 @@ func (p *Parser) ParseIncremental(source []byte, oldTree *Tree) (*Tree, error) {
 	}
 	operationBudget := p.beginParseOperationBudget()
 	defer p.endParseOperationBudget(operationBudget)
-	return p.parseIncrementalChanged(source, oldTree)
+	tree, reason := p.attemptCompactIncrementalParse(source, oldTree, nil)
+	if tree != nil {
+		return tree, nil
+	}
+	tree, err := p.parseIncrementalChanged(source, oldTree)
+	if tree != nil && tree != oldTree {
+		tree.parseRuntime.CompactIncrementalFallbackReason = reason
+	}
+	return tree, err
 }
 
 func (p *Parser) parseIncrementalChanged(source []byte, oldTree *Tree) (*Tree, error) {
 	endParseBudget := p.enterParseBudget()
 	defer endParseBudget()
-	// ParseIncremental is a reuse-consuming path: keep the whole call, including
-	// the reuse-disabled fresh-parse fallback to Parse below, on production.
+	// The compact attempt has declined. Keep this fallback on the legacy engine.
 	defer p.suppressAdmissionCandidateRoute()()
 	p.fullParseRetryPassesTaken = 0
 	if oldTree != nil && oldTree.language != p.language {
@@ -1892,14 +1899,28 @@ func (p *Parser) ParseIncrementalProfiled(source []byte, oldTree *Tree) (*Tree, 
 	}
 	operationBudget := p.beginParseOperationBudget()
 	defer p.endParseOperationBudget(operationBudget)
-	return p.parseIncrementalChangedProfiled(source, oldTree)
+	var compactTiming incrementalParseTiming
+	tree, reason := p.attemptCompactIncrementalParse(source, oldTree, &compactTiming)
+	if tree != nil {
+		return tree, compactTiming.toProfile(), nil
+	}
+	tree, profile, err := p.parseIncrementalChangedProfiled(source, oldTree)
+	profile.ReuseCursorNanos += compactTiming.reuseNanos
+	profile.ReparseNanos += max(int64(0), compactTiming.totalNanos-compactTiming.reuseNanos)
+	profile.ReusedSubtrees += compactTiming.reusedSubtrees
+	profile.ReusedBytes += compactTiming.reusedBytes
+	profile.TokensConsumed += compactTiming.tokensConsumed
+	profile.NewNodesAllocated += compactTiming.newNodes
+	if tree != nil && tree != oldTree {
+		tree.parseRuntime.CompactIncrementalFallbackReason = reason
+	}
+	return tree, profile, err
 }
 
 func (p *Parser) parseIncrementalChangedProfiled(source []byte, oldTree *Tree) (*Tree, IncrementalParseProfile, error) {
 	endParseBudget := p.enterParseBudget()
 	defer endParseBudget()
-	// Reuse-consuming path: keep the reuse-disabled fresh-parse fallback below on
-	// production so ParseIncremental never publishes a compact tree.
+	// The compact attempt has declined. Keep this fallback on the legacy engine.
 	defer p.suppressAdmissionCandidateRoute()()
 	p.fullParseRetryPassesTaken = 0
 	if oldTree != nil && oldTree.language != p.language {

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -3158,10 +3158,11 @@ func TestRecoveryMemoTelemetryPreservesAMD64HotLayouts(t *testing.T) {
 	if got, want := unsafe.Sizeof(Parser{}), uintptr(2224); got != want {
 		t.Fatalf("Parser size = %d, want %d", got, want)
 	}
-	if got, want := unsafe.Sizeof(ParseRuntime{}), uintptr(3040); got != want {
+	// Compact incremental results add 48 bytes of route, reuse, and work telemetry.
+	if got, want := unsafe.Sizeof(ParseRuntime{}), uintptr(3088); got != want {
 		t.Fatalf("ParseRuntime size = %d, want %d", got, want)
 	}
-	if got, want := unsafe.Sizeof(Tree{}), uintptr(3240); got != want {
+	if got, want := unsafe.Sizeof(Tree{}), uintptr(3288); got != want {
 		t.Fatalf("Tree size = %d, want %d", got, want)
 	}
 	if got, want := unsafe.Offsetof(Parser{}.cNodeMemoPeakTier), unsafe.Offsetof(Parser{}.crecoveryCostCompetitionRelevant)+2; got != want {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -50,10 +50,12 @@ const (
 )
 
 type DiagnosticParserCorePrefixOptions struct {
-	Recovery       bool
-	Retry          bool
-	Incremental    bool
-	IncludedRanges bool
+	// compactIncrementalReuse belongs to one public incremental attempt.
+	compactIncrementalReuse *compactIncrementalReuseSession
+	Recovery                bool
+	Retry                   bool
+	Incremental             bool
+	IncludedRanges          bool
 	// GenericStopAtClosedByte publishes a successful closed-frontier receipt
 	// when every authenticated scheduler head closes at this byte. Nil is
 	// unbounded. The boundary is checked before another scanner election.
@@ -2687,7 +2689,7 @@ func canonicalizeDiagnosticParserCoreHeaders(compact *core.Core, headers []diagn
 func diagnosticParserCoreTerminalPayloadView(id uint32, view core.SubtreeView) DiagnosticParserCoreTerminalPayloadView {
 	converted := DiagnosticParserCoreTerminalPayloadView{
 		ID: id, Symbol: Symbol(view.Symbol), ProductionID: view.ProductionID,
-		DynamicPrecedence: view.DynamicPrecedence, StartByte: view.StartByte, EndByte: view.EndByte,
+		DynamicPrecedence: int16(view.DynamicPrecedence), StartByte: view.StartByte, EndByte: view.EndByte,
 		Extra: view.Extra, External: view.External, Terminal: view.Terminal,
 	}
 	for _, child := range view.Children {
@@ -6174,9 +6176,10 @@ const parserCoreMaxRetainedLineStarts = 256 * 1024
 // arena reuse: the warm steady state stops re-allocating the public-tree
 // scratch on every parse.
 type parserCoreRunnerScratch struct {
-	materialization diagnosticParserCoreMaterializationScratch
-	postorder       core.MaterializationPostorderScratch
-	acceptedLeaves  diagnosticParserCoreAcceptedLeafCoverageScratch
+	materialization  diagnosticParserCoreMaterializationScratch
+	postorder        core.MaterializationPostorderScratch
+	acceptedLeaves   diagnosticParserCoreAcceptedLeafCoverageScratch
+	incrementalReuse *compactIncrementalReuseSession
 	// recoveryTerminalAliasSymbol is valid only when the exact artifact rule
 	// also set recoveryTerminalAliasCertified for this materialization.
 	recoveryTerminalAliasSymbol    Symbol
@@ -6198,6 +6201,7 @@ type diagnosticParserCoreAcceptedLeafSpan struct {
 	startByte uint32
 	endByte   uint32
 	hidden    bool
+	borrowed  *Node
 }
 
 type diagnosticParserCoreAcceptedLeafCoverageScratch struct {
@@ -6335,7 +6339,7 @@ func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) hasVisibleTermin
 	})
 	for index < len(scratch.spans) && scratch.spans[index].startByte == startByte {
 		span := scratch.spans[index]
-		if !span.hidden && span.endByte == endByte && uint64(span.id) < uint64(len(nodesByID)) && nodesByID[span.id] == node {
+		if !span.hidden && span.borrowed == nil && span.endByte == endByte && uint64(span.id) < uint64(len(nodesByID)) && nodesByID[span.id] == node {
 			return true
 		}
 		index++
@@ -6447,6 +6451,7 @@ func (s *parserCoreRunnerScratch) resetTreeBuffers() {
 	}
 	s.postorder.Reset()
 	s.acceptedLeaves.reset()
+	s.incrementalReuse = nil
 	s.recoveryTerminalAliasSymbol = 0
 	s.recoveryTerminalAliasCertified = false
 	s.nodesByID = clearNodeScratch(s.nodesByID)
@@ -6794,6 +6799,15 @@ func diagnosticParserCoreAcceptedTreeLeafCoverageGap(root *Node, source []byte, 
 			if err := poll(); err != nil {
 				return err
 			}
+		}
+		if coverage.hasBorrowedSubtree(n) {
+			if n.startByte > cur {
+				if ok, gapErr := acceptGap(cur, n.startByte); gapErr != nil || !ok {
+					return gapErr
+				}
+			}
+			cur = max(cur, n.endByte)
+			return nil
 		}
 		count := n.ChildCount()
 		if count == 0 {
@@ -7157,14 +7171,19 @@ const (
 // the default path unchanged. A tagged diagnostic caller can request the
 // locked-C recover_eof root rule.
 func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compact *core.Core, head core.Head, payloads []core.SubtreeID, parser *Parser, source []byte, scratch *parserCoreRunnerScratch, forceReplayParseStates bool, allowErrorRoot bool, rootFinalization diagnosticParserCoreRootFinalization) (*Tree, error) {
+	var incrementalReuse *compactIncrementalReuseSession
+	if scratch != nil {
+		incrementalReuse = scratch.incrementalReuse
+		defer scratch.resetTreeBuffers()
+	}
 	if compact == nil || parser == nil || parser.language == nil || head.Node == 0 || len(payloads) == 0 {
 		return nil, errors.New("parser-core phase zero: incomplete accepted-tree selection input")
 	}
 	if rootFinalization != diagnosticParserCoreFinalizeDefault && rootFinalization != diagnosticParserCoreFinalizeRecoverEOF {
 		return nil, errors.New("parser-core phase zero: unknown accepted-root finalization")
 	}
-	if scratch != nil {
-		defer scratch.resetTreeBuffers()
+	if incrementalReuse != nil && (allowErrorRoot || rootFinalization != diagnosticParserCoreFinalizeDefault) {
+		return nil, compactIncrementalMaterializationDecline("borrowed subtrees require clean default root finalization")
 	}
 	stats, err := compact.Stats(head)
 	if err != nil {
@@ -7183,13 +7202,24 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 		}
 	}
 	owned := true
+	allocationRecorded := false
+	recordAllocation := func() {
+		if !allocationRecorded && incrementalReuse != nil && incrementalReuse.timing != nil {
+			incrementalReuse.timing.newNodes += uint64(arena.used)
+		}
+		allocationRecorded = true
+	}
 	defer func() {
+		recordAllocation()
 		if owned {
 			arena.Release()
 		}
 	}()
 	poll := func() error {
 		reason := parser.resultMaterializationStopReason(arena)
+		if !resultMaterializationShouldStop(reason) && incrementalReuse != nil && incrementalReuse.scheduler != nil {
+			reason = incrementalReuse.scheduler.stopControlMemoryBudgetReasonWithAdditionalBytes(arenaAllocatedVolume(arena))
+		}
 		if !resultMaterializationShouldStop(reason) {
 			return nil
 		}
@@ -7235,7 +7265,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 	// pass elides hidden nodes and applies aliases. Gated so it can be A/B'd
 	// against the states-free compact route.
 	var replayStates *compactReplayStates
-	if forceReplayParseStates || parserCoreReplayParseStatesEnabled() {
+	if incrementalReuse != nil || forceReplayParseStates || parserCoreReplayParseStatesEnabled() {
 		replayStates, err = parser.replayCompactDerivation(compact, payloads)
 		if err != nil {
 			return nil, err
@@ -7304,7 +7334,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 		acceptedLeaves = &scratch.acceptedLeaves
 	}
 	allowLexerSkippedPrefix := parser.language.CompactLexerSkippedPrefixTilingCertified
-	if !allowErrorRoot && !allowLexerSkippedPrefix {
+	if !allowErrorRoot && !allowLexerSkippedPrefix && incrementalReuse == nil {
 		acceptedLeaves = nil
 	} else if allowLexerSkippedPrefix {
 		acceptedLeaves.prepareLexerSkippedPrefixes(int(stats.Subtrees))
@@ -7314,15 +7344,36 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 		recoveryTerminalAlias = scratch.recoveryTerminalAliasSymbol
 	}
 	materializeVisit := func(materializationScratch *diagnosticParserCoreMaterializationScratch) error {
+		makeParent := func(symbol Symbol, named bool, children []*Node, fields []FieldID, fieldSources []uint8, productionID uint16) *Node {
+			if incrementalReuse != nil {
+				return newParentNodeInArenaNoLinksWithFieldSources(arena, symbol, named, children, fields, fieldSources, productionID, true)
+			}
+			return newParentNodeInArenaWithFieldSources(arena, symbol, named, children, fields, fieldSources, productionID)
+		}
 		visit := func(id core.SubtreeID, view core.MaterializationSubtreeView) error {
 			if view.EndByte < view.StartByte || view.EndByte > uint32(len(source)) {
 				return errors.New("parser-core phase zero: compact subtree extent is outside source")
+			}
+			if view.ReusedKey != 0 {
+				node, err := incrementalReuse.materializeBorrowed(parser, id, view, replayStates, &points)
+				if err != nil {
+					return err
+				}
+				if err := acceptedLeaves.appendBorrowed(id, node, uint32(len(source))); err != nil {
+					return err
+				}
+				if languageUsesExternalScannerCheckpoints(parser.language) {
+					scannerProvenanceTransferProven = false
+				}
+				incrementalReuse.reuseState.markReused(node, arena)
+				nodesByID[id] = node
+				return nil
 			}
 			if acceptedLeaves != nil && view.Terminal {
 				if allowLexerSkippedPrefix {
 					acceptedLeaves.recordLexerSkippedPrefix(id, view)
 				}
-				if allowErrorRoot {
+				if allowErrorRoot || incrementalReuse != nil {
 					hidden := !parser.isVisibleSymbol(Symbol(view.Symbol))
 					if view.Symbol == core.RecoveryErrorSymbol {
 						hidden = false
@@ -7407,6 +7458,11 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 					structuralChildren++
 				}
 			}
+			if incrementalReuse != nil {
+				if err := validateCompactBorrowedReduceInputs(parser, entries, view.ProductionID, arena); err != nil {
+					return err
+				}
+			}
 			// isDerivationRootReduce is true only for the one reduce, per parse,
 			// whose symbol is this language's own inferred grammar root symbol
 			// (parser.rootSymbol / hasRootSymbol -- inferRootSymbol, parser.go: a
@@ -7469,8 +7525,8 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 						parser, entries, children, view.ProductionID, recoveryTerminalAlias, nodesByID,
 					)
 				}
-				parent := newParentNodeInArenaWithFieldSources(
-					arena, Symbol(view.Symbol), named, children, fieldIDs, fieldSources, view.ProductionID,
+				parent := makeParent(
+					Symbol(view.Symbol), named, children, fieldIDs, fieldSources, view.ProductionID,
 				)
 				parent.dynamicPrecedence += int32(view.DynamicPrecedence)
 				parent.startByte = view.StartByte
@@ -7498,7 +7554,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 			}
 			action := ParseAction{
 				Type: ParseActionReduce, Symbol: Symbol(view.Symbol), ChildCount: uint8(structuralChildren),
-				DynamicPrecedence: view.DynamicPrecedence, ProductionID: view.ProductionID,
+				DynamicPrecedence: int16(view.DynamicPrecedence), ProductionID: view.ProductionID,
 			}
 			if child := parser.collapsibleRawUnarySelfReduction(action, Token{}, arena, entries, 0, len(entries)); child != nil {
 				child.productionID = view.ProductionID
@@ -7515,6 +7571,11 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				entries, 0, len(entries), structuralChildren,
 				Symbol(view.Symbol), view.ProductionID, arena,
 			)
+			if incrementalReuse != nil {
+				if err := validateCompactBorrowedReduceProjectionWithScratch(parser, entries, children, arena, &incrementalReuse.projection, poll); err != nil {
+					return fmt.Errorf("reduce symbol=%d production=%d: %w", view.Symbol, view.ProductionID, err)
+				}
+			}
 			if recoveryTerminalAlias != 0 {
 				acceptedLeaves.authenticateDirectTerminalAliases(
 					parser, entries, children, view.ProductionID, recoveryTerminalAlias, nodesByID,
@@ -7531,8 +7592,8 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 				stamp(id, child)
 				return nil
 			}
-			parent := newParentNodeInArenaWithFieldSources(
-				arena, Symbol(view.Symbol), named, children, fieldIDs, fieldSources, view.ProductionID,
+			parent := makeParent(
+				Symbol(view.Symbol), named, children, fieldIDs, fieldSources, view.ProductionID,
 			)
 			parent.dynamicPrecedence += int32(view.DynamicPrecedence)
 			parent.startByte = view.StartByte
@@ -7614,6 +7675,16 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 		defer func() { parser.goCompatFrames = previousGoCompatFrames }()
 	}
 	var tree *Tree
+	var oldTree *Tree
+	var reuseState *parseReuseState
+	if incrementalReuse != nil {
+		oldTree, reuseState = incrementalReuse.oldTree, &incrementalReuse.reuseState
+		for _, node := range nodes {
+			if node.ownerArena != arena {
+				return nil, compactIncrementalMaterializationDecline("accepted root cannot be a borrowed subtree")
+			}
+		}
+	}
 	if rootFinalization == diagnosticParserCoreFinalizeRecoverEOF {
 		if len(nodes) != 1 || nodes[0] == nil || !nodes[0].IsError() {
 			return nil, errors.New("parser-core phase zero: recover_eof finalization requires one ERROR payload")
@@ -7624,13 +7695,19 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 		builder := newResultRootBuild(parser, source, arena, nil, nil, linkScratch)
 		tree = builder.finishRecoverEOFTree(nodes[0], builder.shouldWireParentLinks)
 	} else {
-		tree = parser.buildResultFromNodes(nodes, source, arena, nil, nil, linkScratch)
+		tree = parser.buildResultFromNodes(nodes, source, arena, oldTree, reuseState, linkScratch)
 	}
 	if tree != nil {
 		owned = false // The result tree owns the materialization arena.
+		if incrementalReuse != nil && tree.root != nil {
+			// Incremental builders normally inherit links from parent construction.
+			// This path constructs parents without links to preserve borrowed nodes.
+			arena.deferParentLinks(tree.root)
+		}
 	}
 	rejectTree := func(err error) (*Tree, error) {
 		if tree != nil {
+			recordAllocation()
 			tree.Release()
 		}
 		return nil, err
@@ -7712,6 +7789,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 	tree.incrementalReuseDisabled = !compactIncrementalReuseProven
 	tree.setParseRuntime(ParseRuntime{
 		StopReason:                                     ParseStopAccepted,
+		NodesAllocated:                                 arena.used,
 		SourceLen:                                      sourceLen,
 		ExpectedEOFByte:                                sourceLen,
 		RootEndByte:                                    root.endByte,
@@ -7725,6 +7803,14 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 		ExternalScannerCheckpointLeafNodes:             arena.externalScannerCheckpointLeafNodes,
 		CompactExternalScannerCheckpointTransferProven: scannerProvenanceTransferProven,
 	})
+	if incrementalReuse != nil {
+		runtime := *tree.rawParseRuntime()
+		runtime.IncrementalOldTreeReuseRoute = true
+		runtime.CompactIncrementalReuseRoute = true
+		runtime.CompactIncrementalReusedSubtrees = incrementalReuse.reusedSubtrees
+		runtime.CompactIncrementalReusedBytes = incrementalReuse.reusedBytes
+		tree.setParseRuntime(runtime)
+	}
 	if arena.breakdownEnabled {
 		breakdown := arena.collectArenaBreakdown()
 		tree.setArenaBreakdown(breakdown)
@@ -7995,6 +8081,7 @@ func diagnosticParserCoreSchedulerFootprintBytes(s *diagnosticParserCoreGenericS
 		}
 		addBytes(countBytes * sizeBytes)
 	}
+	addBytes(s.options.compactIncrementalReuse.footprintBytes())
 	// Header copies share immutable version-state pointers. Count each owned
 	// wrapper, region, and lexer snapshot once across the active frontier,
 	// canonical keys/groups, and retained header scratch. The scheduler-owned
@@ -8116,6 +8203,11 @@ func diagnosticParserCoreSchedulerFootprintBytes(s *diagnosticParserCoreGenericS
 // gap this gauge still has, and why closing it further is left as an owner
 // decision rather than a silent default change.
 func (s *diagnosticParserCoreGenericScheduler) stopControlMemoryBudgetReason() ParseStopReason {
+	return s.stopControlMemoryBudgetReasonWithAdditionalBytes(0)
+}
+
+// stopControlMemoryBudgetReasonWithAdditionalBytes includes the new materialization arena during incremental execution.
+func (s *diagnosticParserCoreGenericScheduler) stopControlMemoryBudgetReasonWithAdditionalBytes(additional uint64) ParseStopReason {
 	if s == nil {
 		return ParseStopNone
 	}
@@ -8127,6 +8219,11 @@ func (s *diagnosticParserCoreGenericScheduler) stopControlMemoryBudgetReason() P
 		}
 		if !haveFootprint {
 			footprint = diagnosticParserCoreSchedulerFootprintBytes(s)
+			if additional > math.MaxUint64-footprint {
+				footprint = math.MaxUint64
+			} else {
+				footprint += additional
+			}
 			haveFootprint = true
 		}
 		ratio := uint64(stopControlFootprintChurnRatio)
@@ -8300,6 +8397,15 @@ func (s *diagnosticParserCoreGenericScheduler) run() error {
 			}
 			continue
 		}
+		if s.options.compactIncrementalReuse != nil {
+			progressed, err := s.tryCompactIncrementalReuse()
+			if err != nil {
+				return err
+			}
+			if progressed {
+				continue
+			}
+		}
 		// C4 corridor: when the frontier is the deterministic single-header
 		// shape the bytecode lane owns, run the compiled program instead of
 		// the interpreted dispatch pass. The corridor executes
@@ -8307,7 +8413,7 @@ func (s *diagnosticParserCoreGenericScheduler) run() error {
 		// it never produces a decline of its own, so the generic pass below
 		// still owns every boundary verbatim (spec.c4-bytecode-isa.v1
 		// section 6.2).
-		if s.corridorEligible() {
+		if s.options.compactIncrementalReuse == nil && s.corridorEligible() {
 			progressed, err := s.dispatchCorridor()
 			if err != nil {
 				return err

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -10,20 +10,12 @@ import (
 	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
 )
 
-// parserCoreFreshFullRunner owns the reusable state for the authenticated,
-// fresh UTF-8 compact-parser route. It is deliberately build-tagged and does
-// not participate in Parser.parseInternal: callers must opt into this exact
-// diagnostic route and handle a fail-closed decline themselves.
-//
-// The only admitted identity is the certified embedded Go blob and exact Go
-// external scanner. The route is fresh UTF-8 only and declines recovery,
-// missing/no-lookahead tokens, repetition shifts, extra chains, and any EOF
-// frontier other than one accepted head with one exact derivation.
-//
-// The runner is stateful and not safe for concurrent use. A successful parse
-// returns a caller-owned tree. Every call resets the compact arenas before
-// acquiring a production DFA token source, so a declined or capped parse
-// cannot publish state into the next call.
+// parserCoreFreshFullRunner owns reusable state for compact UTF-8 parsing.
+// Admission configures the language, scanner, and supported recovery paths.
+// Incremental callers can supply an authenticated subtree reuse session.
+// Each call starts a fresh core generation, independent of Parser.parseInternal.
+// Callers must process declines before publishing a tree.
+// The runner is not safe for concurrent use. Successful results belong to the caller.
 type parserCoreFreshFullRunner struct {
 	lang                              *Language
 	parser                            *Parser
@@ -511,6 +503,10 @@ func (r *parserCoreFreshFullRunner) parseWithObserverAndErrorRuns(
 			tree.Release()
 		}
 		return nil, materializeErr
+	}
+	if tree != nil {
+		tree.parseRuntime.TokensConsumed = scheduler.tokens
+		tree.parseRuntime.CompactReductions = scheduler.work.Reductions
 	}
 	return tree, nil
 }

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -17,6 +17,8 @@ import (
 // Callers must process declines before publishing a tree.
 // The runner is not safe for concurrent use. Successful results belong to the caller.
 type parserCoreFreshFullRunner struct {
+	// legacyParseRuns verifies legacy entries without growing the Parser layout.
+	legacyParseRuns                   uint64
 	lang                              *Language
 	parser                            *Parser
 	tables                            *parserCoreRootTables

--- a/parsercore_phase0_incremental.go
+++ b/parsercore_phase0_incremental.go
@@ -10,6 +10,12 @@ import (
 	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
 )
 
+func (p *Parser) recordLegacyParserEntry() {
+	if runner, ok := p.admissionCandidateRunner.(*parserCoreFreshFullRunner); ok {
+		runner.legacyParseRuns++
+	}
+}
+
 // compactIncrementalReuseSession owns references for one incremental attempt.
 // Keys start at one. The Core stores keys, never public node pointers.
 type compactIncrementalReuseSession struct {

--- a/parsercore_phase0_incremental.go
+++ b/parsercore_phase0_incremental.go
@@ -1,0 +1,187 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"time"
+	"unsafe"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// compactIncrementalReuseSession owns references for one incremental attempt.
+// Keys start at one. The Core stores keys, never public node pointers.
+type compactIncrementalReuseSession struct {
+	oldTree        *Tree
+	nodes          []*Node
+	reuseState     parseReuseState
+	projection     compactBorrowedProjectionScratch
+	scheduler      *diagnosticParserCoreGenericScheduler
+	timing         *incrementalParseTiming
+	cursor         reuseCursor
+	reusedSubtrees uint64
+	reusedBytes    uint64
+}
+
+func (p *Parser) attemptCompactIncrementalParse(source []byte, oldTree *Tree, timing *incrementalParseTiming) (*Tree, string) {
+	if oldTree == nil || oldTree.language != p.language || !oldTree.compactMaterialized ||
+		oldTree.incrementalReuseDisabled || len(oldTree.edits) == 0 ||
+		oldTree.root == nil || oldTree.root.HasError() || p.recoveryInitialOnly ||
+		!p.admissionCandidateFullParseEligible(nil, true) {
+		return nil, ""
+	}
+	// Preserve the existing token-invariant fast path for same-width leaf edits.
+	// Width-changing edits cannot use that optimization.
+	if len(oldTree.edits) == 1 && oldTree.edits[0].OldEndByte == oldTree.edits[0].NewEndByte {
+		return nil, ""
+	}
+	if p.language.ExternalScanner != nil {
+		stateless, ok := p.language.ExternalScanner.(StatelessExternalScanner)
+		if !ok || !stateless.ExternalScannerIsStateless() {
+			return nil, ""
+		}
+	}
+	started := time.Now()
+	if timing != nil {
+		defer func() { timing.totalNanos += time.Since(started).Nanoseconds() }()
+	}
+	endBudget := p.enterParseBudget()
+	defer endBudget()
+	runner, err := p.acquireAdmissionCandidateRunner()
+	if err != nil {
+		return nil, err.Error()
+	}
+	oldTree.ensureParentLinks()
+	p.reuseMu.Lock()
+	defer p.reuseMu.Unlock()
+	session := &compactIncrementalReuseSession{oldTree: oldTree, timing: timing, scheduler: &runner.scheduler}
+	session.cursor.disableLeadingSplice = p.disableLeadingRunSplice
+	session.cursor.reset(oldTree, source, &p.reuseScratch)
+	runner.options.compactIncrementalReuse = session
+	runner.scratch.incrementalReuse = session
+	defer func() {
+		runner.options.compactIncrementalReuse = nil
+		runner.scheduler.options.compactIncrementalReuse = nil
+		runner.scratch.incrementalReuse = nil
+		session.cursor.commitScratch(&p.reuseScratch)
+		session.cursor.releaseNodeRefs()
+		clear(session.nodes)
+		session.projection.reset()
+	}()
+	// Recovery and raw ambiguity selection require the original derivation.
+	// An opaque borrowed payload cannot supply it, so this attempt stays clean.
+	runner.scheduler.tokens = 0
+	tree, err := runner.parseWithObserverAndErrorRuns(source, diagnosticParserCoreSeedObserver{}, false, false)
+	if timing != nil {
+		timing.reusedSubtrees = session.reusedSubtrees
+		timing.reusedBytes = session.reusedBytes
+		timing.tokensConsumed = runner.scheduler.tokens
+	}
+	if err != nil || tree == nil || session.reusedSubtrees == 0 {
+		if tree != nil {
+			tree.Release()
+		}
+		resetErr := runner.compact.ResetReleasingRetention()
+		if err == nil {
+			err = errors.New("compact incremental parse found no authenticated subtree")
+		}
+		return nil, errors.Join(err, resetErr).Error()
+	}
+	// Publish parent links only after every decline check has passed.
+	// Borrowed nodes consult their old arena, so deferred new-arena links are insufficient.
+	tree.ensureParentLinks()
+	if timing != nil {
+		timing.oldTreeReuseRoute = true
+		timing.newNodes = uint64(tree.parseRuntime.NodesAllocated)
+		timing.selectResult(tree)
+	}
+	return tree, ""
+}
+
+// tryCompactIncrementalReuse runs before ordinary dispatch, after each reduction.
+// It never consumes a candidate while the current token still requires reduction.
+func (s *diagnosticParserCoreGenericScheduler) tryCompactIncrementalReuse() (bool, error) {
+	session := s.options.compactIncrementalReuse
+	if session == nil {
+		return false, nil
+	}
+	if session.timing != nil {
+		started := time.Now()
+		defer func() { session.timing.reuseNanos += time.Since(started).Nanoseconds() }()
+	}
+	if len(s.headers) != 1 || s.versionLexerOwnershipActive || s.recoveryIsolation {
+		return false, errors.New("compact incremental reuse requires one clean shared-lexer version")
+	}
+	header := &s.headers[0]
+	if header.isRecoveryLineage() || header.recoveryRegion() != nil || header.paused {
+		return false, errors.New("compact incremental reuse cannot enter recovery")
+	}
+	if header.shifted || header.accepted || s.token.Symbol == 0 || s.token.NoLookahead || s.token.Missing {
+		return false, nil
+	}
+	state, offset, err := s.compact.Boundary(header.head)
+	if err != nil {
+		return false, err
+	}
+	row := s.options.materializationParser.lookupAction(StateID(state), s.token.Symbol)
+	if row == nil || len(row.Actions) != 1 || row.Actions[0].Type != ParseActionShift || row.Actions[0].Extra {
+		return false, nil
+	}
+	p := s.options.materializationParser
+	for _, node := range session.cursor.candidates(s.token.StartByte) {
+		if node == nil || node.ChildCount() == 0 || node.IsExtra() || node.HasError() ||
+			node.dirty() || node.isFragile() || !compactNodeMayBeReused(node) ||
+			!compactNodeStateProofAvailable(node) || node.PreGotoState() != StateID(state) ||
+			!session.cursor.topLevelSiblingBlockSpliceEligible(node) ||
+			!session.cursor.nodeBytesUnchanged(node.StartByte(), node.EndByte()) ||
+			!reuseSubtreeGapIsParserPadding(session.cursor.newSource, offset, node.StartByte(), p.lineContinuationEscapeByte()) {
+			continue
+		}
+		next, ok := p.reuseTargetState(StateID(state), node, s.token)
+		if !ok || next != node.parseState || s.freshSessionOwner == nil ||
+			s.tokenSource == nil || s.tokenSource.lexer == nil ||
+			!s.tokenSource.externalScannerQuiescent() ||
+			int(node.EndByte()) < s.tokenSource.lexer.pos || node.EndByte() > uint32(len(session.cursor.newSource)) {
+			continue
+		}
+		key := uint32(len(session.nodes) + 1)
+		if key == 0 {
+			return false, errors.New("compact incremental subtree keys exhausted")
+		}
+		head, _, err := s.compact.PushReusedSubtreeOwnedWithPoll(*s.freshSessionOwner, header.head, core.ReusedSubtree{
+			Key: key, Symbol: core.Symbol(node.Symbol()), PreGotoState: state, State: core.StateID(next),
+			StartByte: node.StartByte(), EndByte: node.EndByte(), DynamicPrecedence: node.dynamicPrecedence,
+		}, s.pollStopControl)
+		if err != nil {
+			return false, err
+		}
+		session.nodes = append(session.nodes, node)
+		session.reusedSubtrees++
+		session.reusedBytes += uint64(node.EndByte() - node.StartByte())
+		header.head = head
+		header.shifted = true
+		s.epochProgress = true
+		// Match SkipToByteWithPoint positioning without consuming the next token.
+		// The next scheduler election owns its state and scanner checkpoint.
+		lexer := s.tokenSource.lexer
+		lexer.pos = int(node.EndByte())
+		lexer.row = node.EndPoint().Row
+		lexer.col = node.EndPoint().Column
+		lexer.includedRangeIdx = 0
+		lexer.normalizeIncludedPosition()
+		return true, nil
+	}
+	return false, nil
+}
+
+func (s *compactIncrementalReuseSession) footprintBytes() uint64 {
+	if s == nil {
+		return 0
+	}
+	return uint64(unsafe.Sizeof(*s)) +
+		uint64(cap(s.nodes)+cap(s.cursor.cached)+cap(s.reuseState.arenaWalk))*uint64(unsafe.Sizeof((*Node)(nil))) +
+		uint64(cap(s.cursor.stack))*uint64(unsafe.Sizeof(reuseFrame{})) +
+		uint64(cap(s.reuseState.arenaRefs))*uint64(unsafe.Sizeof((*nodeArena)(nil))) +
+		s.projection.footprintBytes()
+}

--- a/parsercore_phase0_reuse_materialization.go
+++ b/parsercore_phase0_reuse_materialization.go
@@ -1,0 +1,293 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"sort"
+	"unsafe"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func compactIncrementalMaterializationDecline(detail string) error {
+	return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreAccept, detail: "compact incremental materialization: " + detail}
+}
+
+// materializeBorrowed authenticates a public subtree without changing its metadata.
+func (session *compactIncrementalReuseSession) materializeBorrowed(
+	parser *Parser,
+	id core.SubtreeID,
+	view core.MaterializationSubtreeView,
+	states *compactReplayStates,
+	points *diagnosticParserCorePointIndex,
+) (*Node, error) {
+	if parser == nil || parser.language == nil || points == nil ||
+		session == nil || session.oldTree == nil || session.oldTree.root == nil || session.oldTree.language != parser.language ||
+		view.ReusedKey == 0 || uint64(view.ReusedKey) > uint64(len(session.nodes)) {
+		return nil, compactIncrementalMaterializationDecline("borrowed subtree has no live ownership session")
+	}
+	node := session.nodes[view.ReusedKey-1]
+	if node == nil || node.ownerArena == nil || node.dirty() || node.hasError() || node.isMissing() || node.isFragile() ||
+		node.isExtra() || !compactNodeMayBeReused(node) || nodeChildCountNoMaterialize(node) == 0 ||
+		!parser.isVisibleSymbol(node.symbol) || uint32(node.symbol) < parser.language.TokenCount {
+		return nil, compactIncrementalMaterializationDecline("borrowed subtree is not a clean visible nonterminal")
+	}
+	owned := node.ownerArena == session.oldTree.arena
+	for _, arena := range session.oldTree.borrowedArena {
+		owned = owned || node.ownerArena == arena
+	}
+	if !owned {
+		return nil, compactIncrementalMaterializationDecline("borrowed subtree arena does not belong to the old tree")
+	}
+	if view.Terminal || view.Extra || view.External || view.Missing || view.Fragile ||
+		len(view.Children) != 0 || len(view.Aliases) != 0 ||
+		Symbol(view.Symbol) != node.symbol || view.StartByte != node.startByte || view.EndByte != node.endByte ||
+		int32(view.DynamicPrecedence) != node.dynamicPrecedence ||
+		node.startPoint != points.point(view.StartByte) || node.endPoint != points.point(view.EndByte) ||
+		StateID(view.ReusedPreGotoState) != node.preGotoState || StateID(view.ReusedState) != node.parseState {
+		return nil, compactIncrementalMaterializationDecline("borrowed subtree descriptor does not match the public node")
+	}
+	pre, state, preKnown, stateKnown := states.get(id)
+	if !preKnown || !stateKnown || pre != node.preGotoState || state != node.parseState {
+		return nil, compactIncrementalMaterializationDecline("borrowed subtree states do not match the accepted derivation")
+	}
+	return node, nil
+}
+
+// appendBorrowed records an authenticated subtree span without classifying it as a terminal.
+func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) appendBorrowed(id core.SubtreeID, node *Node, sourceLen uint32) error {
+	if scratch == nil {
+		return nil
+	}
+	if node == nil || node.startByte >= node.endByte || node.endByte > sourceLen {
+		return compactIncrementalMaterializationDecline("borrowed coverage span is invalid")
+	}
+	if count := len(scratch.spans); count > 0 && node.startByte < scratch.spans[count-1].endByte {
+		return compactIncrementalMaterializationDecline("borrowed coverage overlaps an accepted span")
+	}
+	scratch.spans = append(scratch.spans, diagnosticParserCoreAcceptedLeafSpan{
+		id: id, startByte: node.startByte, endByte: node.endByte, borrowed: node,
+	})
+	return nil
+}
+
+func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) hasBorrowedSubtree(node *Node) bool {
+	if scratch == nil || node == nil {
+		return false
+	}
+	index := sort.Search(len(scratch.spans), func(index int) bool {
+		return scratch.spans[index].startByte >= node.startByte
+	})
+	for index < len(scratch.spans) && scratch.spans[index].startByte == node.startByte {
+		span := scratch.spans[index]
+		if span.borrowed == node && span.endByte == node.endByte {
+			return true
+		}
+		index++
+	}
+	return false
+}
+
+// visitCompactBorrowedProjection follows hidden wrappers to the visible children that a reduction can change.
+func visitCompactBorrowedProjection(parser *Parser, node *Node, arena *nodeArena, visit func(*Node) error) error {
+	if node == nil {
+		return nil
+	}
+	if node.ownerArena != arena {
+		return visit(node)
+	}
+	if parser.isVisibleSymbol(node.symbol) {
+		return nil
+	}
+	for _, child := range node.children {
+		if err := visitCompactBorrowedProjection(parser, child, arena, visit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCompactBorrowedReduceInputs(parser *Parser, entries []stackEntry, productionID uint16, arena *nodeArena) error {
+	aliases := parser.reduceAliasSequence(productionID)
+	structuralChild := 0
+	for _, entry := range entries {
+		node := stackEntryNode(entry)
+		if node == nil || node.isExtra() {
+			continue
+		}
+		alias := Symbol(0)
+		if structuralChild < len(aliases) {
+			alias = aliases[structuralChild]
+		}
+		structuralChild++
+		if alias == 0 {
+			continue
+		}
+		if err := visitCompactBorrowedProjection(parser, node, arena, func(*Node) error {
+			return compactIncrementalMaterializationDecline("an alias would change a borrowed subtree")
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type compactBorrowedProjectionCount struct {
+	input, output uint64
+}
+
+type compactBorrowedProjectionFrame struct {
+	node  *Node
+	count compactBorrowedProjectionCount
+}
+
+type compactBorrowedProjectionScratch struct {
+	roots        map[*Node]compactBorrowedProjectionCount
+	borrowed     map[*Node]compactBorrowedProjectionCount
+	walk         []compactBorrowedProjectionFrame
+	rootsPeak    uint64
+	borrowedPeak uint64
+}
+
+func (scratch *compactBorrowedProjectionScratch) reset() {
+	clear(scratch.roots)
+	clear(scratch.borrowed)
+	clear(scratch.walk[:cap(scratch.walk)])
+	scratch.walk = scratch.walk[:0]
+}
+
+func (scratch *compactBorrowedProjectionScratch) footprintBytes() uint64 {
+	if scratch == nil {
+		return 0
+	}
+	// Count map storage conservatively, including growth storage and bucket overhead.
+	bytes := 96*(scratch.rootsPeak+scratch.borrowedPeak) + uint64(cap(scratch.walk))*uint64(unsafe.Sizeof(compactBorrowedProjectionFrame{}))
+	if scratch.roots != nil {
+		bytes += 256
+	}
+	if scratch.borrowed != nil {
+		bytes += 256
+	}
+	return bytes
+}
+
+func validateCompactBorrowedReduceProjection(parser *Parser, entries []stackEntry, children []*Node, arena *nodeArena) error {
+	var scratch compactBorrowedProjectionScratch
+	return validateCompactBorrowedReduceProjectionWithScratch(parser, entries, children, arena, &scratch, nil)
+}
+
+// validateCompactBorrowedReduceProjectionWithScratch compares borrowed identities once on each side.
+// Equal hidden roots preserve an already validated projection and need no descendant walk.
+func validateCompactBorrowedReduceProjectionWithScratch(
+	parser *Parser,
+	entries []stackEntry,
+	children []*Node,
+	arena *nodeArena,
+	scratch *compactBorrowedProjectionScratch,
+	poll func() error,
+) error {
+	defer scratch.reset()
+	steps := uint32(0)
+	check := func() error {
+		steps++
+		if poll != nil && steps&255 == 0 {
+			return poll()
+		}
+		return nil
+	}
+	if poll != nil {
+		if err := poll(); err != nil {
+			return err
+		}
+	}
+	width := max(4, len(entries)+len(children))
+	if scratch.rootsPeak > 64 && scratch.rootsPeak > uint64(width)*4 {
+		scratch.roots, scratch.rootsPeak = nil, 0
+	}
+	if scratch.borrowedPeak > 64 && scratch.borrowedPeak > uint64(width)*4 {
+		scratch.borrowed, scratch.borrowedPeak = nil, 0
+	}
+	if scratch.roots == nil {
+		scratch.roots = make(map[*Node]compactBorrowedProjectionCount, width)
+		scratch.rootsPeak = uint64(width)
+	}
+	record := func(node *Node, input bool) {
+		if node == nil || (node.ownerArena == arena && parser.isVisibleSymbol(node.symbol)) {
+			return
+		}
+		count := scratch.roots[node]
+		if input {
+			count.input++
+		} else {
+			count.output++
+		}
+		scratch.roots[node] = count
+		scratch.rootsPeak = max(scratch.rootsPeak, uint64(len(scratch.roots)))
+	}
+	for _, entry := range entries {
+		if err := check(); err != nil {
+			return err
+		}
+		record(stackEntryNode(entry), true)
+	}
+	for _, child := range children {
+		if err := check(); err != nil {
+			return err
+		}
+		record(child, false)
+	}
+	for node, count := range scratch.roots {
+		if err := check(); err != nil {
+			return err
+		}
+		if count.input == 1 && count.output == 1 {
+			continue
+		}
+		scratch.walk = append(scratch.walk, compactBorrowedProjectionFrame{node: node, count: count})
+	}
+	for len(scratch.walk) != 0 {
+		if err := check(); err != nil {
+			return err
+		}
+		last := len(scratch.walk) - 1
+		frame := scratch.walk[last]
+		scratch.walk[last] = compactBorrowedProjectionFrame{}
+		scratch.walk = scratch.walk[:last]
+		node := frame.node
+		if node == nil {
+			continue
+		}
+		if node.ownerArena != arena {
+			if scratch.borrowed == nil {
+				scratch.borrowed = make(map[*Node]compactBorrowedProjectionCount)
+			}
+			count := scratch.borrowed[node]
+			count.input += frame.count.input
+			count.output += frame.count.output
+			scratch.borrowed[node] = count
+			scratch.borrowedPeak = max(scratch.borrowedPeak, uint64(len(scratch.borrowed)))
+			continue
+		}
+		if parser.isVisibleSymbol(node.symbol) {
+			continue
+		}
+		for _, child := range node.children {
+			if err := check(); err != nil {
+				return err
+			}
+			scratch.walk = append(scratch.walk, compactBorrowedProjectionFrame{node: child, count: frame.count})
+		}
+	}
+	for _, count := range scratch.borrowed {
+		if err := check(); err != nil {
+			return err
+		}
+		if count.input != 1 || count.output != 1 {
+			return compactIncrementalMaterializationDecline("a reduction changed a borrowed subtree projection")
+		}
+	}
+	if poll != nil {
+		return poll()
+	}
+	return nil
+}

--- a/parsercore_phase0_reuse_materialization_test.go
+++ b/parsercore_phase0_reuse_materialization_test.go
@@ -1,0 +1,324 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func compactBorrowedMaterializationFixture(t *testing.T) (*Parser, *compactIncrementalReuseSession, *Node, core.MaterializationSubtreeView, *compactReplayStates, diagnosticParserCorePointIndex) {
+	t.Helper()
+	lang := &Language{
+		TokenCount:     2,
+		SymbolNames:    []string{"end", "a", "_hidden", "item", "root", "alias"},
+		SymbolMetadata: []SymbolMetadata{{}, {Visible: true}, {}, {Visible: true, Named: true}, {Visible: true, Named: true}, {Visible: true, Named: true}},
+		AliasSequences: [][]Symbol{nil, {5}},
+	}
+	parser := NewParser(lang)
+	arena := acquireNodeArena(arenaClassFull)
+	leaf := newLeafNodeInArena(arena, 1, false, 0, 1, Point{}, Point{Column: 1})
+	node := newParentNodeInArena(arena, 3, true, []*Node{leaf}, nil, 0)
+	node.parseState, node.preGotoState = 7, 4
+	node.dynamicPrecedence = 40000
+	node.setCompactMaterialized(true)
+	node.setCompactParseStateProof(true)
+	node.setCompactPreGotoStateProof(true)
+	root := newParentNodeInArena(arena, 4, true, []*Node{node}, nil, 0)
+	oldTree := newTreeWithArenas(root, []byte("a"), lang, arena, nil)
+	t.Cleanup(func() {
+		if oldTree.root != nil {
+			oldTree.Release()
+		}
+	})
+	session := &compactIncrementalReuseSession{oldTree: oldTree, nodes: []*Node{node}}
+	view := core.MaterializationSubtreeView{
+		Symbol: 3, StartByte: 0, EndByte: 1, DynamicPrecedence: 40000,
+		ReusedKey: 1, ReusedPreGotoState: 4, ReusedState: 7,
+	}
+	states := &compactReplayStates{
+		parseState: []StateID{0, 7}, preGotoState: []StateID{0, 4},
+		psKnown: []bool{false, true}, preKnown: []bool{false, true},
+	}
+	points := diagnosticParserCorePointIndex{lineStarts: []uint32{0}}
+	return parser, session, node, view, states, points
+}
+
+func TestCompactBorrowedMaterializationAuthenticatesNode(t *testing.T) {
+	parser, session, node, view, states, points := compactBorrowedMaterializationFixture(t)
+	parent := node.parent
+	got, err := session.materializeBorrowed(parser, 1, view, states, &points)
+	if err != nil || got != node {
+		t.Fatalf("borrowed node = %p, error = %v; want %p", got, err, node)
+	}
+	if node.parent != parent || node.parseState != 7 || node.preGotoState != 4 ||
+		!node.hasCompactParseStateProof() || !node.hasCompactPreGotoStateProof() || node.dynamicPrecedence != 40000 {
+		t.Fatal("borrowed materialization changed node metadata")
+	}
+	for _, test := range []struct {
+		name   string
+		change func(*core.MaterializationSubtreeView)
+	}{
+		{"key", func(v *core.MaterializationSubtreeView) { v.ReusedKey = 2 }},
+		{"symbol", func(v *core.MaterializationSubtreeView) { v.Symbol = 4 }},
+		{"span", func(v *core.MaterializationSubtreeView) { v.EndByte = 2 }},
+		{"state", func(v *core.MaterializationSubtreeView) { v.ReusedState = 8 }},
+		{"pre_state", func(v *core.MaterializationSubtreeView) { v.ReusedPreGotoState = 5 }},
+		{"precedence", func(v *core.MaterializationSubtreeView) { v.DynamicPrecedence = 7232 }},
+		{"terminal", func(v *core.MaterializationSubtreeView) { v.Terminal = true }},
+		{"alias", func(v *core.MaterializationSubtreeView) { v.Aliases = []core.Symbol{5} }},
+		{"children", func(v *core.MaterializationSubtreeView) { v.Children = []core.SubtreeID{2} }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			changed := view
+			test.change(&changed)
+			if _, err := session.materializeBorrowed(parser, 1, changed, states, &points); err == nil {
+				t.Fatal("invalid borrowed descriptor was accepted")
+			}
+		})
+	}
+	states.preKnown[1] = false
+	if _, err := session.materializeBorrowed(parser, 1, view, states, &points); err == nil {
+		t.Fatal("borrowed node without replay proof was accepted")
+	}
+	states.preKnown[1] = true
+	var missing *compactIncrementalReuseSession
+	if _, err := missing.materializeBorrowed(parser, 1, view, states, &points); err == nil {
+		t.Fatal("borrowed node without ownership session was accepted")
+	}
+}
+
+func TestCompactBorrowedMaterializationRetainsArena(t *testing.T) {
+	parser, session, node, _, _, _ := compactBorrowedMaterializationFixture(t)
+	oldArena := node.ownerArena
+	childArena := acquireNodeArena(arenaClassFull)
+	node.children[0] = newLeafNodeInArena(childArena, 1, false, 0, 1, Point{}, Point{Column: 1})
+	session.oldTree.borrowedArena = append(session.oldTree.borrowedArena, childArena)
+	arena := acquireNodeArena(arenaClassFull)
+	root := newParentNodeInArenaNoLinksWithFieldSources(arena, 4, true, []*Node{node}, nil, nil, 0, true)
+	oldParent := node.parent
+	session.reuseState.markReused(node, arena)
+	var links []*Node
+	tree := parser.buildResultFromNodes([]*Node{root}, []byte("a"), arena, session.oldTree, &session.reuseState, &links)
+	if tree == nil {
+		arena.Release()
+		t.Fatal("result builder returned no tree")
+	}
+	defer tree.Release()
+	if len(tree.borrowedArena) != 2 || tree.borrowedArena[0] != oldArena || oldArena.refs.Load() != 2 || childArena.refs.Load() != 2 {
+		t.Fatalf("result did not retain the borrowed arenas: borrowed=%d refs=%d child_refs=%d", len(tree.borrowedArena), oldArena.refs.Load(), childArena.refs.Load())
+	}
+	if node.parent != oldParent {
+		t.Fatal("result construction changed the borrowed parent link")
+	}
+	session.oldTree.Release()
+	if oldArena.refs.Load() != 1 || childArena.refs.Load() != 1 || node.symbol != 3 || node.children[0].symbol != 1 || tree.root.children[0] != node {
+		t.Fatal("old tree release invalidated the reused subtree")
+	}
+}
+
+func TestCompactBorrowedMaterializationCoverage(t *testing.T) {
+	_, _, node, _, _, _ := compactBorrowedMaterializationFixture(t)
+	var coverage diagnosticParserCoreAcceptedLeafCoverageScratch
+	if err := coverage.appendBorrowed(1, node, 1); err != nil {
+		t.Fatal(err)
+	}
+	nodes := []*Node{nil, node}
+	if !coverage.hasBorrowedSubtree(node) || coverage.hasVisibleTerminalNode(0, 1, node, nodes) {
+		t.Fatal("borrowed nonterminal was not distinguished from a terminal")
+	}
+	if _, _, gap, err := diagnosticParserCoreAcceptedDerivationLeafCoverageGap(&coverage, []byte("a"), 0, 1, nil); err != nil || gap {
+		t.Fatalf("borrowed derivation coverage: gap=%t error=%v", gap, err)
+	}
+	if _, _, gap, err := diagnosticParserCoreAcceptedTreeLeafCoverageGap(node, []byte("a"), 0, 1, 2, &coverage, nodes, nil); err != nil || gap {
+		t.Fatalf("borrowed public coverage: gap=%t error=%v", gap, err)
+	}
+	if err := coverage.appendBorrowed(2, node, 1); err == nil {
+		t.Fatal("overlapping borrowed coverage was accepted")
+	}
+	coverage.reset()
+	if coverage.hasBorrowedSubtree(node) {
+		t.Fatal("coverage reset retained a borrowed node")
+	}
+}
+
+func TestCompactBorrowedMaterializationRejectsProjection(t *testing.T) {
+	parser, _, node, _, _, _ := compactBorrowedMaterializationFixture(t)
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	hidden := newParentNodeInArenaNoLinksWithFieldSources(arena, 2, false, []*Node{node}, nil, nil, 0, true)
+	for _, entry := range []*Node{node, hidden} {
+		entries := []stackEntry{newStackEntryNode(0, entry)}
+		if err := validateCompactBorrowedReduceInputs(parser, entries, 1, arena); err == nil {
+			t.Fatal("alias of borrowed subtree was accepted")
+		}
+		if err := validateCompactBorrowedReduceInputs(parser, entries, 0, arena); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateCompactBorrowedReduceProjection(parser, entries, []*Node{node}, arena); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateCompactBorrowedReduceProjection(parser, entries, []*Node{hidden}, arena); err != nil {
+			t.Fatalf("preserved hidden wrapper lost its borrowed projection: %v", err)
+		}
+		for _, children := range [][]*Node{nil, {node, node}, {hidden, node}, {hidden, hidden}} {
+			if err := validateCompactBorrowedReduceProjection(parser, entries, children, arena); err == nil {
+				t.Fatal("changed borrowed projection was accepted")
+			}
+		}
+	}
+}
+
+func TestCompactBorrowedMaterializationClearsSessionOnError(t *testing.T) {
+	_, session, _, _, _, _ := compactBorrowedMaterializationFixture(t)
+	scratch := parserCoreRunnerScratch{incrementalReuse: session}
+	_, err := materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(nil, core.Head{}, nil, nil, nil, &scratch, false, false, diagnosticParserCoreFinalizeDefault)
+	if err == nil || scratch.incrementalReuse != nil {
+		t.Fatal("failed materialization retained the reuse session")
+	}
+}
+
+func TestCompactBorrowedMaterializationReplayChecksTransition(t *testing.T) {
+	parser := &Parser{denseLimit: 8, language: &Language{
+		TokenCount: 2, SymbolCount: 4, StateCount: 8, InitialState: 1, LargeStateCount: 8,
+		ParseTable: [][]uint16{nil, nil, nil, nil, {0, 0, 0, 7}},
+	}}
+	view := core.MaterializationReplayView{Symbol: 3, ReusedKey: 1, ReusedPreGotoState: 4, ReusedState: 7}
+	state, known, err := parser.replayCompactMaterializationTransition(4, view)
+	if err != nil || !known || state != 7 {
+		t.Fatalf("borrowed replay: state=%d known=%t error=%v", state, known, err)
+	}
+	view.ReusedPreGotoState = 3
+	if _, _, err := parser.replayCompactMaterializationTransition(4, view); err == nil {
+		t.Fatal("borrowed replay accepted a mismatched parent state")
+	}
+	view.ReusedPreGotoState, view.ReusedState = 4, 6
+	if _, _, err := parser.replayCompactMaterializationTransition(4, view); err == nil {
+		t.Fatal("borrowed replay accepted a mismatched goto state")
+	}
+	view.ReusedState, view.Terminal = 7, true
+	if _, _, err := parser.replayCompactMaterializationTransition(4, view); err == nil {
+		t.Fatal("borrowed replay accepted a terminal classification")
+	}
+}
+
+func TestCompactBorrowedMaterializationProjectionMultiplicity(t *testing.T) {
+	parser, _, first, _, _, _ := compactBorrowedMaterializationFixture(t)
+	second := newParentNodeInArenaNoLinksWithFieldSources(first.ownerArena, 3, true, []*Node{first.children[0]}, nil, nil, 0, true)
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	input := newParentNodeInArenaNoLinksWithFieldSources(arena, 2, false, []*Node{first, second}, nil, nil, 0, true)
+	entries := []stackEntry{newStackEntryNode(0, input)}
+	for _, children := range [][]*Node{{first, second}, {input}} {
+		if err := validateCompactBorrowedReduceProjection(parser, entries, children, arena); err != nil {
+			t.Fatalf("unchanged borrowed identities declined: %v", err)
+		}
+	}
+	for _, children := range [][]*Node{{first, first}, {first}, {first, second, second}} {
+		if err := validateCompactBorrowedReduceProjection(parser, entries, children, arena); err == nil {
+			t.Fatal("changed borrowed multiplicity was accepted")
+		}
+	}
+}
+
+func TestCompactBorrowedMaterializationProjectionPolling(t *testing.T) {
+	parser, _, first, _, _, _ := compactBorrowedMaterializationFixture(t)
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	const width = 2048
+	children := make([]*Node, width)
+	for i := range children {
+		children[i] = newParentNodeInArenaNoLinksWithFieldSources(first.ownerArena, 3, true, []*Node{first.children[0]}, nil, nil, 0, true)
+	}
+	input := newParentNodeInArenaNoLinksWithFieldSources(arena, 2, false, children, nil, nil, 0, true)
+	output := newParentNodeInArenaNoLinksWithFieldSources(arena, 2, false, children, nil, nil, 0, true)
+	entries := []stackEntry{newStackEntryNode(0, input)}
+	var scratch compactBorrowedProjectionScratch
+	polls := 0
+	if err := validateCompactBorrowedReduceProjectionWithScratch(parser, entries, []*Node{input}, arena, &scratch, func() error {
+		polls++
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if polls != 2 || scratch.borrowedPeak != 0 {
+		t.Fatalf("unchanged hidden wrapper expanded its descendants: polls=%d borrowed_peak=%d", polls, scratch.borrowedPeak)
+	}
+	polls = 0
+	if err := validateCompactBorrowedReduceProjectionWithScratch(parser, entries, []*Node{output}, arena, &scratch, func() error {
+		polls++
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if polls < 3 || polls > 5*width/256+4 {
+		t.Fatalf("projection work did not remain linear: polls=%d", polls)
+	}
+	if scratch.footprintBytes() < uint64(width)*96 {
+		t.Fatal("projection accounting omitted retained identity maps")
+	}
+	stop := errors.New("cancel projection")
+	polls = 0
+	err := validateCompactBorrowedReduceProjectionWithScratch(parser, entries, []*Node{output}, arena, &scratch, func() error {
+		polls++
+		if polls > 1 {
+			return stop
+		}
+		return nil
+	})
+	if !errors.Is(err, stop) || polls != 2 {
+		t.Fatalf("projection did not stop at its next poll: polls=%d error=%v", polls, err)
+	}
+	if len(scratch.roots) != 0 || len(scratch.borrowed) != 0 || len(scratch.walk) != 0 {
+		t.Fatal("cancelled projection retained node references")
+	}
+}
+
+func TestCompactBorrowedMaterializationProjectionMemoryBudget(t *testing.T) {
+	parser, session, first, _, _, _ := compactBorrowedMaterializationFixture(t)
+	var scheduler diagnosticParserCoreGenericScheduler
+	scheduler.options.compactIncrementalReuse = session
+	session.scheduler = &scheduler
+	baseline := diagnosticParserCoreSchedulerFootprintBytes(&scheduler)
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	const width = 512
+	entries := make([]stackEntry, width)
+	children := make([]*Node, width)
+	for i := range children {
+		children[i] = newParentNodeInArenaNoLinksWithFieldSources(first.ownerArena, 3, true, []*Node{first.children[0]}, nil, nil, 0, true)
+		entries[i] = newStackEntryNode(0, children[i])
+	}
+	if got := diagnosticParserCoreSchedulerFootprintBytes(&scheduler); got != baseline {
+		t.Fatal("session accounting included borrowed node arena contents")
+	}
+	scheduler.options.stopControlMemoryBudgetBytes = int64(baseline + 4096)
+	stop := errors.New("projection memory budget")
+	polls := 0
+	err := validateCompactBorrowedReduceProjectionWithScratch(parser, entries, children, arena, &session.projection, func() error {
+		polls++
+		if scheduler.stopControlMemoryBudgetReasonWithAdditionalBytes(0) == ParseStopMemoryBudget {
+			return stop
+		}
+		return nil
+	})
+	if !errors.Is(err, stop) || polls != 2 {
+		t.Fatalf("projection allocation escaped the budget poll: polls=%d error=%v", polls, err)
+	}
+	if len(session.projection.roots) != 0 || len(session.projection.borrowed) != 0 || len(session.projection.walk) != 0 {
+		t.Fatal("budget rejection retained borrowed references")
+	}
+	retained := diagnosticParserCoreSchedulerFootprintBytes(&scheduler)
+	scheduler.options.stopControlMemoryBudgetBytes = int64(retained + 128)
+	if reason := scheduler.stopControlMemoryBudgetReasonWithAdditionalBytes(0); reason != ParseStopNone {
+		t.Fatalf("unexpected stop below the combined budget: %s", reason)
+	}
+	if reason := scheduler.stopControlMemoryBudgetReasonWithAdditionalBytes(128); reason != ParseStopMemoryBudget {
+		t.Fatal("combined budget omitted materialization arena bytes")
+	}
+	if reason := scheduler.stopControlMemoryBudgetReasonWithAdditionalBytes(^uint64(0)); reason != ParseStopMemoryBudget {
+		t.Fatal("combined budget overflow bypassed the limit")
+	}
+}

--- a/parsercore_phase0_reuse_navigation_test.go
+++ b/parsercore_phase0_reuse_navigation_test.go
@@ -1,0 +1,88 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestCompactBorrowedFirstNavigationUsesNewTree(t *testing.T) {
+	parser := newAdmissionCandidateGoParser(t)
+	parser.SetAdmissionCandidateRoute(true)
+	source := []byte("package p\nfunc a() { _ = 1 }\nfunc b() { _ = 2 }\n")
+	old, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer old.Release()
+	borrowed := compactExecutionNode(old.RootNode(), parser.language, "function_declaration", uint32(bytes.Index(source, []byte("func b"))))
+	if borrowed == nil {
+		t.Fatal("initial tree has no function b")
+	}
+	offset := bytes.IndexByte(source, '1')
+	edited, edit := compactExecutionEdit(source, offset, offset+1, "1+3")
+	old.Edit(edit)
+	next, err := parser.ParseIncremental(edited, old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer next.Release()
+	if !next.compactMaterialized {
+		t.Fatal("incremental execution did not return a compact tree")
+	}
+	// Navigate the borrowed pointer before any accessor visits the new root.
+	if got := borrowed.Parent(); got != next.root {
+		t.Fatalf("first borrowed Parent call returned %p; want new root %p", got, next.root)
+	}
+	if sibling := borrowed.PrevSibling(); sibling == nil || sibling.ownerArena != next.arena || sibling.Text(edited) != "func a() { _ = 1+3 }" {
+		t.Fatal("first borrowed sibling call did not use the reparsed function")
+	}
+}
+
+func TestCompactBorrowedMaterializationRecordsRejectedAllocation(t *testing.T) {
+	parser := newAdmissionCandidateGoParser(t)
+	parser.SetAdmissionCandidateRoute(true)
+	source := []byte("package p\nfunc a() { _ = 1 }\n")
+	old, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer old.Release()
+	runner, ok := parser.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+	if !ok || !old.compactMaterialized {
+		t.Fatal("initial parse did not retain an accepted compact derivation")
+	}
+	for _, reject := range []bool{false, true} {
+		materializationSource := source
+		if reject {
+			materializationSource = append(append([]byte(nil), source...), '@')
+		}
+		var timing incrementalParseTiming
+		session := &compactIncrementalReuseSession{oldTree: old, timing: &timing}
+		scratch := parserCoreRunnerScratch{incrementalReuse: session}
+		tree, err := materializeDiagnosticParserCoreAcceptedTree(runner.compact, runner.scheduler.acceptedHead, runner.parser, materializationSource, &scratch, true, false)
+		if reject {
+			if tree != nil {
+				tree.Release()
+			}
+			if err == nil {
+				t.Fatal("materialization accepted an uncovered source suffix")
+			}
+		} else {
+			if err != nil {
+				t.Fatal(err)
+			}
+			if timing.newNodes != uint64(tree.rawParseRuntime().NodesAllocated) {
+				t.Fatal("successful materialization allocation disagrees with its runtime")
+			}
+			tree.Release()
+		}
+		if timing.newNodes == 0 {
+			t.Fatalf("materialization discarded its allocated-node count: rejected=%t", reject)
+		}
+		if scratch.incrementalReuse != nil {
+			t.Fatal("materialization retained the allocation timing session")
+		}
+	}
+}

--- a/parsestate_replay_compact.go
+++ b/parsestate_replay_compact.go
@@ -171,7 +171,10 @@ func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.Subtre
 		if err != nil {
 			return fail(err)
 		}
-		rootParseState, rootStateKnown := p.replayTransition(seed, Symbol(view.Symbol), view.Terminal)
+		rootParseState, rootStateKnown, err := p.replayCompactMaterializationTransition(seed, view)
+		if err != nil {
+			return fail(err)
+		}
 		if rootStateKnown && uint64(root) < uint64(len(states.parseState)) {
 			states.parseState[root] = rootParseState
 			states.psKnown[root] = true
@@ -205,7 +208,10 @@ func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.Subtre
 			if err != nil {
 				return fail(err)
 			}
-			childParseState, childStateKnown := p.replayTransition(childPreGoto, Symbol(cview.Symbol), cview.Terminal)
+			childParseState, childStateKnown, err := p.replayCompactMaterializationTransition(childPreGoto, cview)
+			if err != nil {
+				return fail(err)
+			}
 			top.cursor = childParseState
 			if childStateKnown && uint64(child) < uint64(len(states.parseState)) {
 				// Record only authoritative transitions. A failed transition
@@ -225,4 +231,16 @@ func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.Subtre
 	// Retain the cleared worklist backing store for the next parse.
 	states.frames = stack[:0]
 	return states, nil
+}
+
+func (p *Parser) replayCompactMaterializationTransition(pre StateID, view core.MaterializationReplayView) (StateID, bool, error) {
+	state, known := p.replayTransition(pre, Symbol(view.Symbol), view.Terminal)
+	if view.ReusedKey == 0 {
+		return state, known, nil
+	}
+	if view.Terminal || view.Extra || view.Children.Len() != 0 || !known ||
+		pre != StateID(view.ReusedPreGotoState) || state != StateID(view.ReusedState) {
+		return 0, false, compactIncrementalMaterializationDecline("borrowed replay transition does not match the parser tables")
+	}
+	return StateID(view.ReusedState), true, nil
 }

--- a/tree.go
+++ b/tree.go
@@ -1076,6 +1076,14 @@ type ParseRuntime struct {
 	// IncrementalOldTreeReuseRoute reports whether this result was produced by
 	// an actual old-tree reuse parse rather than an internal fresh fallback.
 	IncrementalOldTreeReuseRoute bool
+	// CompactIncrementalReuseRoute records execution with borrowed compact subtrees.
+	CompactIncrementalReuseRoute     bool
+	CompactIncrementalReusedSubtrees uint64
+	CompactIncrementalReusedBytes    uint64
+	// CompactIncrementalFallbackReason records an attempted compact reparse decline.
+	CompactIncrementalFallbackReason string
+	// CompactReductions counts reductions executed by the compact scheduler.
+	CompactReductions uint64
 	// CRecoveryEnteredErrorState is true when the faithful C error-recovery
 	// port (parser_recover_c.go) actually ran ts_parser__handle_error at
 	// least once while producing this specific tree — i.e. some no-action

--- a/w1_block_splice_test.go
+++ b/w1_block_splice_test.go
@@ -1,5 +1,8 @@
 package gotreesitter_test
 
+// These tests explicitly select the legacy engine because BlockSpliceSteps measures its W1 loop.
+// The compact incremental execution tests verify compact reuse separately.
+
 // Campaign O(edit) workstream W1 block-splice composition (spec.campaign.oedit):
 // after the edited item settles, the whole run of following unchanged top-level
 // siblings is spliced inside one parse-loop iteration instead of one iteration
@@ -43,7 +46,7 @@ func TestW1BlockSpliceOracleEquality(t *testing.T) {
 	lang := grammars.GoLanguage()
 	src := w1BlockCleanGo(400)
 	off := bytes.Index(src, []byte("func B0(a")) + len("func B0(")
-	fresh, incr, profile, edited := w1bParseProfiled(t, lang, src, off)
+	fresh, incr, profile, edited := w1bParseProfiledWithParser(t, lang, src, off, w1BlockLegacyParser)
 
 	if incr.HasError() {
 		t.Fatal("incremental tree unexpectedly has errors")
@@ -69,8 +72,8 @@ func TestW1BlockSpliceFiresAndIsBounded(t *testing.T) {
 	offS := bytes.Index(small, []byte("func B0(a")) + len("func B0(")
 	offL := bytes.Index(large, []byte("func B0(a")) + len("func B0(")
 
-	_, incrS, profS, editedS := w1bParseProfiled(t, lang, small, offS)
-	_, incrL, profL, editedL := w1bParseProfiled(t, lang, large, offL)
+	_, incrS, profS, editedS := w1bParseProfiledWithParser(t, lang, small, offS, w1BlockLegacyParser)
+	_, incrL, profL, editedL := w1bParseProfiledWithParser(t, lang, large, offL, w1BlockLegacyParser)
 
 	if incrS.HasError() || incrL.HasError() {
 		t.Fatal("incremental tree unexpectedly has errors")
@@ -103,7 +106,7 @@ func TestW1BlockSpliceIsDeterministic(t *testing.T) {
 	edited, edit := w1bInsertByte(src, off)
 
 	run := func() (*gts.Node, uint64) {
-		p := gts.NewParser(lang)
+		p := w1BlockLegacyParser(lang)
 		old, err := p.Parse(src)
 		if err != nil {
 			t.Fatalf("base parse: %v", err)
@@ -170,7 +173,7 @@ func TestW1BlockSpliceConfinesUntypedParamAmbiguity(t *testing.T) {
 		StartPoint: w1bPointAt(src, bOff), OldEndPoint: w1bPointAt(src, bOff+2), NewEndPoint: w1bPointAt(src, bOff),
 	}
 
-	parser := gts.NewParser(lang)
+	parser := w1BlockLegacyParser(lang)
 	old, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("base parse: %v", err)
@@ -180,7 +183,7 @@ func TestW1BlockSpliceConfinesUntypedParamAmbiguity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("incremental parse: %v", err)
 	}
-	freshTree, err := gts.NewParser(lang).Parse(edited)
+	freshTree, err := w1BlockLegacyParser(lang).Parse(edited)
 	if err != nil {
 		t.Fatalf("fresh parse: %v", err)
 	}
@@ -213,4 +216,10 @@ func TestW1BlockSpliceConfinesUntypedParamAmbiguity(t *testing.T) {
 				i, fc.Type(lang), fc.StartByte(), fc.EndByte(), d)
 		}
 	}
+}
+
+func w1BlockLegacyParser(lang *gts.Language) *gts.Parser {
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	return parser
 }

--- a/w1b_reduce_settle_test.go
+++ b/w1b_reduce_settle_test.go
@@ -113,8 +113,12 @@ func w1bCleanGo(n int) []byte {
 }
 
 func w1bParseProfiled(t *testing.T, lang *gts.Language, src []byte, off int) (fresh, incr *gts.Node, profile gts.IncrementalParseProfile, edited []byte) {
+	return w1bParseProfiledWithParser(t, lang, src, off, gts.NewParser)
+}
+
+func w1bParseProfiledWithParser(t *testing.T, lang *gts.Language, src []byte, off int, newParser func(*gts.Language) *gts.Parser) (fresh, incr *gts.Node, profile gts.IncrementalParseProfile, edited []byte) {
 	t.Helper()
-	parser := gts.NewParser(lang)
+	parser := newParser(lang)
 	oldTree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("base parse: %v", err)
@@ -125,7 +129,7 @@ func w1bParseProfiled(t *testing.T, lang *gts.Language, src []byte, off int) (fr
 
 	edited, edit := w1bInsertByte(src, off)
 
-	freshParser := gts.NewParser(lang)
+	freshParser := newParser(lang)
 	freshTree, err := freshParser.Parse(edited)
 	if err != nil {
 		t.Fatalf("fresh parse of edited: %v", err)


### PR DESCRIPTION
## Change

Run eligible edited reparses through the compact scheduler. Reuse authenticated unchanged subtrees without invoking the legacy parser.

Previously, edited compact trees still entered the legacy incremental engine. This change supplies the first compact execution path for those edits.

The regression changes `1` to `1+3` in this source:

```go
package p
func a() { _ = 1 }
func b() { _ = 2 }
```

The new result preserves function `b` by identity and matches fresh and incremental locked C output exactly.
The baseline already matched C. It failed the new compact execution requirement.

## Ownership and limits

- Authenticate the source span, parser states, node identity, and scanner state before each splice.
- Retain borrowed arenas and publish parent links after acceptance.
- Invalidate cached checks when lineage or fragility changes.
- Count allocations and work, including declined attempts.
- Keep full-parse admission counters unchanged during incremental calls.
- Poll cancellation and account for new validation and materialization storage.

The route requires one clean version and a scanner without persistent state.
Recovery, ambiguity, checkpointed scanners, and unsupported projections retain the legacy fallback.
Single same-width edits retain the existing token-invariant optimization.
This change does not complete incremental graduation or retire the legacy parser.

## Verification

- The focused core package tests pass in Docker, including alternate build tags.
- Go growth and comment edits match exact fresh and incremental locked C trees.
- The existing Go fresh, incremental, error, and Stage 6 certification tests pass.
- Repeated edits preserve identity after releasing the old tree.
- Navigation, copy isolation, language mismatch, cancellation, and memory-budget tests pass.
- Execution tests prove fewer tokens, reductions, and new nodes than a fresh compact parse.
- Independent Astra-medium review found no remaining correctness blockers after fixes.
- Independent focused race tests pass in a 4 GiB Docker container.
- The emergency build and route-counter controls pass.

The separate randomized benchmark comparison uses 20 seeds, one process per seed, and 750 ms samples.
Results will follow in a comment. No unrelated optimization is included.

## Existing recovery defect

Deleting the first closing brace exposes a nested identifier error-flag mismatch against C.
Both baseline engines reproduce it. The runtime baseline is identical to main at `474202b`.
The negative splice test requires exact fresh-production equivalence and rejects reuse of function `b` in the changed context.
It does not claim C recovery parity for that input.
