### PR TITLE
fix(parser): route fresh parses through the production engine by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fresh parse route default
+
+- Route eligible fresh full parses through the production engine by default.
+  The compact candidate route is now opt-in. Select it with
+  `GTS_ADMISSION_CANDIDATE=1`, `SetAdmissionCandidateRouteDefault(true)`, or
+  the per-Parser override. An unset or unrecognized value keeps the production route.
+- Issue [#454](https://github.com/odvcencio/gotreesitter/issues/454) compared
+  v0.52.0 with v0.48.1 on 137 KiB editor fixtures. Clean full parses ran 2 to
+  3 times slower on 41 of 48 grammars. Seven grammars lost most incremental
+  reuse. A single-byte Go delete did not terminate.
+- Pull request [#631](https://github.com/odvcencio/gotreesitter/pull/631)
+  removed the 64 KiB size decline, so large files reached the compact route
+  for the first time. The compact route was already the process default.
+- Forcing the production route restores v0.48.1-class results on every
+  reported item. On a 137 KiB Scala fixture, the full parse returns from
+  212 ms to 75 ms. On a 137 KiB TOML fixture, insert reuse returns from
+  62 percent to 100 percent. On a 137 KiB Go fixture, the single-byte delete
+  returns from no termination to 15 ms.
+  See the [route default report](docs/performance/issue-454-compact-route-default-2026-09-07.md).
+- The production route is also faster or equal on 4 KiB to 48 KiB fixtures,
+  which the compact route already served at v0.48.1. Compact-only conflict
+  policies, such as the Markdown inline route, and native compact error
+  recovery now apply only to processes that opt in.
+- The package tests still opt in to the compact route, so certification and
+  parity coverage does not change. This change does not alter compact parser
+  graduation status.
+- Halt a GLR stack at a no-action point when a sibling stack accepts the
+  lookahead, before the previous-shift recovery runs. Tree-sitter C halts a
+  version when a better version exists. Pull request
+  [#709](https://github.com/odvcencio/gotreesitter/pull/709) added a per-stack
+  re-lex that kept the constructor-specifier fork of
+  `static inline void f(int *v) {}` alive on the production route, and the
+  recovered fork then won selection with an ERROR node. The compact default had
+  masked this regression since v0.49.0. Five C++ witnesses now match the compact
+  route on the production route, and the Apex parity suite still passes.
+
 ### Compact parser correctness
 
 - Authenticate terminal aliases at ordinary grammar reductions during recovery. Preserve separate rules for synthetic ERROR reductions and retain span coverage checks.

--- a/README.md
+++ b/README.md
@@ -748,6 +748,16 @@ GOTREESITTER_GRAMMAR_STRING_INTERN_LIMIT=200000
 GOTREESITTER_GRAMMAR_TRANSITION_INTERN_LIMIT=20000
 ```
 
+**Compact parser route (opt-in)**:
+
+```sh
+GTS_ADMISSION_CANDIDATE=1  # route eligible fresh full parses through the compact parser
+```
+
+The production route is the default. The compact route stays opt-in until
+compact parser graduation completes. See the Roadmap section for the
+[issue #454](https://github.com/odvcencio/gotreesitter/issues/454) measurements.
+
 **GLR stack cap override**:
 
 ```sh
@@ -835,10 +845,16 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 The current release is **v0.52.0**.
 
-Eligible fresh parses use the compact parser by default, with legacy fallback
-for unsupported cases. This release adds bounded compact incremental reuse,
-including authenticated nested nonterminals, and bounded Go end-of-file recovery.
-These changes do not complete compact parser graduation.
+The v0.52.0 release routed eligible fresh parses through the compact parser
+by default, with legacy fallback for unsupported cases. It added bounded
+compact incremental reuse, including authenticated nested nonterminals, and
+bounded Go end-of-file recovery. These changes do not complete compact parser
+graduation.
+
+After [issue #454](https://github.com/odvcencio/gotreesitter/issues/454), the
+compact route is opt-in on `main`. The production route serves fresh full
+parses unless a process sets `GTS_ADMISSION_CANDIDATE=1`, calls
+`SetAdmissionCandidateRouteDefault(true)`, or uses the per-Parser override.
 
 The v0.52.0 release disables the unsafe shortcut as a temporary mitigation for
 [issue #1087](https://github.com/odvcencio/gotreesitter/issues/1087).

--- a/admission_default_test.go
+++ b/admission_default_test.go
@@ -1,0 +1,28 @@
+package gotreesitter
+
+import (
+	"os"
+	"testing"
+)
+
+// The shipping default routes fresh full parses to the production engine; see
+// admissionCandidateEnvEnabled. The package tests opt in to the compact
+// candidate route when GTS_ADMISSION_CANDIDATE is unset, so the certification,
+// parity, and counter suites keep their established coverage and an explicit
+// GTS_ADMISSION_CANDIDATE=0 still pins a test run to the production route.
+func init() {
+	if _, set := os.LookupEnv("GTS_ADMISSION_CANDIDATE"); !set {
+		SetAdmissionCandidateRouteDefault(true)
+	}
+}
+
+// TestPackageTestsOptIntoCompactRoute documents the test-binary opt-in above.
+// TestAdmissionSwitchEnvVarContract locks the shipping default separately.
+func TestPackageTestsOptIntoCompactRoute(t *testing.T) {
+	if _, set := os.LookupEnv("GTS_ADMISSION_CANDIDATE"); set {
+		t.Skip("GTS_ADMISSION_CANDIDATE is set; the environment owns the default")
+	}
+	if !AdmissionCandidateRouteDefault() {
+		t.Fatal("package tests must opt in to the compact candidate route when GTS_ADMISSION_CANDIDATE is unset")
+	}
+}

--- a/admission_switch.go
+++ b/admission_switch.go
@@ -29,14 +29,18 @@ import (
 //  2. the process-wide default set with SetAdmissionCandidateRouteDefault;
 //  3. the process-wide default seeded from the GTS_ADMISSION_CANDIDATE
 //     environment variable at package initialization;
-//  4. ON.
+//  4. OFF.
 //
-// Phase-3 admission flipped the default to ON: the compact route is now the
-// default full-parse route for eligible languages. Set GTS_ADMISSION_CANDIDATE=0
-// (or false/off/no) to force the production route -- the documented escape
-// hatch. An emergency build (-tags gts_no_parsercorephase0) compiles the
-// compact engine out entirely and every eligible full parse then falls back to
-// production.
+// The compact route is opt-in until it graduates. Phase-3 admission made it
+// the default full-parse route, and issue #454 then measured the cost on
+// 137 KiB editor fixtures: clean full parses ran 2 to 3 times slower than the
+// production route, materialized compact trees lost most incremental reuse,
+// and native Go error recovery grew superlinearly until a single-byte delete
+// no longer terminated. Set GTS_ADMISSION_CANDIDATE=1 (or true/on/yes), call
+// SetAdmissionCandidateRouteDefault(true), or use the per-Parser override to
+// select the compact route. An emergency build (-tags gts_no_parsercorephase0)
+// compiles the compact engine out entirely and every eligible full parse then
+// falls back to production.
 
 // admissionRouteMode is the per-Parser override state. The zero value follows
 // the process-wide default.
@@ -74,16 +78,17 @@ func init() {
 // admissionCandidateEnvEnabled resolves the process-wide default the switch
 // seeds from GTS_ADMISSION_CANDIDATE at package initialization.
 //
-// Phase-3 admission made the compact route the default full-parse route, so an
-// unset or unrecognized value resolves ON. Only an explicit off value
-// ("0", "false", "off", "no", any case) resolves OFF -- the documented escape
-// hatch that forces every eligible full parse back to the production route.
+// The compact route has not graduated, so an unset or unrecognized value
+// resolves OFF and every eligible full parse uses the production route. Only
+// an explicit on value ("1", "true", "on", "yes", any case) resolves ON. The
+// package tests opt in through SetAdmissionCandidateRouteDefault so the
+// certification and parity suites keep exercising the compact route.
 func admissionCandidateEnvEnabled() bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("GTS_ADMISSION_CANDIDATE"))) {
-	case "0", "false", "off", "no":
-		return false
-	default:
+	case "1", "true", "on", "yes":
 		return true
+	default:
+		return false
 	}
 }
 

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -369,16 +369,17 @@ func TestAdmissionSwitchPooledParserScrubsRouteState(t *testing.T) {
 // TestAdmissionSwitchEnvVarContract proves GTS_ADMISSION_CANDIDATE seeds the
 // process-wide default: init calls this same parser at package load.
 //
-// Phase-3 admission made the compact route the default, so an unset or
-// unrecognized value resolves ON; only an explicit off value forces the
-// production route (the escape hatch).
+// The compact route is opt-in until it graduates (issue #454), so an unset or
+// unrecognized value resolves OFF and keeps the production route; only an
+// explicit on value selects the compact route.
 func TestAdmissionSwitchEnvVarContract(t *testing.T) {
 	for _, tc := range []struct {
 		value string
 		want  bool
 	}{
 		{"1", true}, {"true", true}, {"on", true}, {"yes", true}, {"YES", true},
-		{"", true}, {"nonsense", true}, {"On", true}, {"Yes", true},
+		{"On", true}, {"Yes", true}, {" on ", true}, {"On\t", true},
+		{"", false}, {"nonsense", false},
 		{"0", false}, {"false", false}, {"off", false}, {"no", false}, {"NO", false},
 		{"Off", false}, {"No", false}, {"False", false}, {"OFF", false},
 		{" off ", false}, {"Off\t", false},

--- a/cgo_harness/admission_default_test.go
+++ b/cgo_harness/admission_default_test.go
@@ -1,0 +1,18 @@
+package cgoharness
+
+import (
+	"os"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// The shipping default routes fresh full parses to the production engine. These
+// tests opt in to the compact candidate route when GTS_ADMISSION_CANDIDATE is
+// unset, so route receipts and counter assertions keep their established
+// coverage. An explicit GTS_ADMISSION_CANDIDATE=0 still pins a run to the
+// production route. See admission_default_test.go in the root package.
+func init() {
+	if _, set := os.LookupEnv("GTS_ADMISSION_CANDIDATE"); !set {
+		gotreesitter.SetAdmissionCandidateRouteDefault(true)
+	}
+}

--- a/cmd/issue454bench/main.go
+++ b/cmd/issue454bench/main.go
@@ -1,0 +1,234 @@
+// Command issue454bench reproduces the downstream editor measurements from
+// issue #454 on synthetic single-language fixtures.
+//
+// It generates a repetitive source of the requested size, then either times a
+// fresh full parse or applies one single-byte edit (replace, insert, or
+// delete) at the first near-top identifier and reports the incremental parse
+// profile against a fresh parse of the edited bytes.
+//
+// Usage:
+//
+//	go run ./cmd/issue454bench <lang> <sizeKB> <full|replace|insert|delete> [reps]
+//
+// Set GTS_ADMISSION_CANDIDATE=1 to route fresh full parses through the compact
+// parser; the default is the production route.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	ts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func gen(lang string, n int) ([]byte, string) {
+	var b bytes.Buffer
+	m := "x0"
+	switch lang {
+	case "go":
+		b.WriteString("package main\n\nimport \"fmt\"\n\n")
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, "func f%d(a int, b int) int {\n\tx := a + b\n\tfmt.Println(\"f%d\", x)\n\treturn x\n}\n\n", i, i)
+		}
+		m = "x := a + b"
+	case "rust":
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, "fn f%d(a: i32, b: i32) -> i32 {\n    let x0 = a + b;\n    println!(\"f%d {}\", x0);\n    x0\n}\n\n", i, i)
+		}
+	case "scala":
+		b.WriteString("object Main {\n")
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, "  def f%d(a: Int, b: Int): Int = {\n    val x0 = a + b\n    println(x0)\n    x0\n  }\n\n", i)
+		}
+		b.WriteString("}\n")
+	case "cmake":
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, "function(f%d a b)\n  set(x0 ${a})\n  message(STATUS \"f%d ${x0}\")\nendfunction()\n\n", i, i)
+		}
+	case "toml":
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, "[section%d]\nx0 = %d\nname = \"f%d\"\nenabled = true\n\n", i, i, i)
+		}
+	case "ini":
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, "[section%d]\nx0 = %d\nname = f%d\n\n", i, i, i)
+		}
+	case "make":
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, "f%d: x0.o\n\t$(CC) -o f%d x0.o\n\n", i, i)
+		}
+	case "css", "scss", "less":
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, ".f%d {\n  color: red;\n  width: 10px;\n}\n\n", i)
+		}
+		m = "red"
+	case "typescript", "tsx", "javascript":
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, "function f%d(a: number, b: number): number {\n  const x0 = a + b;\n  console.log(\"f%d\", x0);\n  return x0;\n}\n\n", i, i)
+		}
+		if lang == "javascript" {
+			b.Reset()
+			for i := 0; b.Len() < n; i++ {
+				fmt.Fprintf(&b, "function f%d(a, b) {\n  const x0 = a + b;\n  console.log(\"f%d\", x0);\n  return x0;\n}\n\n", i, i)
+			}
+		}
+	case "json":
+		b.WriteString("[\n")
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, "  {\"x0\": %d, \"name\": \"f%d\"},\n", i, i)
+		}
+		s := strings.TrimSuffix(b.String(), ",\n") + "\n]\n"
+		b.Reset()
+		b.WriteString(s)
+	case "haskell":
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, "f%d :: Int -> Int -> Int\nf%d a b = x0\n  where x0 = a + b\n\n", i, i)
+		}
+	case "hcl":
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, "resource \"aws_instance\" \"f%d\" {\n  x0 = %d\n  name = \"f%d\"\n}\n\n", i, i, i)
+		}
+	case "diff":
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, "diff --git a/f%d.txt b/f%d.txt\n--- a/f%d.txt\n+++ b/f%d.txt\n@@ -1,2 +1,2 @@\n-x0 old\n+x0 new\n", i, i, i, i)
+		}
+	case "c":
+		b.WriteString("#include <stdio.h>\n\n")
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, "int f%d(int a, int b) {\n    int x0 = a + b;\n    printf(\"f%d %%d\\n\", x0);\n    return x0;\n}\n\n", i, i)
+		}
+	case "python":
+		for i := 0; b.Len() < n; i++ {
+			fmt.Fprintf(&b, "def f%d(a, b):\n    x0 = a + b\n    print(\"f%d\", x0)\n    return x0\n\n\n", i, i)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "no generator for %s\n", lang)
+		os.Exit(2)
+	}
+	return b.Bytes(), m
+}
+
+func point(src []byte, off int) ts.Point {
+	row := bytes.Count(src[:off], []byte{'\n'})
+	col := off - (bytes.LastIndexByte(src[:off], '\n') + 1)
+	return ts.Point{Row: uint32(row), Column: uint32(col)}
+}
+
+func countNodes(n *ts.Node) int {
+	if n == nil {
+		return 0
+	}
+	c := 1
+	for i := 0; i < n.ChildCount(); i++ {
+		c += countNodes(n.Child(i))
+	}
+	return c
+}
+
+func median(d []time.Duration) time.Duration {
+	sort.Slice(d, func(i, j int) bool { return d[i] < d[j] })
+	return d[len(d)/2]
+}
+
+func main() {
+	if len(os.Args) < 4 {
+		fmt.Fprintln(os.Stderr, "usage: bench <lang> <sizeKB> <full|replace|insert|delete> [reps]")
+		os.Exit(2)
+	}
+	lang := os.Args[1]
+	kb, _ := strconv.Atoi(os.Args[2])
+	mode := os.Args[3]
+	reps := 5
+	if len(os.Args) > 4 {
+		reps, _ = strconv.Atoi(os.Args[4])
+	}
+	entry := grammars.DetectLanguageByName(lang)
+	if entry == nil || entry.Language() == nil {
+		fmt.Fprintf(os.Stderr, "language %q unavailable\n", lang)
+		os.Exit(2)
+	}
+	language := entry.Language()
+	src, marker := gen(lang, kb<<10)
+	site := bytes.Index(src, []byte(marker))
+	if site < 0 {
+		fmt.Fprintf(os.Stderr, "marker %q not found\n", marker)
+		os.Exit(2)
+	}
+	parser := ts.NewParser(language)
+
+	if mode == "full" {
+		var ds []time.Duration
+		nodes := 0
+		hasErr := false
+		for i := 0; i < reps; i++ {
+			t0 := time.Now()
+			tree, err := parser.Parse(src)
+			ds = append(ds, time.Since(t0))
+			if err != nil {
+				fmt.Printf("RESULT lang=%s size=%dKB mode=full err=%v\n", lang, kb, err)
+				os.Exit(1)
+			}
+			nodes = countNodes(tree.RootNode())
+			hasErr = tree.RootNode().HasError()
+		}
+		fmt.Printf("RESULT lang=%s size=%dKB mode=full bytes=%d full_ms=%.3f min_ms=%.3f nodes=%d has_error=%v\n",
+			lang, kb, len(src), float64(median(ds))/1e6, float64(ds[0])/1e6, nodes, hasErr)
+		return
+	}
+
+	var edited []byte
+	var edit ts.InputEdit
+	sp := point(src, site)
+	switch mode {
+	case "replace":
+		edited = append([]byte{}, src...)
+		edited[site]++
+		edit = ts.InputEdit{StartByte: uint32(site), OldEndByte: uint32(site + 1), NewEndByte: uint32(site + 1),
+			StartPoint: sp, OldEndPoint: ts.Point{Row: sp.Row, Column: sp.Column + 1}, NewEndPoint: ts.Point{Row: sp.Row, Column: sp.Column + 1}}
+	case "insert":
+		edited = append(append(append([]byte{}, src[:site]...), src[site]), src[site:]...)
+		edit = ts.InputEdit{StartByte: uint32(site), OldEndByte: uint32(site), NewEndByte: uint32(site + 1),
+			StartPoint: sp, OldEndPoint: sp, NewEndPoint: ts.Point{Row: sp.Row, Column: sp.Column + 1}}
+	case "delete":
+		edited = append(append([]byte{}, src[:site]...), src[site+1:]...)
+		edit = ts.InputEdit{StartByte: uint32(site), OldEndByte: uint32(site + 1), NewEndByte: uint32(site),
+			StartPoint: sp, OldEndPoint: ts.Point{Row: sp.Row, Column: sp.Column + 1}, NewEndPoint: sp}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown mode %s\n", mode)
+		os.Exit(2)
+	}
+
+	t0 := time.Now()
+	old, err := parser.Parse(src)
+	fullD := time.Since(t0)
+	if err != nil {
+		fmt.Printf("RESULT lang=%s size=%dKB mode=%s err=%v\n", lang, kb, mode, err)
+		os.Exit(1)
+	}
+	old.Edit(edit)
+	t0 = time.Now()
+	inc, prof, err := parser.ParseIncrementalProfiled(edited, old)
+	incD := time.Since(t0)
+	if err != nil {
+		fmt.Printf("RESULT lang=%s size=%dKB mode=%s inc_err=%v inc_ms=%.3f\n", lang, kb, mode, err, float64(incD)/1e6)
+		os.Exit(1)
+	}
+	t0 = time.Now()
+	fresh, err := parser.Parse(edited)
+	freshD := time.Since(t0)
+	if err != nil {
+		fmt.Printf("RESULT lang=%s size=%dKB mode=%s fresh_err=%v\n", lang, kb, mode, err)
+		os.Exit(1)
+	}
+	in := countNodes(inc.RootNode())
+	fn := countNodes(fresh.RootNode())
+	fmt.Printf("RESULT lang=%s size=%dKB mode=%s site=%d full_ms=%.3f inc_ms=%.3f fresh_ms=%.3f ratio_inc_full=%.2f inc_nodes=%d fresh_nodes=%d match=%v inc_err=%v fresh_err=%v reused_subtrees=%d reused_bytes=%d reuse_pct=%.1f new_nodes=%d tokens=%d unsupported=%v reason=%q rej_rootnonleaf=%d rej_scanner=%d stop=%v\n",
+		lang, kb, mode, site, float64(fullD)/1e6, float64(incD)/1e6, float64(freshD)/1e6, float64(incD)/float64(fullD), in, fn, in == fn, inc.RootNode().HasError(), fresh.RootNode().HasError(),
+		prof.ReusedSubtrees, prof.ReusedBytes, 100*float64(prof.ReusedBytes)/float64(len(edited)), prof.NewNodesAllocated, prof.TokensConsumed, prof.ReuseUnsupported, prof.ReuseUnsupportedReason, prof.ReuseRejectRootNonLeafChanged, prof.ReuseRejectScannerUnquiescent, prof.StopReason)
+}

