### PR TITLE
Run same-width token changes on the compact engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1261,7 +1261,7 @@ jobs:
             --cpus 2 \
             --gomemlimit 3GiB \
             --wall-timeout 10m \
-            -- "cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^(TestGoCompactIncrementalExecutionParity|TestStage6GoCompactCertification)$' -count=1 -parallel 1 -timeout 5m -v"
+            -- "cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^(TestGoCompactIncrementalExecution.*Parity|TestStage6GoCompactCertification)$' -count=1 -parallel 1 -timeout 5m -v"
 
       - name: Compact recovery incremental JavaScript witnesses
         run: |

--- a/cgo_harness/go_compact_incremental_execution_test.go
+++ b/cgo_harness/go_compact_incremental_execution_test.go
@@ -18,6 +18,7 @@ func TestGoCompactIncrementalExecutionParity(t *testing.T) {
 	}{
 		{"growth", "", "1", "1+3", true},
 		{"comment", "// between declarations\n", "1", "1+3", true},
+		{"same_width_kind_change", "", "1", "x", true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			source := []byte("package p\nfunc a() { _ = 1 }\n" + tc.separator + "func b() { _ = 2 }\n")
@@ -100,5 +101,74 @@ func TestGoCompactIncrementalExecutionParity(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGoCompactIncrementalExecutionRepeatedSameWidthParity(t *testing.T) {
+	source := []byte("package p\nfunc a() { _ = 1 }\nfunc b() { _ = 2 }\n")
+	lang := grammars.GoLanguage()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	old, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { old.Release() }()
+	bStart := uint32(bytes.Index(source, []byte("func b")))
+	oldB := findGoNodeByTypeAndStart(old.RootNode(), lang, "function_declaration", bStart)
+	if oldB == nil {
+		t.Fatal("initial tree has no function b")
+	}
+	cLang, err := ParityCLanguage("go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cp := sitter.NewParser()
+	defer cp.Close()
+	if err := cp.SetLanguage(cLang); err != nil {
+		t.Fatal(err)
+	}
+	cOld := cp.Parse(source, nil)
+	if cOld == nil {
+		t.Fatal("C parser returned no source tree")
+	}
+	defer func() { cOld.Close() }()
+	offset := bytes.IndexByte(source, '1')
+	for _, replacement := range []byte{'x', '3', 'y'} {
+		edited := append([]byte(nil), source...)
+		edited[offset] = replacement
+		edit := gts.InputEdit{StartByte: uint32(offset), OldEndByte: uint32(offset + 1), NewEndByte: uint32(offset + 1), StartPoint: pointAtOffset(source, offset), OldEndPoint: pointAtOffset(source, offset+1), NewEndPoint: pointAtOffset(edited, offset+1)}
+		old.Edit(edit)
+		next, err := parser.ParseIncremental(edited, old)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if next == old {
+			t.Fatal("kind change returned the old tree")
+		}
+		old.Release()
+		old = next
+		ce := realCorpusCInputEdit(edit)
+		cOld.Edit(&ce)
+		cNext := cp.Parse(edited, cOld)
+		if cNext == nil {
+			t.Fatal("C incremental parser returned no tree")
+		}
+		cOld.Close()
+		cOld = cNext
+		cFresh := cp.Parse(edited, nil)
+		if cFresh == nil {
+			t.Fatal("C fresh parser returned no tree")
+		}
+		assertLockedCTreeExact(t, string(replacement)+" versus fresh C", next, lang, cFresh)
+		cFresh.Close()
+		assertLockedCTreeExact(t, string(replacement)+" versus incremental C", next, lang, cNext)
+		if got := findGoNodeByTypeAndStart(next.RootNode(), lang, "function_declaration", bStart); got != oldB {
+			t.Fatal("repeated kind change lost function b identity")
+		}
+		if !next.ParseRuntime().CompactIncrementalReuseRoute {
+			t.Errorf("edit to %q skipped compact execution: %q", replacement, next.ParseRuntime().CompactIncrementalFallbackReason)
+		}
+		source = edited
 	}
 }

--- a/compact_incremental_execution_test.go
+++ b/compact_incremental_execution_test.go
@@ -147,6 +147,193 @@ func TestCompactIncrementalExecutionLanguageMismatch(t *testing.T) {
 	}
 }
 
+func TestCompactIncrementalExecutionSameWidth(t *testing.T) {
+	for _, replacement := range []string{"x", "2"} {
+		t.Run(replacement, func(t *testing.T) {
+			parser := newAdmissionCandidateGoParser(t)
+			parser.SetAdmissionCandidateRoute(true)
+			source := []byte("package p\nfunc a() { _ = 1 }\nfunc b() { _ = 2 }\n")
+			old, err := parser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !old.compactMaterialized {
+				old.Release()
+				t.Fatal("initial tree is not compact")
+			}
+			oldRoot := old.RootNode()
+			bStart := uint32(bytes.Index(source, []byte("func b")))
+			oldB := compactExecutionNode(oldRoot, parser.language, "function_declaration", bStart)
+			if oldB == nil {
+				old.Release()
+				t.Fatal("initial tree has no function b")
+			}
+			offset := bytes.IndexByte(source, '1')
+			edited, edit := compactExecutionEdit(source, offset, offset+1, replacement)
+			old.Edit(edit)
+			runner := parser.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+			legacyRuns := runner.legacyParseRuns
+			routed, fallback := AdmissionCandidateCounters()
+			parser.fullParseRetryPassesTaken = 3
+			next, profile, err := parser.ParseIncrementalProfiled(edited, old)
+			old.Release()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer next.Release()
+			if parser.fullParseRetryPassesTaken != 0 {
+				t.Fatal("incremental parse retained the previous retry count")
+			}
+			if r, f := AdmissionCandidateCounters(); r != routed || f != fallback {
+				t.Fatal("incremental parse changed full admission counters")
+			}
+			if got := compactExecutionNode(next.RootNode(), parser.language, "function_declaration", bStart); got != oldB {
+				t.Fatal("same-width edit lost the borrowed function b")
+			}
+			if next.RootNode().HasError() {
+				t.Fatal("same-width edit produced an error")
+			}
+			if replacement == "2" {
+				if next.RootNode() != oldRoot || profile.ReparseNanos != 0 || profile.NewNodesAllocated != 0 {
+					t.Fatalf("token-invariant shortcut regressed: same_root=%t profile=%+v", next.RootNode() == oldRoot, profile)
+				}
+				if profile.ReusedBytes != uint64(len(edited)) || next.ParseRuntime().CompactIncrementalReuseRoute {
+					t.Fatalf("token-invariant edit entered a reparse route: %+v", profile)
+				}
+				return
+			}
+			if changed := compactExecutionNode(next.RootNode(), parser.language, "identifier", uint32(offset)); changed == nil || changed.Text(edited) != "x" {
+				t.Fatal("same-width kind change did not produce an identifier")
+			}
+			if runner.legacyParseRuns != legacyRuns {
+				t.Errorf("same-width kind change invoked the legacy parser: calls=%d", runner.legacyParseRuns-legacyRuns)
+			}
+			if !next.compactMaterialized || !next.ParseRuntime().CompactIncrementalReuseRoute {
+				t.Errorf("same-width kind change skipped compact execution: compact=%t route=%t decline=%q", next.compactMaterialized, next.ParseRuntime().CompactIncrementalReuseRoute, next.ParseRuntime().CompactIncrementalFallbackReason)
+			}
+		})
+	}
+}
+
+func TestCompactIncrementalExecutionSameWidthCopyLifetime(t *testing.T) {
+	parser := newAdmissionCandidateGoParser(t)
+	parser.SetAdmissionCandidateRoute(true)
+	source := []byte("package p\nfunc a() { _ = 1 }\nfunc b() { _ = 2 }\n")
+	original, err := parser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer original.Release()
+	if !original.compactMaterialized {
+		t.Fatal("initial tree is not compact")
+	}
+	snapshot := original.Copy()
+	defer snapshot.Release()
+	current := original.Copy()
+	defer func() { current.Release() }()
+	bStart := uint32(bytes.Index(source, []byte("func b")))
+	borrowedB := compactExecutionNode(current.RootNode(), parser.language, "function_declaration", bStart)
+	if borrowedB == nil || borrowedB == compactExecutionNode(original.RootNode(), parser.language, "function_declaration", bStart) {
+		t.Fatal("copy did not isolate function b")
+	}
+	offset := bytes.IndexByte(source, '1')
+	for _, replacement := range []string{"x", "3", "y"} {
+		edited, edit := compactExecutionEdit(source, offset, offset+1, replacement)
+		current.Edit(edit)
+		compactExecutionEqual(t, original.RootNode(), snapshot.RootNode(), parser.language)
+		if len(original.Edits()) != 0 {
+			t.Fatal("editing a copy changed the original edit list")
+		}
+		runner := parser.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+		before := runner.legacyParseRuns
+		routed, fallback := AdmissionCandidateCounters()
+		next, _, err := parser.ParseIncrementalProfiled(edited, current)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if next == current {
+			t.Fatal("kind change returned the old tree")
+		}
+		current.Release()
+		current = next
+		if r, f := AdmissionCandidateCounters(); r != routed || f != fallback {
+			t.Fatal("incremental parse changed full admission counters")
+		}
+		if got := compactExecutionNode(next.RootNode(), parser.language, "function_declaration", bStart); got != borrowedB {
+			t.Fatalf("edit to %q lost the borrowed sibling", replacement)
+		}
+		if next.RootNode().HasError() || borrowedB.Text(edited) != "func b() { _ = 2 }" {
+			t.Fatal("released tree damaged its successor")
+		}
+		compactExecutionEqual(t, original.RootNode(), snapshot.RootNode(), parser.language)
+		if runner.legacyParseRuns != before {
+			t.Errorf("edit to %q invoked legacy parsing %d times", replacement, runner.legacyParseRuns-before)
+		}
+		if !next.compactMaterialized || !next.ParseRuntime().CompactIncrementalReuseRoute {
+			t.Errorf("edit to %q skipped compact execution: %q", replacement, next.ParseRuntime().CompactIncrementalFallbackReason)
+		}
+		source = edited
+	}
+}
+
+func TestCompactIncrementalExecutionSameWidthUnsupported(t *testing.T) {
+	for _, test := range []struct {
+		name, replacement string
+		mismatch          bool
+	}{
+		{"recovery", "}", false},
+		{"language_mismatch", "x", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			parser := newAdmissionCandidateGoParser(t)
+			parser.SetAdmissionCandidateRoute(true)
+			source := []byte("package p\nfunc a() { _ = 1 }\nfunc b() { _ = 2 }\n")
+			old, err := parser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer old.Release()
+			offset := bytes.IndexByte(source, '1')
+			oldLeaf := compactExecutionNode(old.RootNode(), parser.language, "int_literal", uint32(offset))
+			if oldLeaf == nil {
+				t.Fatal("initial tree has no edited leaf")
+			}
+			edited, edit := compactExecutionEdit(source, offset, offset+1, test.replacement)
+			old.Edit(edit)
+			if test.mismatch {
+				language := *parser.language
+				parser = NewParser(&language)
+				parser.SetAdmissionCandidateRoute(true)
+			}
+			next, profile, err := parser.ParseIncrementalProfiled(edited, old)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer next.Release()
+			if next.ParseRuntime().CompactIncrementalReuseRoute {
+				t.Fatal("unsupported edit published compact reuse")
+			}
+			if compactExecutionContains(next.RootNode(), oldLeaf) {
+				t.Fatal("unsupported edit reused the changed leaf")
+			}
+			if test.mismatch && profile.ReusedSubtrees != 0 {
+				t.Fatal("language mismatch reused old nodes")
+			}
+			if !test.mismatch && !next.RootNode().HasError() {
+				t.Fatal("malformed edit produced no recovery error")
+			}
+			freshParser := NewParser(parser.language)
+			freshParser.SetAdmissionCandidateRoute(false)
+			fresh, err := freshParser.Parse(edited)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer fresh.Release()
+			compactExecutionEqual(t, next.RootNode(), fresh.RootNode(), parser.language)
+		})
+	}
+}
+
 // This test checks recovery fallback against production. It does not certify C parity.
 func TestCompactIncrementalExecutionMissingBraceRejectsWrongSplice(t *testing.T) {
 	parser := newAdmissionCandidateGoParser(t)

--- a/parser_api.go
+++ b/parser_api.go
@@ -320,11 +320,9 @@ func checkpointedScannerSoleChildPaddingEdit(oldSource, newSource []byte, edit I
 	return true
 }
 
-// tryTokenInvariantReuseBeforePrefixFrontierFallback permits only the narrow
-// leaf path to bypass a prefix-sensitive scanner fallback. The leaf scan must
-// authenticate the new token under the recorded parser and scanner boundary.
-// A failed authentication returns control to the fresh-parse fallback.
-func (p *Parser) tryTokenInvariantReuseBeforePrefixFrontierFallback(source []byte, oldTree *Tree, timing *incrementalParseTiming) (*Tree, bool) {
+// tryTokenInvariantReuseWithDFA authenticates an edited leaf before choosing a reparse route.
+// The scan must preserve the token at its recorded parser and scanner boundary.
+func (p *Parser) tryTokenInvariantReuseWithDFA(source []byte, oldTree *Tree, timing *incrementalParseTiming) (*Tree, bool) {
 	if oldTreeDisablesIncrementalReuse(oldTree) {
 		return nil, false
 	}
@@ -1734,7 +1732,7 @@ func (p *Parser) parseIncrementalChanged(source []byte, oldTree *Tree) (*Tree, e
 		// scanner refusal and full-reparse work retain normal attribution.
 	}
 	if checkpointedScannerPrefixFrontierUnproven(source, oldTree) {
-		if tree, ok := p.tryTokenInvariantReuseBeforePrefixFrontierFallback(source, oldTree, nil); ok {
+		if tree, ok := p.tryTokenInvariantReuseWithDFA(source, oldTree, nil); ok {
 			return tree, nil
 		}
 		return p.Parse(source)
@@ -1943,7 +1941,7 @@ func (p *Parser) parseIncrementalChangedProfiled(source []byte, oldTree *Tree) (
 	}
 	if checkpointedScannerPrefixFrontierUnproven(source, oldTree) {
 		timing := &incrementalParseTiming{}
-		if tree, ok := p.tryTokenInvariantReuseBeforePrefixFrontierFallback(source, oldTree, timing); ok {
+		if tree, ok := p.tryTokenInvariantReuseWithDFA(source, oldTree, timing); ok {
 			return tree, timing.toProfile(), nil
 		}
 		start := time.Now()

--- a/parsercore_phase0_incremental.go
+++ b/parsercore_phase0_incremental.go
@@ -37,10 +37,22 @@ func (p *Parser) attemptCompactIncrementalParse(source []byte, oldTree *Tree, ti
 		!p.admissionCandidateFullParseEligible(nil, true) {
 		return nil, ""
 	}
+	p.fullParseRetryPassesTaken = 0
 	// Preserve the existing token-invariant fast path for same-width leaf edits.
-	// Width-changing edits cannot use that optimization.
+	// Reparse on the compact engine when the token proof fails.
 	if len(oldTree.edits) == 1 && oldTree.edits[0].OldEndByte == oldTree.edits[0].NewEndByte {
-		return nil, ""
+		var probeStarted time.Time
+		if timing != nil {
+			probeStarted = time.Now()
+		}
+		if tree, ok := p.tryTokenInvariantReuseWithDFA(source, oldTree, timing); ok {
+			return tree, ""
+		}
+		if timing != nil {
+			probeNanos := time.Since(probeStarted).Nanoseconds()
+			timing.totalNanos += probeNanos
+			timing.reuseNanos += probeNanos
+		}
 	}
 	if p.language.ExternalScanner != nil {
 		stateless, ok := p.language.ExternalScanner.(StatelessExternalScanner)


### PR DESCRIPTION
## Change

Continue compact incremental execution when a same-width edit changes its token kind.

The previous width guard sent every same-width edit to the legacy parser. It did not test token equivalence.

The compact route now tries the existing token-invariant proof first. A failed proof continues through authenticated compact subtree reuse.

Reuse the existing DFA probe helper. Reset the operation's retry count and account for failed probe time.

## Minimal regression

```go
package p
func a() { _ = 1 }
func b() { _ = 2 }
```

Change `1` to `x`. Before this change, exact C comparison passes, but the parser invokes the legacy engine once.

After this change, compact execution preserves `b` and invokes no legacy parse.

The `1` to `2` control preserves the original root, zero reparse time, and zero new nodes.

## Verification

- Compare fresh and incremental Go trees against locked C, including fields, ranges, points, and error flags.
- Exercise both public incremental APIs and repeated `1` to `x` to `3` to `y` edits.
- Check borrowed-node lifetime, copy isolation, cancellation, language mismatch, and recovery fallback.
- Run focused Docker race checks and both parser build configurations.
- Review independently with Astra at medium effort.

The standard randomized benchmark comparison follows correctness checks. Results appear in a separate PR comment.

This change does not admit recovery, stateful scanners, or unsupported token sources into compact subtree reuse.
