### PR TITLE
Authenticate compact reuse inside edited declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,8 @@ jobs:
           TestAdmissionSwitchParseIncrementalDoesNotCountFullRoute
           TestCompactIncrementalExecution.*
           TestCompactBorrowed.*
+          TestCompactNestedReuse.*
+          TestCompactReuseDependency.*
           TestAdmissionSwitchParseProductionWhenOff
           TestAdmissionSwitchParseRoutesCandidateWhenOn
           TestAdmissionSwitchRecoveryDoesNotLeakCompactTree
@@ -1283,7 +1285,7 @@ jobs:
             --cpus 2 \
             --gomemlimit 3GiB \
             --wall-timeout 10m \
-            -- "cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^(TestGoCompactIncrementalExecution.*Parity|TestStage6GoCompactCertification)$' -count=1 -parallel 1 -timeout 5m -v"
+            -- "cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^(TestGoCompactIncrementalExecution.*Parity|TestGoCompactNestedReuse.*LockedC|TestStage6GoCompactCertification)$' -count=1 -parallel 1 -timeout 5m -v"
 
       - name: Compact recovery incremental JavaScript witnesses
         run: |
@@ -1299,7 +1301,7 @@ jobs:
             --test-parallel 1 \
             --c-ref-build-jobs 1 \
             --timeout 20m \
-            -- "cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^(TestCompactRecoveryJavaScriptIncrementalCOracle|TestCompactRecoveryJavaScriptInsertionRegression)$' -count=1 -parallel 1 -timeout 20m -v"
+            -- "cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^(TestCompactRecoveryJavaScriptIncrementalCOracle|TestCompactRecoveryJavaScriptInsertionRegression|TestJavaScriptCompactNestedReuseLookaheadLockedC)$' -count=1 -parallel 1 -timeout 20m -v"
 
       - name: Compact recovery incremental YAML witness
         run: |

