### PR TITLE
Restore paired performance evidence and authenticated work counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Repository hygiene
         run: bash scripts/repository_hygiene_test.sh
 
+      - name: Randomized benchmark driver contracts
+        run: bash scripts/run_randomized_benchmarks_test.sh
+
       - name: Build
         run: go build ./...
 
@@ -1525,6 +1528,7 @@ jobs:
           set -euo pipefail
 
           BENCH_RE='^(BenchmarkGoParseFullDFA|BenchmarkGoParseIncrementalSingleByteEditDFA|BenchmarkGoParseIncrementalNoEditDFA)$'
+          BENCH_REQUIRED='BenchmarkGoParseFullDFA,BenchmarkGoParseIncrementalSingleByteEditDFA,BenchmarkGoParseIncrementalNoEditDFA'
           OUT_DIR="${RUNNER_TEMP}/bench-gate"
           BASE_TREE="${RUNNER_TEMP}/bench-base"
           mkdir -p "${OUT_DIR}"
@@ -1552,29 +1556,46 @@ jobs:
 
           git fetch --no-tags origin "${BASE_SHA}" "${GATE_BASE_SHA}"
           git worktree add "${BASE_TREE}" "${GATE_BASE_SHA}"
-          trap 'git worktree remove --force "${BASE_TREE}"' EXIT
+          PR_BASE_TREE=""
+          cleanup_bench_worktrees() {
+            if [ -n "${PR_BASE_TREE}" ]; then
+              git worktree remove --force "${PR_BASE_TREE}" || true
+            fi
+            git worktree remove --force "${BASE_TREE}"
+          }
+          trap cleanup_bench_worktrees EXIT
 
           export GOMAXPROCS=1
-          if [ -n "${BENCH_NODE_SCALE}" ]; then
-            (cd "${BASE_TREE}" && GOT_PARSE_NODE_LIMIT_SCALE="${BENCH_NODE_SCALE}" go test -run '^$' -bench "${BENCH_RE}" -benchmem -count=10 -benchtime=750ms .) > "${OUT_DIR}/base.txt"
-            GOT_PARSE_NODE_LIMIT_SCALE="${BENCH_NODE_SCALE}" go test -run '^$' -bench "${BENCH_RE}" -benchmem -count=10 -benchtime=750ms . > "${OUT_DIR}/head.txt"
-          else
-            (cd "${BASE_TREE}" && go test -run '^$' -bench "${BENCH_RE}" -benchmem -count=10 -benchtime=750ms .) > "${OUT_DIR}/base.txt"
-            go test -run '^$' -bench "${BENCH_RE}" -benchmem -count=10 -benchtime=750ms . > "${OUT_DIR}/head.txt"
-          fi
+          run_paired_comparison() {
+            local baseline_root=$1
+            local baseline_output=$2
+            local head_output=$3
+            local args=(
+              --baseline-root "${baseline_root}"
+              --baseline-output "${baseline_output}"
+              --output "${head_output}"
+              --runs 20 --seed-start 1 --benchtime 750ms
+              --bench-regex "${BENCH_RE}" --package . --tags ''
+              --require-benchmarks "${BENCH_REQUIRED}"
+            )
+            if [ -n "${BENCH_NODE_SCALE}" ]; then
+              GOT_PARSE_NODE_LIMIT_SCALE="${BENCH_NODE_SCALE}" \
+                bash scripts/run_randomized_benchmarks.sh "${args[@]}"
+            else
+              bash scripts/run_randomized_benchmarks.sh "${args[@]}"
+            fi
+          }
+          run_paired_comparison "${BASE_TREE}" "${OUT_DIR}/base.txt" "${OUT_DIR}/head.txt"
           if [ "${GATE_BASE_SHA}" != "${BASE_SHA}" ]; then
             PR_BASE_TREE="${RUNNER_TEMP}/bench-pr-base"
             git worktree add "${PR_BASE_TREE}" "${BASE_SHA}"
-            if [ -n "${BENCH_NODE_SCALE}" ]; then
-              (cd "${PR_BASE_TREE}" && GOT_PARSE_NODE_LIMIT_SCALE="${BENCH_NODE_SCALE}" go test -run '^$' -bench "${BENCH_RE}" -benchmem -count=10 -benchtime=750ms .) > "${OUT_DIR}/pr_base.txt"
-            else
-              (cd "${PR_BASE_TREE}" && go test -run '^$' -bench "${BENCH_RE}" -benchmem -count=10 -benchtime=750ms .) > "${OUT_DIR}/pr_base.txt"
-            fi
+            run_paired_comparison "${PR_BASE_TREE}" "${OUT_DIR}/pr_base.txt" "${OUT_DIR}/pr_head.txt"
             git worktree remove --force "${PR_BASE_TREE}"
+            PR_BASE_TREE=""
             echo "informational compare vs PR base (non-blocking):"
             if ! go run ./cmd/benchgate \
               -base "${OUT_DIR}/pr_base.txt" \
-              -head "${OUT_DIR}/head.txt" \
+              -head "${OUT_DIR}/pr_head.txt" \
               -max-ns-regression 10 \
               -max-bytes-regression 10 \
               -max-allocs-regression 10; then
@@ -1638,12 +1659,13 @@ jobs:
         run: |
           set -euo pipefail
           OUT_DIR="${RUNNER_TEMP}/bench-gate"
-          if [ ! -f "${OUT_DIR}/base.txt" ] || [ ! -f "${OUT_DIR}/head.txt" ]; then
+          if [ "$(tail -n 1 "${OUT_DIR}/base.txt" 2>/dev/null)" != '# status: complete' ] || \
+             [ "$(tail -n 1 "${OUT_DIR}/head.txt" 2>/dev/null)" != '# status: complete' ]; then
             {
               echo "### Perf Definitive Outcome"
               echo ""
               echo "- outcome: \`INCONCLUSIVE\`"
-              echo "- reason: benchmark artifacts missing"
+              echo "- reason: randomized benchmark campaign is missing or incomplete"
             } >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi

--- a/cgo_harness/work_count_board_test.go
+++ b/cgo_harness/work_count_board_test.go
@@ -378,7 +378,7 @@ func TestAuthenticatedFourFixtureWorkCountBoard(t *testing.T) {
 				t.Fatalf("source snapshot sha=%s want=%s", got, fixture.Fixture.SHA256)
 			}
 
