### PR TITLE
Restore C-backed admission test contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,10 +133,9 @@ jobs:
         # the same allow-list convention the two lanes above use. -timeout
         # is set to roughly twice the measured wall time.
         #
-        # 12 tagged tests are excluded, not fixed here (out of scope for
+        # Elm and external-payload contracts run in isolated grammar steps below.
+        # 10 tagged tests are excluded, not fixed here (out of scope for
         # this maintenance lane; see docs/ci-gate-coverage.md Part 4):
-        #   TestAdmissionCandidateElmHighlightDirect: digest mismatch (Elm highlight)
-        #   TestAdmissionCandidateExactExternalPayloadCorpus: kotlin/perl blocker-text mismatch
         #   TestDiagnosticParserCoreConflictAllUnchangedPauses: conflict creation sequence overflow
         #   TestDiagnosticParserCoreConflictFiltersUnchangedArm: conflict creation sequence overflow
         #   TestDiagnosticParserCoreGenericSchedulerCapsPublishNothing: no_action drop coverage mismatch (before-accept)
@@ -1252,6 +1251,29 @@ jobs:
             --c-ref-build-jobs 1 \
             --timeout 20m \
             --run '^(TestCompactT3OracleAdjudication|TestCompactT3JavaScriptRecoveryProfileCharacterization|TestCompactT3JavaScriptRecoveryRouteSeedOracleParity|TestCompactT3JavaScriptRecoveryMutationDifferential|TestCompactJavaScriptS5RecoveryMutationDifferential|TestCompactRouteLockedCExceptions)$'
+
+      - name: Elm admission contract against locked C
+        run: |
+          bash cgo_harness/docker/run_parity_in_docker.sh \
+            --label ci-admission-elm-contract \
+            --memory 4g \
+            --cpus 2 \
+            --gomemlimit 3GiB \
+            --wall-timeout 5m \
+            -- "cd /workspace && go test . -tags gts_parsercorephase0 -run '^TestAdmissionCandidateElmHighlightDirect$' -count=1 -timeout 2m && cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^TestAdmissionCandidateElmHighlightCOracle$' -count=1 -timeout 2m -v"
+
+      - name: External payload contracts by grammar
+        run: |
+          set -euo pipefail
+          for grammar in kotlin ocaml perl rust; do
+            bash cgo_harness/docker/run_parity_in_docker.sh \
+              --label "ci-admission-external-payload-${grammar}" \
+              --memory 4g \
+              --cpus 2 \
+              --gomemlimit 3GiB \
+              --wall-timeout 5m \
+              -- "cd /workspace && go test . -tags gts_parsercorephase0 -run '^TestAdmissionCandidateExactExternalPayloadCorpus$/${grammar}$' -count=1 -timeout 2m -v"
+          done
 
       - name: Compact incremental Go execution
         run: |

--- a/admission_direct_corpus_test.go
+++ b/admission_direct_corpus_test.go
@@ -98,7 +98,8 @@ func TestAdmissionCandidateElmHighlightDirect(t *testing.T) {
 		// Its path is test/highlight/basic.elm.
 		sourceBytes  = 1231
 		sourceSHA256 = "8fca87bd8cc2735e83704acd8d06ffbc6cf04e386505de45596218d7fb72642c"
-		wantDetail   = "digest 67329ce8b319"
+		// TestAdmissionCandidateElmHighlightCOracle authenticates this digest.
+		wantDetail = "digest f9e33776ce39"
 	)
 
 	source, err := os.ReadFile(fixturePath)

