### PR TITLE
Run Go EOF recovery on version-owned compact state

### DIFF
--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -47,6 +47,7 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		return nil, errors.New("admission candidate route: parser has no language")
 	}
 	allowRecoverEOF := compactRecoverEOFArtifactConfigured(p.language)
+	allowOwnedEOFRecovery := p.language.CompactOwnedEOFRecoveryCertified
 	options := DiagnosticParserCorePrefixOptions{
 		ReceiptMode:                    DiagnosticParserCoreReceiptSummary,
 		MaxTokens:                      1 << 24,
@@ -63,18 +64,18 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		allowCompactAcceptanceStructuralElection: p.language.CompactAcceptanceStructuralElectionCertified,
 		allowConvergedSplitDropArtifact:          p.language.CompactConvergedReductionSplitDropsCertified,
 		captureLexerSkippedPrefixProvenance:      p.language.CompactLexerSkippedPrefixTilingCertified,
-		// Recovery admits either the certified S3 base mechanism or the
-		// dedicated recover_eof root route. The latter does not enable S3, S4,
-		// or S5.
-		Recovery:                          p.language.CompactStrategy2ErrorRegionCertified || allowRecoverEOF,
-		allowCompactStrategy2ErrorRegion:  p.language.CompactStrategy2ErrorRegionCertified,
+		// Recovery binds the shared mechanism, the dedicated recover_eof route,
+		// or the owned EOF bundle. The bundle cannot publish shared recovery.
+		Recovery:                          p.language.CompactStrategy2ErrorRegionCertified || allowRecoverEOF || allowOwnedEOFRecovery,
+		allowCompactStrategy2ErrorRegion:  p.language.CompactStrategy2ErrorRegionCertified || allowOwnedEOFRecovery,
 		allowCompactRecoverEOF:            allowRecoverEOF,
 		allowCompactStackSummaryRecovery:  p.language.CompactStackSummaryRecoveryCertified,
-		allowCompactMissingTokenInsertion: p.language.CompactMissingTokenInsertionCertified,
+		allowCompactMissingTokenInsertion: p.language.CompactMissingTokenInsertionCertified || allowOwnedEOFRecovery,
 		allowCompactS5EOFMissingInsertion: p.language.CompactS5EOFMissingInsertionCertified,
-		allowCompactFaithfulS5Recovery:    p.language.CompactFaithfulS5RecoveryCertified,
-		allowCompactRecoveryLineageSelection: p.language.CompactStrategy2ErrorRegionCertified &&
-			(p.language.CompactStackSummaryRecoveryCertified || p.language.CompactMissingTokenInsertionCertified),
+		allowCompactFaithfulS5Recovery:    p.language.CompactFaithfulS5RecoveryCertified || allowOwnedEOFRecovery,
+		allowCompactRecoveryVersionTurns:  allowOwnedEOFRecovery,
+		allowCompactRecoveryLineageSelection: allowOwnedEOFRecovery || (p.language.CompactStrategy2ErrorRegionCertified &&
+			(p.language.CompactStackSummaryRecoveryCertified || p.language.CompactMissingTokenInsertionCertified)),
 		allowCompactRecoveryTrailingLineageRetirement: p.language.CompactRecoveryTrailingLineageRetirementCertified,
 		allowCompactRecoveryErrorModeKeywordCapture:   p.language.CompactRecoveryErrorModeKeywordCaptureCertified,
 		noLookaheadRootSymbol:                         p.rootSymbol,
@@ -104,7 +105,7 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		// for the proof and still fails closed per tree when it is incomplete.
 		replayParseStates:                 true,
 		allowConvergedReductionSplitDrops: p.language.CompactConvergedReductionSplitDropsCertified,
-		recoveryPlainFirst:                p.language.CompactRecoveryPlainFirstCertified,
+		recoveryPlainFirst:                p.language.CompactRecoveryPlainFirstCertified || allowOwnedEOFRecovery,
 	}, nil
 }
 

--- a/admission_switch_stub.go
+++ b/admission_switch_stub.go
@@ -4,8 +4,12 @@ package gotreesitter
 
 func (p *Parser) recordLegacyParserEntry() {}
 
