### PR TITLE
Authenticate shared recovery aliases from grammar reductions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1324,7 +1324,7 @@ jobs:
             --test-parallel 1 \
             --c-ref-build-jobs 1 \
             --timeout 20m \
-            -- "cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^(TestCompactRecoveryJavaScriptIncrementalCOracle|TestCompactRecoveryJavaScriptInsertionRegression|TestJavaScriptCompactNestedReuseLookaheadLockedC)$' -count=1 -parallel 1 -timeout 20m -v"
+            -- "cd /workspace/cgo_harness && go test . -tags 'treesitter_c_parity gts_parsercorephase0' -run '^(TestCompactRecoveryJavaScriptIncrementalCOracle|TestCompactRecoveryJavaScriptInsertionRegression|TestJavaScriptCompactNestedReuseLookaheadLockedC|TestJavaScriptSharedRecoveryAliasWithoutArtifactGrantLockedC)$' -count=1 -parallel 1 -timeout 20m -v"
 
       - name: Compact recovery incremental YAML witness
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ for tags and release notes while still in `0.x`.
 
 ### Compact parser correctness
 
+- Authenticate terminal aliases at ordinary grammar reductions during recovery. Preserve separate rules for synthetic ERROR reductions and retain span coverage checks.
 - Preserve inherited alternative history when a reduction joins an active sibling.
 - Retain convergence and resurrection restrictions after adoption. Preserve existing blended-history rejection checks.
 - Parse `foo<A00>(2);` through compact without fallback, with exact locked-C tree parity.

--- a/admission_route_equality_leaf_tiling_test.go
+++ b/admission_route_equality_leaf_tiling_test.go
@@ -10,6 +10,7 @@ import (
 
 	gts "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 )
 
 // compactT3RouteEqualityWitnessManifestPath is the manifest committed by PR
@@ -275,11 +276,9 @@ func TestCompactRouteAdjudicatesFalseCleanWitnesses(t *testing.T) {
 	}
 }
 
-// TestCompactRouteDeclinesUncertifiedRecoveryAliasResume pins a mutation
-// where the same property_identifier alias appears after a different resume.
-// The compact tree swallows the next class into the arrow expression. The
-// exact JavaScript artifact has no alias rule for that resume state.
-func TestCompactRouteDeclinesUncertifiedRecoveryAliasResume(t *testing.T) {
+// Recovery closes the arrow before it combines the class with the outer expression.
+// The digest comes from the locked C oracle, including ranges and error flags.
+func TestCompactRoutePreservesRecoverySiblingSelection(t *testing.T) {
 	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
 	lang := grammars.JavascriptLanguage()
 	source := []byte("const f = (a) => a + 1#&\nclass A { m() { return 1 } }\n\n")
@@ -294,15 +293,16 @@ func TestCompactRouteDeclinesUncertifiedRecoveryAliasResume(t *testing.T) {
 	defer tree.Release()
 
 	routed, fallback := gts.AdmissionCandidateCounters()
-	if routed != 0 || fallback != 1 {
-		t.Fatalf("route counters routed=%d fallback=%d, want 0/1", routed, fallback)
+	if routed != 1 || fallback != 0 {
+		t.Fatalf("route counters routed=%d fallback=%d, want 1/0", routed, fallback)
 	}
-	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "accepted compact root leaves do not tile the accepted span") {
-		t.Fatalf("fallback reason=%q, want an accepted-root leaf gap", reason)
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), lang)
+	if err != nil || inspection.SHA256 != "a4e2303ba08955196c8a0bcbef55f2137530fb26aefeaa5d2986a4e71c70e5a9" {
+		t.Fatalf("locked C recovery digest=%s err=%v", inspection.SHA256, err)
 	}
 }
 
-func TestCompactRouteDeclinesRetiredRecoveryWithoutAliasRule(t *testing.T) {
+func TestCompactRouteAuthenticatesRecoveryAliasFromReduction(t *testing.T) {
 	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
 	lang := *grammars.JavascriptLanguage()
 	lang.CompactRecoveryTerminalAliasRules = nil
@@ -318,11 +318,12 @@ func TestCompactRouteDeclinesRetiredRecoveryWithoutAliasRule(t *testing.T) {
 	defer tree.Release()
 
 	routed, fallback := gts.AdmissionCandidateCounters()
-	if routed != 0 || fallback != 1 {
-		t.Fatalf("route counters routed=%d fallback=%d, want 0/1", routed, fallback)
+	if routed != 1 || fallback != 0 {
+		t.Fatalf("route counters routed=%d fallback=%d, want 1/0", routed, fallback)
 	}
-	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "accepted compact root leaves do not tile the accepted span") {
-		t.Fatalf("fallback reason=%q, want an accepted-root leaf gap", reason)
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), &lang)
+	if err != nil || inspection.SHA256 != "b559b17af8e7096b4f5d62ff757e5ebc56ad9397c336bc9de5cd85f9833bf01f" {
+		t.Fatalf("locked C recovery alias digest=%s err=%v", inspection.SHA256, err)
 	}
 }
 

--- a/cgo_harness/compact_javascript_s5_scan_test.go
+++ b/cgo_harness/compact_javascript_s5_scan_test.go
@@ -120,11 +120,10 @@ func TestCompactJavaScriptS5RecoveryMutationDifferential(t *testing.T) {
 			}
 		}
 	}
-	// Trailing-lineage retirement adds 15 exact routes to the prior 26-route
-	// S5 frontier. Error-mode keyword capture adds four more. The loop compares
-	// every expanded tree with C above.
-	if expanded != 45 || contracted != 0 {
-		t.Fatalf("S5 route delta expanded=%d contracted=%d, want 45/0 across %d cases", expanded, contracted, cases)
+	// Stateless external-scanner recovery adds 13 exact routes to the prior
+	// 45-route frontier. The loop compares every expanded tree with C above.
+	if expanded != 58 || contracted != 0 {
+		t.Fatalf("S5 route delta expanded=%d contracted=%d, want 58/0 across %d cases", expanded, contracted, cases)
 	}
 	t.Logf("JavaScript S5 mutation differential: cases=%d expanded=%d contracted=%d", cases, expanded, contracted)
 }