--- a/admission_external_payload_corpus_test.go
+++ b/admission_external_payload_corpus_test.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 )
 
 func TestAdmissionCandidateExactExternalPayloadCorpus(t *testing.T) {
@@ -21,10 +23,9 @@ func TestAdmissionCandidateExactExternalPayloadCorpus(t *testing.T) {
 	}{
 		// kotlinx-datetime@292e7e0ce510, core/common/src/serializers/DateTimeUnitSerializers.kt
 		{
-			language:   "kotlin",
-			path:       "testdata/admission_direct/external_payload/kotlin.kt",
-			sha256:     "e825c4c57c95082c9aa2b62f35853d0b2edfc24934a349ce9f1195d14ae7522b",
-			nextReason: "live-link cap exceeded",
+			language: "kotlin",
+			path:     "testdata/admission_direct/external_payload/kotlin.kt",
+			sha256:   "e825c4c57c95082c9aa2b62f35853d0b2edfc24934a349ce9f1195d14ae7522b",
 		},
 		// ocaml/ocaml@7c51f06c0a5d, testsuite/tools/environment.mli
 		{
@@ -35,10 +36,9 @@ func TestAdmissionCandidateExactExternalPayloadCorpus(t *testing.T) {
 		},
 		// tree-sitter-perl@ad74e6db234c, unicode_ranges.pl
 		{
-			language:   "perl",
-			path:       "testdata/admission_direct/external_payload/perl.pl",
-			sha256:     "84b468672c82a73ba88d62a47591e85d02f9e35952a7ce45a494db71d1fa3ad4",
-			nextReason: "shallow non-exact outer edge",
+			language: "perl",
+			path:     "testdata/admission_direct/external_payload/perl.pl",
+			sha256:   "84b468672c82a73ba88d62a47591e85d02f9e35952a7ce45a494db71d1fa3ad4",
 		},
 		// tree-sitter-rust@77a3747266f4, examples/weird-exprs.rs
 		{
@@ -75,12 +75,63 @@ func TestAdmissionCandidateExactExternalPayloadCorpus(t *testing.T) {
 				if strings.Contains(row.detail, "external payload") {
 					t.Fatalf("exact external payload still declined: %s", row.detail)
 				}
-				if !strings.Contains(row.detail, test.nextReason) {
+				if test.nextReason != "" && !strings.Contains(row.detail, test.nextReason) {
 					t.Fatalf("fallback=%q, want the next blocker %q", row.detail, test.nextReason)
+				}
+				if test.nextReason == "" {
+					// Independent scheduler guards can stop these corpora first.
+					// Core's TestRecursiveInsertAcceptsExactExternalScannerProvenance
+					// proves insertion for exact top-level and descendant payloads.
+					// TestRecursiveInsertKeepsScannerCheckpointMismatchSeparate
+					// protects the corresponding negative identity contract.
+					frontierDecline := strings.HasPrefix(row.detail, "compact route declined at no_action")
+					linkCap := strings.HasPrefix(row.detail, "compact route error: parser-core phase zero: shared (") &&
+						strings.Contains(row.detail, "live-link cap exceeded")
+					if !frontierDecline && !linkCap {
+						t.Fatalf("unexpected fallback category: %s", row.detail)
+					}
+					assertExternalPayloadFallbackEquivalent(t, entry, source)
 				}
 			default:
 				t.Fatalf("compact route=%s: %s", row.status, row.detail)
 			}
 		})
+	}
+}
+
+func assertExternalPayloadFallbackEquivalent(t *testing.T, entry grammars.LangEntry, source []byte) {
+	t.Helper()
+	language := entry.Language()
+	var legacyDigest string
+	for _, route := range []bool{false, true} {
+		parser := gotreesitter.NewParser(language)
+		parser.SetAdmissionCandidateRoute(route)
+		beforeRouted, beforeFallback := gotreesitter.AdmissionCandidateCounters()
+		tree, err := parser.Parse(source)
+		if err != nil || tree == nil {
+			t.Fatalf("compact=%t parse failed: %v", route, err)
+		}
+		defer tree.Release()
+		afterRouted, afterFallback := gotreesitter.AdmissionCandidateCounters()
+		wantFallback := uint64(0)
+		if route {
+			wantFallback = 1
+		}
+		if afterRouted != beforeRouted || afterFallback-beforeFallback != wantFallback {
+			t.Fatalf("compact=%t route counters=%d/%d, want 0/%d", route, afterRouted-beforeRouted, afterFallback-beforeFallback, wantFallback)
+		}
+		runtime := tree.ParseRuntime()
+		if tree.ParseStopReason() != gotreesitter.ParseStopAccepted || runtime.Truncated || runtime.TokenSourceEOFEarly ||
+			runtime.ExpectedEOFByte != uint32(len(source)) || runtime.LastTokenEndByte != uint32(len(source)) || !runtime.LastTokenWasEOF {
+			t.Fatalf("compact=%t incomplete parse: %s", route, runtime.Summary())
+		}
+		inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if route && inspection.SHA256 != legacyDigest {
+			t.Fatalf("fallback digest=%s, forced legacy=%s", inspection.SHA256, legacyDigest)
+		}
+		legacyDigest = inspection.SHA256
 	}
 }

--- a/cgo_harness/admission_elm_direct_parity_test.go
+++ b/cgo_harness/admission_elm_direct_parity_test.go
@@ -1,0 +1,72 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+func TestAdmissionCandidateElmHighlightCOracle(t *testing.T) {
+	const sourceSHA256 = "8fca87bd8cc2735e83704acd8d06ffbc6cf04e386505de45596218d7fb72642c"
+	const treeSHA256 = "f9e33776ce39fa7ebed6e3e8a845a3b5d4dd87e03e09b6f6fa8fc1a02db852c8"
+	source, err := os.ReadFile("../testdata/admission_direct/elm_highlight_basic.elm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != sourceSHA256 {
+		t.Fatalf("Elm fixture SHA-256=%s, want %s", got, sourceSHA256)
+	}
+	cLanguage, err := ParityCLanguage("elm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cTree := compactT3ParseC(t, cLanguage, source)
+	defer cTree.Close()
+	cDigest, err := COracleDeepDigest(cTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cDigest != treeSHA256 {
+		t.Fatalf("locked C digest=%s, want %s", cDigest, treeSHA256)
+	}
+	language := grammars.ElmLanguage()
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	for _, route := range []bool{false, true} {
+		t.Run(fmt.Sprintf("compact_%t", route), func(t *testing.T) {
+			parser := gotreesitter.NewParser(language)
+			parser.SetAdmissionCandidateRoute(route)
+			beforeRouted, beforeFallback := gotreesitter.AdmissionCandidateCounters()
+			tree, err := parser.Parse(source)
+			if err != nil || tree == nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+			defer tree.Release()
+			afterRouted, afterFallback := gotreesitter.AdmissionCandidateCounters()
+			wantRouted := uint64(0)
+			if route {
+				wantRouted = 1
+			}
+			if afterRouted-beforeRouted != wantRouted || afterFallback != beforeFallback {
+				t.Fatalf("route counters=%d/%d, want %d/0", afterRouted-beforeRouted, afterFallback-beforeFallback, wantRouted)
+			}
+			runtime := tree.ParseRuntime()
+			if runtime.Truncated || runtime.TokenSourceEOFEarly || tree.ParseStopReason() != gotreesitter.ParseStopAccepted {
+				t.Fatalf("incomplete Elm parse: %s", runtime.Summary())
+			}
+			inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if inspection.SHA256 != cDigest {
+				t.Fatalf("Go digest=%s, locked C=%s", inspection.SHA256, cDigest)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Changes

- Authenticate the Elm highlight digest against the locked C parser.
- Check complete Kotlin and Perl fallback trees against the forced legacy route.
- Preserve narrow decline categories and exact external-payload provenance tests.
- Restore continuous integration coverage in separate grammar containers.

This change modifies tests and CI only. It does not change parser behavior or broaden admission.

The old Elm digest differed from C and both current Go routes. The new companion authenticates the complete tree before updating that digest.

Kotlin and Perl now stop at independent scheduler guards before their previously recorded blockers. The assertions retain source hashes, external-payload rejection checks, and complete returned-tree equivalence.

## Verification

- Elm root and C-oracle tests pass in one bounded Docker container.
- Kotlin, Perl, OCaml, and Rust pass in separate Docker containers.
- Elm, Kotlin, and Perl pass under the race detector.
- Exact external-provenance acceptance, checkpoint rejection, and rollback tests pass under the race detector.
- `actionlint` and `git diff --check` pass.
- An independent Astra reviewer found no blocking findings.

Local artifacts remain outside the repository under `/tmp/gts-owned-turn-review/20260905T03*-maintenance-*`.

This verifies fallback safety and core provenance separately. It does not claim each corpus reaches external insertion before another guard.

Refs #1063.