-			uninstGo := workCountRunGoAdmission(t, goAdmissionArtifact, fixture.Fixture.ID, sourcePath, fixtureTemp, goEnvironment)
+			uninstGo := workCountRunGoAdmission(t, sourceSnapshot.Root, goAdmissionArtifact, fixture.Fixture.ID, sourcePath, fixtureTemp, goEnvironment)
 			workCountValidateGoChild(t, "ordinary Go admission", workCountGoAdmissionChildSchema, "go-production-glr-untagged", uninstGo, fixture)
 			uninstC := workCountUninstrumentedCAdmission(t, fixture, sourcePath, fixtureTemp)
 			if uninstGo.DeepTreeSHA256 != uninstC || uninstC != fixture.Fixture.DeepTreeSHA256 {
@@ -391,7 +391,7 @@ func TestAuthenticatedFourFixtureWorkCountBoard(t *testing.T) {
 			untaggedScheduling := workCountScheduling(uninstGo)
 			switch goBackend {
 			case workCountBoardGoProduction:
-				goResult := workCountRunGo(t, goArtifact, fixture.Fixture.ID, sourcePath, fixtureTemp, goEnvironment)
+				goResult := workCountRunGo(t, sourceSnapshot.Root, goArtifact, fixture.Fixture.ID, sourcePath, fixtureTemp, goEnvironment)
 				workCountValidateGoChild(t, "tagged Go", workCountTaggedGoChildSchema, "go-production-glr-tagged-diagnostic", goResult.workCountGoChildResult, fixture)
 				workCountValidateGoBoardCounters(t, goResult.Counters, uint32(len(fixture.Source)))
 				if cResult.DeepTreeSHA256 != goResult.DeepTreeSHA256 {
@@ -410,8 +410,8 @@ func TestAuthenticatedFourFixtureWorkCountBoard(t *testing.T) {
 					Metrics: metrics,
 				})
 			case workCountBoardGoParserCore:
-				first := workCountRunParserCoreGo(t, goArtifact, fixture.Fixture.ID, sourcePath, fixtureTemp, "first", goEnvironment)
-				second := workCountRunParserCoreGo(t, goArtifact, fixture.Fixture.ID, sourcePath, fixtureTemp, "repeat", goEnvironment)
+				first := workCountRunParserCoreGo(t, sourceSnapshot.Root, goArtifact, fixture.Fixture.ID, sourcePath, fixtureTemp, "first", goEnvironment)
+				second := workCountRunParserCoreGo(t, sourceSnapshot.Root, goArtifact, fixture.Fixture.ID, sourcePath, fixtureTemp, "repeat", goEnvironment)
 				workCountValidateParserCoreChild(t, first, fixture)
 				workCountValidateParserCoreChild(t, second, fixture)
 				if !reflect.DeepEqual(first, second) {
@@ -578,10 +578,10 @@ func workCountBuildParserCoreGo(t *testing.T, source workCountSourceSnapshot, te
 	}
 }
 
-func workCountRunParserCoreGo(t *testing.T, artifact, fixtureID, sourcePath, tempRoot, pass string, environment workCountEnvironment) workCountBoardParserCoreChildResult {
+func workCountRunParserCoreGo(t *testing.T, sourceRoot, artifact, fixtureID, sourcePath, tempRoot, pass string, environment workCountEnvironment) workCountBoardParserCoreChildResult {
 	t.Helper()
 	resultPath := filepath.Join(tempRoot, "go-parsercore-work-count-"+pass+".json")
-	workCountRunGoChild(t, artifact, "^TestParserCoreWorkCountChild$", fixtureID, sourcePath, resultPath, environment)
+	workCountRunGoChild(t, sourceRoot, artifact, "^TestParserCoreWorkCountChild$", fixtureID, sourcePath, resultPath, environment)
 	data, err := os.ReadFile(resultPath)
 	if err != nil {
 		t.Fatal(err)

--- a/cgo_harness/work_count_board_test.go
+++ b/cgo_harness/work_count_board_test.go
@@ -21,7 +21,7 @@ const (
 	workCountBoardGoBackendEnv            = "GTS_WORK_COUNT_GO_BACKEND"
 	workCountBoardGoProduction            = "production"
 	workCountBoardGoParserCore            = "parsercore_phase0"
-	workCountBoardParserCoreChildSchema   = "gts-work-count-parsercore-child/v4"
+	workCountBoardParserCoreChildSchema   = "gts-work-count-parsercore-child/v5"
 	workCountBoardParserCoreEngine        = "go-compact-parsercore-phase0-tagged-diagnostic"
 	workCountBoardSchema                  = "gts-work-count-board/v5"
 	workCountBoardContractSchema          = "gts-work-count-board-contract/v3"
@@ -140,6 +140,9 @@ type workCountBoardParserCoreWork struct {
 }
 
 type workCountBoardParserCoreScheduler struct {
+	Passes                     uint64 `json:"passes"`
+	SingleHeaderPasses         uint64 `json:"single_header_passes"`
+	CorridorPasses             uint64 `json:"corridor_passes"`
 	ActionLookups              uint64 `json:"action_lookups"`
 	Accepts                    uint64 `json:"accepts"`
 	Elections                  uint64 `json:"elections"`
@@ -359,7 +362,7 @@ func TestAuthenticatedFourFixtureWorkCountBoard(t *testing.T) {
 			PublicationTimingArtifact:         "ordinary untagged Go plus locked uninstrumented static C only",
 			GoBackend:                         goBackend,
 			UntaggedAssemblyTest:              "TestWorkCountProductionAssemblyHasNoDiagnosticScaffolding",
-			SchedulingFields:                  []string{"production: max_stacks_seen/multi_stack_iterations/multi_stack_tokens", "parsercore_phase0: action_lookups/accepts/elections/forks/conflicts/conflict_actions/canonicalizations/peak_headers"},
+			SchedulingFields:                  []string{"production: max_stacks_seen/multi_stack_iterations/multi_stack_tokens", "parsercore_phase0: passes/single_header_passes/corridor_passes/action_lookups/accepts/elections/forks/conflicts/conflict_actions/canonicalizations/peak_headers"},
 		},
 		Rows: make([]workCountBoardRow, 0, len(fixtures)),
 	}
@@ -596,9 +599,47 @@ func workCountRunParserCoreGo(t *testing.T, sourceRoot, artifact, fixtureID, sou
 		"candidate_fallbacks", "board_direct", "core_work", "scheduler_work", "selected_census", "raw_selected_internal_census",
 	})
 	workCountValidateBoardDirectObject(t, raw["board_direct"])
+	if err := workCountValidateParserCoreSchedulerObject(raw["scheduler_work"]); err != nil {
+		t.Fatalf("parser-core scheduler protocol: %v", err)
+	}
 	var result workCountBoardParserCoreChildResult
 	workCountDecodeExact(t, data, &result)
 	return result
+}
+
+var workCountParserCoreSchedulerFields = []string{
+	"passes", "single_header_passes", "corridor_passes", "action_lookups", "accepts", "elections",
+	"forks", "conflicts", "conflict_actions", "conflict_action_arms_admitted", "causal_conflict_forks",
+	"canonicalizations", "peak_headers", "overflow",
+}
+
+func workCountValidateParserCoreSchedulerObject(data json.RawMessage) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("decode scheduler object: %w", err)
+	}
+	if len(raw) != len(workCountParserCoreSchedulerFields) {
+		return fmt.Errorf("scheduler field count=%d want=%d", len(raw), len(workCountParserCoreSchedulerFields))
+	}
+	for _, field := range workCountParserCoreSchedulerFields {
+		value, exists := raw[field]
+		if !exists || strings.TrimSpace(string(value)) == "null" {
+			return fmt.Errorf("scheduler field %q is absent or null", field)
+		}
+	}
+	var scheduler workCountBoardParserCoreScheduler
+	if err := json.Unmarshal(data, &scheduler); err != nil {
+		return fmt.Errorf("decode scheduler counters: %w", err)
+	}
+	return workCountValidateParserCorePassMix(scheduler)
+}
+
+func workCountValidateParserCorePassMix(scheduler workCountBoardParserCoreScheduler) error {
+	if scheduler.Passes == 0 || scheduler.SingleHeaderPasses == 0 ||
+		scheduler.SingleHeaderPasses > scheduler.Passes || scheduler.CorridorPasses > scheduler.SingleHeaderPasses {
+		return fmt.Errorf("invalid scheduler pass partition: passes=%d single_header=%d corridor=%d", scheduler.Passes, scheduler.SingleHeaderPasses, scheduler.CorridorPasses)
+	}
+	return nil
 }
 
 func workCountValidateParserCoreChild(t *testing.T, result workCountBoardParserCoreChildResult, fixture benchfixtures.LoadedFixture) {
@@ -646,6 +687,9 @@ func workCountValidateParserCoreChild(t *testing.T, result workCountBoardParserC
 func workCountValidateParserCoreCounterEnvelope(result workCountBoardParserCoreChildResult) error {
 	if result.CoreWork.Overflow || result.SchedulerWork.Overflow || result.RawSelected.Overflow {
 		return fmt.Errorf("counter overflow: core=%t scheduler=%t raw=%t", result.CoreWork.Overflow, result.SchedulerWork.Overflow, result.RawSelected.Overflow)
+	}
+	if err := workCountValidateParserCorePassMix(result.SchedulerWork); err != nil {
+		return err
 	}
 	if result.CoreWork.LeafConstructionsProxy < result.RawSelected.Leaves || result.CoreWork.ParentConstructionsProxy < result.RawSelected.Parents {
 		return fmt.Errorf("construction surplus underflow: core=%+v raw=%+v", result.CoreWork, result.RawSelected)
@@ -935,6 +979,9 @@ func workCountValidateBoard(t *testing.T, contract workCountBoardContract, board
 			if row.TaggedGoScheduling != nil || row.ParserCoreScheduler == nil || !row.RepeatIdenticalCounts || row.ParserCoreScheduler.Accepts != 1 || row.ParserCoreScheduler.ActionLookups == 0 {
 				t.Fatalf("parser-core row scheduling proof invalid: %+v", row)
 			}
+			if err := workCountValidateParserCorePassMix(*row.ParserCoreScheduler); err != nil {
+				t.Fatalf("parser-core row pass partition: %v", err)
+			}
 		default:
 			t.Fatalf("unknown row backend: %+v", row)
 		}
@@ -1061,7 +1108,7 @@ func TestWorkCountBoardMetricStatusAndRatios(t *testing.T) {
 			PredecessorLinkUnionAttempts: 3, PredecessorLinkUnionDuplicateNoop: 1,
 			PredecessorLinkUnionAlternateAppended: 2,
 		},
-		SchedulerWork: workCountBoardParserCoreScheduler{ActionLookups: 12, Accepts: 1, Elections: 7, Forks: 4, Conflicts: 3, ConflictActionArmsAdmitted: 4, CausalConflictForks: 1},
+		SchedulerWork: workCountBoardParserCoreScheduler{Passes: 10, SingleHeaderPasses: 8, ActionLookups: 12, Accepts: 1, Elections: 7, Forks: 4, Conflicts: 3, ConflictActionArmsAdmitted: 4, CausalConflictForks: 1},
 		Selected:      workCountBoardSelectedCensus{Nodes: 3, Parents: 1, Leaves: 2},
 		RawSelected:   workCountBoardRawSelectedCensus{Nodes: 3, Parents: 1, Leaves: 2},
 	}
@@ -1171,7 +1218,10 @@ func TestWorkCountPerVersionCLexRequestCannotSatisfyUnionFrontierContract(t *tes
 		t.Fatalf("%s lacks lexer_elections metric", label)
 	}
 	assertUnavailable("production", workCountBuildBoardMetrics(t, contract, counts, counts, goDirect, cDirect))
-	candidate := workCountBoardParserCoreChildResult{BoardDirect: goDirect}
+	candidate := workCountBoardParserCoreChildResult{
+		BoardDirect:   goDirect,
+		SchedulerWork: workCountBoardParserCoreScheduler{Passes: 1, SingleHeaderPasses: 1},
+	}
 	assertUnavailable("parsercore", workCountBuildParserCoreBoardMetrics(t, contract, candidate, counts, cDirect))
 }
 
@@ -1195,5 +1245,88 @@ func TestWorkCountParserCoreChildSchedulerOverflowProtocol(t *testing.T) {
 	}
 	if err := workCountValidateParserCoreCounterEnvelope(got); err == nil || !strings.Contains(err.Error(), "scheduler=true") {
 		t.Fatalf("scheduler overflow protocol did not fail closed: %v", err)
+	}
+}
+
+func TestWorkCountParserCoreChildSchedulerV5Protocol(t *testing.T) {
+	want := workCountBoardParserCoreChildResult{
+		Schema: workCountBoardParserCoreChildSchema,
+		SchedulerWork: workCountBoardParserCoreScheduler{
+			Passes: 100, SingleHeaderPasses: 80, CorridorPasses: 60,
+			ActionLookups: 140, Accepts: 1, Elections: 40, PeakHeaders: 8,
+		},
+	}
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got workCountBoardParserCoreChildResult
+	workCountDecodeExact(t, data, &got)
+	if got.Schema != "gts-work-count-parsercore-child/v5" || got.SchedulerWork != want.SchedulerWork {
+		t.Fatalf("scheduler v5 protocol drifted: %+v", got)
+	}
+	schedulerData, err := json.Marshal(got.SchedulerWork)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := workCountValidateParserCoreSchedulerObject(schedulerData); err != nil {
+		t.Fatalf("valid scheduler v5 object: %v", err)
+	}
+	if err := workCountValidateParserCoreCounterEnvelope(got); err != nil {
+		t.Fatalf("valid scheduler v5 envelope: %v", err)
+	}
+	got.SchedulerWork.CorridorPasses = 0
+	if err := workCountValidateParserCorePassMix(got.SchedulerWork); err != nil {
+		t.Fatalf("disabled corridor failed admission: %v", err)
+	}
+
+	for _, field := range workCountParserCoreSchedulerFields {
+		for _, corruption := range []string{"missing", "null"} {
+			t.Run(field+"/"+corruption, func(t *testing.T) {
+				var raw map[string]json.RawMessage
+				if err := json.Unmarshal(schedulerData, &raw); err != nil {
+					t.Fatal(err)
+				}
+				if corruption == "missing" {
+					delete(raw, field)
+				} else {
+					raw[field] = json.RawMessage("null")
+				}
+				data, err := json.Marshal(raw)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := workCountValidateParserCoreSchedulerObject(data); err == nil {
+					t.Fatalf("scheduler admitted %s field %q", corruption, field)
+				}
+			})
+		}
+	}
+	for _, tc := range []struct {
+		name, field, value string
+	}{
+		{"unknown", "future_counter", "0"},
+		{"wrong_type", "single_header_passes", `"80"`},
+		{"negative", "passes", "-1"},
+		{"overflow", "passes", "18446744073709551616"},
+		{"zero_passes", "passes", "0"},
+		{"zero_single", "single_header_passes", "0"},
+		{"single_exceeds_total", "single_header_passes", "101"},
+		{"corridor_exceeds_single", "corridor_passes", "81"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var raw map[string]json.RawMessage
+			if err := json.Unmarshal(schedulerData, &raw); err != nil {
+				t.Fatal(err)
+			}
+			raw[tc.field] = json.RawMessage(tc.value)
+			data, err := json.Marshal(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := workCountValidateParserCoreSchedulerObject(data); err == nil {
+				t.Fatalf("scheduler admitted %s", tc.name)
+			}
+		})
 	}
 }

--- a/cgo_harness/work_count_oracle_test.go
+++ b/cgo_harness/work_count_oracle_test.go
@@ -514,7 +514,7 @@ func TestAuthenticatedWorkCountOracle(t *testing.T) {
 	t.Log("build: ordinary untagged Go admission child")
 	goAdmissionArtifact, goAdmissionIdentity, goAdmissionRecheck := workCountBuildGo(t, sourceSnapshot, tempRoot, goEnvironment, false)
 	t.Log("admission: ordinary untagged Go child")
-	uninstGo := workCountRunGoAdmission(t, goAdmissionArtifact, fixture.Fixture.ID, sourcePath, tempRoot, goEnvironment)
+	uninstGo := workCountRunGoAdmission(t, sourceSnapshot.Root, goAdmissionArtifact, fixture.Fixture.ID, sourcePath, tempRoot, goEnvironment)
 	workCountValidateGoChild(t, "ordinary Go admission", workCountGoAdmissionChildSchema, "go-production-glr-untagged", uninstGo, fixture)
 	t.Log("admission: unmodified static C")
 	uninstC := workCountUninstrumentedCAdmission(t, fixture, sourcePath, tempRoot)
@@ -531,7 +531,7 @@ func TestAuthenticatedWorkCountOracle(t *testing.T) {
 	t.Log("run: instrumented static C child")
 	cResult := workCountRunC(t, cBuild.Artifact, sourcePath, tempRoot)
 	t.Log("run: tagged diagnostic Go child")
-	goResult := workCountRunGo(t, goArtifact, fixture.Fixture.ID, sourcePath, tempRoot, goEnvironment)
+	goResult := workCountRunGo(t, sourceSnapshot.Root, goArtifact, fixture.Fixture.ID, sourcePath, tempRoot, goEnvironment)
 	workCountValidateCChild(t, "static C", "static-c-instrumented-glr", cResult, fixture, uninstC)
 	workCountValidateGoChild(t, "tagged Go", workCountTaggedGoChildSchema, "go-production-glr-tagged-diagnostic", goResult.workCountGoChildResult, fixture)
 	workCountValidateGoCounters(t, "tagged Go", goResult.Counters, uint32(len(fixture.Source)))
@@ -1212,10 +1212,10 @@ func workCountRunC(t *testing.T, artifact, sourcePath, tempRoot string) workCoun
 	return result
 }
 
-func workCountRunGoAdmission(t *testing.T, artifact, fixtureID, sourcePath, tempRoot string, environment workCountEnvironment) workCountGoChildResult {
+func workCountRunGoAdmission(t *testing.T, sourceRoot, artifact, fixtureID, sourcePath, tempRoot string, environment workCountEnvironment) workCountGoChildResult {
 	t.Helper()
 	resultPath := filepath.Join(tempRoot, "go-admission.json")
-	workCountRunGoChild(t, artifact, "^TestWorkCountAdmissionChild$", fixtureID, sourcePath, resultPath, environment)
+	workCountRunGoChild(t, sourceRoot, artifact, "^TestWorkCountAdmissionChild$", fixtureID, sourcePath, resultPath, environment)
 	data, err := os.ReadFile(resultPath)
 	if err != nil {
 		t.Fatal(err)
@@ -1223,10 +1223,10 @@ func workCountRunGoAdmission(t *testing.T, artifact, fixtureID, sourcePath, temp
 	return workCountDecodeGoChild(t, data)
 }
 
-func workCountRunGo(t *testing.T, artifact, fixtureID, sourcePath, tempRoot string, environment workCountEnvironment) workCountTaggedChildResult {
+func workCountRunGo(t *testing.T, sourceRoot, artifact, fixtureID, sourcePath, tempRoot string, environment workCountEnvironment) workCountTaggedChildResult {
 	t.Helper()
 	resultPath := filepath.Join(tempRoot, "go-work-count.json")
-	workCountRunGoChild(t, artifact, "^TestDiagnosticWorkCountChild$", fixtureID, sourcePath, resultPath, environment)
+	workCountRunGoChild(t, sourceRoot, artifact, "^TestDiagnosticWorkCountChild$", fixtureID, sourcePath, resultPath, environment)
 	data, err := os.ReadFile(resultPath)
 	if err != nil {
 		t.Fatal(err)
@@ -1234,8 +1234,11 @@ func workCountRunGo(t *testing.T, artifact, fixtureID, sourcePath, tempRoot stri
 	return workCountDecodeTaggedGoChild(t, data)
 }
 
-func workCountRunGoChild(t *testing.T, artifact, testPattern, fixtureID, sourcePath, resultPath string, environment workCountEnvironment) {
+func workCountRunGoChild(t *testing.T, sourceRoot, artifact, testPattern, fixtureID, sourcePath, resultPath string, environment workCountEnvironment) {
 	t.Helper()
+	if !filepath.IsAbs(sourceRoot) {
+		t.Fatal("Go child source root must be an absolute snapshot path")
+	}
 	if strings.TrimSpace(fixtureID) == "" {
 		t.Fatal("Go child fixture ID is empty")
 	}
@@ -1247,7 +1250,9 @@ func workCountRunGoChild(t *testing.T, artifact, testPattern, fixtureID, sourceP
 		"GTS_WORK_COUNT_SOURCE": sourcePath,
 		"GTS_WORK_COUNT_RESULT": resultPath,
 	})
-	stdout, stderr, err := workCountRunCaptured("", runtimeEnv, workCountTimeout+staticCPerfWallGrace, artifact, "-test.run", testPattern, "-test.count=1")
+	// Package initialization can read fixtures before the selected test starts.
+	// Resolve those files inside the authenticated source snapshot.
+	stdout, stderr, err := workCountRunCaptured(sourceRoot, runtimeEnv, workCountTimeout+staticCPerfWallGrace, artifact, "-test.run", testPattern, "-test.count=1")
 	if err != nil {
 		t.Fatalf("Go child: %v: stdout=%s stderr=%s", err, strings.TrimSpace(string(stdout)), strings.TrimSpace(string(stderr)))
 	}

--- a/cgo_harness/work_count_security_test.go
+++ b/cgo_harness/work_count_security_test.go
@@ -705,6 +705,60 @@ func TestWorkCountSanitizedEnvDropsParserAndGoOverrides(t *testing.T) {
 	}
 }
 
+func TestWorkCountGoChildUsesPrivateSourceDirectory(t *testing.T) {
+	const fixtureID = "private-source-directory-probe"
+	const witnessName = "work-count-child-directory.txt"
+	if os.Getenv(workCountFixtureEnv) == fixtureID {
+		data, err := os.ReadFile(filepath.Join("testdata", witnessName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(os.Getenv("GTS_WORK_COUNT_RESULT"), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+
+	parentDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(sourceRoot, "testdata"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	witness := []byte("private snapshot fixture\n")
+	sourcePath := filepath.Join(sourceRoot, "testdata", witnessName)
+	if err := os.WriteFile(sourcePath, witness, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	beforeSHA, beforeFiles, err := workCountTreeSHA(sourceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := workCountMakeTreeReadOnly(sourceRoot); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = workCountMakeTreeWritable(sourceRoot) })
+	artifact, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultPath := filepath.Join(t.TempDir(), "child-result.txt")
+	workCountRunGoChild(t, sourceRoot, artifact, "^TestWorkCountGoChildUsesPrivateSourceDirectory$",
+		fixtureID, sourcePath, resultPath, workCountChosenEnvironment())
+	got, err := os.ReadFile(resultPath)
+	if err != nil || !bytes.Equal(got, witness) {
+		t.Fatalf("child fixture=%q want=%q err=%v", got, witness, err)
+	}
+	if got, err := os.Getwd(); err != nil || got != parentDirectory {
+		t.Fatalf("parent directory=%q want=%q err=%v", got, parentDirectory, err)
+	}
+	if gotSHA, gotFiles, err := workCountTreeSHA(sourceRoot); err != nil || gotSHA != beforeSHA || gotFiles != beforeFiles {
+		t.Fatalf("private snapshot changed: sha=%s files=%d want=%s/%d err=%v", gotSHA, gotFiles, beforeSHA, beforeFiles, err)
+	}
+}
+
 func TestWorkCountRunCapturedKillsDescendantProcessGroup(t *testing.T) {
 	marker := filepath.Join(t.TempDir(), "descendant-escaped")
 	environment := workCountSanitizedEnv(os.Environ(), nil, map[string]string{

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,11 +43,41 @@ export GTS_RECOVERY_CORPUS_FILE=/absolute/path/to/corpus-file
 export GTS_RECOVERY_CORPUS_LANG=elixir
 ```
 
-Run both checkouts with the same seed range. Alternate checkout order between
-seed batches when the host cannot stay thermally stable.
+Run a paired comparison from the candidate checkout. Supply the baseline
+checkout and a separate output path.
 
 ```sh
-bash scripts/run_randomized_benchmarks.sh --output /tmp/gts-base.txt
-bash scripts/run_randomized_benchmarks.sh --output /tmp/gts-head.txt
+bash scripts/run_randomized_benchmarks.sh \
+  --baseline-root /absolute/path/to/baseline \
+  --baseline-output /tmp/gts-base.txt \
+  --output /tmp/gts-head.txt
 benchstat /tmp/gts-base.txt /tmp/gts-head.txt
 ```
+
+Each pair uses the same shuffle seed. The driver reverses checkout order for
+each successive seed and holds one lock across the complete campaign.
+Each process uses `GOMAXPROCS=1`, `-count=1`, and `-benchmem`.
+The defaults remain 20 seeds and a 750 millisecond benchmark duration.
+
+The current driver runs both checkouts. The baseline does not need to contain
+this script. Each output records the checkout identity, settings, and seed
+boundaries. Dirty checkout metadata identifies development runs; it does not
+authenticate their source contents.
+
+Require `# status: complete` as the final line in both outputs before comparing
+them. A failed or interrupted process leaves the campaign incomplete.
+Output paths must differ and must not already exist.
+
+Use `--require-benchmarks` with comma-separated names to require those timing
+rows in every process. The driver removes Go's CPU suffix before matching.
+Continuous integration requires each member of the primary trio for every
+seed. A partial sample set cannot pass as a complete comparison.
+
+Set the same build tags and fixture controls for both checkouts. Use
+`--tags ''` to measure the ordinary build. Keep instrumented diagnostics
+separate from timing evidence. Paired order reduces drift bias but does not
+establish a quiet host or certify grammar parity.
+
+Continuous integration uses paired runs for its advisory Go benchmark trio.
+It retains the separate memory probe and reports interrupted campaigns as
+inconclusive. Use certified corpus and fleet runs for language-wide claims.

--- a/scripts/run_randomized_benchmarks.sh
+++ b/scripts/run_randomized_benchmarks.sh
@@ -7,27 +7,38 @@ usage() {
 Usage: scripts/run_randomized_benchmarks.sh --output PATH [options]
 
 Run the combined performance set once for each shuffle seed.
+Pair a baseline with the current directory to alternate execution order.
 
 Options:
-  --output PATH       Append raw go test output to PATH.
+  --output PATH       Write raw output for the current directory to PATH.
+  --baseline-root DIR Run the same seeds in DIR. Requires --baseline-output.
+  --baseline-output PATH
+                      Write baseline output to PATH. Requires --baseline-root.
   --lock-path PATH    Host lock path. Default: /tmp/gotreesitter-run-randomized-benchmarks.lock.
   --runs N            Number of seeds to run. Default: 20.
   --seed-start N      First shuffle seed. Default: 1.
   --benchtime D       Benchmark duration. Default: 750ms.
   --tags TAGS         Go build tags. Default: gts_parsercorephase0.
   --bench-regex REGEX Benchmark selection regex. Default: combined set.
+  --require-benchmarks CSV
+                      Require each exact benchmark name once per process, with all three standard metrics.
   --package PATH      Go package path. Default: .
   --help              Show this help.
 EOF
 }
 
 output_path=""
+baseline_root=""
+baseline_output=""
+baseline_root_set=0
+baseline_output_set=0
 lock_path="/tmp/gotreesitter-run-randomized-benchmarks.lock"
 runs=20
 seed_start=1
 benchtime=750ms
 build_tags=gts_parsercorephase0
 package_path=.
+required_benchmarks=""
 benchmark_re='^(BenchmarkGoParse(FullDFA|CoreDFA|IncrementalSingleByteEditDFA|IncrementalNoEditDFA|IncrementalRandomSingleByteEdit)|Benchmark(KDLRecoveryGarbageSuffix|RecoveryCorpusFile)|BenchmarkExpectedRootCanFrameLongRepeat|BenchmarkDiagnosticParserCore(CorridorSchedulerOnly|WarmSchedulerOnlyQueryCompile|WarmMaterializationOnlyQueryCompile)|BenchmarkParserCoreFreshFull(Canonical|SelectedStoreCanonical)|Benchmark(TaggerTag(Tree)?Go|ExtractCodeUnderstanding(Tree)?Go|ExtractAllFactsTreeGo|FactProgram(All)?(Tree)?Go))$'
 
 while (($# > 0)); do
@@ -38,6 +49,24 @@ while (($# > 0)); do
 			exit 2
 		fi
 		output_path=$2
+		shift 2
+		;;
+	--baseline-root)
+		if (($# < 2)) || [[ -z "$2" ]]; then
+			printf '%s\n' "--baseline-root requires a directory" >&2
+			exit 2
+		fi
+		baseline_root=$2
+		baseline_root_set=1
+		shift 2
+		;;
+	--baseline-output)
+		if (($# < 2)) || [[ -z "$2" ]]; then
+			printf '%s\n' "--baseline-output requires a path" >&2
+			exit 2
+		fi
+		baseline_output=$2
+		baseline_output_set=1
 		shift 2
 		;;
 	--lock-path)
@@ -88,6 +117,14 @@ while (($# > 0)); do
 		benchmark_re=$2
 		shift 2
 		;;
+	--require-benchmarks)
+		if (($# < 2)) || [[ -z "$2" ]]; then
+			printf '%s\n' '--require-benchmarks requires a comma-separated name list' >&2
+			exit 2
+		fi
+		required_benchmarks=$2
+		shift 2
+		;;
 	--package)
 		if (($# < 2)); then
 			printf '%s\n' "--package requires a path" >&2
@@ -124,13 +161,69 @@ if [[ ! "$seed_start" =~ ^[0-9]+$ ]]; then
 	exit 2
 fi
 
-if [[ -e "$output_path" ]]; then
-	printf 'output already exists: %s\n' "$output_path" >&2
+if [[ -z "$lock_path" ]]; then
+	printf '%s\n' "--lock-path requires a path" >&2
 	exit 2
 fi
 
-if [[ -z "$lock_path" ]]; then
-	printf '%s\n' "--lock-path requires a path" >&2
+if [[ -n "$required_benchmarks" ]]; then
+	if [[ "$required_benchmarks" == ,* || "$required_benchmarks" == *, || "$required_benchmarks" == *,,* ]]; then
+		printf '%s\n' '--require-benchmarks contains an empty name' >&2
+		exit 2
+	fi
+	declare -A required_seen=()
+	IFS=',' read -r -a required_names <<<"$required_benchmarks"
+	for name in "${required_names[@]}"; do
+		if [[ ! "$name" =~ ^Benchmark[^[:space:],]+$ || -n "${required_seen[$name]:-}" ]]; then
+			printf 'invalid or duplicate required benchmark name: %s\n' "$name" >&2
+			exit 2
+		fi
+		required_seen[$name]=1
+	done
+fi
+
+if ((baseline_root_set != baseline_output_set)); then
+	printf '%s\n' '--baseline-root and --baseline-output must be supplied together' >&2
+	exit 2
+fi
+
+head_root=$(pwd -P)
+protocol=single-seed-processes
+if ((baseline_root_set)); then
+	if [[ ! -d "$baseline_root" ]]; then
+		printf 'baseline directory does not exist: %s\n' "$baseline_root" >&2
+		exit 2
+	fi
+	baseline_root=$(cd -- "$baseline_root" && pwd -P)
+	protocol=paired-alternating-seeds
+fi
+
+if ! command -v realpath >/dev/null 2>&1; then
+	printf '%s\n' 'realpath is required to validate output paths' >&2
+	exit 2
+fi
+
+requested_outputs=("$output_path")
+if ((baseline_root_set)); then
+	requested_outputs+=("$baseline_output")
+fi
+for path in "${requested_outputs[@]}"; do
+	if [[ -e "$path" || -L "$path" ]]; then
+		printf 'output already exists: %s\n' "$path" >&2
+		exit 2
+	fi
+done
+output_path=$(realpath -m -- "$output_path")
+canonical_lock=$(realpath -m -- "$lock_path")
+if ((baseline_root_set)); then
+	baseline_output=$(realpath -m -- "$baseline_output")
+	if [[ "$output_path" == "$baseline_output" ]]; then
+		printf '%s\n' 'baseline and current output paths must be distinct' >&2
+		exit 2
+	fi
+fi
+if [[ "$output_path" == "$canonical_lock" || "$baseline_output" == "$canonical_lock" ]]; then
+	printf '%s\n' 'output and lock paths must be distinct' >&2
 	exit 2
 fi
 
@@ -143,6 +236,14 @@ lock_dir=$(dirname -- "$lock_path")
 mkdir -p -- "$lock_dir"
 lock_fd=""
 lock_held=0
+created_outputs=()
+
+mark_incomplete() {
+	local path
+	for path in "${created_outputs[@]}"; do
+		printf '# status: incomplete\n' >>"$path" || true
+	done
+}
 
 release_lock() {
 	if ((lock_held == 0)); then
@@ -155,12 +256,16 @@ release_lock() {
 
 exit_with_lock_status() {
 	local status=$?
+	if ((status != 0)); then
+		mark_incomplete
+	fi
 	release_lock
 	exit "$status"
 }
 
 exit_after_signal() {
 	local signal=$1
+	mark_incomplete
 	release_lock
 	trap - "$signal"
 	kill -s "$signal" "$$"
@@ -194,32 +299,141 @@ lock_cwd=$(pwd -P)
 	printf 'started=%s\n' "$lock_started"
 	printf 'cwd=%s\n' "$lock_cwd"
 	printf 'output=%s\n' "$output_path"
+	if ((baseline_root_set)); then
+		printf 'baseline_root=%s\n' "$baseline_root"
+		printf 'baseline_output=%s\n' "$baseline_output"
+	fi
 } >"$lock_path"
 
-output_dir=$(dirname -- "$output_path")
-mkdir -p -- "$output_dir"
+source_metadata() {
+	local root=$1 suffix=$2 repository revision dirty state
+	repository=$(git --no-optional-locks -C "$root" rev-parse --show-toplevel 2>/dev/null) || repository=unavailable
+	revision=$(git --no-optional-locks -C "$root" rev-parse --verify HEAD 2>/dev/null) || revision=unavailable
+	dirty=unknown
+	if state=$(git --no-optional-locks -C "$root" status --porcelain=v1 --untracked-files=normal 2>/dev/null); then
+		dirty=false
+		[[ -z "$state" ]] || dirty=true
+	fi
+	printf '# repository root%s: %s\n' "$suffix" "$repository"
+	printf '# revision%s: %s\n' "$suffix" "$revision"
+	printf '# dirty%s: %s\n' "$suffix" "$dirty"
+}
+
+initialize_output() {
+	local root=$1 role=$2 path=$3 identity
+	identity=$(source_metadata "$root" '')
+	mkdir -p -- "$(dirname -- "$path")"
+	if ! (set -o noclobber; : >"$path"); then
+		printf 'cannot create output without overwriting it: %s\n' "$path" >&2
+		return 2
+	fi
+	created_outputs+=("$path")
+	{
+		printf '# status: incomplete\n'
+		printf '# protocol: %s\n' "$protocol"
+		printf '# role: %s\n' "$role"
+		printf '# working directory: %s\n' "$root"
+		printf '%s\n' "$identity"
+		printf '# source metadata: informational; no source snapshot authentication\n'
+		printf '# started: %s\n' "$lock_started"
+		printf '# package: %s\n' "$package_path"
+		printf '# bench regex: %s\n' "$benchmark_re"
+		printf '# required benchmarks: %s\n' "${required_benchmarks:-none}"
+		printf '# build tags: %s\n' "$build_tags"
+		printf '# seeds: %s..%s\n' "$seed_start" "$((seed_start + runs - 1))"
+		printf '# benchtime: %s\n' "$benchtime"
+		printf '# GOMAXPROCS: 1\n'
+		printf '# count per process: 1\n'
+	} >>"$path"
+}
+
+run_seed() {
+	local root=$1 role=$2 path=$3 seed=$4 position=$5 sample_start
+	printf 'running %s shuffle seed %d\n' "$role" "$seed" >&2
+	printf '# seed: %d; position: %d\n' "$seed" "$position" >>"$path"
+	sample_start=$(wc -c <"$path")
+	(
+		cd -- "$root"
+		GOMAXPROCS=1 go test -tags "$build_tags" "$package_path" \
+			-run '^$' \
+			-bench "$benchmark_re" \
+			-benchmem \
+			-count=1 \
+			-benchtime="$benchtime" \
+			-shuffle="$seed"
+	) >>"$path"
+	if ! tail -c "+$((sample_start + 1))" "$path" | GTS_BENCH_REQUIRED_NAMES="$required_benchmarks" awk '
+		BEGIN {
+			required = ENVIRON["GTS_BENCH_REQUIRED_NAMES"]
+			if (required != "") {
+				n = split(required, names, ",")
+				for (i = 1; i <= n; i++) wanted[names[i]] = 1
+			}
+		}
+		/^Benchmark[^[:space:]]+[[:space:]]/ && $2 ~ /^[1-9][0-9]*$/ {
+			name = $1
+			if (!(name in wanted)) sub(/-[0-9]+$/, "", name)
+			ns = bytes = allocs = 0
+			for (i = 3; i < NF; i += 2) {
+				if ($i ~ /^([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?$/) {
+					if ($(i + 1) == "ns/op") ns = 1
+					if ($(i + 1) == "B/op") bytes = 1
+					if ($(i + 1) == "allocs/op") allocs = 1
+				}
+			}
+			if (ns) found = 1
+			if (name in wanted) {
+				counts[name]++
+				if (!ns || !bytes || !allocs) invalid[name] = 1
+			}
+		}
+		END {
+			bad = !found
+			for (name in wanted) {
+				if (counts[name] != 1 || invalid[name]) {
+					printf "required benchmark %s needs one valid ns/op, B/op, and allocs/op row; rows=%d\n", name, counts[name] > "/dev/stderr"
+					bad = 1
+				}
+			}
+			exit bad
+		}
+	'; then
+		printf '%s seed %d produced no valid benchmark timing row or an incomplete required set\n' "$role" "$seed" >&2
+		return 1
+	fi
+}
 
 printf 'randomized benchmark output: %s\n' "$output_path" >&2
 printf 'seeds: %s..%s\n' "$seed_start" "$((seed_start + runs - 1))" >&2
 printf 'benchtime: %s\n' "$benchtime" >&2
-{
-	printf '# package: %s\n' "$package_path"
-	printf '# bench regex: %s\n' "$benchmark_re"
-	printf '# build tags: %s\n' "$build_tags"
-	printf '# seeds: %s..%s\n' "$seed_start" "$((seed_start + runs - 1))"
-	printf '# benchtime: %s\n' "$benchtime"
-} >"$output_path"
+initialize_output "$head_root" head "$output_path"
+if ((baseline_root_set)); then
+	printf 'randomized baseline output: %s\n' "$baseline_output" >&2
+	initialize_output "$baseline_root" baseline "$baseline_output"
+fi
 
 for ((offset = 0; offset < runs; offset++)); do
 	seed=$((seed_start + offset))
-	printf 'running shuffle seed %d\n' "$seed" >&2
-	GOMAXPROCS=1 go test -tags "$build_tags" "$package_path" \
-		-run '^$' \
-		-bench "$benchmark_re" \
-		-benchmem \
-		-count=1 \
-		-benchtime="$benchtime" \
-		-shuffle="$seed" >>"$output_path"
+	if ((baseline_root_set == 0)); then
+		run_seed "$head_root" head "$output_path" "$seed" 1
+	elif ((offset % 2 == 0)); then
+		run_seed "$baseline_root" baseline "$baseline_output" "$seed" 1
+		run_seed "$head_root" head "$output_path" "$seed" 2
+	else
+		run_seed "$head_root" head "$output_path" "$seed" 1
+		run_seed "$baseline_root" baseline "$baseline_output" "$seed" 2
+	fi
+	seed_completed=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+	for path in "${created_outputs[@]}"; do
+		printf '# completed seed: %d; at: %s\n' "$seed" "$seed_completed" >>"$path"
+	done
 done
 
+source_metadata "$head_root" ' at end' >>"$output_path"
+if ((baseline_root_set)); then
+	source_metadata "$baseline_root" ' at end' >>"$baseline_output"
+fi
+for path in "${created_outputs[@]}"; do
+	printf '# completed runs: %d\n# status: complete\n' "$runs" >>"$path"
+done
 printf 'completed %d randomized runs\n' "$runs" >&2

--- a/scripts/run_randomized_benchmarks_test.sh
+++ b/scripts/run_randomized_benchmarks_test.sh
@@ -14,10 +14,13 @@ dash_pid=""
 signal_pid=""
 independent_a_pid=""
 independent_b_pid=""
+paired_pid=""
+paired_release=""
 
 cleanup() {
 	local pid
-	for pid in "$first_pid" "$dash_pid" "$signal_pid" "$independent_a_pid" "$independent_b_pid"; do
+	[[ -z "$paired_release" ]] || : >"$paired_release"
+	for pid in "$first_pid" "$dash_pid" "$signal_pid" "$independent_a_pid" "$independent_b_pid" "$paired_pid"; do
 		if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
 			kill -TERM "$pid" 2>/dev/null || true
 		fi
@@ -47,6 +50,11 @@ assert_not_contains() {
 	if grep -F -- "$needle" "$file" >/dev/null; then
 		fail "unexpected '$needle' in $file"
 	fi
+}
+
+assert_status() {
+	local status=$1 file=$2
+	[[ "$(tail -n 1 "$file")" == "# status: $status" ]] || fail "final status is not $status in $file"
 }
 
 line_count() {
@@ -81,6 +89,13 @@ set -euo pipefail
 
 : "${MOCK_GO_LOG:?MOCK_GO_LOG is required}"
 printf 'pid=%s args=%s\n' "$$" "$*" >>"$MOCK_GO_LOG"
+if [[ -n "${MOCK_GO_SEQUENCE_LOG:-}" ]]; then
+	printf '%s\t%s\t%s\n' "$PWD" "${GOMAXPROCS:-}" "$*" >>"$MOCK_GO_SEQUENCE_LOG"
+fi
+if [[ -n "${MOCK_GO_FAIL_CALL:-}" ]] && [[ "$(wc -l <"$MOCK_GO_LOG")" -eq "$MOCK_GO_FAIL_CALL" ]]; then
+	printf '%s\n' 'mock benchmark failure' >&2
+	exit 23
+fi
 if [[ -n "${MOCK_GO_READY:-}" ]]; then
 	: >"$MOCK_GO_READY"
 fi
@@ -89,8 +104,51 @@ if [[ -n "${MOCK_GO_WAIT_FILE:-}" ]]; then
 		sleep 0.01
 	done
 fi
+case "${MOCK_GO_OUTPUT_KIND:-valid}" in
+	none) printf '%s\n' 'PASS' ;;
+	malformed) printf '%s\n' 'BenchmarkWitness-1 1 invalid ns/op 16 B/op 1 allocs/op' ;;
+	numeric-subbenchmark) printf '%s\n' 'BenchmarkFixture/size-64 5 100 ns/op 16 B/op 1 allocs/op' ;;
+	trio|partial-trio|duplicate-trio|invalid-trio)
+		printf '%s\n' 'BenchmarkGoParseFullDFA-12 5 100 ns/op 16 B/op 1 allocs/op'
+		printf '%s\n' 'BenchmarkGoParseIncrementalSingleByteEditDFA-12 5 20 ns/op 0 B/op 0 allocs/op'
+		case "$MOCK_GO_OUTPUT_KIND" in
+			partial-trio)
+				if [[ "$(wc -l <"$MOCK_GO_LOG")" -eq 3 ]]; then
+					exit 0
+				fi
+				;;
+			duplicate-trio)
+				printf '%s\n' 'BenchmarkGoParseFullDFA-12 5 100 ns/op 16 B/op 1 allocs/op'
+				;;
+			invalid-trio)
+				printf '%s\n' 'BenchmarkGoParseIncrementalNoEditDFA-12 5 1 ns/op 0 allocs/op'
+				exit 0
+				;;
+		esac
+		printf '%s\n' 'BenchmarkGoParseIncrementalNoEditDFA-12 5 1 ns/op 0 B/op 0 allocs/op'
+		;;
+	*) printf '%s\n' 'BenchmarkWitness-1 1 100 ns/op 16 B/op 1 allocs/op' ;;
+esac
 EOF
 chmod +x "$mock_bin/go"
+
+real_date=$(command -v date)
+cat >"$mock_bin/date" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -n "${MOCK_DATE_AFTER_CALLS:-}" ]] && [[ -f "$MOCK_GO_LOG" ]] && \
+	[[ "$(wc -l <"$MOCK_GO_LOG")" -eq "$MOCK_DATE_AFTER_CALLS" ]] && [[ ! -e "$MOCK_DATE_READY" ]]; then
+	: >"$MOCK_DATE_READY"
+	while [[ ! -e "$MOCK_DATE_RELEASE" ]]; do
+		sleep 0.01
+	done
+fi
+exec "$MOCK_REAL_DATE" "$@"
+EOF
+chmod +x "$mock_bin/date"
+export MOCK_REAL_DATE="$real_date"
 
 cd -- "$repo_root"
 
@@ -135,6 +193,9 @@ pass 'the first runner owns the lock and the second runner fails before go'
 first_status=0
 wait "$first_pid" || first_status=$?
 [[ "$first_status" -eq 0 ]] || fail "first runner returned $first_status"
+assert_status complete "$first_output"
+assert_contains '# protocol: single-seed-processes' "$first_output"
+assert_contains '# completed runs: 1' "$first_output"
 
 printf '%s\n' \
 	'pid=stale' \
@@ -208,6 +269,7 @@ kill -TERM -- "-$signal_pid" 2>/dev/null || kill -TERM "$signal_pid"
 signal_status=0
 wait "$signal_pid" || signal_status=$?
 [[ "$signal_status" -ne 0 ]] || fail 'signal termination returned success'
+assert_status incomplete "$test_root/signal.txt"
 if ! flock -n "$signal_lock" -c ':'; then
 	fail 'the signal path did not release the lock'
 fi
@@ -263,5 +325,182 @@ wait "$independent_b_pid" || independent_b_status=$?
 [[ "$(line_count "$independent_b_log")" -eq 1 ]] || fail 'lock path B did not invoke its mock go'
 pass 'distinct explicit lock paths run independently'
 
+baseline_root="$test_root/baseline checkout/cgo_harness"
+mkdir -p -- "$baseline_root"
+head_root="$repo_root/cgo_harness"
+paired_log="$test_root/paired-go.log"
+paired_sequence="$test_root/paired-sequence.txt"
+paired_head="$test_root/paired-head.txt"
+paired_base="$test_root/paired-base.txt"
+paired_bench='^BenchmarkWitness(A|B)$'
+(
+	cd -- "$head_root"
+	PATH="$mock_bin:$PATH" MOCK_GO_LOG="$paired_log" MOCK_GO_SEQUENCE_LOG="$paired_sequence" \
+	bash "$runner" --output "$paired_head" --baseline-root "$baseline_root" \
+		--baseline-output "$paired_base" --runs 4 --seed-start 17 --benchtime 37ms \
+		--tags fixture,other --package ./cmd/fixture --bench-regex "$paired_bench" \
+		--lock-path "$test_root/paired.lock" >"$test_root/paired.stdout" 2>"$test_root/paired.stderr"
+)
+{
+	for ((offset = 0; offset < 4; offset++)); do
+		seed=$((17 + offset))
+		if ((offset % 2 == 0)); then
+			roots=("$baseline_root" "$head_root")
+		else
+			roots=("$head_root" "$baseline_root")
+		fi
+		for root in "${roots[@]}"; do
+			printf '%s\t1\ttest -tags fixture,other ./cmd/fixture -run ^$ -bench %s -benchmem -count=1 -benchtime=37ms -shuffle=%d\n' \
+				"$root" "$paired_bench" "$seed"
+		done
+	done
+} >"$test_root/paired-expected.txt"
+cmp "$paired_sequence" "$test_root/paired-expected.txt" || fail 'paired order, directory, environment, or arguments differ'
+for file in "$paired_head" "$paired_base"; do
+	assert_status complete "$file"
+	assert_contains '# protocol: paired-alternating-seeds' "$file"
+	assert_contains '# completed runs: 4' "$file"
+	assert_contains '# completed seed: 20;' "$file"
+done
+assert_contains "# working directory: $head_root" "$paired_head"
+assert_contains "# repository root: $repo_root" "$paired_head"
+assert_contains "# revision: $(git -C "$repo_root" rev-parse HEAD)" "$paired_head"
+assert_contains '# repository root: unavailable' "$paired_base"
+assert_contains '# dirty: unknown' "$paired_base"
+assert_contains '# source metadata: informational; no source snapshot authentication' "$paired_head"
+assert_contains '# seed: 17; position: 1' "$paired_base"
+assert_contains '# seed: 18; position: 1' "$paired_head"
+pass 'paired seeds alternate directories with identical settings and separate source metadata'
+
+reject_count=0
+expect_rejected() {
+	local status=0 head
+	reject_count=$((reject_count + 1))
+	head="$test_root/rejected-head-$reject_count.txt"
+	PATH="$mock_bin:$PATH" MOCK_GO_LOG="$test_root/rejected-go.log" \
+	bash "$runner" --output "$head" --runs 1 --lock-path "$test_root/rejected.lock" "$@" \
+		>"$test_root/rejected.stdout" 2>"$test_root/rejected.stderr" || status=$?
+	[[ "$status" -eq 2 ]] || fail "invalid paired arguments returned $status, want 2"
+	[[ ! -e "$head" ]] || fail 'invalid arguments created an output'
+	[[ ! -e "$test_root/rejected-go.log" ]] || fail 'invalid arguments invoked go'
+}
+expect_rejected --baseline-root "$baseline_root"
+expect_rejected --baseline-output "$test_root/unused.txt"
+expect_rejected --baseline-root '' --baseline-output "$test_root/unused.txt"
+expect_rejected --baseline-root "$test_root/missing" --baseline-output "$test_root/unused.txt"
+expect_rejected --baseline-root "$baseline_root" --baseline-output "$paired_base"
+expect_rejected --baseline-root "$baseline_root" --baseline-output "$test_root/rejected-head-6.txt"
+mkdir -p "$test_root/real-output"
+ln -s "$test_root/real-output" "$test_root/output-alias"
+expect_rejected --output "$test_root/real-output/new.txt" --baseline-root "$baseline_root" \
+	--baseline-output "$test_root/output-alias/new.txt"
+[[ ! -e "$test_root/real-output/new.txt" ]] || fail 'aliased outputs created a file'
+ln -s "$test_root/dangling-target.txt" "$test_root/dangling-output.txt"
+expect_rejected --baseline-root "$baseline_root" --baseline-output "$test_root/dangling-output.txt"
+[[ ! -e "$test_root/dangling-target.txt" ]] || fail 'a dangling output symlink was followed'
+expect_rejected --output "$test_root/rejected.lock"
+expect_rejected --require-benchmarks ''
+expect_rejected --require-benchmarks 'BenchmarkWitness,BenchmarkWitness'
+expect_rejected --require-benchmarks 'BenchmarkWitness,'
+expect_rejected --require-benchmarks 'BenchmarkWitness, AnotherBenchmark'
+pass 'paired options and output collisions fail before file creation or go'
+
+failed_log="$test_root/failed-go.log"
+failed_head="$test_root/failed-head.txt"
+failed_base="$test_root/failed-base.txt"
+failed_status=0
+PATH="$mock_bin:$PATH" MOCK_GO_LOG="$failed_log" MOCK_GO_FAIL_CALL=3 \
+bash "$runner" --output "$failed_head" --baseline-root "$baseline_root" --baseline-output "$failed_base" \
+	--runs 3 --seed-start 17 --tags '' --lock-path "$test_root/failed.lock" \
+	>"$test_root/failed.stdout" 2>"$test_root/failed.stderr" || failed_status=$?
+[[ "$failed_status" -eq 23 ]] || fail "partial failure returned $failed_status, want 23"
+[[ "$(line_count "$failed_log")" -eq 3 ]] || fail 'the runner continued after a failed benchmark'
+for file in "$failed_head" "$failed_base"; do
+	assert_status incomplete "$file"
+	assert_contains '# completed seed: 17;' "$file"
+	assert_not_contains '# completed seed: 18;' "$file"
+	assert_not_contains '# status: complete' "$file"
+done
+assert_contains 'args=test -tags  . -run ^$' "$failed_log"
+if ! flock -n "$test_root/failed.lock" -c ':'; then
+	fail 'a failed pair retained the host lock'
+fi
+pass 'partial paired failure preserves diagnostics and leaves both outputs incomplete'
+
+for output_kind in none malformed; do
+	empty_status=0
+	PATH="$mock_bin:$PATH" MOCK_GO_LOG="$test_root/$output_kind-go.log" MOCK_GO_OUTPUT_KIND="$output_kind" \
+	bash "$runner" --output "$test_root/$output_kind-head.txt" --baseline-root "$baseline_root" \
+		--baseline-output "$test_root/$output_kind-base.txt" --runs 2 --lock-path "$test_root/$output_kind.lock" \
+		>"$test_root/$output_kind.stdout" 2>"$test_root/$output_kind.stderr" || empty_status=$?
+	[[ "$empty_status" -eq 1 ]] || fail "$output_kind benchmark output returned $empty_status, want 1"
+	[[ "$(line_count "$test_root/$output_kind-go.log")" -eq 1 ]] || fail 'invalid benchmark output did not stop the campaign'
+	assert_status incomplete "$test_root/$output_kind-head.txt"
+	assert_status incomplete "$test_root/$output_kind-base.txt"
+	assert_contains 'produced no valid benchmark timing row' "$test_root/$output_kind.stderr"
+done
+pass 'successful processes without valid timing rows cannot complete a campaign'
+
+required_trio='BenchmarkGoParseFullDFA,BenchmarkGoParseIncrementalSingleByteEditDFA,BenchmarkGoParseIncrementalNoEditDFA'
+for output_kind in trio partial-trio duplicate-trio invalid-trio; do
+	trio_status=0
+	PATH="$mock_bin:$PATH" MOCK_GO_LOG="$test_root/$output_kind-go.log" MOCK_GO_OUTPUT_KIND="$output_kind" \
+	bash "$runner" --output "$test_root/$output_kind-head.txt" --baseline-root "$baseline_root" \
+		--baseline-output "$test_root/$output_kind-base.txt" --runs 2 --seed-start 17 \
+		--require-benchmarks "$required_trio" --lock-path "$test_root/$output_kind.lock" \
+		>"$test_root/$output_kind.stdout" 2>"$test_root/$output_kind.stderr" || trio_status=$?
+	if [[ "$output_kind" == trio ]]; then
+		[[ "$trio_status" -eq 0 ]] || fail "the complete benchmark set returned $trio_status"
+		assert_status complete "$test_root/$output_kind-head.txt"
+		assert_status complete "$test_root/$output_kind-base.txt"
+		[[ "$(line_count "$test_root/$output_kind-go.log")" -eq 4 ]] || fail 'the complete set did not finish both seeds'
+	else
+		[[ "$trio_status" -eq 1 ]] || fail "$output_kind returned $trio_status, want 1"
+		assert_status incomplete "$test_root/$output_kind-head.txt"
+		assert_status incomplete "$test_root/$output_kind-base.txt"
+		assert_contains 'required benchmark BenchmarkGoParse' "$test_root/$output_kind.stderr"
+	fi
+done
+[[ "$(line_count "$test_root/partial-trio-go.log")" -eq 3 ]] || fail 'a partial later seed did not stop the campaign'
+assert_contains '# completed seed: 17;' "$test_root/partial-trio-head.txt"
+assert_not_contains '# completed seed: 18;' "$test_root/partial-trio-head.txt"
+pass 'required names need one complete metric row in every seed, including later seeds'
+
+PATH="$mock_bin:$PATH" MOCK_GO_LOG="$test_root/numeric-subbenchmark.log" MOCK_GO_OUTPUT_KIND=numeric-subbenchmark \
+bash "$runner" --output "$test_root/numeric-subbenchmark.txt" --runs 1 \
+	--require-benchmarks 'BenchmarkFixture/size-64' --lock-path "$test_root/numeric-subbenchmark.lock" \
+	>"$test_root/numeric-subbenchmark.stdout" 2>"$test_root/numeric-subbenchmark.stderr"
+assert_status complete "$test_root/numeric-subbenchmark.txt"
+pass 'exact numeric subbenchmark names take precedence over CPU suffix normalization'
+
+paired_lock="$test_root/paired-interval.lock"
+paired_ready="$test_root/paired-interval-ready"
+paired_release="$test_root/paired-interval-release"
+interval_log="$test_root/paired-interval-go.log"
+PATH="$mock_bin:$PATH" MOCK_GO_LOG="$interval_log" MOCK_DATE_AFTER_CALLS=2 \
+MOCK_DATE_READY="$paired_ready" MOCK_DATE_RELEASE="$paired_release" \
+bash "$runner" --output "$test_root/interval-head.txt" --baseline-root "$baseline_root" \
+	--baseline-output "$test_root/interval-base.txt" --runs 2 --lock-path "$paired_lock" \
+	>"$test_root/interval.stdout" 2>"$test_root/interval.stderr" &
+paired_pid=$!
+wait_for_file "$paired_ready"
+[[ "$(line_count "$interval_log")" -eq 2 ]] || fail 'the pause did not occur between seed pairs'
+if flock -n "$paired_lock" -c ':'; then
+	fail 'the host lock was released between seed pairs'
+fi
+interval_status=0
+PATH="$mock_bin:$PATH" MOCK_GO_LOG="$interval_log" \
+bash "$runner" --output "$test_root/interval-contender.txt" --runs 1 --lock-path "$paired_lock" \
+	>"$test_root/interval-contender.stdout" 2>"$test_root/interval-contender.stderr" || interval_status=$?
+[[ "$interval_status" -eq 75 ]] || fail "the between-pair contender returned $interval_status, want 75"
+assert_contains "baseline_root=$baseline_root" "$test_root/interval-contender.stderr"
+[[ "$(line_count "$interval_log")" -eq 2 ]] || fail 'the contender invoked go between seed pairs'
+: >"$paired_release"
+wait "$paired_pid" || fail 'the paired campaign failed after resuming'
+[[ "$(line_count "$interval_log")" -eq 4 ]] || fail 'the paired campaign did not finish both seeds'
+assert_status complete "$test_root/interval-head.txt"
+assert_status complete "$test_root/interval-base.txt"
+pass 'one host lock covers the interval between paired seeds'
+
 assert_not_contains 'go test' "$test_root/second.stderr"
-printf '%s\n' 'all randomized benchmark lock tests passed'
+printf '%s\n' 'all randomized benchmark runner tests passed'

--- a/work_count_admission_child_test.go
+++ b/work_count_admission_child_test.go
@@ -19,6 +19,8 @@ func TestWorkCountAdmissionChild(t *testing.T) {
 		t.Fatal(err)
 	}
 	parser := gotreesitter.NewParser(input.lang)
+	parser.SetAdmissionCandidateRoute(false)
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
 	tree, parseErr := parser.Parse(input.source)
 	if parseErr != nil {
 		if tree != nil {
@@ -27,6 +29,10 @@ func TestWorkCountAdmissionChild(t *testing.T) {
 		t.Fatalf("parse: %v", parseErr)
 	}
 	defer tree.Release()
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter != routedBefore || fallbackAfter != fallbackBefore {
+		t.Fatalf("production admission attempted compact parsing: routed=%d->%d fallback=%d->%d", routedBefore, routedAfter, fallbackBefore, fallbackAfter)
+	}
 	result, err := authenticateWorkCountTree(input, tree)
 	if err != nil {
 		t.Fatal(err)
@@ -35,4 +41,8 @@ func TestWorkCountAdmissionChild(t *testing.T) {
 	if err := writeWorkCountChildResult(result); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestWorkCountAdmissionChildUsesProductionRoute(t *testing.T) {
+	runWorkCountProductionRouteRegression(t, TestWorkCountAdmissionChild, workCountGoChildSchema, workCountAdmissionEngine)
 }

--- a/work_count_child_common_test.go
+++ b/work_count_child_common_test.go
@@ -173,3 +173,45 @@ func TestLoadWorkCountChildInputSelectsEveryCanonicalFixture(t *testing.T) {
 		})
 	}
 }
+
+func runWorkCountProductionRouteRegression(t *testing.T, child func(*testing.T), schema, engine string) {
+	t.Helper()
+	fixtures, err := benchfixtures.LoadGoFullParseFixtures()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture benchfixtures.LoadedFixture
+	for _, candidate := range fixtures {
+		if candidate.Fixture.ID == "rewrite" {
+			fixture = candidate
+			break
+		}
+	}
+	if fixture.Fixture.ID == "" {
+		t.Fatal("rewrite fixture is absent")
+	}
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "rewrite.go")
+	resultPath := filepath.Join(root, "result.json")
+	if err := os.WriteFile(sourcePath, fixture.Source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(workCountFixtureIDEnv, fixture.Fixture.ID)
+	t.Setenv(workCountSourcePathEnv, sourcePath)
+	t.Setenv(workCountResultPathEnv, resultPath)
+	previousDefault := gotreesitter.AdmissionCandidateRouteDefault()
+	gotreesitter.SetAdmissionCandidateRouteDefault(true)
+	t.Cleanup(func() { gotreesitter.SetAdmissionCandidateRouteDefault(previousDefault) })
+	child(t)
+	data, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result workCountGoChildResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Schema != schema || result.Engine != engine || result.DeepTreeSHA256 != fixture.Fixture.DeepTreeSHA256 {
+		t.Fatalf("production child identity=%q/%q tree=%s want=%q/%q/%s", result.Schema, result.Engine, result.DeepTreeSHA256, schema, engine, fixture.Fixture.DeepTreeSHA256)
+	}
+}

--- a/work_count_child_test.go
+++ b/work_count_child_test.go
@@ -29,6 +29,8 @@ func TestDiagnosticWorkCountChild(t *testing.T) {
 	}
 
 	parser := gotreesitter.NewParser(input.lang)
+	parser.SetAdmissionCandidateRoute(false)
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
 	gotreesitter.BeginDiagnosticWorkCount()
 	tree, parseErr := parser.Parse(input.source)
 	counts := gotreesitter.EndDiagnosticWorkCount()
@@ -45,6 +47,10 @@ func TestDiagnosticWorkCountChild(t *testing.T) {
 		t.Fatal("parse returned no root")
 	}
 	defer tree.Release()
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter != routedBefore || fallbackAfter != fallbackBefore {
+		t.Fatalf("production diagnostic attempted compact parsing: routed=%d->%d fallback=%d->%d", routedBefore, routedAfter, fallbackBefore, fallbackAfter)
+	}
 
 	base, err := authenticateWorkCountTree(input, tree)
 	if err != nil {
@@ -59,6 +65,10 @@ func TestDiagnosticWorkCountChild(t *testing.T) {
 	if err := writeWorkCountChildResult(result); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestDiagnosticWorkCountChildUsesProductionRoute(t *testing.T) {
+	runWorkCountProductionRouteRegression(t, TestDiagnosticWorkCountChild, workCountTaggedGoChildSchema, workCountTaggedEngine)
 }
 
 func countSelectedGoNodes(root *gotreesitter.Node, counts *gotreesitter.DiagnosticWorkCount) error {


### PR DESCRIPTION
## What does this PR do?

Restore reproducible performance comparisons and authenticated work counts on current main.
The existing benchmark driver now pairs baseline and candidate processes under one lock.
Each pair uses the same seed. Successive pairs reverse checkout order.

The work-count board now runs Go children inside its authenticated source snapshot.
Production children explicitly select the legacy route and reject compact activity.
The parent accepts the existing compact schema version five and validates its pass counters.

## Why this approach?

Continuous integration previously ran ten baseline samples before ten candidate samples.
The documented procedure requires twenty shuffled processes, and earlier experiments exposed order bias.
Use the existing driver to enforce that procedure in local comparisons and continuous integration.

Every required benchmark must emit one valid timing and allocation row in every process.
Interrupted campaigns remain incomplete. Source metadata is informational; it does not authenticate dirty checkouts.

The work-count fixes preserve source, artifact, fixture, and tree-digest checks.
They retain unavailable and incomparable metrics.

## Correctness

- The complete mocked driver suite passed, including interruptions, locks, path aliases, missing rows, and malformed metrics.
- Workflow shell extraction, YAML parsing, and actionlint passed.
- Focused Docker regressions passed for snapshot execution, production routing, and compact schema validation.
- Independent review approved the driver and both work-count fixes.
- The authenticated board completed all four frozen Go fixtures from clean `4e8d780c`.
- Each fixture preserved its locked tree digest and repeat-identical counts.

The board still reports one instrumentation blocker.
C per-version lexer requests cannot satisfy the Go union-frontier election contract.
That metric remains unavailable and incomparable. Diagnostic artifacts remain ineligible for timing.

Run the focused endpoint regressions:

```sh
bash scripts/run_randomized_benchmarks_test.sh
bash cgo_harness/docker/run_parity_in_docker.sh -- \
  "cd /workspace && go test . -run '^TestWorkCountAdmissionChildUsesProductionRoute$' -count=1"
bash cgo_harness/docker/run_parity_in_docker.sh -- \
  "cd /workspace && go test . -tags gts_workcount -run '^Test(WorkCountAdmissionChild|DiagnosticWorkCountChild)UsesProductionRoute$' -count=1"
bash cgo_harness/docker/run_parity_in_docker.sh -- \
  "cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity treesitter_c_perfscan' -run '^TestWorkCount(ParserCoreChildScheduler.*Protocol|BoardMetricStatusAndRatios|PerVersionCLexRequestCannotSatisfyUnionFrontierContract)$' -count=1"
```

## Performance

This PR changes measurement tools and test endpoints. It makes no parser speed claim.
The driver completed a real twenty-pair comparison for the separate recovery-count cache experiment.
It used one process per seed, `GOMAXPROCS=1`, `-benchtime=750ms`, and `-benchmem`.

Keep the existing advisory merge policy separate from universal performance certification.
The generated Go trio alone does not cover real-source compact workloads.