--- a/cgo_harness/compact_t3_oracle_adjudication_test.go
+++ b/cgo_harness/compact_t3_oracle_adjudication_test.go
@@ -499,9 +499,10 @@ func TestCompactT3JavaScriptRecoveryMutationDifferential(t *testing.T) {
 	if routed == 0 || fallback == 0 {
 		t.Fatalf("mutation differential lacked both route outcomes: cases=%d routed=%d fallback=%d", cases, routed, fallback)
 	}
-	// Trailing retirement adds 46 exact routes. Error-mode keyword capture and
-	// EOF pricing add 25 more. The loop compares each published tree with C.
-	const certifiedS5Expansions = 71
+	// Trailing retirement, keyword capture, and EOF pricing add 71 routes.
+	// Two more require S5 because standalone S3 rejects mixed shift/reduce
+	// closure states without an authenticated resume rule.
+	const certifiedS5Expansions = 73
 	if missingExpanded != certifiedS5Expansions || missingContracted != 0 {
 		t.Fatalf("T3 neighborhood S5 boundary: expanded=%d contracted=%d, want %d/0",
 			missingExpanded, missingContracted, certifiedS5Expansions)

--- a/cgo_harness/javascript_recovery_selection_test.go
+++ b/cgo_harness/javascript_recovery_selection_test.go
@@ -18,6 +18,22 @@ func TestJavaScriptClassBodyRecoverySelectionLockedC(t *testing.T) {
 	requireJavaScriptRecoverySelectionLockedC(t, []byte("const f = (a) => a + 1;\nclass  A { m() { return 1 }?)}\n"))
 }
 
+func TestJavaScriptClosingParenRecoveryDeclinesLossyClosure(t *testing.T) {
+	source := []byte("const f = (a) => a + 1)&\nclass A { m() { return 1 } }\n\n")
+	parser := gts.NewParser(grammars.JavascriptLanguage())
+	parser.SetAdmissionCandidateRoute(true)
+	routedBefore, fallbackBefore := gts.AdmissionCandidateCounters()
+	tree, err := parser.Parse(source)
+	if err != nil || tree == nil {
+		t.Fatalf("Go parse: %v", err)
+	}
+	defer tree.Release()
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if routed-routedBefore != 0 || fallback-fallbackBefore != 1 {
+		t.Fatalf("compact recovery route=%d/%d, want 0/1", routed-routedBefore, fallback-fallbackBefore)
+	}
+}
+
 func requireJavaScriptRecoverySelectionLockedC(t *testing.T, source []byte) {
 	t.Helper()
 	language := grammars.JavascriptLanguage()

--- a/cgo_harness/javascript_recovery_selection_test.go
+++ b/cgo_harness/javascript_recovery_selection_test.go
@@ -1,0 +1,70 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0
+
+package cgoharness
+
+import (
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	"testing"
+)
+
+func TestJavaScriptRecoverySiblingSelectionLockedC(t *testing.T) {
+	requireJavaScriptRecoverySelectionLockedC(t, []byte("const f = (a) => a + 1#&\nclass A { m() { return 1 } }\n\n"))
+}
+
+func TestJavaScriptClassBodyRecoverySelectionLockedC(t *testing.T) {
+	requireJavaScriptRecoverySelectionLockedC(t, []byte("const f = (a) => a + 1;\nclass  A { m() { return 1 }?)}\n"))
+}
+
+func requireJavaScriptRecoverySelectionLockedC(t *testing.T, source []byte) {
+	t.Helper()
+	language := grammars.JavascriptLanguage()
+	parser := gts.NewParser(language)
+	parser.SetAdmissionCandidateRoute(true)
+	routedBefore, fallbackBefore := gts.AdmissionCandidateCounters()
+	tree, err := parser.Parse(source)
+	if err != nil || tree == nil {
+		t.Fatalf("Go parse: %v", err)
+	}
+	defer tree.Release()
+	cLanguage, err := ParityCLanguage("javascript")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatal(err)
+	}
+	oracle := cParser.Parse(source, nil)
+	if oracle == nil {
+		t.Fatal("C returned no tree")
+	}
+	defer oracle.Close()
+	routed, fallback := gts.AdmissionCandidateCounters()
+	routed -= routedBefore
+	fallback -= fallbackBefore
+	if routed != 1 || fallback != 0 {
+		t.Fatalf("compact recovery route=%d/%d reason=%q", routed, fallback, gts.AdmissionCandidateLastFallbackReason())
+	}
+	if diff := FirstDivergenceDumpV1(tree.RootNode(), language, oracle.RootNode()); diff != nil {
+		t.Fatalf("recovery selection mismatch: %+v\nGo: %s\nC: %s", diff, tree.RootNode().SExpr(language), oracle.RootNode().ToSexp())
+	}
+	if diff := firstLockedCTreeFlagDivergence(tree.RootNode(), language, oracle.RootNode(), "/"); diff != nil {
+		t.Fatalf("recovery flags: %v", diff)
+	}
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := COracleDeepDigest(oracle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.SHA256 != digest {
+		t.Fatalf("recovery digest Go=%s C=%s", inspection.SHA256, digest)
+	}
+	t.Logf("exact recovery digest: %s", digest)
+}

--- a/cgo_harness/shared_recovery_alias_proof_test.go
+++ b/cgo_harness/shared_recovery_alias_proof_test.go
@@ -1,0 +1,65 @@
+//go:build cgo && treesitter_c_parity && gts_parsercorephase0
+
+package cgoharness
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestJavaScriptSharedRecoveryAliasWithoutArtifactGrantLockedC(t *testing.T) {
+	language := *grammars.JavascriptLanguage()
+	language.CompactRecoveryTerminalAliasRules = nil
+	if language.CompactOwnedEOFRecoveryCertified {
+		t.Fatal("fixture unexpectedly uses owned EOF recovery")
+	}
+	source := []byte(stage6JavaScriptRecoverySource)
+	cLanguage, err := ParityCLanguage("javascript")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatal(err)
+	}
+	oracle := cParser.Parse(source, nil)
+	if oracle == nil {
+		t.Fatal("C parser returned no tree")
+	}
+	defer oracle.Close()
+	parser := gts.NewParser(&language)
+	parser.SetAdmissionCandidateRoute(true)
+	routedBefore, fallbackBefore := gts.AdmissionCandidateCounters()
+	tree, err := parser.Parse(source)
+	if err != nil || tree == nil {
+		t.Fatalf("shared recovery parse: %v", err)
+	}
+	defer tree.Release()
+	routedAfter, fallbackAfter := gts.AdmissionCandidateCounters()
+	if routedAfter-routedBefore != 1 || fallbackAfter-fallbackBefore != 0 {
+		t.Fatalf("shared recovery route=%d/%d reason=%q", routedAfter-routedBefore, fallbackAfter-fallbackBefore, gts.AdmissionCandidateLastFallbackReason())
+	}
+	if diff := FirstDivergenceDumpV1(tree.RootNode(), &language, oracle.RootNode()); diff != nil {
+		t.Fatalf("shared recovery shape: %+v", diff)
+	}
+	if diff := firstLockedCTreeFlagDivergence(tree.RootNode(), &language, oracle.RootNode(), "/"); diff != nil {
+		t.Fatalf("shared recovery flags: %v", diff)
+	}
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), &language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := COracleDeepDigest(oracle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.SHA256 != digest {
+		t.Fatalf("shared recovery digest Go=%s C=%s", inspection.SHA256, digest)
+	}
+	t.Logf("shared recovery without alias grant matches locked C: %s", digest)
+}

--- a/cgo_harness/shared_recovery_alias_proof_test.go
+++ b/cgo_harness/shared_recovery_alias_proof_test.go
@@ -12,12 +12,20 @@ import (
 )
 
 func TestJavaScriptSharedRecoveryAliasWithoutArtifactGrantLockedC(t *testing.T) {
+	requireJavaScriptSharedRecoveryAliasLockedC(t, []byte(stage6JavaScriptRecoverySource))
+}
+
+func TestJavaScriptRetiredRecoveryAliasWithoutArtifactGrantLockedC(t *testing.T) {
+	requireJavaScriptSharedRecoveryAliasLockedC(t, []byte("const f = (a) =. + + 1;\nclass A { m() { return 1 } }\n\n"))
+}
+
+func requireJavaScriptSharedRecoveryAliasLockedC(t *testing.T, source []byte) {
+	t.Helper()
 	language := *grammars.JavascriptLanguage()
 	language.CompactRecoveryTerminalAliasRules = nil
 	if language.CompactOwnedEOFRecoveryCertified {
 		t.Fatal("fixture unexpectedly uses owned EOF recovery")
 	}
-	source := []byte(stage6JavaScriptRecoverySource)
 	cLanguage, err := ParityCLanguage("javascript")
 	if err != nil {
 		t.Fatal(err)

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -31,6 +31,7 @@ type builtinLanguageRuntimeProfile struct {
 	exactStackNodeEquivalence           bool
 	compactPackedGSSVersionOrder        bool
 	compactStrategy2ErrorRegion         bool
+	compactS3MixedShiftReduceStates     []gotreesitter.StateID
 	compactRecoverEOFArtifact           gotreesitter.CompactRecoverEOFArtifactReceipt
 	compactStackSummaryRecovery         bool
 	compactMissingTokenInsertion        bool
@@ -173,12 +174,15 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// explicit forest parsing and non-certified languages keep the full budget.
 	//
 	// The same exact artifact certifies the complete pinned compact recovery
-	// frontier. All eight witnesses route with exact C parity.
+	// frontier. All eight witnesses route with exact C parity. State 1042 keeps
+	// its mixed closure because js_log_3 and its 2,954-case mutation sweep match
+	// C there. Other mixed states decline instead of losing reduction versions.
 	"javascript": {
 		blobSHA256:                        mustRuntimeProfileSHA256("6706f93890f24d8ea90d6a140df5dde29c02ec8a3213bae16e8cc4df37e33ee0"),
 		automaticForestMemoryAllowance:    javascriptAutomaticForestMemoryAllowance,
 		compactConvergedSplitDrops:        true,
 		compactStrategy2ErrorRegion:       true,
+		compactS3MixedShiftReduceStates:   []gotreesitter.StateID{1042},
 		compactMissingTokenInsertion:      true,
 		compactRecoveryTrailingRetirement: true,
 		compactRecoveryErrorModeKeyword:   true,
@@ -804,6 +808,10 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	}
 	if profile.compactStrategy2ErrorRegion && !lang.CompactStrategy2ErrorRegionCertified {
 		lang.CompactStrategy2ErrorRegionCertified = true
+		changed = true
+	}
+	if !slices.Equal(profile.compactS3MixedShiftReduceStates, lang.CompactS3MixedShiftReduceClosureStates) {
+		lang.CompactS3MixedShiftReduceClosureStates = slices.Clone(profile.compactS3MixedShiftReduceStates)
 		changed = true
 	}
 	if profile.compactRecoverEOFArtifact.BlobSHA256 != ([32]byte{}) {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -136,6 +136,9 @@ func TestJavaScriptProfileCertifiesCompactRecoveryFrontier(t *testing.T) {
 		!lang.CompactRecoveryErrorModeKeywordCaptureCertified {
 		t.Fatal("the JavaScript profile did not attach its compact recovery capabilities")
 	}
+	if !slices.Equal(lang.CompactS3MixedShiftReduceClosureStates, []gotreesitter.StateID{1042}) {
+		t.Fatalf("mixed S3 closure states=%v, want [1042]", lang.CompactS3MixedShiftReduceClosureStates)
+	}
 	if lang.CompactFaithfulS5RecoveryCertified {
 		t.Fatal("the JavaScript profile unexpectedly enabled the Scala S5 route")
 	}
@@ -156,6 +159,7 @@ func TestJavaScriptProfileCertifiesCompactRecoveryFrontier(t *testing.T) {
 		uncertified.CompactStrategy2ErrorRegionCertified || uncertified.CompactMissingTokenInsertionCertified ||
 		uncertified.CompactRecoveryPlainFirstCertified || uncertified.CompactRecoveryTrailingLineageRetirementCertified ||
 		uncertified.CompactRecoveryErrorModeKeywordCaptureCertified ||
+		len(uncertified.CompactS3MixedShiftReduceClosureStates) != 0 ||
 		len(uncertified.CompactRecoveryTerminalAliasRules) != 0 {
 		t.Fatal("a mismatched JavaScript blob received compact recovery certification")
 	}

--- a/internal/parsercorephase0/cohort_final_identity_test.go
+++ b/internal/parsercorephase0/cohort_final_identity_test.go
@@ -1,0 +1,106 @@
+package parsercorephase0
+
+import "testing"
+
+func TestShiftCohortReturnsFinalPhysicalHeads(t *testing.T) {
+	for _, extra := range []bool{false, true} {
+		kind := "ordinary"
+		if extra {
+			kind = "extra"
+		}
+		for _, sharedTarget := range []bool{false, true} {
+			name := "distinct_targets"
+			if sharedTarget {
+				name = "shared_target"
+			}
+			t.Run(kind+"/"+name, func(t *testing.T) {
+				rightTarget := StateID(5)
+				if sharedTarget {
+					rightTarget = 4
+				}
+				tables := &fakeTable{actions: map[tableCell][]Action{
+					{state: 1, symbol: 3}: {{Type: ActionShift, State: 2}},
+					{state: 1, symbol: 4}: {{Type: ActionShift, State: 3}},
+					{state: 2, symbol: 9}: {{Type: ActionShift, State: 4, Extra: extra}},
+					{state: 3, symbol: 9}: {{Type: ActionShift, State: rightTarget, Extra: extra}},
+				}}
+				compact, err := New(tables, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+				if err != nil {
+					t.Fatal(err)
+				}
+				seed, err := compact.Seed(1, 0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				boundaries := make([]ClassifiedBoundary, 2)
+				prefixHeads := make([]Head, 2)
+				for i, symbol := range []Symbol{3, 4} {
+					head, err := compact.Shift(seed, symbol, 0, Token{Symbol: symbol, EndByte: 1}, ForkOrder{})
+					if err != nil {
+						t.Fatal(err)
+					}
+					prefixHeads[i] = head
+				}
+				for i, head := range prefixHeads {
+					boundaries[i], err = compact.ClassifyBoundary(head, 9)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				var heads []Head
+				// Only this owned invocation can merge the new cohort outputs.
+				err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+					token := Token{Symbol: 9, StartByte: 1, EndByte: 2, Extra: extra}
+					var err error
+					if extra {
+						heads, err = compact.ShiftExtraClassifiedCohortWithLiveCondenseCandidatesOwned(owner, nil, boundaries, token)
+					} else {
+						heads, err = compact.ShiftOrdinaryClassifiedCohortWithLiveCondenseCandidatesOwned(owner, nil, boundaries, token)
+					}
+					return err
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(heads) != 2 || (heads[0] == heads[1]) != sharedTarget {
+					t.Fatalf("cohort heads=%+v, shared target=%t", heads, sharedTarget)
+				}
+				for i, head := range heads {
+					paths, err := compact.Derivations(head)
+					if err != nil {
+						t.Fatal(err)
+					}
+					wantPaths := 1
+					if sharedTarget {
+						wantPaths = 2
+					}
+					if len(paths) != wantPaths {
+						t.Fatalf("head %d paths=%+v, want %d", i, paths, wantPaths)
+					}
+					seen := make(map[Symbol]int)
+					for _, path := range paths {
+						if len(path.Payloads) != 2 {
+							t.Fatalf("path=%+v, want prefix and shifted token", path)
+						}
+						prefix, err := compact.Subtree(path.Payloads[0])
+						if err != nil {
+							t.Fatal(err)
+						}
+						seen[prefix.Symbol]++
+						tail, err := compact.Subtree(path.Payloads[1])
+						if err != nil || tail.Symbol != 9 || tail.Extra != extra {
+							t.Fatalf("shifted payload=%+v err=%v", tail, err)
+						}
+					}
+					if sharedTarget {
+						if seen[3] != 1 || seen[4] != 1 {
+							t.Fatalf("merged prefix counts=%v, want each prefix once", seen)
+						}
+					} else if seen[Symbol(3+i)] != 1 {
+						t.Fatalf("head %d prefix counts=%v, want its original prefix", i, seen)
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -1250,8 +1250,8 @@ func TestShiftOrdinaryCohortSharesOneTerminalPayload(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(paths) != index+1 {
-			t.Fatalf("shifted head %d paths=%d, want %d", index, len(paths), index+1)
+		if len(paths) != 2 {
+			t.Fatalf("shifted head %d paths=%d, want 2 final cohort paths", index, len(paths))
 		}
 		for _, path := range paths {
 			if len(path.Payloads) != 1 {

--- a/internal/parsercorephase0/recovery_sibling_merge_test.go
+++ b/internal/parsercorephase0/recovery_sibling_merge_test.go
@@ -1,0 +1,154 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestRecoverySiblingMergePreservesIncumbentAndPublishes(t *testing.T) {
+	for _, changed := range []bool{false, true} {
+		name := "unchanged_tie"
+		if changed {
+			name = "distinct_payloads"
+		}
+		t.Run(name, func(t *testing.T) {
+			compact, sibling, incoming, payload := recoverySiblingMergeFixture(t, changed)
+			var merged Head
+			err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				var err error
+				merged, err = compact.MergeEquivalentRecoverySiblingHeadsOwned(owner, 3, 1, 0, false, sibling, incoming, recoverySiblingPayloadHasError)
+				return err
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			canonical, ok := compact.CanonicalBoundary(3, 1, false, 0)
+			if !ok || canonical != merged {
+				t.Fatalf("canonical=%+v/%t, merged=%+v", canonical, ok, merged)
+			}
+			paths, err := compact.Derivations(merged)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if changed {
+				if merged == sibling || merged == incoming || len(paths) != 2 {
+					t.Fatalf("changed merge=%+v paths=%+v", merged, paths)
+				}
+			} else if merged != sibling || len(paths) != 1 || len(paths[0].Payloads) != 1 || paths[0].Payloads[0] != payload {
+				t.Fatalf("tie lost incumbent: merged=%+v paths=%+v", merged, paths)
+			}
+			lineage, err := compact.nodeLineage(merged.Node)
+			if err != nil || lineage.storedErrorCost != 10 || lineage.rank != CleanPathRankUnknown {
+				t.Fatalf("merged lineage=%+v err=%v", lineage, err)
+			}
+		})
+	}
+}
+
+func TestRecoverySiblingMergeRollbackRestoresPublicationAndLineage(t *testing.T) {
+	for _, changed := range []bool{false, true} {
+		compact, sibling, incoming, _ := recoverySiblingMergeFixture(t, changed)
+		beforeLineages := append([]nodeLineageRecord(nil), compact.nodeLineages...)
+		beforeNodes, beforeLinks, beforeWork := len(compact.nodes), len(compact.links), compact.Work()
+		abort := errors.New("abort sibling merge")
+		err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+			if _, err := compact.MergeEquivalentRecoverySiblingHeadsOwned(owner, 3, 1, 0, false, sibling, incoming, recoverySiblingPayloadHasError); err != nil {
+				return err
+			}
+			return abort
+		})
+		canonical, ok := compact.CanonicalBoundary(3, 1, false, 0)
+		if !errors.Is(err, abort) || !ok || canonical != incoming || len(compact.nodes) != beforeNodes || len(compact.links) != beforeLinks || compact.Work() != beforeWork || !reflect.DeepEqual(compact.nodeLineages, beforeLineages) {
+			t.Fatalf("rollback changed=%t err=%v canonical=%+v/%t", changed, err, canonical, ok)
+		}
+	}
+}
+
+func TestRecoverySiblingMergeRejectsUnownedBoundaryAndUnequalCosts(t *testing.T) {
+	for _, reason := range []string{"boundary", "cost", "checkpoint", "callback"} {
+		t.Run(reason, func(t *testing.T) {
+			compact, sibling, incoming, _ := recoverySiblingMergeFixture(t, false)
+			callback := PayloadErrorPresenceFunc(recoverySiblingPayloadHasError)
+			checkpoint := CheckpointID(0)
+			switch reason {
+			case "boundary":
+				other, err := compact.appendNode(nodeRecord{state: 3, byteOffset: 1})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := compact.writeBoundary(compact.boundaryKey(3, 1), other); err != nil {
+					t.Fatal(err)
+				}
+			case "cost":
+				compact.nodeLineages[incoming.Node-1].storedErrorCost++
+			case "checkpoint":
+				checkpoint = 1
+			case "callback":
+				callback = nil
+			}
+			beforeLineages := append([]nodeLineageRecord(nil), compact.nodeLineages...)
+			beforeNodes, beforeLinks, beforeWork := len(compact.nodes), len(compact.links), compact.Work()
+			beforeCanonical, beforeOK := compact.CanonicalBoundary(3, 1, false, 0)
+			err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				_, err := compact.MergeEquivalentRecoverySiblingHeadsOwned(owner, 3, 1, checkpoint, false, sibling, incoming, callback)
+				return err
+			})
+			canonical, ok := compact.CanonicalBoundary(3, 1, false, 0)
+			if err == nil || ok != beforeOK || canonical != beforeCanonical || len(compact.nodes) != beforeNodes || len(compact.links) != beforeLinks || compact.Work() != beforeWork || !reflect.DeepEqual(compact.nodeLineages, beforeLineages) {
+				t.Fatalf("rejection changed state: err=%v canonical=%+v/%t", err, canonical, ok)
+			}
+		})
+	}
+}
+
+func TestRecoverySiblingMergeKeepsExistingAPICanonicalRestriction(t *testing.T) {
+	compact, sibling, incoming, _ := recoverySiblingMergeFixture(t, true)
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		_, err := compact.MergeEquivalentRecoveryHeadsOwned(owner, 3, 1, 0, false, sibling, incoming, recoverySiblingPayloadHasError)
+		return err
+	})
+	if err == nil || err.Error() != "parser-core phase zero: physical head merge lost its incumbent boundary" {
+		t.Fatalf("existing API error=%v", err)
+	}
+}
+
+func recoverySiblingPayloadHasError(SubtreeID) (bool, error) { return true, nil }
+
+func recoverySiblingMergeFixture(t *testing.T, distinctSymbol bool) (*Core, Head, Head, SubtreeID) {
+	t.Helper()
+	compact := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	heads := make([]Head, 2)
+	var firstPayload SubtreeID
+	for i := range heads {
+		symbol := Symbol(10)
+		if i == 1 && distinctSymbol {
+			symbol++
+		}
+		payload, err := compact.appendSubtree(subtreeRecord{symbol: symbol, startByte: uint32(i), endByte: 1, terminal: true}, nil, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if i == 0 {
+			firstPayload = payload
+		}
+		link := compact.appendGraphLink(linkRecord{prev: seed.Node, payload: payload})
+		node, err := compact.appendNode(nodeRecord{state: 3, byteOffset: 1, firstLink: uint32(link), linkCount: 1, pathCount: 1})
+		if err != nil {
+			t.Fatal(err)
+		}
+		heads[i] = Head{Node: node}
+		compact.nodeLineages[node-1].storedErrorCost = 10
+		if err := compact.recordNodeLineage(heads[i], CleanPathRankSelected, uint16(i+1)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := compact.writeBoundary(compact.boundaryKey(3, 1), heads[1].Node); err != nil {
+		t.Fatal(err)
+	}
+	return compact, heads[0], heads[1], firstPayload
+}

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -587,8 +587,27 @@ func (c *Core) mergeEquivalentHeadsAtBoundaryUncheckpointedWithRecovery(
 	allowNonzeroCost bool,
 	recovery *recoveryMergeEquivalenceContext,
 ) (Head, error) {
+	return c.mergeEquivalentHeadsAtBoundaryPreservingIncumbent(
+		key, incumbent, incoming, allowNonzeroCost, recovery, false,
+	)
+}
+
+func (c *Core) mergeEquivalentHeadsAtBoundaryPreservingIncumbent(
+	key boundaryKey,
+	incumbent Head,
+	incoming Head,
+	allowNonzeroCost bool,
+	recovery *recoveryMergeEquivalenceContext,
+	canonicalMayBeIncoming bool,
+) (Head, error) {
 	if key.frontier != c.frontier {
 		return Head{}, errors.New("parser-core phase zero: physical head merge frontier mismatch")
+	}
+	if canonicalMayBeIncoming {
+		probe, existing := c.boundaries.probe(boundaryIdentityFromKey(key))
+		if !probe.found || (existing != incumbent.Node && existing != incoming.Node) {
+			return Head{}, errors.New("parser-core phase zero: recovery sibling merge boundary belongs to neither operand")
+		}
 	}
 	if incumbent == incoming {
 		return incumbent, nil
@@ -680,6 +699,17 @@ func (c *Core) mergeEquivalentHeadsAtBoundaryUncheckpointedWithRecovery(
 		if err := c.mergeNodeLineageMetadata(incumbent.Node, incoming.Node, incumbent.Node); err != nil {
 			return Head{}, err
 		}
+		if canonicalMayBeIncoming {
+			probe, existing := c.boundaries.probe(boundaryIdentityFromKey(key))
+			if !probe.found || (existing != incumbent.Node && existing != incoming.Node) {
+				return Head{}, errors.New("parser-core phase zero: recovery sibling merge lost its boundary")
+			}
+			if existing != incumbent.Node {
+				if err := c.publishBoundary(probe, incumbent.Node); err != nil {
+					return Head{}, err
+				}
+			}
+		}
 		c.addWork(&c.work.PhysicalHeadMergeSuccesses, 1)
 		return incumbent, nil
 	}
@@ -697,7 +727,7 @@ func (c *Core) mergeEquivalentHeadsAtBoundaryUncheckpointedWithRecovery(
 		return Head{}, err
 	}
 	probe, existing := c.boundaries.probe(boundaryIdentityFromKey(key))
-	if !probe.found || existing != incumbent.Node {
+	if !probe.found || (existing != incumbent.Node && (!canonicalMayBeIncoming || existing != incoming.Node)) {
 		return Head{}, errors.New("parser-core phase zero: physical head merge lost its incumbent boundary")
 	}
 	if err := c.publishBoundary(probe, merged); err != nil {
@@ -788,6 +818,38 @@ func (c *Core) MergeEquivalentRecoveryHeadsOwned(
 	context := recoveryMergeEquivalenceContext{payloadHasError: payloadHasError}
 	out, err = c.mergeEquivalentHeadsAtBoundaryUncheckpointedWithRecovery(
 		key, incumbent, incoming, true, &context,
+	)
+	return out, c.finishSchedulerOwned(owner, err)
+}
+
+// MergeEquivalentRecoverySiblingHeadsOwned preserves the supplied sibling as incumbent.
+// Either operand must own the current canonical boundary. Equal precedence
+// retains the sibling's equivalent payload, even when the reduction published last.
+// The scheduler must authenticate live sibling order and exact lexer ownership.
+func (c *Core) MergeEquivalentRecoverySiblingHeadsOwned(
+	owner SchedulerTransactionToken,
+	state StateID,
+	byteOffset uint32,
+	checkpoint CheckpointID,
+	shifted bool,
+	sibling Head,
+	reduction Head,
+	payloadHasError PayloadErrorPresenceFunc,
+) (out Head, err error) {
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return out, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if payloadHasError == nil {
+		return out, c.finishSchedulerOwned(owner, errors.New("parser-core phase zero: recovery sibling merge pricing context is unavailable"))
+	}
+	key := boundaryKey{
+		frontier: c.frontier, state: state, byteOffset: byteOffset,
+		shifted: shifted, checkpoint: checkpoint,
+	}
+	context := recoveryMergeEquivalenceContext{payloadHasError: payloadHasError}
+	out, err = c.mergeEquivalentHeadsAtBoundaryPreservingIncumbent(
+		key, sibling, reduction, true, &context, true,
 	)
 	return out, c.finishSchedulerOwned(owner, err)
 }
@@ -1189,6 +1251,13 @@ func (c *Core) shiftOrdinaryClassifiedCohortUncheckpointed(boundaries []Classifi
 			return nil, err
 		}
 		out[index] = outcome.head
+		// Earlier outputs with this target share the final merged boundary.
+		// Restrict replacement to this invocation, not historical boundary entries.
+		for prior := 0; prior < index; prior++ {
+			if targets[prior] == targets[index] {
+				out[prior] = outcome.head
+			}
+		}
 	}
 	c.addWork(&c.work.Shifts, uint64(len(boundaries)))
 	return out, nil
@@ -1315,6 +1384,13 @@ func (c *Core) shiftExtraClassifiedCohortUncheckpointed(boundaries []ClassifiedB
 			return nil, err
 		}
 		out[index] = outcome.head
+		// Earlier outputs with this target share the final merged boundary.
+		// Restrict replacement to this invocation, not historical boundary entries.
+		for prior := 0; prior < index; prior++ {
+			if targets[prior] == targets[index] {
+				out[prior] = outcome.head
+			}
+		}
 	}
 	c.addWork(&c.work.Shifts, uint64(len(boundaries)))
 	return out, nil

--- a/language.go
+++ b/language.go
@@ -888,6 +888,11 @@ type Language struct {
 	// no-action point exactly as before this stage landed.
 	CompactStrategy2ErrorRegionCertified bool
 
+	// CompactS3MixedShiftReduceClosureStates permits standalone strategy-2
+	// recovery to stop its single-path closure at one certified state that has
+	// both shift and reduce actions across terminals. Other mixed states decline.
+	CompactS3MixedShiftReduceClosureStates []StateID
+
 	// CompactRecoverEOFCertified permits one exact EOF no-action lineage to
 	// publish tree-sitter's non-extra ERROR root from recover_eof. It is a
 	// compatibility marker. The compact route also requires the explicit,

--- a/parsercore_phase0_canonical_recovery_identity_internal_test.go
+++ b/parsercore_phase0_canonical_recovery_identity_internal_test.go
@@ -1,0 +1,103 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func TestDiagnosticParserCoreCanonicalizePreservesRecoveryPhysicalIdentity(t *testing.T) {
+	for _, kind := range []string{"costed", "marked", "region"} {
+		for _, count := range []int{1, 2} {
+			name := "sole"
+			if count == 2 {
+				name = "multiple"
+			}
+			t.Run(kind+"/"+name, func(t *testing.T) {
+				compact, heads := canonicalRecoveryIdentityFixture(t)
+				headers := make([]diagnosticParserCoreHeader, count)
+				for i := range headers {
+					headers[i] = diagnosticParserCoreHeader{head: heads[i], shifted: true, creationSeq: uint64(i + 1)}
+					switch kind {
+					case "costed":
+						headers[i].markRecoveryCosted()
+					case "marked":
+						headers[i].markRecoveryLineage()
+					case "region":
+						headers[i].setRecoveryRegion(&diagnosticParserCoreS3Region{})
+					}
+				}
+				// Recovery headers remain live, but ordinary condensation excludes them.
+				scheduler := diagnosticParserCoreGenericScheduler{compact: compact, headers: headers}
+				if candidates := scheduler.collectCondenseCandidates(0); len(candidates) != 0 {
+					t.Fatalf("recovery condense candidates=%+v", candidates)
+				}
+				var scratch diagnosticParserCoreCanonicalScratch
+				got, err := scratch.canonicalize(compact, headers)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(got) != count {
+					t.Fatalf("canonical headers=%+v, want %d physical versions", got, count)
+				}
+				for i := range got {
+					if got[i].head != heads[i] || got[i].creationSeq != headers[i].creationSeq || got[i].versionState != headers[i].versionState || got[i].recoveryFlags != headers[i].recoveryFlags {
+						t.Fatalf("header %d lost physical identity or recovery ownership: got=%+v want=%+v", i, got[i], headers[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestDiagnosticParserCoreCanonicalizeStillRemapsCleanPhysicalIdentity(t *testing.T) {
+	for _, count := range []int{1, 2} {
+		compact, heads := canonicalRecoveryIdentityFixture(t)
+		headers := make([]diagnosticParserCoreHeader, count)
+		for i := range headers {
+			headers[i] = diagnosticParserCoreHeader{head: heads[i], shifted: true, creationSeq: uint64(i + 1)}
+		}
+		var scratch diagnosticParserCoreCanonicalScratch
+		got, err := scratch.canonicalize(compact, headers)
+		if err != nil || len(got) != 1 || got[0].head != heads[2] {
+			t.Fatalf("clean count=%d canonical headers=%+v err=%v, want newest head=%+v", count, got, err, heads[2])
+		}
+	}
+}
+
+// Each frontier publishes a distinct payload at the same boundary.
+// The scheduler retains older physical heads independently of the boundary index.
+func canonicalRecoveryIdentityFixture(t *testing.T) (*core.Core, []core.Head) {
+	t.Helper()
+	table := &genericConflictTable{cells: map[genericConflictCell][]core.Action{
+		{state: 1, symbol: 3}: {{Type: core.ActionShift, State: 2}},
+		{state: 1, symbol: 4}: {{Type: core.ActionShift, State: 2}},
+		{state: 1, symbol: 5}: {{Type: core.ActionShift, State: 2}},
+	}}
+	compact, err := core.New(table, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var heads []core.Head
+	for _, symbol := range []core.Symbol{3, 4, 5} {
+		if err := compact.BeginFrontier(); err != nil {
+			t.Fatal(err)
+		}
+		seed, err := compact.Seed(1, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		head, err := compact.Shift(seed, symbol, 0, core.Token{Symbol: symbol, EndByte: 1}, core.ForkOrder{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		heads = append(heads, head)
+	}
+	canonical, ok := compact.CanonicalBoundary(2, 1, true, 0)
+	if !ok || canonical != heads[2] || heads[0] == heads[1] || heads[1] == heads[2] {
+		t.Fatalf("invalid physical-head fixture: heads=%+v canonical=%+v/%t", heads, canonical, ok)
+	}
+	return compact, heads
+}

--- a/parsercore_phase0_coverage_stage_test.go
+++ b/parsercore_phase0_coverage_stage_test.go
@@ -1,0 +1,29 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompactRecoveryCoverageFailureIdentifiesStage(t *testing.T) {
+	for _, stage := range []string{"derivation", "public-tree"} {
+		t.Run(stage, func(t *testing.T) {
+			root := &Node{symbol: 2, endByte: 1}
+			var coverage diagnosticParserCoreAcceptedLeafCoverageScratch
+			var nodesByID []*Node
+			if stage == "public-tree" {
+				// Raw coverage is complete, but the projected nonterminal leaf
+				// has no authenticated relationship to the raw terminal.
+				coverage.spans = []diagnosticParserCoreAcceptedLeafSpan{{id: 1, endByte: 1}}
+				nodesByID = []*Node{nil, {symbol: 1, endByte: 1}}
+			}
+			err := finalizeDiagnosticParserCoreAcceptedRootSpan(root, []byte("x"), 1, true, 0,
+				func() error { return nil }, 2, &coverage, nodesByID)
+			if err == nil || !strings.Contains(err.Error(), "coverage="+stage+" gap=0..1") {
+				t.Fatalf("coverage failure did not identify %s: %v", stage, err)
+			}
+		})
+	}
+}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -6646,7 +6646,7 @@ func finalizeDiagnosticParserCoreAcceptedRootSpanWithSplice(root *Node, source [
 				return fmt.Errorf("parser-core phase zero: accepted compact derivation leaf coverage: %w", err)
 			} else if gapped {
 				return fmt.Errorf(
-					"parser-core phase zero: accepted compact root leaves do not tile the accepted span: gap=%d..%d root=%d..%d",
+					"parser-core phase zero: accepted compact root leaves do not tile the accepted span: coverage=derivation gap=%d..%d root=%d..%d",
 					gapStart, gapEnd, root.startByte, root.endByte,
 				)
 			}
@@ -6654,7 +6654,7 @@ func finalizeDiagnosticParserCoreAcceptedRootSpanWithSplice(root *Node, source [
 				return fmt.Errorf("parser-core phase zero: accepted compact public-tree leaf coverage: %w", err)
 			} else if gapped {
 				return fmt.Errorf(
-					"parser-core phase zero: accepted compact root leaves do not tile the accepted span: gap=%d..%d root=%d..%d",
+					"parser-core phase zero: accepted compact root leaves do not tile the accepted span: coverage=public-tree gap=%d..%d root=%d..%d",
 					gapStart, gapEnd, root.startByte, root.endByte,
 				)
 			}
@@ -7638,16 +7638,11 @@ func materializeDiagnosticParserCoreAcceptedSelectionWithRootFinalization(compac
 					return fmt.Errorf("reduce symbol=%d production=%d: %w", view.Symbol, view.ProductionID, err)
 				}
 			}
-			// Production alias authentication belongs to native owned recovery.
-			// Existing shared recovery keeps its artifact-specific admission.
-			if allowErrorRoot && parser.language.CompactOwnedEOFRecoveryCertified &&
-				rootFinalization != diagnosticParserCoreFinalizeDefault {
+			// Authenticate terminal aliases at their exact grammar reduction.
+			// Shared recovery needs the same raw-terminal and clone proof.
+			if allowErrorRoot {
 				acceptedLeaves.authenticateDirectTerminalAliases(
 					parser, entries, children, view.ProductionID, 0, nodesByID,
-				)
-			} else if recoveryTerminalAlias != 0 {
-				acceptedLeaves.authenticateDirectTerminalAliases(
-					parser, entries, children, view.ProductionID, recoveryTerminalAlias, nodesByID,
 				)
 			}
 			if child := parser.collapsibleUnarySelfReduction(action, Token{}, arena, entries, 0, len(entries), children, fieldIDs); child != nil {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2352,7 +2352,8 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeWithMutation(
 			s.headerBuffers[target] = normalized[:0]
 			return nil, 0, err
 		}
-		if canonical, ok := compact.CanonicalBoundary(state, byteOffset, header.shifted, header.checkpoint); ok {
+		if canonical, ok := compact.CanonicalBoundary(state, byteOffset, header.shifted, header.checkpoint); ok &&
+			!header.isRecoveryLineage() && header.recoveryRegion() == nil && !header.isRecoveryCosted() {
 			header.head = canonical
 		}
 		header.freshness = 0
@@ -2383,7 +2384,8 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeWithMutation(
 			s.keys = s.keys[:0]
 			return nil, 0, err
 		}
-		if canonical, ok := compact.CanonicalBoundary(state, byteOffset, header.shifted, header.checkpoint); ok {
+		if canonical, ok := compact.CanonicalBoundary(state, byteOffset, header.shifted, header.checkpoint); ok &&
+			!header.isRecoveryLineage() && header.recoveryRegion() == nil && !header.isRecoveryCosted() {
 			header.head = canonical
 		}
 		versionState := header.versionState
@@ -4876,19 +4878,26 @@ func (s *diagnosticParserCoreGenericScheduler) relexExternalTokenForState(state 
 	}
 	d := s.tokenSource
 	lang := d.language
-	if lang == nil || lang.ExternalScanner == nil || !languageUsesExternalScannerCheckpoints(lang) {
+	if lang == nil || lang.ExternalScanner == nil {
 		return shared, false
 	}
-	provider, ok := externalScannerCheckpointIdentityProviderForScanner(lang.ExternalScanner)
-	if !ok {
+	contract, contractErr := diagnosticParserCoreVersionLexerScannerContractForLanguage(lang)
+	if contractErr != nil || (!languageUsesExternalScannerCheckpoints(lang) && !contract.stateless) ||
+		!s.versionLexerBefore.externalScannerPresent ||
+		(len(s.versionLexerBefore.externalPayload) == 0 && !contract.stateless) {
 		return shared, false
 	}
-	identity, ok := provider.CheckpointIdentity()
-	if !ok || !identity.complete() || !s.versionLexerBefore.externalScannerPresent || len(s.versionLexerBefore.externalPayload) == 0 {
+	provider, providerOK := externalScannerCheckpointIdentityProviderForScanner(lang.ExternalScanner)
+	var identity ExternalScannerCheckpointIdentity
+	identityOK := false
+	if providerOK {
+		identity, identityOK = provider.CheckpointIdentity()
+	}
+	if !contract.stateless && (!identityOK || !identity.complete()) {
 		return shared, false
 	}
-	if s.compact != nil {
-		if !s.versionLexerBeforeIdentityValid || parserCoreExternalScannerIdentityFingerprint(identity) != s.versionLexerBeforeIdentity {
+	if s.compact != nil && !contract.stateless {
+		if !contract.stateless && (!s.versionLexerBeforeIdentityValid || parserCoreExternalScannerIdentityFingerprint(identity) != s.versionLexerBeforeIdentity) {
 			return shared, false
 		}
 	}
@@ -8995,6 +9004,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			// witness (html_log_8) that needs this to avoid resuming one
 			// byte early.
 			resumeToken := s.token
+			stateRelexed := false
 			relexDisagreesUnmodeled := false
 			if relexed, relexOK := s.s3ErrorModeRelex(region.endByte); relexOK {
 				sharedIsRealContent := s.token.StartByte != s.token.EndByte
@@ -9034,6 +9044,16 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 					relexDisagreesUnmodeled = true
 				}
 			}
+			markerState, _, markerErr := s.compact.Boundary(header.head)
+			if markerErr != nil {
+				return nil, markerErr
+			}
+			if markerState == 0 {
+				if relexed, ok := s.relexTokenForState(StateID(region.state), resumeToken); ok {
+					resumeToken = relexed
+					stateRelexed = true
+				}
+			}
 			hasAction, actErr := s3RegionResumeAction(s.compact, region.state, Symbol(resumeToken.Symbol))
 			if actErr != nil {
 				return nil, actErr
@@ -9061,6 +9081,17 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			}
 			switch {
 			case hasAction:
+				ordered, orderErr := s.lexicalErrorResumeMatchesSummary(*header, Symbol(resumeToken.Symbol))
+				if orderErr != nil {
+					return nil, orderErr
+				}
+				if !ordered {
+					return &diagnosticParserCoreGenericUnsupported{
+						boundary:    DiagnosticParserCoreRecovery,
+						detail:      "merged lexical recovery requires a different summary resume state",
+						headerIndex: index,
+					}, nil
+				}
 				if s.s3ResumeCount == math.MaxUint32 {
 					return nil, errors.New("parser-core phase zero: strategy-2 resume count overflow")
 				}
@@ -9104,6 +9135,9 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				}
 				s.headers[index].head = newHead
 				s.headers[index].closeRecoveryRegion()
+				if stateRelexed && resumeToken.ExternalScannerToken {
+					return s.activateVersionLexerOwnershipAtRagged(index)
+				}
 			case resumeToken.Symbol == 0:
 				// EOF while a region is open: cRecoverEOFAccept's whole-file
 				// wrap is out of S3 scope (s3TryOpenErrorRegion's doc
@@ -9417,6 +9451,13 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				// This foundation owns only the sole-header, sole-no-action shape.
 				// Unmodeled ambiguity falls through to the existing decline.
 				if len(s.headers) == 1 && len(noActionIndices) == 1 {
+					lexicalHandled, lexicalErr := s.tryLexicalErrorRecovery(noActionIndices[0])
+					if lexicalErr != nil {
+						return nil, lexicalErr
+					}
+					if lexicalHandled {
+						return nil, nil
+					}
 					handled, s5Err := s.s5TryMissingTokenInsertion(noActionIndices[0])
 					if s5Err != nil {
 						return nil, s5Err
@@ -12191,6 +12232,15 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		if !outputDropCohortRefs.Empty() || outputDropCohortRefs.Overflowed() || outputDropCohortRefs.Blended() {
 			if _, err := s.compact.UnionDropCohortRefsChecked(&replacement.dropCohortRefs, outputDropCohortRefs); err != nil {
 				return err
+			}
+		}
+		if recoveryCostRequired && !s.recoveryIsolation {
+			merged, err := s.mergeRecoveredReductionSiblingOwned(owner, int(cell.headerIndex), replacement)
+			if err != nil {
+				return err
+			}
+			if merged {
+				continue
 			}
 		}
 		if len(replacements) > 0 {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -10186,6 +10186,25 @@ const s3CloseInProgressProductionsMaxSteps = 64
 // changed reports whether at least one reduction actually ran (so the
 // caller knows to adopt the returned head instead of discarding it).
 func (s *diagnosticParserCoreGenericScheduler) s3CloseInProgressProductions(head core.Head) (out core.Head, changed bool, ok bool, err error) {
+	return s.s3CloseInProgressProductionsMode(head, false)
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s3MixedClosureStateAdmitted(state core.StateID) bool {
+	if s == nil || s.tokenSource == nil || s.tokenSource.language == nil {
+		return false
+	}
+	for _, certified := range s.tokenSource.language.CompactS3MixedShiftReduceClosureStates {
+		if core.StateID(certified) == state {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s3CloseInProgressProductionsMode(
+	head core.Head,
+	rejectMixedShiftReduce bool,
+) (out core.Head, changed bool, ok bool, err error) {
 	if s.tokenSource == nil || s.tokenSource.language == nil {
 		return head, false, false, nil
 	}
@@ -10236,6 +10255,10 @@ func (s *diagnosticParserCoreGenericScheduler) s3CloseInProgressProductions(head
 			}
 		}
 		if hasShift {
+			if rejectMixedShiftReduce && (reduceCandidates != 0 || sawUnmodeledReduce) &&
+				!s.s3MixedClosureStateAdmitted(state) {
+				return current, changed, false, nil
+			}
 			// A real dispatchable action exists here regardless of what else
 			// this state also offers: stop closing, nothing more to do.
 			return current, changed, true, nil
@@ -10505,7 +10528,7 @@ func (s *diagnosticParserCoreGenericScheduler) s3TryOpenErrorRegionWithAlternati
 	// extra records this closure left behind. No dirty state escapes a
 	// decline; only tree records that are already immutable, unreferenced
 	// by anything the caller ultimately serves, and cheap.
-	closedHead, changed, ok, closeErr := s.s3CloseInProgressProductions(header.head)
+	closedHead, changed, ok, closeErr := s.s3CloseInProgressProductionsMode(header.head, !alternativesResolved)
 	if closeErr != nil {
 		return false, closeErr
 	}

--- a/parsercore_phase0_driver_coverage_internal_test.go
+++ b/parsercore_phase0_driver_coverage_internal_test.go
@@ -279,6 +279,12 @@ func TestDiagnosticParserCoreAcceptedLeafCoverageProductionAliases(t *testing.T)
 			if got := coverage.hasAuthenticatedAlias(clone); got != (name == "valid") {
 				t.Fatalf("production alias authenticated=%t", got)
 			}
+			if name == "valid" || name == "wrong_production" || name == "unmatched_raw" || name == "duplicate_clone" {
+				_, _, gapped, err := diagnosticParserCoreAcceptedTreeLeafCoverageGap(clone, []byte("x"), 0, 1, 100, &coverage, nodesByID, nil)
+				if err != nil || gapped != (name != "valid") {
+					t.Fatalf("public alias coverage gap=%t err=%v", gapped, err)
+				}
+			}
 			// Authentication belongs to the exact projected node, not its range.
 			if coverage.hasAuthenticatedAlias(parser.aliasedNodeInArena(arena, raw, 101)) {
 				t.Fatal("an unrelated clone inherited production authentication")

--- a/parsercore_phase0_lexical_error_recovery.go
+++ b/parsercore_phase0_lexical_error_recovery.go
@@ -1,0 +1,100 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+
+// lexicalErrorResumeMatchesSummary checks the first eligible recovery state.
+// A merged marker must not resume through a later closure history.
+func (s *diagnosticParserCoreGenericScheduler) lexicalErrorResumeMatchesSummary(
+	header diagnosticParserCoreHeader, lookahead Symbol,
+) (bool, error) {
+	state, markerByte, err := s.compact.Boundary(header.head)
+	if err != nil || state != 0 || s.recoveryIsolation {
+		return err == nil, err
+	}
+	region := header.recoveryRegion()
+	if region == nil || len(s.headers) != 1 {
+		return false, nil
+	}
+	candidates, err := s.compact.StackSummaryCandidates(header.head, cRecoverMaxSummaryDepth)
+	if err != nil {
+		return false, err
+	}
+	for _, candidate := range candidates {
+		if candidate.State() == 0 || candidate.ByteOffset() >= region.endByte {
+			continue
+		}
+		row, err := s.compact.Actions(candidate.State(), core.Symbol(lookahead))
+		if err != nil {
+			return false, err
+		}
+		if row.Len() == 0 {
+			continue
+		}
+		return candidate.Depth() == 1 && candidate.ByteOffset() == markerByte && candidate.State() == region.state, nil
+	}
+	return false, nil
+}
+
+// tryLexicalErrorRecovery closes every reduction before opening one error region.
+// It does not enable missing-token insertion or recovery version competition.
+func (s *diagnosticParserCoreGenericScheduler) tryLexicalErrorRecovery(index int) (bool, error) {
+	if s == nil || s.compact == nil || !s.s3ErrorRegionAdmitted() ||
+		len(s.headers) != 1 || index != 0 || s.token.Symbol != errorSymbol ||
+		s.token.Missing || s.token.NoLookahead || s.token.EndByte <= s.token.StartByte ||
+		s.tokenSource == nil || s.tokenSource.language == nil || s.tokenSource.lexer == nil ||
+		s.headers[0].recoveryRegion() != nil || s.s3RegionOpened || s.s3ResumeCount != 0 {
+		return false, nil
+	}
+	if s.token.StartByte <= firstNonTriviaByteStart(s.tokenSource.lexer.source) {
+		return false, nil
+	}
+	// The synthetic error symbol cannot be a grammar lookahead.
+	if s.tokenSource.language.TokenCount <= 1 || uint32(s.tokenSource.language.TokenCount) > uint32(errorSymbol) {
+		return false, nil
+	}
+	if relexed, ok := s.s3ErrorModeRelex(s.token.StartByte); ok && relexed.Symbol != errorSymbol &&
+		(relexed.Symbol != s.token.Symbol || relexed.EndByte != s.token.EndByte) {
+		return false, nil
+	}
+	return s.s5TryRecoveryTransaction(index, true)
+}
+
+func (s *diagnosticParserCoreGenericScheduler) runLexicalErrorRecoveryOwned(
+	owner core.SchedulerTransactionToken,
+	index int,
+	staged *diagnosticParserCoreS5Work,
+) (bool, error) {
+	_, position, err := s.compact.Boundary(s.headers[index].head)
+	if err != nil || position > s.token.StartByte {
+		return false, err
+	}
+	if _, err := s.s5RunReductionFrontierOwned(owner, index, diagnosticParserCoreS5AnyTerminal, core.Symbol(s.token.Symbol), staged); err != nil {
+		return false, err
+	}
+	frontier := diagnosticParserCoreS5CloneSlice(s.headers)
+	if len(frontier) == 0 {
+		return false, nil
+	}
+	baseline, supported, err := s.s5RecoveryBaseline(frontier)
+	if err != nil || !supported {
+		return false, err
+	}
+	absorb, err := s.s5AppendAndMergeAbsorberOwned(owner, frontier, baseline, 0, staged)
+	if err != nil || absorb.head.Node == 0 {
+		return false, err
+	}
+	absorb.clearRecoveryLineage()
+	clear(s.headers)
+	s.headers = append(s.headers[:0], absorb)
+	s.recoveryIsolation = false
+	s.epochProgress = true
+	if err := s.canonicalizeOwned(owner); err != nil {
+		return false, err
+	}
+	if err := s.persistHeaderLineageOwned(owner); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/parsercore_phase0_lexical_error_recovery_internal_test.go
+++ b/parsercore_phase0_lexical_error_recovery_internal_test.go
@@ -1,0 +1,127 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+type lexicalRecoveryFaultTable struct {
+	recoveryLineageForkTable
+	failure error
+}
+
+func (table lexicalRecoveryFaultTable) Actions(state core.StateID, symbol core.Symbol) (core.ActionRow, error) {
+	if symbol == 1 && state == 2 {
+		return core.NewActionRow([]core.Action{{Type: core.ActionReduce, Symbol: 5, ChildCount: 1}}, false), nil
+	}
+	if symbol == 1 && state == 3 {
+		return core.ActionRow{}, table.failure
+	}
+	return table.recoveryLineageForkTable.Actions(state, symbol)
+}
+
+func TestLexicalErrorRecoveryRollsBackReductionFailure(t *testing.T) {
+	failure := errors.New("lexical recovery reduction fault")
+	s := newRecoveryLineageForkSchedulerWithTable(t, lexicalRecoveryFaultTable{failure: failure}, true)
+	head, err := s.compact.Shift(s.headers[0].head, 2, 0, core.Token{Symbol: 2, StartByte: 1, EndByte: 2}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.headers[0].head = head
+	s.token = Token{Symbol: errorSymbol, StartByte: 2, EndByte: 3}
+	s.tokenSource.lexer.source = []byte("aa?")
+	s.receipt = &DiagnosticParserCoreGenericScheduler{Tokens: 7}
+	s.verifierHeaderPtr = &s.headers[0]
+	s.verifierBound = len(s.headers)
+	original := s.headers[0]
+	before, err := s.compact.Stats(original.head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	work := s.compact.Work()
+	receipt := s.receipt
+	handled, err := s.tryLexicalErrorRecovery(0)
+	if handled || !errors.Is(err, failure) {
+		t.Fatalf("recovery handled=%t err=%v, want reduction failure", handled, err)
+	}
+	requireS5ForkRollback(t, s, original, before, work, receipt)
+}
+
+func TestLexicalErrorRecoveryEntryGuardsPreserveState(t *testing.T) {
+	cases := []struct {
+		name   string
+		change func(*diagnosticParserCoreGenericScheduler)
+	}{
+		{"disabled", func(s *diagnosticParserCoreGenericScheduler) { s.options.Recovery = false }},
+		{"real_token", func(s *diagnosticParserCoreGenericScheduler) { s.token.Symbol = 4 }},
+		{"empty_token", func(s *diagnosticParserCoreGenericScheduler) { s.token.EndByte = s.token.StartByte }},
+		{"missing_token", func(s *diagnosticParserCoreGenericScheduler) { s.token.Missing = true }},
+		{"no_lookahead", func(s *diagnosticParserCoreGenericScheduler) { s.token.NoLookahead = true }},
+		{"leading_gap", func(s *diagnosticParserCoreGenericScheduler) { s.token.StartByte = 0 }},
+		{"prior_region", func(s *diagnosticParserCoreGenericScheduler) { s.s3RegionOpened = true }},
+		{"prior_resume", func(s *diagnosticParserCoreGenericScheduler) { s.s3ResumeCount = 1 }},
+		{"empty_table", func(s *diagnosticParserCoreGenericScheduler) { s.tokenSource.language.TokenCount = 1 }},
+		{"error_is_terminal", func(s *diagnosticParserCoreGenericScheduler) {
+			s.tokenSource.language.TokenCount = uint32(errorSymbol) + 1
+		}},
+		{"multiple_headers", func(s *diagnosticParserCoreGenericScheduler) { s.headers = append(s.headers, s.headers[0]) }},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			s := newRecoveryLineageForkScheduler(t, true)
+			s.token.Symbol = errorSymbol
+			test.change(s)
+			headers := append([]diagnosticParserCoreHeader(nil), s.headers...)
+			before, err := s.compact.Stats(s.headers[0].head)
+			if err != nil {
+				t.Fatal(err)
+			}
+			work := s.compact.Work()
+			handled, err := s.tryLexicalErrorRecovery(0)
+			after, statsErr := s.compact.Stats(s.headers[0].head)
+			if err != nil || handled || statsErr != nil || before != after || work != s.compact.Work() || !reflect.DeepEqual(headers, s.headers) {
+				t.Fatalf("guard changed state: handled=%t err=%v stats=%v", handled, err, statsErr)
+			}
+		})
+	}
+}
+
+func TestLexicalErrorRecoverySummaryKeepsFirstEligibleState(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		lookahead Symbol
+		want      bool
+	}{
+		{"first_state", 2, true},
+		{"later_state", 4, false},
+		{"no_state", 99, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s := newRecoveryLineageForkScheduler(t, true)
+			other, err := s.compact.Seed(3, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			frontier := []diagnosticParserCoreHeader{s.headers[0], {head: other}}
+			var absorb diagnosticParserCoreHeader
+			err = s.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+				var err error
+				absorb, err = s.s5AppendAndMergeAbsorberOwned(owner, frontier, 0, 0, &diagnosticParserCoreS5Work{})
+				return err
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			s.headers = []diagnosticParserCoreHeader{absorb}
+			got, err := s.lexicalErrorResumeMatchesSummary(absorb, test.lookahead)
+			if err != nil || got != test.want {
+				t.Fatalf("summary matches=%t want=%t err=%v", got, test.want, err)
+			}
+		})
+	}
+}

--- a/parsercore_phase0_owned_alias_scope_test.go
+++ b/parsercore_phase0_owned_alias_scope_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 )
 
-func TestCompactRecoveryProductionAliasScope(t *testing.T) {
+func TestCompactRecoveryProductionAliasDoesNotRequireOwnedCertificate(t *testing.T) {
 	p := newCompactRecoveryVersionTurnGoParser(t)
 	source := []byte("package p\nfunc f(){}\nfunc g(){}+")
 	tree, routed, reason := p.tryCompactFullParseRoute(source)
 	if !routed || tree == nil {
 		t.Fatalf("owned recovery declined: %s", reason)
 	}
+	want := tree.RootNode().SExpr(p.language)
 	tree.Release()
 	runner := p.admissionCandidateRunner.(*parserCoreFreshFullRunner)
 	for _, mode := range []string{"default_finalization", "uncertified_language"} {
@@ -30,11 +31,21 @@ func TestCompactRecoveryProductionAliasScope(t *testing.T) {
 				runner.compact, runner.scheduler.acceptedHead, runner.scheduler.acceptedPayloads,
 				NewParser(&language), source, &scratch, false, true, finalization,
 			)
-			if tree != nil {
-				tree.Release()
+			if mode == "default_finalization" {
+				if tree != nil {
+					tree.Release()
+				}
+				if err == nil || !strings.Contains(err.Error(), "accepted compact root carries an error-bearing trailing extra payload") {
+					t.Fatalf("default finalization must retain its trailing-error guard: %v", err)
+				}
+				return
 			}
-			if err == nil || !strings.Contains(err.Error(), "leaves do not tile") {
-				t.Fatalf("uncertified production alias materialization err=%v", err)
+			if err != nil || tree == nil {
+				t.Fatalf("authenticated production alias materialization err=%v", err)
+			}
+			defer tree.Release()
+			if got := tree.RootNode().SExpr(&language); got != want {
+				t.Fatalf("alias projection=%s, want %s", got, want)
 			}
 		})
 	}

--- a/parsercore_phase0_recovery_condense.go
+++ b/parsercore_phase0_recovery_condense.go
@@ -54,6 +54,18 @@ func (s *diagnosticParserCoreGenericScheduler) mergeEquivalentRecoveryCondenseEn
 	source core.RecoveryCostSource,
 	memo *core.RecoveryCostMemo,
 ) (bool, error) {
+	return s.mergeEquivalentRecoveryEntriesOwned(owner, target, candidate, symbols, source, memo, false)
+}
+
+func (s *diagnosticParserCoreGenericScheduler) mergeEquivalentRecoveryEntriesOwned(
+	owner core.SchedulerTransactionToken,
+	target *diagnosticParserCoreRecoveryCondenseEntry,
+	candidate diagnosticParserCoreRecoveryCondenseEntry,
+	symbols []core.SelectedSymbolPolicy,
+	source core.RecoveryCostSource,
+	memo *core.RecoveryCostMemo,
+	preserveSibling bool,
+) (bool, error) {
 	if s == nil || s.compact == nil || target == nil || target.header.accepted ||
 		candidate.header.accepted || target.header.paused || candidate.header.paused ||
 		target.header.recoveryRegion() != nil || candidate.header.recoveryRegion() != nil ||
@@ -72,16 +84,20 @@ func (s *diagnosticParserCoreGenericScheduler) mergeEquivalentRecoveryCondenseEn
 	if !ok {
 		return false, nil
 	}
-	if canonical == incoming {
+	if canonical == incoming && !preserveSibling {
 		incumbent, incoming = incoming, incumbent
-	} else if canonical != incumbent {
+	} else if canonical != incumbent && canonical != incoming {
 		return false, nil
 	}
 	payloadHasError := func(payload core.SubtreeID) (bool, error) {
 		cost, err := core.RecoveryNodeErrorCostMemo(symbols, source, memo, payload)
 		return cost > 0, err
 	}
-	merged, err := s.compact.MergeEquivalentRecoveryHeadsOwned(
+	mergeHeads := s.compact.MergeEquivalentRecoveryHeadsOwned
+	if preserveSibling {
+		mergeHeads = s.compact.MergeEquivalentRecoverySiblingHeadsOwned
+	}
+	merged, err := mergeHeads(
 		owner,
 		target.key.state,
 		target.key.byteOffset,

--- a/parsercore_phase0_recovery_error_mode_keyword_test.go
+++ b/parsercore_phase0_recovery_error_mode_keyword_test.go
@@ -75,7 +75,7 @@ func TestCompactJavaScriptErrorModeKeywordCaptureRequiresArtifact(t *testing.T) 
 	}
 }
 
-func TestCompactJavaScriptSelectedAbsorbAliasRequiresRule(t *testing.T) {
+func TestCompactJavaScriptSelectedAbsorbAliasUsesProductionProof(t *testing.T) {
 	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
 	lang := *grammars.JavascriptLanguage()
 	lang.CompactRecoveryTerminalAliasRules = nil
@@ -89,10 +89,7 @@ func TestCompactJavaScriptSelectedAbsorbAliasRequiresRule(t *testing.T) {
 	}
 	defer tree.Release()
 	routed, fallback := gts.AdmissionCandidateCounters()
-	if routed != 0 || fallback != 1 {
-		t.Fatalf("route counters=%d/%d, want 0/1", routed, fallback)
-	}
-	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "accepted compact root leaves do not tile") {
-		t.Fatalf("fallback reason=%q, want an accepted-root leaf gap", reason)
+	if routed != 1 || fallback != 0 {
+		t.Fatalf("route counters=%d/%d, want 1/0; reason=%q", routed, fallback, gts.AdmissionCandidateLastFallbackReason())
 	}
 }

--- a/parsercore_phase0_recovery_lineage_fork_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_fork_internal_test.go
@@ -835,7 +835,19 @@ func TestRecoveryCanonicalizationKeepsMarkedOwnersSeparate(t *testing.T) {
 		headers[index].clearRecoveryLineage()
 		headers[index].shifted = true
 	}
-	ordinary, err := scratch.canonicalize(compact, headers)
+	costed, err := scratch.canonicalize(compact, headers)
+	if err != nil {
+		t.Fatalf("canonicalize costed: %v", err)
+	}
+	if len(costed) != 2 {
+		t.Fatalf("costed canonicalization retained %d heads, want 2", len(costed))
+	}
+
+	ordinaryHeaders := []diagnosticParserCoreHeader{
+		{head: left, creationSeq: 1, shifted: true},
+		{head: right, creationSeq: 2, shifted: true},
+	}
+	ordinary, err := scratch.canonicalize(compact, ordinaryHeaders)
 	if err != nil {
 		t.Fatalf("canonicalize ordinary: %v", err)
 	}

--- a/parsercore_phase0_recovery_lineage_fork_internal_test.go
+++ b/parsercore_phase0_recovery_lineage_fork_internal_test.go
@@ -244,6 +244,8 @@ func TestS5AbsorberPreservesMixedParserStatesForRecoverySelection(t *testing.T) 
 		scheduler.headers[0],
 		{head: other, creationSeq: 4},
 	}
+	headers[0].altSet = core.NewAlternativeSetMember(1, 0)
+	headers[1].altSet = core.NewAlternativeSetMember(1, 1)
 	staged := diagnosticParserCoreS5Work{}
 	var absorb diagnosticParserCoreHeader
 	err = scheduler.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
@@ -267,6 +269,9 @@ func TestS5AbsorberPreservesMixedParserStatesForRecoverySelection(t *testing.T) 
 	region := absorb.recoveryRegion()
 	if region == nil || region.state != 1 {
 		t.Fatalf("mixed-state recovery region=%+v, want first recovery state 1", region)
+	}
+	if !absorb.blended || absorb.altSet.Len() != 2 {
+		t.Fatalf("merged recovery lost incomparable histories: blended=%t alternatives=%d", absorb.blended, absorb.altSet.Len())
 	}
 }
 

--- a/parsercore_phase0_recovery_sibling.go
+++ b/parsercore_phase0_recovery_sibling.go
@@ -1,0 +1,75 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+
+// mergeRecoveredReductionSiblingOwned preserves C's existing sibling order.
+// Equal stored costs permit a merge; they do not select an ambiguity winner.
+func (s *diagnosticParserCoreGenericScheduler) mergeRecoveredReductionSiblingOwned(
+	owner core.SchedulerTransactionToken,
+	sourceIndex int,
+	incoming diagnosticParserCoreHeader,
+) (bool, error) {
+	if incoming.recoveryRegion() != nil || incoming.paused || incoming.accepted {
+		return false, nil
+	}
+	state, position, err := s.compact.Boundary(incoming.head)
+	if err != nil {
+		return false, err
+	}
+	cost, err := s.compact.RecoveryStoredErrorCost(incoming.head)
+	if err != nil || cost == 0 {
+		return false, err
+	}
+	key := diagnosticParserCoreRecoveryCondenseKey{
+		state: state, byteOffset: position, cost: cost,
+		checkpoint: incoming.checkpoint, shifted: incoming.shifted,
+	}
+	for index := range s.headers {
+		if index == sourceIndex {
+			continue
+		}
+		sibling := s.headers[index]
+		if sibling.accepted || sibling.paused || sibling.recoveryRegion() != nil ||
+			sibling.shifted != incoming.shifted || sibling.checkpoint != incoming.checkpoint ||
+			!s.versionLexerStateEqual(sibling.versionState, incoming.versionState) {
+			continue
+		}
+		siblingState, siblingPosition, err := s.compact.Boundary(sibling.head)
+		if err != nil {
+			return false, err
+		}
+		if siblingState != state || siblingPosition != position {
+			continue
+		}
+		siblingCost, err := s.compact.RecoveryStoredErrorCost(sibling.head)
+		if err != nil {
+			return false, err
+		}
+		if siblingCost != cost {
+			continue
+		}
+		source, err := newDiagnosticParserCoreRecoveryCostSource(s.compact, s.options.materializationSource)
+		if err != nil {
+			return false, err
+		}
+		var memo core.RecoveryCostMemo
+		target := diagnosticParserCoreRecoveryCondenseEntry{header: sibling, key: key}
+		candidate := diagnosticParserCoreRecoveryCondenseEntry{header: incoming, key: key}
+		merged, err := s.mergeEquivalentRecoveryEntriesOwned(owner, &target, candidate,
+			diagnosticParserCoreRecoverySymbolPolicy(s.tokenSource.language), source, &memo, true)
+		memo.Reset()
+		if err != nil {
+			return false, err
+		}
+		if merged {
+			if err := s.compact.RecordDropCohortProducerMutation(owner, core.DropCohortProducerSiblingAdoption); err != nil {
+				return false, err
+			}
+			s.headers[index] = target.header
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/parsercore_phase0_s5.go
+++ b/parsercore_phase0_s5.go
@@ -949,8 +949,9 @@ func (s *diagnosticParserCoreGenericScheduler) s5AppendAndMergeAbsorberOwned(
 		if _, err := s.compact.UnionDropCohortRefsChecked(&absorb.dropCohortRefs, header.dropCohortRefs); err != nil {
 			return diagnosticParserCoreHeader{}, err
 		}
+		incomparable := s.compact.AlternativeSetIncomparable(absorb.altSet, header.altSet)
 		s.compact.UnionAlternativeSet(&absorb.altSet, header.altSet)
-		absorb.blended = absorb.blended || header.blended
+		absorb.blended = absorb.blended || header.blended || incomparable
 	}
 	s.s3RegionOpened = true
 	return absorb, nil
@@ -1152,14 +1153,21 @@ func (s *diagnosticParserCoreGenericScheduler) s5RunOwned(
 }
 
 func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertionFaithful(index int) (handled bool, err error) {
+	return s.s5TryRecoveryTransaction(index, false)
+}
+
+func (s *diagnosticParserCoreGenericScheduler) s5TryRecoveryTransaction(index int, lexicalError bool) (handled bool, err error) {
 	// Keep unsupported shapes on the cheap path. The full snapshot is reserved
 	// for an admitted sole header that can enter the S5 transaction.
-	if s == nil || s.compact == nil || !s.s5MissingTokenAdmitted() ||
+	if s == nil || s.compact == nil || (!lexicalError && !s.s5MissingTokenAdmitted()) ||
 		len(s.headers) != 1 || index != 0 ||
 		s.s5MissingInsertions >= maxDiagnosticParserCoreMissingInsertions ||
-		s.token.Missing || s.token.NoLookahead || s.token.Symbol == errorSymbol ||
+		s.token.Missing || s.token.NoLookahead ||
 		s.tokenSource == nil || s.tokenSource.language == nil ||
 		s.headers[0].recoveryRegion() != nil {
+		return false, nil
+	}
+	if !lexicalError && s.token.Symbol == errorSymbol {
 		return false, nil
 	}
 	if s.token.Symbol == 0 && !s.options.allowCompactS5EOFMissingInsertion {
@@ -1197,7 +1205,11 @@ func (s *diagnosticParserCoreGenericScheduler) s5TryMissingTokenInsertionFaithfu
 		var committed bool
 		if err := s.compact.ApplySchedulerSpeculation(parent, func(owner core.SchedulerTransactionToken) (bool, error) {
 			var runErr error
-			committed, runErr = s.s5RunOwned(owner, index, &staged)
+			if lexicalError {
+				committed, runErr = s.runLexicalErrorRecoveryOwned(owner, index, &staged)
+			} else {
+				committed, runErr = s.s5RunOwned(owner, index, &staged)
+			}
 			return committed, runErr
 		}); err != nil {
 			return err

--- a/parsercore_phase0_shared_alias_materialization_test.go
+++ b/parsercore_phase0_shared_alias_materialization_test.go
@@ -1,0 +1,68 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+type sharedRecoveryAliasTable struct{ genericConflictTable }
+
+func (*sharedRecoveryAliasTable) ProductionAliases(production uint16, count int) ([]core.Symbol, error) {
+	if production == 1 && count == 1 {
+		return []core.Symbol{3}, nil
+	}
+	return nil, nil
+}
+
+func TestCompactSharedRecoveryAuthenticatesDirectTerminalAlias(t *testing.T) {
+	table := &sharedRecoveryAliasTable{genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 1}: {{Type: core.ActionShift, State: 2}},
+			{state: 2, symbol: 0}: {{Type: core.ActionReduce, Symbol: 2, ChildCount: 1, ProductionID: 1}},
+		},
+		gotos: map[genericConflictCell]core.StateID{{state: 1, symbol: 2}: 3},
+	}}
+	compact, err := core.New(table, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer compact.ResetReleasingRetention()
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	shifted, err := compact.Shift(seed, 1, 0, core.Token{Symbol: 1, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	heads, err := compact.Reduce(shifted, 0, 0, core.ForkOrder{})
+	if err != nil || len(heads) != 1 {
+		t.Fatalf("reduction heads=%v err=%v", heads, err)
+	}
+	paths, err := compact.Derivations(heads[0])
+	if err != nil || len(paths) != 1 {
+		t.Fatalf("derivations=%v err=%v", paths, err)
+	}
+	lang := &Language{
+		Name: "shared_alias_fixture", TokenCount: 2, SymbolCount: 4,
+		SymbolNames:    []string{"end", "identifier", "root", "type_identifier"},
+		SymbolMetadata: []SymbolMetadata{{}, {Visible: true, Named: true}, {Visible: true, Named: true}, {Visible: true, Named: true}},
+	}
+	parser := &Parser{language: lang, reduceAliasSeq: [][]Symbol{nil, {3}}}
+	var scratch parserCoreRunnerScratch
+	tree, err := materializeDiagnosticParserCoreAcceptedSelection(compact, heads[0], paths[0].Payloads, parser, []byte("x"), &scratch, false, true)
+	if err != nil || tree == nil {
+		t.Fatalf("shared alias materialization: %v", err)
+	}
+	defer tree.Release()
+	root := tree.RootNode()
+	if root.ChildCount() != 1 || root.Child(0).Symbol() != 3 || root.Child(0).StartByte() != 0 || root.Child(0).EndByte() != 1 {
+		t.Fatalf("shared alias projection=%s", root.SExpr(lang))
+	}
+	if lang.CompactOwnedEOFRecoveryCertified || len(lang.CompactRecoveryTerminalAliasRules) != 0 {
+		t.Fatal("fixture unexpectedly supplied artifact alias authority")
+	}
+}


### PR DESCRIPTION
## Change

Authenticate direct terminal aliases during admitted recovery.

Preserve physical recovery identity across canonicalization and ordinary cohorts. Merge equal-cost recovery siblings without replacing the existing sibling.

Run the full any-terminal reduction closure before lexical error recovery. Re-enter a stateless external scanner after a recovery marker resumes.

Keep ordinary ambiguity grammar-driven. Keep recovery selection cost-driven.

## Locked C proof

Four JavaScript witnesses match the locked C oracle exactly.

- Shared alias digest: 753db41ff1b7605bba9bcdb9afe3833003a95f50c1a4c75dd1a70c5cf3fc691e
- Retired alias digest: b559b17af8e7096b4f5d62ff757e5ebc56ad9397c336bc9de5cd85f9833bf01f
- Recovery sibling digest: a4e2303ba08955196c8a0bcbef55f2137530fb26aefeaa5d2986a4e71c70e5a9
- Class-body recovery digest: fba8f1b8774a9edbcd5e780e91641486af8d6c23a6424353c0447667b8eeff83

The JavaScript mutation differential covers 5,267 edits. It records 58 exact-C route expansions and zero contractions.

## Ownership proof

Focused tests cover canonical identity, final cohort heads, sibling merge order, rollback, unequal costs, and invalid boundaries.

An independent final source review found no blocker. Fresh full CI remains required before merge.

Refs #1063, #1064.