### PR TITLE
fix(bash): preserve whitespace after empty assignments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1265,7 +1265,7 @@ jobs:
             --test-parallel 1 \
             --c-ref-build-jobs 1 \
             --timeout 20m \
-            --run '^(TestCompactT3OracleAdjudication|TestCompactT3JavaScriptRecoveryProfileCharacterization|TestCompactT3JavaScriptRecoveryRouteSeedOracleParity|TestCompactT3JavaScriptRecoveryMutationDifferential|TestCompactJavaScriptS5RecoveryMutationDifferential|TestCompactRouteLockedCExceptions)$'
+            --run '^(TestCompactT3OracleAdjudication|TestCompactT3JavaScriptRecoveryProfileCharacterization|TestCompactT3JavaScriptRecoveryRouteSeedOracleParity|TestCompactT3JavaScriptRecoveryMutationDifferential|TestCompactJavaScriptS5RecoveryMutationDifferential|TestCompactRouteLockedCExceptions|TestIssue1106BashEmptyAssignmentsCParity)$'
 
       - name: Elm admission contract against locked C
         run: |

--- a/cgo_harness/bash_issue1106_parity_test.go
+++ b/cgo_harness/bash_issue1106_parity_test.go
@@ -1,0 +1,94 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	harness "github.com/odvcencio/gotreesitter/cgo_harness"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestIssue1106BashEmptyAssignmentsCParity(t *testing.T) {
+	data, err := os.ReadFile("../grammars/testdata/bash_empty_assignments.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cases []struct {
+		Name    string
+		Source  string
+		Invalid bool
+	}
+	if err := json.Unmarshal(data, &cases); err != nil {
+		t.Fatal(err)
+	}
+	cLang, err := harness.COracleLanguage("bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lang := grammars.BashLanguage()
+	for _, test := range cases {
+		if test.Invalid {
+			continue
+		}
+		t.Run(test.Name, func(t *testing.T) {
+			source := []byte(test.Source)
+			parser := sitter.NewParser()
+			defer parser.Close()
+			if err := parser.SetLanguage(cLang); err != nil {
+				t.Fatal(err)
+			}
+			cTree := parser.Parse(source, nil)
+			if cTree == nil {
+				t.Fatal("C parser returned no tree")
+			}
+			defer cTree.Close()
+			if cTree.RootNode() == nil || cTree.RootNode().HasError() {
+				t.Fatal("C parser did not return a complete tree")
+			}
+			cDigest, err := harness.COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, route := range []string{"strict", "production", "raw"} {
+				t.Run(route, func(t *testing.T) {
+					goParser := gotreesitter.NewParser(lang)
+					var tree *gotreesitter.Tree
+					var err error
+					switch route {
+					case "strict":
+						tree, err = goParser.ParseStrict(source)
+					case "production":
+						tree, err = goParser.Parse(source)
+					case "raw":
+						goParser.SetAdmissionCandidateRoute(false)
+						tree, err = goParser.ParseNoResultCompatibilityBenchmarkOnly(source)
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer tree.Release()
+					root := tree.RootNode()
+					if root == nil || root.HasErrorOrMissing() {
+						t.Fatal("Go parser did not return a complete tree")
+					}
+					if diff := harness.FirstDivergenceDumpV1(root, lang, cTree.RootNode()); diff != nil {
+						t.Fatalf("tree divergence: %+v", diff)
+					}
+					inspection, err := benchfixtures.InspectGoTree(root, lang)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if inspection.SHA256 != cDigest {
+						t.Fatalf("deep digest Go=%s C=%s", inspection.SHA256, cDigest)
+					}
+				})
+			}
+		})
+	}
+}

--- a/grammars/bash_issue1106_regression_test.go
+++ b/grammars/bash_issue1106_regression_test.go
@@ -1,0 +1,90 @@
+package grammars_test
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestIssue1106BashEmptyAssignments(t *testing.T) {
+	data, err := os.ReadFile("testdata/bash_empty_assignments.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cases []struct {
+		Name        string
+		Source      string
+		Assignments map[string]string
+		Command     string
+		Invalid     bool
+	}
+	if err := json.Unmarshal(data, &cases); err != nil {
+		t.Fatal(err)
+	}
+	lang := grammars.BashLanguage()
+	for _, test := range cases {
+		t.Run(test.Name, func(t *testing.T) {
+			source := []byte(test.Source)
+			tree, err := gotreesitter.NewParser(lang).ParseStrict(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tree.Release()
+			root := tree.RootNode()
+			if root == nil {
+				t.Fatal("parse returned no root")
+			}
+			if root.HasErrorOrMissing() != test.Invalid {
+				t.Fatalf("invalid = %v, want %v: %s", root.HasErrorOrMissing(), test.Invalid, root.SExpr(lang))
+			}
+			if test.Invalid {
+				return
+			}
+			if root.EndByte() != uint32(len(source)) {
+				t.Fatalf("root ends at %d, want %d", root.EndByte(), len(source))
+			}
+			assignments := make(map[string]bool)
+			foundCommand := test.Command == ""
+			gotreesitter.Walk(root, func(node *gotreesitter.Node, _ int) gotreesitter.WalkAction {
+				switch node.Type(lang) {
+				case "variable_assignment":
+					name := node.ChildByFieldName("name", lang)
+					if name == nil {
+						t.Fatal("assignment has no name")
+					}
+					key := name.Text(source)
+					want, ok := test.Assignments[key]
+					if !ok || assignments[key] {
+						t.Fatalf("unexpected or duplicate assignment %q", key)
+					}
+					assignments[key] = true
+					value := node.ChildByFieldName("value", lang)
+					if want == "" {
+						if value != nil {
+							t.Fatalf("%s= has a value node: %s", key, value.SExpr(lang))
+						}
+					} else if value == nil || value.Text(source) != want {
+						t.Fatalf("%s value does not match %q: %s", key, want, node.SExpr(lang))
+					}
+					start := strings.Index(test.Source, key+"=")
+					if node.StartByte() != uint32(start) || node.EndByte() != uint32(start+len(key)+1+len(want)) {
+						t.Fatalf("%s assignment span = [%d,%d)", key, node.StartByte(), node.EndByte())
+					}
+				case "command":
+					name := node.ChildByFieldName("name", lang)
+					if name != nil && name.Text(source) == test.Command {
+						foundCommand = true
+					}
+				}
+				return gotreesitter.WalkContinue
+			})
+			if len(assignments) != len(test.Assignments) || !foundCommand {
+				t.Fatalf("assignments = %v, command found = %v: %s", assignments, foundCommand, root.SExpr(lang))
+			}
+		})
+	}
+}

--- a/grammars/bash_scanner.go
+++ b/grammars/bash_scanner.go
@@ -345,7 +345,8 @@ func bshIsReservedWordBoundary(r rune) bool {
 }
 
 func bshScanOpeningParen(lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
-	if !bshIsValid(validSymbols, bshTokConcat) {
+	// Preserve the separator until EMPTY_VALUE can emit its zero-width token.
+	if !bshIsValid(validSymbols, bshTokConcat) && !bshIsValid(validSymbols, bshTokEmptyValue) {
 		bshSkipHorizontalSpace(lexer)
 	}
 	if lexer.Lookahead() != '(' {

--- a/grammars/testdata/bash_empty_assignments.json
+++ b/grammars/testdata/bash_empty_assignments.json
@@ -1,0 +1,20 @@
+[
+  {"name":"negated", "source":"! A=x B= command\n", "assignments":{"A":"x","B":""}, "command":"command"},
+  {"name":"plain", "source":"A=x B= command\n", "assignments":{"A":"x","B":""}, "command":"command"},
+  {"name":"single", "source":"! B= command\n", "assignments":{"B":""}, "command":"command"},
+  {"name":"multiple", "source":"! A=x B= C= command\n", "assignments":{"A":"x","B":"","C":""}, "command":"command"},
+  {"name":"tab", "source":"! A=x B=\tcommand\n", "assignments":{"A":"x","B":""}, "command":"command"},
+  {"name":"crlf_unicode", "source":"# café\r\n! A=x B= command\r\n", "assignments":{"A":"x","B":""}, "command":"command"},
+  {"name":"if_condition", "source":"if ! GOBIN=\"$bindir\" GOFLAGS= $command; then :; fi\n", "assignments":{"GOBIN":"\"$bindir\"","GOFLAGS":""}, "command":"$command"},
+  {"name":"case_body", "source":"case \"$x\" in a) A= command;; esac\n", "assignments":{"A":""}, "command":"command"},
+  {"name":"redirect", "source":"! A=x B= command >output\n", "assignments":{"A":"x","B":""}, "command":"command"},
+  {"name":"pipeline", "source":"! A=x B= command | next\n", "assignments":{"A":"x","B":""}, "command":"command"},
+  {"name":"continuation", "source":"! A=x B= \\\ncommand\n", "assignments":{"A":"x","B":""}, "command":"command"},
+  {"name":"substitution", "source":"! A=x B= command \"${name} $(printf text)\"\n", "assignments":{"A":"x","B":""}, "command":"command"},
+  {"name":"nonempty", "source":"! A=x B=value command\n", "assignments":{"A":"x","B":"value"}, "command":"command"},
+  {"name":"concatenated", "source":"! A=x B=foo\"bar\" command\n", "assignments":{"A":"x","B":"foo\"bar\""}, "command":"command"},
+  {"name":"quoted_empty", "source":"! A=x B=\"\" command\n", "assignments":{"A":"x","B":"\"\""}, "command":"command"},
+  {"name":"array", "source":"A=(one two)\n", "assignments":{"A":"(one two)"}},
+  {"name":"unterminated_if", "source":"if ! A=x B= command; then\n", "invalid":true},
+  {"name":"unterminated_quote", "source":"! A=x B=\"unfinished\n", "invalid":true}
+]


### PR DESCRIPTION
Fixes #1106.

`! A=x B= command` must leave `B` empty and preserve `command` as the command name. The opening-parenthesis probe consumed the separating whitespace before the scanner reached `EMPTY_VALUE`. Some inputs produced a missing word. Others produced an incorrect assignment without an error flag.

Preserve whitespace when `EMPTY_VALUE` is valid. The existing scanner then emits its zero-width token. The change adds one condition and leaves grammar data, token identities, and parser recovery unchanged.

Add shared inputs and blackbox tests:

- Check assignment values, command names, byte ranges, and `HasErrorOrMissing()`.
- Cover negation, multiple assignments, tabs, CRLF, Unicode, substitutions, redirects, pipelines, case bodies, arrays, and quoted values.
- Keep incomplete syntax invalid.
- Compare valid inputs with the locked C grammar across strict, production, and raw Go parsing.
- Include the new C comparison in the existing CI job.

Validation used a dedicated Linux Docker container with two CPUs and an 8 GiB memory limit. No repository-wide host sweep ran.

- Before the fix: 12 of 18 new cases failed.
- With the fix: all 18 cases and available Bash regressions passed.
- The locked C comparison passed for 16 valid inputs across three routes. It checks symbols, fields, byte/point spans, flags, child order, and deep digests.
- Existing Bash fresh/incremental parity and C-reference regressions passed.

- The final fix passed Bash race tests on Go 1.27.0.
- Bash tests passed with `CGO_ENABLED=0` on Go 1.22.0, the module's declared minimum compiler.
- Actionlint passed for the changed workflow.

`TestBashForestRepetitionFoldDispatch` skipped because its optional real-corpus fixture was absent.

Reproduce the scoped checks inside a Docker container:

```sh
go test -race ./grammars -run '^Test(Issue1106Bash|Bash)' -count=1
CGO_ENABLED=0 GOTOOLCHAIN=go1.22.0 go test ./grammars -run '^Test(Issue1106Bash|Bash)' -count=1
cd cgo_harness
go test . -tags treesitter_c_parity -run '^(TestBash.*COracleParity|TestIssue1106BashEmptyAssignmentsCParity)$' -count=1
GTS_PARITY_MODE=smoke go test . -tags treesitter_c_parity -run '^TestParity(FreshParse|IncrementalParse|HasNoErrors)$/^bash$' -count=1
```