--- a/docs/performance/issue-454-compact-route-default-2026-09-07.md
+++ b/docs/performance/issue-454-compact-route-default-2026-09-07.md
@@ -1,0 +1,181 @@
+# Issue 454 compact route default
+
+Date: 2026-09-07.
+
+## Summary
+
+A downstream editor compared v0.52.0 with v0.48.1 on 137 KiB synthetic fixtures
+([issue #454](https://github.com/odvcencio/gotreesitter/issues/454)).
+Clean full parses ran 2 to 3 times slower on 41 of 48 grammars.
+Seven grammars lost most incremental reuse.
+A single-byte Go delete did not terminate.
+
+This report reproduces those results on Linux and attributes them to one cause.
+The compact candidate route was the process default for fresh full parses.
+Pull request [#631](https://github.com/odvcencio/gotreesitter/pull/631) removed
+the 64 KiB size decline on 2026-08-02. Files above 64 KiB then reached the
+compact route for the first time in v0.49.0.
+Forcing the production route with `GTS_ADMISSION_CANDIDATE=0` restores
+v0.48.1-class results on every reported item.
+
+The accompanying change makes the compact route opt-in.
+It does not change compact parser graduation status.
+
+## Environment and method
+
+- linux/amd64 under Windows Subsystem for Linux, 20 logical CPUs, go1.25.1.
+- Shared development host. Other work ran during some samples.
+- Harness: `go run ./cmd/issue454bench <lang> 137 <full|replace|insert|delete>`.
+- Fixtures: generated repetitive sources, 137 KiB, one language per process.
+- Full parse: median of five parses in one process.
+- Edits: one single-byte edit at the first near-top identifier, as in the report.
+- Correctness: node count of the incremental tree against a fresh parse of the edited bytes.
+- Every row is one process run. These are attribution samples, not paired benchmark evidence.
+
+Measured revisions:
+
+- `v0.48.1` at `bbd24cda`.
+- `v0.52.0` at `22958710`.
+- `main` at `a50f1532`, the base of this change.
+- `fix`: this change, with `GTS_ADMISSION_CANDIDATE` unset.
+
+## Full parse, 137 KiB, median milliseconds
+
+| Grammar | v0.48.1 | v0.52.0 | main | v0.52.0, compact off | fix |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| go | 70.5 | 138.1 | 150.2 | 93.3 | |
+| rust | 57.1 | 140.4 | 137.5 | 73.8 | 69.9 |
+| scala | 74.5 | 212.1 | 195.6 | 75.0 | 75.6 |
+| cmake | 89.7 | 235.9 | 235.2 | 105.0 | 109.5 |
+| toml | 43.4 | 94.5 | 100.0 | 57.4 | 56.7 |
+| make | 48.8 | 91.4 | 90.3 | | |
+| css | 35.6 | 79.2 | 88.6 | 41.6 | |
+| scss | 33.9 | 75.7 | 85.6 | | |
+| less | 58.7 | 126.4 | 173.1 | | |
+| typescript | 63.4 | 116.3 | 111.7 | | |
+| tsx | 51.0 | 106.5 | 109.5 | | |
+| ini | 37.8 | 74.2 | 73.2 | | |
+| diff | 24.8 | 54.0 | 54.4 | | |
+| json | 44.7 | 105.5 | 108.2 | 56.0 | |
+| hcl | 64.0 | 192.8 | 195.1 | 75.4 | |
+| haskell (fixture has an error) | 97.1 | 102.3 | 116.8 | | |
+| c | 124.4 | 107.1 | 111.2 | | |
+| python | 180.5 | 197.8 | 199.1 | | |
+| javascript | 98.0 | 94.7 | 88.4 | | |
+
+The four flat grammars do not use the compact route for these fixtures.
+That matches the seven flat grammars in the downstream report.
+
+## Incremental edits, 137 KiB
+
+Reuse is reused bytes as a percentage of the edited source.
+Time is the incremental parse in milliseconds.
+
+| Grammar, edit | v0.48.1 | v0.52.0 | main | fix |
+| --- | --- | --- | --- | --- |
+| toml insert | 100.0%, 3.1 ms | 62.5%, 61.1 ms | 62.5%, 60.3 ms | 100.0%, 3.7 ms |
+| make insert | 100.0%, 3.7 ms | 29.9%, 56.1 ms | 29.9%, 57.0 ms | 100.0%, 13.2 ms |
+| css delete | 95.1%, 3.9 ms | 68.0%, 26.2 ms | 95.1%, 5.0 ms | 95.1%, 6.2 ms |
+| scss insert | 95.1%, 3.0 ms | 56.5%, 26.6 ms | 95.1%, 4.7 ms | 95.1%, 8.0 ms |
+| typescript insert | 98.1%, 4.8 ms | 54.3%, 67.9 ms | 54.3%, 71.3 ms | 98.1%, 11.6 ms |
+| ini insert | 97.3%, 10.4 ms | 0.0%, 58.2 ms | 0.0%, 57.8 ms | 97.3%, 17.1 ms |
+| diff insert | 99.9%, 1.4 ms | 25.1%, 36.4 ms | 25.1%, 38.3 ms | 99.9%, 2.6 ms |
+| json insert | 69.2%, 48.7 ms | 69.2%, 203.9 ms | 69.2%, 212.7 ms | 69.2%, 70.2 ms |
+
+At v0.52.0 the `ini` refusal reason is
+`old tree was compact-materialized without a scanner-quiescence proof`.
+Every row above matched its fresh parse by node count.
+
+## Go single-byte delete, transient syntax error
+
+The downstream report calls this the item that blocks adoption.
+The cost sits in the fresh parse of the edited bytes, not in reuse selection.
+
+| Size | v0.48.1 incremental | v0.52.0 incremental | v0.52.0 fresh parse of edited bytes | fix incremental |
+| --- | ---: | ---: | ---: | ---: |
+| 2 KiB | 1.5 ms | 31.2 ms | 32.2 ms | |
+| 4 KiB | 1.6 ms | 118.3 ms | 127.9 ms | |
+| 8 KiB | 2.1 ms | 669.2 ms | 731.3 ms | |
+| 16 KiB | 3.0 ms | 4,179.8 ms | 4,291.5 ms | 2.2 ms |
+| 137 KiB | 11.4 ms (downstream) | no termination in 420 s (downstream) | | 26.2 ms |
+
+With `GTS_ADMISSION_CANDIDATE=0`, v0.52.0 completes the 137 KiB delete in 15.5 ms.
+With `GTS_ADMISSION_CANDIDATE=1`, the fix reproduces the 16 KiB blowup at 4,548.7 ms.
+The opt-in switch therefore selects the compact route as documented.
+
+## Small files, both routes on this change
+
+At v0.48.1 the compact route already served inputs at or below 64 KiB.
+This table checks whether the production default costs anything on those sizes.
+Each cell is the median of seven full parses in one process.
+
+| Grammar | 4 KiB production | 4 KiB compact | 16 KiB production | 16 KiB compact | 48 KiB production | 48 KiB compact |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| go | 3.7 ms | 4.9 ms | 8.6 ms | 17.2 ms | 23.0 ms | 49.2 ms |
+| rust | 3.2 ms | 4.9 ms | 7.8 ms | 16.2 ms | 19.5 ms | 46.1 ms |
+| json | 2.7 ms | 4.5 ms | 7.6 ms | 13.9 ms | 16.3 ms | 39.2 ms |
+| toml | 2.8 ms | 4.2 ms | 5.4 ms | 11.8 ms | 15.5 ms | 33.5 ms |
+| css | 2.5 ms | 3.5 ms | 6.5 ms | 10.1 ms | 14.0 ms | 28.6 ms |
+| typescript | 3.8 ms | 4.0 ms | 8.0 ms | 12.5 ms | 19.3 ms | 38.5 ms |
+| scala | 4.1 ms | 5.4 ms | 9.1 ms | 21.3 ms | 24.8 ms | 63.6 ms |
+| python | 6.9 ms | 7.0 ms | 23.3 ms | 22.8 ms | 61.8 ms | 68.0 ms |
+
+The production route is faster or equal at every measured size.
+The compact-to-production ratio grows with input size, from about 1.0 to 1.6 at 4 KiB to about 2.0 to 2.6 at 48 KiB.
+
+## Behavior that changes for inputs at or below 64 KiB
+
+Inputs at or below 64 KiB used the compact route at v0.48.1 and now use the production route.
+
+- Compact-only conflict policies no longer apply by default. The Markdown inline route
+  carries four such policies from v0.52.0. Those inputs return the production tree,
+  which is the v0.48.1 tree, because the compact route declined them before v0.52.0.
+- Native compact error recovery no longer runs by default. The production recovery path
+  serves error-bearing inputs, as it did at v0.48.1.
+- Processes that opt in through `GTS_ADMISSION_CANDIDATE=1` or the API keep every v0.52.0 behavior.
+
+## Attribution
+
+- At v0.48.1, `admissionCandidateInputSizeEligible` declined inputs above 64 KiB.
+  The 137 KiB fixtures used the production route.
+- Pull request #631 removed that decline. The compact route was already the process default.
+- v0.52.0 added native compact Go end-of-file recovery. The error-bearing fresh parse then stayed on the compact route instead of falling back to production.
+- Tests that force the compact route or read its counters keep their coverage. The test binaries opt in when `GTS_ADMISSION_CANDIDATE` is unset.
+
+## Production-route regression exposed by the default change
+
+Running the grammars suite with `GTS_ADMISSION_CANDIDATE=0` exposed one production-route
+regression that the compact default had masked since v0.49.0:
+`static inline void f(int *v) {}` and every function definition with two consecutive
+storage-class specifiers returned an ERROR node around the type.
+The same test passes on both routes at v0.48.1.
+
+A bisect names `02ee8546` (pull request #709, Apex class-literal election parity).
+That change added a per-stack DFA re-lex to the plain multi-stack dispatch loop.
+The GLR trace shows the mechanism:
+
+1. At `inline`, the parser forks between a declaration-specifier reading and a
+   constructor-specifier reading.
+2. At `void`, the constructor fork has no action for `primitive_type`. Before #709 it died.
+   The re-lex reads `void` as an `identifier`, the constructor name, so it survives.
+3. At `f`, the constructor fork has no action again. The previous-shift recovery
+   wraps `void` in an ERROR and keeps the fork alive next to the error-free sibling.
+4. Both forks reach the same state at `*`, merge, and the recovered fork wins selection.
+
+Tree-sitter C halts a version at a no-action point when a better version exists.
+This change adds that rule before the previous-shift recovery: a sibling stack that
+already shifted the lookahead, accepted the input, or carries an action for it is a
+better version, so the failing stack falls through to the existing multi-stack kill.
+`TestCppConsecutiveStorageClassSpecifiersProductionRouteMatchesCompact` pins five
+witnesses on the production route against the compact route. The Apex parity suite
+from #709 still passes on both routes.
+
+## Remaining items outside this change
+
+- TypeScript transient-error delete on the production route: 64.0 ms at v0.48.1, 318.5 ms at v0.52.0 with the compact route off.
+  A bisect with a 2.5x incremental-to-full ratio threshold names `bf7ab056` (pull request #613, memory-budget fail-closed retry for incremental parse).
+  The tree stays correct. The cost is a fail-closed full-parse retry.
+- C transient-error delete at 137 KiB: 2.1 s with a wrong one-node tree at v0.48.1, 21.1 s at v0.52.0, 3.8 s on this change with a correct tree.
+  The `incremental_parse_memory_budget_full_retry` route still explores about 3.2 million nodes before the retry. The C fallback attribution work on issue #454 owns this item.
+- Production-route full parse costs 1.1 to 1.3 times v0.48.1 on several grammars, for example rust at 57.1 ms against 69.9 ms. This report does not attribute that residual.
+- `ReusedBytes` exceeds the source length on the delete arm at both versions, for example 194.9 percent for Go. This is a profiler accounting defect, not a parse defect.

--- a/grammars/admission_default_test.go
+++ b/grammars/admission_default_test.go
@@ -1,0 +1,18 @@
+package grammars
+
+import (
+	"os"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// The shipping default routes fresh full parses to the production engine. These
+// tests opt in to the compact candidate route when GTS_ADMISSION_CANDIDATE is
+// unset, so route receipts and counter assertions keep their established
+// coverage. An explicit GTS_ADMISSION_CANDIDATE=0 still pins a run to the
+// production route. See admission_default_test.go in the root package.
+func init() {
+	if _, set := os.LookupEnv("GTS_ADMISSION_CANDIDATE"); !set {
+		gotreesitter.SetAdmissionCandidateRouteDefault(true)
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -6361,7 +6361,19 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					}
 					continue
 				}
+				// Tree-sitter C halts a version at a no-action point when a
+				// better version exists (ts_parser__recover via
+				// ts_parser__better_version_exists). A sibling stack that
+				// accepts this lookahead is that better version, so the
+				// previous-shift recovery below must not keep this stack
+				// alive next to it: the recovered fork can later merge with
+				// the error-free sibling and win result selection with an
+				// ERROR the C oracle never produces. Witness: the
+				// constructor-specifier fork of `static inline void f() {}`
+				// after the per-stack re-lex reads `void` as an identifier
+				// (issue #454 follow-up).
 				if _, _, hasRecoverAction := p.findRecoverActionOnStack(s, tok.Symbol, timing); !hasRecoverAction &&
+					!p.glrSiblingAcceptsLookahead(stacks, s, tok) &&
 					p.tryRecoverPreviousShiftAsError(s, tok, &nodeCount, arena, &scratch.entries, trackChildErrors) {
 					anyReduced = true
 					needToken = false
@@ -8205,6 +8217,26 @@ func (p *Parser) tryRelexSingleParserState(tok Token, state StateID, ts TokenSou
 	// the live frontier before its next read, and same-pass re-lex paths set it.
 	scratch.releaseDFARelexSnapshot(retainedSnapshot)
 	return next, true
+}
+
+// glrSiblingAcceptsLookahead reports whether a live stack other than self
+// accepts tok in the current dispatch pass: it already shifted tok, it has
+// accepted the input, or its top state carries a real action for tok. Paused
+// C-recovery versions and dead or empty stacks are not better versions.
+func (p *Parser) glrSiblingAcceptsLookahead(stacks []glrStack, self *glrStack, tok Token) bool {
+	for stackIndex := range stacks {
+		candidate := &stacks[stackIndex]
+		if candidate == self || candidate.dead || candidate.cPaused || candidate.depth() == 0 {
+			continue
+		}
+		if candidate.accepted || candidate.shifted {
+			return true
+		}
+		if p.stateHasActionForSymbol(candidate.top().state, tok.Symbol) {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Parser) noLiveStackCanAcceptLookahead(stacks []glrStack, tok Token) bool {

--- a/parser_cpp_storage_specifier_production_route_test.go
+++ b/parser_cpp_storage_specifier_production_route_test.go
@@ -1,0 +1,51 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestCppConsecutiveStorageClassSpecifiersProductionRouteMatchesCompact pins an
+// issue #454 follow-up. Pull request #709 added a per-stack re-lex to the plain
+// multi-stack dispatch loop. That re-lex let the doomed constructor-specifier
+// fork of `static inline void f(...) {}` read `void` as an identifier, and the
+// previous-shift recovery then kept that fork alive next to an error-free
+// sibling. The recovered fork won result selection with an ERROR node.
+// Tree-sitter C halts a version when a better one exists, so the production
+// route must return the error-free tree and match the compact route.
+func TestCppConsecutiveStorageClassSpecifiersProductionRouteMatchesCompact(t *testing.T) {
+	lang := grammars.CppLanguage()
+	if lang == nil {
+		t.Skip("cpp grammar not registered")
+	}
+	for _, src := range []string{
+		"static inline void f(int *v) {}\n",
+		"extern inline void f(Foo<Rule> *v) {}\n",
+		"static inline void f(std::vector<Rule> &v) {}\n",
+		"static inline int g(std::vector<Rule> *v) { return 0; }\n",
+		"#include <vector>\nstruct Rule {};\nstatic inline void f(std::vector<Rule> *v) {}\n",
+	} {
+		production := gts.NewParser(lang)
+		production.SetAdmissionCandidateRoute(false)
+		productionTree, err := production.Parse([]byte(src))
+		if err != nil {
+			t.Fatalf("production parse %q: %v", src, err)
+		}
+		compact := gts.NewParser(lang)
+		compact.SetAdmissionCandidateRoute(true)
+		compactTree, err := compact.Parse([]byte(src))
+		if err != nil {
+			t.Fatalf("compact parse %q: %v", src, err)
+		}
+		got := productionTree.RootNode().SExpr(lang)
+		want := compactTree.RootNode().SExpr(lang)
+		if productionTree.RootNode().HasError() {
+			t.Errorf("production route reported an error for %q:\n  %s", src, got)
+		}
+		if got != want {
+			t.Errorf("production route diverges from compact route for %q:\n  production: %s\n  compact:    %s", src, got, want)
+		}
+	}
+}

--- a/roottest/parse/admission_default_test.go
+++ b/roottest/parse/admission_default_test.go
@@ -1,0 +1,18 @@
+package parse_test
+
+import (
+	"os"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// The shipping default routes fresh full parses to the production engine. These
+// tests opt in to the compact candidate route when GTS_ADMISSION_CANDIDATE is
+// unset, so route receipts and counter assertions keep their established
+// coverage. An explicit GTS_ADMISSION_CANDIDATE=0 still pins a run to the
+// production route. See admission_default_test.go in the root package.
+func init() {
+	if _, set := os.LookupEnv("GTS_ADMISSION_CANDIDATE"); !set {
+		gotreesitter.SetAdmissionCandidateRouteDefault(true)
+	}
+}


### PR DESCRIPTION
## Summary

The compact route became the default for fresh full parses in v0.52.0. Issue #454 then measured 2 to 3 times slower clean full parses, lost incremental reuse, and a non-terminating Go delete on large editor fixtures. This change restores the production route as the default, keeps the compact route opt-in until graduation, and fixes a production-route GLR regression the compact default had hidden.

## Changes

- Flip the process default for eligible fresh full parses from the compact route to the production route. An unset or unrecognized GTS_ADMISSION_CANDIDATE now resolves to the production route; opt in with GTS_ADMISSION_CANDIDATE=1, SetAdmissionCandidateRouteDefault(true), or the per-Parser override.
- Add test-binary init hooks in the root, cgo_harness, grammars, and roottest packages so the certification and parity suites keep exercising the compact route when the environment variable is unset.
- Halt a GLR stack at a no-action point when a sibling stack already shifts or accepts the lookahead, before the previous-shift recovery runs. This fixes the C++ consecutive storage-class specifier regression that the compact default masked since v0.49.0.
- Add a C++ production-vs-compact route parity test pinning the five storage-class specifier witnesses, and a package test documenting the compact-route opt-in.

## Testing

- go test . -run 'TestAdmissionSwitchEnvVarContract|TestPackageTestsOptIntoCompactRoute' -count=1
- go test . -run TestCppConsecutiveStorageClassSpecifiersProductionRouteMatchesCompact -count=1
- go test ./... -run '^$' -count=1 and go vet ./...
- go test . -count=1 with GTS_ADMISSION_CANDIDATE unset and with GTS_ADMISSION_CANDIDATE=0 (only the pre-existing TestResultCompatibilityRetiredCommitProvenance failure remains on main)
- go test ./grammars ./parser_result_test ./roottest/... -count=1 with the variable unset and with GTS_ADMISSION_CANDIDATE=0
- GOMAXPROCS=1 go test -tags gts_parsercorephase0 . -run '^(TestAdmission|TestCompact|TestDiagnosticParserCoreSelectedStore)' -count=1
- go run ./cmd/issue454bench go 137 delete

## Related Issues

- Refs #454
- Refs #709

## Review Focus

Review the GLR halt condition glrSiblingAcceptsLookahead for interaction with existing multi-stack recovery, and confirm the compact-route opt-in semantics stay consistent for any opt-out value.