-func (p *Parser) attemptCompactIncrementalParse(_ []byte, _ *Tree, _ *incrementalParseTiming) (*Tree, string) {
-	return nil, ""
+func (p *Parser) attemptCompactIncrementalParse(_ []byte, _ *Tree, _ *incrementalParseTiming) (*Tree, string, bool) {
+	return nil, "", false
+}
+
+func (p *Parser) attemptCompactIncrementalRecoveryFullParse(_ []byte, _ string, _ bool, _ *incrementalParseTiming) *Tree {
+	return nil
 }
 
 // tryCompactFullParseRoute is the emergency-build stub for the compact

--- a/cgo_harness/go_compact_recovery_version_turns_test.go
+++ b/cgo_harness/go_compact_recovery_version_turns_test.go
@@ -1,0 +1,158 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0
+
+package cgoharness
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestGoCompactRecoveryVersionTurnsLockedC(t *testing.T) {
+	// Require the actual artifact profile without adding diagnostic grants.
+	language := *grammars.GoLanguage()
+	if !language.CompactOwnedEOFRecoveryCertified {
+		t.Fatal("Go artifact has no owned EOF recovery profile")
+	}
+	cLanguage, err := ParityCLanguage("go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fixture := range []struct{ name, source string }{
+		{"without_package", "func f(){}\nfunc g(){}\n"},
+		{"package_alias", "package p\nfunc f(){}\nfunc g(){}\n"},
+		{"parameters", "package p\nfunc f(x int) int { return x + 1 }\nfunc g(){}\n"},
+		{"loop", "package p\nfunc f(){for i:=0;i<2;i++{_ = i}}\nfunc g(){}\n"},
+		{"strings", "package p\nfunc f(){_ = \"a+b\"; _ = `raw`}\nfunc g(){}\n"},
+	} {
+		t.Run(fixture.name, func(t *testing.T) {
+			original := fixture.source
+			edited := original[:len(original)-1] + "+"
+			edit := gts.InputEdit{StartByte: uint32(len(original) - 1), OldEndByte: uint32(len(original)), NewEndByte: uint32(len(edited)), StartPoint: pointAtOffset([]byte(original), len(original)-1), OldEndPoint: pointAtOffset([]byte(original), len(original)), NewEndPoint: pointAtOffset([]byte(edited), len(edited))}
+			for _, incremental := range []bool{false, true} {
+				name := "fresh"
+				if incremental {
+					name = "incremental"
+				}
+				t.Run(name, func(t *testing.T) {
+					parser := gts.NewParser(&language)
+					parser.SetAdmissionCandidateRoute(true)
+					cp := sitter.NewParser()
+					defer cp.Close()
+					if err := cp.SetLanguage(cLanguage); err != nil {
+						t.Fatal(err)
+					}
+					var old *gts.Tree
+					var cOld *sitter.Tree
+					if incremental {
+						old, err = parser.Parse([]byte(original))
+						if err != nil {
+							t.Fatal(err)
+						}
+						if old.RootNode().Child(0).Parent() != old.RootNode() {
+							t.Fatal("old compact tree has an invalid parent link")
+						}
+						old.Edit(edit)
+						cOld = cp.Parse([]byte(original), nil)
+						if cOld == nil {
+							t.Fatal("C returned no old tree")
+						}
+						ce := realCorpusCInputEdit(edit)
+						cOld.Edit(&ce)
+					}
+					routedBefore, fallbackBefore := gts.AdmissionCandidateCounters()
+					var tree *gts.Tree
+					if incremental {
+						tree, err = parser.ParseIncremental([]byte(edited), old)
+						old.Release()
+					} else {
+						tree, err = parser.Parse([]byte(edited))
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer tree.Release()
+					for i := 0; i < tree.RootNode().ChildCount(); i++ {
+						if tree.RootNode().Child(i).Parent() != tree.RootNode() {
+							t.Fatal("new tree lost its parent links after the old tree was released")
+						}
+					}
+					if tree.ParseRuntime().NormalizationPassesRun != 0 {
+						t.Fatal("native compact recovery ran a result normalization pass")
+					}
+					oracle := cp.Parse([]byte(edited), cOld)
+					if cOld != nil {
+						cOld.Close()
+					}
+					if oracle == nil {
+						t.Fatal("C returned no edited tree")
+					}
+					defer oracle.Close()
+					fresh := cp.Parse([]byte(edited), nil)
+					if fresh == nil {
+						t.Fatal("C returned no fresh tree")
+					}
+					defer fresh.Close()
+					for _, ct := range []*sitter.Tree{oracle, fresh} {
+						if diff := FirstDivergenceDumpV1(tree.RootNode(), &language, ct.RootNode()); diff != nil {
+							t.Fatalf("C divergence: %+v", diff)
+						}
+						if diff := firstLockedCTreeFlagDivergence(tree.RootNode(), &language, ct.RootNode(), "/"); diff != nil {
+							t.Fatal(diff)
+						}
+					}
+					routedAfter, fallbackAfter := gts.AdmissionCandidateCounters()
+					if incremental {
+						runtime := tree.ParseRuntime()
+						if !runtime.CompactIncrementalFullRecoveryRoute || runtime.CompactIncrementalReuseRoute || runtime.CompactIncrementalReusedSubtrees != 0 || runtime.CompactIncrementalReusedBytes != 0 {
+							t.Fatalf("incremental did not publish an honest full compact recovery: %+v", runtime)
+						}
+						if routedAfter != routedBefore || fallbackAfter != fallbackBefore {
+							t.Fatal("incremental recovery changed full-parse admission counters")
+						}
+					} else if routedAfter-routedBefore != 1 || fallbackAfter != fallbackBefore {
+						t.Fatalf("compact fresh route=%d fallback=%d reason=%q", routedAfter-routedBefore, fallbackAfter-fallbackBefore, gts.AdmissionCandidateLastFallbackReason())
+					}
+					if incremental {
+						for _, replacement := range []string{"", "\n"} {
+							repaired := edited[:len(edited)-1] + replacement
+							repairEdit := gts.InputEdit{StartByte: uint32(len(edited) - 1), OldEndByte: uint32(len(edited)), NewEndByte: uint32(len(repaired)), StartPoint: pointAtOffset([]byte(edited), len(edited)-1), OldEndPoint: pointAtOffset([]byte(edited), len(edited)), NewEndPoint: pointAtOffset([]byte(repaired), len(repaired))}
+							borrowed := tree.Copy()
+							borrowed.Edit(repairEdit)
+							repairTree, err := parser.ParseIncremental([]byte(repaired), borrowed)
+							borrowed.Release()
+							if err != nil {
+								t.Fatal(err)
+							}
+							defer repairTree.Release()
+							cBorrowed := oracle.Clone()
+							ce := realCorpusCInputEdit(repairEdit)
+							cBorrowed.Edit(&ce)
+							cRepair := cp.Parse([]byte(repaired), cBorrowed)
+							cBorrowed.Close()
+							cFreshRepair := cp.Parse([]byte(repaired), nil)
+							if cRepair == nil || cFreshRepair == nil {
+								t.Fatal("C returned no repaired tree")
+							}
+							defer cRepair.Close()
+							defer cFreshRepair.Close()
+							for _, ct := range []*sitter.Tree{cRepair, cFreshRepair} {
+								if diff := FirstDivergenceDumpV1(repairTree.RootNode(), &language, ct.RootNode()); diff != nil {
+									t.Fatalf("repair %q C divergence: %+v", replacement, diff)
+								}
+								if diff := firstLockedCTreeFlagDivergence(repairTree.RootNode(), &language, ct.RootNode(), "/"); diff != nil {
+									t.Fatal(diff)
+								}
+							}
+							if !tree.RootNode().HasError() || tree.RootNode().EndByte() != uint32(len(edited)) {
+								t.Fatal("repairing a copy changed the original recovery tree")
+							}
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/compact_recovery_version_turns_test.go
+++ b/compact_recovery_version_turns_test.go
@@ -1,0 +1,296 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func TestCompactRecoveryVersionTurnFinishedCostIsStrict(t *testing.T) {
+	// A paused head adds 500 recovery cost. The finished span supplies the tie.
+	for _, tc := range []struct {
+		finished, paused uint32
+		want             bool
+	}{{501, 1, false}, {500, 1, true}, {502, 1, false}} {
+		for _, reversed := range []bool{false, true} {
+			t.Run(fmt.Sprintf("finished=%d/paused=%d/reversed=%t", tc.finished, tc.paused, reversed), func(t *testing.T) {
+				scheduler := newStage3RecoveryCondenseScheduler(t, []uint32{tc.finished, tc.paused})
+				scheduler.options.materializationSource = []byte(strings.Repeat("x", 502))
+				for i := range scheduler.headers {
+					header := &scheduler.headers[i]
+					region := header.recoveryRegion()
+					// Price the real ERROR spans; do not simulate cost through the cache.
+					err := scheduler.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+						var err error
+						header.head, _, err = scheduler.compact.RecoverEOFAcceptWithOpenRegionAndCostOwned(owner, header.head, region.startByte, region.endByte, region.children,
+							func(core.NodeID, core.SubtreeID) (uint32, error) { return 0, nil })
+						return err
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					header.closeRecoveryRegion()
+					header.markRecoveryCosted()
+				}
+				scheduler.headers[0].accepted = true
+				scheduler.headers[1].paused = true
+				if reversed {
+					scheduler.headers[0], scheduler.headers[1] = scheduler.headers[1], scheduler.headers[0]
+				}
+				got, err := scheduler.finishedRecoveryTreeBeatsPausedFrontier()
+				if err != nil || got != tc.want {
+					t.Fatalf("finished cost gate=%t err=%v, want %t", got, err, tc.want)
+				}
+			})
+		}
+	}
+}
+
+func TestCompactRecoveryVersionTurnUsesCOrder(t *testing.T) {
+	entries := []diagnosticParserCoreRecoveryCondenseEntry{
+		{key: diagnosticParserCoreRecoveryCondenseKey{recoveryGroup: 1}, status: core.RecoveryErrorStatus{Cost: 100, IsInError: true}},
+		{key: diagnosticParserCoreRecoveryCondenseKey{missingGroup: 1}, status: core.RecoveryErrorStatus{Cost: 100}},
+	}
+	legacy := diagnosticParserCoreRecoveryCondensePairwise(entries, []int{0, 1})
+	owned := diagnosticParserCoreRecoveryCondensePairwiseMode(entries, []int{0, 1}, true)
+	if !reflect.DeepEqual(legacy, []int{0, 1}) || !reflect.DeepEqual(owned, []int{1, 0}) {
+		t.Fatalf("recovery order legacy=%v owned=%v, want legacy absorber-first and owned C preference", legacy, owned)
+	}
+}
+
+func TestCompactRecoveryVersionTurnCancellationPreservesFork(t *testing.T) {
+	scheduler := newRecoveryLineageForkScheduler(t, true)
+	handled, err := scheduler.s5TryMissingTokenInsertion(0)
+	if err != nil || !handled || len(scheduler.headers) != 2 {
+		t.Fatalf("create recovery fork: handled=%t err=%v headers=%d", handled, err, len(scheduler.headers))
+	}
+	scheduler.options.allowCompactRecoveryVersionTurns = true
+	scheduler.recoveryTurns = diagnosticParserCoreRecoveryTurns{active: true, lastByte: 2}
+	cancelled := uint32(1)
+	parser := NewParser(scheduler.tokenSource.language)
+	parser.SetCancellationFlag(&cancelled)
+	scheduler.options.stopControlParser = parser
+	beforeTurns := scheduler.recoveryTurns
+	beforeHeaders := append([]diagnosticParserCoreHeader(nil), scheduler.headers...)
+	beforeRequests := append([]diagnosticParserCoreVersionLexerRequest(nil), scheduler.versionLexerRequests...)
+	beforeOwnership := scheduler.versionLexerOwnershipActive
+	stop, err := scheduler.dispatchRecoveryVersionTurn()
+	if err == nil || stop != nil {
+		t.Fatalf("cancelled recovery turn: stop=%+v err=%v", stop, err)
+	}
+	if scheduler.recoveryTurns != beforeTurns || scheduler.versionLexerOwnershipActive != beforeOwnership ||
+		!reflect.DeepEqual(scheduler.headers, beforeHeaders) || !reflect.DeepEqual(scheduler.versionLexerRequests, beforeRequests) {
+		t.Fatal("cancelled recovery turn changed the fork or lexer ownership")
+	}
+}
+
+func newCompactRecoveryVersionTurnEOFScheduler(t *testing.T, table core.TableView) *diagnosticParserCoreGenericScheduler {
+	t.Helper()
+	scheduler := newRecoveryLineageForkSchedulerWithTable(t, table, true)
+	scheduler.options.materializationSource = []byte("a+")
+	scheduler.options.MaxDispatches = 16
+	handled, err := scheduler.s5TryMissingTokenInsertion(0)
+	if err != nil || !handled || len(scheduler.headers) != 2 {
+		t.Fatalf("create recovery fork: handled=%t err=%v", handled, err)
+	}
+	language := scheduler.tokenSource.language
+	absorberCursor := newDiagnosticParserCoreOwnedLexerSnapshot(t, scheduler.compact, language, 2)
+	siblingCursor := newDiagnosticParserCoreOwnedLexerSnapshot(t, scheduler.compact, language, 1)
+	scheduler.versionLexerRequests = []diagnosticParserCoreVersionLexerRequest{
+		newDiagnosticParserCoreOwnedLexerRequest(scheduler.electionIndex, 0, Token{StartByte: 2, EndByte: 2}, absorberCursor, absorberCursor),
+		newDiagnosticParserCoreOwnedLexerRequest(scheduler.electionIndex, 3, Token{Symbol: 4, Text: "+", StartByte: 1, EndByte: 2}, siblingCursor, absorberCursor),
+	}
+	for i, cursor := range []*diagnosticParserCoreVersionLexerSnapshot{absorberCursor, siblingCursor} {
+		header := &scheduler.headers[i]
+		baseline, set := header.recoveryNodeBaseline()
+		header.publishVersionState(header.recoveryRegion(), cursor, uint32(i+1), header.recoveryGroupIdentity(), header.recoveryMissingGroupIdentity(), baseline, set)
+		header.shifted = false
+	}
+	scheduler.options.allowCompactRecoveryVersionTurns = true
+	scheduler.versionLexerOwnershipActive = true
+	scheduler.recoveryTurns = diagnosticParserCoreRecoveryTurns{active: true, lastByte: 2}
+	return scheduler
+}
+
+func TestCompactRecoveryVersionTurnAbsorberEOFPreservesSibling(t *testing.T) {
+	scheduler := newCompactRecoveryVersionTurnEOFScheduler(t, recoveryLineageForkTable{})
+	sibling := scheduler.headers[1]
+	siblingRequest := scheduler.versionLexerRequests[1]
+	stop, err := scheduler.dispatchRecoveryVersionTurn()
+	if err != nil || stop != nil {
+		t.Fatalf("absorber EOF turn: stop=%+v err=%v", stop, err)
+	}
+	if !scheduler.headers[0].accepted || scheduler.work.RecoverEOFAccepts != 1 {
+		t.Fatal("absorber did not process its owned EOF")
+	}
+	if scheduler.headers[1] != sibling || !reflect.DeepEqual(scheduler.versionLexerRequests[1], siblingRequest) || sibling.versionState.relexSnapshot.dfa.lexerPos != 1 {
+		t.Fatal("absorber EOF advanced the sibling or changed its snapshot")
+	}
+}
+
+type compactRecoveryVersionTurnCapTable struct{ recoveryLineageForkTable }
+
+func (table compactRecoveryVersionTurnCapTable) Actions(state core.StateID, symbol core.Symbol) (core.ActionRow, error) {
+	if state == 1 && symbol == 0 {
+		return core.NewActionRow([]core.Action{{Type: core.ActionAccept}}, false), nil
+	}
+	return table.recoveryLineageForkTable.Actions(state, symbol)
+}
+
+func TestCompactRecoveryVersionTurnCapDeclinesBeforeMutation(t *testing.T) {
+	scheduler := newCompactRecoveryVersionTurnEOFScheduler(t, compactRecoveryVersionTurnCapTable{})
+	for len(scheduler.headers) < 6 {
+		header := scheduler.headers[1]
+		header.creationSeq = uint64(len(scheduler.headers) + 10)
+		scheduler.headers = append(scheduler.headers, header)
+	}
+	beforeHeaders := append([]diagnosticParserCoreHeader(nil), scheduler.headers...)
+	beforeRequests := append([]diagnosticParserCoreVersionLexerRequest(nil), scheduler.versionLexerRequests...)
+	beforeTurns, beforeWork, beforeSeq := scheduler.recoveryTurns, scheduler.compact.Work(), scheduler.nextSeq
+	stop, err := scheduler.dispatchRecoveryVersionTurn()
+	if err != nil || stop == nil || !strings.Contains(stop.detail, "version-cap") {
+		t.Fatalf("six-version EOF recovery: stop=%+v err=%v", stop, err)
+	}
+	if scheduler.recoveryTurns != beforeTurns || scheduler.compact.Work() != beforeWork || scheduler.nextSeq != beforeSeq ||
+		!reflect.DeepEqual(scheduler.headers, beforeHeaders) || !reflect.DeepEqual(scheduler.versionLexerRequests, beforeRequests) {
+		t.Fatal("version-cap decline changed the fork before rejecting it")
+	}
+}
+
+func newCompactRecoveryVersionTurnGoParser(t *testing.T) *Parser {
+	t.Helper()
+	p := newAdmissionCandidateGoParser(t)
+	lang := p.language
+	if !lang.CompactOwnedEOFRecoveryCertified {
+		t.Fatal("Go artifact has no owned EOF recovery profile")
+	}
+	p.SetAdmissionCandidateRoute(true)
+	return p
+}
+
+func TestCompactRecoveryGoVersionTurnProfiledFallback(t *testing.T) {
+	p := newCompactRecoveryVersionTurnGoParser(t)
+	source := []byte("func f(){}\nfunc g(){}\n")
+	old, err := p.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	edited, edit := compactExecutionEdit(source, 21, 22, "+")
+	old.Edit(edit)
+	runner := p.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+	legacyBefore := runner.legacyParseRuns
+	next, profile, err := p.ParseIncrementalProfiled(edited, old)
+	old.Release()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer next.Release()
+	if runner.legacyParseRuns != legacyBefore {
+		t.Fatal("full compact recovery invoked legacy parsing")
+	}
+	if profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 || !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "compact_incremental_full_recovery" {
+		t.Fatalf("full compact recovery misreported reuse: %+v", profile)
+	}
+	runtime := next.ParseRuntime()
+	if !runtime.CompactIncrementalFullRecoveryRoute || runtime.CompactIncrementalReuseRoute || runtime.CompactIncrementalReusedSubtrees != 0 || runtime.CompactIncrementalReusedBytes != 0 || runtime.NormalizationPassesRun != 0 {
+		t.Fatalf("full compact recovery runtime=%+v", runtime)
+	}
+	if !next.compactMaterialized || next.RootNode().ChildCount() != 3 {
+		t.Fatal("full recovery did not publish the compact tree")
+	}
+	for i := 0; i < next.RootNode().ChildCount(); i++ {
+		if next.RootNode().Child(i).Parent() != next.RootNode() {
+			t.Fatal("old tree release damaged new parent links")
+		}
+	}
+}
+
+func TestCompactRecoveryGoVersionTurnRejectsLexicalReentry(t *testing.T) {
+	for _, suffix := range []string{"+@", "+@+"} {
+		p := newCompactRecoveryVersionTurnGoParser(t)
+		tree, routed, reason := p.tryCompactFullParseRoute([]byte("func f(){}\nfunc g(){}" + suffix))
+		if tree != nil {
+			tree.Release()
+		}
+		if routed {
+			t.Fatalf("owned recovery admitted unsupported lexical reentry %q", suffix)
+		}
+		if reason == "" {
+			t.Fatal("lexical reentry declined without a reason")
+		}
+	}
+}
+
+func TestCompactRecoveryGoVersionTurnPackageAlias(t *testing.T) {
+	p := newCompactRecoveryVersionTurnGoParser(t)
+	tree, routed, reason := p.tryCompactFullParseRoute([]byte("package p\nfunc f(){}\nfunc g(){}+"))
+	if tree != nil {
+		defer tree.Release()
+	}
+	if !routed {
+		t.Fatalf("package alias recovery declined: %s", reason)
+	}
+	root := tree.RootNode()
+	if !tree.compactMaterialized || !root.HasError() || root.ChildCount() != 4 {
+		t.Fatal("compact recovery lost its package declaration")
+	}
+	identifier := root.Child(0).Child(1)
+	if identifier.Type(p.language) != "package_identifier" || identifier.StartByte() != 8 || identifier.EndByte() != 9 || identifier.HasError() {
+		t.Fatal("compact recovery lost the authenticated package identifier alias")
+	}
+}
+
+func TestCompactRecoveryGoVersionTurnAdmission(t *testing.T) {
+	p := newCompactRecoveryVersionTurnGoParser(t)
+	lang := p.language
+	runner, err := p.acquireAdmissionCandidateRunner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := runner.compact.ResetReleasingRetention(); err != nil {
+			t.Error(err)
+		}
+	}()
+	runner.options.ReceiptMode = DiagnosticParserCoreReceiptFull
+	if !runner.options.allowCompactRecoveryVersionTurns {
+		t.Fatal("Go artifact did not enable owned recovery turns")
+	}
+	source := []byte("func f(){}\nfunc g(){}+")
+	_, _, err = runner.executeSchedulerOpenWithObserverAndErrorRuns(source, runner.compact, true, diagnosticParserCoreSeedObserver{}, true)
+	if err != nil {
+		t.Fatalf("owned recovery declined: %v; stop=%+v", err, runner.scheduler.receipt.Stop)
+	}
+	requests := runner.scheduler.receipt.VersionLexerRequests
+	if len(requests) < 2 {
+		t.Fatal("recovery did not request both owned lookaheads")
+	}
+	if requests[0].State != 0 || requests[0].Token.Symbol != 0 || requests[0].Token.StartByte != 22 ||
+		requests[1].Token.Text != "+" || requests[1].Token.StartByte != 21 || requests[1].Token.EndByte != 22 ||
+		requests[0].HeaderCreationSeq == requests[1].HeaderCreationSeq {
+		t.Fatalf("absorber EOF did not precede the sibling '+': %+v", requests)
+	}
+	tree, err := runner.materializeSelection(source, runner.compact, &runner.scheduler)
+	if err != nil {
+		t.Fatalf("owned recovery did not materialize: %v; acceptance=%+v", err, runner.scheduler.receipt.Acceptance)
+	}
+	defer tree.Release()
+	root := tree.RootNode()
+	if !tree.compactMaterialized || !root.HasError() || root.IsError() || root.ChildCount() != 3 {
+		t.Fatal("owned recovery result is not the compact source_file with local ERROR")
+	}
+	for i := 0; i < 2; i++ {
+		if root.Child(i).Type(lang) != "function_declaration" || root.Child(i).HasError() {
+			t.Errorf("recovery contaminated declaration %d", i)
+		}
+	}
+	tail := root.Child(2)
+	if !tail.IsError() || !tail.IsExtra() || tail.StartByte() != 21 || tail.EndByte() != 22 || tail.ChildCount() != 1 || tail.Child(0).HasError() {
+		t.Error("recovery did not preserve the local tail ERROR and clean '+' leaf")
+	}
+}

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -36,6 +36,7 @@ type builtinLanguageRuntimeProfile struct {
 	compactMissingTokenInsertion        bool
 	compactS5EOFMissingInsertion        bool
 	compactFaithfulS5Recovery           bool
+	compactOwnedEOFRecovery             bool
 	compactRecoveryTrailingRetirement   bool
 	compactRecoveryErrorModeKeyword     bool
 	compactRecoveryTerminalAliases      []compactRecoveryTerminalAliasProfile
@@ -69,9 +70,11 @@ const (
 var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// The canonical compact corpus certifies Go's converged-path split drops
 	// against the production parser and the tree-sitter C oracle.
+	// The owned EOF bundle requires its executed recovery route before publication.
 	"go": {
 		blobSHA256:                 mustRuntimeProfileSHA256("9cf914d26d962d1a62e7954f8b20b302337a44cb7d4a07218eec482c45a57a08"),
 		compactConvergedSplitDrops: true,
+		compactOwnedEOFRecovery:    true,
 	},
 	// YAML's irreducible flow opener has one direct no-action EOF lineage whose
 	// C result is the recover_eof ERROR root. Keep this gate independent from
@@ -827,6 +830,10 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	}
 	if profile.compactFaithfulS5Recovery && !lang.CompactFaithfulS5RecoveryCertified {
 		lang.CompactFaithfulS5RecoveryCertified = true
+		changed = true
+	}
+	if profile.compactOwnedEOFRecovery && !lang.CompactOwnedEOFRecoveryCertified {
+		lang.CompactOwnedEOFRecoveryCertified = true
 		changed = true
 	}
 	if profile.compactRecoveryTrailingRetirement && !lang.CompactRecoveryTrailingLineageRetirementCertified {

--- a/grammars/runtime_profiles_owned_eof_test.go
+++ b/grammars/runtime_profiles_owned_eof_test.go
@@ -1,0 +1,43 @@
+package grammars
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+func TestGoOwnedEOFRecoveryProfileRequiresExactBlob(t *testing.T) {
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+	lang := GoLanguage()
+	if !lang.CompactOwnedEOFRecoveryCertified || !lang.CompactConvergedReductionSplitDropsCertified {
+		t.Fatal("exact Go profile lacks the owned EOF bundle or existing split drops")
+	}
+	if lang.CompactStrategy2ErrorRegionCertified || lang.CompactStackSummaryRecoveryCertified ||
+		lang.CompactMissingTokenInsertionCertified || lang.CompactS5EOFMissingInsertionCertified ||
+		lang.CompactFaithfulS5RecoveryCertified || lang.CompactRecoveryPlainFirstCertified ||
+		lang.CompactRecoverEOFCertified {
+		t.Fatal("the Go bundle leaked independent shared-recovery capabilities")
+	}
+	custom := &gotreesitter.Language{Name: "go"}
+	AttachLanguageSupport("go", custom)
+	if custom.CompactOwnedEOFRecoveryCertified {
+		t.Fatal("same-name custom Go received the owned EOF bundle")
+	}
+	stale := &gotreesitter.Language{Name: "go"}
+	if attachBuiltinLanguageRuntimeProfile("go", sha256.Sum256([]byte("stale")), stale) || stale.CompactOwnedEOFRecoveryCertified {
+		t.Fatal("stale Go received the owned EOF bundle")
+	}
+	exact := &gotreesitter.Language{Name: "go"}
+	if !attachBuiltinLanguageRuntimeProfile("go", sha256.Sum256(BlobByName("go")), exact) || !exact.CompactOwnedEOFRecoveryCertified {
+		t.Fatal("exact Go blob did not receive the owned EOF bundle")
+	}
+	for name, profile := range builtinLanguageRuntimeProfiles {
+		if name != "go" && profile.compactOwnedEOFRecovery {
+			t.Fatalf("the owned EOF bundle unexpectedly certified %s", name)
+		}
+	}
+	if !builtinLanguageRuntimeProfiles["scala"].compactFaithfulS5Recovery {
+		t.Fatal("the independent Scala recovery profile changed")
+	}
+}

--- a/internal/parsercorephase0/ancestor_recovery.go
+++ b/internal/parsercorephase0/ancestor_recovery.go
@@ -254,6 +254,33 @@ func (c *Core) RecoverToAncestorStateWithCostOwned(
 	return out, c.finishSchedulerOwned(owner, err)
 }
 
+// RecoverToAncestorStateWithOpenRegionAndCostOwned folds absorbed region contents
+// after the elected path's payloads into one extra ERROR. Children are region
+// contents, not separate trailing stack extras. Their extra flags stay unchanged.
+// Every failure poisons the surrounding scheduler transaction.
+func (c *Core) RecoverToAncestorStateWithOpenRegionAndCostOwned(
+	owner SchedulerTransactionToken, candidate StackSummaryCandidate,
+	startByte, endByte uint32, children []SubtreeID, cost ReductionOutputCostFunc,
+) (out Head, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return out, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if cost == nil || len(children) == 0 || endByte < startByte {
+		err = errors.New("parser-core phase zero: invalid open-region ancestor recovery")
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	out, err = c.recoverToAncestorStateWithRegionUncheckpointed(candidate, cost, &ancestorRecoveryOpenRegion{
+		startByte: startByte, endByte: endByte, children: children,
+	})
+	return out, c.finishSchedulerOwned(owner, err)
+}
+
+type ancestorRecoveryOpenRegion struct {
+	startByte, endByte uint32
+	children           []SubtreeID
+}
+
 // StackSummaryCandidateRecoverable reports whether one authenticated summary
 // entry identifies exactly one mutable pop path. Summary deduplication can
 // retain an observational entry that is not safe to mutate.
@@ -275,6 +302,10 @@ func (c *Core) StackSummaryCandidateRecoverable(candidate StackSummaryCandidate)
 }
 
 func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandidate, cost ReductionOutputCostFunc) (Head, error) {
+	return c.recoverToAncestorStateWithRegionUncheckpointed(candidate, cost, nil)
+}
+
+func (c *Core) recoverToAncestorStateWithRegionUncheckpointed(candidate StackSummaryCandidate, cost ReductionOutputCostFunc, region *ancestorRecoveryOpenRegion) (Head, error) {
 	if candidate.owner != c {
 		return Head{}, errors.New("parser-core phase zero: stack-summary candidate belongs to a different core")
 	}
@@ -287,14 +318,93 @@ func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandid
 	if _, err := c.node(candidate.source); err != nil {
 		return Head{}, err
 	}
+	if region != nil {
+		source, _ := c.node(candidate.source)
+		if region.startByte < source.byteOffset || uint64(len(region.children)) > uint64(c.limits.MaxChildren) {
+			return Head{}, errors.New("parser-core phase zero: open region precedes its source or exceeds child limit")
+		}
+		previous := region.startByte
+		for _, id := range region.children {
+			child, err := c.subtree(id)
+			if err != nil {
+				return Head{}, err
+			}
+			if child.startByte < previous || child.endByte < child.startByte || child.endByte > region.endByte {
+				return Head{}, errors.New("parser-core phase zero: invalid open-region child span")
+			}
+			previous = child.endByte
+		}
+	}
 
 	links, target, err := c.uniqueAncestorRecoveryPath(candidate)
 	if err != nil {
 		return Head{}, err
 	}
+	var priorChildren []SubtreeID
+	var priorStart uint32
+	var priorScore int64
+	var priorOrder ForkOrder
+	if region != nil {
+		targetNode, err := c.node(target)
+		if err != nil {
+			return Head{}, err
+		}
+		var inline [inlineAdjacencyCapacity]linkRecord
+		targetLinks, err := c.publishedNodeLinksInto(inline[:0], *targetNode)
+		if err != nil {
+			return Head{}, err
+		}
+		for _, link := range targetLinks {
+			if err := link.validateShape(); err != nil {
+				return Head{}, err
+			}
+			if link.isRecoveryDiscontinuity() {
+				continue
+			}
+			prior, err := c.subtree(link.payload)
+			if err != nil {
+				return Head{}, err
+			}
+			if prior.symbol != ErrorRegionSymbol {
+				continue
+			}
+			// C pops one immediately preceding ERROR before it constructs the
+			// replacement. Ambiguous paths need a separate ownership proof.
+			if len(targetLinks) != 1 || prior.missing || prior.childCount == 0 ||
+				link.prev == 0 || link.prev >= target || prior.endByte > candidate.byteOffset ||
+				prior.startByte > prior.endByte || uint64(prior.firstChild)+uint64(prior.childCount) > uint64(len(c.children)) {
+				return Head{}, errors.New("parser-core phase zero: prior ERROR lacks a unique bounded pop proof")
+			}
+			predecessor, err := c.node(link.prev)
+			if err != nil {
+				return Head{}, err
+			}
+			if predecessor.byteOffset > prior.startByte {
+				return Head{}, errors.New("parser-core phase zero: prior ERROR overlaps its predecessor")
+			}
+			priorChildren = c.children[prior.firstChild : prior.firstChild+prior.childCount]
+			previous := prior.startByte
+			for _, id := range priorChildren {
+				child, err := c.subtree(id)
+				if err != nil {
+					return Head{}, err
+				}
+				if child.startByte < previous || child.endByte < child.startByte || child.endByte > prior.endByte {
+					return Head{}, errors.New("parser-core phase zero: invalid prior ERROR child span")
+				}
+				previous = child.endByte
+			}
+			priorStart, priorScore = prior.startByte, link.scoreDelta
+			if link.hasOrder() {
+				priorOrder = ForkOrder{Present: true, Value: link.order}
+			}
+			target = link.prev
+			break
+		}
+	}
 	depth := len(links)
 	trailing := 0
-	for trailing < depth {
+	for region == nil && trailing < depth {
 		if links[trailing].isRecoveryDiscontinuity() {
 			break
 		}
@@ -312,8 +422,7 @@ func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandid
 	}
 
 	children := make([]SubtreeID, 0, depth-trailing)
-	var score int64
-	var order ForkOrder
+	score, order := priorScore, priorOrder
 	for index := depth - 1; index >= trailing; index-- {
 		link := links[index]
 		if link.isRecoveryDiscontinuity() {
@@ -328,6 +437,28 @@ func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandid
 			order = ForkOrder{Present: true, Value: link.order}
 		}
 	}
+	if region != nil {
+		previous := candidate.byteOffset
+		for _, id := range children {
+			child, err := c.subtree(id)
+			if err != nil {
+				return Head{}, err
+			}
+			if child.startByte < previous || child.endByte < child.startByte || child.endByte > region.startByte {
+				return Head{}, errors.New("parser-core phase zero: invalid popped open-region child span")
+			}
+			previous = child.endByte
+		}
+		if uint64(len(c.children))+uint64(len(priorChildren))+uint64(len(children))+uint64(len(region.children)) > uint64(c.limits.MaxChildren) {
+			return Head{}, errors.New("parser-core phase zero: open-region recovery child limit")
+		}
+		if len(priorChildren) != 0 {
+			combined := make([]SubtreeID, 0, len(priorChildren)+len(children)+len(region.children))
+			combined = append(combined, priorChildren...)
+			children = append(combined, children...)
+		}
+		children = append(children, region.children...)
+	}
 	if len(children) == 0 {
 		return Head{}, errors.New("parser-core phase zero: ancestor recovery path has no ERROR payload")
 	}
@@ -339,8 +470,18 @@ func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandid
 	if err != nil {
 		return Head{}, err
 	}
+	startByte, endByte := first.startByte, last.endByte
+	if region != nil {
+		endByte = region.endByte
+		if len(priorChildren) != 0 {
+			startByte = priorStart
+		}
+		if region.startByte < startByte {
+			startByte = region.startByte
+		}
+	}
 	errorPayload, err := c.appendSubtree(subtreeRecord{
-		symbol: ErrorRegionSymbol, startByte: first.startByte, endByte: last.endByte, extra: true,
+		symbol: ErrorRegionSymbol, startByte: startByte, endByte: endByte, extra: true,
 	}, children, nil, nil)
 	if err != nil {
 		return Head{}, err
@@ -357,7 +498,7 @@ func (c *Core) recoverToAncestorStateUncheckpointed(candidate StackSummaryCandid
 		errorLink.hasStoredErrorCost = true
 	}
 	if trailing == 0 {
-		outcome, err := c.condenseWithOutcomeAtomic(c.shiftedBoundaryKey(candidate.state, last.endByte), errorLink)
+		outcome, err := c.condenseWithOutcomeAtomic(c.shiftedBoundaryKey(candidate.state, endByte), errorLink)
 		return outcome.head, err
 	}
 	out, err = c.appendPrivate(candidate.state, last.endByte, errorLink)

--- a/internal/parsercorephase0/ancestor_recovery_open_region_test.go
+++ b/internal/parsercorephase0/ancestor_recovery_open_region_test.go
@@ -1,0 +1,284 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"testing"
+)
+
+func openRegionAncestorFixture(t *testing.T) (*Core, StackSummaryCandidate, []SubtreeID) {
+	t.Helper()
+	c := newAncestorRecoveryTestCore(t, &fakeTable{}, Limits{})
+	seed, err := c.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ordinary := appendAncestorRecoveryPayload(t, c, 1, 0, 1, false)
+	extra := appendAncestorRecoveryPayload(t, c, 2, 1, 2, true)
+	head := appendAncestorRecoveryHead(t, c, seed, 2, ordinary)
+	head = appendAncestorRecoveryHead(t, c, head, 3, extra)
+	candidates, err := c.StackSummaryCandidates(head, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	region := appendAncestorRecoveryPayload(t, c, 3, 3, 4, false)
+	regionExtra := appendAncestorRecoveryPayload(t, c, 4, 4, 5, true)
+	return c, ancestorRecoveryCandidateForState(t, candidates, 1), []SubtreeID{ordinary, extra, region, regionExtra}
+}
+
+func TestRecoverToAncestorOpenRegionScoreOverflow(t *testing.T) {
+	c := newAncestorRecoveryTestCore(t, &fakeTable{}, Limits{})
+	head, err := c.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, score := range []int64{math.MaxInt64, 1} {
+		payload := appendAncestorRecoveryPayload(t, c, 1, uint32(i), uint32(i+1), false)
+		head, err = c.appendPrivate(StateID(i+2), uint32(i+1), linkInput{prev: head.Node, payload: payload, scoreDelta: score})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	candidates, err := c.StackSummaryCandidates(head, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := ancestorRecoveryCandidateForState(t, candidates, 1)
+	child := appendAncestorRecoveryPayload(t, c, 3, 2, 3, false)
+	before := captureSchedulerTransactionState(c)
+	err = c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, _ = c.RecoverToAncestorStateWithOpenRegionAndCostOwned(owner, candidate, 2, 3, []SubtreeID{child}, func(NodeID, SubtreeID) (uint32, error) {
+			t.Fatal("overflow reached cost publication")
+			return 0, nil
+		})
+		return nil
+	})
+	if err == nil {
+		t.Fatal("score overflow committed")
+	}
+	if after := captureSchedulerTransactionState(c); !reflect.DeepEqual(before, after) {
+		t.Fatal("score overflow changed storage")
+	}
+}
+
+func priorErrorAncestorFixture(t *testing.T) (*Core, StackSummaryCandidate, SubtreeID, NodeID, []SubtreeID) {
+	t.Helper()
+	c := newAncestorRecoveryTestCore(t, &fakeTable{}, Limits{})
+	seed, err := c.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	priorChild := appendAncestorRecoveryPayload(t, c, 1, 0, 1, false)
+	prior, err := c.appendSubtree(subtreeRecord{symbol: ErrorRegionSymbol, startByte: 0, endByte: 1, extra: true}, []SubtreeID{priorChild}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := appendAncestorRecoveryHead(t, c, seed, 2, prior)
+	c.nodeLineages[target.Node-1].storedErrorCost = 601
+	ordinary := appendAncestorRecoveryPayload(t, c, 2, 1, 2, false)
+	head := appendAncestorRecoveryHead(t, c, target, 3, ordinary)
+	candidates, err := c.StackSummaryCandidates(head, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := ancestorRecoveryCandidateForState(t, candidates, 2)
+	region := appendAncestorRecoveryPayload(t, c, 3, 2, 3, false)
+	return c, candidate, region, target.Node, []SubtreeID{priorChild, ordinary, region}
+}
+
+func TestRecoverToAncestorOpenRegionPopsPriorError(t *testing.T) {
+	c, candidate, region, target, children := priorErrorAncestorFixture(t)
+	node, err := c.node(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.links[node.firstLink-1].scoreDelta = 7
+	var recovered Head
+	err = c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		var err error
+		recovered, err = c.RecoverToAncestorStateWithOpenRegionAndCostOwned(owner, candidate, 2, 3, []SubtreeID{region}, func(prev NodeID, id SubtreeID) (uint32, error) {
+			prefix, err := c.RecoveryStoredErrorCost(Head{Node: prev})
+			if err != nil {
+				return 0, err
+			}
+			view, err := c.Subtree(id)
+			if err != nil {
+				return 0, err
+			}
+			if prev != 1 || prefix != 0 || view.StartByte != 0 || !reflect.DeepEqual(view.Children, children) {
+				t.Errorf("prior ERROR retained: prev=%d prefixCost=%d region=%+v", prev, prefix, view)
+			}
+			return prefix + 803, nil
+		})
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := c.Derivations(recovered)
+	if err != nil || len(paths) != 1 || paths[0].Score != 7 || len(paths[0].Payloads) != 1 {
+		t.Fatalf("prior ERROR score or topology changed: paths=%+v err=%v", paths, err)
+	}
+	if cost, err := c.RecoveryStoredErrorCost(recovered); err != nil || cost != 803 {
+		t.Fatalf("replacement ERROR cost=%d err=%v, want 803", cost, err)
+	}
+}
+
+func TestRecoverToAncestorOpenRegionPriorErrorRollback(t *testing.T) {
+	for _, name := range []string{"ambiguous", "childless", "bad-span", "cost", "outer", "old-api"} {
+		t.Run(name, func(t *testing.T) {
+			c, candidate, region, target, all := priorErrorAncestorFixture(t)
+			node, _ := c.node(target)
+			links, err := c.publishedNodeLinksInto(nil, *node)
+			if err != nil {
+				t.Fatal(err)
+			}
+			priorID := links[0].payload
+			cost := ReductionOutputCostFunc(func(NodeID, SubtreeID) (uint32, error) { return 803, nil })
+			sentinel := errors.New("prior ERROR rollback")
+			switch name {
+			case "ambiguous":
+				alternate := appendAncestorRecoveryPayload(t, c, 9, 0, 1, true)
+				target, err = c.appendAdjacencyNode(2, 1, []linkRecord{links[0], {prev: links[0].prev, payload: alternate}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				head := appendAncestorRecoveryHead(t, c, Head{Node: target}, 3, all[1])
+				candidates, err := c.StackSummaryCandidates(head, 1)
+				if err != nil {
+					t.Fatal(err)
+				}
+				candidate = ancestorRecoveryCandidateForState(t, candidates, 2)
+			case "childless":
+				c.subtrees[priorID-1].childCount = 0
+			case "bad-span":
+				c.subtrees[priorID-1].endByte = 2
+			case "cost":
+				cost = func(NodeID, SubtreeID) (uint32, error) { return 0, sentinel }
+			}
+			before := captureSchedulerTransactionState(c)
+			err = c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				if name == "old-api" {
+					_, err := c.RecoverToAncestorStateWithCostOwned(owner, candidate, func(prev NodeID, _ SubtreeID) (uint32, error) {
+						if prev != target {
+							t.Fatal("old API popped the prior ERROR")
+						}
+						return 803, nil
+					})
+					return err
+				}
+				_, _ = c.RecoverToAncestorStateWithOpenRegionAndCostOwned(owner, candidate, 2, 3, []SubtreeID{region}, cost)
+				if name == "outer" {
+					return sentinel
+				}
+				return nil
+			})
+			if name == "old-api" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("invalid prior ERROR committed")
+			}
+			if after := captureSchedulerTransactionState(c); !reflect.DeepEqual(before, after) {
+				t.Fatal("prior ERROR failure changed storage")
+			}
+			assertTransactionJournalClean(t, c)
+		})
+	}
+}
+
+func TestRecoverToAncestorOpenRegionFoldsExtrasAndCost(t *testing.T) {
+	c, candidate, children := openRegionAncestorFixture(t)
+	calls := 0
+	err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		out, err := c.RecoverToAncestorStateWithOpenRegionAndCostOwned(owner, candidate, 2, 6, children[2:], func(prev NodeID, id SubtreeID) (uint32, error) {
+			calls++
+			r, err := c.subtree(id)
+			if err != nil {
+				return 0, err
+			}
+			if r.symbol != ErrorRegionSymbol || !r.extra || r.startByte != 0 || r.endByte != 6 {
+				t.Fatalf("wrong region: %+v", r)
+			}
+			got := c.children[r.firstChild : r.firstChild+r.childCount]
+			if !reflect.DeepEqual(got, children) {
+				t.Fatalf("children=%v want=%v", got, children)
+			}
+			return 123, nil
+		})
+		if err != nil {
+			return err
+		}
+		if got, err := c.RecoveryStoredErrorCost(out); err != nil || got != 123 {
+			t.Fatalf("cost=%d err=%v", got, err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("cost calls=%d, want one final region", calls)
+	}
+}
+
+func TestRecoverToAncestorOpenRegionFailurePoisonsAndRollsBack(t *testing.T) {
+	for _, name := range []string{"empty", "span", "invalid-id", "overlap", "foreign", "stale", "cost", "panic", "outer", "limit", "nil-cost"} {
+		t.Run(name, func(t *testing.T) {
+			c, candidate, children := openRegionAncestorFixture(t)
+			region := children[2:]
+			start, end := uint32(2), uint32(6)
+			cost := ReductionOutputCostFunc(func(NodeID, SubtreeID) (uint32, error) { return 1, nil })
+			sentinel := errors.New("reject region")
+			switch name {
+			case "empty":
+				region = nil
+			case "span":
+				end = 1
+			case "invalid-id":
+				region = []SubtreeID{SubtreeID(len(c.subtrees) + 1)}
+			case "overlap":
+				region = []SubtreeID{children[3], children[2]}
+			case "foreign":
+				candidate.owner = &Core{}
+			case "stale":
+				candidate.generation++
+			case "cost":
+				cost = func(NodeID, SubtreeID) (uint32, error) { return 0, sentinel }
+			case "panic":
+				cost = func(NodeID, SubtreeID) (uint32, error) { panic(sentinel) }
+			case "limit":
+				c.limits.MaxChildren = 3
+			case "nil-cost":
+				cost = nil
+			}
+			before := captureSchedulerTransactionState(c)
+			var gotErr error
+			func() {
+				defer func() {
+					if v := recover(); v != nil && name != "panic" {
+						panic(v)
+					}
+				}()
+				gotErr = c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+					_, _ = c.RecoverToAncestorStateWithOpenRegionAndCostOwned(owner, candidate, start, end, region, cost)
+					if name == "outer" {
+						return sentinel
+					}
+					return nil
+				})
+			}()
+			if name != "panic" && gotErr == nil {
+				t.Fatal("ignored failure committed")
+			}
+			if after := captureSchedulerTransactionState(c); !reflect.DeepEqual(before, after) {
+				t.Fatalf("failed region changed storage: before=%+v after=%+v", before, after)
+			}
+			assertTransactionJournalClean(t, c)
+		})
+	}
+}

--- a/internal/parsercorephase0/eof_recovery_live.go
+++ b/internal/parsercorephase0/eof_recovery_live.go
@@ -111,7 +111,15 @@ func (c *Core) recoverEOFAcceptUncheckpointedWithCost(
 	if err := c.validateRecoverEOFAcceptPayloads(payloads, startByte, endByte); err != nil {
 		return Head{}, 0, err
 	}
+	return c.publishRecoverEOFAcceptUncheckpointed(payloads, startByte, endByte, 0, cost)
+}
 
+func (c *Core) publishRecoverEOFAcceptUncheckpointed(
+	payloads []SubtreeID,
+	startByte, endByte uint32,
+	score int64,
+	cost ReductionOutputCostFunc,
+) (Head, SubtreeID, error) {
 	root, err := c.appendSubtree(subtreeRecord{
 		symbol:    ErrorRegionSymbol,
 		startByte: startByte,
@@ -145,7 +153,7 @@ func (c *Core) recoverEOFAcceptUncheckpointedWithCost(
 			return Head{}, 0, costErr
 		}
 	}
-	linkID := c.appendGraphLink(linkRecord{prev: base, payload: root})
+	linkID := c.appendGraphLink(linkRecord{prev: base, payload: root, scoreDelta: score})
 	c.addWork(&c.work.GraphLinkAdditionsProxy, 1)
 	newNode, err := c.appendNodeAt(nodeRecord{
 		state: 1, byteOffset: endByte,

--- a/internal/parsercorephase0/eof_recovery_open_region.go
+++ b/internal/parsercorephase0/eof_recovery_open_region.go
@@ -1,0 +1,59 @@
+package parsercorephase0
+
+import "errors"
+
+// RecoverEOFAcceptWithOpenRegionAndCostOwned includes the live error-repeat
+// contents in C's final ERROR. It does not publish a nested ERROR region.
+// The caller supplies only absorbed children, not independent stack extras.
+func (c *Core) RecoverEOFAcceptWithOpenRegionAndCostOwned(
+	owner SchedulerTransactionToken,
+	head Head,
+	regionStart, regionEnd uint32,
+	children []SubtreeID,
+	cost ReductionOutputCostFunc,
+) (out Head, root SubtreeID, err error) {
+	if c == nil {
+		return Head{}, 0, errors.New("parser-core phase zero: open-region EOF accept on nil core")
+	}
+	err = c.RunSchedulerOwned(owner, func() error {
+		if cost == nil || len(children) == 0 || regionStart >= regionEnd {
+			return errors.New("parser-core phase zero: open-region EOF accept requires children, span, and cost")
+		}
+		paths, pathErr := c.Derivations(head)
+		if pathErr != nil {
+			return pathErr
+		}
+		if len(paths) != 1 || len(paths[0].Payloads)+len(children) > EOFAdmissionMaxTopPayloads {
+			return errors.New("parser-core phase zero: open-region EOF accept requires one bounded path")
+		}
+		payloads := make([]SubtreeID, 0, len(paths[0].Payloads)+len(children))
+		payloads = append(payloads, paths[0].Payloads...)
+		payloads = append(payloads, children...)
+		first, viewErr := c.subtree(payloads[0])
+		if viewErr != nil {
+			return viewErr
+		}
+		// Keep the initial route exact and scanner-independent. The existing
+		// validator rejects missing nodes, extras, and unknown scanner state.
+		if err := c.validateRecoverEOFAcceptPayloads(payloads, first.startByte, regionEnd); err != nil {
+			return err
+		}
+		if err := c.validateRecoverEOFAcceptPayloads(children, regionStart, regionEnd); err != nil {
+			return err
+		}
+		_, position, boundaryErr := c.Boundary(head)
+		if boundaryErr != nil {
+			return boundaryErr
+		}
+		if position > regionStart {
+			return errors.New("parser-core phase zero: open-region EOF contents overlap the stack")
+		}
+		var publishErr error
+		out, root, publishErr = c.publishRecoverEOFAcceptUncheckpointed(payloads, first.startByte, regionEnd, paths[0].Score, cost)
+		return publishErr
+	})
+	if err != nil {
+		return Head{}, 0, err
+	}
+	return out, root, nil
+}

--- a/internal/parsercorephase0/eof_recovery_open_region_test.go
+++ b/internal/parsercorephase0/eof_recovery_open_region_test.go
@@ -1,0 +1,134 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestRecoverEOFAcceptOpenRegionFlattensAndPricesOnce(t *testing.T) {
+	fixture := newRecoverEOFAcceptFixture(t)
+	c := fixture.core
+	child := appendAncestorRecoveryPayload(t, c, 13, 3, 4, false)
+	var head Head
+	var root SubtreeID
+	calls := 0
+	err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		var err error
+		head, root, err = c.RecoverEOFAcceptWithOpenRegionAndCostOwned(owner, fixture.head, 2, 4, []SubtreeID{child}, func(prev NodeID, id SubtreeID) (uint32, error) {
+			calls++
+			prefix, err := c.RecoveryStoredErrorCost(Head{Node: prev})
+			if err != nil || prefix != 0 {
+				t.Fatalf("replacement inherited cost %d: %v", prefix, err)
+			}
+			view, err := c.Subtree(id)
+			if err != nil {
+				return 0, err
+			}
+			want := append(append([]SubtreeID(nil), fixture.payload...), child)
+			if view.Symbol != ErrorRegionSymbol || view.Extra || view.StartByte != 0 || view.EndByte != 4 || !reflect.DeepEqual(view.Children, want) {
+				t.Fatalf("wrong flattened EOF root: %+v", view)
+			}
+			return 834, nil
+		})
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 || !c.IsRecoverEOFAcceptRoot(root) {
+		t.Fatalf("cost calls=%d root=%d", calls, root)
+	}
+	if cost, err := c.RecoveryStoredErrorCost(head); err != nil || cost != 834 {
+		t.Fatalf("cost=%d error=%v", cost, err)
+	}
+	paths, err := c.Derivations(head)
+	if err != nil || len(paths) != 1 || !reflect.DeepEqual(paths[0].Payloads, []SubtreeID{root}) {
+		t.Fatalf("replacement paths=%+v error=%v", paths, err)
+	}
+}
+
+func TestRecoverEOFAcceptOpenRegionPreservesPrecedence(t *testing.T) {
+	fixture := newRecoverEOFAcceptFixture(t)
+	c := fixture.core
+	leaf := appendAncestorRecoveryPayload(t, c, 13, 2, 3, false)
+	head, err := c.appendPrivate(10, 3, linkInput{prev: fixture.head.Node, payload: leaf, scoreDelta: 9})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child := appendAncestorRecoveryPayload(t, c, 14, 3, 4, false)
+	err = c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		var err error
+		head, _, err = c.RecoverEOFAcceptWithOpenRegionAndCostOwned(owner, head, 3, 4, []SubtreeID{child}, func(NodeID, SubtreeID) (uint32, error) { return 1, nil })
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := c.Derivations(head)
+	if err != nil || len(paths) != 1 || paths[0].Score != 9 {
+		t.Fatalf("lost dynamic precedence: paths=%+v error=%v", paths, err)
+	}
+}
+
+func TestRecoverEOFAcceptOpenRegionFailuresRollBack(t *testing.T) {
+	for _, name := range []string{"empty", "span", "unknown-child", "overlap", "cost", "outer", "panic", "limit", "missing", "extra", "unknown-scanner"} {
+		t.Run(name, func(t *testing.T) {
+			fixture := newRecoverEOFAcceptFixture(t)
+			c := fixture.core
+			child := appendAncestorRecoveryPayload(t, c, 13, 2, 3, false)
+			children := []SubtreeID{child}
+			start, end := uint32(2), uint32(3)
+			cost := ReductionOutputCostFunc(func(NodeID, SubtreeID) (uint32, error) { return 1, nil })
+			sentinel := errors.New("stop EOF recovery")
+			switch name {
+			case "empty":
+				children = nil
+			case "span":
+				end = 1
+			case "unknown-child":
+				children[0] = SubtreeID(len(c.subtrees) + 1)
+			case "overlap":
+				start = 0
+				children[0] = fixture.payload[0]
+			case "cost":
+				cost = func(NodeID, SubtreeID) (uint32, error) { return 0, sentinel }
+			case "panic":
+				cost = func(NodeID, SubtreeID) (uint32, error) { panic(sentinel) }
+			case "limit":
+				c.limits.MaxChildren = 1
+			case "missing":
+				c.subtrees[child-1].missing = true
+			case "extra":
+				c.subtrees[child-1].extra = true
+			case "unknown-scanner":
+				c.externalPayloadsQuiescent = false
+				c.subtrees[child-1].external = true
+				c.subtrees[child-1].externalProvenanceState = subtreeExternalProvenanceInexactHasExternal
+			}
+			before := captureSchedulerTransactionState(c)
+			var gotErr error
+			func() {
+				defer func() {
+					if value := recover(); value != nil && name != "panic" {
+						panic(value)
+					}
+				}()
+				gotErr = c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+					_, _, _ = c.RecoverEOFAcceptWithOpenRegionAndCostOwned(owner, fixture.head, start, end, children, cost)
+					if name == "outer" {
+						return sentinel
+					}
+					return nil
+				})
+			}()
+			if name != "panic" && gotErr == nil {
+				t.Fatal("ignored EOF failure committed")
+			}
+			if after := captureSchedulerTransactionState(c); !reflect.DeepEqual(before, after) {
+				t.Fatal("failed EOF recovery changed storage")
+			}
+			assertTransactionJournalClean(t, c)
+		})
+	}
+}

--- a/language.go
+++ b/language.go
@@ -920,6 +920,13 @@ type Language struct {
 	// remains active without this exact artifact capability.
 	CompactFaithfulS5RecoveryCertified bool
 
+	// CompactOwnedEOFRecoveryCertified permits the bounded owned EOF route.
+	// The admission runner binds its required mechanisms as one bundle.
+	// Publication requires executed version-owned EOF recovery, without prior
+	// shared recovery or sibling drops. Other recovery grants remain separate.
+	// Custom, adapted, and stale artifacts retain the false default.
+	CompactOwnedEOFRecoveryCertified bool
+
 	// CompactRecoveryTrailingLineageRetirementCertified permits the compact
 	// scheduler to retire one trailing no-action missing lineage after the
 	// earlier error-absorb lineage consumed the same elected token. This is the

--- a/parser_api.go
+++ b/parser_api.go
@@ -1701,8 +1701,11 @@ func (p *Parser) ParseIncremental(source []byte, oldTree *Tree) (*Tree, error) {
 	}
 	operationBudget := p.beginParseOperationBudget()
 	defer p.endParseOperationBudget(operationBudget)
-	tree, reason := p.attemptCompactIncrementalParse(source, oldTree, nil)
+	tree, reason, recoveryDeclined := p.attemptCompactIncrementalParse(source, oldTree, nil)
 	if tree != nil {
+		return tree, nil
+	}
+	if tree = p.attemptCompactIncrementalRecoveryFullParse(source, reason, recoveryDeclined, nil); tree != nil {
 		return tree, nil
 	}
 	tree, err := p.parseIncrementalChanged(source, oldTree)
@@ -1898,9 +1901,18 @@ func (p *Parser) ParseIncrementalProfiled(source []byte, oldTree *Tree) (*Tree, 
 	operationBudget := p.beginParseOperationBudget()
 	defer p.endParseOperationBudget(operationBudget)
 	var compactTiming incrementalParseTiming
-	tree, reason := p.attemptCompactIncrementalParse(source, oldTree, &compactTiming)
+	tree, reason, recoveryDeclined := p.attemptCompactIncrementalParse(source, oldTree, &compactTiming)
 	if tree != nil {
 		return tree, compactTiming.toProfile(), nil
+	}
+	fallbackStarted := time.Now()
+	if tree = p.attemptCompactIncrementalRecoveryFullParse(source, reason, recoveryDeclined, &compactTiming); tree != nil {
+		profile := profileFreshParseFallback(fallbackStarted, tree, "compact_incremental_full_recovery")
+		profile.ReuseCursorNanos += compactTiming.reuseNanos
+		profile.ReparseNanos += max(int64(0), compactTiming.totalNanos-compactTiming.reuseNanos)
+		profile.TokensConsumed += compactTiming.tokensConsumed
+		profile.NewNodesAllocated += compactTiming.newNodes
+		return tree, profile, nil
 	}
 	tree, profile, err := p.parseIncrementalChangedProfiled(source, oldTree)
 	profile.ReuseCursorNanos += compactTiming.reuseNanos

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -1171,6 +1171,15 @@ func (b *resultRootBuild) finishRecoverEOFTree(root *Node, wireParentLinks bool)
 		return nil
 	}
 	root.setFlag(nodeFlagCompactRecoverEOF, true)
+	return b.finishNativeAcceptedTree(root, wireParentLinks)
+}
+
+// finishNativeAcceptedTree publishes a root that already follows C acceptance.
+// It wires parents without applying language compatibility rewrites.
+func (b *resultRootBuild) finishNativeAcceptedTree(root *Node, wireParentLinks bool) *Tree {
+	if root == nil {
+		return nil
+	}
 	errorSummary := resultErrorSummaryUnknown
 	if wireParentLinks {
 		if !wireParentLinksWithScratchUntil(root, b.linkScratch, b.parser, &errorSummary) && root.ownerArena != nil {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -122,6 +122,9 @@ type DiagnosticParserCorePrefixOptions struct {
 	// allowCompactFaithfulS5Recovery selects the complete S5 physical
 	// graph-head scan. Uncertified artifacts retain the bounded legacy scan.
 	allowCompactFaithfulS5Recovery bool
+	// allowCompactRecoveryVersionTurns enables owned C advance rounds after S5.
+	// Artifact admission remains separate from this private runtime capability.
+	allowCompactRecoveryVersionTurns bool
 	// allowCompactRecoveryLineageSelection permits completeAcceptance to
 	// resolve MORE THAN ONE accepted head by pricing the competing recovery
 	// lineages and publishing the cheaper tree, instead of declining.
@@ -2804,6 +2807,7 @@ type diagnosticParserCoreGenericScheduler struct {
 	// versionLexerOwnershipActive keeps each live header on its own DFA and
 	// scanner cursor until one version remains and rejoins shared election.
 	versionLexerOwnershipActive bool
+	recoveryTurns               diagnosticParserCoreRecoveryTurns
 	// versionLexerNoActionProof is true only during one exact C-style drop:
 	// owned versions shared a token start, at least one shifted, and the
 	// remaining versions exhausted reductions without an action.
@@ -5344,6 +5348,9 @@ func (s *diagnosticParserCoreGenericScheduler) requestVersionLexerHeader(index i
 	if existing := s.versionLexerRequestForHeader(index); existing != nil {
 		return nil
 	}
+	if s.recoveryTurns.active && s.tokens >= s.options.MaxTokens {
+		return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreCap, detail: "generic scheduler token cap"}
+	}
 	header := &s.headers[index]
 	base := header.versionLexerSnapshot()
 	if base == nil {
@@ -5368,6 +5375,9 @@ func (s *diagnosticParserCoreGenericScheduler) requestVersionLexerHeader(index i
 	state, _, err := s.compact.Boundary(header.head)
 	if err != nil {
 		return err
+	}
+	if s.recoveryTurns.active && header.recoveryRegion() != nil {
+		state = 0
 	}
 	s.tokenSource.SetParserState(StateID(state))
 	s.tokenSource.SetGLRStates(nil)
@@ -5422,6 +5432,9 @@ func (s *diagnosticParserCoreGenericScheduler) requestVersionLexerHeader(index i
 	header.checkpoint = afterID
 	s.work.add(&s.work.PerVersionLexPublications, 1) // the after snapshot is a sidecar publication
 	s.work.add(&s.work.PerVersionLexRequests, 1)
+	if s.recoveryTurns.active {
+		s.tokens++
+	}
 	if uint64(len(s.headers)) > s.work.PeakLiveVersions {
 		s.work.PeakLiveVersions = uint64(len(s.headers))
 	}
@@ -6176,10 +6189,14 @@ const parserCoreMaxRetainedLineStarts = 256 * 1024
 // arena reuse: the warm steady state stops re-allocating the public-tree
 // scratch on every parse.
 type parserCoreRunnerScratch struct {
-	materialization  diagnosticParserCoreMaterializationScratch
-	postorder        core.MaterializationPostorderScratch
-	acceptedLeaves   diagnosticParserCoreAcceptedLeafCoverageScratch
-	incrementalReuse *compactIncrementalReuseSession
+	materialization                diagnosticParserCoreMaterializationScratch
+	postorder                      core.MaterializationPostorderScratch
+	acceptedLeaves                 diagnosticParserCoreAcceptedLeafCoverageScratch
+	materializationBudgetScheduler *diagnosticParserCoreGenericScheduler
+	incrementalReuse               *compactIncrementalReuseSession
+	// freshAttemptWork spans fresh retries within one profiled operation.
+	// Its caller clears this pointer after all attempts finish.
+	freshAttemptWork *compactFreshAttemptWork
 	// recoveryTerminalAliasSymbol is valid only when the exact artifact rule
 	// also set recoveryTerminalAliasCertified for this materialization.
 	recoveryTerminalAliasSymbol    Symbol
@@ -6206,7 +6223,7 @@ type diagnosticParserCoreAcceptedLeafSpan struct {
 
 type diagnosticParserCoreAcceptedLeafCoverageScratch struct {
 	spans                           []diagnosticParserCoreAcceptedLeafSpan
-	authenticatedAliases            []*Node
+	authenticatedAliases            map[*Node]struct{}
 	leadingLexerSkippedPrefixStarts []uint32
 }
 
@@ -6220,18 +6237,36 @@ func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) reset() {
 		clear(scratch.spans)
 		scratch.spans = scratch.spans[:0]
 	}
-	if cap(scratch.authenticatedAliases) > parserCoreMaxRetainedAcceptedLeafSpans {
-		scratch.authenticatedAliases = nil
-	} else {
-		clear(scratch.authenticatedAliases)
-		scratch.authenticatedAliases = scratch.authenticatedAliases[:0]
-	}
+	// Recovery-only maps do not retain nodes or buckets between parses.
+	scratch.authenticatedAliases = nil
 	if cap(scratch.leadingLexerSkippedPrefixStarts) > parserCoreMaxRetainedAcceptedLeafSpans {
 		scratch.leadingLexerSkippedPrefixStarts = nil
 	} else {
 		clear(scratch.leadingLexerSkippedPrefixStarts)
 		scratch.leadingLexerSkippedPrefixStarts = scratch.leadingLexerSkippedPrefixStarts[:0]
 	}
+}
+
+// footprintBytes includes coverage buffers and a conservative live map estimate.
+func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) footprintBytes() uint64 {
+	if scratch == nil {
+		return 0
+	}
+	bytes := uint64(cap(scratch.spans))*uint64(unsafe.Sizeof(diagnosticParserCoreAcceptedLeafSpan{})) +
+		uint64(cap(scratch.leadingLexerSkippedPrefixStarts))*uint64(unsafe.Sizeof(uint32(0)))
+	if scratch.authenticatedAliases != nil {
+		// Include map metadata, spare capacity, and growth storage. This is
+		// an estimate, not a dependency on the Go runtime's map layout.
+		bytes += 256 + uint64(len(scratch.authenticatedAliases))*64
+	}
+	return bytes
+}
+
+func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) recordAuthenticatedAlias(node *Node) {
+	if scratch.authenticatedAliases == nil {
+		scratch.authenticatedAliases = make(map[*Node]struct{})
+	}
+	scratch.authenticatedAliases[node] = struct{}{}
 }
 
 func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) prepareLexerSkippedPrefixes(subtrees int) {
@@ -6351,12 +6386,8 @@ func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) hasAuthenticated
 	if scratch == nil {
 		return false
 	}
-	for _, alias := range scratch.authenticatedAliases {
-		if alias == node {
-			return true
-		}
-	}
-	return false
+	_, ok := scratch.authenticatedAliases[node]
+	return ok
 }
 
 func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) authenticateDirectTerminalAliases(
@@ -6367,7 +6398,7 @@ func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) authenticateDire
 	aliasSymbol Symbol,
 	nodesByID []*Node,
 ) {
-	if scratch == nil || parser == nil || parser.language == nil || aliasSymbol == 0 {
+	if scratch == nil || parser == nil || parser.language == nil {
 		return
 	}
 	aliases := parser.reduceAliasSequence(productionID)
@@ -6385,7 +6416,9 @@ func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) authenticateDire
 			alias = aliases[structuralChild]
 		}
 		structuralChild++
-		if alias != aliasSymbol || raw.symbol == alias ||
+		// A zero filter admits each nonzero alias from this production.
+		// The raw terminal and projected clone still require exact provenance.
+		if alias == 0 || (aliasSymbol != 0 && alias != aliasSymbol) || raw.symbol == alias ||
 			uint32(raw.symbol) >= parser.language.TokenCount ||
 			nodeChildCountNoMaterialize(raw) != 0 ||
 			!scratch.hasVisibleTerminalNode(raw.startByte, raw.endByte, raw, nodesByID) {
@@ -6405,7 +6438,7 @@ func (scratch *diagnosticParserCoreAcceptedLeafCoverageScratch) authenticateDire
 			match = child
 		}
 		if match != nil {
-			scratch.authenticatedAliases = append(scratch.authenticatedAliases, match)
+			scratch.recordAuthenticatedAlias(match)
 		}
 	}
 }
@@ -6451,6 +6484,7 @@ func (s *parserCoreRunnerScratch) resetTreeBuffers() {
 	}
 	s.postorder.Reset()
 	s.acceptedLeaves.reset()
+	s.materializationBudgetScheduler = nil
 	s.incrementalReuse = nil
 	s.recoveryTerminalAliasSymbol = 0
 	s.recoveryTerminalAliasCertified = false
@@ -6565,6 +6599,10 @@ func materializeDiagnosticParserCoreAcceptedTree(compact *core.Core, head core.H
 // can complete -- the span-completeness half of the check (root must still
 // cover the whole source) stays in force unconditionally either way.
 func finalizeDiagnosticParserCoreAcceptedRootSpan(root *Node, source []byte, sourceLen uint32, allowErrorRoot bool, continuationEscape byte, poll func() error, tokenCount uint32, coverage *diagnosticParserCoreAcceptedLeafCoverageScratch, nodesByID []*Node) error {
+	return finalizeDiagnosticParserCoreAcceptedRootSpanWithSplice(root, source, sourceLen, allowErrorRoot, continuationEscape, poll, tokenCount, coverage, nodesByID, false)
+}
+
+func finalizeDiagnosticParserCoreAcceptedRootSpanWithSplice(root *Node, source []byte, sourceLen uint32, allowErrorRoot bool, continuationEscape byte, poll func() error, tokenCount uint32, coverage *diagnosticParserCoreAcceptedLeafCoverageScratch, nodesByID []*Node, nativeAcceptSplice bool) error {
 	expectedStart := firstNonTriviaByteStart(source)
 	clean := allowErrorRoot || (!root.IsError() && !root.HasError())
 	if root.startByte == expectedStart && root.endByte < sourceLen && clean {
@@ -6626,7 +6664,7 @@ func finalizeDiagnosticParserCoreAcceptedRootSpan(root *Node, source []byte, sou
 			if err := poll(); err != nil {
 				return err
 			}
-			if diagnosticParserCoreAcceptedRootTrailingErrorExtraGap(root) {
+			if !nativeAcceptSplice && diagnosticParserCoreAcceptedRootTrailingErrorExtraGap(root) {
 				return fmt.Errorf(
 					"parser-core phase zero: accepted compact root carries an error-bearing trailing extra payload after its last non-extra child: root=%d..%d",
 					root.startByte, root.endByte,
@@ -7165,6 +7203,7 @@ type diagnosticParserCoreRootFinalization uint8
 const (
 	diagnosticParserCoreFinalizeDefault diagnosticParserCoreRootFinalization = iota
 	diagnosticParserCoreFinalizeRecoverEOF
+	diagnosticParserCoreFinalizeOwnedRecovery
 )
 
 // materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization keeps
@@ -7179,7 +7218,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 	if compact == nil || parser == nil || parser.language == nil || head.Node == 0 || len(payloads) == 0 {
 		return nil, errors.New("parser-core phase zero: incomplete accepted-tree selection input")
 	}
-	if rootFinalization != diagnosticParserCoreFinalizeDefault && rootFinalization != diagnosticParserCoreFinalizeRecoverEOF {
+	if rootFinalization != diagnosticParserCoreFinalizeDefault && rootFinalization != diagnosticParserCoreFinalizeRecoverEOF && rootFinalization != diagnosticParserCoreFinalizeOwnedRecovery {
 		return nil, errors.New("parser-core phase zero: unknown accepted-root finalization")
 	}
 	if incrementalReuse != nil && (allowErrorRoot || rootFinalization != diagnosticParserCoreFinalizeDefault) {
@@ -7204,8 +7243,13 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 	owned := true
 	allocationRecorded := false
 	recordAllocation := func() {
-		if !allocationRecorded && incrementalReuse != nil && incrementalReuse.timing != nil {
-			incrementalReuse.timing.newNodes += uint64(arena.used)
+		if !allocationRecorded {
+			if incrementalReuse != nil && incrementalReuse.timing != nil {
+				incrementalReuse.timing.newNodes += uint64(arena.used)
+			}
+			if scratch != nil && scratch.freshAttemptWork != nil {
+				scratch.freshAttemptWork.allocatedNodes += uint64(arena.used)
+			}
 		}
 		allocationRecorded = true
 	}
@@ -7215,10 +7259,25 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 			arena.Release()
 		}
 	}()
+	var acceptedLeaves *diagnosticParserCoreAcceptedLeafCoverageScratch
+	var budgetScheduler *diagnosticParserCoreGenericScheduler
+	if scratch != nil {
+		budgetScheduler = scratch.materializationBudgetScheduler
+	}
+	if incrementalReuse != nil && incrementalReuse.scheduler != nil {
+		budgetScheduler = incrementalReuse.scheduler
+	}
 	poll := func() error {
 		reason := parser.resultMaterializationStopReason(arena)
-		if !resultMaterializationShouldStop(reason) && incrementalReuse != nil && incrementalReuse.scheduler != nil {
-			reason = incrementalReuse.scheduler.stopControlMemoryBudgetReasonWithAdditionalBytes(arenaAllocatedVolume(arena))
+		if !resultMaterializationShouldStop(reason) && budgetScheduler != nil {
+			additional := arenaAllocatedVolume(arena)
+			coverageBytes := acceptedLeaves.footprintBytes()
+			if math.MaxUint64-additional < coverageBytes {
+				additional = math.MaxUint64
+			} else {
+				additional += coverageBytes
+			}
+			reason = budgetScheduler.stopControlMemoryBudgetReasonWithAdditionalBytes(additional)
 		}
 		if !resultMaterializationShouldStop(reason) {
 			return nil
@@ -7328,7 +7387,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 		node.setFragileRight(true)
 	}
 	var acceptedLeavesLocal diagnosticParserCoreAcceptedLeafCoverageScratch
-	acceptedLeaves := &acceptedLeavesLocal
+	acceptedLeaves = &acceptedLeavesLocal
 	if scratch != nil {
 		scratch.acceptedLeaves.reset()
 		acceptedLeaves = &scratch.acceptedLeaves
@@ -7576,7 +7635,14 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 					return fmt.Errorf("reduce symbol=%d production=%d: %w", view.Symbol, view.ProductionID, err)
 				}
 			}
-			if recoveryTerminalAlias != 0 {
+			// Production alias authentication belongs to native owned recovery.
+			// Existing shared recovery keeps its artifact-specific admission.
+			if allowErrorRoot && parser.language.CompactOwnedEOFRecoveryCertified &&
+				rootFinalization != diagnosticParserCoreFinalizeDefault {
+				acceptedLeaves.authenticateDirectTerminalAliases(
+					parser, entries, children, view.ProductionID, 0, nodesByID,
+				)
+			} else if recoveryTerminalAlias != 0 {
 				acceptedLeaves.authenticateDirectTerminalAliases(
 					parser, entries, children, view.ProductionID, recoveryTerminalAlias, nodesByID,
 				)
@@ -7694,6 +7760,12 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 		// any language result-compatibility rewrite.
 		builder := newResultRootBuild(parser, source, arena, nil, nil, linkScratch)
 		tree = builder.finishRecoverEOFTree(nodes[0], builder.shouldWireParentLinks)
+	} else if rootFinalization == diagnosticParserCoreFinalizeOwnedRecovery {
+		var buildErr error
+		tree, buildErr = buildCompactOwnedRecoveryAcceptedTree(parser, nodes, source, arena, linkScratch)
+		if buildErr != nil {
+			return nil, buildErr
+		}
 	} else {
 		tree = parser.buildResultFromNodes(nodes, source, arena, oldTree, reuseState, linkScratch)
 	}
@@ -7749,7 +7821,7 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 			))
 		}
 	} else {
-		if err := finalizeDiagnosticParserCoreAcceptedRootSpan(root, source, sourceLen, allowErrorRoot, parser.lineContinuationEscapeByte(), poll, parser.language.TokenCount, acceptedLeaves, nodesByID); err != nil {
+		if err := finalizeDiagnosticParserCoreAcceptedRootSpanWithSplice(root, source, sourceLen, allowErrorRoot, parser.lineContinuationEscapeByte(), poll, parser.language.TokenCount, acceptedLeaves, nodesByID, rootFinalization == diagnosticParserCoreFinalizeOwnedRecovery); err != nil {
 			return rejectTree(err)
 		}
 	}
@@ -8167,6 +8239,7 @@ func diagnosticParserCoreSchedulerFootprintBytes(s *diagnosticParserCoreGenericS
 	add(len(s.seedHeaders), unsafe.Sizeof(diagnosticParserCoreHeader{}))
 	add(len(s.corridorCells), unsafe.Sizeof(diagnosticParserCoreGenericCell{}))
 	add(1, unsafe.Sizeof(s.tokenCell))
+	add(1, unsafe.Sizeof(s.recoveryTurns))
 	if s.compact != nil {
 		coreBytes := s.compact.FootprintBytes()
 		if math.MaxUint64-total < coreBytes {
@@ -8206,7 +8279,8 @@ func (s *diagnosticParserCoreGenericScheduler) stopControlMemoryBudgetReason() P
 	return s.stopControlMemoryBudgetReasonWithAdditionalBytes(0)
 }
 
-// stopControlMemoryBudgetReasonWithAdditionalBytes includes the new materialization arena during incremental execution.
+// stopControlMemoryBudgetReasonWithAdditionalBytes includes the materialization
+// arena and coverage scratch during fresh and incremental execution.
 func (s *diagnosticParserCoreGenericScheduler) stopControlMemoryBudgetReasonWithAdditionalBytes(additional uint64) ParseStopReason {
 	if s == nil {
 		return ParseStopNone
@@ -8334,6 +8408,19 @@ func (s *diagnosticParserCoreGenericScheduler) run() error {
 	for {
 		if err := s.pollStopControl(); err != nil {
 			return err
+		}
+		if s.recoveryTurns.active {
+			stop, err := s.dispatchRecoveryVersionTurn()
+			if err != nil {
+				return err
+			}
+			if stop != nil {
+				return s.finish(stop.boundary, stop.detail, stop.headerIndex)
+			}
+			if s.receipt != nil && (s.receipt.Acceptance != nil || s.receipt.Stop.Detail != "") {
+				return nil
+			}
+			continue
 		}
 		if uint64(len(s.headers)) > s.work.PeakHeaders {
 			s.work.PeakHeaders = uint64(len(s.headers))
@@ -8680,6 +8767,9 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchVersionLexerPassActive() 
 	noActionIndices := s.dispatchScratch.noActionIndices[:0]
 	acceptCell, extraCell, reductionCell, conflictCell, shiftCell := -1, -1, -1, -1, -1
 	for index := range s.headers {
+		if s.recoveryTurns.active && index != s.recoveryTurns.index {
+			continue
+		}
 		if s.headers[index].paused {
 			if s.headers[index].shifted || s.headers[index].accepted ||
 				s.versionLexerRequestForHeader(index) == nil {
@@ -8814,7 +8904,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchVersionLexerPassActive() 
 			if err := s.applyGenericAccept(before, cell); err != nil {
 				return err
 			}
-			if competingRecoveryAccept {
+			if competingRecoveryAccept && !s.recoveryTurns.active {
 				return s.completeAcceptance()
 			}
 			return nil
@@ -10775,6 +10865,12 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() (err error) 
 		return s.finish(DiagnosticParserCoreAccept, "generic scheduler requires one certified accepted derivation", 0)
 	}
 	path := selection.path
+	if s.recoveryTurns.active {
+		s.acceptedRootFinalization = diagnosticParserCoreFinalizeDefault
+		if len(path.Payloads) == 1 && s.compact.IsRecoverEOFAcceptRoot(path.Payloads[0]) {
+			s.acceptedRootFinalization = diagnosticParserCoreFinalizeRecoverEOF
+		}
+	}
 	materialityCertified := selection.materialityCertified
 	// The R1 materiality gate remains the fallback for tied frontiers without
 	// an exact structural-election capability. A certified primary or a
@@ -12119,6 +12215,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		s.work.ReductionPauses++
 	} else if len(replacements) == 1 {
 		s.headers[cell.headerIndex] = replacements[0]
+	} else if s.recoveryTurns.active {
+		s.headers[cell.headerIndex] = replacements[0]
+		s.headers = append(s.headers, replacements[1:]...)
 	} else {
 		s.headers = replaceDiagnosticParserCoreHeader(s.headers, int(cell.headerIndex), replacements)
 	}
@@ -13252,7 +13351,7 @@ func (s *diagnosticParserCoreGenericScheduler) canonicalizeOwnedWithMutation(own
 	if err != nil {
 		return err
 	}
-	if s.recoveryIsolation {
+	if s.recoveryIsolation && (!s.recoveryTurns.active || s.recoveryTurns.condensing) {
 		var drops uint64
 		var applied bool
 		headers, drops, applied, err = s.condenseRecoveryVersions(owner, headers)
@@ -13571,6 +13670,7 @@ func authenticatedParserCoreGoLanguage(scanner ExternalScanner) (*Language, erro
 	decoded.Name = "go"
 	decoded.ExternalScanner = scanner
 	decoded.CompactConvergedReductionSplitDropsCertified = true
+	decoded.CompactOwnedEOFRecoveryCertified = true
 	CertifyCRecoveryCostCompetition(decoded)
 	return decoded, nil
 }

--- a/parsercore_phase0_driver_coverage_internal_test.go
+++ b/parsercore_phase0_driver_coverage_internal_test.go
@@ -93,7 +93,7 @@ func TestDiagnosticParserCoreAcceptedLeafCoverageScratchResetsAndReuses(t *testi
 	if err := coverage.append(1, core.MaterializationSubtreeView{StartByte: 0, EndByte: 1, Terminal: true}, 2, false); err != nil {
 		t.Fatal(err)
 	}
-	coverage.authenticatedAliases = append(coverage.authenticatedAliases, &Node{})
+	coverage.recordAuthenticatedAlias(&Node{})
 	coverage.reset()
 	if len(coverage.spans) != 0 || len(coverage.authenticatedAliases) != 0 {
 		t.Fatalf("reset retained %d spans and %d aliases", len(coverage.spans), len(coverage.authenticatedAliases))
@@ -103,6 +103,43 @@ func TestDiagnosticParserCoreAcceptedLeafCoverageScratchResetsAndReuses(t *testi
 	}
 	if len(coverage.spans) != 1 || coverage.spans[0].startByte != 1 {
 		t.Fatalf("reused spans=%v", coverage.spans)
+	}
+}
+
+func TestDiagnosticParserCoreAcceptedAliasSetAccountingAndReset(t *testing.T) {
+	var coverage diagnosticParserCoreAcceptedLeafCoverageScratch
+	if coverage.footprintBytes() != 0 || coverage.hasAuthenticatedAlias(&Node{}) {
+		t.Fatal("empty coverage has storage or authentication")
+	}
+	nodes := make([]Node, 4096)
+	for index := range nodes {
+		coverage.recordAuthenticatedAlias(&nodes[index])
+	}
+	before := coverage.footprintBytes()
+	if before < uint64(len(nodes))*64 {
+		t.Fatalf("alias footprint=%d does not include live storage", before)
+	}
+	for index := range nodes {
+		if !coverage.hasAuthenticatedAlias(&nodes[index]) {
+			t.Fatalf("alias %d lost authentication", index)
+		}
+		coverage.recordAuthenticatedAlias(&nodes[index])
+	}
+	if coverage.footprintBytes() != before || len(coverage.authenticatedAliases) != len(nodes) {
+		t.Fatal("duplicate aliases increased storage")
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{}
+	scheduler.options.stopControlMemoryBudgetBytes = int64(before - 1)
+	if reason := scheduler.stopControlMemoryBudgetReasonWithAdditionalBytes(before); reason != ParseStopMemoryBudget {
+		t.Fatalf("alias storage did not trip memory budget: %s", reason)
+	}
+	coverage.reset()
+	if coverage.authenticatedAliases != nil || coverage.footprintBytes() != 0 || coverage.hasAuthenticatedAlias(&nodes[0]) {
+		t.Fatal("reset retained alias storage or authentication")
+	}
+	coverage.recordAuthenticatedAlias(&nodes[0])
+	if !coverage.hasAuthenticatedAlias(&nodes[0]) || coverage.hasAuthenticatedAlias(&nodes[1]) {
+		t.Fatal("reuse retained stale alias authentication")
 	}
 }
 
@@ -199,6 +236,54 @@ func TestDiagnosticParserCoreAcceptedLeafCoverageRejectsUnrelatedTerminalAlias(t
 	)
 	if _, _, gapped, err := diagnosticParserCoreAcceptedTreeLeafCoverageGap(unrelated, []byte("x"), 0, 1, 100, &coverage, nodesByID, nil); err != nil || !gapped {
 		t.Fatalf("unrelated terminal alias audit err=%v gapped=%t, want gapped", err, gapped)
+	}
+}
+
+func TestDiagnosticParserCoreAcceptedLeafCoverageProductionAliases(t *testing.T) {
+	for _, name := range []string{"valid", "zero_alias", "wrong_range", "nonterminal", "unmatched_raw", "extra", "duplicate_clone", "wrong_production"} {
+		t.Run(name, func(t *testing.T) {
+			arena := acquireNodeArena(arenaClassFull)
+			defer arena.Release()
+			parser := &Parser{
+				language:       &Language{TokenCount: 100, SymbolMetadata: make([]SymbolMetadata, 103)},
+				reduceAliasSeq: [][]Symbol{nil, {101}},
+			}
+			raw := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
+			clone := parser.aliasedNodeInArena(arena, raw, 101)
+			children := []*Node{clone}
+			production := uint16(1)
+			nodesByID := []*Node{nil, raw}
+			var coverage diagnosticParserCoreAcceptedLeafCoverageScratch
+			if err := coverage.append(1, core.MaterializationSubtreeView{
+				Symbol: 1, StartByte: 0, EndByte: 1, Terminal: true,
+			}, 2, false); err != nil {
+				t.Fatal(err)
+			}
+			switch name {
+			case "zero_alias":
+				parser.reduceAliasSeq[1][0] = 0
+			case "wrong_range":
+				clone.endByte = 2
+			case "nonterminal":
+				raw.symbol = 102
+			case "unmatched_raw":
+				nodesByID[1] = cloneNodeInArena(arena, raw)
+			case "extra":
+				raw.setExtra(true)
+			case "duplicate_clone":
+				children = append(children, parser.aliasedNodeInArena(arena, raw, 101))
+			case "wrong_production":
+				production = 0
+			}
+			coverage.authenticateDirectTerminalAliases(parser, []stackEntry{newStackEntryNode(0, raw)}, children, production, 0, nodesByID)
+			if got := coverage.hasAuthenticatedAlias(clone); got != (name == "valid") {
+				t.Fatalf("production alias authenticated=%t", got)
+			}
+			// Authentication belongs to the exact projected node, not its range.
+			if coverage.hasAuthenticatedAlias(parser.aliasedNodeInArena(arena, raw, 101)) {
+				t.Fatal("an unrelated clone inherited production authentication")
+			}
+		})
 	}
 }
 

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -347,6 +347,13 @@ func (r *parserCoreFreshFullRunner) materializeSelection(source []byte, compact 
 	if r == nil || scheduler == nil {
 		return nil, errors.New("parser-core fresh-full selected materialization is incomplete")
 	}
+	if r.recoveryVersionTurnPublicationRequired(scheduler) &&
+		(!scheduler.recoveryTurns.active || scheduler.work.RecoverEOFAccepts == 0) {
+		return nil, &diagnosticParserCoreDecline{
+			boundary: DiagnosticParserCoreAccept,
+			detail:   "owned recovery publication requires an executed EOF turn",
+		}
+	}
 	gated, err := scheduler.beginCompactEOFRecoveryConstruction(
 		source,
 		compactEOFRecoveryAdmissionRoutePublicTree,
@@ -361,7 +368,13 @@ func (r *parserCoreFreshFullRunner) materializeSelection(source []byte, compact 
 	if r.recoverEOFFinalizationAdmitted(scheduler) {
 		rootFinalization = diagnosticParserCoreFinalizeRecoverEOF
 		allowErrorRoot = true
+	} else if r.options.allowCompactRecoveryVersionTurns && scheduler.recoveryTurns.active && allowErrorRoot {
+		rootFinalization = diagnosticParserCoreFinalizeOwnedRecovery
+		if scheduler.acceptedRootFinalization == diagnosticParserCoreFinalizeRecoverEOF {
+			rootFinalization = diagnosticParserCoreFinalizeRecoverEOF
+		}
 	}
+	r.scratch.materializationBudgetScheduler = scheduler
 	tree, err := materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(
 		compact,
 		scheduler.acceptedHead,
@@ -379,6 +392,13 @@ func (r *parserCoreFreshFullRunner) materializeSelection(source []byte, compact 
 	return tree, err
 }
 
+// The new route does not certify shared S3 recovery. Require its own execution
+// for recovery results, while leaving clean parsing and older routes unchanged.
+func (r *parserCoreFreshFullRunner) recoveryVersionTurnPublicationRequired(scheduler *diagnosticParserCoreGenericScheduler) bool {
+	return r.options.allowCompactRecoveryVersionTurns &&
+		(scheduler.s3RegionOpened || scheduler.recoveryTurns.active || scheduler.work.RecoverEOFAccepts != 0)
+}
+
 func (r *parserCoreFreshFullRunner) materializeSelectedStoreSelection(
 	source []byte,
 	compact *core.Core,
@@ -387,6 +407,9 @@ func (r *parserCoreFreshFullRunner) materializeSelectedStoreSelection(
 ) (*core.SelectedStore, error) {
 	if r == nil || compact == nil || scheduler == nil {
 		return nil, errors.New("parser-core fresh-full selected-store construction is incomplete")
+	}
+	if r.recoveryVersionTurnPublicationRequired(scheduler) {
+		return nil, errors.New("parser-core fresh-full selected-store does not support owned recovery roots")
 	}
 	if scheduler.acceptedRootFinalization == diagnosticParserCoreFinalizeRecoverEOF {
 		return nil, errors.New("parser-core fresh-full selected-store does not support recover_eof roots")
@@ -451,6 +474,9 @@ func (r *parserCoreFreshFullRunner) parseWithObserver(
 		}
 		if !compactRecoveryRetryAfterPlainEligible(err) {
 			return nil, err
+		}
+		if r.scratch.freshAttemptWork != nil {
+			r.scratch.freshAttemptWork.tokens += r.scheduler.tokens
 		}
 		return r.parseWithObserverAndErrorRuns(source, observer, true, true)
 	}

--- a/parsercore_phase0_g18_d6a_acceptance_external_test.go
+++ b/parsercore_phase0_g18_d6a_acceptance_external_test.go
@@ -419,6 +419,8 @@ func TestG18D6bGrammargenLRNoCommonDerivationFallsBack(t *testing.T) {
 
 	language := g18D6aCloneLanguage(grammars.GoLanguage())
 	language.CompactConvergedReductionSplitDropsCertified = false
+	// Inspect one candidate frontier and fallback, without recovery retries.
+	language.CompactOwnedEOFRecoveryCertified = false
 	parser := gts.NewParser(language)
 	parser.SetAdmissionCandidateRoute(true)
 	gts.ResetAdmissionCandidateCountersForTest()

--- a/parsercore_phase0_g18_d6b_driver_internal_test.go
+++ b/parsercore_phase0_g18_d6b_driver_internal_test.go
@@ -34,6 +34,8 @@ func newG18D6bDriverTestRunner(t *testing.T) *parserCoreFreshFullRunner {
 		t.Fatal(err)
 	}
 	lang.CompactConvergedReductionSplitDropsCertified = false
+	// These frontier proofs inspect one candidate attempt, without recovery retries.
+	lang.CompactOwnedEOFRecoveryCertified = false
 	parser := NewParser(lang)
 	parser.SetAdmissionCandidateRoute(true)
 	runner, err := newAdmissionCandidateRunner(parser)

--- a/parsercore_phase0_incremental.go
+++ b/parsercore_phase0_incremental.go
@@ -30,12 +30,12 @@ type compactIncrementalReuseSession struct {
 	reusedBytes    uint64
 }
 
-func (p *Parser) attemptCompactIncrementalParse(source []byte, oldTree *Tree, timing *incrementalParseTiming) (*Tree, string) {
+func (p *Parser) attemptCompactIncrementalParse(source []byte, oldTree *Tree, timing *incrementalParseTiming) (*Tree, string, bool) {
 	if oldTree == nil || oldTree.language != p.language || !oldTree.compactMaterialized ||
 		oldTree.incrementalReuseDisabled || len(oldTree.edits) == 0 ||
 		oldTree.root == nil || oldTree.root.HasError() || p.recoveryInitialOnly ||
 		!p.admissionCandidateFullParseEligible(nil, true) {
-		return nil, ""
+		return nil, "", false
 	}
 	p.fullParseRetryPassesTaken = 0
 	// Preserve the existing token-invariant fast path for same-width leaf edits.
@@ -46,7 +46,7 @@ func (p *Parser) attemptCompactIncrementalParse(source []byte, oldTree *Tree, ti
 			probeStarted = time.Now()
 		}
 		if tree, ok := p.tryTokenInvariantReuseWithDFA(source, oldTree, timing); ok {
-			return tree, ""
+			return tree, "", false
 		}
 		if timing != nil {
 			probeNanos := time.Since(probeStarted).Nanoseconds()
@@ -57,7 +57,7 @@ func (p *Parser) attemptCompactIncrementalParse(source []byte, oldTree *Tree, ti
 	if p.language.ExternalScanner != nil {
 		stateless, ok := p.language.ExternalScanner.(StatelessExternalScanner)
 		if !ok || !stateless.ExternalScannerIsStateless() {
-			return nil, ""
+			return nil, "", false
 		}
 	}
 	started := time.Now()
@@ -68,7 +68,7 @@ func (p *Parser) attemptCompactIncrementalParse(source []byte, oldTree *Tree, ti
 	defer endBudget()
 	runner, err := p.acquireAdmissionCandidateRunner()
 	if err != nil {
-		return nil, err.Error()
+		return nil, err.Error(), false
 	}
 	oldTree.ensureParentLinks()
 	p.reuseMu.Lock()
@@ -97,6 +97,8 @@ func (p *Parser) attemptCompactIncrementalParse(source []byte, oldTree *Tree, ti
 		timing.tokensConsumed = runner.scheduler.tokens
 	}
 	if err != nil || tree == nil || session.reusedSubtrees == 0 {
+		recoveryDeclined := err != nil && runner.scheduler.options.compactIncrementalReuse == session &&
+			runner.scheduler.receipt != nil && runner.scheduler.receipt.Stop.Boundary == DiagnosticParserCoreRecovery
 		if tree != nil {
 			tree.Release()
 		}
@@ -104,7 +106,7 @@ func (p *Parser) attemptCompactIncrementalParse(source []byte, oldTree *Tree, ti
 		if err == nil {
 			err = errors.New("compact incremental parse found no authenticated subtree")
 		}
-		return nil, errors.Join(err, resetErr).Error()
+		return nil, errors.Join(err, resetErr).Error(), recoveryDeclined && resetErr == nil
 	}
 	// Publish parent links only after every decline check has passed.
 	// Borrowed nodes consult their old arena, so deferred new-arena links are insufficient.
@@ -114,7 +116,7 @@ func (p *Parser) attemptCompactIncrementalParse(source []byte, oldTree *Tree, ti
 		timing.newNodes = uint64(tree.parseRuntime.NodesAllocated)
 		timing.selectResult(tree)
 	}
-	return tree, ""
+	return tree, "", false
 }
 
 // tryCompactIncrementalReuse runs before ordinary dispatch, after each reduction.

--- a/parsercore_phase0_incremental_recovery.go
+++ b/parsercore_phase0_incremental_recovery.go
@@ -1,0 +1,56 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import "time"
+
+type compactFreshAttemptWork struct {
+	allocatedNodes uint64
+	tokens         uint64
+}
+
+// attemptCompactIncrementalRecoveryFullParse runs after reuse cleanup.
+// Recovery requires complete descendants, so it starts a fresh compact graph.
+func (p *Parser) attemptCompactIncrementalRecoveryFullParse(source []byte, reason string, recoveryDeclined bool, timing *incrementalParseTiming) (result *Tree) {
+	if !recoveryDeclined || reason == "" || !p.admissionCandidateFullParseEligible(nil, true) {
+		return nil
+	}
+	runner, ok := p.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+	if !ok || runner == nil || runner.lang != p.language ||
+		!runner.options.allowCompactRecoveryVersionTurns || !runner.options.Recovery ||
+		runner.options.compactIncrementalReuse != nil || runner.scheduler.options.compactIncrementalReuse != nil ||
+		runner.scratch.incrementalReuse != nil || runner.scratch.freshAttemptWork != nil {
+		return nil
+	}
+	started := time.Now()
+	var work compactFreshAttemptWork
+	if timing != nil {
+		runner.scratch.freshAttemptWork = &work
+	}
+	defer func() {
+		runner.scratch.freshAttemptWork = nil
+		if timing != nil {
+			// The successful tree reports its own allocations. Charge only
+			// discarded attempts here, including materialization declines.
+			if result != nil {
+				work.allocatedNodes -= uint64(result.parseRuntime.NodesAllocated)
+			}
+			timing.newNodes += work.allocatedNodes
+			timing.tokensConsumed += work.tokens
+		}
+		// Successful work comes from profileFreshParseFallback. A declined
+		// fresh attempt must still be charged before the legacy fallback.
+		if result == nil && timing != nil {
+			timing.totalNanos += time.Since(started).Nanoseconds()
+			timing.tokensConsumed += runner.scheduler.tokens
+		}
+	}()
+	// Do not add an incremental entry to the fresh-parse admission counters.
+	tree, accepted, _ := p.tryCompactFullParseRoute(source)
+	if !accepted || tree == nil {
+		return nil
+	}
+	tree.parseRuntime.CompactIncrementalFullRecoveryRoute = true
+	tree.parseRuntime.CompactIncrementalFallbackReason = reason
+	return tree
+}

--- a/parsercore_phase0_owned_alias_scope_test.go
+++ b/parsercore_phase0_owned_alias_scope_test.go
@@ -1,0 +1,41 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompactRecoveryProductionAliasScope(t *testing.T) {
+	p := newCompactRecoveryVersionTurnGoParser(t)
+	source := []byte("package p\nfunc f(){}\nfunc g(){}+")
+	tree, routed, reason := p.tryCompactFullParseRoute(source)
+	if !routed || tree == nil {
+		t.Fatalf("owned recovery declined: %s", reason)
+	}
+	tree.Release()
+	runner := p.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+	for _, mode := range []string{"default_finalization", "uncertified_language"} {
+		t.Run(mode, func(t *testing.T) {
+			language := *p.language
+			finalization := diagnosticParserCoreFinalizeOwnedRecovery
+			if mode == "default_finalization" {
+				finalization = diagnosticParserCoreFinalizeDefault
+			} else {
+				language.CompactOwnedEOFRecoveryCertified = false
+			}
+			var scratch parserCoreRunnerScratch
+			tree, err := materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(
+				runner.compact, runner.scheduler.acceptedHead, runner.scheduler.acceptedPayloads,
+				NewParser(&language), source, &scratch, false, true, finalization,
+			)
+			if tree != nil {
+				tree.Release()
+			}
+			if err == nil || !strings.Contains(err.Error(), "leaves do not tile") {
+				t.Fatalf("uncertified production alias materialization err=%v", err)
+			}
+		})
+	}
+}

--- a/parsercore_phase0_owned_recovery.go
+++ b/parsercore_phase0_owned_recovery.go
@@ -1,0 +1,273 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"math"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func compactOwnedRecoveryDecline(index int, detail string) *diagnosticParserCoreGenericUnsupported {
+	return &diagnosticParserCoreGenericUnsupported{
+		boundary: DiagnosticParserCoreRecovery, detail: detail, headerIndex: index,
+	}
+}
+
+// ownedRecoveryBetterVersionExists compares actual live positions. Paused
+// versions cannot suppress a recovery. Finished trees compete independently
+// of their former position, as C's finished_tree does.
+func (s *diagnosticParserCoreGenericScheduler) ownedRecoveryBetterVersionExists(
+	index int,
+	current diagnosticParserCoreRecoveryCondenseEntry,
+	cost uint32,
+	symbols []core.SelectedSymbolPolicy,
+	source *diagnosticParserCoreRecoveryCostSource,
+	memo *core.RecoveryCostMemo,
+) (bool, error) {
+	status := current.status
+	status.Cost, status.IsInError = cost, false
+	for otherIndex := range s.headers {
+		if otherIndex == index || s.headers[otherIndex].paused {
+			continue
+		}
+		other, supported, err := s.recoveryCondenseEntry(s.headers[otherIndex], symbols, source, memo)
+		if err != nil {
+			return false, err
+		}
+		if !supported {
+			return false, diagnosticParserCoreLineageCostUnavailable
+		}
+		if s.headers[otherIndex].accepted {
+			if other.status.Cost <= cost {
+				return true, nil
+			}
+			continue
+		}
+		if other.key.byteOffset < current.key.byteOffset {
+			continue
+		}
+		switch core.RecoveryCompareVersions(status, other.status) {
+		case core.RecoveryComparisonTakeRight:
+			return true, nil
+		case core.RecoveryComparisonPreferRight:
+			if current.key.state == other.key.state && current.key.byteOffset == other.key.byteOffset &&
+				current.key.cost == other.key.cost && current.key.checkpoint == other.key.checkpoint {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) ownedRecoverySummaryCandidate(
+	index int,
+	current diagnosticParserCoreRecoveryCondenseEntry,
+	symbols []core.SelectedSymbolPolicy,
+	source *diagnosticParserCoreRecoveryCostSource,
+	memo *core.RecoveryCostMemo,
+) (core.StackSummaryCandidate, bool, error) {
+	if s.token.Symbol == errorSymbol {
+		return core.StackSummaryCandidate{}, false, nil
+	}
+	candidates, err := s.compact.StackSummaryCandidates(s.headers[index].head, cRecoverMaxSummaryDepth)
+	if err != nil {
+		return core.StackSummaryCandidate{}, false, err
+	}
+	position := current.key.byteOffset
+	for candidateIndex, candidate := range candidates {
+		if candidateIndex&63 == 0 {
+			if err := s.pollStopControl(); err != nil {
+				return core.StackSummaryCandidate{}, false, err
+			}
+		}
+		if candidate.State() == 0 || candidate.ByteOffset() >= position {
+			continue
+		}
+		wouldMerge := false
+		for otherIndex := range s.headers {
+			other := &s.headers[otherIndex]
+			if other.accepted || other.recoveryRegion() != nil {
+				continue
+			}
+			state, byteOffset, err := s.compact.Boundary(other.head)
+			if err != nil {
+				return core.StackSummaryCandidate{}, false, err
+			}
+			if state == candidate.State() && byteOffset == position {
+				wouldMerge = true
+				break
+			}
+		}
+		if wouldMerge {
+			continue
+		}
+		cost := uint64(current.status.Cost) + uint64(candidate.Depth())*core.RecoveryCostPerSkippedTree +
+			uint64(position-candidate.ByteOffset())*core.RecoveryCostPerSkippedChar +
+			uint64(source.rowAt(position)-source.rowAt(candidate.ByteOffset()))*core.RecoveryCostPerSkippedLine
+		if cost > math.MaxUint32 {
+			return core.StackSummaryCandidate{}, false, errors.New("parser-core phase zero: owned summary cost overflow")
+		}
+		better, err := s.ownedRecoveryBetterVersionExists(index, current, uint32(cost), symbols, source, memo)
+		if err != nil {
+			return core.StackSummaryCandidate{}, false, err
+		}
+		if better {
+			break
+		}
+		row, err := s.compact.Actions(candidate.State(), core.Symbol(s.token.Symbol))
+		if err != nil {
+			return core.StackSummaryCandidate{}, false, err
+		}
+		if row.Len() == 0 {
+			continue
+		}
+		recoverable, err := s.compact.StackSummaryCandidateRecoverable(candidate)
+		if err != nil {
+			return core.StackSummaryCandidate{}, false, err
+		}
+		if !recoverable {
+			return core.StackSummaryCandidate{}, false, diagnosticParserCoreLineageCostUnavailable
+		}
+		return candidate, true, nil
+	}
+	return core.StackSummaryCandidate{}, false, nil
+}
+
+// dispatchOwnedRecoveryRegion executes one C recovery advance at EOF.
+// Strategy one appends a version before the original accepts its ERROR root.
+func (s *diagnosticParserCoreGenericScheduler) dispatchOwnedRecoveryRegion(
+	index int,
+) (_ *diagnosticParserCoreGenericUnsupported, err error) {
+	if s == nil || s.compact == nil || index < 0 || index >= len(s.headers) {
+		return nil, errors.New("parser-core phase zero: owned recovery index is invalid")
+	}
+	original := s.headers[index]
+	region := original.recoveryRegion()
+	request := s.versionLexerRequestForHeader(index)
+	if region == nil || len(region.children) == 0 || request == nil || request.state != 0 {
+		return compactOwnedRecoveryDecline(index, "owned recovery requires an authenticated error-state token"), nil
+	}
+	if s.token != request.token || s.token.StartByte < region.endByte ||
+		s.token.Missing || s.token.NoLookahead || s.token.ExternalScannerToken {
+		return compactOwnedRecoveryDecline(index, "owned recovery token is outside the internal DFA route"), nil
+	}
+	// Non-EOF recovery also needs lexical-error reentry and bounded region
+	// growth. Do not inherit the shared scheduler's accounting for those paths.
+	if s.token.Symbol != 0 || s.token.StartByte != s.token.EndByte {
+		return compactOwnedRecoveryDecline(index, "owned recovery currently requires EOF after the first absorb"), nil
+	}
+	source, err := s.s5RecoverySource()
+	if err != nil {
+		return nil, err
+	}
+	symbols := diagnosticParserCoreRecoverySymbolPolicy(s.tokenSource.language)
+	var memo core.RecoveryCostMemo
+	defer memo.Reset()
+	current, supported, err := s.recoveryCondenseEntry(original, symbols, source, &memo)
+	if err != nil {
+		return nil, err
+	}
+	if !supported {
+		return compactOwnedRecoveryDecline(index, "owned recovery cannot price the physical head"), nil
+	}
+	candidate, recoverable, err := s.ownedRecoverySummaryCandidate(index, current, symbols, source, &memo)
+	if errors.Is(err, diagnosticParserCoreLineageCostUnavailable) {
+		return compactOwnedRecoveryDecline(index, "owned recovery needs an unambiguous summary path"), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if recoverable && s.nextSeq == math.MaxUint64 {
+		return nil, errors.New("parser-core phase zero: owned recovery sequence overflow")
+	}
+	// C can halt the absorber before EOF acceptance after a seventh version
+	// appears. This bounded route declines before creating that frontier.
+	if recoverable && len(s.headers) >= diagnosticParserCoreRecoveryVersionLimit {
+		return compactOwnedRecoveryDecline(index, "owned EOF recovery requires an unmodeled version-cap transition"), nil
+	}
+	if s.token.Symbol == 0 {
+		paths, err := s.compact.Derivations(original.head)
+		if err != nil {
+			return nil, err
+		}
+		if len(paths) != 1 || len(paths[0].Payloads)+len(region.children) > core.EOFAdmissionMaxTopPayloads {
+			return compactOwnedRecoveryDecline(index, "owned recovery EOF needs one bounded path"), nil
+		}
+		for _, payloads := range [][]core.SubtreeID{paths[0].Payloads, region.children} {
+			for _, payload := range payloads {
+				view, err := s.compact.MaterializationView(payload)
+				if err != nil {
+					return nil, err
+				}
+				if view.Extra || view.Missing {
+					return compactOwnedRecoveryDecline(index, "owned recovery EOF has an unsupported extra or missing payload"), nil
+				}
+			}
+		}
+	}
+	cost, costMemo, err := s.recoveryOutputCostFunc()
+	if err != nil {
+		return nil, err
+	}
+	defer costMemo.Reset()
+	snapshot := captureDiagnosticParserCoreS5Scheduler(s)
+	defer func() {
+		if value := recover(); value != nil {
+			snapshot.restore(s)
+			panic(value)
+		}
+		if err != nil {
+			snapshot.restore(s)
+		}
+	}()
+	run := func(owner core.SchedulerTransactionToken) error {
+		if err := s.reserveDispatches(1); err != nil {
+			return err
+		}
+		if recoverable {
+			head, err := s.compact.RecoverToAncestorStateWithOpenRegionAndCostOwned(
+				owner, candidate, region.startByte, region.endByte, region.children, cost,
+			)
+			if err != nil {
+				return err
+			}
+			recovered := original
+			recovered.head = head
+			recovered.creationSeq = s.nextSeq
+			recovered.closeRecoveryRegion()
+			recovered.shifted, recovered.paused, recovered.accepted = false, false, false
+			recovered.markRecoveryLineage()
+			recovered.markRecoveryCosted()
+			s.nextSeq++
+			s.headers = append(s.headers, recovered)
+			s.work.add(&s.work.StackSummaryRecoveryForks, 1)
+		}
+		head, _, err := s.compact.RecoverEOFAcceptWithOpenRegionAndCostOwned(
+			owner, original.head, region.startByte, region.endByte, region.children, cost,
+		)
+		if err != nil {
+			return err
+		}
+		header := &s.headers[index]
+		header.head = head
+		header.closeRecoveryRegion()
+		header.accepted, header.shifted, header.paused = true, false, false
+		s.work.add(&s.work.Accepts, 1)
+		s.work.add(&s.work.RecoverEOFAccepts, 1)
+		s.invalidateVerifierHeaderBinding()
+		s.epochProgress = true
+		s.work.add(&s.work.Dispatches, 1)
+		return nil
+	}
+	if s.freshSessionOwner != nil {
+		err = run(*s.freshSessionOwner)
+	} else {
+		err = s.compact.ApplySchedulerAtomic(run)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}

--- a/parsercore_phase0_owned_recovery_materialize.go
+++ b/parsercore_phase0_owned_recovery_materialize.go
@@ -1,0 +1,89 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import "errors"
+
+// buildCompactOwnedRecoveryAcceptedTree applies C's acceptance splice to one
+// grammar root and its stack extras. Recovery turns authenticate the stack.
+// Reject other topologies instead of manufacturing a grammar root.
+func buildCompactOwnedRecoveryAcceptedTree(
+	parser *Parser,
+	nodes []*Node,
+	source []byte,
+	arena *nodeArena,
+	linkScratch *[]*Node,
+) (*Tree, error) {
+	if parser == nil || parser.language == nil || arena == nil || len(nodes) == 0 {
+		return nil, errors.New("parser-core phase zero: native recovery acceptance has incomplete input")
+	}
+	rootIndex := -1
+	var previousEnd uint32
+	for index, node := range nodes {
+		if node == nil || node.ownerArena != arena || node.startByte > node.endByte ||
+			(index > 0 && node.startByte < previousEnd) {
+			return nil, errors.New("parser-core phase zero: native recovery acceptance has invalid payload ownership or order")
+		}
+		previousEnd = node.endByte
+		if !node.IsExtra() {
+			if rootIndex >= 0 {
+				return nil, errors.New("parser-core phase zero: native recovery acceptance requires one grammar root")
+			}
+			rootIndex = index
+		}
+	}
+	if rootIndex < 0 || !parser.hasRootSymbol || nodes[rootIndex].Symbol() != parser.rootSymbol {
+		return nil, errors.New("parser-core phase zero: native recovery acceptance has no exact grammar root")
+	}
+	root := nodes[rootIndex]
+	// Materialization has already projected hidden grammar children. Preserve
+	// their field metadata while surrounding them with accepted stack extras.
+	var leading, trailing []*Node
+	for index, node := range nodes {
+		if index == rootIndex {
+			continue
+		}
+		if node.Symbol() != errorSymbol && !symbolIsVisible(parser.language, node.Symbol()) {
+			if node.ChildCount() != 0 {
+				return nil, errors.New("parser-core phase zero: native recovery acceptance cannot project a hidden stack extra")
+			}
+			continue
+		}
+		if index < rootIndex {
+			leading = append(leading, node)
+		} else {
+			trailing = append(trailing, node)
+		}
+	}
+	spliceCompactAcceptedRootExtras(root, leading, trailing, arena)
+	extendResultRootRangeToExtras(root, nodes)
+	if resultNodesHaveError(nodes) {
+		root.setHasError(true)
+	}
+	builder := newResultRootBuild(parser, source, arena, nil, nil, linkScratch)
+	return builder.finishNativeAcceptedTree(root, builder.shouldWireParentLinks), nil
+}
+
+// Preserve stack order even when a zero-width extra shares the root's start.
+func spliceCompactAcceptedRootExtras(root *Node, leading, trailing []*Node, arena *nodeArena) {
+	if len(leading)+len(trailing) == 0 || resultMutableChildrenForMutation(root).SurroundFinalRefs(leading, trailing) {
+		return
+	}
+	children := resultChildSliceForMutation(root)
+	merged := arena.allocNodeSlice(len(leading) + len(children) + len(trailing))
+	copy(merged, leading)
+	copy(merged[len(leading):], children)
+	copy(merged[len(leading)+len(children):], trailing)
+	root.children = merged
+	fields, sources := root.fieldIDs(), root.fieldSources()
+	if len(fields) != 0 {
+		padded := arena.allocFieldIDSlice(len(merged))
+		copy(padded[len(leading):], fields)
+		var paddedSources []uint8
+		if len(sources) != 0 {
+			paddedSources = make([]uint8, len(merged))
+			copy(paddedSources[len(leading):], sources)
+		}
+		root.setFieldMetadata(padded, paddedSources)
+	}
+}

--- a/parsercore_phase0_owned_recovery_materialize_test.go
+++ b/parsercore_phase0_owned_recovery_materialize_test.go
@@ -1,0 +1,116 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCompactOwnedRecoverySpliceKeepsFieldsAndErrors(t *testing.T) {
+	for _, withExtras := range []bool{false, true} {
+		t.Run(map[bool]string{false: "root-only", true: "extras"}[withExtras], func(t *testing.T) {
+			arena := acquireNodeArena(arenaClassFull)
+			lang := &Language{SymbolCount: 4, SymbolMetadata: []SymbolMetadata{{}, {Visible: true, Named: true}, {Visible: true}, {Visible: true, Named: true}}}
+			parser := NewParser(lang)
+			parser.rootSymbol, parser.hasRootSymbol = 3, true
+			child := newLeafNodeInArena(arena, 1, true, 1, 2, Point{Column: 1}, Point{Column: 2})
+			root := newParentNodeInArenaWithFieldSources(arena, 3, true, []*Node{child}, []FieldID{7}, []uint8{fieldSourceDirect}, 9)
+			nodes := []*Node{root}
+			var leading, trailing *Node
+			if withExtras {
+				leading = newLeafNodeInArena(arena, 2, false, 0, 1, Point{}, Point{Column: 1})
+				leading.setExtra(true)
+				bad := newLeafNodeInArena(arena, 2, false, 2, 3, Point{Column: 2}, Point{Column: 3})
+				trailing = newParentNodeInArena(arena, errorSymbol, true, []*Node{bad}, nil, 0)
+				trailing.setExtra(true)
+				trailing.setHasError(true)
+				nodes = []*Node{leading, root, trailing}
+			}
+			var scratch []*Node
+			tree, err := buildCompactOwnedRecoveryAcceptedTree(parser, nodes, []byte("#x+"), arena, &scratch)
+			if err != nil {
+				arena.Release()
+				t.Fatal(err)
+			}
+			defer tree.Release()
+			if tree.RootNode() != root || !tree.resultCompatibilityApplied || compactRecoverEOFTreeMarked(tree) {
+				t.Fatal("native acceptance changed the grammar root or requested compatibility")
+			}
+			wantChildren, wantFields := []*Node{child}, []FieldID{7}
+			if withExtras {
+				wantChildren, wantFields = []*Node{leading, child, trailing}, []FieldID{0, 7, 0}
+				if root.StartByte() != 0 || root.EndByte() != 3 || !root.HasError() || child.HasError() {
+					t.Fatalf("wrong root range or error scope: root=%d..%d error=%t child=%t", root.StartByte(), root.EndByte(), root.HasError(), child.HasError())
+				}
+			}
+			if root.ChildCount() != len(wantChildren) || !reflect.DeepEqual(root.fieldIDs(), wantFields) {
+				t.Fatalf("children=%d fields=%v", root.ChildCount(), root.fieldIDs())
+			}
+			for index, child := range wantChildren {
+				if root.Child(index) != child || child.Parent() != root {
+					t.Fatalf("child %d lost order or parent", index)
+				}
+			}
+			if root.fieldSources()[len(wantFields)/2] != fieldSourceDirect {
+				t.Fatal("splice changed field provenance")
+			}
+		})
+	}
+}
+
+func TestCompactOwnedRecoveryZeroWidthExtrasKeepStackOrder(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	lang := &Language{SymbolCount: 4, SymbolMetadata: []SymbolMetadata{{}, {Visible: true}, {Visible: true}, {Visible: true, Named: true}}}
+	parser := NewParser(lang)
+	parser.rootSymbol, parser.hasRootSymbol = 3, true
+	root := newParentNodeInArena(arena, 3, true, nil, nil, 0)
+	extra := newLeafNodeInArena(arena, errorSymbol, true, 0, 0, Point{}, Point{})
+	extra.setExtra(true)
+	extra.setHasError(true)
+	var scratch []*Node
+	tree, err := buildCompactOwnedRecoveryAcceptedTree(parser, []*Node{root, extra}, nil, arena, &scratch)
+	if err != nil {
+		arena.Release()
+		t.Fatal(err)
+	}
+	defer tree.Release()
+	if root.ChildCount() != 1 || root.Child(0) != extra || !root.HasError() || extra.Parent() != root {
+		t.Fatal("zero-width ERROR vanished from the acceptance splice")
+	}
+}
+
+func TestCompactOwnedRecoverySpliceRejectsUnprovedRoots(t *testing.T) {
+	for _, name := range []string{"wrong-root", "two-roots", "overlap", "foreign-arena", "hidden-composite"} {
+		t.Run(name, func(t *testing.T) {
+			arena, other := acquireNodeArena(arenaClassFull), acquireNodeArena(arenaClassFull)
+			defer arena.Release()
+			defer other.Release()
+			lang := &Language{SymbolCount: 4, SymbolMetadata: []SymbolMetadata{{}, {Visible: true}, {}, {Visible: true}}}
+			parser := NewParser(lang)
+			parser.rootSymbol, parser.hasRootSymbol = 3, true
+			child := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
+			root := newParentNodeInArena(arena, 3, true, []*Node{child}, nil, 0)
+			nodes := []*Node{root}
+			switch name {
+			case "wrong-root":
+				root.symbol = 1
+			case "two-roots":
+				nodes = append(nodes, newLeafNodeInArena(arena, 3, true, 1, 2, Point{Column: 1}, Point{Column: 2}))
+			case "overlap":
+				nodes = append(nodes, child)
+			case "foreign-arena":
+				nodes[0] = newLeafNodeInArena(other, 3, true, 0, 1, Point{}, Point{Column: 1})
+			case "hidden-composite":
+				leaf := newLeafNodeInArena(arena, 1, true, 1, 2, Point{Column: 1}, Point{Column: 2})
+				extra := newParentNodeInArena(arena, 2, false, []*Node{leaf}, nil, 0)
+				extra.setExtra(true)
+				nodes = append(nodes, extra)
+			}
+			var scratch []*Node
+			if tree, err := buildCompactOwnedRecoveryAcceptedTree(parser, nodes, []byte("ab"), arena, &scratch); err == nil || tree != nil {
+				t.Fatal("native acceptance admitted an unproved root")
+			}
+		})
+	}
+}

--- a/parsercore_phase0_recovery_allocation_test.go
+++ b/parsercore_phase0_recovery_allocation_test.go
@@ -1,0 +1,149 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func TestCompactRecoveryMaterializationCountsDiscardedNodes(t *testing.T) {
+	prepared, err := parserCoreWarmPrepare()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var work compactFreshAttemptWork
+	scratch := parserCoreRunnerScratch{freshAttemptWork: &work}
+	truncated := prepared.source[:len(prepared.source)/2]
+	tree, err := materializeDiagnosticParserCoreAcceptedTree(
+		prepared.acceptedCore, prepared.acceptedHead, prepared.parser, truncated, &scratch, false, false,
+	)
+	if tree != nil {
+		tree.Release()
+	}
+	if err == nil || work.allocatedNodes == 0 {
+		t.Fatalf("discarded materialization allocations=%d err=%v", work.allocatedNodes, err)
+	}
+	discarded := work.allocatedNodes
+	tree, err = materializeDiagnosticParserCoreAcceptedTree(
+		prepared.acceptedCore, prepared.acceptedHead, prepared.parser, prepared.source, &scratch, false, false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tree.Release()
+	if work.allocatedNodes != discarded+uint64(tree.parseRuntime.NodesAllocated) {
+		t.Fatalf("retry allocations=%d, want discarded %d plus successful %d", work.allocatedNodes, discarded, tree.parseRuntime.NodesAllocated)
+	}
+	scratch.freshAttemptWork = nil
+	if len(scratch.nodesByID) != 0 || len(scratch.nodes) != 0 {
+		t.Fatal("materialization retained tree pointers")
+	}
+}
+
+func TestCompactRecoveryProfiledAllocationScope(t *testing.T) {
+	p := newCompactRecoveryVersionTurnGoParser(t)
+	source := []byte("func f(){}\nfunc g(){}\n")
+	old, err := p.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer old.Release()
+	edited, edit := compactExecutionEdit(source, 21, 22, "+")
+	old.Edit(edit)
+	var borrowedWork incrementalParseTiming
+	borrowed, _, recoveryDeclined := p.attemptCompactIncrementalParse(edited, old, &borrowedWork)
+	if borrowed != nil {
+		borrowed.Release()
+	}
+	if borrowed != nil || !recoveryDeclined || borrowedWork.tokensConsumed == 0 {
+		t.Fatal("fixture did not exercise the discarded borrowed attempt")
+	}
+	runner := p.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+	plain, plainErr := runner.parseWithObserverAndErrorRuns(edited, diagnosticParserCoreSeedObserver{}, false, false)
+	if plain != nil {
+		plain.Release()
+	}
+	plainTokens := runner.scheduler.tokens
+	if plainErr == nil || plainTokens == 0 {
+		t.Fatal("fixture did not exercise the discarded plain-first attempt")
+	}
+	recovery, err := runner.parseWithObserverAndErrorRuns(edited, diagnosticParserCoreSeedObserver{}, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recoveryTokens := recovery.parseRuntime.TokensConsumed
+	recovery.Release()
+	next, profile, err := p.ParseIncrementalProfiled(edited, old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer next.Release()
+	if !next.parseRuntime.CompactIncrementalFullRecoveryRoute ||
+		profile.NewNodesAllocated < uint64(next.parseRuntime.NodesAllocated) {
+		t.Fatal("profile omitted compact recovery allocations")
+	}
+	if want := borrowedWork.tokensConsumed + plainTokens + recoveryTokens; profile.TokensConsumed != want {
+		t.Fatalf("profile tokens=%d, want borrowed %d + plain %d + recovery %d", profile.TokensConsumed, borrowedWork.tokensConsumed, plainTokens, recoveryTokens)
+	}
+	if runner.scratch.freshAttemptWork != nil {
+		t.Fatal("profile retained its attempt counter")
+	}
+}
+
+func TestCompactRecoveryDeclineReleasesAttemptWork(t *testing.T) {
+	p := newCompactRecoveryVersionTurnGoParser(t)
+	runner, err := p.acquireAdmissionCandidateRunner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := []byte("func f(){}\nfunc g(){}+@")
+	plain, plainErr := runner.parseWithObserverAndErrorRuns(source, diagnosticParserCoreSeedObserver{}, false, false)
+	if plain != nil {
+		plain.Release()
+	}
+	plainTokens := runner.scheduler.tokens
+	if plainErr == nil || plainTokens == 0 {
+		t.Fatal("fixture requires a failed plain attempt")
+	}
+	var timing incrementalParseTiming
+	tree := p.attemptCompactIncrementalRecoveryFullParse(source, "recovery probe", true, &timing)
+	if tree != nil {
+		tree.Release()
+		t.Fatal("unsupported lexical reentry unexpectedly succeeded")
+	}
+	if timing.tokensConsumed != plainTokens+runner.scheduler.tokens {
+		t.Fatalf("declined tokens=%d, want plain %d + recovery %d", timing.tokensConsumed, plainTokens, runner.scheduler.tokens)
+	}
+	if runner.scratch.freshAttemptWork != nil {
+		t.Fatal("declined fallback retained its attempt counter")
+	}
+}
+
+type compactRecoveryPanicTables struct{ *parserCoreRootTables }
+
+func (compactRecoveryPanicTables) Actions(core.StateID, core.Symbol) (core.ActionRow, error) {
+	panic("compact recovery attempt probe")
+}
+
+func TestCompactRecoveryPanicReleasesAttemptWork(t *testing.T) {
+	p := newCompactRecoveryVersionTurnGoParser(t)
+	runner, err := p.acquireAdmissionCandidateRunner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner.compact, err = core.New(compactRecoveryPanicTables{runner.tables}, runner.options.Limits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	panicked := false
+	func() {
+		defer func() { panicked = recover() == "compact recovery attempt probe" }()
+		var timing incrementalParseTiming
+		p.attemptCompactIncrementalRecoveryFullParse([]byte("func f(){}+"), "recovery probe", true, &timing)
+	}()
+	if !panicked || runner.scratch.freshAttemptWork != nil {
+		t.Fatalf("panic=%t retained attempt work=%t", panicked, runner.scratch.freshAttemptWork != nil)
+	}
+}

--- a/parsercore_phase0_recovery_condense.go
+++ b/parsercore_phase0_recovery_condense.go
@@ -146,16 +146,24 @@ func diagnosticParserCoreRecoveryCondensePairwise(
 	entries []diagnosticParserCoreRecoveryCondenseEntry,
 	order []int,
 ) []int {
+	return diagnosticParserCoreRecoveryCondensePairwiseMode(entries, order, false)
+}
+
+func diagnosticParserCoreRecoveryCondensePairwiseMode(
+	entries []diagnosticParserCoreRecoveryCondenseEntry,
+	order []int,
+	ownedTurns bool,
+) []int {
 	for i := 1; i < len(order); i++ {
 		removedCurrent := false
 		for j := 0; j < i; j++ {
 			left := entries[order[j]]
 			right := entries[order[i]]
 			if diagnosticParserCoreRecoveryCondenseSameGroup(left, right) ||
-				diagnosticParserCoreRecoveryCondenseShouldStayBefore(left, right) {
+				(!ownedTurns && diagnosticParserCoreRecoveryCondenseShouldStayBefore(left, right)) {
 				continue
 			}
-			if diagnosticParserCoreRecoveryCondenseShouldStayBefore(right, left) {
+			if !ownedTurns && diagnosticParserCoreRecoveryCondenseShouldStayBefore(right, left) {
 				order[i], order[j] = order[j], order[i]
 				continue
 			}
@@ -485,7 +493,7 @@ func (s *diagnosticParserCoreGenericScheduler) condenseRecoveryVersions(
 			scratch = append(scratch, diagnosticParserCoreRecoveryCondenseEntry{header: headers[index]})
 		}
 	}
-	order = diagnosticParserCoreRecoveryCondensePairwise(scratch, order)
+	order = diagnosticParserCoreRecoveryCondensePairwiseMode(scratch, order, s.recoveryTurns.active)
 
 	var drops uint64
 	if len(order) > diagnosticParserCoreRecoveryVersionLimit {

--- a/parsercore_phase0_recovery_turn_publication_test.go
+++ b/parsercore_phase0_recovery_turn_publication_test.go
@@ -1,0 +1,118 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAdmissionOwnedEOFRecoveryBundle(t *testing.T) {
+	p := newAdmissionCandidateGoParser(t)
+	for _, certified := range []bool{false, true} {
+		language := *p.language
+		language.CompactOwnedEOFRecoveryCertified = certified
+		runner, err := newAdmissionCandidateRunner(NewParser(&language))
+		if err != nil {
+			t.Fatal(err)
+		}
+		options := runner.options
+		for name, enabled := range map[string]bool{
+			"recovery": options.Recovery, "strategy2": options.allowCompactStrategy2ErrorRegion,
+			"missing": options.allowCompactMissingTokenInsertion, "faithful": options.allowCompactFaithfulS5Recovery,
+			"lineage": options.allowCompactRecoveryLineageSelection, "turns": options.allowCompactRecoveryVersionTurns,
+			"plain_first": runner.recoveryPlainFirst,
+		} {
+			if enabled != certified {
+				t.Fatalf("bundle=%t mechanism %s=%t", certified, name, enabled)
+			}
+		}
+		if options.allowCompactStackSummaryRecovery || options.allowCompactS5EOFMissingInsertion || options.allowCompactRecoverEOF ||
+			options.allowCompactRecoveryTrailingLineageRetirement || options.allowCompactRecoveryErrorModeKeywordCapture {
+			t.Fatal("the owned EOF bundle enabled an unrelated recovery route")
+		}
+	}
+}
+
+func TestCompactRecoveryVersionTurnRejectsPriorSharedHistory(t *testing.T) {
+	for _, history := range []string{"opened", "resumed", "dropped"} {
+		t.Run(history, func(t *testing.T) {
+			scheduler := newRecoveryLineageForkScheduler(t, true)
+			scheduler.options.allowCompactRecoveryVersionTurns = true
+			switch history {
+			case "opened":
+				scheduler.s3RegionOpened = true
+			case "resumed":
+				scheduler.s3ResumeCount = 1
+			case "dropped":
+				scheduler.work.NoActionDrops = 1
+			}
+			headers := append([]diagnosticParserCoreHeader(nil), scheduler.headers...)
+			work, coreWork, turns := scheduler.work, scheduler.compact.Work(), scheduler.recoveryTurns
+			handled, err := scheduler.s5TryMissingTokenInsertion(0)
+			if handled || err == nil || !strings.Contains(err.Error(), "no prior shared recovery or no-action drops") {
+				t.Fatalf("prior history handled=%t err=%v", handled, err)
+			}
+			if !reflect.DeepEqual(headers, scheduler.headers) || scheduler.work != work ||
+				scheduler.compact.Work() != coreWork || scheduler.recoveryTurns != turns {
+				t.Fatal("prior-history decline mutated the recovery frontier")
+			}
+		})
+	}
+}
+
+func TestCompactRecoveryVersionTurnRejectsSharedPublication(t *testing.T) {
+	for _, source := range []string{
+		"package/p\nfunc a() { aa := 12; _ = aa + 1 }\nfunc b() { _ = 2 }\n",
+		"package p\nfunc a() { aa := 12; _ = aa + 1'}\nfunc b() { _ = 2 }\n",
+		"package p\nfunc a() { aa := 12; _ = aa + 1 }\nfunc b() { _ = 2'}\n",
+	} {
+		p := newCompactRecoveryVersionTurnGoParser(t)
+		tree, routed, reason := p.tryCompactFullParseRoute([]byte(source))
+		if tree != nil {
+			tree.Release()
+		}
+		if routed || !strings.Contains(reason, "requires an executed EOF turn") {
+			t.Fatalf("shared recovery route=%t reason=%q", routed, reason)
+		}
+		runner := p.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+		scheduler := &runner.scheduler
+		if !scheduler.s3RegionOpened || scheduler.recoveryTurns.active || scheduler.work.RecoverEOFAccepts != 0 {
+			t.Fatal("fixture did not exercise shared recovery without owned EOF")
+		}
+		// A fork alone cannot certify an EOF advance.
+		scheduler.recoveryTurns.active = true
+		if _, err := runner.materializeSelection([]byte(source), nil, scheduler); err == nil ||
+			!strings.Contains(err.Error(), "requires an executed EOF turn") {
+			t.Fatalf("unexecuted fork publication err=%v", err)
+		}
+	}
+}
+
+func TestCompactRecoveryVersionTurnSelectedStoreScope(t *testing.T) {
+	for _, recovery := range []bool{false, true} {
+		p := newCompactRecoveryVersionTurnGoParser(t)
+		source := []byte("package p\nfunc f(){}\nfunc g(){}\n")
+		if recovery {
+			source[len(source)-1] = '+'
+		}
+		tree, routed, reason := p.tryCompactFullParseRoute(source)
+		if !routed || tree == nil {
+			t.Fatalf("public route recovery=%t reason=%q", recovery, reason)
+		}
+		tree.Release()
+		runner := p.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+		store, err := runner.materializeSelectedStoreSelection(source, runner.compact, &runner.scheduler, nil)
+		if store != nil {
+			store.Release()
+		}
+		if recovery {
+			if store != nil || err == nil || !strings.Contains(err.Error(), "does not support owned recovery roots") {
+				t.Fatalf("owned recovery selected store=%v err=%v", store != nil, err)
+			}
+		} else if store == nil || err != nil {
+			t.Fatalf("clean selected store=%v err=%v", store != nil, err)
+		}
+	}
+}

--- a/parsercore_phase0_recovery_turns.go
+++ b/parsercore_phase0_recovery_turns.go
@@ -1,0 +1,279 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// diagnosticParserCoreRecoveryTurns tracks C's physical advance round.
+// Tokens and scanner cursors remain in the existing immutable version state.
+type diagnosticParserCoreRecoveryTurns struct {
+	active     bool
+	index      int
+	lastByte   uint32
+	condensing bool
+}
+
+func (s *diagnosticParserCoreGenericScheduler) activateRecoveryVersionTurns() (err error) {
+	if s.recoveryTurns.active && s.versionLexerOwnershipActive {
+		return nil
+	}
+	if !s.recoveryTurns.active || !s.options.allowCompactRecoveryVersionTurns || !s.recoveryIsolation {
+		return errors.New("parser-core phase zero: recovery turn activation lacks an admitted recovery frontier")
+	}
+	snapshot := captureDiagnosticParserCoreS5Scheduler(s)
+	defer func() {
+		if value := recover(); value != nil {
+			snapshot.restore(s)
+			panic(value)
+		}
+		if err != nil {
+			snapshot.restore(s)
+		}
+	}()
+	if err = s.seedVersionLexerOwnershipMode(true); err != nil {
+		return err
+	}
+	s.versionLexerOwnershipActive = true
+	return nil
+}
+
+// dispatchRecoveryVersionTurn advances only the current physical version.
+// A consumed token opens that version's next request, not a shared election.
+func (s *diagnosticParserCoreGenericScheduler) dispatchRecoveryVersionTurn() (*diagnosticParserCoreGenericUnsupported, error) {
+	if err := s.pollStopControl(); err != nil {
+		return nil, err
+	}
+	if err := s.activateRecoveryVersionTurns(); err != nil {
+		return nil, err
+	}
+	if s.recoveryTurns.index >= len(s.headers) {
+		return s.finishRecoveryVersionRound()
+	}
+	s.pruneRecoveryVersionLexerRequests()
+	index := s.recoveryTurns.index
+	header := &s.headers[index]
+	if header.accepted || header.paused {
+		s.recoveryTurns.index++
+		return nil, nil
+	}
+	if header.shifted {
+		if header.versionLexerRequestReference() != 0 {
+			return nil, errors.New("parser-core phase zero: consumed recovery version retains its lookahead request")
+		}
+		previous := *header
+		header.shifted = false
+		header.frontierSequence = 0
+		if err := s.requestHeaderLexerToken(index); err != nil {
+			*header = previous
+			return nil, err
+		}
+	} else if err := s.requestHeaderLexerToken(index); err != nil {
+		return nil, err
+	}
+	request := s.versionLexerRequestForHeader(index)
+	if request == nil {
+		return nil, errors.New("parser-core phase zero: recovery turn has no authenticated lookahead")
+	}
+	// No-lookahead closure needs a separate per-version progress proof.
+	if request.token.NoLookahead {
+		return &diagnosticParserCoreGenericUnsupported{
+			boundary: DiagnosticParserCoreRoute, detail: "recovery turn reached an unsupported no-lookahead token", headerIndex: index,
+		}, nil
+	}
+	var stop *diagnosticParserCoreGenericUnsupported
+	var err error
+	if header.recoveryRegion() != nil {
+		boundary, boundaryErr := s.compact.ClassifyBoundary(header.head, core.Symbol(request.token.Symbol))
+		if boundaryErr != nil {
+			return nil, boundaryErr
+		}
+		cell := diagnosticParserCoreGenericCell{
+			headerIndex: int32(index), boundary: boundary, versionLexerRequest: header.versionLexerRequestReference(),
+		}
+		err = s.withVersionLexerRequest(cell, func() error {
+			var dispatchErr error
+			stop, dispatchErr = s.dispatchOwnedRecoveryRegion(index)
+			return dispatchErr
+		})
+	} else {
+		stop, err = s.dispatchPass()
+		if err == nil && stop != nil && stop.boundary == DiagnosticParserCoreRecovery &&
+			stop.detail == diagnosticParserCoreNoTableActionDetail {
+			supported, baselineErr := s.resetRecoveryNodeBaseline(&s.headers[index])
+			if baselineErr != nil {
+				return nil, baselineErr
+			}
+			if !supported {
+				return stop, nil
+			}
+			s.headers[index].paused = true
+			stop = nil
+		}
+	}
+	if err != nil || stop != nil {
+		return stop, err
+	}
+	if index >= len(s.headers) {
+		return nil, errors.New("parser-core phase zero: recovery advance removed its physical slot before condensation")
+	}
+	header = &s.headers[index]
+	_, position, err := s.compact.Boundary(header.head)
+	if err != nil {
+		return nil, err
+	}
+	if region := header.recoveryRegion(); region != nil {
+		position = region.endByte
+	}
+	// Match parser.c's advance-loop break condition after the operation.
+	if position > s.recoveryTurns.lastByte || (index > 0 && position == s.recoveryTurns.lastByte) {
+		s.recoveryTurns.lastByte = position
+		s.recoveryTurns.index++
+	} else if header.accepted || header.paused {
+		s.recoveryTurns.index++
+	}
+	return nil, nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) finishRecoveryVersionRound() (stop *diagnosticParserCoreGenericUnsupported, err error) {
+	snapshot := captureDiagnosticParserCoreS5Scheduler(s)
+	defer func() {
+		if value := recover(); value != nil {
+			snapshot.restore(s)
+			panic(value)
+		}
+		if err != nil {
+			snapshot.restore(s)
+		}
+	}()
+	s.recoveryTurns.condensing = true
+	err = s.withVersionLexerOwner(func(owner core.SchedulerTransactionToken) error {
+		return s.canonicalizeOwned(owner)
+	})
+	s.recoveryTurns.condensing = false
+	if err != nil {
+		return nil, err
+	}
+	accepted, runnable := 0, 0
+	for index := range s.headers {
+		if s.headers[index].accepted {
+			accepted++
+		} else if !s.headers[index].paused {
+			runnable++
+		}
+	}
+	complete := accepted == len(s.headers) && accepted != 0
+	if !complete && accepted != 0 && runnable == 0 {
+		var err error
+		complete, err = s.finishedRecoveryTreeBeatsPausedFrontier()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if complete {
+		index := 0
+		for !s.headers[index].accepted {
+			index++
+		}
+		request := s.versionLexerRequestForHeader(index)
+		if request == nil {
+			return nil, errors.New("parser-core phase zero: accepted recovery version lost its EOF request")
+		}
+		boundary, err := s.compact.ClassifyBoundary(s.headers[index].head, core.Symbol(request.token.Symbol))
+		if err != nil {
+			return nil, err
+		}
+		cell := diagnosticParserCoreGenericCell{
+			headerIndex: int32(index), boundary: boundary, versionLexerRequest: s.headers[index].versionLexerRequestReference(),
+		}
+		return nil, s.withVersionLexerRequest(cell, s.completeAcceptance)
+	}
+	if runnable == 0 {
+		return &diagnosticParserCoreGenericUnsupported{
+			boundary: DiagnosticParserCoreRecovery, detail: "recovery turn requires a paused-version resume before acceptance",
+		}, nil
+	}
+	if len(s.headers) == 1 && s.headers[0].shifted && s.headers[0].recoveryRegion() == nil {
+		if err := s.rejoinSharedLexerFromOwnedHeader(); err != nil {
+			return nil, err
+		}
+		s.recoveryTurns = diagnosticParserCoreRecoveryTurns{}
+		return nil, nil
+	}
+	if err := s.compact.BeginFrontier(); err != nil {
+		return nil, err
+	}
+	s.epochProgress = false
+	s.recoveryTurns.index = 0
+	return nil, nil
+}
+
+// C's condense tail resumes the best paused version and returns its stored
+// stack cost, before recovery changes it. A cheaper finished tree ends parsing.
+// This path proves that outcome without constructing versions C then discards.
+func (s *diagnosticParserCoreGenericScheduler) finishedRecoveryTreeBeatsPausedFrontier() (bool, error) {
+	source, err := s.s5RecoverySource()
+	if err != nil {
+		return false, err
+	}
+	symbols := diagnosticParserCoreRecoverySymbolPolicy(s.tokenSource.language)
+	var memo core.RecoveryCostMemo
+	defer memo.Reset()
+	var pausedCost uint32
+	pausedFound := false
+	var finishedCost uint32
+	finishedFound := false
+	for index := range s.headers {
+		header := s.headers[index]
+		if header.accepted && header.recoveryRegion() != nil {
+			return false, nil
+		}
+		if !header.accepted && !header.paused {
+			return false, nil
+		}
+		entry, supported, err := s.recoveryCondenseEntry(header, symbols, source, &memo)
+		if err != nil || !supported {
+			return false, err
+		}
+		if header.accepted {
+			if !finishedFound || entry.status.Cost < finishedCost {
+				finishedCost, finishedFound = entry.status.Cost, true
+			}
+		} else if !pausedFound {
+			// key.cost excludes the paused-status skipped-tree surcharge.
+			pausedCost, pausedFound = entry.key.cost, true
+		}
+	}
+	return finishedFound && pausedFound && finishedCost < pausedCost, nil
+}
+
+// Keep only requests still owned by a live or accepted version.
+// Run outside request callbacks, which temporarily retain pointers into this slice.
+func (s *diagnosticParserCoreGenericScheduler) pruneRecoveryVersionLexerRequests() {
+	write := 0
+	for read := range s.versionLexerRequests {
+		reference := uint32(read + 1)
+		used := false
+		for index := range s.headers {
+			header := &s.headers[index]
+			if header.versionLexerRequestReference() != reference {
+				continue
+			}
+			used = true
+			if write != read {
+				baseline, baselineSet := header.recoveryNodeBaseline()
+				header.publishVersionState(header.recoveryRegion(), header.versionLexerSnapshot(),
+					uint32(write+1), header.recoveryGroupIdentity(), header.recoveryMissingGroupIdentity(), baseline, baselineSet)
+			}
+		}
+		if used {
+			s.versionLexerRequests[write] = s.versionLexerRequests[read]
+			write++
+		}
+	}
+	clear(s.versionLexerRequests[write:])
+	s.versionLexerRequests = s.versionLexerRequests[:write]
+}

--- a/parsercore_phase0_s5.go
+++ b/parsercore_phase0_s5.go
@@ -1133,6 +1133,9 @@ func (s *diagnosticParserCoreGenericScheduler) s5RunOwned(
 	s.epochProgress = true
 	s.s5MissingInsertions++
 	staged.missingTokenCommits++
+	if s.options.allowCompactRecoveryVersionTurns {
+		s.recoveryTurns = diagnosticParserCoreRecoveryTurns{active: true, lastByte: originalByte}
+	}
 	// Match ordinary scheduler publication. Canonicalization clears stale
 	// freshness and reconciles equivalent physical heads before ownership is
 	// persisted for the next dispatch.
@@ -1161,6 +1164,15 @@ func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertionFaithfu
 	}
 	if s.token.Symbol == 0 && !s.options.allowCompactS5EOFMissingInsertion {
 		return false, nil
+	}
+	// This route owns the first recovery episode. Earlier shared recovery or
+	// sibling drops require advance ordering that this route has not executed.
+	if s.options.allowCompactRecoveryVersionTurns &&
+		(s.s3RegionOpened || s.s3ResumeCount != 0 || s.work.NoActionDrops != 0) {
+		return false, &diagnosticParserCoreDecline{
+			boundary: DiagnosticParserCoreRecovery,
+			detail:   "owned recovery requires no prior shared recovery or no-action drops",
+		}
 	}
 	snapshot := captureDiagnosticParserCoreS5Scheduler(s)
 	staged := diagnosticParserCoreS5Work{}

--- a/tree.go
+++ b/tree.go
@@ -1077,9 +1077,12 @@ type ParseRuntime struct {
 	// an actual old-tree reuse parse rather than an internal fresh fallback.
 	IncrementalOldTreeReuseRoute bool
 	// CompactIncrementalReuseRoute records execution with borrowed compact subtrees.
-	CompactIncrementalReuseRoute     bool
-	CompactIncrementalReusedSubtrees uint64
-	CompactIncrementalReusedBytes    uint64
+	CompactIncrementalReuseRoute bool
+	// CompactIncrementalFullRecoveryRoute records a fresh compact recovery fallback.
+	// This route does not borrow old-tree nodes.
+	CompactIncrementalFullRecoveryRoute bool
+	CompactIncrementalReusedSubtrees    uint64
+	CompactIncrementalReusedBytes       uint64
 	// CompactIncrementalFallbackReason records an attempted compact reparse decline.
 	CompactIncrementalFallbackReason string
 	// CompactReductions counts reductions executed by the compact scheduler.


### PR DESCRIPTION
## Summary

Run bounded Go recovery on version-owned compact lexer state.

- Advance the absorbing version to EOF before its missing-token sibling consumes the unexpected token.
- Recover to an ancestor and retain the competing EOF tree until C-equivalent selection completes.
- Apply native acceptance splicing without result normalization.
- Authenticate production aliases without changing existing recovery profiles.
- Retry incremental recovery with a full compact parse after borrowed-node cleanup.
- Report zero reuse for that fallback. Count discarded attempts in the profiled API.

The exact Go grammar profile enables this route. Other recovery capabilities remain separate.

## Scope

This package supports EOF after the first absorbed token. It does not graduate general recovery.

Prior shared recovery, unsupported lexical reentry, and an unmodeled six-version transition decline before mutation. Recovery SelectedStore construction also declines.

The incremental fallback preserves correctness by reparsing. It does not claim subtree reuse.

## Correctness

Compare against main `4c9f1d40177498a684174c858b53e0fd90d8b8aa` and the locked C runtime.

- Original matrix: 1,199 edits; all 226 compact results match C. Ten previous mismatches become exact.
- Expanded matrix: 4,524 edits; all 480 compact results match C. Fifteen previous mismatches become exact.
- Every other complete tree and per-node error flag matches main.
- Tracked cases cover suffix recovery, package aliases, parameters, loops, strings, repairs, and copy isolation.
- Canonical Go fresh and incremental C parity passes.
- JavaScript retains baseline results across 5,267 S5 cases and 2,954 T3 cases.
- Scala recovery and version-owned lexer witnesses retain exact C parity.
- Focused Docker race tests cover recovery, lexer ownership, cancellation, allocation accounting, and memory limits.
- The emergency build passes.

The broader admission race run reports three inherited failures. Each reproduces identically on the unchanged main tree:

- `TestAdmissionCandidateElmHighlightDirect` reports the same digest difference.
- `TestAdmissionCandidateExactExternalPayloadCorpus/kotlin` reports the same blocker difference.
- `TestAdmissionCandidateExactExternalPayloadCorpus/perl` reports the same blocker difference.

## Performance

Run each benchmark in 20 separate processes with explicit shuffle seeds and `GOMAXPROCS=1`. Use `750ms`, allocation reporting, and CPU 18.

The adjacent baseline and candidate runs use the same bounded Docker configuration.

| Benchmark | Main | Candidate | Result |
| --- | --- | --- | --- |
| Full parse | 14.26 ms | 14.07 ms | No significant change; p=0.242 |
| Single-byte edit | 1.235 µs | 1.239 µs | No significant change; p=0.857 |
| No edit | 3.026 ns | 2.893 ns | -4.41%; p<0.001 |

Allocation counts remain unchanged. Both incremental cases retain zero bytes and zero allocations per operation.

The initial contended candidate run was slower. That result did not reproduce in the isolated adjacent comparison. No performance implementation changes were made.

## Campaign

Advance #1063 toward compact parser graduation. Keep the remaining grammar and release gates open.