--- a/arena.go
+++ b/arena.go
@@ -125,6 +125,11 @@ type nodeArena struct {
 	compactCheckpointLeafSlabCursor int
 	finalChildSidecars              []finalChildSidecar
 	missingNodeDependencies         []missingNodeDependencyEntry
+	compactReuseDependencyMu        sync.RWMutex
+	compactReuseDependencies        map[*Node]compactReuseDependency
+	compactReuseDependencyEntries   uint64
+	compactReuseDependencyIndex     []compactReuseDependencyIndexEntry
+	compactReuseDependencyIndexed   bool
 	nodeFieldMetadataSlabs          []nodeFieldMetadataSlab
 	nodeFieldMetadataSlabCursor     int
 
@@ -558,6 +563,10 @@ func (a *nodeArena) reset() {
 	a.resetRawShapeHashCache()
 	a.resetFinalChildSidecars()
 	a.resetMissingNodeDependencies()
+	a.compactReuseDependencies = nil
+	a.compactReuseDependencyEntries = 0
+	a.compactReuseDependencyIndex = nil
+	a.compactReuseDependencyIndexed = false
 	a.resetCompactCheckpointLeafSlabs()
 	a.resetNodeFieldMetadataSlabs()
 	a.resetChildSlabs()
@@ -1883,6 +1892,7 @@ func (a *nodeArena) recomputeAllocatedBytes() {
 		a.rawShapeHashCacheBytesAllocated() +
 		a.finalChildSidecarBytesAllocated() +
 		missingNodeDependencyEntryBytesForCap(cap(a.missingNodeDependencies)) +
+		a.compactReuseDependencyBytesAllocated() +
 		a.compactCheckpointLeafBytesAllocated() +
 		a.childSliceBytesAllocated() +
 		a.fieldIDBytesAllocated() +
@@ -2233,6 +2243,8 @@ func (a *nodeArena) collectArenaBreakdown() *ArenaBreakdown {
 		fieldSourceElements = 0
 	}
 	breakdown := &ArenaBreakdown{
+		CompactReuseDependencyBytesAllocated: a.compactReuseDependencyBytesAllocated(),
+
 		NodeStructBytesAllocated:            a.nodeStructBytesAllocated(),
 		NodeFieldMetadataBytesAllocated:     a.nodeFieldMetadataBytesAllocated(),
 		NoTreeNodeBytesAllocated:            a.noTreeNodeBytesAllocated(),

--- a/cgo_harness/cmd/parse_gap_report/main.go
+++ b/cgo_harness/cmd/parse_gap_report/main.go
@@ -1181,7 +1181,8 @@ func statsFromGoTree(r *runner, tree *gotreesitter.Tree, queryCaptures, cursorNo
 			breakdown.PendingParentBytesAllocated +
 			breakdown.PendingChildEntryBytesAllocated +
 			breakdown.FinalChildSidecarBytesAllocated +
-			breakdown.MissingNodeDependencyBytesAllocated
+			breakdown.MissingNodeDependencyBytesAllocated +
+			breakdown.CompactReuseDependencyBytesAllocated
 		stats.ArenaChildB = breakdown.ChildSliceBytesAllocated
 		stats.ArenaFieldB = breakdown.NodeFieldMetadataBytesAllocated +
 			breakdown.FieldIDBytesAllocated +
@@ -1295,6 +1296,7 @@ func arenaLiveBytes(b gotreesitter.ArenaBreakdown, externalScannerCheckpointByte
 		b.RawShapeHashCacheBytesAllocated +
 		b.FinalChildSidecarBytesAllocated +
 		b.MissingNodeDependencyBytesAllocated +
+		b.CompactReuseDependencyBytesAllocated +
 		b.CompactCheckpointLeafBytesAllocated +
 		b.ChildSliceBytesAllocated +
 		b.FieldIDBytesAllocated +

--- a/cgo_harness/cmd/parse_gap_report/main_test.go
+++ b/cgo_harness/cmd/parse_gap_report/main_test.go
@@ -309,6 +309,8 @@ func TestStatsFromRuntimeReportsScratchAndTransientMemory(t *testing.T) {
 
 func TestArenaLiveBytesIncludesEveryRuntimeArenaComponent(t *testing.T) {
 	breakdown := gotreesitter.ArenaBreakdown{
+		CompactReuseDependencyBytesAllocated: 16,
+
 		NodeStructBytesAllocated:            1,
 		NodeFieldMetadataBytesAllocated:     14,
 		NoTreeNodeBytesAllocated:            2,
@@ -327,7 +329,7 @@ func TestArenaLiveBytesIncludesEveryRuntimeArenaComponent(t *testing.T) {
 	}
 	runtime := gotreesitter.ParseRuntime{
 		ExternalScannerCheckpointBytesAllocated: 13,
-		ArenaBytesAllocated:                     133,
+		ArenaBytesAllocated:                     149,
 	}
 	if got, want := arenaLiveBytes(breakdown, runtime.ExternalScannerCheckpointBytesAllocated), runtime.ArenaBytesAllocated; got != want {
 		t.Fatalf("arenaLiveBytes = %d, runtime arena total = %d", got, want)

--- a/cgo_harness/go_compact_nested_reuse_test.go
+++ b/cgo_harness/go_compact_nested_reuse_test.go
@@ -1,0 +1,202 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package cgoharness
+
+import (
+	"bytes"
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	"testing"
+)
+
+func TestGoCompactNestedReuseLockedC(t *testing.T) {
+	source := []byte("func a(){_=1}")
+	edited := []byte("func a(){_=x}")
+	edit := gts.InputEdit{StartByte: 11, OldEndByte: 12, NewEndByte: 12, StartPoint: pointAtOffset(source, 11), OldEndPoint: pointAtOffset(source, 12), NewEndPoint: pointAtOffset(edited, 12)}
+	lang := grammars.GoLanguage()
+	p := gts.NewParser(lang)
+	p.SetAdmissionCandidateRoute(true)
+	old, err := p.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parameters := findGoNodeByTypeAndStart(old.RootNode(), lang, "parameter_list", 6)
+	if parameters == nil || parameters.EndByte() != 8 {
+		old.Release()
+		t.Fatal("missing parameter list at bytes 6..8")
+	}
+	old.Edit(edit)
+	next, err := p.ParseIncremental(edited, old)
+	old.Release()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer next.Release()
+	cl, err := ParityCLanguage("go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cp := sitter.NewParser()
+	defer cp.Close()
+	if err := cp.SetLanguage(cl); err != nil {
+		t.Fatal(err)
+	}
+	co := cp.Parse(source, nil)
+	if co == nil {
+		t.Fatal("C old tree is nil")
+	}
+	ce := realCorpusCInputEdit(edit)
+	co.Edit(&ce)
+	ci := cp.Parse(edited, co)
+	co.Close()
+	cf := cp.Parse(edited, nil)
+	if ci == nil || cf == nil {
+		t.Fatal("C result is nil")
+	}
+	defer ci.Close()
+	defer cf.Close()
+	for _, oracle := range []*sitter.Tree{cf, ci} {
+		assertLockedCTreeExact(t, "nested parameter list", next, lang, oracle)
+	}
+	runtime := next.ParseRuntime()
+	if !runtime.CompactIncrementalReuseRoute || runtime.CompactIncrementalReusedSubtrees < 1 || runtime.CompactIncrementalReusedBytes < 2 {
+		t.Fatalf("missing compact nonterminal reuse: decline=%q", runtime.CompactIncrementalFallbackReason)
+	}
+	got := findGoNodeByTypeAndStart(next.RootNode(), lang, "parameter_list", 6)
+	if got != parameters || got.Parent() != next.RootNode().Child(0) || got.Text(edited) != "()" {
+		t.Fatal("borrowed parameter list lost its identity or navigation")
+	}
+}
+
+func TestGoCompactNestedReuseBoundaryLockedC(t *testing.T) {
+	for _, tc := range []struct {
+		name, source, before, after string
+	}{
+		{"right_boundary", "func a(){_=1}", "){", ")int{"},
+		{"leading_identifier_width", "func a(){_=1}", "a", "longName"},
+		{"inside_parameters", "func a(){_=1}", "()", "(x int)"},
+		{"parameter_separator", "func a(x int){_=1}", "x int", "x,y int"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := []byte(tc.source)
+			start := bytes.Index(source, []byte(tc.before))
+			edited := bytes.Replace(source, []byte(tc.before), []byte(tc.after), 1)
+			edit := gts.InputEdit{StartByte: uint32(start), OldEndByte: uint32(start + len(tc.before)), NewEndByte: uint32(start + len(tc.after)), StartPoint: pointAtOffset(source, start), OldEndPoint: pointAtOffset(source, start+len(tc.before)), NewEndPoint: pointAtOffset(edited, start+len(tc.after))}
+			if tc.name == "right_boundary" {
+				// Insert at the exact end of the old parameter list.
+				edit = gts.InputEdit{StartByte: 8, OldEndByte: 8, NewEndByte: 11, StartPoint: pointAtOffset(source, 8), OldEndPoint: pointAtOffset(source, 8), NewEndPoint: pointAtOffset(edited, 11)}
+			}
+			lang := grammars.GoLanguage()
+			p := gts.NewParser(lang)
+			p.SetAdmissionCandidateRoute(true)
+			old, err := p.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			parameters := findGoNodeByTypeAndStart(old.RootNode(), lang, "parameter_list", 6)
+			if parameters == nil {
+				old.Release()
+				t.Fatal("old parameter list is absent")
+			}
+			old.Edit(edit)
+			next, err := p.ParseIncremental(edited, old)
+			old.Release()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer next.Release()
+			cl, err := ParityCLanguage("go")
+			if err != nil {
+				t.Fatal(err)
+			}
+			cp := sitter.NewParser()
+			defer cp.Close()
+			if err := cp.SetLanguage(cl); err != nil {
+				t.Fatal(err)
+			}
+			co := cp.Parse(source, nil)
+			if co == nil {
+				t.Fatal("C old tree is nil")
+			}
+			ce := realCorpusCInputEdit(edit)
+			co.Edit(&ce)
+			ci := cp.Parse(edited, co)
+			co.Close()
+			cf := cp.Parse(edited, nil)
+			if ci == nil || cf == nil {
+				t.Fatal("C result is nil")
+			}
+			defer ci.Close()
+			defer cf.Close()
+			for _, oracle := range []*sitter.Tree{cf, ci} {
+				assertLockedCTreeExact(t, tc.name, next, lang, oracle)
+			}
+			var contains func(*gts.Node) bool
+			contains = func(n *gts.Node) bool {
+				if n == parameters {
+					return true
+				}
+				for i := 0; i < n.ChildCount(); i++ {
+					if contains(n.Child(i)) {
+						return true
+					}
+				}
+				return false
+			}
+			// A wider preceding name can preserve the untouched parameter list.
+			if tc.name != "leading_identifier_width" && contains(next.RootNode()) {
+				t.Fatal("edited parameter boundary reused the old parameter list")
+			}
+		})
+	}
+}
+
+func TestGoCompactNestedReuseChangedLookaheadLockedC(t *testing.T) {
+	for _, prefix := range []string{"", "package p\n"} {
+		source := []byte(prefix + "var x = a + b ;")
+		edited := bytes.Replace(source, []byte(";"), []byte("* c ;"), 1)
+		start := len(source) - 1
+		edit := gts.InputEdit{StartByte: uint32(start), OldEndByte: uint32(start + 1), NewEndByte: uint32(start + 5), StartPoint: pointAtOffset(source, start), OldEndPoint: pointAtOffset(source, start+1), NewEndPoint: pointAtOffset(edited, start+5)}
+		lang := grammars.GoLanguage()
+		p := gts.NewParser(lang)
+		p.SetAdmissionCandidateRoute(true)
+		old, err := p.Parse(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		old.Edit(edit)
+		next, err := p.ParseIncremental(edited, old)
+		old.Release()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer next.Release()
+		cl, err := ParityCLanguage("go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		cp := sitter.NewParser()
+		defer cp.Close()
+		if err := cp.SetLanguage(cl); err != nil {
+			t.Fatal(err)
+		}
+		co := cp.Parse(source, nil)
+		if co == nil {
+			t.Fatal("C old tree is nil")
+		}
+		ce := realCorpusCInputEdit(edit)
+		co.Edit(&ce)
+		ci := cp.Parse(edited, co)
+		co.Close()
+		cf := cp.Parse(edited, nil)
+		if ci == nil || cf == nil {
+			t.Fatal("C result is nil")
+		}
+		defer ci.Close()
+		defer cf.Close()
+		for _, oracle := range []*sitter.Tree{cf, ci} {
+			assertLockedCTreeExact(t, "changed lookahead after whitespace", next, lang, oracle)
+		}
+	}
+}

--- a/cgo_harness/javascript_compact_nested_reuse_test.go
+++ b/cgo_harness/javascript_compact_nested_reuse_test.go
@@ -1,0 +1,57 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package cgoharness
+
+import (
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	"testing"
+)
+
+func TestJavaScriptCompactNestedReuseLookaheadLockedC(t *testing.T) {
+	source, edited := []byte("a+b ;"), []byte("a+b *c;")
+	edit := gts.InputEdit{StartByte: 4, OldEndByte: 5, NewEndByte: 7, StartPoint: gts.Point{Column: 4}, OldEndPoint: gts.Point{Column: 5}, NewEndPoint: gts.Point{Column: 7}}
+	lang := grammars.JavascriptLanguage()
+	p := gts.NewParser(lang)
+	p.SetAdmissionCandidateRoute(true)
+	old, err := p.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old.Edit(edit)
+	next, err := p.ParseIncremental(edited, old)
+	old.Release()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer next.Release()
+	runtime := next.ParseRuntime()
+	t.Logf("compact=%t reused=%d/%d decline=%q tree=%s", runtime.CompactIncrementalReuseRoute, runtime.CompactIncrementalReusedSubtrees, runtime.CompactIncrementalReusedBytes, runtime.CompactIncrementalFallbackReason, next.RootNode().SExpr(lang))
+	cl, err := ParityCLanguage("javascript")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cp := sitter.NewParser()
+	defer cp.Close()
+	if err := cp.SetLanguage(cl); err != nil {
+		t.Fatal(err)
+	}
+	co := cp.Parse(source, nil)
+	if co == nil {
+		t.Fatal("C old tree is nil")
+	}
+	ce := realCorpusCInputEdit(edit)
+	co.Edit(&ce)
+	ci := cp.Parse(edited, co)
+	co.Close()
+	cf := cp.Parse(edited, nil)
+	if ci == nil || cf == nil {
+		t.Fatal("C result is nil")
+	}
+	defer ci.Close()
+	defer cf.Close()
+	for _, oracle := range []*sitter.Tree{cf, ci} {
+		assertLockedCTreeExact(t, "nested reduction lookahead", next, lang, oracle)
+	}
+}

--- a/compact_nested_reuse_lookahead_dfa_test.go
+++ b/compact_nested_reuse_lookahead_dfa_test.go
@@ -1,0 +1,63 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammargen"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	"testing"
+)
+
+func TestCompactNestedReuseDFALongestMatchDependency(t *testing.T) {
+	g := grammargen.NewGrammar("nested_longest_match")
+	g.Define("program", grammargen.Repeat1(grammargen.Sym("statement")))
+	g.Define("statement", grammargen.Seq(grammargen.Sym("group"), grammargen.Repeat(grammargen.Sym("letter")), grammargen.Str(";")))
+	g.Define("group", grammargen.Seq(grammargen.Str("("), grammargen.Sym("word")))
+	g.Define("word", grammargen.Pat("a|ab+c"))
+	g.Define("letter", grammargen.Pat("[bcd]"))
+	lang, err := grammargen.GenerateLanguage(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := gts.NewParser(lang)
+	p.SetAdmissionCandidateRoute(true)
+	source, edited := []byte("(abbbd;"), []byte("(abbbcc;")
+	old, err := p.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The word ends at byte 2, but its failed longer match reads byte 5.
+	// The reduction lookahead returns only the first letter at bytes 2..3.
+	oldGroup := old.RootNode().Child(0).Child(0)
+	if old.RootNode().HasError() || oldGroup.Type(lang) != "group" || oldGroup.EndByte() != 2 {
+		old.Release()
+		t.Fatal("old fixture did not retain the short word")
+	}
+	old.Edit(gts.InputEdit{StartByte: 5, OldEndByte: 6, NewEndByte: 7, StartPoint: gts.Point{Column: 5}, OldEndPoint: gts.Point{Column: 6}, NewEndPoint: gts.Point{Column: 7}})
+	next, err := p.ParseIncremental(edited, old)
+	old.Release()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer next.Release()
+	fresh, err := gts.NewParser(lang).Parse(edited)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fresh.Release()
+	if fresh.RootNode().HasError() || fresh.RootNode().Child(0).Child(0).EndByte() != 6 {
+		t.Fatal("fresh fixture did not select the longer word")
+	}
+	a, err := benchfixtures.InspectGoTree(next.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := benchfixtures.InspectGoTree(fresh.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.SHA256 != b.SHA256 {
+		t.Fatalf("longest-match dependency lost: compact=%t incremental=%s fresh=%s", next.ParseRuntime().CompactIncrementalReuseRoute, next.RootNode().SExpr(lang), fresh.RootNode().SExpr(lang))
+	}
+}

--- a/compact_nested_reuse_lookahead_test.go
+++ b/compact_nested_reuse_lookahead_test.go
@@ -1,0 +1,73 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammargen"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	"testing"
+)
+
+// A changed token after unchanged padding can invalidate an earlier reduction.
+func TestCompactNestedReuseChangedReductionLookahead(t *testing.T) {
+	g := grammargen.NewGrammar("nested_lookahead")
+	g.Define("program", grammargen.Repeat1(grammargen.Sym("statement")))
+	g.Define("statement", grammargen.Seq(grammargen.Sym("_expression"), grammargen.Str(";")))
+	g.Define("_expression", grammargen.Choice(grammargen.Sym("binary_expression"), grammargen.Sym("identifier")))
+	g.Define("binary_expression", grammargen.Choice(
+		grammargen.PrecLeft(1, grammargen.Seq(grammargen.Sym("_expression"), grammargen.Str("+"), grammargen.Sym("_expression"))),
+		grammargen.PrecLeft(2, grammargen.Seq(grammargen.Sym("_expression"), grammargen.Str("*"), grammargen.Sym("_expression"))),
+	))
+	g.Define("identifier", grammargen.Pat("[a-z]+"))
+	g.SetExtras(grammargen.Pat("[ ]+"))
+	lang, err := grammargen.GenerateLanguage(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := gts.NewParser(lang)
+	p.SetAdmissionCandidateRoute(true)
+	source := []byte("a+b ;")
+	beforeRouted, beforeFallback := gts.AdmissionCandidateCounters()
+	old, err := p.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer old.Release()
+	afterRouted, afterFallback := gts.AdmissionCandidateCounters()
+	if afterRouted-beforeRouted != 1 || afterFallback != beforeFallback {
+		t.Fatal("old source did not use the compact route")
+	}
+	if old.RootNode().HasError() {
+		t.Fatal("old source did not produce a clean expression")
+	}
+	edited := []byte("a+b *c;")
+	old.Edit(gts.InputEdit{StartByte: 4, OldEndByte: 5, NewEndByte: 7, StartPoint: gts.Point{Column: 4}, OldEndPoint: gts.Point{Column: 5}, NewEndPoint: gts.Point{Column: 7}})
+	next, err := p.ParseIncremental(edited, old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer next.Release()
+	freshParser := gts.NewParser(lang)
+	freshParser.SetAdmissionCandidateRoute(false)
+	fresh, err := freshParser.Parse(edited)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fresh.Release()
+	const want = "(program (statement (binary_expression (identifier) (binary_expression (identifier) (identifier)))))"
+	if fresh.RootNode().HasError() || fresh.RootNode().SExpr(lang) != want {
+		t.Fatalf("fresh parse did not preserve multiplication precedence: %s", fresh.RootNode().SExpr(lang))
+	}
+	a, err := benchfixtures.InspectGoTree(next.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := benchfixtures.InspectGoTree(fresh.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.SHA256 != b.SHA256 {
+		t.Fatalf("incremental=%s fresh=%s; incremental tree=%s", a.SHA256, b.SHA256, next.RootNode().SExpr(lang))
+	}
+}

--- a/compact_nested_reuse_test.go
+++ b/compact_nested_reuse_test.go
@@ -1,0 +1,58 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import "testing"
+
+func TestCompactNestedReuseLifetime(t *testing.T) {
+	p := newAdmissionCandidateGoParser(t)
+	p.SetAdmissionCandidateRoute(true)
+	source := []byte("func a(){_=1}")
+	old, err := p.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { old.Release() }()
+	parameters := compactExecutionNode(old.RootNode(), p.language, "parameter_list", 6)
+	if parameters == nil || parameters.EndByte() != 8 {
+		t.Fatal("missing parameter list at bytes 6..8")
+	}
+	for _, replacement := range []string{"x", "2", "y"} {
+		edited, edit := compactExecutionEdit(source, 11, 12, replacement)
+		old.Edit(edit)
+		runner := p.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+		legacy := runner.legacyParseRuns
+		next, profile, err := p.ParseIncrementalProfiled(edited, old)
+		if err != nil {
+			t.Fatal(err)
+		}
+		old.Release()
+		old = next
+		runtime := next.ParseRuntime()
+		if !runtime.CompactIncrementalReuseRoute || !next.compactMaterialized {
+			t.Fatalf("nested reuse declined: replacement=%q reason=%q", replacement, runtime.CompactIncrementalFallbackReason)
+		}
+		if runner.legacyParseRuns != legacy {
+			t.Fatal("nested compact reuse invoked the legacy parser")
+		}
+		got := compactExecutionNode(next.RootNode(), p.language, "parameter_list", 6)
+		if got != parameters {
+			t.Fatal("parameter list lost its identity after the old tree was released")
+		}
+		if got.Parent() != next.RootNode().Child(0) || got.Parent().Type(p.language) != "function_declaration" || got.Text(edited) != "()" {
+			t.Fatal("borrowed parameter list lost its navigation or text")
+		}
+		if runtime.CompactIncrementalReusedSubtrees < 1 || runtime.CompactIncrementalReusedBytes < 2 || profile.ReusedSubtrees != runtime.CompactIncrementalReusedSubtrees || profile.ReusedBytes != runtime.CompactIncrementalReusedBytes {
+			t.Fatalf("missing nonterminal reuse: runtime=%+v profile=%+v", runtime, profile)
+		}
+		copyTree := next.Copy()
+		before := got.Range()
+		_, copyEdit := compactExecutionEdit(edited, 6, 6, "x int")
+		copyTree.Edit(copyEdit)
+		if got.Range() != before || len(next.Edits()) != 0 {
+			t.Fatal("editing a copy changed the borrowed parameter list")
+		}
+		copyTree.Release()
+		source = edited
+	}
+}

--- a/compact_reuse_dependency.go
+++ b/compact_reuse_dependency.go
@@ -222,26 +222,38 @@ func (tree *Tree) editCompactReuseDependencies(edit InputEdit) {
 	}
 }
 
-// Node.Edit has no Tree arena list. Visit the reachable nodes before editing.
+// Node.Edit has no Tree arena list. Visit public nodes through lazy entries
+// without materializing their children. Pending entries use the containing arena.
 func editCompactReuseDependenciesFromNode(root *Node, edit InputEdit) {
 	if root == nil || inputEditIsNoop(edit) {
 		return
 	}
 	seen := make(map[*nodeArena]struct{})
-	stack := []*Node{root}
+	type frame struct {
+		arena *nodeArena
+		entry stackEntry
+	}
+	stack := []frame{{root.ownerArena, newStackEntryNode(root.parseState, root)}}
 	for len(stack) != 0 {
 		last := len(stack) - 1
-		node := stack[last]
+		current := stack[last]
 		stack = stack[:last]
-		if node == nil {
+		if node := stackEntryNode(current.entry); node != nil {
+			if _, ok := seen[node.ownerArena]; !ok {
+				node.ownerArena.editCompactReuseDependencies(edit)
+				seen[node.ownerArena] = struct{}{}
+			}
+			for i := 0; i < nodeChildCountNoMaterialize(node); i++ {
+				if child, ok := nodeChildEntryAtNoMaterialize(node, i); ok {
+					stack = append(stack, frame{node.ownerArena, child})
+				}
+			}
 			continue
 		}
-		if _, ok := seen[node.ownerArena]; !ok {
-			node.ownerArena.editCompactReuseDependencies(edit)
-			seen[node.ownerArena] = struct{}{}
-		}
-		for i := 0; i < node.ChildCount(); i++ {
-			stack = append(stack, node.Child(i))
+		if parent := stackEntryPendingParent(current.entry); parent != nil {
+			for i := 0; i < parent.childEntryCount(); i++ {
+				stack = append(stack, frame{current.arena, parent.childEntry(current.arena, i)})
+			}
 		}
 	}
 }

--- a/compact_reuse_dependency.go
+++ b/compact_reuse_dependency.go
@@ -1,0 +1,247 @@
+package gotreesitter
+
+import (
+	"slices"
+	"unsafe"
+)
+
+type compactReuseDependency struct {
+	start, end, lookaheadBytes uint32
+	column                     uint32
+}
+
+// Sort immutable receipt coordinates by start byte. Each midpoint stores the
+// largest dependency end in its implicit binary subtree.
+type compactReuseDependencyIndexEntry struct {
+	node   *Node
+	end    uint64
+	maxEnd uint64
+	start  uint32
+	live   bool
+}
+
+// A receipt stores the examined extent beyond the node's end. Map membership
+// distinguishes an authenticated zero extent from a node without a receipt.
+func setCompactReuseDependency(node *Node, lookaheadBytes uint32) bool {
+	if node == nil || node.ownerArena == nil {
+		return false
+	}
+	arena := node.ownerArena
+	arena.compactReuseDependencyMu.Lock()
+	defer arena.compactReuseDependencyMu.Unlock()
+	if prior, ok := arena.compactReuseDependencies[node]; ok {
+		if prior.start == node.startByte && prior.end == node.endByte && prior.column == node.startPoint.Column {
+			lookaheadBytes = maxUint32(lookaheadBytes, prior.lookaheadBytes)
+		}
+		arena.compactReuseDependencies[node] = compactReuseDependency{node.startByte, node.endByte, lookaheadBytes, node.startPoint.Column}
+		arena.compactReuseDependencyIndexed = false
+		return true
+	}
+	// Include map growth and deleted slots. Do not reclaim the charge on deletion.
+	const entryBytes = int64(96)
+	cost := entryBytes
+	if arena.compactReuseDependencies == nil {
+		cost += 256
+	}
+	used := max(int64(0), arena.allocatedBytes-arena.budgetBaselineBytes)
+	if arena.budgetBytes > 0 && (used >= arena.budgetBytes || cost > arena.budgetBytes-used) {
+		return false
+	}
+	if arena.compactReuseDependencies == nil {
+		arena.compactReuseDependencies = make(map[*Node]compactReuseDependency)
+	}
+	arena.compactReuseDependencies[node] = compactReuseDependency{node.startByte, node.endByte, lookaheadBytes, node.startPoint.Column}
+	arena.compactReuseDependencyIndexed = false
+	arena.compactReuseDependencyEntries++
+	arena.allocatedBytes += cost
+	return true
+}
+
+func compactReuseDependencyForNode(node *Node) (uint32, bool) {
+	if node == nil || node.ownerArena == nil {
+		return 0, false
+	}
+	arena := node.ownerArena
+	arena.compactReuseDependencyMu.RLock()
+	receipt, ok := arena.compactReuseDependencies[node]
+	arena.compactReuseDependencyMu.RUnlock()
+	return receipt.lookaheadBytes, ok && receipt.start == node.startByte && receipt.end == node.endByte && receipt.column == node.startPoint.Column
+}
+
+func clearCompactReuseDependency(node *Node) {
+	if node != nil && node.ownerArena != nil {
+		arena := node.ownerArena
+		arena.compactReuseDependencyMu.Lock()
+		delete(arena.compactReuseDependencies, node)
+		arena.compactReuseDependencyIndexed = false
+		arena.compactReuseDependencyMu.Unlock()
+	}
+}
+
+func (arena *nodeArena) compactReuseDependencyBytesAllocated() int64 {
+	if arena == nil {
+		return 0
+	}
+	bytes := int64(cap(arena.compactReuseDependencyIndex)) * int64(unsafe.Sizeof(compactReuseDependencyIndexEntry{}))
+	if arena.compactReuseDependencies != nil {
+		bytes += 256 + 96*int64(arena.compactReuseDependencyEntries)
+	}
+	return bytes
+}
+
+func copyCompactReuseDependency(dst, src *Node) {
+	extent, ok := compactReuseDependencyForNode(src)
+	clearCompactReuseDependency(dst)
+	// A stateless external scanner can still depend on its starting column.
+	if ok && dst != nil && src.startPoint.Column == dst.startPoint.Column {
+		setCompactReuseDependency(dst, extent)
+	}
+}
+
+// Invalidate before coordinates change. The normal edit walk can skip nodes
+// whose text precedes the edit, although their lexer inspected the edited bytes.
+func (arena *nodeArena) editCompactReuseDependencies(edit InputEdit) {
+	if arena == nil || inputEditIsNoop(edit) {
+		return
+	}
+	arena.compactReuseDependencyMu.Lock()
+	defer arena.compactReuseDependencyMu.Unlock()
+	if len(arena.compactReuseDependencies) == 0 {
+		return
+	}
+	if arena.indexCompactReuseDependencies() {
+		arena.invalidateIndexedCompactReuseDependencies(edit, 0, len(arena.compactReuseDependencyIndex))
+		return
+	}
+	// Keep exact invalidation when the budget cannot fund an index.
+	for node, receipt := range arena.compactReuseDependencies {
+		end := uint64(receipt.end) + uint64(receipt.lookaheadBytes)
+		if compactReuseDependencyIntersectsEdit(receipt.start, end, edit) {
+			delete(arena.compactReuseDependencies, node)
+		}
+	}
+}
+
+func compactReuseDependencyIntersectsEdit(start uint32, end uint64, edit InputEdit) bool {
+	// An arena can supply several live trees. Never inspect or relocate another
+	// tree's node coordinates during an edit.
+	if edit.OldEndByte <= start &&
+		(edit.NewEndByte != edit.OldEndByte || edit.NewEndPoint != edit.OldEndPoint) {
+		return true
+	}
+	return uint64(edit.StartByte) < end && (edit.OldEndByte > start ||
+		(edit.StartByte == edit.OldEndByte && edit.StartByte >= start))
+}
+
+// Build only after publication changes the receipts. Reuse the backing storage
+// across edits, and charge growth before allocating it.
+func (arena *nodeArena) indexCompactReuseDependencies() bool {
+	if arena.compactReuseDependencyIndexed {
+		return true
+	}
+	count := len(arena.compactReuseDependencies)
+	if count > cap(arena.compactReuseDependencyIndex) {
+		cost := int64(count-cap(arena.compactReuseDependencyIndex)) * int64(unsafe.Sizeof(compactReuseDependencyIndexEntry{}))
+		used := max(int64(0), arena.allocatedBytes-arena.budgetBaselineBytes)
+		if arena.budgetBytes > 0 && (used >= arena.budgetBytes || cost > arena.budgetBytes-used) {
+			return false
+		}
+		arena.compactReuseDependencyIndex = make([]compactReuseDependencyIndexEntry, count)
+		arena.allocatedBytes += cost
+	} else {
+		clear(arena.compactReuseDependencyIndex)
+		arena.compactReuseDependencyIndex = arena.compactReuseDependencyIndex[:count]
+	}
+	i := 0
+	for node, receipt := range arena.compactReuseDependencies {
+		arena.compactReuseDependencyIndex[i] = compactReuseDependencyIndexEntry{
+			node: node, start: receipt.start, end: uint64(receipt.end) + uint64(receipt.lookaheadBytes),
+		}
+		i++
+	}
+	slices.SortFunc(arena.compactReuseDependencyIndex, func(a, b compactReuseDependencyIndexEntry) int {
+		if a.start < b.start {
+			return -1
+		}
+		if a.start > b.start {
+			return 1
+		}
+		return 0
+	})
+	arena.buildCompactReuseDependencyIndexMax(0, count)
+	arena.compactReuseDependencyIndexed = true
+	return true
+}
+
+func (arena *nodeArena) buildCompactReuseDependencyIndexMax(lo, hi int) uint64 {
+	if lo == hi {
+		return 0
+	}
+	mid := lo + (hi-lo)/2
+	entry := &arena.compactReuseDependencyIndex[mid]
+	entry.maxEnd = max(entry.end, arena.buildCompactReuseDependencyIndexMax(lo, mid), arena.buildCompactReuseDependencyIndexMax(mid+1, hi))
+	entry.live = true
+	return entry.maxEnd
+}
+
+func (arena *nodeArena) invalidateIndexedCompactReuseDependencies(edit InputEdit, lo, hi int) (uint64, bool) {
+	if lo == hi {
+		return 0, false
+	}
+	index := arena.compactReuseDependencyIndex
+	mid := lo + (hi-lo)/2
+	entry := &index[mid]
+	if !entry.live {
+		return 0, false
+	}
+	tailShift := edit.NewEndByte != edit.OldEndByte || edit.NewEndPoint != edit.OldEndPoint
+	if tailShift {
+		if entry.maxEnd <= uint64(edit.StartByte) && index[hi-1].start < edit.OldEndByte {
+			return entry.maxEnd, true
+		}
+	} else if entry.maxEnd <= uint64(edit.StartByte) || index[lo].start >= edit.OldEndByte {
+		return entry.maxEnd, true
+	}
+	if entry.node != nil && compactReuseDependencyIntersectsEdit(entry.start, entry.end, edit) {
+		delete(arena.compactReuseDependencies, entry.node)
+		entry.node, entry.end = nil, 0
+	}
+	leftEnd, leftLive := arena.invalidateIndexedCompactReuseDependencies(edit, lo, mid)
+	rightEnd, rightLive := arena.invalidateIndexedCompactReuseDependencies(edit, mid+1, hi)
+	entry.maxEnd = max(entry.end, leftEnd, rightEnd)
+	entry.live = entry.node != nil || leftLive || rightLive
+	return entry.maxEnd, entry.live
+}
+
+func (tree *Tree) editCompactReuseDependencies(edit InputEdit) {
+	tree.arena.editCompactReuseDependencies(edit)
+	for _, arena := range tree.borrowedArena {
+		if arena != tree.arena {
+			arena.editCompactReuseDependencies(edit)
+		}
+	}
+}
+
+// Node.Edit has no Tree arena list. Visit the reachable nodes before editing.
+func editCompactReuseDependenciesFromNode(root *Node, edit InputEdit) {
+	if root == nil || inputEditIsNoop(edit) {
+		return
+	}
+	seen := make(map[*nodeArena]struct{})
+	stack := []*Node{root}
+	for len(stack) != 0 {
+		last := len(stack) - 1
+		node := stack[last]
+		stack = stack[:last]
+		if node == nil {
+			continue
+		}
+		if _, ok := seen[node.ownerArena]; !ok {
+			node.ownerArena.editCompactReuseDependencies(edit)
+			seen[node.ownerArena] = struct{}{}
+		}
+		for i := 0; i < node.ChildCount(); i++ {
+			stack = append(stack, node.Child(i))
+		}
+	}
+}

--- a/compact_reuse_dependency_test.go
+++ b/compact_reuse_dependency_test.go
@@ -1,0 +1,500 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"sync"
+	"testing"
+)
+
+func newCompactReuseDependencyTestTree(t *testing.T) (*Tree, *Node) {
+	t.Helper()
+	a := acquireNodeArena(arenaClassIncremental)
+	child := newLeafNodeInArena(a, 1, true, 2, 4, Point{Column: 2}, Point{Column: 4})
+	root := newParentNodeInArena(a, 3, true, []*Node{child}, nil, 0)
+	root.startByte, root.endByte = 0, 20
+	root.startPoint, root.endPoint = Point{}, Point{Column: 20}
+	tree := newTreeWithArenas(root, []byte("abcdefghijklmnopqrst"), testLanguage(), a, nil)
+	return tree, child
+}
+
+func TestCompactReuseDependencyMembershipAndMaximum(t *testing.T) {
+	tree, node := newCompactReuseDependencyTestTree(t)
+	defer tree.Release()
+	if _, ok := compactReuseDependencyForNode(node); ok {
+		t.Fatal("new node has an unauthenticated receipt")
+	}
+	if !setCompactReuseDependency(node, 0) {
+		t.Fatal("could not authenticate zero lookahead")
+	}
+	if n, ok := compactReuseDependencyForNode(node); !ok || n != 0 {
+		t.Fatalf("zero receipt=%d/%t", n, ok)
+	}
+	for _, n := range []uint32{7, 2, 0} {
+		if !setCompactReuseDependency(node, n) {
+			t.Fatal("receipt update failed")
+		}
+	}
+	if n, ok := compactReuseDependencyForNode(node); !ok || n != 7 {
+		t.Fatalf("maximum receipt=%d/%t", n, ok)
+	}
+	clearCompactReuseDependency(node)
+	if _, ok := compactReuseDependencyForNode(node); ok {
+		t.Fatal("cleared receipt remained authenticated")
+	}
+	if setCompactReuseDependency(nil, 1) {
+		t.Fatal("nil node acquired a receipt")
+	}
+}
+
+func TestCompactReuseDependencyCopyAndOffset(t *testing.T) {
+	tree, node := newCompactReuseDependencyTestTree(t)
+	if !setCompactReuseDependency(node, 7) {
+		tree.Release()
+		t.Fatal("receipt setup failed")
+	}
+	copyTree := tree.Copy()
+	defer copyTree.Release()
+	copyNode := copyTree.RootNode().Child(0)
+	if n, ok := compactReuseDependencyForNode(copyNode); !ok || n != 7 {
+		t.Fatalf("copy receipt=%d/%t", n, ok)
+	}
+	offset := cloneTreeNodesWithOffset(tree.RootNode(), 5, Point{Row: 1})
+	offsetTree := newTreeWithArenas(offset, nil, testLanguage(), offset.ownerArena, nil)
+	defer offsetTree.Release()
+	offsetNode := offset.Child(0)
+	if offsetNode.StartByte() != 7 || offsetNode.EndByte() != 9 {
+		t.Fatal("offset clone has incorrect coordinates")
+	}
+	if offsetNode.StartPoint() != (Point{Row: 1, Column: 2}) {
+		t.Fatal("row-only clone changed the scanner column")
+	}
+	if n, ok := compactReuseDependencyForNode(offsetNode); !ok || n != 7 {
+		t.Fatalf("offset receipt=%d/%t", n, ok)
+	}
+	columnOffset := cloneTreeNodesWithOffset(tree.RootNode(), 5, Point{Column: 5})
+	columnTree := newTreeWithArenas(columnOffset, nil, testLanguage(), columnOffset.ownerArena, nil)
+	defer columnTree.Release()
+	if _, ok := compactReuseDependencyForNode(columnOffset.Child(0)); ok {
+		t.Fatal("column-changing clone retained a scanner-dependent receipt")
+	}
+	clearCompactReuseDependency(copyNode)
+	if n, ok := compactReuseDependencyForNode(node); !ok || n != 7 {
+		t.Fatal("clearing a copy changed the original receipt")
+	}
+	tree.Release()
+	if n, ok := compactReuseDependencyForNode(offsetNode); !ok || n != 7 {
+		t.Fatal("offset receipt depended on the released arena")
+	}
+}
+
+func TestCompactReuseDependencyEditInvalidation(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		start, end, newEnd uint32
+		keep               bool
+	}{
+		{"inside_node", 3, 4, 4, false},
+		{"examined_suffix", 8, 9, 9, false},
+		{"insert_at_node_end", 4, 4, 5, false},
+		{"before_node", 0, 0, 1, false},
+		{"same_width_before_node", 0, 1, 1, true},
+		{"last_examined_byte_insertion", 9, 9, 10, false},
+		{"after_examined_suffix_insertion", 10, 10, 11, true},
+		{"beyond_dependency", 12, 13, 13, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree, node := newCompactReuseDependencyTestTree(t)
+			defer tree.Release()
+			if !setCompactReuseDependency(node, 6) {
+				t.Fatal("receipt setup failed")
+			}
+			tree.Edit(InputEdit{StartByte: tc.start, OldEndByte: tc.end, NewEndByte: tc.newEnd, StartPoint: Point{Column: tc.start}, OldEndPoint: Point{Column: tc.end}, NewEndPoint: Point{Column: tc.newEnd}})
+			n, ok := compactReuseDependencyForNode(node)
+			if ok != tc.keep || (ok && n != 6) {
+				t.Fatalf("receipt=%d/%t, want keep=%t", n, ok, tc.keep)
+			}
+			if tc.name == "before_node" && node.StartByte() != 3 {
+				t.Fatal("receipt invalidation prevented coordinate adjustment")
+			}
+		})
+	}
+}
+
+func TestCompactReuseDependencyManyUnaffectedReceipts(t *testing.T) {
+	const count = 128
+	a := acquireNodeArena(arenaClassIncremental)
+	nodes := make([]*Node, count)
+	for i := range nodes {
+		start := uint32(4*i + 2)
+		nodes[i] = newLeafNodeInArena(a, 1, true, start, start+1, Point{Column: start}, Point{Column: start + 1})
+		if !setCompactReuseDependency(nodes[i], 0) {
+			a.Release()
+			t.Fatal("receipt setup failed")
+		}
+	}
+	root := newParentNodeInArena(a, 3, true, nodes, nil, 0)
+	tree := newTreeWithArenas(root, make([]byte, 4*count), testLanguage(), a, nil)
+	defer tree.Release()
+	target := nodes[count/2]
+	editStart := target.EndByte() + 1
+	edit := InputEdit{StartByte: editStart, OldEndByte: editStart + 1, NewEndByte: editStart + 1, StartPoint: Point{Column: editStart}, OldEndPoint: Point{Column: editStart + 1}, NewEndPoint: Point{Column: editStart + 1}}
+	for iteration := 0; iteration < 32; iteration++ {
+		// One distant prefix has a long dependency. The others inspect no suffix.
+		if !setCompactReuseDependency(nodes[0], editStart+1-nodes[0].EndByte()) || !setCompactReuseDependency(target, 2) {
+			t.Fatal("receipt reauthentication failed")
+		}
+		if _, ok := compactReuseDependencyForNode(target); !ok {
+			t.Fatal("old edits invalidated a newly authenticated receipt")
+		}
+		tree.Edit(edit)
+		for i, node := range nodes {
+			extent, ok := compactReuseDependencyForNode(node)
+			want := i != 0 && i != count/2
+			if ok != want || (ok && extent != 0) {
+				t.Fatalf("iteration=%d receipt=%d extent=%d present=%t want=%t", iteration, i, extent, ok, want)
+			}
+		}
+	}
+}
+
+func TestCompactReuseDependencyIndexBudgetAndRebuild(t *testing.T) {
+	tree, node := newCompactReuseDependencyTestTree(t)
+	defer tree.Release()
+	a := tree.arena
+	if !setCompactReuseDependency(node, 6) {
+		t.Fatal("receipt setup failed")
+	}
+	a.setBudget(1)
+	before := a.allocatedBytes
+	a.editCompactReuseDependencies(InputEdit{StartByte: 8, OldEndByte: 9, NewEndByte: 9})
+	if _, ok := compactReuseDependencyForNode(node); ok {
+		t.Fatal("budget-blocked index skipped exact invalidation")
+	}
+	if cap(a.compactReuseDependencyIndex) != 0 || a.allocatedBytes != before {
+		t.Fatal("index allocation exceeded its budget")
+	}
+	a.setBudget(0)
+	if !setCompactReuseDependency(node, 6) {
+		t.Fatal("reauthentication failed")
+	}
+	a.editCompactReuseDependencies(InputEdit{StartByte: 12, OldEndByte: 13, NewEndByte: 13})
+	if !a.compactReuseDependencyIndexed || len(a.compactReuseDependencyIndex) != 1 {
+		t.Fatal("index did not build after budget reset")
+	}
+	second := newLeafNodeInArena(a, 1, true, 30, 32, Point{Column: 30}, Point{Column: 32})
+	if !setCompactReuseDependency(second, 1) {
+		t.Fatal("second receipt setup failed")
+	}
+	a.setBudget(1)
+	before = a.allocatedBytes
+	a.editCompactReuseDependencies(InputEdit{StartByte: 31, OldEndByte: 32, NewEndByte: 32})
+	if _, ok := compactReuseDependencyForNode(second); ok {
+		t.Fatal("budget-blocked growth preserved an overlapping receipt")
+	}
+	if n, ok := compactReuseDependencyForNode(node); !ok || n != 6 {
+		t.Fatal("budget fallback lost the unaffected receipt")
+	}
+	if a.allocatedBytes != before || cap(a.compactReuseDependencyIndex) != 1 {
+		t.Fatal("blocked growth changed index allocation")
+	}
+	a.setBudget(0)
+	if !setCompactReuseDependency(second, 1) {
+		t.Fatal("second receipt reauthentication failed")
+	}
+	a.editCompactReuseDependencies(InputEdit{StartByte: 40, OldEndByte: 41, NewEndByte: 41})
+	if !a.compactReuseDependencyIndexed || len(a.compactReuseDependencyIndex) != 2 {
+		t.Fatal("index did not grow after budget reset")
+	}
+	if !setCompactReuseDependency(node, 40) {
+		t.Fatal("dependency extension failed")
+	}
+	a.setBudget(1)
+	before = a.allocatedBytes
+	a.editCompactReuseDependencies(InputEdit{StartByte: 41, OldEndByte: 42, NewEndByte: 42})
+	if _, ok := compactReuseDependencyForNode(node); ok {
+		t.Fatal("rebuilt index ignored an extended dependency")
+	}
+	if !a.compactReuseDependencyIndexed || a.allocatedBytes != before {
+		t.Fatal("same-capacity rebuild required new allocation")
+	}
+	if _, ok := compactReuseDependencyForNode(second); !ok {
+		t.Fatal("rebuild removed an unaffected receipt")
+	}
+}
+
+func TestCompactReuseDependencyRepeatedSuffixDeletionEmptiesIndex(t *testing.T) {
+	a := newNodeArena(arenaClassIncremental)
+	defer a.Release()
+	nodes := make([]*Node, 32)
+	for i := range nodes {
+		start := uint32(4 * i)
+		nodes[i] = newLeafNodeInArena(a, 1, true, start, start+1, Point{Column: start}, Point{Column: start + 1})
+	}
+	for cycle := 0; cycle < 4; cycle++ {
+		for _, node := range nodes {
+			if !setCompactReuseDependency(node, 256) {
+				t.Fatal("receipt setup failed")
+			}
+		}
+		a.editCompactReuseDependencies(InputEdit{StartByte: 200, OldEndByte: 201, NewEndByte: 201})
+		if len(a.compactReuseDependencies) != 0 || !a.compactReuseDependencyIndexed {
+			t.Fatal("suffix invalidation did not empty the indexed receipts")
+		}
+		root := a.compactReuseDependencyIndex[len(a.compactReuseDependencyIndex)/2]
+		if root.live || root.maxEnd != 0 {
+			t.Fatal("empty index root retained a live subtree")
+		}
+		for _, entry := range a.compactReuseDependencyIndex {
+			if entry.node != nil || entry.live {
+				t.Fatal("empty index retained a node reference")
+			}
+		}
+		a.editCompactReuseDependencies(InputEdit{StartByte: 200, OldEndByte: 201, NewEndByte: 201})
+	}
+}
+
+func TestCompactReuseDependencyZeroOriginIsLive(t *testing.T) {
+	a := newNodeArena(arenaClassIncremental)
+	defer a.Release()
+	node := newLeafNodeInArena(a, 1, true, 0, 0, Point{}, Point{})
+	if !setCompactReuseDependency(node, 0) {
+		t.Fatal("zero receipt setup failed")
+	}
+	a.editCompactReuseDependencies(InputEdit{StartByte: 1, OldEndByte: 2, NewEndByte: 2})
+	if n, ok := compactReuseDependencyForNode(node); !ok || n != 0 {
+		t.Fatal("zero-origin receipt was confused with an empty entry")
+	}
+	if len(a.compactReuseDependencyIndex) != 1 || !a.compactReuseDependencyIndex[0].live || a.compactReuseDependencyIndex[0].maxEnd != 0 {
+		t.Fatal("zero-origin index did not retain explicit liveness")
+	}
+	a.editCompactReuseDependencies(InputEdit{StartByte: 0, OldEndByte: 0, NewEndByte: 1, NewEndPoint: Point{Column: 1}})
+	if _, ok := compactReuseDependencyForNode(node); ok || a.compactReuseDependencyIndex[0].live {
+		t.Fatal("insertion at zero did not invalidate the live zero-width receipt")
+	}
+}
+
+func TestCompactReuseDependencySharedArenaPreservesUnexaminedReceipt(t *testing.T) {
+	a := acquireNodeArena(arenaClassIncremental)
+	a.Retain()
+	var trees [2]*Tree
+	var nodes [2]*Node
+	for i := range trees {
+		start := uint32(2 + 20*i)
+		nodes[i] = newLeafNodeInArena(a, 1, true, start, start+2, Point{Column: start}, Point{Column: start + 2})
+		root := newParentNodeInArena(a, 3, true, []*Node{nodes[i]}, nil, 0)
+		trees[i] = newTreeWithArenas(root, make([]byte, 32), testLanguage(), a, nil)
+		defer trees[i].Release()
+		if !setCompactReuseDependency(nodes[i], 1) {
+			t.Fatal("receipt setup failed")
+		}
+	}
+	trees[0].Edit(InputEdit{StartByte: 3, OldEndByte: 4, NewEndByte: 4, StartPoint: Point{Column: 3}, OldEndPoint: Point{Column: 4}, NewEndPoint: Point{Column: 4}})
+	if _, ok := compactReuseDependencyForNode(nodes[0]); ok {
+		t.Fatal("edited receipt remained authenticated")
+	}
+	if n, ok := compactReuseDependencyForNode(nodes[1]); !ok || n != 1 {
+		t.Fatal("same-width edit discarded another tree's unexamined receipt")
+	}
+}
+
+func TestCompactReuseDependencyRejectsStaleCoordinates(t *testing.T) {
+	tree, node := newCompactReuseDependencyTestTree(t)
+	defer tree.Release()
+	if !setCompactReuseDependency(node, 7) {
+		t.Fatal("receipt setup failed")
+	}
+	node.startByte++
+	node.endByte++
+	if _, ok := compactReuseDependencyForNode(node); ok {
+		t.Fatal("changed coordinates reused an old receipt")
+	}
+	copyTree := tree.Copy()
+	defer copyTree.Release()
+	if _, ok := compactReuseDependencyForNode(copyTree.RootNode().Child(0)); ok {
+		t.Fatal("copy authenticated a stale coordinate receipt")
+	}
+	if !setCompactReuseDependency(node, 2) {
+		t.Fatal("coordinate reauthentication failed")
+	}
+	if n, ok := compactReuseDependencyForNode(node); !ok || n != 2 {
+		t.Fatal("reauthentication inherited the stale dependency maximum")
+	}
+}
+
+func TestCompactReuseDependencyRejectsStaleColumn(t *testing.T) {
+	tree, node := newCompactReuseDependencyTestTree(t)
+	defer tree.Release()
+	if !setCompactReuseDependency(node, 7) {
+		t.Fatal("receipt setup failed")
+	}
+	node.startPoint.Column++
+	if _, ok := compactReuseDependencyForNode(node); ok {
+		t.Fatal("changed scanner column reused an old receipt")
+	}
+	if !setCompactReuseDependency(node, 2) {
+		t.Fatal("column reauthentication failed")
+	}
+	if n, ok := compactReuseDependencyForNode(node); !ok || n != 2 {
+		t.Fatal("column reauthentication inherited the stale dependency maximum")
+	}
+}
+
+func TestCompactReuseDependencyConcurrentSharedArena(t *testing.T) {
+	a := acquireNodeArena(arenaClassIncremental)
+	a.Retain()
+	var trees [2]*Tree
+	var nodes [2]*Node
+	for i := range trees {
+		nodes[i] = newLeafNodeInArena(a, 1, true, 2, 4, Point{Column: 2}, Point{Column: 4})
+		root := newParentNodeInArena(a, 3, true, []*Node{nodes[i]}, nil, 0)
+		root.endByte, root.endPoint = 20, Point{Column: 20}
+		trees[i] = newTreeWithArenas(root, []byte("abcdefghijklmnopqrst"), testLanguage(), a, nil)
+		defer trees[i].Release()
+	}
+	// Each goroutine owns its tree and node. Only the receipt arena is shared.
+	var workers sync.WaitGroup
+	start := make(chan struct{})
+	for i := range trees {
+		workers.Add(1)
+		go func(i int) {
+			defer workers.Done()
+			<-start
+			for iteration := 0; iteration < 200; iteration++ {
+				if !setCompactReuseDependency(nodes[i], 6) {
+					t.Error("receipt setup failed")
+					return
+				}
+				if n, ok := compactReuseDependencyForNode(nodes[i]); ok && n != 6 {
+					t.Error("concurrent invalidation changed the receipt extent")
+					return
+				}
+				trees[i].Edit(InputEdit{StartByte: 0, OldEndByte: 0, NewEndByte: 1, StartPoint: Point{}, OldEndPoint: Point{}, NewEndPoint: Point{Column: 1}})
+				if _, ok := compactReuseDependencyForNode(nodes[i]); ok {
+					t.Error("position-changing edit retained its receipt")
+					return
+				}
+			}
+		}(i)
+	}
+	close(start)
+	workers.Wait()
+}
+
+func TestCompactReuseDependencyOverflowAndPastEOF(t *testing.T) {
+	tree, node := newCompactReuseDependencyTestTree(t)
+	defer tree.Release()
+	if !setCompactReuseDependency(node, ^uint32(0)) {
+		t.Fatal("wide dependency was rejected")
+	}
+	if n, ok := compactReuseDependencyForNode(node); !ok || n != ^uint32(0) {
+		t.Fatal("wide relative dependency was truncated")
+	}
+	tree.Edit(InputEdit{StartByte: 15, OldEndByte: 16, NewEndByte: 16, StartPoint: Point{Column: 15}, OldEndPoint: Point{Column: 16}, NewEndPoint: Point{Column: 16}})
+	if _, ok := compactReuseDependencyForNode(node); ok {
+		t.Fatal("overflow wrapped the examined suffix before the edit")
+	}
+}
+
+func TestCompactReuseDependencyBorrowedArenaEdit(t *testing.T) {
+	original, node := newCompactReuseDependencyTestTree(t)
+	if !setCompactReuseDependency(node, 6) {
+		original.Release()
+		t.Fatal("receipt setup failed")
+	}
+	a := acquireNodeArena(arenaClassIncremental)
+	root := newParentNodeInArena(a, 3, true, []*Node{node}, nil, 0)
+	root.endByte, root.endPoint = 20, Point{Column: 20}
+	original.arena.Retain()
+	borrowed := newTreeWithArenas(root, []byte("abcdefghijklmnopqrst"), testLanguage(), a, []*nodeArena{original.arena})
+	defer borrowed.Release()
+	original.Release()
+	if _, ok := compactReuseDependencyForNode(node); !ok {
+		t.Fatal("borrowed receipt vanished when its source tree was released")
+	}
+	borrowed.Edit(InputEdit{StartByte: 8, OldEndByte: 9, NewEndByte: 9, StartPoint: Point{Column: 8}, OldEndPoint: Point{Column: 9}, NewEndPoint: Point{Column: 9}})
+	if _, ok := compactReuseDependencyForNode(node); ok {
+		t.Fatal("editing a borrowed tree left its examined suffix authenticated")
+	}
+}
+
+func TestCompactReuseDependencyResetAndBudget(t *testing.T) {
+	a := newNodeArena(arenaClassIncremental)
+	n := newLeafNodeInArena(a, 1, true, 0, 1, Point{}, Point{Column: 1})
+	baseline := a.allocatedBytes
+	a.setBudget(1)
+	if setCompactReuseDependency(n, 3) || a.allocatedBytes != baseline {
+		t.Fatal("receipt allocation exceeded the arena memory budget")
+	}
+	if _, ok := compactReuseDependencyForNode(n); ok {
+		t.Fatal("a rejected allocation published a receipt")
+	}
+	a.setBudget(4096)
+	if !setCompactReuseDependency(n, 3) || a.allocatedBytes <= baseline {
+		t.Fatal("receipt storage escaped arena allocation accounting")
+	}
+	allocated := a.allocatedBytes
+	clearCompactReuseDependency(n)
+	if a.allocatedBytes != allocated {
+		t.Fatal("clearing a receipt undercounted retained map storage")
+	}
+	if !setCompactReuseDependency(n, 4) {
+		t.Fatal("receipt reinsertion failed")
+	}
+	allocated = a.allocatedBytes
+	a.recomputeAllocatedBytes()
+	if a.allocatedBytes != allocated {
+		t.Fatal("arena recomputation lost the receipt storage charge")
+	}
+	a.reset()
+	if a.compactReuseDependencies != nil {
+		t.Fatal("arena reset retained the receipt map")
+	}
+	if _, ok := compactReuseDependencyForNode(n); ok {
+		t.Fatal("arena reset retained a stale node receipt")
+	}
+	if a.allocatedBytes > baseline {
+		t.Fatal("arena reset retained receipt allocation accounting")
+	}
+	reused := newLeafNodeInArena(a, 1, true, 0, 1, Point{}, Point{Column: 1})
+	if _, ok := compactReuseDependencyForNode(reused); ok {
+		t.Fatal("a reused arena slot inherited a receipt")
+	}
+}
+
+func TestCompactReuseDependencyShortcutDoesNotReviveReceipt(t *testing.T) {
+	p := newAdmissionCandidateGoParser(t)
+	p.SetAdmissionCandidateRoute(true)
+	source := []byte("func a(){_=1}")
+	old, err := p.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parameters := compactExecutionNode(old.RootNode(), p.language, "parameter_list", 6)
+	if parameters == nil || !setCompactReuseDependency(parameters, 4) {
+		old.Release()
+		t.Fatal("parameter receipt setup failed")
+	}
+	edited, edit := compactExecutionEdit(source, 11, 12, "2")
+	old.Edit(edit)
+	if _, ok := compactReuseDependencyForNode(parameters); ok {
+		old.Release()
+		t.Fatal("edit retained an overlapping receipt")
+	}
+	next, err := p.ParseIncremental(edited, old)
+	if err != nil {
+		old.Release()
+		t.Fatal(err)
+	}
+	if next != old {
+		old.Release()
+	}
+	defer next.Release()
+	got := compactExecutionNode(next.RootNode(), p.language, "parameter_list", 6)
+	if got == nil {
+		t.Fatal("shortcut lost the parameter list")
+	}
+	if _, ok := compactReuseDependencyForNode(got); ok {
+		t.Fatal("the token-invariant shortcut revived an invalid receipt")
+	}
+}

--- a/compact_reuse_lazy_edit_test.go
+++ b/compact_reuse_lazy_edit_test.go
@@ -1,0 +1,62 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import "testing"
+
+func TestCompactReuseDependencyNodeEditKeepsBorrowedPendingRefsLazy(t *testing.T) {
+	borrowedArena := newNodeArena(arenaClassIncremental)
+	defer borrowedArena.Release()
+	unaffected := newLeafNodeInArena(borrowedArena, 1, true, 0, 1, Point{}, Point{Column: 1})
+	borrowed := newLeafNodeInArena(borrowedArena, 2, true, 2, 4, Point{Column: 2}, Point{Column: 4})
+	if !setCompactReuseDependency(unaffected, 0) || !setCompactReuseDependency(borrowed, 6) {
+		t.Fatal("could not authenticate borrowed receipts")
+	}
+
+	arena := newNodeArena(arenaClassFull)
+	defer arena.Release()
+	arena.finalChildRefs = true
+	inner := newPendingParentInArena(arena, 3, true, 0, []stackEntry{
+		newStackEntryNode(11, unaffected),
+		newStackEntryNode(12, borrowed),
+	}, 0, 4, Point{}, Point{Column: 4}, false)
+	tail := newCompactFullLeafInArena(arena, 4, true, 10, 12, Point{Column: 10}, Point{Column: 12})
+	outer := newPendingParentInArena(arena, 5, true, 0, []stackEntry{
+		newStackEntryPendingParent(13, inner),
+		newStackEntryCompactFullLeaf(14, tail),
+	}, 0, 12, Point{}, Point{Column: 12}, false)
+	entry := newStackEntryPendingParent(15, outer)
+	root := materializeStackEntryPendingParent(arena, &entry, pendingParentMaterializeForFinalTree)
+	if root == nil {
+		t.Fatal("root materialization failed")
+	}
+	child, ok := nodeChildEntryAtNoMaterialize(root, 0)
+	if !ok || child.kind != stackEntryKindPendingParent {
+		t.Fatal("fixture lost its pending parent behind the final child reference")
+	}
+	pendingBefore := arena.pendingParentMaterialized
+
+	// Node.Edit has no borrowed-arena list. The dependency reaches byte 10,
+	// although both the borrowed node and its pending parent end at byte 4.
+	root.Edit(InputEdit{
+		StartByte: 8, OldEndByte: 9, NewEndByte: 9,
+		StartPoint: Point{Column: 8}, OldEndPoint: Point{Column: 9}, NewEndPoint: Point{Column: 9},
+	})
+	if _, ok := compactReuseDependencyForNode(borrowed); ok {
+		t.Error("Node.Edit retained the borrowed node's intersecting dependency")
+	}
+	if extent, ok := compactReuseDependencyForNode(unaffected); !ok || extent != 0 {
+		t.Error("Node.Edit removed the unaffected zero-extent receipt")
+	}
+	if borrowed.StartByte() != 2 || borrowed.EndByte() != 4 {
+		t.Error("the suffix edit changed the borrowed node's range")
+	}
+	if arena.finalChildRefsMaterializedParents != 0 || arena.finalChildRefsMaterializedChildren != 0 ||
+		arena.finalChildRefsSingleChildMaterializedChildren != 0 || arena.compactFullLeafMaterialized != 0 ||
+		arena.pendingParentMaterialized != pendingBefore || arena.pendingParentMaterializedForEdit != 0 {
+		t.Fatalf("Node.Edit materialized lazy payloads: parents=%d children=%d single=%d leaves=%d pending_delta=%d edit_pending=%d",
+			arena.finalChildRefsMaterializedParents, arena.finalChildRefsMaterializedChildren,
+			arena.finalChildRefsSingleChildMaterializedChildren, arena.compactFullLeafMaterialized,
+			arena.pendingParentMaterialized-pendingBefore, arena.pendingParentMaterializedForEdit)
+	}
+}

--- a/internal/parsercorephase0/reuse_dependency.go
+++ b/internal/parsercorephase0/reuse_dependency.go
@@ -1,0 +1,24 @@
+package parsercorephase0
+
+import "errors"
+
+// SoleHeadPayload returns the payload on an exact single-link frontier.
+// It does not walk the stack or interpret the payload's public projection.
+func (c *Core) SoleHeadPayload(head Head) (SubtreeID, error) {
+	n, err := c.node(head.Node)
+	if err != nil {
+		return 0, err
+	}
+	if n.linkCount != 1 || n.pathCount != 1 {
+		return 0, errors.New("parser-core phase zero: payload requires one exact frontier link")
+	}
+	if n.firstLink == 0 || uint64(n.firstLink) > uint64(len(c.links)) {
+		return 0, errors.New("parser-core phase zero: frontier link is invalid")
+	}
+	link := c.links[n.firstLink-1]
+	if link.next != 0 || link.prev == 0 || uint64(link.prev) > uint64(len(c.nodes)) ||
+		link.payload == 0 || uint64(link.payload) > uint64(len(c.subtrees)) {
+		return 0, errors.New("parser-core phase zero: frontier payload is invalid")
+	}
+	return link.payload, nil
+}

--- a/internal/parsercorephase0/reuse_dependency_test.go
+++ b/internal/parsercorephase0/reuse_dependency_test.go
@@ -1,0 +1,31 @@
+package parsercorephase0
+
+import "testing"
+
+func TestSoleHeadPayloadAuthenticatesBoundary(t *testing.T) {
+	c, seed, reused := reusedFixture(t)
+	if _, err := c.SoleHeadPayload(seed); err == nil {
+		t.Fatal("seed has no payload")
+	}
+	var head Head
+	var payload SubtreeID
+	if err := c.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) (err error) {
+		head, payload, err = c.PushReusedSubtreeOwned(owner, seed, reused)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := c.SoleHeadPayload(head); err != nil || got != payload {
+		t.Fatalf("payload=%d error=%v, want %d", got, err, payload)
+	}
+	n := &c.nodes[head.Node-1]
+	n.pathCount = 2
+	if _, err := c.SoleHeadPayload(head); err == nil {
+		t.Fatal("ambiguous frontier was authenticated")
+	}
+	n.pathCount = 1
+	c.links[n.firstLink-1].payload = 0
+	if _, err := c.SoleHeadPayload(head); err == nil {
+		t.Fatal("absent payload was authenticated")
+	}
+}

--- a/lexer_dependency_probes_test.go
+++ b/lexer_dependency_probes_test.go
@@ -1,0 +1,38 @@
+package gotreesitter
+
+import "testing"
+
+func TestPreferredTokenRetainsDiscardedProbeFrontier(t *testing.T) {
+	for _, raw := range []bool{false, true} {
+		lang := &Language{
+			SymbolNames: []string{"end", "a", "b"},
+			LexModes:    []LexMode{{LexState: 0, AfterWhitespaceLexState: 2}},
+			LexStates: []LexState{
+				{Default: -1, EOF: -1, Transitions: []LexTransition{
+					{Lo: ' ', Hi: ' ', NextState: 0, Skip: true},
+					{Lo: 'a', Hi: 'a', NextState: 1},
+				}},
+				{Default: -1, EOF: -1, AcceptToken: 1},
+				{Default: -1, EOF: -1, Transitions: []LexTransition{
+					{Lo: ' ', Hi: ' ', NextState: 2, Skip: true},
+					{Lo: 'a', Hi: 'a', NextState: 2, Skip: true},
+					{Lo: 'b', Hi: 'b', NextState: 3},
+				}},
+				{Default: -1, EOF: -1, AcceptToken: 2, Transitions: []LexTransition{{Lo: 'b', Hi: 'b', NextState: 3}}},
+			},
+		}
+		d := &dfaTokenSource{language: lang, lexer: NewLexer(lang.LexStates, []byte(" a bbbb!"))}
+		var token Token
+		if raw {
+			token, _, _, _ = d.scanRawPreferredTokenForState(0)
+		} else {
+			token, _, _, _ = d.scanPreferredTokenForState(0)
+		}
+		if token.Symbol != 1 || token.StartByte != 1 || token.EndByte != 2 {
+			t.Fatalf("raw=%t selected token changed: %+v", raw, token)
+		}
+		if token.lexerLookaheadEndByte != 8 {
+			t.Fatalf("raw=%t frontier=%d, want discarded probe frontier8", raw, token.lexerLookaheadEndByte)
+		}
+	}
+}

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -1521,6 +1521,9 @@ func (d *dfaTokenSource) scanPreferredTokenForState(state StateID) (Token, int, 
 
 	baseTok, baseEndPos, baseEndRow, baseEndCol := d.scanDFATokenForState(state, mode.lexState)
 	afterTok, afterEndPos, afterEndRow, afterEndCol := d.scanDFATokenForState(state, mode.afterWhitespaceLexState)
+	// Selection observes both probes, including a discarded longer match.
+	frontier := maxUint32(tokenLookaheadEndByte(baseTok), tokenLookaheadEndByte(afterTok))
+	baseTok.lexerLookaheadEndByte, afterTok.lexerLookaheadEndByte = frontier, frontier
 	if d.shouldPreferBaseLexStateToken(baseTok, afterTok) {
 		return baseTok, baseEndPos, baseEndRow, baseEndCol
 	}
@@ -1624,6 +1627,8 @@ func (d *dfaTokenSource) scanRawPreferredTokenForState(state StateID) (Token, in
 
 	baseTok, baseEndPos, baseEndRow, baseEndCol := d.scanRawDFATokenForLexState(mode.lexState)
 	afterTok, afterEndPos, afterEndRow, afterEndCol := d.scanRawDFATokenForLexState(mode.afterWhitespaceLexState)
+	frontier := maxUint32(tokenLookaheadEndByte(baseTok), tokenLookaheadEndByte(afterTok))
+	baseTok.lexerLookaheadEndByte, afterTok.lexerLookaheadEndByte = frontier, frontier
 	if d.shouldPreferBaseLexStateToken(baseTok, afterTok) {
 		return baseTok, baseEndPos, baseEndRow, baseEndCol
 	}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -9016,6 +9016,7 @@ func aliasedNodeInArena(arena *nodeArena, lang *Language, n *Node, alias Symbol)
 	}
 	cloned.ownerArena = arena
 	copyMissingNodeDependencyForClone(cloned, n)
+	copyCompactReuseDependency(cloned, n)
 	copyExternalScannerCheckpointToNode(cloned, n)
 	return cloned
 }
@@ -9197,6 +9198,7 @@ func cloneNodeInArena(arena *nodeArena, n *Node) *Node {
 	cloned.ownerArena = arena
 	cloneNodeFieldMetadataHeaderInto(cloned, n, arena)
 	copyMissingNodeDependencyForClone(cloned, n)
+	copyCompactReuseDependency(cloned, n)
 	copyExternalScannerCheckpointToNode(cloned, n)
 	if nodeHasFinalChildRefs(n) {
 		childCount := nodeChildCountNoMaterialize(n)

--- a/parser_runtime_test.go
+++ b/parser_runtime_test.go
@@ -1213,6 +1213,7 @@ func assertParseRuntimeArenaBreakdown(t *testing.T, tree *Tree, rt ParseRuntime)
 		arenaBreakdown.RawShapeHashCacheBytesAllocated +
 		arenaBreakdown.FinalChildSidecarBytesAllocated +
 		arenaBreakdown.MissingNodeDependencyBytesAllocated +
+		arenaBreakdown.CompactReuseDependencyBytesAllocated +
 		arenaBreakdown.CompactCheckpointLeafBytesAllocated +
 		arenaBreakdown.ChildSliceBytesAllocated +
 		arenaBreakdown.FieldIDBytesAllocated +

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2808,6 +2808,7 @@ type diagnosticParserCoreGenericScheduler struct {
 	// scanner cursor until one version remains and rejoins shared election.
 	versionLexerOwnershipActive bool
 	recoveryTurns               diagnosticParserCoreRecoveryTurns
+	reuseDependencies           compactReuseDependencies
 	// versionLexerNoActionProof is true only during one exact C-style drop:
 	// owned versions shared a token start, at least one shifted, and the
 	// remaining versions exhausted reductions without an action.
@@ -4351,7 +4352,9 @@ func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGe
 	acceptedPayloads := resetDiagnosticParserCoreRetainedSlice(scheduler.acceptedPayloads)
 	versionLexerRequests := resetDiagnosticParserCoreRetainedSlice(scheduler.versionLexerRequests)
 	versionLexerBeforeScratch := resetDiagnosticParserCoreDFARelexSnapshotScratch(scheduler.versionLexerBeforeScratch)
+	reuseDependencies := scheduler.reuseDependencies.reset()
 	*scheduler = diagnosticParserCoreGenericScheduler{
+		reuseDependencies:    reuseDependencies,
 		summaryHeaderScratch: summaryHeaders,
 		dispatchScratch: diagnosticParserCoreDispatchScratch{
 			cells: dispatchCells, noActionIndices: noActionIndices,
@@ -7859,6 +7862,11 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 		compactIncrementalReuseProvenForLanguage(parser.language) &&
 		scannerProvenanceTransferProven && compactTreeIncrementalReuseProven(root)
 	tree.incrementalReuseDisabled = !compactIncrementalReuseProven
+	if compactIncrementalReuseProven && budgetScheduler != nil {
+		if err := budgetScheduler.publishCompactReuseDependencies(parser, root, arena, nodesByID, compact.MaterializationView, &points, acceptedLeaves.footprintBytes(), poll); err != nil {
+			return rejectTree(err)
+		}
+	}
 	tree.setParseRuntime(ParseRuntime{
 		StopReason:                                     ParseStopAccepted,
 		NodesAllocated:                                 arena.used,
@@ -8130,7 +8138,7 @@ func diagnosticParserCoreSchedulerFootprintBytes(s *diagnosticParserCoreGenericS
 	if s == nil {
 		return 0
 	}
-	total := uint64(0)
+	total := uint64(cap(s.reuseDependencies.ends)) * 4
 	addBytes := func(bytes uint64) {
 		if total == math.MaxUint64 || bytes == 0 {
 			return
@@ -11832,6 +11840,8 @@ func (s *diagnosticParserCoreGenericScheduler) DiagnosticDropGenericNoActionHead
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericReduction(before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) (err error) {
+	dependencyBefore, dependencyActive := s.beginCompactReuseDependency(cell.dispatchToken(s.token))
+	defer s.endCompactReuseDependency(dependencyBefore, dependencyActive, &err)
 	if s.freshSessionOwner != nil {
 		return s.applyGenericReductionOwned(*s.freshSessionOwner, before, cell)
 	}
@@ -12548,6 +12558,7 @@ func (s *diagnosticParserCoreGenericScheduler) reconcileGenericConflictOutputsOw
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericConflict(before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) (err error) {
+	s.reuseDependencies.invalidate()
 	if s.freshSessionOwner != nil {
 		return s.applyGenericConflictOwned(*s.freshSessionOwner, before, cell)
 	}
@@ -12827,6 +12838,12 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericShifts(before []DiagnosticParserCoreHeaderReceipt, cells []diagnosticParserCoreGenericCell) (err error) {
+	dependencyToken := s.token
+	if len(cells) == 1 {
+		dependencyToken = cells[0].dispatchToken(s.token)
+	}
+	dependencyBefore, dependencyActive := s.beginCompactReuseDependency(dependencyToken)
+	defer s.endCompactReuseDependency(dependencyBefore, dependencyActive, &err)
 	if s.freshSessionOwner != nil {
 		return s.applyGenericShiftsOwned(*s.freshSessionOwner, before, cells)
 	}
@@ -12985,6 +13002,12 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []DiagnosticParserCoreHeaderReceipt, cells []diagnosticParserCoreGenericCell) (err error) {
+	dependencyToken := s.token
+	if len(cells) == 1 {
+		dependencyToken = cells[0].dispatchToken(s.token)
+	}
+	dependencyBefore, dependencyActive := s.beginCompactReuseDependency(dependencyToken)
+	defer s.endCompactReuseDependency(dependencyBefore, dependencyActive, &err)
 	if err := s.headerRollbackScratch.begin(s.headers); err != nil {
 		return err
 	}

--- a/parsercore_phase0_incremental.go
+++ b/parsercore_phase0_incremental.go
@@ -150,16 +150,8 @@ func (s *diagnosticParserCoreGenericScheduler) tryCompactIncrementalReuse() (boo
 	}
 	p := s.options.materializationParser
 	for _, node := range session.cursor.candidates(s.token.StartByte) {
-		if node == nil || node.ChildCount() == 0 || node.IsExtra() || node.HasError() ||
-			node.dirty() || node.isFragile() || !compactNodeMayBeReused(node) ||
-			!compactNodeStateProofAvailable(node) || node.PreGotoState() != StateID(state) ||
-			!session.cursor.topLevelSiblingBlockSpliceEligible(node) ||
-			!session.cursor.nodeBytesUnchanged(node.StartByte(), node.EndByte()) ||
-			!reuseSubtreeGapIsParserPadding(session.cursor.newSource, offset, node.StartByte(), p.lineContinuationEscapeByte()) {
-			continue
-		}
-		next, ok := p.reuseTargetState(StateID(state), node, s.token)
-		if !ok || next != node.parseState || s.freshSessionOwner == nil ||
+		next, ok := session.candidateState(p, node, StateID(state), offset, s.token)
+		if !ok || s.freshSessionOwner == nil ||
 			s.tokenSource == nil || s.tokenSource.lexer == nil ||
 			!s.tokenSource.externalScannerQuiescent() ||
 			int(node.EndByte()) < s.tokenSource.lexer.pos || node.EndByte() > uint32(len(session.cursor.newSource)) {
@@ -169,7 +161,7 @@ func (s *diagnosticParserCoreGenericScheduler) tryCompactIncrementalReuse() (boo
 		if key == 0 {
 			return false, errors.New("compact incremental subtree keys exhausted")
 		}
-		head, _, err := s.compact.PushReusedSubtreeOwnedWithPoll(*s.freshSessionOwner, header.head, core.ReusedSubtree{
+		head, payload, err := s.compact.PushReusedSubtreeOwnedWithPoll(*s.freshSessionOwner, header.head, core.ReusedSubtree{
 			Key: key, Symbol: core.Symbol(node.Symbol()), PreGotoState: state, State: core.StateID(next),
 			StartByte: node.StartByte(), EndByte: node.EndByte(), DynamicPrecedence: node.dynamicPrecedence,
 		}, s.pollStopControl)
@@ -180,6 +172,9 @@ func (s *diagnosticParserCoreGenericScheduler) tryCompactIncrementalReuse() (boo
 		session.reusedSubtrees++
 		session.reusedBytes += uint64(node.EndByte() - node.StartByte())
 		header.head = head
+		if err := s.importCompactReuseDependency(payload, node); err != nil {
+			return false, err
+		}
 		header.shifted = true
 		s.epochProgress = true
 		// Match SkipToByteWithPoint positioning without consuming the next token.
@@ -193,6 +188,36 @@ func (s *diagnosticParserCoreGenericScheduler) tryCompactIncrementalReuse() (boo
 		return true, nil
 	}
 	return false, nil
+}
+
+func (s *compactIncrementalReuseSession) candidateState(p *Parser, node *Node, state StateID, offset uint32, lookahead Token) (StateID, bool) {
+	if node == nil || node.ChildCount() == 0 || node.IsExtra() || node.HasError() ||
+		node.dirty() || node.isFragile() || !compactNodeMayBeReused(node) ||
+		!compactNodeStateProofAvailable(node) || node.PreGotoState() != state ||
+		(!s.cursor.topLevelSiblingBlockSpliceEligible(node) && !s.nestedCandidateScopeEligible(p, node, lookahead)) ||
+		!s.cursor.nodeBytesUnchanged(node.StartByte(), node.EndByte()) ||
+		!reuseSubtreeGapIsParserPadding(s.cursor.newSource, offset, node.StartByte(), p.lineContinuationEscapeByte()) {
+		return 0, false
+	}
+	next, ok := p.reuseTargetState(state, node, lookahead)
+	return next, ok && next == node.parseState
+}
+
+// Admit only a direct child of the edited top-level item. The fresh token
+// proves the left boundary. The retained dependency also covers lexer probes
+// and the reduction lookahead beyond the subtree's physical right boundary.
+// Materialization still authenticates ownership and rejects changed projections.
+func (s *compactIncrementalReuseSession) nestedCandidateScopeEligible(p *Parser, node *Node, lookahead Token) bool {
+	if s.oldTree == nil || node.parent == nil || node.parent.parent != s.oldTree.root ||
+		!node.parent.dirty() || !node.isCompactMaterialized() ||
+		uint32(node.symbol) < p.language.TokenCount || !p.isVisibleSymbol(node.symbol) ||
+		s.cursor.rightBoundaryTouchedByEdit(node.EndByte()) || !s.nestedDependencyUnchanged(node) {
+		return false
+	}
+	leaf := leftmostLeaf(node)
+	return leaf != nil && uint32(leaf.symbol) < p.language.TokenCount &&
+		leaf.symbol == lookahead.Symbol && leaf.StartByte() == lookahead.StartByte &&
+		leaf.EndByte() == lookahead.EndByte
 }
 
 func (s *compactIncrementalReuseSession) footprintBytes() uint64 {

--- a/parsercore_phase0_nested_reuse_test.go
+++ b/parsercore_phase0_nested_reuse_test.go
@@ -1,0 +1,90 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import "testing"
+
+func TestCompactNestedReuseCandidateProofs(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		change func(*Parser, *compactIncrementalReuseSession, *Node, *Token)
+	}{
+		{"clean", nil},
+		{"unknown_dependency", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { clearCompactReuseDependency(n) }},
+		{"dependency_beyond_source", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { setCompactReuseDependency(n, 4) }},
+		{"changed_reduction_lookahead", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { setCompactReuseDependency(n, 2) }},
+		{"dirty_node", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { n.setDirty(true) }},
+		{"fragile_node", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { n.setFragileLeft(true) }},
+		{"fragile_parent", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { n.parent.setFragileRight(true) }},
+		{"error_parent", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { n.parent.symbol = errorSymbol }},
+		{"missing_parent", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { n.parent.setMissing(true) }},
+		{"clean_parent", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { n.parent.setDirty(false) }},
+		{"deeper_parent", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { n.parent.parent = &Node{} }},
+		{"unproven_pre_state", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) {
+			n.setCompactPreGotoStateProof(false)
+		}},
+		{"unproven_state", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) {
+			n.setCompactParseStateProof(false)
+		}},
+		{"wrong_pre_state", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { n.preGotoState++ }},
+		{"wrong_goto", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { n.parseState++ }},
+		{"hidden", func(p *Parser, _ *compactIncrementalReuseSession, _ *Node, _ *Token) {
+			p.language.SymbolMetadata[3].Visible = false
+		}},
+		{"terminal", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { n.symbol = 1 }},
+		{"childless", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { n.children = nil }},
+		{"token_symbol", func(_ *Parser, _ *compactIncrementalReuseSession, _ *Node, token *Token) { token.Symbol++ }},
+		{"token_start", func(_ *Parser, _ *compactIncrementalReuseSession, _ *Node, token *Token) { token.StartByte++ }},
+		{"token_end", func(_ *Parser, _ *compactIncrementalReuseSession, _ *Node, token *Token) { token.EndByte++ }},
+		{"aliased_leaf", func(_ *Parser, _ *compactIncrementalReuseSession, n *Node, _ *Token) { n.children[0].symbol = 5 }},
+		{"right_boundary", func(_ *Parser, s *compactIncrementalReuseSession, _ *Node, _ *Token) {
+			s.cursor.edits = []InputEdit{{StartByte: 1, OldEndByte: 1, NewEndByte: 2}}
+		}},
+		{"changed_bytes", func(_ *Parser, s *compactIncrementalReuseSession, _ *Node, _ *Token) {
+			s.cursor.newSource = []byte("b y")
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			p, session, node, _, _, _ := compactBorrowedMaterializationFixture(t)
+			p.language.InitialState, p.language.LargeStateCount = 1, 8
+			p.language.StateCount = 8
+			p.language.ParseTable = [][]uint16{nil, nil, nil, nil, {0, 0, 0, 7}}
+			p.denseLimit = 8
+			if !setCompactReuseDependency(node, 0) {
+				t.Fatal("fixture dependency was not authenticated")
+			}
+			parent := session.oldTree.root
+			parent.endByte = 3
+			parent.setDirty(true)
+			session.oldTree.root = newParentNodeInArena(node.ownerArena, 4, true, []*Node{parent}, nil, 0)
+			session.oldTree.source = []byte("a x")
+			session.oldTree.edits = []InputEdit{{StartByte: 2, OldEndByte: 3, NewEndByte: 3}}
+			session.cursor.reset(session.oldTree, []byte("a y"), nil)
+			token := Token{Symbol: 1, StartByte: 0, EndByte: 1}
+			if test.change != nil {
+				test.change(p, session, node, &token)
+			}
+			state, ok := session.candidateState(p, node, 4, 0, token)
+			if want := test.change == nil; ok != want || (ok && state != 7) {
+				t.Fatalf("candidate state=%d accepted=%t, want accepted=%t", state, ok, want)
+			}
+		})
+	}
+}
+
+func TestCompactNestedReuseRejectsProjectionRewrite(t *testing.T) {
+	p, _, node, _, _, _ := compactBorrowedMaterializationFixture(t)
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	entries := []stackEntry{newStackEntryNode(0, node)}
+	if err := validateCompactBorrowedReduceInputs(p, entries, 1, arena); err == nil {
+		t.Fatal("an owning reduction aliased the borrowed nonterminal")
+	}
+	// An equal-span replacement cannot substitute for the borrowed identity.
+	clone := newParentNodeInArenaNoLinksWithFieldSources(arena, node.symbol, true, node.children, nil, nil, 0, true)
+	for _, output := range []*Node{clone, node.children[0]} {
+		if err := validateCompactBorrowedReduceProjection(p, entries, []*Node{output}, arena); err == nil {
+			t.Fatal("a clone or unary collapse replaced the borrowed projection")
+		}
+	}
+}

--- a/parsercore_phase0_reuse_dependency.go
+++ b/parsercore_phase0_reuse_dependency.go
@@ -145,7 +145,7 @@ func (s *diagnosticParserCoreGenericScheduler) growCompactReuseDependencies(last
 		}
 		additional := (capacity - uint64(cap(d.ends))) * 4
 		if reason := s.stopControlMemoryBudgetReasonWithAdditionalBytes(additional); resultMaterializationShouldStop(reason) {
-			return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreCap, detail: "compact reuse dependency storage stopped: " + string(reason)}
+			return diagnosticParserCoreStopControlTripped(reason)
 		}
 		next := make([]uint32, int(want), int(capacity))
 		copy(next, d.ends)

--- a/parsercore_phase0_reuse_dependency.go
+++ b/parsercore_phase0_reuse_dependency.go
@@ -1,0 +1,322 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"math"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// A frontier includes all lexer probes and the actual reduction lookahead.
+// Zero means unknown. The lexer records even EOF one byte past its cursor.
+type compactReuseDependencies struct {
+	ends     []uint32
+	frontier uint32
+	disabled bool
+}
+
+// Keep at most 64 KiB of pointer-free scratch per runner. Clear every entry
+// before another parse can authenticate payloads with reused numeric IDs.
+const compactReuseDependencyRetainedEntries = 16 * 1024
+
+func (d *compactReuseDependencies) reset() compactReuseDependencies {
+	if cap(d.ends) > compactReuseDependencyRetainedEntries {
+		return compactReuseDependencies{}
+	}
+	clear(d.ends[:cap(d.ends)])
+	return compactReuseDependencies{ends: d.ends[:0]}
+}
+
+// Forward frontiers cannot authenticate prefix reads or contextual repairs.
+// StatelessExternalScanner's existing contract requires local lookahead plus
+// valid symbols and forbids prefix reads; see external_scanner_quiescence.go.
+func (d *dfaTokenSource) compactReuseForwardDependenciesOnly() bool {
+	if d == nil || d.language == nil || d.isBash || d.isBashGenerated || d.isComment ||
+		d.isFortran || d.isScheme || d.isSwift || d.hasZeroWidthSentinelSymbol || supportsCompactCloseAngleSplit(d.language.Name) {
+		return false
+	}
+	// hasZeroWidthTokens/hasZeroWidthStartAccept make table-only choices.
+	// The token gate rejects their synthetic results without DFA provenance.
+	if d.hasExternalSymbols || d.hasExternalScanner || d.language.ExternalScanner != nil {
+		scanner, ok := d.language.ExternalScanner.(StatelessExternalScanner)
+		return d.hasExternalScanner && ok && scanner.ExternalScannerIsStateless()
+	}
+	return true
+}
+
+func (d *compactReuseDependencies) invalidate() {
+	if !d.disabled {
+		clear(d.ends)
+		d.disabled = true
+	}
+}
+
+func (s *diagnosticParserCoreGenericScheduler) endCompactReuseDependency(before uint32, active bool, result *error) {
+	if failure := recover(); failure != nil {
+		s.reuseDependencies.invalidate()
+		panic(failure)
+	}
+	err := s.finishCompactReuseDependency(before, active, *result == nil)
+	if *result == nil {
+		*result = err
+	}
+}
+
+func (s *diagnosticParserCoreGenericScheduler) beginCompactReuseDependency(token Token) (uint32, bool) {
+	d := &s.reuseDependencies
+	if d.disabled {
+		return 0, false
+	}
+	if !s.tokenSource.compactReuseForwardDependenciesOnly() || s.tokenSource.lexer == nil || len(s.headers) != 1 ||
+		s.versionLexerOwnershipActive || s.recoveryIsolation || s.s3RegionOpened ||
+		s.headers[0].isRecoveryLineage() || s.headers[0].recoveryRegion() != nil ||
+		token.Missing || token.NoLookahead || token.EndByte < token.StartByte ||
+		(token.ExternalScannerToken && !s.tokenSource.hasExternalScanner) ||
+		(token.Symbol != 0 && !token.ExternalScannerToken && (!token.lexerInternalDFALexed || token.EndByte <= token.StartByte)) ||
+		token.lexerLookaheadEndByte == 0 {
+		d.invalidate()
+		return 0, false
+	}
+	// Mid-source zero-width scans carry loop-prevention history. A true EOF
+	// sentinel cannot be borrowed: its examined frontier lies beyond source.
+	if token.ExternalScannerToken && token.EndByte == token.StartByte &&
+		(uint64(token.EndByte) != uint64(len(s.tokenSource.lexer.source)) || token.lexerLookaheadEndByte <= token.EndByte) {
+		d.invalidate()
+		return 0, false
+	}
+	stats, err := s.compact.Stats(s.headers[0].head)
+	if err != nil || stats.CurrentExactPaths != 1 || uint64(stats.Subtrees)+1 != uint64(max(1, len(d.ends))) {
+		d.invalidate()
+		return 0, false
+	}
+	d.frontier = maxUint32(d.frontier, tokenLookaheadEndByte(token))
+	return stats.Subtrees, true
+}
+
+func (s *diagnosticParserCoreGenericScheduler) finishCompactReuseDependency(before uint32, active bool, success bool) error {
+	d := &s.reuseDependencies
+	if !active {
+		return nil
+	}
+	if !success || len(s.headers) != 1 || s.versionLexerOwnershipActive || s.recoveryIsolation {
+		d.invalidate()
+		return nil
+	}
+	stats, err := s.compact.Stats(s.headers[0].head)
+	if err != nil {
+		return err
+	}
+	id, err := s.compact.SoleHeadPayload(s.headers[0].head)
+	if err != nil || stats.Subtrees < before || id == 0 {
+		d.invalidate()
+		return nil
+	}
+	if err := s.growCompactReuseDependencies(stats.Subtrees); err != nil {
+		return err
+	}
+	for fresh := uint64(before) + 1; fresh <= uint64(stats.Subtrees); fresh++ {
+		d.ends[fresh] = d.frontier
+		if fresh&255 == 0 {
+			if err := s.pollStopControl(); err != nil {
+				return err
+			}
+		}
+	}
+	// A cached reduction may republish an existing payload. Broaden its proof.
+	if uint64(id) >= uint64(len(d.ends)) {
+		return errors.New("compact reuse dependency payload is outside storage")
+	}
+	d.ends[id] = maxUint32(d.ends[id], d.frontier)
+	return nil
+}
+
+func (s *diagnosticParserCoreGenericScheduler) growCompactReuseDependencies(last uint32) error {
+	d := &s.reuseDependencies
+	want := uint64(last) + 1
+	if want > uint64(math.MaxInt) {
+		return errors.New("compact reuse dependency storage overflow")
+	}
+	if want > uint64(cap(d.ends)) {
+		capacity := max(want, uint64(cap(d.ends))*2, 128)
+		if capacity > uint64(math.MaxInt) {
+			capacity = want
+		}
+		additional := (capacity - uint64(cap(d.ends))) * 4
+		if reason := s.stopControlMemoryBudgetReasonWithAdditionalBytes(additional); resultMaterializationShouldStop(reason) {
+			return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreCap, detail: "compact reuse dependency storage stopped: " + string(reason)}
+		}
+		next := make([]uint32, int(want), int(capacity))
+		copy(next, d.ends)
+		d.ends = next
+	} else {
+		d.ends = d.ends[:int(want)]
+	}
+	return nil
+}
+
+// Publish only candidates that the nested selector can borrow. Resolve exact
+// public pointers after projection, without allocating receipts for interiors.
+// Borrowed nodes keep their original receipts and their original arena owner.
+func (s *diagnosticParserCoreGenericScheduler) publishCompactReuseDependencies(
+	p *Parser, root *Node, arena *nodeArena, nodesByID []*Node,
+	viewFor func(core.SubtreeID) (core.MaterializationSubtreeView, error), points *diagnosticParserCorePointIndex,
+	otherScratchBytes uint64, poll func() error,
+) error {
+	if root == nil || root.HasError() {
+		return nil
+	}
+	eligible := func(node *Node) bool {
+		return node != nil && node.ownerArena == arena && node.ChildCount() != 0 &&
+			node.EndByte() > node.StartByte() && !node.IsExtra() && !node.HasError() &&
+			!node.dirty() && !node.isFragile() && compactNodeMayBeReused(node) &&
+			compactNodeStateProofAvailable(node) && node.isCompactMaterialized() &&
+			uint32(node.symbol) >= p.language.TokenCount && p.isVisibleSymbol(node.symbol)
+	}
+	count := 0
+	visited := 0
+	for _, item := range root.children {
+		if item == nil {
+			continue
+		}
+		for _, node := range item.children {
+			if eligible(node) {
+				count++
+				if s.reuseDependencies.disabled {
+					// A compatibility clone can carry a prior receipt. An unknown
+					// new derivation cannot authenticate that copied projection.
+					clearCompactReuseDependency(node)
+				}
+			}
+			visited++
+			if visited&255 == 0 {
+				if err := poll(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	if count == 0 || s.reuseDependencies.disabled {
+		return nil
+	}
+	// Charge the transient pointer map before allocation. This conservative
+	// estimate includes entries, spare buckets, and the map header.
+	if uint64(count) > (math.MaxUint64-256)/64 {
+		return errors.New("compact reuse publication storage overflow")
+	}
+	mapBytes := uint64(count)*64 + 256
+	if math.MaxUint64-mapBytes < otherScratchBytes {
+		mapBytes = math.MaxUint64
+	} else {
+		mapBytes += otherScratchBytes
+	}
+	check := func() error {
+		if err := poll(); err != nil {
+			return err
+		}
+		additional := arenaAllocatedVolume(arena)
+		if math.MaxUint64-additional < mapBytes {
+			additional = math.MaxUint64
+		} else {
+			additional += mapBytes
+		}
+		if reason := s.stopControlMemoryBudgetReasonWithAdditionalBytes(additional); resultMaterializationShouldStop(reason) {
+			return diagnosticParserCoreStopControlTripped(reason)
+		}
+		return nil
+	}
+	if err := check(); err != nil {
+		return err
+	}
+	type proof struct {
+		end     uint32
+		seen    bool
+		unknown bool
+	}
+	candidates := make(map[*Node]proof, count)
+	for _, item := range root.children {
+		if item == nil {
+			continue
+		}
+		for _, node := range item.children {
+			if eligible(node) {
+				candidates[node] = proof{}
+			}
+			visited++
+			if visited&255 == 0 {
+				if err := check(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	for id, node := range nodesByID {
+		if candidate, ok := candidates[node]; ok {
+			candidate.seen = true
+			if id == 0 || id >= len(s.reuseDependencies.ends) || s.reuseDependencies.ends[id] < node.EndByte() ||
+				viewFor == nil || points == nil {
+				candidate.unknown = true
+			} else {
+				// Pointer identity does not authenticate compatibility rewrites.
+				// Require the original byte range and exact source coordinates.
+				view, err := viewFor(core.SubtreeID(id))
+				if err != nil || view.StartByte != node.StartByte() || view.EndByte != node.EndByte() ||
+					points.point(node.StartByte()) != node.StartPoint() || points.point(node.EndByte()) != node.EndPoint() {
+					candidate.unknown = true
+				} else {
+					candidate.end = maxUint32(candidate.end, s.reuseDependencies.ends[id])
+				}
+			}
+			candidates[node] = candidate
+		}
+		if id&255 == 0 {
+			if err := check(); err != nil {
+				return err
+			}
+		}
+	}
+	for node, candidate := range candidates {
+		// A collapsed outer projection must not inherit an inner proof when
+		// its own dependency is unknown. Unmatched alias clones also abstain.
+		if !candidate.seen || candidate.unknown || !setCompactReuseDependency(node, candidate.end-node.EndByte()) {
+			clearCompactReuseDependency(node)
+		}
+		visited++
+		if visited&255 == 0 {
+			if err := check(); err != nil {
+				return err
+			}
+		}
+	}
+	return check()
+}
+
+func (s *compactIncrementalReuseSession) nestedDependencyUnchanged(node *Node) bool {
+	bytes, ok := compactReuseDependencyForNode(node)
+	end := uint64(node.EndByte()) + uint64(bytes)
+	// Unmapped EOF and invalid-UTF8 sentinels are dependencies, not padding.
+	// Decline rather than clamp them to the source boundary.
+	return ok && end <= uint64(len(s.cursor.newSource)) &&
+		!s.cursor.rightBoundaryTouchedByEdit(uint32(end)) &&
+		s.cursor.nodeBytesUnchanged(node.StartByte(), uint32(end))
+}
+
+func (s *diagnosticParserCoreGenericScheduler) importCompactReuseDependency(id core.SubtreeID, node *Node) error {
+	d := &s.reuseDependencies
+	if d.disabled {
+		return nil
+	}
+	bytes, ok := compactReuseDependencyForNode(node)
+	end := uint64(node.EndByte()) + uint64(bytes)
+	if !ok || end > math.MaxUint32 || uint64(id) != uint64(max(1, len(d.ends))) {
+		d.invalidate()
+		return nil
+	}
+	if err := s.growCompactReuseDependencies(uint32(id)); err != nil {
+		return err
+	}
+	d.frontier = maxUint32(d.frontier, maxUint32(uint32(end), tokenLookaheadEndByte(s.token)))
+	d.ends[id] = d.frontier
+	return nil
+}

--- a/parsercore_phase0_reuse_dependency_scanner_internal_test.go
+++ b/parsercore_phase0_reuse_dependency_scanner_internal_test.go
@@ -1,0 +1,87 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import "testing"
+
+func TestCompactReuseDependencyGoProducerCapabilities(t *testing.T) {
+	p := newAdmissionCandidateGoParser(t)
+	var source dfaTokenSource
+	initDFATokenSourceWithCRecovery(&source, NewLexer(nil, []byte("func a(){_=1}")), p.language, p.lookupActionIndex, nil, nil, nil, false)
+	source.noPool = true
+	defer source.Close()
+	if !source.compactReuseForwardDependenciesOnly() {
+		t.Fatalf("Go source is not forward-only: external=%t/%t scanner=%T zero=%t/%t/%t modes=%t/%t/%t/%t/%t/%t", source.hasExternalScanner, source.hasExternalSymbols, p.language.ExternalScanner, source.hasZeroWidthTokens, source.hasZeroWidthStartAccept, source.hasZeroWidthSentinelSymbol, source.isBash, source.isBashGenerated, source.isComment, source.isFortran, source.isScheme, source.isSwift)
+	}
+}
+
+func TestCompactReuseDependencyRejectsUntrackedSourceReads(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		change func(*dfaTokenSource, *Token)
+	}{
+		{"unproven_scanner", func(d *dfaTokenSource, _ *Token) {
+			d.language.ExternalScanner = diagnosticParserCoreZeroSnapshotScanner{stateless: false}
+			d.hasExternalScanner, d.hasExternalSymbols = true, true
+		}},
+		{"scanner_source", func(d *dfaTokenSource, _ *Token) { d.hasExternalScanner = true }},
+		{"builtin_external_symbols", func(d *dfaTokenSource, _ *Token) { d.hasExternalSymbols = true }},
+		{"bash", func(d *dfaTokenSource, _ *Token) { d.isBash = true }},
+		{"bash_generated", func(d *dfaTokenSource, _ *Token) { d.isBashGenerated = true }},
+		{"comment", func(d *dfaTokenSource, _ *Token) { d.isComment = true }},
+		{"fortran", func(d *dfaTokenSource, _ *Token) { d.isFortran = true }},
+		{"scheme", func(d *dfaTokenSource, _ *Token) { d.isScheme = true }},
+		{"swift", func(d *dfaTokenSource, _ *Token) { d.isSwift = true }},
+		{"close_angle_repair", func(d *dfaTokenSource, _ *Token) { d.language.Name = "java" }},
+		{"zero_width_sentinel", func(d *dfaTokenSource, _ *Token) { d.hasZeroWidthSentinelSymbol = true }},
+		{"zero_width_token", func(_ *dfaTokenSource, token *Token) { token.EndByte = token.StartByte }},
+		{"unproven_token", func(_ *dfaTokenSource, token *Token) { token.lexerInternalDFALexed = false }},
+		{"external_token", func(_ *dfaTokenSource, token *Token) { token.ExternalScannerToken = true }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+			stats, err := compact.Stats(head)
+			if err != nil {
+				t.Fatal(err)
+			}
+			source := &dfaTokenSource{language: &Language{}, lexer: NewLexer(nil, []byte("a"))}
+			token := Token{Symbol: 1, EndByte: 1, lexerLookaheadEndByte: 2, lexerInternalDFALexed: true}
+			s := &diagnosticParserCoreGenericScheduler{compact: compact, tokenSource: source, headers: []diagnosticParserCoreHeader{{head: head}}}
+			s.reuseDependencies.ends = make([]uint32, stats.Subtrees+1)
+			if _, ok := s.beginCompactReuseDependency(token); !ok {
+				t.Fatal("raw internal DFA control was not authenticated")
+			}
+			source.hasZeroWidthTokens, source.hasZeroWidthStartAccept = true, true
+			if _, ok := s.beginCompactReuseDependency(token); !ok {
+				t.Fatal("metadata-only zero-width capability rejected a real DFA token")
+			}
+			test.change(source, &token)
+			if _, ok := s.beginCompactReuseDependency(token); ok || !s.reuseDependencies.disabled {
+				t.Fatal("untracked source reads received a dependency proof")
+			}
+		})
+	}
+}
+
+func TestCompactReuseDependencyAllowsCertifiedForwardScanner(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	stats, err := compact.Stats(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := &dfaTokenSource{
+		language: &Language{ExternalScanner: diagnosticParserCoreZeroSnapshotScanner{stateless: true}},
+		lexer:    NewLexer(nil, nil), hasExternalScanner: true, hasExternalSymbols: true,
+	}
+	s := &diagnosticParserCoreGenericScheduler{compact: compact, tokenSource: source, headers: []diagnosticParserCoreHeader{{head: head}}}
+	s.reuseDependencies.ends = make([]uint32, stats.Subtrees+1)
+	// Certified scanners may emit zero-width EOF sentinels with a real frontier.
+	token := Token{Symbol: 1, ExternalScannerToken: true, lexerLookaheadEndByte: 1}
+	if _, ok := s.beginCompactReuseDependency(token); !ok {
+		t.Fatal("forward-only scanner contract was rejected")
+	}
+	source.lexer.source = []byte("x")
+	if _, ok := s.beginCompactReuseDependency(token); ok {
+		t.Fatal("mid-source zero-width scanner history received a dependency proof")
+	}
+}

--- a/parsercore_phase0_reuse_dependency_test.go
+++ b/parsercore_phase0_reuse_dependency_test.go
@@ -1,0 +1,215 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func compactReusePublicationFixtureView(core.SubtreeID) (core.MaterializationSubtreeView, error) {
+	return core.MaterializationSubtreeView{StartByte: 0, EndByte: 1}, nil
+}
+
+func TestCompactReuseDependencyPublicationAndReset(t *testing.T) {
+	p, session, node, _, _, points := compactBorrowedMaterializationFixture(t)
+	root := newParentNodeInArena(node.ownerArena, 4, true, []*Node{session.oldTree.root}, nil, 0)
+	s := &diagnosticParserCoreGenericScheduler{}
+	base := diagnosticParserCoreSchedulerFootprintBytes(s)
+	s.reuseDependencies.ends = []uint32{0, 4, 6, 0}
+	publish := func(nodes []*Node) {
+		t.Helper()
+		if err := s.publishCompactReuseDependencies(p, root, node.ownerArena, nodes, compactReusePublicationFixtureView, &points, 0, func() error { return nil }); err != nil {
+			t.Fatal(err)
+		}
+	}
+	publish([]*Node{nil, node, node})
+	if bytes, ok := compactReuseDependencyForNode(node); !ok || bytes != 5 {
+		t.Fatalf("outer receipt=%d/%t", bytes, ok)
+	}
+	publish([]*Node{nil, node, node, node})
+	if _, ok := compactReuseDependencyForNode(node); ok {
+		t.Fatal("unknown outer projection retained inner proof")
+	}
+	publish([]*Node{nil, node})
+	publish([]*Node{nil, cloneNodeInArena(node.ownerArena, node)})
+	if _, ok := compactReuseDependencyForNode(node); ok {
+		t.Fatal("unmatched projection retained a receipt")
+	}
+	publish([]*Node{nil, node})
+	s.reuseDependencies.disabled = true
+	publish([]*Node{nil, node})
+	if _, ok := compactReuseDependencyForNode(node); ok {
+		t.Fatal("disabled producer retained a copied receipt")
+	}
+	if got := diagnosticParserCoreSchedulerFootprintBytes(s) - base; got != 16 {
+		t.Fatalf("dependency footprint=%d, want16", got)
+	}
+	if err := resetDiagnosticParserCoreGenericScheduler(s); err != nil {
+		t.Fatal(err)
+	}
+	if len(s.reuseDependencies.ends) != 0 || s.reuseDependencies.frontier != 0 || s.reuseDependencies.disabled {
+		t.Fatal("reset retained a receipt")
+	}
+	for _, end := range s.reuseDependencies.ends[:cap(s.reuseDependencies.ends)] {
+		if end != 0 {
+			t.Fatal("reset retained an authenticated payload in scratch storage")
+		}
+	}
+}
+
+func TestCompactReuseDependencyBoundedScratchRetention(t *testing.T) {
+	for _, count := range []int{0, 1, compactReuseDependencyRetainedEntries, compactReuseDependencyRetainedEntries + 1} {
+		d := compactReuseDependencies{ends: make([]uint32, count), frontier: 9, disabled: true}
+		for i := range d.ends {
+			d.ends[i] = uint32(i + 1)
+		}
+		d.ends = d.ends[:count/2]
+		d = d.reset()
+		if len(d.ends) != 0 || d.frontier != 0 || d.disabled {
+			t.Fatalf("reset retained producer state for capacity %d", count)
+		}
+		if count > compactReuseDependencyRetainedEntries {
+			if d.ends != nil {
+				t.Fatal("reset retained oversized dependency scratch")
+			}
+			continue
+		}
+		if cap(d.ends) != count {
+			t.Fatal("reset discarded bounded dependency scratch")
+		}
+		for _, end := range d.ends[:cap(d.ends)] {
+			if end != 0 {
+				t.Fatal("reset retained stale dependency authorization")
+			}
+		}
+	}
+}
+
+func TestCompactReuseDependencyRetainedScratchBudgetAndBusyReset(t *testing.T) {
+	s := &diagnosticParserCoreGenericScheduler{}
+	base := diagnosticParserCoreSchedulerFootprintBytes(s)
+	s.reuseDependencies.ends = make([]uint32, 1, compactReuseDependencyRetainedEntries)
+	s.reuseDependencies.ends[0] = 7
+	s.dispatchScratch.busy = true
+	if err := resetDiagnosticParserCoreGenericScheduler(s); err == nil || s.reuseDependencies.ends[0] != 7 {
+		t.Fatal("busy reset changed dependency authorization")
+	}
+	s.dispatchScratch.busy = false
+	if err := resetDiagnosticParserCoreGenericScheduler(s); err != nil {
+		t.Fatal(err)
+	}
+	if got := diagnosticParserCoreSchedulerFootprintBytes(s) - base; got != 64*1024 {
+		t.Fatalf("retained dependency footprint=%d, want 65536", got)
+	}
+	s.options.stopControlMemoryBudgetBytes = 32 * 1024
+	if reason := s.stopControlMemoryBudgetReasonWithAdditionalBytes(0); !resultMaterializationShouldStop(reason) {
+		t.Fatal("the next parse omitted retained scratch from its budget")
+	}
+}
+
+func TestCompactReuseDependencyPublishesOnlyEligibleDepth(t *testing.T) {
+	p, session, node, _, _, points := compactBorrowedMaterializationFixture(t)
+	item := session.oldTree.root
+	root := newParentNodeInArena(node.ownerArena, 4, true, []*Node{item}, nil, 0)
+	deep := newParentNodeInArena(node.ownerArena, 3, true, node.children, nil, 0)
+	deep.setCompactMaterialized(true)
+	deep.setCompactParseStateProof(true)
+	deep.setCompactPreGotoStateProof(true)
+	node.children = []*Node{deep}
+	deep.parent = node
+	s := &diagnosticParserCoreGenericScheduler{}
+	s.reuseDependencies.ends = []uint32{0, 4, 5, 6, 7}
+	if err := s.publishCompactReuseDependencies(p, root, node.ownerArena, []*Node{nil, deep, node, item, root}, compactReusePublicationFixtureView, &points, 0, func() error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	for _, ignored := range []*Node{deep, item, root} {
+		if _, ok := compactReuseDependencyForNode(ignored); ok {
+			t.Fatal("publication allocated a receipt outside the candidate depth")
+		}
+	}
+	if bytes, ok := compactReuseDependencyForNode(node); !ok || bytes != 4 {
+		t.Fatalf("candidate receipt=%d/%t, want4/true", bytes, ok)
+	}
+	other := acquireNodeArena(arenaClassFull)
+	defer other.Release()
+	if err := s.publishCompactReuseDependencies(p, root, other, []*Node{nil, node}, compactReusePublicationFixtureView, &points, 0, func() error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if bytes, ok := compactReuseDependencyForNode(node); !ok || bytes != 4 {
+		t.Fatal("publication changed a borrowed arena receipt")
+	}
+}
+
+func TestCompactReuseDependencyRejectsChangedPublicationGeometry(t *testing.T) {
+	for _, change := range []string{"start", "end", "start_point", "end_point", "missing_view", "invalid_view", "missing_points"} {
+		t.Run(change, func(t *testing.T) {
+			p, session, node, _, _, points := compactBorrowedMaterializationFixture(t)
+			root := newParentNodeInArena(node.ownerArena, 4, true, []*Node{session.oldTree.root}, nil, 0)
+			s := &diagnosticParserCoreGenericScheduler{}
+			s.reuseDependencies.ends = []uint32{0, 6}
+			node.startByte, node.endByte = 1, 3
+			node.startPoint, node.endPoint = Point{Column: 1}, Point{Column: 3}
+			viewFor := func(core.SubtreeID) (core.MaterializationSubtreeView, error) {
+				return core.MaterializationSubtreeView{StartByte: 1, EndByte: 3}, nil
+			}
+			pointIndex := &points
+			switch change {
+			case "start":
+				node.startByte, node.startPoint = 0, Point{}
+			case "end":
+				node.endByte, node.endPoint = 4, Point{Column: 4}
+			case "start_point":
+				node.startPoint.Column++
+			case "end_point":
+				node.endPoint.Row++
+			case "missing_view":
+				viewFor = nil
+			case "invalid_view":
+				viewFor = func(core.SubtreeID) (core.MaterializationSubtreeView, error) {
+					return core.MaterializationSubtreeView{}, errors.New("unknown payload")
+				}
+			case "missing_points":
+				pointIndex = nil
+			}
+			// Seed a copied receipt at the final geometry. Publication must not
+			// preserve it merely because the public pointer still matches.
+			if !setCompactReuseDependency(node, 0) {
+				t.Fatal("could not seed the copied receipt")
+			}
+			if err := s.publishCompactReuseDependencies(p, root, node.ownerArena, []*Node{nil, node}, viewFor, pointIndex, 0, func() error { return nil }); err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := compactReuseDependencyForNode(node); ok {
+				t.Fatal("changed or unknown producer geometry retained a receipt")
+			}
+		})
+	}
+}
+
+func TestCompactReuseDependencyBudgetAndPanic(t *testing.T) {
+	s := &diagnosticParserCoreGenericScheduler{}
+	s.options.stopControlMemoryBudgetBytes = 64
+	if err := s.growCompactReuseDependencies(128); err == nil {
+		t.Fatal("dependency storage exceeded its budget")
+	}
+	if cap(s.reuseDependencies.ends) != 0 {
+		t.Fatal("budget rejection allocated dependency storage")
+	}
+	s.reuseDependencies.ends = []uint32{0, 4}
+	func() {
+		defer func() {
+			if recover() != "injected" {
+				t.Fatal("dependency cleanup lost the panic")
+			}
+		}()
+		var err error
+		defer s.endCompactReuseDependency(1, true, &err)
+		panic("injected")
+	}()
+	if !s.reuseDependencies.disabled || s.reuseDependencies.ends[1] != 0 {
+		t.Fatal("panic retained dependency authorization")
+	}
+}

--- a/tree.go
+++ b/tree.go
@@ -1543,6 +1543,8 @@ func (p reduceChildPath) valid() bool {
 // ArenaBreakdown captures optional arena/materialization attribution. It is
 // populated only when EnableArenaBreakdown(true) is set before parsing.
 type ArenaBreakdown struct {
+	CompactReuseDependencyBytesAllocated int64
+
 	NodeStructBytesAllocated            int64
 	NodeFieldMetadataBytesAllocated     int64
 	NoTreeNodeBytesAllocated            int64
@@ -3892,6 +3894,7 @@ func cloneNodeHeaderInto(dst, src *Node, arena *nodeArena, offset *cloneOffset) 
 	dst.parent = nil
 	dst.childIndex = -1
 	dst.ownerArena = arena
+	copyCompactReuseDependency(dst, src)
 	if !copyMissingNodeDependency(dst, src, offset) {
 		if _, present := missingNodeDependencyEntryForNode(src); present {
 			dst.setDirty(true)
@@ -4519,6 +4522,7 @@ func inputEditIsSingleByteReplacement(edit InputEdit) bool {
 // what to re-parse.
 func (t *Tree) Edit(edit InputEdit) {
 	t.ensureResultCompatibility()
+	t.editCompactReuseDependencies(edit)
 	if perfCountersEnabled {
 		perfRecordNodeEditCall()
 		if inputEditIsNoop(edit) {
@@ -4601,6 +4605,7 @@ func coalesceRanges(in []Range) []Range {
 // editNode recursively adjusts a node's byte/point spans for an edit and
 // marks nodes that overlap the edited region as dirty.
 func editNode(n *Node, edit InputEdit) {
+	editCompactReuseDependenciesFromNode(n, edit)
 	byteDelta := int64(edit.NewEndByte) - int64(edit.OldEndByte)
 	rowDelta := int64(edit.NewEndPoint.Row) - int64(edit.OldEndPoint.Row)
 	hasTailShift := byteDelta != 0 || edit.NewEndPoint != edit.OldEndPoint


### PR DESCRIPTION
## Changes

Preserve an unchanged parameter list during `func a(){_=1}` to `func a(){_=x}`.

The compact route now admits bounded nonterminals inside an edited top-level item. It preserves the existing top-level reuse path.

Reuse requires exact parser states, unchanged source dependencies, a matching fresh token, and authenticated node ownership.

The scheduler retains the farthest byte inspected by lexer probes and reduction lookahead. Arena-owned receipts survive safe copies and reject invalid edits.

Receipts use synchronized, coordinate-bound storage. Position-changing edits discard shifted receipts; column-changing copies do not transfer them.

Publish receipts only for nodes that the nested selector can borrow. Authenticate their final ranges and points against the raw derivation.

An interval index restricts edit invalidation to relevant receipts. Repeated edits preserve unaffected receipts, including receipts in shared arenas.

The index uses immutable coordinates and an explicit live bit. A constrained budget selects exact scan-based invalidation without exceeding the limit.

Node and token layouts remain unchanged. Arena and scheduler budgets include the new storage. Reset drops retained receipts.

Scheduler reset clears and retains at most 64 KiB of pointer-free dependency scratch. It drops larger buffers and preserves budget accounting.

## Review-driven regressions

- `a+b ;` to `a+b *c;` must preserve C's multiplication precedence.
- A discarded longer DFA match must retain dependencies beyond the accepted token span.
- Alternate whitespace probes must retain both inspected frontiers, regardless of which token wins.

The first two tests failed against the initial implementation. The JavaScript precedence test uses the locked C parser.

## Scope

The new route rejects recovery, ambiguous producer history, unknown dependency receipts, and dependencies beyond available source bytes.

Scanners must satisfy the existing stateless contract: local lookahead and parser-provided valid symbols only. The Go scanner satisfies that contract.

Contextual token repairs remain excluded until their source dependencies are recorded. Generated zero-width sentinels and unproved synthetic tokens also decline.

Only physical EOF permits a certified external zero-width token. Its beyond-source dependency prevents borrowing a subtree that contains it.

Existing top-level reuse remains unchanged. This change does not retire the legacy parser or claim general scanner support.

## Verification

Focused tests cover exact trees, errors, pointer identity, parent links, copied trees, released source trees, scanner capabilities, and inspected lexer ranges.

Race tests cover shared arenas, repeated edits, empty index ranges, budget rejection, storage reset, and interrupted dependency capture.

Full CI exposed eager child materialization during `Node.Edit` and a nonstandard memory-budget diagnostic. Both now have focused fixes.

The edit walk follows lazy entries into borrowed arenas without creating public children. A new regression checks this ownership boundary directly.

The standard stop-control error preserves the established memory-budget diagnostic. All affected tests pass with the race detector and the diagnostic build tag.

Follow-up review found no actionable issues. Go incremental and certification comparisons still match the locked C parser.

Follow-up artifacts: `/tmp/gts-compact-incremental-tests/20260905T060343Z-nested-ci-tagged-lazy-budget`.

The first benchmark rejected a prototype: single-byte edits became 30.5 times slower, and full-parse allocation increased by 179%.

Candidate-only publication, indexed invalidation, and bounded scratch reuse replace that prototype.

The final comparison alternates baseline and candidate for each of 20 seeds. It reverses their order on even seeds.

Each process uses `GOMAXPROCS=1`, `-count=1`, `-benchtime=750ms`, and `-benchmem` through `scripts/run_randomized_benchmarks.sh`.

| Benchmark | Baseline time | Candidate time | Baseline allocation | Candidate allocation |
| --- | ---: | ---: | ---: | ---: |
| Full parse | 18.73 ms | 18.88 ms | 399.0 KiB | 552.5 KiB |
| Single-byte edit | 1.616 µs | 1.767 µs | 0 B | 0 B |
| No-edit parse | 3.684 ns | 3.757 ns | 0 B | 0 B |

Host load produced 15–18% timing variation. Benchstat found no significant timing difference, but this does not prove equal performance.

Full-parse allocation increased by 38.46%, with 0.18% more allocations. This bounded correctness cost remains an optimization target, not a speed claim.

All 40 benchmark processes completed. Docker reported no out-of-memory failure or timeout. Both incremental controls retained zero allocations per operation.

Final local artifacts:

- `/tmp/gts-compact-incremental-tests/20260905T052845Z-nested-retained-scratch-final`: focused race and Go/C checks.
- `/tmp/gts-compact-incremental-tests/20260905T050151Z-nested-index-geometry-javascript`: JavaScript C comparison.
- `/tmp/gts-compact-incremental-tests/20260905T053224Z-nested-retained-paired-trio`: paired benchmark campaign.

The earlier 5,723-edit comparison found no changed output or route classification. Selective publication subsequently tightened admission; final focused checks cover those changes.

The existing Go `same_line_length_change` canonical case also fails on the unchanged baseline. Its scanner-quiescence admission limitation remains separate.

Issue #1087 records an inherited same-width shortcut defect. This package does not claim to fix that distinct terminal-dependency problem.

Refs #1063.
